### PR TITLE
feat(ci): add amdsmi test group and expand core/all/nightly coverage

### DIFF
--- a/.github/scripts/tests/therock_configure_ci_test.py
+++ b/.github/scripts/tests/therock_configure_ci_test.py
@@ -492,7 +492,7 @@ class ConfigureCITest(unittest.TestCase):
     @patch("therock_configure_ci.get_modified_paths")
     def test_amdsmi_pr_triggers_amdsmi_group(self, mock_get_modified):
         """PR with amdsmi changes should build everything and test amdsmi plus
-        its downstream dependents (blas, rccl, rocprofiler-systems, rocrtst)."""
+        its downstream dependents (blas, rocprofiler-systems, rocrtst)."""
         args = {
             "is_pull_request": True,
             "base_ref": "HEAD^",
@@ -514,18 +514,17 @@ class ConfigureCITest(unittest.TestCase):
                 "rocblas",
                 "hipblas",
                 "hipblaslt",
-                "rccl",
                 "rocprofiler-systems",
                 "rocrtst",
             },
         )
-        # "rdc" is not a TheRock test target, so it must not be listed.
-        self.assertNotIn("rdc", tests)
+        # rccl is intentionally excluded: the main Linux build forces
+        # THEROCK_ENABLE_RCCL=OFF and RCCL runs in its own dedicated pipeline.
+        self.assertNotIn("rccl", tests)
 
     def test_amdsmi_group_uses_valid_test_targets(self):
         """Every test target in the amdsmi group must be a real TheRock test
-        target. rccl is a valid target even though it is dispatched via a
-        separate RCCL CI job, so it is included in the allow-list here."""
+        target (a key in fetch_test_configurations.test_matrix)."""
         # Keys of TheRock's fetch_test_configurations.test_matrix. Kept in sync
         # manually since TheRock is not checked out during unit tests.
         valid_test_targets = {

--- a/.github/scripts/tests/therock_configure_ci_test.py
+++ b/.github/scripts/tests/therock_configure_ci_test.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 import therock_configure_ci
+import therock_matrix
 
 
 class ConfigureCITest(unittest.TestCase):
@@ -487,6 +488,78 @@ class ConfigureCITest(unittest.TestCase):
 
         project_to_run, _ = therock_configure_ci.retrieve_projects(args)
         self.assertEqual(len(project_to_run), 0)
+
+    @patch("therock_configure_ci.get_modified_paths")
+    def test_amdsmi_pr_triggers_amdsmi_group(self, mock_get_modified):
+        """PR with amdsmi changes should build everything and test amdsmi plus
+        its downstream dependents (blas, rccl, rocprofiler-systems, rocrtst)."""
+        args = {
+            "is_pull_request": True,
+            "base_ref": "HEAD^",
+            "platform": "linux",
+        }
+
+        mock_get_modified.return_value = ["projects/amdsmi/src/amdsmi.cpp"]
+
+        project_to_run, _ = therock_configure_ci.retrieve_projects(args)
+        self.assertEqual(len(project_to_run), 1)
+        self.assertIn("DTHEROCK_ENABLE_ALL=ON", project_to_run[0]["cmake_options"])
+        tests = {
+            t.strip() for t in project_to_run[0]["projects_to_test"].split(",")
+        }
+        self.assertEqual(
+            tests,
+            {
+                "amdsmi",
+                "rocblas",
+                "hipblas",
+                "hipblaslt",
+                "rccl",
+                "rocprofiler-systems",
+                "rocrtst",
+            },
+        )
+        # "rdc" is not a TheRock test target, so it must not be listed.
+        self.assertNotIn("rdc", tests)
+
+    def test_amdsmi_group_uses_valid_test_targets(self):
+        """Every test target in the amdsmi group must be a real TheRock test
+        target. rccl is a valid target even though it is dispatched via a
+        separate RCCL CI job, so it is included in the allow-list here."""
+        # Keys of TheRock's fetch_test_configurations.test_matrix. Kept in sync
+        # manually since TheRock is not checked out during unit tests.
+        valid_test_targets = {
+            "sanity", "hip-tests", "hipfile", "rocblas", "rocroller",
+            "tensilelite", "origami", "hipblas", "amdsmi", "hipblaslt",
+            "hipsolver", "rocsolver", "rocprim", "hipcub", "rocgdb-cpu",
+            "rocgdb-gpu", "rocr-debug-agent", "rocthrust", "hipsparse",
+            "rocsparse", "hipsparselt", "rocrand", "hiprand", "rocfft",
+            "hipfft", "miopen", "rccl", "rocshmem", "rocprofiler-sdk",
+            "hipdnn", "hipdnn_install", "hipdnn-integration-tests",
+            "hipdnn-samples", "miopenprovider", "hipblasltprovider",
+            "hipkernelprovider", "rocwmma", "rocalution",
+            "rocprofiler-compute", "rocprofiler-systems", "libhipcxx_amdclang",
+            "libhipcxx_hiprtc", "hipthreads", "hipthreads_examples",
+            "rocdecode", "rocjpeg", "aqlprofile", "rocrtst", "hiptensor",
+        }
+        amdsmi_tests = {
+            t.strip()
+            for t in therock_matrix.project_map["amdsmi"][
+                "projects_to_test"
+            ].split(",")
+        }
+        self.assertTrue(amdsmi_tests <= valid_test_targets, amdsmi_tests)
+
+    def test_amdsmi_in_core_all_nightly_test_targets(self):
+        """amdsmi must be an explicit test target in core, all, and nightly."""
+        for group in ("core", "all", "nightly"):
+            tests = {
+                t.strip()
+                for t in therock_matrix.project_map[group][
+                    "projects_to_test"
+                ].split(",")
+            }
+            self.assertIn("amdsmi", tests, group)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -5,7 +5,7 @@ This dictionary is used to map specific file directory changes to the correspond
 subtree_to_project_map = {
     "emulation/rocjitsu": "emulation",
     "emulation/mirage": "emulation",
-    "projects/amdsmi": "core",
+    "projects/amdsmi": "amdsmi",  # amdsmi changes run amdsmi + its downstream dependents
     "projects/aqlprofile": "profiler",
     "projects/clr": "runtimes",
     "projects/cuid": "rdc",
@@ -35,7 +35,13 @@ subtree_to_project_map = {
 project_map = {
     "core": {
         "cmake_options": ["-DTHEROCK_ENABLE_CORE=ON", "-DTHEROCK_ENABLE_ALL=OFF", "-DTHEROCK_ENABLE_PROFILER=ON"],
-        "projects_to_test": "aqlprofile, rocprofiler-compute, rocprofiler-sdk, rocprofiler-systems",  # will run sanity test to cover rocminfo and amdsmi
+        "projects_to_test": "amdsmi, aqlprofile, rocprofiler-compute, rocprofiler-sdk, rocprofiler-systems",  # will run sanity test to cover rocminfo
+    },
+    # amdsmi changes fan out to its downstream dependents across rocm-systems
+    # and rocm-libraries, so build everything and test amdsmi plus those consumers.
+    "amdsmi": {
+        "cmake_options": ["-DTHEROCK_ENABLE_ALL=ON"],
+        "projects_to_test": "amdsmi, rocblas, hipblas, hipblaslt, rccl, rocprofiler-systems, rocrtst",
     },
     "emulation": {
         "cmake_options": ["-DTHEROCK_ENABLE_ALL=OFF", "-DTHEROCK_ENABLE_EMULATION=ON"],
@@ -85,7 +91,7 @@ project_map = {
     },
     "all": {
         "cmake_options": ["-DTHEROCK_ENABLE_ALL=ON"],
-        "projects_to_test": "hip-tests, rocrtst, aqlprofile, rocprofiler-compute, rocprofiler-sdk, rocprofiler-systems, rocr-debug-agent, rocgdb-cpu, rocgdb-gpu",
+        "projects_to_test": "amdsmi, hip-tests, rocrtst, aqlprofile, rocprofiler-compute, rocprofiler-sdk, rocprofiler-systems, rocr-debug-agent, rocgdb-cpu, rocgdb-gpu",
     },
     # Same test coverage as TheRock submodule-bump PRs (rocm-systems scope).
     # Nightly (schedule) uses this entry explicitly for alignment.
@@ -93,7 +99,7 @@ project_map = {
     # instead of above blanket addition of all tests, we can add logic to determine which mathlibs to test, based on file changes from last nightly run. Can be handled once the tests scripts move to component/monorepo src
     "nightly": {
         "cmake_options": "-DTHEROCK_ENABLE_ALL=ON",
-        "projects_to_test": "hip-tests, rocrtst, aqlprofile, rocprofiler-compute, rocprofiler-sdk, rocprofiler-systems, rocr-debug-agent, rocgdb-cpu, rocgdb-gpu, rocprim, rocthrust, rocrand, hiprand, hipblaslt, rocblas, hipblas, rocroller, miopen, miopenprovider, hipfft, rocfft, rocsparse, hipsparse, hipsparselt, rocsolver, hipsolver, rocwmma",
+        "projects_to_test": "amdsmi, hip-tests, rocrtst, aqlprofile, rocprofiler-compute, rocprofiler-sdk, rocprofiler-systems, rocr-debug-agent, rocgdb-cpu, rocgdb-gpu, rocprim, rocthrust, rocrand, hiprand, hipblaslt, rocblas, hipblas, rocroller, miopen, miopenprovider, hipfft, rocfft, rocsparse, hipsparse, hipsparselt, rocsolver, hipsolver, rocwmma",
     },
 }
 

--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -39,9 +39,13 @@ project_map = {
     },
     # amdsmi changes fan out to its downstream dependents across rocm-systems
     # and rocm-libraries, so build everything and test amdsmi plus those consumers.
+    # Note: rccl is a downstream consumer but is intentionally excluded here.
+    # The main Linux build forces -DTHEROCK_ENABLE_RCCL=OFF (see therock-ci-linux.yml)
+    # and RCCL is exercised by its own dedicated pipeline (run_linux_rccl_ci),
+    # so listing it here would be a no-op.
     "amdsmi": {
         "cmake_options": ["-DTHEROCK_ENABLE_ALL=ON"],
-        "projects_to_test": "amdsmi, rocblas, hipblas, hipblaslt, rccl, rocprofiler-systems, rocrtst",
+        "projects_to_test": "amdsmi, rocblas, hipblas, hipblaslt, rocprofiler-systems, rocrtst",
     },
     "emulation": {
         "cmake_options": ["-DTHEROCK_ENABLE_ALL=OFF", "-DTHEROCK_ENABLE_EMULATION=ON"],


### PR DESCRIPTION
Add amdsmi as an explicit test target in the core, all, and nightly groups (previously covered only implicitly via the sanity test).

Introduce a dedicated "amdsmi" group and route projects/amdsmi changes to it so an amdsmi PR builds everything and tests amdsmi plus its downstream dependents: rocblas/hipblas/hipblaslt (blas), rccl, rocprofiler-systems, and rocrtst. Test-target names verified against TheRock's test_matrix.

Add unit tests covering the amdsmi group resolution, valid test-target names, and amdsmi's presence in the core, all, and nightly groups.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
This PR is a solution we are using to increase testing on amdsmi PRs while we land https://github.com/ROCm/TheRock/issues/3343

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
