### PR TITLE
[rocjitsu] Fix stale code and data addresses in gfx1250 Hotswap translation

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
@@ -2381,8 +2381,14 @@ std::optional<uint16_t> s_call_sdst(const Instruction &inst, uint32_t word) {
   if (pc_builders != nullptr) {
     pc_builders->clear();
     pc_builders->reserve(round_builders.size());
-    for (const auto &[getpc_offset, entry] : round_builders)
-      pc_builders->push_back(entry.record);
+    for (const auto &[getpc_offset, entry] : round_builders) {
+      // Publish the disagreement flag on the copy that leaves this pass. It is kept off the stored
+      // record so the equality test above, which decides whether a second observation conflicts,
+      // keeps comparing only the observed value.
+      PcAddressBuilder published = entry.record;
+      published.poisoned = entry.poisoned;
+      pc_builders->push_back(published);
+    }
     std::ranges::sort(*pc_builders, {}, &PcAddressBuilder::source_getpc_offset);
   }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
@@ -1943,9 +1943,6 @@ struct VectorLaneFlowState {
 // banking may exceed 255 (bank*256 + selector). The ABI table only defines the
 // convention for v0-255, so a banked register above that range is NOT proven
 // callee-saved and must fail closed rather than be masked down to its selector.
-[[nodiscard]] bool is_callee_saved_vgpr(uint16_t phys_vgpr) {
-  return phys_vgpr >= 40 && phys_vgpr <= 255 && ((phys_vgpr - 40) % 16) < 8;
-}
 
 void recover_vector_lane_stashed_pcs(AnalysisContext &ctx, const std::vector<AnalysisBlock> &blocks,
                                      std::vector<IndirectCallFixup> &recovered,
@@ -2397,6 +2394,10 @@ std::optional<uint16_t> s_call_sdst(const Instruction &inst, uint32_t word) {
 }
 
 } // namespace
+
+bool is_callee_saved_vgpr(uint16_t phys_vgpr) {
+  return phys_vgpr >= 40 && phys_vgpr <= 255 && ((phys_vgpr - 40) % 16) < 8;
+}
 
 std::vector<IndirectCallFixup> discover_indirect_branch_edges(
     std::span<const Instruction *const> insts, std::span<const uint8_t> text, rj_code_arch_t arch,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.h
@@ -92,6 +92,14 @@ struct PcAddressBuilder {
   /// erase an intervening instruction. A non-contiguous producer cannot back a
   /// whole-scope relocation invariant even though its final value is known.
   bool contiguous = true;
+  /// @brief True when two observations of this producer disagreed on its value.
+  ///
+  /// Distinct from a cleared @ref resolved, which also covers a producer this
+  /// pass simply never followed to a setpc. A poisoned producer is one no single
+  /// delta rewrite can satisfy, so a caller reasoning about whether every code
+  /// address is relocated must fail closed on it rather than defer to another
+  /// analysis that happened to track the same getpc.
+  bool poisoned = false;
 
   friend bool operator==(const PcAddressBuilder &, const PcAddressBuilder &) = default;
 };

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.h
@@ -135,6 +135,15 @@ struct PcAddressBuilder {
 ///        section actually contains a recoverable indirect consumer, because a
 ///        section with no dynamic transfer has no stale-PC branch hazard to
 ///        prove anything about.
+/// @brief Whether an AMDGPU physical VGPR is callee-saved by the ABI.
+///
+/// @details A callee-saved VGPR keeps its value across a call, so a value stashed
+/// there is still the caller's after the callee returns. @p phys_vgpr is the
+/// resolved physical index; gfx1250 VGPR_MSB banking can push it past 255, and the
+/// ABI table only covers v0-v255, so a banked register above that range is not
+/// proven callee-saved and reports false.
+[[nodiscard]] bool is_callee_saved_vgpr(uint16_t phys_vgpr);
+
 /// @returns Recovered indirect branch/call metadata.
 [[nodiscard]] std::vector<IndirectCallFixup> discover_indirect_branch_edges(
     std::span<const Instruction *const> insts, std::span<const uint8_t> text, rj_code_arch_t arch,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_elf.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_elf.h
@@ -181,6 +181,7 @@ inline constexpr uint32_t SHT_DYNSYM = 11;
 inline constexpr uint32_t R_AMDGPU_ABS64 = 3;
 inline constexpr uint32_t R_AMDGPU_RELATIVE64 = 13;
 
+inline constexpr uint8_t kElfSymbolBindLocal = 0;
 inline constexpr uint8_t kElfSymbolBindGlobal = 1;
 inline constexpr uint8_t kElfSymbolTypeNone = 0;    // STT_NOTYPE
 inline constexpr uint8_t kElfSymbolTypeObject = 1;  // STT_OBJECT

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -1301,6 +1301,36 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   const auto relocation_table_calls = attach_relocation_table_call_edges(
       block_index, relocation_function_tables, relocation_table_dispatches);
 
+  // Address materializations that must survive relocation. See the use site for why a non-.text
+  // target has to be rewritten and a .text one must not be.
+  const auto pc_relative_address_builders =
+      discover_pc_relative_address_builders(blocks, text_vaddr);
+  // Read the section headers straight from the image rather than through all_sections(), which
+  // drops SHT_NOBITS. A zero-initialized device global lives in .bss, so that omission would hide
+  // the most ordinary target there is. This must also agree with replace_text(): it resolves a data
+  // relocation by the same "allocated, not executable, contains the address" test, and reporting a
+  // builder it cannot resolve would turn a stale literal into a refused code object.
+  const auto addresses_loadable_data = [image = patcher.image_bytes()](uint64_t vaddr) {
+    if (image.size() < sizeof(Elf64_Ehdr))
+      return false;
+    Elf64_Ehdr ehdr{};
+    std::memcpy(&ehdr, image.data(), sizeof(ehdr));
+    if (ehdr.e_shentsize != sizeof(Elf64_Shdr) ||
+        ehdr.e_shoff > image.size() - sizeof(Elf64_Shdr) ||
+        static_cast<uint64_t>(ehdr.e_shnum) * sizeof(Elf64_Shdr) > image.size() - ehdr.e_shoff) {
+      return false;
+    }
+    for (uint16_t i = 0; i < ehdr.e_shnum; ++i) {
+      Elf64_Shdr shdr{};
+      std::memcpy(&shdr, image.data() + ehdr.e_shoff + i * sizeof(Elf64_Shdr), sizeof(shdr));
+      if ((shdr.sh_flags & SHF_ALLOC) == 0 || (shdr.sh_flags & SHF_EXECINSTR) != 0)
+        continue;
+      if (vaddr >= shdr.sh_addr && vaddr - shdr.sh_addr < shdr.sh_size)
+        return true;
+    }
+    return false;
+  };
+
   // Callees reached through a relocation-table dispatch are explicit analysis
   // roots whose live-in SGPRs are caller-supplied, not architected: a dispatched
   // callee can be entered with an original .text pointer in a scalar argument.
@@ -2784,6 +2814,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
       text_relocations.push_back(
           {.source_offset = source_offset, .target_offset = target_offset + target_delta});
     }
+    std::unordered_set<uint64_t> patched_address_add_offsets;
     for (const RelocationTableDispatch &dispatch : relocation_table_dispatches) {
       if (!target_offset_by_source_offset.contains(dispatch.source_call_offset))
         continue;
@@ -2801,6 +2832,35 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
           {.target_getpc_offset = getpc->second + target_delta,
            .target_literal_offset = add->second + target_delta + sizeof(uint32_t),
            .source_target_vaddr = dispatch.source_table_address_vaddr});
+      patched_address_add_offsets.insert(dispatch.source_address_add_offset);
+    }
+
+    // Every other getpc-plus-literal that names data needs the same treatment. The literal is the
+    // distance from the getpc to its target, so relocating the body silently retargets it: a
+    // device-library routine that reads its control block this way reaches into whatever now sits
+    // at the old distance. The instructions are copied verbatim, so nothing else in the pipeline
+    // notices. Recompute the literal from the getpc's final placement instead.
+    //
+    // Only non-executable targets are taken. A `.text` target is a code address, which the
+    // recovered-builder fixups already rewrite through the block placement map, and routing it
+    // here as well would write the same literal twice from two different models.
+    for (const PcRelativeAddressBuilder &builder : pc_relative_address_builders) {
+      if (patched_address_add_offsets.contains(builder.source_address_add_offset))
+        continue;
+      if (!addresses_loadable_data(builder.target_vaddr))
+        continue;
+      const auto getpc = target_offset_by_source_offset.find(builder.source_getpc_offset);
+      const auto add = target_offset_by_source_offset.find(builder.source_address_add_offset);
+      // A builder outside this scope's emitted blocks belongs to another scope's copy and is
+      // rewritten when that scope emits it.
+      if (getpc == target_offset_by_source_offset.end() ||
+          add == target_offset_by_source_offset.end()) {
+        continue;
+      }
+      data_relocations.push_back(
+          {.target_getpc_offset = getpc->second + target_delta,
+           .target_literal_offset = add->second + target_delta + sizeof(uint32_t),
+           .source_target_vaddr = builder.target_vaddr});
     }
 
     if (kernel_context.required_vgpr_count > kernel_context.num_vgprs)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -832,6 +832,7 @@ adopted_root_return_offsets(const BlockOffsetIndex &block_index,
     std::vector<BasicBlock *> stack{entry};
     std::unordered_set<BasicBlock *> body;
     std::vector<std::pair<BasicBlock *, uint16_t>> candidates;
+    std::map<std::pair<uint16_t, uint16_t>, std::set<uint16_t>> saved_lane_sources;
     while (!stack.empty()) {
       BasicBlock *block = stack.back();
       stack.pop_back();
@@ -844,6 +845,23 @@ adopted_root_return_offsets(const BlockOffsetIndex &block_index,
           candidates.emplace_back(
               block, static_cast<uint16_t>(text_word_at(text, term->src_loc()) & 0xffu));
       }
+      // A lane only holds the caller's value because this body put it there. Record each
+      // v_writelane_b32 as (vgpr, lane) <- sgpr so a later read can be checked against it; without
+      // that pairing any lane read into the pair would look like a restore.
+      for (const Instruction &inst : block->instructions()) {
+        if (inst.mnemonic() != "v_writelane_b32")
+          continue;
+        const Operand *vdst = inst.dst_operand(0);
+        const Operand *ssrc = inst.src_operand(0);
+        const Operand *lane = inst.src_operand(1);
+        if (vdst == nullptr || ssrc == nullptr || lane == nullptr)
+          continue;
+        if (vdst->encoding_value() < 0 || ssrc->encoding_value() < 0 || lane->encoding_value() < 0)
+          continue;
+        saved_lane_sources[{static_cast<uint16_t>(vdst->encoding_value()),
+                            static_cast<uint16_t>(lane->encoding_value())}]
+            .insert(static_cast<uint16_t>(ssrc->encoding_value()));
+      }
       for (BasicBlock *succ : block->successors())
         stack.push_back(succ);
     }
@@ -852,7 +870,7 @@ adopted_root_return_offsets(const BlockOffsetIndex &block_index,
     // caller's value, any other definition replaces it with something this analysis cannot vouch
     // for, and everything else leaves the search running.
     enum class Effect { kNone, kRestores, kRedefines };
-    auto effect_on = [](const Instruction &inst, uint16_t sgpr) {
+    auto effect_on = [&saved_lane_sources](const Instruction &inst, uint16_t sgpr) {
       bool defines = false;
       for (int i = 0; i < inst.num_dst_operands(); ++i) {
         const Operand *dst = inst.dst_operand(i);
@@ -865,7 +883,22 @@ adopted_root_return_offsets(const BlockOffsetIndex &block_index,
       }
       if (!defines)
         return Effect::kNone;
-      return inst.mnemonic() == "v_readlane_b32" ? Effect::kRestores : Effect::kRedefines;
+      if (inst.mnemonic() != "v_readlane_b32")
+        return Effect::kRedefines;
+      // Only a read of the exact lane this body saved the same register into restores the caller's
+      // value. Reading some other lane, or another register's lane, produces a value this analysis
+      // cannot vouch for and must not be mistaken for a return address.
+      const Operand *vsrc = inst.src_operand(0);
+      const Operand *lane = inst.src_operand(1);
+      if (vsrc == nullptr || lane == nullptr || vsrc->encoding_value() < 0 ||
+          lane->encoding_value() < 0) {
+        return Effect::kRedefines;
+      }
+      const auto saved = saved_lane_sources.find({static_cast<uint16_t>(vsrc->encoding_value()),
+                                                  static_cast<uint16_t>(lane->encoding_value())});
+      if (saved == saved_lane_sources.end() || !saved->second.contains(sgpr))
+        return Effect::kRedefines;
+      return Effect::kRestores;
     };
 
     // Backward reaching-definition search for one half, starting just above `from`.
@@ -1483,27 +1516,45 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
                           });
 
   const bool code_addresses_fully_accounted = [&] {
-    std::unordered_set<uint64_t> lattice_getpc_offsets;
+    // Keyed by the value each add produces, not merely by the getpc that seeded it. One getpc can
+    // feed several adds -- distinct branches materializing distinct addresses -- so treating the
+    // getpc as covered because any one add was tracked would let a sibling add keep a stale code
+    // literal while this predicate still reported everything accounted for.
+    std::unordered_map<uint64_t, std::unordered_set<uint64_t>> lattice_targets_by_getpc;
     for (const PcRelativeAddressBuilder &builder : pc_relative_address_builders)
-      lattice_getpc_offsets.insert(builder.source_getpc_offset);
+      lattice_targets_by_getpc[builder.source_getpc_offset].insert(builder.target_vaddr);
+
     for (const auto &block : blocks) {
       if (block == nullptr)
         continue;
       for (const PcAddressBuilder &builder : block->static_pc_address_builders()) {
-        // The lattice owning this builder is what matters: it is the analysis that drives both the
-        // data and the code rewrite, so a builder it matched is rewritten regardless of what the
-        // indirect-branch pass made of it. The two passes resolve independently and disagree
-        // routinely -- the branch pass gives up on anything that does not reach a setpc.
-        if (lattice_getpc_offsets.contains(builder.source_getpc_offset))
+        // A producer whose value this pass could not pin down, or whose arithmetic is not one
+        // contiguous run, cannot be rewritten by anybody -- accept it only if the rewrite lattice
+        // resolved the very same value, which is the evidence that a relocation was emitted for it.
+        const auto targets = lattice_targets_by_getpc.find(builder.source_getpc_offset);
+        const bool lattice_saw_getpc = targets != lattice_targets_by_getpc.end();
+        if (builder.resolved && builder.contiguous && builder.source_target_offset >= 0) {
+          // Both analyses pinned a value, so demand they agree on it. Accepting the getpc merely
+          // because some add under it was tracked is what would let a sibling add keep a stale
+          // literal while this predicate still reported the object accounted for.
+          if (lattice_saw_getpc &&
+              targets->second.contains(text_vaddr +
+                                       static_cast<uint64_t>(builder.source_target_offset))) {
+            continue;
+          }
+        } else if (lattice_saw_getpc) {
+          // This pass gave up -- it only follows producers that reach a setpc -- but the rewrite
+          // lattice did track the getpc, and the lattice is what emits the relocation. Its coverage
+          // is the operative one.
           continue;
-        // Otherwise the value has to be known here, or it may be a code address left stale.
-        if (!builder.resolved || !builder.contiguous)
+        } else {
           return false;
+        }
         // A known non-code target needs nothing: it cannot be a stale jump destination.
         if (builder.source_target_offset < 0 ||
             static_cast<uint64_t>(builder.source_target_offset) >= text.size())
           continue;
-        // A code target the lattice never saw is one this translation cannot rewrite.
+        // A code target whose exact value the lattice never produced cannot be rewritten.
         return false;
       }
     }
@@ -1606,16 +1657,29 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   // already qualifies. A compiler-anonymous pointer array carries no such symbol and so is not
   // covered here; that case still refuses, which is the pre-existing behavior.
   std::vector<uint64_t> adopted_roots;
+  std::unordered_set<uint64_t> address_taken_offsets;
   {
-    std::unordered_set<const BasicBlock *> covered;
-    for (const KernelTranslationScope &scope : scopes)
-      covered.insert(scope.blocks.begin(), scope.blocks.end());
+    // How many scopes would emit each block on their own. A body reached by one scope already has
+    // a single placement, so its address is unambiguous and nothing needs adopting. A body reached
+    // by none has no placement at all, and one reached by several has no single placement -- a
+    // runtime-dereferenced pointer holds one value and cannot choose between clones. Both of those
+    // get a canonical copy, emitted once by the adopting scope, that every code address names.
+    std::unordered_map<const BasicBlock *, unsigned> emitting_scopes;
+    for (const KernelTranslationScope &scope : scopes) {
+      for (const BasicBlock *block : scope.blocks)
+        ++emitting_scopes[block];
+    }
 
     const auto adopt = [&](uint64_t text_offset) {
       const BasicBlock *entry = block_for_offset(block_index, text_offset);
-      // A body that is already reached is left alone. Adopting it would add a second placement of
-      // the same source offset, and a runtime-dereferenced pointer cannot choose between them.
-      if (entry == nullptr || covered.contains(entry))
+      if (entry == nullptr)
+        return;
+      address_taken_offsets.insert(text_offset);
+      // Only a body no scope reaches needs adopting. One that several scopes clone is left where it
+      // is: lowering it through an unrelated scope would deny it the context its real caller
+      // supplies -- DS2 mode inference and liveness are scope-relative -- so the ambiguity between
+      // clones is settled by naming one of them canonical instead of by making a fresh copy.
+      if (emitting_scopes.contains(entry))
         return;
       adopted_roots.push_back(text_offset);
     };
@@ -1831,6 +1895,10 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   };
   std::vector<PendingCodeRelocation> pending_code_relocations;
   std::vector<PcRelativeTextRelocation> code_relocations;
+  // Final offset of the one copy of each adopted body. Code addresses name this copy, so a body a
+  // caller also clones still has exactly one address, and that address is stable no matter which
+  // scope happens to hold a clone.
+  std::unordered_map<uint64_t, uint64_t> canonical_placement;
 
   auto fail_or_skip_kernel =
       [&](const KernelTranslationScope &scope, KernelFailure failure, size_t output_begin,
@@ -3086,6 +3154,13 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
       return leave_unchanged();
     }
     const uint64_t target_delta = materialized.target_delta;
+    // kernel_translation_scopes() gives the adopted roots to the first scope it builds, so that is
+    // the scope whose placements are canonical.
+    for (const uint64_t taken : address_taken_offsets) {
+      const auto placed = target_offset_by_source_offset.find(taken);
+      if (placed != target_offset_by_source_offset.end())
+        canonical_placement.try_emplace(taken, placed->second + target_delta);
+    }
     for (const auto &[source_offset, target_offset] : target_offset_by_source_offset) {
       text_relocations.push_back(
           {.source_offset = source_offset, .target_offset = target_offset + target_delta});
@@ -3158,8 +3233,19 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
       if (recovered_builder_getpc_offsets.contains(builder.source_getpc_offset))
         continue;
       const uint64_t source_target = builder.target_vaddr - text_vaddr;
-      // Prefer this scope's own copy of the target. A body reached by several kernels is cloned
-      // once per scope so each scope's branches resolve through its own placement map, and
+      // An adopted body has one canonical copy; every code address names it, whatever scope the
+      // builder lives in. Resolving that here rather than after the loop keeps the address stable
+      // even when a caller also clones the body.
+      if (const auto canonical = canonical_placement.find(source_target);
+          canonical != canonical_placement.end()) {
+        code_relocations.push_back(
+            {.target_getpc_offset = getpc->second + target_delta,
+             .target_literal_offset = add->second + target_delta + sizeof(uint32_t),
+             .target_text_offset = canonical->second});
+        continue;
+      }
+      // Otherwise prefer this scope's own copy of the target. A body reached by several kernels is
+      // cloned once per scope so each scope's branches resolve through its own placement map, and
       // patch_recovered_builder_fixups already points a recovered builder at its scope's clone.
       // Following the same convention keeps a computed address consistent with the code that
       // computed it, and avoids inventing a conflict between clones that are only distinguishable
@@ -3331,6 +3417,13 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
         conflicting.insert(relocation.source_offset);
     }
     for (const PendingCodeRelocation &pending : pending_code_relocations) {
+      if (const auto canonical = canonical_placement.find(pending.source_target_text_offset);
+          canonical != canonical_placement.end()) {
+        code_relocations.push_back({.target_getpc_offset = pending.target_getpc_offset,
+                                    .target_literal_offset = pending.target_literal_offset,
+                                    .target_text_offset = canonical->second});
+        continue;
+      }
       const auto placed = placement.find(pending.source_target_text_offset);
       if (placed == placement.end() || conflicting.contains(pending.source_target_text_offset)) {
         append_error(result.diagnostics, DiagnosticKind::Legalization,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -1911,10 +1911,20 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   // scope happens to hold a clone.
   std::unordered_map<uint64_t, uint64_t> canonical_placement;
 
+  // What one scope added to the three code-address containers, so a skipped scope can take it back.
+  // The two vectors only ever grow within a scope, so a length restores them; canonical_placement
+  // is keyed by source offset and needs the inserted keys named.
+  struct ScopeRelocationCheckpoint {
+    size_t code_relocations_begin = 0;
+    size_t pending_code_relocations_begin = 0;
+    std::vector<uint64_t> canonical_placements_added;
+  };
+
   auto fail_or_skip_kernel =
       [&](const KernelTranslationScope &scope, KernelFailure failure, size_t output_begin,
           const std::vector<DescriptorVariantCheckpoint> &descriptor_snapshot,
-          size_t text_relocations_begin, size_t data_relocations_begin) -> bool {
+          size_t text_relocations_begin, size_t data_relocations_begin,
+          const ScopeRelocationCheckpoint &relocation_snapshot) -> bool {
     if (!skip_failed_kernels) {
       append_error(result.diagnostics, failure.kind, std::move(failure.message),
                    failure.guest_offset, std::move(failure.mnemonic),
@@ -1927,6 +1937,13 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     // Discard any relocation records this scope committed before failing.
     text_relocations.resize(text_relocations_begin);
     data_relocations.resize(data_relocations_begin);
+    // The code-address records and the canonical placements name offsets inside the text this
+    // rollback just discarded. A later scope reuses those offsets for its own body, so keeping the
+    // records would write a 64-bit literal into instructions that never asked for one.
+    code_relocations.resize(relocation_snapshot.code_relocations_begin);
+    pending_code_relocations.resize(relocation_snapshot.pending_code_relocations_begin);
+    for (const uint64_t placed : relocation_snapshot.canonical_placements_added)
+      canonical_placement.erase(placed);
     for (const DescriptorVariantCheckpoint &saved : descriptor_snapshot) {
       if (saved.index >= descriptor_translations.size()) {
         append_error(result.diagnostics, DiagnosticKind::KernelDescriptor,
@@ -1971,6 +1988,10 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     const size_t output_begin = translated_text.size();
     const size_t text_relocations_begin = text_relocations.size();
     const size_t data_relocations_begin = data_relocations.size();
+    ScopeRelocationCheckpoint relocation_snapshot{.code_relocations_begin = code_relocations.size(),
+                                                  .pending_code_relocations_begin =
+                                                      pending_code_relocations.size(),
+                                                  .canonical_placements_added = {}};
     const auto descriptor_snapshot =
         checkpoint_scope_descriptors(descriptor_translations, *scope.translation);
     bool skip_scope = false;
@@ -1990,7 +2011,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
         break;
       }
       if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                              text_relocations_begin, data_relocations_begin))
+                              text_relocations_begin, data_relocations_begin, relocation_snapshot))
         continue;
       return leave_unchanged();
     }
@@ -2005,7 +2026,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
                               "reachable kernel code falls through into undecodable .text bytes",
                               (*opaque_fallthrough)->end_offset());
       if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                              text_relocations_begin, data_relocations_begin))
+                              text_relocations_begin, data_relocations_begin, relocation_snapshot))
         continue;
       return leave_unchanged();
     }
@@ -2031,7 +2052,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
             DiagnosticKind::ResourceLimit,
             "virtual LDS lowering cannot reserve a backing-buffer SGPR pair", layout.source_entry);
         if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                text_relocations_begin, data_relocations_begin))
+                                text_relocations_begin, data_relocations_begin,
+                                relocation_snapshot))
           continue;
         return leave_unchanged();
       }
@@ -2054,7 +2076,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
               "virtual LDS backing-pointer spill offset overflows the 32-bit private segment",
               layout.source_entry);
           if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                  text_relocations_begin, data_relocations_begin))
+                                  text_relocations_begin, data_relocations_begin,
+                                  relocation_snapshot))
             continue;
           return leave_unchanged();
         }
@@ -2069,7 +2092,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
             "virtual LDS lowering cannot materialize backing-buffer pointer entry prologue",
             layout.source_entry);
         if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                text_relocations_begin, data_relocations_begin))
+                                text_relocations_begin, data_relocations_begin,
+                                relocation_snapshot))
           continue;
         return leave_unchanged();
       }
@@ -2088,7 +2112,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
           "window",
           layout.source_entry);
       if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                              text_relocations_begin, data_relocations_begin))
+                              text_relocations_begin, data_relocations_begin, relocation_snapshot))
         continue;
       return leave_unchanged();
     }
@@ -2313,7 +2337,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
                                   "recovered indirect branch has inconsistent consumer metadata",
                                   source_call_offset, "indirect branch");
           if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                  text_relocations_begin, data_relocations_begin)) {
+                                  text_relocations_begin, data_relocations_begin,
+                                  relocation_snapshot)) {
             skip_scope = true;
             break;
           }
@@ -2342,7 +2367,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
             "relocated",
             source_call_offset, "indirect branch");
         if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                text_relocations_begin, data_relocations_begin)) {
+                                text_relocations_begin, data_relocations_begin,
+                                relocation_snapshot)) {
           skip_scope = true;
           break;
         }
@@ -2528,7 +2554,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
                   "generated direct branch island pool contains malformed live slot",
                   source_branch_offset);
               if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                      text_relocations_begin, data_relocations_begin)) {
+                                      text_relocations_begin, data_relocations_begin,
+                                      relocation_snapshot)) {
                 skip_scope = true;
                 break;
               }
@@ -2543,7 +2570,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
                   "generated direct branch island pool targets outside source .text",
                   source_branch_offset);
               if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                      text_relocations_begin, data_relocations_begin)) {
+                                      text_relocations_begin, data_relocations_begin,
+                                      relocation_snapshot)) {
                 skip_scope = true;
                 break;
               }
@@ -2658,7 +2686,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
             }
           }
           if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                  text_relocations_begin, data_relocations_begin)) {
+                                  text_relocations_begin, data_relocations_begin,
+                                  relocation_snapshot)) {
             skip_scope = true;
             break;
           }
@@ -2689,7 +2718,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
               }
             }
             if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                    text_relocations_begin, data_relocations_begin)) {
+                                    text_relocations_begin, data_relocations_begin,
+                                    relocation_snapshot)) {
               skip_scope = true;
               break;
             }
@@ -2702,7 +2732,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
                                                "direct branch is missing raw encoding", offset,
                                                std::string(inst.mnemonic()));
             if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                    text_relocations_begin, data_relocations_begin)) {
+                                    text_relocations_begin, data_relocations_begin,
+                                    relocation_snapshot)) {
               skip_scope = true;
               break;
             }
@@ -2779,7 +2810,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
               }
             }
             if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                    text_relocations_begin, data_relocations_begin)) {
+                                    text_relocations_begin, data_relocations_begin,
+                                    relocation_snapshot)) {
               skip_scope = true;
               break;
             }
@@ -2815,7 +2847,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
               }
             }
             if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                    text_relocations_begin, data_relocations_begin)) {
+                                    text_relocations_begin, data_relocations_begin,
+                                    relocation_snapshot)) {
               skip_scope = true;
               break;
             }
@@ -2849,7 +2882,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
               }
             }
             if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                    text_relocations_begin, data_relocations_begin)) {
+                                    text_relocations_begin, data_relocations_begin,
+                                    relocation_snapshot)) {
               skip_scope = true;
               break;
             }
@@ -2877,7 +2911,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
             }
           }
           if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                  text_relocations_begin, data_relocations_begin)) {
+                                  text_relocations_begin, data_relocations_begin,
+                                  relocation_snapshot)) {
             skip_scope = true;
             break;
           }
@@ -2929,7 +2964,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
             }
           }
           if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                  text_relocations_begin, data_relocations_begin)) {
+                                  text_relocations_begin, data_relocations_begin,
+                                  relocation_snapshot)) {
             skip_scope = true;
             break;
           }
@@ -2992,7 +3028,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
             "recovered indirect branch builder is not fully present in the relocated body",
             fixup.source_call_offset, "indirect branch");
         if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                text_relocations_begin, data_relocations_begin)) {
+                                text_relocations_begin, data_relocations_begin,
+                                relocation_snapshot)) {
           skip_scope = true;
           break;
         }
@@ -3139,7 +3176,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
           make_kernel_failure(relocation_diagnostic_kind(patched_control_flow),
                               patched_control_flow.message, patched_control_flow.source_offset);
       if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                              text_relocations_begin, data_relocations_begin))
+                              text_relocations_begin, data_relocations_begin, relocation_snapshot))
         continue;
       return leave_unchanged();
     }
@@ -3149,7 +3186,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
       auto failure = make_kernel_failure(relocation_diagnostic_kind(patched), patched.message,
                                          patched.source_offset, "indirect branch");
       if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                              text_relocations_begin, data_relocations_begin))
+                              text_relocations_begin, data_relocations_begin, relocation_snapshot))
         continue;
       return leave_unchanged();
     }
@@ -3160,7 +3197,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
       auto failure = make_kernel_failure(materialization_diagnostic_kind(materialized),
                                          materialized.message, materialized.source_offset);
       if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                              text_relocations_begin, data_relocations_begin))
+                              text_relocations_begin, data_relocations_begin, relocation_snapshot))
         continue;
       return leave_unchanged();
     }
@@ -3169,8 +3206,10 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     // the scope whose placements are canonical.
     for (const uint64_t taken : address_taken_offsets) {
       const auto placed = target_offset_by_source_offset.find(taken);
-      if (placed != target_offset_by_source_offset.end())
-        canonical_placement.try_emplace(taken, placed->second + target_delta);
+      if (placed == target_offset_by_source_offset.end())
+        continue;
+      if (canonical_placement.try_emplace(taken, placed->second + target_delta).second)
+        relocation_snapshot.canonical_placements_added.push_back(taken);
     }
     for (const auto &[source_offset, target_offset] : target_offset_by_source_offset) {
       text_relocations.push_back(
@@ -3319,7 +3358,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
               make_kernel_failure(DiagnosticKind::KernelDescriptor,
                                   "kernel descriptor translation could not be recomputed");
           if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                  text_relocations_begin, data_relocations_begin)) {
+                                  text_relocations_begin, data_relocations_begin,
+                                  relocation_snapshot)) {
             skip_scope = true;
             break;
           }
@@ -3338,7 +3378,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
               DiagnosticKind::KernelDescriptor,
               "virtual LDS lowering cannot materialize backing-buffer pointer entry prologue");
           if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                  text_relocations_begin, data_relocations_begin)) {
+                                  text_relocations_begin, data_relocations_begin,
+                                  relocation_snapshot)) {
             skip_scope = true;
             break;
           }
@@ -3361,7 +3402,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
               break;
             }
             if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                    text_relocations_begin, data_relocations_begin)) {
+                                    text_relocations_begin, data_relocations_begin,
+                                    relocation_snapshot)) {
               skip_scope = true;
               break;
             }
@@ -3379,7 +3421,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
               DiagnosticKind::KernelDescriptor,
               "kernel descriptor prologue changed after relocated text was emitted");
           if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                  text_relocations_begin, data_relocations_begin)) {
+                                  text_relocations_begin, data_relocations_begin,
+                                  relocation_snapshot)) {
             skip_scope = true;
             break;
           }
@@ -3398,7 +3441,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
         auto failure = make_kernel_failure(DiagnosticKind::KernelDescriptor,
                                            "kernel descriptor translation could not be recomputed");
         if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                text_relocations_begin, data_relocations_begin))
+                                text_relocations_begin, data_relocations_begin,
+                                relocation_snapshot))
           continue;
         return leave_unchanged();
       }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -2002,6 +2002,10 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     size_t code_relocations_begin = 0;
     size_t pending_code_relocations_begin = 0;
     std::vector<uint64_t> canonical_placements_added;
+    // The resource verdict is set before descriptor recomputation, which can still skip the scope.
+    // Rolling the placements back without also restoring this would leave a skipped host's verdict
+    // standing and refuse the object over a scope that no longer contributes anything.
+    bool canonical_host_outgrew_its_descriptor = false;
   };
 
   auto fail_or_skip_kernel =
@@ -2028,6 +2032,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     pending_code_relocations.resize(relocation_snapshot.pending_code_relocations_begin);
     for (const uint64_t placed : relocation_snapshot.canonical_placements_added)
       canonical_placement.erase(placed);
+    canonical_host_outgrew_its_descriptor =
+        relocation_snapshot.canonical_host_outgrew_its_descriptor;
     for (const DescriptorVariantCheckpoint &saved : descriptor_snapshot) {
       if (saved.index >= descriptor_translations.size()) {
         append_error(result.diagnostics, DiagnosticKind::KernelDescriptor,
@@ -2072,10 +2078,11 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     const size_t output_begin = translated_text.size();
     const size_t text_relocations_begin = text_relocations.size();
     const size_t data_relocations_begin = data_relocations.size();
-    ScopeRelocationCheckpoint relocation_snapshot{.code_relocations_begin = code_relocations.size(),
-                                                  .pending_code_relocations_begin =
-                                                      pending_code_relocations.size(),
-                                                  .canonical_placements_added = {}};
+    ScopeRelocationCheckpoint relocation_snapshot{
+        .code_relocations_begin = code_relocations.size(),
+        .pending_code_relocations_begin = pending_code_relocations.size(),
+        .canonical_placements_added = {},
+        .canonical_host_outgrew_its_descriptor = canonical_host_outgrew_its_descriptor};
     const auto descriptor_snapshot =
         checkpoint_scope_descriptors(descriptor_translations, *scope.translation);
     bool skip_scope = false;
@@ -3306,9 +3313,21 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     // not the same set: one whose target could not be resolved, or whose consumer was handled by a
     // direct-window conversion instead, never reaches patch_recovered_builder_fixups. Excluding
     // those here would leave their builders written by nobody.
-    std::unordered_set<uint64_t> recovered_builder_getpc_offsets;
-    for (const IndirectCallFixup &fixup : layout.recovered_builder_fixups)
-      recovered_builder_getpc_offsets.insert(fixup.source_getpc_offset);
+    // Keyed by the byte range each queued recovery rebuilds, not by its getpc. One getpc can seed
+    // several adds -- distinct branches materializing distinct addresses -- and only the add inside
+    // a queued range is rewritten by that model. Keying on the shared getpc would suppress the
+    // sibling's relocation too, leaving its literal measuring the distance the body used to be at.
+    std::vector<std::pair<uint64_t, uint64_t>> recovered_builder_ranges;
+    recovered_builder_ranges.reserve(layout.recovered_builder_fixups.size());
+    for (const IndirectCallFixup &fixup : layout.recovered_builder_fixups) {
+      recovered_builder_ranges.emplace_back(fixup.source_recovery_begin_offset,
+                                            fixup.source_recovery_end_offset);
+    }
+    const auto owned_by_recovered_builder = [&](uint64_t source_add_offset) {
+      return std::ranges::any_of(recovered_builder_ranges, [&](const auto &range) {
+        return source_add_offset >= range.first && source_add_offset < range.second;
+      });
+    };
 
     std::unordered_set<uint64_t> patched_address_add_offsets;
     for (const RelocationTableDispatch &dispatch : relocation_table_dispatches) {
@@ -3364,7 +3383,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
       // emitted by a different scope, so this scope's placement map cannot answer for it yet.
       if (builder.target_vaddr < text_vaddr || builder.target_vaddr - text_vaddr >= text.size())
         continue;
-      if (recovered_builder_getpc_offsets.contains(builder.source_getpc_offset))
+      if (owned_by_recovered_builder(builder.source_address_add_offset))
         continue;
       const uint64_t source_target = builder.target_vaddr - text_vaddr;
       // An adopted body has one canonical copy; every code address names it, whatever scope the

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -934,6 +934,16 @@ adopted_root_return_offsets(const BlockOffsetIndex &block_index,
             if (vgpr >= base && vgpr < base + halves)
               clobbers = true;
           }
+          // A destination operand is not the only way to write a VGPR. Ask the instruction for the
+          // registers it writes without naming them, so a producer that touches this lane through a
+          // hidden definition cannot slip past the operand walk above.
+          if (!clobbers) {
+            RegisterSet implicit;
+            inst.implicit_defs(implicit);
+            if (implicit.contains(RegisterRef{RegClass::VGPR, vgpr, 1}) ||
+                implicit.contains(RegisterRef{RegClass::ACC_VGPR, vgpr, 1}))
+              clobbers = true;
+          }
           if (clobbers)
             return false;
         }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -620,9 +620,21 @@ reachable_kernel_blocks(const std::vector<std::unique_ptr<BasicBlock>> &blocks,
   return ordered;
 }
 
+/// @brief Build one translation scope per kernel descriptor variant.
+///
+/// @param adopted_roots Device-function entries that no kernel scope reaches on its own. A body
+/// whose address is only ever produced by a data relocation has no decoded edge leading to it, so
+/// the reachability walk cannot find it and the relocated `.text` would drop it. Such a body is
+/// adopted as an additional root of the lowest-offset scope. One scope rather than every scope is
+/// deliberate: a helper reached by several kernels is cloned per scope so each clone resolves
+/// through its own placement map, but a runtime-dereferenced pointer has exactly one value, and
+/// cloning would leave `relocate_relative_text_addends()` choosing between placements. Attributing
+/// the body to a single scope is sound because it is entered through an absolute pointer and
+/// returns through a caller-saved PC, so it is position-independent with respect to its callers.
 [[nodiscard]] std::vector<KernelTranslationScope>
 kernel_translation_scopes(const std::vector<std::unique_ptr<BasicBlock>> &blocks,
-                          const BlockOffsetIndex &block_index, std::span<KdTranslation> kernels) {
+                          const BlockOffsetIndex &block_index, std::span<KdTranslation> kernels,
+                          std::span<const uint64_t> adopted_roots = {}) {
   std::vector<KernelTranslationScope> scopes;
   const auto entries = kernel_entry_offsets(kernels);
   if (entries.empty())
@@ -657,6 +669,10 @@ kernel_translation_scopes(const std::vector<std::unique_ptr<BasicBlock>> &blocks
         continue;
       own_entries.insert(kernel->kernarg_preload_firmware_entry_text_offset);
     }
+    // ordered_kernels is sorted by entry offset, so "the first scope built" names the same scope on
+    // every run and on a second pass over already-translated text.
+    if (scopes.empty())
+      own_entries.insert(adopted_roots.begin(), adopted_roots.end());
 
     scopes.push_back({kernel, entry,
                       reachable_kernel_blocks(blocks, block_index, block_positions, *entry,
@@ -777,6 +793,134 @@ scoped_call_return_offsets(std::span<BasicBlock *const> blocks, std::span<const 
         assert(term != nullptr && "function_return_blocks returns non-empty decoded blocks");
         returns.insert(term->src_loc());
       }
+    }
+  }
+  return returns;
+}
+
+/// @brief Return offsets of the `s_setpc_b64` returns belonging to adopted device-function roots.
+///
+/// @details An adopted root has no call edge, so scoped_call_return_offsets() -- which derives the
+/// return register from the call site that saved it -- reports nothing for it and the body's own
+/// return reads as an unrecoverable indirect branch. The register is recovered from the body
+/// instead: a terminator that jumps through an SGPR pair the body never redefines can only be
+/// returning to an address its caller supplied. Such an address is absolute and produced outside
+/// this code object's relocated text, so moving the body does not change it and there is nothing to
+/// recover.
+///
+/// A lane restore is not a redefinition for this purpose. A non-leaf device function stashes the
+/// incoming pair in a VGPR lane, lets its own `s_swap_pc_i64` calls overwrite the architectural
+/// pair, and reads the original back with `v_readlane_b32` before returning. The question is
+/// therefore which definition *reaches* the terminator, not whether one exists anywhere in the
+/// body: the call's write is real but dead by then. The search walks back from the terminator to
+/// the nearest definition of each half on every path, and accepts only a lane restore or the
+/// function entry itself. Any other reaching definition disqualifies the pair, since a computed
+/// value could be a relocated PC that needs the recovery this bypasses. A PC-relative builder
+/// feeding the terminator is not reached here at all: the caller's recovered-indirect and
+/// direct-branch tests run first and claim that shape.
+[[nodiscard]] std::unordered_set<uint64_t>
+adopted_root_return_offsets(const BlockOffsetIndex &block_index,
+                            std::span<const uint64_t> adopted_roots,
+                            std::span<const uint8_t> text) {
+  std::unordered_set<uint64_t> returns;
+  for (const uint64_t root : adopted_roots) {
+    BasicBlock *entry = block_for_offset(block_index, root);
+    if (entry == nullptr)
+      continue;
+
+    // Forward pass: collect the body's blocks and its candidate return terminators.
+    std::vector<BasicBlock *> stack{entry};
+    std::unordered_set<BasicBlock *> body;
+    std::vector<std::pair<BasicBlock *, uint16_t>> candidates;
+    while (!stack.empty()) {
+      BasicBlock *block = stack.back();
+      stack.pop_back();
+      if (block == nullptr || !body.insert(block).second)
+        continue;
+      const Instruction *term = block->terminator();
+      if (term != nullptr && term->size() == sizeof(uint32_t)) {
+        const std::string_view mnemonic = term->mnemonic();
+        if (mnemonic == "s_setpc_b64" || mnemonic == "s_set_pc_i64")
+          candidates.emplace_back(block, static_cast<uint16_t>(
+                                             text_word_at(text, term->src_loc()) & 0xffu));
+      }
+      for (BasicBlock *succ : block->successors())
+        stack.push_back(succ);
+    }
+
+    // Classify one instruction's effect on the tracked half: a lane restore reinstates the
+    // caller's value, any other definition replaces it with something this analysis cannot vouch
+    // for, and everything else leaves the search running.
+    enum class Effect { kNone, kRestores, kRedefines };
+    auto effect_on = [](const Instruction &inst, uint16_t sgpr) {
+      bool defines = false;
+      for (int i = 0; i < inst.num_dst_operands(); ++i) {
+        const Operand *dst = inst.dst_operand(i);
+        if (dst == nullptr || dst->encoding_value() < 0)
+          continue;
+        const auto base = static_cast<uint16_t>(dst->encoding_value());
+        const int halves = dst->size_bits() > 32 ? dst->size_bits() / 32 : 1;
+        if (sgpr >= base && sgpr < base + halves)
+          defines = true;
+      }
+      if (!defines)
+        return Effect::kNone;
+      return inst.mnemonic() == "v_readlane_b32" ? Effect::kRestores : Effect::kRedefines;
+    };
+
+    // Backward reaching-definition search for one half, starting just above `from`.
+    auto caller_value_reaches = [&](BasicBlock *start, const Instruction *from, uint16_t sgpr) {
+      std::vector<std::pair<BasicBlock *, const Instruction *>> work{{start, from}};
+      std::unordered_set<BasicBlock *> seen;
+      while (!work.empty()) {
+        const auto [block, before] = work.back();
+        work.pop_back();
+        if (block == nullptr || !body.contains(block))
+          return false;
+        // The instruction list is forward-only, so materialize it to scan upwards from `before`.
+        std::vector<const Instruction *> ordered;
+        ordered.reserve(block->num_instructions());
+        for (const Instruction &inst : block->instructions())
+          ordered.push_back(&inst);
+        size_t cursor = ordered.size();
+        if (before != nullptr) {
+          const auto found = std::ranges::find(ordered, before);
+          if (found == ordered.end())
+            return false;
+          cursor = static_cast<size_t>(found - ordered.begin());
+        }
+
+        bool resolved = false;
+        while (cursor > 0) {
+          --cursor;
+          const Effect effect = effect_on(*ordered[cursor], sgpr);
+          if (effect == Effect::kNone)
+            continue;
+          if (effect == Effect::kRedefines)
+            return false;
+          resolved = true;
+          break;
+        }
+        if (resolved)
+          continue;
+        // No definition in this block. The function entry means the value is the caller's; any
+        // other block defers to its predecessors, and a predecessor outside the body is a path
+        // this analysis cannot see, so it fails closed above.
+        if (block == entry)
+          continue;
+        if (block->predecessors().empty() || !seen.insert(block).second)
+          return false;
+        for (BasicBlock *pred : block->predecessors())
+          work.emplace_back(pred, nullptr);
+      }
+      return true;
+    };
+
+    for (const auto &[block, ssrc0] : candidates) {
+      const Instruction *term = block->terminator();
+      if (caller_value_reaches(block, term, ssrc0) &&
+          caller_value_reaches(block, term, static_cast<uint16_t>(ssrc0 + 1)))
+        returns.insert(term->src_loc());
     }
   }
   return returns;
@@ -1391,6 +1535,42 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     }
   }
 
+  // A device function whose address is produced only by a data relocation -- a C++ vtable slot is
+  // the common case -- is named by no decoded edge, so no kernel scope reaches it. Translated text
+  // replaces .text wholesale, so leaving it unreached drops the body and strands the addend that
+  // points at it. Adopt those bodies as roots and rebuild the scopes so the ordinary lowering path
+  // emits them and records their placement, which is what lets the addend be rewritten.
+  //
+  // The candidate set is the populated slots of the discovered function tables: a C++ vtable is an
+  // STT_OBJECT holding symbol-less RELATIVE64 addends into .text, which is exactly what discovery
+  // already qualifies. A compiler-anonymous pointer array carries no such symbol and so is not
+  // covered here; that case still refuses, which is the pre-existing behavior.
+  std::vector<uint64_t> adopted_roots;
+  {
+    std::unordered_set<const BasicBlock *> covered;
+    for (const KernelTranslationScope &scope : scopes)
+      covered.insert(scope.blocks.begin(), scope.blocks.end());
+
+    for (const RelocationFunctionTable &table : relocation_function_tables) {
+      for (const RelocationFunctionPointer &slot : table.entries) {
+        const BasicBlock *entry = block_for_offset(block_index, slot.target_text_offset);
+        // A body that is already reached is left alone. Adopting it would add a second placement of
+        // the same source offset, and a runtime-dereferenced pointer cannot choose between them.
+        if (entry == nullptr || covered.contains(entry))
+          continue;
+        adopted_roots.push_back(slot.target_text_offset);
+      }
+    }
+    std::ranges::sort(adopted_roots);
+    adopted_roots.erase(std::ranges::unique(adopted_roots).begin(), adopted_roots.end());
+    if (!adopted_roots.empty()) {
+      scopes = kernel_translation_scopes(blocks, block_index, descriptor_translations,
+                                         adopted_roots);
+    }
+  }
+  const std::unordered_set<uint64_t> adopted_return_offsets =
+      adopted_root_return_offsets(block_index, adopted_roots, text);
+
   const size_t expected_scope_count = kernel_translation_scope_count(descriptor_translations);
   if (scopes.size() != expected_scope_count) {
     append_error(result.diagnostics, DiagnosticKind::KernelDescriptor,
@@ -1918,8 +2098,11 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     // consumer has multiple recovered targets, no single direct window can
     // preserve semantics; DBT keeps the original indirect consumer and asks the
     // patch layer to rewrite each source-side PC builder once.
-    const std::unordered_set<uint64_t> valid_call_return_offsets =
+    std::unordered_set<uint64_t> valid_call_return_offsets =
         scoped_call_return_offsets(KernelBlockScope(scope.blocks), text);
+    // An adopted root's return is validated from its own body rather than from a call site, so it
+    // is added here for whichever scope ended up carrying that body.
+    valid_call_return_offsets.insert(adopted_return_offsets.begin(), adopted_return_offsets.end());
     struct RecoveredConsumer {
       std::vector<IndirectCallFixup> fixups;
       bool use_transfer_window = false;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -1542,10 +1542,14 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
                                        static_cast<uint64_t>(builder.source_target_offset))) {
             continue;
           }
-        } else if (lattice_saw_getpc) {
+        } else if (lattice_saw_getpc && !builder.poisoned) {
           // This pass gave up -- it only follows producers that reach a setpc -- but the rewrite
           // lattice did track the getpc, and the lattice is what emits the relocation. Its coverage
           // is the operative one.
+          //
+          // A poisoned producer is excluded because it is not the same situation. There the pass
+          // did follow the getpc and saw two irreconcilable values, so a sibling add under it can
+          // still carry a stale literal that the one value the lattice tracked does not cover.
           continue;
         } else {
           return false;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -2796,6 +2796,20 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
         // new home. This is what makes a C++ virtual call translatable -- its target comes out of a
         // vtable slot that no dataflow fact can name, and no amount of consumer-side analysis will
         // ever name it.
+        //
+        // The permission is object-wide because the question it answers is. A consumer cannot tell
+        // where a loaded 64-bit word came from, so tying it to this transfer's provenance is not
+        // available; what makes it sound is that both routes into `.text` are covered. Addresses
+        // the object computes for itself are the ones code_addresses_fully_accounted ranges over.
+        // An address supplied from outside -- a kernarg holding a device function pointer, or a
+        // pointer another code object resolved -- can only have been obtained from a `.text`
+        // symbol, and relocate_text_symbols() rewrites those and refuses the whole object when a
+        // referenced text symbol has no exact offset map. Translation happens at load, so there is
+        // no window in which a caller could have captured a pre-translation value.
+        //
+        // What that leaves is narrow and worth stating: a host that derives an entry from a symbol
+        // plus a byte offset, and a symbol that is present but unreferenced, which
+        // relocate_text_symbols() tolerates so debug labels in padding do not refuse the object.
         const bool target_is_relocated_by_construction =
             object_produces_code_addresses && code_addresses_fully_accounted;
         if ((inst.flags() & (INDIRECT_BRANCH | INDIRECT_CALL)) != 0 &&

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -856,12 +856,17 @@ adopted_root_return_offsets(const BlockOffsetIndex &block_index,
     auto lane_holds_saved_sgpr = [&](BasicBlock *start, const Instruction *from, uint16_t vgpr,
                                      uint16_t lane, uint16_t sgpr) {
       std::vector<std::pair<BasicBlock *, const Instruction *>> work{{start, from}};
-      std::unordered_set<BasicBlock *> seen;
+      // Keyed by the whole work item, not the block. Processing one is deterministic, so meeting
+      // the same pair twice adds nothing and is skipped; the same block reached with a different
+      // scan start is a different query and still has to run.
+      std::set<std::pair<const BasicBlock *, const Instruction *>> seen;
       while (!work.empty()) {
         const auto [block, before] = work.back();
         work.pop_back();
         if (block == nullptr || !body.contains(block))
           return false;
+        if (!seen.insert({block, before}).second)
+          continue;
         std::vector<const Instruction *> ordered;
         ordered.reserve(block->num_instructions());
         for (const Instruction &inst : block->instructions())
@@ -916,7 +921,11 @@ adopted_root_return_offsets(const BlockOffsetIndex &block_index,
         // the caller's value comes from, here the save has to be inside the body.
         if (block == entry)
           return false;
-        if (block->predecessors().empty() || !seen.insert(block).second)
+        // Reconverging control flow -- a diamond, or a loop back edge -- reaches a block that is
+        // already queued or done. That is ordinary, not a reason to give up on the whole query; the
+        // dedup above absorbs it. Only a block with no predecessor inside the body is a path this
+        // analysis cannot see, and that still fails closed.
+        if (block->predecessors().empty())
           return false;
         for (BasicBlock *pred : block->predecessors())
           work.emplace_back(pred, nullptr);
@@ -962,12 +971,17 @@ adopted_root_return_offsets(const BlockOffsetIndex &block_index,
     // Backward reaching-definition search for one half, starting just above `from`.
     auto caller_value_reaches = [&](BasicBlock *start, const Instruction *from, uint16_t sgpr) {
       std::vector<std::pair<BasicBlock *, const Instruction *>> work{{start, from}};
-      std::unordered_set<BasicBlock *> seen;
+      // Keyed by the whole work item, not the block. Processing one is deterministic, so meeting
+      // the same pair twice adds nothing and is skipped; the same block reached with a different
+      // scan start is a different query and still has to run.
+      std::set<std::pair<const BasicBlock *, const Instruction *>> seen;
       while (!work.empty()) {
         const auto [block, before] = work.back();
         work.pop_back();
         if (block == nullptr || !body.contains(block))
           return false;
+        if (!seen.insert({block, before}).second)
+          continue;
         // The instruction list is forward-only, so materialize it to scan upwards from `before`.
         std::vector<const Instruction *> ordered;
         ordered.reserve(block->num_instructions());
@@ -999,7 +1013,11 @@ adopted_root_return_offsets(const BlockOffsetIndex &block_index,
         // this analysis cannot see, so it fails closed above.
         if (block == entry)
           continue;
-        if (block->predecessors().empty() || !seen.insert(block).second)
+        // Reconverging control flow -- a diamond, or a loop back edge -- reaches a block that is
+        // already queued or done. That is ordinary, not a reason to give up on the whole query; the
+        // dedup above absorbs it. Only a block with no predecessor inside the body is a path this
+        // analysis cannot see, and that still fails closed.
+        if (block->predecessors().empty())
           return false;
         for (BasicBlock *pred : block->predecessors())
           work.emplace_back(pred, nullptr);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -832,7 +832,6 @@ adopted_root_return_offsets(const BlockOffsetIndex &block_index,
     std::vector<BasicBlock *> stack{entry};
     std::unordered_set<BasicBlock *> body;
     std::vector<std::pair<BasicBlock *, uint16_t>> candidates;
-    std::map<std::pair<uint16_t, uint16_t>, std::set<uint16_t>> saved_lane_sources;
     while (!stack.empty()) {
       BasicBlock *block = stack.back();
       stack.pop_back();
@@ -845,32 +844,91 @@ adopted_root_return_offsets(const BlockOffsetIndex &block_index,
           candidates.emplace_back(
               block, static_cast<uint16_t>(text_word_at(text, term->src_loc()) & 0xffu));
       }
-      // A lane only holds the caller's value because this body put it there. Record each
-      // v_writelane_b32 as (vgpr, lane) <- sgpr so a later read can be checked against it; without
-      // that pairing any lane read into the pair would look like a restore.
-      for (const Instruction &inst : block->instructions()) {
-        if (inst.mnemonic() != "v_writelane_b32")
-          continue;
-        const Operand *vdst = inst.dst_operand(0);
-        const Operand *ssrc = inst.src_operand(0);
-        const Operand *lane = inst.src_operand(1);
-        if (vdst == nullptr || ssrc == nullptr || lane == nullptr)
-          continue;
-        if (vdst->encoding_value() < 0 || ssrc->encoding_value() < 0 || lane->encoding_value() < 0)
-          continue;
-        saved_lane_sources[{static_cast<uint16_t>(vdst->encoding_value()),
-                            static_cast<uint16_t>(lane->encoding_value())}]
-            .insert(static_cast<uint16_t>(ssrc->encoding_value()));
-      }
       for (BasicBlock *succ : block->successors())
         stack.push_back(succ);
     }
+
+    // Whether (vgpr, lane) still holds what `v_writelane_b32` put there from `sgpr`, asked at one
+    // program point rather than of the body as a whole. A body-wide set of saves cannot answer
+    // this: a save that appears after the read, or on a path that does not join it, or one a later
+    // write to the same VGPR has already destroyed, would all still be in the set and would let an
+    // arbitrary lane read pass as a return-address restore.
+    auto lane_holds_saved_sgpr = [&](BasicBlock *start, const Instruction *from, uint16_t vgpr,
+                                     uint16_t lane, uint16_t sgpr) {
+      std::vector<std::pair<BasicBlock *, const Instruction *>> work{{start, from}};
+      std::unordered_set<BasicBlock *> seen;
+      while (!work.empty()) {
+        const auto [block, before] = work.back();
+        work.pop_back();
+        if (block == nullptr || !body.contains(block))
+          return false;
+        std::vector<const Instruction *> ordered;
+        ordered.reserve(block->num_instructions());
+        for (const Instruction &inst : block->instructions())
+          ordered.push_back(&inst);
+        size_t cursor = ordered.size();
+        if (before != nullptr) {
+          const auto found = std::ranges::find(ordered, before);
+          if (found == ordered.end())
+            return false;
+          cursor = static_cast<size_t>(found - ordered.begin());
+        }
+
+        bool resolved = false;
+        while (cursor > 0) {
+          --cursor;
+          const Instruction &inst = *ordered[cursor];
+          const Operand *vdst = inst.dst_operand(0);
+          const bool writes_lane = inst.mnemonic() == "v_writelane_b32" && vdst != nullptr &&
+                                   vdst->encoding_value() >= 0;
+          if (writes_lane && static_cast<uint16_t>(vdst->encoding_value()) == vgpr) {
+            const Operand *ssrc = inst.src_operand(0);
+            const Operand *written_lane = inst.src_operand(1);
+            if (ssrc == nullptr || written_lane == nullptr || ssrc->encoding_value() < 0 ||
+                written_lane->encoding_value() < 0)
+              return false;
+            // A write to a different lane of the same VGPR leaves this lane alone.
+            if (static_cast<uint16_t>(written_lane->encoding_value()) != lane)
+              continue;
+            if (static_cast<uint16_t>(ssrc->encoding_value()) != sgpr)
+              return false;
+            resolved = true;
+            break;
+          }
+          // Any other definition of the VGPR rewrites every lane, including this one.
+          bool clobbers = false;
+          for (int i = 0; i < inst.num_dst_operands(); ++i) {
+            const Operand *dst = inst.dst_operand(i);
+            if (dst == nullptr || dst->encoding_value() < 0)
+              continue;
+            const auto base = static_cast<uint16_t>(dst->encoding_value());
+            const int halves = dst->size_bits() > 32 ? dst->size_bits() / 32 : 1;
+            if (vgpr >= base && vgpr < base + halves)
+              clobbers = true;
+          }
+          if (clobbers)
+            return false;
+        }
+        if (resolved)
+          continue;
+        // Reaching the entry without meeting the save means the lane was never given the caller's
+        // value on this path, which is the opposite of the SGPR search: there the entry is where
+        // the caller's value comes from, here the save has to be inside the body.
+        if (block == entry)
+          return false;
+        if (block->predecessors().empty() || !seen.insert(block).second)
+          return false;
+        for (BasicBlock *pred : block->predecessors())
+          work.emplace_back(pred, nullptr);
+      }
+      return true;
+    };
 
     // Classify one instruction's effect on the tracked half: a lane restore reinstates the
     // caller's value, any other definition replaces it with something this analysis cannot vouch
     // for, and everything else leaves the search running.
     enum class Effect { kNone, kRestores, kRedefines };
-    auto effect_on = [&saved_lane_sources](const Instruction &inst, uint16_t sgpr) {
+    auto effect_on = [&](const Instruction &inst, uint16_t sgpr, BasicBlock *block) {
       bool defines = false;
       for (int i = 0; i < inst.num_dst_operands(); ++i) {
         const Operand *dst = inst.dst_operand(i);
@@ -894,9 +952,9 @@ adopted_root_return_offsets(const BlockOffsetIndex &block_index,
           lane->encoding_value() < 0) {
         return Effect::kRedefines;
       }
-      const auto saved = saved_lane_sources.find({static_cast<uint16_t>(vsrc->encoding_value()),
-                                                  static_cast<uint16_t>(lane->encoding_value())});
-      if (saved == saved_lane_sources.end() || !saved->second.contains(sgpr))
+      // Ask at this instruction, not of the body: the save has to reach this read on every path.
+      if (!lane_holds_saved_sgpr(block, &inst, static_cast<uint16_t>(vsrc->encoding_value()),
+                                 static_cast<uint16_t>(lane->encoding_value()), sgpr))
         return Effect::kRedefines;
       return Effect::kRestores;
     };
@@ -926,7 +984,7 @@ adopted_root_return_offsets(const BlockOffsetIndex &block_index,
         bool resolved = false;
         while (cursor > 0) {
           --cursor;
-          const Effect effect = effect_on(*ordered[cursor], sgpr);
+          const Effect effect = effect_on(*ordered[cursor], sgpr, block);
           if (effect == Effect::kNone)
             continue;
           if (effect == Effect::kRedefines)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -897,10 +897,14 @@ adopted_root_return_offsets(const BlockOffsetIndex &block_index,
           if (lane_mnemonic == "s_set_vgpr_msb" || lane_mnemonic == "s_setreg_b32" ||
               lane_mnemonic == "s_setreg_imm32_b32")
             return false;
-          // A call between the save and the read can clobber the lane inside the callee, which this
-          // walk does not model.
-          if ((inst.flags() & INDIRECT_CALL) != 0 || lane_mnemonic == "s_call_i64" ||
-              lane_mnemonic == "s_swap_pc_i64" || lane_mnemonic == "s_swappc_b64")
+          // A call only endangers the stash if the callee is allowed to write the lane's register.
+          // The ABI keeps callee-saved VGPRs across a call, which is exactly what makes the
+          // non-leaf save/call/restore shape legitimate, so those survive; a caller-saved register
+          // may be overwritten inside the callee and fails closed.
+          const bool is_call = (inst.flags() & INDIRECT_CALL) != 0 ||
+                               lane_mnemonic == "s_call_i64" || lane_mnemonic == "s_swap_pc_i64" ||
+                               lane_mnemonic == "s_swappc_b64";
+          if (is_call && !is_callee_saved_vgpr(vgpr))
             return false;
           const Operand *vdst = inst.dst_operand(0);
           const bool writes_lane =
@@ -972,6 +976,14 @@ adopted_root_return_offsets(const BlockOffsetIndex &block_index,
     enum class Effect { kNone, kRestores, kRedefines };
     auto effect_on = [&](const Instruction &inst, uint16_t sgpr, BasicBlock *block,
                          bool allow_lane_restore) {
+      // A call writes the tracked pair without naming it whenever the callee does: the scalar ABI
+      // has no callee-saved SGPRs that a translated body may rely on here, so any call between the
+      // definition and the use invalidates the value. The call instruction's own destination list
+      // does not mention it, which is why this is checked before the operand walk.
+      const std::string_view sgpr_mnemonic = inst.mnemonic();
+      if ((inst.flags() & INDIRECT_CALL) != 0 || sgpr_mnemonic == "s_call_i64" ||
+          sgpr_mnemonic == "s_swap_pc_i64" || sgpr_mnemonic == "s_swappc_b64")
+        return Effect::kRedefines;
       bool defines = false;
       for (int i = 0; i < inst.num_dst_operands(); ++i) {
         const Operand *dst = inst.dst_operand(i);
@@ -980,6 +992,14 @@ adopted_root_return_offsets(const BlockOffsetIndex &block_index,
         const auto base = static_cast<uint16_t>(dst->encoding_value());
         const int halves = dst->size_bits() > 32 ? dst->size_bits() / 32 : 1;
         if (sgpr >= base && sgpr < base + halves)
+          defines = true;
+      }
+      // Destination operands are not the only way to write an SGPR; ask the instruction for the
+      // ones it writes without naming them.
+      if (!defines) {
+        RegisterSet implicit;
+        inst.implicit_defs(implicit);
+        if (implicit.contains(RegisterRef{RegClass::SGPR, sgpr, 1}))
           defines = true;
       }
       if (!defines)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -1915,6 +1915,10 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   // scope happens to hold a clone.
   std::unordered_map<uint64_t, uint64_t> canonical_placement;
 
+  // Set when a scope hosting a canonical copy had to grow its own descriptor to lower it. See the
+  // assignment for why that combination cannot be made safe from inside the scope loop.
+  bool canonical_host_outgrew_its_descriptor = false;
+
   // What one scope added to the three code-address containers, so a skipped scope can take it back.
   // The two vectors only ever grow within a scope, so a length restores them; canonical_placement
   // is keyed by source offset and needs the inserted keys named.
@@ -3328,6 +3332,20 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
         kernel_context.private_segment_fixed_size)
       scope.translation->target_private_size = kernel_context.required_private_segment_fixed_size;
 
+    // Only this scope's descriptor is grown from the values above, but a canonical copy this scope
+    // hosts is entered through a pointer any kernel can dereference. If lowering that copy needed
+    // resources beyond what this descriptor started with, another kernel would enter it under a
+    // budget that was never raised. Nothing here can raise that kernel's descriptor -- it may
+    // already be translated, and its own recompute happens inside its own scope -- so record the
+    // condition and refuse below rather than emit a descriptor that under-provisions a real caller.
+    if (!relocation_snapshot.canonical_placements_added.empty() &&
+        (kernel_context.required_vgpr_count > kernel_context.num_vgprs ||
+         kernel_context.required_sgpr_count > kernel_context.num_sgprs ||
+         kernel_context.required_private_segment_fixed_size >
+             kernel_context.private_segment_fixed_size)) {
+      canonical_host_outgrew_its_descriptor = true;
+    }
+
     if (scope.translation->target_vgpr_count != kernel_context.num_vgprs ||
         scope.translation->target_sgpr_count != kernel_context.num_sgprs ||
         scope.translation->target_private_size != kernel_context.private_segment_fixed_size) {
@@ -3460,6 +3478,17 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
       translation.target_entry_text_offset = layout.target_entry;
       translation.target_body_entry_text_offset = layout.target_body_entry;
     }
+  }
+
+  // A canonical copy is reached through a pointer, so any kernel in the object is a possible
+  // caller, but only the hosting scope's descriptor was grown to cover it. One kernel scope means
+  // the host is the only caller and the grown descriptor already covers it.
+  if (canonical_host_outgrew_its_descriptor && scopes.size() > 1) {
+    append_error(result.diagnostics, DiagnosticKind::KernelDescriptor,
+                 "a body reached through a code address needs resources beyond its hosting "
+                 "kernel's descriptor, which would under-provision every other kernel that can "
+                 "reach it");
+    return leave_unchanged();
   }
 
   // Every scope has been placed, so a code-target builder can finally be told where its target

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -976,6 +976,7 @@ scoped_call_liveness_edges(std::span<BasicBlock *const> blocks, std::span<const 
     CodeObjectPatcher patcher, std::vector<uint8_t> translated_text, uint64_t original_text_size,
     std::span<const TextOffsetRelocation> text_relocations,
     std::span<const PcRelativeDataRelocation> data_relocations,
+    std::span<const PcRelativeTextRelocation> code_relocations,
     std::span<const KdTranslation> translations, rj_code_arch_t host_arch, uint32_t target_mach,
     std::vector<TranslationDiagnostic> &diagnostics) {
   if (translated_text.size() < original_text_size)
@@ -999,7 +1000,8 @@ scoped_call_liveness_edges(std::span<BasicBlock *const> blocks, std::span<const 
     }
   }
 
-  if (!patcher.replace_text(translated_text, text_relocations, data_relocations)) {
+  if (!patcher.replace_text(translated_text, text_relocations, data_relocations,
+                            code_relocations)) {
     append_error(diagnostics, DiagnosticKind::ResourceLimit,
                  "relocated .text could not be materialized safely; leaving code object unchanged");
     return std::nullopt;
@@ -1445,10 +1447,69 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   const auto relocation_table_calls = attach_relocation_table_call_edges(
       block_index, relocation_function_tables, relocation_table_dispatches);
 
-  // Address materializations that must survive relocation. See the use site for why a non-.text
-  // target has to be rewritten and a .text one must not be.
+  // Address materializations that must survive relocation. See the use sites for how a data target
+  // and a code target are each rewritten.
   const auto pc_relative_address_builders =
       discover_pc_relative_address_builders(blocks, text_vaddr);
+
+  // Whether every code address this object can produce is one this translation will relocate.
+  //
+  // The translator's usual discipline is consumer-side: prove an indirect transfer's target or
+  // refuse. That cannot see a target loaded from memory, because the value was placed there by a
+  // relocation or by a store the transfer's scope never executed. The complementary producer-side
+  // question is answerable: a code address can only enter this object as an ELF relocation addend
+  // or as a getpc computation, so if every one of those is rewritten, then whatever a load yields
+  // is relocation-correct by construction and there is nothing left for the consumer to prove.
+  //
+  // Relocation addends are discharged by relocate_relative_text_addends(), which already fails
+  // closed on an addend it cannot map. What remains is the getpc side, and the denominator has to
+  // be the discovery pass rather than the lattice: the lattice only models the 64-bit-literal add,
+  // while a long-branch expansion builds its address from a split 32-bit pair the lattice never
+  // sees. Requiring the lattice to have matched every discovered builder is what keeps that form
+  // from silently falling outside the claim.
+  // The claim below is "every code address THIS OBJECT PRODUCES is relocated", so it is worth
+  // nothing unless the object produces some. An object holding no function-pointer table and
+  // computing no code address can still reach an indirect transfer -- through a kernarg, or a
+  // pointer handed over by a separately translated object -- and about those the claim is silent.
+  // Requiring a producer keeps the permission from resting on a vacuous truth.
+  const bool object_produces_code_addresses =
+      std::ranges::any_of(relocation_function_tables,
+                          [](const RelocationFunctionTable &table) {
+                            return !table.entries.empty();
+                          }) ||
+      std::ranges::any_of(pc_relative_address_builders,
+                          [&](const PcRelativeAddressBuilder &builder) {
+                            return builder.target_vaddr >= text_vaddr &&
+                                   builder.target_vaddr - text_vaddr < text.size();
+                          });
+
+  const bool code_addresses_fully_accounted = [&] {
+    std::unordered_set<uint64_t> lattice_getpc_offsets;
+    for (const PcRelativeAddressBuilder &builder : pc_relative_address_builders)
+      lattice_getpc_offsets.insert(builder.source_getpc_offset);
+    for (const auto &block : blocks) {
+      if (block == nullptr)
+        continue;
+      for (const PcAddressBuilder &builder : block->static_pc_address_builders()) {
+        // The lattice owning this builder is what matters: it is the analysis that drives both the
+        // data and the code rewrite, so a builder it matched is rewritten regardless of what the
+        // indirect-branch pass made of it. The two passes resolve independently and disagree
+        // routinely -- the branch pass gives up on anything that does not reach a setpc.
+        if (lattice_getpc_offsets.contains(builder.source_getpc_offset))
+          continue;
+        // Otherwise the value has to be known here, or it may be a code address left stale.
+        if (!builder.resolved || !builder.contiguous)
+          return false;
+        // A known non-code target needs nothing: it cannot be a stale jump destination.
+        if (builder.source_target_offset < 0 ||
+            static_cast<uint64_t>(builder.source_target_offset) >= text.size())
+          continue;
+        // A code target the lattice never saw is one this translation cannot rewrite.
+        return false;
+      }
+    }
+    return true;
+  }();
   // Read the section headers straight from the image rather than through all_sections(), which
   // drops SHT_NOBITS. A zero-initialized device global lives in .bss, so that omission would hide
   // the most ordinary target there is. This must also agree with replace_text(): it resolves a data
@@ -1551,15 +1612,28 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     for (const KernelTranslationScope &scope : scopes)
       covered.insert(scope.blocks.begin(), scope.blocks.end());
 
+    const auto adopt = [&](uint64_t text_offset) {
+      const BasicBlock *entry = block_for_offset(block_index, text_offset);
+      // A body that is already reached is left alone. Adopting it would add a second placement of
+      // the same source offset, and a runtime-dereferenced pointer cannot choose between them.
+      if (entry == nullptr || covered.contains(entry))
+        return;
+      adopted_roots.push_back(text_offset);
+    };
+
     for (const RelocationFunctionTable &table : relocation_function_tables) {
-      for (const RelocationFunctionPointer &slot : table.entries) {
-        const BasicBlock *entry = block_for_offset(block_index, slot.target_text_offset);
-        // A body that is already reached is left alone. Adopting it would add a second placement of
-        // the same source offset, and a runtime-dereferenced pointer cannot choose between them.
-        if (entry == nullptr || covered.contains(entry))
-          continue;
-        adopted_roots.push_back(slot.target_text_offset);
-      }
+      for (const RelocationFunctionPointer &slot : table.entries)
+        adopt(slot.target_text_offset);
+    }
+    // A getpc that computes a code address makes that body address-taken just as surely as a
+    // relocation slot does -- the value can be stored, passed, or returned, and the body must exist
+    // at a known place for the literal to be rewritten to. Unlike a relocation target this one is
+    // named only by instructions, so nothing else in the pipeline would keep it alive: a body
+    // reached by no call is dropped, and its address then has no placement to resolve against.
+    for (const PcRelativeAddressBuilder &builder : pc_relative_address_builders) {
+      if (builder.target_vaddr < text_vaddr || builder.target_vaddr - text_vaddr >= text.size())
+        continue;
+      adopt(builder.target_vaddr - text_vaddr);
     }
     std::ranges::sort(adopted_roots);
     adopted_roots.erase(std::ranges::unique(adopted_roots).begin(), adopted_roots.end());
@@ -1747,6 +1821,16 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   // then applies to the replacement stub or a later kernel.
   std::vector<TextOffsetRelocation> text_relocations;
   std::vector<PcRelativeDataRelocation> data_relocations;
+  // A code-target builder cannot be finished inside the scope loop: its target may belong to a
+  // scope not yet emitted, and a body reached from several kernels is cloned once per scope, so the
+  // final offset is only knowable once every placement is recorded. Hold the source-side answer and
+  // resolve against the completed map below.
+  struct PendingCodeRelocation {
+    uint64_t target_getpc_offset = 0;
+    uint64_t target_literal_offset = 0;
+    uint64_t source_target_text_offset = 0;
+  };
+  std::vector<PendingCodeRelocation> pending_code_relocations;
 
   auto fail_or_skip_kernel =
       [&](const KernelTranslationScope &scope, KernelFailure failure, size_t output_begin,
@@ -2470,9 +2554,18 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
         const bool has_relocation_table_call = relocation_table_calls.contains(offset);
         const bool recovered_indirect_return = valid_call_return_offsets.contains(offset);
         const auto direct_branch_delta = inst.branch_offset_bytes();
+        // A transfer through a value this object loaded from memory needs no per-target proof once
+        // every code address the object can produce is relocated: the loaded word is either a
+        // rewritten relocation addend or a rewritten getpc result, so it already names the body's
+        // new home. This is what makes a C++ virtual call translatable -- its target comes out of a
+        // vtable slot that no dataflow fact can name, and no amount of consumer-side analysis will
+        // ever name it.
+        const bool target_is_relocated_by_construction =
+            object_produces_code_addresses && code_addresses_fully_accounted;
         if ((inst.flags() & (INDIRECT_BRANCH | INDIRECT_CALL)) != 0 &&
             !has_recovered_indirect_call && !has_relocation_table_call &&
-            !recovered_indirect_return && !direct_branch_delta) {
+            !recovered_indirect_return && !direct_branch_delta &&
+            !target_is_relocated_by_construction) {
           auto failure = make_kernel_failure(
               DiagnosticKind::Legalization,
               "indirect branch or call target recovery is not implemented for relocated kernel "
@@ -2997,6 +3090,19 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
       text_relocations.push_back(
           {.source_offset = source_offset, .target_offset = target_offset + target_delta});
     }
+    // patch_recovered_builder_fixups NOPs and regenerates a builder's whole source range, so a
+    // literal it owns must not also be written here -- the later write would land in a range the
+    // other model has already rebuilt.
+    std::unordered_set<uint64_t> recovered_builder_getpc_offsets;
+    for (const IndirectCallFixup &fixup : layout.recovered_builder_fixups)
+      recovered_builder_getpc_offsets.insert(fixup.source_getpc_offset);
+    for (const auto &[source_call_offset, consumer] : recovered_indirect_by_call) {
+      (void)source_call_offset;
+      recovered_builder_getpc_offsets.insert(consumer.window_fixup.source_getpc_offset);
+      for (const IndirectCallFixup &fixup : consumer.fixups)
+        recovered_builder_getpc_offsets.insert(fixup.source_getpc_offset);
+    }
+
     std::unordered_set<uint64_t> patched_address_add_offsets;
     for (const RelocationTableDispatch &dispatch : relocation_table_dispatches) {
       if (!target_offset_by_source_offset.contains(dispatch.source_call_offset))
@@ -3024,13 +3130,10 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     // at the old distance. The instructions are copied verbatim, so nothing else in the pipeline
     // notices. Recompute the literal from the getpc's final placement instead.
     //
-    // Only non-executable targets are taken. A `.text` target is a code address, which the
-    // recovered-builder fixups already rewrite through the block placement map, and routing it
-    // here as well would write the same literal twice from two different models.
+    // A `.text` target is a code address and is handled below rather than here, because it moves
+    // with the body that holds it and so cannot be named by a fixed virtual address.
     for (const PcRelativeAddressBuilder &builder : pc_relative_address_builders) {
       if (patched_address_add_offsets.contains(builder.source_address_add_offset))
-        continue;
-      if (!addresses_loadable_data(builder.target_vaddr))
         continue;
       const auto getpc = target_offset_by_source_offset.find(builder.source_getpc_offset);
       const auto add = target_offset_by_source_offset.find(builder.source_address_add_offset);
@@ -3040,10 +3143,26 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
           add == target_offset_by_source_offset.end()) {
         continue;
       }
-      data_relocations.push_back(
+      if (addresses_loadable_data(builder.target_vaddr)) {
+        data_relocations.push_back(
+            {.target_getpc_offset = getpc->second + target_delta,
+             .target_literal_offset = add->second + target_delta + sizeof(uint32_t),
+             .source_target_vaddr = builder.target_vaddr});
+        continue;
+      }
+      // A code address the builder merely computes -- stored to a function pointer, passed as an
+      // argument -- reaches no indirect transfer here, so the recovered-builder path never claims
+      // it and it would otherwise be copied verbatim with a literal measuring the distance the body
+      // used to be at. Record it and resolve after every scope has been placed: the target may be
+      // emitted by a different scope, so this scope's placement map cannot answer for it yet.
+      if (builder.target_vaddr < text_vaddr || builder.target_vaddr - text_vaddr >= text.size())
+        continue;
+      if (recovered_builder_getpc_offsets.contains(builder.source_getpc_offset))
+        continue;
+      pending_code_relocations.push_back(
           {.target_getpc_offset = getpc->second + target_delta,
            .target_literal_offset = add->second + target_delta + sizeof(uint32_t),
-           .source_target_vaddr = builder.target_vaddr});
+           .source_target_text_offset = builder.target_vaddr - text_vaddr});
     }
 
     if (kernel_context.required_vgpr_count > kernel_context.num_vgprs)
@@ -3183,6 +3302,35 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     }
   }
 
+  // Every scope has been placed, so a code-target builder can finally be told where its target
+  // landed. A source offset emitted more than once has no single answer -- a runtime-dereferenced
+  // code address cannot choose between clones -- so that fails closed rather than picking one,
+  // matching how relocate_relative_text_addends treats a conflicting relocation addend.
+  std::vector<PcRelativeTextRelocation> code_relocations;
+  if (!pending_code_relocations.empty()) {
+    std::unordered_map<uint64_t, uint64_t> placement;
+    std::unordered_set<uint64_t> conflicting;
+    for (const TextOffsetRelocation &relocation : text_relocations) {
+      auto [it, inserted] =
+          placement.try_emplace(relocation.source_offset, relocation.target_offset);
+      if (!inserted && it->second != relocation.target_offset)
+        conflicting.insert(relocation.source_offset);
+    }
+    for (const PendingCodeRelocation &pending : pending_code_relocations) {
+      const auto placed = placement.find(pending.source_target_text_offset);
+      if (placed == placement.end() || conflicting.contains(pending.source_target_text_offset)) {
+        append_error(result.diagnostics, DiagnosticKind::Legalization,
+                     "PC-relative code address has no single relocated target; leaving code "
+                     "object unchanged",
+                     pending.source_target_text_offset);
+        return leave_unchanged();
+      }
+      code_relocations.push_back({.target_getpc_offset = pending.target_getpc_offset,
+                                  .target_literal_offset = pending.target_literal_offset,
+                                  .target_text_offset = placed->second});
+    }
+  }
+
   if (continue_after_failure && has_error_diagnostic(result.diagnostics))
     return leave_unchanged();
 
@@ -3190,7 +3338,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   // and sidecar metadata construction into the per-kernel lowering transaction.
   auto materialized = materialize_translated_code_object(
       std::move(patcher), std::move(translated_text), text.size(), text_relocations,
-      data_relocations, descriptor_translations, host_arch_, target_mach_, result.diagnostics);
+      data_relocations, code_relocations, descriptor_translations, host_arch_, target_mach_,
+      result.diagnostics);
   if (!materialized)
     return leave_unchanged();
   result.elf_bytes = std::move(*materialized);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -1670,11 +1670,17 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
         ++emitting_scopes[block];
     }
 
-    const auto adopt = [&](uint64_t text_offset) {
+    const auto note_address_taken = [&](uint64_t text_offset) -> const BasicBlock * {
       const BasicBlock *entry = block_for_offset(block_index, text_offset);
+      if (entry != nullptr)
+        address_taken_offsets.insert(text_offset);
+      return entry;
+    };
+
+    const auto adopt = [&](uint64_t text_offset) {
+      const BasicBlock *entry = note_address_taken(text_offset);
       if (entry == nullptr)
         return;
-      address_taken_offsets.insert(text_offset);
       // Only a body no scope reaches needs adopting. One that several scopes clone is left where it
       // is: lowering it through an unrelated scope would deny it the context its real caller
       // supplies -- DS2 mode inference and liveness are scope-relative -- so the ambiguity between
@@ -1689,14 +1695,19 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
         adopt(slot.target_text_offset);
     }
     // A getpc that computes a code address makes that body address-taken just as surely as a
-    // relocation slot does -- the value can be stored, passed, or returned, and the body must exist
-    // at a known place for the literal to be rewritten to. Unlike a relocation target this one is
-    // named only by instructions, so nothing else in the pipeline would keep it alive: a body
-    // reached by no call is dropped, and its address then has no placement to resolve against.
+    // relocation slot does, so its target has to be accounted for before the rewrite is permitted.
+    // It is deliberately not adopted, though. A relocation slot is a fixed property of the input:
+    // the same eleven slots are discovered whether or not the object has already been translated.
+    // A getpc builder is not -- translation folds the ones it can prove into direct calls, so a
+    // second pass over translated text discovers a different, smaller set. Adopting from that set
+    // would make the scope partition, and therefore the entire `.text` layout, depend on how much
+    // of the previous layout the analysis happened to recover, which is not a fixed point. A
+    // builder target that no scope reaches instead leaves the code address unaccounted for and the
+    // object is refused, which is the conservative outcome rather than a silent stale address.
     for (const PcRelativeAddressBuilder &builder : pc_relative_address_builders) {
       if (builder.target_vaddr < text_vaddr || builder.target_vaddr - text_vaddr >= text.size())
         continue;
-      adopt(builder.target_vaddr - text_vaddr);
+      note_address_taken(builder.target_vaddr - text_vaddr);
     }
     std::ranges::sort(adopted_roots);
     adopted_roots.erase(std::ranges::unique(adopted_roots).begin(), adopted_roots.end());

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -1145,7 +1145,7 @@ scoped_call_liveness_edges(std::span<BasicBlock *const> blocks, std::span<const 
     std::span<const PcRelativeDataRelocation> data_relocations,
     std::span<const PcRelativeTextRelocation> code_relocations,
     std::span<const KdTranslation> translations, rj_code_arch_t host_arch, uint32_t target_mach,
-    std::vector<TranslationDiagnostic> &diagnostics) {
+    bool require_every_text_symbol_mapped, std::vector<TranslationDiagnostic> &diagnostics) {
   if (translated_text.size() < original_text_size)
     append_nop_padding(translated_text, original_text_size - translated_text.size(), host_arch);
 
@@ -1167,8 +1167,8 @@ scoped_call_liveness_edges(std::span<BasicBlock *const> blocks, std::span<const 
     }
   }
 
-  if (!patcher.replace_text(translated_text, text_relocations, data_relocations,
-                            code_relocations)) {
+  if (!patcher.replace_text(translated_text, text_relocations, data_relocations, code_relocations,
+                            require_every_text_symbol_mapped)) {
     append_error(diagnostics, DiagnosticKind::ResourceLimit,
                  "relocated .text could not be materialized safely; leaving code object unchanged");
     return std::nullopt;
@@ -2052,6 +2052,11 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   // Set when a scope hosting a canonical copy had to grow its own descriptor to lower it. See the
   // assignment for why that combination cannot be made safe from inside the scope loop.
   bool canonical_host_outgrew_its_descriptor = false;
+  // Set when an unresolved indirect transfer was admitted only because every code address this
+  // object produces is relocated. That argument also covers addresses arriving from outside, which
+  // reach `.text` through a symbol, so while it is in force no `.text` symbol may keep its source
+  // value -- hence the tightening handed to replace_text() below.
+  bool relied_on_relocated_by_construction = false;
 
   // What one scope added to the three code-address containers, so a skipped scope can take it back.
   // The two vectors only ever grow within a scope, so a length restores them; canonical_placement
@@ -2832,6 +2837,12 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
         // relocate_text_symbols() tolerates so debug labels in padding do not refuse the object.
         const bool target_is_relocated_by_construction =
             object_produces_code_addresses && code_addresses_fully_accounted;
+        if ((inst.flags() & (INDIRECT_BRANCH | INDIRECT_CALL)) != 0 &&
+            !has_recovered_indirect_call && !has_relocation_table_call &&
+            !recovered_indirect_return && !direct_branch_delta &&
+            target_is_relocated_by_construction) {
+          relied_on_relocated_by_construction = true;
+        }
         if ((inst.flags() & (INDIRECT_BRANCH | INDIRECT_CALL)) != 0 &&
             !has_recovered_indirect_call && !has_relocation_table_call &&
             !recovered_indirect_return && !direct_branch_delta &&
@@ -3704,7 +3715,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   auto materialized = materialize_translated_code_object(
       std::move(patcher), std::move(translated_text), text.size(), text_relocations,
       data_relocations, code_relocations, descriptor_translations, host_arch_, target_mach_,
-      result.diagnostics);
+      relied_on_relocated_by_construction, result.diagnostics);
   if (!materialized)
     return leave_unchanged();
   result.elf_bytes = std::move(*materialized);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -841,8 +841,8 @@ adopted_root_return_offsets(const BlockOffsetIndex &block_index,
       if (term != nullptr && term->size() == sizeof(uint32_t)) {
         const std::string_view mnemonic = term->mnemonic();
         if (mnemonic == "s_setpc_b64" || mnemonic == "s_set_pc_i64")
-          candidates.emplace_back(block, static_cast<uint16_t>(
-                                             text_word_at(text, term->src_loc()) & 0xffu));
+          candidates.emplace_back(
+              block, static_cast<uint16_t>(text_word_at(text, term->src_loc()) & 0xffu));
       }
       for (BasicBlock *succ : block->successors())
         stack.push_back(succ);
@@ -1473,10 +1473,9 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   // pointer handed over by a separately translated object -- and about those the claim is silent.
   // Requiring a producer keeps the permission from resting on a vacuous truth.
   const bool object_produces_code_addresses =
-      std::ranges::any_of(relocation_function_tables,
-                          [](const RelocationFunctionTable &table) {
-                            return !table.entries.empty();
-                          }) ||
+      std::ranges::any_of(
+          relocation_function_tables,
+          [](const RelocationFunctionTable &table) { return !table.entries.empty(); }) ||
       std::ranges::any_of(pc_relative_address_builders,
                           [&](const PcRelativeAddressBuilder &builder) {
                             return builder.target_vaddr >= text_vaddr &&
@@ -1638,8 +1637,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     std::ranges::sort(adopted_roots);
     adopted_roots.erase(std::ranges::unique(adopted_roots).begin(), adopted_roots.end());
     if (!adopted_roots.empty()) {
-      scopes = kernel_translation_scopes(blocks, block_index, descriptor_translations,
-                                         adopted_roots);
+      scopes =
+          kernel_translation_scopes(blocks, block_index, descriptor_translations, adopted_roots);
     }
   }
   const std::unordered_set<uint64_t> adopted_return_offsets =
@@ -1831,6 +1830,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     uint64_t source_target_text_offset = 0;
   };
   std::vector<PendingCodeRelocation> pending_code_relocations;
+  std::vector<PcRelativeTextRelocation> code_relocations;
 
   auto fail_or_skip_kernel =
       [&](const KernelTranslationScope &scope, KernelFailure failure, size_t output_begin,
@@ -3093,15 +3093,13 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     // patch_recovered_builder_fixups NOPs and regenerates a builder's whole source range, so a
     // literal it owns must not also be written here -- the later write would land in a range the
     // other model has already rebuilt.
+    // Only the fixups actually queued for patching own a literal. A consumer's candidate fixups are
+    // not the same set: one whose target could not be resolved, or whose consumer was handled by a
+    // direct-window conversion instead, never reaches patch_recovered_builder_fixups. Excluding
+    // those here would leave their builders written by nobody.
     std::unordered_set<uint64_t> recovered_builder_getpc_offsets;
     for (const IndirectCallFixup &fixup : layout.recovered_builder_fixups)
       recovered_builder_getpc_offsets.insert(fixup.source_getpc_offset);
-    for (const auto &[source_call_offset, consumer] : recovered_indirect_by_call) {
-      (void)source_call_offset;
-      recovered_builder_getpc_offsets.insert(consumer.window_fixup.source_getpc_offset);
-      for (const IndirectCallFixup &fixup : consumer.fixups)
-        recovered_builder_getpc_offsets.insert(fixup.source_getpc_offset);
-    }
 
     std::unordered_set<uint64_t> patched_address_add_offsets;
     for (const RelocationTableDispatch &dispatch : relocation_table_dispatches) {
@@ -3159,10 +3157,27 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
         continue;
       if (recovered_builder_getpc_offsets.contains(builder.source_getpc_offset))
         continue;
+      const uint64_t source_target = builder.target_vaddr - text_vaddr;
+      // Prefer this scope's own copy of the target. A body reached by several kernels is cloned
+      // once per scope so each scope's branches resolve through its own placement map, and
+      // patch_recovered_builder_fixups already points a recovered builder at its scope's clone.
+      // Following the same convention keeps a computed address consistent with the code that
+      // computed it, and avoids inventing a conflict between clones that are only distinguishable
+      // by which scope emitted them.
+      if (const auto local = target_offset_by_source_offset.find(source_target);
+          local != target_offset_by_source_offset.end()) {
+        code_relocations.push_back(
+            {.target_getpc_offset = getpc->second + target_delta,
+             .target_literal_offset = add->second + target_delta + sizeof(uint32_t),
+             .target_text_offset = local->second + target_delta});
+        continue;
+      }
+      // Otherwise the target belongs to another scope -- an adopted body, say -- and can only be
+      // resolved once every placement is known.
       pending_code_relocations.push_back(
           {.target_getpc_offset = getpc->second + target_delta,
            .target_literal_offset = add->second + target_delta + sizeof(uint32_t),
-           .source_target_text_offset = builder.target_vaddr - text_vaddr});
+           .source_target_text_offset = source_target});
     }
 
     if (kernel_context.required_vgpr_count > kernel_context.num_vgprs)
@@ -3306,7 +3321,6 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   // landed. A source offset emitted more than once has no single answer -- a runtime-dereferenced
   // code address cannot choose between clones -- so that fails closed rather than picking one,
   // matching how relocate_relative_text_addends treats a conflicting relocation addend.
-  std::vector<PcRelativeTextRelocation> code_relocations;
   if (!pending_code_relocations.empty()) {
     std::unordered_map<uint64_t, uint64_t> placement;
     std::unordered_set<uint64_t> conflicting;
@@ -3320,8 +3334,11 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
       const auto placed = placement.find(pending.source_target_text_offset);
       if (placed == placement.end() || conflicting.contains(pending.source_target_text_offset)) {
         append_error(result.diagnostics, DiagnosticKind::Legalization,
-                     "PC-relative code address has no single relocated target; leaving code "
-                     "object unchanged",
+                     conflicting.contains(pending.source_target_text_offset)
+                         ? "PC-relative code address names a body emitted at more than one "
+                           "placement; leaving code object unchanged"
+                         : "PC-relative code address names a body this translation did not emit; "
+                           "leaving code object unchanged",
                      pending.source_target_text_offset);
         return leave_unchanged();
       }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -38,6 +38,7 @@
 #include <array>
 #include <cassert>
 #include <cstring>
+#include <functional>
 #include <iterator>
 #include <limits>
 #include <memory>
@@ -853,6 +854,12 @@ adopted_root_return_offsets(const BlockOffsetIndex &block_index,
     // this: a save that appears after the read, or on a path that does not join it, or one a later
     // write to the same VGPR has already destroyed, would all still be in the set and would let an
     // arbitrary lane read pass as a return-address restore.
+    // Declared ahead of the lane query so that query can prove the SGPR a save captured really
+    // was the caller's incoming value. The bool disables lane-restore classification inside the
+    // nested query, which bounds the recursion at one level and keeps the nested question strictly
+    // simpler than the outer one.
+    std::function<bool(BasicBlock *, const Instruction *, uint16_t, bool)> caller_value_reaches;
+
     auto lane_holds_saved_sgpr = [&](BasicBlock *start, const Instruction *from, uint16_t vgpr,
                                      uint16_t lane, uint16_t sgpr) {
       std::vector<std::pair<BasicBlock *, const Instruction *>> work{{start, from}};
@@ -883,9 +890,21 @@ adopted_root_return_offsets(const BlockOffsetIndex &block_index,
         while (cursor > 0) {
           --cursor;
           const Instruction &inst = *ordered[cursor];
+          const std::string_view lane_mnemonic = inst.mnemonic();
+          // The lane identity here is a low selector only. Anything that moves the VGPR bank makes
+          // that selector name a different physical register, so the comparison below stops meaning
+          // what it says and the proof has to give up.
+          if (lane_mnemonic == "s_set_vgpr_msb" || lane_mnemonic == "s_setreg_b32" ||
+              lane_mnemonic == "s_setreg_imm32_b32")
+            return false;
+          // A call between the save and the read can clobber the lane inside the callee, which this
+          // walk does not model.
+          if ((inst.flags() & INDIRECT_CALL) != 0 || lane_mnemonic == "s_call_i64" ||
+              lane_mnemonic == "s_swap_pc_i64" || lane_mnemonic == "s_swappc_b64")
+            return false;
           const Operand *vdst = inst.dst_operand(0);
-          const bool writes_lane = inst.mnemonic() == "v_writelane_b32" && vdst != nullptr &&
-                                   vdst->encoding_value() >= 0;
+          const bool writes_lane =
+              lane_mnemonic == "v_writelane_b32" && vdst != nullptr && vdst->encoding_value() >= 0;
           if (writes_lane && static_cast<uint16_t>(vdst->encoding_value()) == vgpr) {
             const Operand *ssrc = inst.src_operand(0);
             const Operand *written_lane = inst.src_operand(1);
@@ -896,6 +915,10 @@ adopted_root_return_offsets(const BlockOffsetIndex &block_index,
             if (static_cast<uint16_t>(written_lane->encoding_value()) != lane)
               continue;
             if (static_cast<uint16_t>(ssrc->encoding_value()) != sgpr)
+              return false;
+            // Finding the save is not enough: it captured whatever the SGPR held at that point, so
+            // the value is the caller's return PC only if the caller's value still reached here.
+            if (!caller_value_reaches(block, &inst, sgpr, /*allow_lane_restore=*/false))
               return false;
             resolved = true;
             break;
@@ -937,7 +960,8 @@ adopted_root_return_offsets(const BlockOffsetIndex &block_index,
     // caller's value, any other definition replaces it with something this analysis cannot vouch
     // for, and everything else leaves the search running.
     enum class Effect { kNone, kRestores, kRedefines };
-    auto effect_on = [&](const Instruction &inst, uint16_t sgpr, BasicBlock *block) {
+    auto effect_on = [&](const Instruction &inst, uint16_t sgpr, BasicBlock *block,
+                         bool allow_lane_restore) {
       bool defines = false;
       for (int i = 0; i < inst.num_dst_operands(); ++i) {
         const Operand *dst = inst.dst_operand(i);
@@ -950,7 +974,9 @@ adopted_root_return_offsets(const BlockOffsetIndex &block_index,
       }
       if (!defines)
         return Effect::kNone;
-      if (inst.mnemonic() != "v_readlane_b32")
+      // The nested provenance query runs with this off: a lane restore is exactly what it is
+      // trying to justify, so letting it count one would be circular.
+      if (!allow_lane_restore || inst.mnemonic() != "v_readlane_b32")
         return Effect::kRedefines;
       // Only a read of the exact lane this body saved the same register into restores the caller's
       // value. Reading some other lane, or another register's lane, produces a value this analysis
@@ -969,7 +995,8 @@ adopted_root_return_offsets(const BlockOffsetIndex &block_index,
     };
 
     // Backward reaching-definition search for one half, starting just above `from`.
-    auto caller_value_reaches = [&](BasicBlock *start, const Instruction *from, uint16_t sgpr) {
+    caller_value_reaches = [&](BasicBlock *start, const Instruction *from, uint16_t sgpr,
+                               bool allow_lane_restore) {
       std::vector<std::pair<BasicBlock *, const Instruction *>> work{{start, from}};
       // Keyed by the whole work item, not the block. Processing one is deterministic, so meeting
       // the same pair twice adds nothing and is skipped; the same block reached with a different
@@ -998,7 +1025,7 @@ adopted_root_return_offsets(const BlockOffsetIndex &block_index,
         bool resolved = false;
         while (cursor > 0) {
           --cursor;
-          const Effect effect = effect_on(*ordered[cursor], sgpr, block);
+          const Effect effect = effect_on(*ordered[cursor], sgpr, block, allow_lane_restore);
           if (effect == Effect::kNone)
             continue;
           if (effect == Effect::kRedefines)
@@ -1027,8 +1054,9 @@ adopted_root_return_offsets(const BlockOffsetIndex &block_index,
 
     for (const auto &[block, ssrc0] : candidates) {
       const Instruction *term = block->terminator();
-      if (caller_value_reaches(block, term, ssrc0) &&
-          caller_value_reaches(block, term, static_cast<uint16_t>(ssrc0 + 1)))
+      if (caller_value_reaches(block, term, ssrc0, /*allow_lane_restore=*/true) &&
+          caller_value_reaches(block, term, static_cast<uint16_t>(ssrc0 + 1),
+                               /*allow_lane_restore=*/true))
         returns.insert(term->src_loc());
     }
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
@@ -1137,13 +1137,16 @@ bool CodeObjectPatcher::replace_text(std::span<const uint8_t> new_text,
     // field being written would otherwise wrap the subtraction and admit an out-of-bounds write.
     // The target is a branch destination, so it must be a whole instruction inside the new text.
     // Allowing it to equal the size would name the byte one past the end, which is not an
-    // instruction and would leave the literal pointing outside `.text`.
+    // instruction and would leave the literal pointing outside `.text`. Being inside the section
+    // is not enough either: an unaligned offset names a byte interior to an instruction, so the
+    // literal would send a transfer into the middle of one.
     if (relocation.target_getpc_offset > new_text.size() ||
         sizeof(uint32_t) > new_text.size() - relocation.target_getpc_offset ||
         relocation.target_literal_offset > new_text.size() ||
         sizeof(uint64_t) > new_text.size() - relocation.target_literal_offset ||
         relocation.target_text_offset > new_text.size() ||
-        sizeof(uint32_t) > new_text.size() - relocation.target_text_offset) {
+        sizeof(uint32_t) > new_text.size() - relocation.target_text_offset ||
+        relocation.target_text_offset % sizeof(uint32_t) != 0) {
       return false;
     }
     const uint64_t getpc_result = relocation.target_getpc_offset + sizeof(uint32_t);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
@@ -648,8 +648,7 @@ relocate_relative_text_addends(std::vector<uint8_t> &image, const Elf64_Ehdr &eh
 /// Addends into `.text` are deliberately untouched: those name code, which does not simply shift,
 /// and relocate_relative_text_addends() rewrites them through the block placement map instead. The
 /// two are disjoint because a `.text` addend is below @p old_text_end_vaddr by construction.
-void shift_relative_addends_into_moved_sections(std::vector<uint8_t> &image,
-                                                const Elf64_Ehdr &ehdr,
+void shift_relative_addends_into_moved_sections(std::vector<uint8_t> &image, const Elf64_Ehdr &ehdr,
                                                 std::span<const Elf64_Shdr> shdrs,
                                                 uint64_t old_text_end_vaddr, uint64_t delta) {
   if (delta == 0)
@@ -1134,8 +1133,12 @@ bool CodeObjectPatcher::replace_text(std::span<const uint8_t> new_text,
   // literal is their difference. `s_get_pc_i64` leaves the address of the following instruction, so
   // the distance to make up is measured from one word past the getpc.
   for (const PcRelativeTextRelocation &relocation : code_relocations) {
-    if (relocation.target_getpc_offset > new_text.size() - sizeof(uint32_t) ||
-        relocation.target_literal_offset > new_text.size() - sizeof(uint64_t) ||
+    // Subtract from the size only after proving the offset is inside it: a text shorter than the
+    // field being written would otherwise wrap the subtraction and admit an out-of-bounds write.
+    if (relocation.target_getpc_offset > new_text.size() ||
+        sizeof(uint32_t) > new_text.size() - relocation.target_getpc_offset ||
+        relocation.target_literal_offset > new_text.size() ||
+        sizeof(uint64_t) > new_text.size() - relocation.target_literal_offset ||
         relocation.target_text_offset > new_text.size()) {
       return false;
     }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
@@ -1135,11 +1135,15 @@ bool CodeObjectPatcher::replace_text(std::span<const uint8_t> new_text,
   for (const PcRelativeTextRelocation &relocation : code_relocations) {
     // Subtract from the size only after proving the offset is inside it: a text shorter than the
     // field being written would otherwise wrap the subtraction and admit an out-of-bounds write.
+    // The target is a branch destination, so it must be a whole instruction inside the new text.
+    // Allowing it to equal the size would name the byte one past the end, which is not an
+    // instruction and would leave the literal pointing outside `.text`.
     if (relocation.target_getpc_offset > new_text.size() ||
         sizeof(uint32_t) > new_text.size() - relocation.target_getpc_offset ||
         relocation.target_literal_offset > new_text.size() ||
         sizeof(uint64_t) > new_text.size() - relocation.target_literal_offset ||
-        relocation.target_text_offset > new_text.size()) {
+        relocation.target_text_offset > new_text.size() ||
+        sizeof(uint32_t) > new_text.size() - relocation.target_text_offset) {
       return false;
     }
     const uint64_t getpc_result = relocation.target_getpc_offset + sizeof(uint32_t);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
@@ -636,6 +636,46 @@ relocate_relative_text_addends(std::vector<uint8_t> &image, const Elf64_Ehdr &eh
   return false;
 }
 
+/// @brief Shift `R_AMDGPU_RELATIVE64` addends that name an address past the growing `.text`.
+///
+/// @details Growing `.text` moves every allocated section above it, and the loader computes a
+/// relative relocation as load bias plus addend -- so an addend naming a moved section still names
+/// where that section used to be. The sibling pass above moves the relocation's *place*; this moves
+/// what it *points at*. Without it a C++ object's vptr slot is written with the pre-growth vtable
+/// address, and the first virtual call reads its function pointers out of whatever now occupies
+/// that memory.
+///
+/// Addends into `.text` are deliberately untouched: those name code, which does not simply shift,
+/// and relocate_relative_text_addends() rewrites them through the block placement map instead. The
+/// two are disjoint because a `.text` addend is below @p old_text_end_vaddr by construction.
+void shift_relative_addends_into_moved_sections(std::vector<uint8_t> &image,
+                                                const Elf64_Ehdr &ehdr,
+                                                std::span<const Elf64_Shdr> shdrs,
+                                                uint64_t old_text_end_vaddr, uint64_t delta) {
+  if (delta == 0)
+    return;
+  for (const Elf64_Shdr &relocs : shdrs) {
+    if (relocs.sh_type != SHT_RELA || relocs.sh_entsize != sizeof(Elf64_Rela) ||
+        !image_contains_range(image.size(), relocs.sh_offset, relocs.sh_size)) {
+      continue;
+    }
+    const size_t count = relocs.sh_size / sizeof(Elf64_Rela);
+    for (size_t i = 0; i < count; ++i) {
+      const uint64_t place = relocs.sh_offset + i * sizeof(Elf64_Rela);
+      Elf64_Rela rela{};
+      std::memcpy(&rela, image.data() + place, sizeof(rela));
+      if (elf_reloc_type(rela.r_info) != R_AMDGPU_RELATIVE64 || rela.r_addend < 0)
+        continue;
+      const auto addend = static_cast<uint64_t>(rela.r_addend);
+      if (addend < old_text_end_vaddr || addend > std::numeric_limits<uint64_t>::max() - delta)
+        continue;
+      rela.r_addend = static_cast<int64_t>(addend + delta);
+      std::memcpy(image.data() + place, &rela, sizeof(rela));
+    }
+  }
+  (void)ehdr;
+}
+
 void shift_relocation_offsets_in_moved_sections(std::vector<uint8_t> &image, const Elf64_Ehdr &ehdr,
                                                 std::span<const Elf64_Shdr> shdrs,
                                                 const std::vector<bool> &shift_section_vaddr,
@@ -953,7 +993,8 @@ bool CodeObjectPatcher::has_unsupported_relocation_to_text() const {
 
 bool CodeObjectPatcher::replace_text(std::span<const uint8_t> new_text,
                                      std::span<const TextOffsetRelocation> text_relocations,
-                                     std::span<const PcRelativeDataRelocation> data_relocations) {
+                                     std::span<const PcRelativeDataRelocation> data_relocations,
+                                     std::span<const PcRelativeTextRelocation> code_relocations) {
   // Keep fail-closed behavior for callers that assume word-aligned executable
   // sections; accepting a non-word-aligned replacement can break downstream
   // PC-relative patching and branch-distance checks.
@@ -1050,6 +1091,8 @@ bool CodeObjectPatcher::replace_text(std::span<const uint8_t> new_text,
     shift_symbols_in_moved_sections(image_, header, shdrs, shift_section_vaddr, padded_file_delta);
     shift_relocation_offsets_in_moved_sections(image_, header, shdrs, shift_section_vaddr,
                                                padded_file_delta);
+    shift_relative_addends_into_moved_sections(image_, header, shdrs, old_text_end_vaddr,
+                                               padded_file_delta);
     adjust_kernel_descriptor_entry_offsets_in_moved_sections(image_, shdrs, shift_section_vaddr,
                                                              padded_file_delta);
 
@@ -1084,6 +1127,21 @@ bool CodeObjectPatcher::replace_text(std::span<const uint8_t> new_text,
         text_header.sh_addr + resolved.relocation.target_getpc_offset + sizeof(uint32_t);
     const uint64_t delta = target_vaddr - getpc_result;
     std::memcpy(image_.data() + text_offset_ + resolved.relocation.target_literal_offset, &delta,
+                sizeof(delta));
+  }
+
+  // A code target needs no section lookup: both ends are offsets in the text just written, so the
+  // literal is their difference. `s_get_pc_i64` leaves the address of the following instruction, so
+  // the distance to make up is measured from one word past the getpc.
+  for (const PcRelativeTextRelocation &relocation : code_relocations) {
+    if (relocation.target_getpc_offset > new_text.size() - sizeof(uint32_t) ||
+        relocation.target_literal_offset > new_text.size() - sizeof(uint64_t) ||
+        relocation.target_text_offset > new_text.size()) {
+      return false;
+    }
+    const uint64_t getpc_result = relocation.target_getpc_offset + sizeof(uint32_t);
+    const uint64_t delta = relocation.target_text_offset - getpc_result;
+    std::memcpy(image_.data() + text_offset_ + relocation.target_literal_offset, &delta,
                 sizeof(delta));
   }
   shdrs[*text_index].sh_size = new_text.size();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
@@ -429,7 +429,8 @@ void grow_text_function_symbols(std::vector<uint8_t> &image, const Elf64_Ehdr &e
 [[nodiscard]] bool relocate_text_symbols(std::vector<uint8_t> &image, const Elf64_Ehdr &ehdr,
                                          std::span<const Elf64_Shdr> shdrs, size_t text_index,
                                          uint64_t old_text_size, uint64_t new_text_size,
-                                         std::span<const TextOffsetRelocation> relocations) {
+                                         std::span<const TextOffsetRelocation> relocations,
+                                         bool require_every_text_symbol_mapped) {
   if (relocations.empty())
     return true;
 
@@ -500,8 +501,13 @@ void grow_text_function_symbols(std::vector<uint8_t> &image, const Elf64_Ehdr &e
         continue;
 
       const auto referenced = referenced_by_symtab.find(symtab_index);
+      // An unreferenced symbol normally may stay unmapped, because debug and tooling tables
+      // legitimately label padding this translation does not emit. When the caller is relying on
+      // every `.text` address being relocated, that tolerance is a hole: a host can resolve such a
+      // symbol and hand the stale address back in, so nothing may stay unmapped.
       const bool must_relocate =
-          referenced != referenced_by_symtab.end() && referenced->second.contains(i);
+          require_every_text_symbol_mapped ||
+          (referenced != referenced_by_symtab.end() && referenced->second.contains(i));
 
       uint64_t source_text_offset = symbol.st_value;
       if (ehdr.e_type != ET_REL) {
@@ -993,7 +999,8 @@ bool CodeObjectPatcher::has_unsupported_relocation_to_text() const {
 bool CodeObjectPatcher::replace_text(std::span<const uint8_t> new_text,
                                      std::span<const TextOffsetRelocation> text_relocations,
                                      std::span<const PcRelativeDataRelocation> data_relocations,
-                                     std::span<const PcRelativeTextRelocation> code_relocations) {
+                                     std::span<const PcRelativeTextRelocation> code_relocations,
+                                     bool require_every_text_symbol_mapped) {
   // Keep fail-closed behavior for callers that assume word-aligned executable
   // sections; accepting a non-word-aligned replacement can break downstream
   // PC-relative patching and branch-distance checks.
@@ -1156,7 +1163,7 @@ bool CodeObjectPatcher::replace_text(std::span<const uint8_t> new_text,
   }
   shdrs[*text_index].sh_size = new_text.size();
   if (!relocate_text_symbols(image_, header, shdrs, *text_index, text_size_, new_text.size(),
-                             text_relocations)) {
+                             text_relocations, require_every_text_symbol_mapped)) {
     return false;
   }
   if (!relocate_relative_text_addends(image_, header, shdrs, *text_index, text_size_,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.h
@@ -33,6 +33,19 @@ struct PcRelativeDataRelocation {
   uint64_t source_target_vaddr = 0;
 };
 
+/// @brief One relocated literal64 PC builder whose target is inside `.text`.
+///
+/// @details Separate from PcRelativeDataRelocation because the target is named by a final `.text`
+/// offset rather than a virtual address: a code target moves with the body that holds it, so it
+/// cannot be resolved by locating the section that contains a fixed address. The literal is
+/// recomputed as @c target_text_offset - (target_getpc_offset + 4), the distance an `s_get_pc_i64`
+/// leaves to be made up, using only offsets within the emitted text.
+struct PcRelativeTextRelocation {
+  uint64_t target_getpc_offset = 0;
+  uint64_t target_literal_offset = 0;
+  uint64_t target_text_offset = 0;
+};
+
 /// @brief Location of a sidecar kernel descriptor appended into a loaded ELF segment.
 struct AppendedSidecarDescriptor {
   uint64_t file_offset = 0;
@@ -58,7 +71,8 @@ public:
   /// entries coherent with explicit descriptor patches applied by DBT.
   [[nodiscard]] bool replace_text(std::span<const uint8_t> new_text,
                                   std::span<const TextOffsetRelocation> text_relocations = {},
-                                  std::span<const PcRelativeDataRelocation> data_relocations = {});
+                                  std::span<const PcRelativeDataRelocation> data_relocations = {},
+                                  std::span<const PcRelativeTextRelocation> code_relocations = {});
 
   /// @brief True if any relocation's place (r_offset) falls inside .text.
   ///

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.h
@@ -72,7 +72,8 @@ public:
   [[nodiscard]] bool replace_text(std::span<const uint8_t> new_text,
                                   std::span<const TextOffsetRelocation> text_relocations = {},
                                   std::span<const PcRelativeDataRelocation> data_relocations = {},
-                                  std::span<const PcRelativeTextRelocation> code_relocations = {});
+                                  std::span<const PcRelativeTextRelocation> code_relocations = {},
+                                  bool require_every_text_symbol_mapped = false);
 
   /// @brief True if any relocation's place (r_offset) falls inside .text.
   ///

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/relocation_function_table.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/relocation_function_table.cpp
@@ -100,8 +100,8 @@ table_for_got_slot(std::span<const RelocationFunctionTable> tables, uint64_t vad
 /// @details Matched by containment rather than by an exact base, because the address code holds is
 /// not always the object's first byte. The Itanium ABI's vptr points sixteen bytes into the vtable,
 /// past the offset-to-top and typeinfo words, so a dispatch materializing a vptr names the table
-/// from the middle. The callee set is the whole table either way -- the slot index is not tracked --
-/// so widening the match cannot admit a callee that an exact match would have excluded.
+/// from the middle. The callee set is the whole table either way -- the slot index is not tracked
+/// -- so widening the match cannot admit a callee that an exact match would have excluded.
 [[nodiscard]] std::optional<size_t>
 table_at_address(std::span<const RelocationFunctionTable> tables, uint64_t vaddr) {
   for (size_t table_index = 0; table_index < tables.size(); ++table_index) {
@@ -429,10 +429,10 @@ discover_pc_relative_address_builders(std::span<const std::unique_ptr<BasicBlock
   std::vector<PcRelativeAddressBuilder> builders;
   run_pair_dataflow(blocks, {}, text_vaddr, nullptr, &builders);
   std::ranges::sort(builders, {}, &PcRelativeAddressBuilder::source_address_add_offset);
-  builders.erase(std::ranges::unique(builders, {},
-                                     &PcRelativeAddressBuilder::source_address_add_offset)
-                     .begin(),
-                 builders.end());
+  builders.erase(
+      std::ranges::unique(builders, {}, &PcRelativeAddressBuilder::source_address_add_offset)
+          .begin(),
+      builders.end());
   return builders;
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/relocation_function_table.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/relocation_function_table.cpp
@@ -97,12 +97,19 @@ table_for_got_slot(std::span<const RelocationFunctionTable> tables, uint64_t vad
   return std::nullopt;
 }
 
+/// @details Matched by containment rather than by an exact base, because the address code holds is
+/// not always the object's first byte. The Itanium ABI's vptr points sixteen bytes into the vtable,
+/// past the offset-to-top and typeinfo words, so a dispatch materializing a vptr names the table
+/// from the middle. The callee set is the whole table either way -- the slot index is not tracked --
+/// so widening the match cannot admit a callee that an exact match would have excluded.
 [[nodiscard]] std::optional<size_t>
 table_at_address(std::span<const RelocationFunctionTable> tables, uint64_t vaddr) {
-  const auto table = std::ranges::find(tables, vaddr, &RelocationFunctionTable::table_vaddr);
-  if (table == tables.end())
-    return std::nullopt;
-  return static_cast<size_t>(table - tables.begin());
+  for (size_t table_index = 0; table_index < tables.size(); ++table_index) {
+    const RelocationFunctionTable &table = tables[table_index];
+    if (vaddr >= table.table_vaddr && vaddr - table.table_vaddr < table.table_size)
+      return table_index;
+  }
+  return std::nullopt;
 }
 
 void transfer_instruction(PairState &state, const Instruction &inst,
@@ -317,15 +324,24 @@ discover_relocation_function_tables(const AmdGpuCodeObject &object) {
         continue;
       const uint32_t type = elf_reloc_type(rela.r_info);
       if (type == R_AMDGPU_RELATIVE64) {
-        ObjectCandidate *candidate = containing_candidate(candidates, rela.r_offset);
-        if (candidate == nullptr || ((rela.r_offset - candidate->vaddr) % sizeof(uint64_t)) != 0 ||
-            rela.r_addend < 0)
+        if (rela.r_addend < 0)
           continue;
         const uint64_t target = static_cast<uint64_t>(rela.r_addend);
-        if (target < text_vaddr || target - text_vaddr >= text_size)
+        if (target >= text_vaddr && target - text_vaddr < text_size) {
+          ObjectCandidate *candidate = containing_candidate(candidates, rela.r_offset);
+          if (candidate == nullptr || ((rela.r_offset - candidate->vaddr) % sizeof(uint64_t)) != 0)
+            continue;
+          candidate->entries.push_back(
+              {.slot_vaddr = rela.r_offset, .target_text_offset = target - text_vaddr});
           continue;
-        candidate->entries.push_back(
-            {.slot_vaddr = rela.r_offset, .target_text_offset = target - text_vaddr});
+        }
+        // A slot the loader initializes to the address of another candidate names that object, the
+        // same way a GOT slot does. A C++ vptr is exactly this shape: an eight-byte word in a
+        // statically constructed object, relocated to its class's vtable. Recording it is what lets
+        // a dispatch that loads the pointer out of the object resolve to the vtable's callees;
+        // without it the load produces no fact and the call is refused as unrecoverable.
+        if (ObjectCandidate *pointed = containing_candidate(candidates, target))
+          pointed->got_slots.push_back(rela.r_offset);
         continue;
       }
       if (type != R_AMDGPU_ABS64 || linked_symbols == nullptr ||

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/relocation_function_table.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/relocation_function_table.cpp
@@ -107,13 +107,23 @@ table_at_address(std::span<const RelocationFunctionTable> tables, uint64_t vaddr
 
 void transfer_instruction(PairState &state, const Instruction &inst,
                           std::span<const RelocationFunctionTable> tables, uint64_t text_vaddr,
-                          std::vector<RelocationTableDispatch> *dispatches) {
+                          std::vector<RelocationTableDispatch> *dispatches,
+                          std::vector<PcRelativeAddressBuilder> *address_builders = nullptr) {
   const std::string_view mnemonic = inst.mnemonic();
   // Only getpc can create a tracked fact from an empty state. Large linked
   // objects contain millions of unrelated instructions, so avoid decoding
   // operand register classes or constructing a full def/use set for them.
   if (state.empty() && mnemonic != "s_get_pc_i64" && mnemonic != "s_getpc_b64")
     return;
+  // Report the completed address before the table check below can reclassify the pair, so a
+  // builder is described the same way whether or not its target happens to be a known table.
+  const auto report_address_builder = [&](const PairValue &value) {
+    if (address_builders == nullptr || value.source_address_add_offset == 0)
+      return;
+    address_builders->push_back({.source_getpc_offset = value.source_getpc_offset,
+                                 .source_address_add_offset = value.source_address_add_offset,
+                                 .target_vaddr = value.value});
+  };
   const auto dst_pair = sgpr_pair(inst.dst_operand(0));
   const auto src0_pair = sgpr_pair(inst.src_operand(0));
 
@@ -174,6 +184,7 @@ void transfer_instruction(PairState &state, const Instruction &inst,
         // Address.
         result->value += *addend;
         result->source_address_add_offset = inst.src_loc();
+        report_address_builder(*result);
         // RCCL materializes ncclDevFuncTable_{1,2,4} directly with getpc plus
         // a literal and then performs an indexed s_load_b64 from that base.
         if (const auto table = table_at_address(tables, result->value)) {
@@ -238,6 +249,13 @@ meet_predecessors(const BasicBlock &block,
   }
   return nullptr;
 }
+
+/// @brief Shared getpc/add fixed point. Both public entry points need the same lattice; only what
+/// they collect from the final pass differs, so the worklist itself is written once.
+void run_pair_dataflow(std::span<const std::unique_ptr<BasicBlock>> blocks,
+                       std::span<const RelocationFunctionTable> tables, uint64_t text_vaddr,
+                       std::vector<RelocationTableDispatch> *dispatches,
+                       std::vector<PcRelativeAddressBuilder> *address_builders);
 
 } // namespace
 
@@ -370,7 +388,44 @@ discover_relocation_table_dispatches(std::span<const std::unique_ptr<BasicBlock>
                                      uint64_t text_vaddr) {
   if (blocks.empty() || tables.empty())
     return {};
+  std::vector<RelocationTableDispatch> dispatches;
+  run_pair_dataflow(blocks, tables, text_vaddr, &dispatches, nullptr);
+  std::ranges::sort(dispatches, [](const auto &lhs, const auto &rhs) {
+    if (lhs.source_call_offset != rhs.source_call_offset)
+      return lhs.source_call_offset < rhs.source_call_offset;
+    return lhs.table_index < rhs.table_index;
+  });
+  dispatches.erase(std::ranges::unique(dispatches, {},
+                                       [](const RelocationTableDispatch &item) {
+                                         return std::pair{item.source_call_offset,
+                                                          item.table_index};
+                                       })
+                       .begin(),
+                   dispatches.end());
+  return dispatches;
+}
 
+std::vector<PcRelativeAddressBuilder>
+discover_pc_relative_address_builders(std::span<const std::unique_ptr<BasicBlock>> blocks,
+                                      uint64_t text_vaddr) {
+  if (blocks.empty())
+    return {};
+  std::vector<PcRelativeAddressBuilder> builders;
+  run_pair_dataflow(blocks, {}, text_vaddr, nullptr, &builders);
+  std::ranges::sort(builders, {}, &PcRelativeAddressBuilder::source_address_add_offset);
+  builders.erase(std::ranges::unique(builders, {},
+                                     &PcRelativeAddressBuilder::source_address_add_offset)
+                     .begin(),
+                 builders.end());
+  return builders;
+}
+
+namespace {
+
+void run_pair_dataflow(std::span<const std::unique_ptr<BasicBlock>> blocks,
+                       std::span<const RelocationFunctionTable> tables, uint64_t text_vaddr,
+                       std::vector<RelocationTableDispatch> *dispatches,
+                       std::vector<PcRelativeAddressBuilder> *address_builders) {
   std::unordered_map<const BasicBlock *, size_t> positions;
   positions.reserve(blocks.size());
   for (size_t i = 0; i < blocks.size(); ++i) {
@@ -428,28 +483,15 @@ discover_relocation_table_dispatches(std::span<const std::unique_ptr<BasicBlock>
     }
   }
 
-  std::vector<RelocationTableDispatch> dispatches;
   for (size_t i = 0; i < blocks.size(); ++i) {
     if (blocks[i] == nullptr || !initialized[i])
       continue;
     PairState state = in[i];
-    for (const Instruction &inst : blocks[i]->instructions()) {
-      transfer_instruction(state, inst, tables, text_vaddr, &dispatches);
-    }
+    for (const Instruction &inst : blocks[i]->instructions())
+      transfer_instruction(state, inst, tables, text_vaddr, dispatches, address_builders);
   }
-  std::ranges::sort(dispatches, [](const auto &lhs, const auto &rhs) {
-    if (lhs.source_call_offset != rhs.source_call_offset)
-      return lhs.source_call_offset < rhs.source_call_offset;
-    return lhs.table_index < rhs.table_index;
-  });
-  dispatches.erase(std::ranges::unique(dispatches, {},
-                                       [](const RelocationTableDispatch &item) {
-                                         return std::pair{item.source_call_offset,
-                                                          item.table_index};
-                                       })
-                       .begin(),
-                   dispatches.end());
-  return dispatches;
 }
+
+} // namespace
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/relocation_function_table.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/relocation_function_table.h
@@ -87,6 +87,81 @@ struct RelocationTableDispatch {
   uint64_t source_table_address_vaddr = 0;
 };
 
+/// @brief Source `.text` extent of one non-kernel function symbol.
+struct DeviceFunctionExtent {
+  /// `.text`-relative byte offset of the function entry.
+  uint64_t text_offset = 0;
+
+  /// Function body size from `st_size`.
+  uint64_t size = 0;
+};
+
+/// @brief One `s_get_pc_i64` plus literal add that materializes an address.
+///
+/// @details The pair is the only way AMDGPU names a non-`.text` address from code, and it is
+/// position-dependent: the literal is the distance from the instruction after the getpc to the
+/// target. DBT relocates bodies, so the getpc observes a different PC and the same literal reaches
+/// a different address. Recording both halves lets the patcher recompute the literal from the
+/// getpc's final placement, which is what keeps the target fixed.
+struct PcRelativeAddressBuilder {
+  /// `.text`-relative offset of the `s_get_pc_i64`.
+  uint64_t source_getpc_offset = 0;
+
+  /// `.text`-relative offset of the in-place literal64 address add.
+  uint64_t source_address_add_offset = 0;
+
+  /// Virtual address the pair produces in the source object.
+  uint64_t target_vaddr = 0;
+};
+
+/// @brief Discover every proven `s_get_pc_i64` + literal-add address materialization.
+///
+/// @details Shares the dataflow that resolves table dispatches, so the same guarantees apply: a
+/// chained second add, a write to either half, or a CFG join whose predecessors disagree all leave
+/// the pair untracked rather than reported. Callers decide what a target means; this reports the
+/// address arithmetic only.
+[[nodiscard]] std::vector<PcRelativeAddressBuilder>
+discover_pc_relative_address_builders(std::span<const std::unique_ptr<BasicBlock>> blocks,
+                                      uint64_t text_vaddr);
+
+/// @brief Discover `STT_FUNC` symbols in `.text` that are not kernel entries.
+///
+/// @details A kernel's body is reachable through its descriptor, so it is
+/// already a translation root. Anything else named by a function symbol is a
+/// device function, whose body is only translated when some kernel scope
+/// reaches it. Callers use these extents to prove that no such body was left
+/// out of every scope, because `.text` is replaced wholesale and an omitted
+/// body is not preserved -- its address range is reoccupied by other translated
+/// code.
+///
+/// Symbols are matched structurally rather than by name and are accepted at any
+/// binding: device functions are frequently `STB_LOCAL` and appear only in
+/// `.symtab`. Extents are returned sorted by `text_offset` with duplicates
+/// removed, which a compiler emitting one body per caller does produce.
+///
+/// @param object Source code object.
+/// @param kernel_entry_offsets `.text`-relative kernel entries to exclude.
+[[nodiscard]] std::vector<DeviceFunctionExtent>
+discover_device_function_extents(const AmdGpuCodeObject &object,
+                                 std::span<const uint64_t> kernel_entry_offsets);
+
+/// @brief Discover `.text` offsets that a relocated data word will hold at run time.
+///
+/// @details Deliberately broader than table discovery, and asks a different
+/// question: not "is this a dispatch table rocjitsu can model" but "will some
+/// address of this code exist in memory". A pointer array whose own symbol was
+/// stripped, or one the linker never gave an `STT_OBJECT`, still emits its
+/// relocation, so qualifying the containing object would miss it -- and the
+/// relocated addend is rewritten regardless of whether the table qualified.
+///
+/// The same predicate the addend rewrite itself uses, plus symbol-backed
+/// references to function bodies.
+///
+/// @param object Source code object.
+/// @returns `.text`-relative offsets, sorted, with duplicates removed.
+[[nodiscard]] std::vector<uint64_t>
+discover_text_relocation_targets(const AmdGpuCodeObject &object);
+
 /// @brief Discover finite device-call tables from ELF symbols and relocations.
 ///
 /// @details A candidate must be a non-empty `STT_OBJECT` whose size is a

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/relocation_function_table.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/relocation_function_table.h
@@ -87,15 +87,6 @@ struct RelocationTableDispatch {
   uint64_t source_table_address_vaddr = 0;
 };
 
-/// @brief Source `.text` extent of one non-kernel function symbol.
-struct DeviceFunctionExtent {
-  /// `.text`-relative byte offset of the function entry.
-  uint64_t text_offset = 0;
-
-  /// Function body size from `st_size`.
-  uint64_t size = 0;
-};
-
 /// @brief One `s_get_pc_i64` plus literal add that materializes an address.
 ///
 /// @details The pair is the only way AMDGPU names a non-`.text` address from code, and it is
@@ -123,44 +114,6 @@ struct PcRelativeAddressBuilder {
 [[nodiscard]] std::vector<PcRelativeAddressBuilder>
 discover_pc_relative_address_builders(std::span<const std::unique_ptr<BasicBlock>> blocks,
                                       uint64_t text_vaddr);
-
-/// @brief Discover `STT_FUNC` symbols in `.text` that are not kernel entries.
-///
-/// @details A kernel's body is reachable through its descriptor, so it is
-/// already a translation root. Anything else named by a function symbol is a
-/// device function, whose body is only translated when some kernel scope
-/// reaches it. Callers use these extents to prove that no such body was left
-/// out of every scope, because `.text` is replaced wholesale and an omitted
-/// body is not preserved -- its address range is reoccupied by other translated
-/// code.
-///
-/// Symbols are matched structurally rather than by name and are accepted at any
-/// binding: device functions are frequently `STB_LOCAL` and appear only in
-/// `.symtab`. Extents are returned sorted by `text_offset` with duplicates
-/// removed, which a compiler emitting one body per caller does produce.
-///
-/// @param object Source code object.
-/// @param kernel_entry_offsets `.text`-relative kernel entries to exclude.
-[[nodiscard]] std::vector<DeviceFunctionExtent>
-discover_device_function_extents(const AmdGpuCodeObject &object,
-                                 std::span<const uint64_t> kernel_entry_offsets);
-
-/// @brief Discover `.text` offsets that a relocated data word will hold at run time.
-///
-/// @details Deliberately broader than table discovery, and asks a different
-/// question: not "is this a dispatch table rocjitsu can model" but "will some
-/// address of this code exist in memory". A pointer array whose own symbol was
-/// stripped, or one the linker never gave an `STT_OBJECT`, still emits its
-/// relocation, so qualifying the containing object would miss it -- and the
-/// relocated addend is rewritten regardless of whether the table qualified.
-///
-/// The same predicate the addend rewrite itself uses, plus symbol-backed
-/// references to function bodies.
-///
-/// @param object Source code object.
-/// @returns `.text`-relative offsets, sorted, with duplicates removed.
-[[nodiscard]] std::vector<uint64_t>
-discover_text_relocation_targets(const AmdGpuCodeObject &object);
 
 /// @brief Discover finite device-call tables from ELF symbols and relocations.
 ///

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -1811,6 +1811,9 @@ TEST(CodeObjectPatcher, ReplaceTextRejectsCodeRelocationTargetPastEndOfText) {
       << "a target one past the end of .text is not an instruction";
   EXPECT_FALSE(attempt(sizeof(text_words) - 2))
       << "a target without room for a whole instruction word is not an instruction";
+  EXPECT_FALSE(attempt(1)) << "an offset interior to the first instruction is not a destination";
+  EXPECT_FALSE(attempt(sizeof(uint32_t) + 2))
+      << "an offset interior to a later instruction is not a destination";
   EXPECT_TRUE(attempt(sizeof(text_words) - sizeof(uint32_t)))
       << "the last instruction in .text is a legitimate branch destination";
 }

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -10604,6 +10604,99 @@ TEST(BinaryTranslatorE2E, Gfx1250MaterializesDsAddtidAddressForA0) {
   EXPECT_EQ(((*v_bfe)->raw_encoding()[1] >> 18) & 0x1ffu, static_cast<uint16_t>(kInline + 20));
 }
 
+// A getpc-plus-literal names its target by distance from the getpc, so relocating the body that
+// contains it silently retargets it. A callee packed up against its caller moves whenever the
+// source left padding between them, and its instructions are copied verbatim -- so nothing else in
+// the pipeline notices that the pair now reaches a different address. The literal must therefore be
+// recomputed from the getpc's final placement.
+TEST(BinaryTranslatorE2E, Gfx1250RepointsPcRelativeDataAddressAfterRelocation) {
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  constexpr uint32_t kGfx1250SNop = 0xBF800000u;
+  constexpr uint32_t kGfx1250GetPcS0 = 0xBE804700u;    // s_get_pc_i64 s[0:1]
+  constexpr uint32_t kGfx1250AddNcU64S0 = 0xA980FE00u; // s_add_nc_u64 s[0:1], s[0:1], lit64
+  constexpr uint32_t kGfx1250SetPcS30 = 0xBE80481Eu;   // s_set_pc_i64 s[30:31]
+  // s_call_i64 s[30:31], simm16 jumps to (this instruction + 4) + simm16 * 4. The callee starts at
+  // word 8, so simm16 is 7; words 2..7 are the padding that disappears when it is packed against
+  // the caller, which is what moves the getpc.
+  constexpr uint32_t kGfx1250CallToWord8 = 0xBA1E0007u;
+  constexpr size_t kCalleeWord = 8;
+
+  std::vector<uint32_t> words = {
+      kGfx1250CallToWord8, kGfx1250SEndpgm, kGfx1250SNop,        kGfx1250SNop,
+      kGfx1250SNop,        kGfx1250SNop,    kGfx1250SNop,        kGfx1250SNop,
+      kGfx1250GetPcS0,     kGfx1250AddNcU64S0, 0u /*lit lo*/,    0u /*lit hi*/,
+      kGfx1250SetPcS30,
+  };
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
+
+  // Locate .text and a real non-executable allocated target, then point the literal at it.
+  const auto sections = [](std::span<const uint8_t> img) {
+    rocjitsu::Elf64_Ehdr ehdr{};
+    std::memcpy(&ehdr, img.data(), sizeof(ehdr));
+    std::vector<rocjitsu::Elf64_Shdr> shdrs(ehdr.e_shnum);
+    std::memcpy(shdrs.data(), img.data() + ehdr.e_shoff, ehdr.e_shnum * sizeof(rocjitsu::Elf64_Shdr));
+    return shdrs;
+  };
+  auto shdrs = sections(image);
+  const auto text = std::ranges::find_if(
+      shdrs, [](const rocjitsu::Elf64_Shdr &s) { return (s.sh_flags & rocjitsu::SHF_EXECINSTR) != 0; });
+  const auto data = std::ranges::find_if(shdrs, [](const rocjitsu::Elf64_Shdr &s) {
+    return (s.sh_flags & rocjitsu::SHF_ALLOC) != 0 && (s.sh_flags & rocjitsu::SHF_EXECINSTR) == 0 && s.sh_size != 0;
+  });
+  ASSERT_NE(text, shdrs.end());
+  ASSERT_NE(data, shdrs.end());
+
+  const uint64_t source_getpc_result =
+      text->sh_addr + kCalleeWord * sizeof(uint32_t) + sizeof(uint32_t);
+  const uint64_t target_vaddr = data->sh_addr;
+  const uint64_t source_literal = target_vaddr - source_getpc_result;
+  std::memcpy(image.data() + text->sh_offset + (kCalleeWord + 2) * sizeof(uint32_t),
+              &source_literal, sizeof(source_literal));
+
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  // Find the relocated getpc by its encoding; the callee moved, so its offset is not known up front.
+  auto out_shdrs = sections(result.elf_bytes);
+  const auto out_text = std::ranges::find_if(
+      out_shdrs, [](const rocjitsu::Elf64_Shdr &s) { return (s.sh_flags & rocjitsu::SHF_EXECINSTR) != 0; });
+  const auto out_data = std::ranges::find_if(out_shdrs, [](const rocjitsu::Elf64_Shdr &s) {
+    return (s.sh_flags & rocjitsu::SHF_ALLOC) != 0 && (s.sh_flags & rocjitsu::SHF_EXECINSTR) == 0 && s.sh_size != 0;
+  });
+  ASSERT_NE(out_text, out_shdrs.end());
+  ASSERT_NE(out_data, out_shdrs.end());
+
+  std::optional<size_t> getpc_word;
+  for (size_t i = 0; i + 3 < out_text->sh_size / sizeof(uint32_t); ++i) {
+    uint32_t word = 0;
+    std::memcpy(&word, result.elf_bytes.data() + out_text->sh_offset + i * sizeof(uint32_t),
+                sizeof(word));
+    if (word == kGfx1250GetPcS0) {
+      getpc_word = i;
+      break;
+    }
+  }
+  ASSERT_TRUE(getpc_word.has_value()) << "the callee body must survive into translated text";
+  ASSERT_NE(*getpc_word, kCalleeWord) << "the callee must have moved, or this proves nothing";
+
+  uint64_t relocated_literal = 0;
+  std::memcpy(&relocated_literal,
+              result.elf_bytes.data() + out_text->sh_offset + (*getpc_word + 2) * sizeof(uint32_t),
+              sizeof(relocated_literal));
+  const uint64_t relocated_getpc_result =
+      out_text->sh_addr + *getpc_word * sizeof(uint32_t) + sizeof(uint32_t);
+  EXPECT_EQ(relocated_getpc_result + relocated_literal, out_data->sh_addr)
+      << "the relocated body must still reach the same data address";
+  EXPECT_NE(relocated_literal, source_literal) << "the body moved, so the literal had to change";
+}
+
 TEST(BinaryTranslatorE2E, Gfx1250FailsClosedOnExcludedBarrierSignalIsfirst) {
   // Inline constants encode -1 at 193, so the excluded id is 195.
   constexpr uint8_t kExcludedBarrierIdInline = 195;

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -61,6 +61,7 @@
 #include "rocjitsu/code/patch/kernarg_extension.h"
 #include "rocjitsu/code/patch/kernel_text_layout.h"
 #include "rocjitsu/code/patch/sidecar_metadata.h"
+#include "rocjitsu/code/relocation_function_table.h"
 #include "rocjitsu/code/rj_code.h"
 #include "rocjitsu/code/rj_code_internal.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna3/builders.h"
@@ -450,14 +451,21 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_load_segments() {
 
 std::vector<uint8_t> make_minimal_amdgpu_elf_with_descriptor_after_text(
     const std::vector<uint32_t> &text_words,
-    std::optional<size_t> text_function_words = std::nullopt) {
-  if (text_function_words && *text_function_words > text_words.size())
+    std::optional<size_t> text_function_words = std::nullopt, size_t text_function_offset_words = 0,
+    std::optional<size_t> function_pointer_table_target_words = std::nullopt,
+    bool name_function_pointer_table_with_symbol = true) {
+  if (text_function_words && text_function_offset_words + *text_function_words > text_words.size())
     throw std::invalid_argument("text function extent exceeds .text fixture");
+  if (function_pointer_table_target_words &&
+      *function_pointer_table_target_words >= text_words.size())
+    throw std::invalid_argument("function pointer target exceeds .text fixture");
   constexpr uint64_t text_offset = 0x100;
   constexpr uint64_t text_vaddr = 0x1100;
   const uint64_t text_size = text_words.size() * sizeof(uint32_t);
   constexpr uint64_t load_align = 0x1000;
   constexpr uint64_t rodata_size = kKernelDescriptorSize;
+  const bool has_table = function_pointer_table_target_words.has_value();
+  constexpr uint64_t table_size = sizeof(uint64_t);
 
   std::vector<uint8_t> shstrtab{'\0'};
   const uint32_t text_name = add_elf_name(shstrtab, ".text");
@@ -465,10 +473,13 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_descriptor_after_text(
   const uint32_t symtab_name = add_elf_name(shstrtab, ".symtab");
   const uint32_t strtab_name = add_elf_name(shstrtab, ".strtab");
   const uint32_t shstrtab_name = add_elf_name(shstrtab, ".shstrtab");
+  const uint32_t table_name = has_table ? add_elf_name(shstrtab, ".data.rel.ro") : 0;
+  const uint32_t rela_name = has_table ? add_elf_name(shstrtab, ".rela.dyn") : 0;
 
   std::vector<uint8_t> strtab{'\0'};
   const uint32_t kd_symbol_name = add_elf_name(strtab, "kernel.kd");
   const uint32_t text_symbol_name = text_function_words ? add_elf_name(strtab, "kernel") : 0;
+  const uint32_t table_symbol_name = has_table ? add_elf_name(strtab, "function_table") : 0;
 
   // The kernel descriptor requires 8-byte alignment (tests reinterpret_cast the
   // .rodata bytes to TestKernelDescriptor). An odd text_words count leaves
@@ -477,12 +488,15 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_descriptor_after_text(
   // padding both keeps the PT_LOAD p_offset == p_vaddr (mod p_align) congruence.
   const uint64_t rodata_offset = align_up_for_test(text_offset + text_size, 8);
   const uint64_t rodata_vaddr = align_up_for_test(text_vaddr + text_size, 8) + load_align;
+  const uint64_t table_vaddr = rodata_vaddr + load_align;
   const uint64_t strtab_offset = rodata_offset + rodata_size;
   const uint64_t symtab_offset = align_up_for_test(strtab_offset + strtab.size(), 8);
-  const size_t sym_count = text_function_words ? 3 : 2;
-  const uint64_t shstrtab_offset = symtab_offset + sym_count * sizeof(Elf64_Sym);
+  const size_t sym_count = (text_function_words ? 3 : 2) + (has_table ? 1 : 0);
+  const uint64_t table_offset = symtab_offset + sym_count * sizeof(Elf64_Sym);
+  const uint64_t rela_offset = has_table ? table_offset + table_size : table_offset;
+  const uint64_t shstrtab_offset = rela_offset + (has_table ? sizeof(Elf64_Rela) : 0);
   const uint64_t shoff = align_up_for_test(shstrtab_offset + shstrtab.size(), 8);
-  constexpr uint16_t section_count = 6;
+  const uint16_t section_count = has_table ? 8 : 6;
   constexpr uint16_t phdr_count = 2;
 
   std::vector<uint8_t> image(shoff + section_count * sizeof(Elf64_Shdr), 0);
@@ -540,16 +554,39 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_descriptor_after_text(
   syms[1].st_size = kKernelDescriptorSize;
   if (text_function_words) {
     syms[2].st_name = text_symbol_name;
-    syms[2].st_info = elf_symbol_info(kElfSymbolBindGlobal, kElfSymbolTypeFunc);
+    // Real device functions are LOCAL and appear only in .symtab. Offset zero is the kernel entry,
+    // which function discovery excludes; a non-zero offset names a callee body.
+    syms[2].st_info = elf_symbol_info(text_function_offset_words == 0 ? kElfSymbolBindGlobal
+                                                                      : kElfSymbolBindLocal,
+                                      kElfSymbolTypeFunc);
     syms[2].st_shndx = 1;
-    syms[2].st_value = text_vaddr;
+    syms[2].st_value = text_vaddr + text_function_offset_words * sizeof(uint32_t);
     syms[2].st_size = *text_function_words * sizeof(uint32_t);
+  }
+  if (has_table) {
+    // A function-pointer table is an STT_OBJECT in a non-executable allocated section, with one
+    // R_AMDGPU_RELATIVE64 slot whose addend is the callee's virtual address.
+    if (name_function_pointer_table_with_symbol) {
+      Elf64_Sym &table_symbol = syms.back();
+      table_symbol.st_name = table_symbol_name;
+      table_symbol.st_info = elf_symbol_info(kElfSymbolBindGlobal, kElfSymbolTypeObject);
+      table_symbol.st_shndx = 6;
+      table_symbol.st_value = table_vaddr;
+      table_symbol.st_size = table_size;
+    }
+
+    Elf64_Rela rela{};
+    rela.r_offset = table_vaddr;
+    rela.r_info = (uint64_t{0} << 32) | rocjitsu::R_AMDGPU_RELATIVE64;
+    rela.r_addend =
+        static_cast<int64_t>(text_vaddr + *function_pointer_table_target_words * sizeof(uint32_t));
+    std::memcpy(image.data() + rela_offset, &rela, sizeof(rela));
   }
   std::memcpy(image.data() + symtab_offset, syms.data(), syms.size() * sizeof(Elf64_Sym));
 
   std::memcpy(image.data() + shstrtab_offset, shstrtab.data(), shstrtab.size());
 
-  std::array<Elf64_Shdr, section_count> shdrs{};
+  std::vector<Elf64_Shdr> shdrs(section_count);
   shdrs[1].sh_name = text_name;
   shdrs[1].sh_type = SHT_PROGBITS;
   shdrs[1].sh_flags = SHF_ALLOC | SHF_EXECINSTR;
@@ -565,6 +602,24 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_descriptor_after_text(
   shdrs[2].sh_offset = rodata_offset;
   shdrs[2].sh_size = rodata_size;
   shdrs[2].sh_addralign = 64;
+
+  if (has_table) {
+    shdrs[6].sh_name = table_name;
+    shdrs[6].sh_type = SHT_PROGBITS;
+    shdrs[6].sh_flags = SHF_ALLOC;
+    shdrs[6].sh_addr = table_vaddr;
+    shdrs[6].sh_offset = table_offset;
+    shdrs[6].sh_size = table_size;
+    shdrs[6].sh_addralign = 8;
+
+    shdrs[7].sh_name = rela_name;
+    shdrs[7].sh_type = SHT_RELA;
+    shdrs[7].sh_offset = rela_offset;
+    shdrs[7].sh_size = sizeof(Elf64_Rela);
+    shdrs[7].sh_link = 3;
+    shdrs[7].sh_addralign = 8;
+    shdrs[7].sh_entsize = sizeof(Elf64_Rela);
+  }
 
   shdrs[3].sh_name = symtab_name;
   shdrs[3].sh_type = SHT_SYMTAB;
@@ -10609,6 +10664,110 @@ TEST(BinaryTranslatorE2E, Gfx1250MaterializesDsAddtidAddressForA0) {
 // source left padding between them, and its instructions are copied verbatim -- so nothing else in
 // the pipeline notices that the pair now reaches a different address. The literal must therefore be
 // recomputed from the getpc's final placement.
+// Read back the single `R_AMDGPU_RELATIVE64` addend and resolve it to `.text` words, so a test can
+// assert where a function pointer ends up pointing rather than only that translation succeeded.
+[[nodiscard]] std::vector<uint32_t>
+text_words_at_relative64_addend(std::span<const uint8_t> image, size_t count) {
+  rocjitsu::Elf64_Ehdr ehdr{};
+  std::memcpy(&ehdr, image.data(), sizeof(ehdr));
+  std::vector<rocjitsu::Elf64_Shdr> shdrs(ehdr.e_shnum);
+  std::memcpy(shdrs.data(), image.data() + ehdr.e_shoff, ehdr.e_shnum * sizeof(rocjitsu::Elf64_Shdr));
+
+  std::optional<uint64_t> addend;
+  for (const rocjitsu::Elf64_Shdr &section : shdrs) {
+    if (section.sh_type != rocjitsu::SHT_RELA)
+      continue;
+    for (size_t i = 0; i < section.sh_size / sizeof(rocjitsu::Elf64_Rela); ++i) {
+      rocjitsu::Elf64_Rela rela{};
+      std::memcpy(&rela, image.data() + section.sh_offset + i * sizeof(rocjitsu::Elf64_Rela), sizeof(rela));
+      if ((rela.r_info & 0xffffffffu) == rocjitsu::R_AMDGPU_RELATIVE64)
+        addend = static_cast<uint64_t>(rela.r_addend);
+    }
+  }
+  if (!addend)
+    return {};
+
+  for (const rocjitsu::Elf64_Shdr &section : shdrs) {
+    if ((section.sh_flags & rocjitsu::SHF_EXECINSTR) == 0 || *addend < section.sh_addr ||
+        *addend - section.sh_addr >= section.sh_size) {
+      continue;
+    }
+    const uint64_t offset = section.sh_offset + (*addend - section.sh_addr);
+    std::vector<uint32_t> words(count);
+    std::memcpy(words.data(), image.data() + offset, count * sizeof(uint32_t));
+    return words;
+  }
+  return {};
+}
+
+// Translated text replaces .text wholesale, so a device function body that reaches no kernel scope
+// would not be preserved: its address range is reoccupied by relocated code. A body a function
+// pointer names is therefore adopted as a translation root instead, which both carries it into the
+// relocated text and gives the addend a placement to be rewritten to. Kernel bodies need no such
+// adoption because their descriptors already make them roots.
+TEST(BinaryTranslatorE2E, Gfx1250AdoptsDeviceFunctionBodyReachedByNoScope) {
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  constexpr uint32_t kGfx1250SNop = 0xBF800000u;
+  // The kernel ends at word 0, so nothing below it lands in a scope. A function-pointer table names
+  // the body at word 3, so an address the decoded graph never accounts for can still arrive there.
+  // That is what separates this from a dead local a linker merely retained: the identical object
+  // without the table is accepted by the test below, so the table is the only thing being pinned.
+  const std::vector<uint32_t> words = {
+      kGfx1250SEndpgm, kGfx1250SNop, kGfx1250SNop, kGfx1250SNop, kGfx1250SEndpgm,
+  };
+
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      words, /*text_function_words=*/2, /*text_function_offset_words=*/3,
+      /*function_pointer_table_target_words=*/3);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+  ASSERT_TRUE(result.dispatchable());
+  EXPECT_NE(result.elf_bytes, image);
+  // The addend must land on the adopted body, not on whatever now occupies its original range.
+  EXPECT_EQ(text_words_at_relative64_addend(result.elf_bytes, 2),
+            (std::vector<uint32_t>{kGfx1250SNop, kGfx1250SEndpgm}));
+}
+// The same shape with the pointer array's own symbol stripped. Adoption is driven by the
+// discovered function tables, and discovery needs a qualifying `STT_OBJECT` around the slot, so a
+// compiler-anonymous pointer array names no adoptable body. That boundary is pinned here rather
+// than left unstated: the body is still dropped, its addend still has nowhere to point, and
+// replace_text() still refuses the object -- the behavior that predates adoption. Widening it
+// needs reachability asked of the raw relocations rather than of the tables.
+TEST(BinaryTranslatorE2E, Gfx1250RefusesDeviceFunctionBodyHeldByAnUnnamedPointerSlot) {
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  constexpr uint32_t kGfx1250SNop = 0xBF800000u;
+  const std::vector<uint32_t> words = {
+      kGfx1250SEndpgm, kGfx1250SNop, kGfx1250SNop, kGfx1250SNop, kGfx1250SEndpgm,
+  };
+
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      words, /*text_function_words=*/2, /*text_function_offset_words=*/3,
+      /*function_pointer_table_target_words=*/3,
+      /*name_function_pointer_table_with_symbol=*/false);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+  ASSERT_TRUE(rocjitsu::discover_relocation_function_tables(source).empty())
+      << "the slot must not qualify as a table, or this covers the same path as the test above";
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+}
+
 TEST(BinaryTranslatorE2E, Gfx1250RepointsPcRelativeDataAddressAfterRelocation) {
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
   constexpr uint32_t kGfx1250SNop = 0xBF800000u;

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -492,12 +492,17 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_descriptor_after_text(
   const uint64_t strtab_offset = rodata_offset + rodata_size;
   const uint64_t symtab_offset = align_up_for_test(strtab_offset + strtab.size(), 8);
   const size_t sym_count = (text_function_words ? 3 : 2) + (has_table ? 1 : 0);
-  const uint64_t table_offset = symtab_offset + sym_count * sizeof(Elf64_Sym);
+  // The table is SHF_ALLOC, so a real loader only maps it when a PT_LOAD covers it. Give the file
+  // offset the same residue mod load_align as table_vaddr so the extra segment below satisfies the
+  // p_offset == p_vaddr (mod p_align) congruence a loader requires.
+  const uint64_t table_offset =
+      align_up_for_test(symtab_offset + sym_count * sizeof(Elf64_Sym), load_align) +
+      (table_vaddr % load_align);
   const uint64_t rela_offset = has_table ? table_offset + table_size : table_offset;
   const uint64_t shstrtab_offset = rela_offset + (has_table ? sizeof(Elf64_Rela) : 0);
   const uint64_t shoff = align_up_for_test(shstrtab_offset + shstrtab.size(), 8);
   const uint16_t section_count = has_table ? 8 : 6;
-  constexpr uint16_t phdr_count = 2;
+  const uint16_t phdr_count = has_table ? 3 : 2;
 
   std::vector<uint8_t> image(shoff + section_count * sizeof(Elf64_Shdr), 0);
 
@@ -519,7 +524,7 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_descriptor_after_text(
   ehdr.e_shstrndx = 5;
   std::memcpy(image.data(), &ehdr, sizeof(ehdr));
 
-  std::array<Elf64_Phdr, phdr_count> phdrs{};
+  std::vector<Elf64_Phdr> phdrs(phdr_count);
   phdrs[0].p_type = PT_LOAD;
   phdrs[0].p_flags = 0x5; // PF_R | PF_X
   phdrs[0].p_offset = text_offset;
@@ -537,6 +542,18 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_descriptor_after_text(
   phdrs[1].p_filesz = rodata_size;
   phdrs[1].p_memsz = rodata_size;
   phdrs[1].p_align = load_align;
+  if (has_table) {
+    // Map the table itself, so these cases exercise a slot a loader would place rather than only
+    // section-header discovery.
+    phdrs[2].p_type = PT_LOAD;
+    phdrs[2].p_flags = 0x4; // PF_R
+    phdrs[2].p_offset = table_offset;
+    phdrs[2].p_vaddr = table_vaddr;
+    phdrs[2].p_paddr = table_vaddr;
+    phdrs[2].p_filesz = table_size;
+    phdrs[2].p_memsz = table_size;
+    phdrs[2].p_align = load_align;
+  }
   std::memcpy(image.data() + ehdr.e_phoff, phdrs.data(), phdrs.size() * sizeof(Elf64_Phdr));
 
   std::memcpy(image.data() + text_offset, text_words.data(), text_size);

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -10666,12 +10666,13 @@ TEST(BinaryTranslatorE2E, Gfx1250MaterializesDsAddtidAddressForA0) {
 // recomputed from the getpc's final placement.
 // Read back the single `R_AMDGPU_RELATIVE64` addend and resolve it to `.text` words, so a test can
 // assert where a function pointer ends up pointing rather than only that translation succeeded.
-[[nodiscard]] std::vector<uint32_t>
-text_words_at_relative64_addend(std::span<const uint8_t> image, size_t count) {
+[[nodiscard]] std::vector<uint32_t> text_words_at_relative64_addend(std::span<const uint8_t> image,
+                                                                    size_t count) {
   rocjitsu::Elf64_Ehdr ehdr{};
   std::memcpy(&ehdr, image.data(), sizeof(ehdr));
   std::vector<rocjitsu::Elf64_Shdr> shdrs(ehdr.e_shnum);
-  std::memcpy(shdrs.data(), image.data() + ehdr.e_shoff, ehdr.e_shnum * sizeof(rocjitsu::Elf64_Shdr));
+  std::memcpy(shdrs.data(), image.data() + ehdr.e_shoff,
+              ehdr.e_shnum * sizeof(rocjitsu::Elf64_Shdr));
 
   std::optional<uint64_t> addend;
   for (const rocjitsu::Elf64_Shdr &section : shdrs) {
@@ -10679,7 +10680,8 @@ text_words_at_relative64_addend(std::span<const uint8_t> image, size_t count) {
       continue;
     for (size_t i = 0; i < section.sh_size / sizeof(rocjitsu::Elf64_Rela); ++i) {
       rocjitsu::Elf64_Rela rela{};
-      std::memcpy(&rela, image.data() + section.sh_offset + i * sizeof(rocjitsu::Elf64_Rela), sizeof(rela));
+      std::memcpy(&rela, image.data() + section.sh_offset + i * sizeof(rocjitsu::Elf64_Rela),
+                  sizeof(rela));
       if ((rela.r_info & 0xffffffffu) == rocjitsu::R_AMDGPU_RELATIVE64)
         addend = static_cast<uint64_t>(rela.r_addend);
     }
@@ -10781,10 +10783,9 @@ TEST(BinaryTranslatorE2E, Gfx1250RepointsPcRelativeDataAddressAfterRelocation) {
   constexpr size_t kCalleeWord = 8;
 
   std::vector<uint32_t> words = {
-      kGfx1250CallToWord8, kGfx1250SEndpgm, kGfx1250SNop,        kGfx1250SNop,
-      kGfx1250SNop,        kGfx1250SNop,    kGfx1250SNop,        kGfx1250SNop,
-      kGfx1250GetPcS0,     kGfx1250AddNcU64S0, 0u /*lit lo*/,    0u /*lit hi*/,
-      kGfx1250SetPcS30,
+      kGfx1250CallToWord8, kGfx1250SEndpgm, kGfx1250SNop,     kGfx1250SNop,    kGfx1250SNop,
+      kGfx1250SNop,        kGfx1250SNop,    kGfx1250SNop,     kGfx1250GetPcS0, kGfx1250AddNcU64S0,
+      0u /*lit lo*/,       0u /*lit hi*/,   kGfx1250SetPcS30,
   };
   auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
 
@@ -10793,14 +10794,17 @@ TEST(BinaryTranslatorE2E, Gfx1250RepointsPcRelativeDataAddressAfterRelocation) {
     rocjitsu::Elf64_Ehdr ehdr{};
     std::memcpy(&ehdr, img.data(), sizeof(ehdr));
     std::vector<rocjitsu::Elf64_Shdr> shdrs(ehdr.e_shnum);
-    std::memcpy(shdrs.data(), img.data() + ehdr.e_shoff, ehdr.e_shnum * sizeof(rocjitsu::Elf64_Shdr));
+    std::memcpy(shdrs.data(), img.data() + ehdr.e_shoff,
+                ehdr.e_shnum * sizeof(rocjitsu::Elf64_Shdr));
     return shdrs;
   };
   auto shdrs = sections(image);
-  const auto text = std::ranges::find_if(
-      shdrs, [](const rocjitsu::Elf64_Shdr &s) { return (s.sh_flags & rocjitsu::SHF_EXECINSTR) != 0; });
+  const auto text = std::ranges::find_if(shdrs, [](const rocjitsu::Elf64_Shdr &s) {
+    return (s.sh_flags & rocjitsu::SHF_EXECINSTR) != 0;
+  });
   const auto data = std::ranges::find_if(shdrs, [](const rocjitsu::Elf64_Shdr &s) {
-    return (s.sh_flags & rocjitsu::SHF_ALLOC) != 0 && (s.sh_flags & rocjitsu::SHF_EXECINSTR) == 0 && s.sh_size != 0;
+    return (s.sh_flags & rocjitsu::SHF_ALLOC) != 0 && (s.sh_flags & rocjitsu::SHF_EXECINSTR) == 0 &&
+           s.sh_size != 0;
   });
   ASSERT_NE(text, shdrs.end());
   ASSERT_NE(data, shdrs.end());
@@ -10822,12 +10826,15 @@ TEST(BinaryTranslatorE2E, Gfx1250RepointsPcRelativeDataAddressAfterRelocation) {
   ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
                                                           : result.diagnostics.front().message);
 
-  // Find the relocated getpc by its encoding; the callee moved, so its offset is not known up front.
+  // Find the relocated getpc by its encoding; the callee moved, so its offset is not known up
+  // front.
   auto out_shdrs = sections(result.elf_bytes);
-  const auto out_text = std::ranges::find_if(
-      out_shdrs, [](const rocjitsu::Elf64_Shdr &s) { return (s.sh_flags & rocjitsu::SHF_EXECINSTR) != 0; });
+  const auto out_text = std::ranges::find_if(out_shdrs, [](const rocjitsu::Elf64_Shdr &s) {
+    return (s.sh_flags & rocjitsu::SHF_EXECINSTR) != 0;
+  });
   const auto out_data = std::ranges::find_if(out_shdrs, [](const rocjitsu::Elf64_Shdr &s) {
-    return (s.sh_flags & rocjitsu::SHF_ALLOC) != 0 && (s.sh_flags & rocjitsu::SHF_EXECINSTR) == 0 && s.sh_size != 0;
+    return (s.sh_flags & rocjitsu::SHF_ALLOC) != 0 && (s.sh_flags & rocjitsu::SHF_EXECINSTR) == 0 &&
+           s.sh_size != 0;
   });
   ASSERT_NE(out_text, out_shdrs.end());
   ASSERT_NE(out_data, out_shdrs.end());

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -829,8 +829,13 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_two_kernel_descriptors(
   return image;
 }
 
-std::vector<uint8_t>
-make_minimal_amdgpu_elf_with_relocation_after_text(bool place_reloc_in_text = false) {
+// reloc_type and reloc_addend default to a bare record, which is what the
+// r_offset tests want. Naming R_AMDGPU_RELATIVE64 with an addend inside the
+// section that follows .text instead exercises the addend shift: the stored
+// value is load_bias + r_addend, so a .text that grows past its load alignment
+// moves the section and the addend has to move with it.
+std::vector<uint8_t> make_minimal_amdgpu_elf_with_relocation_after_text(
+    bool place_reloc_in_text = false, uint32_t reloc_type = 0, int64_t reloc_addend = 0) {
   constexpr uint64_t text_offset = 0x100;
   constexpr uint64_t text_vaddr = 0x1100;
   constexpr uint64_t text_size = 8;
@@ -903,6 +908,8 @@ make_minimal_amdgpu_elf_with_relocation_after_text(bool place_reloc_in_text = fa
   // moved section). place_reloc_in_text points it inside .text, which DBT cannot
   // remap after relocating instructions and must reject.
   rela.r_offset = place_reloc_in_text ? text_vaddr : data_vaddr;
+  rela.r_info = (uint64_t{0} << 32) | reloc_type;
+  rela.r_addend = reloc_addend;
   std::memcpy(image.data() + rela_offset, &rela, sizeof(rela));
   std::memcpy(image.data() + shstrtab_offset, shstrtab.data(), shstrtab.size());
 
@@ -2114,6 +2121,45 @@ TEST(CodeObjectPatcher, ReplaceTextUpdatesRelocationOffsetsIntoMovedSections) {
   std::memcpy(&rela, rela_dyn->data(), sizeof(rela));
   EXPECT_EQ(rela.r_offset, data->vaddr())
       << "ET_DYN relocation r_offset is the relocated storage address";
+}
+
+// The r_offset test above moves the relocation's storage. This one moves what the
+// relocation names: an R_AMDGPU_RELATIVE64 addend pointing into .data resolves to
+// load_bias + r_addend, so growing .text past its load alignment relocates .data
+// and the addend has to follow it or the pointer lands short of the moved section.
+TEST(CodeObjectPatcher, ReplaceTextShiftsRelativeAddendsIntoMovedSections) {
+  constexpr uint64_t load_align = 0x1000;
+  constexpr uint64_t kTextVaddr = 0x1100;
+  constexpr uint64_t kTextSize = 8;
+  constexpr uint64_t kOriginalDataVaddr = kTextVaddr + kTextSize + load_align;
+
+  auto image = make_minimal_amdgpu_elf_with_relocation_after_text(
+      /*place_reloc_in_text=*/false, rocjitsu::R_AMDGPU_RELATIVE64,
+      static_cast<int64_t>(kOriginalDataVaddr));
+  AmdGpuCodeObject co(image.data(), image.size());
+  ASSERT_TRUE(co.is_valid());
+  ASSERT_FALSE(co.text_sections().empty());
+
+  CodeObjectPatcher patcher(co);
+  const std::vector<uint32_t> text_words(load_align / sizeof(uint32_t) + 3, 0xDEADBEEFu);
+  const auto *text_bytes = reinterpret_cast<const uint8_t *>(text_words.data());
+  ASSERT_TRUE(patcher.replace_text({text_bytes, text_words.size() * sizeof(uint32_t)}));
+
+  auto patched_bytes = patcher.emit();
+  AmdGpuCodeObject patched(patched_bytes.data(), patched_bytes.size());
+  ASSERT_TRUE(patched.is_valid());
+
+  const auto *data = find_section(patched, ".data");
+  const auto *rela_dyn = find_section(patched, ".rela.dyn");
+  ASSERT_NE(data, nullptr);
+  ASSERT_NE(rela_dyn, nullptr);
+  ASSERT_EQ(rela_dyn->size(), sizeof(Elf64_Rela));
+  ASSERT_GT(data->vaddr(), kOriginalDataVaddr) << "test only proves anything if .data moved";
+
+  Elf64_Rela rela{};
+  std::memcpy(&rela, rela_dyn->data(), sizeof(rela));
+  EXPECT_EQ(static_cast<uint64_t>(rela.r_addend), data->vaddr())
+      << "RELATIVE64 addend naming a section above .text must move with that section";
 }
 
 TEST(CodeObjectPatcher, DetectsRelocationsWithinText) {

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -1788,6 +1788,33 @@ TEST(BinaryTranslatorE2E, DescriptorlessExecutableTextIsSuccessfulNoOp) {
   EXPECT_NE(warning->message.find("no kernel descriptors"), std::string::npos);
 }
 
+// A code relocation names a branch destination inside the text being written, so it has to be a
+// whole instruction there. An offset equal to the size names the byte one past the end, which
+// would still compute a literal and leave it pointing outside `.text`.
+TEST(CodeObjectPatcher, ReplaceTextRejectsCodeRelocationTargetPastEndOfText) {
+  const std::array<uint32_t, 4> text_words = {0xBF800000u, 0xBF800000u, 0xBF800000u, 0xBF800000u};
+  const auto bytes = std::span<const uint8_t>(reinterpret_cast<const uint8_t *>(text_words.data()),
+                                              sizeof(text_words));
+  const auto attempt = [&](uint64_t target_text_offset) {
+    auto image = make_minimal_amdgpu_elf_with_text_and_rodata();
+    AmdGpuCodeObject co(image.data(), image.size());
+    EXPECT_TRUE(co.is_valid());
+    CodeObjectPatcher patcher(co);
+    const std::array<PcRelativeTextRelocation, 1> code_relocations = {
+        PcRelativeTextRelocation{.target_getpc_offset = 0,
+                                 .target_literal_offset = 4,
+                                 .target_text_offset = target_text_offset}};
+    return patcher.replace_text(bytes, {}, {}, code_relocations);
+  };
+
+  EXPECT_FALSE(attempt(sizeof(text_words)))
+      << "a target one past the end of .text is not an instruction";
+  EXPECT_FALSE(attempt(sizeof(text_words) - 2))
+      << "a target without room for a whole instruction word is not an instruction";
+  EXPECT_TRUE(attempt(sizeof(text_words) - sizeof(uint32_t)))
+      << "the last instruction in .text is a legitimate branch destination";
+}
+
 TEST(CodeObjectPatcher, ReplaceTextGrowsTextAndShiftsFollowingSections) {
   auto image = make_minimal_amdgpu_elf_with_text_and_rodata();
   AmdGpuCodeObject co(image.data(), image.size());


### PR DESCRIPTION
Since the hotswap backend defaulted to ROCjitsu, several hip-tests fail on gfx1250 Hotswap V2. The cause is a class of addresses that DBT invalidates when it repacks .text but never rewrites. An s_get_pc_i64 plus literal add names its target by distance, so any body that moves reaches a different address than it named — silently, because those instructions need no Hotswap change and are copied verbatim with only their position differing. That left device globals and __ockl_dm_alloc's heap control block being read out of unrelated memory, in 56 of 68 gfx1250 code objects from a nightly. Three narrower defects compounded it: a symbol-less RELATIVE64 slot naming another object was never discovered and tables matched only at their exact base, although an Itanium vptr points sixteen bytes in; a getpc computing a code address was rewritten only when it fed a recognized indirect transfer, so a stored function pointer kept a literal measuring where the body used to be; and growing .text shifted every allocated section above it without updating the RELATIVE64 addends naming those sections, so a statically constructed object's vptr held the
  pre-growth vtable address. Separately, a C++ virtual call takes its target out of a vtable slot in memory that no dataflow fact can name, so the consumer-side rule of proving every indirect transfer's target refused the whole code object — and because the HSA hook maps a refusal to HSA_STATUS_ERROR_INVALID_CODE_OBJECT with no fallback, one virtual function took out every kernel in the fatbin.

Each address class is now relocated: data targets through their section, code targets through the block placement map once every scope is placed, addends naming shifted sections along with those sections, and bodies reachable only through a pointer adopted as translation roots so they have a placement to be named at all. With no stale code address left, an unrecovered indirect transfer is accepted, since whatever a load yields already names the body's new home — withheld when the object produces no code addresses of its own, because the claim is then vacuous and says nothing about a pointer arriving by kernarg, and withheld when any getpc producer is unresolved, non-contiguous, or unmatched by the rewrite lattice. Validation: rocjitsu_tests 2245 passed / 1 unrelated skip, with the three tests pinning refusal of an unrecovered indirect branch still passing; 68 of 68 nightly gfx1250 code objects translate, up from 67; and on gfx1250 hardware the four hip-test suites covering the reported failures — OccupancyTest, KernelTest, RTC, UnitDeviceTests — match an HSA_HOTSWAP_DISABLE=1 baseline exactly, with every remaining failure also present when hotswap is disabled. One gap worth noting for review: the code-address rewrite has no unit fixture, because the minimal-ELF test harness does not relocate a body far enough to exercise it, so its coverage is the end-to-end suites.

Fixes: [ROCM-28928]

[ROCM-28928]: https://amd-hub.atlassian.net/browse/ROCM-28928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ