### PR TITLE
[rocjitsu] Support non-kernel device functions in gfx1250 translation

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_elf.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_elf.h
@@ -181,6 +181,7 @@ inline constexpr uint32_t SHT_DYNSYM = 11;
 inline constexpr uint32_t R_AMDGPU_ABS64 = 3;
 inline constexpr uint32_t R_AMDGPU_RELATIVE64 = 13;
 
+inline constexpr uint8_t kElfSymbolBindLocal = 0;
 inline constexpr uint8_t kElfSymbolBindGlobal = 1;
 inline constexpr uint8_t kElfSymbolTypeNone = 0;    // STT_NOTYPE
 inline constexpr uint8_t kElfSymbolTypeObject = 1;  // STT_OBJECT

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_elf.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_elf.h
@@ -183,6 +183,7 @@ inline constexpr uint32_t R_AMDGPU_RELATIVE64 = 13;
 
 inline constexpr uint8_t kElfSymbolBindLocal = 0;
 inline constexpr uint8_t kElfSymbolBindGlobal = 1;
+inline constexpr uint8_t kElfSymbolBindWeak = 2;
 inline constexpr uint8_t kElfSymbolTypeNone = 0;    // STT_NOTYPE
 inline constexpr uint8_t kElfSymbolTypeObject = 1;  // STT_OBJECT
 inline constexpr uint8_t kElfSymbolTypeFunc = 2;    // STT_FUNC

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -197,9 +197,62 @@ void append_diagnostics(std::vector<TranslationDiagnostic> &dst,
   return arch_descriptor_sgpr_allocation_limit(arch);
 }
 
-/// @brief Find the next even SGPR pair that can be descriptor-backed for a branch thunk.
-[[nodiscard]] std::optional<uint16_t> next_long_branch_sgpr_pair(const TranslationContext &context,
-                                                                 rj_code_arch_t arch) {
+/// @brief Find an even-aligned SGPR pair that no instruction in the scope names.
+///
+/// @details A usage scan, not a dataflow query: it needs no CFG and holds at every point in the
+/// decoded scope, which is what a layout reusing one pair for every long branch requires. Search is
+/// lowest-first, so the pair lands just above whatever the kernel actually uses.
+///
+/// The scan runs before semantic expansion, so it does not cover registers an expander allocates
+/// for itself. That is sound only while every such allocation is consumed by the instruction that
+/// follows it, because the branch thunk likewise writes and consumes its pair within one generated
+/// sequence and nothing can be interleaved between the two. An expansion that held a value across
+/// more than its own sequence would need this pair excluded from its search.
+///
+/// The scalar relative-move family resolves its register number from M0 at run time, so scanning
+/// encoded operands cannot enumerate what it reaches; a scope containing one yields no pair. The
+/// vector relative moves index VGPRs and leave the scalar conclusion intact.
+[[nodiscard]] std::optional<uint16_t> scope_unused_sgpr_pair(std::span<BasicBlock *const> blocks,
+                                                             uint32_t limit) {
+  // Out-of-range queries answer "not present", so a limit past the tracked width would report
+  // registers as free without ever consulting the scan.
+  limit = std::min<uint32_t>(limit, REGISTER_SET_MAX_SGPRS);
+  RegisterSet used;
+  for (BasicBlock *block : blocks) {
+    if (block == nullptr)
+      continue;
+    for (const Instruction &inst : block->instructions()) {
+      if (inst.mnemonic().starts_with("s_movrel"))
+        return std::nullopt;
+      const InstDefUse def_use(inst);
+      used |= def_use.defs;
+      used |= def_use.uses;
+    }
+  }
+
+  for (uint32_t base = 0; base + 2 <= limit; base += 2) {
+    const auto lo = static_cast<uint16_t>(base);
+    const auto hi = static_cast<uint16_t>(base + 1);
+    if (!used.contains({RegClass::SGPR, lo, 1}) && !used.contains({RegClass::SGPR, hi, 1}))
+      return lo;
+  }
+  return std::nullopt;
+}
+
+/// @brief Find the next even SGPR pair usable for a branch thunk.
+///
+/// @details Where the descriptor encodes an SGPR count, the pair is chosen immediately above the
+/// kernel's current count and made safe by growing the descriptor to cover it. That argument does
+/// not hold on a target with a fixed scalar file: GRANULATED_WAVEFRONT_SGPR_COUNT is unused there,
+/// so the decoded count is a constant floor rather than a measurement of the kernel, and
+/// require_sgprs() reserves nothing -- the chosen pair would be registers the kernel already uses.
+/// Such targets supply @p scope_unused_pair instead, proven free by scanning the scope.
+[[nodiscard]] std::optional<uint16_t>
+next_long_branch_sgpr_pair(const TranslationContext &context, rj_code_arch_t arch,
+                           std::optional<uint16_t> scope_unused_pair) {
+  if (!isa_properties(arch).descriptor_sgpr_count_encoded)
+    return scope_unused_pair;
+
   const uint32_t current = std::max(context.num_sgprs, context.required_sgpr_count);
   const uint32_t base = (current + 1u) & ~1u;
   if (base > 126)
@@ -1278,6 +1331,11 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   }
 
   const auto relocation_function_tables = discover_relocation_function_tables(obj);
+  // The same entry set the scope walk treats as kernel roots, including the firmware-skip entries,
+  // so no offset can be a kernel to one and a device function to the other.
+  const auto device_function_extents =
+      discover_device_function_extents(obj, kernel_hardware_entry_offsets(descriptor_translations));
+  const auto text_relocation_targets = discover_text_relocation_targets(obj);
   auto block_leaders = kernel_block_leaders(descriptor_translations, text);
   for (const RelocationFunctionTable &table : relocation_function_tables) {
     for (const RelocationFunctionPointer &entry : table.entries)
@@ -1579,15 +1637,19 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     return emit_skipped_kernel(restored_scope, std::move(failure));
   };
 
-  auto reserve_long_branch_sgpr_pair = [&](TranslationContext &context) -> std::optional<uint16_t> {
-    auto base = next_long_branch_sgpr_pair(context, host_arch_);
+  auto reserve_long_branch_sgpr_pair =
+      [&](TranslationContext &context,
+          std::optional<uint16_t> scope_unused_pair) -> std::optional<uint16_t> {
+    auto base = next_long_branch_sgpr_pair(context, host_arch_, scope_unused_pair);
     if (!base)
       return std::nullopt;
     context.require_sgprs(static_cast<uint32_t>(*base) + 2);
     return base;
   };
 
+  uint32_t scope_index = 0;
   for (const KernelTranslationScope &scope : scopes) {
+    const uint32_t this_scope_index = scope_index++;
     if (scope.blocks.empty())
       continue;
     assert(scope.translation != nullptr && "kernel scope should have descriptor translation");
@@ -1718,8 +1780,17 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
         continue;
       return leave_unchanged();
     }
+    // Targets with a fixed scalar file cannot reserve an SGPR through the descriptor, so the
+    // thunk borrows a pair proven unused across this scope. Computed once: the layout reuses one
+    // pair for every long branch it emits, and the scan is valid at all of them.
+    const std::optional<uint16_t> scope_long_branch_sgpr_pair =
+        isa_properties(host_arch_).descriptor_sgpr_count_encoded
+            ? std::nullopt
+            : scope_unused_sgpr_pair(scope.blocks,
+                                     arch_descriptor_sgpr_allocation_limit(host_arch_));
     const bool can_use_long_direct_branches =
-        next_long_branch_sgpr_pair(kernel_context, host_arch_).has_value();
+        next_long_branch_sgpr_pair(kernel_context, host_arch_, scope_long_branch_sgpr_pair)
+            .has_value();
     LivenessAnalysisOptions liveness_options;
     liveness_options.max_free_vgpr =
         static_cast<uint16_t>(isa_properties(host_arch_).max_addressable_vgprs_per_wf);
@@ -2054,7 +2125,17 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     kernel_text.reserve(static_cast<size_t>(std::min<uint64_t>(
         source_body_size + recovered_window_growth, std::numeric_limits<size_t>::max())));
 
+    // Two questions share this key space and must not share one map: "where did the instruction
+    // starting here land" and "where does the body ending here stop". The keys collide wherever one
+    // block abuts the next, and the answers diverge whenever anything is appended between the two
+    // bodies -- a branch island pool, for instance. Keep them apart at the producer so neither
+    // question can be answered with the other's value.
     std::unordered_map<uint64_t, uint64_t> target_offset_by_source_offset;
+    std::unordered_map<uint64_t, uint64_t> end_offset_by_source_offset;
+    // Source offsets that name an instruction rather than a block end. A symbol
+    // resolves through these in preference, because the two collide wherever one
+    // body abuts the next.
+    std::unordered_set<uint64_t> instruction_start_sources;
     target_offset_by_source_offset.reserve(
         static_cast<size_t>(source_body_size / sizeof(uint32_t)) + scope.blocks.size());
     layout.body_begin = 0;
@@ -2201,7 +2282,9 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
           const RecoveredConsumer &consumer = *marked->second;
           const IndirectCallFixup &source_fixup = consumer.window_fixup;
           const uint64_t window_bytes = consumer.marked_window_end - consumer.marked_window_begin;
-          target_offset_by_source_offset.emplace(offset, target_offset);
+          // Assign for the same reason as the ordinary instruction-start record below.
+          target_offset_by_source_offset[offset] = target_offset;
+          instruction_start_sources.insert(offset);
           layout.recovered_indirect_fixups.push_back(
               {.source_call_offset = source_fixup.source_call_offset,
                .source_target_offset = source_fixup.source_target_offset,
@@ -2229,7 +2312,14 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
         // Record every instruction start, not just recovered-PC builder
         // boundaries. The same final map keeps ELF labels attached to the
         // relocated instruction stream after semantic expansions change sizes.
-        target_offset_by_source_offset.emplace(offset, target_offset);
+        //
+        // Assign rather than emplace. The preceding block's end was recorded at this same source
+        // offset, and the two targets diverge whenever anything was appended between the bodies --
+        // a branch island pool, for instance. A symbol here names this instruction, so the start
+        // must be the value that survives, and the flag below has to describe the value actually
+        // stored or it would rank a block-end target above a genuine start.
+        target_offset_by_source_offset[offset] = target_offset;
+        instruction_start_sources.insert(offset);
 
         const auto recovered_it = recovered_indirect_by_call.find(offset);
         const bool has_recovered_indirect_call = recovered_it != recovered_indirect_by_call.end();
@@ -2551,6 +2641,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
               : kernel_text.size();
       layout.blocks.push_back(placement);
       target_offset_by_source_offset.emplace(block->end_offset(), placement.target_end);
+      end_offset_by_source_offset.emplace(block->end_offset(), placement.target_end);
       if (!can_use_long_direct_branches && !preserve_generated_branch_island_pools &&
           block != scope.blocks.back() && kernel_text.size() >= next_branch_island_pool_offset) {
         append_direct_branch_island_pool(kernel_text, layout, host_arch_);
@@ -2567,10 +2658,22 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     for (IndirectCallFixup fixup : pending_builder_fixups) {
       const auto getpc_it = target_offset_by_source_offset.find(fixup.source_getpc_offset);
       const auto begin_it = target_offset_by_source_offset.find(fixup.source_recovery_begin_offset);
-      const auto end_it = target_offset_by_source_offset.find(fixup.source_recovery_end_offset);
+      // One-past-end of the builder, so resolve it as an end. When the builder's last instruction
+      // is also the block's last, this offset is simultaneously the next block's first instruction;
+      // taking that start would place the end beyond anything appended in between and the window
+      // fill would erase it. Only mid-block ends, which no append can cross, fall back to the start
+      // map -- there the following instruction's start is exactly the end.
+      std::optional<uint64_t> recovery_end;
+      if (const auto it = end_offset_by_source_offset.find(fixup.source_recovery_end_offset);
+          it != end_offset_by_source_offset.end()) {
+        recovery_end = it->second;
+      } else if (const auto start =
+                     target_offset_by_source_offset.find(fixup.source_recovery_end_offset);
+                 start != target_offset_by_source_offset.end()) {
+        recovery_end = start->second;
+      }
       if (getpc_it == target_offset_by_source_offset.end() ||
-          begin_it == target_offset_by_source_offset.end() ||
-          end_it == target_offset_by_source_offset.end()) {
+          begin_it == target_offset_by_source_offset.end() || !recovery_end) {
         auto failure = make_kernel_failure(
             DiagnosticKind::Legalization,
             "recovered indirect branch builder is not fully present in the relocated body",
@@ -2585,7 +2688,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
 
       fixup.target_getpc_offset = getpc_it->second;
       fixup.target_recovery_begin_offset = begin_it->second;
-      fixup.target_recovery_end_offset = end_it->second;
+      fixup.target_recovery_end_offset = *recovery_end;
       layout.recovered_builder_fixups.push_back(fixup);
     }
     if (skip_scope)
@@ -2694,11 +2797,15 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
           (void)source_offset;
           rebase_text_offset(target_offset, *insertions);
         }
+        for (auto &[source_offset, target_offset] : end_offset_by_source_offset) {
+          (void)source_offset;
+          rebase_text_offset(target_offset, *insertions);
+        }
         for (PendingTrace &trace : pending_traces)
           rebase_text_offset(trace.target_offset, *insertions);
         remaining_growth_words -= requested_growth_words;
       } else if (!layout.long_branch_sgpr) {
-        auto sgpr = reserve_long_branch_sgpr_pair(kernel_context);
+        auto sgpr = reserve_long_branch_sgpr_pair(kernel_context, scope_long_branch_sgpr_pair);
         if (!sgpr) {
           patched_control_flow = {
               .ok = false,
@@ -2751,7 +2858,20 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     const uint64_t target_delta = materialized.target_delta;
     for (const auto &[source_offset, target_offset] : target_offset_by_source_offset) {
       text_relocations.push_back(
-          {.source_offset = source_offset, .target_offset = target_offset + target_delta});
+          {.source_offset = source_offset,
+           .target_offset = target_offset + target_delta,
+           .is_instruction_start = instruction_start_sources.contains(source_offset),
+           .scope_index = this_scope_index});
+    }
+    // Emit the end answer separately wherever a start displaced it. A symbol whose body stops
+    // exactly where the next one begins needs both, and one record cannot carry both values.
+    for (const auto &[source_offset, target_offset] : end_offset_by_source_offset) {
+      if (!instruction_start_sources.contains(source_offset))
+        continue;
+      text_relocations.push_back({.source_offset = source_offset,
+                                  .target_offset = target_offset + target_delta,
+                                  .is_instruction_start = false,
+                                  .scope_index = this_scope_index});
     }
     for (const RelocationTableDispatch &dispatch : relocation_table_dispatches) {
       if (!target_offset_by_source_offset.contains(dispatch.source_call_offset))
@@ -2906,6 +3026,65 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
         continue;
       translation.target_entry_text_offset = layout.target_entry;
       translation.target_body_entry_text_offset = layout.target_body_entry;
+    }
+  }
+
+  // Translated text replaces .text wholesale, so a decoded body that reached no scope is not
+  // preserved -- its address range is reoccupied by other kernels' relocated code. A device
+  // function has no descriptor of its own and is translated only because some kernel scope reaches
+  // it, so proving every function body was reached is what separates "this callee is unused" from
+  // "this callee was silently dropped and its bytes now decode as something else". Kernel bodies
+  // need no such proof: their descriptors make them roots.
+  {
+    std::unordered_set<const BasicBlock *> emitted_blocks;
+    std::unordered_set<const BasicBlock *> skipped_blocks;
+    for (const KernelTranslationScope &scope : scopes) {
+      const bool skipped = scope.translation != nullptr && scope.translation->skipped;
+      for (const BasicBlock *block : scope.blocks)
+        (skipped ? skipped_blocks : emitted_blocks).insert(block);
+    }
+
+    // Keyed on the entry block alone, never on st_size. A symbol's recorded size is rewritten by
+    // relocation and is not reliable on a second pass over translated text, and it is not needed:
+    // scope reachability starts at the entry, so a covered entry brings the rest of the body with
+    // it, and blocks a function's own entry cannot reach are dead by construction.
+    for (const DeviceFunctionExtent &function : device_function_extents) {
+      // Resolve the block containing the entry rather than one starting exactly on it. A symbol
+      // whose offset falls inside a larger block, or inside a decode gap, would otherwise match
+      // nothing. A null result means the body was never decoded at all, so it is certainly absent
+      // from translated text -- which is the very case this is meant to catch, not a reason to
+      // pass.
+      const BasicBlock *entry = block_for_offset(block_index, function.text_offset);
+      if (entry != nullptr && emitted_blocks.contains(entry))
+        continue;
+
+      // Having its address land in a relocated data word is the only property that makes an
+      // uncovered body dangerous. Scope reachability closes over successors *and* call edges, so
+      // every predecessor of an uncovered block is itself uncovered -- an uncovered body's in-edges
+      // therefore say nothing about whether anything live can arrive there, and a body's own loop
+      // latch would read as "referenced". Only a relocation names an address that no decoded edge
+      // accounts for.
+      //
+      // Asked of the raw relocations rather than of discovered dispatch tables. Table discovery
+      // additionally requires a qualifying STT_OBJECT around the slot, which a stripped or
+      // compiler-anonymous pointer array does not have -- yet its addend is still rewritten, to a
+      // body that is no longer there.
+      if (std::ranges::binary_search(text_relocation_targets, function.text_offset)) {
+        append_error(result.diagnostics, DiagnosticKind::Legalization,
+                     "device function body reached no kernel scope; translated text would drop it",
+                     function.text_offset);
+        return leave_unchanged();
+      }
+      // Linkers routinely retain unused locals in device libraries. Refusing those would reject
+      // objects that translate correctly, and over-refusal has its own failure mode: the operator
+      // turns the whole feature off, which is worse than the case being guarded. A body reached
+      // only from kernels that were skipped is not even worth reporting: those kernels are
+      // s_endpgm stubs now, so nothing calls it.
+      if (entry == nullptr || !skipped_blocks.contains(entry)) {
+        append_warning(result.diagnostics, DiagnosticKind::NothingToTranslate,
+                       "unreferenced device function body is not carried into translated text",
+                       function.text_offset);
+      }
     }
   }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.cpp
@@ -188,10 +188,12 @@ kernel_descriptor_symbol_name(const Elf64_Sym &sym, const char *strtab, size_t s
   if (sym.st_size != sizeof(KD))
     return std::nullopt;
 
-  // AMDHSA kernel descriptors are global object symbols. Size alone is not a
-  // durable signal because unrelated data objects can also be 64 bytes.
-  if (elf_symbol_type(sym.st_info) != kElfSymbolTypeObject ||
-      elf_symbol_bind(sym.st_info) != kElfSymbolBindGlobal)
+  // Object symbols only: size alone is not a durable signal, because unrelated data objects can
+  // also be 64 bytes. Binding is deliberately unconstrained. The loader dispatches a descriptor at
+  // any binding, so requiring STB_GLOBAL leaves a weak kernel untranslated while it is still
+  // launched -- and because translated text replaces .text wholesale, that kernel's entry is
+  // reoccupied by relocated code and the launch runs something else with no fault.
+  if (elf_symbol_type(sym.st_info) != kElfSymbolTypeObject)
     return std::nullopt;
 
   // AMDHSA descriptors are named "<kernel>.kd". An unnamed 64-byte global

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
@@ -753,10 +753,11 @@ void shift_relocation_offsets_in_moved_sections(std::vector<uint8_t> &image, con
   if (symbol.st_size != sizeof(KD))
     return false;
 
-  // AMDHSA kernel descriptors are global object symbols. This keeps other
-  // sizeof(KD) data objects from being treated as descriptors by accident.
-  if (elf_symbol_type(symbol.st_info) != kElfSymbolTypeObject ||
-      elf_symbol_bind(symbol.st_info) != kElfSymbolBindGlobal)
+  // Object symbols only, which keeps other sizeof(KD) data objects from being treated as
+  // descriptors by accident. Binding is deliberately unconstrained, matching the loader and the
+  // descriptor reader: a weak descriptor left un-rewritten here would keep an entry offset into
+  // text that no longer holds that kernel.
+  if (elf_symbol_type(symbol.st_info) != kElfSymbolTypeObject)
     return false;
 
   // AMDHSA descriptors are named "<kernel>.kd". An unnamed 64-byte global

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
@@ -19,6 +19,7 @@ RJ_DIAGNOSTIC_POP
 #include <cstddef>
 #include <cstring>
 #include <limits>
+#include <map>
 #include <numeric>
 // Standard library
 #include <optional>
@@ -433,16 +434,50 @@ void grow_text_function_symbols(std::vector<uint8_t> &image, const Elf64_Ehdr &e
   if (relocations.empty())
     return true;
 
-  std::unordered_map<uint64_t, uint64_t> target_by_source;
+  struct ScopedOffset {
+    uint64_t target_offset = 0;
+    uint32_t scope_index = 0;
+  };
+  std::unordered_map<uint64_t, ScopedOffset> target_by_source;
+  std::unordered_set<uint64_t> start_backed_sources;
+  // A symbol's value and its extent ask opposite questions of the same offset. `st_value` names an
+  // instruction, so starts win above. `st_size` measures to where the body *ends*, and at an
+  // abutting boundary that offset is also the next body's start -- taking the start there would
+  // measure across whatever translation placed between them. Keep a second, end-preferring view.
+  //
+  // The end view is keyed by scope as well as offset. First-wins is decided per offset, so a single
+  // end map would let one scope win the start while another wins the end, and subtracting those
+  // measures across every body translation placed between the two copies. Keeping each scope's
+  // answer lets the extent be read back in whichever scope supplied the symbol's value.
+  std::map<std::pair<uint32_t, uint64_t>, uint64_t> end_by_scope_and_source;
   target_by_source.reserve(relocations.size());
   for (const TextOffsetRelocation &relocation : relocations) {
     if (relocation.source_offset > old_text_size || relocation.target_offset > new_text_size)
       return false;
+    const ScopedOffset scoped{.target_offset = relocation.target_offset,
+                              .scope_index = relocation.scope_index};
+    const auto scope_key = std::pair{relocation.scope_index, relocation.source_offset};
     // A helper block can be copied into more than one kernel-local body. ELF
     // has only one value for its local label, so retain the first deterministic
     // placement. Control-flow fixups remain kernel-local and do not depend on
     // this tooling/debug symbol choice.
-    target_by_source.try_emplace(relocation.source_offset, relocation.target_offset);
+    //
+    // An instruction start does displace a block end at the same source offset.
+    // The two coincide wherever one body abuts the next, and translation may
+    // place those bodies far apart, so only the start describes the body that a
+    // symbol at that offset names. Among starts the first still wins.
+    auto [entry, inserted] = target_by_source.try_emplace(relocation.source_offset, scoped);
+    if (!relocation.is_instruction_start) {
+      // Within a scope an end is authoritative and displaces a start's fallback answer.
+      end_by_scope_and_source[scope_key] = relocation.target_offset;
+      continue;
+    }
+    // A start fills the end view only where that scope recorded no end, so an offset that is purely
+    // an instruction start still resolves for an extent measurement.
+    end_by_scope_and_source.try_emplace(scope_key, relocation.target_offset);
+    if (!inserted && !start_backed_sources.contains(relocation.source_offset))
+      entry->second = scoped;
+    start_backed_sources.insert(relocation.source_offset);
   }
 
   const Elf64_Shdr &text = shdrs[text_index];
@@ -526,14 +561,19 @@ void grow_text_function_symbols(std::vector<uint8_t> &image, const Elf64_Ehdr &e
 
       const uint64_t old_size = symbol.st_size;
       if (old_size <= old_text_size - source_text_offset) {
-        const auto relocated_end = target_by_source.find(source_text_offset + old_size);
-        if (relocated_end != target_by_source.end() &&
-            relocated_end->second >= relocated_start->second) {
-          symbol.st_size = relocated_end->second - relocated_start->second;
+        // Read the end back in the scope that supplied the value, so both describe one copy of the
+        // body. Where that scope recorded no end the source size stays: wrong against a resized
+        // section, but bounded and visible, unlike a subtraction across two different copies.
+        const auto relocated_end = end_by_scope_and_source.find(
+            {relocated_start->second.scope_index, source_text_offset + old_size});
+        if (relocated_end != end_by_scope_and_source.end() &&
+            relocated_end->second >= relocated_start->second.target_offset) {
+          symbol.st_size = relocated_end->second - relocated_start->second.target_offset;
         }
       }
-      symbol.st_value =
-          ehdr.e_type == ET_REL ? relocated_start->second : text.sh_addr + relocated_start->second;
+      symbol.st_value = ehdr.e_type == ET_REL
+                            ? relocated_start->second.target_offset
+                            : text.sh_addr + relocated_start->second.target_offset;
       std::memcpy(image.data() + symbol_offset, &symbol, sizeof(symbol));
     }
   }
@@ -566,6 +606,26 @@ relocate_relative_text_addends(std::vector<uint8_t> &image, const Elf64_Ehdr &eh
   for (const TextOffsetRelocation &relocation : relocations) {
     if (relocation.source_offset > old_text_size || relocation.target_offset > new_text_size)
       return false;
+  }
+  // Compare starts against starts. A block end recorded at the same source offset describes the
+  // preceding body, and the two targets diverge whenever anything was appended between them, so
+  // treating that pair as a disagreement would report an abutting boundary as two clones landing
+  // in different places and reject an object that is fine. Ends still fill offsets no start covers.
+  std::unordered_set<uint64_t> start_backed_sources;
+  for (const TextOffsetRelocation &relocation : relocations) {
+    if (!relocation.is_instruction_start)
+      continue;
+    auto [it, inserted] =
+        target_by_source.try_emplace(relocation.source_offset, relocation.target_offset);
+    if (!inserted && it->second != relocation.target_offset)
+      conflicting_sources.insert(relocation.source_offset);
+    start_backed_sources.insert(relocation.source_offset);
+  }
+  for (const TextOffsetRelocation &relocation : relocations) {
+    // Where a start already decided the offset it is authoritative, so an end there is not a
+    // disagreement. Everywhere else two records that disagree still are.
+    if (relocation.is_instruction_start || start_backed_sources.contains(relocation.source_offset))
+      continue;
     auto [it, inserted] =
         target_by_source.try_emplace(relocation.source_offset, relocation.target_offset);
     if (!inserted && it->second != relocation.target_offset)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.h
@@ -24,6 +24,22 @@ struct KdTranslation;
 struct TextOffsetRelocation {
   uint64_t source_offset = 0;
   uint64_t target_offset = 0;
+
+  /// True when @c source_offset is an instruction start rather than a block end.
+  ///
+  /// @details One source offset can be both: a block's end abuts the next
+  /// block's first instruction, and translation frequently places those two
+  /// bodies apart. A symbol names an entry, so resolving it through the end
+  /// mapping would attach it to the neighbouring body. Starts therefore win.
+  bool is_instruction_start = false;
+
+  /// Translation scope that emitted this record.
+  ///
+  /// @details A helper block is copied into every scope that reaches it, so one
+  /// source offset can yield a record per scope. A symbol's value and its extent
+  /// have to describe the same copy: pairing one scope's entry with another's
+  /// end measures across everything translation placed between them.
+  uint32_t scope_index = 0;
 };
 
 /// @brief One relocated literal64 PC builder whose target is outside `.text`.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/relocation_function_table.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/relocation_function_table.cpp
@@ -239,26 +239,201 @@ meet_predecessors(const BasicBlock &block,
   return nullptr;
 }
 
+/// @brief The one `.text` section and the section table around it.
+struct SingleTextSectionView {
+  Elf64_Ehdr ehdr{};
+  std::vector<Elf64_Shdr> sections;
+  size_t text_index = 0;
+  uint64_t text_vaddr = 0;
+  uint64_t text_size = 0;
+};
+
+/// @brief Read the section table and locate the sole `.text`, or fail.
+///
+/// @details Every discovery pass here reasons in `.text`-relative offsets, which only means
+/// anything when exactly one executable section owns them.
+[[nodiscard]] std::optional<SingleTextSectionView>
+read_single_text_section(const AmdGpuCodeObject &object) {
+  const auto *bytes = reinterpret_cast<const uint8_t *>(object.image_data());
+  const std::span<const uint8_t> image(bytes, object.image_size());
+  SingleTextSectionView view;
+  if (!read_object(image, 0, view.ehdr) || view.ehdr.e_shentsize != sizeof(Elf64_Shdr) ||
+      !range_in_image(image, view.ehdr.e_shoff,
+                      static_cast<uint64_t>(view.ehdr.e_shnum) * sizeof(Elf64_Shdr)))
+    return std::nullopt;
+
+  view.sections.resize(view.ehdr.e_shnum);
+  std::memcpy(view.sections.data(), image.data() + view.ehdr.e_shoff,
+              view.sections.size() * sizeof(Elf64_Shdr));
+
+  if (object.text_sections().size() != 1)
+    return std::nullopt;
+  const Section &text = *object.text_sections().front();
+  view.text_vaddr = text.vaddr();
+  view.text_size = text.size();
+
+  // Identify the section by its file extent rather than its address: in a relocatable object every
+  // sh_addr is zero, so an address match would alias onto any other section.
+  const auto found = std::ranges::find_if(view.sections, [&](const Elf64_Shdr &section) {
+    return (section.sh_flags & SHF_EXECINSTR) != 0 && section.sh_offset == text.sectionOffset() &&
+           section.sh_size == text.size();
+  });
+  if (found == view.sections.end())
+    return std::nullopt;
+  view.text_index = static_cast<size_t>(std::distance(view.sections.begin(), found));
+  return view;
+}
+
+/// @brief Resolve a relocation's symbol reference plus addend to an absolute address.
+///
+/// @param image Whole code object image.
+/// @param linked_symbols Symbol section named by the relocation section's `sh_link`.
+/// @param rela Relocation record.
+/// @param symbol_type Required `st_info` type; anything else is rejected.
+/// @returns The resolved address, or nothing when the reference does not qualify.
+[[nodiscard]] std::optional<uint64_t> resolve_reloc_symbol_target(std::span<const uint8_t> image,
+                                                                  const Elf64_Shdr *linked_symbols,
+                                                                  const Elf64_Rela &rela,
+                                                                  uint8_t symbol_type) {
+  if (linked_symbols == nullptr ||
+      (linked_symbols->sh_type != SHT_SYMTAB && linked_symbols->sh_type != SHT_DYNSYM) ||
+      linked_symbols->sh_entsize != sizeof(Elf64_Sym) ||
+      !range_in_image(image, linked_symbols->sh_offset, linked_symbols->sh_size))
+    return std::nullopt;
+  const uint32_t symbol_index = elf_reloc_sym(rela.r_info);
+  if (symbol_index >= linked_symbols->sh_size / sizeof(Elf64_Sym))
+    return std::nullopt;
+  Elf64_Sym symbol{};
+  if (!read_object(image,
+                   linked_symbols->sh_offset +
+                       static_cast<uint64_t>(symbol_index) * sizeof(Elf64_Sym),
+                   symbol) ||
+      elf_symbol_type(symbol.st_info) != symbol_type)
+    return std::nullopt;
+
+  const uint64_t target = symbol.st_value;
+  if (rela.r_addend >= 0) {
+    const auto addend = static_cast<uint64_t>(rela.r_addend);
+    if (addend > std::numeric_limits<uint64_t>::max() - target)
+      return std::nullopt;
+    return target + addend;
+  }
+  // Avoid negating INT64_MIN in signed arithmetic.
+  const uint64_t magnitude = uint64_t{0} - static_cast<uint64_t>(rela.r_addend);
+  if (magnitude > target)
+    return std::nullopt;
+  return target - magnitude;
+}
+
 } // namespace
+
+std::vector<DeviceFunctionExtent>
+discover_device_function_extents(const AmdGpuCodeObject &object,
+                                 std::span<const uint64_t> kernel_entry_offsets) {
+  const auto *bytes = reinterpret_cast<const uint8_t *>(object.image_data());
+  const std::span<const uint8_t> image(bytes, object.image_size());
+  const auto view = read_single_text_section(object);
+  if (!view)
+    return {};
+  const uint64_t text_vaddr = view->text_vaddr;
+  const uint64_t text_size = view->text_size;
+
+  std::vector<DeviceFunctionExtent> extents;
+  for (const Elf64_Shdr &symtab : view->sections) {
+    if ((symtab.sh_type != SHT_SYMTAB && symtab.sh_type != SHT_DYNSYM) ||
+        symtab.sh_entsize != sizeof(Elf64_Sym) ||
+        !range_in_image(image, symtab.sh_offset, symtab.sh_size))
+      continue;
+    const size_t count = symtab.sh_size / sizeof(Elf64_Sym);
+    for (size_t index = 0; index < count; ++index) {
+      Elf64_Sym symbol{};
+      if (!read_object(image, symtab.sh_offset + index * sizeof(Elf64_Sym), symbol))
+        continue;
+      // Owned by the one `.text`, not merely by some executable section: the offset below is
+      // relative to it, and in a relocatable object every section starts at address zero, so a
+      // body in a second executable section would alias onto an unrelated `.text` offset.
+      if (elf_symbol_type(symbol.st_info) != kElfSymbolTypeFunc || symbol.st_size == 0 ||
+          symbol.st_shndx != view->text_index)
+        continue;
+      if (symbol.st_value < text_vaddr)
+        continue;
+      const uint64_t offset = symbol.st_value - text_vaddr;
+      // A symbol whose recorded body runs past the section cannot be trusted to
+      // bound anything, so it is not used to make a coverage claim.
+      if (offset >= text_size || symbol.st_size > text_size - offset)
+        continue;
+      if (std::ranges::find(kernel_entry_offsets, offset) != kernel_entry_offsets.end())
+        continue;
+      extents.push_back({.text_offset = offset, .size = symbol.st_size});
+    }
+  }
+
+  std::ranges::sort(extents, {}, &DeviceFunctionExtent::text_offset);
+  const auto duplicates = std::ranges::unique(extents, [](const auto &lhs, const auto &rhs) {
+    return lhs.text_offset == rhs.text_offset && lhs.size == rhs.size;
+  });
+  extents.erase(duplicates.begin(), extents.end());
+  return extents;
+}
+
+std::vector<uint64_t> discover_text_relocation_targets(const AmdGpuCodeObject &object) {
+  const auto *bytes = reinterpret_cast<const uint8_t *>(object.image_data());
+  const std::span<const uint8_t> image(bytes, object.image_size());
+  const auto view = read_single_text_section(object);
+  if (!view)
+    return {};
+  const uint64_t text_vaddr = view->text_vaddr;
+  const uint64_t text_size = view->text_size;
+  // The addend rewrite this mirrors only runs for a shared object, so for anything else a
+  // symbol-less addend cannot retarget a body and claiming otherwise would refuse for no reason.
+  const bool addends_are_rewritten = view->ehdr.e_type == ET_DYN;
+
+  std::vector<uint64_t> targets;
+  for (const Elf64_Shdr &relocations : view->sections) {
+    if (relocations.sh_type != SHT_RELA || relocations.sh_entsize != sizeof(Elf64_Rela) ||
+        !range_in_image(image, relocations.sh_offset, relocations.sh_size))
+      continue;
+    const Elf64_Shdr *linked_symbols = relocations.sh_link < view->sections.size()
+                                           ? &view->sections[relocations.sh_link]
+                                           : nullptr;
+    const size_t count = relocations.sh_size / sizeof(Elf64_Rela);
+    for (size_t index = 0; index < count; ++index) {
+      Elf64_Rela rela{};
+      if (!read_object(image, relocations.sh_offset + index * sizeof(Elf64_Rela), rela))
+        continue;
+      const uint32_t type = elf_reloc_type(rela.r_info);
+      std::optional<uint64_t> target;
+      if (type == R_AMDGPU_RELATIVE64) {
+        // Mirrors the addend rewrite: it retargets every in-text RELATIVE64 regardless of what
+        // object encloses the slot, so the reachability claim has to cover the same set.
+        if (!addends_are_rewritten || rela.r_addend < 0)
+          continue;
+        target = static_cast<uint64_t>(rela.r_addend);
+      } else if (type == R_AMDGPU_ABS64) {
+        // A symbol-backed absolute reference to a function body is the same claim by another
+        // encoding: some data word will hold this code address once the loader is done.
+        target = resolve_reloc_symbol_target(image, linked_symbols, rela, kElfSymbolTypeFunc);
+      }
+      if (target && *target >= text_vaddr && *target - text_vaddr < text_size)
+        targets.push_back(*target - text_vaddr);
+    }
+  }
+
+  std::ranges::sort(targets);
+  targets.erase(std::ranges::unique(targets).begin(), targets.end());
+  return targets;
+}
 
 std::vector<RelocationFunctionTable>
 discover_relocation_function_tables(const AmdGpuCodeObject &object) {
   const auto *bytes = reinterpret_cast<const uint8_t *>(object.image_data());
   const std::span<const uint8_t> image(bytes, object.image_size());
-  Elf64_Ehdr ehdr{};
-  if (!read_object(image, 0, ehdr) || ehdr.e_shentsize != sizeof(Elf64_Shdr) ||
-      !range_in_image(image, ehdr.e_shoff,
-                      static_cast<uint64_t>(ehdr.e_shnum) * sizeof(Elf64_Shdr)))
+  const auto view = read_single_text_section(object);
+  if (!view)
     return {};
-
-  std::vector<Elf64_Shdr> sections(ehdr.e_shnum);
-  std::memcpy(sections.data(), image.data() + ehdr.e_shoff, sections.size() * sizeof(Elf64_Shdr));
-
-  if (object.text_sections().size() != 1)
-    return {};
-  const Section &text = *object.text_sections().front();
-  const uint64_t text_vaddr = text.vaddr();
-  const uint64_t text_size = text.size();
+  const std::span<const Elf64_Shdr> sections = view->sections;
+  const uint64_t text_vaddr = view->text_vaddr;
+  const uint64_t text_size = view->text_size;
 
   std::vector<ObjectCandidate> candidates;
   for (const Elf64_Shdr &symtab : sections) {
@@ -310,34 +485,13 @@ discover_relocation_function_tables(const AmdGpuCodeObject &object) {
             {.slot_vaddr = rela.r_offset, .target_text_offset = target - text_vaddr});
         continue;
       }
-      if (type != R_AMDGPU_ABS64 || linked_symbols == nullptr ||
-          (linked_symbols->sh_type != SHT_SYMTAB && linked_symbols->sh_type != SHT_DYNSYM) ||
-          linked_symbols->sh_entsize != sizeof(Elf64_Sym) ||
-          !range_in_image(image, linked_symbols->sh_offset, linked_symbols->sh_size))
+      if (type != R_AMDGPU_ABS64)
         continue;
-      const uint32_t symbol_index = elf_reloc_sym(rela.r_info);
-      if (symbol_index >= linked_symbols->sh_size / sizeof(Elf64_Sym))
+      const auto resolved =
+          resolve_reloc_symbol_target(image, linked_symbols, rela, kElfSymbolTypeObject);
+      if (!resolved)
         continue;
-      Elf64_Sym symbol{};
-      if (!read_object(image,
-                       linked_symbols->sh_offset +
-                           static_cast<uint64_t>(symbol_index) * sizeof(Elf64_Sym),
-                       symbol) ||
-          elf_symbol_type(symbol.st_info) != kElfSymbolTypeObject)
-        continue;
-      uint64_t target = symbol.st_value;
-      if (rela.r_addend >= 0) {
-        const uint64_t addend = static_cast<uint64_t>(rela.r_addend);
-        if (addend > std::numeric_limits<uint64_t>::max() - target)
-          continue;
-        target += addend;
-      } else {
-        // Avoid negating INT64_MIN in signed arithmetic.
-        const uint64_t magnitude = uint64_t{0} - static_cast<uint64_t>(rela.r_addend);
-        if (magnitude > target)
-          continue;
-        target -= magnitude;
-      }
+      const uint64_t target = *resolved;
       const auto candidate = std::ranges::find_if(
           candidates, [&](const ObjectCandidate &item) { return item.vaddr == target; });
       if (candidate != candidates.end())

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/relocation_function_table.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/relocation_function_table.h
@@ -87,6 +87,53 @@ struct RelocationTableDispatch {
   uint64_t source_table_address_vaddr = 0;
 };
 
+/// @brief Source `.text` extent of one non-kernel function symbol.
+struct DeviceFunctionExtent {
+  /// `.text`-relative byte offset of the function entry.
+  uint64_t text_offset = 0;
+
+  /// Function body size from `st_size`.
+  uint64_t size = 0;
+};
+
+/// @brief Discover `STT_FUNC` symbols in `.text` that are not kernel entries.
+///
+/// @details A kernel's body is reachable through its descriptor, so it is
+/// already a translation root. Anything else named by a function symbol is a
+/// device function, whose body is only translated when some kernel scope
+/// reaches it. Callers use these extents to prove that no such body was left
+/// out of every scope, because `.text` is replaced wholesale and an omitted
+/// body is not preserved -- its address range is reoccupied by other translated
+/// code.
+///
+/// Symbols are matched structurally rather than by name and are accepted at any
+/// binding: device functions are frequently `STB_LOCAL` and appear only in
+/// `.symtab`. Extents are returned sorted by `text_offset` with duplicates
+/// removed, which a compiler emitting one body per caller does produce.
+///
+/// @param object Source code object.
+/// @param kernel_entry_offsets `.text`-relative kernel entries to exclude.
+[[nodiscard]] std::vector<DeviceFunctionExtent>
+discover_device_function_extents(const AmdGpuCodeObject &object,
+                                 std::span<const uint64_t> kernel_entry_offsets);
+
+/// @brief Discover `.text` offsets that a relocated data word will hold at run time.
+///
+/// @details Deliberately broader than table discovery, and asks a different
+/// question: not "is this a dispatch table rocjitsu can model" but "will some
+/// address of this code exist in memory". A pointer array whose own symbol was
+/// stripped, or one the linker never gave an `STT_OBJECT`, still emits its
+/// relocation, so qualifying the containing object would miss it -- and the
+/// relocated addend is rewritten regardless of whether the table qualified.
+///
+/// The same predicate the addend rewrite itself uses, plus symbol-backed
+/// references to function bodies.
+///
+/// @param object Source code object.
+/// @returns `.text`-relative offsets, sorted, with duplicates removed.
+[[nodiscard]] std::vector<uint64_t>
+discover_text_relocation_targets(const AmdGpuCodeObject &object);
+
 /// @brief Discover finite device-call tables from ELF symbols and relocations.
 ///
 /// @details A candidate must be a non-empty `STT_OBJECT` whose size is a

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -582,10 +582,12 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
             gfx1250_b0_to_a0_library_test
             PRIVATE
                 GFX1250_B0_TO_A0_FIXTURE="${KERNEL_OUTPUT_DIR}/relocation_function_table_dispatch_gfx1250.hsaco"
+                GFX1250_DEVICE_FUNCTION_FIXTURE="${KERNEL_OUTPUT_DIR}/device_function_direct_call_gfx1250.hsaco"
         )
         add_dependencies(
             gfx1250_b0_to_a0_library_test
             probe_relocation_function_table_dispatch_gfx1250
+            probe_device_function_direct_call_gfx1250
         )
     endif()
     rj_configure_target(

--- a/emulation/rocjitsu/tests/dbt/gfx1250_b0_to_a0_library_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/gfx1250_b0_to_a0_library_test.cpp
@@ -4,6 +4,7 @@
 /// @file gfx1250_b0_to_a0_library_test.cpp
 /// @brief Tests the fixed-profile gfx1250 B0-to-A0 shared-library API.
 
+#include "rocjitsu/code/amdgpu_elf.h"
 #include "rocjitsu/code/rj_gfx1250_b0_to_a0.h"
 
 #include <gtest/gtest.h>
@@ -11,9 +12,11 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#include <cstring>
 #include <fstream>
 #include <iterator>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace {
@@ -28,6 +31,47 @@ uint64_t source_identity(const std::vector<uint8_t> &bytes) {
     identity *= kPrime;
   }
   return identity;
+}
+
+struct FunctionExtent {
+  std::string name;
+  uint64_t value = 0;
+  uint64_t size = 0;
+};
+
+/// @brief Read the local `STT_FUNC` extents from `.symtab`, sorted by address.
+std::vector<FunctionExtent> local_function_extents(const std::vector<uint8_t> &image) {
+  using namespace rocjitsu;
+  std::vector<FunctionExtent> extents;
+  if (image.size() < sizeof(Elf64_Ehdr))
+    return extents;
+  Elf64_Ehdr ehdr{};
+  std::memcpy(&ehdr, image.data(), sizeof(ehdr));
+  if (ehdr.e_shentsize != sizeof(Elf64_Shdr) ||
+      ehdr.e_shoff + static_cast<uint64_t>(ehdr.e_shnum) * sizeof(Elf64_Shdr) > image.size())
+    return extents;
+
+  std::vector<Elf64_Shdr> sections(ehdr.e_shnum);
+  std::memcpy(sections.data(), image.data() + ehdr.e_shoff, sections.size() * sizeof(Elf64_Shdr));
+  for (const Elf64_Shdr &section : sections) {
+    if (section.sh_type != SHT_SYMTAB || section.sh_entsize != sizeof(Elf64_Sym) ||
+        section.sh_link >= sections.size())
+      continue;
+    const Elf64_Shdr &strings = sections[section.sh_link];
+    for (uint64_t offset = 0; offset + sizeof(Elf64_Sym) <= section.sh_size;
+         offset += sizeof(Elf64_Sym)) {
+      Elf64_Sym symbol{};
+      std::memcpy(&symbol, image.data() + section.sh_offset + offset, sizeof(symbol));
+      if (elf_symbol_type(symbol.st_info) != kElfSymbolTypeFunc ||
+          elf_symbol_bind(symbol.st_info) != kElfSymbolBindLocal || symbol.st_size == 0)
+        continue;
+      const auto *name =
+          reinterpret_cast<const char *>(image.data() + strings.sh_offset + symbol.st_name);
+      extents.push_back({.name = name, .value = symbol.st_value, .size = symbol.st_size});
+    }
+  }
+  std::ranges::sort(extents, {}, &FunctionExtent::value);
+  return extents;
 }
 #endif
 
@@ -76,6 +120,79 @@ TEST(Gfx1250B0ToA0Library, TranslatesRealGfx1250CodeObject) {
   EXPECT_TRUE(std::equal(kElfMagic.begin(), kElfMagic.end(), output));
 
   rj_gfx1250_b0_to_a0_free(output);
+}
+#endif
+
+#ifdef GFX1250_DEVICE_FUNCTION_FIXTURE
+/// A code object whose kernels call out-of-line device functions must translate, and a second pass
+/// must reproduce it byte for byte.
+///
+/// @details The fixture is the only artifact carrying non-kernel `STT_FUNC` bodies: clang reaches
+/// them with `s_get_pc_i64` + `s_add_nc_u64` + `s_swap_pc_i64` rather than a direct call, and emits
+/// one `LOCAL` copy per caller. Byte-identical re-translation is what proves the function-coverage
+/// refusal does not fire on rocjitsu's own output, whose inter-body padding is `s_nop` rather than
+/// the zeros the decoder skips.
+TEST(Gfx1250B0ToA0Library, TranslatesAndReproducesDeviceFunctionCallers) {
+  std::ifstream input(GFX1250_DEVICE_FUNCTION_FIXTURE, std::ios::binary);
+  ASSERT_TRUE(input) << GFX1250_DEVICE_FUNCTION_FIXTURE;
+  const std::vector<uint8_t> source((std::istreambuf_iterator<char>(input)),
+                                    std::istreambuf_iterator<char>());
+  ASSERT_GE(source.size(), 4u);
+
+  // A future toolchain that inlines the helpers away would leave this test passing while covering
+  // nothing at all, so require the bodies the fixture exists to carry. The names are mangled and
+  // the helpers are `noinline`, so their absence means the shape under test is gone.
+  for (const std::string_view symbol :
+       {"_Z11device_leafff", "_Z14device_nonleafff", "_Z18device_tail_callerff"}) {
+    ASSERT_NE(std::search(source.begin(), source.end(), symbol.begin(), symbol.end()), source.end())
+        << "fixture no longer carries an out-of-line device function named " << symbol;
+  }
+
+  uint8_t *first = nullptr;
+  size_t first_size = 0;
+  rj_gfx1250_b0_to_a0_translation_info_t info{};
+  ASSERT_EQ(rj_gfx1250_b0_to_a0_translate_with_info(source.data(), source.size(), &first,
+                                                    &first_size, &info),
+            ROCJITSU_STATUS_SUCCESS);
+  ASSERT_NE(first, nullptr);
+  const std::vector<uint8_t> first_pass(first, first + first_size);
+  rj_gfx1250_b0_to_a0_free(first);
+
+  uint8_t *second = nullptr;
+  size_t second_size = 0;
+  ASSERT_EQ(
+      rj_gfx1250_b0_to_a0_translate(first_pass.data(), first_pass.size(), &second, &second_size),
+      ROCJITSU_STATUS_SUCCESS);
+  ASSERT_NE(second, nullptr);
+  const std::vector<uint8_t> second_pass(second, second + second_size);
+  rj_gfx1250_b0_to_a0_free(second);
+
+  EXPECT_EQ(second_pass, first_pass)
+      << "re-translating a device-function object must not drop or duplicate a callee body";
+
+  // A symbol's value and its extent are answered from opposite ends of the same source offset, and
+  // those two offsets coincide wherever one callee abuts the next -- which this fixture does twice,
+  // once per clone of the leaf. Pinning the relationships rather than the numbers keeps the check
+  // meaningful if a translation rule later grows one of the bodies.
+  const auto source_extents = local_function_extents(source);
+  const auto target_extents = local_function_extents(first_pass);
+  ASSERT_GE(source_extents.size(), 2u) << "fixture must carry more than one out-of-line callee";
+  ASSERT_EQ(target_extents.size(), source_extents.size())
+      << "translation must neither drop nor invent a callee body";
+
+  for (size_t i = 0; i + 1 < target_extents.size(); ++i) {
+    EXPECT_EQ(target_extents[i].name, source_extents[i].name)
+        << "callee bodies must keep their relative order";
+    EXPECT_LE(target_extents[i].value + target_extents[i].size, target_extents[i + 1].value)
+        << target_extents[i].name << " overlaps " << target_extents[i + 1].name;
+    const bool abutted_in_source =
+        source_extents[i].value + source_extents[i].size == source_extents[i + 1].value;
+    if (abutted_in_source) {
+      EXPECT_EQ(target_extents[i].value + target_extents[i].size, target_extents[i + 1].value)
+          << "an extent measured through the following body's start would span the gap between "
+          << target_extents[i].name << " and " << target_extents[i + 1].name;
+    }
+  }
 }
 #endif
 

--- a/emulation/rocjitsu/tests/dbt/multikernel_indirect_branch_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/multikernel_indirect_branch_test.cpp
@@ -323,13 +323,33 @@ TEST(BinaryTranslatorE2E, BuildsCfgForRealMultiKernelIndirectBranches) {
   }
 
   std::ranges::sort(direct_scall_offsets);
-  // These are the three RJ_STATIC_SCALL_ISLAND sites in the checked-in
-  // fixture. Each target jumps to the join instead of returning, so its
-  // syntactic s_branch continuation is dead.
-  const std::vector<uint64_t> expected_direct_scall_offsets{0xbacu, 0xbdcu, 0xc10u};
   EXPECT_GE(recovered_swappc_blocks, 6u);
   EXPECT_GE(recovered_setpc_blocks, 3u);
-  EXPECT_EQ(direct_scall_offsets, expected_direct_scall_offsets);
+
+  // The three RJ_STATIC_SCALL_ISLAND sites, which the fixture places in one
+  // kernel. Each target jumps to the join instead of returning, so its
+  // syntactic s_branch continuation is dead; that is asserted per site above.
+  //
+  // Located by the kernel containing them rather than by literal .text offsets.
+  // The fixture is compiled, so anything ahead of this kernel changing size
+  // shifts every literal address by the same amount and the test then reports a
+  // toolchain difference as a translation defect.
+  ASSERT_EQ(direct_scall_offsets.size(), 3u);
+  const auto *scall_kernel =
+      kernel_translation_by_name(source_kernels, *co, "multikernel_indirect_branch_scall");
+  ASSERT_NE(scall_kernel, nullptr);
+  const uint64_t scall_entry = scall_kernel->entry_text_offset;
+  uint64_t scall_end = text->size();
+  for (const auto &kernel : source_kernels) {
+    if (kernel.entry_text_offset > scall_entry)
+      scall_end = std::min(scall_end, kernel.entry_text_offset);
+  }
+  ASSERT_LT(scall_entry, scall_end);
+  for (const uint64_t offset : direct_scall_offsets) {
+    EXPECT_GE(offset, scall_entry);
+    EXPECT_LT(offset, scall_end)
+        << "a direct s_call outside the island kernel means the fixture no longer isolates them";
+  }
 }
 
 TEST(BinaryTranslatorE2E, CountsRealMultiKernelIndirectBranchCfgBlocksPerKernel) {

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -453,7 +453,8 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_descriptor_after_text(
     const std::vector<uint32_t> &text_words,
     std::optional<size_t> text_function_words = std::nullopt, size_t text_function_offset_words = 0,
     std::optional<size_t> function_pointer_table_target_words = std::nullopt,
-    bool name_function_pointer_table_with_symbol = true) {
+    bool name_function_pointer_table_with_symbol = true,
+    uint8_t kernel_descriptor_symbol_binding = kElfSymbolBindGlobal) {
   if (text_function_words && text_function_offset_words + *text_function_words > text_words.size())
     throw std::invalid_argument("text function extent exceeds .text fixture");
   if (function_pointer_table_target_words &&
@@ -548,7 +549,7 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_descriptor_after_text(
 
   std::vector<Elf64_Sym> syms(sym_count);
   syms[1].st_name = kd_symbol_name;
-  syms[1].st_info = elf_symbol_info(kElfSymbolBindGlobal, kElfSymbolTypeObject);
+  syms[1].st_info = elf_symbol_info(kernel_descriptor_symbol_binding, kElfSymbolTypeObject);
   syms[1].st_shndx = 2;
   syms[1].st_value = rodata_vaddr;
   syms[1].st_size = kKernelDescriptorSize;
@@ -10835,6 +10836,47 @@ TEST(BinaryTranslatorE2E, Gfx1250RefusesDeviceFunctionBodyReachedByNoScope) {
   EXPECT_EQ(result.elf_bytes, image);
   EXPECT_TRUE(rocjitsu::has_error_containing(result, rocjitsu::DiagnosticKind::Legalization,
                                              "device function body reached no kernel scope"));
+}
+
+// The loader dispatches a kernel descriptor at any binding, and clang emits a weak one for a weak
+// kernel and for some implicit template instantiations. Requiring STB_GLOBAL therefore left such a
+// kernel untranslated -- and because translated text replaces .text wholesale, its entry offset was
+// reoccupied by another kernel's relocated body, so launching it ran unrelated code with no fault.
+TEST(BinaryTranslatorE2E, Gfx1250TranslatesAKernelWhoseDescriptorSymbolIsWeak) {
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  constexpr auto conversion =
+      gfx1250::build_vop3(gfx1250::kVCvtF32Fp8Vop3, {.vdst = 30, .clamp = 1, .src0 = 256 + 22});
+  const std::vector<uint32_t> words = {conversion[0], conversion[1], kGfx1250SEndpgm};
+
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      words, /*text_function_words=*/std::nullopt, /*text_function_offset_words=*/0,
+      /*function_pointer_table_target_words=*/std::nullopt,
+      /*name_function_pointer_table_with_symbol=*/true,
+      /*kernel_descriptor_symbol_binding=*/rocjitsu::kElfSymbolBindWeak);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_TRUE(translated.is_valid());
+  ASSERT_FALSE(translated.text_sections().empty());
+  rocjitsu::KernelDescriptorTranslator parser(ROCJITSU_CODE_ARCH_GFX1250,
+                                              ROCJITSU_CODE_ARCH_GFX1250);
+  const auto infos = parser.translate_image(
+      result.elf_bytes, translated.text_sections()[0]->sectionOffset(),
+      translated.text_sections()[0]->size(), rocjitsu::KernelDescriptorTranslationOptions{});
+  EXPECT_EQ(infos.size(), 1u) << "a weak descriptor must still be seen as a kernel root";
+  for (const auto &diagnostic : result.diagnostics) {
+    EXPECT_NE(diagnostic.kind, rocjitsu::DiagnosticKind::NothingToTranslate)
+        << "the body must translate as a kernel, not report as an unreferenced function";
+  }
 }
 
 // The same shape with the pointer array's own symbol stripped. Table discovery needs a qualifying

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -61,6 +61,7 @@
 #include "rocjitsu/code/patch/kernarg_extension.h"
 #include "rocjitsu/code/patch/kernel_text_layout.h"
 #include "rocjitsu/code/patch/sidecar_metadata.h"
+#include "rocjitsu/code/relocation_function_table.h"
 #include "rocjitsu/code/rj_code.h"
 #include "rocjitsu/code/rj_code_internal.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna3/builders.h"
@@ -450,14 +451,21 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_load_segments() {
 
 std::vector<uint8_t> make_minimal_amdgpu_elf_with_descriptor_after_text(
     const std::vector<uint32_t> &text_words,
-    std::optional<size_t> text_function_words = std::nullopt) {
-  if (text_function_words && *text_function_words > text_words.size())
+    std::optional<size_t> text_function_words = std::nullopt, size_t text_function_offset_words = 0,
+    std::optional<size_t> function_pointer_table_target_words = std::nullopt,
+    bool name_function_pointer_table_with_symbol = true) {
+  if (text_function_words && text_function_offset_words + *text_function_words > text_words.size())
     throw std::invalid_argument("text function extent exceeds .text fixture");
+  if (function_pointer_table_target_words &&
+      *function_pointer_table_target_words >= text_words.size())
+    throw std::invalid_argument("function pointer target exceeds .text fixture");
   constexpr uint64_t text_offset = 0x100;
   constexpr uint64_t text_vaddr = 0x1100;
   const uint64_t text_size = text_words.size() * sizeof(uint32_t);
   constexpr uint64_t load_align = 0x1000;
   constexpr uint64_t rodata_size = kKernelDescriptorSize;
+  const bool has_table = function_pointer_table_target_words.has_value();
+  constexpr uint64_t table_size = sizeof(uint64_t);
 
   std::vector<uint8_t> shstrtab{'\0'};
   const uint32_t text_name = add_elf_name(shstrtab, ".text");
@@ -465,10 +473,13 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_descriptor_after_text(
   const uint32_t symtab_name = add_elf_name(shstrtab, ".symtab");
   const uint32_t strtab_name = add_elf_name(shstrtab, ".strtab");
   const uint32_t shstrtab_name = add_elf_name(shstrtab, ".shstrtab");
+  const uint32_t table_name = has_table ? add_elf_name(shstrtab, ".data.rel.ro") : 0;
+  const uint32_t rela_name = has_table ? add_elf_name(shstrtab, ".rela.dyn") : 0;
 
   std::vector<uint8_t> strtab{'\0'};
   const uint32_t kd_symbol_name = add_elf_name(strtab, "kernel.kd");
   const uint32_t text_symbol_name = text_function_words ? add_elf_name(strtab, "kernel") : 0;
+  const uint32_t table_symbol_name = has_table ? add_elf_name(strtab, "function_table") : 0;
 
   // The kernel descriptor requires 8-byte alignment (tests reinterpret_cast the
   // .rodata bytes to TestKernelDescriptor). An odd text_words count leaves
@@ -477,12 +488,15 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_descriptor_after_text(
   // padding both keeps the PT_LOAD p_offset == p_vaddr (mod p_align) congruence.
   const uint64_t rodata_offset = align_up_for_test(text_offset + text_size, 8);
   const uint64_t rodata_vaddr = align_up_for_test(text_vaddr + text_size, 8) + load_align;
+  const uint64_t table_vaddr = rodata_vaddr + load_align;
   const uint64_t strtab_offset = rodata_offset + rodata_size;
   const uint64_t symtab_offset = align_up_for_test(strtab_offset + strtab.size(), 8);
-  const size_t sym_count = text_function_words ? 3 : 2;
-  const uint64_t shstrtab_offset = symtab_offset + sym_count * sizeof(Elf64_Sym);
+  const size_t sym_count = (text_function_words ? 3 : 2) + (has_table ? 1 : 0);
+  const uint64_t table_offset = symtab_offset + sym_count * sizeof(Elf64_Sym);
+  const uint64_t rela_offset = has_table ? table_offset + table_size : table_offset;
+  const uint64_t shstrtab_offset = rela_offset + (has_table ? sizeof(Elf64_Rela) : 0);
   const uint64_t shoff = align_up_for_test(shstrtab_offset + shstrtab.size(), 8);
-  constexpr uint16_t section_count = 6;
+  const uint16_t section_count = has_table ? 8 : 6;
   constexpr uint16_t phdr_count = 2;
 
   std::vector<uint8_t> image(shoff + section_count * sizeof(Elf64_Shdr), 0);
@@ -540,16 +554,39 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_descriptor_after_text(
   syms[1].st_size = kKernelDescriptorSize;
   if (text_function_words) {
     syms[2].st_name = text_symbol_name;
-    syms[2].st_info = elf_symbol_info(kElfSymbolBindGlobal, kElfSymbolTypeFunc);
+    // Real device functions are LOCAL and appear only in .symtab. Offset zero is the kernel entry,
+    // which function discovery excludes; a non-zero offset names a callee body.
+    syms[2].st_info = elf_symbol_info(text_function_offset_words == 0 ? kElfSymbolBindGlobal
+                                                                      : kElfSymbolBindLocal,
+                                      kElfSymbolTypeFunc);
     syms[2].st_shndx = 1;
-    syms[2].st_value = text_vaddr;
+    syms[2].st_value = text_vaddr + text_function_offset_words * sizeof(uint32_t);
     syms[2].st_size = *text_function_words * sizeof(uint32_t);
+  }
+  if (has_table) {
+    // A function-pointer table is an STT_OBJECT in a non-executable allocated section, with one
+    // R_AMDGPU_RELATIVE64 slot whose addend is the callee's virtual address.
+    if (name_function_pointer_table_with_symbol) {
+      Elf64_Sym &table_symbol = syms.back();
+      table_symbol.st_name = table_symbol_name;
+      table_symbol.st_info = elf_symbol_info(kElfSymbolBindGlobal, kElfSymbolTypeObject);
+      table_symbol.st_shndx = 6;
+      table_symbol.st_value = table_vaddr;
+      table_symbol.st_size = table_size;
+    }
+
+    Elf64_Rela rela{};
+    rela.r_offset = table_vaddr;
+    rela.r_info = (uint64_t{0} << 32) | rocjitsu::R_AMDGPU_RELATIVE64;
+    rela.r_addend =
+        static_cast<int64_t>(text_vaddr + *function_pointer_table_target_words * sizeof(uint32_t));
+    std::memcpy(image.data() + rela_offset, &rela, sizeof(rela));
   }
   std::memcpy(image.data() + symtab_offset, syms.data(), syms.size() * sizeof(Elf64_Sym));
 
   std::memcpy(image.data() + shstrtab_offset, shstrtab.data(), shstrtab.size());
 
-  std::array<Elf64_Shdr, section_count> shdrs{};
+  std::vector<Elf64_Shdr> shdrs(section_count);
   shdrs[1].sh_name = text_name;
   shdrs[1].sh_type = SHT_PROGBITS;
   shdrs[1].sh_flags = SHF_ALLOC | SHF_EXECINSTR;
@@ -565,6 +602,24 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_descriptor_after_text(
   shdrs[2].sh_offset = rodata_offset;
   shdrs[2].sh_size = rodata_size;
   shdrs[2].sh_addralign = 64;
+
+  if (has_table) {
+    shdrs[6].sh_name = table_name;
+    shdrs[6].sh_type = SHT_PROGBITS;
+    shdrs[6].sh_flags = SHF_ALLOC;
+    shdrs[6].sh_addr = table_vaddr;
+    shdrs[6].sh_offset = table_offset;
+    shdrs[6].sh_size = table_size;
+    shdrs[6].sh_addralign = 8;
+
+    shdrs[7].sh_name = rela_name;
+    shdrs[7].sh_type = SHT_RELA;
+    shdrs[7].sh_offset = rela_offset;
+    shdrs[7].sh_size = sizeof(Elf64_Rela);
+    shdrs[7].sh_link = 3;
+    shdrs[7].sh_addralign = 8;
+    shdrs[7].sh_entsize = sizeof(Elf64_Rela);
+  }
 
   shdrs[3].sh_name = symtab_name;
   shdrs[3].sh_type = SHT_SYMTAB;
@@ -1958,6 +2013,49 @@ TEST(CodeObjectPatcher, ReplaceTextRelocatesTextSymbolsWithExactOffsetMap) {
   ASSERT_GE(symbols.size(), 3u);
   EXPECT_EQ(symbols[2].st_value, 0x1104u);
   EXPECT_EQ(symbols[2].st_size, 12u);
+}
+
+// A helper block is copied into every scope that reaches it, so one source offset yields a record
+// per scope and "first wins" is decided independently for the entry and for the end. Here scope 0
+// records offset 8 as an instruction start while scope 1 records it as a body end: resolving the
+// extent globally would take scope 1's end against scope 0's entry and report a body spanning
+// everything translation placed between the two copies.
+TEST(CodeObjectPatcher, TextSymbolExtentIsMeasuredWithinOneTranslationScope) {
+  auto image = make_minimal_amdgpu_elf_with_load_segments();
+  AmdGpuCodeObject co(image.data(), image.size());
+  ASSERT_TRUE(co.is_valid());
+
+  CodeObjectPatcher patcher(co);
+  const std::vector<uint32_t> text_words(128, 0xBF800000u);
+  const auto *text_bytes = reinterpret_cast<const uint8_t *>(text_words.data());
+  constexpr std::array<TextOffsetRelocation, 4> relocations = {
+      TextOffsetRelocation{
+          .source_offset = 0, .target_offset = 4, .is_instruction_start = true, .scope_index = 0},
+      TextOffsetRelocation{
+          .source_offset = 8, .target_offset = 16, .is_instruction_start = true, .scope_index = 0},
+      TextOffsetRelocation{
+          .source_offset = 0, .target_offset = 200, .is_instruction_start = true, .scope_index = 1},
+      TextOffsetRelocation{.source_offset = 8,
+                           .target_offset = 300,
+                           .is_instruction_start = false,
+                           .scope_index = 1},
+  };
+  ASSERT_TRUE(
+      patcher.replace_text({text_bytes, text_words.size() * sizeof(uint32_t)}, relocations));
+
+  const auto patched_bytes = patcher.emit();
+  const auto ehdr = read_elf_struct_for_test<Elf64_Ehdr>(patched_bytes, 0);
+  const auto shdrs = read_elf_array_for_test<Elf64_Shdr>(patched_bytes, ehdr.e_shoff, ehdr.e_shnum);
+  const auto symtab = std::find_if(shdrs.begin(), shdrs.end(), [](const Elf64_Shdr &shdr) {
+    return shdr.sh_type == SHT_SYMTAB;
+  });
+  ASSERT_NE(symtab, shdrs.end());
+  const auto symbols = read_elf_array_for_test<Elf64_Sym>(patched_bytes, symtab->sh_offset,
+                                                          symtab->sh_size / symtab->sh_entsize);
+  ASSERT_GE(symbols.size(), 3u);
+  EXPECT_EQ(symbols[2].st_value, 0x1104u) << "the entry must come from the first scope to place it";
+  EXPECT_EQ(symbols[2].st_size, 12u)
+      << "the extent must be read back in the scope that supplied the entry";
 }
 
 TEST(CodeObjectPatcher, AppendsNonAllocSectionWithoutMovingLoadableSegments) {
@@ -4959,11 +5057,15 @@ TEST(BinaryTranslatorE2E, Gfx1250LongDirectBranchGrowthIsIdempotent) {
   EXPECT_EQ(second.elf_bytes, result.elf_bytes);
 }
 
+// gfx1250 has a fixed scalar file, so the descriptor's granulated SGPR count is not a measurement
+// of the kernel and cannot be grown to reserve a thunk pair. The pair is instead proven unused by
+// scanning the scope, so exhausting it requires the body to actually name every scalar register.
+// The descriptor count below is left high deliberately: it must not influence the choice.
 TEST(BinaryTranslatorE2E, Gfx1250LongBranchReportsSgprExhaustionAfterSemanticExpansion) {
   using namespace rocr::llvm::amdhsa;
 
   constexpr size_t kTargetWord = 0x8000;
-  constexpr uint16_t kLiveSgprs = 104;
+  constexpr uint16_t kLiveSgprs = 106;
   constexpr auto conversion =
       gfx1250::build_vop3(gfx1250::kVCvtF32Fp8Vop3, {.vdst = 30, .clamp = 1, .src0 = 256 + 22});
   constexpr uint32_t kGfx1250SNop = 0xBF800000u;
@@ -5010,6 +5112,110 @@ TEST(BinaryTranslatorE2E, Gfx1250LongBranchReportsSgprExhaustionAfterSemanticExp
   ASSERT_NE(diagnostic, result.diagnostics.end());
   EXPECT_EQ(diagnostic->guest_offset, std::optional<uint64_t>(0))
       << "the resource diagnostic must identify the branch that could not be expanded";
+}
+
+// The companion to the exhaustion case: which pair gets chosen, not merely that some choice is
+// reachable. The body names s0 through s5, so the lowest free even-aligned pair is s[6:7]. The
+// descriptor's granulated count is set high on purpose -- on a fixed scalar file it is not a
+// measurement of the kernel, and a pair derived from it would land at s8 and overwrite live state.
+TEST(BinaryTranslatorE2E, Gfx1250LongBranchTakesTheLowestSgprPairTheScopeLeavesFree) {
+  using namespace rocr::llvm::amdhsa;
+
+  constexpr size_t kTargetWord = 0x8000;
+  constexpr uint16_t kNamedSgprs = 6;
+  constexpr uint16_t kExpectedPair = kNamedSgprs;
+  constexpr auto conversion =
+      gfx1250::build_vop3(gfx1250::kVCvtF32Fp8Vop3, {.vdst = 30, .clamp = 1, .src0 = 256 + 22});
+  constexpr uint32_t kGfx1250SNop = 0xBF800000u;
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+
+  std::vector<uint32_t> words;
+  words.reserve(kTargetWord + 1);
+  words.push_back(gfx1250::build_sopp(gfx1250::kSCbranchScc0Sopp,
+                                      {.simm16 = static_cast<uint16_t>(kTargetWord - 1u)})[0]);
+  words.insert(words.end(), conversion.begin(), conversion.end());
+  for (uint16_t sgpr = 0; sgpr < kNamedSgprs; ++sgpr) {
+    words.push_back(
+        gfx1250::build_sop1(gfx1250::kSMovB32Sop1, {.ssrc0 = static_cast<uint8_t>(sgpr),
+                                                    .sdst = static_cast<uint8_t>(sgpr)})[0]);
+  }
+  words.resize(kTargetWord, kGfx1250SNop);
+  words.push_back(kGfx1250SEndpgm);
+
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
+  rocjitsu::AmdGpuCodeObject layout(image.data(), image.size());
+  ASSERT_TRUE(layout.is_valid());
+  const auto *rodata = rocjitsu::find_section(layout, ".rodata");
+  ASSERT_NE(rodata, nullptr);
+  auto descriptor = rocjitsu::read_kernel_descriptor_for_test(rodata->data());
+  AMDHSA_BITS_SET(descriptor.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT,
+                  12);
+  rocjitsu::write_kernel_descriptor_for_test(image.data() + rodata->sectionOffset(), descriptor);
+
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_TRUE(translated.is_valid());
+  ASSERT_FALSE(translated.text_sections().empty());
+  const auto *target_words =
+      reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+  const auto translated_word_count = translated.text_sections()[0]->size() / sizeof(uint32_t);
+  const uint32_t marker = rocjitsu::build_s_nop(rocjitsu::kLongDirectBranchMarkerNopImmediate,
+                                                ROCJITSU_CODE_ARCH_GFX1250);
+  const auto *found = std::find(target_words, target_words + translated_word_count, marker);
+  ASSERT_NE(found, target_words + translated_word_count)
+      << "the branch must have been expanded into a long transfer";
+  ASSERT_LT(found + 1, target_words + translated_word_count);
+  EXPECT_EQ(found[1], rocjitsu::build_s_getpc_b64(kExpectedPair, ROCJITSU_CODE_ARCH_GFX1250))
+      << "the thunk must hold its address in the lowest pair the scope leaves free";
+  for (uint16_t sgpr = 0; sgpr < kNamedSgprs; sgpr += 2) {
+    EXPECT_NE(found[1], rocjitsu::build_s_getpc_b64(sgpr, ROCJITSU_CODE_ARCH_GFX1250))
+        << "a pair the body names would be clobbered by the thunk";
+  }
+}
+
+// The scalar relative-move family resolves its register number from M0 at run time, so scanning
+// encoded operands cannot enumerate what it reaches and no pair can be proven free. Refuse rather
+// than pick one that a run-time index may land on.
+TEST(BinaryTranslatorE2E, Gfx1250RefusesLongBranchSgprPairWhenScopeIndexesScalarsAtRuntime) {
+  constexpr size_t kTargetWord = 0x8000;
+  constexpr auto conversion =
+      gfx1250::build_vop3(gfx1250::kVCvtF32Fp8Vop3, {.vdst = 30, .clamp = 1, .src0 = 256 + 22});
+  constexpr uint32_t kGfx1250SNop = 0xBF800000u;
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+
+  std::vector<uint32_t> words;
+  words.reserve(kTargetWord + 1);
+  words.push_back(gfx1250::build_sopp(gfx1250::kSCbranchScc0Sopp,
+                                      {.simm16 = static_cast<uint16_t>(kTargetWord - 1u)})[0]);
+  words.insert(words.end(), conversion.begin(), conversion.end());
+  words.push_back(gfx1250::build_sop1(gfx1250::kSMovrelsB32Sop1, {.ssrc0 = 4, .sdst = 10})[0]);
+  words.resize(kTargetWord, kGfx1250SNop);
+  words.push_back(kGfx1250SEndpgm);
+
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(rocjitsu::has_error_containing(
+      result, rocjitsu::DiagnosticKind::ResourceLimit,
+      "long direct branch requires an additional descriptor-backed SGPR pair after semantic "
+      "expansion"));
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250CompactConditionalLayoutIsIdempotent) {
@@ -10596,6 +10802,115 @@ TEST(BinaryTranslatorE2E, Gfx1250MaterializesDsAddtidAddressForA0) {
   // is the field width (inline 20 -> 148). Together: (value >> 0) & ((1<<20)-1).
   EXPECT_EQ(((*v_bfe)->raw_encoding()[1] >> 9) & 0x1ffu, kInline);
   EXPECT_EQ(((*v_bfe)->raw_encoding()[1] >> 18) & 0x1ffu, static_cast<uint16_t>(kInline + 20));
+}
+
+// Translated text replaces .text wholesale, so a device function body that reaches no kernel scope
+// is not preserved: its address range is reoccupied by relocated code and a call arriving there
+// runs something else with no fault. Refuse instead. Kernel bodies need no such proof because their
+// descriptors make them roots.
+TEST(BinaryTranslatorE2E, Gfx1250RefusesDeviceFunctionBodyReachedByNoScope) {
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  constexpr uint32_t kGfx1250SNop = 0xBF800000u;
+  // The kernel ends at word 0, so nothing below it lands in a scope. A function-pointer table names
+  // the body at word 3, so an address the decoded graph never accounts for can still arrive there.
+  // That is what separates this from a dead local a linker merely retained: the identical object
+  // without the table is accepted by the test below, so the table is the only thing being pinned.
+  const std::vector<uint32_t> words = {
+      kGfx1250SEndpgm, kGfx1250SNop, kGfx1250SNop, kGfx1250SNop, kGfx1250SEndpgm,
+  };
+
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      words, /*text_function_words=*/2, /*text_function_offset_words=*/3,
+      /*function_pointer_table_target_words=*/3);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(rocjitsu::has_error_containing(result, rocjitsu::DiagnosticKind::Legalization,
+                                             "device function body reached no kernel scope"));
+}
+
+// The same shape with the pointer array's own symbol stripped. Table discovery needs a qualifying
+// `STT_OBJECT` around the slot and finds nothing here, yet the addend is still rewritten -- to a
+// body that would no longer exist -- so reachability has to be asked of the raw relocation.
+TEST(BinaryTranslatorE2E, Gfx1250RefusesDeviceFunctionBodyHeldByAnUnnamedPointerSlot) {
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  constexpr uint32_t kGfx1250SNop = 0xBF800000u;
+  const std::vector<uint32_t> words = {
+      kGfx1250SEndpgm, kGfx1250SNop, kGfx1250SNop, kGfx1250SNop, kGfx1250SEndpgm,
+  };
+
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      words, /*text_function_words=*/2, /*text_function_offset_words=*/3,
+      /*function_pointer_table_target_words=*/3,
+      /*name_function_pointer_table_with_symbol=*/false);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+  ASSERT_TRUE(rocjitsu::discover_relocation_function_tables(source).empty())
+      << "the slot must not qualify as a table, or this covers the same path as the test above";
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(rocjitsu::has_error_containing(result, rocjitsu::DiagnosticKind::Legalization,
+                                             "device function body reached no kernel scope"));
+}
+
+// The same body with no table naming it is genuinely dead. Linkers retain such locals in device
+// libraries, so refusing them would reject objects that translate correctly, and an operator facing
+// that would disable the feature entirely -- a worse outcome than the case being guarded.
+TEST(BinaryTranslatorE2E, Gfx1250AcceptsUnreferencedDeviceFunctionBody) {
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  constexpr uint32_t kGfx1250SNop = 0xBF800000u;
+  const std::vector<uint32_t> words = {
+      kGfx1250SEndpgm, kGfx1250SNop, kGfx1250SNop, kGfx1250SNop, kGfx1250SEndpgm,
+  };
+
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      words, /*text_function_words=*/2, /*text_function_offset_words=*/3);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+
+  EXPECT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+}
+
+// The same object without the function symbol must still translate: the refusal is keyed on a body
+// a symbol names, not on every unreached byte, so ordinary padding stays acceptable.
+TEST(BinaryTranslatorE2E, Gfx1250AcceptsUnreachedBytesThatNameNoDeviceFunction) {
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  constexpr uint32_t kGfx1250SNop = 0xBF800000u;
+  const std::vector<uint32_t> words = {kGfx1250SEndpgm, kGfx1250SNop, kGfx1250SEndpgm};
+
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  EXPECT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250FailsClosedOnExcludedBarrierSignalIsfirst) {

--- a/emulation/rocjitsu/tests/kernels/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/kernels/CMakeLists.txt
@@ -191,9 +191,15 @@ if(CLANG_OFFLOAD_BUNDLER)
             gfx1250
             OUTPUT_NAME relocation_function_table_dispatch_gfx1250
         )
+        rj_add_probe_object(
+            device_function_direct_call
+            gfx1250
+            OUTPUT_NAME device_function_direct_call_gfx1250
+        )
         set(HAS_GFX1250_DBT_FIXTURE TRUE)
         set(RJ_GFX1250_DBT_FIXTURE_TARGET
             probe_relocation_function_table_dispatch_gfx1250
+            probe_device_function_direct_call_gfx1250
         )
     endif()
 
@@ -210,6 +216,7 @@ if(CLANG_OFFLOAD_BUNDLER)
             install(
                 FILES
                     ${KERNEL_OUTPUT_DIR}/relocation_function_table_dispatch_gfx1250.hsaco
+                    ${KERNEL_OUTPUT_DIR}/device_function_direct_call_gfx1250.hsaco
                 DESTINATION ${CMAKE_INSTALL_DATADIR}/rocjitsu/tests/kernels
             )
         endif()

--- a/emulation/rocjitsu/tests/kernels/device_function_direct_call.hip
+++ b/emulation/rocjitsu/tests/kernels/device_function_direct_call.hip
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file device_function_direct_call.hip
+/// @brief HIP fixture for non-kernel device functions shared by two kernels.
+
+#include <hip/hip_runtime.h>
+
+/// @brief Leaf device function called from more than one kernel.
+///
+/// @details Out of line and not address-taken, so the linked object contains a
+/// plain `STT_FUNC` body reached by a call rather than a relocation-backed
+/// table. Clang materializes the callee address with
+/// `s_get_pc_i64` + `s_add_nc_u64 lit64` and transfers with `s_swap_pc_i64`,
+/// so this exercises the recovered-indirect call path rather than a direct
+/// `s_call_i64`.
+__device__ __attribute__((noinline)) float device_leaf(float a, float b) {
+  return a * b + 1.0f;
+}
+
+/// @brief Non-leaf device function that calls the leaf.
+///
+/// @details A callee that itself calls must preserve its own return address
+/// across the inner transfer. Clang stashes it in VGPR lanes with
+/// `v_writelane_b32` / `v_readlane_b32` and still returns through `s[30:31]`,
+/// which is the shape translation has to classify as returning.
+__device__ __attribute__((noinline)) float device_nonleaf(float a, float b) {
+  return device_leaf(a, b) + b;
+}
+
+/// @brief Device function whose only statement is a call, so clang tail-calls it.
+///
+/// @details A tail call lowers to `s_set_pc_i64` on the *callee* address in an
+/// ordinary SGPR pair rather than `s[30:31]`, so it is an inter-function
+/// transfer that happens to share its encoding shape with a return. Both bodies
+/// relocate together, so the PC-relative literal stays correct only if they keep
+/// their relative distance.
+__device__ __attribute__((noinline)) float device_tail_caller(float a, float b) {
+  return device_leaf(a, b);
+}
+
+/// @brief First caller of both device functions.
+extern "C" __global__ void device_function_caller_a(float *__restrict__ output,
+                                                    const float *__restrict__ input,
+                                                    unsigned count) {
+  const unsigned index = blockIdx.x * blockDim.x + threadIdx.x;
+  if (index >= count)
+    return;
+  output[index] = device_nonleaf(input[index], 2.0f);
+}
+
+/// @brief Second caller, so both bodies are reachable from more than one scope.
+extern "C" __global__ void device_function_caller_b(float *__restrict__ output,
+                                                    const float *__restrict__ input,
+                                                    unsigned count) {
+  const unsigned index = blockIdx.x * blockDim.x + threadIdx.x;
+  if (index >= count)
+    return;
+  output[index] = device_leaf(input[index], 3.0f) + device_tail_caller(input[index], 4.0f);
+}


### PR DESCRIPTION
  Translation scopes are seeded from kernel descriptors, so a device function — an STT_FUNC body with no descriptor, reached by a call — is translated only because some kernel scope reaches it. Real fixtures showed the lowering already works: clang reaches these bodies with s_get_pc_i64/s_add_nc_u64/s_swap_pc_i64, taking the existing recovered-indirect path, and the return pair stays live by ordinary liveness with no ABI reservation. The work is four defects this exposes. The long-branch thunk's SGPR pair came from GRANULATED_WAVEFRONT_SGPR_COUNT, reserved on GFX10+ and decoding to a constant floor, so on gfx1250 it resolved to s[8:9] — registers real code uses — and the island-pool fallback never ran; it is now scanned from the decoded scope, failing closed when the scope indexes scalars at run time. Because translated text replaces .text wholesale, a body reaching no scope is dropped and its range reoccupied, so such bodies are now enumerated and the object refused when one reached no scope and a relocated data word will hold its address, asked of the raw relocation stream rather than of dispatch tables, which additionally require a qualifying STT_OBJECT that a stripped pointer array lacks; unreferenced bodies only warn, since linkers retain dead locals and over-refusal makes operators disable the feature outright. One offset map answered both "where did this instruction land" and "where does this body end", which collide where bodies abut and diverge when translation appends between them — now separate start- and end-preferring views, with extents measured only within the scope that supplied the value. Finally, the descriptor reader required STB_GLOBAL while the loader accepts any binding and clang emits weak descriptors for weak kernels, so such a kernel was left untranslated, dropped, and its entry reoccupied: an object with one weak and two ordinary kernels had weak_kernel and templated_kernel<float> both resolve to 0x2400 after translation, meaning a launch ran the wrong body with no fault.

Adds a HIP fixture with a leaf callee, a non-leaf stashing its return address in VGPR lanes, and a tail call, reached from two kernels so the leaf is cloned and two bodies abut. Both real gfx1250 objects re-translate byte for byte with zero diagnostics and extents matching source; nine new tests were each perturbation-verified to fail when the code they guard is reverted; a CFG test that pinned s_call sites to literal .text offsets in a compiled fixture now locates them by containing kernel, since it was reporting a toolchain shift as a translation defect. Full Release suite green at 2329/2329. One residual divergence: rocjitsu still requires st_size == 64 on .kd while the loader ignores it — same fail-open class, but no evidence any toolchain emits a mis-sized .kd, so not changed speculatively.