### PR TITLE
ci(rocprofiler-systems): Enable `jpeg-decode` tests

### DIFF
--- a/.github/workflows/rocprofiler-systems-continuous-integration.yml
+++ b/.github/workflows/rocprofiler-systems-continuous-integration.yml
@@ -57,7 +57,7 @@ env:
   ROCPROFSYS_TMPDIR: "%env{PWD}%/testing-tmp"
   ROCM_PATH: "/opt/rocm"
 
-  EXCLUDED_TESTS: "fork.*|jacobi-usm-sys-run|jacobi-roctx.*|jpeg-decode-.*|kfd-.*|unified-memory-output-sys-run|rccl-alltoall-perf-sys-run"
+  EXCLUDED_TESTS: "fork.*|jacobi-usm-sys-run|jacobi-roctx.*|kfd-.*|unified-memory-output-sys-run|rccl-alltoall-perf-sys-run"
   EXCLUDED_LABELS: "thread_limit"
 
 jobs:

--- a/projects/rocprofiler-systems/tests/test_categories.yaml
+++ b/projects/rocprofiler-systems/tests/test_categories.yaml
@@ -36,7 +36,6 @@ _common_therock_regex_excludes: &_common_therock_regex_excludes
   - "openmp-target.*"
   - "jacobi-usm-sys-run"
   - "jacobi-roctx.*"
-  - "jpeg-decode.*"
   - "matrix-exponential.*"
   - "scratch-memory.*"
   - "shmem-pingpong.*"
@@ -64,7 +63,8 @@ test_categories:
       - "cli-help.*"
       - "openmp-fortran-offload-sys-run"
       - "roctx-sampling"
-      # Jpeg and video decode should be added once the binaries can be built on TheRock
+      - "jpeg-decode-sys-run"
+      # Video decode should be added once the binary is built on TheRock
     regex_excludes:
       - *_common_therock_regex_excludes
       - "transpose-runtime-instrument"


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Enable `jpeg-decode` set of tests on `gfx950` runner and have the `sys-run` variant run on `quick` preset.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

To get the test running on TheRock CI, I'll have to open a follow up PR on TheRock (see Test Result section for more information on how that would work).

- Remove `jpeg-decode.*` from `gfx950` regex exclude.
- Remove `jpeg-decode.*` from `test_categories.yaml`
- ADd `jpeg-decode-sys-run` to quick test preset. It runs in ~2-4 seconds. Sampling can take upwards of 10 seconds.

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

JIRA ID: AIPROFSYST-705

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Local GFX950 workflows

Results from enabling it on TheRock:
https://github.com/ROCm/TheRock/pull/7065 (the jpeg component of this PR will go in after this PR).

## Test Result

Locally on the `gfx950` workflow, the tests pass (https://github.com/ROCm/rocm-systems/actions/runs/30933140724/job/92072807617?pr=9606)

As of now, this has no effect on TheRock, it will be skipped. However, with, https://github.com/ROCm/TheRock/pull/7065 (builds our example suite with `jpeg-decode` lib as a runtime dep), the workflow shows the test passes:
https://github.com/ROCm/TheRock/actions/runs/30778553198/job/91587903813?pr=7065
```
    Start 192: jpeg-decode-sampling
2/6 Test #192: jpeg-decode-sampling ................   Passed    7.71 sec
    Start 193: jpeg-decode-sys-run
3/6 Test #193: jpeg-decode-sys-run .................   Passed    2.75 sec
    Start 649: video-decode-sampling
```


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
