### PR TITLE
test(rccl): add DDA fabric epoch-counter and scratch-capacity unit tests

### DIFF
--- a/projects/rccl/src/include/algorithms/CollCommon.h
+++ b/projects/rccl/src/include/algorithms/CollCommon.h
@@ -297,6 +297,13 @@ __host__ __device__ __forceinline__ void ddaLLEpochRestamp(uint32_t* __restrict_
 // Entry: tid 0 reads this block's epoch cell (all cells hold the same value),
 // derives the next flag on-device, and broadcasts it via the caller-provided
 // shared slot. Returns the flag for this launch.
+//
+// BLOCK-COOPERATIVE: contains __syncthreads() (the shared-slot store by tid 0
+// must be published before the other threads read the returned flag). ALL
+// threads in the block must call this from uniform control flow -- every DDA
+// LL/LL128 kernel does, unconditionally at entry (the only earlier `return` is
+// keyed on blockIdx, so a block exits whole, never partially). Not host-callable;
+// use the pure ddaLLEpochFlag/ddaLLEpochBank for the arithmetic in host code.
 __device__ __forceinline__ uint32_t ddaLLEpochBegin(const uint32_t* __restrict__ epochDev, int flatBlockId,
                                                     uint32_t& s_flag) {
   if (threadIdx.x == 0) {
@@ -307,7 +314,9 @@ __device__ __forceinline__ uint32_t ddaLLEpochBegin(const uint32_t* __restrict__
 }
 
 // Exit: tid 0 restamps every epoch cell this block strides over to `flag`.
-// `total` == gridDim.x * gridDim.y.
+// `total` == gridDim.x * gridDim.y. Unlike ddaLLEpochBegin this needs NO barrier
+// -- nothing is broadcast back to the block, and the next launch on the stream is
+// serialized after this one -- so it is safe under thread-0 divergence.
 __device__ __forceinline__ void ddaLLEpochEnd(uint32_t* __restrict__ epochDev, int flatBlockId, int total, int epochLen,
                                               uint32_t flag) {
   if (threadIdx.x == 0) {

--- a/projects/rccl/src/include/algorithms/CollCommon.h
+++ b/projects/rccl/src/include/algorithms/CollCommon.h
@@ -259,4 +259,60 @@ __device__ __forceinline__ void ddaLLLoadLineB128(const uint32_t* src, uint32_t&
 #endif
 }
 
+// ---- Shared per-block epoch arithmetic (used by all LL and LL128 kernels) ----
+// The pure helpers below are host-callable (__host__ __device__) so the host
+// unit tests exercise the exact same code the kernels run; the device wrappers
+// (ddaLLEpochBegin/ddaLLEpochEnd) add the thread-0 guard and barrier and stay
+// __device__ only.
+
+// Derive this launch's flag from a block's epoch cell: f = cell + 1, skipping
+// the 0 "cleared scratch" sentinel so bank parity (flag & 1) is preserved.
+__host__ __device__ __forceinline__ uint32_t ddaLLEpochFlag(uint32_t cell) {
+  uint32_t f = cell + 1u;
+  if (f == 0u) {
+    f = 2u; // skip 0 sentinel; keep bank parity
+  }
+  return f;
+}
+
+// Double-buffer bank selector: bank = flag & 1.
+__host__ __device__ __forceinline__ unsigned ddaLLEpochBank(uint32_t flag) {
+  return flag & 1u;
+}
+
+// Advance every epoch cell this block strides over to `flag`, so all cells stay
+// in lock-step even when a later launch uses a different block count.
+// Preconditions (no runtime assert -- this is a kernel utility; callers, i.e.
+// the device wrappers and the test's applyLaunch, are constructed to satisfy
+// them): total > 0 (total == 0 would make the loop non-terminating),
+// 0 <= flatBlockId, 0 <= epochLen, and epochDev points to at least epochLen cells.
+__host__ __device__ __forceinline__ void ddaLLEpochRestamp(uint32_t* __restrict__ epochDev, int flatBlockId, int total,
+                                                           int epochLen, uint32_t flag) {
+  for (int e = flatBlockId; e < epochLen; e += total) {
+    epochDev[e] = flag;
+  }
+}
+
+// HIP-graph-safe per-block epoch (shared by all LL/LL128 kernels).
+// Entry: tid 0 reads this block's epoch cell (all cells hold the same value),
+// derives the next flag on-device, and broadcasts it via the caller-provided
+// shared slot. Returns the flag for this launch.
+__device__ __forceinline__ uint32_t ddaLLEpochBegin(const uint32_t* __restrict__ epochDev, int flatBlockId,
+                                                    uint32_t& s_flag) {
+  if (threadIdx.x == 0) {
+    s_flag = ddaLLEpochFlag(epochDev[flatBlockId]);
+  }
+  __syncthreads();
+  return s_flag;
+}
+
+// Exit: tid 0 restamps every epoch cell this block strides over to `flag`.
+// `total` == gridDim.x * gridDim.y.
+__device__ __forceinline__ void ddaLLEpochEnd(uint32_t* __restrict__ epochDev, int flatBlockId, int total, int epochLen,
+                                              uint32_t flag) {
+  if (threadIdx.x == 0) {
+    ddaLLEpochRestamp(epochDev, flatBlockId, total, epochLen, flag);
+  }
+}
+
 } // namespace meta::comms

--- a/projects/rccl/src/include/algorithms/CollCommon_ll128.h
+++ b/projects/rccl/src/include/algorithms/CollCommon_ll128.h
@@ -19,8 +19,9 @@
  *
  * HIP-graph safety: the flag/bank are derived on-device from the per-block
  * epoch array (comm->ddaLLEpochDev), never passed from the host, so nothing is
- * baked into a captured graph. See ddaLLEpochBegin / ddaLLEpochEnd below and
- * commit 6820b6f4a9 ("Make DDA LL kernels HIP graph-capture safe").
+ * baked into a captured graph. See ddaLLEpochBegin / ddaLLEpochEnd in
+ * algorithms/CollCommon.h and commit 6820b6f4a9 ("Make DDA LL kernels HIP
+ * graph-capture safe").
  *
  * See LICENSE.txt for license information.
  ************************************************************************/
@@ -81,32 +82,9 @@ __device__ __forceinline__ uint64_t ddaLL128AddWord(uint64_t a, uint64_t b) {
   return ((uint64_t)hi << 32) | (uint64_t)lo;
 }
 
-// ---- HIP-graph-safe per-block epoch (shared by all LL/LL128 kernels) ----
-// Entry: tid 0 reads this block's epoch cell (all cells hold the same value),
-// derives the next flag on-device, and broadcasts it via the caller-provided
-// shared slot. flag 0 is the "cleared scratch" sentinel and is skipped so bank
-// parity (flag & 1) is preserved. Returns the flag for this launch.
-__device__ __forceinline__ uint32_t ddaLLEpochBegin(const uint32_t* __restrict__ epochDev, int flatBlockId,
-                                                    uint32_t& s_flag) {
-  if (threadIdx.x == 0) {
-    uint32_t f = epochDev[flatBlockId] + 1u;
-    if (f == 0u) f = 2u; // skip 0 sentinel; keep bank parity
-    s_flag = f;
-  }
-  __syncthreads();
-  return s_flag;
-}
-
-// Exit: tid 0 advances every epoch cell this block strides over to `flag`, so
-// all cells stay in lock-step even when a later launch uses a different block
-// count. `total` == gridDim.x * gridDim.y.
-__device__ __forceinline__ void ddaLLEpochEnd(uint32_t* __restrict__ epochDev, int flatBlockId, int total, int epochLen,
-                                              uint32_t flag) {
-  if (threadIdx.x == 0) {
-    for (int e = flatBlockId; e < epochLen; e += total) {
-      epochDev[e] = flag;
-    }
-  }
-}
+// ddaLLEpochBegin / ddaLLEpochEnd and the pure epoch arithmetic
+// (ddaLLEpochFlag / ddaLLEpochBank / ddaLLEpochRestamp) now live in
+// algorithms/CollCommon.h so both the LL and LL128 kernels share them; they are
+// visible here transitively via that include.
 
 } // namespace meta::comms

--- a/projects/rccl/src/include/algorithms/all_gather/all_gather_dda_fabric_ll.h
+++ b/projects/rccl/src/include/algorithms/all_gather/all_gather_dda_fabric_ll.h
@@ -69,14 +69,8 @@ __launch_bounds__(512)
   const int flatBlockId = blockIdx.x * gridDim.y + blockIdx.y;
   const int total = gridDim.x * gridDim.y;
   __shared__ uint32_t s_flag;
-  if (tid == 0) {
-    uint32_t f = epochDev[flatBlockId] + 1u;
-    if (f == 0u) f = 2u;                   // skip 0 sentinel; keep bank parity
-    s_flag = f;
-  }
-  __syncthreads();
-  const uint32_t flag = s_flag;
-  const size_t bankOffsetPkts = (size_t)(flag & 1u) * (size_t)nRanks * slot;
+  const uint32_t flag = ddaLLEpochBegin(epochDev, flatBlockId, s_flag);
+  const size_t bankOffsetPkts = (size_t)ddaLLEpochBank(flag) * (size_t)nRanks * slot;
 
   // This block's packet range [pkBegin, pkEnd); [0, nPk) when nChunks == 1.
   const size_t pkPerChunk = (nPk + (size_t)nChunks - 1) / (size_t)nChunks;
@@ -129,11 +123,7 @@ __launch_bounds__(512)
     }
   }
 
-  if (tid == 0) {
-    for (int e = flatBlockId; e < epochLen; e += total) {
-      epochDev[e] = flag;
-    }
-  }
+  ddaLLEpochEnd(epochDev, flatBlockId, total, epochLen, flag);
 }
 
 } // namespace meta::comms

--- a/projects/rccl/src/include/algorithms/all_gather/all_gather_dda_fabric_ll128.h
+++ b/projects/rccl/src/include/algorithms/all_gather/all_gather_dda_fabric_ll128.h
@@ -68,7 +68,7 @@ __launch_bounds__(1024)
   const int total = gridDim.x * gridDim.y;
   __shared__ uint32_t s_flag;
   const uint32_t flag = ddaLLEpochBegin(epochDev, flatBlockId, s_flag);
-  const size_t bankOffsetLines = (size_t)(flag & 1u) * (size_t)nRanks * slot;
+  const size_t bankOffsetLines = (size_t)ddaLLEpochBank(flag) * (size_t)nRanks * slot;
 
   // This block's line range [lnBegin, lnEnd); [0, numLines) when nChunks == 1.
   const size_t lnPerChunk = (numLines + (size_t)nChunks - 1) / (size_t)nChunks;

--- a/projects/rccl/src/include/algorithms/all_reduce/all_reduce_dda_fabric_ll128.h
+++ b/projects/rccl/src/include/algorithms/all_reduce/all_reduce_dda_fabric_ll128.h
@@ -70,7 +70,7 @@ __launch_bounds__(1024)
   const int total = gridDim.x;
   __shared__ uint32_t s_flag;
   const uint32_t flag = ddaLLEpochBegin(epochDev, flatBlockId, s_flag);
-  const size_t bankOffsetLines = (size_t)(flag & 1u) * (size_t)nRanks * slot;
+  const size_t bankOffsetLines = (size_t)ddaLLEpochBank(flag) * (size_t)nRanks * slot;
 
   // 16 lanes cooperate on one 128B line; grid-stride over line-groups.
   const int group = threadIdx.x / kDdaLL128Lanes;

--- a/projects/rccl/src/include/algorithms/all_reduce/all_reduce_dda_ll.h
+++ b/projects/rccl/src/include/algorithms/all_reduce/all_reduce_dda_ll.h
@@ -73,14 +73,8 @@ __launch_bounds__(512)
   const int flatBlockId = blockIdx.x;
   const int total = gridDim.x;
   __shared__ uint32_t s_flag;
-  if (threadIdx.x == 0) {
-    uint32_t f = epochDev[flatBlockId] + 1u;
-    if (f == 0u) f = 2u;                   // skip 0 sentinel; keep bank parity
-    s_flag = f;
-  }
-  __syncthreads();
-  const uint32_t flag = s_flag;
-  const size_t bankOffsetPkts = (size_t)(flag & 1u) * (size_t)nRanks * slot;
+  const uint32_t flag = ddaLLEpochBegin(epochDev, flatBlockId, s_flag);
+  const size_t bankOffsetPkts = (size_t)ddaLLEpochBank(flag) * (size_t)nRanks * slot;
 
   const size_t gtid = (size_t)blockIdx.x * blockDim.x + threadIdx.x;
   const size_t stride = (size_t)gridDim.x * blockDim.x;
@@ -120,11 +114,7 @@ __launch_bounds__(512)
     out[2 * pk + 1] = acc1;
   }
 
-  if (threadIdx.x == 0) {
-    for (int e = flatBlockId; e < epochLen; e += total) {
-      epochDev[e] = flag;
-    }
-  }
+  ddaLLEpochEnd(epochDev, flatBlockId, total, epochLen, flag);
 }
 
 } // namespace meta::comms

--- a/projects/rccl/src/include/algorithms/alltoall/alltoall_dda_fabric_ll.h
+++ b/projects/rccl/src/include/algorithms/alltoall/alltoall_dda_fabric_ll.h
@@ -70,14 +70,8 @@ __launch_bounds__(512)
   const int flatBlockId = blockIdx.x * gridDim.y + blockIdx.y;
   const int total = gridDim.x * gridDim.y;
   __shared__ uint32_t s_flag;
-  if (tid == 0) {
-    uint32_t f = epochDev[flatBlockId] + 1u;
-    if (f == 0u) f = 2u;                   // skip 0 sentinel; keep bank parity
-    s_flag = f;
-  }
-  __syncthreads();
-  const uint32_t flag = s_flag;
-  const size_t bankOffsetPkts = (size_t)(flag & 1u) * (size_t)nRanks * slot;
+  const uint32_t flag = ddaLLEpochBegin(epochDev, flatBlockId, s_flag);
+  const size_t bankOffsetPkts = (size_t)ddaLLEpochBank(flag) * (size_t)nRanks * slot;
 
   // This block's packet range [pkBegin, pkEnd); [0, nPk) when nChunks == 1.
   const size_t pkPerChunk = (nPk + (size_t)nChunks - 1) / (size_t)nChunks;
@@ -131,11 +125,7 @@ __launch_bounds__(512)
     }
   }
 
-  if (tid == 0) {
-    for (int e = flatBlockId; e < epochLen; e += total) {
-      epochDev[e] = flag;
-    }
-  }
+  ddaLLEpochEnd(epochDev, flatBlockId, total, epochLen, flag);
 }
 
 } // namespace meta::comms

--- a/projects/rccl/src/include/algorithms/alltoall/alltoall_dda_fabric_ll128.h
+++ b/projects/rccl/src/include/algorithms/alltoall/alltoall_dda_fabric_ll128.h
@@ -72,7 +72,7 @@ __launch_bounds__(1024)
   const int total = gridDim.x * gridDim.y;
   __shared__ uint32_t s_flag;
   const uint32_t flag = ddaLLEpochBegin(epochDev, flatBlockId, s_flag);
-  const size_t bankOffsetLines = (size_t)(flag & 1u) * (size_t)nRanks * slot;
+  const size_t bankOffsetLines = (size_t)ddaLLEpochBank(flag) * (size_t)nRanks * slot;
 
   // This block's line range [lnBegin, lnEnd); [0, numLines) when nChunks == 1.
   const size_t lnPerChunk = (numLines + (size_t)nChunks - 1) / (size_t)nChunks;

--- a/projects/rccl/src/include/algorithms/reduce_scatter/reduce_scatter_dda_fabric_ll.h
+++ b/projects/rccl/src/include/algorithms/reduce_scatter/reduce_scatter_dda_fabric_ll.h
@@ -70,14 +70,8 @@ __launch_bounds__(512)
   const int flatBlockId = blockIdx.x;
   const int total = gridDim.x;
   __shared__ uint32_t s_flag;
-  if (threadIdx.x == 0) {
-    uint32_t f = epochDev[flatBlockId] + 1u;
-    if (f == 0u) f = 2u; // skip 0 sentinel; keep bank parity
-    s_flag = f;
-  }
-  __syncthreads();
-  const uint32_t flag = s_flag;
-  const size_t bankOffsetPkts = (size_t)(flag & 1u) * (size_t)nRanks * slot;
+  const uint32_t flag = ddaLLEpochBegin(epochDev, flatBlockId, s_flag);
+  const size_t bankOffsetPkts = (size_t)ddaLLEpochBank(flag) * (size_t)nRanks * slot;
 
   const size_t gtid = (size_t)blockIdx.x * blockDim.x + threadIdx.x;
   const size_t stride = (size_t)gridDim.x * blockDim.x;
@@ -118,11 +112,7 @@ __launch_bounds__(512)
     out[2 * pk + 1] = acc1;
   }
 
-  if (threadIdx.x == 0) {
-    for (int e = flatBlockId; e < epochLen; e += total) {
-      epochDev[e] = flag;
-    }
-  }
+  ddaLLEpochEnd(epochDev, flatBlockId, total, epochLen, flag);
 }
 
 } // namespace meta::comms

--- a/projects/rccl/src/include/algorithms/reduce_scatter/reduce_scatter_dda_fabric_ll128.h
+++ b/projects/rccl/src/include/algorithms/reduce_scatter/reduce_scatter_dda_fabric_ll128.h
@@ -72,7 +72,7 @@ __launch_bounds__(1024)
   const int total = gridDim.x;
   __shared__ uint32_t s_flag;
   const uint32_t flag = ddaLLEpochBegin(epochDev, flatBlockId, s_flag);
-  const size_t bankOffsetLines = (size_t)(flag & 1u) * (size_t)nRanks * slot;
+  const size_t bankOffsetLines = (size_t)ddaLLEpochBank(flag) * (size_t)nRanks * slot;
 
   // 16 lanes cooperate on one 128B line; grid-stride over line-groups.
   const int group = threadIdx.x / kDdaLL128Lanes;

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -358,6 +358,7 @@ if(BUILD_TESTS)
       DdaAlltoAllThresholdTests.cpp
       DdaIpcEligibilityTests.cpp
       DdaFabricEligibilityTests.cpp
+      DdaFabricEpochTests.cpp
       EnqueueTests.cpp
       IpcsocketTests.cpp
       TopoEnvPolicyTests.cpp

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -359,6 +359,7 @@ if(BUILD_TESTS)
       DdaAlltoAllThresholdTests.cpp
       DdaIpcEligibilityTests.cpp
       DdaFabricEligibilityTests.cpp
+      DdaFabricScratchTests.cpp
       EnqueueTests.cpp
       IpcsocketTests.cpp
       TopoEnvPolicyTests.cpp

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -255,6 +255,7 @@ if(BUILD_TESTS)
       RomeTopoConsensusTests.cpp
       EnqueueCountTests.cpp
       DdaCollCommonTests.cpp
+      DdaFabricEpochTests.cpp
       VersionInfoTests.cpp
       device/TestOp128.cpp
       device/GinDeviceTests.cpp
@@ -358,7 +359,6 @@ if(BUILD_TESTS)
       DdaAlltoAllThresholdTests.cpp
       DdaIpcEligibilityTests.cpp
       DdaFabricEligibilityTests.cpp
-      DdaFabricEpochTests.cpp
       EnqueueTests.cpp
       IpcsocketTests.cpp
       TopoEnvPolicyTests.cpp

--- a/projects/rccl/test/DdaFabricEligibilityTests.cpp
+++ b/projects/rccl/test/DdaFabricEligibilityTests.cpp
@@ -16,13 +16,8 @@
 namespace RcclUnitTesting
 {
 
-class DdaFabricEligibilityTest : public ::testing::Test
-{
-protected:
-    DdaFabricMockComm mockComm_;
-    void*             sendbuff_{reinterpret_cast<void*>(0x1000)};
-    void*             recvbuff_{reinterpret_cast<void*>(0x2000)};
-};
+// Fixture (mock comm + dummy buffers) is shared via DdaFabricTestHelpers.hpp.
+using DdaFabricEligibilityTest = DdaFabricFixture;
 
 // ---------------------------------------------------------------------------
 // AllGather

--- a/projects/rccl/test/DdaFabricEpochTests.cpp
+++ b/projects/rccl/test/DdaFabricEpochTests.cpp
@@ -1,0 +1,189 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Host-side consistency tests for the shared LL epoch counter used by the DDA
+// fabric collectives (AllGather / AllReduce / ReduceScatter / AllToAll).
+//
+// comm->ddaLLEpochDev is a single device array of comm->ddaLLEpochLen uint32
+// cells, shared across those collectives and sized by ddaLLEpochCount() to cover
+// the widest block grid any of them launches. On each launch tid 0 of block b
+// reads its epoch cell and derives this launch's LL flag:
+//     f = cell + 1;  if (f == 0) f = 2;   // skip the 0 sentinel
+//     bank = f & 1;                        // double-buffer selector
+// and at the end re-stamps the array over its full length:
+//     for (e = flatBlockId; e < ddaLLEpochLen; e += total) epoch[e] = flag;
+//
+// The collectives rely on every cell of the shared array advancing in lock-step
+// so peer-swapped block pairs derive the same flag and bank. For AllGather the
+// reader (rank R, block peer=P, chunk c) uses epoch[P*bpp+c] while the matching
+// writer (rank P, block peer=R, chunk c) uses epoch[R*bpp+c]; since every rank
+// evolves the array identically (SPMD), the poll matches only when
+// epoch[P*bpp+c] == epoch[R*bpp+c] for all R,P,c. AllReduce/ReduceScatter are
+// 1-D and same-index paired (reader block b pairs with writer block b).
+//
+// These tests replay the epoch arithmetic on the host, using the real constants
+// from dda_init_detail.h, and verify the array stays uniform and the AllGather
+// pairing stays consistent across single and mixed-size collective sequences.
+// They need no GPU. They mirror:
+//   src/include/algorithms/all_gather/all_gather_dda_fabric_ll.h
+//   src/include/algorithms/all_reduce/all_reduce_dda_ll.h
+//   src/dda_all_gather_fabric_ll.cu, src/dda_all_reduce_fabric_ll.cu
+
+#include "dda_init_detail.h" // nccl_dda_detail::{ddaLLEpochCount,kDdaFabricLLArMaxBlocks,kDdaLLAgMaxBlocksPerPeer}, DDA_FABRIC_MAXBLOCKS
+
+#include "gtest/gtest.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+namespace RcclUnitTesting
+{
+namespace
+{
+
+using nccl_dda_detail::ddaLLEpochCount;
+using nccl_dda_detail::kDdaFabricLLArMaxBlocks;
+using nccl_dda_detail::kDdaLLAgMaxBlocksPerPeer;
+
+// Number of shared epoch cells, from the real sizing function.
+int allocCells(int nRanks) { return static_cast<int>(ddaLLEpochCount(nRanks, DDA_FABRIC_MAXBLOCKS)); }
+
+// Per-block LL flag from its epoch cell:  f = cell + 1; if (f == 0) f = 2.
+uint32_t deriveFlag(uint32_t cell)
+{
+    uint32_t f = cell + 1u;
+    if (f == 0u) f = 2u;
+    return f;
+}
+
+// Replay one launch's epoch update: `total` blocks, full-length write-back over
+// [0, ddaLLEpochLen), block b owning cells b, b+total, b+2*total, ... exactly as
+// the kernels do:  for (e = flatBlockId; e < epochLen; e += total) epoch[e]=flag.
+void applyLaunch(std::vector<uint32_t>& epoch, int total)
+{
+    const int epochLen = static_cast<int>(epoch.size()); // full ddaLLEpochLen
+    std::vector<uint32_t> flag(total);
+    for (int b = 0; b < total; ++b)
+        flag[b] = deriveFlag(epoch[b]);
+    for (int b = 0; b < total; ++b)
+        for (int e = b; e < epochLen; e += total)
+            epoch[e] = flag[b];
+}
+
+// AllGather launch: grid = nRanks x blocksPerPeer, total = nRanks*bpp.
+void applyAllGather(std::vector<uint32_t>& epoch, int nRanks, int bpp) { applyLaunch(epoch, nRanks * bpp); }
+
+// AllReduce launch: 1-D grid of arBlocks (<= kDdaFabricLLArMaxBlocks) blocks.
+void applyAllReduce(std::vector<uint32_t>& epoch, int arBlocks) { applyLaunch(epoch, arBlocks); }
+
+// AllGather peer-swap pairing violations an AG launch with `bpp` would see when
+// reading `epoch`: for each (R,P,c) with P!=R the reader cell (P*bpp+c) and the
+// paired writer cell (R*bpp+c) must derive the same flag.
+long agPairingMismatches(const std::vector<uint32_t>& epoch, int nRanks, int bpp)
+{
+    long mismatches = 0;
+    for (int R = 0; R < nRanks; ++R)
+        for (int P = 0; P < nRanks; ++P)
+        {
+            if (P == R) continue; // self column is a local copy, no cross-rank flag
+            for (int c = 0; c < bpp; ++c)
+                if (deriveFlag(epoch[P * bpp + c]) != deriveFlag(epoch[R * bpp + c])) ++mismatches;
+        }
+    return mismatches;
+}
+
+// True when every shared epoch cell holds the same value.
+bool allCellsUniform(const std::vector<uint32_t>& epoch)
+{
+    for (size_t i = 1; i < epoch.size(); ++i)
+        if (epoch[i] != epoch[0]) return false;
+    return true;
+}
+
+constexpr int kSmallBpp = 1;                        // tiny message: one block per peer
+constexpr int kLargeBpp = kDdaLLAgMaxBlocksPerPeer; // 8: widest per-peer fan-out
+constexpr int kArBlocks = 16;                       // representative AR grid (<= 24)
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// The shared array is sized to cover the widest LL collective.
+// ---------------------------------------------------------------------------
+TEST(DdaFabricEpochTest, EpochCount_CoversWidestCollective)
+{
+    for (int nRanks : {2, 4, 8})
+    {
+        const int cells = static_cast<int>(ddaLLEpochCount(nRanks, DDA_FABRIC_MAXBLOCKS));
+        EXPECT_EQ(cells, std::max(nRanks * kDdaLLAgMaxBlocksPerPeer, DDA_FABRIC_MAXBLOCKS)) << "nRanks=" << nRanks;
+        // Must index the widest AllGather grid (nRanks*8) and the AR cap (24).
+        EXPECT_GE(cells, nRanks * kLargeBpp) << "nRanks=" << nRanks;
+        EXPECT_GE(cells, kDdaFabricLLArMaxBlocks) << "nRanks=" << nRanks;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// A small AllGather followed by a large one: the shared array stays uniform and
+// the wider AllGather's peer-swap pairing stays consistent.
+// ---------------------------------------------------------------------------
+TEST(DdaFabricEpochTest, SharedEpoch_AllGatherSmallThenLarge_StaysConsistent)
+{
+    for (int nRanks : {4, 8})
+    {
+        std::vector<uint32_t> epoch(allocCells(nRanks), 0u); // cudaMemset(epochDev, 0)
+        applyAllGather(epoch, nRanks, kSmallBpp);
+        EXPECT_TRUE(allCellsUniform(epoch)) << "after small AG, nRanks=" << nRanks;
+        EXPECT_EQ(agPairingMismatches(epoch, nRanks, kLargeBpp), 0)
+            << "large AG must find every peer-swap pair consistent (nRanks=" << nRanks << ")";
+    }
+}
+
+// ---------------------------------------------------------------------------
+// A tiny AllReduce followed by a wide AllGather leaves the shared array
+// consistent for the AllGather.
+// ---------------------------------------------------------------------------
+TEST(DdaFabricEpochTest, SharedEpoch_AllReduceThenAllGather_StaysConsistent)
+{
+    for (int nRanks : {4, 8})
+    {
+        std::vector<uint32_t> epoch(allocCells(nRanks), 0u);
+        applyAllReduce(epoch, kArBlocks);
+        EXPECT_TRUE(allCellsUniform(epoch)) << "after AR, nRanks=" << nRanks;
+        EXPECT_EQ(agPairingMismatches(epoch, nRanks, kLargeBpp), 0)
+            << "AG after AR must find every peer-swap pair consistent (nRanks=" << nRanks << ")";
+    }
+}
+
+// ---------------------------------------------------------------------------
+// A long interleaved sequence of mixed-size AllGather / AllReduce launches keeps
+// the shared array uniform and each AllGather pairing-consistent every iteration.
+// ---------------------------------------------------------------------------
+TEST(DdaFabricEpochTest, SharedEpoch_RepeatedMixedSizes_StaysConsistent)
+{
+    const int agBpp[] = {1, 2, 4, 8, 3};
+    const int arBlk[] = {1, 4, 16, 24, 7};
+    for (int nRanks : {4, 8})
+    {
+        std::vector<uint32_t> epoch(allocCells(nRanks), 0u);
+        for (int iter = 0; iter < 50; ++iter)
+        {
+            for (int bpp : agBpp)
+            {
+                EXPECT_EQ(agPairingMismatches(epoch, nRanks, bpp), 0)
+                    << "iter=" << iter << " nRanks=" << nRanks << " bpp=" << bpp;
+                applyAllGather(epoch, nRanks, bpp);
+                EXPECT_TRUE(allCellsUniform(epoch)) << "after AG iter=" << iter << " bpp=" << bpp;
+            }
+            for (int blk : arBlk)
+            {
+                applyAllReduce(epoch, blk);
+                EXPECT_TRUE(allCellsUniform(epoch)) << "after AR iter=" << iter << " blk=" << blk;
+            }
+        }
+    }
+}
+
+} // namespace RcclUnitTesting

--- a/projects/rccl/test/DdaFabricEpochTests.cpp
+++ b/projects/rccl/test/DdaFabricEpochTests.cpp
@@ -4,186 +4,327 @@
  * See LICENSE.txt for license information
  ************************************************************************/
 
-// Host-side consistency tests for the shared LL epoch counter used by the DDA
-// fabric collectives (AllGather / AllReduce / ReduceScatter / AllToAll).
+// Host-side tests for the shared LL epoch counter (comm->ddaLLEpochDev) used by
+// the DDA fabric collectives (AllGather / AllReduce / ReduceScatter / AllToAll,
+// LL and LL128). The counter is sized by ddaLLEpochCount() and restamped every
+// launch; each block derives its LL flag from its cell (bank = flag & 1) and the
+// collectives rely on every cell advancing in lock-step so peer-swapped block
+// pairs derive the same flag+bank. Source of truth:
+//   src/include/algorithms/all_gather/all_gather_dda_fabric_ll.h  (flag+write-back)
+//   src/include/algorithms/alltoall/alltoall_dda_fabric_ll.h      (same 2-D shape)
+//   src/include/algorithms/reduce_scatter/reduce_scatter_dda_fabric_ll.h (1-D)
+//   src/include/dda_init_detail.h                                 (ddaLLEpochCount)
 //
-// comm->ddaLLEpochDev is a single device array of comm->ddaLLEpochLen uint32
-// cells, shared across those collectives and sized by ddaLLEpochCount() to cover
-// the widest block grid any of them launches. On each launch tid 0 of block b
-// reads its epoch cell and derives this launch's LL flag:
-//     f = cell + 1;  if (f == 0) f = 2;   // skip the 0 sentinel
-//     bank = f & 1;                        // double-buffer selector
-// and at the end re-stamps the array over its full length:
-//     for (e = flatBlockId; e < ddaLLEpochLen; e += total) epoch[e] = flag;
+// Faithfulness notes for the host replay below:
+//  * A launch is modelled as read-all-then-write-all. That is a valid
+//    serialization despite the absence of any grid-wide sync because block b
+//    reads only cell b and writes only cells e == b (mod total); those residue
+//    classes are disjoint, so no block writes a cell another block reads.
+//  * Cross-launch lock-step (bank alternation) holds only because DDA launches on
+//    a comm are stream-serialized, so launch N fully restamps before launch N+1.
 //
-// The collectives rely on every cell of the shared array advancing in lock-step
-// so peer-swapped block pairs derive the same flag and bank. For AllGather the
-// reader (rank R, block peer=P, chunk c) uses epoch[P*bpp+c] while the matching
-// writer (rank P, block peer=R, chunk c) uses epoch[R*bpp+c]; since every rank
-// evolves the array identically (SPMD), the poll matches only when
-// epoch[P*bpp+c] == epoch[R*bpp+c] for all R,P,c. AllReduce/ReduceScatter are
-// 1-D and same-index paired (reader block b pairs with writer block b).
-//
-// These tests replay the epoch arithmetic on the host, using the real constants
-// from dda_init_detail.h, and verify the array stays uniform and the AllGather
-// pairing stays consistent across single and mixed-size collective sequences.
-// They need no GPU. They mirror:
-//   src/include/algorithms/all_gather/all_gather_dda_fabric_ll.h
-//   src/include/algorithms/all_reduce/all_reduce_dda_ll.h
-//   src/dda_all_gather_fabric_ll.cu, src/dda_all_reduce_fabric_ll.cu
+// The tests import the real dda_init_detail.h constants/functions so they track
+// the source, and include a negative control that fails if the full-length
+// restamp (all_gather_dda_fabric_ll.h: `for (e=flatBlockId; e<epochLen; e+=total)`)
+// is weakened to own-cell-only. No GPU is needed.
 
-#include "dda_init_detail.h" // nccl_dda_detail::{ddaLLEpochCount,kDdaFabricLLArMaxBlocks,kDdaLLAgMaxBlocksPerPeer}, DDA_FABRIC_MAXBLOCKS
+#include "dda_init_detail.h" // ddaLLEpochCount, kDdaFabricLLArMaxBlocks, kDdaLLAgMaxBlocksPerPeer, DDA_FABRIC_MAXBLOCKS
+#include "fabric_gpu_barrier.h" // meta::comms::kDdaMaxNranks
 
 #include "gtest/gtest.h"
 
 #include <algorithm>
 #include <cstdint>
+#include <string>
 #include <vector>
 
-namespace RcclUnitTesting
-{
-namespace
-{
+namespace RcclUnitTesting {
+
+namespace {
 
 using nccl_dda_detail::ddaLLEpochCount;
 using nccl_dda_detail::kDdaFabricLLArMaxBlocks;
 using nccl_dda_detail::kDdaLLAgMaxBlocksPerPeer;
 
+// Sentinel meaning "restamp the whole array" (the production epochLen).
+constexpr int kFullWriteBack = -1;
+
 // Number of shared epoch cells, from the real sizing function.
-int allocCells(int nRanks) { return static_cast<int>(ddaLLEpochCount(nRanks, DDA_FABRIC_MAXBLOCKS)); }
+size_t epochCells(int nRanks, int arMaxBlocks = DDA_FABRIC_MAXBLOCKS) {
+    return ddaLLEpochCount(nRanks, arMaxBlocks);
+}
 
 // Per-block LL flag from its epoch cell:  f = cell + 1; if (f == 0) f = 2.
-uint32_t deriveFlag(uint32_t cell)
-{
+uint32_t deriveFlag(uint32_t cell) {
     uint32_t f = cell + 1u;
-    if (f == 0u) f = 2u;
+    if (f == 0u) {
+        f = 2u; // skip 0 sentinel; keep bank parity
+    }
     return f;
 }
 
-// Replay one launch's epoch update: `total` blocks, full-length write-back over
-// [0, ddaLLEpochLen), block b owning cells b, b+total, b+2*total, ... exactly as
-// the kernels do:  for (e = flatBlockId; e < epochLen; e += total) epoch[e]=flag.
-void applyLaunch(std::vector<uint32_t>& epoch, int total)
-{
-    const int epochLen = static_cast<int>(epoch.size()); // full ddaLLEpochLen
-    std::vector<uint32_t> flag(total);
-    for (int b = 0; b < total; ++b)
-        flag[b] = deriveFlag(epoch[b]);
-    for (int b = 0; b < total; ++b)
-        for (int e = b; e < epochLen; e += total)
-            epoch[e] = flag[b];
+unsigned bankOf(uint32_t flag) {
+    return flag & 1u;
 }
 
-// AllGather launch: grid = nRanks x blocksPerPeer, total = nRanks*bpp.
-void applyAllGather(std::vector<uint32_t>& epoch, int nRanks, int bpp) { applyLaunch(epoch, nRanks * bpp); }
-
-// AllReduce launch: 1-D grid of arBlocks (<= kDdaFabricLLArMaxBlocks) blocks.
-void applyAllReduce(std::vector<uint32_t>& epoch, int arBlocks) { applyLaunch(epoch, arBlocks); }
-
-// AllGather peer-swap pairing violations an AG launch with `bpp` would see when
-// reading `epoch`: for each (R,P,c) with P!=R the reader cell (P*bpp+c) and the
-// paired writer cell (R*bpp+c) must derive the same flag.
-long agPairingMismatches(const std::vector<uint32_t>& epoch, int nRanks, int bpp)
-{
-    long mismatches = 0;
-    for (int R = 0; R < nRanks; ++R)
-        for (int P = 0; P < nRanks; ++P)
-        {
-            if (P == R) continue; // self column is a local copy, no cross-rank flag
-            for (int c = 0; c < bpp; ++c)
-                if (deriveFlag(epoch[P * bpp + c]) != deriveFlag(epoch[R * bpp + c])) ++mismatches;
+// Replay one launch's epoch update: `total` launched blocks, restamping cells
+// [0, writeBackLen) with block b owning cells b, b+total, b+2*total, ... exactly
+// as the kernels do: `for (e = flatBlockId; e < epochLen; e += total) epoch[e]=flag`.
+// writeBackLen == kFullWriteBack models the production full-length restamp.
+void applyLaunch(std::vector<uint32_t>& epoch, int total, int writeBackLen = kFullWriteBack) {
+    const int cells    = static_cast<int>(epoch.size());
+    const int epochLen = (writeBackLen == kFullWriteBack) ? cells : writeBackLen;
+    ASSERT_GT(total, 0);
+    ASSERT_LE(total, cells);    // read index flatBlockId < total stays in bounds
+    ASSERT_LE(epochLen, cells); // write index stays in bounds
+    std::vector<uint32_t> flag(total);
+    for (int b = 0; b < total; ++b) {
+        flag[b] = deriveFlag(epoch[b]);
+    }
+    for (int b = 0; b < total; ++b) {
+        for (int e = b; e < epochLen; e += total) {
+            epoch[e] = flag[b];
         }
+    }
+}
+
+// AllGather / AllToAll: 2-D grid nRanks x bpp, total = nRanks*bpp.
+void applyAllGather(std::vector<uint32_t>& epoch, int nRanks, int bpp, int writeBackLen = kFullWriteBack) {
+    applyLaunch(epoch, nRanks * bpp, writeBackLen);
+}
+
+void applyAllToAll(std::vector<uint32_t>& epoch, int nRanks, int bpp) {
+    applyLaunch(epoch, nRanks * bpp);
+}
+
+// AllReduce / ReduceScatter: 1-D grid of `blocks` (<= kDdaFabricLLArMaxBlocks or
+// clamped to ddaLLEpochLen at the launch site).
+void applyAllReduce(std::vector<uint32_t>& epoch, int blocks) {
+    applyLaunch(epoch, blocks);
+}
+
+void applyReduceScatter(std::vector<uint32_t>& epoch, int blocks) {
+    applyLaunch(epoch, blocks);
+}
+
+// AllGather/AllToAll peer-swap pairing violations for a launch with `bpp`: for
+// each (R,P,c) with P!=R the reader cell (P*bpp+c) and the paired writer cell
+// (R*bpp+c) must derive the same flag. Returns the mismatch count (-1 on OOB).
+long agPairingMismatches(const std::vector<uint32_t>& epoch, int nRanks, int bpp) {
+    if (nRanks * bpp > static_cast<int>(epoch.size())) {
+        ADD_FAILURE() << "pairing check indexes past the epoch array: nRanks*bpp=" << nRanks * bpp
+                      << " cells=" << epoch.size();
+        return -1;
+    }
+    long mismatches = 0;
+    for (int R = 0; R < nRanks; ++R) {
+        for (int P = 0; P < nRanks; ++P) {
+            if (P == R) {
+                continue; // self column is a local copy, no cross-rank flag
+            }
+            for (int c = 0; c < bpp; ++c) {
+                if (deriveFlag(epoch[P * bpp + c]) != deriveFlag(epoch[R * bpp + c])) {
+                    ++mismatches;
+                }
+            }
+        }
+    }
     return mismatches;
 }
 
-// True when every shared epoch cell holds the same value.
-bool allCellsUniform(const std::vector<uint32_t>& epoch)
-{
-    for (size_t i = 1; i < epoch.size(); ++i)
-        if (epoch[i] != epoch[0]) return false;
+bool allCellsUniform(const std::vector<uint32_t>& epoch) {
+    for (size_t i = 1; i < epoch.size(); ++i) {
+        if (epoch[i] != epoch[0]) {
+            return false;
+        }
+    }
     return true;
 }
 
-constexpr int kSmallBpp = 1;                        // tiny message: one block per peer
-constexpr int kLargeBpp = kDdaLLAgMaxBlocksPerPeer; // 8: widest per-peer fan-out
-constexpr int kArBlocks = 16;                       // representative AR grid (<= 24)
+constexpr int kSmallBpp = 1;
+constexpr int kLargeBpp = kDdaLLAgMaxBlocksPerPeer; // widest per-peer fan-out
 
 } // namespace
 
-// ---------------------------------------------------------------------------
-// The shared array is sized to cover the widest LL collective.
-// ---------------------------------------------------------------------------
-TEST(DdaFabricEpochTest, EpochCount_CoversWidestCollective)
-{
-    for (int nRanks : {2, 4, 8})
-    {
-        const int cells = static_cast<int>(ddaLLEpochCount(nRanks, DDA_FABRIC_MAXBLOCKS));
-        EXPECT_EQ(cells, std::max(nRanks * kDdaLLAgMaxBlocksPerPeer, DDA_FABRIC_MAXBLOCKS)) << "nRanks=" << nRanks;
-        // Must index the widest AllGather grid (nRanks*8) and the AR cap (24).
-        EXPECT_GE(cells, nRanks * kLargeBpp) << "nRanks=" << nRanks;
-        EXPECT_GE(cells, kDdaFabricLLArMaxBlocks) << "nRanks=" << nRanks;
+// ===========================================================================
+// Static contracts (no rank fixture)
+// ===========================================================================
+
+// The array must be sized to cover the widest collective across the full rank
+// range (up to kDdaMaxNranks) and every RCCL_DDA_FABRIC_MAXBLOCKS value [1,256].
+// Uses nRanks past the nRanks*8 vs 256 crossover (>32) so both arms of the max
+// are exercised.
+TEST(DdaFabricEpochStatic, EpochCount_CoversWidestCollective) {
+    for (int arMaxBlocks : {1, kDdaFabricLLArMaxBlocks, DDA_FABRIC_MAXBLOCKS}) {
+        for (int nRanks : {2, 8, 32, 33, meta::comms::kDdaMaxNranks}) {
+            const long cells = static_cast<long>(ddaLLEpochCount(nRanks, arMaxBlocks));
+            EXPECT_EQ(cells, std::max(nRanks * kDdaLLAgMaxBlocksPerPeer, arMaxBlocks))
+                << "nRanks=" << nRanks << " arMaxBlocks=" << arMaxBlocks;
+            // Must index the widest AllGather/AllToAll grid (nRanks*8) and the
+            // actual AR grid, which is capped at min(arMaxBlocks, kDdaFabricLLArMaxBlocks).
+            EXPECT_GE(cells, static_cast<long>(nRanks) * kDdaLLAgMaxBlocksPerPeer);
+            EXPECT_GE(cells, std::min(arMaxBlocks, kDdaFabricLLArMaxBlocks));
+        }
     }
 }
 
-// ---------------------------------------------------------------------------
-// A small AllGather followed by a large one: the shared array stays uniform and
-// the wider AllGather's peer-swap pairing stays consistent.
-// ---------------------------------------------------------------------------
-TEST(DdaFabricEpochTest, SharedEpoch_AllGatherSmallThenLarge_StaysConsistent)
-{
-    for (int nRanks : {4, 8})
-    {
-        std::vector<uint32_t> epoch(allocCells(nRanks), 0u); // cudaMemset(epochDev, 0)
-        applyAllGather(epoch, nRanks, kSmallBpp);
-        EXPECT_TRUE(allCellsUniform(epoch)) << "after small AG, nRanks=" << nRanks;
-        EXPECT_EQ(agPairingMismatches(epoch, nRanks, kLargeBpp), 0)
-            << "large AG must find every peer-swap pair consistent (nRanks=" << nRanks << ")";
+// The AllGather launcher has no runtime clamp; it relies on ddaLLAgBlocksPerPeer
+// capping per-peer blocks at kDdaLLAgMaxBlocksPerPeer. That cap must keep the
+// grid within the epoch array for every rank count and MAXBLOCKS setting.
+TEST(DdaFabricEpochStatic, AllGatherGridAlwaysFitsEpochArray) {
+    for (int arMaxBlocks : {1, kDdaFabricLLArMaxBlocks, DDA_FABRIC_MAXBLOCKS}) {
+        for (int nRanks = 2; nRanks <= meta::comms::kDdaMaxNranks; ++nRanks) {
+            const long widestGrid = static_cast<long>(nRanks) * kDdaLLAgMaxBlocksPerPeer;
+            EXPECT_LE(widestGrid, static_cast<long>(ddaLLEpochCount(nRanks, arMaxBlocks)))
+                << "nRanks=" << nRanks << " arMaxBlocks=" << arMaxBlocks;
+        }
     }
 }
 
-// ---------------------------------------------------------------------------
-// A tiny AllReduce followed by a wide AllGather leaves the shared array
-// consistent for the AllGather.
-// ---------------------------------------------------------------------------
-TEST(DdaFabricEpochTest, SharedEpoch_AllReduceThenAllGather_StaysConsistent)
-{
-    for (int nRanks : {4, 8})
-    {
-        std::vector<uint32_t> epoch(allocCells(nRanks), 0u);
-        applyAllReduce(epoch, kArBlocks);
-        EXPECT_TRUE(allCellsUniform(epoch)) << "after AR, nRanks=" << nRanks;
-        EXPECT_EQ(agPairingMismatches(epoch, nRanks, kLargeBpp), 0)
-            << "AG after AR must find every peer-swap pair consistent (nRanks=" << nRanks << ")";
+// Flag derivation must skip the 0 sentinel and preserve bank parity, including
+// at the uint32 wraparound the kernel comment guards against.
+TEST(DdaFabricEpochStatic, DeriveFlag_SkipsZeroKeepsBankParity) {
+    for (uint32_t x : {0u, 1u, 2u, 3u, 100u, UINT32_MAX - 1u, UINT32_MAX}) {
+        EXPECT_NE(deriveFlag(x), 0u) << "x=" << x;
+        EXPECT_EQ(bankOf(deriveFlag(x)), (x + 1u) & 1u) << "x=" << x; // parity survives wrap
     }
 }
 
-// ---------------------------------------------------------------------------
-// A long interleaved sequence of mixed-size AllGather / AllReduce launches keeps
-// the shared array uniform and each AllGather pairing-consistent every iteration.
-// ---------------------------------------------------------------------------
-TEST(DdaFabricEpochTest, SharedEpoch_RepeatedMixedSizes_StaysConsistent)
-{
-    const int agBpp[] = {1, 2, 4, 8, 3};
-    const int arBlk[] = {1, 4, 16, 24, 7};
-    for (int nRanks : {4, 8})
-    {
-        std::vector<uint32_t> epoch(allocCells(nRanks), 0u);
-        for (int iter = 0; iter < 50; ++iter)
-        {
-            for (int bpp : agBpp)
-            {
-                EXPECT_EQ(agPairingMismatches(epoch, nRanks, bpp), 0)
-                    << "iter=" << iter << " nRanks=" << nRanks << " bpp=" << bpp;
-                applyAllGather(epoch, nRanks, bpp);
-                EXPECT_TRUE(allCellsUniform(epoch)) << "after AG iter=" << iter << " bpp=" << bpp;
-            }
-            for (int blk : arBlk)
-            {
-                applyAllReduce(epoch, blk);
-                EXPECT_TRUE(allCellsUniform(epoch)) << "after AR iter=" << iter << " blk=" << blk;
+// ===========================================================================
+// Rank-parameterized behavior
+// ===========================================================================
+
+class DdaFabricEpoch : public ::testing::TestWithParam<int> {
+};
+
+// Name the instances 2Ranks / 4Ranks / 8Ranks / 72Ranks instead of /0../3.
+INSTANTIATE_TEST_SUITE_P(Ranks, DdaFabricEpoch, ::testing::Values(2, 4, 8, meta::comms::kDdaMaxNranks),
+                         [](const ::testing::TestParamInfo<int>& info) {
+                             return std::to_string(info.param) + "Ranks";
+                         });
+
+// A small AllGather then a large one: array stays uniform, the wider AllGather's
+// peer-swap pairing is consistent, and consecutive launches alternate banks.
+TEST_P(DdaFabricEpoch, AllGatherSmallThenLarge_StaysConsistent) {
+    const int nRanks = GetParam();
+    std::vector<uint32_t> epoch(epochCells(nRanks), 0u);
+
+    const uint32_t f1 = deriveFlag(epoch[0]);
+    applyAllGather(epoch, nRanks, kSmallBpp);
+    ASSERT_TRUE(allCellsUniform(epoch));
+    ASSERT_EQ(agPairingMismatches(epoch, nRanks, kLargeBpp), 0);
+
+    const uint32_t f2 = deriveFlag(epoch[0]);
+    ASSERT_NE(bankOf(f2), bankOf(f1)) << "consecutive launches must alternate banks";
+    applyAllGather(epoch, nRanks, kLargeBpp);
+    ASSERT_TRUE(allCellsUniform(epoch));
+    ASSERT_EQ(agPairingMismatches(epoch, nRanks, kLargeBpp), 0);
+}
+
+TEST_P(DdaFabricEpoch, AllReduceThenAllGather_StaysConsistent) {
+    const int nRanks = GetParam();
+    std::vector<uint32_t> epoch(epochCells(nRanks), 0u);
+    applyAllReduce(epoch, kDdaFabricLLArMaxBlocks); // widest AR grid
+    ASSERT_TRUE(allCellsUniform(epoch));
+    ASSERT_EQ(agPairingMismatches(epoch, nRanks, kLargeBpp), 0);
+}
+
+TEST_P(DdaFabricEpoch, ReduceScatterThenAllGather_StaysConsistent) {
+    const int nRanks = GetParam();
+    std::vector<uint32_t> epoch(epochCells(nRanks), 0u);
+    applyReduceScatter(epoch, std::min<int>(kDdaFabricLLArMaxBlocks, static_cast<int>(epoch.size())));
+    ASSERT_TRUE(allCellsUniform(epoch));
+    ASSERT_EQ(agPairingMismatches(epoch, nRanks, kLargeBpp), 0);
+}
+
+TEST_P(DdaFabricEpoch, AllToAllThenAllGather_StaysConsistent) {
+    const int nRanks = GetParam();
+    std::vector<uint32_t> epoch(epochCells(nRanks), 0u);
+    applyAllToAll(epoch, nRanks, kLargeBpp); // A2A is peer-swapped like AG
+    ASSERT_TRUE(allCellsUniform(epoch));
+    ASSERT_EQ(agPairingMismatches(epoch, nRanks, kLargeBpp), 0);
+}
+
+// Interleaved mixed-size launches keep the array uniform and every AllGather /
+// AllToAll pairing consistent each step. ASSERT_ stops at the first divergence.
+TEST_P(DdaFabricEpoch, RepeatedMixedSizes_StaysConsistent) {
+    const int nRanks = GetParam();
+    const int agBpp[] = {1, 2, 4, kLargeBpp, 3};
+    const int arBlk[] = {1, 4, kDdaFabricLLArMaxBlocks, 7};
+    std::vector<uint32_t> epoch(epochCells(nRanks), 0u);
+
+    uint32_t prevFlag = 0u;
+    for (int iter = 0; iter < 4; ++iter) {
+        for (int bpp : agBpp) {
+            ASSERT_EQ(agPairingMismatches(epoch, nRanks, bpp), 0) << "iter=" << iter << " bpp=" << bpp;
+            const uint32_t f = deriveFlag(epoch[0]);
+            ASSERT_NE(bankOf(f), bankOf(prevFlag)) << "banks must alternate, iter=" << iter << " bpp=" << bpp;
+            prevFlag = f;
+            applyAllGather(epoch, nRanks, bpp);
+            ASSERT_TRUE(allCellsUniform(epoch)) << "after AG iter=" << iter << " bpp=" << bpp;
+        }
+        for (int blk : arBlk) {
+            const uint32_t f = deriveFlag(epoch[0]);
+            ASSERT_NE(bankOf(f), bankOf(prevFlag)) << "banks must alternate, iter=" << iter << " blk=" << blk;
+            prevFlag = f;
+            applyAllReduce(epoch, blk);
+            ASSERT_TRUE(allCellsUniform(epoch)) << "after AR iter=" << iter << " blk=" << blk;
+        }
+    }
+}
+
+// ===========================================================================
+// Negative controls -- these MUST fail if the harness (or the modelled kernel
+// behavior) loses the property; they prove the positive tests have teeth.
+// ===========================================================================
+
+// If the full-length restamp is weakened to own-cell-only (the exact regression
+// `e < epochLen` -> `e < total` in all_gather_dda_fabric_ll.h:133), a small AG
+// followed by a wide AG leaves stale high cells and the pairing breaks. The
+// full-length restamp on the same sequence stays consistent.
+TEST_P(DdaFabricEpoch, NegativeControl_ShortWriteBackBreaksPairing) {
+    const int nRanks = GetParam();
+
+    std::vector<uint32_t> full(epochCells(nRanks), 0u);
+    applyAllGather(full, nRanks, kSmallBpp, kFullWriteBack);
+    ASSERT_EQ(agPairingMismatches(full, nRanks, kLargeBpp), 0) << "full restamp must stay consistent";
+
+    std::vector<uint32_t> shortWb(epochCells(nRanks), 0u);
+    applyAllGather(shortWb, nRanks, kSmallBpp, /*writeBackLen=*/nRanks * kSmallBpp); // own-cell-only
+    EXPECT_GT(agPairingMismatches(shortWb, nRanks, kLargeBpp), 0)
+        << "own-cell-only restamp must break pairing -> proves the full-length restamp is load-bearing";
+}
+
+// The kernels early-return for blocks with peer >= nRanks (grid.x > nRanks)
+// BEFORE the write-back, so those residue classes are never restamped and the
+// array goes non-uniform. Launch sites use grid.x == nRanks; this pins that
+// assumption.
+TEST_P(DdaFabricEpoch, NegativeControl_PeerBeyondNRanksBreaksUniformity) {
+    const int nRanks = GetParam();
+    const int bpp    = 2;
+
+    std::vector<uint32_t> ok(epochCells(nRanks), 0u);
+    applyAllGather(ok, nRanks, bpp);
+    ASSERT_TRUE(allCellsUniform(ok)) << "grid.x == nRanks must stay uniform";
+
+    // Model grid.x == nRanks+1: all blocks read, but peer==nRanks blocks return
+    // before restamping their residue class.
+    std::vector<uint32_t> bad(epochCells(nRanks), 0u);
+    const int gridX = nRanks + 1;
+    const int total = gridX * bpp;
+    ASSERT_LE(total, static_cast<int>(bad.size()));
+    std::vector<uint32_t> flag(total);
+    for (int b = 0; b < total; ++b) {
+        flag[b] = deriveFlag(bad[b]);
+    }
+    for (int b = 0; b < total; ++b) {
+        if (b / bpp < nRanks) { // peer = flatBlockId / bpp; peer >= nRanks returns early
+            for (int e = b; e < static_cast<int>(bad.size()); e += total) {
+                bad[e] = flag[b];
             }
         }
     }
+    EXPECT_FALSE(allCellsUniform(bad)) << "grid.x > nRanks leaves residue classes unstamped -> non-uniform";
 }
 
 } // namespace RcclUnitTesting

--- a/projects/rccl/test/DdaFabricEpochTests.cpp
+++ b/projects/rccl/test/DdaFabricEpochTests.cpp
@@ -36,7 +36,7 @@
 // symbols, so the producer-coverage assertion runs in Release CI too.
 
 #include "common/DdaFabricFootprints.hpp" // shared footprint mirrors
-#include "dda_init_detail.h" // ddaLLEpochCount, kDdaFabricLLArMaxBlocks, kDdaLLAgMaxBlocksPerPeer, DDA_FABRIC_MAXBLOCKS, DDA_FABRIC_BUFFER_SIZE
+#include "dda_init_detail.h" // epoch/sizing constants + DDA_FABRIC_MAXBLOCKS/BUFFER_SIZE
 #include "fabric_gpu_barrier.h" // meta::comms::kDdaMaxNranks
 
 // Real launcher constants, to pin every DdaFabricFootprints.hpp mirror at compile
@@ -51,9 +51,10 @@
 #include "algorithms/all_gather/all_gather_dda_fabric_ll.h"         // kDdaLLAgMaxPerRankBytes
 #include "algorithms/alltoall/alltoall_dda_fabric_ll.h"            // kDdaLLA2AMaxPerChunkBytes
 #include "algorithms/reduce_scatter/reduce_scatter_dda_fabric_ll.h" // kDdaLLRsMaxBytes
-#include "algorithms/all_gather/all_gather_dda_fabric_ll128.h"      // kDdaLL128AgMaxPerRankBytes, kDdaLL128AgSlotStrideLines
-#include "algorithms/alltoall/alltoall_dda_fabric_ll128.h"          // kDdaLL128A2AMaxPerChunkBytes
-#include "algorithms/reduce_scatter/reduce_scatter_dda_fabric_ll128.h" // kDdaLL128RsMaxBytes
+#include "algorithms/all_reduce/all_reduce_dda_fabric_ll128.h"      // kDdaLL128ArMaxBytes
+#include "algorithms/all_gather/all_gather_dda_fabric_ll128.h"      // kDdaLL128Ag{MaxPerRankBytes,SlotStrideLines}
+#include "algorithms/alltoall/alltoall_dda_fabric_ll128.h"          // kDdaLL128A2A{MaxPerChunkBytes,SlotStrideLines}
+#include "algorithms/reduce_scatter/reduce_scatter_dda_fabric_ll128.h" // kDdaLL128Rs{MaxBytes,SlotStrideLines}
 
 #include "gtest/gtest.h"
 
@@ -66,12 +67,13 @@ namespace RcclUnitTesting
 {
 
 // Compile-time tie between every footprint mirror and the real launcher
-// constants. All independently-declared per-tier caps are asserted (not just one
-// per family), plus the two derived slot strides -- a correct cap with a
-// redefined stride would still yield a wrong footprint.
+// constants: all eight per-tier caps AND all seven slot strides are asserted
+// (not one per family) -- a correct cap with a redefined stride would still
+// yield a wrong footprint, so each independently-declared constant is pinned.
 static_assert(kLLPacketBytes == sizeof(meta::comms::LLPacket16), "LLPacket16 size mirror drift");
 static_assert(kLL128LineBytes == sizeof(meta::comms::LLLine128), "LLLine128 size mirror drift");
 static_assert(kLL128DataElems == static_cast<size_t>(meta::comms::kDdaLL128DataElems), "LL128 data-elems mirror drift");
+// Per-tier caps (4 LL + 3 fixed LL128 + AR-LL128).
 static_assert(kLLTierMaxBytes == meta::comms::kDdaLLArMaxBytes, "LL AR cap mirror drift");
 static_assert(kLLTierMaxBytes == meta::comms::kDdaLLAgMaxPerRankBytes, "LL AG cap mirror drift");
 static_assert(kLLTierMaxBytes == meta::comms::kDdaLLA2AMaxPerChunkBytes, "LL A2A cap mirror drift");
@@ -79,9 +81,18 @@ static_assert(kLLTierMaxBytes == meta::comms::kDdaLLRsMaxBytes, "LL RS cap mirro
 static_assert(kLL128TierMaxBytes == meta::comms::kDdaLL128AgMaxPerRankBytes, "LL128 AG cap mirror drift");
 static_assert(kLL128TierMaxBytes == meta::comms::kDdaLL128A2AMaxPerChunkBytes, "LL128 A2A cap mirror drift");
 static_assert(kLL128TierMaxBytes == meta::comms::kDdaLL128RsMaxBytes, "LL128 RS cap mirror drift");
-static_assert(kLLTierMaxBytes / 8 == meta::comms::kDdaLLArSlotStridePkts, "LL slot-stride mirror drift");
+static_assert(kLL128ArMaxBytes == meta::comms::kDdaLL128ArMaxBytes, "LL128 AR cap mirror drift");
+// Slot strides (4 LL packets + 3 LL128 lines).
+static_assert(kLLTierMaxBytes / 8 == meta::comms::kDdaLLArSlotStridePkts, "LL AR slot-stride mirror drift");
+static_assert(kLLTierMaxBytes / 8 == meta::comms::kDdaLLAgSlotStridePkts, "LL AG slot-stride mirror drift");
+static_assert(kLLTierMaxBytes / 8 == meta::comms::kDdaLLA2ASlotStridePkts, "LL A2A slot-stride mirror drift");
+static_assert(kLLTierMaxBytes / 8 == meta::comms::kDdaLLRsSlotStridePkts, "LL RS slot-stride mirror drift");
 static_assert(ddaLL128LinesForBytes(kLL128TierMaxBytes) == meta::comms::kDdaLL128AgSlotStrideLines,
-              "LL128 slot-stride mirror drift");
+              "LL128 AG slot-stride mirror drift");
+static_assert(ddaLL128LinesForBytes(kLL128TierMaxBytes) == meta::comms::kDdaLL128A2ASlotStrideLines,
+              "LL128 A2A slot-stride mirror drift");
+static_assert(ddaLL128LinesForBytes(kLL128TierMaxBytes) == meta::comms::kDdaLL128RsSlotStrideLines,
+              "LL128 RS slot-stride mirror drift");
 
 namespace
 {
@@ -93,10 +104,10 @@ using nccl_dda_detail::kDdaLLAgMaxBlocksPerPeer;
 // Sentinel meaning "restamp the whole array" (the production epochLen).
 constexpr int kFullWriteBack = -1;
 
-// Number of shared epoch cells, from the real sizing function.
-size_t epochCells(int nRanks, int arMaxBlocks = DDA_FABRIC_MAXBLOCKS)
+// Number of shared epoch cells, from the real sizing function (fabric MAXBLOCKS).
+size_t epochCells(int nRanks)
 {
-    return ddaLLEpochCount(nRanks, arMaxBlocks);
+    return ddaLLEpochCount(nRanks, DDA_FABRIC_MAXBLOCKS);
 }
 
 // Per-block LL flag from its epoch cell:  f = cell + 1; if (f == 0) f = 2.
@@ -454,7 +465,9 @@ TEST_P(DdaFabricEpochTest, NegativeControl_PeerBeyondNRanksBreaksUniformity)
     }
     for (int b = 0; b < total; ++b)
     {
-        if (b / bpp < nRanks) { // peer = flatBlockId / bpp; peer >= nRanks returns early
+        // peer = flatBlockId / bpp; peer >= nRanks returns early (skips write-back)
+        if (b / bpp < nRanks)
+        {
             for (int e = b; e < static_cast<int>(bad.size()); e += total)
             {
                 bad[e] = flag[b];

--- a/projects/rccl/test/DdaFabricEpochTests.cpp
+++ b/projects/rccl/test/DdaFabricEpochTests.cpp
@@ -35,9 +35,17 @@
 // inline/constexpr helpers and the DDA_FABRIC_BUFFER_SIZE macro, no librccl
 // symbols, so the producer-coverage assertion runs in Release CI too.
 
-#include "common/DdaFabricFootprints.hpp" // shared footprint mirrors (dependency-free)
+#include "common/DdaFabricFootprints.hpp" // shared footprint mirrors
 #include "dda_init_detail.h" // ddaLLEpochCount, kDdaFabricLLArMaxBlocks, kDdaLLAgMaxBlocksPerPeer, DDA_FABRIC_MAXBLOCKS, DDA_FABRIC_BUFFER_SIZE
 #include "fabric_gpu_barrier.h" // meta::comms::kDdaMaxNranks
+
+// Real launcher constants, to pin the DdaFabricFootprints.hpp mirrors at compile
+// time. This TU builds under hipcc in the Release fixtures target, so including
+// the (device-code-bearing) kernel headers is fine, and the static_asserts below
+// run in Release CI -- a production stride/cap change fails this build.
+#include "algorithms/CollCommon_ll128.h"                       // meta::comms::{LLLine128,kDdaLL128DataElems}
+#include "algorithms/all_reduce/all_reduce_dda_ll.h"           // meta::comms::{kDdaLLArMaxBytes,LLPacket16}
+#include "algorithms/all_gather/all_gather_dda_fabric_ll128.h" // meta::comms::kDdaLL128AgMaxPerRankBytes
 
 #include "gtest/gtest.h"
 
@@ -47,6 +55,15 @@
 #include <vector>
 
 namespace RcclUnitTesting {
+
+// Compile-time tie between the footprint mirrors and the real launcher constants
+// (the per-tier caps for RS/A2A are additionally pinned at runtime by the
+// exact-boundary tests in DdaFabricScratchTests.cpp, which call the real predicates).
+static_assert(kLLPacketBytes == sizeof(meta::comms::LLPacket16), "LLPacket16 size mirror drift");
+static_assert(kLL128LineBytes == sizeof(meta::comms::LLLine128), "LLLine128 size mirror drift");
+static_assert(kLL128DataElems == static_cast<size_t>(meta::comms::kDdaLL128DataElems), "LL128 data-elems mirror drift");
+static_assert(kLLTierMaxBytes == meta::comms::kDdaLLArMaxBytes, "LL tier cap mirror drift");
+static_assert(kLL128TierMaxBytes == meta::comms::kDdaLL128AgMaxPerRankBytes, "LL128 tier cap mirror drift");
 
 namespace {
 
@@ -86,6 +103,7 @@ void applyLaunch(std::vector<uint32_t>& epoch, int total, int writeBackLen = kFu
     const int cells    = static_cast<int>(epoch.size());
     const int epochLen = (writeBackLen == kFullWriteBack) ? cells : writeBackLen;
     ASSERT_GT(total, 0);
+    ASSERT_GT(epochLen, 0);     // a zero write-back would make allCellsUniform vacuous
     ASSERT_LE(total, cells);    // read index flatBlockId < total stays in bounds
     ASSERT_LE(epochLen, cells); // write index stays in bounds
     std::vector<uint32_t> flag(total);
@@ -175,19 +193,24 @@ TEST(DdaFabricEpochStaticTest, EpochCount_CoversWidestCollective) {
             const long cells = static_cast<long>(ddaLLEpochCount(nRanks, arMaxBlocks));
             ASSERT_EQ(cells, std::max(nRanks * kDdaLLAgMaxBlocksPerPeer, arMaxBlocks))
                 << "nRanks=" << nRanks << " arMaxBlocks=" << arMaxBlocks;
-            // Must index the widest AllGather/AllToAll grid (nRanks*8) and the
-            // actual AR grid, which is capped at min(arMaxBlocks, kDdaFabricLLArMaxBlocks).
+            // Must index the widest AllGather/AllToAll grid (nRanks*8), the AR-LL
+            // grid (capped at kDdaFabricLLArMaxBlocks), and the RS-LL / LL128 grids
+            // which launch up to comm->ddaFabricMaxBlocks (== arMaxBlocks here).
             ASSERT_GE(cells, static_cast<long>(nRanks) * kDdaLLAgMaxBlocksPerPeer)
                 << "nRanks=" << nRanks << " arMaxBlocks=" << arMaxBlocks;
             ASSERT_GE(cells, std::min(arMaxBlocks, kDdaFabricLLArMaxBlocks))
+                << "nRanks=" << nRanks << " arMaxBlocks=" << arMaxBlocks;
+            ASSERT_GE(cells, arMaxBlocks) // RS-LL / AR-LL128 / RS-LL128 launch up to ddaFabricMaxBlocks
                 << "nRanks=" << nRanks << " arMaxBlocks=" << arMaxBlocks;
         }
     }
 }
 
-// The AllGather launcher has no runtime clamp; it relies on ddaLLAgBlocksPerPeer
-// capping per-peer blocks at kDdaLLAgMaxBlocksPerPeer. That cap must keep the
-// grid within the epoch array for every rank count and MAXBLOCKS setting.
+// The AllGather-LL launcher has no runtime clamp; it relies on
+// ddaLLAgBlocksPerPeer capping per-peer blocks at kDdaLLAgMaxBlocksPerPeer. (The
+// LL128 AG/A2A launchers instead clamp blocksPerPeer against epochLen at runtime,
+// since RCCL_DDA_LL128_AG_MAXBPP can raise their cap.) That compile-time cap must
+// keep the AG-LL grid within the epoch array for every rank count and MAXBLOCKS.
 TEST(DdaFabricEpochStaticTest, AllGatherGridAlwaysFitsEpochArray) {
     for (int arMaxBlocks : {1, kDdaFabricLLArMaxBlocks, DDA_FABRIC_MAXBLOCKS}) {
         for (int nRanks = 2; nRanks <= meta::comms::kDdaMaxNranks; ++nRanks) {
@@ -256,7 +279,7 @@ TEST_P(DdaFabricEpochTest, AllGatherSmallThenLarge_StaysConsistent) {
 // AR then AG: after an AllReduce, the shared array is still pairing-consistent for
 // a following AllGather (no AllGather is applied here -- the check is the pairing
 // a subsequent AG would derive).
-TEST_P(DdaFabricEpochTest, AllReduceThenAllGatherPairingHolds) {
+TEST_P(DdaFabricEpochTest, AllReduce_LeavesArrayAllGatherPairable) {
     const int nRanks = GetParam();
     std::vector<uint32_t> epoch(epochCells(nRanks), 0u);
     ASSERT_NO_FATAL_FAILURE(applyAllReduce(epoch, kDdaFabricLLArMaxBlocks)); // widest AR grid
@@ -267,7 +290,7 @@ TEST_P(DdaFabricEpochTest, AllReduceThenAllGatherPairingHolds) {
 // RS then AG. ReduceScatter's real cap is DDA_FABRIC_MAXBLOCKS (clamped to the
 // cell count), not the AR-only cap; also exercise a block count that does not
 // divide the cell count (the write-back stride must still tile every cell).
-TEST_P(DdaFabricEpochTest, ReduceScatterThenAllGatherPairingHolds) {
+TEST_P(DdaFabricEpochTest, ReduceScatter_LeavesArrayAllGatherPairable) {
     const int nRanks = GetParam();
     const int cells  = static_cast<int>(epochCells(nRanks));
 
@@ -283,7 +306,7 @@ TEST_P(DdaFabricEpochTest, ReduceScatterThenAllGatherPairingHolds) {
     ASSERT_EQ(agPairingMismatches(epoch, nRanks, kLargeBpp), 0);
 }
 
-TEST_P(DdaFabricEpochTest, AllToAllThenAllGatherPairingHolds) {
+TEST_P(DdaFabricEpochTest, AllToAll_LeavesArrayAllGatherPairable) {
     const int nRanks = GetParam();
     std::vector<uint32_t> epoch(epochCells(nRanks), 0u);
     ASSERT_NO_FATAL_FAILURE(applyAllToAll(epoch, nRanks, kLargeBpp)); // A2A is peer-swapped like AG

--- a/projects/rccl/test/DdaFabricEpochTests.cpp
+++ b/projects/rccl/test/DdaFabricEpochTests.cpp
@@ -25,15 +25,18 @@
 //  * Cross-launch lock-step (bank alternation) holds only because DDA launches on
 //    a comm are stream-serialized, so launch N fully restamps before launch N+1.
 //
-// Scope note: these tests validate the HOST MODEL of the epoch arithmetic (using
-// the real dda_init_detail.h constants) and the producer/consumer scratch
-// contract. The negative controls fail if the *model* loses a property, proving
-// the positive assertions are not vacuous; they do NOT read the device kernels,
-// so they cannot detect a device-side regression (e.g. the write-back loop in
-// all_gather_dda_fabric_ll.h being changed from `e < epochLen` to `e < total`).
+// Scope note: the flag/bank/write-back arithmetic is NOT re-implemented here --
+// this file drives the exact shared production helpers meta::comms::ddaLLEpochFlag,
+// ddaLLEpochBank and ddaLLEpochRestamp (src/include/algorithms/CollCommon.h),
+// which every LL and LL128 kernel now calls via ddaLLEpochBegin/ddaLLEpochEnd. So
+// a regression in that arithmetic (e.g. the write-back loop changed from
+// `e < epochLen` to `e < total`) turns these tests red -- the host model and the
+// kernels share one code path. What is still NOT host-testable is the device-only
+// wrapper behavior (the tid-0 guard and __syncthreads() in ddaLLEpochBegin/End);
+// the model serializes a launch as read-all-then-write-all instead.
 // This file is in rccl-UnitTestsFixtures (Release+Debug): it uses only
-// inline/constexpr helpers and the DDA_FABRIC_BUFFER_SIZE macro, no librccl
-// symbols, so the producer-coverage assertion runs in Release CI too.
+// inline/constexpr/host-device helpers and the DDA_FABRIC_BUFFER_SIZE macro, no
+// librccl symbols, so the producer-coverage assertion runs in Release CI too.
 
 #include "common/DdaFabricFootprints.hpp" // shared footprint mirrors
 #include "dda_init_detail.h" // epoch/sizing constants + DDA_FABRIC_MAXBLOCKS/BUFFER_SIZE
@@ -46,6 +49,7 @@
 // The static_asserts below build in the Release-capable rccl-UnitTestsFixtures
 // target -- a production stride/cap change fails this build. LLPacket16 comes from
 // CollCommon.h (pulled via dda_init_detail.h).
+#include "algorithms/CollCommon.h"                                  // meta::comms::{ddaLLEpochFlag,ddaLLEpochBank,ddaLLEpochRestamp}
 #include "algorithms/CollCommon_ll128.h"                            // meta::comms::{LLLine128,kDdaLL128DataElems}
 #include "algorithms/all_reduce/all_reduce_dda_ll.h"                // kDdaLLArMaxBytes, kDdaLLArSlotStridePkts
 #include "algorithms/all_gather/all_gather_dda_fabric_ll.h"         // kDdaLLAgMaxPerRankBytes
@@ -101,6 +105,12 @@ using nccl_dda_detail::ddaLLEpochCount;
 using nccl_dda_detail::kDdaFabricLLArMaxBlocks;
 using nccl_dda_detail::kDdaLLAgMaxBlocksPerPeer;
 
+// The shared production epoch arithmetic (src/include/algorithms/CollCommon.h),
+// exercised here so the host model runs the same code as the kernels.
+using meta::comms::ddaLLEpochBank;
+using meta::comms::ddaLLEpochFlag;
+using meta::comms::ddaLLEpochRestamp;
+
 // Sentinel meaning "restamp the whole array" (the production epochLen).
 constexpr int kFullWriteBack = -1;
 
@@ -108,22 +118,6 @@ constexpr int kFullWriteBack = -1;
 size_t epochCells(int nRanks)
 {
     return ddaLLEpochCount(nRanks, DDA_FABRIC_MAXBLOCKS);
-}
-
-// Per-block LL flag from its epoch cell:  f = cell + 1; if (f == 0) f = 2.
-uint32_t deriveFlag(uint32_t cell)
-{
-    uint32_t f = cell + 1u;
-    if (f == 0u)
-    {
-        f = 2u; // skip 0 sentinel; keep bank parity
-    }
-    return f;
-}
-
-unsigned bankOf(uint32_t flag)
-{
-    return flag & 1u;
 }
 
 // Replay one launch's epoch update: `total` launched blocks, restamping cells
@@ -144,14 +138,11 @@ void applyLaunch(std::vector<uint32_t>& epoch, int total, int writeBackLen = kFu
     std::vector<uint32_t> flag(total);
     for (int b = 0; b < total; ++b)
     {
-        flag[b] = deriveFlag(epoch[b]);
+        flag[b] = ddaLLEpochFlag(epoch[b]);
     }
     for (int b = 0; b < total; ++b)
     {
-        for (int e = b; e < epochLen; e += total)
-        {
-            epoch[e] = flag[b];
-        }
+        ddaLLEpochRestamp(epoch.data(), b, total, epochLen, flag[b]);
     }
 }
 
@@ -204,7 +195,7 @@ long agPairingMismatches(const std::vector<uint32_t>& epoch, int nRanks, int bpp
             }
             for (int c = 0; c < bpp; ++c)
             {
-                if (deriveFlag(epoch[P * bpp + c]) != deriveFlag(epoch[R * bpp + c]))
+                if (ddaLLEpochFlag(epoch[P * bpp + c]) != ddaLLEpochFlag(epoch[R * bpp + c]))
                 {
                     ++mismatches;
                 }
@@ -301,8 +292,39 @@ TEST(DdaFabricEpochStaticTest, DeriveFlag_SkipsZeroKeepsBankParity)
 {
     for (uint32_t x : {0u, 1u, 2u, 3u, 100u, UINT32_MAX - 1u, UINT32_MAX})
     {
-        EXPECT_NE(deriveFlag(x), 0u) << "x=" << x;
-        EXPECT_EQ(bankOf(deriveFlag(x)), (x + 1u) & 1u) << "x=" << x; // parity survives wrap
+        EXPECT_NE(ddaLLEpochFlag(x), 0u) << "x=" << x;
+        EXPECT_EQ(ddaLLEpochBank(ddaLLEpochFlag(x)), (x + 1u) & 1u) << "x=" << x; // parity survives wrap
+    }
+}
+
+// Directly pin ddaLLEpochRestamp's stride/ownership: one block (flatBlockId, total)
+// restamps exactly its residue class (flatBlockId, +total, +2*total, ...) and
+// touches no other cell. Diagnoses a helper regression at the helper instead of
+// indirectly through a whole-array uniformity failure.
+TEST(DdaFabricEpochStaticTest, RestampUpdatesOwnedResidueClassOnly)
+{
+    constexpr int      kFlatBlockId = 2;
+    constexpr int      kTotal       = 5;
+    constexpr uint32_t kSentinel    = 0xABCDu; // distinct from every seeded value below
+    std::vector<uint32_t> epoch(20u);
+    for (size_t i = 0; i < epoch.size(); ++i)
+    {
+        epoch[i] = static_cast<uint32_t>(i); // distinct initial values
+    }
+
+    ddaLLEpochRestamp(epoch.data(), kFlatBlockId, kTotal, static_cast<int>(epoch.size()), kSentinel);
+
+    for (size_t i = 0; i < epoch.size(); ++i)
+    {
+        const bool owned = (static_cast<int>(i) >= kFlatBlockId) && ((static_cast<int>(i) - kFlatBlockId) % kTotal == 0);
+        if (owned)
+        {
+            EXPECT_EQ(epoch[i], kSentinel) << "owned cell " << i << " must be restamped";
+        }
+        else
+        {
+            EXPECT_EQ(epoch[i], static_cast<uint32_t>(i)) << "cell " << i << " outside residue class must be untouched";
+        }
     }
 }
 
@@ -328,13 +350,13 @@ TEST_P(DdaFabricEpochTest, AllGatherSmallThenLarge_StaysConsistent)
     const int nRanks = GetParam();
     std::vector<uint32_t> epoch(epochCells(nRanks), 0u);
 
-    const uint32_t f1 = deriveFlag(epoch[0]);
+    const uint32_t f1 = ddaLLEpochFlag(epoch[0]);
     ASSERT_NO_FATAL_FAILURE(applyAllGather(epoch, nRanks, kSmallBpp));
     ASSERT_TRUE(allCellsUniform(epoch));
     ASSERT_EQ(agPairingMismatches(epoch, nRanks, kLargeBpp), 0);
 
-    const uint32_t f2 = deriveFlag(epoch[0]);
-    ASSERT_NE(bankOf(f2), bankOf(f1)) << "consecutive launches must alternate banks";
+    const uint32_t f2 = ddaLLEpochFlag(epoch[0]);
+    ASSERT_NE(ddaLLEpochBank(f2), ddaLLEpochBank(f1)) << "consecutive launches must alternate banks";
     ASSERT_NO_FATAL_FAILURE(applyAllGather(epoch, nRanks, kLargeBpp));
     ASSERT_TRUE(allCellsUniform(epoch));
     ASSERT_EQ(agPairingMismatches(epoch, nRanks, kLargeBpp), 0);
@@ -391,23 +413,23 @@ TEST_P(DdaFabricEpochTest, RepeatedMixedSizes_StaysConsistent)
     std::vector<uint32_t> epoch(epochCells(nRanks), 0u);
 
     // Seed for the first bank-alternation check: bank 0 vs the first launch's
-    // flag deriveFlag(0)=1 (bank 1), so the first iteration's ASSERT_NE holds.
+    // flag ddaLLEpochFlag(0)=1 (bank 1), so the first iteration's ASSERT_NE holds.
     uint32_t prevFlag = 0u;
     for (int iter = 0; iter < 4; ++iter)
     {
         for (int bpp : agBpp)
         {
             ASSERT_EQ(agPairingMismatches(epoch, nRanks, bpp), 0) << "iter=" << iter << " bpp=" << bpp;
-            const uint32_t f = deriveFlag(epoch[0]);
-            ASSERT_NE(bankOf(f), bankOf(prevFlag)) << "banks must alternate, iter=" << iter << " bpp=" << bpp;
+            const uint32_t f = ddaLLEpochFlag(epoch[0]);
+            ASSERT_NE(ddaLLEpochBank(f), ddaLLEpochBank(prevFlag)) << "banks must alternate, iter=" << iter << " bpp=" << bpp;
             prevFlag = f;
             ASSERT_NO_FATAL_FAILURE(applyAllGather(epoch, nRanks, bpp));
             ASSERT_TRUE(allCellsUniform(epoch)) << "after AG iter=" << iter << " bpp=" << bpp;
         }
         for (int blk : arBlk)
         {
-            const uint32_t f = deriveFlag(epoch[0]);
-            ASSERT_NE(bankOf(f), bankOf(prevFlag)) << "banks must alternate, iter=" << iter << " blk=" << blk;
+            const uint32_t f = ddaLLEpochFlag(epoch[0]);
+            ASSERT_NE(ddaLLEpochBank(f), ddaLLEpochBank(prevFlag)) << "banks must alternate, iter=" << iter << " blk=" << blk;
             prevFlag = f;
             ASSERT_NO_FATAL_FAILURE(applyAllReduce(epoch, blk));
             ASSERT_TRUE(allCellsUniform(epoch)) << "after AR iter=" << iter << " blk=" << blk;
@@ -416,15 +438,17 @@ TEST_P(DdaFabricEpochTest, RepeatedMixedSizes_StaysConsistent)
 }
 
 // ===========================================================================
-// Negative controls -- these MUST fail if the modelled behavior loses the
-// property; they prove the positive tests are not vacuous. They validate the
-// HOST MODEL, not the device kernels.
+// Negative controls -- these MUST fail if the epoch behavior loses the property;
+// they prove the positive tests are not vacuous. The full-restamp arm drives the
+// shared production ddaLLEpochRestamp; the "weakened" arm models a shorter
+// write-back by passing a truncated epochLen, so it does not mutate production.
 // ===========================================================================
 
 // If the full-length restamp is weakened to own-cell-only (modelling the
 // `e < epochLen` -> `e < total` regression in the write-back loop), a small AG
 // followed by a wide AG leaves stale high cells and the pairing breaks. The
-// full-length restamp on the same sequence stays consistent.
+// full-length restamp on the same sequence -- run through the real
+// ddaLLEpochRestamp -- stays consistent.
 TEST_P(DdaFabricEpochTest, NegativeControl_ShortWriteBackBreaksPairing)
 {
     const int nRanks = GetParam();
@@ -461,17 +485,14 @@ TEST_P(DdaFabricEpochTest, NegativeControl_PeerBeyondNRanksBreaksUniformity)
     std::vector<uint32_t> flag(total);
     for (int b = 0; b < total; ++b)
     {
-        flag[b] = deriveFlag(bad[b]);
+        flag[b] = ddaLLEpochFlag(bad[b]);
     }
     for (int b = 0; b < total; ++b)
     {
         // peer = flatBlockId / bpp; peer >= nRanks returns early (skips write-back)
         if (b / bpp < nRanks)
         {
-            for (int e = b; e < static_cast<int>(bad.size()); e += total)
-            {
-                bad[e] = flag[b];
-            }
+            ddaLLEpochRestamp(bad.data(), b, total, static_cast<int>(bad.size()), flag[b]);
         }
     }
     EXPECT_FALSE(allCellsUniform(bad)) << "grid.x > nRanks leaves residue classes unstamped -> non-uniform";

--- a/projects/rccl/test/DdaFabricEpochTests.cpp
+++ b/projects/rccl/test/DdaFabricEpochTests.cpp
@@ -9,11 +9,13 @@
 // LL and LL128). The counter is sized by ddaLLEpochCount() and restamped every
 // launch; each block derives its LL flag from its cell (bank = flag & 1) and the
 // collectives rely on every cell advancing in lock-step so peer-swapped block
-// pairs derive the same flag+bank. Source of truth:
-//   src/include/algorithms/all_gather/all_gather_dda_fabric_ll.h  (flag+write-back)
-//   src/include/algorithms/alltoall/alltoall_dda_fabric_ll.h      (same 2-D shape)
+// pairs derive the same flag+bank. Source of truth for the modelled kernels:
+//   src/include/algorithms/all_gather/all_gather_dda_fabric_ll.h       (2-D flag+write-back)
+//   src/include/algorithms/alltoall/alltoall_dda_fabric_ll.h           (same 2-D shape)
+//   src/include/algorithms/all_reduce/all_reduce_dda_ll.h              (1-D; note: the AR-LL
+//       kernel lives here, there is NO all_reduce_dda_fabric_ll.h)
 //   src/include/algorithms/reduce_scatter/reduce_scatter_dda_fabric_ll.h (1-D)
-//   src/include/dda_init_detail.h                                 (ddaLLEpochCount)
+//   src/include/dda_init_detail.h                                      (ddaLLEpochCount)
 //
 // Faithfulness notes for the host replay below:
 //  * A launch is modelled as read-all-then-write-all. That is a valid
@@ -23,12 +25,18 @@
 //  * Cross-launch lock-step (bank alternation) holds only because DDA launches on
 //    a comm are stream-serialized, so launch N fully restamps before launch N+1.
 //
-// The tests import the real dda_init_detail.h constants/functions so they track
-// the source, and include a negative control that fails if the full-length
-// restamp (all_gather_dda_fabric_ll.h: `for (e=flatBlockId; e<epochLen; e+=total)`)
-// is weakened to own-cell-only. No GPU is needed.
+// Scope note: these tests validate the HOST MODEL of the epoch arithmetic (using
+// the real dda_init_detail.h constants) and the producer/consumer scratch
+// contract. The negative controls fail if the *model* loses a property, proving
+// the positive assertions are not vacuous; they do NOT read the device kernels,
+// so they cannot detect a device-side regression (e.g. the write-back loop in
+// all_gather_dda_fabric_ll.h being changed from `e < epochLen` to `e < total`).
+// This file is in rccl-UnitTestsFixtures (Release+Debug): it uses only
+// inline/constexpr helpers and the DDA_FABRIC_BUFFER_SIZE macro, no librccl
+// symbols, so the producer-coverage assertion runs in Release CI too.
 
-#include "dda_init_detail.h" // ddaLLEpochCount, kDdaFabricLLArMaxBlocks, kDdaLLAgMaxBlocksPerPeer, DDA_FABRIC_MAXBLOCKS
+#include "common/DdaFabricFootprints.hpp" // shared footprint mirrors (dependency-free)
+#include "dda_init_detail.h" // ddaLLEpochCount, kDdaFabricLLArMaxBlocks, kDdaLLAgMaxBlocksPerPeer, DDA_FABRIC_MAXBLOCKS, DDA_FABRIC_BUFFER_SIZE
 #include "fabric_gpu_barrier.h" // meta::comms::kDdaMaxNranks
 
 #include "gtest/gtest.h"
@@ -71,6 +79,9 @@ unsigned bankOf(uint32_t flag) {
 // [0, writeBackLen) with block b owning cells b, b+total, b+2*total, ... exactly
 // as the kernels do: `for (e = flatBlockId; e < epochLen; e += total) epoch[e]=flag`.
 // writeBackLen == kFullWriteBack models the production full-length restamp.
+// The ASSERT_ bounds guards are preconditions (call sites are constructed to
+// satisfy them); wrap calls in ASSERT_NO_FATAL_FAILURE so a guard trip stops the
+// caller instead of cascading against an unmodified array.
 void applyLaunch(std::vector<uint32_t>& epoch, int total, int writeBackLen = kFullWriteBack) {
     const int cells    = static_cast<int>(epoch.size());
     const int epochLen = (writeBackLen == kFullWriteBack) ? cells : writeBackLen;
@@ -93,16 +104,20 @@ void applyAllGather(std::vector<uint32_t>& epoch, int nRanks, int bpp, int write
     applyLaunch(epoch, nRanks * bpp, writeBackLen);
 }
 
+// AllToAll shares AllGather's 2-D grid shape; alias for readability at call sites.
 void applyAllToAll(std::vector<uint32_t>& epoch, int nRanks, int bpp) {
     applyLaunch(epoch, nRanks * bpp);
 }
 
-// AllReduce / ReduceScatter: 1-D grid of `blocks` (<= kDdaFabricLLArMaxBlocks or
-// clamped to ddaLLEpochLen at the launch site).
+// AllReduce: 1-D grid capped at kDdaFabricLLArMaxBlocks (the AR-only cap,
+// dda_all_reduce_fabric_ll.cu).
 void applyAllReduce(std::vector<uint32_t>& epoch, int blocks) {
     applyLaunch(epoch, blocks);
 }
 
+// ReduceScatter: 1-D grid. Its launcher uses nBlocksMax = comm->ddaFabricMaxBlocks
+// (up to DDA_FABRIC_MAXBLOCKS = 256), then clamps to ddaLLEpochLen -- NOT the
+// AR-only kDdaFabricLLArMaxBlocks. `blocks` need not divide the cell count.
 void applyReduceScatter(std::vector<uint32_t>& epoch, int blocks) {
     applyLaunch(epoch, blocks);
 }
@@ -154,16 +169,18 @@ constexpr int kLargeBpp = kDdaLLAgMaxBlocksPerPeer; // widest per-peer fan-out
 // range (up to kDdaMaxNranks) and every RCCL_DDA_FABRIC_MAXBLOCKS value [1,256].
 // Uses nRanks past the nRanks*8 vs 256 crossover (>32) so both arms of the max
 // are exercised.
-TEST(DdaFabricEpochStatic, EpochCount_CoversWidestCollective) {
+TEST(DdaFabricEpochStaticTest, EpochCount_CoversWidestCollective) {
     for (int arMaxBlocks : {1, kDdaFabricLLArMaxBlocks, DDA_FABRIC_MAXBLOCKS}) {
         for (int nRanks : {2, 8, 32, 33, meta::comms::kDdaMaxNranks}) {
             const long cells = static_cast<long>(ddaLLEpochCount(nRanks, arMaxBlocks));
-            EXPECT_EQ(cells, std::max(nRanks * kDdaLLAgMaxBlocksPerPeer, arMaxBlocks))
+            ASSERT_EQ(cells, std::max(nRanks * kDdaLLAgMaxBlocksPerPeer, arMaxBlocks))
                 << "nRanks=" << nRanks << " arMaxBlocks=" << arMaxBlocks;
             // Must index the widest AllGather/AllToAll grid (nRanks*8) and the
             // actual AR grid, which is capped at min(arMaxBlocks, kDdaFabricLLArMaxBlocks).
-            EXPECT_GE(cells, static_cast<long>(nRanks) * kDdaLLAgMaxBlocksPerPeer);
-            EXPECT_GE(cells, std::min(arMaxBlocks, kDdaFabricLLArMaxBlocks));
+            ASSERT_GE(cells, static_cast<long>(nRanks) * kDdaLLAgMaxBlocksPerPeer)
+                << "nRanks=" << nRanks << " arMaxBlocks=" << arMaxBlocks;
+            ASSERT_GE(cells, std::min(arMaxBlocks, kDdaFabricLLArMaxBlocks))
+                << "nRanks=" << nRanks << " arMaxBlocks=" << arMaxBlocks;
         }
     }
 }
@@ -171,19 +188,34 @@ TEST(DdaFabricEpochStatic, EpochCount_CoversWidestCollective) {
 // The AllGather launcher has no runtime clamp; it relies on ddaLLAgBlocksPerPeer
 // capping per-peer blocks at kDdaLLAgMaxBlocksPerPeer. That cap must keep the
 // grid within the epoch array for every rank count and MAXBLOCKS setting.
-TEST(DdaFabricEpochStatic, AllGatherGridAlwaysFitsEpochArray) {
+TEST(DdaFabricEpochStaticTest, AllGatherGridAlwaysFitsEpochArray) {
     for (int arMaxBlocks : {1, kDdaFabricLLArMaxBlocks, DDA_FABRIC_MAXBLOCKS}) {
         for (int nRanks = 2; nRanks <= meta::comms::kDdaMaxNranks; ++nRanks) {
             const long widestGrid = static_cast<long>(nRanks) * kDdaLLAgMaxBlocksPerPeer;
-            EXPECT_LE(widestGrid, static_cast<long>(ddaLLEpochCount(nRanks, arMaxBlocks)))
+            ASSERT_LE(widestGrid, static_cast<long>(ddaLLEpochCount(nRanks, arMaxBlocks)))
                 << "nRanks=" << nRanks << " arMaxBlocks=" << arMaxBlocks;
         }
     }
 }
 
+// Producer side of the scratch contract: the shipped fabric scratch buffer must
+// cover every fixed-footprint tier at the maximum rank count. This is the
+// consumer-side gate's counterpart (the eligibility predicates, exercised in
+// DdaFabricScratchTests.cpp) and runs in Release CI. If DDA_FABRIC_BUFFER_SIZE is
+// lowered (or a tier's fixed footprint raised) below this, LL/LL128 fall back at
+// runtime with no error -- this assertion catches that.
+TEST(DdaFabricEpochStaticTest, ScratchBufferCoversFixedTiersAtMaxRanks) {
+    const int n = meta::comms::kDdaMaxNranks;
+    EXPECT_GE(DDA_FABRIC_BUFFER_SIZE, ddaLLFixedFootprint(n)) << "scratch < LL footprint at " << n << " ranks";
+    EXPECT_GE(DDA_FABRIC_BUFFER_SIZE, ddaLL128FixedFootprint(n))
+        << "scratch < LL128 AG/A2A/RS footprint at " << n << " ranks";
+    // (AR-LL128 is message-dependent and intentionally NOT covered to its 1 GiB
+    //  cap at high rank counts; see DdaFabricScratchTests EffectiveCapShrinksWithRanks.)
+}
+
 // Flag derivation must skip the 0 sentinel and preserve bank parity, including
 // at the uint32 wraparound the kernel comment guards against.
-TEST(DdaFabricEpochStatic, DeriveFlag_SkipsZeroKeepsBankParity) {
+TEST(DdaFabricEpochStaticTest, DeriveFlag_SkipsZeroKeepsBankParity) {
     for (uint32_t x : {0u, 1u, 2u, 3u, 100u, UINT32_MAX - 1u, UINT32_MAX}) {
         EXPECT_NE(deriveFlag(x), 0u) << "x=" << x;
         EXPECT_EQ(bankOf(deriveFlag(x)), (x + 1u) & 1u) << "x=" << x; // parity survives wrap
@@ -194,65 +226,81 @@ TEST(DdaFabricEpochStatic, DeriveFlag_SkipsZeroKeepsBankParity) {
 // Rank-parameterized behavior
 // ===========================================================================
 
-class DdaFabricEpoch : public ::testing::TestWithParam<int> {
+class DdaFabricEpochTest : public ::testing::TestWithParam<int> {
 };
 
 // Name the instances 2Ranks / 4Ranks / 8Ranks / 72Ranks instead of /0../3.
-INSTANTIATE_TEST_SUITE_P(Ranks, DdaFabricEpoch, ::testing::Values(2, 4, 8, meta::comms::kDdaMaxNranks),
+INSTANTIATE_TEST_SUITE_P(Ranks, DdaFabricEpochTest, ::testing::Values(2, 4, 8, meta::comms::kDdaMaxNranks),
                          [](const ::testing::TestParamInfo<int>& info) {
                              return std::to_string(info.param) + "Ranks";
                          });
 
 // A small AllGather then a large one: array stays uniform, the wider AllGather's
 // peer-swap pairing is consistent, and consecutive launches alternate banks.
-TEST_P(DdaFabricEpoch, AllGatherSmallThenLarge_StaysConsistent) {
+TEST_P(DdaFabricEpochTest, AllGatherSmallThenLarge_StaysConsistent) {
     const int nRanks = GetParam();
     std::vector<uint32_t> epoch(epochCells(nRanks), 0u);
 
     const uint32_t f1 = deriveFlag(epoch[0]);
-    applyAllGather(epoch, nRanks, kSmallBpp);
+    ASSERT_NO_FATAL_FAILURE(applyAllGather(epoch, nRanks, kSmallBpp));
     ASSERT_TRUE(allCellsUniform(epoch));
     ASSERT_EQ(agPairingMismatches(epoch, nRanks, kLargeBpp), 0);
 
     const uint32_t f2 = deriveFlag(epoch[0]);
     ASSERT_NE(bankOf(f2), bankOf(f1)) << "consecutive launches must alternate banks";
-    applyAllGather(epoch, nRanks, kLargeBpp);
+    ASSERT_NO_FATAL_FAILURE(applyAllGather(epoch, nRanks, kLargeBpp));
     ASSERT_TRUE(allCellsUniform(epoch));
     ASSERT_EQ(agPairingMismatches(epoch, nRanks, kLargeBpp), 0);
 }
 
-TEST_P(DdaFabricEpoch, AllReduceThenAllGather_StaysConsistent) {
+// AR then AG: after an AllReduce, the shared array is still pairing-consistent for
+// a following AllGather (no AllGather is applied here -- the check is the pairing
+// a subsequent AG would derive).
+TEST_P(DdaFabricEpochTest, AllReduceThenAllGatherPairingHolds) {
     const int nRanks = GetParam();
     std::vector<uint32_t> epoch(epochCells(nRanks), 0u);
-    applyAllReduce(epoch, kDdaFabricLLArMaxBlocks); // widest AR grid
+    ASSERT_NO_FATAL_FAILURE(applyAllReduce(epoch, kDdaFabricLLArMaxBlocks)); // widest AR grid
     ASSERT_TRUE(allCellsUniform(epoch));
     ASSERT_EQ(agPairingMismatches(epoch, nRanks, kLargeBpp), 0);
 }
 
-TEST_P(DdaFabricEpoch, ReduceScatterThenAllGather_StaysConsistent) {
+// RS then AG. ReduceScatter's real cap is DDA_FABRIC_MAXBLOCKS (clamped to the
+// cell count), not the AR-only cap; also exercise a block count that does not
+// divide the cell count (the write-back stride must still tile every cell).
+TEST_P(DdaFabricEpochTest, ReduceScatterThenAllGatherPairingHolds) {
     const int nRanks = GetParam();
-    std::vector<uint32_t> epoch(epochCells(nRanks), 0u);
-    applyReduceScatter(epoch, std::min<int>(kDdaFabricLLArMaxBlocks, static_cast<int>(epoch.size())));
+    const int cells  = static_cast<int>(epochCells(nRanks));
+
+    std::vector<uint32_t> epoch(cells, 0u);
+    ASSERT_NO_FATAL_FAILURE(applyReduceScatter(epoch, std::min(DDA_FABRIC_MAXBLOCKS, cells))); // widest real RS grid
     ASSERT_TRUE(allCellsUniform(epoch));
+    ASSERT_EQ(agPairingMismatches(epoch, nRanks, kLargeBpp), 0);
+
+    const int nonDividing = 100; // 100 divides neither 256 nor 576; <= 256 cap and <= cells
+    ASSERT_LE(nonDividing, cells);
+    ASSERT_NO_FATAL_FAILURE(applyReduceScatter(epoch, nonDividing));
+    ASSERT_TRUE(allCellsUniform(epoch)) << "non-dividing block count must still restamp every cell";
     ASSERT_EQ(agPairingMismatches(epoch, nRanks, kLargeBpp), 0);
 }
 
-TEST_P(DdaFabricEpoch, AllToAllThenAllGather_StaysConsistent) {
+TEST_P(DdaFabricEpochTest, AllToAllThenAllGatherPairingHolds) {
     const int nRanks = GetParam();
     std::vector<uint32_t> epoch(epochCells(nRanks), 0u);
-    applyAllToAll(epoch, nRanks, kLargeBpp); // A2A is peer-swapped like AG
+    ASSERT_NO_FATAL_FAILURE(applyAllToAll(epoch, nRanks, kLargeBpp)); // A2A is peer-swapped like AG
     ASSERT_TRUE(allCellsUniform(epoch));
     ASSERT_EQ(agPairingMismatches(epoch, nRanks, kLargeBpp), 0);
 }
 
 // Interleaved mixed-size launches keep the array uniform and every AllGather /
 // AllToAll pairing consistent each step. ASSERT_ stops at the first divergence.
-TEST_P(DdaFabricEpoch, RepeatedMixedSizes_StaysConsistent) {
+TEST_P(DdaFabricEpochTest, RepeatedMixedSizes_StaysConsistent) {
     const int nRanks = GetParam();
-    const int agBpp[] = {1, 2, 4, kLargeBpp, 3};
+    const int agBpp[] = {kSmallBpp, 2, 4, kLargeBpp, 3};
     const int arBlk[] = {1, 4, kDdaFabricLLArMaxBlocks, 7};
     std::vector<uint32_t> epoch(epochCells(nRanks), 0u);
 
+    // Seed for the first bank-alternation check: bank 0 vs the first launch's
+    // flag deriveFlag(0)=1 (bank 1), so the first iteration's ASSERT_NE holds.
     uint32_t prevFlag = 0u;
     for (int iter = 0; iter < 4; ++iter) {
         for (int bpp : agBpp) {
@@ -260,37 +308,38 @@ TEST_P(DdaFabricEpoch, RepeatedMixedSizes_StaysConsistent) {
             const uint32_t f = deriveFlag(epoch[0]);
             ASSERT_NE(bankOf(f), bankOf(prevFlag)) << "banks must alternate, iter=" << iter << " bpp=" << bpp;
             prevFlag = f;
-            applyAllGather(epoch, nRanks, bpp);
+            ASSERT_NO_FATAL_FAILURE(applyAllGather(epoch, nRanks, bpp));
             ASSERT_TRUE(allCellsUniform(epoch)) << "after AG iter=" << iter << " bpp=" << bpp;
         }
         for (int blk : arBlk) {
             const uint32_t f = deriveFlag(epoch[0]);
             ASSERT_NE(bankOf(f), bankOf(prevFlag)) << "banks must alternate, iter=" << iter << " blk=" << blk;
             prevFlag = f;
-            applyAllReduce(epoch, blk);
+            ASSERT_NO_FATAL_FAILURE(applyAllReduce(epoch, blk));
             ASSERT_TRUE(allCellsUniform(epoch)) << "after AR iter=" << iter << " blk=" << blk;
         }
     }
 }
 
 // ===========================================================================
-// Negative controls -- these MUST fail if the harness (or the modelled kernel
-// behavior) loses the property; they prove the positive tests have teeth.
+// Negative controls -- these MUST fail if the modelled behavior loses the
+// property; they prove the positive tests are not vacuous. They validate the
+// HOST MODEL, not the device kernels.
 // ===========================================================================
 
-// If the full-length restamp is weakened to own-cell-only (the exact regression
-// `e < epochLen` -> `e < total` in all_gather_dda_fabric_ll.h:133), a small AG
+// If the full-length restamp is weakened to own-cell-only (modelling the
+// `e < epochLen` -> `e < total` regression in the write-back loop), a small AG
 // followed by a wide AG leaves stale high cells and the pairing breaks. The
 // full-length restamp on the same sequence stays consistent.
-TEST_P(DdaFabricEpoch, NegativeControl_ShortWriteBackBreaksPairing) {
+TEST_P(DdaFabricEpochTest, NegativeControl_ShortWriteBackBreaksPairing) {
     const int nRanks = GetParam();
 
     std::vector<uint32_t> full(epochCells(nRanks), 0u);
-    applyAllGather(full, nRanks, kSmallBpp, kFullWriteBack);
+    ASSERT_NO_FATAL_FAILURE(applyAllGather(full, nRanks, kSmallBpp, kFullWriteBack));
     ASSERT_EQ(agPairingMismatches(full, nRanks, kLargeBpp), 0) << "full restamp must stay consistent";
 
     std::vector<uint32_t> shortWb(epochCells(nRanks), 0u);
-    applyAllGather(shortWb, nRanks, kSmallBpp, /*writeBackLen=*/nRanks * kSmallBpp); // own-cell-only
+    ASSERT_NO_FATAL_FAILURE(applyAllGather(shortWb, nRanks, kSmallBpp, /*writeBackLen=*/nRanks * kSmallBpp));
     EXPECT_GT(agPairingMismatches(shortWb, nRanks, kLargeBpp), 0)
         << "own-cell-only restamp must break pairing -> proves the full-length restamp is load-bearing";
 }
@@ -299,12 +348,12 @@ TEST_P(DdaFabricEpoch, NegativeControl_ShortWriteBackBreaksPairing) {
 // BEFORE the write-back, so those residue classes are never restamped and the
 // array goes non-uniform. Launch sites use grid.x == nRanks; this pins that
 // assumption.
-TEST_P(DdaFabricEpoch, NegativeControl_PeerBeyondNRanksBreaksUniformity) {
+TEST_P(DdaFabricEpochTest, NegativeControl_PeerBeyondNRanksBreaksUniformity) {
     const int nRanks = GetParam();
     const int bpp    = 2;
 
     std::vector<uint32_t> ok(epochCells(nRanks), 0u);
-    applyAllGather(ok, nRanks, bpp);
+    ASSERT_NO_FATAL_FAILURE(applyAllGather(ok, nRanks, bpp));
     ASSERT_TRUE(allCellsUniform(ok)) << "grid.x == nRanks must stay uniform";
 
     // Model grid.x == nRanks+1: all blocks read, but peer==nRanks blocks return

--- a/projects/rccl/test/DdaFabricEpochTests.cpp
+++ b/projects/rccl/test/DdaFabricEpochTests.cpp
@@ -62,7 +62,8 @@
 #include <string>
 #include <vector>
 
-namespace RcclUnitTesting {
+namespace RcclUnitTesting
+{
 
 // Compile-time tie between every footprint mirror and the real launcher
 // constants. All independently-declared per-tier caps are asserted (not just one
@@ -82,7 +83,8 @@ static_assert(kLLTierMaxBytes / 8 == meta::comms::kDdaLLArSlotStridePkts, "LL sl
 static_assert(ddaLL128LinesForBytes(kLL128TierMaxBytes) == meta::comms::kDdaLL128AgSlotStrideLines,
               "LL128 slot-stride mirror drift");
 
-namespace {
+namespace
+{
 
 using nccl_dda_detail::ddaLLEpochCount;
 using nccl_dda_detail::kDdaFabricLLArMaxBlocks;
@@ -92,20 +94,24 @@ using nccl_dda_detail::kDdaLLAgMaxBlocksPerPeer;
 constexpr int kFullWriteBack = -1;
 
 // Number of shared epoch cells, from the real sizing function.
-size_t epochCells(int nRanks, int arMaxBlocks = DDA_FABRIC_MAXBLOCKS) {
+size_t epochCells(int nRanks, int arMaxBlocks = DDA_FABRIC_MAXBLOCKS)
+{
     return ddaLLEpochCount(nRanks, arMaxBlocks);
 }
 
 // Per-block LL flag from its epoch cell:  f = cell + 1; if (f == 0) f = 2.
-uint32_t deriveFlag(uint32_t cell) {
+uint32_t deriveFlag(uint32_t cell)
+{
     uint32_t f = cell + 1u;
-    if (f == 0u) {
+    if (f == 0u)
+    {
         f = 2u; // skip 0 sentinel; keep bank parity
     }
     return f;
 }
 
-unsigned bankOf(uint32_t flag) {
+unsigned bankOf(uint32_t flag)
+{
     return flag & 1u;
 }
 
@@ -116,7 +122,8 @@ unsigned bankOf(uint32_t flag) {
 // The ASSERT_ bounds guards are preconditions (call sites are constructed to
 // satisfy them); wrap calls in ASSERT_NO_FATAL_FAILURE so a guard trip stops the
 // caller instead of cascading against an unmodified array.
-void applyLaunch(std::vector<uint32_t>& epoch, int total, int writeBackLen = kFullWriteBack) {
+void applyLaunch(std::vector<uint32_t>& epoch, int total, int writeBackLen = kFullWriteBack)
+{
     const int cells    = static_cast<int>(epoch.size());
     const int epochLen = (writeBackLen == kFullWriteBack) ? cells : writeBackLen;
     ASSERT_GT(total, 0);
@@ -124,56 +131,70 @@ void applyLaunch(std::vector<uint32_t>& epoch, int total, int writeBackLen = kFu
     ASSERT_LE(total, cells);    // read index flatBlockId < total stays in bounds
     ASSERT_LE(epochLen, cells); // write index stays in bounds
     std::vector<uint32_t> flag(total);
-    for (int b = 0; b < total; ++b) {
+    for (int b = 0; b < total; ++b)
+    {
         flag[b] = deriveFlag(epoch[b]);
     }
-    for (int b = 0; b < total; ++b) {
-        for (int e = b; e < epochLen; e += total) {
+    for (int b = 0; b < total; ++b)
+    {
+        for (int e = b; e < epochLen; e += total)
+        {
             epoch[e] = flag[b];
         }
     }
 }
 
 // AllGather / AllToAll: 2-D grid nRanks x bpp, total = nRanks*bpp.
-void applyAllGather(std::vector<uint32_t>& epoch, int nRanks, int bpp, int writeBackLen = kFullWriteBack) {
+void applyAllGather(std::vector<uint32_t>& epoch, int nRanks, int bpp, int writeBackLen = kFullWriteBack)
+{
     applyLaunch(epoch, nRanks * bpp, writeBackLen);
 }
 
 // AllToAll shares AllGather's 2-D grid shape; alias for readability at call sites.
-void applyAllToAll(std::vector<uint32_t>& epoch, int nRanks, int bpp) {
+void applyAllToAll(std::vector<uint32_t>& epoch, int nRanks, int bpp)
+{
     applyLaunch(epoch, nRanks * bpp);
 }
 
 // AllReduce: 1-D grid capped at kDdaFabricLLArMaxBlocks (the AR-only cap,
 // dda_all_reduce_fabric_ll.cu).
-void applyAllReduce(std::vector<uint32_t>& epoch, int blocks) {
+void applyAllReduce(std::vector<uint32_t>& epoch, int blocks)
+{
     applyLaunch(epoch, blocks);
 }
 
 // ReduceScatter: 1-D grid. Its launcher uses nBlocksMax = comm->ddaFabricMaxBlocks
 // (up to DDA_FABRIC_MAXBLOCKS = 256), then clamps to ddaLLEpochLen -- NOT the
 // AR-only kDdaFabricLLArMaxBlocks. `blocks` need not divide the cell count.
-void applyReduceScatter(std::vector<uint32_t>& epoch, int blocks) {
+void applyReduceScatter(std::vector<uint32_t>& epoch, int blocks)
+{
     applyLaunch(epoch, blocks);
 }
 
 // AllGather/AllToAll peer-swap pairing violations for a launch with `bpp`: for
 // each (R,P,c) with P!=R the reader cell (P*bpp+c) and the paired writer cell
 // (R*bpp+c) must derive the same flag. Returns the mismatch count (-1 on OOB).
-long agPairingMismatches(const std::vector<uint32_t>& epoch, int nRanks, int bpp) {
-    if (nRanks * bpp > static_cast<int>(epoch.size())) {
+long agPairingMismatches(const std::vector<uint32_t>& epoch, int nRanks, int bpp)
+{
+    if (nRanks * bpp > static_cast<int>(epoch.size()))
+    {
         ADD_FAILURE() << "pairing check indexes past the epoch array: nRanks*bpp=" << nRanks * bpp
                       << " cells=" << epoch.size();
         return -1;
     }
     long mismatches = 0;
-    for (int R = 0; R < nRanks; ++R) {
-        for (int P = 0; P < nRanks; ++P) {
-            if (P == R) {
+    for (int R = 0; R < nRanks; ++R)
+    {
+        for (int P = 0; P < nRanks; ++P)
+        {
+            if (P == R)
+            {
                 continue; // self column is a local copy, no cross-rank flag
             }
-            for (int c = 0; c < bpp; ++c) {
-                if (deriveFlag(epoch[P * bpp + c]) != deriveFlag(epoch[R * bpp + c])) {
+            for (int c = 0; c < bpp; ++c)
+            {
+                if (deriveFlag(epoch[P * bpp + c]) != deriveFlag(epoch[R * bpp + c]))
+                {
                     ++mismatches;
                 }
             }
@@ -182,9 +203,12 @@ long agPairingMismatches(const std::vector<uint32_t>& epoch, int nRanks, int bpp
     return mismatches;
 }
 
-bool allCellsUniform(const std::vector<uint32_t>& epoch) {
-    for (size_t i = 1; i < epoch.size(); ++i) {
-        if (epoch[i] != epoch[0]) {
+bool allCellsUniform(const std::vector<uint32_t>& epoch)
+{
+    for (size_t i = 1; i < epoch.size(); ++i)
+    {
+        if (epoch[i] != epoch[0])
+        {
             return false;
         }
     }
@@ -204,9 +228,12 @@ constexpr int kLargeBpp = kDdaLLAgMaxBlocksPerPeer; // widest per-peer fan-out
 // range (up to kDdaMaxNranks) and every RCCL_DDA_FABRIC_MAXBLOCKS value [1,256].
 // Uses nRanks past the nRanks*8 vs 256 crossover (>32) so both arms of the max
 // are exercised.
-TEST(DdaFabricEpochStaticTest, EpochCount_CoversWidestCollective) {
-    for (int arMaxBlocks : {1, kDdaFabricLLArMaxBlocks, DDA_FABRIC_MAXBLOCKS}) {
-        for (int nRanks : {2, 8, 32, 33, meta::comms::kDdaMaxNranks}) {
+TEST(DdaFabricEpochStaticTest, EpochCount_CoversWidestCollective)
+{
+    for (int arMaxBlocks : {1, kDdaFabricLLArMaxBlocks, DDA_FABRIC_MAXBLOCKS})
+    {
+        for (int nRanks : {2, 8, 32, 33, meta::comms::kDdaMaxNranks})
+        {
             const long cells = static_cast<long>(ddaLLEpochCount(nRanks, arMaxBlocks));
             ASSERT_EQ(cells, std::max(nRanks * kDdaLLAgMaxBlocksPerPeer, arMaxBlocks))
                 << "nRanks=" << nRanks << " arMaxBlocks=" << arMaxBlocks;
@@ -228,9 +255,12 @@ TEST(DdaFabricEpochStaticTest, EpochCount_CoversWidestCollective) {
 // LL128 AG/A2A launchers instead clamp blocksPerPeer against epochLen at runtime,
 // since RCCL_DDA_LL128_AG_MAXBPP / _A2A_MAXBPP can raise their cap.) That compile-time cap must
 // keep the AG-LL grid within the epoch array for every rank count and MAXBLOCKS.
-TEST(DdaFabricEpochStaticTest, AllGatherGridAlwaysFitsEpochArray) {
-    for (int arMaxBlocks : {1, kDdaFabricLLArMaxBlocks, DDA_FABRIC_MAXBLOCKS}) {
-        for (int nRanks = 2; nRanks <= meta::comms::kDdaMaxNranks; ++nRanks) {
+TEST(DdaFabricEpochStaticTest, AllGatherGridAlwaysFitsEpochArray)
+{
+    for (int arMaxBlocks : {1, kDdaFabricLLArMaxBlocks, DDA_FABRIC_MAXBLOCKS})
+    {
+        for (int nRanks = 2; nRanks <= meta::comms::kDdaMaxNranks; ++nRanks)
+        {
             const long widestGrid = static_cast<long>(nRanks) * kDdaLLAgMaxBlocksPerPeer;
             ASSERT_LE(widestGrid, static_cast<long>(ddaLLEpochCount(nRanks, arMaxBlocks)))
                 << "nRanks=" << nRanks << " arMaxBlocks=" << arMaxBlocks;
@@ -244,7 +274,8 @@ TEST(DdaFabricEpochStaticTest, AllGatherGridAlwaysFitsEpochArray) {
 // DdaFabricScratchTests.cpp) and runs in Release CI. If DDA_FABRIC_BUFFER_SIZE is
 // lowered (or a tier's fixed footprint raised) below this, LL/LL128 fall back at
 // runtime with no error -- this assertion catches that.
-TEST(DdaFabricEpochStaticTest, ScratchBufferCoversFixedTiersAtMaxRanks) {
+TEST(DdaFabricEpochStaticTest, ScratchBufferCoversFixedTiersAtMaxRanks)
+{
     const int n = meta::comms::kDdaMaxNranks;
     EXPECT_GE(DDA_FABRIC_BUFFER_SIZE, ddaLLFixedFootprint(n)) << "scratch < LL footprint at " << n << " ranks";
     EXPECT_GE(DDA_FABRIC_BUFFER_SIZE, ddaLL128FixedFootprint(n))
@@ -255,8 +286,10 @@ TEST(DdaFabricEpochStaticTest, ScratchBufferCoversFixedTiersAtMaxRanks) {
 
 // Flag derivation must skip the 0 sentinel and preserve bank parity, including
 // at the uint32 wraparound the kernel comment guards against.
-TEST(DdaFabricEpochStaticTest, DeriveFlag_SkipsZeroKeepsBankParity) {
-    for (uint32_t x : {0u, 1u, 2u, 3u, 100u, UINT32_MAX - 1u, UINT32_MAX}) {
+TEST(DdaFabricEpochStaticTest, DeriveFlag_SkipsZeroKeepsBankParity)
+{
+    for (uint32_t x : {0u, 1u, 2u, 3u, 100u, UINT32_MAX - 1u, UINT32_MAX})
+    {
         EXPECT_NE(deriveFlag(x), 0u) << "x=" << x;
         EXPECT_EQ(bankOf(deriveFlag(x)), (x + 1u) & 1u) << "x=" << x; // parity survives wrap
     }
@@ -266,18 +299,21 @@ TEST(DdaFabricEpochStaticTest, DeriveFlag_SkipsZeroKeepsBankParity) {
 // Rank-parameterized behavior
 // ===========================================================================
 
-class DdaFabricEpochTest : public ::testing::TestWithParam<int> {
+class DdaFabricEpochTest : public ::testing::TestWithParam<int>
+{
 };
 
 // Name the instances 2Ranks / 4Ranks / 8Ranks / 72Ranks instead of /0../3.
 INSTANTIATE_TEST_SUITE_P(Ranks, DdaFabricEpochTest, ::testing::Values(2, 4, 8, meta::comms::kDdaMaxNranks),
-                         [](const ::testing::TestParamInfo<int>& info) {
+                         [](const ::testing::TestParamInfo<int>& info)
+                         {
                              return std::to_string(info.param) + "Ranks";
                          });
 
 // A small AllGather then a large one: array stays uniform, the wider AllGather's
 // peer-swap pairing is consistent, and consecutive launches alternate banks.
-TEST_P(DdaFabricEpochTest, AllGatherSmallThenLarge_StaysConsistent) {
+TEST_P(DdaFabricEpochTest, AllGatherSmallThenLarge_StaysConsistent)
+{
     const int nRanks = GetParam();
     std::vector<uint32_t> epoch(epochCells(nRanks), 0u);
 
@@ -296,7 +332,8 @@ TEST_P(DdaFabricEpochTest, AllGatherSmallThenLarge_StaysConsistent) {
 // AR then AG: after an AllReduce, the shared array is still pairing-consistent for
 // a following AllGather (no AllGather is applied here -- the check is the pairing
 // a subsequent AG would derive).
-TEST_P(DdaFabricEpochTest, AllReduce_LeavesArrayAllGatherPairable) {
+TEST_P(DdaFabricEpochTest, AllReduce_LeavesArrayAllGatherPairable)
+{
     const int nRanks = GetParam();
     std::vector<uint32_t> epoch(epochCells(nRanks), 0u);
     ASSERT_NO_FATAL_FAILURE(applyAllReduce(epoch, kDdaFabricLLArMaxBlocks)); // widest AR grid
@@ -307,7 +344,8 @@ TEST_P(DdaFabricEpochTest, AllReduce_LeavesArrayAllGatherPairable) {
 // RS then AG. ReduceScatter's real cap is DDA_FABRIC_MAXBLOCKS (clamped to the
 // cell count), not the AR-only cap; also exercise a block count that does not
 // divide the cell count (the write-back stride must still tile every cell).
-TEST_P(DdaFabricEpochTest, ReduceScatter_LeavesArrayAllGatherPairable) {
+TEST_P(DdaFabricEpochTest, ReduceScatter_LeavesArrayAllGatherPairable)
+{
     const int nRanks = GetParam();
     const int cells  = static_cast<int>(epochCells(nRanks));
 
@@ -323,7 +361,8 @@ TEST_P(DdaFabricEpochTest, ReduceScatter_LeavesArrayAllGatherPairable) {
     ASSERT_EQ(agPairingMismatches(epoch, nRanks, kLargeBpp), 0);
 }
 
-TEST_P(DdaFabricEpochTest, AllToAll_LeavesArrayAllGatherPairable) {
+TEST_P(DdaFabricEpochTest, AllToAll_LeavesArrayAllGatherPairable)
+{
     const int nRanks = GetParam();
     std::vector<uint32_t> epoch(epochCells(nRanks), 0u);
     ASSERT_NO_FATAL_FAILURE(applyAllToAll(epoch, nRanks, kLargeBpp)); // A2A is peer-swapped like AG
@@ -333,7 +372,8 @@ TEST_P(DdaFabricEpochTest, AllToAll_LeavesArrayAllGatherPairable) {
 
 // Interleaved mixed-size launches keep the array uniform and every AllGather /
 // AllToAll pairing consistent each step. ASSERT_ stops at the first divergence.
-TEST_P(DdaFabricEpochTest, RepeatedMixedSizes_StaysConsistent) {
+TEST_P(DdaFabricEpochTest, RepeatedMixedSizes_StaysConsistent)
+{
     const int nRanks = GetParam();
     const int agBpp[] = {kSmallBpp, 2, 4, kLargeBpp, 3};
     const int arBlk[] = {1, 4, kDdaFabricLLArMaxBlocks, 7};
@@ -342,8 +382,10 @@ TEST_P(DdaFabricEpochTest, RepeatedMixedSizes_StaysConsistent) {
     // Seed for the first bank-alternation check: bank 0 vs the first launch's
     // flag deriveFlag(0)=1 (bank 1), so the first iteration's ASSERT_NE holds.
     uint32_t prevFlag = 0u;
-    for (int iter = 0; iter < 4; ++iter) {
-        for (int bpp : agBpp) {
+    for (int iter = 0; iter < 4; ++iter)
+    {
+        for (int bpp : agBpp)
+        {
             ASSERT_EQ(agPairingMismatches(epoch, nRanks, bpp), 0) << "iter=" << iter << " bpp=" << bpp;
             const uint32_t f = deriveFlag(epoch[0]);
             ASSERT_NE(bankOf(f), bankOf(prevFlag)) << "banks must alternate, iter=" << iter << " bpp=" << bpp;
@@ -351,7 +393,8 @@ TEST_P(DdaFabricEpochTest, RepeatedMixedSizes_StaysConsistent) {
             ASSERT_NO_FATAL_FAILURE(applyAllGather(epoch, nRanks, bpp));
             ASSERT_TRUE(allCellsUniform(epoch)) << "after AG iter=" << iter << " bpp=" << bpp;
         }
-        for (int blk : arBlk) {
+        for (int blk : arBlk)
+        {
             const uint32_t f = deriveFlag(epoch[0]);
             ASSERT_NE(bankOf(f), bankOf(prevFlag)) << "banks must alternate, iter=" << iter << " blk=" << blk;
             prevFlag = f;
@@ -371,7 +414,8 @@ TEST_P(DdaFabricEpochTest, RepeatedMixedSizes_StaysConsistent) {
 // `e < epochLen` -> `e < total` regression in the write-back loop), a small AG
 // followed by a wide AG leaves stale high cells and the pairing breaks. The
 // full-length restamp on the same sequence stays consistent.
-TEST_P(DdaFabricEpochTest, NegativeControl_ShortWriteBackBreaksPairing) {
+TEST_P(DdaFabricEpochTest, NegativeControl_ShortWriteBackBreaksPairing)
+{
     const int nRanks = GetParam();
 
     std::vector<uint32_t> full(epochCells(nRanks), 0u);
@@ -388,7 +432,8 @@ TEST_P(DdaFabricEpochTest, NegativeControl_ShortWriteBackBreaksPairing) {
 // BEFORE the write-back, so those residue classes are never restamped and the
 // array goes non-uniform. Launch sites use grid.x == nRanks; this pins that
 // assumption.
-TEST_P(DdaFabricEpochTest, NegativeControl_PeerBeyondNRanksBreaksUniformity) {
+TEST_P(DdaFabricEpochTest, NegativeControl_PeerBeyondNRanksBreaksUniformity)
+{
     const int nRanks = GetParam();
     const int bpp    = 2;
 
@@ -403,12 +448,15 @@ TEST_P(DdaFabricEpochTest, NegativeControl_PeerBeyondNRanksBreaksUniformity) {
     const int total = gridX * bpp;
     ASSERT_LE(total, static_cast<int>(bad.size()));
     std::vector<uint32_t> flag(total);
-    for (int b = 0; b < total; ++b) {
+    for (int b = 0; b < total; ++b)
+    {
         flag[b] = deriveFlag(bad[b]);
     }
-    for (int b = 0; b < total; ++b) {
+    for (int b = 0; b < total; ++b)
+    {
         if (b / bpp < nRanks) { // peer = flatBlockId / bpp; peer >= nRanks returns early
-            for (int e = b; e < static_cast<int>(bad.size()); e += total) {
+            for (int e = b; e < static_cast<int>(bad.size()); e += total)
+            {
                 bad[e] = flag[b];
             }
         }

--- a/projects/rccl/test/DdaFabricEpochTests.cpp
+++ b/projects/rccl/test/DdaFabricEpochTests.cpp
@@ -39,13 +39,21 @@
 #include "dda_init_detail.h" // ddaLLEpochCount, kDdaFabricLLArMaxBlocks, kDdaLLAgMaxBlocksPerPeer, DDA_FABRIC_MAXBLOCKS, DDA_FABRIC_BUFFER_SIZE
 #include "fabric_gpu_barrier.h" // meta::comms::kDdaMaxNranks
 
-// Real launcher constants, to pin the DdaFabricFootprints.hpp mirrors at compile
-// time. This TU builds under hipcc in the Release fixtures target, so including
-// the (device-code-bearing) kernel headers is fine, and the static_asserts below
-// run in Release CI -- a production stride/cap change fails this build.
-#include "algorithms/CollCommon_ll128.h"                       // meta::comms::{LLLine128,kDdaLL128DataElems}
-#include "algorithms/all_reduce/all_reduce_dda_ll.h"           // meta::comms::{kDdaLLArMaxBytes,LLPacket16}
-#include "algorithms/all_gather/all_gather_dda_fabric_ll128.h" // meta::comms::kDdaLL128AgMaxPerRankBytes
+// Real launcher constants, to pin every DdaFabricFootprints.hpp mirror at compile
+// time. These test sources compile as host TUs with __HIP_PLATFORM_AMD__ defined
+// and link hip::device, so including the device-code-bearing kernel headers is
+// fine (nothing instantiates the kernels); device/TestOp128.cpp is the precedent.
+// The static_asserts below build in the Release-capable rccl-UnitTestsFixtures
+// target -- a production stride/cap change fails this build. LLPacket16 comes from
+// CollCommon.h (pulled via dda_init_detail.h).
+#include "algorithms/CollCommon_ll128.h"                            // meta::comms::{LLLine128,kDdaLL128DataElems}
+#include "algorithms/all_reduce/all_reduce_dda_ll.h"                // kDdaLLArMaxBytes, kDdaLLArSlotStridePkts
+#include "algorithms/all_gather/all_gather_dda_fabric_ll.h"         // kDdaLLAgMaxPerRankBytes
+#include "algorithms/alltoall/alltoall_dda_fabric_ll.h"            // kDdaLLA2AMaxPerChunkBytes
+#include "algorithms/reduce_scatter/reduce_scatter_dda_fabric_ll.h" // kDdaLLRsMaxBytes
+#include "algorithms/all_gather/all_gather_dda_fabric_ll128.h"      // kDdaLL128AgMaxPerRankBytes, kDdaLL128AgSlotStrideLines
+#include "algorithms/alltoall/alltoall_dda_fabric_ll128.h"          // kDdaLL128A2AMaxPerChunkBytes
+#include "algorithms/reduce_scatter/reduce_scatter_dda_fabric_ll128.h" // kDdaLL128RsMaxBytes
 
 #include "gtest/gtest.h"
 
@@ -56,14 +64,23 @@
 
 namespace RcclUnitTesting {
 
-// Compile-time tie between the footprint mirrors and the real launcher constants
-// (the per-tier caps for RS/A2A are additionally pinned at runtime by the
-// exact-boundary tests in DdaFabricScratchTests.cpp, which call the real predicates).
+// Compile-time tie between every footprint mirror and the real launcher
+// constants. All independently-declared per-tier caps are asserted (not just one
+// per family), plus the two derived slot strides -- a correct cap with a
+// redefined stride would still yield a wrong footprint.
 static_assert(kLLPacketBytes == sizeof(meta::comms::LLPacket16), "LLPacket16 size mirror drift");
 static_assert(kLL128LineBytes == sizeof(meta::comms::LLLine128), "LLLine128 size mirror drift");
 static_assert(kLL128DataElems == static_cast<size_t>(meta::comms::kDdaLL128DataElems), "LL128 data-elems mirror drift");
-static_assert(kLLTierMaxBytes == meta::comms::kDdaLLArMaxBytes, "LL tier cap mirror drift");
-static_assert(kLL128TierMaxBytes == meta::comms::kDdaLL128AgMaxPerRankBytes, "LL128 tier cap mirror drift");
+static_assert(kLLTierMaxBytes == meta::comms::kDdaLLArMaxBytes, "LL AR cap mirror drift");
+static_assert(kLLTierMaxBytes == meta::comms::kDdaLLAgMaxPerRankBytes, "LL AG cap mirror drift");
+static_assert(kLLTierMaxBytes == meta::comms::kDdaLLA2AMaxPerChunkBytes, "LL A2A cap mirror drift");
+static_assert(kLLTierMaxBytes == meta::comms::kDdaLLRsMaxBytes, "LL RS cap mirror drift");
+static_assert(kLL128TierMaxBytes == meta::comms::kDdaLL128AgMaxPerRankBytes, "LL128 AG cap mirror drift");
+static_assert(kLL128TierMaxBytes == meta::comms::kDdaLL128A2AMaxPerChunkBytes, "LL128 A2A cap mirror drift");
+static_assert(kLL128TierMaxBytes == meta::comms::kDdaLL128RsMaxBytes, "LL128 RS cap mirror drift");
+static_assert(kLLTierMaxBytes / 8 == meta::comms::kDdaLLArSlotStridePkts, "LL slot-stride mirror drift");
+static_assert(ddaLL128LinesForBytes(kLL128TierMaxBytes) == meta::comms::kDdaLL128AgSlotStrideLines,
+              "LL128 slot-stride mirror drift");
 
 namespace {
 
@@ -209,7 +226,7 @@ TEST(DdaFabricEpochStaticTest, EpochCount_CoversWidestCollective) {
 // The AllGather-LL launcher has no runtime clamp; it relies on
 // ddaLLAgBlocksPerPeer capping per-peer blocks at kDdaLLAgMaxBlocksPerPeer. (The
 // LL128 AG/A2A launchers instead clamp blocksPerPeer against epochLen at runtime,
-// since RCCL_DDA_LL128_AG_MAXBPP can raise their cap.) That compile-time cap must
+// since RCCL_DDA_LL128_AG_MAXBPP / _A2A_MAXBPP can raise their cap.) That compile-time cap must
 // keep the AG-LL grid within the epoch array for every rank count and MAXBLOCKS.
 TEST(DdaFabricEpochStaticTest, AllGatherGridAlwaysFitsEpochArray) {
     for (int arMaxBlocks : {1, kDdaFabricLLArMaxBlocks, DDA_FABRIC_MAXBLOCKS}) {

--- a/projects/rccl/test/DdaFabricScratchTests.cpp
+++ b/projects/rccl/test/DdaFabricScratchTests.cpp
@@ -9,7 +9,7 @@
 // every DDA fabric tier that is nominally enabled, and each tier's eligibility
 // predicate must fail closed (return false, i.e. fall back) when it is not.
 //
-// Whatever sizes the scratch buffer is the producer; these tests pin the
+// The code that sizes the scratch buffer is the producer; these tests pin the
 // consumer side, which lives in the eligibility predicates:
 //   ncclAllReduceDdaFabricLL/LL128Eligible, and the AllGather/AllToAll/
 //   ReduceScatter counterparts (declared in dda_*.h). The sibling
@@ -47,9 +47,10 @@ namespace RcclUnitTesting {
 namespace {
 
 // Footprint constants/helpers (kLLPacketBytes, kLL128LineBytes, ddaLLFixedFootprint,
-// ddaLL128FixedFootprint, ddaLL128ArFootprintForBytes) are shared via
-// DdaFabricTestHelpers.hpp so this file and DdaFabricEpochTests.cpp mirror the
-// launcher constants in one place.
+// ddaLL128FixedFootprint, ddaLL128ArFootprintForBytes) come from
+// common/DdaFabricFootprints.hpp, so this file and DdaFabricEpochTests.cpp mirror
+// the launcher constants in one place (pinned to the real constants by
+// static_assert in DdaFabricEpochTests.cpp).
 
 // 4 * float32 = 16 B clears every non-scratch gate: %16 (AG/A2A), %8 (AR/RS),
 // all MaxBytes caps, op == ncclSum. So the scratch clause alone decides.
@@ -250,7 +251,7 @@ TEST_F(DdaFabricScratchTest, AllGather_LL128_FootprintScalesWithRanks) {
 
 TEST_F(DdaFabricScratchTest, AllReduce_LL128_FootprintGrowsWithMessage) {
     const int    nRanks     = mockComm_.comm.nRanks;
-    const size_t smallBytes = (size_t)kValidElemCount * sizeof(float); // 16 B
+    const size_t smallBytes = static_cast<size_t>(kValidElemCount) * sizeof(float); // 16 B
     const size_t bigCount   = 65536 / sizeof(float);                   // 64 KiB message
     const size_t bigBytes   = bigCount * sizeof(float);
 
@@ -274,7 +275,7 @@ TEST_F(DdaFabricScratchTest, AllReduce_LL128_EffectiveCapShrinksWithRanks) {
     // A message at the advertised cap (kDdaLL128ArMaxBytes = 1 GiB) is eligible
     // against the real buffer at a low rank count but not at kDdaMaxNranks,
     // because AR-LL128 scratch scales with nRanks * message.
-    const size_t oneGiB = (size_t)1 << 30;
+    const size_t oneGiB = static_cast<size_t>(1) << 30;
     const size_t count  = oneGiB / sizeof(float);
     mockComm_.comm.ddaScratchBytes = DDA_FABRIC_BUFFER_SIZE;
 

--- a/projects/rccl/test/DdaFabricScratchTests.cpp
+++ b/projects/rccl/test/DdaFabricScratchTests.cpp
@@ -9,22 +9,30 @@
 // every DDA fabric tier that is nominally enabled, and each tier's eligibility
 // predicate must fail closed (return false, i.e. fall back) when it is not.
 //
-// Whatever sizes the scratch buffer (a fixed value, or a derived one computed
-// from the DDA thresholds and rank count) is the producer; these tests pin the
-// consumer side, which lives in the eligibility predicates on this branch:
+// Whatever sizes the scratch buffer is the producer; these tests pin the
+// consumer side, which lives in the eligibility predicates:
 //   ncclAllReduceDdaFabricLL/LL128Eligible, and the AllGather/AllToAll/
-//   ReduceScatter counterparts (declared in dda_*.h). The existing
+//   ReduceScatter counterparts (declared in dda_*.h). The sibling
 //   DdaFabricEligibilityTests.cpp exercises only the umbrella *DdaFabricEligible
-//   predicates and only a single fixed mock scratch; it never calls the LL/LL128
-//   predicates nor varies scratch around a tier's footprint. This file fills
-//   those gaps:
+//   predicates and does not call these LL/LL128 predicates at all. This file
+//   fills that gap:
 //   - every LL/LL128 predicate is invoked and shown to gate on scratch capacity;
-//   - the scratch boundary is checked exactly (footprint vs footprint-16);
-//   - the fixed LL footprint is shown to scale with nRanks, so a scratch that
-//     suffices at a low rank count is correctly rejected at a high one.
+//   - the scratch boundary is checked exactly (footprint vs footprint-one-line);
+//   - the fixed LL/LL128 footprints are shown to scale with nRanks, so a scratch
+//     that suffices at a low rank count is correctly rejected at a high one;
+//   - LL128 AllReduce (the one message-dependent footprint) is shown to grow
+//     with the message and to have a rank-dependent effective cap.
+// The producer side of the same invariant (the shipped scratch buffer is large
+// enough for the fixed tiers) is asserted in DdaFabricEpochTests.cpp, which also
+// runs in Release CI.
 //
-// No GPU is required: the predicates are pure host checks over comm fields.
+// Target: rccl-UnitTestsFixturesDebug. The *DdaFabric{LL,LL128}Eligible
+// predicates are out-of-line definitions in librccl (hidden under Release
+// visibility), so this file must build in the Debug fixtures target, like its
+// sibling DdaFabricEligibilityTests.cpp. No GPU is required: the predicates are
+// pure host checks over comm fields.
 
+#include "common/DdaFabricFootprints.hpp"
 #include "common/DdaFabricTestHelpers.hpp"
 
 #include "dda_all_gather.h"
@@ -38,132 +46,266 @@ namespace RcclUnitTesting {
 
 namespace {
 
-// Fixed LL fabric scratch footprint, mirroring ddaLL{Ar,Ag,A2A,Rs}ScratchSize in
-// the launchers:  2 banks * nRanks slots * (kDdaLL*MaxBytes/8) pkts * 16B.
-// kDdaLL*MaxBytes is 128 KiB for every LL tier, so the footprint is a fixed
-// 512 KiB * nRanks, independent of the message size or configured LL threshold.
-// If the source constant changes, the exact-boundary tests below go red (the
-// real predicate uses the real constant), which is the intended drift alarm.
-constexpr size_t kLLMaxBytesPerRank = 131072; // mirrors meta::comms::kDdaLLArMaxBytes etc.
+// Footprint constants/helpers (kLLPacketBytes, kLL128LineBytes, ddaLLFixedFootprint,
+// ddaLL128FixedFootprint, ddaLL128ArFootprintForBytes) are shared via
+// DdaFabricTestHelpers.hpp so this file and DdaFabricEpochTests.cpp mirror the
+// launcher constants in one place.
 
-size_t llFootprint(int nRanks) {
-    return (size_t)2 * (size_t)nRanks * (kLLMaxBytesPerRank / 8) * 16;
-}
-
-// Larger than any tier's footprint at kDdaMaxNranks, so scratch is never the
-// limiting factor. Set explicitly rather than relying on the mock default.
-constexpr size_t kAmpleScratch = (size_t)16 << 30; // 16 GiB
+// 4 * float32 = 16 B clears every non-scratch gate: %16 (AG/A2A), %8 (AR/RS),
+// all MaxBytes caps, op == ncclSum. So the scratch clause alone decides.
+constexpr int    kValidElemCount  = 4;
+constexpr size_t kTooSmallScratch = 8; // below any tier footprint
 
 } // namespace
 
-class DdaFabricScratchTest : public ::testing::Test {
-protected:
-    DdaFabricMockComm mockComm_;
-    void*             sendbuff_{reinterpret_cast<void*>(0x1000)};
-    void*             recvbuff_{reinterpret_cast<void*>(0x2000)};
+// Fixture (mock comm + dummy buffers) is shared via DdaFabricTestHelpers.hpp.
+class DdaFabricScratchTest : public DdaFabricFixture {
 };
 
 // ---------------------------------------------------------------------------
 // Every LL / LL128 predicate is invoked and gates on scratch capacity
-// (ample -> eligible, too small -> ineligible). Uses minimal valid messages so
-// only the scratch check decides the outcome.
+// (ample -> eligible, too small -> ineligible). Ample is the real shipped
+// buffer, so the eligible arm asserts a reachable configuration.
 // ---------------------------------------------------------------------------
 
 TEST_F(DdaFabricScratchTest, AllReduce_LL_GatesOnScratchCapacity) {
-    mockComm_.comm.ddaScratchBytes = kAmpleScratch;
-    EXPECT_TRUE(ncclAllReduceDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32, ncclSum));
-    mockComm_.comm.ddaScratchBytes = 8;
-    EXPECT_FALSE(ncclAllReduceDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32, ncclSum));
+    mockComm_.comm.ddaScratchBytes = DDA_FABRIC_BUFFER_SIZE;
+    EXPECT_TRUE(
+        ncclAllReduceDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32, ncclSum));
+    mockComm_.comm.ddaScratchBytes = kTooSmallScratch;
+    EXPECT_FALSE(
+        ncclAllReduceDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32, ncclSum));
 }
 
 TEST_F(DdaFabricScratchTest, AllReduce_LL128_GatesOnScratchCapacity) {
-    mockComm_.comm.ddaScratchBytes = kAmpleScratch;
-    EXPECT_TRUE(ncclAllReduceDdaFabricLL128Eligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32, ncclSum));
-    mockComm_.comm.ddaScratchBytes = 8;
-    EXPECT_FALSE(ncclAllReduceDdaFabricLL128Eligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32, ncclSum));
+    mockComm_.comm.ddaScratchBytes = DDA_FABRIC_BUFFER_SIZE;
+    EXPECT_TRUE(ncclAllReduceDdaFabricLL128Eligible(
+        mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32, ncclSum));
+    mockComm_.comm.ddaScratchBytes = kTooSmallScratch;
+    EXPECT_FALSE(ncclAllReduceDdaFabricLL128Eligible(
+        mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32, ncclSum));
 }
 
 TEST_F(DdaFabricScratchTest, AllGather_LL_GatesOnScratchCapacity) {
-    mockComm_.comm.ddaScratchBytes = kAmpleScratch;
-    EXPECT_TRUE(ncclAllGatherDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32));
-    mockComm_.comm.ddaScratchBytes = 8;
-    EXPECT_FALSE(ncclAllGatherDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32));
+    mockComm_.comm.ddaScratchBytes = DDA_FABRIC_BUFFER_SIZE;
+    EXPECT_TRUE(ncclAllGatherDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32));
+    mockComm_.comm.ddaScratchBytes = kTooSmallScratch;
+    EXPECT_FALSE(ncclAllGatherDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32));
 }
 
 TEST_F(DdaFabricScratchTest, AllGather_LL128_GatesOnScratchCapacity) {
-    mockComm_.comm.ddaScratchBytes = kAmpleScratch;
-    EXPECT_TRUE(ncclAllGatherDdaFabricLL128Eligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32));
-    mockComm_.comm.ddaScratchBytes = 8;
-    EXPECT_FALSE(ncclAllGatherDdaFabricLL128Eligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32));
+    mockComm_.comm.ddaScratchBytes = DDA_FABRIC_BUFFER_SIZE;
+    EXPECT_TRUE(
+        ncclAllGatherDdaFabricLL128Eligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32));
+    mockComm_.comm.ddaScratchBytes = kTooSmallScratch;
+    EXPECT_FALSE(
+        ncclAllGatherDdaFabricLL128Eligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32));
 }
 
 TEST_F(DdaFabricScratchTest, AllToAll_LL_GatesOnScratchCapacity) {
-    mockComm_.comm.ddaScratchBytes = kAmpleScratch;
-    EXPECT_TRUE(ncclAllToAllDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32));
-    mockComm_.comm.ddaScratchBytes = 8;
-    EXPECT_FALSE(ncclAllToAllDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32));
+    mockComm_.comm.ddaScratchBytes = DDA_FABRIC_BUFFER_SIZE;
+    EXPECT_TRUE(ncclAllToAllDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32));
+    mockComm_.comm.ddaScratchBytes = kTooSmallScratch;
+    EXPECT_FALSE(ncclAllToAllDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32));
 }
 
 TEST_F(DdaFabricScratchTest, AllToAll_LL128_GatesOnScratchCapacity) {
-    mockComm_.comm.ddaScratchBytes = kAmpleScratch;
-    EXPECT_TRUE(ncclAllToAllDdaFabricLL128Eligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32));
-    mockComm_.comm.ddaScratchBytes = 8;
-    EXPECT_FALSE(ncclAllToAllDdaFabricLL128Eligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32));
+    mockComm_.comm.ddaScratchBytes = DDA_FABRIC_BUFFER_SIZE;
+    EXPECT_TRUE(
+        ncclAllToAllDdaFabricLL128Eligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32));
+    mockComm_.comm.ddaScratchBytes = kTooSmallScratch;
+    EXPECT_FALSE(
+        ncclAllToAllDdaFabricLL128Eligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32));
 }
 
 TEST_F(DdaFabricScratchTest, ReduceScatter_LL_GatesOnScratchCapacity) {
-    mockComm_.comm.ddaScratchBytes = kAmpleScratch;
-    EXPECT_TRUE(ncclReduceScatterDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32, ncclSum));
-    mockComm_.comm.ddaScratchBytes = 8;
-    EXPECT_FALSE(ncclReduceScatterDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32, ncclSum));
+    mockComm_.comm.ddaScratchBytes = DDA_FABRIC_BUFFER_SIZE;
+    EXPECT_TRUE(ncclReduceScatterDdaFabricLLEligible(
+        mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32, ncclSum));
+    mockComm_.comm.ddaScratchBytes = kTooSmallScratch;
+    EXPECT_FALSE(ncclReduceScatterDdaFabricLLEligible(
+        mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32, ncclSum));
 }
 
 TEST_F(DdaFabricScratchTest, ReduceScatter_LL128_GatesOnScratchCapacity) {
-    mockComm_.comm.ddaScratchBytes = kAmpleScratch;
-    EXPECT_TRUE(
-        ncclReduceScatterDdaFabricLL128Eligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32, ncclSum));
-    mockComm_.comm.ddaScratchBytes = 8;
-    EXPECT_FALSE(
-        ncclReduceScatterDdaFabricLL128Eligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32, ncclSum));
+    mockComm_.comm.ddaScratchBytes = DDA_FABRIC_BUFFER_SIZE;
+    EXPECT_TRUE(ncclReduceScatterDdaFabricLL128Eligible(
+        mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32, ncclSum));
+    mockComm_.comm.ddaScratchBytes = kTooSmallScratch;
+    EXPECT_FALSE(ncclReduceScatterDdaFabricLL128Eligible(
+        mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32, ncclSum));
 }
 
 // ---------------------------------------------------------------------------
-// Exact scratch boundary for the fixed LL footprint (512 KiB * nRanks): scratch
-// exactly equal to the footprint is eligible; one packet short is not.
+// Exact scratch boundary: scratch equal to the tier footprint is eligible; one
+// line/packet short is not. Covers all four LL tiers and the three fixed-stride
+// LL128 tiers. If a mirrored constant drifts from the real launcher constant,
+// these go red.
 // ---------------------------------------------------------------------------
 
 TEST_F(DdaFabricScratchTest, AllReduce_LL_ScratchBoundaryIsExact) {
-    const int nRanks               = mockComm_.comm.nRanks; // mock default (8)
-    mockComm_.comm.ddaScratchBytes = llFootprint(nRanks);
-    EXPECT_TRUE(ncclAllReduceDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32, ncclSum));
-    mockComm_.comm.ddaScratchBytes = llFootprint(nRanks) - 16;
-    EXPECT_FALSE(ncclAllReduceDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32, ncclSum));
+    const int nRanks               = mockComm_.comm.nRanks;
+    mockComm_.comm.ddaScratchBytes = ddaLLFixedFootprint(nRanks);
+    EXPECT_TRUE(
+        ncclAllReduceDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32, ncclSum));
+    mockComm_.comm.ddaScratchBytes = ddaLLFixedFootprint(nRanks) - kLLPacketBytes;
+    EXPECT_FALSE(
+        ncclAllReduceDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32, ncclSum));
 }
 
 TEST_F(DdaFabricScratchTest, AllGather_LL_ScratchBoundaryIsExact) {
     const int nRanks               = mockComm_.comm.nRanks;
-    mockComm_.comm.ddaScratchBytes = llFootprint(nRanks);
-    EXPECT_TRUE(ncclAllGatherDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32));
-    mockComm_.comm.ddaScratchBytes = llFootprint(nRanks) - 16;
-    EXPECT_FALSE(ncclAllGatherDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32));
+    mockComm_.comm.ddaScratchBytes = ddaLLFixedFootprint(nRanks);
+    EXPECT_TRUE(ncclAllGatherDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32));
+    mockComm_.comm.ddaScratchBytes = ddaLLFixedFootprint(nRanks) - kLLPacketBytes;
+    EXPECT_FALSE(ncclAllGatherDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32));
+}
+
+TEST_F(DdaFabricScratchTest, AllToAll_LL_ScratchBoundaryIsExact) {
+    const int nRanks               = mockComm_.comm.nRanks;
+    mockComm_.comm.ddaScratchBytes = ddaLLFixedFootprint(nRanks);
+    EXPECT_TRUE(ncclAllToAllDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32));
+    mockComm_.comm.ddaScratchBytes = ddaLLFixedFootprint(nRanks) - kLLPacketBytes;
+    EXPECT_FALSE(ncclAllToAllDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32));
+}
+
+TEST_F(DdaFabricScratchTest, ReduceScatter_LL_ScratchBoundaryIsExact) {
+    const int nRanks               = mockComm_.comm.nRanks;
+    mockComm_.comm.ddaScratchBytes = ddaLLFixedFootprint(nRanks);
+    EXPECT_TRUE(ncclReduceScatterDdaFabricLLEligible(
+        mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32, ncclSum));
+    mockComm_.comm.ddaScratchBytes = ddaLLFixedFootprint(nRanks) - kLLPacketBytes;
+    EXPECT_FALSE(ncclReduceScatterDdaFabricLLEligible(
+        mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32, ncclSum));
+}
+
+TEST_F(DdaFabricScratchTest, AllGather_LL128_ScratchBoundaryIsExact) {
+    const int nRanks               = mockComm_.comm.nRanks;
+    mockComm_.comm.ddaScratchBytes = ddaLL128FixedFootprint(nRanks);
+    EXPECT_TRUE(
+        ncclAllGatherDdaFabricLL128Eligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32));
+    mockComm_.comm.ddaScratchBytes = ddaLL128FixedFootprint(nRanks) - kLL128LineBytes;
+    EXPECT_FALSE(
+        ncclAllGatherDdaFabricLL128Eligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32));
+}
+
+TEST_F(DdaFabricScratchTest, AllToAll_LL128_ScratchBoundaryIsExact) {
+    const int nRanks               = mockComm_.comm.nRanks;
+    mockComm_.comm.ddaScratchBytes = ddaLL128FixedFootprint(nRanks);
+    EXPECT_TRUE(
+        ncclAllToAllDdaFabricLL128Eligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32));
+    mockComm_.comm.ddaScratchBytes = ddaLL128FixedFootprint(nRanks) - kLL128LineBytes;
+    EXPECT_FALSE(
+        ncclAllToAllDdaFabricLL128Eligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32));
+}
+
+TEST_F(DdaFabricScratchTest, ReduceScatter_LL128_ScratchBoundaryIsExact) {
+    const int nRanks               = mockComm_.comm.nRanks;
+    mockComm_.comm.ddaScratchBytes = ddaLL128FixedFootprint(nRanks);
+    EXPECT_TRUE(ncclReduceScatterDdaFabricLL128Eligible(
+        mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32, ncclSum));
+    mockComm_.comm.ddaScratchBytes = ddaLL128FixedFootprint(nRanks) - kLL128LineBytes;
+    EXPECT_FALSE(ncclReduceScatterDdaFabricLL128Eligible(
+        mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32, ncclSum));
 }
 
 // ---------------------------------------------------------------------------
-// The fixed LL footprint scales with nRanks, so a scratch that is exactly
-// enough at a low rank count must be rejected at a high one. This is the shape
-// of the under-provisioning risk: a scratch not sized per rank count silently
-// disables the tier at scale.
+// Fixed footprints scale with nRanks: a scratch that is exactly enough at a low
+// rank count must be rejected at kDdaMaxNranks. This is the shape of the
+// under-provisioning risk: a scratch not sized per rank count silently disables
+// the tier at scale.
 // ---------------------------------------------------------------------------
 
 TEST_F(DdaFabricScratchTest, AllReduce_LL_FootprintScalesWithRanks) {
-    mockComm_.comm.ddaScratchBytes = llFootprint(2); // enough for 2 ranks only
+    mockComm_.comm.ddaScratchBytes = ddaLLFixedFootprint(2); // enough for 2 ranks only
 
     mockComm_.comm.nRanks = 2;
-    EXPECT_TRUE(ncclAllReduceDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32, ncclSum));
+    EXPECT_TRUE(
+        ncclAllReduceDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32, ncclSum));
 
     mockComm_.comm.nRanks = meta::comms::kDdaMaxNranks;
-    EXPECT_FALSE(ncclAllReduceDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32, ncclSum))
+    EXPECT_FALSE(
+        ncclAllReduceDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32, ncclSum))
         << "a scratch sized for 2 ranks must not satisfy " << meta::comms::kDdaMaxNranks << " ranks";
+}
+
+TEST_F(DdaFabricScratchTest, AllGather_LL128_FootprintScalesWithRanks) {
+    mockComm_.comm.ddaScratchBytes = ddaLL128FixedFootprint(2); // enough for 2 ranks only
+
+    mockComm_.comm.nRanks = 2;
+    EXPECT_TRUE(
+        ncclAllGatherDdaFabricLL128Eligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32));
+
+    mockComm_.comm.nRanks = meta::comms::kDdaMaxNranks;
+    EXPECT_FALSE(
+        ncclAllGatherDdaFabricLL128Eligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32))
+        << "a scratch sized for 2 ranks must not satisfy " << meta::comms::kDdaMaxNranks << " ranks";
+}
+
+// ---------------------------------------------------------------------------
+// LL128 AllReduce is the one message-dependent footprint: its required scratch
+// grows with the message, and (against a fixed buffer) its effective message cap
+// therefore shrinks as nRanks grows.
+// ---------------------------------------------------------------------------
+
+TEST_F(DdaFabricScratchTest, AllReduce_LL128_FootprintGrowsWithMessage) {
+    const int    nRanks     = mockComm_.comm.nRanks;
+    const size_t smallBytes = (size_t)kValidElemCount * sizeof(float); // 16 B
+    const size_t bigCount   = 65536 / sizeof(float);                   // 64 KiB message
+    const size_t bigBytes   = bigCount * sizeof(float);
+
+    // Scratch sized for the small message: small message eligible, 64 KiB not.
+    mockComm_.comm.ddaScratchBytes = ddaLL128ArFootprintForBytes(nRanks, smallBytes);
+    EXPECT_TRUE(ncclAllReduceDdaFabricLL128Eligible(
+        mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32, ncclSum));
+    EXPECT_FALSE(
+        ncclAllReduceDdaFabricLL128Eligible(mockComm_.get(), sendbuff_, recvbuff_, bigCount, ncclFloat32, ncclSum));
+
+    // Grow scratch to the 64 KiB footprint (exact boundary): now eligible.
+    mockComm_.comm.ddaScratchBytes = ddaLL128ArFootprintForBytes(nRanks, bigBytes);
+    EXPECT_TRUE(
+        ncclAllReduceDdaFabricLL128Eligible(mockComm_.get(), sendbuff_, recvbuff_, bigCount, ncclFloat32, ncclSum));
+    mockComm_.comm.ddaScratchBytes = ddaLL128ArFootprintForBytes(nRanks, bigBytes) - kLL128LineBytes;
+    EXPECT_FALSE(
+        ncclAllReduceDdaFabricLL128Eligible(mockComm_.get(), sendbuff_, recvbuff_, bigCount, ncclFloat32, ncclSum));
+}
+
+TEST_F(DdaFabricScratchTest, AllReduce_LL128_EffectiveCapShrinksWithRanks) {
+    // A message at the advertised cap (kDdaLL128ArMaxBytes = 1 GiB) is eligible
+    // against the real buffer at a low rank count but not at kDdaMaxNranks,
+    // because AR-LL128 scratch scales with nRanks * message.
+    const size_t oneGiB = (size_t)1 << 30;
+    const size_t count  = oneGiB / sizeof(float);
+    mockComm_.comm.ddaScratchBytes = DDA_FABRIC_BUFFER_SIZE;
+
+    mockComm_.comm.nRanks = 2;
+    EXPECT_TRUE(
+        ncclAllReduceDdaFabricLL128Eligible(mockComm_.get(), sendbuff_, recvbuff_, count, ncclFloat32, ncclSum));
+
+    mockComm_.comm.nRanks = meta::comms::kDdaMaxNranks;
+    EXPECT_FALSE(
+        ncclAllReduceDdaFabricLL128Eligible(mockComm_.get(), sendbuff_, recvbuff_, count, ncclFloat32, ncclSum))
+        << "the 1 GiB AR-LL128 cap is not reachable at " << meta::comms::kDdaMaxNranks
+        << " ranks against a fixed scratch buffer";
+}
+
+// ---------------------------------------------------------------------------
+// Count-side gates that precede the scratch check.
+// ---------------------------------------------------------------------------
+
+// The per-message alignment gate differs across siblings: AR/RS require %8, AG/A2A
+// require %16. count=2 float32 (8 B) is aligned for AR-LL but not AG-LL.
+TEST_F(DdaFabricScratchTest, AlignmentGateDiffersAcrossCollectives) {
+    mockComm_.comm.ddaScratchBytes = DDA_FABRIC_BUFFER_SIZE;
+    EXPECT_TRUE(ncclAllReduceDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, 2, ncclFloat32, ncclSum));
+    EXPECT_FALSE(ncclAllGatherDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, 2, ncclFloat32));
+}
+
+// A zero count is rejected before the scratch check, even with ample scratch.
+TEST_F(DdaFabricScratchTest, ZeroCountIneligibleRegardlessOfScratch) {
+    mockComm_.comm.ddaScratchBytes = DDA_FABRIC_BUFFER_SIZE;
+    EXPECT_FALSE(ncclAllReduceDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, 0, ncclFloat32, ncclSum));
+    EXPECT_FALSE(ncclAllGatherDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, 0, ncclFloat32));
 }
 
 } // namespace RcclUnitTesting

--- a/projects/rccl/test/DdaFabricScratchTests.cpp
+++ b/projects/rccl/test/DdaFabricScratchTests.cpp
@@ -299,7 +299,7 @@ TEST_F(DdaFabricScratchTest, AllReduce_LL128_EffectiveCapShrinksWithRanks)
     // A message at the advertised cap (kDdaLL128ArMaxBytes = 1 GiB) is eligible
     // against the real buffer at a low rank count but not at kDdaMaxNranks,
     // because AR-LL128 scratch scales with nRanks * message.
-    const size_t oneGiB = static_cast<size_t>(1) << 30;
+    const size_t oneGiB = kLL128ArMaxBytes; // 1 GiB, pinned to kDdaLL128ArMaxBytes
     const size_t count  = oneGiB / sizeof(float);
     mockComm_.comm.ddaScratchBytes = kAmpleScratch;
 

--- a/projects/rccl/test/DdaFabricScratchTests.cpp
+++ b/projects/rccl/test/DdaFabricScratchTests.cpp
@@ -1,0 +1,169 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Host-side tests for the DDA fabric scratch-capacity contract: the single
+// per-comm scratch buffer (comm->ddaScratchBytes) must be large enough for
+// every DDA fabric tier that is nominally enabled, and each tier's eligibility
+// predicate must fail closed (return false, i.e. fall back) when it is not.
+//
+// Whatever sizes the scratch buffer (a fixed value, or a derived one computed
+// from the DDA thresholds and rank count) is the producer; these tests pin the
+// consumer side, which lives in the eligibility predicates on this branch:
+//   ncclAllReduceDdaFabricLL/LL128Eligible, and the AllGather/AllToAll/
+//   ReduceScatter counterparts (declared in dda_*.h). The existing
+//   DdaFabricEligibilityTests.cpp exercises only the umbrella *DdaFabricEligible
+//   predicates and only a single fixed mock scratch; it never calls the LL/LL128
+//   predicates nor varies scratch around a tier's footprint. This file fills
+//   those gaps:
+//   - every LL/LL128 predicate is invoked and shown to gate on scratch capacity;
+//   - the scratch boundary is checked exactly (footprint vs footprint-16);
+//   - the fixed LL footprint is shown to scale with nRanks, so a scratch that
+//     suffices at a low rank count is correctly rejected at a high one.
+//
+// No GPU is required: the predicates are pure host checks over comm fields.
+
+#include "common/DdaFabricTestHelpers.hpp"
+
+#include "dda_all_gather.h"
+#include "dda_all_reduce.h"
+#include "dda_alltoall.h"
+#include "dda_reduce_scatter.h"
+#include "fabric_gpu_barrier.h"
+#include "gtest/gtest.h"
+
+namespace RcclUnitTesting {
+
+namespace {
+
+// Fixed LL fabric scratch footprint, mirroring ddaLL{Ar,Ag,A2A,Rs}ScratchSize in
+// the launchers:  2 banks * nRanks slots * (kDdaLL*MaxBytes/8) pkts * 16B.
+// kDdaLL*MaxBytes is 128 KiB for every LL tier, so the footprint is a fixed
+// 512 KiB * nRanks, independent of the message size or configured LL threshold.
+// If the source constant changes, the exact-boundary tests below go red (the
+// real predicate uses the real constant), which is the intended drift alarm.
+constexpr size_t kLLMaxBytesPerRank = 131072; // mirrors meta::comms::kDdaLLArMaxBytes etc.
+
+size_t llFootprint(int nRanks) {
+    return (size_t)2 * (size_t)nRanks * (kLLMaxBytesPerRank / 8) * 16;
+}
+
+// Larger than any tier's footprint at kDdaMaxNranks, so scratch is never the
+// limiting factor. Set explicitly rather than relying on the mock default.
+constexpr size_t kAmpleScratch = (size_t)16 << 30; // 16 GiB
+
+} // namespace
+
+class DdaFabricScratchTest : public ::testing::Test {
+protected:
+    DdaFabricMockComm mockComm_;
+    void*             sendbuff_{reinterpret_cast<void*>(0x1000)};
+    void*             recvbuff_{reinterpret_cast<void*>(0x2000)};
+};
+
+// ---------------------------------------------------------------------------
+// Every LL / LL128 predicate is invoked and gates on scratch capacity
+// (ample -> eligible, too small -> ineligible). Uses minimal valid messages so
+// only the scratch check decides the outcome.
+// ---------------------------------------------------------------------------
+
+TEST_F(DdaFabricScratchTest, AllReduce_LL_GatesOnScratchCapacity) {
+    mockComm_.comm.ddaScratchBytes = kAmpleScratch;
+    EXPECT_TRUE(ncclAllReduceDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32, ncclSum));
+    mockComm_.comm.ddaScratchBytes = 8;
+    EXPECT_FALSE(ncclAllReduceDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32, ncclSum));
+}
+
+TEST_F(DdaFabricScratchTest, AllReduce_LL128_GatesOnScratchCapacity) {
+    mockComm_.comm.ddaScratchBytes = kAmpleScratch;
+    EXPECT_TRUE(ncclAllReduceDdaFabricLL128Eligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32, ncclSum));
+    mockComm_.comm.ddaScratchBytes = 8;
+    EXPECT_FALSE(ncclAllReduceDdaFabricLL128Eligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32, ncclSum));
+}
+
+TEST_F(DdaFabricScratchTest, AllGather_LL_GatesOnScratchCapacity) {
+    mockComm_.comm.ddaScratchBytes = kAmpleScratch;
+    EXPECT_TRUE(ncclAllGatherDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32));
+    mockComm_.comm.ddaScratchBytes = 8;
+    EXPECT_FALSE(ncclAllGatherDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32));
+}
+
+TEST_F(DdaFabricScratchTest, AllGather_LL128_GatesOnScratchCapacity) {
+    mockComm_.comm.ddaScratchBytes = kAmpleScratch;
+    EXPECT_TRUE(ncclAllGatherDdaFabricLL128Eligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32));
+    mockComm_.comm.ddaScratchBytes = 8;
+    EXPECT_FALSE(ncclAllGatherDdaFabricLL128Eligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32));
+}
+
+TEST_F(DdaFabricScratchTest, AllToAll_LL_GatesOnScratchCapacity) {
+    mockComm_.comm.ddaScratchBytes = kAmpleScratch;
+    EXPECT_TRUE(ncclAllToAllDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32));
+    mockComm_.comm.ddaScratchBytes = 8;
+    EXPECT_FALSE(ncclAllToAllDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32));
+}
+
+TEST_F(DdaFabricScratchTest, AllToAll_LL128_GatesOnScratchCapacity) {
+    mockComm_.comm.ddaScratchBytes = kAmpleScratch;
+    EXPECT_TRUE(ncclAllToAllDdaFabricLL128Eligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32));
+    mockComm_.comm.ddaScratchBytes = 8;
+    EXPECT_FALSE(ncclAllToAllDdaFabricLL128Eligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32));
+}
+
+TEST_F(DdaFabricScratchTest, ReduceScatter_LL_GatesOnScratchCapacity) {
+    mockComm_.comm.ddaScratchBytes = kAmpleScratch;
+    EXPECT_TRUE(ncclReduceScatterDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32, ncclSum));
+    mockComm_.comm.ddaScratchBytes = 8;
+    EXPECT_FALSE(ncclReduceScatterDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32, ncclSum));
+}
+
+TEST_F(DdaFabricScratchTest, ReduceScatter_LL128_GatesOnScratchCapacity) {
+    mockComm_.comm.ddaScratchBytes = kAmpleScratch;
+    EXPECT_TRUE(
+        ncclReduceScatterDdaFabricLL128Eligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32, ncclSum));
+    mockComm_.comm.ddaScratchBytes = 8;
+    EXPECT_FALSE(
+        ncclReduceScatterDdaFabricLL128Eligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32, ncclSum));
+}
+
+// ---------------------------------------------------------------------------
+// Exact scratch boundary for the fixed LL footprint (512 KiB * nRanks): scratch
+// exactly equal to the footprint is eligible; one packet short is not.
+// ---------------------------------------------------------------------------
+
+TEST_F(DdaFabricScratchTest, AllReduce_LL_ScratchBoundaryIsExact) {
+    const int nRanks               = mockComm_.comm.nRanks; // mock default (8)
+    mockComm_.comm.ddaScratchBytes = llFootprint(nRanks);
+    EXPECT_TRUE(ncclAllReduceDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32, ncclSum));
+    mockComm_.comm.ddaScratchBytes = llFootprint(nRanks) - 16;
+    EXPECT_FALSE(ncclAllReduceDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32, ncclSum));
+}
+
+TEST_F(DdaFabricScratchTest, AllGather_LL_ScratchBoundaryIsExact) {
+    const int nRanks               = mockComm_.comm.nRanks;
+    mockComm_.comm.ddaScratchBytes = llFootprint(nRanks);
+    EXPECT_TRUE(ncclAllGatherDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32));
+    mockComm_.comm.ddaScratchBytes = llFootprint(nRanks) - 16;
+    EXPECT_FALSE(ncclAllGatherDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32));
+}
+
+// ---------------------------------------------------------------------------
+// The fixed LL footprint scales with nRanks, so a scratch that is exactly
+// enough at a low rank count must be rejected at a high one. This is the shape
+// of the under-provisioning risk: a scratch not sized per rank count silently
+// disables the tier at scale.
+// ---------------------------------------------------------------------------
+
+TEST_F(DdaFabricScratchTest, AllReduce_LL_FootprintScalesWithRanks) {
+    mockComm_.comm.ddaScratchBytes = llFootprint(2); // enough for 2 ranks only
+
+    mockComm_.comm.nRanks = 2;
+    EXPECT_TRUE(ncclAllReduceDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32, ncclSum));
+
+    mockComm_.comm.nRanks = meta::comms::kDdaMaxNranks;
+    EXPECT_FALSE(ncclAllReduceDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32, ncclSum))
+        << "a scratch sized for 2 ranks must not satisfy " << meta::comms::kDdaMaxNranks << " ranks";
+}
+
+} // namespace RcclUnitTesting

--- a/projects/rccl/test/DdaFabricScratchTests.cpp
+++ b/projects/rccl/test/DdaFabricScratchTests.cpp
@@ -43,9 +43,11 @@
 #include "fabric_gpu_barrier.h"
 #include "gtest/gtest.h"
 
-namespace RcclUnitTesting {
+namespace RcclUnitTesting
+{
 
-namespace {
+namespace
+{
 
 // Footprint constants/helpers (kLLPacketBytes, kLL128LineBytes, ddaLLFixedFootprint,
 // ddaLL128FixedFootprint, ddaLL128ArFootprintForBytes) come from
@@ -62,7 +64,8 @@ constexpr size_t kAmpleScratch    = DDA_FABRIC_BUFFER_SIZE;  // the shipped scra
 } // namespace
 
 // Fixture (mock comm + dummy buffers) is shared via DdaFabricTestHelpers.hpp.
-class DdaFabricScratchTest : public DdaFabricFixture {
+class DdaFabricScratchTest : public DdaFabricFixture
+{
 };
 
 // ---------------------------------------------------------------------------
@@ -71,7 +74,8 @@ class DdaFabricScratchTest : public DdaFabricFixture {
 // buffer, so the eligible arm asserts a reachable configuration.
 // ---------------------------------------------------------------------------
 
-TEST_F(DdaFabricScratchTest, AllReduce_LL_GatesOnScratchCapacity) {
+TEST_F(DdaFabricScratchTest, AllReduce_LL_GatesOnScratchCapacity)
+{
     mockComm_.comm.ddaScratchBytes = kAmpleScratch;
     EXPECT_TRUE(
         ncclAllReduceDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32, ncclSum));
@@ -80,7 +84,8 @@ TEST_F(DdaFabricScratchTest, AllReduce_LL_GatesOnScratchCapacity) {
         ncclAllReduceDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32, ncclSum));
 }
 
-TEST_F(DdaFabricScratchTest, AllReduce_LL128_GatesOnScratchCapacity) {
+TEST_F(DdaFabricScratchTest, AllReduce_LL128_GatesOnScratchCapacity)
+{
     mockComm_.comm.ddaScratchBytes = kAmpleScratch;
     EXPECT_TRUE(ncclAllReduceDdaFabricLL128Eligible(
         mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32, ncclSum));
@@ -89,14 +94,16 @@ TEST_F(DdaFabricScratchTest, AllReduce_LL128_GatesOnScratchCapacity) {
         mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32, ncclSum));
 }
 
-TEST_F(DdaFabricScratchTest, AllGather_LL_GatesOnScratchCapacity) {
+TEST_F(DdaFabricScratchTest, AllGather_LL_GatesOnScratchCapacity)
+{
     mockComm_.comm.ddaScratchBytes = kAmpleScratch;
     EXPECT_TRUE(ncclAllGatherDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32));
     mockComm_.comm.ddaScratchBytes = kTooSmallScratch;
     EXPECT_FALSE(ncclAllGatherDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32));
 }
 
-TEST_F(DdaFabricScratchTest, AllGather_LL128_GatesOnScratchCapacity) {
+TEST_F(DdaFabricScratchTest, AllGather_LL128_GatesOnScratchCapacity)
+{
     mockComm_.comm.ddaScratchBytes = kAmpleScratch;
     EXPECT_TRUE(
         ncclAllGatherDdaFabricLL128Eligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32));
@@ -105,14 +112,16 @@ TEST_F(DdaFabricScratchTest, AllGather_LL128_GatesOnScratchCapacity) {
         ncclAllGatherDdaFabricLL128Eligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32));
 }
 
-TEST_F(DdaFabricScratchTest, AllToAll_LL_GatesOnScratchCapacity) {
+TEST_F(DdaFabricScratchTest, AllToAll_LL_GatesOnScratchCapacity)
+{
     mockComm_.comm.ddaScratchBytes = kAmpleScratch;
     EXPECT_TRUE(ncclAllToAllDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32));
     mockComm_.comm.ddaScratchBytes = kTooSmallScratch;
     EXPECT_FALSE(ncclAllToAllDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32));
 }
 
-TEST_F(DdaFabricScratchTest, AllToAll_LL128_GatesOnScratchCapacity) {
+TEST_F(DdaFabricScratchTest, AllToAll_LL128_GatesOnScratchCapacity)
+{
     mockComm_.comm.ddaScratchBytes = kAmpleScratch;
     EXPECT_TRUE(
         ncclAllToAllDdaFabricLL128Eligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32));
@@ -121,7 +130,8 @@ TEST_F(DdaFabricScratchTest, AllToAll_LL128_GatesOnScratchCapacity) {
         ncclAllToAllDdaFabricLL128Eligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32));
 }
 
-TEST_F(DdaFabricScratchTest, ReduceScatter_LL_GatesOnScratchCapacity) {
+TEST_F(DdaFabricScratchTest, ReduceScatter_LL_GatesOnScratchCapacity)
+{
     mockComm_.comm.ddaScratchBytes = kAmpleScratch;
     EXPECT_TRUE(ncclReduceScatterDdaFabricLLEligible(
         mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32, ncclSum));
@@ -130,7 +140,8 @@ TEST_F(DdaFabricScratchTest, ReduceScatter_LL_GatesOnScratchCapacity) {
         mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32, ncclSum));
 }
 
-TEST_F(DdaFabricScratchTest, ReduceScatter_LL128_GatesOnScratchCapacity) {
+TEST_F(DdaFabricScratchTest, ReduceScatter_LL128_GatesOnScratchCapacity)
+{
     mockComm_.comm.ddaScratchBytes = kAmpleScratch;
     EXPECT_TRUE(ncclReduceScatterDdaFabricLL128Eligible(
         mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32, ncclSum));
@@ -146,7 +157,8 @@ TEST_F(DdaFabricScratchTest, ReduceScatter_LL128_GatesOnScratchCapacity) {
 // these go red.
 // ---------------------------------------------------------------------------
 
-TEST_F(DdaFabricScratchTest, AllReduce_LL_ScratchBoundaryIsExact) {
+TEST_F(DdaFabricScratchTest, AllReduce_LL_ScratchBoundaryIsExact)
+{
     const int nRanks               = mockComm_.comm.nRanks;
     mockComm_.comm.ddaScratchBytes = ddaLLFixedFootprint(nRanks);
     EXPECT_TRUE(
@@ -156,7 +168,8 @@ TEST_F(DdaFabricScratchTest, AllReduce_LL_ScratchBoundaryIsExact) {
         ncclAllReduceDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32, ncclSum));
 }
 
-TEST_F(DdaFabricScratchTest, AllGather_LL_ScratchBoundaryIsExact) {
+TEST_F(DdaFabricScratchTest, AllGather_LL_ScratchBoundaryIsExact)
+{
     const int nRanks               = mockComm_.comm.nRanks;
     mockComm_.comm.ddaScratchBytes = ddaLLFixedFootprint(nRanks);
     EXPECT_TRUE(ncclAllGatherDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32));
@@ -164,7 +177,8 @@ TEST_F(DdaFabricScratchTest, AllGather_LL_ScratchBoundaryIsExact) {
     EXPECT_FALSE(ncclAllGatherDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32));
 }
 
-TEST_F(DdaFabricScratchTest, AllToAll_LL_ScratchBoundaryIsExact) {
+TEST_F(DdaFabricScratchTest, AllToAll_LL_ScratchBoundaryIsExact)
+{
     const int nRanks               = mockComm_.comm.nRanks;
     mockComm_.comm.ddaScratchBytes = ddaLLFixedFootprint(nRanks);
     EXPECT_TRUE(ncclAllToAllDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32));
@@ -172,7 +186,8 @@ TEST_F(DdaFabricScratchTest, AllToAll_LL_ScratchBoundaryIsExact) {
     EXPECT_FALSE(ncclAllToAllDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32));
 }
 
-TEST_F(DdaFabricScratchTest, ReduceScatter_LL_ScratchBoundaryIsExact) {
+TEST_F(DdaFabricScratchTest, ReduceScatter_LL_ScratchBoundaryIsExact)
+{
     const int nRanks               = mockComm_.comm.nRanks;
     mockComm_.comm.ddaScratchBytes = ddaLLFixedFootprint(nRanks);
     EXPECT_TRUE(ncclReduceScatterDdaFabricLLEligible(
@@ -182,7 +197,8 @@ TEST_F(DdaFabricScratchTest, ReduceScatter_LL_ScratchBoundaryIsExact) {
         mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32, ncclSum));
 }
 
-TEST_F(DdaFabricScratchTest, AllGather_LL128_ScratchBoundaryIsExact) {
+TEST_F(DdaFabricScratchTest, AllGather_LL128_ScratchBoundaryIsExact)
+{
     const int nRanks               = mockComm_.comm.nRanks;
     mockComm_.comm.ddaScratchBytes = ddaLL128FixedFootprint(nRanks);
     EXPECT_TRUE(
@@ -192,7 +208,8 @@ TEST_F(DdaFabricScratchTest, AllGather_LL128_ScratchBoundaryIsExact) {
         ncclAllGatherDdaFabricLL128Eligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32));
 }
 
-TEST_F(DdaFabricScratchTest, AllToAll_LL128_ScratchBoundaryIsExact) {
+TEST_F(DdaFabricScratchTest, AllToAll_LL128_ScratchBoundaryIsExact)
+{
     const int nRanks               = mockComm_.comm.nRanks;
     mockComm_.comm.ddaScratchBytes = ddaLL128FixedFootprint(nRanks);
     EXPECT_TRUE(
@@ -202,7 +219,8 @@ TEST_F(DdaFabricScratchTest, AllToAll_LL128_ScratchBoundaryIsExact) {
         ncclAllToAllDdaFabricLL128Eligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32));
 }
 
-TEST_F(DdaFabricScratchTest, ReduceScatter_LL128_ScratchBoundaryIsExact) {
+TEST_F(DdaFabricScratchTest, ReduceScatter_LL128_ScratchBoundaryIsExact)
+{
     const int nRanks               = mockComm_.comm.nRanks;
     mockComm_.comm.ddaScratchBytes = ddaLL128FixedFootprint(nRanks);
     EXPECT_TRUE(ncclReduceScatterDdaFabricLL128Eligible(
@@ -219,7 +237,8 @@ TEST_F(DdaFabricScratchTest, ReduceScatter_LL128_ScratchBoundaryIsExact) {
 // the tier at scale.
 // ---------------------------------------------------------------------------
 
-TEST_F(DdaFabricScratchTest, AllReduce_LL_FootprintScalesWithRanks) {
+TEST_F(DdaFabricScratchTest, AllReduce_LL_FootprintScalesWithRanks)
+{
     mockComm_.comm.ddaScratchBytes = ddaLLFixedFootprint(2); // enough for 2 ranks only
 
     mockComm_.comm.nRanks = 2;
@@ -232,7 +251,8 @@ TEST_F(DdaFabricScratchTest, AllReduce_LL_FootprintScalesWithRanks) {
         << "a scratch sized for 2 ranks must not satisfy " << meta::comms::kDdaMaxNranks << " ranks";
 }
 
-TEST_F(DdaFabricScratchTest, AllGather_LL128_FootprintScalesWithRanks) {
+TEST_F(DdaFabricScratchTest, AllGather_LL128_FootprintScalesWithRanks)
+{
     mockComm_.comm.ddaScratchBytes = ddaLL128FixedFootprint(2); // enough for 2 ranks only
 
     mockComm_.comm.nRanks = 2;
@@ -251,7 +271,8 @@ TEST_F(DdaFabricScratchTest, AllGather_LL128_FootprintScalesWithRanks) {
 // therefore shrinks as nRanks grows.
 // ---------------------------------------------------------------------------
 
-TEST_F(DdaFabricScratchTest, AllReduce_LL128_FootprintGrowsWithMessage) {
+TEST_F(DdaFabricScratchTest, AllReduce_LL128_FootprintGrowsWithMessage)
+{
     const int    nRanks     = mockComm_.comm.nRanks;
     const size_t smallBytes = static_cast<size_t>(kValidElemCount) * sizeof(float); // 16 B
     const size_t bigCount   = 65536 / sizeof(float);                   // 64 KiB message
@@ -273,7 +294,8 @@ TEST_F(DdaFabricScratchTest, AllReduce_LL128_FootprintGrowsWithMessage) {
         ncclAllReduceDdaFabricLL128Eligible(mockComm_.get(), sendbuff_, recvbuff_, bigCount, ncclFloat32, ncclSum));
 }
 
-TEST_F(DdaFabricScratchTest, AllReduce_LL128_EffectiveCapShrinksWithRanks) {
+TEST_F(DdaFabricScratchTest, AllReduce_LL128_EffectiveCapShrinksWithRanks)
+{
     // A message at the advertised cap (kDdaLL128ArMaxBytes = 1 GiB) is eligible
     // against the real buffer at a low rank count but not at kDdaMaxNranks,
     // because AR-LL128 scratch scales with nRanks * message.
@@ -298,14 +320,16 @@ TEST_F(DdaFabricScratchTest, AllReduce_LL128_EffectiveCapShrinksWithRanks) {
 
 // The per-message alignment gate differs across siblings: AR/RS require %8, AG/A2A
 // require %16. count=2 float32 (8 B) is aligned for AR-LL but not AG-LL.
-TEST_F(DdaFabricScratchTest, AlignmentGateDiffersAcrossCollectives) {
+TEST_F(DdaFabricScratchTest, AlignmentGateDiffersAcrossCollectives)
+{
     mockComm_.comm.ddaScratchBytes = kAmpleScratch;
     EXPECT_TRUE(ncclAllReduceDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, 2, ncclFloat32, ncclSum));
     EXPECT_FALSE(ncclAllGatherDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, 2, ncclFloat32));
 }
 
 // A zero count is rejected before the scratch check, even with ample scratch.
-TEST_F(DdaFabricScratchTest, ZeroCountIneligibleRegardlessOfScratch) {
+TEST_F(DdaFabricScratchTest, ZeroCountIneligibleRegardlessOfScratch)
+{
     mockComm_.comm.ddaScratchBytes = kAmpleScratch;
     EXPECT_FALSE(ncclAllReduceDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, 0, ncclFloat32, ncclSum));
     EXPECT_FALSE(ncclAllGatherDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, 0, ncclFloat32));

--- a/projects/rccl/test/DdaFabricScratchTests.cpp
+++ b/projects/rccl/test/DdaFabricScratchTests.cpp
@@ -35,6 +35,7 @@
 #include "common/DdaFabricFootprints.hpp"
 #include "common/DdaFabricTestHelpers.hpp"
 
+#include "dda_init_detail.h" // DDA_FABRIC_BUFFER_SIZE (the shipped scratch size)
 #include "dda_all_gather.h"
 #include "dda_all_reduce.h"
 #include "dda_alltoall.h"
@@ -55,7 +56,8 @@ namespace {
 // 4 * float32 = 16 B clears every non-scratch gate: %16 (AG/A2A), %8 (AR/RS),
 // all MaxBytes caps, op == ncclSum. So the scratch clause alone decides.
 constexpr int    kValidElemCount  = 4;
-constexpr size_t kTooSmallScratch = 8; // below any tier footprint
+constexpr size_t kTooSmallScratch = 8;                       // below any tier footprint
+constexpr size_t kAmpleScratch    = DDA_FABRIC_BUFFER_SIZE;  // the shipped scratch buffer
 
 } // namespace
 
@@ -70,7 +72,7 @@ class DdaFabricScratchTest : public DdaFabricFixture {
 // ---------------------------------------------------------------------------
 
 TEST_F(DdaFabricScratchTest, AllReduce_LL_GatesOnScratchCapacity) {
-    mockComm_.comm.ddaScratchBytes = DDA_FABRIC_BUFFER_SIZE;
+    mockComm_.comm.ddaScratchBytes = kAmpleScratch;
     EXPECT_TRUE(
         ncclAllReduceDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32, ncclSum));
     mockComm_.comm.ddaScratchBytes = kTooSmallScratch;
@@ -79,7 +81,7 @@ TEST_F(DdaFabricScratchTest, AllReduce_LL_GatesOnScratchCapacity) {
 }
 
 TEST_F(DdaFabricScratchTest, AllReduce_LL128_GatesOnScratchCapacity) {
-    mockComm_.comm.ddaScratchBytes = DDA_FABRIC_BUFFER_SIZE;
+    mockComm_.comm.ddaScratchBytes = kAmpleScratch;
     EXPECT_TRUE(ncclAllReduceDdaFabricLL128Eligible(
         mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32, ncclSum));
     mockComm_.comm.ddaScratchBytes = kTooSmallScratch;
@@ -88,14 +90,14 @@ TEST_F(DdaFabricScratchTest, AllReduce_LL128_GatesOnScratchCapacity) {
 }
 
 TEST_F(DdaFabricScratchTest, AllGather_LL_GatesOnScratchCapacity) {
-    mockComm_.comm.ddaScratchBytes = DDA_FABRIC_BUFFER_SIZE;
+    mockComm_.comm.ddaScratchBytes = kAmpleScratch;
     EXPECT_TRUE(ncclAllGatherDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32));
     mockComm_.comm.ddaScratchBytes = kTooSmallScratch;
     EXPECT_FALSE(ncclAllGatherDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32));
 }
 
 TEST_F(DdaFabricScratchTest, AllGather_LL128_GatesOnScratchCapacity) {
-    mockComm_.comm.ddaScratchBytes = DDA_FABRIC_BUFFER_SIZE;
+    mockComm_.comm.ddaScratchBytes = kAmpleScratch;
     EXPECT_TRUE(
         ncclAllGatherDdaFabricLL128Eligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32));
     mockComm_.comm.ddaScratchBytes = kTooSmallScratch;
@@ -104,14 +106,14 @@ TEST_F(DdaFabricScratchTest, AllGather_LL128_GatesOnScratchCapacity) {
 }
 
 TEST_F(DdaFabricScratchTest, AllToAll_LL_GatesOnScratchCapacity) {
-    mockComm_.comm.ddaScratchBytes = DDA_FABRIC_BUFFER_SIZE;
+    mockComm_.comm.ddaScratchBytes = kAmpleScratch;
     EXPECT_TRUE(ncclAllToAllDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32));
     mockComm_.comm.ddaScratchBytes = kTooSmallScratch;
     EXPECT_FALSE(ncclAllToAllDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32));
 }
 
 TEST_F(DdaFabricScratchTest, AllToAll_LL128_GatesOnScratchCapacity) {
-    mockComm_.comm.ddaScratchBytes = DDA_FABRIC_BUFFER_SIZE;
+    mockComm_.comm.ddaScratchBytes = kAmpleScratch;
     EXPECT_TRUE(
         ncclAllToAllDdaFabricLL128Eligible(mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32));
     mockComm_.comm.ddaScratchBytes = kTooSmallScratch;
@@ -120,7 +122,7 @@ TEST_F(DdaFabricScratchTest, AllToAll_LL128_GatesOnScratchCapacity) {
 }
 
 TEST_F(DdaFabricScratchTest, ReduceScatter_LL_GatesOnScratchCapacity) {
-    mockComm_.comm.ddaScratchBytes = DDA_FABRIC_BUFFER_SIZE;
+    mockComm_.comm.ddaScratchBytes = kAmpleScratch;
     EXPECT_TRUE(ncclReduceScatterDdaFabricLLEligible(
         mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32, ncclSum));
     mockComm_.comm.ddaScratchBytes = kTooSmallScratch;
@@ -129,7 +131,7 @@ TEST_F(DdaFabricScratchTest, ReduceScatter_LL_GatesOnScratchCapacity) {
 }
 
 TEST_F(DdaFabricScratchTest, ReduceScatter_LL128_GatesOnScratchCapacity) {
-    mockComm_.comm.ddaScratchBytes = DDA_FABRIC_BUFFER_SIZE;
+    mockComm_.comm.ddaScratchBytes = kAmpleScratch;
     EXPECT_TRUE(ncclReduceScatterDdaFabricLL128Eligible(
         mockComm_.get(), sendbuff_, recvbuff_, kValidElemCount, ncclFloat32, ncclSum));
     mockComm_.comm.ddaScratchBytes = kTooSmallScratch;
@@ -277,7 +279,7 @@ TEST_F(DdaFabricScratchTest, AllReduce_LL128_EffectiveCapShrinksWithRanks) {
     // because AR-LL128 scratch scales with nRanks * message.
     const size_t oneGiB = static_cast<size_t>(1) << 30;
     const size_t count  = oneGiB / sizeof(float);
-    mockComm_.comm.ddaScratchBytes = DDA_FABRIC_BUFFER_SIZE;
+    mockComm_.comm.ddaScratchBytes = kAmpleScratch;
 
     mockComm_.comm.nRanks = 2;
     EXPECT_TRUE(
@@ -297,14 +299,14 @@ TEST_F(DdaFabricScratchTest, AllReduce_LL128_EffectiveCapShrinksWithRanks) {
 // The per-message alignment gate differs across siblings: AR/RS require %8, AG/A2A
 // require %16. count=2 float32 (8 B) is aligned for AR-LL but not AG-LL.
 TEST_F(DdaFabricScratchTest, AlignmentGateDiffersAcrossCollectives) {
-    mockComm_.comm.ddaScratchBytes = DDA_FABRIC_BUFFER_SIZE;
+    mockComm_.comm.ddaScratchBytes = kAmpleScratch;
     EXPECT_TRUE(ncclAllReduceDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, 2, ncclFloat32, ncclSum));
     EXPECT_FALSE(ncclAllGatherDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, 2, ncclFloat32));
 }
 
 // A zero count is rejected before the scratch check, even with ample scratch.
 TEST_F(DdaFabricScratchTest, ZeroCountIneligibleRegardlessOfScratch) {
-    mockComm_.comm.ddaScratchBytes = DDA_FABRIC_BUFFER_SIZE;
+    mockComm_.comm.ddaScratchBytes = kAmpleScratch;
     EXPECT_FALSE(ncclAllReduceDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, 0, ncclFloat32, ncclSum));
     EXPECT_FALSE(ncclAllGatherDdaFabricLLEligible(mockComm_.get(), sendbuff_, recvbuff_, 0, ncclFloat32));
 }

--- a/projects/rccl/test/common/DdaFabricFootprints.hpp
+++ b/projects/rccl/test/common/DdaFabricFootprints.hpp
@@ -26,7 +26,8 @@
 
 #include <cstddef>
 
-namespace RcclUnitTesting {
+namespace RcclUnitTesting
+{
 
 constexpr size_t kLLTierMaxBytes    = 131072; // 128 KiB LL per-tier cap
 constexpr size_t kLL128TierMaxBytes = 524288; // 512 KiB LL128 AG/A2A/RS per-tier cap
@@ -37,7 +38,8 @@ constexpr size_t kLL128LineBytes    = 128;    // sizeof(LLLine128)
 // Payload words -> 128B lines. Production uses `bytes >> 3` (truncating); every
 // caller here passes a multiple of 8 (the predicates reject bytes % 8 != 0), so
 // truncation and ceil agree. bytes/8 matches production literally.
-constexpr size_t ddaLL128LinesForBytes(size_t bytes) {
+constexpr size_t ddaLL128LinesForBytes(size_t bytes)
+{
     // precondition: bytes % 8 == 0 (predicates reject otherwise), so bytes/8
     // matches production's `bytes >> 3`. constexpr so it can pin the slot stride.
     return (bytes / 8 + kLL128DataElems - 1) / kLL128DataElems;
@@ -45,18 +47,21 @@ constexpr size_t ddaLL128LinesForBytes(size_t bytes) {
 
 // Fixed LL footprint (all four LL tiers): 2 banks * nRanks slots *
 // (kLLTierMaxBytes/8) pkts * 16B = 512 KiB * nRanks, independent of message size.
-inline size_t ddaLLFixedFootprint(int nRanks) {
+inline size_t ddaLLFixedFootprint(int nRanks)
+{
     return static_cast<size_t>(2) * static_cast<size_t>(nRanks) * (kLLTierMaxBytes / 8) * kLLPacketBytes;
 }
 
 // Fixed LL128 AG/A2A/RS footprint: 2 banks * nRanks slots * ceil(cap/8/15) lines * 128B.
-inline size_t ddaLL128FixedFootprint(int nRanks) {
+inline size_t ddaLL128FixedFootprint(int nRanks)
+{
     return static_cast<size_t>(2) * static_cast<size_t>(nRanks) * ddaLL128LinesForBytes(kLL128TierMaxBytes)
          * kLL128LineBytes;
 }
 
 // LL128 AllReduce footprint tracks the actual message size (compact slot stride).
-inline size_t ddaLL128ArFootprintForBytes(int nRanks, size_t bytes) {
+inline size_t ddaLL128ArFootprintForBytes(int nRanks, size_t bytes)
+{
     return static_cast<size_t>(2) * static_cast<size_t>(nRanks) * ddaLL128LinesForBytes(bytes) * kLL128LineBytes;
 }
 

--- a/projects/rccl/test/common/DdaFabricFootprints.hpp
+++ b/projects/rccl/test/common/DdaFabricFootprints.hpp
@@ -8,11 +8,14 @@
 
 // DDA fabric scratch footprints, mirrored from the launcher headers so tests can
 // compute expected sizes without pulling the device kernel headers everywhere.
-// The mirrors are pinned to the real constants by static_assert in
-// DdaFabricEpochTests.cpp (which builds in the Release fixtures target), so a
-// production stride/cap change fails the build rather than silently passing.
-// Kept lightweight (only <cstddef>) so the Release epoch TU need not include the
-// kernel headers except at the one static_assert site. Mirror sources:
+// Every mirror below (all seven per-tier caps, both slot strides, the two sizeof
+// values and the data-elems count) is pinned to its real constant by a
+// static_assert in DdaFabricEpochTests.cpp, which builds in the Release-capable
+// rccl-UnitTestsFixtures target -- so a production stride/cap change fails that
+// build rather than silently passing. The only piece not pinnable that way is the
+// literal 2 bank factor, since ddaLL*ScratchSize are static-inline in .cu TUs.
+// Kept lightweight (only <cstddef>) so most TUs need not pull the kernel headers.
+// Mirror sources:
 //   kLLTierMaxBytes    : kDdaLLArMaxBytes / kDdaLLAgMaxPerRankBytes /
 //                        kDdaLLA2AMaxPerChunkBytes / kDdaLLRsMaxBytes  (all 128 KiB)
 //   kLL128TierMaxBytes : kDdaLL128AgMaxPerRankBytes / kDdaLL128A2AMaxPerChunkBytes /
@@ -34,9 +37,10 @@ constexpr size_t kLL128LineBytes    = 128;    // sizeof(LLLine128)
 // Payload words -> 128B lines. Production uses `bytes >> 3` (truncating); every
 // caller here passes a multiple of 8 (the predicates reject bytes % 8 != 0), so
 // truncation and ceil agree. bytes/8 matches production literally.
-inline size_t ddaLL128LinesForBytes(size_t bytes) {
-    const size_t words = bytes / 8; // precondition: bytes % 8 == 0
-    return (words + kLL128DataElems - 1) / kLL128DataElems;
+constexpr size_t ddaLL128LinesForBytes(size_t bytes) {
+    // precondition: bytes % 8 == 0 (predicates reject otherwise), so bytes/8
+    // matches production's `bytes >> 3`. constexpr so it can pin the slot stride.
+    return (bytes / 8 + kLL128DataElems - 1) / kLL128DataElems;
 }
 
 // Fixed LL footprint (all four LL tiers): 2 banks * nRanks slots *

--- a/projects/rccl/test/common/DdaFabricFootprints.hpp
+++ b/projects/rccl/test/common/DdaFabricFootprints.hpp
@@ -1,0 +1,58 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#pragma once
+
+// DDA fabric scratch footprints, mirrored once from the launcher headers so
+// tests track the source (exact-boundary tests go red if a mirror drifts, since
+// the real predicate uses the real constant). Kept dependency-free (no comm.h /
+// gtest) so it can be included by both the Debug-only scratch tests and the
+// Release+Debug epoch tests. Sources:
+//   kLLTierMaxBytes    : kDdaLLArMaxBytes / kDdaLLAgMaxPerRankBytes /
+//                        kDdaLLA2AMaxPerChunkBytes / kDdaLLRsMaxBytes  (all 128 KiB)
+//   kLL128TierMaxBytes : kDdaLL128AgMaxPerRankBytes / kDdaLL128A2AMaxPerChunkBytes /
+//                        kDdaLL128RsMaxBytes  (all 512 KiB)
+//   kLL128DataElems    : meta::comms::kDdaLL128DataElems
+//   kLLPacketBytes     : sizeof(meta::comms::LLPacket16)
+//   kLL128LineBytes    : sizeof(meta::comms::LLLine128)
+
+#include <cstddef>
+
+namespace RcclUnitTesting
+{
+
+constexpr size_t kLLTierMaxBytes    = 131072; // 128 KiB LL per-tier cap
+constexpr size_t kLL128TierMaxBytes = 524288; // 512 KiB LL128 AG/A2A/RS per-tier cap
+constexpr size_t kLL128DataElems    = 15;     // payload words per 128B line
+constexpr size_t kLLPacketBytes     = 16;     // sizeof(LLPacket16)
+constexpr size_t kLL128LineBytes    = 128;    // sizeof(LLLine128)
+
+inline size_t ddaLL128LinesForBytes(size_t bytes)
+{
+    const size_t words = (bytes + 7) / 8;
+    return (words + kLL128DataElems - 1) / kLL128DataElems;
+}
+
+// Fixed LL footprint (all four LL tiers): 2 banks * nRanks slots *
+// (kLLTierMaxBytes/8) pkts * 16B = 512 KiB * nRanks, independent of message size.
+inline size_t ddaLLFixedFootprint(int nRanks)
+{
+    return (size_t)2 * (size_t)nRanks * (kLLTierMaxBytes / 8) * kLLPacketBytes;
+}
+
+// Fixed LL128 AG/A2A/RS footprint: 2 banks * nRanks slots * ceil(cap/8/15) lines * 128B.
+inline size_t ddaLL128FixedFootprint(int nRanks)
+{
+    return (size_t)2 * (size_t)nRanks * ddaLL128LinesForBytes(kLL128TierMaxBytes) * kLL128LineBytes;
+}
+
+// LL128 AllReduce footprint tracks the actual message size (compact slot stride).
+inline size_t ddaLL128ArFootprintForBytes(int nRanks, size_t bytes)
+{
+    return (size_t)2 * (size_t)nRanks * ddaLL128LinesForBytes(bytes) * kLL128LineBytes;
+}
+
+} // namespace RcclUnitTesting

--- a/projects/rccl/test/common/DdaFabricFootprints.hpp
+++ b/projects/rccl/test/common/DdaFabricFootprints.hpp
@@ -4,7 +4,8 @@
  * See LICENSE.txt for license information
  ************************************************************************/
 
-#pragma once
+#ifndef RCCL_TEST_DDA_FABRIC_FOOTPRINTS_HPP
+#define RCCL_TEST_DDA_FABRIC_FOOTPRINTS_HPP
 
 // DDA fabric scratch footprints, mirrored from the launcher headers so tests can
 // compute expected sizes without pulling the device kernel headers everywhere.
@@ -70,3 +71,5 @@ inline size_t ddaLL128ArFootprintForBytes(int nRanks, size_t bytes)
 }
 
 } // namespace RcclUnitTesting
+
+#endif // RCCL_TEST_DDA_FABRIC_FOOTPRINTS_HPP

--- a/projects/rccl/test/common/DdaFabricFootprints.hpp
+++ b/projects/rccl/test/common/DdaFabricFootprints.hpp
@@ -6,11 +6,13 @@
 
 #pragma once
 
-// DDA fabric scratch footprints, mirrored once from the launcher headers so
-// tests track the source (exact-boundary tests go red if a mirror drifts, since
-// the real predicate uses the real constant). Kept dependency-free (no comm.h /
-// gtest) so it can be included by both the Debug-only scratch tests and the
-// Release+Debug epoch tests. Sources:
+// DDA fabric scratch footprints, mirrored from the launcher headers so tests can
+// compute expected sizes without pulling the device kernel headers everywhere.
+// The mirrors are pinned to the real constants by static_assert in
+// DdaFabricEpochTests.cpp (which builds in the Release fixtures target), so a
+// production stride/cap change fails the build rather than silently passing.
+// Kept lightweight (only <cstddef>) so the Release epoch TU need not include the
+// kernel headers except at the one static_assert site. Mirror sources:
 //   kLLTierMaxBytes    : kDdaLLArMaxBytes / kDdaLLAgMaxPerRankBytes /
 //                        kDdaLLA2AMaxPerChunkBytes / kDdaLLRsMaxBytes  (all 128 KiB)
 //   kLL128TierMaxBytes : kDdaLL128AgMaxPerRankBytes / kDdaLL128A2AMaxPerChunkBytes /
@@ -21,8 +23,7 @@
 
 #include <cstddef>
 
-namespace RcclUnitTesting
-{
+namespace RcclUnitTesting {
 
 constexpr size_t kLLTierMaxBytes    = 131072; // 128 KiB LL per-tier cap
 constexpr size_t kLL128TierMaxBytes = 524288; // 512 KiB LL128 AG/A2A/RS per-tier cap
@@ -30,29 +31,29 @@ constexpr size_t kLL128DataElems    = 15;     // payload words per 128B line
 constexpr size_t kLLPacketBytes     = 16;     // sizeof(LLPacket16)
 constexpr size_t kLL128LineBytes    = 128;    // sizeof(LLLine128)
 
-inline size_t ddaLL128LinesForBytes(size_t bytes)
-{
-    const size_t words = (bytes + 7) / 8;
+// Payload words -> 128B lines. Production uses `bytes >> 3` (truncating); every
+// caller here passes a multiple of 8 (the predicates reject bytes % 8 != 0), so
+// truncation and ceil agree. bytes/8 matches production literally.
+inline size_t ddaLL128LinesForBytes(size_t bytes) {
+    const size_t words = bytes / 8; // precondition: bytes % 8 == 0
     return (words + kLL128DataElems - 1) / kLL128DataElems;
 }
 
 // Fixed LL footprint (all four LL tiers): 2 banks * nRanks slots *
 // (kLLTierMaxBytes/8) pkts * 16B = 512 KiB * nRanks, independent of message size.
-inline size_t ddaLLFixedFootprint(int nRanks)
-{
-    return (size_t)2 * (size_t)nRanks * (kLLTierMaxBytes / 8) * kLLPacketBytes;
+inline size_t ddaLLFixedFootprint(int nRanks) {
+    return static_cast<size_t>(2) * static_cast<size_t>(nRanks) * (kLLTierMaxBytes / 8) * kLLPacketBytes;
 }
 
 // Fixed LL128 AG/A2A/RS footprint: 2 banks * nRanks slots * ceil(cap/8/15) lines * 128B.
-inline size_t ddaLL128FixedFootprint(int nRanks)
-{
-    return (size_t)2 * (size_t)nRanks * ddaLL128LinesForBytes(kLL128TierMaxBytes) * kLL128LineBytes;
+inline size_t ddaLL128FixedFootprint(int nRanks) {
+    return static_cast<size_t>(2) * static_cast<size_t>(nRanks) * ddaLL128LinesForBytes(kLL128TierMaxBytes)
+         * kLL128LineBytes;
 }
 
 // LL128 AllReduce footprint tracks the actual message size (compact slot stride).
-inline size_t ddaLL128ArFootprintForBytes(int nRanks, size_t bytes)
-{
-    return (size_t)2 * (size_t)nRanks * ddaLL128LinesForBytes(bytes) * kLL128LineBytes;
+inline size_t ddaLL128ArFootprintForBytes(int nRanks, size_t bytes) {
+    return static_cast<size_t>(2) * static_cast<size_t>(nRanks) * ddaLL128LinesForBytes(bytes) * kLL128LineBytes;
 }
 
 } // namespace RcclUnitTesting

--- a/projects/rccl/test/common/DdaFabricFootprints.hpp
+++ b/projects/rccl/test/common/DdaFabricFootprints.hpp
@@ -8,13 +8,16 @@
 
 // DDA fabric scratch footprints, mirrored from the launcher headers so tests can
 // compute expected sizes without pulling the device kernel headers everywhere.
-// Every mirror below (all seven per-tier caps, both slot strides, the two sizeof
-// values and the data-elems count) is pinned to its real constant by a
+// Every mirror below (all eight per-tier caps, all seven slot strides, the two
+// sizeof values and the data-elems count) is pinned to its real constant by a
 // static_assert in DdaFabricEpochTests.cpp, which builds in the Release-capable
 // rccl-UnitTestsFixtures target -- so a production stride/cap change fails that
-// build rather than silently passing. The only piece not pinnable that way is the
-// literal 2 bank factor, since ddaLL*ScratchSize are static-inline in .cu TUs.
-// Kept lightweight (only <cstddef>) so most TUs need not pull the kernel headers.
+// build rather than silently passing. What is NOT pinnable that way: the literal
+// 2 bank factor, the footprint formula shape (2*nRanks*stride*elemSize), and the
+// ddaLL128ArSlotLines identity -- all eight ddaLL*ScratchSize functions are
+// static-inline in .cu TUs, so those are pinned only behaviorally by the
+// exact-boundary tests in DdaFabricScratchTests.cpp (Debug target). Kept
+// lightweight (only <cstddef>) so most TUs need not pull the kernel headers.
 // Mirror sources:
 //   kLLTierMaxBytes    : kDdaLLArMaxBytes / kDdaLLAgMaxPerRankBytes /
 //                        kDdaLLA2AMaxPerChunkBytes / kDdaLLRsMaxBytes  (all 128 KiB)
@@ -29,8 +32,9 @@
 namespace RcclUnitTesting
 {
 
-constexpr size_t kLLTierMaxBytes    = 131072; // 128 KiB LL per-tier cap
-constexpr size_t kLL128TierMaxBytes = 524288; // 512 KiB LL128 AG/A2A/RS per-tier cap
+constexpr size_t kLLTierMaxBytes    = 131072;     // 128 KiB LL per-tier cap
+constexpr size_t kLL128TierMaxBytes = 524288;     // 512 KiB LL128 AG/A2A/RS per-tier cap
+constexpr size_t kLL128ArMaxBytes   = 1073741824; // 1 GiB LL128 AllReduce cap (message-dependent tier)
 constexpr size_t kLL128DataElems    = 15;     // payload words per 128B line
 constexpr size_t kLLPacketBytes     = 16;     // sizeof(LLPacket16)
 constexpr size_t kLL128LineBytes    = 128;    // sizeof(LLLine128)

--- a/projects/rccl/test/common/DdaFabricTestHelpers.hpp
+++ b/projects/rccl/test/common/DdaFabricTestHelpers.hpp
@@ -4,7 +4,8 @@
  * See LICENSE.txt for license information
  ************************************************************************/
 
-#pragma once
+#ifndef RCCL_TEST_DDA_FABRIC_TEST_HELPERS_HPP
+#define RCCL_TEST_DDA_FABRIC_TEST_HELPERS_HPP
 
 #include <cstring>
 
@@ -69,3 +70,5 @@ protected:
 };
 
 } // namespace RcclUnitTesting
+
+#endif // RCCL_TEST_DDA_FABRIC_TEST_HELPERS_HPP

--- a/projects/rccl/test/common/DdaFabricTestHelpers.hpp
+++ b/projects/rccl/test/common/DdaFabricTestHelpers.hpp
@@ -11,6 +11,7 @@
 #include "comm.h"
 #include "dda_init_detail.h"
 #include "fabric_gpu_barrier.h"
+#include "gtest/gtest.h"
 
 namespace RcclUnitTesting
 {
@@ -55,6 +56,16 @@ struct DdaFabricMockComm
     }
 
     ncclComm* get() { return &comm; }
+};
+
+// Shared fixture for DDA fabric host tests: a mock comm plus dummy user-buffer
+// pointers (every fabric eligibility predicate ignores the buffer pointers).
+class DdaFabricFixture : public ::testing::Test
+{
+protected:
+    DdaFabricMockComm mockComm_;
+    void*             sendbuff_{reinterpret_cast<void*>(0x1000)};
+    void*             recvbuff_{reinterpret_cast<void*>(0x2000)};
 };
 
 } // namespace RcclUnitTesting


### PR DESCRIPTION
## Motivation

Adds host-side unit-test coverage for two previously-untested parts of the gfx1250 DDA fabric path
— its shared LL **epoch counter** and its **scratch-capacity** eligibility gating — and refactors the
epoch arithmetic so those tests exercise the **real production code path** rather than a re-implemented
model.

Originally the epoch tests replayed a host copy of the kernel's flag/bank/write-back arithmetic, so a
regression in the actual kernels could not turn them red. This revision extracts that arithmetic into
shared helpers used by both the kernels and the tests, closing that gap and de-duplicating the four LL
kernels against the four LL128 kernels (which already shared the helpers).

## Technical Details

### 1. Shared epoch arithmetic — `src/include/algorithms/CollCommon.h`
The per-block LL/LL128 epoch flag/bank/write-back arithmetic is now three pure
`__host__ __device__` helpers in `CollCommon.h` (the one header all eight kernels include):
`ddaLLEpochFlag` (`f = cell + 1; if (f == 0) f = 2`), `ddaLLEpochBank` (`flag & 1`), and
`ddaLLEpochRestamp` (the `for (e = flatBlockId; e < epochLen; e += total)` write-back). The device
wrappers `ddaLLEpochBegin` / `ddaLLEpochEnd` (the thread-0 guard + `__syncthreads()`) move here too,
re-expressed on top of the pure helpers, and stay `__device__`-only.

- The **four LL kernels** (AllGather / AllReduce / AllToAll / ReduceScatter) now call
  `ddaLLEpochBegin` / `ddaLLEpochEnd` instead of hand-inlining the arithmetic, matching what the four
  LL128 kernels already did.
- **All eight** kernels use `ddaLLEpochBank(flag)` for the bank offset.

### 2. Shared epoch-counter tests — `test/DdaFabricEpochTests.cpp` (rccl-UnitTestsFixtures)
The tests now drive the production helpers (`ddaLLEpochFlag` / `ddaLLEpochBank` / `ddaLLEpochRestamp`)
directly instead of a local copy, so an epoch-arithmetic regression fails the host suite. Adds a
direct `RestampUpdatesOwnedResidueClassOnly` contract test and keeps the rank-parameterized
consistency checks and the two negative controls. (Device-only thread-guard/barrier behavior remains
outside the host suite's claims; the model serializes a launch as read-all-then-write-all.)

### 3. Scratch-capacity gating — `test/DdaFabricScratchTests.cpp` (rccl-UnitTestsFixturesDebug)
Invokes all eight LL/LL128 eligibility predicates (AG/AR/A2A/RS) and shows each gates on scratch
capacity (ample → eligible, too small → ineligible), checks the fixed LL/LL128 footprint boundaries
exactly, and shows the footprints scale with `nRanks`. Unchanged from the prior revision.

## Test Plan

Built and run on gfx942 (ROCm 7.0.2) in both build configs:

```
./install.sh --debug -t --amdgpu_targets=gfx942     # Debug
./install.sh -t --amdgpu_targets=gfx942             # Release
./build/debug/test/rccl-UnitTestsFixtures       --gtest_filter='*DdaFabricEpoch*'
./build/debug/test/rccl-UnitTestsFixturesDebug  --gtest_filter='DdaFabricScratchTest.*'
./build/release/test/rccl-UnitTestsFixtures     --gtest_filter='*DdaFabricEpoch*'
```

## Test Result

Built and run on gfx942 (ROCm 7.0.2). Both build configs green:

```
Debug   rccl-UnitTestsFixtures       : [  PASSED  ] 33 tests.   (DdaFabricEpoch*)
Debug   rccl-UnitTestsFixturesDebug  : [  PASSED  ] 21 tests.   (DdaFabricScratchTest.*)
Release rccl-UnitTestsFixtures       : [  PASSED  ] 33 tests.   (DdaFabricEpoch*)
```

**Closed-loop check** (proving the tests now guard production): temporarily changing the shared
`ddaLLEpochRestamp` bound from `e < epochLen` to `e < total` turns **28 of 33** epoch tests red
(the arithmetic-independent static tests stay green); reverting restores all-green.

## Submission Checklist

- [x] Tests added for the covered areas (including negative controls + a direct helper contract test)
- [x] Epoch arithmetic shared between production kernels and tests (production refactor; behavior-preserving)
- [x] Built and unit-tested on gfx942/ROCm 7.0.2 in Debug and Release
