### PR TITLE
[rocjitsu] Model synchronous DRM timelines

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/events.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/events.cpp
@@ -7,6 +7,7 @@
 /// @details Implements the EventState methods that model KFD's event
 /// lifecycle and the SimulatedKfd ioctl wrappers that delegate to them.
 
+#include "rocjitsu/kmd/linux/libc_passthrough.h"
 #include "rocjitsu/kmd/linux/simulated_kfd.h"
 #include "util/log.h"
 
@@ -32,7 +33,7 @@ void write_event_slot(void *page, size_t page_size, uint32_t event_id, uint64_t 
 
 EventState::~EventState() {
   if (memfd >= 0)
-    ::close(memfd);
+    libc_passthrough().close(memfd);
 }
 
 void EventState::adopt_page(void *ptr, size_t size) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -49,7 +49,7 @@ RJ_DIAGNOSTIC_POP
 #include <cerrno>
 #include <charconv>
 #include <chrono>
-#include <condition_variable>
+#include <climits>
 #include <csignal>
 #include <cstdarg>
 #include <cstdio>
@@ -59,6 +59,8 @@ RJ_DIAGNOSTIC_POP
 #include <dlfcn.h>
 #include <exception>
 #include <fcntl.h>
+#include <limits>
+#include <linux/futex.h>
 #include <linux/memfd.h>
 #include <memory>
 #include <mutex>
@@ -66,6 +68,7 @@ RJ_DIAGNOSTIC_POP
 #include <pthread.h>
 #include <signal.h>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <sys/ioctl.h>
@@ -89,6 +92,21 @@ using rocjitsu::SimulatedKfd;
 using rocjitsu::Sysfs;
 
 namespace {
+
+static_assert(std::atomic<uint32_t>::is_always_lock_free,
+              "futex-backed state requires a lock-free uint32_t atomic");
+
+/// @brief Sleep while @p word still equals @p expected, until @p deadline or a signal.
+long futex_wait_until(std::atomic<uint32_t> &word, uint32_t expected, const timespec *deadline) {
+  return syscall(SYS_futex, &word, FUTEX_WAIT_BITSET_PRIVATE, expected, deadline, nullptr,
+                 FUTEX_BITSET_MATCH_ANY);
+}
+
+/// @brief Wake every waiter sleeping on @p word.
+void futex_wake_all(std::atomic<uint32_t> &word) {
+  (void)syscall(SYS_futex, &word, FUTEX_WAKE_PRIVATE, std::numeric_limits<int>::max(), nullptr,
+                nullptr, 0);
+}
 
 /// @brief Attempt to connect @p sock to the AF_UNIX socket at @p path.
 /// @returns A connected socket fd on success; -1 with errno set on failure.
@@ -329,20 +347,9 @@ public:
     remote_open_refs_.store(0, std::memory_order_relaxed);
     new (&init_mutex_) std::mutex();
     new (&fd_mutex_) std::mutex();
+    new (&drm_fd_lifecycle_mutex_) std::mutex();
     new (&remote_mutex_) std::mutex();
     sysfs_fds_.clear();
-    // A parent thread may have been asleep on one of these wait queues when the
-    // process forked. Reconstruct each shared DRM-file queue exactly once before
-    // dropping the inherited state; destroying or notifying a condition variable
-    // that still records a vanished parent waiter has undefined behavior. The flag
-    // handles duplicated DRM fds, which deliberately share one DrmFileState.
-    for (auto &[fd, state] : drm_fds_) {
-      (void)fd;
-      if (state && !state->syncobj_cv_reset_after_fork) {
-        new (&state->syncobj_cv) std::condition_variable();
-        state->syncobj_cv_reset_after_fork = true;
-      }
-    }
     drm_fds_.clear();
     kfd_dup_fds_.clear();
     // Drop GEM bookkeeping WITHOUT munmapping cpu_ptr or unmapping PTEs: those host
@@ -863,22 +870,36 @@ public:
   struct DrmFileState {
     uint64_t id = 0;
     uint32_t render_minor = 128;
+    // Guarded by InterposerContext::fd_mutex_. Reservations and tracked fds both
+    // contribute one reference, so the state and its namespaces remain live while
+    // an ioctl or duplication operation holds a token.
     size_t open_fds = 0;
     uint32_t next_syncobj_handle = 1;
     std::unordered_map<uint32_t, std::shared_ptr<SyncobjEntry>> syncobj_entries;
     // Timeline activity on one DRM file must not wake waiters belonging to every
-    // other open DRM file in the process.
-    std::condition_variable syncobj_cv;
-    bool syncobj_cv_reset_after_fork = false;
+    // other open DRM file in the process. Waiters sleep on this generation with
+    // futex(2), which preserves EINTR instead of transparently restarting after a
+    // signal as std::condition_variable does.
+    std::atomic<uint32_t> syncobj_generation{0};
   };
 
   using DrmFileToken = std::shared_ptr<DrmFileState>;
+
+  /// @brief Serialize synthetic DRM fd-table mutations with kernel fd operations.
+  /// @details The lock may cover only metadata operations and calls through the
+  /// real-libc passthrough table. Backend teardown, RPC, GEM cleanup, and any
+  /// interposed libc entry point must run after this lock is released.
+  std::unique_lock<std::mutex> lock_drm_fd_lifecycle() {
+    return std::unique_lock(drm_fd_lifecycle_mutex_);
+  }
 
   struct DrmUntrackResult {
     bool tracked = false;
     std::optional<uint64_t> closed_file_id;
   };
 
+  /// @brief Drop one fd or reservation reference while fd_mutex_ is held.
+  /// @returns The DRM-file identity when the final reference was removed.
   std::optional<uint64_t> release_drm_file_locked(const DrmFileToken &state) {
     if (!state)
       return std::nullopt;
@@ -890,7 +911,10 @@ public:
     return state->open_fds == 0 ? std::optional(state->id) : std::nullopt;
   }
 
-  void track_drm(int fd, uint32_t render_minor = 128) {
+  /// @brief Track a newly opened synthetic DRM fd.
+  /// @returns The identity of a stale displaced DRM file whose final reference
+  /// was removed, if any. The caller reaps it after releasing the lifecycle lock.
+  [[nodiscard]] std::optional<uint64_t> track_drm(int fd, uint32_t render_minor = 128) {
     auto state = std::make_shared<DrmFileState>();
     state->render_minor = render_minor;
     state->open_fds = 1;
@@ -905,10 +929,14 @@ public:
         drm_fds_.emplace(fd, std::move(state));
       }
     }
-    if (closed_file_id)
-      reap_gem_for_drm_file(*closed_file_id);
+    return closed_file_id;
   }
 
+  /// @brief Pin the DRM file currently tracked at @p fd.
+  /// @details The fd-table lifecycle lock is required when this reservation must
+  /// stay paired with a following kernel fd operation such as dup(). An ioctl may
+  /// call this directly: fd_mutex_ makes the lookup and increment atomic with
+  /// untracking, and the returned shared state remains valid if close races later.
   DrmFileToken reserve_drm_file(int fd) {
     std::lock_guard lock(fd_mutex_);
     auto it = drm_fds_.find(fd);
@@ -918,6 +946,8 @@ public:
     return it->second;
   }
 
+  /// @brief Release a token obtained from reserve_drm_file().
+  /// @details Final GEM cleanup runs outside fd_mutex_ and any lifecycle lock.
   void release_drm_file_reservation(const DrmFileToken &state) {
     if (!state)
       return;
@@ -930,27 +960,70 @@ public:
       reap_gem_for_drm_file(*closed_file_id);
   }
 
-  void commit_drm_dup(int fd, const DrmFileToken &state) {
-    if (fd < 0 || !state)
-      return;
+  /// @brief Scoped ioctl reservation that preserves the ioctl's final errno.
+  class DrmFileReservation {
+  public:
+    DrmFileReservation(InterposerContext &context, DrmFileToken file)
+        : context_(&context), file_(std::move(file)) {}
+    DrmFileReservation(const DrmFileReservation &) = delete;
+    DrmFileReservation &operator=(const DrmFileReservation &) = delete;
+    DrmFileReservation(DrmFileReservation &&other) noexcept
+        : context_(std::exchange(other.context_, nullptr)), file_(std::move(other.file_)) {}
+    DrmFileReservation &operator=(DrmFileReservation &&) = delete;
+    ~DrmFileReservation() {
+      if (!context_)
+        return;
+      const int saved_errno = errno;
+      context_->release_drm_file_reservation(file_);
+      errno = saved_errno;
+    }
+
+    [[nodiscard]] const DrmFileToken &file() const { return file_; }
+
+  private:
+    InterposerContext *context_;
+    DrmFileToken file_;
+  };
+
+  /// @brief Capture a stable DRM-file identity for one ioctl invocation.
+  [[nodiscard]] DrmFileReservation reserve_drm_file_for_ioctl(int fd) {
+    return DrmFileReservation(*this, reserve_drm_file(fd));
+  }
+
+  /// @brief Reconcile DRM tracking after a successful descriptor duplication.
+  /// @details Replaces stale target tracking even when @p state is null, so an
+  /// ordinary duplicate cannot inherit a recycled synthetic DRM identity. A
+  /// non-null state consumes the source reservation as the new fd's reference.
+  /// @returns The identity of a displaced DRM file whose final reference was
+  /// removed, if any. The caller performs GEM cleanup after releasing the
+  /// lifecycle lock.
+  [[nodiscard]] std::optional<uint64_t> commit_drm_dup(int fd, const DrmFileToken &state) {
+    if (fd < 0)
+      return std::nullopt;
     std::optional<uint64_t> closed_file_id;
     {
       std::lock_guard lock(fd_mutex_);
       if (auto stale = drm_fds_.find(fd); stale != drm_fds_.end()) {
         auto displaced = std::move(stale->second);
-        stale->second = state;
+        if (state)
+          stale->second = state;
+        else
+          drm_fds_.erase(stale);
         closed_file_id = release_drm_file_locked(displaced);
-      } else {
+      } else if (state) {
         drm_fds_.emplace(fd, state);
       }
     }
-    if (closed_file_id)
-      reap_gem_for_drm_file(*closed_file_id);
+    return closed_file_id;
   }
 
   bool is_drm(int fd) {
     std::lock_guard lock(fd_mutex_);
     return drm_fds_.count(fd) != 0;
+  }
+
+  static uint32_t drm_render_minor(const DrmFileToken &file) {
+    return file ? file->render_minor : 128;
   }
 
   uint32_t drm_render_minor(int fd) {
@@ -959,6 +1032,7 @@ public:
     return (it != drm_fds_.end()) ? it->second->render_minor : 128;
   }
 
+  /// @brief Remove @p fd from DRM tracking while preserving outstanding tokens.
   DrmUntrackResult untrack_drm(int fd) {
     std::lock_guard lock(fd_mutex_);
     auto it = drm_fds_.find(fd);
@@ -969,39 +1043,50 @@ public:
     return {.tracked = true, .closed_file_id = release_drm_file_locked(state)};
   }
 
-  int create_syncobj(int fd, uint32_t flags, uint32_t *handle) {
+  /// @brief Allocate a syncobj handle in @p file's private namespace.
+  int create_syncobj(const DrmFileToken &file, uint32_t flags, uint32_t *handle) {
     if (!handle || (flags & ~DRM_SYNCOBJ_CREATE_SIGNALED) != 0)
       return -EINVAL;
-    std::lock_guard lock(fd_mutex_);
-    auto file = drm_fds_.find(fd);
-    if (file == drm_fds_.end())
+    if (!file)
       return -EBADF;
-    auto &state = *file->second;
+    std::lock_guard lock(fd_mutex_);
+    auto &state = *file;
+    if (state.syncobj_entries.size() == std::numeric_limits<uint32_t>::max())
+      return -ENOSPC;
     uint32_t candidate = state.next_syncobj_handle++;
     while (candidate == 0 || state.syncobj_entries.count(candidate) != 0)
       candidate = state.next_syncobj_handle++;
-    auto entry = std::make_shared<SyncobjEntry>();
-    entry->has_fence = (flags & DRM_SYNCOBJ_CREATE_SIGNALED) != 0;
-    state.syncobj_entries[candidate] = std::move(entry);
+    try {
+      auto entry = std::make_shared<SyncobjEntry>();
+      entry->has_fence = (flags & DRM_SYNCOBJ_CREATE_SIGNALED) != 0;
+      state.syncobj_entries.emplace(candidate, std::move(entry));
+    } catch (const std::bad_alloc &) {
+      return -ENOMEM;
+    } catch (const std::length_error &) {
+      return -ENOMEM;
+    }
     *handle = candidate;
     return 0;
   }
 
-  int destroy_syncobj(int fd, uint32_t handle) {
-    std::lock_guard lock(fd_mutex_);
-    auto file = drm_fds_.find(fd);
-    if (file == drm_fds_.end())
+  /// @brief Remove a syncobj handle from @p file's private namespace.
+  int destroy_syncobj(const DrmFileToken &file, uint32_t handle) {
+    if (!file)
       return -EBADF;
-    if (file->second->syncobj_entries.erase(handle) == 0)
+    std::lock_guard lock(fd_mutex_);
+    if (file->syncobj_entries.erase(handle) == 0)
       return -EINVAL;
     return 0;
   }
 
+  /// @brief Copy a caller-owned array without faulting inside the interposer.
   template <typename T>
   static int snapshot_user_array(uint64_t address, uint32_t count, std::vector<T> &snapshot) {
     try {
       snapshot.resize(count);
     } catch (const std::bad_alloc &) {
+      return -ENOMEM;
+    } catch (const std::length_error &) {
       return -ENOMEM;
     }
     const size_t bytes = static_cast<size_t>(count) * sizeof(T);
@@ -1009,19 +1094,23 @@ public:
     iovec remote{reinterpret_cast<void *>(static_cast<uintptr_t>(address)), bytes};
     long copied;
     do {
-      copied = syscall(SYS_process_vm_readv, getpid(), &local, 1, &remote, 1, 0);
+      copied = process_vm_readv(getpid(), &local, 1, &remote, 1, 0);
     } while (copied < 0 && errno == EINTR);
     return copied == static_cast<long>(bytes) ? 0 : -EFAULT;
   }
 
-  int wait_syncobj_timeline(int fd, drm_syncobj_timeline_wait *wait) {
+  /// @brief Wait for one or all requested points in a DRM-file namespace.
+  /// @details Waiters use a per-file generation futex. Producers update the
+  /// points under fd_mutex_, increment the generation with release ordering, and
+  /// wake all sleepers; waiters recheck state under the same mutex after waking.
+  int wait_syncobj_timeline(const DrmFileToken &file, drm_syncobj_timeline_wait *wait) {
     if (!wait)
       return -EINVAL;
     const drm_syncobj_timeline_wait request = *wait;
     constexpr uint32_t kSupportedFlags =
         DRM_SYNCOBJ_WAIT_FLAGS_WAIT_ALL | DRM_SYNCOBJ_WAIT_FLAGS_WAIT_FOR_SUBMIT |
         DRM_SYNCOBJ_WAIT_FLAGS_WAIT_AVAILABLE | DRM_SYNCOBJ_WAIT_FLAGS_WAIT_DEADLINE;
-    if ((request.flags & ~kSupportedFlags) != 0 || request.pad != 0)
+    if ((request.flags & ~kSupportedFlags) != 0)
       return -EINVAL;
     if (request.count_handles == 0)
       return 0;
@@ -1031,22 +1120,37 @@ public:
       return rc;
     if (int rc = snapshot_user_array(request.points, request.count_handles, points); rc != 0)
       return rc;
-    std::unique_lock lock(fd_mutex_);
-    auto file = drm_fds_.find(fd);
-    if (file == drm_fds_.end())
+    if (!file)
       return -EBADF;
-    auto file_state = file->second;
     std::vector<std::shared_ptr<SyncobjEntry>> entries;
-    entries.reserve(request.count_handles);
+    try {
+      entries.reserve(request.count_handles);
+    } catch (const std::bad_alloc &) {
+      return -ENOMEM;
+    } catch (const std::length_error &) {
+      return -ENOMEM;
+    }
+    std::unique_lock lock(fd_mutex_);
     for (uint32_t i = 0; i < request.count_handles; ++i) {
-      auto it = file->second->syncobj_entries.find(handles[i]);
-      if (it == file->second->syncobj_entries.end())
+      auto it = file->syncobj_entries.find(handles[i]);
+      if (it == file->syncobj_entries.end())
         return -ENOENT;
       entries.push_back(it->second);
     }
     const bool wait_all = (request.flags & DRM_SYNCOBJ_WAIT_FLAGS_WAIT_ALL) != 0;
     const bool wait_for_submit = (request.flags & DRM_SYNCOBJ_WAIT_FLAGS_WAIT_FOR_SUBMIT) != 0;
     const bool wait_available = (request.flags & DRM_SYNCOBJ_WAIT_FLAGS_WAIT_AVAILABLE) != 0;
+    // The kernel validates fence availability once when the wait begins. A later
+    // unrelated wakeup must not turn a valid pending wait into EINVAL.
+    if (!wait_for_submit && !wait_available) {
+      for (uint32_t i = 0; i < request.count_handles; ++i) {
+        const auto &entry = *entries[i];
+        const bool submitted =
+            entry.has_fence && (points[i] == 0 || entry.submitted_point >= points[i]);
+        if (!submitted)
+          return -EINVAL;
+      }
+    }
     const auto evaluate = [&]() -> std::pair<int, uint32_t> {
       bool all_ready = true;
       bool any_ready = false;
@@ -1055,8 +1159,6 @@ public:
         const auto &entry = *entries[i];
         const bool submitted =
             entry.has_fence && (points[i] == 0 || entry.submitted_point >= points[i]);
-        if (!submitted && !wait_for_submit && !wait_available)
-          return {-EINVAL, 0};
         const bool ready = wait_available ? submitted
                                           : entry.has_fence && (points[i] == 0 ||
                                                                 entry.signaled_point >= points[i]);
@@ -1074,8 +1176,7 @@ public:
       if (state < 0)
         return state;
       if (state > 0) {
-        if (!wait_all)
-          wait->first_signaled = first_ready;
+        wait->first_signaled = wait_all ? std::numeric_limits<uint32_t>::max() : first_ready;
         return 0;
       }
 
@@ -1085,19 +1186,42 @@ public:
       const int64_t now_ns = static_cast<int64_t>(now.tv_sec) * 1'000'000'000LL + now.tv_nsec;
       if (request.timeout_nsec <= now_ns)
         return -ETIME;
-      file_state->syncobj_cv.wait_for(lock,
-                                      std::chrono::nanoseconds(request.timeout_nsec - now_ns));
+      const uint32_t generation = file->syncobj_generation.load(std::memory_order_relaxed);
+      lock.unlock();
+      const timespec deadline{static_cast<time_t>(request.timeout_nsec / 1'000'000'000LL),
+                              static_cast<long>(request.timeout_nsec % 1'000'000'000LL)};
+      // This user-space model cannot recover which signal interrupted futex(2),
+      // so it cannot apply the kernel ioctl layer's SA_RESTART decision. Surface
+      // EINTR consistently and let callers retry; the focused regression pins
+      // that documented difference from the in-kernel DRM implementation.
+      const long rc = futex_wait_until(file->syncobj_generation, generation, &deadline);
+      const int wait_errno = errno;
+      lock.lock();
+      if (rc == 0 || wait_errno == EAGAIN)
+        continue;
+      if (wait_errno == ETIMEDOUT)
+        return -ETIME;
+      if (wait_errno == EINTR)
+        return -EINTR;
+      return -wait_errno;
     }
   }
 
+  /// @brief Publish a completed binary or timeline fence under fd_mutex_.
   static void signal_syncobj_locked(const std::shared_ptr<SyncobjEntry> &entry, uint64_t point) {
     if (!entry)
       return;
     entry->has_fence = true;
+    if (point == 0) {
+      entry->submitted_point = 0;
+      entry->signaled_point = 0;
+      return;
+    }
     entry->submitted_point = std::max(entry->submitted_point, point);
     entry->signaled_point = std::max(entry->signaled_point, point);
   }
 
+  /// @brief Resolve one handle while fd_mutex_ is held.
   static std::shared_ptr<SyncobjEntry> lookup_syncobj_locked(const DrmFileToken &file,
                                                              uint32_t handle) {
     if (!file || handle == 0)
@@ -1106,9 +1230,12 @@ public:
     return entry != file->syncobj_entries.end() ? entry->second : nullptr;
   }
 
+  /// @brief Advance the per-file generation and wake every futex waiter.
   static void notify_syncobj_waiters(const DrmFileToken &file) {
-    if (file)
-      file->syncobj_cv.notify_all();
+    if (!file)
+      return;
+    file->syncobj_generation.fetch_add(1, std::memory_order_release);
+    futex_wake_all(file->syncobj_generation);
   }
 
   bool create_local_vm(const std::string &config_path) {
@@ -1228,10 +1355,11 @@ public:
   /// file, and returns the handle. Handle 0 is never minted, so callers may treat 0
   /// as "no handle".
   /// @returns The stable GEM handle (>= 1).
-  uint32_t prime_import(int dmabuf_fd, int drm_fd, uint64_t size) {
+  uint32_t prime_import(int dmabuf_fd, const DrmFileToken &drm_file, uint64_t size) {
     std::lock_guard lock(fd_mutex_);
-    auto drm_file = drm_fds_.find(drm_fd);
-    if (drm_file == drm_fds_.end())
+    if (!drm_file)
+      return 0;
+    if (gem_entries_.size() == std::numeric_limits<uint32_t>::max())
       return 0;
     uint32_t alloc_flags = 0;
     if (auto it = pending_gem_flags_.find(dmabuf_fd); it != pending_gem_flags_.end()) {
@@ -1257,7 +1385,7 @@ public:
     gem = {};
     gem.dmabuf_fd = (backing_fd >= 0) ? backing_fd : dmabuf_fd;
     gem.owns_dmabuf_fd = (backing_fd >= 0);
-    gem.drm_file_id = drm_file->second->id;
+    gem.drm_file_id = drm_file->id;
     gem.size = size;
     gem.alloc_flags = alloc_flags;
     return handle;
@@ -1275,28 +1403,30 @@ public:
   /// the PTEs, and publishes the output timeline point. The lock order
   /// fd_mutex_ -> driver page-table lock matches
   /// teardown_gem_entry_locked, so there is no inversion.
-  /// @param replace When true (AMDGPU_VA_OP_REPLACE), first evict any existing range
-  ///   in the calling DRM-file namespace that OVERLAPS {va_address, map_size}, so the
-  ///   old owner's bookkeeping does not later tear down the replacement's PTEs.
-  ///   When false (AMDGPU_VA_OP_MAP), an overlapping pre-existing range is a conflict.
+  /// @param replace When true (AMDGPU_VA_OP_REPLACE), reject overlap with another
+  ///   DRM file before evicting an existing range in the calling DRM-file namespace.
+  ///   The namespaces share one simulated GPU page table, so neither operation may
+  ///   overwrite another file's PTEs. When false (AMDGPU_VA_OP_MAP), any overlapping
+  ///   pre-existing range is a conflict.
+  /// @param publish_timeline Whether this update publishes its output timeline.
+  ///   AMDGPU_VM_DELAY_UPDATE suppresses publication, matching the kernel contract.
   /// @returns Zero when the range was installed, `-ENOENT` for an unknown handle in
   ///   this DRM-file namespace, or another negative errno for invalid requests.
-  [[nodiscard]] int gem_map(int drm_fd, uint32_t handle, uint64_t va_address, uint64_t offset_in_bo,
-                            uint64_t map_size, bool replace, uint32_t timeline_handle = 0,
+  [[nodiscard]] int gem_map(const DrmFileToken &file, uint32_t handle, uint64_t va_address,
+                            uint64_t offset_in_bo, uint64_t map_size, bool replace,
+                            bool publish_timeline = true, uint32_t timeline_handle = 0,
                             uint64_t timeline_point = 0) {
     std::unique_lock lock(fd_mutex_);
-    auto file = drm_fds_.find(drm_fd);
-    if (file == drm_fds_.end())
+    if (!file)
       return -EBADF;
-    auto file_state = file->second;
-    auto timeline = lookup_syncobj_locked(file_state, timeline_handle);
+    auto timeline = lookup_syncobj_locked(file, timeline_handle);
     if (timeline_handle != 0 && !timeline)
       return -ENOENT;
     auto *drv = dynamic_cast<SimulatedKfd *>(driver());
     if (!drv)
       return -ENODEV;
     auto it = gem_entries_.find(handle);
-    if (it == gem_entries_.end() || it->second.drm_file_id != file->second->id)
+    if (it == gem_entries_.end() || it->second.drm_file_id != file->id)
       return -ENOENT;
     GemEntry &gem = it->second;
     // Bound the request within the BO without letting offset_in_bo + map_size
@@ -1307,14 +1437,25 @@ public:
         map_size > gem.size - offset_in_bo)
       return -EINVAL;
     const GemMapping range{va_address, map_size};
-    // Handle the target VA range's current occupant. REPLACE evicts any current
-    // holder (possibly a different handle) so its records cannot later unmap the new
-    // PTEs. Plain MAP treats an existing range as a conflict rather than silently
-    // double-mapping over another handle's PTEs.
+    // Handle the target VA range's current occupant. Independent DRM files have
+    // private handle namespaces but currently share one simulated GPU page table,
+    // so a foreign mapping must never be overwritten. REPLACE may evict only a
+    // current holder from this DRM file; plain MAP rejects any current holder.
+    const bool foreign_overlap = range_is_mapped_by_other_drm_file_locked(file->id, range);
+    if (foreign_overlap) {
+      // TODO: Give each independent DRM file its own simulated GPUVM. Until then,
+      // permitting this overlap would overwrite the single shared page table and
+      // let either file tear down the other's PTEs. Make the model limitation
+      // visible instead of silently accepting or rejecting the update.
+      util::Logger::warn("DRM files currently share one simulated GPUVM; rejecting overlapping "
+                         "GEM_VA range at address ",
+                         va_address);
+      return -EINVAL;
+    }
     if (replace) {
-      if (!evict_range_locked(drv, file->second->id, range, /*allow_missing=*/true))
+      if (!evict_range_locked(drv, file->id, range, /*allow_missing=*/true))
         return -EINVAL;
-    } else if (range_is_mapped_locked(file->second->id, range)) {
+    } else if (range_is_mapped_locked(range)) {
       return -EINVAL;
     }
     if (!gem.cpu_ptr) {
@@ -1344,10 +1485,11 @@ public:
     if (!drv->gem_va_map(va_address, host, map_size, gem.alloc_flags))
       return -EINVAL;
     gem.installed_vas.push_back(range);
-    signal_syncobj_locked(timeline, timeline_point);
+    if (publish_timeline)
+      signal_syncobj_locked(timeline, timeline_point);
     lock.unlock();
-    if (timeline)
-      notify_syncobj_waiters(file_state);
+    if (publish_timeline && timeline)
+      notify_syncobj_waiters(file);
     return 0;
   }
 
@@ -1359,21 +1501,20 @@ public:
   /// own and cannot report success for a no-op.
   /// @returns Zero when the range was unmapped, `-ENOENT` for an unknown handle in
   ///   this DRM-file namespace, or another negative errno for invalid requests.
-  [[nodiscard]] int gem_unmap(int drm_fd, uint32_t handle, uint64_t va_address, uint64_t map_size,
+  [[nodiscard]] int gem_unmap(const DrmFileToken &file, uint32_t handle, uint64_t va_address,
+                              uint64_t map_size, bool publish_timeline = true,
                               uint32_t timeline_handle = 0, uint64_t timeline_point = 0) {
     std::unique_lock lock(fd_mutex_);
-    auto file = drm_fds_.find(drm_fd);
-    if (file == drm_fds_.end())
+    if (!file)
       return -EBADF;
-    auto file_state = file->second;
-    auto timeline = lookup_syncobj_locked(file_state, timeline_handle);
+    auto timeline = lookup_syncobj_locked(file, timeline_handle);
     if (timeline_handle != 0 && !timeline)
       return -ENOENT;
     auto *drv = dynamic_cast<SimulatedKfd *>(driver());
     if (!drv)
       return -ENODEV;
     auto it = gem_entries_.find(handle);
-    if (it == gem_entries_.end() || it->second.drm_file_id != file->second->id)
+    if (it == gem_entries_.end() || it->second.drm_file_id != file->id)
       return -ENOENT;
     GemEntry &gem = it->second;
     const GemMapping range{va_address, map_size};
@@ -1383,10 +1524,11 @@ public:
     if (!drv->gem_va_unmap(va_address, map_size))
       return -EINVAL;
     std::erase(gem.installed_vas, range);
-    signal_syncobj_locked(timeline, timeline_point);
+    if (publish_timeline)
+      signal_syncobj_locked(timeline, timeline_point);
     lock.unlock();
-    if (timeline)
-      notify_syncobj_waiters(file_state);
+    if (publish_timeline && timeline)
+      notify_syncobj_waiters(file);
     return 0;
   }
 
@@ -1399,26 +1541,26 @@ public:
   /// phantom clear).
   /// @returns Zero when an overlapping range in the calling DRM-file namespace was
   ///   cleared, or a negative errno when no such range exists or the request fails.
-  [[nodiscard]] int gem_clear(int drm_fd, uint64_t va_address, uint64_t map_size,
-                              uint32_t timeline_handle = 0, uint64_t timeline_point = 0) {
+  [[nodiscard]] int gem_clear(const DrmFileToken &file, uint64_t va_address, uint64_t map_size,
+                              bool publish_timeline = true, uint32_t timeline_handle = 0,
+                              uint64_t timeline_point = 0) {
     std::unique_lock lock(fd_mutex_);
-    auto file = drm_fds_.find(drm_fd);
-    if (file == drm_fds_.end())
+    if (!file)
       return -EBADF;
-    auto file_state = file->second;
-    auto timeline = lookup_syncobj_locked(file_state, timeline_handle);
+    auto timeline = lookup_syncobj_locked(file, timeline_handle);
     if (timeline_handle != 0 && !timeline)
       return -ENOENT;
     auto *drv = dynamic_cast<SimulatedKfd *>(driver());
     if (!drv)
       return -ENODEV;
-    if (!evict_range_locked(drv, file->second->id, GemMapping{va_address, map_size},
+    if (!evict_range_locked(drv, file->id, GemMapping{va_address, map_size},
                             /*allow_missing=*/false))
       return -EINVAL;
-    signal_syncobj_locked(timeline, timeline_point);
+    if (publish_timeline)
+      signal_syncobj_locked(timeline, timeline_point);
     lock.unlock();
-    if (timeline)
-      notify_syncobj_waiters(file_state);
+    if (publish_timeline && timeline)
+      notify_syncobj_waiters(file);
     return 0;
   }
 
@@ -1445,13 +1587,12 @@ public:
   /// and munmaps the host mapping entirely under fd_mutex_, so no GemEntry pointer
   /// or driver pointer escapes the lock and a concurrent GEM_VA cannot race the
   /// teardown.
-  int untrack_gem(int drm_fd, uint32_t handle) {
+  int untrack_gem(const DrmFileToken &file, uint32_t handle) {
     std::lock_guard lock(fd_mutex_);
-    auto file = drm_fds_.find(drm_fd);
-    if (file == drm_fds_.end())
+    if (!file)
       return -EBADF;
     auto it = gem_entries_.find(handle);
-    if (it == gem_entries_.end() || it->second.drm_file_id != file->second->id)
+    if (it == gem_entries_.end() || it->second.drm_file_id != file->id)
       return -ENOENT;
     teardown_gem_entry_locked(it->second);
     gem_entries_.erase(it);
@@ -1630,6 +1771,14 @@ private:
 
   std::mutex init_mutex_;
   std::mutex fd_mutex_;
+  /// Serializes synthetic DRM fd-table operations with tracking updates. The
+  /// kernel makes close and duplication atomic with respect to the process fd
+  /// table; this lock extends that atomicity through the interposer's drm_fds_
+  /// bookkeeping so a recycled integer fd cannot acquire an older DRM file's
+  /// namespaces. Its scope is deliberately limited to source lookup plus the
+  /// kernel fd operation and DRM tracking update. Backend teardown, RPC, GEM
+  /// cleanup, and other interposed libc calls must run after it is released.
+  std::mutex drm_fd_lifecycle_mutex_;
   std::mutex remote_mutex_;
   std::unordered_map<int, std::string> sysfs_fds_;
   std::unordered_map<int, DrmFileToken> drm_fds_;
@@ -1723,12 +1872,27 @@ private:
     return evicted_any || allow_missing;
   }
 
-  /// @brief Whether any GEM entry owns a range OVERLAPPING @p range. Caller holds
-  /// fd_mutex_. Used by plain MAP to reject a map that would collide with (not just
-  /// exactly duplicate) an existing range's PTEs.
-  [[nodiscard]] bool range_is_mapped_locked(uint64_t drm_file_id, const GemMapping &range) const {
+  /// @brief Whether any GEM entry owns a range OVERLAPPING @p range in the shared
+  /// simulated GPU page table. Caller holds fd_mutex_. Used by plain MAP to reject
+  /// a map that would collide with an existing range's PTEs, regardless of which
+  /// DRM file owns it.
+  [[nodiscard]] bool range_is_mapped_locked(const GemMapping &range) const {
     for (const auto &[handle, gem] : gem_entries_) {
-      if (gem.drm_file_id != drm_file_id)
+      for (const auto &existing : gem.installed_vas)
+        if (existing.overlaps(range))
+          return true;
+    }
+    return false;
+  }
+
+  /// @brief Whether a GEM entry owned by a DRM file other than @p drm_file_id
+  /// overlaps @p range in the shared simulated GPU page table. Caller holds
+  /// fd_mutex_. Used by REPLACE to reject a foreign collision before evicting any
+  /// mapping owned by the caller.
+  [[nodiscard]] bool range_is_mapped_by_other_drm_file_locked(uint64_t drm_file_id,
+                                                              const GemMapping &range) const {
+    for (const auto &[handle, gem] : gem_entries_) {
+      if (gem.drm_file_id == drm_file_id)
         continue;
       for (const auto &existing : gem.installed_vas)
         if (existing.overlaps(range))
@@ -1844,7 +2008,18 @@ static SyntheticDrmOpenResult open_synthetic_drm_fd(const char *path) {
     return {true, -1};
   }
 
-  InterposerContext::ctx.track_drm(high_fd, render_minor);
+  std::optional<uint64_t> closed_file_id;
+  try {
+    auto drm_lifecycle = InterposerContext::ctx.lock_drm_fd_lifecycle();
+    closed_file_id = InterposerContext::ctx.track_drm(high_fd, render_minor);
+  } catch (const std::bad_alloc &) {
+    const int saved_errno = ENOMEM;
+    InterposerContext::real().close(high_fd);
+    errno = saved_errno;
+    return {true, -1};
+  }
+  if (closed_file_id)
+    InterposerContext::ctx.reap_gem_for_drm_file(*closed_file_id);
   return {true, high_fd};
 }
 
@@ -1999,11 +2174,16 @@ RJ_INTERPOSER_EXPORT int close(int fd) {
   // handler). Closing the DRM FILE itself, however, is the true backstop: reap any
   // handles still open on it (mirroring the kernel dropping a drm_file's GEM
   // objects) so a leaked/never-GEM_CLOSE'd handle cannot outlive its DRM file.
-  auto drm_close = InterposerContext::ctx.untrack_drm(fd);
+  InterposerContext::DrmUntrackResult drm_close;
+  {
+    auto drm_lifecycle = InterposerContext::ctx.lock_drm_fd_lifecycle();
+    drm_close = InterposerContext::ctx.untrack_drm(fd);
+    if (drm_close.tracked)
+      InterposerContext::real().close(fd);
+  }
   if (drm_close.tracked) {
     if (drm_close.closed_file_id)
       InterposerContext::ctx.reap_gem_for_drm_file(*drm_close.closed_file_id);
-    InterposerContext::real().close(fd);
     return 0;
   }
   if (InterposerContext::ctx.is_kfd_dup(fd)) {
@@ -2038,7 +2218,9 @@ RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
   constexpr unsigned kDrmIoctlNrSyncobjDestroy = _IOC_NR(DRM_IOCTL_SYNCOBJ_DESTROY);
   constexpr unsigned kDrmIoctlNrSyncobjTimelineWait = _IOC_NR(DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT);
 
-  if (InterposerContext::ctx.is_drm(fd)) {
+  auto drm_file_reservation = InterposerContext::ctx.reserve_drm_file_for_ioctl(fd);
+  const auto &drm_file = drm_file_reservation.file();
+  if (drm_file) {
     unsigned nr = _IOC_NR(request);
     unsigned type = _IOC_TYPE(request);
     if (type == kDrmIoctlType && nr == kDrmIoctlNrVersion && arg) {
@@ -2092,7 +2274,7 @@ RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
       // Mint a stable handle (independent of the fd number) scoped to this DRM file,
       // folding in the alloc flags captured at EXPORT_DMABUF. The caller closes the
       // export fd right after access setup; the handle — not the fd — owns the BO.
-      prime->handle = InterposerContext::ctx.prime_import(prime->fd, fd, sz);
+      prime->handle = InterposerContext::ctx.prime_import(prime->fd, drm_file, sz);
       if (prime->handle == 0) {
         errno = EBADF;
         return -1;
@@ -2102,7 +2284,7 @@ RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
     if (type == kDrmIoctlType && nr == kDrmIoctlNrSyncobjCreate && arg) {
       auto *create = static_cast<drm_syncobj_create *>(arg);
       return kfd_ioctl_ret(
-          InterposerContext::ctx.create_syncobj(fd, create->flags, &create->handle));
+          InterposerContext::ctx.create_syncobj(drm_file, create->flags, &create->handle));
     }
     if (type == kDrmIoctlType && nr == kDrmIoctlNrSyncobjDestroy && arg) {
       auto *destroy = static_cast<drm_syncobj_destroy *>(arg);
@@ -2110,11 +2292,11 @@ RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
         errno = EINVAL;
         return -1;
       }
-      return kfd_ioctl_ret(InterposerContext::ctx.destroy_syncobj(fd, destroy->handle));
+      return kfd_ioctl_ret(InterposerContext::ctx.destroy_syncobj(drm_file, destroy->handle));
     }
     if (type == kDrmIoctlType && nr == kDrmIoctlNrSyncobjTimelineWait && arg) {
       return kfd_ioctl_ret(InterposerContext::ctx.wait_syncobj_timeline(
-          fd, static_cast<drm_syncobj_timeline_wait *>(arg)));
+          drm_file, static_cast<drm_syncobj_timeline_wait *>(arg)));
     }
     if (type == kDrmIoctlType && nr == kDrmIoctlNrAmdgpuInfo && arg) {
       // Service the AMDGPU_INFO queries that real libdrm_amdgpu issues during
@@ -2125,7 +2307,7 @@ RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
       //   READ_MMR_REG (gb_addr_cfg is mandatory for all families),
       //   VRAM_GTT, MEMORY. Failures (-1) abort device init.
       auto *info = static_cast<drm_amdgpu_info *>(arg);
-      auto gpu_info = interposer_gpu_info(InterposerContext::ctx.drm_render_minor(fd));
+      auto gpu_info = interposer_gpu_info(InterposerContext::ctx.drm_render_minor(drm_file));
       if (!gpu_info) {
         errno = ENODEV;
         return -1;
@@ -2220,7 +2402,7 @@ RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
       // BEFORE munmapping the host pages, entirely under fd_mutex_ so no state
       // escapes the lock.
       auto *gc = static_cast<drm_gem_close *>(arg);
-      return kfd_ioctl_ret(InterposerContext::ctx.untrack_gem(fd, gc->handle));
+      return kfd_ioctl_ret(InterposerContext::ctx.untrack_gem(drm_file, gc->handle));
     }
     if (type == kDrmIoctlType && nr == kDrmIoctlNrGemVa && arg) {
       // GEM_VA installs (or tears down) a GPU virtual mapping for a prime-
@@ -2229,10 +2411,11 @@ RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
       // VAs. We map by GEM handle, lazily mmap the backing pages, and
       // install/remove them in the GPU page table.
       auto *va = static_cast<drm_amdgpu_gem_va *>(arg);
-      // Input fences require the VM update to remain pending until another
-      // operation signals them. This local model only supports synchronous
-      // updates, so reject that contract instead of applying the mapping early.
-      if (va->num_syncobj_handles != 0 || va->input_fence_syncobj_handles != 0) {
+      // The kernel waits synchronously for every input fence before touching the
+      // VM. This model has no input-fence lookup/wait implementation, so reject a
+      // nonzero authoritative count instead of applying the update before its
+      // dependencies. The pointer is unused and ignored when the count is zero.
+      if (va->num_syncobj_handles != 0) {
         errno = EINVAL;
         return -1;
       }
@@ -2247,6 +2430,7 @@ RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
         errno = ENODEV;
         return -1;
       }
+      const bool publish_timeline = (va->flags & AMDGPU_VM_DELAY_UPDATE) == 0;
       int result = 0;
       switch (va->operation) {
       case AMDGPU_VA_OP_MAP:
@@ -2254,21 +2438,22 @@ RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
         // REPLACE evicts any prior occupant of the VA range in this DRM-file
         // namespace before installing the new mapping, so closing the old handle
         // cannot later unmap the replacement. MAP rejects a range already in use.
-        result = InterposerContext::ctx.gem_map(fd, va->handle, va->va_address, va->offset_in_bo,
-                                                va->map_size,
-                                                /*replace=*/va->operation == AMDGPU_VA_OP_REPLACE,
-                                                va->vm_timeline_syncobj_out, va->vm_timeline_point);
+        result = InterposerContext::ctx.gem_map(
+            drm_file, va->handle, va->va_address, va->offset_in_bo, va->map_size,
+            /*replace=*/va->operation == AMDGPU_VA_OP_REPLACE, publish_timeline,
+            va->vm_timeline_syncobj_out, va->vm_timeline_point);
         break;
       case AMDGPU_VA_OP_UNMAP:
         // UNMAP requires the supplied handle to own the exact range.
-        result =
-            InterposerContext::ctx.gem_unmap(fd, va->handle, va->va_address, va->map_size,
-                                             va->vm_timeline_syncobj_out, va->vm_timeline_point);
+        result = InterposerContext::ctx.gem_unmap(
+            drm_file, va->handle, va->va_address, va->map_size, publish_timeline,
+            va->vm_timeline_syncobj_out, va->vm_timeline_point);
         break;
       case AMDGPU_VA_OP_CLEAR:
         // CLEAR is handle-agnostic within the calling DRM-file namespace.
-        result = InterposerContext::ctx.gem_clear(
-            fd, va->va_address, va->map_size, va->vm_timeline_syncobj_out, va->vm_timeline_point);
+        result = InterposerContext::ctx.gem_clear(drm_file, va->va_address, va->map_size,
+                                                  publish_timeline, va->vm_timeline_syncobj_out,
+                                                  va->vm_timeline_point);
         break;
       default:
         // Unknown GEM_VA operation — do not claim it succeeded.
@@ -2354,24 +2539,34 @@ RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
 
 RJ_INTERPOSER_EXPORT int dup(int oldfd) {
   assert(InterposerContext::real().ready());
-  // Reserve the source backend's open reference BEFORE the syscall so a racing
-  // last-close cannot tear the backend down between the dup and tracking the new
-  // fd (which would leave a valid KFD dup untracked / unreferenced).
-  auto reserved = InterposerContext::ctx.reserve_dup_backend(oldfd);
-  auto drm_file = InterposerContext::ctx.reserve_drm_file(oldfd);
-  int rc = InterposerContext::real().dup(oldfd);
+  std::optional<InterposerContext::DupBackend> reserved;
+  InterposerContext::DrmFileToken drm_file;
+  std::optional<uint64_t> closed_file_id;
+  int rc;
+  {
+    auto drm_lifecycle = InterposerContext::ctx.lock_drm_fd_lifecycle();
+    // Keep the source kernel fd and its DRM identity paired until dup() and the
+    // tracking update complete. Backend and GEM cleanup run after this scope.
+    reserved = InterposerContext::ctx.reserve_dup_backend(oldfd);
+    drm_file = InterposerContext::ctx.reserve_drm_file(oldfd);
+    rc = InterposerContext::real().dup(oldfd);
+    if (rc >= 0)
+      closed_file_id = InterposerContext::ctx.commit_drm_dup(rc, drm_file);
+  }
   if (rc < 0) {
-    // Syscall failed: roll back the reservation.
+    const int saved_errno = errno;
     if (reserved)
       InterposerContext::ctx.release_backend(*reserved);
     InterposerContext::ctx.release_drm_file_reservation(drm_file);
+    errno = saved_errno;
     return rc;
   }
   if (reserved)
     InterposerContext::ctx.commit_dup(rc, *reserved);
   else
     InterposerContext::ctx.untrack_dup(rc);
-  InterposerContext::ctx.commit_drm_dup(rc, drm_file);
+  if (closed_file_id)
+    InterposerContext::ctx.reap_gem_for_drm_file(*closed_file_id);
   return rc;
 }
 
@@ -2381,7 +2576,7 @@ namespace {
 // dup2/dup3 atomically CLOSE newfd before installing the duplicate, so any
 // tracking/reference newfd previously held must be dropped before the
 // replacement is tracked:
-//   - stale sysfs/DRM tracking for newfd is removed;
+//   - stale sysfs tracking for newfd is removed;
 //   - if newfd was a tracked KFD dup, its reference is released and its stale
 //     kfd_dup_fds_ entry erased (otherwise commit_dup would see the stale entry
 //     and release the newly-reserved backend, leaving the OLD backend recorded);
@@ -2390,7 +2585,7 @@ namespace {
 //     routes to the old backend.
 // Then the replacement is recorded on the reserved source backend.
 void reconcile_dup_target(int newfd, std::optional<InterposerContext::DupBackend> reserved,
-                          const InterposerContext::DrmFileToken &drm_file) {
+                          std::optional<uint64_t> closed_drm_file_id) {
   InterposerContext::ctx.untrack_sysfs(newfd);
   // dup2/dup3 atomically close whatever newfd was, bypassing the close() hook, so
   // every per-fd cleanup close() performs must be mirrored here. Drop any transient
@@ -2399,17 +2594,11 @@ void reconcile_dup_target(int newfd, std::optional<InterposerContext::DupBackend
   // PRIME on the recycled fd number could misapply as the wrong PTE MTYPE. No-op for
   // non-dmabuf fds.
   InterposerContext::ctx.drop_pending_gem_flags(newfd);
-  // If newfd was a DRM render fd still owning live GEM handles, reap them here just as
-  // close() does (untrack_drm + reap_gem_for_drm_file) — otherwise those GemEntry
-  // objects owned by newfd's DRM file leak their PTEs, host mmap, and dup'd dmabuf
-  // fd, and a later commit_dup could re-tag the same number as a KFD dup.
-  auto drm_close = InterposerContext::ctx.untrack_drm(newfd);
-  if (drm_close.closed_file_id)
-    InterposerContext::ctx.reap_gem_for_drm_file(*drm_close.closed_file_id);
+  if (closed_drm_file_id)
+    InterposerContext::ctx.reap_gem_for_drm_file(*closed_drm_file_id);
   InterposerContext::ctx.invalidate_overwritten_kfd_fd(newfd);
   if (reserved)
     InterposerContext::ctx.commit_dup(newfd, *reserved);
-  InterposerContext::ctx.commit_drm_dup(newfd, drm_file);
 }
 } // namespace
 
@@ -2419,17 +2608,32 @@ RJ_INTERPOSER_EXPORT int dup2(int oldfd, int newfd) {
   // tracking would drop a still-open ref. Forward without touching tracking.
   if (oldfd == newfd)
     return InterposerContext::real().dup2(oldfd, newfd);
-  // Reserve the source backend before the syscall (see dup()).
-  auto reserved = InterposerContext::ctx.reserve_dup_backend(oldfd);
-  auto drm_file = InterposerContext::ctx.reserve_drm_file(oldfd);
-  int rc = InterposerContext::real().dup2(oldfd, newfd);
+  std::optional<InterposerContext::DupBackend> reserved;
+  InterposerContext::DrmFileToken drm_file;
+  std::optional<uint64_t> closed_drm_file_id;
+  int rc;
+  {
+    auto drm_lifecycle = InterposerContext::ctx.lock_drm_fd_lifecycle();
+    reserved = InterposerContext::ctx.reserve_dup_backend(oldfd);
+    drm_file = InterposerContext::ctx.reserve_drm_file(oldfd);
+    rc = InterposerContext::real().dup2(oldfd, newfd);
+    if (rc >= 0) {
+      auto drm_close = InterposerContext::ctx.untrack_drm(rc);
+      closed_drm_file_id = drm_close.closed_file_id;
+      auto displaced = InterposerContext::ctx.commit_drm_dup(rc, drm_file);
+      if (displaced)
+        closed_drm_file_id = displaced;
+    }
+  }
   if (rc < 0) {
+    const int saved_errno = errno;
     if (reserved)
       InterposerContext::ctx.release_backend(*reserved);
     InterposerContext::ctx.release_drm_file_reservation(drm_file);
+    errno = saved_errno;
     return rc;
   }
-  reconcile_dup_target(rc, reserved, drm_file);
+  reconcile_dup_target(rc, reserved, closed_drm_file_id);
   return rc;
 }
 
@@ -2438,16 +2642,32 @@ RJ_INTERPOSER_EXPORT int dup3(int oldfd, int newfd, int flags) {
   assert(InterposerContext::real().ready());
   // dup3(fd, fd, ...) is required to fail with EINVAL without altering the
   // descriptor; do not mutate tracking before the syscall confirms that.
-  auto reserved = InterposerContext::ctx.reserve_dup_backend(oldfd);
-  auto drm_file = InterposerContext::ctx.reserve_drm_file(oldfd);
-  int rc = InterposerContext::real().dup3(oldfd, newfd, flags);
+  std::optional<InterposerContext::DupBackend> reserved;
+  InterposerContext::DrmFileToken drm_file;
+  std::optional<uint64_t> closed_drm_file_id;
+  int rc;
+  {
+    auto drm_lifecycle = InterposerContext::ctx.lock_drm_fd_lifecycle();
+    reserved = InterposerContext::ctx.reserve_dup_backend(oldfd);
+    drm_file = InterposerContext::ctx.reserve_drm_file(oldfd);
+    rc = InterposerContext::real().dup3(oldfd, newfd, flags);
+    if (rc >= 0) {
+      auto drm_close = InterposerContext::ctx.untrack_drm(rc);
+      closed_drm_file_id = drm_close.closed_file_id;
+      auto displaced = InterposerContext::ctx.commit_drm_dup(rc, drm_file);
+      if (displaced)
+        closed_drm_file_id = displaced;
+    }
+  }
   if (rc < 0) {
+    const int saved_errno = errno;
     if (reserved)
       InterposerContext::ctx.release_backend(*reserved);
     InterposerContext::ctx.release_drm_file_reservation(drm_file);
+    errno = saved_errno;
     return rc;
   }
-  reconcile_dup_target(rc, reserved, drm_file);
+  reconcile_dup_target(rc, reserved, closed_drm_file_id);
   return rc;
 }
 #endif
@@ -2524,39 +2744,45 @@ int fcntl_impl(int fd, int cmd, void *ptr_arg, int int_arg) {
   const bool is_dupfd = (cmd == F_DUPFD || cmd == F_DUPFD_CLOEXEC);
   std::optional<InterposerContext::DupBackend> reserved;
   InterposerContext::DrmFileToken drm_file;
+  std::optional<uint64_t> closed_file_id;
+  const auto invoke = [&]() -> long {
+    switch (kind) {
+    case FcntlArgKind::Int:
+      return InterposerContext::real().fcntl(fd, cmd, int_arg);
+    case FcntlArgKind::Ptr:
+      return InterposerContext::real().fcntl(fd, cmd, ptr_arg);
+    case FcntlArgKind::None:
+    default:
+      return InterposerContext::real().fcntl(fd, cmd, 0L);
+    }
+  };
+
+  long rc;
   if (is_dupfd) {
+    auto drm_lifecycle = InterposerContext::ctx.lock_drm_fd_lifecycle();
     reserved = InterposerContext::ctx.reserve_dup_backend(fd);
     drm_file = InterposerContext::ctx.reserve_drm_file(fd);
-  }
-
-  long rc = 0;
-  switch (kind) {
-  case FcntlArgKind::Int:
-    rc = InterposerContext::real().fcntl(fd, cmd, int_arg);
-    break;
-  case FcntlArgKind::Ptr:
-    rc = InterposerContext::real().fcntl(fd, cmd, ptr_arg);
-    break;
-  case FcntlArgKind::None:
-  default:
-    rc = InterposerContext::real().fcntl(fd, cmd, 0L);
-    break;
+    rc = invoke();
+    if (rc >= 0)
+      closed_file_id = InterposerContext::ctx.commit_drm_dup(static_cast<int>(rc), drm_file);
+  } else {
+    rc = invoke();
   }
 
   if (is_dupfd) {
     if (rc < 0) {
-      // Syscall failed: roll back the reservation.
+      const int saved_errno = errno;
       if (reserved)
         InterposerContext::ctx.release_backend(*reserved);
       InterposerContext::ctx.release_drm_file_reservation(drm_file);
+      errno = saved_errno;
     } else {
       if (reserved)
         InterposerContext::ctx.commit_dup(static_cast<int>(rc), *reserved);
       else
         InterposerContext::ctx.untrack_dup(static_cast<int>(rc));
-      // libdrm duplicates the render fd and expects the new descriptor to share
-      // the same DRM-file handle and syncobj namespaces.
-      InterposerContext::ctx.commit_drm_dup(static_cast<int>(rc), drm_file);
+      if (closed_file_id)
+        InterposerContext::ctx.reap_gem_for_drm_file(*closed_file_id);
     }
   }
   return static_cast<int>(rc);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -48,6 +48,8 @@ RJ_DIAGNOSTIC_POP
 #include <cassert>
 #include <cerrno>
 #include <charconv>
+#include <chrono>
+#include <condition_variable>
 #include <csignal>
 #include <cstdarg>
 #include <cstdio>
@@ -72,6 +74,7 @@ RJ_DIAGNOSTIC_POP
 #include <sys/stat.h>
 #include <sys/syscall.h>
 #include <sys/sysmacros.h>
+#include <sys/uio.h>
 #include <sys/un.h>
 #include <thread>
 #include <unistd.h>
@@ -328,6 +331,18 @@ public:
     new (&fd_mutex_) std::mutex();
     new (&remote_mutex_) std::mutex();
     sysfs_fds_.clear();
+    // A parent thread may have been asleep on one of these wait queues when the
+    // process forked. Reconstruct each shared DRM-file queue exactly once before
+    // dropping the inherited state; destroying or notifying a condition variable
+    // that still records a vanished parent waiter has undefined behavior. The flag
+    // handles duplicated DRM fds, which deliberately share one DrmFileState.
+    for (auto &[fd, state] : drm_fds_) {
+      (void)fd;
+      if (state && !state->syncobj_cv_reset_after_fork) {
+        new (&state->syncobj_cv) std::condition_variable();
+        state->syncobj_cv_reset_after_fork = true;
+      }
+    }
     drm_fds_.clear();
     kfd_dup_fds_.clear();
     // Drop GEM bookkeeping WITHOUT munmapping cpu_ptr or unmapping PTEs: those host
@@ -839,9 +854,98 @@ public:
     sysfs_fds_.erase(fd);
   }
 
+  struct SyncobjEntry {
+    bool has_fence = false;
+    uint64_t submitted_point = 0;
+    uint64_t signaled_point = 0;
+  };
+
+  struct DrmFileState {
+    uint64_t id = 0;
+    uint32_t render_minor = 128;
+    size_t open_fds = 0;
+    uint32_t next_syncobj_handle = 1;
+    std::unordered_map<uint32_t, std::shared_ptr<SyncobjEntry>> syncobj_entries;
+    // Timeline activity on one DRM file must not wake waiters belonging to every
+    // other open DRM file in the process.
+    std::condition_variable syncobj_cv;
+    bool syncobj_cv_reset_after_fork = false;
+  };
+
+  using DrmFileToken = std::shared_ptr<DrmFileState>;
+
+  struct DrmUntrackResult {
+    bool tracked = false;
+    std::optional<uint64_t> closed_file_id;
+  };
+
+  std::optional<uint64_t> release_drm_file_locked(const DrmFileToken &state) {
+    if (!state)
+      return std::nullopt;
+    if (state->open_fds == 0) {
+      util::Logger::warn("DRM file refcount underflow, id=", state->id);
+      return std::nullopt;
+    }
+    --state->open_fds;
+    return state->open_fds == 0 ? std::optional(state->id) : std::nullopt;
+  }
+
   void track_drm(int fd, uint32_t render_minor = 128) {
+    auto state = std::make_shared<DrmFileState>();
+    state->render_minor = render_minor;
+    state->open_fds = 1;
+    std::optional<uint64_t> closed_file_id;
+    {
+      std::lock_guard lock(fd_mutex_);
+      state->id = next_drm_file_id_++;
+      if (auto stale = drm_fds_.find(fd); stale != drm_fds_.end()) {
+        closed_file_id = release_drm_file_locked(stale->second);
+        stale->second = std::move(state);
+      } else {
+        drm_fds_.emplace(fd, std::move(state));
+      }
+    }
+    if (closed_file_id)
+      reap_gem_for_drm_file(*closed_file_id);
+  }
+
+  DrmFileToken reserve_drm_file(int fd) {
     std::lock_guard lock(fd_mutex_);
-    drm_fds_[fd] = render_minor;
+    auto it = drm_fds_.find(fd);
+    if (it == drm_fds_.end())
+      return nullptr;
+    ++it->second->open_fds;
+    return it->second;
+  }
+
+  void release_drm_file_reservation(const DrmFileToken &state) {
+    if (!state)
+      return;
+    std::optional<uint64_t> closed_file_id;
+    {
+      std::lock_guard lock(fd_mutex_);
+      closed_file_id = release_drm_file_locked(state);
+    }
+    if (closed_file_id)
+      reap_gem_for_drm_file(*closed_file_id);
+  }
+
+  void commit_drm_dup(int fd, const DrmFileToken &state) {
+    if (fd < 0 || !state)
+      return;
+    std::optional<uint64_t> closed_file_id;
+    {
+      std::lock_guard lock(fd_mutex_);
+      if (auto stale = drm_fds_.find(fd); stale != drm_fds_.end()) {
+        auto displaced = std::move(stale->second);
+        stale->second = state;
+        closed_file_id = release_drm_file_locked(displaced);
+      } else {
+        drm_fds_.emplace(fd, state);
+      }
+    }
+    if (closed_file_id)
+      reap_gem_for_drm_file(*closed_file_id);
   }
 
   bool is_drm(int fd) {
@@ -852,12 +956,159 @@ public:
   uint32_t drm_render_minor(int fd) {
     std::lock_guard lock(fd_mutex_);
     auto it = drm_fds_.find(fd);
-    return (it != drm_fds_.end()) ? it->second : 128;
+    return (it != drm_fds_.end()) ? it->second->render_minor : 128;
   }
 
-  bool untrack_drm(int fd) {
+  DrmUntrackResult untrack_drm(int fd) {
     std::lock_guard lock(fd_mutex_);
-    return drm_fds_.erase(fd) != 0;
+    auto it = drm_fds_.find(fd);
+    if (it == drm_fds_.end())
+      return {};
+    auto state = std::move(it->second);
+    drm_fds_.erase(it);
+    return {.tracked = true, .closed_file_id = release_drm_file_locked(state)};
+  }
+
+  int create_syncobj(int fd, uint32_t flags, uint32_t *handle) {
+    if (!handle || (flags & ~DRM_SYNCOBJ_CREATE_SIGNALED) != 0)
+      return -EINVAL;
+    std::lock_guard lock(fd_mutex_);
+    auto file = drm_fds_.find(fd);
+    if (file == drm_fds_.end())
+      return -EBADF;
+    auto &state = *file->second;
+    uint32_t candidate = state.next_syncobj_handle++;
+    while (candidate == 0 || state.syncobj_entries.count(candidate) != 0)
+      candidate = state.next_syncobj_handle++;
+    auto entry = std::make_shared<SyncobjEntry>();
+    entry->has_fence = (flags & DRM_SYNCOBJ_CREATE_SIGNALED) != 0;
+    state.syncobj_entries[candidate] = std::move(entry);
+    *handle = candidate;
+    return 0;
+  }
+
+  int destroy_syncobj(int fd, uint32_t handle) {
+    std::lock_guard lock(fd_mutex_);
+    auto file = drm_fds_.find(fd);
+    if (file == drm_fds_.end())
+      return -EBADF;
+    if (file->second->syncobj_entries.erase(handle) == 0)
+      return -EINVAL;
+    return 0;
+  }
+
+  template <typename T>
+  static int snapshot_user_array(uint64_t address, uint32_t count, std::vector<T> &snapshot) {
+    try {
+      snapshot.resize(count);
+    } catch (const std::bad_alloc &) {
+      return -ENOMEM;
+    }
+    const size_t bytes = static_cast<size_t>(count) * sizeof(T);
+    iovec local{snapshot.data(), bytes};
+    iovec remote{reinterpret_cast<void *>(static_cast<uintptr_t>(address)), bytes};
+    long copied;
+    do {
+      copied = syscall(SYS_process_vm_readv, getpid(), &local, 1, &remote, 1, 0);
+    } while (copied < 0 && errno == EINTR);
+    return copied == static_cast<long>(bytes) ? 0 : -EFAULT;
+  }
+
+  int wait_syncobj_timeline(int fd, drm_syncobj_timeline_wait *wait) {
+    if (!wait)
+      return -EINVAL;
+    const drm_syncobj_timeline_wait request = *wait;
+    constexpr uint32_t kSupportedFlags =
+        DRM_SYNCOBJ_WAIT_FLAGS_WAIT_ALL | DRM_SYNCOBJ_WAIT_FLAGS_WAIT_FOR_SUBMIT |
+        DRM_SYNCOBJ_WAIT_FLAGS_WAIT_AVAILABLE | DRM_SYNCOBJ_WAIT_FLAGS_WAIT_DEADLINE;
+    if ((request.flags & ~kSupportedFlags) != 0 || request.pad != 0)
+      return -EINVAL;
+    if (request.count_handles == 0)
+      return 0;
+    std::vector<uint32_t> handles;
+    std::vector<uint64_t> points;
+    if (int rc = snapshot_user_array(request.handles, request.count_handles, handles); rc != 0)
+      return rc;
+    if (int rc = snapshot_user_array(request.points, request.count_handles, points); rc != 0)
+      return rc;
+    std::unique_lock lock(fd_mutex_);
+    auto file = drm_fds_.find(fd);
+    if (file == drm_fds_.end())
+      return -EBADF;
+    auto file_state = file->second;
+    std::vector<std::shared_ptr<SyncobjEntry>> entries;
+    entries.reserve(request.count_handles);
+    for (uint32_t i = 0; i < request.count_handles; ++i) {
+      auto it = file->second->syncobj_entries.find(handles[i]);
+      if (it == file->second->syncobj_entries.end())
+        return -ENOENT;
+      entries.push_back(it->second);
+    }
+    const bool wait_all = (request.flags & DRM_SYNCOBJ_WAIT_FLAGS_WAIT_ALL) != 0;
+    const bool wait_for_submit = (request.flags & DRM_SYNCOBJ_WAIT_FLAGS_WAIT_FOR_SUBMIT) != 0;
+    const bool wait_available = (request.flags & DRM_SYNCOBJ_WAIT_FLAGS_WAIT_AVAILABLE) != 0;
+    const auto evaluate = [&]() -> std::pair<int, uint32_t> {
+      bool all_ready = true;
+      bool any_ready = false;
+      uint32_t first_ready = 0;
+      for (uint32_t i = 0; i < request.count_handles; ++i) {
+        const auto &entry = *entries[i];
+        const bool submitted =
+            entry.has_fence && (points[i] == 0 || entry.submitted_point >= points[i]);
+        if (!submitted && !wait_for_submit && !wait_available)
+          return {-EINVAL, 0};
+        const bool ready = wait_available ? submitted
+                                          : entry.has_fence && (points[i] == 0 ||
+                                                                entry.signaled_point >= points[i]);
+        all_ready = all_ready && ready;
+        if (!wait_all && ready && !any_ready) {
+          first_ready = i;
+          any_ready = true;
+        }
+      }
+      return {(wait_all ? all_ready : any_ready) ? 1 : 0, first_ready};
+    };
+
+    while (true) {
+      auto [state, first_ready] = evaluate();
+      if (state < 0)
+        return state;
+      if (state > 0) {
+        if (!wait_all)
+          wait->first_signaled = first_ready;
+        return 0;
+      }
+
+      timespec now{};
+      if (clock_gettime(CLOCK_MONOTONIC, &now) != 0)
+        return -errno;
+      const int64_t now_ns = static_cast<int64_t>(now.tv_sec) * 1'000'000'000LL + now.tv_nsec;
+      if (request.timeout_nsec <= now_ns)
+        return -ETIME;
+      file_state->syncobj_cv.wait_for(lock,
+                                      std::chrono::nanoseconds(request.timeout_nsec - now_ns));
+    }
+  }
+
+  static void signal_syncobj_locked(const std::shared_ptr<SyncobjEntry> &entry, uint64_t point) {
+    if (!entry)
+      return;
+    entry->has_fence = true;
+    entry->submitted_point = std::max(entry->submitted_point, point);
+    entry->signaled_point = std::max(entry->signaled_point, point);
+  }
+
+  static std::shared_ptr<SyncobjEntry> lookup_syncobj_locked(const DrmFileToken &file,
+                                                             uint32_t handle) {
+    if (!file || handle == 0)
+      return nullptr;
+    auto entry = file->syncobj_entries.find(handle);
+    return entry != file->syncobj_entries.end() ? entry->second : nullptr;
+  }
+
+  static void notify_syncobj_waiters(const DrmFileToken &file) {
+    if (file)
+      file->syncobj_cv.notify_all();
   }
 
   bool create_local_vm(const std::string &config_path) {
@@ -939,7 +1190,7 @@ public:
   struct GemEntry {
     int dmabuf_fd = -1;          ///< Private dup of the backing dmabuf fd for the lazy mmap.
     bool owns_dmabuf_fd = false; ///< True if dmabuf_fd is our dup (close at teardown).
-    int drm_fd = -1;             ///< Owning DRM file; the entry is reaped when it closes.
+    uint64_t drm_file_id = 0;    ///< Owning DRM file; the entry is reaped on its last close.
     uint64_t size = 0;
     uint32_t alloc_flags = 0;
     void *cpu_ptr = nullptr;
@@ -979,6 +1230,9 @@ public:
   /// @returns The stable GEM handle (>= 1).
   uint32_t prime_import(int dmabuf_fd, int drm_fd, uint64_t size) {
     std::lock_guard lock(fd_mutex_);
+    auto drm_file = drm_fds_.find(drm_fd);
+    if (drm_file == drm_fds_.end())
+      return 0;
     uint32_t alloc_flags = 0;
     if (auto it = pending_gem_flags_.find(dmabuf_fd); it != pending_gem_flags_.end()) {
       alloc_flags = it->second;
@@ -1003,7 +1257,7 @@ public:
     gem = {};
     gem.dmabuf_fd = (backing_fd >= 0) ? backing_fd : dmabuf_fd;
     gem.owns_dmabuf_fd = (backing_fd >= 0);
-    gem.drm_fd = drm_fd;
+    gem.drm_file_id = drm_file->second->id;
     gem.size = size;
     gem.alloc_flags = alloc_flags;
     return handle;
@@ -1011,30 +1265,39 @@ public:
 
   /// @brief Install (or replace) a GEM_VA range in the GPU page table for @p handle.
   /// @details Runs entirely under fd_mutex_ and performs BOTH the bookkeeping AND
-  /// the page-table install (drv->gem_va_map) atomically, so a concurrent GEM_CLOSE
+  /// the page-table install (drv->gem_va_map) and output timeline signal atomically,
+  /// so a concurrent GEM_CLOSE
   /// (untrack_gem, also under fd_mutex_) can never interleave between recording the
   /// range and installing the PTEs — which would otherwise leave PTEs pointing into
   /// a munmapped cpu_ptr with no entry left to tear them down. It lazily mmaps the
   /// dmabuf fd's backing pages the first time (the fd is still open at GEM_VA time),
-  /// bounds-checks the request against the BO size, records the range, and installs
-  /// the PTEs. The lock order fd_mutex_ -> driver page-table lock matches
+  /// bounds-checks the request against the BO size, records the range, installs
+  /// the PTEs, and publishes the output timeline point. The lock order
+  /// fd_mutex_ -> driver page-table lock matches
   /// teardown_gem_entry_locked, so there is no inversion.
   /// @param replace When true (AMDGPU_VA_OP_REPLACE), first evict any existing range
-  ///   that OVERLAPS {va_address, map_size} — from whatever handle currently owns it —
-  ///   so the old owner's bookkeeping does not later tear down the replacement's PTEs.
+  ///   in the calling DRM-file namespace that OVERLAPS {va_address, map_size}, so the
+  ///   old owner's bookkeeping does not later tear down the replacement's PTEs.
   ///   When false (AMDGPU_VA_OP_MAP), an overlapping pre-existing range is a conflict.
-  /// @retval true the range was installed.
-  /// @retval false unknown handle, out-of-bounds request, failed mmap, no driver, or
-  ///   (MAP only) the range is already mapped.
-  [[nodiscard]] bool gem_map(uint32_t handle, uint64_t va_address, uint64_t offset_in_bo,
-                             uint64_t map_size, bool replace) {
-    std::lock_guard lock(fd_mutex_);
+  /// @returns Zero when the range was installed, `-ENOENT` for an unknown handle in
+  ///   this DRM-file namespace, or another negative errno for invalid requests.
+  [[nodiscard]] int gem_map(int drm_fd, uint32_t handle, uint64_t va_address, uint64_t offset_in_bo,
+                            uint64_t map_size, bool replace, uint32_t timeline_handle = 0,
+                            uint64_t timeline_point = 0) {
+    std::unique_lock lock(fd_mutex_);
+    auto file = drm_fds_.find(drm_fd);
+    if (file == drm_fds_.end())
+      return -EBADF;
+    auto file_state = file->second;
+    auto timeline = lookup_syncobj_locked(file_state, timeline_handle);
+    if (timeline_handle != 0 && !timeline)
+      return -ENOENT;
     auto *drv = dynamic_cast<SimulatedKfd *>(driver());
     if (!drv)
-      return false;
+      return -ENODEV;
     auto it = gem_entries_.find(handle);
-    if (it == gem_entries_.end())
-      return false;
+    if (it == gem_entries_.end() || it->second.drm_file_id != file->second->id)
+      return -ENOENT;
     GemEntry &gem = it->second;
     // Bound the request within the BO without letting offset_in_bo + map_size
     // overflow (both are caller-controlled __u64 from the UAPI struct): a wrap
@@ -1042,23 +1305,23 @@ public:
     // the mmap. Reject a zero-size BO, a zero-size map, and any range past the end.
     if (gem.size == 0 || map_size == 0 || offset_in_bo > gem.size ||
         map_size > gem.size - offset_in_bo)
-      return false;
+      return -EINVAL;
     const GemMapping range{va_address, map_size};
     // Handle the target VA range's current occupant. REPLACE evicts any current
     // holder (possibly a different handle) so its records cannot later unmap the new
     // PTEs. Plain MAP treats an existing range as a conflict rather than silently
     // double-mapping over another handle's PTEs.
     if (replace) {
-      if (!evict_range_locked(drv, range, /*allow_missing=*/true))
-        return false;
-    } else if (range_is_mapped_locked(range)) {
-      return false;
+      if (!evict_range_locked(drv, file->second->id, range, /*allow_missing=*/true))
+        return -EINVAL;
+    } else if (range_is_mapped_locked(file->second->id, range)) {
+      return -EINVAL;
     }
     if (!gem.cpu_ptr) {
       void *p = InterposerContext::real().mmap(nullptr, gem.size, PROT_READ | PROT_WRITE,
                                                MAP_SHARED, gem.dmabuf_fd, 0);
       if (p == MAP_FAILED)
-        return false;
+        return -EINVAL;
       gem.cpu_ptr = p;
     }
     // Record which SimulatedKfd's page table receives these PTEs so GEM_CLOSE (or a
@@ -1079,9 +1342,13 @@ public:
     // failed map (do not record the range) so GEM_VA reports the error rather than a
     // phantom success.
     if (!drv->gem_va_map(va_address, host, map_size, gem.alloc_flags))
-      return false;
+      return -EINVAL;
     gem.installed_vas.push_back(range);
-    return true;
+    signal_syncobj_locked(timeline, timeline_point);
+    lock.unlock();
+    if (timeline)
+      notify_syncobj_waiters(file_state);
+    return 0;
   }
 
   /// @brief Remove a GEM_VA range from the GPU page table for @p handle (UNMAP).
@@ -1090,41 +1357,69 @@ public:
   /// owns the exact {va_address, map_size} range before mutating the page table, so
   /// an UNMAP with a wrong handle or range cannot tear down PTEs the handle does not
   /// own and cannot report success for a no-op.
-  /// @retval true the range was owned by @p handle and has been unmapped.
-  /// @retval false no driver, unknown handle, or @p handle does not own that range.
-  [[nodiscard]] bool gem_unmap(uint32_t handle, uint64_t va_address, uint64_t map_size) {
-    std::lock_guard lock(fd_mutex_);
+  /// @returns Zero when the range was unmapped, `-ENOENT` for an unknown handle in
+  ///   this DRM-file namespace, or another negative errno for invalid requests.
+  [[nodiscard]] int gem_unmap(int drm_fd, uint32_t handle, uint64_t va_address, uint64_t map_size,
+                              uint32_t timeline_handle = 0, uint64_t timeline_point = 0) {
+    std::unique_lock lock(fd_mutex_);
+    auto file = drm_fds_.find(drm_fd);
+    if (file == drm_fds_.end())
+      return -EBADF;
+    auto file_state = file->second;
+    auto timeline = lookup_syncobj_locked(file_state, timeline_handle);
+    if (timeline_handle != 0 && !timeline)
+      return -ENOENT;
     auto *drv = dynamic_cast<SimulatedKfd *>(driver());
     if (!drv)
-      return false;
+      return -ENODEV;
     auto it = gem_entries_.find(handle);
-    if (it == gem_entries_.end())
-      return false;
+    if (it == gem_entries_.end() || it->second.drm_file_id != file->second->id)
+      return -ENOENT;
     GemEntry &gem = it->second;
     const GemMapping range{va_address, map_size};
     if (std::find(gem.installed_vas.begin(), gem.installed_vas.end(), range) ==
         gem.installed_vas.end())
-      return false; // This handle does not own the exact range — do not touch PTEs.
+      return -EINVAL; // This handle does not own the exact range — do not touch PTEs.
     if (!drv->gem_va_unmap(va_address, map_size))
-      return false;
+      return -EINVAL;
     std::erase(gem.installed_vas, range);
-    return true;
+    signal_syncobj_locked(timeline, timeline_point);
+    lock.unlock();
+    if (timeline)
+      notify_syncobj_waiters(file_state);
+    return 0;
   }
 
   /// @brief Clear a GEM_VA range from the GPU page table (CLEAR).
-  /// @details CLEAR is handle-agnostic: it tears down every recorded range that
-  /// OVERLAPS {va_address, map_size} wherever it is currently recorded, updating the
-  /// owning entries' bookkeeping so a later GEM_CLOSE does not double-unmap them.
+  /// @details CLEAR is handle-agnostic within one DRM file: it tears down every
+  /// recorded range that OVERLAPS {va_address, map_size} in the calling file's
+  /// namespace, updating the owning entries' bookkeeping so a later GEM_CLOSE does
+  /// not double-unmap them.
   /// Fails if no recorded range overlaps (so the ioctl reports EINVAL instead of a
   /// phantom clear).
-  /// @retval true at least one overlapping range was found and cleared.
-  /// @retval false no driver, or no recorded range overlaps.
-  [[nodiscard]] bool gem_clear(uint64_t va_address, uint64_t map_size) {
-    std::lock_guard lock(fd_mutex_);
+  /// @returns Zero when an overlapping range in the calling DRM-file namespace was
+  ///   cleared, or a negative errno when no such range exists or the request fails.
+  [[nodiscard]] int gem_clear(int drm_fd, uint64_t va_address, uint64_t map_size,
+                              uint32_t timeline_handle = 0, uint64_t timeline_point = 0) {
+    std::unique_lock lock(fd_mutex_);
+    auto file = drm_fds_.find(drm_fd);
+    if (file == drm_fds_.end())
+      return -EBADF;
+    auto file_state = file->second;
+    auto timeline = lookup_syncobj_locked(file_state, timeline_handle);
+    if (timeline_handle != 0 && !timeline)
+      return -ENOENT;
     auto *drv = dynamic_cast<SimulatedKfd *>(driver());
     if (!drv)
-      return false;
-    return evict_range_locked(drv, GemMapping{va_address, map_size}, /*allow_missing=*/false);
+      return -ENODEV;
+    if (!evict_range_locked(drv, file->second->id, GemMapping{va_address, map_size},
+                            /*allow_missing=*/false))
+      return -EINVAL;
+    signal_syncobj_locked(timeline, timeline_point);
+    lock.unlock();
+    if (timeline)
+      notify_syncobj_waiters(file_state);
+    return 0;
   }
 
   /// @brief Reap every GEM handle owned by a closing DRM file (at its close()).
@@ -1132,10 +1427,10 @@ public:
   /// leave handles live; the DRM file close is their backstop, mirroring the kernel
   /// dropping a drm_file's GEM objects. Tears each entry's PTEs + host mmap down
   /// under fd_mutex_ before erasing, so no state escapes the lock.
-  void reap_gem_for_drm_fd(int drm_fd) {
+  void reap_gem_for_drm_file(uint64_t drm_file_id) {
     std::lock_guard lock(fd_mutex_);
     for (auto it = gem_entries_.begin(); it != gem_entries_.end();) {
-      if (it->second.drm_fd == drm_fd) {
+      if (it->second.drm_file_id == drm_file_id) {
         teardown_gem_entry_locked(it->second);
         it = gem_entries_.erase(it);
       } else {
@@ -1150,13 +1445,17 @@ public:
   /// and munmaps the host mapping entirely under fd_mutex_, so no GemEntry pointer
   /// or driver pointer escapes the lock and a concurrent GEM_VA cannot race the
   /// teardown.
-  void untrack_gem(uint32_t handle) {
+  int untrack_gem(int drm_fd, uint32_t handle) {
     std::lock_guard lock(fd_mutex_);
+    auto file = drm_fds_.find(drm_fd);
+    if (file == drm_fds_.end())
+      return -EBADF;
     auto it = gem_entries_.find(handle);
-    if (it == gem_entries_.end())
-      return;
+    if (it == gem_entries_.end() || it->second.drm_file_id != file->second->id)
+      return -ENOENT;
     teardown_gem_entry_locked(it->second);
     gem_entries_.erase(it);
+    return 0;
   }
 
   LinuxKfd *get_or_create() {
@@ -1333,7 +1632,8 @@ private:
   std::mutex fd_mutex_;
   std::mutex remote_mutex_;
   std::unordered_map<int, std::string> sysfs_fds_;
-  std::unordered_map<int, uint32_t> drm_fds_;
+  std::unordered_map<int, DrmFileToken> drm_fds_;
+  uint64_t next_drm_file_id_ = 1;
   /// @brief Tracked KFD dup fds → the backend that holds their open reference.
   /// @details Each dup of a KFD fd retains one open reference. The backend is
   /// captured at track time so untrack releases the SAME backend even if the
@@ -1344,7 +1644,7 @@ private:
   /// @brief Imported GEM buffer objects, keyed by a stable, minted GEM handle.
   /// @details The handle (never fd-derived) owns the mapping lifetime; entries live
   /// from PRIME_FD_TO_HANDLE until DRM_IOCTL_GEM_CLOSE, or until the owning DRM file
-  /// closes (reap_gem_for_drm_fd). Because handles are not recycled with fd numbers,
+  /// closes (reap_gem_for_drm_file). Because handles are not recycled with fd numbers,
   /// a reused dmabuf fd can never collide with a still-live BO.
   std::unordered_map<uint32_t, GemEntry> gem_entries_;
   /// @brief Next stable GEM handle to mint. Starts at 1 so 0 means "no handle".
@@ -1382,17 +1682,18 @@ private:
     gem.owns_dmabuf_fd = false;
   }
 
-  /// @brief Evict every recorded range that OVERLAPS @p range, across all handles.
-  /// @details Caller holds fd_mutex_ and passes the live simulated @p drv. Used by
-  /// GEM_VA REPLACE (evict prior mappings before installing the new one) and CLEAR
-  /// (handle-agnostic teardown). Matching is by interval intersection, not exact
-  /// equality: a REPLACE at a VA previously mapped with a DIFFERENT size (or a
-  /// sub/super-range) must still evict the old mapping, otherwise its stale
-  /// bookkeeping would later double-unmap or leak the new PTEs. Each overlapping
-  /// range is unmapped by its OWN {va_address, map_size} extent (not @p range's) so
-  /// the page-table removal matches what was installed, then dropped from its entry's
-  /// bookkeeping. The host mmap is left intact — the owning handle still exists and
-  /// other ranges may reference it; it is munmapped only at GEM_CLOSE / reap.
+  /// @brief Evict every recorded range that OVERLAPS @p range in one DRM file.
+  /// @details Caller holds fd_mutex_ and passes the live simulated @p drv and stable
+  /// DRM-file identity. Used by GEM_VA REPLACE (evict prior mappings before installing
+  /// the new one) and CLEAR (handle-agnostic teardown). Matching is by interval
+  /// intersection, not exact equality: a REPLACE at a VA previously mapped with a
+  /// DIFFERENT size (or a sub/super-range) must still evict the old mapping, otherwise
+  /// its stale bookkeeping would later double-unmap or leak the new PTEs. Each
+  /// overlapping range is unmapped by its OWN {va_address, map_size} extent (not @p
+  /// range's) so the page-table removal matches what was installed, then dropped from
+  /// its entry's bookkeeping. The host mmap is left intact — the owning handle still
+  /// exists and other ranges may reference it; it is munmapped only at GEM_CLOSE /
+  /// reap.
   /// @param allow_missing When true, no overlap is a success (a MAP onto a free VA has
   ///   nothing to evict); when false (REPLACE/CLEAR), no overlap is a failure so the
   ///   ioctl reports EINVAL.
@@ -1402,10 +1703,12 @@ private:
   ///   evicted. This is safe because gem_va_unmap() only fails when the local process
   ///   has already vanished (SimulatedKfd::gem_va_unmap), i.e. its page table is being
   ///   torn down anyway, so a partially-evicted state is never observed by a live GPU.
-  [[nodiscard]] bool evict_range_locked(SimulatedKfd *drv, const GemMapping &range,
-                                        bool allow_missing) {
+  [[nodiscard]] bool evict_range_locked(SimulatedKfd *drv, uint64_t drm_file_id,
+                                        const GemMapping &range, bool allow_missing) {
     bool evicted_any = false;
     for (auto &[handle, gem] : gem_entries_) {
+      if (gem.drm_file_id != drm_file_id)
+        continue;
       for (auto vit = gem.installed_vas.begin(); vit != gem.installed_vas.end();) {
         if (!vit->overlaps(range)) {
           ++vit;
@@ -1423,11 +1726,14 @@ private:
   /// @brief Whether any GEM entry owns a range OVERLAPPING @p range. Caller holds
   /// fd_mutex_. Used by plain MAP to reject a map that would collide with (not just
   /// exactly duplicate) an existing range's PTEs.
-  [[nodiscard]] bool range_is_mapped_locked(const GemMapping &range) const {
-    for (const auto &[handle, gem] : gem_entries_)
+  [[nodiscard]] bool range_is_mapped_locked(uint64_t drm_file_id, const GemMapping &range) const {
+    for (const auto &[handle, gem] : gem_entries_) {
+      if (gem.drm_file_id != drm_file_id)
+        continue;
       for (const auto &existing : gem.installed_vas)
         if (existing.overlaps(range))
           return true;
+    }
     return false;
   }
 
@@ -1693,8 +1999,10 @@ RJ_INTERPOSER_EXPORT int close(int fd) {
   // handler). Closing the DRM FILE itself, however, is the true backstop: reap any
   // handles still open on it (mirroring the kernel dropping a drm_file's GEM
   // objects) so a leaked/never-GEM_CLOSE'd handle cannot outlive its DRM file.
-  if (InterposerContext::ctx.untrack_drm(fd)) {
-    InterposerContext::ctx.reap_gem_for_drm_fd(fd);
+  auto drm_close = InterposerContext::ctx.untrack_drm(fd);
+  if (drm_close.tracked) {
+    if (drm_close.closed_file_id)
+      InterposerContext::ctx.reap_gem_for_drm_file(*drm_close.closed_file_id);
     InterposerContext::real().close(fd);
     return 0;
   }
@@ -1726,6 +2034,9 @@ RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
   constexpr unsigned kDrmIoctlNrAmdgpuInfo = DRM_COMMAND_BASE + DRM_AMDGPU_INFO;
   constexpr unsigned kDrmIoctlNrGemVa = DRM_COMMAND_BASE + DRM_AMDGPU_GEM_VA;
   constexpr unsigned kDrmIoctlNrPrimeFdToHandle = _IOC_NR(DRM_IOCTL_PRIME_FD_TO_HANDLE);
+  constexpr unsigned kDrmIoctlNrSyncobjCreate = _IOC_NR(DRM_IOCTL_SYNCOBJ_CREATE);
+  constexpr unsigned kDrmIoctlNrSyncobjDestroy = _IOC_NR(DRM_IOCTL_SYNCOBJ_DESTROY);
+  constexpr unsigned kDrmIoctlNrSyncobjTimelineWait = _IOC_NR(DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT);
 
   if (InterposerContext::ctx.is_drm(fd)) {
     unsigned nr = _IOC_NR(request);
@@ -1782,7 +2093,28 @@ RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
       // folding in the alloc flags captured at EXPORT_DMABUF. The caller closes the
       // export fd right after access setup; the handle — not the fd — owns the BO.
       prime->handle = InterposerContext::ctx.prime_import(prime->fd, fd, sz);
+      if (prime->handle == 0) {
+        errno = EBADF;
+        return -1;
+      }
       return 0;
+    }
+    if (type == kDrmIoctlType && nr == kDrmIoctlNrSyncobjCreate && arg) {
+      auto *create = static_cast<drm_syncobj_create *>(arg);
+      return kfd_ioctl_ret(
+          InterposerContext::ctx.create_syncobj(fd, create->flags, &create->handle));
+    }
+    if (type == kDrmIoctlType && nr == kDrmIoctlNrSyncobjDestroy && arg) {
+      auto *destroy = static_cast<drm_syncobj_destroy *>(arg);
+      if (destroy->pad != 0) {
+        errno = EINVAL;
+        return -1;
+      }
+      return kfd_ioctl_ret(InterposerContext::ctx.destroy_syncobj(fd, destroy->handle));
+    }
+    if (type == kDrmIoctlType && nr == kDrmIoctlNrSyncobjTimelineWait && arg) {
+      return kfd_ioctl_ret(InterposerContext::ctx.wait_syncobj_timeline(
+          fd, static_cast<drm_syncobj_timeline_wait *>(arg)));
     }
     if (type == kDrmIoctlType && nr == kDrmIoctlNrAmdgpuInfo && arg) {
       // Service the AMDGPU_INFO queries that real libdrm_amdgpu issues during
@@ -1888,8 +2220,7 @@ RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
       // BEFORE munmapping the host pages, entirely under fd_mutex_ so no state
       // escapes the lock.
       auto *gc = static_cast<drm_gem_close *>(arg);
-      InterposerContext::ctx.untrack_gem(gc->handle);
-      return 0;
+      return kfd_ioctl_ret(InterposerContext::ctx.untrack_gem(fd, gc->handle));
     }
     if (type == kDrmIoctlType && nr == kDrmIoctlNrGemVa && arg) {
       // GEM_VA installs (or tears down) a GPU virtual mapping for a prime-
@@ -1898,51 +2229,61 @@ RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
       // VAs. We map by GEM handle, lazily mmap the backing pages, and
       // install/remove them in the GPU page table.
       auto *va = static_cast<drm_amdgpu_gem_va *>(arg);
+      // Input fences require the VM update to remain pending until another
+      // operation signals them. This local model only supports synchronous
+      // updates, so reject that contract instead of applying the mapping early.
+      if (va->num_syncobj_handles != 0 || va->input_fence_syncobj_handles != 0) {
+        errno = EINVAL;
+        return -1;
+      }
       // GEM_VA page-table installation only applies to the local simulated driver;
       // there is no such path for a remote (daemon) or DBT-guest backend. Report
       // failure rather than a phantom success so userspace does not record a mapping
       // that was never installed and later fault on the GPU page table. gem_map/
       // gem_unmap do the bookkeeping AND the page-table mutation atomically under
       // fd_mutex_ (so a concurrent GEM_CLOSE cannot leave dangling PTEs); they
-      // return false on no-driver / unknown handle / out-of-bounds / failed mmap.
+      // return a kernel-style negative errno on failure.
       if (!InterposerContext::ctx.driver_is_simulated()) {
         errno = ENODEV;
         return -1;
       }
-      bool ok = false;
+      int result = 0;
       switch (va->operation) {
       case AMDGPU_VA_OP_MAP:
       case AMDGPU_VA_OP_REPLACE:
-        // REPLACE evicts any prior occupant of the VA range (from whatever handle
-        // owns it) before installing the new mapping, so closing the old handle
+        // REPLACE evicts any prior occupant of the VA range in this DRM-file
+        // namespace before installing the new mapping, so closing the old handle
         // cannot later unmap the replacement. MAP rejects a range already in use.
-        ok = InterposerContext::ctx.gem_map(va->handle, va->va_address, va->offset_in_bo,
-                                            va->map_size,
-                                            /*replace=*/va->operation == AMDGPU_VA_OP_REPLACE);
+        result = InterposerContext::ctx.gem_map(fd, va->handle, va->va_address, va->offset_in_bo,
+                                                va->map_size,
+                                                /*replace=*/va->operation == AMDGPU_VA_OP_REPLACE,
+                                                va->vm_timeline_syncobj_out, va->vm_timeline_point);
         break;
       case AMDGPU_VA_OP_UNMAP:
         // UNMAP requires the supplied handle to own the exact range.
-        ok = InterposerContext::ctx.gem_unmap(va->handle, va->va_address, va->map_size);
+        result =
+            InterposerContext::ctx.gem_unmap(fd, va->handle, va->va_address, va->map_size,
+                                             va->vm_timeline_syncobj_out, va->vm_timeline_point);
         break;
       case AMDGPU_VA_OP_CLEAR:
-        // CLEAR is handle-agnostic: tear down the exact range wherever it lives.
-        ok = InterposerContext::ctx.gem_clear(va->va_address, va->map_size);
+        // CLEAR is handle-agnostic within the calling DRM-file namespace.
+        result = InterposerContext::ctx.gem_clear(
+            fd, va->va_address, va->map_size, va->vm_timeline_syncobj_out, va->vm_timeline_point);
         break;
       default:
         // Unknown GEM_VA operation — do not claim it succeeded.
         errno = EINVAL;
         return -1;
       }
-      if (!ok) {
-        errno = EINVAL;
-        return -1;
-      }
+      if (result != 0)
+        return kfd_ioctl_ret(result);
       return 0;
     }
-    // Only DRM command ioctls (nr >= DRM_COMMAND_BASE) carry an AMDGPU-relative
-    // command number; core DRM ioctls (nr < DRM_COMMAND_BASE) would underflow and
-    // log a nonsense "AMDGPU cmd", so report the raw nr for those.
-    if (nr >= DRM_COMMAND_BASE) {
+    // The AMDGPU command range starts at DRM_COMMAND_BASE, while generic DRM
+    // requests occupy ranges on both sides of it (timeline syncobj requests, for
+    // example, start at 0xbf). Only label requests in the range defined by this
+    // vendored AMDGPU UAPI as driver-relative commands.
+    if (nr >= DRM_COMMAND_BASE && nr < DRM_COMMAND_END) {
       util::Logger::warn("DRM ioctl rejected: nr=0x", std::hex, nr, " (AMDGPU cmd 0x",
                          nr - DRM_COMMAND_BASE, std::dec, ") fd=", fd);
     } else {
@@ -2017,17 +2358,20 @@ RJ_INTERPOSER_EXPORT int dup(int oldfd) {
   // last-close cannot tear the backend down between the dup and tracking the new
   // fd (which would leave a valid KFD dup untracked / unreferenced).
   auto reserved = InterposerContext::ctx.reserve_dup_backend(oldfd);
+  auto drm_file = InterposerContext::ctx.reserve_drm_file(oldfd);
   int rc = InterposerContext::real().dup(oldfd);
   if (rc < 0) {
     // Syscall failed: roll back the reservation.
     if (reserved)
       InterposerContext::ctx.release_backend(*reserved);
+    InterposerContext::ctx.release_drm_file_reservation(drm_file);
     return rc;
   }
   if (reserved)
     InterposerContext::ctx.commit_dup(rc, *reserved);
   else
     InterposerContext::ctx.untrack_dup(rc);
+  InterposerContext::ctx.commit_drm_dup(rc, drm_file);
   return rc;
 }
 
@@ -2045,7 +2389,8 @@ namespace {
 //     invalidated and its reference released, so the reused fd number no longer
 //     routes to the old backend.
 // Then the replacement is recorded on the reserved source backend.
-void reconcile_dup_target(int newfd, std::optional<InterposerContext::DupBackend> reserved) {
+void reconcile_dup_target(int newfd, std::optional<InterposerContext::DupBackend> reserved,
+                          const InterposerContext::DrmFileToken &drm_file) {
   InterposerContext::ctx.untrack_sysfs(newfd);
   // dup2/dup3 atomically close whatever newfd was, bypassing the close() hook, so
   // every per-fd cleanup close() performs must be mirrored here. Drop any transient
@@ -2055,14 +2400,16 @@ void reconcile_dup_target(int newfd, std::optional<InterposerContext::DupBackend
   // non-dmabuf fds.
   InterposerContext::ctx.drop_pending_gem_flags(newfd);
   // If newfd was a DRM render fd still owning live GEM handles, reap them here just as
-  // close() does (untrack_drm + reap_gem_for_drm_fd) — otherwise those GemEntry
-  // objects (keyed by drm_fd == newfd) leak their PTEs, host mmap, and dup'd dmabuf
+  // close() does (untrack_drm + reap_gem_for_drm_file) — otherwise those GemEntry
+  // objects owned by newfd's DRM file leak their PTEs, host mmap, and dup'd dmabuf
   // fd, and a later commit_dup could re-tag the same number as a KFD dup.
-  if (InterposerContext::ctx.untrack_drm(newfd))
-    InterposerContext::ctx.reap_gem_for_drm_fd(newfd);
+  auto drm_close = InterposerContext::ctx.untrack_drm(newfd);
+  if (drm_close.closed_file_id)
+    InterposerContext::ctx.reap_gem_for_drm_file(*drm_close.closed_file_id);
   InterposerContext::ctx.invalidate_overwritten_kfd_fd(newfd);
   if (reserved)
     InterposerContext::ctx.commit_dup(newfd, *reserved);
+  InterposerContext::ctx.commit_drm_dup(newfd, drm_file);
 }
 } // namespace
 
@@ -2074,13 +2421,15 @@ RJ_INTERPOSER_EXPORT int dup2(int oldfd, int newfd) {
     return InterposerContext::real().dup2(oldfd, newfd);
   // Reserve the source backend before the syscall (see dup()).
   auto reserved = InterposerContext::ctx.reserve_dup_backend(oldfd);
+  auto drm_file = InterposerContext::ctx.reserve_drm_file(oldfd);
   int rc = InterposerContext::real().dup2(oldfd, newfd);
   if (rc < 0) {
     if (reserved)
       InterposerContext::ctx.release_backend(*reserved);
+    InterposerContext::ctx.release_drm_file_reservation(drm_file);
     return rc;
   }
-  reconcile_dup_target(rc, reserved);
+  reconcile_dup_target(rc, reserved, drm_file);
   return rc;
 }
 
@@ -2090,13 +2439,15 @@ RJ_INTERPOSER_EXPORT int dup3(int oldfd, int newfd, int flags) {
   // dup3(fd, fd, ...) is required to fail with EINVAL without altering the
   // descriptor; do not mutate tracking before the syscall confirms that.
   auto reserved = InterposerContext::ctx.reserve_dup_backend(oldfd);
+  auto drm_file = InterposerContext::ctx.reserve_drm_file(oldfd);
   int rc = InterposerContext::real().dup3(oldfd, newfd, flags);
   if (rc < 0) {
     if (reserved)
       InterposerContext::ctx.release_backend(*reserved);
+    InterposerContext::ctx.release_drm_file_reservation(drm_file);
     return rc;
   }
-  reconcile_dup_target(rc, reserved);
+  reconcile_dup_target(rc, reserved, drm_file);
   return rc;
 }
 #endif
@@ -2172,8 +2523,11 @@ int fcntl_impl(int fd, int cmd, void *ptr_arg, int int_arg) {
   // existing fd, so no primary/dup reconciliation of a target is needed.
   const bool is_dupfd = (cmd == F_DUPFD || cmd == F_DUPFD_CLOEXEC);
   std::optional<InterposerContext::DupBackend> reserved;
-  if (is_dupfd)
+  InterposerContext::DrmFileToken drm_file;
+  if (is_dupfd) {
     reserved = InterposerContext::ctx.reserve_dup_backend(fd);
+    drm_file = InterposerContext::ctx.reserve_drm_file(fd);
+  }
 
   long rc = 0;
   switch (kind) {
@@ -2194,18 +2548,15 @@ int fcntl_impl(int fd, int cmd, void *ptr_arg, int int_arg) {
       // Syscall failed: roll back the reservation.
       if (reserved)
         InterposerContext::ctx.release_backend(*reserved);
+      InterposerContext::ctx.release_drm_file_reservation(drm_file);
     } else {
       if (reserved)
         InterposerContext::ctx.commit_dup(static_cast<int>(rc), *reserved);
       else
         InterposerContext::ctx.untrack_dup(static_cast<int>(rc));
-      // Propagate DRM render-node tracking across dup so ioctls on the duped fd
-      // are still recognized. libdrm's amdgpu_device_initialize duplicates the
-      // render fd (via fcntl64 F_DUPFD_CLOEXEC) and issues all AMDGPU_INFO ioctls
-      // on the copy.
-      if (InterposerContext::ctx.is_drm(fd))
-        InterposerContext::ctx.track_drm(static_cast<int>(rc),
-                                         InterposerContext::ctx.drm_render_minor(fd));
+      // libdrm duplicates the render fd and expects the new descriptor to share
+      // the same DRM-file handle and syncobj namespaces.
+      InterposerContext::ctx.commit_drm_dup(static_cast<int>(rc), drm_file);
     }
   }
   return static_cast<int>(rc);

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -1368,50 +1368,54 @@ add_executable(interposer_dup_test interposer_dup_test.cpp)
 rj_configure_target(interposer_dup_test TEST)
 target_include_directories(
     interposer_dup_test
-    PRIVATE ${CMAKE_SOURCE_DIR}/lib/rocjitsu/external_headers/hsa_headers
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}/lib/rocjitsu/external_headers/hsa_headers
+        ${CMAKE_SOURCE_DIR}/lib/rocjitsu/external_headers/drm_headers
 )
 target_link_libraries(interposer_dup_test PRIVATE GTest::gtest_main)
 add_dependencies(interposer_dup_test rocjitsu_bin rocjitsu_shared)
 if(RJ_INSTALL_TESTS)
     rj_install_test_target(interposer_dup_test)
 endif()
-foreach(
-    _interposer_dup_test
-    IN
-    ITEMS
-        DupKeepsKfdRoutingAfterPrimaryClose
-        FcntlDupfdKeepsKfdRouting
-        Dup2OverPrimaryInvalidatesKfdIdentity
-        Dup2OntoFreshFdRoutesKfd
-        Dup3RoutesKfdAndRejectsSameFd
-        ReopenAfterPrimaryOverwriteKeepsBackend
-        SerializedReopenUnderContentionStaysRoutable
-)
-    rj_add_test(
-        NAME "InterposerDupTest.${_interposer_dup_test}"
-        COMMAND
-            ${RJ_CLI}
-            --config
-            ${RJ_CDNA4_KMD_CONFIG}
-            --
-            $<TARGET_FILE:interposer_dup_test>
-            "--gtest_filter=InterposerDupTest.${_interposer_dup_test}"
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-        SKIP_REGULAR_EXPRESSION "\\[  SKIPPED \\]"
-        INSTALL_COMMAND
-            "\${RJ_INSTALLED_BINDIR}/rocjitsu"
-            "--config"
-            "\${RJ_INSTALLED_CONFIG_DIR}/${RJ_CDNA4_KMD_CONFIG_NAME}"
-            "--"
-            "bin/interposer_dup_test"
-            "--gtest_filter=InterposerDupTest.${_interposer_dup_test}"
-    )
-endforeach()
+function(rj_add_interposer_test_suite _suite)
+    foreach(_case IN LISTS ARGN)
+        rj_add_test(
+            NAME "${_suite}.${_case}"
+            COMMAND
+                ${RJ_CLI}
+                --config
+                ${RJ_CDNA4_KMD_CONFIG}
+                --
+                $<TARGET_FILE:interposer_dup_test>
+                "--gtest_filter=${_suite}.${_case}"
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            SKIP_REGULAR_EXPRESSION "\\[  SKIPPED \\]"
+            INSTALL_COMMAND
+                "\${RJ_INSTALLED_BINDIR}/rocjitsu"
+                "--config"
+                "\${RJ_INSTALLED_CONFIG_DIR}/${RJ_CDNA4_KMD_CONFIG_NAME}"
+                "--"
+                "bin/interposer_dup_test"
+                "--gtest_filter=${_suite}.${_case}"
+        )
+    endforeach()
+endfunction()
 
-foreach(
-    _interposer_gem_test
-    IN
-    ITEMS
+rj_add_interposer_test_suite(
+    InterposerDupTest
+    DupKeepsKfdRoutingAfterPrimaryClose
+    FcntlDupfdKeepsKfdRouting
+    Dup2OverPrimaryInvalidatesKfdIdentity
+    Dup2OntoFreshFdRoutesKfd
+    Dup3RoutesKfdAndRejectsSameFd
+    ReopenAfterPrimaryOverwriteKeepsBackend
+    SerializedReopenUnderContentionStaysRoutable
+    FcntlDupfdReplacesStaleDrmTracking
+)
+
+rj_add_interposer_test_suite(
+    InterposerGemTest
+        GemNamespaceIsPrivateButSharedByDuplicates
         ReusedDmabufFdMintsDistinctHandles
         UnmapWithWrongHandleFails
         MapSucceedsAfterExportFdClosed
@@ -1419,26 +1423,21 @@ foreach(
         ReplaceTransfersOwnershipAcrossOldOwnerClose
         ClearUpdatesOwnerBookkeeping
 )
-    rj_add_test(
-        NAME "InterposerGemTest.${_interposer_gem_test}"
-        COMMAND
-            ${RJ_CLI}
-            --config
-            ${RJ_CDNA4_KMD_CONFIG}
-            --
-            $<TARGET_FILE:interposer_dup_test>
-            "--gtest_filter=InterposerGemTest.${_interposer_gem_test}"
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-        SKIP_REGULAR_EXPRESSION "\\[  SKIPPED \\]"
-        INSTALL_COMMAND
-            "\${RJ_INSTALLED_BINDIR}/rocjitsu"
-            "--config"
-            "\${RJ_INSTALLED_CONFIG_DIR}/${RJ_CDNA4_KMD_CONFIG_NAME}"
-            "--"
-            "bin/interposer_dup_test"
-            "--gtest_filter=InterposerGemTest.${_interposer_gem_test}"
-    )
-endforeach()
+
+rj_add_interposer_test_suite(
+    InterposerSyncobjTest
+    VmTimelineWaitObservesSynchronousMapAndUnmap
+    GemVaSignalsBinarySyncobjsAtPointZero
+    DuplicateDrmFdsShareNamespaceAndLifetime
+    IndependentDrmOpensHaveSeparateNamespaces
+    CreateSignaledSeedsOnlyTheInitialPoint
+    WaitValidationMatchesDrm
+    DestroyRejectsInvalidInput
+    TimelineWaitBlocksUntilSignalOrDeadline
+    ForkedChildReinitializesTimelineWaitQueue
+    ConcurrentVmUpdatesShareTimeline
+    OutOfOrderTimelinePointPreservesWatermark
+)
 
 # --- rocminfo test (requires rocminfo binary + HSA runtime + CLI launcher) ---
 # Spawns rocminfo via the rocjitsu CLI and validates output.

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -1372,7 +1372,10 @@ target_include_directories(
         ${CMAKE_SOURCE_DIR}/lib/rocjitsu/external_headers/hsa_headers
         ${CMAKE_SOURCE_DIR}/lib/rocjitsu/external_headers/drm_headers
 )
-target_link_libraries(interposer_dup_test PRIVATE GTest::gtest_main)
+target_link_libraries(
+    interposer_dup_test
+    PRIVATE GTest::gtest_main ${CMAKE_DL_LIBS}
+)
 add_dependencies(interposer_dup_test rocjitsu_bin rocjitsu_shared)
 if(RJ_INSTALL_TESTS)
     rj_install_test_target(interposer_dup_test)
@@ -1401,8 +1404,7 @@ function(rj_add_interposer_test_suite _suite)
     endforeach()
 endfunction()
 
-rj_add_interposer_test_suite(
-    InterposerDupTest
+set(_rj_interposer_dup_tests
     DupKeepsKfdRoutingAfterPrimaryClose
     FcntlDupfdKeepsKfdRouting
     Dup2OverPrimaryInvalidatesKfdIdentity
@@ -1411,32 +1413,59 @@ rj_add_interposer_test_suite(
     ReopenAfterPrimaryOverwriteKeepsBackend
     SerializedReopenUnderContentionStaysRoutable
     FcntlDupfdReplacesStaleDrmTracking
+    NonDrmDuplicatesClearStaleDrmTracking
 )
+# TSan models concurrent close/dup on one descriptor as an application-level fd
+# race even though the interposer deliberately serializes the kernel operation.
+# Keep the lifecycle regression in regular and ASan builds, where it exercises
+# the intended close/reuse schedule without a sanitizer false positive.
+if(NOT RJ_ENABLE_TSAN)
+    list(
+        APPEND _rj_interposer_dup_tests
+        DrmCloseReuseRaceNeverMisclassifiesDuplicate
+    )
+endif()
+rj_add_interposer_test_suite(InterposerDupTest ${_rj_interposer_dup_tests})
 
 rj_add_interposer_test_suite(
     InterposerGemTest
-        GemNamespaceIsPrivateButSharedByDuplicates
-        ReusedDmabufFdMintsDistinctHandles
-        UnmapWithWrongHandleFails
-        MapSucceedsAfterExportFdClosed
-        ReplaceEvictsOverlappingDifferentSizeRange
-        ReplaceTransfersOwnershipAcrossOldOwnerClose
-        ClearUpdatesOwnerBookkeeping
+    GemNamespaceIsPrivateButSharedByDuplicates
+    IndependentDrmFilesRejectOverlappingMappings
+    ReusedDmabufFdMintsDistinctHandles
+    UnmapWithWrongHandleFails
+    MapSucceedsAfterExportFdClosed
+    ReplaceEvictsOverlappingDifferentSizeRange
+    ReplaceTransfersOwnershipAcrossOldOwnerClose
+    ClearUpdatesOwnerBookkeeping
 )
 
-rj_add_interposer_test_suite(
-    InterposerSyncobjTest
+set(_rj_interposer_syncobj_tests
     VmTimelineWaitObservesSynchronousMapAndUnmap
+    VmDelayUpdateSuppressesTimelinePublication
     GemVaSignalsBinarySyncobjsAtPointZero
+    PointZeroOutputReplacesTimelinePayload
     DuplicateDrmFdsShareNamespaceAndLifetime
     IndependentDrmOpensHaveSeparateNamespaces
     CreateSignaledSeedsOnlyTheInitialPoint
     WaitValidationMatchesDrm
     DestroyRejectsInvalidInput
     TimelineWaitBlocksUntilSignalOrDeadline
-    ForkedChildReinitializesTimelineWaitQueue
+    TimelineWaitReturnsEintrForSignal
     ConcurrentVmUpdatesShareTimeline
     OutOfOrderTimelinePointPreservesWatermark
+)
+# TSan cannot start new threads after a multithreaded fork. This regression
+# intentionally exercises inherited interposer state in that unsupported child,
+# so retain it for regular and ASan builds and omit it from TSan configurations.
+if(NOT RJ_ENABLE_TSAN)
+    list(
+        APPEND _rj_interposer_syncobj_tests
+        ForkedChildReinitializesTimelineFutexState
+    )
+endif()
+rj_add_interposer_test_suite(
+    InterposerSyncobjTest
+    ${_rj_interposer_syncobj_tests}
 )
 
 # --- rocminfo test (requires rocminfo binary + HSA runtime + CLI launcher) ---

--- a/emulation/rocjitsu/tests/interposer_dup_test.cpp
+++ b/emulation/rocjitsu/tests/interposer_dup_test.cpp
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 /// @file interposer_dup_test.cpp
-/// @brief LD_PRELOAD regression tests for the interposer's KFD fd/backend
-///        bookkeeping across dup / dup2 / dup3 / fcntl(F_DUPFD).
+/// @brief LD_PRELOAD regression tests for KFD/DRM descriptor bookkeeping,
+///        GEM/PRIME mappings, and synchronous DRM timeline state.
 ///
 /// @details These run with librocjitsu.so preloaded (see the ENVIRONMENT set in
 /// tests/CMakeLists.txt) so that open("/dev/kfd") is serviced by the simulated
@@ -17,20 +17,28 @@
 #include "rocjitsu/base/rj_compiler.h"
 RJ_DIAGNOSTIC_PUSH
 RJ_DIAGNOSTIC_IGNORE_PEDANTIC
-#include "drm/amdgpu_drm.h"
-#include "drm/drm.h"
+// Use the checked-in UAPI because older system libdrm headers do not expose the
+// GEM_VA timeline fields exercised by these tests.
+#include "linux/uapi/drm/amdgpu_drm.h"
+#include "linux/uapi/drm/drm.h"
 #include "linux/uapi/kfd_ioctl.h"
 RJ_DIAGNOSTIC_POP
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <atomic>
+#include <barrier>
 #include <cerrno>
 #include <chrono>
+#include <cstring>
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
 #include <thread>
+#include <time.h>
 #include <unistd.h>
 
 namespace {
@@ -45,6 +53,10 @@ bool kfd_version_ok(int fd) {
 
 int open_kfd() { return open("/dev/kfd", O_RDWR | O_CLOEXEC); }
 
+} // namespace
+
+namespace {
+int open_drm_render();
 } // namespace
 
 // A plain dup() of the KFD fd must keep routing KFD ioctls to the driver, and
@@ -292,6 +304,39 @@ TEST(InterposerDupTest, SerializedReopenUnderContentionStaysRoutable) {
   EXPECT_EQ(close(keeper), 0);
 }
 
+TEST(InterposerDupTest, FcntlDupfdReplacesStaleDrmTracking) {
+  int kfd = open_kfd();
+  ASSERT_GE(kfd, 0);
+  ASSERT_TRUE(kfd_version_ok(kfd));
+  int first = open_drm_render();
+  if (first < 0)
+    GTEST_SKIP() << "synthetic DRM render node unavailable in this configuration";
+  int stale_fd = dup(first);
+  ASSERT_GE(stale_fd, 0);
+  int second = open_drm_render();
+  ASSERT_GE(second, 0);
+
+  drm_syncobj_create first_syncobj{};
+  drm_syncobj_create second_syncobj{};
+  ASSERT_EQ(ioctl(first, DRM_IOCTL_SYNCOBJ_CREATE, &first_syncobj), 0);
+  ASSERT_EQ(ioctl(second, DRM_IOCTL_SYNCOBJ_CREATE, &second_syncobj), 0);
+
+  ASSERT_EQ(syscall(SYS_close, stale_fd), 0);
+  int reused = fcntl(second, F_DUPFD_CLOEXEC, stale_fd);
+  ASSERT_EQ(reused, stale_fd);
+
+  drm_syncobj_destroy destroy{};
+  destroy.handle = second_syncobj.handle;
+  EXPECT_EQ(ioctl(reused, DRM_IOCTL_SYNCOBJ_DESTROY, &destroy), 0);
+  destroy.handle = first_syncobj.handle;
+  EXPECT_EQ(ioctl(first, DRM_IOCTL_SYNCOBJ_DESTROY, &destroy), 0);
+
+  EXPECT_EQ(close(reused), 0);
+  EXPECT_EQ(close(second), 0);
+  EXPECT_EQ(close(first), 0);
+  EXPECT_EQ(close(kfd), 0);
+}
+
 namespace {
 
 // Open the synthetic DRM render node the interposer exposes for the simulated GPU
@@ -335,7 +380,721 @@ int gem_close(int drm_fd, uint32_t handle) {
   return ioctl(drm_fd, DRM_IOCTL_GEM_CLOSE, &gc);
 }
 
+int64_t monotonic_deadline_after(std::chrono::nanoseconds delay) {
+  timespec now{};
+  if (clock_gettime(CLOCK_MONOTONIC, &now) != 0)
+    return 0;
+  return static_cast<int64_t>(now.tv_sec) * 1'000'000'000LL + now.tv_nsec + delay.count();
+}
+
 } // namespace
+
+TEST(InterposerSyncobjTest, VmTimelineWaitObservesSynchronousMapAndUnmap) {
+  int kfd = open_kfd();
+  ASSERT_GE(kfd, 0);
+  ASSERT_TRUE(kfd_version_ok(kfd));
+  int drm = open_drm_render();
+  if (drm < 0)
+    GTEST_SKIP() << "synthetic DRM render node unavailable in this configuration";
+
+  drm_syncobj_create create{};
+  ASSERT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_CREATE, &create), 0);
+  ASSERT_NE(create.handle, 0u);
+
+  constexpr size_t kBoSize = 0x1000;
+  constexpr uint64_t kVa = 0x1000000000ULL;
+  int dmabuf = make_sized_memfd(kBoSize);
+  ASSERT_GE(dmabuf, 0);
+  uint32_t gem_handle = 0;
+  ASSERT_TRUE(prime_import(drm, dmabuf, &gem_handle));
+
+  uint32_t handles[] = {create.handle};
+  uint64_t points[] = {1};
+  drm_syncobj_timeline_wait wait{};
+  wait.handles = reinterpret_cast<uintptr_t>(handles);
+  wait.points = reinterpret_cast<uintptr_t>(points);
+  wait.count_handles = 1;
+  wait.flags = DRM_SYNCOBJ_WAIT_FLAGS_WAIT_ALL;
+  EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &wait), -1);
+  EXPECT_EQ(errno, EINVAL);
+  wait.flags |= DRM_SYNCOBJ_WAIT_FLAGS_WAIT_FOR_SUBMIT;
+  EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &wait), -1);
+  EXPECT_EQ(errno, ETIME);
+
+  const unsigned long gem_va = DRM_AMDGPU_GEM_VA_request();
+  drm_amdgpu_gem_va map{};
+  map.handle = gem_handle;
+  map.operation = AMDGPU_VA_OP_MAP;
+  map.flags = AMDGPU_VM_PAGE_READABLE | AMDGPU_VM_PAGE_WRITEABLE;
+  map.va_address = kVa;
+  map.map_size = kBoSize;
+  map.vm_timeline_point = 1;
+  map.vm_timeline_syncobj_out = create.handle;
+  uint32_t input_handle = create.handle;
+  map.num_syncobj_handles = 1;
+  map.input_fence_syncobj_handles = reinterpret_cast<uintptr_t>(&input_handle);
+  EXPECT_EQ(ioctl(drm, gem_va, &map), -1);
+  EXPECT_EQ(errno, EINVAL);
+  map.num_syncobj_handles = 0;
+  map.input_fence_syncobj_handles = 0;
+  ASSERT_EQ(ioctl(drm, gem_va, &map), 0);
+
+  EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &wait), 0);
+
+  drm_amdgpu_gem_va unmap{};
+  unmap.handle = gem_handle;
+  unmap.operation = AMDGPU_VA_OP_UNMAP;
+  unmap.va_address = kVa;
+  unmap.map_size = kBoSize;
+  unmap.vm_timeline_point = 2;
+  unmap.vm_timeline_syncobj_out = create.handle;
+  ASSERT_EQ(ioctl(drm, gem_va, &unmap), 0);
+  points[0] = unmap.vm_timeline_point;
+  EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &wait), 0);
+
+  drm_syncobj_destroy destroy{};
+  destroy.handle = create.handle;
+  EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_DESTROY, &destroy), 0);
+  EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &wait), -1);
+  EXPECT_EQ(errno, ENOENT);
+
+  EXPECT_EQ(gem_close(drm, gem_handle), 0);
+  EXPECT_EQ(close(dmabuf), 0);
+  EXPECT_EQ(close(drm), 0);
+  EXPECT_EQ(close(kfd), 0);
+}
+
+TEST(InterposerSyncobjTest, GemVaSignalsBinarySyncobjsAtPointZero) {
+  int kfd = open_kfd();
+  ASSERT_GE(kfd, 0);
+  ASSERT_TRUE(kfd_version_ok(kfd));
+  int drm = open_drm_render();
+  if (drm < 0)
+    GTEST_SKIP() << "synthetic DRM render node unavailable in this configuration";
+
+  std::array<drm_syncobj_create, 3> syncobjs{};
+  for (auto &syncobj : syncobjs)
+    ASSERT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_CREATE, &syncobj), 0);
+
+  constexpr size_t kBoSize = 0x1000;
+  constexpr uint64_t kVa = 0x1000000000ULL;
+  int dmabuf = make_sized_memfd(kBoSize);
+  ASSERT_GE(dmabuf, 0);
+  uint32_t gem_handle = 0;
+  ASSERT_TRUE(prime_import(drm, dmabuf, &gem_handle));
+
+  const unsigned long gem_va = DRM_AMDGPU_GEM_VA_request();
+  drm_amdgpu_gem_va update{};
+  update.handle = gem_handle;
+  update.operation = AMDGPU_VA_OP_MAP;
+  update.flags = AMDGPU_VM_PAGE_READABLE | AMDGPU_VM_PAGE_WRITEABLE;
+  update.va_address = kVa;
+  update.map_size = kBoSize;
+  update.vm_timeline_syncobj_out = syncobjs[0].handle;
+  update.vm_timeline_point = 0;
+  ASSERT_EQ(ioctl(drm, gem_va, &update), 0);
+
+  auto expect_binary_signaled = [&](uint32_t handle) {
+    uint32_t handles[] = {handle};
+    uint64_t points[] = {0};
+    drm_syncobj_timeline_wait wait{};
+    wait.handles = reinterpret_cast<uintptr_t>(handles);
+    wait.points = reinterpret_cast<uintptr_t>(points);
+    wait.count_handles = 1;
+    wait.flags = DRM_SYNCOBJ_WAIT_FLAGS_WAIT_ALL;
+    EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &wait), 0);
+  };
+  expect_binary_signaled(syncobjs[0].handle);
+
+  update.operation = AMDGPU_VA_OP_UNMAP;
+  update.flags = 0;
+  update.vm_timeline_syncobj_out = syncobjs[1].handle;
+  ASSERT_EQ(ioctl(drm, gem_va, &update), 0);
+  expect_binary_signaled(syncobjs[1].handle);
+
+  // A zero output handle still means no fence. Point zero alone must not change
+  // that contract, and the mapping remains available for the following CLEAR.
+  update.operation = AMDGPU_VA_OP_MAP;
+  update.flags = AMDGPU_VM_PAGE_READABLE | AMDGPU_VM_PAGE_WRITEABLE;
+  update.vm_timeline_syncobj_out = 0;
+  ASSERT_EQ(ioctl(drm, gem_va, &update), 0);
+
+  update.handle = 0;
+  update.operation = AMDGPU_VA_OP_CLEAR;
+  update.flags = 0;
+  update.vm_timeline_syncobj_out = syncobjs[2].handle;
+  ASSERT_EQ(ioctl(drm, gem_va, &update), 0);
+  expect_binary_signaled(syncobjs[2].handle);
+
+  for (const auto &syncobj : syncobjs) {
+    drm_syncobj_destroy destroy{};
+    destroy.handle = syncobj.handle;
+    EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_DESTROY, &destroy), 0);
+  }
+  EXPECT_EQ(gem_close(drm, gem_handle), 0);
+  EXPECT_EQ(close(dmabuf), 0);
+  EXPECT_EQ(close(drm), 0);
+  EXPECT_EQ(close(kfd), 0);
+}
+
+TEST(InterposerSyncobjTest, DuplicateDrmFdsShareNamespaceAndLifetime) {
+  int kfd = open_kfd();
+  ASSERT_GE(kfd, 0);
+  ASSERT_TRUE(kfd_version_ok(kfd));
+  int drm = open_drm_render();
+  if (drm < 0)
+    GTEST_SKIP() << "synthetic DRM render node unavailable in this configuration";
+  int drm_dup = dup(drm);
+  ASSERT_GE(drm_dup, 0);
+
+  drm_syncobj_create create{};
+  ASSERT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_CREATE, &create), 0);
+  ASSERT_NE(create.handle, 0u);
+  EXPECT_EQ(close(drm), 0);
+
+  uint32_t handles[] = {create.handle};
+  uint64_t points[] = {1};
+  drm_syncobj_timeline_wait wait{};
+  wait.handles = reinterpret_cast<uintptr_t>(handles);
+  wait.points = reinterpret_cast<uintptr_t>(points);
+  wait.count_handles = 1;
+  wait.flags = DRM_SYNCOBJ_WAIT_FLAGS_WAIT_ALL;
+  EXPECT_EQ(ioctl(drm_dup, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &wait), -1);
+  EXPECT_EQ(errno, EINVAL);
+
+  drm_syncobj_destroy destroy{};
+  destroy.handle = create.handle;
+  EXPECT_EQ(ioctl(drm_dup, DRM_IOCTL_SYNCOBJ_DESTROY, &destroy), 0);
+  EXPECT_EQ(close(drm_dup), 0);
+  EXPECT_EQ(close(kfd), 0);
+}
+
+TEST(InterposerSyncobjTest, IndependentDrmOpensHaveSeparateNamespaces) {
+  int kfd = open_kfd();
+  ASSERT_GE(kfd, 0);
+  ASSERT_TRUE(kfd_version_ok(kfd));
+  int first_drm = open_drm_render();
+  int second_drm = open_drm_render();
+  if (first_drm < 0 || second_drm < 0)
+    GTEST_SKIP() << "synthetic DRM render node unavailable in this configuration";
+
+  drm_syncobj_create create{};
+  ASSERT_EQ(ioctl(first_drm, DRM_IOCTL_SYNCOBJ_CREATE, &create), 0);
+  drm_syncobj_destroy destroy{};
+  destroy.handle = create.handle;
+  EXPECT_EQ(ioctl(second_drm, DRM_IOCTL_SYNCOBJ_DESTROY, &destroy), -1);
+  EXPECT_EQ(errno, EINVAL);
+  EXPECT_EQ(ioctl(first_drm, DRM_IOCTL_SYNCOBJ_DESTROY, &destroy), 0);
+
+  EXPECT_EQ(close(second_drm), 0);
+  EXPECT_EQ(close(first_drm), 0);
+  EXPECT_EQ(close(kfd), 0);
+}
+
+TEST(InterposerSyncobjTest, CreateSignaledSeedsOnlyTheInitialPoint) {
+  int kfd = open_kfd();
+  ASSERT_GE(kfd, 0);
+  ASSERT_TRUE(kfd_version_ok(kfd));
+  int drm = open_drm_render();
+  if (drm < 0)
+    GTEST_SKIP() << "synthetic DRM render node unavailable in this configuration";
+
+  drm_syncobj_create create{};
+  create.flags = DRM_SYNCOBJ_CREATE_SIGNALED;
+  ASSERT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_CREATE, &create), 0);
+  uint32_t handles[] = {create.handle};
+  uint64_t points[] = {0};
+  drm_syncobj_timeline_wait wait{};
+  wait.handles = reinterpret_cast<uintptr_t>(handles);
+  wait.points = reinterpret_cast<uintptr_t>(points);
+  wait.count_handles = 1;
+  wait.flags = DRM_SYNCOBJ_WAIT_FLAGS_WAIT_ALL;
+  EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &wait), 0);
+
+  points[0] = 1;
+  EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &wait), -1);
+  EXPECT_EQ(errno, EINVAL);
+  wait.flags |= DRM_SYNCOBJ_WAIT_FLAGS_WAIT_FOR_SUBMIT;
+  EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &wait), -1);
+  EXPECT_EQ(errno, ETIME);
+  wait.flags = 1u << 31;
+  EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &wait), -1);
+  EXPECT_EQ(errno, EINVAL);
+
+  drm_syncobj_create second{};
+  second.flags = DRM_SYNCOBJ_CREATE_SIGNALED;
+  ASSERT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_CREATE, &second), 0);
+  uint32_t any_handles[] = {create.handle, second.handle};
+  uint64_t any_points[] = {1, 0};
+  wait.handles = reinterpret_cast<uintptr_t>(any_handles);
+  wait.points = reinterpret_cast<uintptr_t>(any_points);
+  wait.count_handles = 2;
+  wait.flags = DRM_SYNCOBJ_WAIT_FLAGS_WAIT_FOR_SUBMIT;
+  wait.first_signaled = UINT32_MAX;
+  EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &wait), 0);
+  EXPECT_EQ(wait.first_signaled, 1u);
+
+  drm_syncobj_destroy destroy{};
+  destroy.handle = create.handle;
+  EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_DESTROY, &destroy), 0);
+  destroy.handle = second.handle;
+  EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_DESTROY, &destroy), 0);
+  EXPECT_EQ(close(drm), 0);
+  EXPECT_EQ(close(kfd), 0);
+}
+
+TEST(InterposerSyncobjTest, WaitValidationMatchesDrm) {
+  int kfd = open_kfd();
+  ASSERT_GE(kfd, 0);
+  ASSERT_TRUE(kfd_version_ok(kfd));
+  int drm = open_drm_render();
+  if (drm < 0)
+    GTEST_SKIP() << "synthetic DRM render node unavailable in this configuration";
+
+  drm_syncobj_timeline_wait empty{};
+  EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &empty), 0);
+  empty.flags = 1u << 31;
+  EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &empty), -1);
+  EXPECT_EQ(errno, EINVAL);
+
+  drm_syncobj_create create{};
+  ASSERT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_CREATE, &create), 0);
+  uint32_t handles[] = {create.handle};
+  uint64_t points[] = {1};
+  drm_syncobj_timeline_wait wait{};
+  wait.handles = reinterpret_cast<uintptr_t>(handles);
+  wait.points = reinterpret_cast<uintptr_t>(points);
+  wait.count_handles = 1;
+  wait.flags = DRM_SYNCOBJ_WAIT_FLAGS_WAIT_ALL | DRM_SYNCOBJ_WAIT_FLAGS_WAIT_AVAILABLE;
+  EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &wait), -1);
+  EXPECT_EQ(errno, ETIME);
+
+  uint32_t mixed_handles[] = {create.handle, UINT32_MAX};
+  uint64_t mixed_points[] = {1, 0};
+  wait.handles = reinterpret_cast<uintptr_t>(mixed_handles);
+  wait.points = reinterpret_cast<uintptr_t>(mixed_points);
+  wait.count_handles = 2;
+  wait.flags = DRM_SYNCOBJ_WAIT_FLAGS_WAIT_ALL | DRM_SYNCOBJ_WAIT_FLAGS_WAIT_FOR_SUBMIT;
+  wait.first_signaled = 17;
+  EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &wait), -1);
+  EXPECT_EQ(errno, ENOENT);
+  EXPECT_EQ(wait.first_signaled, 17u);
+
+  wait.count_handles = 1;
+  wait.flags = DRM_SYNCOBJ_WAIT_FLAGS_WAIT_ALL;
+  wait.handles = 1;
+  wait.points = reinterpret_cast<uintptr_t>(points);
+  EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &wait), -1);
+  EXPECT_EQ(errno, EFAULT);
+
+  wait.handles = reinterpret_cast<uintptr_t>(handles);
+  wait.points = 1;
+  EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &wait), -1);
+  EXPECT_EQ(errno, EFAULT);
+
+  drm_syncobj_destroy destroy{};
+  destroy.handle = create.handle;
+  EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_DESTROY, &destroy), 0);
+  EXPECT_EQ(close(drm), 0);
+  EXPECT_EQ(close(kfd), 0);
+}
+
+TEST(InterposerSyncobjTest, DestroyRejectsInvalidInput) {
+  int kfd = open_kfd();
+  ASSERT_GE(kfd, 0);
+  ASSERT_TRUE(kfd_version_ok(kfd));
+  int drm = open_drm_render();
+  if (drm < 0)
+    GTEST_SKIP() << "synthetic DRM render node unavailable in this configuration";
+
+  drm_syncobj_destroy destroy{};
+  destroy.handle = UINT32_MAX;
+  EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_DESTROY, &destroy), -1);
+  EXPECT_EQ(errno, EINVAL);
+
+  drm_syncobj_create create{};
+  ASSERT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_CREATE, &create), 0);
+  destroy.handle = create.handle;
+  destroy.pad = 1;
+  EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_DESTROY, &destroy), -1);
+  EXPECT_EQ(errno, EINVAL);
+  destroy.pad = 0;
+  EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_DESTROY, &destroy), 0);
+
+  EXPECT_EQ(close(drm), 0);
+  EXPECT_EQ(close(kfd), 0);
+}
+
+TEST(InterposerSyncobjTest, TimelineWaitBlocksUntilSignalOrDeadline) {
+  int kfd = open_kfd();
+  ASSERT_GE(kfd, 0);
+  ASSERT_TRUE(kfd_version_ok(kfd));
+  int drm = open_drm_render();
+  if (drm < 0)
+    GTEST_SKIP() << "synthetic DRM render node unavailable in this configuration";
+
+  drm_syncobj_create create{};
+  ASSERT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_CREATE, &create), 0);
+  constexpr size_t kBoSize = 0x1000;
+  constexpr uint64_t kVa = 0x1000000000ULL;
+  int dmabuf = make_sized_memfd(kBoSize);
+  ASSERT_GE(dmabuf, 0);
+  uint32_t gem_handle = 0;
+  ASSERT_TRUE(prime_import(drm, dmabuf, &gem_handle));
+
+  uint32_t handles[] = {create.handle};
+  uint64_t points[] = {1};
+  drm_syncobj_timeline_wait wait{};
+  wait.handles = reinterpret_cast<uintptr_t>(handles);
+  wait.points = reinterpret_cast<uintptr_t>(points);
+  wait.count_handles = 1;
+  wait.flags = DRM_SYNCOBJ_WAIT_FLAGS_WAIT_ALL | DRM_SYNCOBJ_WAIT_FLAGS_WAIT_FOR_SUBMIT;
+  wait.timeout_nsec = monotonic_deadline_after(std::chrono::seconds(1));
+
+  std::barrier ready(2);
+  std::atomic<int> wait_rc{-2};
+  std::atomic<int> wait_errno{0};
+  std::thread waiter([&] {
+    ready.arrive_and_wait();
+    wait_rc = ioctl(drm, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &wait);
+    wait_errno = errno;
+  });
+  ready.arrive_and_wait();
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+  const unsigned long gem_va = DRM_AMDGPU_GEM_VA_request();
+  drm_amdgpu_gem_va map{};
+  map.handle = gem_handle;
+  map.operation = AMDGPU_VA_OP_MAP;
+  map.flags = AMDGPU_VM_PAGE_READABLE | AMDGPU_VM_PAGE_WRITEABLE;
+  map.va_address = kVa;
+  map.map_size = kBoSize;
+  map.vm_timeline_point = 1;
+  map.vm_timeline_syncobj_out = create.handle;
+  const int map_rc = ioctl(drm, gem_va, &map);
+  waiter.join();
+  ASSERT_EQ(map_rc, 0);
+  EXPECT_EQ(wait_rc.load(), 0) << "wait errno=" << wait_errno.load();
+
+  points[0] = 2;
+  wait.timeout_nsec = monotonic_deadline_after(std::chrono::milliseconds(100));
+  const auto timeout_start = std::chrono::steady_clock::now();
+  EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &wait), -1);
+  const auto timeout_elapsed = std::chrono::steady_clock::now() - timeout_start;
+  EXPECT_EQ(errno, ETIME);
+  EXPECT_GE(timeout_elapsed, std::chrono::milliseconds(50));
+
+  drm_amdgpu_gem_va unmap{};
+  unmap.handle = gem_handle;
+  unmap.operation = AMDGPU_VA_OP_UNMAP;
+  unmap.va_address = kVa;
+  unmap.map_size = kBoSize;
+  EXPECT_EQ(ioctl(drm, gem_va, &unmap), 0);
+  drm_syncobj_destroy destroy{};
+  destroy.handle = create.handle;
+  EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_DESTROY, &destroy), 0);
+  EXPECT_EQ(gem_close(drm, gem_handle), 0);
+  EXPECT_EQ(close(dmabuf), 0);
+  EXPECT_EQ(close(drm), 0);
+  EXPECT_EQ(close(kfd), 0);
+}
+
+TEST(InterposerSyncobjTest, ForkedChildReinitializesTimelineWaitQueue) {
+  int kfd = open_kfd();
+  ASSERT_GE(kfd, 0);
+  ASSERT_TRUE(kfd_version_ok(kfd));
+  int drm = open_drm_render();
+  if (drm < 0)
+    GTEST_SKIP() << "synthetic DRM render node unavailable in this configuration";
+
+  drm_syncobj_create create{};
+  ASSERT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_CREATE, &create), 0);
+  constexpr size_t kBoSize = 0x1000;
+  constexpr uint64_t kVa = 0x1000000000ULL;
+  int dmabuf = make_sized_memfd(kBoSize);
+  ASSERT_GE(dmabuf, 0);
+  uint32_t gem_handle = 0;
+  ASSERT_TRUE(prime_import(drm, dmabuf, &gem_handle));
+
+  uint32_t handles[] = {create.handle};
+  uint64_t points[] = {1};
+  drm_syncobj_timeline_wait wait{};
+  wait.handles = reinterpret_cast<uintptr_t>(handles);
+  wait.points = reinterpret_cast<uintptr_t>(points);
+  wait.count_handles = 1;
+  wait.flags = DRM_SYNCOBJ_WAIT_FLAGS_WAIT_ALL | DRM_SYNCOBJ_WAIT_FLAGS_WAIT_FOR_SUBMIT;
+  wait.timeout_nsec = monotonic_deadline_after(std::chrono::seconds(2));
+
+  std::barrier ready(2);
+  std::atomic<int> wait_rc{-2};
+  std::thread waiter([&] {
+    ready.arrive_and_wait();
+    wait_rc = ioctl(drm, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &wait);
+  });
+  ready.arrive_and_wait();
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+  const pid_t child = fork();
+  if (child < 0) {
+    const int fork_errno = errno;
+    waiter.join();
+    EXPECT_EQ(gem_close(drm, gem_handle), 0);
+    EXPECT_EQ(close(dmabuf), 0);
+    EXPECT_EQ(close(drm), 0);
+    EXPECT_EQ(close(kfd), 0);
+    FAIL() << "fork failed: " << std::strerror(fork_errno);
+  }
+  if (child == 0) {
+    alarm(3);
+    int child_kfd = open_kfd();
+    if (child_kfd < 0 || !kfd_version_ok(child_kfd))
+      _exit(1);
+    int child_drm = open_drm_render();
+    if (child_drm < 0)
+      _exit(2);
+    drm_syncobj_create child_create{};
+    if (ioctl(child_drm, DRM_IOCTL_SYNCOBJ_CREATE, &child_create) != 0)
+      _exit(3);
+    int child_dmabuf = make_sized_memfd(kBoSize);
+    uint32_t child_gem_handle = 0;
+    if (child_dmabuf < 0 || !prime_import(child_drm, child_dmabuf, &child_gem_handle))
+      _exit(4);
+    drm_amdgpu_gem_va child_map{};
+    child_map.handle = child_gem_handle;
+    child_map.operation = AMDGPU_VA_OP_MAP;
+    child_map.flags = AMDGPU_VM_PAGE_READABLE | AMDGPU_VM_PAGE_WRITEABLE;
+    child_map.va_address = kVa;
+    child_map.map_size = kBoSize;
+    child_map.vm_timeline_point = 1;
+    child_map.vm_timeline_syncobj_out = child_create.handle;
+    if (ioctl(child_drm, DRM_AMDGPU_GEM_VA_request(), &child_map) != 0)
+      _exit(5);
+    uint32_t child_handles[] = {child_create.handle};
+    uint64_t child_points[] = {1};
+    drm_syncobj_timeline_wait child_wait{};
+    child_wait.handles = reinterpret_cast<uintptr_t>(child_handles);
+    child_wait.points = reinterpret_cast<uintptr_t>(child_points);
+    child_wait.count_handles = 1;
+    child_wait.flags = DRM_SYNCOBJ_WAIT_FLAGS_WAIT_ALL;
+    child_wait.timeout_nsec = monotonic_deadline_after(std::chrono::seconds(1));
+    _exit(ioctl(child_drm, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &child_wait) == 0 ? 0 : 6);
+  }
+
+  drm_amdgpu_gem_va map{};
+  map.handle = gem_handle;
+  map.operation = AMDGPU_VA_OP_MAP;
+  map.flags = AMDGPU_VM_PAGE_READABLE | AMDGPU_VM_PAGE_WRITEABLE;
+  map.va_address = kVa;
+  map.map_size = kBoSize;
+  map.vm_timeline_point = 1;
+  map.vm_timeline_syncobj_out = create.handle;
+  EXPECT_EQ(ioctl(drm, DRM_AMDGPU_GEM_VA_request(), &map), 0);
+  waiter.join();
+  EXPECT_EQ(wait_rc.load(), 0);
+
+  int status = 0;
+  ASSERT_EQ(waitpid(child, &status, 0), child);
+  ASSERT_TRUE(WIFEXITED(status));
+  EXPECT_EQ(WEXITSTATUS(status), 0);
+
+  EXPECT_EQ(gem_close(drm, gem_handle), 0);
+  EXPECT_EQ(close(dmabuf), 0);
+  EXPECT_EQ(close(drm), 0);
+  EXPECT_EQ(close(kfd), 0);
+}
+
+TEST(InterposerSyncobjTest, ConcurrentVmUpdatesShareTimeline) {
+  int kfd = open_kfd();
+  ASSERT_GE(kfd, 0);
+  ASSERT_TRUE(kfd_version_ok(kfd));
+  int drm = open_drm_render();
+  if (drm < 0)
+    GTEST_SKIP() << "synthetic DRM render node unavailable in this configuration";
+
+  drm_syncobj_create create{};
+  ASSERT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_CREATE, &create), 0);
+  constexpr size_t kBoSize = 0x1000;
+  const std::array<uint64_t, 2> vas = {0x1000000000ULL, 0x1000100000ULL};
+  std::array<int, 2> dmabufs = {make_sized_memfd(kBoSize), make_sized_memfd(kBoSize)};
+  ASSERT_GE(dmabufs[0], 0);
+  ASSERT_GE(dmabufs[1], 0);
+  std::array<uint32_t, 2> gem_handles{};
+  ASSERT_TRUE(prime_import(drm, dmabufs[0], &gem_handles[0]));
+  ASSERT_TRUE(prime_import(drm, dmabufs[1], &gem_handles[1]));
+
+  const unsigned long gem_va = DRM_AMDGPU_GEM_VA_request();
+  std::atomic<uint64_t> next_point{0};
+  std::array<int, 2> results = {-1, -1};
+  std::barrier start(3);
+  auto submit = [&](size_t index) {
+    drm_amdgpu_gem_va map{};
+    map.handle = gem_handles[index];
+    map.operation = AMDGPU_VA_OP_MAP;
+    map.flags = AMDGPU_VM_PAGE_READABLE | AMDGPU_VM_PAGE_WRITEABLE;
+    map.va_address = vas[index];
+    map.map_size = kBoSize;
+    map.vm_timeline_point = next_point.fetch_add(1) + 1;
+    map.vm_timeline_syncobj_out = create.handle;
+    start.arrive_and_wait();
+    results[index] = ioctl(drm, gem_va, &map);
+  };
+  std::thread first(submit, 0);
+  std::thread second(submit, 1);
+  start.arrive_and_wait();
+  first.join();
+  second.join();
+  EXPECT_EQ(results[0], 0);
+  EXPECT_EQ(results[1], 0);
+
+  uint32_t handles[] = {create.handle};
+  uint64_t points[] = {2};
+  drm_syncobj_timeline_wait wait{};
+  wait.handles = reinterpret_cast<uintptr_t>(handles);
+  wait.points = reinterpret_cast<uintptr_t>(points);
+  wait.count_handles = 1;
+  wait.flags = DRM_SYNCOBJ_WAIT_FLAGS_WAIT_ALL;
+  EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &wait), 0);
+
+  for (size_t i = 0; i < gem_handles.size(); ++i) {
+    drm_amdgpu_gem_va unmap{};
+    unmap.handle = gem_handles[i];
+    unmap.operation = AMDGPU_VA_OP_UNMAP;
+    unmap.va_address = vas[i];
+    unmap.map_size = kBoSize;
+    EXPECT_EQ(ioctl(drm, gem_va, &unmap), 0);
+    EXPECT_EQ(gem_close(drm, gem_handles[i]), 0);
+    EXPECT_EQ(close(dmabufs[i]), 0);
+  }
+  drm_syncobj_destroy destroy{};
+  destroy.handle = create.handle;
+  EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_DESTROY, &destroy), 0);
+  EXPECT_EQ(close(drm), 0);
+  EXPECT_EQ(close(kfd), 0);
+}
+
+TEST(InterposerSyncobjTest, OutOfOrderTimelinePointPreservesWatermark) {
+  int kfd = open_kfd();
+  ASSERT_GE(kfd, 0);
+  ASSERT_TRUE(kfd_version_ok(kfd));
+  int drm = open_drm_render();
+  if (drm < 0)
+    GTEST_SKIP() << "synthetic DRM render node unavailable in this configuration";
+
+  drm_syncobj_create create{};
+  ASSERT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_CREATE, &create), 0);
+  constexpr size_t kBoSize = 0x1000;
+  constexpr uint64_t kVa = 0x1000000000ULL;
+  int dmabuf = make_sized_memfd(kBoSize);
+  ASSERT_GE(dmabuf, 0);
+  uint32_t gem_handle = 0;
+  ASSERT_TRUE(prime_import(drm, dmabuf, &gem_handle));
+
+  const unsigned long gem_va = DRM_AMDGPU_GEM_VA_request();
+  drm_amdgpu_gem_va map{};
+  map.handle = gem_handle;
+  map.operation = AMDGPU_VA_OP_MAP;
+  map.flags = AMDGPU_VM_PAGE_READABLE | AMDGPU_VM_PAGE_WRITEABLE;
+  map.va_address = kVa;
+  map.map_size = kBoSize;
+  map.vm_timeline_point = 2;
+  map.vm_timeline_syncobj_out = create.handle;
+  ASSERT_EQ(ioctl(drm, gem_va, &map), 0);
+
+  drm_amdgpu_gem_va unmap{};
+  unmap.handle = gem_handle;
+  unmap.operation = AMDGPU_VA_OP_UNMAP;
+  unmap.va_address = kVa;
+  unmap.map_size = kBoSize;
+  unmap.vm_timeline_point = 1;
+  unmap.vm_timeline_syncobj_out = create.handle;
+  EXPECT_EQ(ioctl(drm, gem_va, &unmap), 0);
+
+  uint32_t handles[] = {create.handle};
+  uint64_t points[] = {2};
+  drm_syncobj_timeline_wait wait{};
+  wait.handles = reinterpret_cast<uintptr_t>(handles);
+  wait.points = reinterpret_cast<uintptr_t>(points);
+  wait.count_handles = 1;
+  wait.flags = DRM_SYNCOBJ_WAIT_FLAGS_WAIT_ALL;
+  EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &wait), 0);
+
+  drm_syncobj_destroy destroy{};
+  destroy.handle = create.handle;
+  EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_DESTROY, &destroy), 0);
+  EXPECT_EQ(gem_close(drm, gem_handle), 0);
+  EXPECT_EQ(close(dmabuf), 0);
+  EXPECT_EQ(close(drm), 0);
+  EXPECT_EQ(close(kfd), 0);
+}
+
+TEST(InterposerGemTest, GemNamespaceIsPrivateButSharedByDuplicates) {
+  int kfd = open_kfd();
+  ASSERT_GE(kfd, 0);
+  ASSERT_TRUE(kfd_version_ok(kfd));
+  int owner = open_drm_render();
+  int foreign = open_drm_render();
+  if (owner < 0 || foreign < 0)
+    GTEST_SKIP() << "synthetic DRM render node unavailable in this configuration";
+  int owner_dup = dup(owner);
+  ASSERT_GE(owner_dup, 0);
+
+  constexpr size_t kBoSize = 0x1000;
+  constexpr uint64_t kVa = 0x1000000000ULL;
+  int dmabuf = make_sized_memfd(kBoSize);
+  ASSERT_GE(dmabuf, 0);
+  uint32_t gem_handle = 0;
+  ASSERT_TRUE(prime_import(owner, dmabuf, &gem_handle));
+
+  const unsigned long gem_va = DRM_AMDGPU_GEM_VA_request();
+  drm_amdgpu_gem_va update{};
+  update.handle = gem_handle;
+  update.operation = AMDGPU_VA_OP_MAP;
+  update.flags = AMDGPU_VM_PAGE_READABLE | AMDGPU_VM_PAGE_WRITEABLE;
+  update.va_address = kVa;
+  update.map_size = kBoSize;
+
+  EXPECT_EQ(ioctl(foreign, gem_va, &update), -1);
+  EXPECT_EQ(errno, ENOENT);
+  update.operation = AMDGPU_VA_OP_REPLACE;
+  EXPECT_EQ(ioctl(foreign, gem_va, &update), -1);
+  EXPECT_EQ(errno, ENOENT);
+
+  // A duplicate resolves to the same DRM file and can use the imported handle.
+  update.operation = AMDGPU_VA_OP_MAP;
+  ASSERT_EQ(ioctl(owner_dup, gem_va, &update), 0);
+
+  update.operation = AMDGPU_VA_OP_UNMAP;
+  EXPECT_EQ(ioctl(foreign, gem_va, &update), -1);
+  EXPECT_EQ(errno, ENOENT);
+  ASSERT_EQ(ioctl(owner, gem_va, &update), 0);
+
+  update.operation = AMDGPU_VA_OP_MAP;
+  ASSERT_EQ(ioctl(owner, gem_va, &update), 0);
+  drm_amdgpu_gem_va clear{};
+  clear.operation = AMDGPU_VA_OP_CLEAR;
+  clear.va_address = kVa;
+  clear.map_size = kBoSize;
+  EXPECT_EQ(ioctl(foreign, gem_va, &clear), -1);
+  EXPECT_EQ(errno, EINVAL);
+  update.operation = AMDGPU_VA_OP_UNMAP;
+  ASSERT_EQ(ioctl(owner, gem_va, &update), 0)
+      << "a foreign CLEAR must not remove the owner's mapping";
+
+  update.operation = AMDGPU_VA_OP_MAP;
+  ASSERT_EQ(ioctl(owner, gem_va, &update), 0);
+  EXPECT_EQ(gem_close(foreign, gem_handle), -1);
+  EXPECT_EQ(errno, ENOENT);
+  update.operation = AMDGPU_VA_OP_UNMAP;
+  ASSERT_EQ(ioctl(owner, gem_va, &update), 0)
+      << "a foreign GEM_CLOSE must not destroy the owner's handle";
+
+  EXPECT_EQ(gem_close(owner_dup, gem_handle), 0);
+  EXPECT_EQ(close(dmabuf), 0);
+  EXPECT_EQ(close(owner_dup), 0);
+  EXPECT_EQ(close(foreign), 0);
+  EXPECT_EQ(close(owner), 0);
+  EXPECT_EQ(close(kfd), 0);
+}
 
 // A dmabuf export fd number that is closed and then recycled by a second export
 // must resolve to a DISTINCT, stable GEM handle — never one derived from the fd

--- a/emulation/rocjitsu/tests/interposer_dup_test.cpp
+++ b/emulation/rocjitsu/tests/interposer_dup_test.cpp
@@ -31,10 +31,12 @@ RJ_DIAGNOSTIC_POP
 #include <barrier>
 #include <cerrno>
 #include <chrono>
+#include <csignal>
 #include <cstring>
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
+#include <sys/stat.h>
 #include <sys/syscall.h>
 #include <sys/wait.h>
 #include <thread>
@@ -53,10 +55,13 @@ bool kfd_version_ok(int fd) {
 
 int open_kfd() { return open("/dev/kfd", O_RDWR | O_CLOEXEC); }
 
+void noop_signal_handler(int) {}
+
 } // namespace
 
 namespace {
 int open_drm_render();
+int make_sized_memfd(size_t size);
 } // namespace
 
 // A plain dup() of the KFD fd must keep routing KFD ioctls to the driver, and
@@ -321,6 +326,8 @@ TEST(InterposerDupTest, FcntlDupfdReplacesStaleDrmTracking) {
   ASSERT_EQ(ioctl(first, DRM_IOCTL_SYNCOBJ_CREATE, &first_syncobj), 0);
   ASSERT_EQ(ioctl(second, DRM_IOCTL_SYNCOBJ_CREATE, &second_syncobj), 0);
 
+  // Deliberately bypass the interposed close() so its DRM tracking entry stays
+  // stale; the fcntl duplicate below must replace that stale entry safely.
   ASSERT_EQ(syscall(SYS_close, stale_fd), 0);
   int reused = fcntl(second, F_DUPFD_CLOEXEC, stale_fd);
   ASSERT_EQ(reused, stale_fd);
@@ -334,6 +341,107 @@ TEST(InterposerDupTest, FcntlDupfdReplacesStaleDrmTracking) {
   EXPECT_EQ(close(reused), 0);
   EXPECT_EQ(close(second), 0);
   EXPECT_EQ(close(first), 0);
+  EXPECT_EQ(close(kfd), 0);
+}
+
+TEST(InterposerDupTest, NonDrmDuplicatesClearStaleDrmTracking) {
+  int kfd = open_kfd();
+  ASSERT_GE(kfd, 0);
+  ASSERT_TRUE(kfd_version_ok(kfd));
+  int drm = open_drm_render();
+  if (drm < 0)
+    GTEST_SKIP() << "synthetic DRM render node unavailable in this configuration";
+
+  drm_syncobj_create create{};
+  ASSERT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_CREATE, &create), 0);
+  int ordinary = make_sized_memfd(0x1000);
+  ASSERT_GE(ordinary, 0);
+  int stale_plain = dup(drm);
+  int stale_fcntl = dup(drm);
+  ASSERT_GE(stale_plain, 0);
+  ASSERT_GE(stale_fcntl, 0);
+
+  // Bypass the interposed close so both DRM entries remain stale, then force
+  // ordinary-file duplicates onto those exact numbers. Successful duplication
+  // must replace-or-clear tracking rather than preserving the old namespace.
+  ASSERT_EQ(syscall(SYS_close, stale_plain), 0);
+  ASSERT_EQ(syscall(SYS_close, stale_fcntl), 0);
+  int plain = dup(ordinary);
+  ASSERT_EQ(plain, stale_plain);
+  int fcntl_dup = fcntl(ordinary, F_DUPFD_CLOEXEC, stale_fcntl);
+  ASSERT_EQ(fcntl_dup, stale_fcntl);
+
+  drm_syncobj_destroy destroy{};
+  destroy.handle = create.handle;
+  EXPECT_EQ(ioctl(plain, DRM_IOCTL_SYNCOBJ_DESTROY, &destroy), -1);
+  EXPECT_EQ(errno, ENOTTY);
+  EXPECT_EQ(ioctl(fcntl_dup, DRM_IOCTL_SYNCOBJ_DESTROY, &destroy), -1);
+  EXPECT_EQ(errno, ENOTTY);
+  EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_DESTROY, &destroy), 0);
+
+  EXPECT_EQ(close(fcntl_dup), 0);
+  EXPECT_EQ(close(plain), 0);
+  EXPECT_EQ(close(ordinary), 0);
+  EXPECT_EQ(close(drm), 0);
+  EXPECT_EQ(close(kfd), 0);
+}
+
+TEST(InterposerDupTest, DrmCloseReuseRaceNeverMisclassifiesDuplicate) {
+  int kfd = open_kfd();
+  ASSERT_GE(kfd, 0);
+  ASSERT_TRUE(kfd_version_ok(kfd));
+
+  constexpr int kIterations = 200;
+  for (int iteration = 0; iteration < kIterations; ++iteration) {
+    int drm = open_drm_render();
+    ASSERT_GE(drm, 0);
+    drm_syncobj_create create{};
+    ASSERT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_CREATE, &create), 0);
+    struct stat drm_stat {};
+    ASSERT_EQ(syscall(SYS_fstat, drm, &drm_stat), 0);
+
+    int replacement = make_sized_memfd(0x1000);
+    ASSERT_GE(replacement, 0);
+    struct stat replacement_stat {};
+    ASSERT_EQ(syscall(SYS_fstat, replacement, &replacement_stat), 0);
+
+    std::barrier start(3);
+    std::atomic<int> duplicated{-1};
+    std::atomic<int> close_result{-1};
+    std::atomic<int> reuse_result{-1};
+    std::thread duplicator([&] {
+      start.arrive_and_wait();
+      duplicated = dup(drm);
+    });
+    std::thread closer([&] {
+      start.arrive_and_wait();
+      close_result = close(drm);
+      reuse_result = dup2(replacement, drm);
+    });
+    start.arrive_and_wait();
+    duplicator.join();
+    closer.join();
+    ASSERT_EQ(close_result.load(), 0);
+    ASSERT_EQ(reuse_result.load(), drm);
+
+    if (duplicated.load() >= 0) {
+      struct stat duplicate_stat {};
+      ASSERT_EQ(syscall(SYS_fstat, duplicated.load(), &duplicate_stat), 0);
+      drm_syncobj_destroy destroy{};
+      destroy.handle = create.handle;
+      if (duplicate_stat.st_ino == drm_stat.st_ino) {
+        EXPECT_EQ(ioctl(duplicated.load(), DRM_IOCTL_SYNCOBJ_DESTROY, &destroy), 0);
+      } else {
+        EXPECT_EQ(duplicate_stat.st_ino, replacement_stat.st_ino);
+        EXPECT_EQ(ioctl(duplicated.load(), DRM_IOCTL_SYNCOBJ_DESTROY, &destroy), -1);
+        EXPECT_EQ(errno, ENOTTY);
+      }
+      EXPECT_EQ(close(duplicated.load()), 0);
+    }
+
+    EXPECT_EQ(close(drm), 0);
+    EXPECT_EQ(close(replacement), 0);
+  }
   EXPECT_EQ(close(kfd), 0);
 }
 
@@ -436,7 +544,8 @@ TEST(InterposerSyncobjTest, VmTimelineWaitObservesSynchronousMapAndUnmap) {
   EXPECT_EQ(ioctl(drm, gem_va, &map), -1);
   EXPECT_EQ(errno, EINVAL);
   map.num_syncobj_handles = 0;
-  map.input_fence_syncobj_handles = 0;
+  // The count is authoritative. A reusable caller buffer may leave this unused
+  // pointer non-null when there are no input fences.
   ASSERT_EQ(ioctl(drm, gem_va, &map), 0);
 
   EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &wait), 0);
@@ -458,6 +567,57 @@ TEST(InterposerSyncobjTest, VmTimelineWaitObservesSynchronousMapAndUnmap) {
   EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &wait), -1);
   EXPECT_EQ(errno, ENOENT);
 
+  EXPECT_EQ(gem_close(drm, gem_handle), 0);
+  EXPECT_EQ(close(dmabuf), 0);
+  EXPECT_EQ(close(drm), 0);
+  EXPECT_EQ(close(kfd), 0);
+}
+
+TEST(InterposerSyncobjTest, VmDelayUpdateSuppressesTimelinePublication) {
+  int kfd = open_kfd();
+  ASSERT_GE(kfd, 0);
+  ASSERT_TRUE(kfd_version_ok(kfd));
+  int drm = open_drm_render();
+  if (drm < 0)
+    GTEST_SKIP() << "synthetic DRM render node unavailable in this configuration";
+
+  drm_syncobj_create create{};
+  ASSERT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_CREATE, &create), 0);
+  constexpr size_t kBoSize = 0x1000;
+  constexpr uint64_t kVa = 0x1000000000ULL;
+  int dmabuf = make_sized_memfd(kBoSize);
+  ASSERT_GE(dmabuf, 0);
+  uint32_t gem_handle = 0;
+  ASSERT_TRUE(prime_import(drm, dmabuf, &gem_handle));
+
+  drm_amdgpu_gem_va update{};
+  update.handle = gem_handle;
+  update.operation = AMDGPU_VA_OP_MAP;
+  update.flags = AMDGPU_VM_PAGE_READABLE | AMDGPU_VM_PAGE_WRITEABLE | AMDGPU_VM_DELAY_UPDATE;
+  update.va_address = kVa;
+  update.map_size = kBoSize;
+  update.vm_timeline_point = 1;
+  update.vm_timeline_syncobj_out = create.handle;
+  ASSERT_EQ(ioctl(drm, DRM_AMDGPU_GEM_VA_request(), &update), 0);
+
+  uint32_t handles[] = {create.handle};
+  uint64_t points[] = {1};
+  drm_syncobj_timeline_wait wait{};
+  wait.handles = reinterpret_cast<uintptr_t>(handles);
+  wait.points = reinterpret_cast<uintptr_t>(points);
+  wait.count_handles = 1;
+  wait.flags = DRM_SYNCOBJ_WAIT_FLAGS_WAIT_ALL | DRM_SYNCOBJ_WAIT_FLAGS_WAIT_FOR_SUBMIT;
+  EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &wait), -1);
+  EXPECT_EQ(errno, ETIME);
+
+  update.operation = AMDGPU_VA_OP_UNMAP;
+  update.flags = 0;
+  ASSERT_EQ(ioctl(drm, DRM_AMDGPU_GEM_VA_request(), &update), 0);
+  EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &wait), 0);
+
+  drm_syncobj_destroy destroy{};
+  destroy.handle = create.handle;
+  EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_DESTROY, &destroy), 0);
   EXPECT_EQ(gem_close(drm, gem_handle), 0);
   EXPECT_EQ(close(dmabuf), 0);
   EXPECT_EQ(close(drm), 0);
@@ -537,6 +697,62 @@ TEST(InterposerSyncobjTest, GemVaSignalsBinarySyncobjsAtPointZero) {
   EXPECT_EQ(close(kfd), 0);
 }
 
+TEST(InterposerSyncobjTest, PointZeroOutputReplacesTimelinePayload) {
+  int kfd = open_kfd();
+  ASSERT_GE(kfd, 0);
+  ASSERT_TRUE(kfd_version_ok(kfd));
+  int drm = open_drm_render();
+  if (drm < 0)
+    GTEST_SKIP() << "synthetic DRM render node unavailable in this configuration";
+
+  drm_syncobj_create create{};
+  ASSERT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_CREATE, &create), 0);
+  constexpr size_t kBoSize = 0x1000;
+  constexpr uint64_t kVa = 0x1000000000ULL;
+  int dmabuf = make_sized_memfd(kBoSize);
+  ASSERT_GE(dmabuf, 0);
+  uint32_t gem_handle = 0;
+  ASSERT_TRUE(prime_import(drm, dmabuf, &gem_handle));
+
+  drm_amdgpu_gem_va update{};
+  update.handle = gem_handle;
+  update.operation = AMDGPU_VA_OP_MAP;
+  update.flags = AMDGPU_VM_PAGE_READABLE | AMDGPU_VM_PAGE_WRITEABLE;
+  update.va_address = kVa;
+  update.map_size = kBoSize;
+  update.vm_timeline_syncobj_out = create.handle;
+  update.vm_timeline_point = 2;
+  ASSERT_EQ(ioctl(drm, DRM_AMDGPU_GEM_VA_request(), &update), 0);
+
+  uint32_t handles[] = {create.handle};
+  uint64_t points[] = {2};
+  drm_syncobj_timeline_wait wait{};
+  wait.handles = reinterpret_cast<uintptr_t>(handles);
+  wait.points = reinterpret_cast<uintptr_t>(points);
+  wait.count_handles = 1;
+  wait.flags = DRM_SYNCOBJ_WAIT_FLAGS_WAIT_ALL;
+  ASSERT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &wait), 0);
+
+  update.operation = AMDGPU_VA_OP_UNMAP;
+  update.flags = 0;
+  update.vm_timeline_point = 0;
+  ASSERT_EQ(ioctl(drm, DRM_AMDGPU_GEM_VA_request(), &update), 0);
+
+  points[0] = 0;
+  EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &wait), 0);
+  points[0] = 2;
+  EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &wait), -1);
+  EXPECT_EQ(errno, EINVAL);
+
+  drm_syncobj_destroy destroy{};
+  destroy.handle = create.handle;
+  EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_DESTROY, &destroy), 0);
+  EXPECT_EQ(gem_close(drm, gem_handle), 0);
+  EXPECT_EQ(close(dmabuf), 0);
+  EXPECT_EQ(close(drm), 0);
+  EXPECT_EQ(close(kfd), 0);
+}
+
 TEST(InterposerSyncobjTest, DuplicateDrmFdsShareNamespaceAndLifetime) {
   int kfd = open_kfd();
   ASSERT_GE(kfd, 0);
@@ -609,7 +825,9 @@ TEST(InterposerSyncobjTest, CreateSignaledSeedsOnlyTheInitialPoint) {
   wait.points = reinterpret_cast<uintptr_t>(points);
   wait.count_handles = 1;
   wait.flags = DRM_SYNCOBJ_WAIT_FLAGS_WAIT_ALL;
+  wait.first_signaled = 17;
   EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &wait), 0);
+  EXPECT_EQ(wait.first_signaled, UINT32_MAX);
 
   points[0] = 1;
   EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &wait), -1);
@@ -653,6 +871,9 @@ TEST(InterposerSyncobjTest, WaitValidationMatchesDrm) {
 
   drm_syncobj_timeline_wait empty{};
   EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &empty), 0);
+  empty.pad = UINT32_MAX;
+  EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &empty), 0);
+  empty.pad = 0;
   empty.flags = 1u << 31;
   EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &empty), -1);
   EXPECT_EQ(errno, EINVAL);
@@ -799,7 +1020,64 @@ TEST(InterposerSyncobjTest, TimelineWaitBlocksUntilSignalOrDeadline) {
   EXPECT_EQ(close(kfd), 0);
 }
 
-TEST(InterposerSyncobjTest, ForkedChildReinitializesTimelineWaitQueue) {
+TEST(InterposerSyncobjTest, TimelineWaitReturnsEintrForSignal) {
+  int kfd = open_kfd();
+  ASSERT_GE(kfd, 0);
+  ASSERT_TRUE(kfd_version_ok(kfd));
+  int drm = open_drm_render();
+  if (drm < 0)
+    GTEST_SKIP() << "synthetic DRM render node unavailable in this configuration";
+
+  drm_syncobj_create create{};
+  ASSERT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_CREATE, &create), 0);
+  uint32_t handles[] = {create.handle};
+  uint64_t points[] = {1};
+  drm_syncobj_timeline_wait wait{};
+  wait.handles = reinterpret_cast<uintptr_t>(handles);
+  wait.points = reinterpret_cast<uintptr_t>(points);
+  wait.count_handles = 1;
+  wait.flags = DRM_SYNCOBJ_WAIT_FLAGS_WAIT_ALL | DRM_SYNCOBJ_WAIT_FLAGS_WAIT_FOR_SUBMIT;
+  wait.timeout_nsec = monotonic_deadline_after(std::chrono::seconds(2));
+
+  struct sigaction action {};
+  struct sigaction old_action {};
+  action.sa_handler = noop_signal_handler;
+  sigemptyset(&action.sa_mask);
+  action.sa_flags = 0;
+  ASSERT_EQ(sigaction(SIGUSR1, &action, &old_action), 0);
+
+  std::atomic<bool> entered{false};
+  std::atomic<int> wait_rc{-2};
+  std::atomic<int> wait_errno{0};
+  const auto start = std::chrono::steady_clock::now();
+  std::thread waiter([&] {
+    entered.store(true, std::memory_order_release);
+    wait_rc = ioctl(drm, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &wait);
+    wait_errno = errno;
+  });
+  while (!entered.load(std::memory_order_acquire))
+    std::this_thread::yield();
+  const auto signal_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+  while (wait_rc.load(std::memory_order_acquire) == -2 &&
+         std::chrono::steady_clock::now() < signal_deadline) {
+    EXPECT_EQ(pthread_kill(waiter.native_handle(), SIGUSR1), 0);
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+  }
+  waiter.join();
+  const auto elapsed = std::chrono::steady_clock::now() - start;
+  EXPECT_EQ(wait_rc.load(), -1);
+  EXPECT_EQ(wait_errno.load(), EINTR);
+  EXPECT_LT(elapsed, std::chrono::seconds(1));
+  EXPECT_EQ(sigaction(SIGUSR1, &old_action, nullptr), 0);
+
+  drm_syncobj_destroy destroy{};
+  destroy.handle = create.handle;
+  EXPECT_EQ(ioctl(drm, DRM_IOCTL_SYNCOBJ_DESTROY, &destroy), 0);
+  EXPECT_EQ(close(drm), 0);
+  EXPECT_EQ(close(kfd), 0);
+}
+
+TEST(InterposerSyncobjTest, ForkedChildReinitializesTimelineFutexState) {
   int kfd = open_kfd();
   ASSERT_GE(kfd, 0);
   ASSERT_TRUE(kfd_version_ok(kfd));
@@ -1093,6 +1371,66 @@ TEST(InterposerGemTest, GemNamespaceIsPrivateButSharedByDuplicates) {
   EXPECT_EQ(close(owner_dup), 0);
   EXPECT_EQ(close(foreign), 0);
   EXPECT_EQ(close(owner), 0);
+  EXPECT_EQ(close(kfd), 0);
+}
+
+TEST(InterposerGemTest, IndependentDrmFilesRejectOverlappingMappings) {
+  int kfd = open_kfd();
+  ASSERT_GE(kfd, 0);
+  ASSERT_TRUE(kfd_version_ok(kfd));
+  int first_drm = open_drm_render();
+  int second_drm = open_drm_render();
+  if (first_drm < 0 || second_drm < 0)
+    GTEST_SKIP() << "synthetic DRM render node unavailable in this configuration";
+
+  constexpr size_t kBoSize = 0x1000;
+  constexpr uint64_t kVa = 0x1000000000ULL;
+  int first_dmabuf = make_sized_memfd(kBoSize);
+  int second_dmabuf = make_sized_memfd(kBoSize);
+  ASSERT_GE(first_dmabuf, 0);
+  ASSERT_GE(second_dmabuf, 0);
+  uint32_t first_handle = 0;
+  uint32_t second_handle = 0;
+  ASSERT_TRUE(prime_import(first_drm, first_dmabuf, &first_handle));
+  ASSERT_TRUE(prime_import(second_drm, second_dmabuf, &second_handle));
+
+  const unsigned long gem_va = DRM_AMDGPU_GEM_VA_request();
+  drm_amdgpu_gem_va first_map{};
+  first_map.handle = first_handle;
+  first_map.operation = AMDGPU_VA_OP_MAP;
+  first_map.flags = AMDGPU_VM_PAGE_READABLE | AMDGPU_VM_PAGE_WRITEABLE;
+  first_map.va_address = kVa;
+  first_map.map_size = kBoSize;
+  ASSERT_EQ(ioctl(first_drm, gem_va, &first_map), 0);
+
+  drm_amdgpu_gem_va second_map = first_map;
+  second_map.handle = second_handle;
+  EXPECT_EQ(ioctl(second_drm, gem_va, &second_map), -1);
+  EXPECT_EQ(errno, EINVAL);
+  second_map.operation = AMDGPU_VA_OP_REPLACE;
+  EXPECT_EQ(ioctl(second_drm, gem_va, &second_map), -1);
+  EXPECT_EQ(errno, EINVAL);
+
+  drm_amdgpu_gem_va first_unmap = first_map;
+  first_unmap.operation = AMDGPU_VA_OP_UNMAP;
+  first_unmap.flags = 0;
+  ASSERT_EQ(ioctl(first_drm, gem_va, &first_unmap), 0)
+      << "rejected foreign updates must leave the first mapping intact";
+
+  // Once the first file releases the shared VA, the second file may claim it.
+  second_map.operation = AMDGPU_VA_OP_MAP;
+  ASSERT_EQ(ioctl(second_drm, gem_va, &second_map), 0);
+  drm_amdgpu_gem_va second_unmap = second_map;
+  second_unmap.operation = AMDGPU_VA_OP_UNMAP;
+  second_unmap.flags = 0;
+  EXPECT_EQ(ioctl(second_drm, gem_va, &second_unmap), 0);
+
+  EXPECT_EQ(gem_close(second_drm, second_handle), 0);
+  EXPECT_EQ(gem_close(first_drm, first_handle), 0);
+  EXPECT_EQ(close(second_dmabuf), 0);
+  EXPECT_EQ(close(first_dmabuf), 0);
+  EXPECT_EQ(close(second_drm), 0);
+  EXPECT_EQ(close(first_drm), 0);
   EXPECT_EQ(close(kfd), 0);
 }
 


### PR DESCRIPTION
## Motivation

ROCr attaches DRM syncobj timeline points to GEM VA updates and waits for their completion. The local simulator performs these updates synchronously but did not own the associated timeline state, so simulator execution could depend on unavailable host DRM behavior and invalid timeline points could partially mutate mappings.

## Technical Details

- Model syncobj creation, destruction, submission, signaling, and timeline waits within each simulated DRM file.
- Reserve timeline points before GEM VA changes and signal them only after successful updates. Nonzero points form a monotonic watermark: an older point does not reduce the current state, and the mapping update still applies.
- Share syncobj and GEM namespaces across duplicated DRM descriptors while isolating independent opens and retaining state until the final descriptor closes.
- Preserve DRM file identity across dup, dup2, dup3, and fcntl duplication races without holding the descriptor-lifecycle lock during backend teardown.
- Match timeline-wait validation, WAIT_ALL reporting, point-zero replacement, delayed-update publication, interruption, and fd-reuse behavior covered by the Linux contract.
- Keep independent DRM handle namespaces while rejecting and warning on cross-file VA overlap until the simulator has a separate GPUVM per DRM file.

## Issue Tracking

N/A

## Test Plan

- Build the complete RocJITsu tree and run the complete non-Rocblas CTest suite.
- Run the AMD ISA Python tests.
- Run the focused interposer descriptor, GEM, and syncobj tests under regular, Clang TSan, and Clang ASan+UBSan configurations.
- Run the repository hooks over the complete PR range.

## Test Result

- Complete build passed.
- Complete CTest: 3,083/3,083 executed tests passed; one disabled and three skipped.
- AMD ISA Python tests: 1,319 passed, 46 skipped.
- Regular focused interposer tests: 32/32 passed.
- Clang TSan focused interposer tests: 30/30 passed; the multithreaded-fork and concurrent descriptor-reuse stress cases are not registered in this configuration.
- Clang ASan+UBSan focused interposer tests: 32/32 passed.
- All applicable range-scoped repository hooks passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
