### PR TITLE
[rocjitsu] Bound simulator mapped memory accesses

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
@@ -16,6 +16,7 @@
 #include "rocjitsu/vm/amdgpu/mtype.h"
 #include "util/unique_handle.h"
 
+#include <algorithm>
 #include <atomic>
 #include <cassert>
 #include <cstdint>
@@ -23,6 +24,8 @@
 #include <shared_mutex>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
+#include <variant>
 #include <vector>
 
 #include <sys/types.h> // pid_t
@@ -173,13 +176,175 @@ public:
     pid_t debugger_pid = 0;
   };
 
-  /// @brief Per-page translation entry, mirroring HW PTE fields.
-  /// @details Stores the host pointer for VA→PA translation and the PTE MTYPE
-  /// that the GPU MMU uses to override instruction-level caching. On real
-  /// AMDGPU hardware, PTE bits 57:55 encode MTYPE per page.
-  struct PageTableEntry {
+  // GPUVM uses the simulator's fixed 4 KiB translation granule. This models
+  // the GPU page table and is intentionally independent of the host page size.
+  static constexpr uint64_t kPageShift = 12;
+  static constexpr uint64_t kPageSize = 1ULL << kPageShift;
+
+  /// @brief One host-backed interval within a GPU page.
+  struct HostExtent {
     uint8_t *host_ptr = nullptr;
+    /// Number of host-allocation-backed bytes starting at host_ptr.
+    size_t host_backed_bytes = 0;
+    /// GPU-page offset that corresponds to host_ptr.
+    size_t gpu_page_offset = 0;
+  };
+
+  /// @brief One inline host extent, spilling to dynamic storage only for split pages.
+  class HostExtentList {
+  public:
+    HostExtentList() = default;
+    HostExtentList(const HostExtentList &other) { copy_from(other); }
+    HostExtentList(HostExtentList &&other) noexcept { move_from(std::move(other)); }
+    HostExtentList(std::initializer_list<HostExtent> extents) {
+      for (const auto &extent : extents)
+        push_back(extent);
+    }
+
+    HostExtentList &operator=(const HostExtentList &other) {
+      if (this != &other)
+        copy_from(other);
+      return *this;
+    }
+    HostExtentList &operator=(HostExtentList &&other) noexcept {
+      if (this != &other)
+        move_from(std::move(other));
+      return *this;
+    }
+
+    [[nodiscard]] size_t size() const {
+      if (std::holds_alternative<std::monostate>(storage_))
+        return 0;
+      if (std::holds_alternative<HostExtent>(storage_))
+        return 1;
+      return std::get<std::vector<HostExtent>>(storage_).size();
+    }
+    [[nodiscard]] bool empty() const { return size() == 0; }
+
+    HostExtent *data() {
+      if (auto *single = std::get_if<HostExtent>(&storage_))
+        return single;
+      if (auto *many = std::get_if<std::vector<HostExtent>>(&storage_))
+        return many->data();
+      return nullptr;
+    }
+    const HostExtent *data() const {
+      if (const auto *single = std::get_if<HostExtent>(&storage_))
+        return single;
+      if (const auto *many = std::get_if<std::vector<HostExtent>>(&storage_))
+        return many->data();
+      return nullptr;
+    }
+    HostExtent *begin() { return data(); }
+    const HostExtent *begin() const { return data(); }
+    HostExtent *end() {
+      auto *first = data();
+      return first ? first + size() : nullptr;
+    }
+    const HostExtent *end() const {
+      const auto *first = data();
+      return first ? first + size() : nullptr;
+    }
+    HostExtent &front() { return (*this)[0]; }
+    const HostExtent &front() const { return (*this)[0]; }
+    HostExtent &back() { return (*this)[size() - 1]; }
+    const HostExtent &back() const { return (*this)[size() - 1]; }
+    HostExtent &operator[](size_t index) { return data()[index]; }
+    const HostExtent &operator[](size_t index) const { return data()[index]; }
+
+    void reserve(size_t capacity) {
+      if (capacity <= 1)
+        return;
+      if (auto *many = std::get_if<std::vector<HostExtent>>(&storage_)) {
+        many->reserve(capacity);
+        return;
+      }
+      std::vector<HostExtent> many;
+      many.reserve(capacity);
+      if (auto *single = std::get_if<HostExtent>(&storage_))
+        many.push_back(*single);
+      storage_.emplace<std::vector<HostExtent>>(std::move(many));
+    }
+
+    void push_back(const HostExtent &extent) {
+      if (std::holds_alternative<std::monostate>(storage_)) {
+        storage_.emplace<HostExtent>(extent);
+        return;
+      }
+      if (auto *single = std::get_if<HostExtent>(&storage_)) {
+        std::vector<HostExtent> many;
+        many.reserve(2);
+        many.push_back(*single);
+        many.push_back(extent);
+        storage_.emplace<std::vector<HostExtent>>(std::move(many));
+        return;
+      }
+      std::get<std::vector<HostExtent>>(storage_).push_back(extent);
+    }
+
+    void resize(size_t count) {
+      if (count == 0) {
+        storage_.emplace<std::monostate>();
+        return;
+      }
+      if (count == 1) {
+        if (auto *many = std::get_if<std::vector<HostExtent>>(&storage_)) {
+          HostExtent single = many->front();
+          storage_.emplace<HostExtent>(single);
+        }
+        return;
+      }
+      reserve(count);
+      std::get<std::vector<HostExtent>>(storage_).resize(count);
+    }
+
+    HostExtentList &operator=(std::vector<HostExtent> extents) {
+      if (extents.empty())
+        storage_.emplace<std::monostate>();
+      else if (extents.size() == 1)
+        storage_.emplace<HostExtent>(extents.front());
+      else
+        storage_.emplace<std::vector<HostExtent>>(std::move(extents));
+      return *this;
+    }
+
+  private:
+    void copy_from(const HostExtentList &other) {
+      if (const auto *single = std::get_if<HostExtent>(&other.storage_))
+        storage_.emplace<HostExtent>(*single);
+      else if (const auto *many = std::get_if<std::vector<HostExtent>>(&other.storage_))
+        storage_.emplace<std::vector<HostExtent>>(*many);
+      else
+        storage_.emplace<std::monostate>();
+    }
+
+    void move_from(HostExtentList &&other) {
+      if (auto *single = std::get_if<HostExtent>(&other.storage_))
+        storage_.emplace<HostExtent>(*single);
+      else if (auto *many = std::get_if<std::vector<HostExtent>>(&other.storage_))
+        storage_.emplace<std::vector<HostExtent>>(std::move(*many));
+      else
+        storage_.emplace<std::monostate>();
+    }
+
+    std::variant<std::monostate, HostExtent, std::vector<HostExtent>> storage_;
+  };
+
+  /// @brief Per-page translation entry, mirroring HW PTE fields.
+  /// @details A hardware PTE has one page-wide MTYPE, while local USERPTR
+  /// allocations can contribute several disjoint host-backed intervals to the
+  /// same GPU page. Keeping all intervals prevents a later sub-page mapping or
+  /// unmapping from silently replacing an unrelated sibling.
+  struct PageTableEntry {
+    PageTableEntry() = default;
+    PageTableEntry(uint8_t *host_ptr, amdgpu::Mtype page_mtype)
+        : mtype(page_mtype), host_extents{{host_ptr, kPageSize, 0}} {}
+    PageTableEntry(uint8_t *host_ptr, amdgpu::Mtype page_mtype, size_t host_backed_bytes,
+                   size_t gpu_page_offset)
+        : mtype(page_mtype), host_extents{{host_ptr, host_backed_bytes, gpu_page_offset}} {}
+
     amdgpu::Mtype mtype = amdgpu::Mtype::RW;
+    HostExtentList host_extents;
   };
 
   /// @brief Per-process GPU page table (GPU VA page number → PTE).
@@ -188,17 +353,27 @@ public:
   ///          on each memory access (TLB-like role).
   using PageTable = std::unordered_map<uint64_t, PageTableEntry>;
 
-  static constexpr uint64_t kPageShift = 12;
-  static constexpr uint64_t kPageSize = 1ULL << kPageShift;
-
   /// @brief Map host pages into this process's GPU page table.
   /// @param mtype PTE MTYPE for these pages (derived from allocation flags).
   void map_pages(uint64_t gpu_va, void *host_ptr, size_t size,
                  amdgpu::Mtype mtype = amdgpu::Mtype::RW) {
     std::unique_lock lock(page_table_mutex_);
     auto *base = static_cast<uint8_t *>(host_ptr);
-    for (size_t off = 0; off < size; off += kPageSize)
-      page_table_[(gpu_va + off) >> kPageShift] = {base + off, mtype};
+    uint64_t mapped_va = gpu_va;
+    size_t host_offset = 0;
+    while (host_offset < size) {
+      const size_t gpu_page_offset = mapped_va & (kPageSize - 1);
+      const size_t host_backed_bytes =
+          std::min<size_t>(kPageSize - gpu_page_offset, size - host_offset);
+      auto [page, inserted] = page_table_.try_emplace(mapped_va >> kPageShift, base + host_offset,
+                                                      mtype, host_backed_bytes, gpu_page_offset);
+      if (!inserted) {
+        page->second.mtype = mtype;
+        replace_host_extent(page->second, {base + host_offset, host_backed_bytes, gpu_page_offset});
+      }
+      mapped_va += host_backed_bytes;
+      host_offset += host_backed_bytes;
+    }
     // Keep publication in the page-table critical section. Cached readers
     // validate this generation while holding the shared side of the same lock;
     // publishing after unlock would permit a stale-cache hit in between.
@@ -208,8 +383,20 @@ public:
   /// @brief Unmap pages from this process's GPU page table.
   void unmap_pages(uint64_t gpu_va, size_t size) {
     std::unique_lock lock(page_table_mutex_);
-    for (size_t off = 0; off < size; off += kPageSize)
-      page_table_.erase((gpu_va + off) >> kPageShift);
+    uint64_t mapped_va = gpu_va;
+    size_t unmapped_bytes = 0;
+    while (unmapped_bytes < size) {
+      const size_t chunk =
+          std::min<size_t>(kPageSize - (mapped_va & (kPageSize - 1)), size - unmapped_bytes);
+      auto page = page_table_.find(mapped_va >> kPageShift);
+      if (page != page_table_.end()) {
+        erase_host_extent(page->second, mapped_va & (kPageSize - 1), chunk);
+        if (page->second.host_extents.empty())
+          page_table_.erase(page);
+      }
+      mapped_va += chunk;
+      unmapped_bytes += chunk;
+    }
     // See map_pages(): the mutation and generation publication are one
     // page-table critical section by design.
     publish_page_table_mutation_locked();
@@ -224,13 +411,28 @@ public:
     auto *old_base = static_cast<uint8_t *>(old_host_ptr);
     auto *new_base = static_cast<uint8_t *>(new_host_ptr);
     bool changed = false;
-    for (size_t off = 0; off < size; off += kPageSize) {
-      auto it = page_table_.find((gpu_va + off) >> kPageShift);
-      if (it != page_table_.end() && it->second.host_ptr == old_base + off &&
-          it->second.host_ptr != new_base + off) {
-        it->second.host_ptr = new_base + off;
-        changed = true;
+    uint64_t mapped_va = gpu_va;
+    size_t host_offset = 0;
+    while (host_offset < size) {
+      auto page = page_table_.find(mapped_va >> kPageShift);
+      if (page != page_table_.end()) {
+        const uint64_t page_base = mapped_va & ~(kPageSize - 1);
+        for (auto &extent : page->second.host_extents) {
+          const uint64_t extent_va = page_base + extent.gpu_page_offset;
+          if (extent_va < gpu_va || extent_va - gpu_va >= size)
+            continue;
+          const size_t extent_host_offset = extent_va - gpu_va;
+          if (extent.host_ptr == old_base + extent_host_offset &&
+              extent.host_ptr != new_base + extent_host_offset) {
+            extent.host_ptr = new_base + extent_host_offset;
+            changed = true;
+          }
+        }
       }
+      const size_t chunk =
+          std::min<size_t>(kPageSize - (mapped_va & (kPageSize - 1)), size - host_offset);
+      mapped_va += chunk;
+      host_offset += chunk;
     }
     if (changed)
       publish_page_table_mutation_locked();
@@ -240,12 +442,18 @@ public:
   void set_page_mtype(uint64_t gpu_va, size_t size, amdgpu::Mtype mtype) {
     std::unique_lock lock(page_table_mutex_);
     bool changed = false;
-    for (size_t off = 0; off < size; off += kPageSize) {
-      auto it = page_table_.find((gpu_va + off) >> kPageShift);
+    uint64_t mapped_va = gpu_va;
+    size_t updated_bytes = 0;
+    while (updated_bytes < size) {
+      auto it = page_table_.find(mapped_va >> kPageShift);
       if (it != page_table_.end() && it->second.mtype != mtype) {
         it->second.mtype = mtype;
         changed = true;
       }
+      const size_t chunk =
+          std::min<size_t>(kPageSize - (mapped_va & (kPageSize - 1)), size - updated_bytes);
+      mapped_va += chunk;
+      updated_bytes += chunk;
     }
     if (changed)
       publish_page_table_mutation_locked();
@@ -302,6 +510,77 @@ public:
   DebugSession debug_session_;
 
 private:
+  static void normalize_host_extents(PageTableEntry &page) {
+    auto &extents = page.host_extents;
+    if (extents.size() > 1)
+      std::sort(extents.begin(), extents.end(), [](const HostExtent &lhs, const HostExtent &rhs) {
+        return lhs.gpu_page_offset < rhs.gpu_page_offset;
+      });
+    size_t out = 0;
+    for (const auto &extent : extents) {
+      if (extent.host_ptr == nullptr || extent.host_backed_bytes == 0)
+        continue;
+      if (out > 0) {
+        auto &previous = extents[out - 1];
+        if (previous.gpu_page_offset + previous.host_backed_bytes == extent.gpu_page_offset &&
+            previous.host_ptr + previous.host_backed_bytes == extent.host_ptr) {
+          previous.host_backed_bytes += extent.host_backed_bytes;
+          continue;
+        }
+      }
+      extents[out++] = extent;
+    }
+    extents.resize(out);
+  }
+
+  static void replace_host_extent(PageTableEntry &page, HostExtent replacement) {
+    const size_t replacement_begin = replacement.gpu_page_offset;
+    const size_t replacement_end = replacement_begin + replacement.host_backed_bytes;
+    if (replacement_begin == 0 && replacement_end == kPageSize) {
+      page.host_extents = std::vector<HostExtent>{replacement};
+      return;
+    }
+    std::vector<HostExtent> updated;
+    updated.reserve(page.host_extents.size() + 1);
+    for (const auto &extent : page.host_extents) {
+      const size_t extent_begin = extent.gpu_page_offset;
+      const size_t extent_end = extent_begin + extent.host_backed_bytes;
+      if (extent_end <= replacement_begin || replacement_end <= extent_begin) {
+        updated.push_back(extent);
+        continue;
+      }
+      if (extent_begin < replacement_begin)
+        updated.push_back({extent.host_ptr, replacement_begin - extent_begin, extent_begin});
+      if (replacement_end < extent_end)
+        updated.push_back({extent.host_ptr + (replacement_end - extent_begin),
+                           extent_end - replacement_end, replacement_end});
+    }
+    updated.push_back(replacement);
+    page.host_extents = std::move(updated);
+    normalize_host_extents(page);
+  }
+
+  static void erase_host_extent(PageTableEntry &page, size_t erased_begin, size_t erased_bytes) {
+    const size_t erased_end = erased_begin + erased_bytes;
+    std::vector<HostExtent> updated;
+    updated.reserve(page.host_extents.size() + 1);
+    for (const auto &extent : page.host_extents) {
+      const size_t extent_begin = extent.gpu_page_offset;
+      const size_t extent_end = extent_begin + extent.host_backed_bytes;
+      if (extent_end <= erased_begin || erased_end <= extent_begin) {
+        updated.push_back(extent);
+        continue;
+      }
+      if (extent_begin < erased_begin)
+        updated.push_back({extent.host_ptr, erased_begin - extent_begin, extent_begin});
+      if (erased_end < extent_end)
+        updated.push_back(
+            {extent.host_ptr + (erased_end - extent_begin), extent_end - erased_end, erased_end});
+    }
+    page.host_extents = std::move(updated);
+    normalize_host_extents(page);
+  }
+
   void publish_page_table_mutation_locked() { ++page_table_generation_; }
 
   /// @brief Page table version counter, bumped on every PTE mutation.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
@@ -1548,11 +1548,13 @@ int SimulatedKfd::create_queue_ioctl(KfdProcess &proc, void *arg) {
     if (!daemon_mode_) {
       map_to_gpu(proc, args->ring_base_address, reinterpret_cast<void *>(args->ring_base_address),
                  args->ring_size, amdgpu::Mtype::UC);
-      uint64_t rptr_page = args->read_pointer_address & ~0xFFFULL;
-      uint64_t wptr_page = args->write_pointer_address & ~0xFFFULL;
-      map_to_gpu(proc, rptr_page, reinterpret_cast<void *>(rptr_page), 4096, amdgpu::Mtype::UC);
-      if (wptr_page != rptr_page)
-        map_to_gpu(proc, wptr_page, reinterpret_cast<void *>(wptr_page), 4096, amdgpu::Mtype::UC);
+      map_to_gpu(proc, args->read_pointer_address,
+                 reinterpret_cast<void *>(args->read_pointer_address), sizeof(uint64_t),
+                 amdgpu::Mtype::UC);
+      if (args->write_pointer_address != args->read_pointer_address)
+        map_to_gpu(proc, args->write_pointer_address,
+                   reinterpret_cast<void *>(args->write_pointer_address), sizeof(uint64_t),
+                   amdgpu::Mtype::UC);
     }
 
     uint32_t queue_id = proc.next_queue_id_++;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -1435,10 +1435,8 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
   if (host_accessible && memory_) {
     auto [host_range_base, host_range_size] =
         memory_->find_host_range(pkt.kernel_object, queue.process_id);
-    auto *kernel_object_page = memory_->resolve_host_ptr(pkt.kernel_object, queue.process_id);
-    if (host_range_base != 0 && kernel_object_page) {
-      auto *kernel_object_host_ptr =
-          kernel_object_page + (pkt.kernel_object & GpuMemory::PAGE_MASK);
+    auto *kernel_object_host_ptr = memory_->resolve_host_ptr(pkt.kernel_object, queue.process_id);
+    if (host_range_base != 0 && kernel_object_host_ptr) {
       auto *host_range_begin = reinterpret_cast<const uint8_t *>(host_range_base);
       auto *elf_base = find_elf_base(kernel_object_host_ptr, host_range_begin);
       if (elf_base) {
@@ -1488,12 +1486,12 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
                       dp.kernarg_addr, dp.num_user_sgprs);
     if (memory_) {
       auto *ko_ptr = memory_->translate_debug(pkt.kernel_object, queue.process_id);
-      auto *pc_ptr = memory_->translate_debug(entry_pc, queue.process_id);
+      auto *pc_ptr = memory_->translate_debug(entry_pc, queue.process_id, sizeof(uint32_t));
       os << std::format(" ko_mapped={} pc_mapped={} mem={:#x}", ko_ptr != nullptr,
                         pc_ptr != nullptr, reinterpret_cast<uintptr_t>(memory_));
       if (pc_ptr) {
         uint32_t first_word;
-        std::memcpy(&first_word, pc_ptr + (entry_pc & 0xFFF), 4);
+        std::memcpy(&first_word, pc_ptr, sizeof(first_word));
         os << std::format(" first_inst={:#010x}", first_word);
       }
     }
@@ -2010,13 +2008,10 @@ void CommandProcessor::handle_doorbell(simdojo::Tick now) {
 /// so we use GpuMemory::resolve_host_ptr() to find the correct address. In local
 /// mode, the GPU VA IS the host VA (identity mapping), so we cast directly.
 /// @returns Host pointer, or nullptr if the VA is not mapped.
-static void *resolve_sdma_ptr(GpuMemory *memory, uint64_t va, uint32_t vmid) {
+static void *resolve_sdma_ptr(GpuMemory *memory, uint64_t va, uint32_t vmid, size_t size) {
   if (!memory)
     return nullptr;
-  auto *page_base = memory->resolve_host_ptr(va, vmid);
-  if (!page_base)
-    return nullptr;
-  return page_base + (va & 0xFFF);
+  return memory->resolve_host_ptr(va, vmid, size);
 }
 
 // SDMA opcodes.
@@ -2048,6 +2043,7 @@ constexpr uint32_t CONST_FILL_SIZE = 5;
 constexpr uint32_t TIMESTAMP_SIZE = 3;
 constexpr uint32_t GCR_SIZE = 5;
 constexpr uint32_t GCR_GFX1250_SIZE = 6;
+constexpr size_t TRANSFER_SCRATCH_BYTES = GpuMemory::PAGE_SIZE;
 
 // GCR GL2 cache-op control bits. The control dword and bit positions genuinely
 // differ by dialect (the gfx1250 GCR packet is a distinct layout, not a resized
@@ -2135,14 +2131,39 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
   // Helper: resolve a GPU VA from an SDMA packet to a host pointer.
   // In daemon mode, the VA belongs to the client process; we go through the
   // VMID page table. In local mode, the VA IS the host address.
-  auto resolve = [&](uint64_t va) -> void * {
-    return resolve_sdma_ptr(memory_, va, queue.process_id);
+  auto resolve = [&](uint64_t va, size_t size = 1) -> void * {
+    return resolve_sdma_ptr(memory_, va, queue.process_id, size);
+  };
+  auto copy_linear = [&](uint64_t src_va, std::span<const uint64_t> dst_vas, uint32_t count) {
+    const auto range_fits = [count](uint64_t va) {
+      return static_cast<uint64_t>(count - 1) <= std::numeric_limits<uint64_t>::max() - va;
+    };
+    const bool source_known = resolve(src_va, count) != nullptr ||
+                              memory_->has_range_mapping(src_va, count, queue.process_id);
+    const bool destinations_known = std::ranges::all_of(dst_vas, [&](uint64_t dst_va) {
+      return range_fits(dst_va) && (resolve(dst_va, count) != nullptr ||
+                                    memory_->has_range_mapping(dst_va, count, queue.process_id));
+    });
+    if (!range_fits(src_va) || !source_known || !destinations_known)
+      return false;
+
+    std::array<uint8_t, sdma::TRANSFER_SCRATCH_BYTES> copy_buffer{};
+    size_t offset = 0;
+    while (offset < count) {
+      const size_t chunk = std::min(copy_buffer.size(), static_cast<size_t>(count) - offset);
+      auto bytes = std::span<uint8_t>(copy_buffer).first(chunk);
+      memory_->read_block(src_va + offset, bytes, queue.process_id);
+      for (uint64_t dst_va : dst_vas)
+        memory_->write_block(dst_va + offset, std::span<const uint8_t>(bytes), queue.process_id);
+      offset += chunk;
+    }
+    return true;
   };
   auto write_read_ptr = [&] {
     uint64_t rptr_val = rpos * sizeof(uint32_t);
     assert((queue.read_ptr_va & (alignof(uint64_t) - 1)) == 0 &&
            "SDMA queue read pointer must be 64-bit aligned");
-    auto *read_ptr = static_cast<uint64_t *>(resolve(queue.read_ptr_va));
+    auto *read_ptr = static_cast<uint64_t *>(resolve(queue.read_ptr_va, sizeof(uint64_t)));
     // The queue read pointer is ABI-aligned, so use an atomic store when the VA
     // translates to one naturally aligned host pointer inside a single page. The
     // byte-wise fallback preserves functional behavior for sparse-memory paths
@@ -2204,7 +2225,7 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
           uint64_t wait_ref = static_cast<uint64_t>(dw(4)) | (static_cast<uint64_t>(dw(5)) << 32);
           uint64_t wait_mask = static_cast<uint64_t>(dw(6)) | (static_cast<uint64_t>(dw(7)) << 32);
           if (wait_addr > 0x1000) {
-            auto *wait_ptr = static_cast<uint64_t *>(resolve(wait_addr));
+            auto *wait_ptr = static_cast<uint64_t *>(resolve(wait_addr, sizeof(uint64_t)));
             if (!wait_ptr) {
               return stop_and_retry_current_packet();
             }
@@ -2228,7 +2249,7 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
                         (static_cast<uint64_t>(dw(signal_base + 4)) << 32);
 
           if (signal_addr > 0x1000 && signal_op == 0x70) {
-            signal_ptr = static_cast<int64_t *>(resolve(signal_addr));
+            signal_ptr = static_cast<int64_t *>(resolve(signal_addr, sizeof(int64_t)));
             if (!signal_ptr) {
               return stop_and_retry_current_packet();
             }
@@ -2241,12 +2262,6 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
                           (static_cast<uint64_t>(dw(copy_base + 3)) << 32);
         uint64_t dst_va = static_cast<uint64_t>(dw(copy_base + 4)) |
                           (static_cast<uint64_t>(dw(copy_base + 5)) << 32);
-        auto *src_ptr = resolve(src_va);
-        auto *dst_ptr = resolve(dst_va);
-        if (!src_ptr || !dst_ptr) {
-          return stop_and_retry_current_packet();
-        }
-
         // Emulated SDMA writes straight to the backing store, bypassing the GPU
         // caches. Real SDMA does not snoop GL2; coherence is re-established by
         // the consuming kernel's acquire fence at dispatch. We model that with a
@@ -2257,7 +2272,9 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
         // supersedes it instead of being clobbered by a later flush. After the
         // flush the caches are empty, so the destination re-reads fresh backing.
         flush_gpu_caches();
-        std::memcpy(dst_ptr, src_ptr, count);
+        const std::array destinations = {dst_va};
+        if (!copy_linear(src_va, destinations, count))
+          return stop_and_retry_current_packet();
 
         if (signal_decrement) {
           std::atomic_ref<int64_t>(*signal_ptr)
@@ -2277,11 +2294,6 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
       uint64_t dst_va = static_cast<uint64_t>(dw(5)) | (static_cast<uint64_t>(dw(6)) << 32);
       util::Logger::vm("SDMA COPY: src=", std::hex, src_va, " dst=", dst_va, std::dec,
                        " count=", count, " (", count / 1024, " KB)");
-      auto *src_ptr = resolve(src_va);
-      auto *dst_ptr = resolve(dst_va);
-      if (!src_ptr || !dst_ptr) {
-        return stop_and_retry_current_packet();
-      }
       // GFX11+ COPY_LINEAR uses bit 28 for NPD metadata. The two-destination
       // broadcast form is marked by bit 27 and extends the packet with DW7/DW8.
       bool is_broadcast_copy = uses_gfx11_plus_sdma_packets()
@@ -2289,20 +2301,19 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
                                    : (header & (1u << 28)) != 0;
       if (is_broadcast_copy) {
         uint64_t dst2_va = static_cast<uint64_t>(dw(7)) | (static_cast<uint64_t>(dw(8)) << 32);
-        auto *dst2_ptr = resolve(dst2_va);
-        if (!dst2_ptr) {
-          return stop_and_retry_current_packet();
-        }
         // Flush before the direct write (see COPY_LINEAR_WAITSIGNAL above): a
         // destination-overlapping dirty L2 line must be written back first so
         // the SDMA write supersedes it rather than being clobbered afterward.
         flush_gpu_caches();
-        std::memcpy(dst_ptr, src_ptr, count);
-        std::memcpy(dst2_ptr, src_ptr, count);
+        const std::array destinations = {dst_va, dst2_va};
+        if (!copy_linear(src_va, destinations, count))
+          return stop_and_retry_current_packet();
         pkt_dwords = sdma::COPY_LINEAR_BROADCAST_SIZE;
       } else {
         flush_gpu_caches();
-        std::memcpy(dst_ptr, src_ptr, count);
+        const std::array destinations = {dst_va};
+        if (!copy_linear(src_va, destinations, count))
+          return stop_and_retry_current_packet();
         pkt_dwords = sdma::COPY_LINEAR_SIZE;
       }
       break;
@@ -2317,7 +2328,7 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
         uint64_t addr_va =
             static_cast<uint64_t>(dw(1) & ~0x7u) | (static_cast<uint64_t>(dw(2)) << 32);
         uint64_t data = static_cast<uint64_t>(dw(3)) | (static_cast<uint64_t>(dw(4)) << 32);
-        auto *ptr = static_cast<uint64_t *>(resolve(addr_va));
+        auto *ptr = static_cast<uint64_t *>(resolve(addr_va, sizeof(uint64_t)));
         if (ptr) {
           // Flush before the store so a destination-overlapping dirty line is
           // published first and the fence write supersedes it.
@@ -2330,7 +2341,7 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
 
       uint64_t addr_va = static_cast<uint64_t>(dw(1)) | (static_cast<uint64_t>(dw(2)) << 32);
       uint32_t data = dw(3);
-      auto *ptr = static_cast<uint32_t *>(resolve(addr_va));
+      auto *ptr = static_cast<uint32_t *>(resolve(addr_va, sizeof(uint32_t)));
       if (ptr) {
         flush_gpu_caches();
         std::atomic_ref<uint32_t>(*ptr).store(data, std::memory_order_release);
@@ -2357,7 +2368,7 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
         uint64_t ref = static_cast<uint64_t>(dw(3)) | (static_cast<uint64_t>(dw(4)) << 32);
         uint64_t mask = static_cast<uint64_t>(dw(5)) | (static_cast<uint64_t>(dw(6)) << 32);
         if (addr > 0x1000) {
-          auto *ptr = static_cast<uint64_t *>(resolve(addr));
+          auto *ptr = static_cast<uint64_t *>(resolve(addr, sizeof(uint64_t)));
           if (!ptr) {
             return stop_and_retry_current_packet();
           }
@@ -2379,7 +2390,7 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
       if (!mem_poll) {
         // Register poll / HDP flush — no-op in functional sim.
       } else if (addr_va > 0x1000) {
-        auto *ptr = static_cast<uint32_t *>(resolve(addr_va));
+        auto *ptr = static_cast<uint32_t *>(resolve(addr_va, sizeof(uint32_t)));
         if (!ptr) {
           return stop_and_retry_current_packet();
         }
@@ -2418,7 +2429,7 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
       uint32_t atomic_op = (header >> 25) & 0x7F;
       // SDMA_ATOMIC_ADD64 = 47
       if (atomic_op == 47 && addr_va > 0x1000) {
-        auto *ptr = static_cast<int64_t *>(resolve(addr_va));
+        auto *ptr = static_cast<int64_t *>(resolve(addr_va, sizeof(int64_t)));
         if (ptr) {
           // Flush before the RMW: the fetch_add reads the backing value, so a
           // dirty overlapping L2 line must be written back first or the atomic
@@ -2430,12 +2441,12 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
           if (static_cast<int64_t>(src_data) < 0 && interrupt_cb_) {
             // Signal layout: addr is at offset 8 (value field) from sig base.
             uint64_t sig_base = addr_va - 8;
-            auto *mb = static_cast<uint64_t *>(resolve(sig_base + 16));
-            auto *eid = static_cast<uint32_t *>(resolve(sig_base + 24));
+            auto *mb = static_cast<uint64_t *>(resolve(sig_base + 16, sizeof(uint64_t)));
+            auto *eid = static_cast<uint32_t *>(resolve(sig_base + 24, sizeof(uint32_t)));
             uint64_t mailbox_ptr = mb ? *mb : 0;
             uint32_t event_id = eid ? *eid : 0;
             if (mailbox_ptr != 0) {
-              auto *mb_dst = static_cast<uint64_t *>(resolve(mailbox_ptr));
+              auto *mb_dst = static_cast<uint64_t *>(resolve(mailbox_ptr, sizeof(uint64_t)));
               if (mb_dst) {
                 flush_gpu_caches();
                 std::atomic_ref<uint64_t>(*mb_dst).store(uint64_t(event_id),
@@ -2454,16 +2465,37 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
       uint32_t data = dw(3);
       uint32_t count = (dw(4) & 0x3FFFFFF) + 1;
       uint32_t fillsize = (header >> 30) & 0x3;
-      auto *dst = static_cast<uint8_t *>(resolve(addr_va));
-      if (dst) {
+      const bool range_fits =
+          static_cast<uint64_t>(count - 1) <= std::numeric_limits<uint64_t>::max() - addr_va;
+      const bool destination_known =
+          range_fits && (resolve(addr_va, count) != nullptr ||
+                         memory_->has_range_mapping(addr_va, count, queue.process_id));
+      if (!destination_known)
+        return stop_and_retry_current_packet();
+      {
         // Flush before the fill so a destination-overlapping dirty line is
         // published first and the fill supersedes it.
         flush_gpu_caches();
-        if (fillsize == 2) {
-          for (uint32_t i = 0; i < count; i += 4)
-            std::memcpy(dst + i, &data, 4);
-        } else {
-          std::memset(dst, static_cast<int>(data & 0xFF), count);
+
+        std::array<uint8_t, sdma::TRANSFER_SCRATCH_BYTES> fill_buffer{};
+        std::array<uint8_t, sizeof(data)> fill_pattern{};
+        std::memcpy(fill_pattern.data(), &data, sizeof(data));
+        size_t offset = 0;
+        while (offset < count) {
+          const uint64_t chunk_va = addr_va + offset;
+          const size_t chunk = std::min(
+              {fill_buffer.size(), static_cast<size_t>(count) - offset,
+               GpuMemory::PAGE_SIZE - static_cast<size_t>(chunk_va & GpuMemory::PAGE_MASK)});
+          if (fillsize == 2) {
+            for (size_t i = 0; i < chunk; ++i)
+              fill_buffer[i] = fill_pattern[(offset + i) % fill_pattern.size()];
+          } else {
+            std::fill_n(fill_buffer.begin(), chunk, static_cast<uint8_t>(data));
+          }
+          if (memory_->has_page_mapping(chunk_va, queue.process_id))
+            memory_->write_block(chunk_va, std::span<const uint8_t>(fill_buffer).first(chunk),
+                                 queue.process_id);
+          offset += chunk;
         }
       }
       pkt_dwords = sdma::CONST_FILL_SIZE;
@@ -2475,7 +2507,7 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
         auto now = std::chrono::steady_clock::now().time_since_epoch();
         uint64_t ts = static_cast<uint64_t>(
             std::chrono::duration_cast<std::chrono::nanoseconds>(now).count());
-        auto *ptr = static_cast<uint64_t *>(resolve(addr_va));
+        auto *ptr = static_cast<uint64_t *>(resolve(addr_va, sizeof(uint64_t)));
         if (ptr) {
           // Flush before the direct store so a dirty cached line overlapping the
           // timestamp address is published first and the timestamp supersedes it

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/completion_tracker.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/completion_tracker.cpp
@@ -85,25 +85,20 @@ void CompletionTracker::fire_queue_idle_signal(uint64_t queue_desc_va, uint32_t 
   constexpr uint32_t EVENT_ID_OFF = 24;
 
   uint64_t sig_handle_va = queue_desc_va + kQueueInactiveSigOff;
-  auto *desc_page = memory_->resolve_host_ptr(sig_handle_va, process_id);
-  if (!desc_page)
-    return;
-
-  size_t page_offset = sig_handle_va & 0xFFF;
-  if (page_offset + sizeof(uint64_t) > 0x1000)
+  auto *sig_handle = memory_->resolve_host_ptr(sig_handle_va, process_id, sizeof(uint64_t));
+  if (!sig_handle)
     return;
 
   uint64_t sig_addr = 0;
-  std::memcpy(&sig_addr, desc_page + page_offset, sizeof(sig_addr));
+  std::memcpy(&sig_addr, sig_handle, sizeof(sig_addr));
   if (sig_addr == 0)
     return;
 
   if ((sig_addr & 0x3F) != 0)
     return;
-  auto *sig_page = memory_->resolve_host_ptr(sig_addr, process_id);
-  if (!sig_page)
+  auto *sig_base = memory_->resolve_host_ptr(sig_addr, process_id, EVENT_ID_OFF + sizeof(uint32_t));
+  if (!sig_base)
     return;
-  auto *sig_base = sig_page + (sig_addr & 0xFFF);
 
   constexpr uint32_t SIG_VAL_OFF = 8;
   constexpr uint64_t kIdleStatus = 0x10;
@@ -126,9 +121,9 @@ void CompletionTracker::fire_queue_idle_signal(uint64_t queue_desc_va, uint32_t 
   uint64_t mailbox_ptr = 0;
   std::memcpy(&mailbox_ptr, sig_base + MAILBOX_PTR_OFF, sizeof(mailbox_ptr));
   if (mailbox_ptr != 0) {
-    auto *mb_page = memory_->resolve_host_ptr(mailbox_ptr, process_id);
-    if (mb_page) {
-      auto *mb_ptr = reinterpret_cast<uint64_t *>(mb_page + (mailbox_ptr & 0xFFF));
+    auto *mb_ptr = reinterpret_cast<uint64_t *>(
+        memory_->resolve_host_ptr(mailbox_ptr, process_id, sizeof(uint64_t)));
+    if (mb_ptr) {
       std::atomic_ref<uint64_t>(*mb_ptr).store(uint64_t(event_id), std::memory_order_release);
     }
   }
@@ -167,22 +162,21 @@ void CompletionTracker::fire_signal(const DispatchEntry &entry) {
   constexpr uint32_t END_TS_OFF = 40;
 
   if (memory_) {
-    auto *sig_page =
-        memory_->resolve_host_ptr(entry.completion_signal + SIG_VAL_OFF, entry.process_id);
+    auto *sig_base = memory_->resolve_host_ptr(entry.completion_signal, entry.process_id,
+                                               END_TS_OFF + sizeof(uint64_t));
     uint64_t start_ts = entry.profiling_start_timestamp;
     if (start_ts == 0)
       start_ts = hsa_system_timestamp();
     uint64_t end_ts = std::max(hsa_system_timestamp(), start_ts + 1);
 
     util::Logger::cp([&](auto &os) {
-      auto *page0 = memory_->resolve_host_ptr(entry.completion_signal, entry.process_id);
       uint64_t kind_raw = 0, val_raw = 0, mbx_raw = 0;
       uint32_t eid_raw = 0;
-      if (page0) {
-        std::memcpy(&kind_raw, page0 + (entry.completion_signal & 0xFFF), 8);
-        std::memcpy(&val_raw, page0 + ((entry.completion_signal + SIG_VAL_OFF) & 0xFFF), 8);
-        std::memcpy(&mbx_raw, page0 + ((entry.completion_signal + MAILBOX_PTR_OFF) & 0xFFF), 8);
-        std::memcpy(&eid_raw, page0 + ((entry.completion_signal + EVENT_ID_OFF) & 0xFFF), 4);
+      if (sig_base) {
+        std::memcpy(&kind_raw, sig_base, sizeof(kind_raw));
+        std::memcpy(&val_raw, sig_base + SIG_VAL_OFF, sizeof(val_raw));
+        std::memcpy(&mbx_raw, sig_base + MAILBOX_PTR_OFF, sizeof(mbx_raw));
+        std::memcpy(&eid_raw, sig_base + EVENT_ID_OFF, sizeof(eid_raw));
       } else {
         kind_raw = memory_->read64(entry.completion_signal, entry.process_id);
         val_raw = memory_->read64(entry.completion_signal + SIG_VAL_OFF, entry.process_id);
@@ -192,22 +186,19 @@ void CompletionTracker::fire_signal(const DispatchEntry &entry) {
       os << std::format("SIGNAL_DUMP d={} sig={:#x} pid={} host_page={} kind={:#x} val={} "
                         "mailbox={:#x} event_id={}",
                         entry.dispatch_id, entry.completion_signal, entry.process_id,
-                        page0 != nullptr, kind_raw, static_cast<int64_t>(val_raw), mbx_raw,
+                        sig_base != nullptr, kind_raw, static_cast<int64_t>(val_raw), mbx_raw,
                         eid_raw);
     });
 
     int64_t old = 0;
     uint64_t new_val = 0;
-    if (sig_page) {
-      auto *start_ptr = reinterpret_cast<uint64_t *>(
-          sig_page + ((entry.completion_signal + START_TS_OFF) & 0xFFF));
-      auto *end_ptr =
-          reinterpret_cast<uint64_t *>(sig_page + ((entry.completion_signal + END_TS_OFF) & 0xFFF));
+    if (sig_base) {
+      auto *start_ptr = reinterpret_cast<uint64_t *>(sig_base + START_TS_OFF);
+      auto *end_ptr = reinterpret_cast<uint64_t *>(sig_base + END_TS_OFF);
       std::atomic_ref<uint64_t>(*start_ptr).store(start_ts, std::memory_order_relaxed);
       std::atomic_ref<uint64_t>(*end_ptr).store(end_ts, std::memory_order_release);
 
-      auto *sig_ptr = reinterpret_cast<uint64_t *>(
-          sig_page + ((entry.completion_signal + SIG_VAL_OFF) & 0xFFF));
+      auto *sig_ptr = reinterpret_cast<uint64_t *>(sig_base + SIG_VAL_OFF);
       old =
           static_cast<int64_t>(std::atomic_ref<uint64_t>(*sig_ptr).load(std::memory_order_relaxed));
       new_val = static_cast<uint64_t>(old - 1);
@@ -232,9 +223,9 @@ void CompletionTracker::fire_signal(const DispatchEntry &entry) {
     });
 
     if (mailbox_ptr != 0) {
-      auto *mb_page = memory_->resolve_host_ptr(mailbox_ptr, entry.process_id);
-      if (mb_page) {
-        auto *mb_ptr = reinterpret_cast<uint64_t *>(mb_page + (mailbox_ptr & 0xFFF));
+      auto *mb_ptr = reinterpret_cast<uint64_t *>(
+          memory_->resolve_host_ptr(mailbox_ptr, entry.process_id, sizeof(uint64_t)));
+      if (mb_ptr) {
         std::atomic_ref<uint64_t>(*mb_ptr).store(uint64_t(event_id), std::memory_order_release);
       } else {
         memory_->write64(mailbox_ptr, uint64_t(event_id), entry.process_id);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
@@ -29,8 +29,27 @@
 #include <unordered_map>
 #include <utility>
 
+#if defined(__SANITIZE_ADDRESS__)
+#define RJ_GPU_MEMORY_WITH_ASAN 1
+#elif defined(__has_feature)
+#if __has_feature(address_sanitizer)
+#define RJ_GPU_MEMORY_WITH_ASAN 1
+#endif
+#endif
+
+#if defined(RJ_GPU_MEMORY_WITH_ASAN)
+#include <sanitizer/asan_interface.h>
+#endif
+
 namespace rocjitsu {
 namespace amdgpu {
+
+class GpuMemoryTestAccess;
+
+static_assert(KfdProcess::kPageShift == simdojo::SparseMemory::PAGE_SHIFT,
+              "KFD and sparse-memory page shifts must match");
+static_assert(KfdProcess::kPageSize == simdojo::SparseMemory::PAGE_SIZE,
+              "KFD and sparse-memory page sizes must match");
 
 /// @brief AMDGPU VRAM memory with VMID-based per-process page table resolution.
 ///
@@ -107,12 +126,63 @@ public:
   /// mapping and is only valid when simulator and target share an address space.
   void set_passthrough(bool v) { passthrough_ = v; }
 
-  /// @brief Resolve a GPU VA to a borrowed host-page pointer.
+  /// @brief Return whether the page containing an address has a known mapping.
+  /// @details Unlike resolve_host_ptr(), this deliberately ignores the current
+  /// host accessibility of the requested byte. Callers use it to distinguish a
+  /// known mapping whose live extent is clipped from a page that may not have
+  /// been installed yet.
+  bool has_page_mapping(uint64_t addr, uint32_t vmid = 0) const {
+    if (vmid == 0)
+      return passthrough_ && addr < kUserSpaceLimit && addr != 0;
+
+    std::shared_lock vmid_lock(vmid_mutex_);
+    auto vmid_entry = vmid_table_.find(vmid);
+    if (vmid_entry == vmid_table_.end())
+      return passthrough_ && addr < kUserSpaceLimit && addr != 0;
+
+    auto &entry = vmid_entry->second;
+    std::shared_lock page_table_lock(*entry.mutex);
+    if (entry.page_table->contains(addr >> PAGE_SHIFT))
+      return true;
+    return passthrough_ && addr < kUserSpaceLimit && addr != 0;
+  }
+
+  /// @brief Return whether every page touched by an address range is known.
+  /// @details This checks page-table presence rather than live host extents, so
+  /// callers can retry a not-yet-installed range while still allowing a mapped
+  /// page's deliberately clipped extent to produce bounded partial accesses.
+  bool has_range_mapping(uint64_t addr, size_t size, uint32_t vmid = 0) const {
+    if (size == 0 || size - 1 > std::numeric_limits<uint64_t>::max() - addr)
+      return false;
+    bool mapped = true;
+    for_each_page_chunk(addr, size, [&](uint64_t ea, size_t, size_t) {
+      if (mapped && !has_page_mapping(ea, vmid))
+        mapped = false;
+    });
+    return mapped;
+  }
+
+  /// @brief Resolve a GPU VA range to its first borrowed host byte.
   /// @details The returned pointer is only valid while page-table remapping and
   /// process teardown are quiesced. Normal memory operations use an internal
   /// callback that keeps the page-table shared lock held through the copy.
-  uint8_t *resolve_host_ptr(uint64_t addr, uint32_t vmid = 0) const {
-    return translate(addr, vmid);
+  uint8_t *resolve_host_ptr(uint64_t addr, uint32_t vmid = 0, size_t size = 1) const {
+    if (size == 0 || size - 1 > std::numeric_limits<uint64_t>::max() - addr)
+      return nullptr;
+    uint8_t *first_host_ptr = nullptr;
+    bool contiguous = true;
+    for_each_page_chunk(addr, size, [&](uint64_t ea, size_t offset, size_t chunk) {
+      if (!contiguous)
+        return;
+      auto *host_ptr = translate(ea, vmid, chunk);
+      if (!host_ptr || (first_host_ptr && host_ptr != first_host_ptr + offset)) {
+        contiguous = false;
+        return;
+      }
+      if (!first_host_ptr)
+        first_host_ptr = host_ptr;
+    });
+    return contiguous ? first_host_ptr : nullptr;
   }
 
   /// @brief Look up PTE MTYPE for a GPU VA in the given VMID's page table.
@@ -129,7 +199,9 @@ public:
 
   /// @brief Read a contiguous range from simulated GPU memory.
   /// @details Handles each page through mapped host memory, client memory, or
-  /// sparse backing memory.
+  /// sparse backing memory. A mapped access clipped by a host extent remains
+  /// zero-filled and emits a VM diagnostic so a future strict-fault mode can
+  /// reuse the same boundary detection.
   void read_block(uint64_t addr, std::span<uint8_t> dst, uint32_t vmid = 0) const {
     for_each_page_chunk(addr, dst.size(), [&](uint64_t ea, size_t offset, size_t chunk) {
       auto out = dst.subspan(offset, chunk);
@@ -144,7 +216,8 @@ public:
 
   /// @brief Write a contiguous range to simulated GPU memory.
   /// @details Handles each page through mapped host memory, client memory, or
-  /// sparse backing memory.
+  /// sparse backing memory. A mapped access clipped by a host extent is dropped
+  /// for the missing bytes and emits a VM diagnostic.
   void write_block(uint64_t addr, std::span<const uint8_t> src, uint32_t vmid = 0) {
     for_each_page_chunk(addr, src.size(), [&](uint64_t ea, size_t offset, size_t chunk) {
       auto in = src.subspan(offset, chunk);
@@ -161,7 +234,9 @@ public:
   /// @details Storage classification and the page-table shared lock remain
   /// stable through the callback. Mapped aliases rendezvous on a process-wide
   /// host-address stripe; unmapped sparse/client accesses use an address-space
-  /// stripe instead.
+  /// stripe instead. Bytes outside a mapped host extent read as zero and discard
+  /// callback writes, including accesses that straddle the extent boundary.
+  /// Such clipping emits a VM diagnostic rather than remaining silent.
   /// @param addr GPU virtual address of the target.
   /// @param size Access size in bytes (4 or 8).
   /// @param fn Callback invoked with a pointer to the target bytes.
@@ -183,19 +258,20 @@ public:
 
     auto &entry = vmid_entry->second;
     std::shared_lock page_table_lock(*entry.mutex);
-    auto pte = entry.page_table->find(addr >> PAGE_SHIFT);
+    const uint64_t page_key = addr >> PAGE_SHIFT;
+    auto pte = entry.page_table->find(page_key);
     if (pte != entry.page_table->end()) {
-      if (pte->second.host_ptr != nullptr)
-        atomic_rmw_mapped(addr, pte->second.host_ptr, fn);
-      else
-        atomic_rmw_fallback(addr, size, entry.client_pid, fn);
+      if (!atomic_rmw_mapped_page(pte->second, addr & PAGE_MASK, size, fn))
+        note_clipped_mapped_access("atomic", addr, size, vmid);
       return;
     }
 
     atomic_rmw_unmapped(addr, size, entry.client_pid, fn);
   }
 
-  uint8_t *translate_debug(uint64_t addr, uint32_t vmid) const { return translate(addr, vmid); }
+  uint8_t *translate_debug(uint64_t addr, uint32_t vmid, size_t size = 1) const {
+    return translate(addr, vmid, size);
+  }
 
   /// @brief Find the contiguous host range containing a VMID-scoped GPU VA.
   /// @details KFD dispatches use per-process page tables. Kernel-symbol
@@ -203,10 +279,12 @@ public:
   /// backward from the kernel descriptor to the loaded ELF header.
   std::pair<uint64_t, uint64_t> find_host_range(uint64_t addr, uint32_t vmid) const {
     if (vmid == 0) {
-      auto *host = translate(addr, vmid);
+      auto *host = translate(addr, vmid, 1);
       if (!host)
         return {0, 0};
-      return {reinterpret_cast<uint64_t>(host), PAGE_SIZE};
+      auto *page = host - (addr & PAGE_MASK);
+      auto [range, size] = addressable_range_containing(page, PAGE_SIZE, host);
+      return {reinterpret_cast<uint64_t>(range), size};
     }
 
     std::shared_lock vmid_lock(vmid_mutex_);
@@ -221,30 +299,49 @@ public:
     if (page_entry == entry.page_table->end())
       return {0, 0};
 
+    const size_t page_offset = addr & PAGE_MASK;
+    const auto *current_extent = host_extent_at(page_entry->second, page_offset);
+    if (!current_extent)
+      return {0, 0};
+
     uint64_t first_page = page;
-    uint8_t *first_host_page = page_entry->second.host_ptr;
-    while (first_page > 0) {
+    const auto *first_extent = current_extent;
+    uint8_t *first_host_byte = first_extent->host_ptr;
+    while (first_page > 0 && first_extent->gpu_page_offset == 0) {
       auto previous_page_entry = entry.page_table->find(first_page - 1);
-      if (previous_page_entry == entry.page_table->end() ||
-          previous_page_entry->second.host_ptr + PAGE_SIZE != first_host_page)
+      if (previous_page_entry == entry.page_table->end())
+        break;
+      const auto *previous_extent = host_extent_ending_at_page(previous_page_entry->second);
+      if (!previous_extent ||
+          previous_extent->host_ptr + previous_extent->host_backed_bytes != first_host_byte)
         break;
       --first_page;
-      first_host_page = previous_page_entry->second.host_ptr;
+      first_extent = previous_extent;
+      first_host_byte = first_extent->host_ptr;
     }
 
     uint64_t last_page = page;
-    uint8_t *last_host_page = page_entry->second.host_ptr;
-    while (true) {
+    const auto *last_extent = current_extent;
+    while (last_extent->gpu_page_offset + last_extent->host_backed_bytes == PAGE_SIZE) {
       auto next_page_entry = entry.page_table->find(last_page + 1);
-      if (next_page_entry == entry.page_table->end() ||
-          next_page_entry->second.host_ptr != last_host_page + PAGE_SIZE)
+      if (next_page_entry == entry.page_table->end())
+        break;
+      const auto *next_extent = host_extent_starting_at_page(next_page_entry->second);
+      if (!next_extent ||
+          next_extent->host_ptr != last_extent->host_ptr + last_extent->host_backed_bytes)
         break;
       ++last_page;
-      last_host_page = next_page_entry->second.host_ptr;
+      last_extent = next_extent;
     }
 
-    const uint64_t range_size = ((last_page - first_page) + 1) << PAGE_SHIFT;
-    return {reinterpret_cast<uint64_t>(first_host_page), range_size};
+    const uintptr_t first_host_address = reinterpret_cast<uintptr_t>(first_host_byte);
+    const uintptr_t last_host_address = reinterpret_cast<uintptr_t>(last_extent->host_ptr);
+    const uint64_t declared_range_size =
+        last_host_address - first_host_address + last_extent->host_backed_bytes;
+    auto *host_byte = current_extent->host_ptr + (page_offset - current_extent->gpu_page_offset);
+    auto [range, range_size] =
+        addressable_range_containing(first_host_byte, declared_range_size, host_byte);
+    return {reinterpret_cast<uint64_t>(range), range_size};
   }
 
   std::string debug_page_table_info(uint32_t vmid, uint64_t page_key) const {
@@ -338,6 +435,8 @@ public:
   }
 
 private:
+  friend class GpuMemoryTestAccess;
+
   // The largest supported atomic is eight bytes, so discard the three byte
   // offset bits before choosing a lock stripe.
   static constexpr unsigned kBackingAtomicGranuleShift = 3;
@@ -351,27 +450,43 @@ private:
   static_assert((kBackingAtomicLockStripes & (kBackingAtomicLockStripes - 1)) == 0,
                 "atomic lock stripe count must be a power of two");
 
-  static std::mutex &backing_atomic_mutex(uintptr_t key) {
+  static auto &backing_atomic_mutexes() {
     static std::array<std::mutex, kBackingAtomicLockStripes> mutexes;
+    return mutexes;
+  }
+
+  static size_t backing_atomic_mutex_index(uintptr_t key) {
     key >>= kBackingAtomicGranuleShift;
     key ^= key >> kBackingAtomicHashFoldShift1;
     key ^= key >> kBackingAtomicHashFoldShift2;
-    return mutexes[key & (mutexes.size() - 1)];
+    return key & (kBackingAtomicLockStripes - 1);
   }
 
-  template <typename F> static void atomic_rmw_mapped(uint64_t addr, uint8_t *page, F &fn) {
-    uint8_t *target = page + (addr & PAGE_MASK);
+  static std::mutex &backing_atomic_mutex_at(size_t index) {
+    return backing_atomic_mutexes()[index];
+  }
+
+  static std::mutex &backing_atomic_mutex(uintptr_t key) {
+    return backing_atomic_mutex_at(backing_atomic_mutex_index(key));
+  }
+
+  template <typename F> static void atomic_rmw_mapped(uint8_t *target, F &fn) {
     std::lock_guard lock(backing_atomic_mutex(reinterpret_cast<uintptr_t>(target)));
     fn(target);
   }
 
   template <typename F>
   void atomic_rmw_unmapped(uint64_t addr, uint32_t size, pid_t client_pid, F &fn) {
-    auto *page = reinterpret_cast<uint8_t *>(addr & ~PAGE_MASK);
-    if (passthrough_ && addr < kUserSpaceLimit && page != nullptr)
-      atomic_rmw_mapped(addr, page, fn);
-    else
-      atomic_rmw_fallback(addr, size, client_pid, fn);
+    auto *target = reinterpret_cast<uint8_t *>(addr);
+    if (passthrough_ && addr < kUserSpaceLimit && size <= kUserSpaceLimit - addr &&
+        target != nullptr) {
+      if (addressable_prefix(target, size) == size)
+        atomic_rmw_mapped(target, fn);
+      else
+        atomic_rmw_discarded(fn);
+      return;
+    }
+    atomic_rmw_fallback(addr, size, client_pid, fn);
   }
 
   template <typename F>
@@ -401,6 +516,75 @@ private:
       simdojo::SparseMemory::write8(addr + i, value[i]);
   }
 
+  template <typename F>
+  static bool atomic_rmw_mapped_page(const KfdProcess::PageTableEntry &pte, size_t page_offset,
+                                     size_t size, F &fn) {
+    const auto *extent = host_extent_at(pte, page_offset);
+    if (extent && size <= extent->host_backed_bytes - (page_offset - extent->gpu_page_offset)) {
+      auto *target = extent->host_ptr + (page_offset - extent->gpu_page_offset);
+      if (addressable_prefix(target, size) == size) {
+        atomic_rmw_mapped(target, fn);
+        return true;
+      }
+    }
+
+    struct AtomicSpan {
+      size_t value_offset = 0;
+      uint8_t *host_ptr = nullptr;
+      size_t size = 0;
+    };
+    std::array<AtomicSpan, sizeof(uint64_t)> spans{};
+    size_t span_count = 0;
+    const size_t mapped_bytes = for_each_mapped_span(
+        pte, page_offset, size, [&](size_t value_offset, uint8_t *host_ptr, size_t span_size) {
+          assert(span_count < spans.size());
+          spans[span_count++] = {value_offset, host_ptr, span_size};
+        });
+    if (span_count == 0) {
+      atomic_rmw_discarded(fn);
+      return false;
+    }
+
+    std::array<size_t, sizeof(uint64_t)> lock_indices{};
+    lock_indices.fill(kBackingAtomicLockStripes);
+    for (size_t i = 0; i < span_count; ++i) {
+      for (size_t byte = 0; byte < spans[i].size; ++byte) {
+        const size_t index =
+            backing_atomic_mutex_index(reinterpret_cast<uintptr_t>(spans[i].host_ptr + byte));
+        if (std::find(lock_indices.begin(), lock_indices.end(), index) != lock_indices.end())
+          continue;
+        auto free_slot =
+            std::find(lock_indices.begin(), lock_indices.end(), kBackingAtomicLockStripes);
+        if (free_slot == lock_indices.end()) {
+          atomic_rmw_discarded(fn);
+          return false;
+        }
+        *free_slot = index;
+      }
+    }
+    std::sort(lock_indices.begin(), lock_indices.end());
+    std::array<std::unique_lock<std::mutex>, sizeof(uint64_t)> locks;
+    size_t lock_count = 0;
+    while (lock_count < lock_indices.size() &&
+           lock_indices[lock_count] != kBackingAtomicLockStripes) {
+      const size_t i = lock_count++;
+      locks[i] = std::unique_lock(backing_atomic_mutex_at(lock_indices[i]));
+    }
+
+    std::array<uint8_t, sizeof(uint64_t)> value{};
+    for (size_t i = 0; i < span_count; ++i)
+      std::memcpy(value.data() + spans[i].value_offset, spans[i].host_ptr, spans[i].size);
+    fn(value.data());
+    for (size_t i = 0; i < span_count; ++i)
+      std::memcpy(spans[i].host_ptr, value.data() + spans[i].value_offset, spans[i].size);
+    return mapped_bytes == size;
+  }
+
+  template <typename F> static void atomic_rmw_discarded(F &fn) {
+    std::array<uint8_t, sizeof(uint64_t)> value{};
+    fn(value.data());
+  }
+
   template <typename F> static void for_each_page_chunk(uint64_t addr, size_t len, F &&fn) {
     size_t offset = 0;
     while (offset < len) {
@@ -412,6 +596,101 @@ private:
   }
 
   static constexpr uint64_t kUserSpaceLimit = 0x800000000000ULL;
+
+  static size_t addressable_prefix(const uint8_t *ptr, size_t len) {
+    if (ptr == nullptr)
+      return 0;
+#if defined(RJ_GPU_MEMORY_WITH_ASAN)
+    if (auto *poisoned = static_cast<const uint8_t *>(
+            __asan_region_is_poisoned(const_cast<uint8_t *>(ptr), len)))
+      return static_cast<size_t>(poisoned - ptr);
+#endif
+    return len;
+  }
+
+  static std::pair<uint8_t *, size_t> addressable_range_containing(uint8_t *base, size_t len,
+                                                                   uint8_t *address) {
+    if (base == nullptr || address < base || static_cast<size_t>(address - base) >= len)
+      return {nullptr, 0};
+#if defined(RJ_GPU_MEMORY_WITH_ASAN)
+    len = heap_allocation_bounded_length(base, len);
+    if (static_cast<size_t>(address - base) >= len)
+      return {nullptr, 0};
+    if (__asan_address_is_poisoned(address))
+      return {nullptr, 0};
+    auto *begin = address;
+    constexpr size_t kBackwardProbeBytes = 4096;
+    while (begin > base) {
+      auto *chunk_begin = begin - std::min<size_t>(begin - base, kBackwardProbeBytes);
+      if (__asan_region_is_poisoned(chunk_begin, begin - chunk_begin) == nullptr) {
+        begin = chunk_begin;
+        continue;
+      }
+      while (begin > chunk_begin && !__asan_address_is_poisoned(begin - 1))
+        --begin;
+      break;
+    }
+    auto *limit = base + len;
+    auto *end = address + addressable_prefix(address, limit - address);
+    return {begin, static_cast<size_t>(end - begin)};
+#else
+    return {base, len};
+#endif
+  }
+
+  template <typename F>
+  static void for_each_bounded_addressable_span(uint8_t *base, size_t len, F &&fn) {
+    if (base == nullptr || len == 0)
+      return;
+#if defined(RJ_GPU_MEMORY_WITH_ASAN)
+    size_t offset = 0;
+    while (offset < len) {
+      auto *poisoned =
+          static_cast<uint8_t *>(__asan_region_is_poisoned(base + offset, len - offset));
+      if (poisoned == nullptr) {
+        fn(offset, len - offset);
+        break;
+      }
+      const size_t poisoned_offset = poisoned - base;
+      if (offset < poisoned_offset)
+        fn(offset, poisoned_offset - offset);
+      offset = poisoned_offset;
+      while (offset < len && __asan_address_is_poisoned(base + offset))
+        ++offset;
+    }
+#else
+    fn(0, len);
+#endif
+  }
+
+  template <typename F> static void for_each_addressable_span(uint8_t *base, size_t len, F &&fn) {
+    if (base == nullptr || len == 0)
+      return;
+#if defined(RJ_GPU_MEMORY_WITH_ASAN)
+    len = heap_allocation_bounded_length(base, len);
+#endif
+    for_each_bounded_addressable_span(base, len, std::forward<F>(fn));
+  }
+
+  static size_t heap_allocation_bounded_length([[maybe_unused]] uint8_t *base, size_t len) {
+#if defined(RJ_GPU_MEMORY_WITH_ASAN)
+    std::array<char, 1> name{};
+    void *region_address = nullptr;
+    size_t region_size = 0;
+    const char *region_kind =
+        __asan_locate_address(base, name.data(), name.size(), &region_address, &region_size);
+    // GCC's ASan can report stack-variable metadata from the current thread for
+    // an address on another thread's stack. Its global shadow remains accurate,
+    // so only use allocator metadata to bound actual heap allocations.
+    const auto base_address = reinterpret_cast<uintptr_t>(base);
+    const auto region_begin = reinterpret_cast<uintptr_t>(region_address);
+    if (region_kind != nullptr && std::strcmp(region_kind, "heap") == 0 &&
+        region_address != nullptr && base_address >= region_begin &&
+        base_address - region_begin < region_size)
+      return std::min(len, region_size - (base_address - region_begin));
+#endif
+    return len;
+  }
 
   struct VmidEntry {
     KfdProcess::PageTable *page_table = nullptr;
@@ -433,6 +712,60 @@ private:
     std::shared_mutex *mutex = nullptr;
     const uint64_t *generation_ptr = nullptr;
   };
+
+  static const KfdProcess::HostExtent *host_extent_at(const KfdProcess::PageTableEntry &pte,
+                                                      size_t page_offset) {
+    for (const auto &extent : pte.host_extents) {
+      if (page_offset >= extent.gpu_page_offset &&
+          page_offset - extent.gpu_page_offset < extent.host_backed_bytes)
+        return &extent;
+    }
+    return nullptr;
+  }
+
+  static const KfdProcess::HostExtent *
+  host_extent_starting_at_page(const KfdProcess::PageTableEntry &pte) {
+    return !pte.host_extents.empty() && pte.host_extents.front().gpu_page_offset == 0
+               ? &pte.host_extents.front()
+               : nullptr;
+  }
+
+  static const KfdProcess::HostExtent *
+  host_extent_ending_at_page(const KfdProcess::PageTableEntry &pte) {
+    if (pte.host_extents.empty())
+      return nullptr;
+    const auto &extent = pte.host_extents.back();
+    return extent.gpu_page_offset + extent.host_backed_bytes == PAGE_SIZE ? &extent : nullptr;
+  }
+
+  template <typename F>
+  static size_t for_each_mapped_span(const KfdProcess::PageTableEntry &pte, size_t access_begin,
+                                     size_t len, F &&fn) {
+    const size_t access_end = access_begin + len;
+    size_t mapped_bytes = 0;
+    for (const auto &extent : pte.host_extents) {
+      const size_t extent_begin = extent.gpu_page_offset;
+      const size_t extent_end = extent_begin + extent.host_backed_bytes;
+      const size_t overlap_begin = std::max(access_begin, extent_begin);
+      const size_t overlap_end = std::min(access_end, extent_end);
+      if (overlap_begin >= overlap_end)
+        continue;
+      auto *host_begin = extent.host_ptr + (overlap_begin - extent_begin);
+      for_each_bounded_addressable_span(
+          host_begin, overlap_end - overlap_begin, [&](size_t span_offset, size_t span_size) {
+            mapped_bytes += span_size;
+            fn(overlap_begin - access_begin + span_offset, host_begin + span_offset, span_size);
+          });
+    }
+    return mapped_bytes;
+  }
+
+  void note_clipped_mapped_access(const char *operation, uint64_t addr, size_t size,
+                                  uint32_t vmid) const {
+    const uint64_t count = clipped_mapped_accesses_.fetch_add(1, std::memory_order_relaxed) + 1;
+    util::Logger::vm("GPU memory ", operation, " clipped: addr=0x", std::hex, addr, std::dec,
+                     " size=", size, " vmid=", vmid, " count=", count);
+  }
 
   /// @brief Walk a VMID page table with a generation-keyed thread-local cache.
   /// @details The callback runs while both VMID registration and the selected
@@ -476,33 +809,40 @@ private:
       cache.found = it != cache.page_table->end();
       if (cache.found)
         cache.pte = it->second;
+#if defined(RJ_GPU_MEMORY_WITH_ASAN)
+      if (cache.found) {
+        for (auto &extent : cache.pte.host_extents)
+          extent.host_backed_bytes =
+              heap_allocation_bounded_length(extent.host_ptr, extent.host_backed_bytes);
+      }
+#endif
     }
 
     return fn(cache.found ? &cache.pte : nullptr);
   }
 
-  template <typename F> bool with_host_ptr(uint64_t addr, uint32_t vmid, F &&fn) const {
+  template <typename F> bool with_page_mapping(uint64_t addr, uint32_t vmid, F &&fn) const {
     if (vmid == 0) {
       auto *page = reinterpret_cast<uint8_t *>(addr & ~PAGE_MASK);
       if (!passthrough_ || addr >= kUserSpaceLimit || page == nullptr)
         return false;
-      fn(page);
+      fn(nullptr, page);
       return true;
     }
 
     static thread_local PteCache cache;
     return cached_walk(addr, vmid, cache, [&](const KfdProcess::PageTableEntry *pte) {
       if (pte) {
-        if (pte->host_ptr == nullptr)
+        if (pte->host_extents.empty())
           return false;
-        fn(pte->host_ptr);
+        fn(pte, nullptr);
         return true;
       }
       if (passthrough_ && addr < kUserSpaceLimit) {
         auto *page = reinterpret_cast<uint8_t *>(addr & ~PAGE_MASK);
         if (page == nullptr)
           return false;
-        fn(page);
+        fn(nullptr, page);
         return true;
       }
       return false;
@@ -512,20 +852,76 @@ private:
   bool read_mapped(uint64_t addr, void *dst, size_t len, uint32_t vmid) const {
     if ((addr & PAGE_MASK) + len > PAGE_SIZE)
       return false;
-    return with_host_ptr(
-        addr, vmid, [&](const uint8_t *page) { std::memcpy(dst, page + (addr & PAGE_MASK), len); });
+    std::memset(dst, 0, len);
+    return with_page_mapping(
+        addr, vmid, [&](const KfdProcess::PageTableEntry *pte, uint8_t *passthrough_page) {
+          const size_t access_begin = addr & PAGE_MASK;
+          if (pte) {
+            const size_t mapped_bytes = for_each_mapped_span(
+                *pte, access_begin, len,
+                [&](size_t value_offset, uint8_t *host_ptr, size_t span_size) {
+                  std::memcpy(static_cast<uint8_t *>(dst) + value_offset, host_ptr, span_size);
+                });
+            if (mapped_bytes != len)
+              note_clipped_mapped_access("read", addr, len, vmid);
+            return;
+          }
+          auto *host_ptr = passthrough_page + access_begin;
+          for_each_addressable_span(host_ptr, len, [&](size_t value_offset, size_t span_size) {
+            std::memcpy(static_cast<uint8_t *>(dst) + value_offset, host_ptr + value_offset,
+                        span_size);
+          });
+        });
   }
 
   bool write_mapped(uint64_t addr, const void *src, size_t len, uint32_t vmid) {
     if ((addr & PAGE_MASK) + len > PAGE_SIZE)
       return false;
-    return with_host_ptr(addr, vmid,
-                         [&](uint8_t *page) { std::memcpy(page + (addr & PAGE_MASK), src, len); });
+    return with_page_mapping(
+        addr, vmid, [&](const KfdProcess::PageTableEntry *pte, uint8_t *passthrough_page) {
+          const size_t access_begin = addr & PAGE_MASK;
+          if (pte) {
+            const size_t mapped_bytes = for_each_mapped_span(
+                *pte, access_begin, len,
+                [&](size_t value_offset, uint8_t *host_ptr, size_t span_size) {
+                  std::memcpy(host_ptr, static_cast<const uint8_t *>(src) + value_offset,
+                              span_size);
+                });
+            if (mapped_bytes != len)
+              note_clipped_mapped_access("write", addr, len, vmid);
+            return;
+          }
+          auto *host_ptr = passthrough_page + access_begin;
+          for_each_addressable_span(host_ptr, len, [&](size_t value_offset, size_t span_size) {
+            std::memcpy(host_ptr + value_offset, static_cast<const uint8_t *>(src) + value_offset,
+                        span_size);
+          });
+        });
   }
 
-  uint8_t *translate(uint64_t addr, uint32_t vmid) const {
+  uint8_t *translate(uint64_t addr, uint32_t vmid, size_t size) const {
+    if (size == 0 || (addr & PAGE_MASK) + size > PAGE_SIZE)
+      return nullptr;
     uint8_t *host_ptr = nullptr;
-    with_host_ptr(addr, vmid, [&](uint8_t *page) { host_ptr = page; });
+    with_page_mapping(
+        addr, vmid, [&](const KfdProcess::PageTableEntry *pte, uint8_t *passthrough_page) {
+          const size_t page_offset = addr & PAGE_MASK;
+          if (pte) {
+            const auto *extent = host_extent_at(*pte, page_offset);
+            if (!extent ||
+                size > extent->host_backed_bytes - (page_offset - extent->gpu_page_offset))
+              return;
+            auto *candidate = extent->host_ptr + (page_offset - extent->gpu_page_offset);
+            if (addressable_prefix(candidate, size) == size)
+              host_ptr = candidate;
+            return;
+          }
+          if (addr >= kUserSpaceLimit || size > kUserSpaceLimit - addr)
+            return;
+          auto *candidate = passthrough_page + page_offset;
+          if (addressable_prefix(candidate, size) == size)
+            host_ptr = candidate;
+        });
     return host_ptr;
   }
 
@@ -580,10 +976,13 @@ private:
   std::unordered_map<uint32_t, VmidEntry> vmid_table_;
   // Version of VMID-to-page-table bindings, accessed only under vmid_mutex_.
   uint64_t vmid_registry_generation_ = 1;
+  mutable std::atomic<uint64_t> clipped_mapped_accesses_{0};
   bool passthrough_ = false;
 };
 
 } // namespace amdgpu
 } // namespace rocjitsu
+
+#undef RJ_GPU_MEMORY_WITH_ASAN
 
 #endif // ROCJITSU_VM_AMDGPU_GPU_MEMORY_H_

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -50,6 +50,29 @@ RJ_DIAGNOSTIC_POP
 #include <unistd.h>
 #include <vector>
 
+#if defined(__SANITIZE_ADDRESS__)
+#define RJ_AMDGPU_VM_TEST_WITH_ASAN 1
+#elif defined(__has_feature)
+#if __has_feature(address_sanitizer)
+#define RJ_AMDGPU_VM_TEST_WITH_ASAN 1
+#endif
+#endif
+
+#if defined(RJ_AMDGPU_VM_TEST_WITH_ASAN)
+#include <sanitizer/asan_interface.h>
+#endif
+
+namespace rocjitsu::amdgpu {
+
+class GpuMemoryTestAccess {
+public:
+  static std::mutex *backing_atomic_mutex_for(const void *address) {
+    return &GpuMemory::backing_atomic_mutex(reinterpret_cast<uintptr_t>(address));
+  }
+};
+
+} // namespace rocjitsu::amdgpu
+
 namespace {
 
 // SOPP encoding: bits[31:23] = 0x17F (SOPP prefix), bits[22:16] = op.
@@ -498,7 +521,7 @@ TEST(GpuMemoryTest, VmidMappedKernelSymbolUsesTranslatedHostPointer) {
   // the descriptor offset recorded in .dynsym.
   auto *mapped_page = mem.translate_debug(kernel_object, process.process_id());
   ASSERT_NE(mapped_page, nullptr);
-  auto *kernel_object_host = mapped_page + (kernel_object & amdgpu::GpuMemory::PAGE_MASK);
+  auto *kernel_object_host = mapped_page;
 
   EXPECT_NE(reinterpret_cast<uint64_t>(kernel_object_host), kernel_object);
   EXPECT_EQ(find_kernel_symbol(kernel_object_host, reinterpret_cast<const uint8_t *>(host_base),
@@ -522,7 +545,7 @@ TEST(GpuMemoryTest, UnregisterInvalidatesThreadLocalTranslationCaches) {
   memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
                           process.page_table_generation());
 
-  EXPECT_EQ(memory.resolve_host_ptr(kAddr, kPid), page.data());
+  EXPECT_EQ(memory.resolve_host_ptr(kAddr, kPid), page.data() + kOffset);
   EXPECT_EQ(memory.read8(kAddr, kPid), page[kOffset]);
   EXPECT_EQ(memory.pte_mtype(kAddr, kPid), amdgpu::Mtype::UC);
 
@@ -550,13 +573,13 @@ TEST(GpuMemoryTest, ReregisterProcessInvalidatesThreadLocalTranslationCaches) {
 
   memory.register_process(kPid, &first_process.page_table_, &first_process.page_table_mutex_,
                           first_process.page_table_generation());
-  ASSERT_EQ(memory.resolve_host_ptr(kAddr, kPid), first_page.data());
+  ASSERT_EQ(memory.resolve_host_ptr(kAddr, kPid), first_page.data() + kOffset);
   ASSERT_EQ(memory.read8(kAddr, kPid), first_page[kOffset]);
   ASSERT_EQ(memory.pte_mtype(kAddr, kPid), amdgpu::Mtype::UC);
 
   memory.register_process(kPid, &second_process.page_table_, &second_process.page_table_mutex_,
                           second_process.page_table_generation());
-  EXPECT_EQ(memory.resolve_host_ptr(kAddr, kPid), second_page.data());
+  EXPECT_EQ(memory.resolve_host_ptr(kAddr, kPid), second_page.data() + kOffset);
   EXPECT_EQ(memory.read8(kAddr, kPid), second_page[kOffset]);
   EXPECT_EQ(memory.pte_mtype(kAddr, kPid), amdgpu::Mtype::CC);
 }
@@ -586,6 +609,442 @@ TEST(GpuMemoryTest, PageTableEntryMutationsInvalidateCachedPtes) {
   process.set_page_mtype(kBaseVa, new_page.size(), amdgpu::Mtype::CC);
   EXPECT_EQ(memory.pte_mtype(kAddr, kPid), amdgpu::Mtype::CC);
 }
+
+TEST(GpuMemoryTest, UnalignedMappingUsesGpuPageOffsetForHostTranslation) {
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kPid = 7;
+  constexpr uint64_t kBaseVa = 0x40000800;
+  constexpr size_t kMappingSize = KfdProcess::kPageSize;
+
+  KfdProcess process(kPid);
+  std::array<uint8_t, kMappingSize> allocation{};
+  allocation.front() = 0x11;
+  allocation.back() = 0x22;
+  process.map_pages(kBaseVa, allocation.data(), allocation.size());
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  EXPECT_EQ(memory.read8(kBaseVa, kPid), 0x11);
+  EXPECT_EQ(memory.read8(kBaseVa + kMappingSize - 1, kPid), 0x22);
+  EXPECT_EQ(memory.resolve_host_ptr(kBaseVa, kPid, kMappingSize), allocation.data());
+  EXPECT_EQ(memory.resolve_host_ptr(kBaseVa, kPid), allocation.data());
+  EXPECT_EQ(memory.resolve_host_ptr(kBaseVa + kMappingSize - 1, kPid),
+            allocation.data() + kMappingSize - 1);
+  EXPECT_EQ(memory.find_host_range(kBaseVa + kMappingSize - 1, kPid),
+            std::make_pair(reinterpret_cast<uint64_t>(allocation.data()),
+                           static_cast<uint64_t>(kMappingSize)));
+
+  memory.write8(kBaseVa + kMappingSize - 1, 0x33, kPid);
+  EXPECT_EQ(allocation.back(), 0x33);
+
+  process.unmap_pages(kBaseVa, kMappingSize);
+  EXPECT_EQ(memory.resolve_host_ptr(kBaseVa, kPid), nullptr);
+  EXPECT_EQ(memory.resolve_host_ptr(kBaseVa + kMappingSize - 1, kPid), nullptr);
+}
+
+TEST(GpuMemoryTest, PartialMappedPageReadsZeroFillAndWritesClipToAllocation) {
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kPid = 7;
+  constexpr uint64_t kBaseVa = 0x40000000;
+  constexpr size_t kAllocationSize = 24;
+  constexpr size_t kCacheLineSize = 64;
+
+  KfdProcess process(kPid);
+  std::array<uint8_t, kAllocationSize> allocation{};
+  for (size_t i = 0; i < allocation.size(); ++i)
+    allocation[i] = static_cast<uint8_t>(i + 1);
+  process.map_pages(kBaseVa, allocation.data(), allocation.size());
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  EXPECT_EQ(memory.resolve_host_ptr(kBaseVa + kAllocationSize - 1, kPid),
+            allocation.data() + kAllocationSize - 1);
+  EXPECT_EQ(memory.resolve_host_ptr(kBaseVa + kAllocationSize - 1, kPid, 2), nullptr);
+  EXPECT_EQ(memory.resolve_host_ptr(kBaseVa + kAllocationSize, kPid), nullptr);
+  EXPECT_EQ(memory.find_host_range(kBaseVa + kAllocationSize - 1, kPid),
+            std::make_pair(reinterpret_cast<uint64_t>(allocation.data()),
+                           static_cast<uint64_t>(kAllocationSize)));
+  EXPECT_EQ(memory.find_host_range(kBaseVa + kAllocationSize, kPid),
+            (std::pair<uint64_t, uint64_t>{0, 0}));
+
+  constexpr size_t kAtomicOffset = 8;
+  uint32_t atomic_value = 7;
+  std::memcpy(allocation.data() + kAtomicOffset, &atomic_value, sizeof(atomic_value));
+  memory.atomic_rmw(
+      kBaseVa + kAtomicOffset, sizeof(atomic_value),
+      [](uint8_t *storage) {
+        uint32_t value = 0;
+        std::memcpy(&value, storage, sizeof(value));
+        ++value;
+        std::memcpy(storage, &value, sizeof(value));
+      },
+      kPid);
+  EXPECT_EQ(memory.read32(kBaseVa + kAtomicOffset, kPid), 8u);
+
+  uint32_t invalid_atomic_read = std::numeric_limits<uint32_t>::max();
+  memory.atomic_rmw(
+      kBaseVa + kAllocationSize, sizeof(invalid_atomic_read),
+      [&](uint8_t *storage) {
+        std::memcpy(&invalid_atomic_read, storage, sizeof(invalid_atomic_read));
+        const uint32_t replacement = 0xa5a5a5a5;
+        std::memcpy(storage, &replacement, sizeof(replacement));
+      },
+      kPid);
+  EXPECT_EQ(invalid_atomic_read, 0u);
+  EXPECT_EQ(memory.read32(kBaseVa + kAllocationSize, kPid), 0u);
+
+  constexpr size_t kStraddlingAtomicOffset = kAllocationSize - 2;
+  allocation[kStraddlingAtomicOffset] = 0x11;
+  allocation[kStraddlingAtomicOffset + 1] = 0x22;
+  std::array<uint8_t, sizeof(uint32_t)> straddling_atomic_read{};
+  memory.atomic_rmw(
+      kBaseVa + kStraddlingAtomicOffset, sizeof(uint32_t),
+      [&](uint8_t *storage) {
+        std::memcpy(straddling_atomic_read.data(), storage, straddling_atomic_read.size());
+        const std::array<uint8_t, sizeof(uint32_t)> replacement = {0x31, 0x32, 0x33, 0x34};
+        std::memcpy(storage, replacement.data(), replacement.size());
+      },
+      kPid);
+  EXPECT_EQ(straddling_atomic_read, (std::array<uint8_t, sizeof(uint32_t)>{0x11, 0x22, 0, 0}));
+  EXPECT_EQ(allocation[kStraddlingAtomicOffset], 0x31);
+  EXPECT_EQ(allocation[kStraddlingAtomicOffset + 1], 0x32);
+
+  std::array<uint8_t, kCacheLineSize> cache_line{};
+  memory.read_block(kBaseVa, std::span<uint8_t>(cache_line), kPid);
+  EXPECT_TRUE(std::equal(allocation.begin(), allocation.end(), cache_line.begin()));
+  EXPECT_TRUE(std::all_of(cache_line.begin() + kAllocationSize, cache_line.end(),
+                          [](uint8_t value) { return value == 0; }));
+
+  std::array<uint8_t, kCacheLineSize> replacement{};
+  replacement.fill(0xa5);
+  memory.write_block(kBaseVa, std::span<const uint8_t>(replacement), kPid);
+  EXPECT_TRUE(std::all_of(allocation.begin(), allocation.end(),
+                          [](uint8_t value) { return value == 0xa5; }));
+}
+
+TEST(GpuMemoryTest, SamePageMappingsRemainIndependent) {
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kPid = 7;
+  constexpr uint64_t kPageVa = 0x40000000;
+  constexpr uint64_t kFirstVa = kPageVa + 0x100;
+  constexpr uint64_t kSecondVa = kPageVa + 0x300;
+
+  KfdProcess process(kPid);
+  std::array<uint8_t, 32> first{};
+  std::array<uint8_t, 32> second{};
+  first.fill(0x11);
+  second.fill(0x22);
+  process.map_pages(kFirstVa, first.data(), first.size());
+  process.map_pages(kSecondVa, second.data(), second.size());
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  EXPECT_EQ(memory.read8(kFirstVa, kPid), 0x11);
+  EXPECT_EQ(memory.read8(kSecondVa, kPid), 0x22);
+  EXPECT_EQ(memory.resolve_host_ptr(kFirstVa, kPid, first.size()), first.data());
+  EXPECT_EQ(memory.resolve_host_ptr(kSecondVa, kPid, second.size()), second.data());
+
+  process.unmap_pages(kFirstVa, first.size());
+  EXPECT_EQ(memory.resolve_host_ptr(kFirstVa, kPid), nullptr);
+  EXPECT_EQ(memory.resolve_host_ptr(kSecondVa, kPid, second.size()), second.data());
+  memory.write8(kSecondVa, 0x33, kPid);
+  EXPECT_EQ(second.front(), 0x33);
+}
+
+TEST(GpuMemoryThreadingTest, SplitMappedAtomicLocksEveryBackingStripe) {
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kPid = 7;
+  constexpr uint64_t kAtomicVa = 0x40000100;
+
+  KfdProcess process(kPid);
+  alignas(8) std::array<uint8_t, sizeof(uint64_t)> first_backing = {1, 2, 3, 4, 5, 6, 7, 8};
+  alignas(8) std::array<uint8_t, KfdProcess::kPageSize> second_pool{};
+  auto *first_mutex = amdgpu::GpuMemoryTestAccess::backing_atomic_mutex_for(first_backing.data());
+  uint8_t *second_backing = nullptr;
+  for (size_t offset = 0; offset + sizeof(uint32_t) <= second_pool.size(); offset += 8) {
+    auto *candidate = second_pool.data() + offset;
+    if (amdgpu::GpuMemoryTestAccess::backing_atomic_mutex_for(candidate) != first_mutex) {
+      second_backing = candidate;
+      break;
+    }
+  }
+  ASSERT_NE(second_backing, nullptr);
+  std::copy_n(first_backing.begin() + sizeof(uint32_t), sizeof(uint32_t), second_backing);
+
+  process.map_pages(kAtomicVa, first_backing.data(), sizeof(uint32_t));
+  process.map_pages(kAtomicVa + sizeof(uint32_t), second_backing, sizeof(uint32_t));
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  bool second_stripe_locked = false;
+  std::array<uint8_t, sizeof(uint64_t)> observed{};
+  const std::array<uint8_t, sizeof(uint64_t)> replacement = {8, 7, 6, 5, 4, 3, 2, 1};
+  memory.atomic_rmw(
+      kAtomicVa, sizeof(uint64_t),
+      [&](uint8_t *storage) {
+        std::memcpy(observed.data(), storage, observed.size());
+        std::thread probe([&] {
+          auto *second_mutex =
+              amdgpu::GpuMemoryTestAccess::backing_atomic_mutex_for(second_backing);
+          if (second_mutex->try_lock()) {
+            second_mutex->unlock();
+            return;
+          }
+          second_stripe_locked = true;
+        });
+        probe.join();
+        std::memcpy(storage, replacement.data(), replacement.size());
+      },
+      kPid);
+
+  EXPECT_TRUE(second_stripe_locked);
+  EXPECT_EQ(observed, (std::array<uint8_t, sizeof(uint64_t)>{1, 2, 3, 4, 5, 6, 7, 8}));
+  EXPECT_TRUE(std::equal(replacement.begin(), replacement.begin() + sizeof(uint32_t),
+                         first_backing.begin()));
+  EXPECT_TRUE(
+      std::equal(replacement.begin() + sizeof(uint32_t), replacement.end(), second_backing));
+}
+
+TEST(GpuMemoryTest, IdentityMappedEntryStillEnforcesItsExtent) {
+  amdgpu::GpuMemory memory("memory");
+  memory.set_passthrough(true);
+  constexpr uint32_t kPid = 7;
+  constexpr size_t kAllocationSize = 32;
+
+  KfdProcess process(kPid);
+  alignas(KfdProcess::kPageSize) std::array<uint8_t, KfdProcess::kPageSize> backing{};
+  const uint64_t gpu_va = reinterpret_cast<uint64_t>(backing.data());
+  process.map_pages(gpu_va, backing.data(), kAllocationSize);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  EXPECT_EQ(memory.resolve_host_ptr(gpu_va, kPid, kAllocationSize), backing.data());
+  EXPECT_EQ(memory.resolve_host_ptr(gpu_va, kPid, kAllocationSize + 1), nullptr);
+  EXPECT_EQ(memory.resolve_host_ptr(gpu_va + kAllocationSize, kPid), nullptr);
+}
+
+#if defined(RJ_AMDGPU_VM_TEST_WITH_ASAN)
+TEST(GpuMemoryTest, SanitizedCacheLineAccessClipsRoundedMapping) {
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kPid = 7;
+  constexpr uint64_t kBaseVa = 0x40000000;
+  constexpr size_t kAllocationSize = 24;
+  constexpr size_t kCacheLineSize = 64;
+
+  KfdProcess process(kPid);
+  auto allocation = std::make_unique<uint8_t[]>(kAllocationSize);
+  std::fill_n(allocation.get(), kAllocationSize, 0x5a);
+  process.map_pages(kBaseVa, allocation.get(), KfdProcess::kPageSize);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  EXPECT_EQ(memory.resolve_host_ptr(kBaseVa + kAllocationSize - 1, kPid),
+            allocation.get() + kAllocationSize - 1);
+  EXPECT_EQ(memory.resolve_host_ptr(kBaseVa + kAllocationSize - 1, kPid, 2), nullptr);
+  EXPECT_EQ(memory.resolve_host_ptr(kBaseVa + kAllocationSize, kPid), nullptr);
+  EXPECT_EQ(memory.find_host_range(kBaseVa + kAllocationSize - 1, kPid),
+            std::make_pair(reinterpret_cast<uint64_t>(allocation.get()),
+                           static_cast<uint64_t>(kAllocationSize)));
+  EXPECT_EQ(memory.find_host_range(kBaseVa + kAllocationSize, kPid),
+            (std::pair<uint64_t, uint64_t>{0, 0}));
+
+  constexpr size_t kAtomicOffset = 8;
+  uint32_t atomic_value = 7;
+  std::memcpy(allocation.get() + kAtomicOffset, &atomic_value, sizeof(atomic_value));
+  memory.atomic_rmw(
+      kBaseVa + kAtomicOffset, sizeof(atomic_value),
+      [](uint8_t *storage) {
+        uint32_t value = 0;
+        std::memcpy(&value, storage, sizeof(value));
+        ++value;
+        std::memcpy(storage, &value, sizeof(value));
+      },
+      kPid);
+  EXPECT_EQ(memory.read32(kBaseVa + kAtomicOffset, kPid), 8u);
+
+  uint32_t invalid_atomic_read = std::numeric_limits<uint32_t>::max();
+  memory.atomic_rmw(
+      kBaseVa + kAllocationSize, sizeof(invalid_atomic_read),
+      [&](uint8_t *storage) {
+        std::memcpy(&invalid_atomic_read, storage, sizeof(invalid_atomic_read));
+        const uint32_t replacement = 0xa5a5a5a5;
+        std::memcpy(storage, &replacement, sizeof(replacement));
+      },
+      kPid);
+  EXPECT_EQ(invalid_atomic_read, 0u);
+  EXPECT_EQ(memory.read32(kBaseVa + kAllocationSize, kPid), 0u);
+
+  constexpr size_t kStraddlingAtomicOffset = kAllocationSize - 2;
+  allocation[kStraddlingAtomicOffset] = 0x11;
+  allocation[kStraddlingAtomicOffset + 1] = 0x22;
+  std::array<uint8_t, sizeof(uint32_t)> straddling_atomic_read{};
+  memory.atomic_rmw(
+      kBaseVa + kStraddlingAtomicOffset, sizeof(uint32_t),
+      [&](uint8_t *storage) {
+        std::memcpy(straddling_atomic_read.data(), storage, straddling_atomic_read.size());
+        const std::array<uint8_t, sizeof(uint32_t)> replacement = {0x31, 0x32, 0x33, 0x34};
+        std::memcpy(storage, replacement.data(), replacement.size());
+      },
+      kPid);
+  EXPECT_EQ(straddling_atomic_read, (std::array<uint8_t, sizeof(uint32_t)>{0x11, 0x22, 0, 0}));
+  EXPECT_EQ(allocation[kStraddlingAtomicOffset], 0x31);
+  EXPECT_EQ(allocation[kStraddlingAtomicOffset + 1], 0x32);
+
+  std::fill_n(allocation.get(), kAllocationSize, 0x5a);
+  std::array<uint8_t, kCacheLineSize> cache_line{};
+  memory.read_block(kBaseVa, std::span<uint8_t>(cache_line), kPid);
+  EXPECT_TRUE(std::all_of(cache_line.begin(), cache_line.begin() + kAllocationSize,
+                          [](uint8_t value) { return value == 0x5a; }));
+  EXPECT_TRUE(std::all_of(cache_line.begin() + kAllocationSize, cache_line.end(),
+                          [](uint8_t value) { return value == 0; }));
+
+  cache_line.fill(0xa5);
+  memory.write_block(kBaseVa, std::span<const uint8_t>(cache_line), kPid);
+  EXPECT_TRUE(std::all_of(allocation.get(), allocation.get() + kAllocationSize,
+                          [](uint8_t value) { return value == 0xa5; }));
+
+  constexpr size_t kRemappedAllocationSize = 8;
+  auto remapped_allocation = std::make_unique<uint8_t[]>(kRemappedAllocationSize);
+  std::fill_n(remapped_allocation.get(), kRemappedAllocationSize, 0x3c);
+  process.remap_page_host_ptrs(kBaseVa, allocation.get(), remapped_allocation.get(),
+                               KfdProcess::kPageSize);
+
+  cache_line.fill(0xff);
+  memory.read_block(kBaseVa, std::span<uint8_t>(cache_line), kPid);
+  EXPECT_TRUE(std::all_of(cache_line.begin(), cache_line.begin() + kRemappedAllocationSize,
+                          [](uint8_t value) { return value == 0x3c; }));
+  EXPECT_TRUE(std::all_of(cache_line.begin() + kRemappedAllocationSize, cache_line.end(),
+                          [](uint8_t value) { return value == 0; }));
+}
+
+TEST(GpuMemoryTest, SanitizedMappedExtentTracksCurrentShadowState) {
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kPid = 7;
+  constexpr uint64_t kBaseVa = 0x40000000;
+  constexpr size_t kInitialExtentBytes = 256;
+  constexpr size_t kReducedExtentBytes = 1024;
+  constexpr size_t kAllocationSize = KfdProcess::kPageSize;
+  constexpr size_t kInitialInsideOffset = kInitialExtentBytes / 2;
+  constexpr size_t kGrowthProbeOffset = kInitialExtentBytes * 2;
+  constexpr size_t kReducedInsideOffset = kReducedExtentBytes - sizeof(uint32_t);
+  constexpr size_t kReducedOutsideOffset = kReducedExtentBytes + 512;
+  constexpr size_t kInteriorPoisonOffset = kInitialExtentBytes * 2;
+  constexpr size_t kInteriorPoisonBytes = 256;
+  constexpr size_t kLaterLiveOffset = kInteriorPoisonOffset + kInteriorPoisonBytes + 256;
+
+  KfdProcess process(kPid);
+  auto allocation = std::make_unique<uint8_t[]>(kAllocationSize);
+  std::fill_n(allocation.get(), kAllocationSize, 0);
+  process.map_pages(kBaseVa, allocation.get(), kAllocationSize);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  __asan_poison_memory_region(allocation.get() + kInitialExtentBytes,
+                              kAllocationSize - kInitialExtentBytes);
+  memory.write32(kBaseVa + kInitialInsideOffset, 0x11111111, kPid);
+  EXPECT_EQ(memory.read32(kBaseVa + kInitialInsideOffset, kPid), 0x11111111u);
+  memory.write32(kBaseVa + kGrowthProbeOffset, 0xeeeeeeee, kPid);
+  EXPECT_EQ(memory.read32(kBaseVa + kGrowthProbeOffset, kPid), 0u);
+
+  __asan_unpoison_memory_region(allocation.get() + kInitialExtentBytes,
+                                kAllocationSize - kInitialExtentBytes);
+  memory.write32(kBaseVa + kGrowthProbeOffset, 0x22222222, kPid);
+  EXPECT_EQ(memory.read32(kBaseVa + kGrowthProbeOffset, kPid), 0x22222222u);
+
+  __asan_poison_memory_region(allocation.get() + kReducedExtentBytes,
+                              kAllocationSize - kReducedExtentBytes);
+  memory.write32(kBaseVa + kReducedInsideOffset, 0x33333333, kPid);
+  EXPECT_EQ(memory.read32(kBaseVa + kReducedInsideOffset, kPid), 0x33333333u);
+  memory.write32(kBaseVa + kReducedOutsideOffset, 0xeeeeeeee, kPid);
+  EXPECT_EQ(memory.read32(kBaseVa + kReducedOutsideOffset, kPid), 0u);
+
+  __asan_poison_memory_region(allocation.get(), kAllocationSize);
+  memory.write32(kBaseVa + kInitialInsideOffset, 0xeeeeeeee, kPid);
+  EXPECT_EQ(memory.read32(kBaseVa + kInitialInsideOffset, kPid), 0u);
+
+  __asan_unpoison_memory_region(allocation.get(), kAllocationSize);
+  memory.write32(kBaseVa + kInitialInsideOffset, 0x44444444, kPid);
+  EXPECT_EQ(memory.read32(kBaseVa + kInitialInsideOffset, kPid), 0x44444444u);
+
+  __asan_poison_memory_region(allocation.get() + kInteriorPoisonOffset, kInteriorPoisonBytes);
+  memory.write32(kBaseVa + kInteriorPoisonOffset, 0xeeeeeeee, kPid);
+  EXPECT_EQ(memory.read32(kBaseVa + kInteriorPoisonOffset, kPid), 0u);
+  memory.write32(kBaseVa + kLaterLiveOffset, 0x55555555, kPid);
+  EXPECT_EQ(memory.read32(kBaseVa + kLaterLiveOffset, kPid), 0x55555555u);
+  __asan_unpoison_memory_region(allocation.get() + kInteriorPoisonOffset, kInteriorPoisonBytes);
+}
+
+TEST(GpuMemoryTest, SanitizedCacheLinePreservesLiveBytesAfterInteriorGap) {
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kPid = 7;
+  constexpr uint64_t kBaseVa = 0x40000000;
+  constexpr size_t kCacheLineSize = 64;
+  constexpr size_t kGapOffset = 16;
+  constexpr size_t kGapSize = 16;
+
+  KfdProcess process(kPid);
+  auto allocation = std::make_unique<uint8_t[]>(KfdProcess::kPageSize);
+  std::fill_n(allocation.get(), KfdProcess::kPageSize, 0x5a);
+  process.map_pages(kBaseVa, allocation.get(), KfdProcess::kPageSize);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  __asan_poison_memory_region(allocation.get() + kGapOffset, kGapSize);
+  std::array<uint8_t, kCacheLineSize> cache_line{};
+  memory.read_block(kBaseVa, cache_line, kPid);
+  EXPECT_TRUE(std::all_of(cache_line.begin(), cache_line.begin() + kGapOffset,
+                          [](uint8_t value) { return value == 0x5a; }));
+  EXPECT_TRUE(std::all_of(cache_line.begin() + kGapOffset,
+                          cache_line.begin() + kGapOffset + kGapSize,
+                          [](uint8_t value) { return value == 0; }));
+  EXPECT_TRUE(std::all_of(cache_line.begin() + kGapOffset + kGapSize, cache_line.end(),
+                          [](uint8_t value) { return value == 0x5a; }));
+
+  cache_line.fill(0xa5);
+  memory.write_block(kBaseVa, cache_line, kPid);
+  EXPECT_TRUE(std::all_of(allocation.get(), allocation.get() + kGapOffset,
+                          [](uint8_t value) { return value == 0xa5; }));
+  EXPECT_TRUE(std::all_of(allocation.get() + kGapOffset + kGapSize,
+                          allocation.get() + kCacheLineSize,
+                          [](uint8_t value) { return value == 0xa5; }));
+  __asan_unpoison_memory_region(allocation.get() + kGapOffset, kGapSize);
+}
+
+TEST(GpuMemoryTest, SanitizedCrossPageResolveIgnoresEarlierGap) {
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kPid = 7;
+  constexpr uint64_t kBaseVa = 0x40000000;
+  constexpr size_t kMappingSize = 2 * KfdProcess::kPageSize;
+
+  KfdProcess process(kPid);
+  auto allocation = std::make_unique<uint8_t[]>(kMappingSize);
+  process.map_pages(kBaseVa, allocation.get(), kMappingSize);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  __asan_poison_memory_region(allocation.get() + 256, 64);
+  constexpr size_t kResolveOffset = KfdProcess::kPageSize - 8;
+  EXPECT_EQ(memory.resolve_host_ptr(kBaseVa + kResolveOffset, kPid, 16),
+            allocation.get() + kResolveOffset);
+  __asan_unpoison_memory_region(allocation.get() + 256, 64);
+}
+
+TEST(GpuMemoryTest, SanitizedPassthroughCrossPageResolveChecksEveryPage) {
+  amdgpu::GpuMemory memory("memory");
+  memory.set_passthrough(true);
+  constexpr size_t kMappingSize = 2 * KfdProcess::kPageSize;
+
+  void *raw_mapping =
+      mmap(nullptr, kMappingSize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE(raw_mapping, MAP_FAILED);
+  auto *mapping = static_cast<uint8_t *>(raw_mapping);
+  __asan_poison_memory_region(mapping + KfdProcess::kPageSize, 8);
+  const uint64_t gpu_va = reinterpret_cast<uint64_t>(mapping + KfdProcess::kPageSize - 8);
+  EXPECT_EQ(memory.resolve_host_ptr(gpu_va, 0, 16), nullptr);
+  __asan_unpoison_memory_region(mapping + KfdProcess::kPageSize, 8);
+  EXPECT_EQ(munmap(mapping, kMappingSize), 0);
+}
+#endif
 
 TEST(GpuMemoryTest, ReusedMemoryInstanceInvalidatesThreadLocalTranslationCaches) {
   constexpr uint32_t kPid = 7;

--- a/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
+++ b/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
@@ -310,6 +310,7 @@ public:
                        queue_state_.size() * sizeof(queue_state_[0]));
     process_.map_pages(kSrcVa, src_.data(), src_.size());
     process_.map_pages(kDstVa, dst_.data(), dst_.size());
+    process_.map_pages(kDst2Va, dst2_.data(), dst2_.size());
     process_.map_pages(kSignalVa, signal_.data(), signal_.size() * sizeof(signal_[0]));
     process_.map_pages(kPollVa, poll_.data(), poll_.size() * sizeof(poll_[0]));
 
@@ -335,13 +336,33 @@ public:
   uint32_t *ring() { return ring_.data(); }
   uint8_t *src() { return src_.data(); }
   uint8_t *dst() { return dst_.data(); }
+  uint8_t *dst2() { return dst2_.data(); }
   int64_t &signal_value() { return signal_[0]; }
   uint64_t &poll_value() { return poll_[0]; }
 
   uint64_t src_va() const { return kSrcVa; }
   uint64_t dst_va() const { return kDstVa; }
+  uint64_t dst2_va() const { return kDst2Va; }
   uint64_t signal_va() const { return kSignalVa; }
   uint64_t poll_va() const { return kPollVa; }
+
+  void clip_dst_mapping(size_t size) {
+    process_.unmap_pages(kDstVa, dst_.size());
+    process_.map_pages(kDstVa, dst_.data(), size);
+  }
+
+  void unmap_src_tail_page() {
+    process_.unmap_pages(kSrcVa + KfdProcess::kPageSize, KfdProcess::kPageSize);
+  }
+
+  void unmap_dst_tail_page() {
+    process_.unmap_pages(kDstVa + KfdProcess::kPageSize, KfdProcess::kPageSize);
+  }
+
+  void remap_dst_tail_page() {
+    process_.map_pages(kDstVa + KfdProcess::kPageSize, dst_.data() + KfdProcess::kPageSize,
+                       KfdProcess::kPageSize);
+  }
 
   void submit(uint32_t dwords) {
     uint64_t write_idx = static_cast<uint64_t>(dwords) * sizeof(uint32_t);
@@ -360,16 +381,18 @@ private:
   static constexpr uint64_t kRingVa = 0x1000'0000'0000ULL;
   static constexpr uint64_t kQueueStateVa = 0x1000'0000'1000ULL;
   static constexpr uint64_t kSrcVa = 0x1000'0000'2000ULL;
-  static constexpr uint64_t kDstVa = 0x1000'0000'3000ULL;
-  static constexpr uint64_t kSignalVa = 0x1000'0000'4000ULL;
-  static constexpr uint64_t kPollVa = 0x1000'0000'5000ULL;
+  static constexpr uint64_t kDstVa = 0x1000'0000'4000ULL;
+  static constexpr uint64_t kDst2Va = 0x1000'0000'6000ULL;
+  static constexpr uint64_t kSignalVa = 0x1000'0000'8000ULL;
+  static constexpr uint64_t kPollVa = 0x1000'0000'9000ULL;
 
   Gfx1250Sim &sim_;
   KfdProcess process_;
   alignas(4096) std::array<uint32_t, 1024> ring_{};
   alignas(4096) std::array<uint64_t, 512> queue_state_{};
-  alignas(4096) std::array<uint8_t, 4096> src_{};
-  alignas(4096) std::array<uint8_t, 4096> dst_{};
+  alignas(4096) std::array<uint8_t, 8192> src_{};
+  alignas(4096) std::array<uint8_t, 8192> dst_{};
+  alignas(4096) std::array<uint8_t, 8192> dst2_{};
   alignas(4096) std::array<int64_t, 512> signal_{};
   alignas(4096) std::array<uint64_t, 512> poll_{};
   std::array<uint64_t, 1> doorbells_{};
@@ -783,6 +806,51 @@ TEST(Gfx1250SdmaTest, ConstFillSupersedesOverlappingDirtyL2Line) {
   EXPECT_NE(sim.memory->read32(queue.dst_va(), kProcessId), kStaleWord);
 }
 
+TEST(Gfx1250SdmaTest, ConstFillWritesMappedPrefixAndAdvances) {
+  Gfx1250Sim sim;
+  TranslatedSdmaQueueForTest queue(sim);
+  constexpr size_t kFillBytes = 128;
+  constexpr size_t kMappedBytes = 64;
+  constexpr uint8_t kInitialByte = 0xa5;
+  constexpr uint32_t kFillWord = 0x44332211;
+  queue.clip_dst_mapping(kMappedBytes);
+  std::fill_n(queue.dst(), kFillBytes, kInitialByte);
+
+  auto *packet = queue.ring();
+  packet[0] = kSdmaOpConstFill | (0x2u << 30); // fillsize=2 (dword granularity).
+  write_sdma_qword_va(packet, 1, 2, queue.dst_va());
+  packet[3] = kFillWord;
+  packet[4] = kFillBytes - 1;
+
+  queue.submit(5);
+  ASSERT_TRUE(sim.engine->step());
+  EXPECT_EQ(queue.read_idx(), 5u * sizeof(uint32_t));
+
+  std::array<uint8_t, sizeof(kFillWord)> pattern{};
+  std::memcpy(pattern.data(), &kFillWord, sizeof(kFillWord));
+  for (size_t i = 0; i < kMappedBytes; ++i)
+    EXPECT_EQ(queue.dst()[i], pattern[i % pattern.size()]);
+  EXPECT_TRUE(std::all_of(queue.dst() + kMappedBytes, queue.dst() + kFillBytes,
+                          [](uint8_t value) { return value == kInitialByte; }));
+}
+
+TEST(Gfx1250SdmaTest, ConstFillUnmappedTailDoesNotAdvance) {
+  Gfx1250Sim sim;
+  TranslatedSdmaQueueForTest queue(sim);
+  constexpr size_t kFillBytes = 8192;
+  queue.unmap_dst_tail_page();
+
+  auto *packet = queue.ring();
+  packet[0] = kSdmaOpConstFill | (0x2u << 30);
+  write_sdma_qword_va(packet, 1, 2, queue.dst_va());
+  packet[3] = 0x44332211;
+  packet[4] = kFillBytes - 1;
+
+  queue.submit(5);
+  ASSERT_TRUE(sim.engine->step());
+  EXPECT_EQ(queue.read_idx(), 0u);
+}
+
 // A scalar L1 (K$) can retain a clean snapshot overlapping an SDMA destination.
 // The pre-write maintenance invalidates that snapshot, and later K$ maintenance
 // must not publish it over the direct SDMA result.
@@ -1135,6 +1203,139 @@ TEST(Gfx1250SdmaTest, CopyLinearUnresolvedDstDoesNotAdvance) {
   ASSERT_TRUE(sim.engine->step());
   EXPECT_EQ(queue.read_idx(), 0u);
   EXPECT_NE(std::memcmp(queue.dst(), queue.src(), kCopyBytes), 0);
+}
+
+TEST(Gfx1250SdmaTest, CopyLinearUnmappedTailDoesNotAdvance) {
+  Gfx1250Sim sim;
+  TranslatedSdmaQueueForTest queue(sim);
+  constexpr uint32_t kCopyBytes = 8192;
+  queue.unmap_dst_tail_page();
+
+  auto *packet = queue.ring();
+  packet[0] = kSdmaOpCopy | (kSdmaSubopCopyLinear << 8);
+  packet[1] = kCopyBytes - 1;
+  write_sdma_qword_va(packet, 3, 4, queue.src_va());
+  write_sdma_qword_va(packet, 5, 6, queue.dst_va());
+
+  queue.submit(7);
+  ASSERT_TRUE(sim.engine->step());
+  EXPECT_EQ(queue.read_idx(), 0u);
+}
+
+TEST(Gfx1250SdmaTest, CopyLinearResumesAfterTailMappingIsInstalled) {
+  Gfx1250Sim sim;
+  TranslatedSdmaQueueForTest queue(sim);
+  constexpr uint32_t kCopyBytes = 8192;
+  for (uint32_t i = 0; i < kCopyBytes; ++i) {
+    queue.src()[i] = static_cast<uint8_t>((i * 31 + 11) & 0xff);
+    queue.dst()[i] = 0;
+  }
+  queue.unmap_dst_tail_page();
+
+  auto *packet = queue.ring();
+  packet[0] = kSdmaOpCopy | (kSdmaSubopCopyLinear << 8);
+  packet[1] = kCopyBytes - 1;
+  write_sdma_qword_va(packet, 3, 4, queue.src_va());
+  write_sdma_qword_va(packet, 5, 6, queue.dst_va());
+
+  queue.submit(7);
+  ASSERT_TRUE(sim.engine->step());
+  EXPECT_EQ(queue.read_idx(), 0u);
+
+  queue.remap_dst_tail_page();
+  // A page-table update is followed by the same doorbell recheck a real queue
+  // receives from its host-side monitor.
+  sim.engine->schedule_event_now(sim.cp()->doorbell_event());
+  (void)sim.engine->step();
+  EXPECT_EQ(queue.read_idx(), 7u * sizeof(uint32_t));
+  EXPECT_EQ(std::memcmp(queue.dst(), queue.src(), kCopyBytes), 0);
+}
+
+TEST(Gfx1250SdmaTest, CopyLinearUnmappedSourceTailDoesNotAdvance) {
+  Gfx1250Sim sim;
+  TranslatedSdmaQueueForTest queue(sim);
+  constexpr uint32_t kCopyBytes = 8192;
+  queue.unmap_src_tail_page();
+
+  auto *packet = queue.ring();
+  packet[0] = kSdmaOpCopy | (kSdmaSubopCopyLinear << 8);
+  packet[1] = kCopyBytes - 1;
+  write_sdma_qword_va(packet, 3, 4, queue.src_va());
+  write_sdma_qword_va(packet, 5, 6, queue.dst_va());
+
+  queue.submit(7);
+  ASSERT_TRUE(sim.engine->step());
+  EXPECT_EQ(queue.read_idx(), 0u);
+}
+
+TEST(Gfx1250SdmaTest, CopyLinearClippedDstAdvancesDeterministically) {
+  Gfx1250Sim sim;
+  TranslatedSdmaQueueForTest queue(sim);
+  constexpr uint32_t kCopyBytes = 128;
+  constexpr uint32_t kMappedBytes = 64;
+  queue.clip_dst_mapping(kMappedBytes);
+  for (uint32_t i = 0; i < kCopyBytes; ++i) {
+    queue.src()[i] = static_cast<uint8_t>(i ^ 0x6d);
+    queue.dst()[i] = 0;
+  }
+
+  auto *packet = queue.ring();
+  packet[0] = kSdmaOpCopy | (kSdmaSubopCopyLinear << 8);
+  packet[1] = kCopyBytes - 1;
+  write_sdma_qword_va(packet, 3, 4, queue.src_va());
+  write_sdma_qword_va(packet, 5, 6, queue.dst_va());
+
+  queue.submit(7);
+  ASSERT_TRUE(sim.engine->step());
+  EXPECT_EQ(queue.read_idx(), 7u * sizeof(uint32_t));
+  EXPECT_EQ(std::memcmp(queue.dst(), queue.src(), kMappedBytes), 0);
+  EXPECT_TRUE(std::all_of(queue.dst() + kMappedBytes, queue.dst() + kCopyBytes,
+                          [](uint8_t value) { return value == 0; }));
+}
+
+TEST(Gfx1250SdmaTest, CopyLinearTransfersMultipleScratchChunks) {
+  Gfx1250Sim sim;
+  TranslatedSdmaQueueForTest queue(sim);
+  constexpr uint32_t kCopyBytes = 8192;
+  for (uint32_t i = 0; i < kCopyBytes; ++i) {
+    queue.src()[i] = static_cast<uint8_t>((i * 17 + 3) & 0xff);
+    queue.dst()[i] = 0;
+  }
+
+  auto *packet = queue.ring();
+  packet[0] = kSdmaOpCopy | (kSdmaSubopCopyLinear << 8);
+  packet[1] = kCopyBytes - 1;
+  write_sdma_qword_va(packet, 3, 4, queue.src_va());
+  write_sdma_qword_va(packet, 5, 6, queue.dst_va());
+
+  queue.submit(7);
+  ASSERT_TRUE(sim.engine->step());
+  EXPECT_EQ(queue.read_idx(), 7u * sizeof(uint32_t));
+  EXPECT_EQ(std::memcmp(queue.dst(), queue.src(), kCopyBytes), 0);
+}
+
+TEST(Gfx1250SdmaTest, BroadcastCopyTransfersMultipleScratchChunks) {
+  Gfx1250Sim sim;
+  TranslatedSdmaQueueForTest queue(sim);
+  constexpr uint32_t kCopyBytes = 8192;
+  for (uint32_t i = 0; i < kCopyBytes; ++i) {
+    queue.src()[i] = static_cast<uint8_t>((i * 29 + 7) & 0xff);
+    queue.dst()[i] = 0;
+    queue.dst2()[i] = 0;
+  }
+
+  auto *packet = queue.ring();
+  packet[0] = kSdmaOpCopy | (kSdmaSubopCopyLinear << 8) | (1u << 27);
+  packet[1] = kCopyBytes - 1;
+  write_sdma_qword_va(packet, 3, 4, queue.src_va());
+  write_sdma_qword_va(packet, 5, 6, queue.dst_va());
+  write_sdma_qword_va(packet, 7, 8, queue.dst2_va());
+
+  queue.submit(9);
+  ASSERT_TRUE(sim.engine->step());
+  EXPECT_EQ(queue.read_idx(), 9u * sizeof(uint32_t));
+  EXPECT_EQ(std::memcmp(queue.dst(), queue.src(), kCopyBytes), 0);
+  EXPECT_EQ(std::memcmp(queue.dst2(), queue.src(), kCopyBytes), 0);
 }
 
 TEST(Gfx1250SdmaTest, CopyLinearNpdBitDoesNotDecodeAsBroadcast) {


### PR DESCRIPTION
## Motivation

Simulator page-table entries assumed that one GPU page corresponded to one contiguous host allocation. Sanitizer redzones and allocator suballocations can instead place multiple live extents inside the same page, so accesses could cross mapped or addressable boundaries.

## Technical Details

- Track disjoint host-backed extents within each simulated GPU page and preserve neighboring mappings during partial map, replace, and unmap operations.
- Resolve only complete live ranges, including current ASan shadow state, and clip reads, writes, atomics, completion signals, and translations at mapped boundaries.
- Route SDMA copies through bounded block accesses so clipped transfers have deterministic zero-fill behavior.
- Cover same-page suballocations, poisoned gaps, cross-page accesses, identity mappings, and clipped SDMA copies.

## Issue Tracking

N/A

## Test Plan

Build and run the complete simulator suite with Clang and GCC ASan+UBSan, then run the simulator corpus smoke matrix for gfx942, gfx950, gfx1100, gfx1201, and gfx1250 with both toolchains.

## Test Result

- The Clang ASan+UBSan suite passed 2,287/2,287 with six expected skips.
- The GCC ASan+UBSan suite passed 2,281/2,281 with six expected skips.
- The Clang and GCC simulator corpus smoke matrices each passed 15/15 (fpsan cast and core tests across 5 arches).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.