### PR TITLE
[rocjitsu] Relocate one-past-end data targets

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -1700,29 +1700,9 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   }();
   // Read the section headers straight from the image rather than through all_sections(), which
   // drops SHT_NOBITS. A zero-initialized device global lives in .bss, so that omission would hide
-  // the most ordinary target there is. This must also agree with replace_text(): it resolves a data
-  // relocation by the same "allocated, not executable, contains the address" test, and reporting a
-  // builder it cannot resolve would turn a stale literal into a refused code object.
-  const auto addresses_loadable_data = [image = patcher.image_bytes()](uint64_t vaddr) {
-    if (image.size() < sizeof(Elf64_Ehdr))
-      return false;
-    Elf64_Ehdr ehdr{};
-    std::memcpy(&ehdr, image.data(), sizeof(ehdr));
-    if (ehdr.e_shentsize != sizeof(Elf64_Shdr) ||
-        ehdr.e_shoff > image.size() - sizeof(Elf64_Shdr) ||
-        static_cast<uint64_t>(ehdr.e_shnum) * sizeof(Elf64_Shdr) > image.size() - ehdr.e_shoff) {
-      return false;
-    }
-    for (uint16_t i = 0; i < ehdr.e_shnum; ++i) {
-      Elf64_Shdr shdr{};
-      std::memcpy(&shdr, image.data() + ehdr.e_shoff + i * sizeof(Elf64_Shdr), sizeof(shdr));
-      if ((shdr.sh_flags & SHF_ALLOC) == 0 || (shdr.sh_flags & SHF_EXECINSTR) != 0)
-        continue;
-      if (vaddr >= shdr.sh_addr && vaddr - shdr.sh_addr < shdr.sh_size)
-        return true;
-    }
-    return false;
-  };
+  // the most ordinary target there is. Both classification and replacement consume the patcher's
+  // validated table and shared resolver, so a reported data builder is always actionable.
+  const auto source_section_headers = patcher.section_headers();
 
   // Callees reached through a relocation-table dispatch are explicit analysis
   // roots whose live-in SGPRs are caller-supplied, not architected: a dispatched
@@ -3452,7 +3432,12 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
           add == target_offset_by_source_offset.end()) {
         continue;
       }
-      if (addresses_loadable_data(builder.target_vaddr)) {
+      const bool target_is_in_text =
+          builder.target_vaddr >= text_vaddr && builder.target_vaddr - text_vaddr < text.size();
+      // When a data section ends exactly where .text begins, preserve the pre-endpoint-widening
+      // classification: an address inside source text remains a code target.
+      if (resolve_pc_relative_data_section_address(source_section_headers, builder.target_vaddr,
+                                                   text_vaddr, text.size())) {
         data_relocations.push_back(
             {.target_getpc_offset = getpc->second + target_delta,
              .target_literal_offset = add->second + target_delta + sizeof(uint32_t),
@@ -3464,7 +3449,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
       // it and it would otherwise be copied verbatim with a literal measuring the distance the body
       // used to be at. Record it and resolve after every scope has been placed: the target may be
       // emitted by a different scope, so this scope's placement map cannot answer for it yet.
-      if (builder.target_vaddr < text_vaddr || builder.target_vaddr - text_vaddr >= text.size())
+      if (!target_is_in_text)
         continue;
       if (owned_by_recovered_builder(builder.source_address_add_offset))
         continue;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
@@ -822,6 +822,29 @@ void adjust_kernel_descriptor_entry_offsets_in_moved_sections(
 
 } // namespace
 
+std::optional<AllocatedDataSectionAddress>
+resolve_allocated_data_section_address(std::span<const Elf64_Shdr> sections, uint64_t vaddr) {
+  const auto section = std::ranges::find_if(sections, [&](const Elf64_Shdr &candidate) {
+    return (candidate.sh_flags & SHF_ALLOC) != 0 && (candidate.sh_flags & SHF_EXECINSTR) == 0 &&
+           candidate.sh_size != 0 && vaddr >= candidate.sh_addr &&
+           vaddr - candidate.sh_addr <= candidate.sh_size;
+  });
+  if (section == sections.end())
+    return std::nullopt;
+  return AllocatedDataSectionAddress{
+      .section_index = static_cast<size_t>(section - sections.begin()),
+      .section_offset = vaddr - section->sh_addr,
+  };
+}
+
+std::optional<AllocatedDataSectionAddress>
+resolve_pc_relative_data_section_address(std::span<const Elf64_Shdr> sections, uint64_t vaddr,
+                                         uint64_t text_vaddr, uint64_t text_size) {
+  if (vaddr >= text_vaddr && vaddr - text_vaddr < text_size)
+    return std::nullopt;
+  return resolve_allocated_data_section_address(sections, vaddr);
+}
+
 CodeObjectPatcher::CodeObjectPatcher(const AmdGpuCodeObject &obj)
     : image_(obj.image_data(), obj.image_data() + obj.image_size()), text_offset_(0), text_size_(0),
       text_vaddr_(0), text_tail_size_(0) {
@@ -839,6 +862,19 @@ std::span<uint8_t> CodeObjectPatcher::text_bytes() {
 
 std::span<const uint8_t> CodeObjectPatcher::text_bytes() const {
   return {image_.data() + text_offset_, text_size_};
+}
+
+std::vector<Elf64_Shdr> CodeObjectPatcher::section_headers() const {
+  if (image_.size() < sizeof(Elf64_Ehdr))
+    return {};
+  Elf64_Ehdr header{};
+  std::memcpy(&header, image_.data(), sizeof(header));
+  const uint64_t table_size = static_cast<uint64_t>(header.e_shnum) * sizeof(Elf64_Shdr);
+  if (header.e_shentsize != sizeof(Elf64_Shdr) || header.e_shoff > image_.size() ||
+      table_size > image_.size() - header.e_shoff) {
+    return {};
+  }
+  return read_section_headers(image_, header);
 }
 
 bool CodeObjectPatcher::has_relocations_within_text() const {
@@ -1018,7 +1054,7 @@ bool CodeObjectPatcher::replace_text(std::span<const uint8_t> new_text,
 
   auto *ehdr = reinterpret_cast<Elf64_Ehdr *>(image_.data());
   auto header = *ehdr;
-  auto shdrs = read_section_headers(image_, header);
+  auto shdrs = section_headers();
   auto phdrs = read_program_headers(image_, header);
 
   const auto text_index = find_text_section(shdrs, text_offset_, text_size_);
@@ -1042,17 +1078,15 @@ bool CodeObjectPatcher::replace_text(std::span<const uint8_t> new_text,
         sizeof(uint64_t) > new_text.size() - relocation.target_literal_offset) {
       return false;
     }
-    const auto section = std::ranges::find_if(shdrs, [&](const Elf64_Shdr &candidate) {
-      return (candidate.sh_flags & SHF_ALLOC) != 0 && (candidate.sh_flags & SHF_EXECINSTR) == 0 &&
-             relocation.source_target_vaddr >= candidate.sh_addr &&
-             relocation.source_target_vaddr - candidate.sh_addr < candidate.sh_size;
-    });
-    if (section == shdrs.end())
+    const auto target =
+        resolve_allocated_data_section_address(shdrs, relocation.source_target_vaddr);
+    if (!target)
       return false;
-    resolved_data_relocations.push_back(
-        {.relocation = relocation,
-         .target_section = static_cast<size_t>(section - shdrs.begin()),
-         .target_section_offset = relocation.source_target_vaddr - section->sh_addr});
+    // In a well-formed image, abutting allocated sections lie on the same side of .text and shift
+    // by the same delta below, so either section reconstructs their shared boundary after growth.
+    resolved_data_relocations.push_back({.relocation = relocation,
+                                         .target_section = target->section_index,
+                                         .target_section_offset = target->section_offset});
   }
   const uint64_t old_text_end_file = text_offset_ + text_size_;
   const uint64_t old_text_end_vaddr = text_header.sh_addr + text_size_;
@@ -1117,8 +1151,9 @@ bool CodeObjectPatcher::replace_text(std::span<const uint8_t> new_text,
 
   std::memcpy(image_.data() + text_offset_, new_text.data(), new_text.size());
   for (const ResolvedDataRelocation &resolved : resolved_data_relocations) {
+    // Unlike a code target, a data address may be the non-dereferenced end of a [begin, end) range.
     if (resolved.target_section >= shdrs.size() ||
-        resolved.target_section_offset >= shdrs[resolved.target_section].sh_size) {
+        resolved.target_section_offset > shdrs[resolved.target_section].sh_size) {
       return false;
     }
     const uint64_t target_vaddr =

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.h
@@ -3,8 +3,10 @@
 
 #pragma once
 
+#include "rocjitsu/code/amdgpu_elf.h"
 #include "rocjitsu/code/rj_code.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <optional>
 #include <span>
@@ -33,6 +35,25 @@ struct PcRelativeDataRelocation {
   uint64_t source_target_vaddr = 0;
 };
 
+/// @brief Section-relative location of an address in allocated non-executable storage.
+struct AllocatedDataSectionAddress {
+  size_t section_index = 0;
+  uint64_t section_offset = 0;
+};
+
+/// @brief Resolve a data address, including a nonempty section's one-past-end value.
+///
+/// @details Returns the first allocated, non-executable, nonempty section that contains @p vaddr or
+/// ends there. Empty sections do not own an endpoint. If two sections meet at @p vaddr, callers
+/// must not rely on which one is returned.
+[[nodiscard]] std::optional<AllocatedDataSectionAddress>
+resolve_allocated_data_section_address(std::span<const Elf64_Shdr> sections, uint64_t vaddr);
+
+/// @brief Resolve a PC-relative data target without reclassifying an address inside source text.
+[[nodiscard]] std::optional<AllocatedDataSectionAddress>
+resolve_pc_relative_data_section_address(std::span<const Elf64_Shdr> sections, uint64_t vaddr,
+                                         uint64_t text_vaddr, uint64_t text_size);
+
 /// @brief One relocated literal64 PC builder whose target is inside `.text`.
 ///
 /// @details Separate from PcRelativeDataRelocation because the target is named by a final `.text`
@@ -60,6 +81,8 @@ public:
   std::span<const uint8_t> text_bytes() const;
 
   std::span<const uint8_t> image_bytes() const { return {image_.data(), image_.size()}; }
+  /// @brief Validated raw section headers, including SHT_NOBITS entries.
+  [[nodiscard]] std::vector<Elf64_Shdr> section_headers() const;
   uint64_t text_offset() const { return text_offset_; }
   uint64_t text_size() const { return text_size_; }
 

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -1835,6 +1835,52 @@ TEST(CodeObjectPatcher, ReplaceTextRejectsCodeRelocationTargetPastEndOfText) {
       << "the last instruction in .text is a legitimate branch destination";
 }
 
+TEST(CodeObjectPatcher, ResolvesAllocatedDataPayloadsAndEndpoints) {
+  std::array<Elf64_Shdr, 5> sections{};
+  sections[0].sh_addr = 0x1000;
+  sections[0].sh_size = 0x8;
+  sections[1].sh_flags = SHF_ALLOC;
+  sections[1].sh_addr = 0x2000;
+  sections[1].sh_size = 0x10;
+  sections[2].sh_flags = SHF_ALLOC;
+  sections[2].sh_addr = 0x2010;
+  sections[2].sh_size = 0;
+  sections[3].sh_flags = SHF_ALLOC;
+  sections[3].sh_addr = 0x2010;
+  sections[3].sh_size = 0x8;
+  sections[4].sh_flags = SHF_ALLOC | SHF_EXECINSTR;
+  sections[4].sh_addr = 0x3000;
+  sections[4].sh_size = 0x8;
+
+  struct Case {
+    uint64_t target;
+    size_t section_index;
+    uint64_t section_offset;
+  };
+  for (const Case &test :
+       {Case{0x2000, 1, 0}, Case{0x200f, 1, 0xf}, Case{0x2011, 3, 1}, Case{0x2018, 3, 8}}) {
+    const auto resolved = resolve_allocated_data_section_address(sections, test.target);
+    ASSERT_TRUE(resolved.has_value()) << "target 0x" << std::hex << test.target;
+    EXPECT_EQ(resolved->section_index, test.section_index);
+    EXPECT_EQ(resolved->section_offset, test.section_offset);
+  }
+  EXPECT_TRUE(resolve_allocated_data_section_address(sections, 0x2010))
+      << "either nonempty section may own their shared boundary";
+
+  std::array<Elf64_Shdr, 1> empty_section{};
+  empty_section[0].sh_flags = SHF_ALLOC;
+  empty_section[0].sh_addr = 0x4000;
+  EXPECT_FALSE(resolve_allocated_data_section_address(empty_section, 0x4000));
+  EXPECT_FALSE(resolve_allocated_data_section_address(sections, 0x1000));
+  EXPECT_FALSE(resolve_allocated_data_section_address(sections, 0x2019));
+  EXPECT_FALSE(resolve_allocated_data_section_address(sections, 0x2100));
+  EXPECT_FALSE(resolve_allocated_data_section_address(sections, 0x3000));
+
+  ASSERT_TRUE(resolve_allocated_data_section_address(sections, 0x2010));
+  EXPECT_FALSE(resolve_pc_relative_data_section_address(sections, 0x2010, 0x2010, 0x8))
+      << "source text takes precedence over a data section ending at the same address";
+}
+
 TEST(CodeObjectPatcher, ReplaceTextGrowsTextAndShiftsFollowingSections) {
   auto image = make_minimal_amdgpu_elf_with_text_and_rodata();
   AmdGpuCodeObject co(image.data(), image.size());
@@ -10863,7 +10909,7 @@ TEST(BinaryTranslatorE2E, Gfx1250RefusesDeviceFunctionBodyHeldByAnUnnamedPointer
   EXPECT_EQ(result.elf_bytes, image);
 }
 
-TEST(BinaryTranslatorE2E, Gfx1250RepointsPcRelativeDataAddressAfterRelocation) {
+TEST(BinaryTranslatorE2E, Gfx1250RepointsPcRelativeDataRangeBoundsAfterRelocation) {
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
   constexpr uint32_t kGfx1250SNop = 0xBF800000u;
   constexpr uint32_t kGfx1250GetPcS0 = 0xBE804700u;    // s_get_pc_i64 s[0:1]
@@ -10880,9 +10926,6 @@ TEST(BinaryTranslatorE2E, Gfx1250RepointsPcRelativeDataAddressAfterRelocation) {
       kGfx1250SNop,        kGfx1250SNop,    kGfx1250SNop,     kGfx1250GetPcS0, kGfx1250AddNcU64S0,
       0u /*lit lo*/,       0u /*lit hi*/,   kGfx1250SetPcS30,
   };
-  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
-
-  // Locate .text and a real non-executable allocated target, then point the literal at it.
   const auto sections = [](std::span<const uint8_t> img) {
     rocjitsu::Elf64_Ehdr ehdr{};
     std::memcpy(&ehdr, img.data(), sizeof(ehdr));
@@ -10891,69 +10934,90 @@ TEST(BinaryTranslatorE2E, Gfx1250RepointsPcRelativeDataAddressAfterRelocation) {
                 ehdr.e_shnum * sizeof(rocjitsu::Elf64_Shdr));
     return shdrs;
   };
-  auto shdrs = sections(image);
-  const auto text = std::ranges::find_if(shdrs, [](const rocjitsu::Elf64_Shdr &s) {
-    return (s.sh_flags & rocjitsu::SHF_EXECINSTR) != 0;
-  });
-  const auto data = std::ranges::find_if(shdrs, [](const rocjitsu::Elf64_Shdr &s) {
-    return (s.sh_flags & rocjitsu::SHF_ALLOC) != 0 && (s.sh_flags & rocjitsu::SHF_EXECINSTR) == 0 &&
-           s.sh_size != 0;
-  });
-  ASSERT_NE(text, shdrs.end());
-  ASSERT_NE(data, shdrs.end());
 
-  const uint64_t source_getpc_result =
-      text->sh_addr + kCalleeWord * sizeof(uint32_t) + sizeof(uint32_t);
-  const uint64_t target_vaddr = data->sh_addr;
-  const uint64_t source_literal = target_vaddr - source_getpc_result;
-  std::memcpy(image.data() + text->sh_offset + (kCalleeWord + 2) * sizeof(uint32_t),
-              &source_literal, sizeof(source_literal));
+  const auto verify_target = [&](bool points_one_past_end) {
+    SCOPED_TRACE(points_one_past_end ? "one-past-end pointer" : "section-start pointer");
+    auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
 
-  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
-  ASSERT_TRUE(source.is_valid());
-  rocjitsu::BinaryTranslator translator(
-      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
-      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
-                               rocjitsu::ProcessorRevision::Gfx1250A0));
-  const auto result = translator.translate(source);
-  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
-                                                          : result.diagnostics.front().message);
+    // Locate .text and a real non-executable allocated target, then point the literal at either
+    // bound of that section. Both bounds are valid values in a compiler-generated [begin, end)
+    // pair, and both must follow the section when text growth shifts it.
+    auto shdrs = sections(image);
+    const auto text = std::ranges::find_if(shdrs, [](const rocjitsu::Elf64_Shdr &s) {
+      return (s.sh_flags & rocjitsu::SHF_EXECINSTR) != 0;
+    });
+    const auto data = std::ranges::find_if(shdrs, [](const rocjitsu::Elf64_Shdr &s) {
+      return (s.sh_flags & rocjitsu::SHF_ALLOC) != 0 &&
+             (s.sh_flags & rocjitsu::SHF_EXECINSTR) == 0 && s.sh_size != 0;
+    });
+    ASSERT_NE(text, shdrs.end());
+    ASSERT_NE(data, shdrs.end());
 
-  // Find the relocated getpc by its encoding; the callee moved, so its offset is not known up
-  // front.
-  auto out_shdrs = sections(result.elf_bytes);
-  const auto out_text = std::ranges::find_if(out_shdrs, [](const rocjitsu::Elf64_Shdr &s) {
-    return (s.sh_flags & rocjitsu::SHF_EXECINSTR) != 0;
-  });
-  const auto out_data = std::ranges::find_if(out_shdrs, [](const rocjitsu::Elf64_Shdr &s) {
-    return (s.sh_flags & rocjitsu::SHF_ALLOC) != 0 && (s.sh_flags & rocjitsu::SHF_EXECINSTR) == 0 &&
-           s.sh_size != 0;
-  });
-  ASSERT_NE(out_text, out_shdrs.end());
-  ASSERT_NE(out_data, out_shdrs.end());
+    const uint64_t source_getpc_result =
+        text->sh_addr + kCalleeWord * sizeof(uint32_t) + sizeof(uint32_t);
+    const uint64_t target_section_offset = points_one_past_end ? data->sh_size : 0;
+    const uint64_t target_vaddr = data->sh_addr + target_section_offset;
+    const uint64_t source_literal = target_vaddr - source_getpc_result;
+    std::memcpy(image.data() + text->sh_offset + (kCalleeWord + 2) * sizeof(uint32_t),
+                &source_literal, sizeof(source_literal));
 
-  std::optional<size_t> getpc_word;
-  for (size_t i = 0; i + 3 < out_text->sh_size / sizeof(uint32_t); ++i) {
-    uint32_t word = 0;
-    std::memcpy(&word, result.elf_bytes.data() + out_text->sh_offset + i * sizeof(uint32_t),
-                sizeof(word));
-    if (word == kGfx1250GetPcS0) {
-      getpc_word = i;
-      break;
+    rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+    ASSERT_TRUE(source.is_valid());
+    rocjitsu::BinaryTranslator translator(
+        ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+        gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                                 rocjitsu::ProcessorRevision::Gfx1250A0));
+    const auto result = translator.translate(source);
+    ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                            : result.diagnostics.front().message);
+
+    // Find the relocated getpc by its encoding; the callee moved, so its offset is not known up
+    // front.
+    auto out_shdrs = sections(result.elf_bytes);
+    const auto out_text = std::ranges::find_if(out_shdrs, [](const rocjitsu::Elf64_Shdr &s) {
+      return (s.sh_flags & rocjitsu::SHF_EXECINSTR) != 0;
+    });
+    const auto out_data = std::ranges::find_if(out_shdrs, [](const rocjitsu::Elf64_Shdr &s) {
+      return (s.sh_flags & rocjitsu::SHF_ALLOC) != 0 &&
+             (s.sh_flags & rocjitsu::SHF_EXECINSTR) == 0 && s.sh_size != 0;
+    });
+    ASSERT_NE(out_text, out_shdrs.end());
+    ASSERT_NE(out_data, out_shdrs.end());
+
+    std::optional<size_t> getpc_word;
+    for (size_t i = 0; i + 3 < out_text->sh_size / sizeof(uint32_t); ++i) {
+      uint32_t word = 0;
+      std::memcpy(&word, result.elf_bytes.data() + out_text->sh_offset + i * sizeof(uint32_t),
+                  sizeof(word));
+      if (word == kGfx1250GetPcS0) {
+        getpc_word = i;
+        break;
+      }
     }
-  }
-  ASSERT_TRUE(getpc_word.has_value()) << "the callee body must survive into translated text";
-  ASSERT_NE(*getpc_word, kCalleeWord) << "the callee must have moved, or this proves nothing";
+    ASSERT_TRUE(getpc_word.has_value()) << "the callee body must survive into translated text";
+    ASSERT_NE(*getpc_word, kCalleeWord) << "the callee must have moved, or this proves nothing";
 
-  uint64_t relocated_literal = 0;
-  std::memcpy(&relocated_literal,
-              result.elf_bytes.data() + out_text->sh_offset + (*getpc_word + 2) * sizeof(uint32_t),
-              sizeof(relocated_literal));
-  const uint64_t relocated_getpc_result =
-      out_text->sh_addr + *getpc_word * sizeof(uint32_t) + sizeof(uint32_t);
-  EXPECT_EQ(relocated_getpc_result + relocated_literal, out_data->sh_addr)
-      << "the relocated body must still reach the same data address";
-  EXPECT_NE(relocated_literal, source_literal) << "the body moved, so the literal had to change";
+    uint64_t relocated_literal = 0;
+    std::memcpy(&relocated_literal,
+                result.elf_bytes.data() + out_text->sh_offset +
+                    (*getpc_word + 2) * sizeof(uint32_t),
+                sizeof(relocated_literal));
+    const uint64_t relocated_getpc_result =
+        out_text->sh_addr + *getpc_word * sizeof(uint32_t) + sizeof(uint32_t);
+    EXPECT_EQ(relocated_getpc_result + relocated_literal, out_data->sh_addr + target_section_offset)
+        << "the relocated body must still reach the same data address";
+    EXPECT_NE(relocated_literal, source_literal) << "the body moved, so the literal had to change";
+
+    rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+    ASSERT_TRUE(translated.is_valid());
+    const auto second = translator.translate(translated);
+    ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
+                                                            : second.diagnostics.front().message);
+    EXPECT_EQ(second.elf_bytes, result.elf_bytes);
+  };
+
+  ASSERT_NO_FATAL_FAILURE(verify_target(false));
+  ASSERT_NO_FATAL_FAILURE(verify_target(true));
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250FailsClosedOnExcludedBarrierSignalIsfirst) {


### PR DESCRIPTION
## Motivation

PR #9597 added relocation for PC-relative data builders, but required the target to lie strictly inside an allocated data section. A valid one-past-end target was classified as code, leaving its literal stale after `.text` was repacked and breaking idempotence.

## Technical Details

- Treat the endpoint of a nonempty allocated data section as a relocatable address.
- Preserve source-text precedence when a data endpoint meets `.text`.
- Share section parsing and address qualification between discovery and patching, with focused boundary coverage.

## Issue Tracking

N/A

## Test Plan

Build RocJITsu, run focused patcher and translator tests, verify the reported corpus object idempotently, and run the complete CTest suite.

## Test Result

- The reported corpus object translated idempotently.
- Focused patcher and translator tests passed 260/260.
- CTest passed 2,357/2,357; three environment-specific tests were skipped.
- Two local peanut-review rounds completed with all findings resolved.
- Repository hooks passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.