### PR TITLE
[rocjitsu][feat]: Surface fieldless special operands to def/use analysis

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -13883,6 +13883,36 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
             f'}}'
         )
 
+        # to_special_reg_class(): maps a special operand (VCC/EXEC/SDST_EXEC/
+        # SSRC_SPECIAL_SCC/M0/PC) to its special RegClass so InstDefUse can
+        # record it as a singleton member of its defs/uses set by operand
+        # direction. Driven by the shared fieldless operand policy table's
+        # effect column, so it keys only on the operand type. A special register
+        # named through a generic selector field instead (e.g. EXEC_LO encoded as
+        # selector value 126 on OPR_SDST) is not handled here and stays nullopt;
+        # surfacing those would add encoding_value_-guarded sub-branches per
+        # selector type. See def_use_chain.h for the consumer-facing contract.
+        special_ref_cases = []
+        for opnd_type in self.isa_spec.operand_types:
+            effect = fieldless_policy(opnd_type).effect
+            if effect is not None and effect.special_reg is not None:
+                special_ref_cases.append(
+                    f'case OperandType::{opnd_type}: '
+                    f'return RegClass::{effect.special_reg.name};'
+                )
+        special_ref_cases.sort()
+        special_ref_body = '\n'.join(special_ref_cases)
+        special_ref_impl = (
+            f'std::optional<RegClass> Operand::to_special_reg_class() const {{\n'
+            f'switch (opr_type_) {{\n'
+            f'{special_ref_body}\n'
+            f'default:\n'
+            f'  break;\n'
+            f'}}\n'
+            f'return std::nullopt;\n'
+            f'}}'
+        )
+
         operand_ctor_decl = (
             '  Operand(int size_bits, OperandType opr_type, int encoding_value,\n'
             '          bool packed_16bit_source = false, bool packed_16bit_dst = false);\n'
@@ -14022,6 +14052,7 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
                 '  std::string name() const override;\n'
                 f'{literal64_decl}'
                 '  std::optional<RegisterRef> to_register_ref() const override;\n'
+                '  std::optional<RegClass> to_special_reg_class() const override;\n'
                 f'{execution_backend_public_decl}'
                 f'{execution_decls}'
                 '  uint64_t widened_literal32_value() const;\n'
@@ -14179,6 +14210,7 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
                 cgen.Line(const_value_impl),
                 cgen.Line(name_impl),
                 cgen.Line(ref_impl),
+                cgen.Line(special_ref_impl),
             ]
         )
 

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -13709,6 +13709,36 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
             f'}}'
         )
 
+        # to_special_reg_class(): maps a special operand (VCC/EXEC/SDST_EXEC/
+        # SSRC_SPECIAL_SCC/M0/PC) to its special RegClass so InstDefUse can
+        # record it as a singleton member of its defs/uses set by operand
+        # direction. Driven by the shared fieldless operand policy table's
+        # effect column, so it keys only on the operand type. A special register
+        # named through a generic selector field instead (e.g. EXEC_LO encoded as
+        # selector value 126 on OPR_SDST) is not handled here and stays nullopt;
+        # surfacing those would add encoding_value_-guarded sub-branches per
+        # selector type. See def_use_chain.h for the consumer-facing contract.
+        special_ref_cases = []
+        for opnd_type in self.isa_spec.operand_types:
+            effect = fieldless_policy(opnd_type).effect
+            if effect is not None and effect.special_reg is not None:
+                special_ref_cases.append(
+                    f'case OperandType::{opnd_type}: '
+                    f'return RegClass::{effect.special_reg.name};'
+                )
+        special_ref_cases.sort()
+        special_ref_body = '\n'.join(special_ref_cases)
+        special_ref_impl = (
+            f'std::optional<RegClass> Operand::to_special_reg_class() const {{\n'
+            f'switch (opr_type_) {{\n'
+            f'{special_ref_body}\n'
+            f'default:\n'
+            f'  break;\n'
+            f'}}\n'
+            f'return std::nullopt;\n'
+            f'}}'
+        )
+
         operand_ctor_decl = (
             '  Operand(int size_bits, OperandType opr_type, int encoding_value,\n'
             '          bool packed_16bit_source = false, bool packed_16bit_dst = false);\n'
@@ -13848,6 +13878,7 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
                 '  std::string name() const override;\n'
                 f'{literal64_decl}'
                 '  std::optional<RegisterRef> to_register_ref() const override;\n'
+                '  std::optional<RegClass> to_special_reg_class() const override;\n'
                 f'{execution_backend_public_decl}'
                 f'{execution_decls}'
                 '  uint64_t widened_literal32_value() const;\n'
@@ -14005,6 +14036,7 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
                 cgen.Line(const_value_impl),
                 cgen.Line(name_impl),
                 cgen.Line(ref_impl),
+                cgen.Line(special_ref_impl),
             ]
         )
 

--- a/emulation/rocjitsu/lib/python/amdisa/fieldless_policy.py
+++ b/emulation/rocjitsu/lib/python/amdisa/fieldless_policy.py
@@ -76,11 +76,12 @@ class SpecialRegClass(enum.Enum):
     Mirrors the special (non-indexed) members of the C++ ``RegClass`` enum
     (``register_set.h``): each value's name is the C++ enumerator (so generator
     lowers ``SpecialRegClass.VCC`` to ``RegClass::VCC``). Only the classes a
-    fieldless operand currently denotes are listed. FLAT_SCRATCH is the one
-    remaining special ``RegClass`` value not produced here yet: its operand
-    (``OPR_FLAT_SCRATCH``) classifies as ``SPECIAL_REGISTER`` in the policy
-    table but supplies no ``FieldlessEffect.special_reg``, so no fieldless
-    operand lowers to it.
+    fieldless operand currently denotes are listed. Two C++ ``RegClass`` values
+    are not produced here: FLAT_SCRATCH (its operand ``OPR_FLAT_SCRATCH``
+    classifies as ``SPECIAL_REGISTER`` in the policy table but supplies no
+    ``FieldlessEffect.special_reg``) and TTMP (a per-index trap-temporary file
+    that is not a fieldless operand at all), so no fieldless operand lowers to
+    either.
     """
 
     EXEC = 'EXEC'

--- a/emulation/rocjitsu/lib/python/amdisa/fieldless_policy.py
+++ b/emulation/rocjitsu/lib/python/amdisa/fieldless_policy.py
@@ -40,7 +40,9 @@ class FieldlessCategory(enum.Enum):
       SPECIAL_REGISTER: a real architectural register that has no encoding
         field -- VCC/EXEC/SCC/M0/PC and FLAT_SCRATCH (per-wave scratch-base
         register state held in SGPRs). The concrete operand_type -> C++
-        RegClass mapping is not modeled here.
+        RegClass mapping is carried by ``FieldlessEffect.special_reg`` (a
+        :class:`SpecialRegClass`) for VCC/EXEC/SCC/M0/PC; FLAT_SCRATCH is
+        classified here but supplies no special_reg yet.
       MEMORY_PSEUDO: a memory-resource pseudo-operand (global/LDS) that carries
         memory-effect meaning but never a register value.
       LITERAL: a value-bearing fieldless literal (``OPR_SIMM32``).
@@ -73,10 +75,12 @@ class SpecialRegClass(enum.Enum):
 
     Mirrors the special (non-indexed) members of the C++ ``RegClass`` enum
     (``register_set.h``): each value's name is the C++ enumerator (so generator
-    lowers ``SpecialRegClass.VCC`` to ``RegClass::VCC``). Only the
-    classes a fieldless operand can currently denote are listed; FLAT_SCRATCH
-    and TTMP are C++ RegClass values but are not produced here yet (FLAT_SCRATCH
-    is bucketed as a memory pseudo-operand; see the policy table).
+    lowers ``SpecialRegClass.VCC`` to ``RegClass::VCC``). Only the classes a
+    fieldless operand currently denotes are listed. FLAT_SCRATCH is the one
+    remaining special ``RegClass`` value not produced here yet: its operand
+    (``OPR_FLAT_SCRATCH``) classifies as ``SPECIAL_REGISTER`` in the policy
+    table but supplies no ``FieldlessEffect.special_reg``, so no fieldless
+    operand lowers to it.
     """
 
     EXEC = 'EXEC'

--- a/emulation/rocjitsu/lib/python/amdisa/fieldless_policy.py
+++ b/emulation/rocjitsu/lib/python/amdisa/fieldless_policy.py
@@ -14,10 +14,13 @@ columns are
   * ``caps``    -- runtime capability for the normal read/write/SIMD accessors
                    (:class:`FieldlessCaps`),
   * ``display`` -- disassembly display policy (:class:`FieldlessDisplay`),
-  * ``effect``  -- architectural-effect metadata.
+  * ``effect``  -- architectural-effect metadata (:class:`FieldlessEffect`): the
+                   special register a fieldless operand corresponds to, or
+                   ``None`` for types with no effect modeled yet.
 
-``role`` and ``caps`` are live today: the generator consumes them to classify
-and lower each operand. ``display`` and ``effect`` are staged extension points.
+``role``, ``caps`` and ``effect`` are live today: the generator consumes them to
+classify and lower each operand and to emit ``to_special_reg_class()``.
+``display`` is a staged extension point.
 """
 
 from __future__ import annotations
@@ -63,6 +66,41 @@ class FieldlessDisplay(enum.Enum):
     """
 
     HIDDEN = 'hidden'
+
+
+class SpecialRegClass(enum.Enum):
+    """An architectural special register a fieldless operand corresponds to.
+
+    Mirrors the special (non-indexed) members of the C++ ``RegClass`` enum
+    (``register_set.h``): each value's name is the C++ enumerator (so generator
+    lowers ``SpecialRegClass.VCC`` to ``RegClass::VCC``). Only the
+    classes a fieldless operand can currently denote are listed; FLAT_SCRATCH
+    and TTMP are C++ RegClass values but are not produced here yet (FLAT_SCRATCH
+    is bucketed as a memory pseudo-operand; see the policy table).
+    """
+
+    EXEC = 'EXEC'
+    VCC = 'VCC'
+    SCC = 'SCC'
+    M0 = 'M0'
+    PC = 'PC'
+
+
+@dataclass(frozen=True)
+class FieldlessEffect:
+    """Architectural-effect metadata for a fieldless operand (one effect object).
+
+    Lives on the :class:`FieldlessPolicy` row so effect data cannot drift into a
+    separate type-keyed map. For now it carries only the special register the
+    operand denotes; memory-effect fields (for the ``MEMORY_PSEUDO`` types) are
+    deferred.
+
+    Attributes:
+        special_reg: The special register this operand reads/writes as an
+            architectural effect, or ``None`` if it denotes no special register.
+    """
+
+    special_reg: SpecialRegClass | None = None
 
 
 @dataclass(frozen=True)
@@ -128,16 +166,16 @@ class FieldlessPolicy:
         role: Semantic category.
         caps: Runtime capability for the normal accessors.
         display: Disassembly display policy.
-        effect: Architectural-effect metadata. Stub (``None``) for now; a later
-            slice populates the special-register / memory effect a fieldless
-            operand corresponds to. Present here so effect data lives on the
-            same policy row rather than in a separate type-keyed map.
+        effect: Architectural-effect metadata (:class:`FieldlessEffect`), or
+            ``None`` for a type with no effect modeled yet (literal, memory
+            pseudo, placeholder). Present here so effect data lives on the same
+            policy row rather than in a separate type-keyed map.
     """
 
     role: FieldlessCategory
     caps: FieldlessCaps
     display: FieldlessDisplay = FieldlessDisplay.HIDDEN
-    effect: object | None = None
+    effect: FieldlessEffect | None = None
 
 
 #: The fieldless operand policy table: every fieldless ``operand_type`` ->
@@ -146,14 +184,40 @@ class FieldlessPolicy:
 _FIELDLESS_POLICY: dict[str, FieldlessPolicy] = {
     # Value-bearing literal: the one fieldless operand read as a real value.
     'OPR_SIMM32': FieldlessPolicy(FieldlessCategory.LITERAL, _VALUE_ONLY),
-    # Architectural special registers: inert through normal accessors; their
-    # architectural effects are exposed through a later special-effect API.
-    'OPR_VCC': FieldlessPolicy(FieldlessCategory.SPECIAL_REGISTER, _INERT),
-    'OPR_EXEC': FieldlessPolicy(FieldlessCategory.SPECIAL_REGISTER, _INERT),
-    'OPR_SDST_EXEC': FieldlessPolicy(FieldlessCategory.SPECIAL_REGISTER, _INERT),
-    'OPR_SSRC_SPECIAL_SCC': FieldlessPolicy(FieldlessCategory.SPECIAL_REGISTER, _INERT),
-    'OPR_PC': FieldlessPolicy(FieldlessCategory.SPECIAL_REGISTER, _INERT),
-    'OPR_SDST_M0': FieldlessPolicy(FieldlessCategory.SPECIAL_REGISTER, _INERT),
+    # Architectural special registers: inert through normal accessors, but their
+    # architectural effect (the special register they denote) is carried in the
+    # effect column and consumed by the generated to_special_reg_class() helper.
+    # SDST_EXEC is the SDST-namespace alias for EXEC, so both map to EXEC.
+    'OPR_VCC': FieldlessPolicy(
+        FieldlessCategory.SPECIAL_REGISTER,
+        _INERT,
+        effect=FieldlessEffect(SpecialRegClass.VCC),
+    ),
+    'OPR_EXEC': FieldlessPolicy(
+        FieldlessCategory.SPECIAL_REGISTER,
+        _INERT,
+        effect=FieldlessEffect(SpecialRegClass.EXEC),
+    ),
+    'OPR_SDST_EXEC': FieldlessPolicy(
+        FieldlessCategory.SPECIAL_REGISTER,
+        _INERT,
+        effect=FieldlessEffect(SpecialRegClass.EXEC),
+    ),
+    'OPR_SSRC_SPECIAL_SCC': FieldlessPolicy(
+        FieldlessCategory.SPECIAL_REGISTER,
+        _INERT,
+        effect=FieldlessEffect(SpecialRegClass.SCC),
+    ),
+    'OPR_PC': FieldlessPolicy(
+        FieldlessCategory.SPECIAL_REGISTER,
+        _INERT,
+        effect=FieldlessEffect(SpecialRegClass.PC),
+    ),
+    'OPR_SDST_M0': FieldlessPolicy(
+        FieldlessCategory.SPECIAL_REGISTER,
+        _INERT,
+        effect=FieldlessEffect(SpecialRegClass.M0),
+    ),
     # Memory pseudo-operands: no register value; drive memory-effect metadata
     # in a later slice.
     'OPR_DSMEM': FieldlessPolicy(FieldlessCategory.MEMORY_PSEUDO, _INERT),

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_fieldless_operands.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_fieldless_operands.py
@@ -26,7 +26,9 @@ from amdisa.fieldless_policy import (
     FieldlessCaps,
     FieldlessCategory,
     FieldlessDisplay,
+    FieldlessEffect,
     FieldlessPolicy,
+    SpecialRegClass,
     fieldless_policy,
     validate_fieldless_taxonomy,
 )
@@ -431,14 +433,26 @@ def test_fieldless_policy_table_is_golden():
     mp = FieldlessCategory.MEMORY_PSEUDO
     hidden = FieldlessDisplay.HIDDEN
     value = FieldlessCaps(reads_value=True, writable=False, is_vgpr=False)
+
+    def sreg(cls):
+        return FieldlessEffect(special_reg=cls)
+
     assert fieldless_policy_mod._FIELDLESS_POLICY == {
         'OPR_SIMM32': FieldlessPolicy(FieldlessCategory.LITERAL, value, hidden, None),
-        'OPR_VCC': FieldlessPolicy(sr, _INERT_CAPS, hidden, None),
-        'OPR_EXEC': FieldlessPolicy(sr, _INERT_CAPS, hidden, None),
-        'OPR_SDST_EXEC': FieldlessPolicy(sr, _INERT_CAPS, hidden, None),
-        'OPR_SSRC_SPECIAL_SCC': FieldlessPolicy(sr, _INERT_CAPS, hidden, None),
-        'OPR_PC': FieldlessPolicy(sr, _INERT_CAPS, hidden, None),
-        'OPR_SDST_M0': FieldlessPolicy(sr, _INERT_CAPS, hidden, None),
+        'OPR_VCC': FieldlessPolicy(sr, _INERT_CAPS, hidden, sreg(SpecialRegClass.VCC)),
+        'OPR_EXEC': FieldlessPolicy(
+            sr, _INERT_CAPS, hidden, sreg(SpecialRegClass.EXEC)
+        ),
+        'OPR_SDST_EXEC': FieldlessPolicy(
+            sr, _INERT_CAPS, hidden, sreg(SpecialRegClass.EXEC)
+        ),
+        'OPR_SSRC_SPECIAL_SCC': FieldlessPolicy(
+            sr, _INERT_CAPS, hidden, sreg(SpecialRegClass.SCC)
+        ),
+        'OPR_PC': FieldlessPolicy(sr, _INERT_CAPS, hidden, sreg(SpecialRegClass.PC)),
+        'OPR_SDST_M0': FieldlessPolicy(
+            sr, _INERT_CAPS, hidden, sreg(SpecialRegClass.M0)
+        ),
         'OPR_DSMEM': FieldlessPolicy(mp, _INERT_CAPS, hidden, None),
         'OPR_GPUMEM': FieldlessPolicy(mp, _INERT_CAPS, hidden, None),
         # FLAT_SCRATCH is the per-wave scratch-base register state (SGPR pair),
@@ -511,14 +525,70 @@ def test_validate_fieldless_taxonomy_is_fatal_on_unknown_type():
 
 
 def test_fieldless_policy_entry_carries_all_columns_on_one_object():
-    # Single-table design: capability, role, display, and (stubbed) effect are
-    # fields of one FieldlessPolicy object, so they cannot drift as independent
-    # type-keyed maps.
+    # Single-table design: capability, role, display, and effect are fields of
+    # one FieldlessPolicy object, so they cannot drift as independent type-keyed
+    # maps.
     policy = fieldless_policy('OPR_VCC')
     assert policy.role == FieldlessCategory.SPECIAL_REGISTER
     assert isinstance(policy.caps, FieldlessCaps)
     assert policy.display == FieldlessDisplay.HIDDEN
-    assert policy.effect is None  # stubbed until the special-effect slice
+    assert policy.effect == FieldlessEffect(special_reg=SpecialRegClass.VCC)
+
+
+# The special register each SPECIAL_REGISTER fieldless type denotes, consumed by
+# the generated to_special_reg_class() helper. SDST_EXEC is the SDST-namespace
+# alias for EXEC, so both map to EXEC.
+_EXPECTED_SPECIAL_REG = {
+    'OPR_VCC': SpecialRegClass.VCC,
+    'OPR_EXEC': SpecialRegClass.EXEC,
+    'OPR_SDST_EXEC': SpecialRegClass.EXEC,
+    'OPR_SSRC_SPECIAL_SCC': SpecialRegClass.SCC,
+    'OPR_PC': SpecialRegClass.PC,
+    'OPR_SDST_M0': SpecialRegClass.M0,
+}
+
+
+def test_special_register_types_carry_expected_effect():
+    # Every SPECIAL_REGISTER fieldless type maps to its architectural special
+    # register through the effect column; the mapping is the sole source the
+    # generator lowers into to_special_reg_class().
+    for opr_type, reg in _EXPECTED_SPECIAL_REG.items():
+        policy = fieldless_policy(opr_type)
+        assert policy.role == FieldlessCategory.SPECIAL_REGISTER, opr_type
+        assert policy.effect == FieldlessEffect(special_reg=reg), opr_type
+
+
+def test_special_register_role_and_effect_agree():
+    # Every type carrying a special-register effect is a SPECIAL_REGISTER, and
+    # the effect set is exactly the mapped types. FLAT_SCRATCH is the one
+    # SPECIAL_REGISTER whose architectural effect is intentionally deferred (no
+    # SpecialRegClass produced yet), so role and effect are not identical sets.
+    # Guards against a mapped special reg gaining/losing its effect, or a
+    # non-special type sprouting one, without a conscious edit.
+    with_effect = {
+        t
+        for t in _OBSERVED_FIELDLESS_TYPES
+        if fieldless_policy(t).effect is not None
+        and fieldless_policy(t).effect.special_reg is not None
+    }
+    is_special = {
+        t
+        for t in _OBSERVED_FIELDLESS_TYPES
+        if fieldless_policy(t).role == FieldlessCategory.SPECIAL_REGISTER
+    }
+    assert with_effect == set(_EXPECTED_SPECIAL_REG)
+    assert with_effect < is_special
+    assert is_special - with_effect == {'OPR_FLAT_SCRATCH'}
+
+
+def test_types_without_special_reg_mapping_have_no_effect():
+    # Everything outside the mapped special-register set models no architectural
+    # effect yet: literal, memory-pseudo, placeholder, and the deferred
+    # FLAT_SCRATCH special register.
+    for opr_type in _OBSERVED_FIELDLESS_TYPES:
+        if opr_type in _EXPECTED_SPECIAL_REG:
+            continue
+        assert fieldless_policy(opr_type).effect is None, opr_type
 
 
 def test_fieldless_caps_stmt_emits_policy_caps():

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/def_use_chain.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/def_use_chain.cpp
@@ -80,6 +80,8 @@ InstDefUse::InstDefUse(const Instruction &inst, const Gfx1250VgprMsbAnalysis *vg
       expand_operand_register(defs, inst, *op, *ref, vgpr_msb, OperandExpansionKind::Def,
                               unknown_vgpr_defs);
       has_vector_def |= is_vector_def(*ref);
+    } else if (auto sc = op->to_special_reg_class()) {
+      defs.expand(RegisterRef{*sc, 0, 1}); // singleton special def
     }
   }
   has_exec_masked_vector_def = has_vector_def && !ignores_exec;
@@ -96,6 +98,8 @@ InstDefUse::InstDefUse(const Instruction &inst, const Gfx1250VgprMsbAnalysis *vg
     if (auto ref = op->to_register_ref())
       expand_operand_register(uses, inst, *op, *ref, vgpr_msb, OperandExpansionKind::Use,
                               unknown_vgpr_defs);
+    else if (auto sc = op->to_special_reg_class())
+      uses.expand(RegisterRef{*sc, 0, 1}); // singleton special use
   }
 
   if (vgpr_msb == nullptr) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/def_use_chain.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/def_use_chain.cpp
@@ -20,6 +20,20 @@ namespace {
   return ref.cls == RegClass::VGPR || ref.cls == RegClass::ACC_VGPR;
 }
 
+// InstDefUse surfaces only ordinary register-file refs (SGPR/VGPR/AccVGPR)
+// through to_register_ref(). A generic selector operand can decode to a special
+// register (e.g. EXEC_LO/EXEC_HI in an OPR_SDST field), but that ref collapses
+// the LO/HI halves (and, for TTMP, the register index) into one class-wide
+// singleton, so it is dropped here rather than recorded imprecisely. Genuinely
+// fieldless special operands are surfaced instead through to_special_reg_class().
+// See def_use_chain.h.
+[[nodiscard]] std::optional<RegisterRef> ordinary_register_ref(const Operand &op) {
+  auto ref = op.to_register_ref();
+  if (ref && is_special_reg_class(ref->cls))
+    return std::nullopt;
+  return ref;
+}
+
 /// @brief Distinguishes a use (may-read) expansion from a def (must-write) one.
 /// @details When the VGPR-MSB bank is unknown, a USE conservatively reads any of
 /// the four candidate tuples (a sound may-read over-approximation), but a DEF must
@@ -76,7 +90,7 @@ InstDefUse::InstDefUse(const Instruction &inst, const Gfx1250VgprMsbAnalysis *vg
     const auto *op = inst.dst_operand(i);
     if (op == nullptr)
       continue;
-    if (auto ref = op->to_register_ref()) {
+    if (auto ref = ordinary_register_ref(*op)) {
       expand_operand_register(defs, inst, *op, *ref, vgpr_msb, OperandExpansionKind::Def,
                               unknown_vgpr_defs);
       has_vector_def |= is_vector_def(*ref);
@@ -95,7 +109,7 @@ InstDefUse::InstDefUse(const Instruction &inst, const Gfx1250VgprMsbAnalysis *vg
     const auto *op = inst.src_operand(i);
     if (op == nullptr)
       continue;
-    if (auto ref = op->to_register_ref())
+    if (auto ref = ordinary_register_ref(*op))
       expand_operand_register(uses, inst, *op, *ref, vgpr_msb, OperandExpansionKind::Use,
                               unknown_vgpr_defs);
     else if (auto sc = op->to_special_reg_class())
@@ -121,7 +135,7 @@ InstDefUse::InstDefUse(const Instruction &inst, const Gfx1250VgprMsbAnalysis *vg
   for (const Operand *op : implicit_use_operand_list) {
     if (op == nullptr)
       continue;
-    if (auto ref = op->to_register_ref())
+    if (auto ref = ordinary_register_ref(*op))
       expand_operand_register(uses, inst, *op, *ref, vgpr_msb, OperandExpansionKind::Use,
                               unknown_vgpr_defs);
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/def_use_chain.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/def_use_chain.cpp
@@ -102,8 +102,13 @@ InstDefUse::InstDefUse(const Instruction &inst, const Gfx1250VgprMsbAnalysis *vg
   // No generated instruction currently reports an implicit VGPR def. If one is
   // added for gfx1250, it must expose an operand with a VGPR-MSB role so global
   // usage can resolve the physical bank instead of recording only the raw low
-  // eight-bit index.
-  inst.implicit_defs(defs);
+  // eight-bit index. Merge only the ordinary projection: an implicit hook that
+  // surfaces a special via a generic selector (to_register_ref()) collapses it
+  // to a class-wide singleton, so it is dropped here for the same reason the
+  // explicit dst loop above drops selector-encoded specials.
+  RegisterSet implicit_defs_set;
+  inst.implicit_defs(implicit_defs_set);
+  defs |= implicit_defs_set.ordinary_only();
 
   for (int i = 0; i < inst.num_src_operands(); ++i) {
     const auto *op = inst.src_operand(i);
@@ -118,8 +123,13 @@ InstDefUse::InstDefUse(const Instruction &inst, const Gfx1250VgprMsbAnalysis *vg
 
   if (vgpr_msb == nullptr) {
     // No dynamic VGPR banking (non-gfx1250): the flat hook already reports every
-    // implicit read at its physical index.
-    inst.implicit_uses(uses);
+    // implicit read at its physical index. Merge only the ordinary projection so
+    // a selector-encoded special surfaced by the hook (e.g. an exec_lo
+    // preserve-read on a partial-write op) is dropped rather than recorded as an
+    // imprecise class-wide singleton — matching the explicit src loop above.
+    RegisterSet implicit_uses_set;
+    inst.implicit_uses(implicit_uses_set);
+    uses |= implicit_uses_set.ordinary_only();
     return;
   }
 
@@ -144,11 +154,12 @@ InstDefUse::InstDefUse(const Instruction &inst, const Gfx1250VgprMsbAnalysis *vg
   // operand (e.g. FLAT/GLOBAL saddr, an SGPR). Merge only those: the VGPR reads
   // it would add carry no bank, and the operand path above already resolved them
   // to the correct physical tuple, so re-adding the raw low-8 index would mark a
-  // wrong, unbanked register live.
+  // wrong, unbanked register live. Also drop any selector-encoded special the
+  // hook surfaces, for the same reason as the non-gfx1250 path above.
   RegisterSet flat_implicit;
   inst.implicit_uses(flat_implicit);
   flat_implicit.clear_class(RegClass::VGPR);
-  uses |= flat_implicit;
+  uses |= flat_implicit.ordinary_only();
 }
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/def_use_chain.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/def_use_chain.cpp
@@ -23,8 +23,8 @@ namespace {
 // InstDefUse surfaces only ordinary register-file refs (SGPR/VGPR/AccVGPR)
 // through to_register_ref(). A generic selector operand can decode to a special
 // register (e.g. EXEC_LO/EXEC_HI in an OPR_SDST field), but that ref collapses
-// the LO/HI halves (and, for TTMP, the register index) into one class-wide
-// singleton, so it is dropped here rather than recorded imprecisely. Genuinely
+// the LO/HI halves into one class-wide singleton, so it is dropped here rather
+// than recorded imprecisely. Genuinely
 // fieldless special operands are surfaced instead through to_special_reg_class().
 // See def_use_chain.h.
 [[nodiscard]] std::optional<RegisterRef> ordinary_register_ref(const Operand &op) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/def_use_chain.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/def_use_chain.h
@@ -21,12 +21,15 @@
 /// OPR_SSRC_SPECIAL_SCC, OPR_VCC) whose `to_special_reg_class()` names the class
 /// directly. A special register named through a *generic selector* field instead
 /// (e.g. `s_mov_b32 exec_lo, 0`, where EXEC_LO is encoding value 126 in the
-/// OPR_SDST selector) is not yet surfaced: `to_register_ref()` maps only the
-/// SGPR/VGPR/AccVGPR selector ranges and `to_special_reg_class()` keys only on
-/// the operand type, so such an effect appears in neither `defs`/`uses` nor the
-/// ordinary projection. Closing this gap is a generator change (map special
-/// selector values to their RegClass) plus a regen, and is left as follow-up
-/// work; consumers must not assume selector-encoded EXEC/VCC/M0 writes are
+/// OPR_SDST selector) *does* decode to a special `RegisterRef` via
+/// `to_register_ref()`, but that ref collapses the LO/HI halves (and, for TTMP,
+/// the register index) into one class-wide singleton — an imprecise
+/// representation — so InstDefUse drops it: only ordinary SGPR/VGPR/AccVGPR refs
+/// from `to_register_ref()` are recorded, and such selector-encoded specials
+/// appear in neither `defs`/`uses` nor the ordinary projection. Surfacing them
+/// precisely is follow-up work (a generator change mapping special selector
+/// values to their RegClass, plus width-aware special storage); until then,
+/// consumers must not assume selector-encoded EXEC/VCC/M0 reads or writes are
 /// visible here.
 
 #pragma once

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/def_use_chain.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/def_use_chain.h
@@ -9,6 +9,25 @@
 /// registers, source operands use registers. Operand::to_register_ref()
 /// determines which register class and index are involved. Instruction
 /// subclasses may also report hidden register effects through implicit hooks.
+///
+/// `defs`/`uses` hold both ordinary register-file effects (SGPR/VGPR/AccVGPR)
+/// and architectural special-register effects (EXEC/VCC/SCC/M0/PC/...) in one
+/// RegisterSet each. Special registers are singleton members of that set;
+/// consumers that drive scratch-allocation liveness project them out with
+/// `RegisterSet::ordinary_only()` so special state never looks allocatable.
+///
+/// Special-register effects are surfaced only from *field-less* special operands
+/// — dedicated operand types (OPR_PC, OPR_SDST_EXEC, OPR_SDST_M0,
+/// OPR_SSRC_SPECIAL_SCC, OPR_VCC) whose `to_special_reg_class()` names the class
+/// directly. A special register named through a *generic selector* field instead
+/// (e.g. `s_mov_b32 exec_lo, 0`, where EXEC_LO is encoding value 126 in the
+/// OPR_SDST selector) is not yet surfaced: `to_register_ref()` maps only the
+/// SGPR/VGPR/AccVGPR selector ranges and `to_special_reg_class()` keys only on
+/// the operand type, so such an effect appears in neither `defs`/`uses` nor the
+/// ordinary projection. Closing this gap is a generator change (map special
+/// selector values to their RegClass) plus a regen, and is left as follow-up
+/// work; consumers must not assume selector-encoded EXEC/VCC/M0 writes are
+/// visible here.
 
 #pragma once
 
@@ -33,8 +52,8 @@ public:
   InstDefUse(const Instruction &inst, const Gfx1250VgprMsbAnalysis *vgpr_msb = nullptr,
              UnknownVgprDefPolicy unknown_vgpr_defs = UnknownVgprDefPolicy::Omit);
 
-  RegisterSet defs; ///< Registers overwritten by the instruction.
-  RegisterSet uses; ///< Registers read before the instruction writes defs.
+  RegisterSet defs; ///< Registers written (ordinary lanes + special singletons).
+  RegisterSet uses; ///< Registers read before defs (ordinary lanes + special singletons).
   bool has_exec_masked_vector_def =
       false; ///< True if the instruction doesn't ignore EXEC and has a vector def.
   bool has_predicated_def = false; ///< True if defs preserve old values on some paths.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/def_use_chain.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/def_use_chain.h
@@ -22,9 +22,9 @@
 /// directly. A special register named through a *generic selector* field instead
 /// (e.g. `s_mov_b32 exec_lo, 0`, where EXEC_LO is encoding value 126 in the
 /// OPR_SDST selector) *does* decode to a special `RegisterRef` via
-/// `to_register_ref()`, but that ref collapses the LO/HI halves (and, for TTMP,
-/// the register index) into one class-wide singleton — an imprecise
-/// representation — so InstDefUse drops it: only ordinary SGPR/VGPR/AccVGPR refs
+/// `to_register_ref()`, but that ref collapses the LO/HI halves into one
+/// class-wide singleton — an imprecise representation — so InstDefUse drops it:
+/// only ordinary SGPR/VGPR/AccVGPR refs
 /// from `to_register_ref()` are recorded, and such selector-encoded specials
 /// appear in neither `defs`/`uses` nor the ordinary projection. Surfacing them
 /// precisely is follow-up work (a generator change mapping special selector

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/liveness.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/liveness.cpp
@@ -61,7 +61,9 @@ void dfs_reverse_post_order(const BasicBlock &start,
 }
 
 [[nodiscard]] RegisterSet kill_defs(const InstDefUse &du, ExecState exec_before) {
-  RegisterSet kills = du.defs;
+  // Ordinary registers only: special singletons (EXEC/VCC/...) live in du.defs
+  // but are not part of scratch-allocation liveness and must not become kills.
+  RegisterSet kills = du.defs.ordinary_only();
   // Predicated defs preserve old values on at least one control-flow path, so
   // they can never be unconditional kills.
   if (du.has_predicated_def)
@@ -288,7 +290,7 @@ void LivenessAnalysis::analyze(KernelBlockScope blocks, bool restrict_live_befor
         ++requested_live_before_by_block[i];
       InstDefUse du(inst, gfx1250_vgpr_msb_.get());
       RegisterSet kills = kill_defs(du, exec_before(inst));
-      RegisterSet upward_uses = du.uses;
+      RegisterSet upward_uses = du.uses.ordinary_only();
       upward_uses -= state.kill;
       state.gen |= upward_uses;
       state.kill |= kills;
@@ -358,7 +360,7 @@ void LivenessAnalysis::analyze(KernelBlockScope blocks, bool restrict_live_befor
       InstDefUse du(*inst, gfx1250_vgpr_msb_.get());
       RegisterSet kills = kill_defs(du, exec_before(*inst));
       live -= kills;
-      live |= du.uses;
+      live |= du.uses.ordinary_only();
       if (!filter_live_before || requested_live_before.contains(inst)) {
         live_before_.emplace(inst, live);
         if (filter_live_before && --remaining_requested == 0)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/liveness.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/liveness.cpp
@@ -216,8 +216,8 @@ void LivenessAnalysis::collect_global_register_usage(KernelBlockScope blocks,
         global_vgpr_usage_is_complete_ = false;
 
       const InstDefUse accesses(inst, gfx1250_vgpr_msb_.get(), UnknownVgprDefPolicy::ExpandAll);
-      globally_used_registers_ |= accesses.defs;
-      globally_used_registers_ |= accesses.uses;
+      globally_used_registers_ |= accesses.defs.ordinary_only();
+      globally_used_registers_ |= accesses.uses.ordinary_only();
     }
   }
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/liveness.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/liveness.h
@@ -54,6 +54,9 @@ struct ScopedCfgEdge {
 /// block. The standard backward equations are:
 ///   live_out(B) = union(live_in(S) for S in successors(B))
 ///   live_in(B)  = gen(B) union (live_out(B) - kill(B))
+///
+/// All four sets are ordinary-register-only; special singletons are projected
+/// out of each instruction's def/use before the transfer function runs.
 struct BlockLiveness {
   RegisterSet live_in;
   RegisterSet live_out;
@@ -189,9 +192,15 @@ public:
   [[nodiscard]] bool has_live_before(const Instruction &inst) const;
 
   /// @brief Registers live immediately before @p inst executes.
+  ///
+  /// @details Ordinary registers only. Special singletons (EXEC/M0/PC/...) are
+  /// deliberately excluded: implicit special uses are not yet fully modeled, so
+  /// this analysis does not answer special-register liveness.
   [[nodiscard]] const RegisterSet &live_before(const Instruction &inst) const;
 
-  /// @brief Convenience predicate for one register reference.
+  /// @brief Convenience predicate for one register reference. Only meaningful
+  /// for ordinary classes; special-register liveness is not tracked (see
+  /// live_before()).
   [[nodiscard]] bool is_live_before(const Instruction &inst, RegisterRef ref) const;
 
   /// @brief gfx1250 VGPR bank selected for @p role before @p inst.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/def_use_chain.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/def_use_chain.cpp
@@ -80,6 +80,8 @@ InstDefUse::InstDefUse(const Instruction &inst, const Gfx1250VgprMsbAnalysis *vg
       expand_operand_register(defs, inst, *op, *ref, vgpr_msb, OperandExpansionKind::Def,
                               unknown_vgpr_defs);
       has_vector_def |= is_vector_def(*ref);
+    } else if (auto sc = op->to_special_reg_class()) {
+      defs.expand(RegisterRef{*sc, 0, 1}); // singleton special def
     }
   }
   has_exec_masked_vector_def = has_vector_def && !ignores_exec;
@@ -96,6 +98,8 @@ InstDefUse::InstDefUse(const Instruction &inst, const Gfx1250VgprMsbAnalysis *vg
     if (auto ref = op->to_register_ref())
       expand_operand_register(uses, inst, *op, *ref, vgpr_msb, OperandExpansionKind::Use,
                               unknown_vgpr_defs);
+    else if (auto sc = op->to_special_reg_class())
+      uses.expand(RegisterRef{*sc, 0, 1}); // singleton special use
   }
 
   if (vgpr_msb == nullptr) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/def_use_chain.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/def_use_chain.cpp
@@ -20,6 +20,20 @@ namespace {
   return ref.cls == RegClass::VGPR || ref.cls == RegClass::ACC_VGPR;
 }
 
+// InstDefUse surfaces only ordinary register-file refs (SGPR/VGPR/AccVGPR)
+// through to_register_ref(). A generic selector operand can decode to a special
+// register (e.g. EXEC_LO/EXEC_HI in an OPR_SDST field), but that ref collapses
+// the LO/HI halves (and, for TTMP, the register index) into one class-wide
+// singleton, so it is dropped here rather than recorded imprecisely. Genuinely
+// fieldless special operands are surfaced instead through to_special_reg_class().
+// See def_use_chain.h.
+[[nodiscard]] std::optional<RegisterRef> ordinary_register_ref(const Operand &op) {
+  auto ref = op.to_register_ref();
+  if (ref && is_special_reg_class(ref->cls))
+    return std::nullopt;
+  return ref;
+}
+
 /// @brief Distinguishes a use (may-read) expansion from a def (must-write) one.
 /// @details When the VGPR-MSB bank is unknown, a USE conservatively reads any of
 /// the four candidate tuples (a sound may-read over-approximation), but a DEF must
@@ -76,7 +90,7 @@ InstDefUse::InstDefUse(const Instruction &inst, const Gfx1250VgprMsbAnalysis *vg
     const auto *op = inst.dst_operand(i);
     if (op == nullptr)
       continue;
-    if (auto ref = op->to_register_ref()) {
+    if (auto ref = ordinary_register_ref(*op)) {
       expand_operand_register(defs, inst, *op, *ref, vgpr_msb, OperandExpansionKind::Def,
                               unknown_vgpr_defs);
       has_vector_def |= is_vector_def(*ref);
@@ -95,7 +109,7 @@ InstDefUse::InstDefUse(const Instruction &inst, const Gfx1250VgprMsbAnalysis *vg
     const auto *op = inst.src_operand(i);
     if (op == nullptr)
       continue;
-    if (auto ref = op->to_register_ref())
+    if (auto ref = ordinary_register_ref(*op))
       expand_operand_register(uses, inst, *op, *ref, vgpr_msb, OperandExpansionKind::Use,
                               unknown_vgpr_defs);
     else if (auto sc = op->to_special_reg_class())
@@ -121,7 +135,7 @@ InstDefUse::InstDefUse(const Instruction &inst, const Gfx1250VgprMsbAnalysis *vg
   for (const Operand *op : implicit_use_operand_list) {
     if (op == nullptr)
       continue;
-    if (auto ref = op->to_register_ref())
+    if (auto ref = ordinary_register_ref(*op))
       expand_operand_register(uses, inst, *op, *ref, vgpr_msb, OperandExpansionKind::Use,
                               unknown_vgpr_defs);
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/def_use_chain.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/def_use_chain.cpp
@@ -102,8 +102,13 @@ InstDefUse::InstDefUse(const Instruction &inst, const Gfx1250VgprMsbAnalysis *vg
   // No generated instruction currently reports an implicit VGPR def. If one is
   // added for gfx1250, it must expose an operand with a VGPR-MSB role so global
   // usage can resolve the physical bank instead of recording only the raw low
-  // eight-bit index.
-  inst.implicit_defs(defs);
+  // eight-bit index. Merge only the ordinary projection: an implicit hook that
+  // surfaces a special via a generic selector (to_register_ref()) collapses it
+  // to a class-wide singleton, so it is dropped here for the same reason the
+  // explicit dst loop above drops selector-encoded specials.
+  RegisterSet implicit_defs_set;
+  inst.implicit_defs(implicit_defs_set);
+  defs |= implicit_defs_set.ordinary_only();
 
   for (int i = 0; i < inst.num_src_operands(); ++i) {
     const auto *op = inst.src_operand(i);
@@ -118,8 +123,13 @@ InstDefUse::InstDefUse(const Instruction &inst, const Gfx1250VgprMsbAnalysis *vg
 
   if (vgpr_msb == nullptr) {
     // No dynamic VGPR banking (non-gfx1250): the flat hook already reports every
-    // implicit read at its physical index.
-    inst.implicit_uses(uses);
+    // implicit read at its physical index. Merge only the ordinary projection so
+    // a selector-encoded special surfaced by the hook (e.g. an exec_lo
+    // preserve-read on a partial-write op) is dropped rather than recorded as an
+    // imprecise class-wide singleton — matching the explicit src loop above.
+    RegisterSet implicit_uses_set;
+    inst.implicit_uses(implicit_uses_set);
+    uses |= implicit_uses_set.ordinary_only();
     return;
   }
 
@@ -144,11 +154,12 @@ InstDefUse::InstDefUse(const Instruction &inst, const Gfx1250VgprMsbAnalysis *vg
   // operand (e.g. FLAT/GLOBAL saddr, an SGPR). Merge only those: the VGPR reads
   // it would add carry no bank, and the operand path above already resolved them
   // to the correct physical tuple, so re-adding the raw low-8 index would mark a
-  // wrong, unbanked register live.
+  // wrong, unbanked register live. Also drop any selector-encoded special the
+  // hook surfaces, for the same reason as the non-gfx1250 path above.
   RegisterSet flat_implicit;
   inst.implicit_uses(flat_implicit);
   flat_implicit.clear_class(RegClass::VGPR);
-  uses |= flat_implicit;
+  uses |= flat_implicit.ordinary_only();
 }
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/def_use_chain.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/def_use_chain.cpp
@@ -23,8 +23,8 @@ namespace {
 // InstDefUse surfaces only ordinary register-file refs (SGPR/VGPR/AccVGPR)
 // through to_register_ref(). A generic selector operand can decode to a special
 // register (e.g. EXEC_LO/EXEC_HI in an OPR_SDST field), but that ref collapses
-// the LO/HI halves (and, for TTMP, the register index) into one class-wide
-// singleton, so it is dropped here rather than recorded imprecisely. Genuinely
+// the LO/HI halves into one class-wide singleton, so it is dropped here rather
+// than recorded imprecisely. Genuinely
 // fieldless special operands are surfaced instead through to_special_reg_class().
 // See def_use_chain.h.
 [[nodiscard]] std::optional<RegisterRef> ordinary_register_ref(const Operand &op) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/def_use_chain.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/def_use_chain.h
@@ -21,12 +21,15 @@
 /// OPR_SSRC_SPECIAL_SCC, OPR_VCC) whose `to_special_reg_class()` names the class
 /// directly. A special register named through a *generic selector* field instead
 /// (e.g. `s_mov_b32 exec_lo, 0`, where EXEC_LO is encoding value 126 in the
-/// OPR_SDST selector) is not yet surfaced: `to_register_ref()` maps only the
-/// SGPR/VGPR/AccVGPR selector ranges and `to_special_reg_class()` keys only on
-/// the operand type, so such an effect appears in neither `defs`/`uses` nor the
-/// ordinary projection. Closing this gap is a generator change (map special
-/// selector values to their RegClass) plus a regen, and is left as follow-up
-/// work; consumers must not assume selector-encoded EXEC/VCC/M0 writes are
+/// OPR_SDST selector) *does* decode to a special `RegisterRef` via
+/// `to_register_ref()`, but that ref collapses the LO/HI halves (and, for TTMP,
+/// the register index) into one class-wide singleton — an imprecise
+/// representation — so InstDefUse drops it: only ordinary SGPR/VGPR/AccVGPR refs
+/// from `to_register_ref()` are recorded, and such selector-encoded specials
+/// appear in neither `defs`/`uses` nor the ordinary projection. Surfacing them
+/// precisely is follow-up work (a generator change mapping special selector
+/// values to their RegClass, plus width-aware special storage); until then,
+/// consumers must not assume selector-encoded EXEC/VCC/M0 reads or writes are
 /// visible here.
 
 #pragma once

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/def_use_chain.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/def_use_chain.h
@@ -9,6 +9,25 @@
 /// registers, source operands use registers. Operand::to_register_ref()
 /// determines which register class and index are involved. Instruction
 /// subclasses may also report hidden register effects through implicit hooks.
+///
+/// `defs`/`uses` hold both ordinary register-file effects (SGPR/VGPR/AccVGPR)
+/// and architectural special-register effects (EXEC/VCC/SCC/M0/PC/...) in one
+/// RegisterSet each. Special registers are singleton members of that set;
+/// consumers that drive scratch-allocation liveness project them out with
+/// `RegisterSet::ordinary_only()` so special state never looks allocatable.
+///
+/// Special-register effects are surfaced only from *field-less* special operands
+/// — dedicated operand types (OPR_PC, OPR_SDST_EXEC, OPR_SDST_M0,
+/// OPR_SSRC_SPECIAL_SCC, OPR_VCC) whose `to_special_reg_class()` names the class
+/// directly. A special register named through a *generic selector* field instead
+/// (e.g. `s_mov_b32 exec_lo, 0`, where EXEC_LO is encoding value 126 in the
+/// OPR_SDST selector) is not yet surfaced: `to_register_ref()` maps only the
+/// SGPR/VGPR/AccVGPR selector ranges and `to_special_reg_class()` keys only on
+/// the operand type, so such an effect appears in neither `defs`/`uses` nor the
+/// ordinary projection. Closing this gap is a generator change (map special
+/// selector values to their RegClass) plus a regen, and is left as follow-up
+/// work; consumers must not assume selector-encoded EXEC/VCC/M0 writes are
+/// visible here.
 
 #pragma once
 
@@ -33,8 +52,8 @@ public:
   InstDefUse(const Instruction &inst, const Gfx1250VgprMsbAnalysis *vgpr_msb = nullptr,
              UnknownVgprDefPolicy unknown_vgpr_defs = UnknownVgprDefPolicy::Omit);
 
-  RegisterSet defs; ///< Registers overwritten by the instruction.
-  RegisterSet uses; ///< Registers read before the instruction writes defs.
+  RegisterSet defs; ///< Registers written (ordinary lanes + special singletons).
+  RegisterSet uses; ///< Registers read before defs (ordinary lanes + special singletons).
   bool has_exec_masked_vector_def =
       false; ///< True if the instruction doesn't ignore EXEC and has a vector def.
   bool has_predicated_def = false; ///< True if defs preserve old values on some paths.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/def_use_chain.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/def_use_chain.h
@@ -22,9 +22,9 @@
 /// directly. A special register named through a *generic selector* field instead
 /// (e.g. `s_mov_b32 exec_lo, 0`, where EXEC_LO is encoding value 126 in the
 /// OPR_SDST selector) *does* decode to a special `RegisterRef` via
-/// `to_register_ref()`, but that ref collapses the LO/HI halves (and, for TTMP,
-/// the register index) into one class-wide singleton — an imprecise
-/// representation — so InstDefUse drops it: only ordinary SGPR/VGPR/AccVGPR refs
+/// `to_register_ref()`, but that ref collapses the LO/HI halves into one
+/// class-wide singleton — an imprecise representation — so InstDefUse drops it:
+/// only ordinary SGPR/VGPR/AccVGPR refs
 /// from `to_register_ref()` are recorded, and such selector-encoded specials
 /// appear in neither `defs`/`uses` nor the ordinary projection. Surfacing them
 /// precisely is follow-up work (a generator change mapping special selector

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/liveness.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/liveness.cpp
@@ -217,8 +217,8 @@ void LivenessAnalysis::collect_global_register_usage(KernelBlockScope blocks,
         global_vgpr_usage_is_complete_ = false;
 
       const InstDefUse accesses(inst, gfx1250_vgpr_msb_.get(), UnknownVgprDefPolicy::ExpandAll);
-      globally_used_registers_ |= accesses.defs;
-      globally_used_registers_ |= accesses.uses;
+      globally_used_registers_ |= accesses.defs.ordinary_only();
+      globally_used_registers_ |= accesses.uses.ordinary_only();
     }
   }
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/liveness.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/liveness.cpp
@@ -62,7 +62,9 @@ void dfs_reverse_post_order(const BasicBlock &start,
 }
 
 [[nodiscard]] RegisterSet kill_defs(const InstDefUse &du, ExecState exec_before) {
-  RegisterSet kills = du.defs;
+  // Ordinary registers only: special singletons (EXEC/VCC/...) live in du.defs
+  // but are not part of scratch-allocation liveness and must not become kills.
+  RegisterSet kills = du.defs.ordinary_only();
   // Predicated defs preserve old values on at least one control-flow path, so
   // they can never be unconditional kills.
   if (du.has_predicated_def)
@@ -289,7 +291,7 @@ void LivenessAnalysis::analyze(KernelBlockScope blocks, bool restrict_live_befor
         ++requested_live_before_by_block[i];
       InstDefUse du(inst, gfx1250_vgpr_msb_.get());
       RegisterSet kills = kill_defs(du, exec_before(inst));
-      RegisterSet upward_uses = du.uses;
+      RegisterSet upward_uses = du.uses.ordinary_only();
       upward_uses -= state.kill;
       state.gen |= upward_uses;
       state.kill |= kills;
@@ -359,7 +361,7 @@ void LivenessAnalysis::analyze(KernelBlockScope blocks, bool restrict_live_befor
       InstDefUse du(*inst, gfx1250_vgpr_msb_.get());
       RegisterSet kills = kill_defs(du, exec_before(*inst));
       live -= kills;
-      live |= du.uses;
+      live |= du.uses.ordinary_only();
       if (!filter_live_before || requested_live_before.contains(inst)) {
         live_before_.emplace(inst, live);
         if (filter_live_before && --remaining_requested == 0)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/liveness.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/liveness.h
@@ -54,6 +54,9 @@ struct ScopedCfgEdge {
 /// block. The standard backward equations are:
 ///   live_out(B) = union(live_in(S) for S in successors(B))
 ///   live_in(B)  = gen(B) union (live_out(B) - kill(B))
+///
+/// All four sets are ordinary-register-only; special singletons are projected
+/// out of each instruction's def/use before the transfer function runs.
 struct BlockLiveness {
   RegisterSet live_in;
   RegisterSet live_out;
@@ -189,9 +192,15 @@ public:
   [[nodiscard]] bool has_live_before(const Instruction &inst) const;
 
   /// @brief Registers live immediately before @p inst executes.
+  ///
+  /// @details Ordinary registers only. Special singletons (EXEC/M0/PC/...) are
+  /// deliberately excluded: implicit special uses are not yet fully modeled, so
+  /// this analysis does not answer special-register liveness.
   [[nodiscard]] const RegisterSet &live_before(const Instruction &inst) const;
 
-  /// @brief Convenience predicate for one register reference.
+  /// @brief Convenience predicate for one register reference. Only meaningful
+  /// for ordinary classes; special-register liveness is not tracked (see
+  /// live_before()).
   [[nodiscard]] bool is_live_before(const Instruction &inst, RegisterRef ref) const;
 
   /// @brief gfx1250 VGPR bank selected for @p role before @p inst.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.cpp
@@ -172,7 +172,8 @@ inline constexpr std::array<std::string_view, 17> kExactB0ToA0TranslationMnemoni
     const Instruction &inst,
     const std::unordered_map<uint64_t, const Instruction *> &source_instruction_by_offset,
     const Gfx1250VgprMsbAnalysis &vgpr_msb) {
-  RegisterSet pending_defs = InstDefUse(inst, &vgpr_msb, UnknownVgprDefPolicy::ExpandAll).defs;
+  RegisterSet pending_defs =
+      InstDefUse(inst, &vgpr_msb, UnknownVgprDefPolicy::ExpandAll).defs.ordinary_only();
   uint64_t next_offset = inst.src_loc() + inst.size();
   while (true) {
     const auto next_it = source_instruction_by_offset.find(next_offset);
@@ -200,7 +201,7 @@ inline constexpr std::array<std::string_view, 17> kExactB0ToA0TranslationMnemoni
     const InstDefUse access(next, &vgpr_msb, UnknownVgprDefPolicy::ExpandAll);
     if (access.uses.intersects(pending_defs))
       return false;
-    pending_defs |= access.defs;
+    pending_defs |= access.defs.ordinary_only();
 
     if (next.size() <= 0)
       return false;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
@@ -250,7 +250,7 @@ constexpr uint16_t kGfx1250ScratchBaseSgprEnd = 104;
 /// high-bank scratch requires physicalizing this set first.
 [[nodiscard]] RegisterSet gfx1250_instruction_registers(const Instruction &inst) {
   const InstDefUse def_use(inst);
-  return def_use.uses | def_use.defs;
+  return (def_use.uses | def_use.defs).ordinary_only();
 }
 
 /// @brief Whether an ordinary SGPR window satisfies one scratch request.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
@@ -112,8 +112,6 @@ std::string reg_name(RegisterRef ref) {
     return "m0";
   case RegClass::FLAT_SCRATCH:
     return "flat_scratch";
-  case RegClass::TTMP:
-    return "ttmp";
   case RegClass::PC:
     return "pc";
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
@@ -92,23 +92,32 @@ struct AppliedSite {
   uint16_t target_pair_base = 0;
 };
 
-// Human-readable single-lane register name for spill diagnostics.
+// Human-readable register name for spill diagnostics. Ordinary registers are
+// named by prefix and index (s5, v3, acc2); special singletons carry no index.
 std::string reg_name(RegisterRef ref) {
-  const char *prefix = "?";
   switch (ref.cls) {
   case RegClass::SGPR:
-    prefix = "s";
-    break;
+    return "s" + std::to_string(ref.index);
   case RegClass::VGPR:
-    prefix = "v";
-    break;
+    return "v" + std::to_string(ref.index);
   case RegClass::ACC_VGPR:
-    prefix = "acc";
-    break;
-  default:
-    break;
+    return "acc" + std::to_string(ref.index);
+  case RegClass::EXEC:
+    return "exec";
+  case RegClass::VCC:
+    return "vcc";
+  case RegClass::SCC:
+    return "scc";
+  case RegClass::M0:
+    return "m0";
+  case RegClass::FLAT_SCRATCH:
+    return "flat_scratch";
+  case RegClass::TTMP:
+    return "ttmp";
+  case RegClass::PC:
+    return "pc";
   }
-  return std::string(prefix) + std::to_string(ref.index);
+  return "?" + std::to_string(ref.index);
 }
 
 // Largest positive byte offset encodable in the scratch store/load offset field,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
@@ -102,6 +102,8 @@ std::string reg_name(RegisterRef ref) {
     return "v" + std::to_string(ref.index);
   case RegClass::ACC_VGPR:
     return "acc" + std::to_string(ref.index);
+  case RegClass::TTMP:
+    return "ttmp" + std::to_string(ref.index);
   case RegClass::EXEC:
     return "exec";
   case RegClass::VCC:

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
@@ -91,23 +91,32 @@ struct AppliedSite {
   uint16_t target_pair_base = 0;
 };
 
-// Human-readable single-lane register name for spill diagnostics.
+// Human-readable register name for spill diagnostics. Ordinary registers are
+// named by prefix and index (s5, v3, acc2); special singletons carry no index.
 std::string reg_name(RegisterRef ref) {
-  const char *prefix = "?";
   switch (ref.cls) {
   case RegClass::SGPR:
-    prefix = "s";
-    break;
+    return "s" + std::to_string(ref.index);
   case RegClass::VGPR:
-    prefix = "v";
-    break;
+    return "v" + std::to_string(ref.index);
   case RegClass::ACC_VGPR:
-    prefix = "acc";
-    break;
-  default:
-    break;
+    return "acc" + std::to_string(ref.index);
+  case RegClass::EXEC:
+    return "exec";
+  case RegClass::VCC:
+    return "vcc";
+  case RegClass::SCC:
+    return "scc";
+  case RegClass::M0:
+    return "m0";
+  case RegClass::FLAT_SCRATCH:
+    return "flat_scratch";
+  case RegClass::TTMP:
+    return "ttmp";
+  case RegClass::PC:
+    return "pc";
   }
-  return std::string(prefix) + std::to_string(ref.index);
+  return "?" + std::to_string(ref.index);
 }
 
 // Largest positive byte offset encodable in the scratch store/load offset field,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
@@ -111,8 +111,6 @@ std::string reg_name(RegisterRef ref) {
     return "m0";
   case RegClass::FLAT_SCRATCH:
     return "flat_scratch";
-  case RegClass::TTMP:
-    return "ttmp";
   case RegClass::PC:
     return "pc";
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/probe_clobber.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/probe_clobber.cpp
@@ -169,9 +169,11 @@ std::optional<ProbeClobberSummary> build_probe_clobber_summary(const ProbeCallab
       return std::nullopt;
     }
 
-    // Ordinary clobbers (SGPR/VGPR/AccVGPR), including implicit defs.
+    // Ordinary clobbers (SGPR/VGPR/AccVGPR), including implicit defs. Special
+    // singletons in du.defs are projected out — they are summarized separately
+    // via scan_special_state below and must not enter ordinary_clobbers.
     const InstDefUse du(*inst);
-    summary.ordinary_clobbers |= du.defs;
+    summary.ordinary_clobbers |= du.defs.ordinary_only();
 
     scan_special_state(*inst, summary);
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/probe_clobber.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/probe_clobber.cpp
@@ -158,9 +158,11 @@ std::optional<ProbeClobberSummary> build_probe_clobber_summary(const ProbeCallab
       return std::nullopt;
     }
 
-    // Ordinary clobbers (SGPR/VGPR/AccVGPR), including implicit defs.
+    // Ordinary clobbers (SGPR/VGPR/AccVGPR), including implicit defs. Special
+    // singletons in du.defs are projected out — they are summarized separately
+    // via scan_special_state below and must not enter ordinary_clobbers.
     const InstDefUse du(*inst);
-    summary.ordinary_clobbers |= du.defs;
+    summary.ordinary_clobbers |= du.defs.ordinary_only();
 
     scan_special_state(*inst, summary);
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/spill_manager.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/spill_manager.cpp
@@ -15,8 +15,9 @@ namespace rocjitsu {
 namespace {
 
 /// Per-class hardware bound. Indices >= this are not representable in
-/// RegisterSet's bitsets and indicate either a programming error or a class
-/// that RegisterSet doesn't track (EXEC, VCC, etc.).
+/// RegisterSet's per-index bitsets and indicate either a programming error or a
+/// special singleton class (EXEC, VCC, ...) that has no scratch slot; those
+/// return 0 so every index is rejected.
 [[nodiscard]] size_t per_class_max(RegClass cls) {
   switch (cls) {
   case RegClass::SGPR:
@@ -85,9 +86,16 @@ std::optional<uint32_t> SpillManager::allocate_slots(RegisterRef reg, unsigned w
 }
 
 bool SpillManager::reserve(const RegisterSet &set) {
+  // Special singletons (EXEC/VCC/...) have no scratch slot. Reject the whole
+  // request up front rather than letting one reach allocate_slot's bounds
+  // rejection and trip the post-capacity-check assert below. Special-register
+  // preservation is out of scope for this allocator.
+  if (set.has_specials())
+    return false;
+
   // Count NEW registers (cache misses) so we can size-check upfront.
   unsigned num_new = 0;
-  set.for_each([&](RegisterRef reg) {
+  set.for_each_ordinary([&](RegisterRef reg) {
     const std::pair<RegClass, uint16_t> key{reg.cls, reg.index};
     if (!reg_to_offset_.contains(key))
       ++num_new;
@@ -97,9 +105,9 @@ bool SpillManager::reserve(const RegisterSet &set) {
   }
 
   // Capacity check passed — no failure possible from here. Every reg from
-  // for_each is within per-class bounds (the bitset itself enforces that),
-  // and we just verified there's enough room.
-  set.for_each([this](RegisterRef reg) {
+  // for_each_ordinary is within per-class bounds (the bitset itself enforces
+  // that), and we just verified there's enough room.
+  set.for_each_ordinary([this](RegisterRef reg) {
     [[maybe_unused]] auto off = allocate_slot(reg);
     assert(off.has_value() && "allocate_slot failed after capacity check");
   });

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/spill_manager.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/spill_manager.h
@@ -114,10 +114,12 @@ public:
   ///       partially-completed allocation never becomes visible.
   [[nodiscard]] std::optional<uint32_t> allocate_slots(RegisterRef reg, unsigned width);
 
-  /// @brief Allocate slots for every register in @p set.
+  /// @brief Allocate slots for every ordinary register in @p set.
   /// @returns true on success. On failure the manager is unchanged — the
   ///          capacity check runs upfront across all new registers, so no
   ///          partial commit is possible.
+  /// @note A set containing any special singleton (EXEC/VCC/...) fails cleanly
+  ///       and reserves nothing: special registers have no scratch slot.
   /// @note An empty set or a set whose registers are all already cached
   ///       returns true even on an over-limit manager — no new bytes are
   ///       requested, so no capacity check fires.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/operand.cpp
@@ -1422,6 +1422,24 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
   return std::nullopt;
 }
 
+std::optional<RegClass> Operand::to_special_reg_class() const {
+  switch (opr_type_) {
+  case OperandType::OPR_PC:
+    return RegClass::PC;
+  case OperandType::OPR_SDST_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_SDST_M0:
+    return RegClass::M0;
+  case OperandType::OPR_SSRC_SPECIAL_SCC:
+    return RegClass::SCC;
+  case OperandType::OPR_VCC:
+    return RegClass::VCC;
+  default:
+    break;
+  }
+  return std::nullopt;
+}
+
 bool Operand::simd_capable() const {
   decltype(ExecutionBackend::simd_capable) callback =
       execution_backend_ ? execution_backend_->simd_capable : nullptr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/operand.cpp
@@ -1360,6 +1360,24 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
   return std::nullopt;
 }
 
+std::optional<RegClass> Operand::to_special_reg_class() const {
+  switch (opr_type_) {
+  case OperandType::OPR_PC:
+    return RegClass::PC;
+  case OperandType::OPR_SDST_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_SDST_M0:
+    return RegClass::M0;
+  case OperandType::OPR_SSRC_SPECIAL_SCC:
+    return RegClass::SCC;
+  case OperandType::OPR_VCC:
+    return RegClass::VCC;
+  default:
+    break;
+  }
+  return std::nullopt;
+}
+
 bool Operand::simd_capable() const {
   decltype(ExecutionBackend::simd_capable) callback =
       execution_backend_ ? execution_backend_->simd_capable : nullptr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/operand.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/operand.h
@@ -28,6 +28,7 @@ public:
   std::optional<uint64_t> literal64_value() const override;
   std::optional<uint64_t> const_value() const override;
   std::optional<RegisterRef> to_register_ref() const override;
+  std::optional<RegClass> to_special_reg_class() const override;
   /// @brief Return the immutable full-simulator operand table.
   static const void *full_execution_backend();
   /// @brief Validate that every full-simulator operand callback is present.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/operand.cpp
@@ -1277,6 +1277,24 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
   return std::nullopt;
 }
 
+std::optional<RegClass> Operand::to_special_reg_class() const {
+  switch (opr_type_) {
+  case OperandType::OPR_PC:
+    return RegClass::PC;
+  case OperandType::OPR_SDST_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_SDST_M0:
+    return RegClass::M0;
+  case OperandType::OPR_SSRC_SPECIAL_SCC:
+    return RegClass::SCC;
+  case OperandType::OPR_VCC:
+    return RegClass::VCC;
+  default:
+    break;
+  }
+  return std::nullopt;
+}
+
 bool Operand::simd_capable() const {
   decltype(ExecutionBackend::simd_capable) callback =
       execution_backend_ ? execution_backend_->simd_capable : nullptr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/operand.cpp
@@ -1215,6 +1215,24 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
   return std::nullopt;
 }
 
+std::optional<RegClass> Operand::to_special_reg_class() const {
+  switch (opr_type_) {
+  case OperandType::OPR_PC:
+    return RegClass::PC;
+  case OperandType::OPR_SDST_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_SDST_M0:
+    return RegClass::M0;
+  case OperandType::OPR_SSRC_SPECIAL_SCC:
+    return RegClass::SCC;
+  case OperandType::OPR_VCC:
+    return RegClass::VCC;
+  default:
+    break;
+  }
+  return std::nullopt;
+}
+
 bool Operand::simd_capable() const {
   decltype(ExecutionBackend::simd_capable) callback =
       execution_backend_ ? execution_backend_->simd_capable : nullptr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/operand.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/operand.h
@@ -28,6 +28,7 @@ public:
   std::optional<uint64_t> literal64_value() const override;
   std::optional<uint64_t> const_value() const override;
   std::optional<RegisterRef> to_register_ref() const override;
+  std::optional<RegClass> to_special_reg_class() const override;
   /// @brief Return the immutable full-simulator operand table.
   static const void *full_execution_backend();
   /// @brief Validate that every full-simulator operand callback is present.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/operand.cpp
@@ -1277,6 +1277,24 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
   return std::nullopt;
 }
 
+std::optional<RegClass> Operand::to_special_reg_class() const {
+  switch (opr_type_) {
+  case OperandType::OPR_PC:
+    return RegClass::PC;
+  case OperandType::OPR_SDST_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_SDST_M0:
+    return RegClass::M0;
+  case OperandType::OPR_SSRC_SPECIAL_SCC:
+    return RegClass::SCC;
+  case OperandType::OPR_VCC:
+    return RegClass::VCC;
+  default:
+    break;
+  }
+  return std::nullopt;
+}
+
 bool Operand::simd_capable() const {
   decltype(ExecutionBackend::simd_capable) callback =
       execution_backend_ ? execution_backend_->simd_capable : nullptr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/operand.cpp
@@ -1215,6 +1215,24 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
   return std::nullopt;
 }
 
+std::optional<RegClass> Operand::to_special_reg_class() const {
+  switch (opr_type_) {
+  case OperandType::OPR_PC:
+    return RegClass::PC;
+  case OperandType::OPR_SDST_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_SDST_M0:
+    return RegClass::M0;
+  case OperandType::OPR_SSRC_SPECIAL_SCC:
+    return RegClass::SCC;
+  case OperandType::OPR_VCC:
+    return RegClass::VCC;
+  default:
+    break;
+  }
+  return std::nullopt;
+}
+
 bool Operand::simd_capable() const {
   decltype(ExecutionBackend::simd_capable) callback =
       execution_backend_ ? execution_backend_->simd_capable : nullptr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/operand.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/operand.h
@@ -28,6 +28,7 @@ public:
   std::optional<uint64_t> literal64_value() const override;
   std::optional<uint64_t> const_value() const override;
   std::optional<RegisterRef> to_register_ref() const override;
+  std::optional<RegClass> to_special_reg_class() const override;
   /// @brief Return the immutable full-simulator operand table.
   static const void *full_execution_backend();
   /// @brief Validate that every full-simulator operand callback is present.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/operand.cpp
@@ -1277,6 +1277,24 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
   return std::nullopt;
 }
 
+std::optional<RegClass> Operand::to_special_reg_class() const {
+  switch (opr_type_) {
+  case OperandType::OPR_PC:
+    return RegClass::PC;
+  case OperandType::OPR_SDST_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_SDST_M0:
+    return RegClass::M0;
+  case OperandType::OPR_SSRC_SPECIAL_SCC:
+    return RegClass::SCC;
+  case OperandType::OPR_VCC:
+    return RegClass::VCC;
+  default:
+    break;
+  }
+  return std::nullopt;
+}
+
 bool Operand::simd_capable() const {
   decltype(ExecutionBackend::simd_capable) callback =
       execution_backend_ ? execution_backend_->simd_capable : nullptr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/operand.cpp
@@ -1215,6 +1215,24 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
   return std::nullopt;
 }
 
+std::optional<RegClass> Operand::to_special_reg_class() const {
+  switch (opr_type_) {
+  case OperandType::OPR_PC:
+    return RegClass::PC;
+  case OperandType::OPR_SDST_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_SDST_M0:
+    return RegClass::M0;
+  case OperandType::OPR_SSRC_SPECIAL_SCC:
+    return RegClass::SCC;
+  case OperandType::OPR_VCC:
+    return RegClass::VCC;
+  default:
+    break;
+  }
+  return std::nullopt;
+}
+
 bool Operand::simd_capable() const {
   decltype(ExecutionBackend::simd_capable) callback =
       execution_backend_ ? execution_backend_->simd_capable : nullptr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/operand.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/operand.h
@@ -28,6 +28,7 @@ public:
   std::optional<uint64_t> literal64_value() const override;
   std::optional<uint64_t> const_value() const override;
   std::optional<RegisterRef> to_register_ref() const override;
+  std::optional<RegClass> to_special_reg_class() const override;
   /// @brief Return the immutable full-simulator operand table.
   static const void *full_execution_backend();
   /// @brief Validate that every full-simulator operand callback is present.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/operand.cpp
@@ -1540,6 +1540,26 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
   return std::nullopt;
 }
 
+std::optional<RegClass> Operand::to_special_reg_class() const {
+  switch (opr_type_) {
+  case OperandType::OPR_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_PC:
+    return RegClass::PC;
+  case OperandType::OPR_SDST_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_SDST_M0:
+    return RegClass::M0;
+  case OperandType::OPR_SSRC_SPECIAL_SCC:
+    return RegClass::SCC;
+  case OperandType::OPR_VCC:
+    return RegClass::VCC;
+  default:
+    break;
+  }
+  return std::nullopt;
+}
+
 bool Operand::simd_capable() const {
   decltype(ExecutionBackend::simd_capable) callback =
       execution_backend_ ? execution_backend_->simd_capable : nullptr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/operand.cpp
@@ -1220,6 +1220,26 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
   return std::nullopt;
 }
 
+std::optional<RegClass> Operand::to_special_reg_class() const {
+  switch (opr_type_) {
+  case OperandType::OPR_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_PC:
+    return RegClass::PC;
+  case OperandType::OPR_SDST_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_SDST_M0:
+    return RegClass::M0;
+  case OperandType::OPR_SSRC_SPECIAL_SCC:
+    return RegClass::SCC;
+  case OperandType::OPR_VCC:
+    return RegClass::VCC;
+  default:
+    break;
+  }
+  return std::nullopt;
+}
+
 bool Operand::simd_capable() const {
   decltype(ExecutionBackend::simd_capable) callback =
       execution_backend_ ? execution_backend_->simd_capable : nullptr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/operand.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/operand.h
@@ -31,6 +31,7 @@ public:
   std::optional<uint64_t> literal64_value() const override;
   std::optional<uint64_t> const_value() const override;
   std::optional<RegisterRef> to_register_ref() const override;
+  std::optional<RegClass> to_special_reg_class() const override;
   /// @brief Return the immutable full-simulator operand table.
   static const void *full_execution_backend();
   /// @brief Validate that every full-simulator operand callback is present.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/operand.cpp
@@ -1264,6 +1264,26 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
   return std::nullopt;
 }
 
+std::optional<RegClass> Operand::to_special_reg_class() const {
+  switch (opr_type_) {
+  case OperandType::OPR_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_PC:
+    return RegClass::PC;
+  case OperandType::OPR_SDST_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_SDST_M0:
+    return RegClass::M0;
+  case OperandType::OPR_SSRC_SPECIAL_SCC:
+    return RegClass::SCC;
+  case OperandType::OPR_VCC:
+    return RegClass::VCC;
+  default:
+    break;
+  }
+  return std::nullopt;
+}
+
 bool Operand::simd_capable() const {
   decltype(ExecutionBackend::simd_capable) callback =
       execution_backend_ ? execution_backend_->simd_capable : nullptr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/operand.cpp
@@ -1202,6 +1202,26 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
   return std::nullopt;
 }
 
+std::optional<RegClass> Operand::to_special_reg_class() const {
+  switch (opr_type_) {
+  case OperandType::OPR_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_PC:
+    return RegClass::PC;
+  case OperandType::OPR_SDST_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_SDST_M0:
+    return RegClass::M0;
+  case OperandType::OPR_SSRC_SPECIAL_SCC:
+    return RegClass::SCC;
+  case OperandType::OPR_VCC:
+    return RegClass::VCC;
+  default:
+    break;
+  }
+  return std::nullopt;
+}
+
 bool Operand::simd_capable() const {
   decltype(ExecutionBackend::simd_capable) callback =
       execution_backend_ ? execution_backend_->simd_capable : nullptr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/operand.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/operand.h
@@ -28,6 +28,7 @@ public:
   std::optional<uint64_t> literal64_value() const override;
   std::optional<uint64_t> const_value() const override;
   std::optional<RegisterRef> to_register_ref() const override;
+  std::optional<RegClass> to_special_reg_class() const override;
   /// @brief Return the immutable full-simulator operand table.
   static const void *full_execution_backend();
   /// @brief Validate that every full-simulator operand callback is present.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/operand.cpp
@@ -1235,6 +1235,26 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
   return std::nullopt;
 }
 
+std::optional<RegClass> Operand::to_special_reg_class() const {
+  switch (opr_type_) {
+  case OperandType::OPR_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_PC:
+    return RegClass::PC;
+  case OperandType::OPR_SDST_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_SDST_M0:
+    return RegClass::M0;
+  case OperandType::OPR_SSRC_SPECIAL_SCC:
+    return RegClass::SCC;
+  case OperandType::OPR_VCC:
+    return RegClass::VCC;
+  default:
+    break;
+  }
+  return std::nullopt;
+}
+
 bool Operand::simd_capable() const {
   decltype(ExecutionBackend::simd_capable) callback =
       execution_backend_ ? execution_backend_->simd_capable : nullptr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/operand.cpp
@@ -1173,6 +1173,26 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
   return std::nullopt;
 }
 
+std::optional<RegClass> Operand::to_special_reg_class() const {
+  switch (opr_type_) {
+  case OperandType::OPR_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_PC:
+    return RegClass::PC;
+  case OperandType::OPR_SDST_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_SDST_M0:
+    return RegClass::M0;
+  case OperandType::OPR_SSRC_SPECIAL_SCC:
+    return RegClass::SCC;
+  case OperandType::OPR_VCC:
+    return RegClass::VCC;
+  default:
+    break;
+  }
+  return std::nullopt;
+}
+
 bool Operand::simd_capable() const {
   decltype(ExecutionBackend::simd_capable) callback =
       execution_backend_ ? execution_backend_->simd_capable : nullptr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/operand.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/operand.h
@@ -28,6 +28,7 @@ public:
   std::optional<uint64_t> literal64_value() const override;
   std::optional<uint64_t> const_value() const override;
   std::optional<RegisterRef> to_register_ref() const override;
+  std::optional<RegClass> to_special_reg_class() const override;
   /// @brief Return the immutable full-simulator operand table.
   static const void *full_execution_backend();
   /// @brief Validate that every full-simulator operand callback is present.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/operand.cpp
@@ -918,6 +918,26 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
   return std::nullopt;
 }
 
+std::optional<RegClass> Operand::to_special_reg_class() const {
+  switch (opr_type_) {
+  case OperandType::OPR_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_PC:
+    return RegClass::PC;
+  case OperandType::OPR_SDST_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_SDST_M0:
+    return RegClass::M0;
+  case OperandType::OPR_SSRC_SPECIAL_SCC:
+    return RegClass::SCC;
+  case OperandType::OPR_VCC:
+    return RegClass::VCC;
+  default:
+    break;
+  }
+  return std::nullopt;
+}
+
 bool Operand::simd_capable() const {
   decltype(ExecutionBackend::simd_capable) callback =
       execution_backend_ ? execution_backend_->simd_capable : nullptr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/operand.cpp
@@ -880,6 +880,26 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
   return std::nullopt;
 }
 
+std::optional<RegClass> Operand::to_special_reg_class() const {
+  switch (opr_type_) {
+  case OperandType::OPR_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_PC:
+    return RegClass::PC;
+  case OperandType::OPR_SDST_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_SDST_M0:
+    return RegClass::M0;
+  case OperandType::OPR_SSRC_SPECIAL_SCC:
+    return RegClass::SCC;
+  case OperandType::OPR_VCC:
+    return RegClass::VCC;
+  default:
+    break;
+  }
+  return std::nullopt;
+}
+
 bool Operand::simd_capable() const {
   decltype(ExecutionBackend::simd_capable) callback =
       execution_backend_ ? execution_backend_->simd_capable : nullptr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/operand.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/operand.h
@@ -31,6 +31,7 @@ public:
   std::optional<uint64_t> literal64_value() const override;
   std::optional<uint64_t> const_value() const override;
   std::optional<RegisterRef> to_register_ref() const override;
+  std::optional<RegClass> to_special_reg_class() const override;
   /// @brief Return the immutable full-simulator operand table.
   static const void *full_execution_backend();
   /// @brief Validate that every full-simulator operand callback is present.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/operand.cpp
@@ -946,6 +946,26 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
   return std::nullopt;
 }
 
+std::optional<RegClass> Operand::to_special_reg_class() const {
+  switch (opr_type_) {
+  case OperandType::OPR_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_PC:
+    return RegClass::PC;
+  case OperandType::OPR_SDST_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_SDST_M0:
+    return RegClass::M0;
+  case OperandType::OPR_SSRC_SPECIAL_SCC:
+    return RegClass::SCC;
+  case OperandType::OPR_VCC:
+    return RegClass::VCC;
+  default:
+    break;
+  }
+  return std::nullopt;
+}
+
 bool Operand::simd_capable() const {
   decltype(ExecutionBackend::simd_capable) callback =
       execution_backend_ ? execution_backend_->simd_capable : nullptr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/operand.cpp
@@ -908,6 +908,26 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
   return std::nullopt;
 }
 
+std::optional<RegClass> Operand::to_special_reg_class() const {
+  switch (opr_type_) {
+  case OperandType::OPR_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_PC:
+    return RegClass::PC;
+  case OperandType::OPR_SDST_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_SDST_M0:
+    return RegClass::M0;
+  case OperandType::OPR_SSRC_SPECIAL_SCC:
+    return RegClass::SCC;
+  case OperandType::OPR_VCC:
+    return RegClass::VCC;
+  default:
+    break;
+  }
+  return std::nullopt;
+}
+
 bool Operand::simd_capable() const {
   decltype(ExecutionBackend::simd_capable) callback =
       execution_backend_ ? execution_backend_->simd_capable : nullptr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/operand.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/operand.h
@@ -31,6 +31,7 @@ public:
   std::optional<uint64_t> literal64_value() const override;
   std::optional<uint64_t> const_value() const override;
   std::optional<RegisterRef> to_register_ref() const override;
+  std::optional<RegClass> to_special_reg_class() const override;
   /// @brief Return the immutable full-simulator operand table.
   static const void *full_execution_backend();
   /// @brief Validate that every full-simulator operand callback is present.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/operand.cpp
@@ -979,6 +979,26 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
   return std::nullopt;
 }
 
+std::optional<RegClass> Operand::to_special_reg_class() const {
+  switch (opr_type_) {
+  case OperandType::OPR_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_PC:
+    return RegClass::PC;
+  case OperandType::OPR_SDST_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_SDST_M0:
+    return RegClass::M0;
+  case OperandType::OPR_SSRC_SPECIAL_SCC:
+    return RegClass::SCC;
+  case OperandType::OPR_VCC:
+    return RegClass::VCC;
+  default:
+    break;
+  }
+  return std::nullopt;
+}
+
 bool Operand::simd_capable() const {
   decltype(ExecutionBackend::simd_capable) callback =
       execution_backend_ ? execution_backend_->simd_capable : nullptr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/operand.cpp
@@ -930,6 +930,26 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
   return std::nullopt;
 }
 
+std::optional<RegClass> Operand::to_special_reg_class() const {
+  switch (opr_type_) {
+  case OperandType::OPR_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_PC:
+    return RegClass::PC;
+  case OperandType::OPR_SDST_EXEC:
+    return RegClass::EXEC;
+  case OperandType::OPR_SDST_M0:
+    return RegClass::M0;
+  case OperandType::OPR_SSRC_SPECIAL_SCC:
+    return RegClass::SCC;
+  case OperandType::OPR_VCC:
+    return RegClass::VCC;
+  default:
+    break;
+  }
+  return std::nullopt;
+}
+
 bool Operand::simd_capable() const {
   decltype(ExecutionBackend::simd_capable) callback =
       execution_backend_ ? execution_backend_->simd_capable : nullptr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/operand.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/operand.h
@@ -31,6 +31,7 @@ public:
   std::optional<uint64_t> literal64_value() const override;
   std::optional<uint64_t> const_value() const override;
   std::optional<RegisterRef> to_register_ref() const override;
+  std::optional<RegClass> to_special_reg_class() const override;
   /// @brief Return the immutable full-simulator operand table.
   static const void *full_execution_backend();
   /// @brief Validate that every full-simulator operand callback is present.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/operand.cpp
@@ -30,6 +30,8 @@ Result Operand::emit_encoding_error(const util::DiagnosticEmitter &emit_error) c
 
 std::optional<RegisterRef> Operand::to_register_ref() const { return std::nullopt; }
 
+std::optional<RegClass> Operand::to_special_reg_class() const { return std::nullopt; }
+
 uint32_t Operand::read_scalar(const amdgpu::Wavefront & /*wf*/) const {
   throw std::logic_error("read_scalar not implemented for this operand type");
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/operand.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/operand.h
@@ -188,6 +188,17 @@ public:
   /// parse the display string returned by name().
   [[nodiscard]] virtual std::optional<RegisterRef> to_register_ref() const;
 
+  /// @brief Map this operand to the architectural special register it denotes.
+  ///
+  /// @details Returns the special RegClass (EXEC/VCC/SCC/M0/PC) for a fieldless
+  /// architectural special operand, or nullopt for everything else. This is the
+  /// special-register counterpart of to_register_ref(): special registers are
+  /// recorded as singleton members of a RegisterSet, which scratch-allocation
+  /// liveness projects out with ordinary_only() so they never look allocatable.
+  /// ISA-specific subclasses override this from the generated fieldless operand
+  /// policy effect column; the base returns nullopt.
+  [[nodiscard]] virtual std::optional<RegClass> to_special_reg_class() const;
+
   /// @brief Raw encoding value from the instruction binary.
   int encoding_value() const { return encoding_value_; }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/register_set.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/register_set.cpp
@@ -61,7 +61,6 @@ void RegisterSet::expand(RegisterRef ref) {
   case RegClass::SCC:
   case RegClass::M0:
   case RegClass::FLAT_SCRATCH:
-  case RegClass::TTMP:
   case RegClass::PC:
     // Special singleton: index/width are meaningless, so just set its bit.
     special_regs_ |= special_bit(ref.cls);
@@ -86,7 +85,6 @@ void RegisterSet::erase(RegisterRef ref) {
   case RegClass::SCC:
   case RegClass::M0:
   case RegClass::FLAT_SCRATCH:
-  case RegClass::TTMP:
   case RegClass::PC:
     special_regs_ &= static_cast<uint16_t>(~special_bit(ref.cls));
     break;
@@ -109,7 +107,6 @@ void RegisterSet::clear_class(RegClass cls) {
   case RegClass::SCC:
   case RegClass::M0:
   case RegClass::FLAT_SCRATCH:
-  case RegClass::TTMP:
   case RegClass::PC:
     special_regs_ &= static_cast<uint16_t>(~special_bit(cls));
     break;
@@ -130,7 +127,6 @@ bool RegisterSet::contains(RegisterRef ref) const {
   case RegClass::SCC:
   case RegClass::M0:
   case RegClass::FLAT_SCRATCH:
-  case RegClass::TTMP:
   case RegClass::PC:
     return (special_regs_ & special_bit(ref.cls)) != 0;
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/register_set.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/register_set.cpp
@@ -4,6 +4,7 @@
 #include "rocjitsu/isa/register_set.h"
 
 #include <algorithm>
+#include <bit>
 
 namespace rocjitsu {
 
@@ -56,6 +57,8 @@ void RegisterSet::expand(RegisterRef ref) {
     set_range(acc_vgprs_, ref.index, width);
     break;
   default:
+    // Special singleton: index/width are meaningless, so just set its bit.
+    special_regs_ |= special_bit(ref.cls);
     break;
   }
 }
@@ -73,6 +76,7 @@ void RegisterSet::erase(RegisterRef ref) {
     reset_range(acc_vgprs_, ref.index, width);
     break;
   default:
+    special_regs_ &= static_cast<uint16_t>(~special_bit(ref.cls));
     break;
   }
 }
@@ -89,6 +93,7 @@ void RegisterSet::clear_class(RegClass cls) {
     acc_vgprs_.reset();
     break;
   default:
+    special_regs_ &= static_cast<uint16_t>(~special_bit(cls));
     break;
   }
 }
@@ -103,13 +108,21 @@ bool RegisterSet::contains(RegisterRef ref) const {
   case RegClass::ACC_VGPR:
     return contains_range(acc_vgprs_, ref.index, width);
   default:
-    return false;
+    return (special_regs_ & special_bit(ref.cls)) != 0;
   }
 }
 
-bool RegisterSet::none() const { return sgprs_.none() && vgprs_.none() && acc_vgprs_.none(); }
+bool RegisterSet::none() const {
+  return sgprs_.none() && vgprs_.none() && acc_vgprs_.none() && special_regs_ == 0;
+}
 
-size_t RegisterSet::size() const { return sgprs_.count() + vgprs_.count() + acc_vgprs_.count(); }
+size_t RegisterSet::size() const {
+  return ordinary_size() + static_cast<size_t>(std::popcount(special_regs_));
+}
+
+size_t RegisterSet::ordinary_size() const {
+  return sgprs_.count() + vgprs_.count() + acc_vgprs_.count();
+}
 
 bool RegisterSet::intersects(RegisterRef ref) const {
   const size_t width = std::max<size_t>(1, ref.width);
@@ -127,13 +140,14 @@ bool RegisterSet::intersects(RegisterRef ref) const {
 
 bool RegisterSet::intersects(const RegisterSet &rhs) const {
   return (sgprs_ & rhs.sgprs_).any() || (vgprs_ & rhs.vgprs_).any() ||
-         (acc_vgprs_ & rhs.acc_vgprs_).any();
+         (acc_vgprs_ & rhs.acc_vgprs_).any() || (special_regs_ & rhs.special_regs_) != 0;
 }
 
 RegisterSet &RegisterSet::operator|=(const RegisterSet &rhs) {
   sgprs_ |= rhs.sgprs_;
   vgprs_ |= rhs.vgprs_;
   acc_vgprs_ |= rhs.acc_vgprs_;
+  special_regs_ |= rhs.special_regs_;
   return *this;
 }
 
@@ -141,6 +155,7 @@ RegisterSet &RegisterSet::operator&=(const RegisterSet &rhs) {
   sgprs_ &= rhs.sgprs_;
   vgprs_ &= rhs.vgprs_;
   acc_vgprs_ &= rhs.acc_vgprs_;
+  special_regs_ &= rhs.special_regs_;
   return *this;
 }
 
@@ -148,6 +163,7 @@ RegisterSet &RegisterSet::operator-=(const RegisterSet &rhs) {
   subtract(sgprs_, rhs.sgprs_);
   subtract(vgprs_, rhs.vgprs_);
   subtract(acc_vgprs_, rhs.acc_vgprs_);
+  special_regs_ &= static_cast<uint16_t>(~rhs.special_regs_);
   return *this;
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/register_set.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/register_set.cpp
@@ -56,7 +56,13 @@ void RegisterSet::expand(RegisterRef ref) {
   case RegClass::ACC_VGPR:
     set_range(acc_vgprs_, ref.index, width);
     break;
-  default:
+  case RegClass::EXEC:
+  case RegClass::VCC:
+  case RegClass::SCC:
+  case RegClass::M0:
+  case RegClass::FLAT_SCRATCH:
+  case RegClass::TTMP:
+  case RegClass::PC:
     // Special singleton: index/width are meaningless, so just set its bit.
     special_regs_ |= special_bit(ref.cls);
     break;
@@ -75,7 +81,13 @@ void RegisterSet::erase(RegisterRef ref) {
   case RegClass::ACC_VGPR:
     reset_range(acc_vgprs_, ref.index, width);
     break;
-  default:
+  case RegClass::EXEC:
+  case RegClass::VCC:
+  case RegClass::SCC:
+  case RegClass::M0:
+  case RegClass::FLAT_SCRATCH:
+  case RegClass::TTMP:
+  case RegClass::PC:
     special_regs_ &= static_cast<uint16_t>(~special_bit(ref.cls));
     break;
   }
@@ -92,7 +104,13 @@ void RegisterSet::clear_class(RegClass cls) {
   case RegClass::ACC_VGPR:
     acc_vgprs_.reset();
     break;
-  default:
+  case RegClass::EXEC:
+  case RegClass::VCC:
+  case RegClass::SCC:
+  case RegClass::M0:
+  case RegClass::FLAT_SCRATCH:
+  case RegClass::TTMP:
+  case RegClass::PC:
     special_regs_ &= static_cast<uint16_t>(~special_bit(cls));
     break;
   }
@@ -107,9 +125,16 @@ bool RegisterSet::contains(RegisterRef ref) const {
     return contains_range(vgprs_, ref.index, width);
   case RegClass::ACC_VGPR:
     return contains_range(acc_vgprs_, ref.index, width);
-  default:
+  case RegClass::EXEC:
+  case RegClass::VCC:
+  case RegClass::SCC:
+  case RegClass::M0:
+  case RegClass::FLAT_SCRATCH:
+  case RegClass::TTMP:
+  case RegClass::PC:
     return (special_regs_ & special_bit(ref.cls)) != 0;
   }
+  return false; // unreachable for a valid RegClass; a new class trips -Wswitch first
 }
 
 bool RegisterSet::none() const {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/register_set.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/register_set.cpp
@@ -56,6 +56,11 @@ void RegisterSet::expand(RegisterRef ref) {
   case RegClass::ACC_VGPR:
     set_range(acc_vgprs_, ref.index, width);
     break;
+  case RegClass::TTMP:
+    // Trap temporaries are known to the ISA but not tracked by this set: no
+    // bitset and no mask bit, so index/width are dropped (as they are on the
+    // general def/use path). Explicit arm keeps the switch exhaustive.
+    break;
   case RegClass::EXEC:
   case RegClass::VCC:
   case RegClass::SCC:
@@ -80,6 +85,8 @@ void RegisterSet::erase(RegisterRef ref) {
   case RegClass::ACC_VGPR:
     reset_range(acc_vgprs_, ref.index, width);
     break;
+  case RegClass::TTMP: // untracked: nothing to clear
+    break;
   case RegClass::EXEC:
   case RegClass::VCC:
   case RegClass::SCC:
@@ -102,6 +109,8 @@ void RegisterSet::clear_class(RegClass cls) {
   case RegClass::ACC_VGPR:
     acc_vgprs_.reset();
     break;
+  case RegClass::TTMP: // untracked: nothing to clear
+    break;
   case RegClass::EXEC:
   case RegClass::VCC:
   case RegClass::SCC:
@@ -122,6 +131,8 @@ bool RegisterSet::contains(RegisterRef ref) const {
     return contains_range(vgprs_, ref.index, width);
   case RegClass::ACC_VGPR:
     return contains_range(acc_vgprs_, ref.index, width);
+  case RegClass::TTMP: // untracked: never present
+    return false;
   case RegClass::EXEC:
   case RegClass::VCC:
   case RegClass::SCC:

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/register_set.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/register_set.cpp
@@ -4,6 +4,7 @@
 #include "rocjitsu/isa/register_set.h"
 
 #include <algorithm>
+#include <bit>
 
 namespace rocjitsu {
 
@@ -47,6 +48,8 @@ void RegisterSet::expand(RegisterRef ref) {
     set_range(acc_vgprs_, ref.index, width);
     break;
   default:
+    // Special singleton: index/width are meaningless, so just set its bit.
+    special_regs_ |= special_bit(ref.cls);
     break;
   }
 }
@@ -64,6 +67,7 @@ void RegisterSet::erase(RegisterRef ref) {
     reset_range(acc_vgprs_, ref.index, width);
     break;
   default:
+    special_regs_ &= static_cast<uint16_t>(~special_bit(ref.cls));
     break;
   }
 }
@@ -80,6 +84,7 @@ void RegisterSet::clear_class(RegClass cls) {
     acc_vgprs_.reset();
     break;
   default:
+    special_regs_ &= static_cast<uint16_t>(~special_bit(cls));
     break;
   }
 }
@@ -94,23 +99,32 @@ bool RegisterSet::contains(RegisterRef ref) const {
   case RegClass::ACC_VGPR:
     return contains_range(acc_vgprs_, ref.index, width);
   default:
-    return false;
+    return (special_regs_ & special_bit(ref.cls)) != 0;
   }
 }
 
-bool RegisterSet::none() const { return sgprs_.none() && vgprs_.none() && acc_vgprs_.none(); }
+bool RegisterSet::none() const {
+  return sgprs_.none() && vgprs_.none() && acc_vgprs_.none() && special_regs_ == 0;
+}
 
-size_t RegisterSet::size() const { return sgprs_.count() + vgprs_.count() + acc_vgprs_.count(); }
+size_t RegisterSet::size() const {
+  return ordinary_size() + static_cast<size_t>(std::popcount(special_regs_));
+}
+
+size_t RegisterSet::ordinary_size() const {
+  return sgprs_.count() + vgprs_.count() + acc_vgprs_.count();
+}
 
 bool RegisterSet::intersects(const RegisterSet &rhs) const {
   return (sgprs_ & rhs.sgprs_).any() || (vgprs_ & rhs.vgprs_).any() ||
-         (acc_vgprs_ & rhs.acc_vgprs_).any();
+         (acc_vgprs_ & rhs.acc_vgprs_).any() || (special_regs_ & rhs.special_regs_) != 0;
 }
 
 RegisterSet &RegisterSet::operator|=(const RegisterSet &rhs) {
   sgprs_ |= rhs.sgprs_;
   vgprs_ |= rhs.vgprs_;
   acc_vgprs_ |= rhs.acc_vgprs_;
+  special_regs_ |= rhs.special_regs_;
   return *this;
 }
 
@@ -118,6 +132,7 @@ RegisterSet &RegisterSet::operator&=(const RegisterSet &rhs) {
   sgprs_ &= rhs.sgprs_;
   vgprs_ &= rhs.vgprs_;
   acc_vgprs_ &= rhs.acc_vgprs_;
+  special_regs_ &= rhs.special_regs_;
   return *this;
 }
 
@@ -125,6 +140,7 @@ RegisterSet &RegisterSet::operator-=(const RegisterSet &rhs) {
   subtract(sgprs_, rhs.sgprs_);
   subtract(vgprs_, rhs.vgprs_);
   subtract(acc_vgprs_, rhs.acc_vgprs_);
+  special_regs_ &= static_cast<uint16_t>(~rhs.special_regs_);
   return *this;
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/register_set.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/register_set.cpp
@@ -52,7 +52,6 @@ void RegisterSet::expand(RegisterRef ref) {
   case RegClass::SCC:
   case RegClass::M0:
   case RegClass::FLAT_SCRATCH:
-  case RegClass::TTMP:
   case RegClass::PC:
     // Special singleton: index/width are meaningless, so just set its bit.
     special_regs_ |= special_bit(ref.cls);
@@ -77,7 +76,6 @@ void RegisterSet::erase(RegisterRef ref) {
   case RegClass::SCC:
   case RegClass::M0:
   case RegClass::FLAT_SCRATCH:
-  case RegClass::TTMP:
   case RegClass::PC:
     special_regs_ &= static_cast<uint16_t>(~special_bit(ref.cls));
     break;
@@ -100,7 +98,6 @@ void RegisterSet::clear_class(RegClass cls) {
   case RegClass::SCC:
   case RegClass::M0:
   case RegClass::FLAT_SCRATCH:
-  case RegClass::TTMP:
   case RegClass::PC:
     special_regs_ &= static_cast<uint16_t>(~special_bit(cls));
     break;
@@ -121,7 +118,6 @@ bool RegisterSet::contains(RegisterRef ref) const {
   case RegClass::SCC:
   case RegClass::M0:
   case RegClass::FLAT_SCRATCH:
-  case RegClass::TTMP:
   case RegClass::PC:
     return (special_regs_ & special_bit(ref.cls)) != 0;
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/register_set.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/register_set.cpp
@@ -47,7 +47,13 @@ void RegisterSet::expand(RegisterRef ref) {
   case RegClass::ACC_VGPR:
     set_range(acc_vgprs_, ref.index, width);
     break;
-  default:
+  case RegClass::EXEC:
+  case RegClass::VCC:
+  case RegClass::SCC:
+  case RegClass::M0:
+  case RegClass::FLAT_SCRATCH:
+  case RegClass::TTMP:
+  case RegClass::PC:
     // Special singleton: index/width are meaningless, so just set its bit.
     special_regs_ |= special_bit(ref.cls);
     break;
@@ -66,7 +72,13 @@ void RegisterSet::erase(RegisterRef ref) {
   case RegClass::ACC_VGPR:
     reset_range(acc_vgprs_, ref.index, width);
     break;
-  default:
+  case RegClass::EXEC:
+  case RegClass::VCC:
+  case RegClass::SCC:
+  case RegClass::M0:
+  case RegClass::FLAT_SCRATCH:
+  case RegClass::TTMP:
+  case RegClass::PC:
     special_regs_ &= static_cast<uint16_t>(~special_bit(ref.cls));
     break;
   }
@@ -83,7 +95,13 @@ void RegisterSet::clear_class(RegClass cls) {
   case RegClass::ACC_VGPR:
     acc_vgprs_.reset();
     break;
-  default:
+  case RegClass::EXEC:
+  case RegClass::VCC:
+  case RegClass::SCC:
+  case RegClass::M0:
+  case RegClass::FLAT_SCRATCH:
+  case RegClass::TTMP:
+  case RegClass::PC:
     special_regs_ &= static_cast<uint16_t>(~special_bit(cls));
     break;
   }
@@ -98,9 +116,16 @@ bool RegisterSet::contains(RegisterRef ref) const {
     return contains_range(vgprs_, ref.index, width);
   case RegClass::ACC_VGPR:
     return contains_range(acc_vgprs_, ref.index, width);
-  default:
+  case RegClass::EXEC:
+  case RegClass::VCC:
+  case RegClass::SCC:
+  case RegClass::M0:
+  case RegClass::FLAT_SCRATCH:
+  case RegClass::TTMP:
+  case RegClass::PC:
     return (special_regs_ & special_bit(ref.cls)) != 0;
   }
+  return false; // unreachable for a valid RegClass; a new class trips -Wswitch first
 }
 
 bool RegisterSet::none() const {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/register_set.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/register_set.h
@@ -6,7 +6,7 @@
 ///
 /// @details Tracks the ordinary indexed register files (SGPR, VGPR, AccVGPR) as
 /// per-index bitsets and the architectural special registers (EXEC, VCC, SCC,
-/// M0, FLAT_SCRATCH, TTMP, PC) as a compact singleton mask in the same set.
+/// M0, FLAT_SCRATCH, PC) as a compact singleton mask in the same set.
 /// Consumers that only reason about allocatable/indexed registers (scratch
 /// liveness, spilling) project the special members out with `ordinary_only()`.
 
@@ -66,12 +66,11 @@ enum class RegClass : uint8_t {
   SCC,          ///< Scalar condition code bit. Special singleton register.
   M0,           ///< M0 special scalar register. Special singleton register.
   FLAT_SCRATCH, ///< Flat-scratch base pair. Special singleton register.
-  TTMP,         ///< Trap-temporary registers. Special singleton register.
   PC,           ///< Program counter/control-flow dep. Special singleton register.
 };
 
 /// @brief True if @p cls is an architectural special register (EXEC, VCC, SCC,
-/// M0, FLAT_SCRATCH, TTMP, PC) rather than an ordinary indexed register file
+/// M0, FLAT_SCRATCH, PC) rather than an ordinary indexed register file
 /// (SGPR, VGPR, ACC_VGPR). Special registers are singletons held in the set's
 /// special mask; ordinary ones occupy per-index bitsets.
 [[nodiscard]] constexpr bool is_special_reg_class(RegClass cls) {
@@ -81,7 +80,6 @@ enum class RegClass : uint8_t {
   case RegClass::SCC:
   case RegClass::M0:
   case RegClass::FLAT_SCRATCH:
-  case RegClass::TTMP:
   case RegClass::PC:
     return true;
   case RegClass::SGPR:
@@ -90,6 +88,18 @@ enum class RegClass : uint8_t {
     return false;
   }
   return false;
+}
+
+/// @brief Widest special-class value that can set a bit in a special mask.
+/// @details Derived from `is_special_reg_class` rather than a named enumerator,
+/// so appending a RegClass keeps the bound correct without updating callers.
+[[nodiscard]] constexpr uint8_t widest_special_reg_class() {
+  uint8_t widest = 0;
+  for (unsigned v = 0; v <= 0xFF; ++v) {
+    if (is_special_reg_class(static_cast<RegClass>(v)))
+      widest = static_cast<uint8_t>(v);
+  }
+  return widest;
 }
 
 /// @brief A contiguous register reference within one register file.
@@ -236,11 +246,12 @@ private:
     return static_cast<uint16_t>(1u << static_cast<uint8_t>(cls));
   }
 
-  // The special mask indexes bits by raw RegClass value, so every class must
-  // fit in `special_regs_`. If RegClass ever grows past the mask width, widen
-  // it (and the shift base in `special_bit`) rather than truncating membership.
-  static_assert(static_cast<uint8_t>(RegClass::PC) < 16,
-                "special_regs_ must hold a bit for every RegClass value");
+  // The special mask indexes bits by raw RegClass value, so every special class
+  // must fit in `special_regs_`. If a special class ever grows past the mask
+  // width, widen it (and the shift base in `special_bit`) rather than
+  // truncating membership.
+  static_assert(widest_special_reg_class() < 16,
+                "special_regs_ must hold a bit for every special RegClass");
 
   std::bitset<REGISTER_SET_MAX_SGPRS> sgprs_;
   std::bitset<REGISTER_SET_MAX_VGPRS> vgprs_;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/register_set.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/register_set.h
@@ -4,10 +4,11 @@
 /// @file register_set.h
 /// @brief Register references and register sets for ISA-level register files.
 ///
-/// @details Tracks scalar registers, vector registers, and AccVGPRs. Other
-/// architectural register classes may appear in decoded metadata, but they are
-/// ignored by RegisterSet until there is a concrete consumer for
-/// special-register liveness.
+/// @details Tracks the ordinary indexed register files (SGPR, VGPR, AccVGPR) as
+/// per-index bitsets and the architectural special registers (EXEC, VCC, SCC,
+/// M0, FLAT_SCRATCH, TTMP, PC) as a compact singleton mask in the same set.
+/// Consumers that only reason about allocatable/indexed registers (scratch
+/// liveness, spilling) project the special members out with `ordinary_only()`.
 
 #pragma once
 
@@ -16,6 +17,7 @@
 #include "rocjitsu/isa/arch/amdgpu/shared/rdna_isa_base.h"
 
 #include <algorithm>
+#include <bit>
 #include <bitset>
 #include <cstddef>
 #include <cstdint>
@@ -48,18 +50,47 @@ inline constexpr size_t REGISTER_SET_ALLOCATABLE_SGPRS =
 /// enum is deliberately small and hardware-oriented; operands that are literals,
 /// labels, waitcnt immediates, message IDs, and other non-register values should
 /// not produce a RegisterRef.
+/// @details The first three classes (SGPR, VGPR, ACC_VGPR) are ordinary
+/// indexed register files with a per-index bitset. The remainder are
+/// architectural special registers: they are singletons (there is one EXEC,
+/// one SCC, ...), are not used for scratch allocation, and are stored in a
+/// compact membership mask. `is_special_reg_class()` distinguishes the two
+/// groups; keep the ordinary classes first so that predicate stays a simple
+/// partition.
 enum class RegClass : uint8_t {
-  SGPR,         ///< Scalar general-purpose register, indexed as sN.
-  VGPR,         ///< Vector general-purpose register, indexed as vN.
-  ACC_VGPR,     ///< CDNA accumulator VGPR, indexed as accN.
-  EXEC,         ///< EXEC mask. Not currently tracked by RegisterSet.
-  VCC,          ///< VCC condition mask. Not currently tracked by RegisterSet.
-  SCC,          ///< Scalar condition code bit. Not currently tracked by RegisterSet.
-  M0,           ///< M0 special scalar register. Not currently tracked by RegisterSet.
-  FLAT_SCRATCH, ///< Flat-scratch base pair. Not currently tracked by RegisterSet.
-  TTMP,         ///< Trap-temporary registers. Not currently tracked by RegisterSet.
-  PC,           ///< Program counter/control-flow dependency. Not currently tracked by RegisterSet.
+  SGPR,         ///< Scalar general-purpose register, indexed as sN. Ordinary, per-index.
+  VGPR,         ///< Vector general-purpose register, indexed as vN. Ordinary, per-index.
+  ACC_VGPR,     ///< CDNA accumulator VGPR, indexed as accN. Ordinary, per-index.
+  EXEC,         ///< EXEC mask. Special singleton register.
+  VCC,          ///< VCC condition mask. Special singleton register.
+  SCC,          ///< Scalar condition code bit. Special singleton register.
+  M0,           ///< M0 special scalar register. Special singleton register.
+  FLAT_SCRATCH, ///< Flat-scratch base pair. Special singleton register.
+  TTMP,         ///< Trap-temporary registers. Special singleton register.
+  PC,           ///< Program counter/control-flow dep. Special singleton register.
 };
+
+/// @brief True if @p cls is an architectural special register (EXEC, VCC, SCC,
+/// M0, FLAT_SCRATCH, TTMP, PC) rather than an ordinary indexed register file
+/// (SGPR, VGPR, ACC_VGPR). Special registers are singletons held in the set's
+/// special mask; ordinary ones occupy per-index bitsets.
+[[nodiscard]] constexpr bool is_special_reg_class(RegClass cls) {
+  switch (cls) {
+  case RegClass::EXEC:
+  case RegClass::VCC:
+  case RegClass::SCC:
+  case RegClass::M0:
+  case RegClass::FLAT_SCRATCH:
+  case RegClass::TTMP:
+  case RegClass::PC:
+    return true;
+  case RegClass::SGPR:
+  case RegClass::VGPR:
+  case RegClass::ACC_VGPR:
+    return false;
+  }
+  return false;
+}
 
 /// @brief A contiguous register reference within one register file.
 ///
@@ -78,21 +109,34 @@ struct RegisterRef {
 /// @brief Per-class register set used for def/use and liveness dataflow.
 ///
 /// @details A RegisterSet can represent an instruction's use set, def set,
-/// basic-block live-in/live-out set, or live-before/live-after set. Set
-/// operations are member-wise across tracked register classes, so SGPR, VGPR,
-/// and AccVGPR lanes stay disjoint.
+/// basic-block live-in/live-out set, or live-before/live-after set. It stores
+/// the ordinary indexed classes (SGPR, VGPR, AccVGPR) as per-index bitsets and
+/// the architectural special registers (EXEC, VCC, ...) as a singleton
+/// membership mask. Set operations are member-wise, so the ordinary classes
+/// and the special mask all stay disjoint.
+///
+/// @details Special classes are singleton resources: `expand`, `erase`, and
+/// `contains` ignore a special `RegisterRef`'s index/width and act on the
+/// class as a whole, and full iteration emits a canonical `{cls, 0, 1}` ref
+/// per present special class. The general APIs (`size`, `none`, `for_each`)
+/// describe the full set; consumers that reason only about allocatable/indexed
+/// registers use the ordinary views (`ordinary_size`, `for_each_ordinary`,
+/// `ordinary_only`) so singleton special state never looks spillable or indexed.
 class RegisterSet {
 public:
-  /// @brief Add every 32-bit register lane covered by `ref`.
+  /// @brief Add `ref`. For ordinary classes this marks every 32-bit lane it
+  /// covers; for special classes it marks the singleton (index/width ignored).
   void expand(RegisterRef ref);
 
-  /// @brief Remove every 32-bit register lane covered by `ref`.
+  /// @brief Remove `ref`. For ordinary classes this clears every lane it
+  /// covers; for special classes it clears the singleton (index/width ignored).
   void erase(RegisterRef ref);
 
-  /// @brief Remove all tracked registers in one register class.
+  /// @brief Remove every register in one class (ordinary bitset or special bit).
   void clear_class(RegClass cls);
 
-  /// @brief Return true if every lane covered by `ref` is present.
+  /// @brief Return true if `ref` is present. For ordinary classes every covered
+  /// lane must be present; for special classes only membership is checked.
   [[nodiscard]] bool contains(RegisterRef ref) const;
 
   /// @brief Return true if any lane covered by `ref` is present.
@@ -103,14 +147,22 @@ public:
   /// false, matching contains().
   [[nodiscard]] bool intersects(RegisterRef ref) const;
 
-  /// @brief Return true when no register class contains any live bits.
+  /// @brief Return true when neither the ordinary bitsets nor the special mask
+  /// hold any member.
   [[nodiscard]] bool none() const;
 
-  /// @brief Return the total number of single-lane registers tracked across
-  ///        all classes (SGPR + VGPR + AccVGPR).
+  /// @brief Total number of members: ordinary single-lane registers plus
+  /// distinct special singletons.
   [[nodiscard]] size_t size() const;
 
-  /// @brief Return true if any register lane is present in both sets.
+  /// @brief Number of ordinary single-lane registers only (SGPR + VGPR +
+  /// AccVGPR), excluding special singletons. Use this for scratch/slot sizing.
+  [[nodiscard]] size_t ordinary_size() const;
+
+  /// @brief True if any special singleton is present.
+  [[nodiscard]] bool has_specials() const { return special_regs_ != 0; }
+
+  /// @brief Return true if any member is present in both sets (ordinary or special).
   [[nodiscard]] bool intersects(const RegisterSet &rhs) const;
 
   RegisterSet &operator|=(const RegisterSet &rhs);
@@ -132,12 +184,27 @@ public:
 
   friend bool operator==(const RegisterSet &, const RegisterSet &) = default;
 
-  /// @brief Invoke @p f with each tracked single-lane register in the set.
+  /// @brief Return a copy holding only the ordinary members; special singletons
+  /// are dropped. This is the projection scratch/liveness/spill consumers use.
+  [[nodiscard]] RegisterSet ordinary_only() const {
+    RegisterSet copy = *this;
+    copy.special_regs_ = 0;
+    return copy;
+  }
+
+  /// @brief Invoke @p f with each member of the full set.
   ///
-  /// @details Visits SGPRs, then VGPRs, then AccVGPRs in ascending index
-  /// order. Each yielded RegisterRef has @c width=1 — multi-lane refs that
-  /// were inserted via @c expand are visited as their constituent lanes.
+  /// @details Visits ordinary SGPRs, VGPRs, then AccVGPRs in ascending index
+  /// order (each as a @c width=1 RegisterRef), then each present special class
+  /// in ascending `RegClass` order as a canonical `{cls, 0, 1}` ref.
   template <typename F> void for_each(F &&f) const {
+    for_each_ordinary(f);
+    for_each_special([&](RegClass cls) { f(RegisterRef{cls, 0, 1}); });
+  }
+
+  /// @brief Invoke @p f with each ordinary single-lane register (SGPR, VGPR,
+  /// AccVGPR) in ascending index order. Special singletons are not visited.
+  template <typename F> void for_each_ordinary(F &&f) const {
     for (size_t i = 0; i < sgprs_.size(); ++i) {
       if (sgprs_.test(i))
         f(RegisterRef{RegClass::SGPR, static_cast<uint16_t>(i), 1});
@@ -152,10 +219,36 @@ public:
     }
   }
 
+  /// @brief Invoke @p f with each present special class, in ascending
+  /// `RegClass` value order.
+  template <typename F> void for_each_special(F &&f) const {
+    uint16_t bits = special_regs_;
+    while (bits != 0) {
+      const auto i = static_cast<uint8_t>(std::countr_zero(bits));
+      f(static_cast<RegClass>(i));
+      bits &= static_cast<uint16_t>(bits - 1);
+    }
+  }
+
 private:
+  /// @brief Mask bit for a special class. Only valid for special classes.
+  static constexpr uint16_t special_bit(RegClass cls) {
+    return static_cast<uint16_t>(1u << static_cast<uint8_t>(cls));
+  }
+
+  // The special mask indexes bits by raw RegClass value, so every class must
+  // fit in `special_regs_`. If RegClass ever grows past the mask width, widen
+  // it (and the shift base in `special_bit`) rather than truncating membership.
+  static_assert(static_cast<uint8_t>(RegClass::PC) < 16,
+                "special_regs_ must hold a bit for every RegClass value");
+
   std::bitset<REGISTER_SET_MAX_SGPRS> sgprs_;
   std::bitset<REGISTER_SET_MAX_VGPRS> vgprs_;
   std::bitset<REGISTER_SET_MAX_ACC_VGPRS> acc_vgprs_;
+
+  /// @brief Bit `static_cast<uint8_t>(cls)` set iff special class `cls` is
+  /// present. Only special-class bits are ever set (see `expand`).
+  uint16_t special_regs_ = 0;
 };
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/register_set.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/register_set.h
@@ -50,13 +50,14 @@ inline constexpr size_t REGISTER_SET_ALLOCATABLE_SGPRS =
 /// enum is deliberately small and hardware-oriented; operands that are literals,
 /// labels, waitcnt immediates, message IDs, and other non-register values should
 /// not produce a RegisterRef.
-/// @details The first three classes (SGPR, VGPR, ACC_VGPR) are ordinary
-/// indexed register files with a per-index bitset. The remainder are
-/// architectural special registers: they are singletons (there is one EXEC,
-/// one SCC, ...), are not used for scratch allocation, and are stored in a
-/// compact membership mask. `is_special_reg_class()` distinguishes the two
-/// groups; keep the ordinary classes first so that predicate stays a simple
-/// partition.
+/// @details SGPR, VGPR, and ACC_VGPR are ordinary indexed register files with a
+/// per-index bitset. EXEC, VCC, SCC, M0, FLAT_SCRATCH, and PC are architectural
+/// special registers: singletons (there is one EXEC, one SCC, ...), not used for
+/// scratch allocation, stored in a compact membership mask. TTMP is a per-index
+/// trap-temporary file that this set deliberately does not track — it has
+/// neither a bitset nor a mask bit. `is_special_reg_class()` therefore names
+/// specifically "held in the special mask" (true for EXEC..PC), not "is it
+/// indexed": it is false for TTMP just as for the ordinary classes.
 enum class RegClass : uint8_t {
   SGPR,         ///< Scalar general-purpose register, indexed as sN. Ordinary, per-index.
   VGPR,         ///< Vector general-purpose register, indexed as vN. Ordinary, per-index.
@@ -66,6 +67,7 @@ enum class RegClass : uint8_t {
   SCC,          ///< Scalar condition code bit. Special singleton register.
   M0,           ///< M0 special scalar register. Special singleton register.
   FLAT_SCRATCH, ///< Flat-scratch base pair. Special singleton register.
+  TTMP,         ///< Trap-temporary file (ttmpN). Per-index, but untracked here.
   PC,           ///< Program counter/control-flow dep. Special singleton register.
 };
 
@@ -85,6 +87,7 @@ enum class RegClass : uint8_t {
   case RegClass::SGPR:
   case RegClass::VGPR:
   case RegClass::ACC_VGPR:
+  case RegClass::TTMP: // per-index, but held in no mask: untracked, not special
     return false;
   }
   return false;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/register_set.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/register_set.h
@@ -6,7 +6,7 @@
 ///
 /// @details Tracks the ordinary indexed register files (SGPR, VGPR, AccVGPR) as
 /// per-index bitsets and the architectural special registers (EXEC, VCC, SCC,
-/// M0, FLAT_SCRATCH, TTMP, PC) as a compact singleton mask in the same set.
+/// M0, FLAT_SCRATCH, PC) as a compact singleton mask in the same set.
 /// Consumers that only reason about allocatable/indexed registers (scratch
 /// liveness, spilling) project the special members out with `ordinary_only()`.
 
@@ -65,12 +65,11 @@ enum class RegClass : uint8_t {
   SCC,          ///< Scalar condition code bit. Special singleton register.
   M0,           ///< M0 special scalar register. Special singleton register.
   FLAT_SCRATCH, ///< Flat-scratch base pair. Special singleton register.
-  TTMP,         ///< Trap-temporary registers. Special singleton register.
   PC,           ///< Program counter/control-flow dep. Special singleton register.
 };
 
 /// @brief True if @p cls is an architectural special register (EXEC, VCC, SCC,
-/// M0, FLAT_SCRATCH, TTMP, PC) rather than an ordinary indexed register file
+/// M0, FLAT_SCRATCH, PC) rather than an ordinary indexed register file
 /// (SGPR, VGPR, ACC_VGPR). Special registers are singletons held in the set's
 /// special mask; ordinary ones occupy per-index bitsets.
 [[nodiscard]] constexpr bool is_special_reg_class(RegClass cls) {
@@ -80,7 +79,6 @@ enum class RegClass : uint8_t {
   case RegClass::SCC:
   case RegClass::M0:
   case RegClass::FLAT_SCRATCH:
-  case RegClass::TTMP:
   case RegClass::PC:
     return true;
   case RegClass::SGPR:
@@ -89,6 +87,18 @@ enum class RegClass : uint8_t {
     return false;
   }
   return false;
+}
+
+/// @brief Widest special-class value that can set a bit in a special mask.
+/// @details Derived from `is_special_reg_class` rather than a named enumerator,
+/// so appending a RegClass keeps the bound correct without updating callers.
+[[nodiscard]] constexpr uint8_t widest_special_reg_class() {
+  uint8_t widest = 0;
+  for (unsigned v = 0; v <= 0xFF; ++v) {
+    if (is_special_reg_class(static_cast<RegClass>(v)))
+      widest = static_cast<uint8_t>(v);
+  }
+  return widest;
 }
 
 /// @brief A contiguous register reference within one register file.
@@ -227,11 +237,12 @@ private:
     return static_cast<uint16_t>(1u << static_cast<uint8_t>(cls));
   }
 
-  // The special mask indexes bits by raw RegClass value, so every class must
-  // fit in `special_regs_`. If RegClass ever grows past the mask width, widen
-  // it (and the shift base in `special_bit`) rather than truncating membership.
-  static_assert(static_cast<uint8_t>(RegClass::PC) < 16,
-                "special_regs_ must hold a bit for every RegClass value");
+  // The special mask indexes bits by raw RegClass value, so every special class
+  // must fit in `special_regs_`. If a special class ever grows past the mask
+  // width, widen it (and the shift base in `special_bit`) rather than
+  // truncating membership.
+  static_assert(widest_special_reg_class() < 16,
+                "special_regs_ must hold a bit for every special RegClass");
 
   std::bitset<REGISTER_SET_MAX_SGPRS> sgprs_;
   std::bitset<REGISTER_SET_MAX_VGPRS> vgprs_;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/register_set.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/register_set.h
@@ -4,10 +4,11 @@
 /// @file register_set.h
 /// @brief Register references and register sets for ISA-level register files.
 ///
-/// @details Tracks scalar registers, vector registers, and AccVGPRs. Other
-/// architectural register classes may appear in decoded metadata, but they are
-/// ignored by RegisterSet until there is a concrete consumer for
-/// special-register liveness.
+/// @details Tracks the ordinary indexed register files (SGPR, VGPR, AccVGPR) as
+/// per-index bitsets and the architectural special registers (EXEC, VCC, SCC,
+/// M0, FLAT_SCRATCH, TTMP, PC) as a compact singleton mask in the same set.
+/// Consumers that only reason about allocatable/indexed registers (scratch
+/// liveness, spilling) project the special members out with `ordinary_only()`.
 
 #pragma once
 
@@ -16,6 +17,7 @@
 #include "rocjitsu/isa/arch/amdgpu/shared/rdna_isa_base.h"
 
 #include <algorithm>
+#include <bit>
 #include <bitset>
 #include <cstddef>
 #include <cstdint>
@@ -47,18 +49,47 @@ inline constexpr size_t REGISTER_SET_ALLOCATABLE_SGPRS =
 /// enum is deliberately small and hardware-oriented; operands that are literals,
 /// labels, waitcnt immediates, message IDs, and other non-register values should
 /// not produce a RegisterRef.
+/// @details The first three classes (SGPR, VGPR, ACC_VGPR) are ordinary
+/// indexed register files with a per-index bitset. The remainder are
+/// architectural special registers: they are singletons (there is one EXEC,
+/// one SCC, ...), are not used for scratch allocation, and are stored in a
+/// compact membership mask. `is_special_reg_class()` distinguishes the two
+/// groups; keep the ordinary classes first so that predicate stays a simple
+/// partition.
 enum class RegClass : uint8_t {
-  SGPR,         ///< Scalar general-purpose register, indexed as sN.
-  VGPR,         ///< Vector general-purpose register, indexed as vN.
-  ACC_VGPR,     ///< CDNA accumulator VGPR, indexed as accN.
-  EXEC,         ///< EXEC mask. Not currently tracked by RegisterSet.
-  VCC,          ///< VCC condition mask. Not currently tracked by RegisterSet.
-  SCC,          ///< Scalar condition code bit. Not currently tracked by RegisterSet.
-  M0,           ///< M0 special scalar register. Not currently tracked by RegisterSet.
-  FLAT_SCRATCH, ///< Flat-scratch base pair. Not currently tracked by RegisterSet.
-  TTMP,         ///< Trap-temporary registers. Not currently tracked by RegisterSet.
-  PC,           ///< Program counter/control-flow dependency. Not currently tracked by RegisterSet.
+  SGPR,         ///< Scalar general-purpose register, indexed as sN. Ordinary, per-index.
+  VGPR,         ///< Vector general-purpose register, indexed as vN. Ordinary, per-index.
+  ACC_VGPR,     ///< CDNA accumulator VGPR, indexed as accN. Ordinary, per-index.
+  EXEC,         ///< EXEC mask. Special singleton register.
+  VCC,          ///< VCC condition mask. Special singleton register.
+  SCC,          ///< Scalar condition code bit. Special singleton register.
+  M0,           ///< M0 special scalar register. Special singleton register.
+  FLAT_SCRATCH, ///< Flat-scratch base pair. Special singleton register.
+  TTMP,         ///< Trap-temporary registers. Special singleton register.
+  PC,           ///< Program counter/control-flow dep. Special singleton register.
 };
+
+/// @brief True if @p cls is an architectural special register (EXEC, VCC, SCC,
+/// M0, FLAT_SCRATCH, TTMP, PC) rather than an ordinary indexed register file
+/// (SGPR, VGPR, ACC_VGPR). Special registers are singletons held in the set's
+/// special mask; ordinary ones occupy per-index bitsets.
+[[nodiscard]] constexpr bool is_special_reg_class(RegClass cls) {
+  switch (cls) {
+  case RegClass::EXEC:
+  case RegClass::VCC:
+  case RegClass::SCC:
+  case RegClass::M0:
+  case RegClass::FLAT_SCRATCH:
+  case RegClass::TTMP:
+  case RegClass::PC:
+    return true;
+  case RegClass::SGPR:
+  case RegClass::VGPR:
+  case RegClass::ACC_VGPR:
+    return false;
+  }
+  return false;
+}
 
 /// @brief A contiguous register reference within one register file.
 ///
@@ -77,31 +108,52 @@ struct RegisterRef {
 /// @brief Per-class register set used for def/use and liveness dataflow.
 ///
 /// @details A RegisterSet can represent an instruction's use set, def set,
-/// basic-block live-in/live-out set, or live-before/live-after set. Set
-/// operations are member-wise across tracked register classes, so SGPR, VGPR,
-/// and AccVGPR lanes stay disjoint.
+/// basic-block live-in/live-out set, or live-before/live-after set. It stores
+/// the ordinary indexed classes (SGPR, VGPR, AccVGPR) as per-index bitsets and
+/// the architectural special registers (EXEC, VCC, ...) as a singleton
+/// membership mask. Set operations are member-wise, so the ordinary classes
+/// and the special mask all stay disjoint.
+///
+/// @details Special classes are singleton resources: `expand`, `erase`, and
+/// `contains` ignore a special `RegisterRef`'s index/width and act on the
+/// class as a whole, and full iteration emits a canonical `{cls, 0, 1}` ref
+/// per present special class. The general APIs (`size`, `none`, `for_each`)
+/// describe the full set; consumers that reason only about allocatable/indexed
+/// registers use the ordinary views (`ordinary_size`, `for_each_ordinary`,
+/// `ordinary_only`) so singleton special state never looks spillable or indexed.
 class RegisterSet {
 public:
-  /// @brief Add every 32-bit register lane covered by `ref`.
+  /// @brief Add `ref`. For ordinary classes this marks every 32-bit lane it
+  /// covers; for special classes it marks the singleton (index/width ignored).
   void expand(RegisterRef ref);
 
-  /// @brief Remove every 32-bit register lane covered by `ref`.
+  /// @brief Remove `ref`. For ordinary classes this clears every lane it
+  /// covers; for special classes it clears the singleton (index/width ignored).
   void erase(RegisterRef ref);
 
-  /// @brief Remove all tracked registers in one register class.
+  /// @brief Remove every register in one class (ordinary bitset or special bit).
   void clear_class(RegClass cls);
 
-  /// @brief Return true if every lane covered by `ref` is present.
+  /// @brief Return true if `ref` is present. For ordinary classes every covered
+  /// lane must be present; for special classes only membership is checked.
   [[nodiscard]] bool contains(RegisterRef ref) const;
 
-  /// @brief Return true when no register class contains any live bits.
+  /// @brief Return true when neither the ordinary bitsets nor the special mask
+  /// hold any member.
   [[nodiscard]] bool none() const;
 
-  /// @brief Return the total number of single-lane registers tracked across
-  ///        all classes (SGPR + VGPR + AccVGPR).
+  /// @brief Total number of members: ordinary single-lane registers plus
+  /// distinct special singletons.
   [[nodiscard]] size_t size() const;
 
-  /// @brief Return true if any register lane is present in both sets.
+  /// @brief Number of ordinary single-lane registers only (SGPR + VGPR +
+  /// AccVGPR), excluding special singletons. Use this for scratch/slot sizing.
+  [[nodiscard]] size_t ordinary_size() const;
+
+  /// @brief True if any special singleton is present.
+  [[nodiscard]] bool has_specials() const { return special_regs_ != 0; }
+
+  /// @brief Return true if any member is present in both sets (ordinary or special).
   [[nodiscard]] bool intersects(const RegisterSet &rhs) const;
 
   RegisterSet &operator|=(const RegisterSet &rhs);
@@ -123,12 +175,27 @@ public:
 
   friend bool operator==(const RegisterSet &, const RegisterSet &) = default;
 
-  /// @brief Invoke @p f with each tracked single-lane register in the set.
+  /// @brief Return a copy holding only the ordinary members; special singletons
+  /// are dropped. This is the projection scratch/liveness/spill consumers use.
+  [[nodiscard]] RegisterSet ordinary_only() const {
+    RegisterSet copy = *this;
+    copy.special_regs_ = 0;
+    return copy;
+  }
+
+  /// @brief Invoke @p f with each member of the full set.
   ///
-  /// @details Visits SGPRs, then VGPRs, then AccVGPRs in ascending index
-  /// order. Each yielded RegisterRef has @c width=1 — multi-lane refs that
-  /// were inserted via @c expand are visited as their constituent lanes.
+  /// @details Visits ordinary SGPRs, VGPRs, then AccVGPRs in ascending index
+  /// order (each as a @c width=1 RegisterRef), then each present special class
+  /// in ascending `RegClass` order as a canonical `{cls, 0, 1}` ref.
   template <typename F> void for_each(F &&f) const {
+    for_each_ordinary(f);
+    for_each_special([&](RegClass cls) { f(RegisterRef{cls, 0, 1}); });
+  }
+
+  /// @brief Invoke @p f with each ordinary single-lane register (SGPR, VGPR,
+  /// AccVGPR) in ascending index order. Special singletons are not visited.
+  template <typename F> void for_each_ordinary(F &&f) const {
     for (size_t i = 0; i < sgprs_.size(); ++i) {
       if (sgprs_.test(i))
         f(RegisterRef{RegClass::SGPR, static_cast<uint16_t>(i), 1});
@@ -143,10 +210,36 @@ public:
     }
   }
 
+  /// @brief Invoke @p f with each present special class, in ascending
+  /// `RegClass` value order.
+  template <typename F> void for_each_special(F &&f) const {
+    uint16_t bits = special_regs_;
+    while (bits != 0) {
+      const auto i = static_cast<uint8_t>(std::countr_zero(bits));
+      f(static_cast<RegClass>(i));
+      bits &= static_cast<uint16_t>(bits - 1);
+    }
+  }
+
 private:
+  /// @brief Mask bit for a special class. Only valid for special classes.
+  static constexpr uint16_t special_bit(RegClass cls) {
+    return static_cast<uint16_t>(1u << static_cast<uint8_t>(cls));
+  }
+
+  // The special mask indexes bits by raw RegClass value, so every class must
+  // fit in `special_regs_`. If RegClass ever grows past the mask width, widen
+  // it (and the shift base in `special_bit`) rather than truncating membership.
+  static_assert(static_cast<uint8_t>(RegClass::PC) < 16,
+                "special_regs_ must hold a bit for every RegClass value");
+
   std::bitset<REGISTER_SET_MAX_SGPRS> sgprs_;
   std::bitset<REGISTER_SET_MAX_VGPRS> vgprs_;
   std::bitset<REGISTER_SET_MAX_ACC_VGPRS> acc_vgprs_;
+
+  /// @brief Bit `static_cast<uint8_t>(cls)` set iff special class `cls` is
+  /// present. Only special-class bits are ever set (see `expand`).
+  uint16_t special_regs_ = 0;
 };
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -507,16 +507,22 @@ TEST(GeneratedInstDefUse, MubufCmpswapReturnUsesElementWidthAndTargetGate) {
   }
 }
 
-TEST(RegisterSetAnalysis, IgnoresSpecialRegisterClasses) {
+TEST(RegisterSetAnalysis, SpecialClassesAreHeldButCarryNoOrdinaryLanes) {
   RegisterSet set;
   set.expand({RegClass::EXEC, 0, 2});
   set.expand({RegClass::SCC, 0, 1});
   set.expand({RegClass::FLAT_SCRATCH, 0, 2});
 
-  EXPECT_TRUE(set.none());
-  EXPECT_FALSE(set.contains({RegClass::EXEC, 0, 1}));
-  EXPECT_FALSE(set.contains({RegClass::SCC, 0, 1}));
-  EXPECT_FALSE(set.contains({RegClass::FLAT_SCRATCH, 0, 2}));
+  // Special classes are singleton members, not dropped.
+  EXPECT_FALSE(set.none());
+  EXPECT_TRUE(set.has_specials());
+  EXPECT_TRUE(set.contains({RegClass::EXEC, 0, 1}));
+  EXPECT_TRUE(set.contains({RegClass::SCC, 0, 1}));
+  EXPECT_TRUE(set.contains({RegClass::FLAT_SCRATCH, 0, 2}));
+
+  // But they contribute no ordinary lanes and vanish under ordinary_only().
+  EXPECT_EQ(set.ordinary_size(), 0u);
+  EXPECT_TRUE(set.ordinary_only().none());
 }
 
 TEST(RegisterSetAnalysis, GeneratedCdna4OperandsMapTrackedRegisterRefs) {
@@ -550,6 +556,487 @@ TEST(RegisterSetAnalysis, Cdna4WritelaneDestinationIsUseAndDef) {
   EXPECT_TRUE(du.defs.contains({RegClass::VGPR, 141, 1}));
   EXPECT_TRUE(du.uses.contains({RegClass::VGPR, 141, 1}));
   EXPECT_TRUE(du.uses.contains({RegClass::SGPR, 4, 1}));
+}
+
+// ---------------------------------------------------------------------------
+// Architectural special-register + memory effect API. Special registers are
+// singleton members of the same RegisterSet as ordinary registers; consumers
+// that drive scratch-allocation liveness project them out with ordinary_only().
+// ---------------------------------------------------------------------------
+
+// Collect a set's special members in ascending RegClass order, so a test can
+// assert the *exact* set of special registers an instruction reads or writes,
+// not just membership.
+std::vector<RegClass> specials_in(const RegisterSet &set) {
+  std::vector<RegClass> classes;
+  set.for_each_special([&](RegClass c) { classes.push_back(c); });
+  return classes;
+}
+
+// Expected special-register list, sorted to match specials_in()'s ascending
+// iteration order.
+std::vector<RegClass> special_regs(std::initializer_list<RegClass> classes) {
+  std::vector<RegClass> sorted(classes);
+  std::ranges::sort(sorted);
+  return sorted;
+}
+
+TEST(RegisterSetSpecial, ClassifiesSpecialVersusOrdinaryClasses) {
+  EXPECT_FALSE(is_special_reg_class(RegClass::SGPR));
+  EXPECT_FALSE(is_special_reg_class(RegClass::VGPR));
+  EXPECT_FALSE(is_special_reg_class(RegClass::ACC_VGPR));
+  EXPECT_TRUE(is_special_reg_class(RegClass::EXEC));
+  EXPECT_TRUE(is_special_reg_class(RegClass::VCC));
+  EXPECT_TRUE(is_special_reg_class(RegClass::SCC));
+  EXPECT_TRUE(is_special_reg_class(RegClass::M0));
+  EXPECT_TRUE(is_special_reg_class(RegClass::FLAT_SCRATCH));
+  EXPECT_TRUE(is_special_reg_class(RegClass::TTMP));
+  EXPECT_TRUE(is_special_reg_class(RegClass::PC));
+}
+
+TEST(RegisterSetSpecial, OrdinaryAndSpecialInsertionCoexist) {
+  RegisterSet s;
+  s.expand({RegClass::SGPR, 4, 2});
+  s.expand({RegClass::EXEC, 0, 1});
+  s.expand({RegClass::VCC, 0, 1});
+
+  // size() counts ordinary lanes plus special singletons; ordinary_size() sees
+  // only the two SGPR lanes.
+  EXPECT_EQ(s.ordinary_size(), 2u);
+  EXPECT_EQ(s.size(), 4u);
+  EXPECT_TRUE(s.has_specials());
+  EXPECT_TRUE(s.contains({RegClass::SGPR, 4, 1}));
+  EXPECT_TRUE(s.contains({RegClass::EXEC, 0, 1}));
+  EXPECT_EQ(specials_in(s), special_regs({RegClass::EXEC, RegClass::VCC}));
+}
+
+TEST(RegisterSetSpecial, SpecialMembershipIgnoresIndexAndWidth) {
+  // Special classes are singletons: any index/width refers to the same member.
+  RegisterSet s;
+  s.expand({RegClass::EXEC, 42, 8});
+  EXPECT_TRUE(s.contains({RegClass::EXEC, 0, 1}));
+  EXPECT_TRUE(s.contains({RegClass::EXEC, 99, 2}));
+  EXPECT_EQ(s.size(), 1u);
+
+  s.erase({RegClass::EXEC, 7, 4});
+  EXPECT_FALSE(s.contains({RegClass::EXEC, 0, 1}));
+  EXPECT_TRUE(s.none());
+}
+
+TEST(RegisterSetSpecial, FullIterationEmitsCanonicalSpecialRefs) {
+  RegisterSet s;
+  s.expand({RegClass::VGPR, 1, 1});
+  s.expand({RegClass::PC, 5, 2});
+
+  // for_each visits the ordinary lane first, then the special as a canonical
+  // {cls, 0, 1} ref regardless of the index/width it was inserted with.
+  std::vector<RegisterRef> seen;
+  s.for_each([&](RegisterRef r) { seen.push_back(r); });
+  ASSERT_EQ(seen.size(), 2u);
+  EXPECT_EQ(seen[0], (RegisterRef{RegClass::VGPR, 1, 1}));
+  EXPECT_EQ(seen[1], (RegisterRef{RegClass::PC, 0, 1}));
+
+  // for_each_ordinary skips the special member entirely.
+  std::vector<RegisterRef> ordinary;
+  s.for_each_ordinary([&](RegisterRef r) { ordinary.push_back(r); });
+  EXPECT_EQ(ordinary, (std::vector<RegisterRef>{{RegClass::VGPR, 1, 1}}));
+}
+
+TEST(RegisterSetSpecial, OrdinaryOnlyDropsSpecialMembers) {
+  RegisterSet s;
+  s.expand({RegClass::SGPR, 3, 1});
+  s.expand({RegClass::SCC, 0, 1});
+
+  const RegisterSet ordinary = s.ordinary_only();
+  EXPECT_FALSE(ordinary.has_specials());
+  EXPECT_EQ(ordinary.size(), 1u);
+  EXPECT_TRUE(ordinary.contains({RegClass::SGPR, 3, 1}));
+  EXPECT_TRUE(s.has_specials()); // source unchanged
+}
+
+TEST(RegisterSetSpecial, SetAlgebraSpansOrdinaryAndSpecial) {
+  RegisterSet a;
+  a.expand({RegClass::SGPR, 0, 1});
+  a.expand({RegClass::EXEC, 0, 1});
+  RegisterSet b;
+  b.expand({RegClass::SGPR, 1, 1});
+  b.expand({RegClass::EXEC, 0, 1});
+  b.expand({RegClass::VCC, 0, 1});
+
+  EXPECT_TRUE(a.intersects(b)); // shared EXEC
+
+  const RegisterSet u = a | b;
+  EXPECT_EQ(u.size(), 4u); // s0, s1, EXEC, VCC
+  EXPECT_EQ(specials_in(u), special_regs({RegClass::EXEC, RegClass::VCC}));
+
+  const RegisterSet i = a & b;
+  EXPECT_EQ(specials_in(i), special_regs({RegClass::EXEC}));
+  EXPECT_FALSE(i.contains({RegClass::SGPR, 0, 1})); // s0 only in a
+
+  const RegisterSet d = b - a; // removes shared EXEC; keeps VCC and s1
+  EXPECT_EQ(specials_in(d), special_regs({RegClass::VCC}));
+  EXPECT_TRUE(d.contains({RegClass::SGPR, 1, 1}));
+
+  RegisterSet cleared = u;
+  cleared.clear_class(RegClass::EXEC);
+  EXPECT_EQ(specials_in(cleared), special_regs({RegClass::VCC}));
+  EXPECT_EQ(cleared.ordinary_size(), 2u); // clear_class(special) leaves ordinary intact
+}
+
+TEST(RegisterSetSpecial, EqualityDistinguishesSpecialMembership) {
+  RegisterSet a;
+  a.expand({RegClass::SGPR, 0, 1});
+  RegisterSet b = a;
+  EXPECT_EQ(a, b);
+  b.expand({RegClass::EXEC, 0, 1});
+  EXPECT_NE(a, b); // the special mask participates in equality
+}
+
+TEST(RegisterSetSpecial, HighValuedTtmpAndPcMaskBitsRoundTrip) {
+  // TTMP and PC are the highest RegClass values, where a mask-width bug would
+  // first surface.
+  RegisterSet s;
+  s.expand({RegClass::TTMP, 0, 1});
+  s.expand({RegClass::PC, 0, 1});
+  EXPECT_EQ(specials_in(s), special_regs({RegClass::TTMP, RegClass::PC}));
+  EXPECT_FALSE(s.contains({RegClass::SGPR, 0, 1})); // no aliasing onto bit 0
+}
+
+TEST(InstDefUseSpecialEffects, SpecialDefaultEmpty) {
+  // A decoded instruction with only ordinary operands reports no special
+  // members; ordinary def/use extraction is unchanged.
+  TestInstruction inst("test_sp", {{RegClass::SGPR, 4, 1}}, {{RegClass::VGPR, 0, 1}});
+  InstDefUse du(inst);
+
+  EXPECT_TRUE(du.defs.contains({RegClass::SGPR, 4, 1}));
+  EXPECT_TRUE(du.uses.contains({RegClass::VGPR, 0, 1}));
+  EXPECT_FALSE(du.defs.has_specials());
+  EXPECT_FALSE(du.uses.has_specials());
+}
+
+TEST(InstDefUseSpecialEffects, SpecialMembersStayOutOfOrdinaryProjection) {
+  // Special singletons live in defs/uses alongside ordinary registers, but the
+  // ordinary projection that drives scratch allocation is unaffected.
+  TestInstruction inst("test_sp", {{RegClass::SGPR, 4, 1}}, {});
+  InstDefUse du(inst);
+
+  du.defs.expand({RegClass::EXEC, 0, 1});
+  du.uses.expand({RegClass::VCC, 0, 1});
+
+  EXPECT_EQ(du.defs.ordinary_size(), 1u);
+  EXPECT_TRUE(du.defs.ordinary_only().contains({RegClass::SGPR, 4, 1}));
+  EXPECT_FALSE(du.defs.ordinary_only().has_specials());
+  EXPECT_TRUE(du.defs.contains({RegClass::EXEC, 0, 1}));
+  EXPECT_TRUE(du.uses.contains({RegClass::VCC, 0, 1}));
+}
+
+TEST(SpecialEffectAnalysis, SaveexecReportsExecAndSccFromDecodedOperands) {
+  // Real decoded instruction: s_and_saveexec_b64 s[0:1], s[0:1] (CDNA4). Its
+  // fieldless special operands become singleton members of defs/uses by
+  // direction:
+  //   dst EXEC + dst SCC  -> special members of defs
+  //   src EXEC (old exec) -> special member of uses
+  // while the ordinary sdst/ssrc0 SGPRs stay in the same sets as ordinary
+  // members. The ordinary projection (ordinary_only) sees only the SGPRs.
+  const uint32_t words[] = {0xBE802000u, 0x00000000u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "s_and_saveexec_b64");
+
+  InstDefUse du(*inst);
+
+  EXPECT_EQ(specials_in(du.defs), special_regs({RegClass::EXEC, RegClass::SCC}));
+  EXPECT_EQ(specials_in(du.uses), special_regs({RegClass::EXEC}));
+
+  // Ordinary sdst/ssrc0 (s[0:1]) still tracked as ordinary registers.
+  EXPECT_TRUE(du.defs.contains({RegClass::SGPR, 0, 2}));
+  EXPECT_TRUE(du.uses.contains({RegClass::SGPR, 0, 2}));
+
+  // EXEC/SCC are members of du.defs but stay out of the ordinary projection
+  // that feeds scratch allocation.
+  EXPECT_TRUE(du.defs.contains({RegClass::EXEC, 0, 1}));
+  EXPECT_FALSE(du.defs.ordinary_only().has_specials());
+}
+
+TEST(SpecialEffectAnalysis, OrdinaryInstructionReportsNoSpecialEffects) {
+  // A plain vector op with only ordinary register operands exposes no special
+  // effects -- both special sets stay empty.
+  constexpr std::array<uint32_t, 2> kWritelaneV141S4Lane2 = {0xd28a008du, 0x00010404u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(kWritelaneV141S4Lane2.data()));
+  ASSERT_NE(inst, nullptr);
+
+  InstDefUse du(*inst);
+  EXPECT_FALSE(du.defs.has_specials());
+  EXPECT_FALSE(du.uses.has_specials());
+}
+
+// Decode-time special-effect coverage for the hidden-side-effect instruction
+// families. Encodings are built through the generated per-ISA encoders so they
+// cannot silently drift, and each case locks the operand-driven special
+// defs/uses so a change elsewhere cannot alter them unnoticed.
+
+// V_CMPX writes EXEC on every ISA, and additionally VCC on CDNA/GFX9 (its
+// operand list carries a VCC destination). gfx1250 is EXEC-only, so the same
+// mnemonic has a genuinely different side-effect set across ISAs.
+TEST(SpecialEffectAnalysis, CmpxWritesVccAndExecOnCdna) {
+  const auto built = cdna3::build_vopc(cdna3::kVCmpxEqF32Vopc, {.src0 = 256, .vsrc1 = 1});
+  const std::array<uint32_t, 2> words{built[0], 0u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "v_cmpx_eq_f32_e32");
+
+  InstDefUse du(*inst);
+  EXPECT_EQ(specials_in(du.defs), special_regs({RegClass::EXEC, RegClass::VCC}));
+  EXPECT_FALSE(du.uses.has_specials());
+}
+
+TEST(SpecialEffectAnalysis, CmpxWritesExecOnlyOnGfx1250) {
+  const auto built = gfx1250::build_vopc(gfx1250::kVCmpxEqF32Vopc, {.src0 = 256, .vsrc1 = 1});
+  const std::array<uint32_t, 2> words{built[0], 0u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "v_cmpx_eq_f32_e32");
+
+  InstDefUse du(*inst);
+  EXPECT_EQ(specials_in(du.defs), special_regs({RegClass::EXEC}));
+  EXPECT_FALSE(du.uses.has_specials());
+}
+
+// RDNA CMPX is EXEC-only like gfx1250 (and unlike CDNA), tested directly on an
+// RDNA target rather than inferred from the CDNA-family gfx1250.
+TEST(SpecialEffectAnalysis, CmpxWritesExecOnlyOnRdna) {
+  const auto built = rdna4::build_vopc(rdna4::kVCmpxEqF32Vopc, {.src0 = 256, .vsrc1 = 1});
+  const std::array<uint32_t, 2> words{built[0], 0u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "v_cmpx_eq_f32_e32");
+
+  InstDefUse du(*inst);
+  EXPECT_EQ(specials_in(du.defs), special_regs({RegClass::EXEC}));
+  EXPECT_FALSE(du.uses.has_specials());
+}
+
+// s_cbranch_{scc,vcc,exec}* read a special condition register and branch. The
+// condition operand is a special use; nothing is defined.
+TEST(SpecialEffectAnalysis, CbranchSccIsSpecialSccUse) {
+  const uint32_t word = cdna3::build_sopp(cdna3::kSCbranchScc0Sopp, {.simm16 = 0})[0];
+  const std::array<uint32_t, 2> words{word, 0u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "s_cbranch_scc0");
+
+  InstDefUse du(*inst);
+  EXPECT_EQ(specials_in(du.uses), special_regs({RegClass::SCC}));
+  EXPECT_FALSE(du.defs.has_specials());
+}
+
+TEST(SpecialEffectAnalysis, CbranchVccIsSpecialVccUse) {
+  const uint32_t word = cdna3::build_sopp(cdna3::kSCbranchVcczSopp, {.simm16 = 0})[0];
+  const std::array<uint32_t, 2> words{word, 0u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "s_cbranch_vccz");
+
+  InstDefUse du(*inst);
+  EXPECT_EQ(specials_in(du.uses), special_regs({RegClass::VCC}));
+  EXPECT_FALSE(du.defs.has_specials());
+}
+
+TEST(SpecialEffectAnalysis, CbranchExecIsSpecialExecUse) {
+  const uint32_t word = cdna3::build_sopp(cdna3::kSCbranchExeczSopp, {.simm16 = 0})[0];
+  const std::array<uint32_t, 2> words{word, 0u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "s_cbranch_execz");
+
+  InstDefUse du(*inst);
+  EXPECT_EQ(specials_in(du.uses), special_regs({RegClass::EXEC}));
+  EXPECT_FALSE(du.defs.has_specials());
+}
+
+// VOP2 carry reads and writes VCC implicitly. The mnemonic differs by ISA
+// (CDNA/GFX9 v_addc_co_u32 vs RDNA/gfx1250 v_add_co_ci_u32) but both expose the
+// same VCC carry-in use and carry-out def.
+TEST(SpecialEffectAnalysis, Vop2CarryCdnaAddcUsesAndDefsVcc) {
+  const auto built =
+      cdna3::build_vop2(cdna3::kVAddcCoU32Vop2, {.src0 = 256, .vsrc1 = 1, .vdst = 2});
+  const std::array<uint32_t, 2> words{built[0], 0u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "v_addc_co_u32_e32");
+
+  InstDefUse du(*inst);
+  EXPECT_EQ(specials_in(du.defs), special_regs({RegClass::VCC}));
+  EXPECT_EQ(specials_in(du.uses), special_regs({RegClass::VCC}));
+  EXPECT_TRUE(du.defs.contains({RegClass::VGPR, 2, 1})); // ordinary vdst still tracked
+}
+
+TEST(SpecialEffectAnalysis, Vop2CarryGfx1250AddCoCiUsesAndDefsVcc) {
+  const auto built =
+      gfx1250::build_vop2(gfx1250::kVAddCoCiU32Vop2, {.src0 = 256, .vsrc1 = 1, .vdst = 2});
+  const std::array<uint32_t, 2> words{built[0], 0u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "v_add_co_ci_u32_e32");
+
+  InstDefUse du(*inst);
+  EXPECT_EQ(specials_in(du.defs), special_regs({RegClass::VCC}));
+  EXPECT_EQ(specials_in(du.uses), special_regs({RegClass::VCC}));
+}
+
+// PC family: getpc reads PC (writes an ordinary SGPR pair), setpc writes PC
+// (reads an ordinary SGPR pair), s_call does both.
+TEST(SpecialEffectAnalysis, GetpcReadsPc) {
+  const uint32_t word = cdna3::build_sop1(0x1c, {.ssrc0 = 0, .sdst = 8})[0]; // s_getpc_b64 s[8:9]
+  const std::array<uint32_t, 2> words{word, 0u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "s_getpc_b64");
+
+  InstDefUse du(*inst);
+  EXPECT_EQ(specials_in(du.uses), special_regs({RegClass::PC}));
+  EXPECT_FALSE(du.defs.has_specials());
+  EXPECT_TRUE(du.defs.contains({RegClass::SGPR, 8, 2}));
+}
+
+TEST(SpecialEffectAnalysis, SetpcWritesPc) {
+  const uint32_t word = cdna3::build_sop1(0x1d, {.ssrc0 = 8, .sdst = 0})[0]; // s_setpc_b64 s[8:9]
+  const std::array<uint32_t, 2> words{word, 0u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "s_setpc_b64");
+
+  InstDefUse du(*inst);
+  EXPECT_EQ(specials_in(du.defs), special_regs({RegClass::PC}));
+  EXPECT_FALSE(du.uses.has_specials());
+  EXPECT_TRUE(du.uses.contains({RegClass::SGPR, 8, 2}));
+}
+
+TEST(SpecialEffectAnalysis, ScallReadsAndWritesPc) {
+  const uint32_t word = build_s_call_b64(8, 0); // s_call_b64 s[8:9], <rel>
+  const std::array<uint32_t, 2> words{word, 0u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "s_call_b64");
+
+  InstDefUse du(*inst);
+  EXPECT_EQ(specials_in(du.defs), special_regs({RegClass::PC}));
+  EXPECT_EQ(specials_in(du.uses), special_regs({RegClass::PC}));
+  EXPECT_TRUE(du.defs.contains({RegClass::SGPR, 8, 2}));
+}
+
+// M0 family: s_movrels_b32 reads M0 as its relative index (special use), while
+// s_set_gpr_idx_idx both reads M0 and writes it back (special use and def). The
+// M0 operand is fieldless on both, so it surfaces only through the special path.
+TEST(SpecialEffectAnalysis, MovrelsReadsM0) {
+  const uint32_t word = cdna3::build_sop1(cdna3::kSMovrelsB32Sop1, {.ssrc0 = 0, .sdst = 8})[0];
+  const std::array<uint32_t, 2> words{word, 0u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "s_movrels_b32");
+
+  InstDefUse du(*inst);
+  EXPECT_EQ(specials_in(du.uses), special_regs({RegClass::M0}));
+  EXPECT_FALSE(du.defs.has_specials());
+  EXPECT_TRUE(du.defs.contains({RegClass::SGPR, 8, 1})); // ordinary sdst still tracked
+}
+
+TEST(SpecialEffectAnalysis, SetGprIdxIdxReadsAndWritesM0) {
+  const uint32_t word = cdna3::build_sop1(cdna3::kSSetGprIdxIdxSop1, {.ssrc0 = 0})[0];
+  const std::array<uint32_t, 2> words{word, 0u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "s_set_gpr_idx_idx");
+
+  InstDefUse du(*inst);
+  EXPECT_EQ(specials_in(du.defs), special_regs({RegClass::M0}));
+  EXPECT_EQ(specials_in(du.uses), special_regs({RegClass::M0}));
+}
+
+// A buffer load's fieldless GPUMEM operand is inert: it yields neither a special
+// register class nor an ordinary register ref, so it contributes nothing to
+// defs/uses.
+TEST(SpecialEffectAnalysis, MemoryPseudoOperandProducesNoSpecialEffect) {
+  const auto words =
+      gfx1250::build_vbuffer(gfx1250::kBufferLoadB32Vbuffer, {.vdata = 1, .rsrc = 0});
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "buffer_load_b32");
+
+  InstDefUse du(*inst);
+  EXPECT_FALSE(du.defs.has_specials());
+  EXPECT_FALSE(du.uses.has_specials());
+}
+
+// Liveness models ordinary scratch registers only: an instruction's special
+// def/use appears in InstDefUse but must never reach BlockLiveness or
+// live_before(), which drive scratch allocation.
+TEST(SpecialEffectLiveness, SpecialEffectsAreAbsentFromOrdinaryLiveness) {
+  // s_and_saveexec_b64 s[0:1], s[0:1] defs {s[0:1], EXEC, SCC} and uses
+  // {s[0:1], EXEC}; s_endpgm terminates the single block.
+  std::vector<uint32_t> words = {
+      0xBE802000u, // s_and_saveexec_b64 s[0:1], s[0:1]
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),
+  };
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_FALSE(blocks.empty());
+
+  BasicBlock *entry = block_starting_at(blocks, 0);
+  ASSERT_NE(entry, nullptr);
+  auto &insts = entry->instructions();
+  ASSERT_NE(insts.begin(), insts.end());
+  const Instruction &saveexec = *insts.begin();
+  ASSERT_EQ(saveexec.mnemonic(), "s_and_saveexec_b64");
+
+  // InstDefUse records the special effects.
+  const InstDefUse du(saveexec);
+  EXPECT_TRUE(du.defs.contains({RegClass::EXEC, 0, 1}));
+  EXPECT_TRUE(du.defs.contains({RegClass::SCC, 0, 1}));
+  EXPECT_TRUE(du.uses.contains({RegClass::EXEC, 0, 1}));
+
+  // Liveness projects them out of every ordinary set.
+  const LivenessAnalysis liveness = analyze_scope(blocks);
+  const BlockLiveness &bl = liveness.block_liveness(*entry);
+  EXPECT_FALSE(bl.live_in.has_specials());
+  EXPECT_FALSE(bl.live_out.has_specials());
+  EXPECT_FALSE(bl.gen.has_specials());
+  EXPECT_FALSE(bl.kill.has_specials());
+  EXPECT_FALSE(liveness.live_before(saveexec).has_specials());
 }
 
 TEST(CfgAnalysis, LoopBackEdgeLinksPredecessor) {

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -785,6 +785,52 @@ TEST(SpecialEffectAnalysis, SelectorEncodedExecWriteIsNotSurfaced) {
   }
 }
 
+// The selector-drop policy must also cover implicit reads. s_cvt_f16_f32 writes
+// the low 16 bits of sdst and preserves the high half, so its generated
+// implicit_uses() hook surfaces a preserve-read of sdst via to_register_ref().
+// With an ordinary sdst that read is a real ordinary use; with a selector-encoded
+// special sdst (exec_lo) it collapses to a class-wide EXEC singleton and must be
+// dropped, or EXEC would be used-but-never-defined (the explicit dst path already
+// drops the selector-encoded def).
+TEST(SpecialEffectAnalysis, ImplicitPreserveReadDropsSelectorEncodedSpecial) {
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(decoder, nullptr);
+
+  // Ordinary destination: the implicit preserve-read of s4 is a real use.
+  {
+    const auto built = rdna4::build_sop1(rdna4::kSCvtF16F32Sop1, {.ssrc0 = 0, .sdst = 4});
+    const std::array<uint32_t, 2> words{built[0], 0u};
+    std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+    ASSERT_NE(inst, nullptr);
+    ASSERT_EQ(inst->mnemonic(), "s_cvt_f16_f32");
+
+    InstDefUse du(*inst);
+    EXPECT_TRUE(du.defs.contains({RegClass::SGPR, 4, 1}));
+    EXPECT_TRUE(du.uses.contains({RegClass::SGPR, 0, 1}));
+    EXPECT_TRUE(du.uses.contains({RegClass::SGPR, 4, 1})); // preserve-read via the hook
+    EXPECT_FALSE(du.defs.has_specials());
+    EXPECT_FALSE(du.uses.has_specials());
+  }
+
+  // Selector-encoded exec_lo destination (OPR_SDST value 126): the preserve-read
+  // decodes to a class-wide EXEC ref and must be dropped from uses, and the def
+  // is likewise dropped, leaving no special members and no ordinary destination.
+  {
+    const auto built = rdna4::build_sop1(rdna4::kSCvtF16F32Sop1, {.ssrc0 = 0, .sdst = 126});
+    const std::array<uint32_t, 2> words{built[0], 0u};
+    std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+    ASSERT_NE(inst, nullptr);
+    ASSERT_EQ(inst->mnemonic(), "s_cvt_f16_f32");
+
+    InstDefUse du(*inst);
+    EXPECT_FALSE(du.uses.has_specials());
+    EXPECT_FALSE(du.defs.has_specials());
+    EXPECT_EQ(du.defs.ordinary_size(), 0u); // selector-encoded dst dropped
+    EXPECT_EQ(du.uses.ordinary_size(), 1u); // only the ordinary ssrc0 (s0) remains
+    EXPECT_TRUE(du.uses.contains({RegClass::SGPR, 0, 1}));
+  }
+}
+
 TEST(SpecialEffectAnalysis, OrdinaryInstructionReportsNoSpecialEffects) {
   // A plain vector op with only ordinary register operands exposes no special
   // effects -- both special sets stay empty.

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -822,7 +822,7 @@ TEST(SpecialEffectAnalysis, CmpxWritesVccAndExecOnCdna) {
 }
 
 TEST(SpecialEffectAnalysis, CmpxWritesExecOnlyOnGfx1250) {
-  const auto built = gfx1250::build_vopc(gfx1250::kVCmpxEqF32Vopc, {.src0 = 256, .vsrc1 = 1});
+  const auto built = cdna5::build_vopc(cdna5::kVCmpxEqF32Vopc, {.src0 = 256, .vsrc1 = 1});
   const std::array<uint32_t, 2> words{built[0], 0u};
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
@@ -916,7 +916,7 @@ TEST(SpecialEffectAnalysis, Vop2CarryCdnaAddcUsesAndDefsVcc) {
 
 TEST(SpecialEffectAnalysis, Vop2CarryGfx1250AddCoCiUsesAndDefsVcc) {
   const auto built =
-      gfx1250::build_vop2(gfx1250::kVAddCoCiU32Vop2, {.src0 = 256, .vsrc1 = 1, .vdst = 2});
+      cdna5::build_vop2(cdna5::kVAddCoCiU32Vop2, {.src0 = 256, .vsrc1 = 1, .vdst = 2});
   const std::array<uint32_t, 2> words{built[0], 0u};
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
@@ -1012,8 +1012,7 @@ TEST(SpecialEffectAnalysis, SetGprIdxIdxReadsAndWritesM0) {
 // register class nor an ordinary register ref, so it contributes nothing to
 // defs/uses.
 TEST(SpecialEffectAnalysis, MemoryPseudoOperandProducesNoSpecialEffect) {
-  const auto words =
-      gfx1250::build_vbuffer(gfx1250::kBufferLoadB32Vbuffer, {.vdata = 1, .rsrc = 0});
+  const auto words = cdna5::build_vbuffer(cdna5::kBufferLoadB32Vbuffer, {.vdata = 1, .rsrc = 0});
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
   std::unique_ptr<Instruction> inst(decoder->decode(words.data()));

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -590,7 +590,6 @@ TEST(RegisterSetSpecial, ClassifiesSpecialVersusOrdinaryClasses) {
   EXPECT_TRUE(is_special_reg_class(RegClass::SCC));
   EXPECT_TRUE(is_special_reg_class(RegClass::M0));
   EXPECT_TRUE(is_special_reg_class(RegClass::FLAT_SCRATCH));
-  EXPECT_TRUE(is_special_reg_class(RegClass::TTMP));
   EXPECT_TRUE(is_special_reg_class(RegClass::PC));
 }
 
@@ -692,13 +691,13 @@ TEST(RegisterSetSpecial, EqualityDistinguishesSpecialMembership) {
   EXPECT_NE(a, b); // the special mask participates in equality
 }
 
-TEST(RegisterSetSpecial, HighValuedTtmpAndPcMaskBitsRoundTrip) {
-  // TTMP and PC are the highest RegClass values, where a mask-width bug would
-  // first surface.
+TEST(RegisterSetSpecial, HighValuedSpecialMaskBitsRoundTrip) {
+  // FLAT_SCRATCH and PC are the highest RegClass values, where a mask-width bug
+  // would first surface.
   RegisterSet s;
-  s.expand({RegClass::TTMP, 0, 1});
+  s.expand({RegClass::FLAT_SCRATCH, 0, 1});
   s.expand({RegClass::PC, 0, 1});
-  EXPECT_EQ(specials_in(s), special_regs({RegClass::TTMP, RegClass::PC}));
+  EXPECT_EQ(specials_in(s), special_regs({RegClass::FLAT_SCRATCH, RegClass::PC}));
   EXPECT_FALSE(s.contains({RegClass::SGPR, 0, 1})); // no aliasing onto bit 0
 }
 
@@ -741,7 +740,7 @@ TEST(SpecialEffectAnalysis, SaveexecReportsExecAndSccFromDecodedOperands) {
   const uint32_t words[] = {0xBE802000u, 0x00000000u};
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(inst->mnemonic(), "s_and_saveexec_b64");
 
@@ -773,7 +772,7 @@ TEST(SpecialEffectAnalysis, SelectorEncodedExecWriteIsNotSurfaced) {
   for (const uint32_t word :
        {0xbefe0080u /* s_mov_b32 exec_lo, 0 */, 0xbeff0080u /* s_mov_b32 exec_hi, 0 */}) {
     const std::array<uint32_t, 2> words{word, 0u};
-    std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(inst->mnemonic(), "s_mov_b32") << std::hex << word;
 
@@ -800,7 +799,7 @@ TEST(SpecialEffectAnalysis, ImplicitPreserveReadDropsSelectorEncodedSpecial) {
   {
     const auto built = rdna4::build_sop1(rdna4::kSCvtF16F32Sop1, {.ssrc0 = 0, .sdst = 4});
     const std::array<uint32_t, 2> words{built[0], 0u};
-    std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(inst->mnemonic(), "s_cvt_f16_f32");
 
@@ -818,7 +817,7 @@ TEST(SpecialEffectAnalysis, ImplicitPreserveReadDropsSelectorEncodedSpecial) {
   {
     const auto built = rdna4::build_sop1(rdna4::kSCvtF16F32Sop1, {.ssrc0 = 0, .sdst = 126});
     const std::array<uint32_t, 2> words{built[0], 0u};
-    std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(inst->mnemonic(), "s_cvt_f16_f32");
 
@@ -837,7 +836,7 @@ TEST(SpecialEffectAnalysis, OrdinaryInstructionReportsNoSpecialEffects) {
   constexpr std::array<uint32_t, 2> kWritelaneV141S4Lane2 = {0xd28a008du, 0x00010404u};
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(kWritelaneV141S4Lane2.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, kWritelaneV141S4Lane2.data()));
   ASSERT_NE(inst, nullptr);
 
   InstDefUse du(*inst);
@@ -858,7 +857,7 @@ TEST(SpecialEffectAnalysis, CmpxWritesVccAndExecOnCdna) {
   const std::array<uint32_t, 2> words{built[0], 0u};
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(inst->mnemonic(), "v_cmpx_eq_f32_e32");
 
@@ -870,9 +869,9 @@ TEST(SpecialEffectAnalysis, CmpxWritesVccAndExecOnCdna) {
 TEST(SpecialEffectAnalysis, CmpxWritesExecOnlyOnGfx1250) {
   const auto built = cdna5::build_vopc(cdna5::kVCmpxEqF32Vopc, {.src0 = 256, .vsrc1 = 1});
   const std::array<uint32_t, 2> words{built[0], 0u};
-  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA5);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(inst->mnemonic(), "v_cmpx_eq_f32_e32");
 
@@ -888,7 +887,7 @@ TEST(SpecialEffectAnalysis, CmpxWritesExecOnlyOnRdna) {
   const std::array<uint32_t, 2> words{built[0], 0u};
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(inst->mnemonic(), "v_cmpx_eq_f32_e32");
 
@@ -904,7 +903,7 @@ TEST(SpecialEffectAnalysis, CbranchSccIsSpecialSccUse) {
   const std::array<uint32_t, 2> words{word, 0u};
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(inst->mnemonic(), "s_cbranch_scc0");
 
@@ -918,7 +917,7 @@ TEST(SpecialEffectAnalysis, CbranchVccIsSpecialVccUse) {
   const std::array<uint32_t, 2> words{word, 0u};
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(inst->mnemonic(), "s_cbranch_vccz");
 
@@ -932,7 +931,7 @@ TEST(SpecialEffectAnalysis, CbranchExecIsSpecialExecUse) {
   const std::array<uint32_t, 2> words{word, 0u};
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(inst->mnemonic(), "s_cbranch_execz");
 
@@ -950,7 +949,7 @@ TEST(SpecialEffectAnalysis, Vop2CarryCdnaAddcUsesAndDefsVcc) {
   const std::array<uint32_t, 2> words{built[0], 0u};
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(inst->mnemonic(), "v_addc_co_u32_e32");
 
@@ -964,9 +963,9 @@ TEST(SpecialEffectAnalysis, Vop2CarryGfx1250AddCoCiUsesAndDefsVcc) {
   const auto built =
       cdna5::build_vop2(cdna5::kVAddCoCiU32Vop2, {.src0 = 256, .vsrc1 = 1, .vdst = 2});
   const std::array<uint32_t, 2> words{built[0], 0u};
-  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA5);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(inst->mnemonic(), "v_add_co_ci_u32_e32");
 
@@ -982,7 +981,7 @@ TEST(SpecialEffectAnalysis, GetpcReadsPc) {
   const std::array<uint32_t, 2> words{word, 0u};
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(inst->mnemonic(), "s_getpc_b64");
 
@@ -997,7 +996,7 @@ TEST(SpecialEffectAnalysis, SetpcWritesPc) {
   const std::array<uint32_t, 2> words{word, 0u};
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(inst->mnemonic(), "s_setpc_b64");
 
@@ -1012,7 +1011,7 @@ TEST(SpecialEffectAnalysis, ScallReadsAndWritesPc) {
   const std::array<uint32_t, 2> words{word, 0u};
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(inst->mnemonic(), "s_call_b64");
 
@@ -1030,7 +1029,7 @@ TEST(SpecialEffectAnalysis, MovrelsReadsM0) {
   const std::array<uint32_t, 2> words{word, 0u};
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(inst->mnemonic(), "s_movrels_b32");
 
@@ -1045,7 +1044,7 @@ TEST(SpecialEffectAnalysis, SetGprIdxIdxReadsAndWritesM0) {
   const std::array<uint32_t, 2> words{word, 0u};
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(inst->mnemonic(), "s_set_gpr_idx_idx");
 
@@ -1059,9 +1058,9 @@ TEST(SpecialEffectAnalysis, SetGprIdxIdxReadsAndWritesM0) {
 // defs/uses.
 TEST(SpecialEffectAnalysis, MemoryPseudoOperandProducesNoSpecialEffect) {
   const auto words = cdna5::build_vbuffer(cdna5::kBufferLoadB32Vbuffer, {.vdata = 1, .rsrc = 0});
-  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA5);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(inst->mnemonic(), "buffer_load_b32");
 
@@ -1083,7 +1082,7 @@ TEST(SpecialEffectLiveness, SpecialEffectsAreAbsentFromOrdinaryLiveness) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_FALSE(blocks.empty());
 
   BasicBlock *entry = block_starting_at(blocks, 0);

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -585,12 +585,29 @@ TEST(RegisterSetSpecial, ClassifiesSpecialVersusOrdinaryClasses) {
   EXPECT_FALSE(is_special_reg_class(RegClass::SGPR));
   EXPECT_FALSE(is_special_reg_class(RegClass::VGPR));
   EXPECT_FALSE(is_special_reg_class(RegClass::ACC_VGPR));
+  EXPECT_FALSE(is_special_reg_class(RegClass::TTMP)); // per-index, untracked, not in the mask
   EXPECT_TRUE(is_special_reg_class(RegClass::EXEC));
   EXPECT_TRUE(is_special_reg_class(RegClass::VCC));
   EXPECT_TRUE(is_special_reg_class(RegClass::SCC));
   EXPECT_TRUE(is_special_reg_class(RegClass::M0));
   EXPECT_TRUE(is_special_reg_class(RegClass::FLAT_SCRATCH));
   EXPECT_TRUE(is_special_reg_class(RegClass::PC));
+}
+
+// TTMP is a known register class that this set deliberately does not track:
+// no bitset, no special-mask bit. Adding one never makes the set non-empty and
+// never reports the register as present, and removal paths are safe no-ops.
+TEST(RegisterSetSpecial, TtmpIsUntracked) {
+  RegisterSet s;
+  s.expand({RegClass::TTMP, 0, 1});
+  EXPECT_FALSE(s.contains({RegClass::TTMP, 0, 1}));
+  EXPECT_FALSE(s.contains({RegClass::TTMP, 15, 1}));
+  EXPECT_TRUE(s.none());
+  EXPECT_EQ(s.ordinary_size(), 0u);
+  EXPECT_FALSE(s.has_specials());
+  s.erase({RegClass::TTMP, 15, 1});
+  s.clear_class(RegClass::TTMP);
+  EXPECT_TRUE(s.none());
 }
 
 TEST(RegisterSetSpecial, OrdinaryAndSpecialInsertionCoexist) {

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -760,6 +760,31 @@ TEST(SpecialEffectAnalysis, SaveexecReportsExecAndSccFromDecodedOperands) {
   EXPECT_FALSE(du.defs.ordinary_only().has_specials());
 }
 
+// Counterpart to the fieldless case above: a special register named through a
+// *generic selector* field (s_mov_b32 exec_lo/exec_hi, where EXEC_LO/HI are
+// encoding values 126/127 in the OPR_SDST selector) decodes to a special
+// RegisterRef, but its class-wide singleton representation would collapse the
+// LO/HI halves. InstDefUse deliberately drops such selector-encoded specials
+// rather than record them imprecisely, so EXEC appears in neither defs nor uses.
+TEST(SpecialEffectAnalysis, SelectorEncodedExecWriteIsNotSurfaced) {
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA2);
+  ASSERT_NE(decoder, nullptr);
+
+  for (const uint32_t word :
+       {0xbefe0080u /* s_mov_b32 exec_lo, 0 */, 0xbeff0080u /* s_mov_b32 exec_hi, 0 */}) {
+    const std::array<uint32_t, 2> words{word, 0u};
+    std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+    ASSERT_NE(inst, nullptr);
+    ASSERT_EQ(inst->mnemonic(), "s_mov_b32") << std::hex << word;
+
+    InstDefUse du(*inst);
+    EXPECT_FALSE(du.defs.has_specials()) << std::hex << word;
+    EXPECT_FALSE(du.uses.has_specials()) << std::hex << word;
+    // The dropped EXEC ref must not leak into the ordinary files either.
+    EXPECT_EQ(du.defs.ordinary_size(), 0u) << std::hex << word;
+  }
+}
+
 TEST(SpecialEffectAnalysis, OrdinaryInstructionReportsNoSpecialEffects) {
   // A plain vector op with only ordinary register operands exposes no special
   // effects -- both special sets stay empty.

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -710,6 +710,31 @@ TEST(SpecialEffectAnalysis, SaveexecReportsExecAndSccFromDecodedOperands) {
   EXPECT_FALSE(du.defs.ordinary_only().has_specials());
 }
 
+// Counterpart to the fieldless case above: a special register named through a
+// *generic selector* field (s_mov_b32 exec_lo/exec_hi, where EXEC_LO/HI are
+// encoding values 126/127 in the OPR_SDST selector) decodes to a special
+// RegisterRef, but its class-wide singleton representation would collapse the
+// LO/HI halves. InstDefUse deliberately drops such selector-encoded specials
+// rather than record them imprecisely, so EXEC appears in neither defs nor uses.
+TEST(SpecialEffectAnalysis, SelectorEncodedExecWriteIsNotSurfaced) {
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA2);
+  ASSERT_NE(decoder, nullptr);
+
+  for (const uint32_t word :
+       {0xbefe0080u /* s_mov_b32 exec_lo, 0 */, 0xbeff0080u /* s_mov_b32 exec_hi, 0 */}) {
+    const std::array<uint32_t, 2> words{word, 0u};
+    std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+    ASSERT_NE(inst, nullptr);
+    ASSERT_EQ(inst->mnemonic(), "s_mov_b32") << std::hex << word;
+
+    InstDefUse du(*inst);
+    EXPECT_FALSE(du.defs.has_specials()) << std::hex << word;
+    EXPECT_FALSE(du.uses.has_specials()) << std::hex << word;
+    // The dropped EXEC ref must not leak into the ordinary files either.
+    EXPECT_EQ(du.defs.ordinary_size(), 0u) << std::hex << word;
+  }
+}
+
 TEST(SpecialEffectAnalysis, OrdinaryInstructionReportsNoSpecialEffects) {
   // A plain vector op with only ordinary register operands exposes no special
   // effects -- both special sets stay empty.

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -540,7 +540,6 @@ TEST(RegisterSetSpecial, ClassifiesSpecialVersusOrdinaryClasses) {
   EXPECT_TRUE(is_special_reg_class(RegClass::SCC));
   EXPECT_TRUE(is_special_reg_class(RegClass::M0));
   EXPECT_TRUE(is_special_reg_class(RegClass::FLAT_SCRATCH));
-  EXPECT_TRUE(is_special_reg_class(RegClass::TTMP));
   EXPECT_TRUE(is_special_reg_class(RegClass::PC));
 }
 
@@ -642,13 +641,13 @@ TEST(RegisterSetSpecial, EqualityDistinguishesSpecialMembership) {
   EXPECT_NE(a, b); // the special mask participates in equality
 }
 
-TEST(RegisterSetSpecial, HighValuedTtmpAndPcMaskBitsRoundTrip) {
-  // TTMP and PC are the highest RegClass values, where a mask-width bug would
-  // first surface.
+TEST(RegisterSetSpecial, HighValuedSpecialMaskBitsRoundTrip) {
+  // FLAT_SCRATCH and PC are the highest RegClass values, where a mask-width bug
+  // would first surface.
   RegisterSet s;
-  s.expand({RegClass::TTMP, 0, 1});
+  s.expand({RegClass::FLAT_SCRATCH, 0, 1});
   s.expand({RegClass::PC, 0, 1});
-  EXPECT_EQ(specials_in(s), special_regs({RegClass::TTMP, RegClass::PC}));
+  EXPECT_EQ(specials_in(s), special_regs({RegClass::FLAT_SCRATCH, RegClass::PC}));
   EXPECT_FALSE(s.contains({RegClass::SGPR, 0, 1})); // no aliasing onto bit 0
 }
 
@@ -691,7 +690,7 @@ TEST(SpecialEffectAnalysis, SaveexecReportsExecAndSccFromDecodedOperands) {
   const uint32_t words[] = {0xBE802000u, 0x00000000u};
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(inst->mnemonic(), "s_and_saveexec_b64");
 
@@ -723,7 +722,7 @@ TEST(SpecialEffectAnalysis, SelectorEncodedExecWriteIsNotSurfaced) {
   for (const uint32_t word :
        {0xbefe0080u /* s_mov_b32 exec_lo, 0 */, 0xbeff0080u /* s_mov_b32 exec_hi, 0 */}) {
     const std::array<uint32_t, 2> words{word, 0u};
-    std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(inst->mnemonic(), "s_mov_b32") << std::hex << word;
 
@@ -750,7 +749,7 @@ TEST(SpecialEffectAnalysis, ImplicitPreserveReadDropsSelectorEncodedSpecial) {
   {
     const auto built = rdna4::build_sop1(rdna4::kSCvtF16F32Sop1, {.ssrc0 = 0, .sdst = 4});
     const std::array<uint32_t, 2> words{built[0], 0u};
-    std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(inst->mnemonic(), "s_cvt_f16_f32");
 
@@ -768,7 +767,7 @@ TEST(SpecialEffectAnalysis, ImplicitPreserveReadDropsSelectorEncodedSpecial) {
   {
     const auto built = rdna4::build_sop1(rdna4::kSCvtF16F32Sop1, {.ssrc0 = 0, .sdst = 126});
     const std::array<uint32_t, 2> words{built[0], 0u};
-    std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
     ASSERT_NE(inst, nullptr);
     ASSERT_EQ(inst->mnemonic(), "s_cvt_f16_f32");
 
@@ -787,7 +786,7 @@ TEST(SpecialEffectAnalysis, OrdinaryInstructionReportsNoSpecialEffects) {
   constexpr std::array<uint32_t, 2> kWritelaneV141S4Lane2 = {0xd28a008du, 0x00010404u};
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(kWritelaneV141S4Lane2.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, kWritelaneV141S4Lane2.data()));
   ASSERT_NE(inst, nullptr);
 
   InstDefUse du(*inst);
@@ -808,7 +807,7 @@ TEST(SpecialEffectAnalysis, CmpxWritesVccAndExecOnCdna) {
   const std::array<uint32_t, 2> words{built[0], 0u};
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(inst->mnemonic(), "v_cmpx_eq_f32_e32");
 
@@ -820,9 +819,9 @@ TEST(SpecialEffectAnalysis, CmpxWritesVccAndExecOnCdna) {
 TEST(SpecialEffectAnalysis, CmpxWritesExecOnlyOnGfx1250) {
   const auto built = cdna5::build_vopc(cdna5::kVCmpxEqF32Vopc, {.src0 = 256, .vsrc1 = 1});
   const std::array<uint32_t, 2> words{built[0], 0u};
-  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA5);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(inst->mnemonic(), "v_cmpx_eq_f32_e32");
 
@@ -838,7 +837,7 @@ TEST(SpecialEffectAnalysis, CmpxWritesExecOnlyOnRdna) {
   const std::array<uint32_t, 2> words{built[0], 0u};
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(inst->mnemonic(), "v_cmpx_eq_f32_e32");
 
@@ -854,7 +853,7 @@ TEST(SpecialEffectAnalysis, CbranchSccIsSpecialSccUse) {
   const std::array<uint32_t, 2> words{word, 0u};
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(inst->mnemonic(), "s_cbranch_scc0");
 
@@ -868,7 +867,7 @@ TEST(SpecialEffectAnalysis, CbranchVccIsSpecialVccUse) {
   const std::array<uint32_t, 2> words{word, 0u};
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(inst->mnemonic(), "s_cbranch_vccz");
 
@@ -882,7 +881,7 @@ TEST(SpecialEffectAnalysis, CbranchExecIsSpecialExecUse) {
   const std::array<uint32_t, 2> words{word, 0u};
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(inst->mnemonic(), "s_cbranch_execz");
 
@@ -900,7 +899,7 @@ TEST(SpecialEffectAnalysis, Vop2CarryCdnaAddcUsesAndDefsVcc) {
   const std::array<uint32_t, 2> words{built[0], 0u};
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(inst->mnemonic(), "v_addc_co_u32_e32");
 
@@ -914,9 +913,9 @@ TEST(SpecialEffectAnalysis, Vop2CarryGfx1250AddCoCiUsesAndDefsVcc) {
   const auto built =
       cdna5::build_vop2(cdna5::kVAddCoCiU32Vop2, {.src0 = 256, .vsrc1 = 1, .vdst = 2});
   const std::array<uint32_t, 2> words{built[0], 0u};
-  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA5);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(inst->mnemonic(), "v_add_co_ci_u32_e32");
 
@@ -932,7 +931,7 @@ TEST(SpecialEffectAnalysis, GetpcReadsPc) {
   const std::array<uint32_t, 2> words{word, 0u};
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(inst->mnemonic(), "s_getpc_b64");
 
@@ -947,7 +946,7 @@ TEST(SpecialEffectAnalysis, SetpcWritesPc) {
   const std::array<uint32_t, 2> words{word, 0u};
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(inst->mnemonic(), "s_setpc_b64");
 
@@ -962,7 +961,7 @@ TEST(SpecialEffectAnalysis, ScallReadsAndWritesPc) {
   const std::array<uint32_t, 2> words{word, 0u};
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(inst->mnemonic(), "s_call_b64");
 
@@ -980,7 +979,7 @@ TEST(SpecialEffectAnalysis, MovrelsReadsM0) {
   const std::array<uint32_t, 2> words{word, 0u};
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(inst->mnemonic(), "s_movrels_b32");
 
@@ -995,7 +994,7 @@ TEST(SpecialEffectAnalysis, SetGprIdxIdxReadsAndWritesM0) {
   const std::array<uint32_t, 2> words{word, 0u};
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(inst->mnemonic(), "s_set_gpr_idx_idx");
 
@@ -1009,9 +1008,9 @@ TEST(SpecialEffectAnalysis, SetGprIdxIdxReadsAndWritesM0) {
 // defs/uses.
 TEST(SpecialEffectAnalysis, MemoryPseudoOperandProducesNoSpecialEffect) {
   const auto words = cdna5::build_vbuffer(cdna5::kBufferLoadB32Vbuffer, {.vdata = 1, .rsrc = 0});
-  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA5);
   ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(inst->mnemonic(), "buffer_load_b32");
 
@@ -1033,7 +1032,7 @@ TEST(SpecialEffectLiveness, SpecialEffectsAreAbsentFromOrdinaryLiveness) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_FALSE(blocks.empty());
 
   BasicBlock *entry = block_starting_at(blocks, 0);

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -735,6 +735,52 @@ TEST(SpecialEffectAnalysis, SelectorEncodedExecWriteIsNotSurfaced) {
   }
 }
 
+// The selector-drop policy must also cover implicit reads. s_cvt_f16_f32 writes
+// the low 16 bits of sdst and preserves the high half, so its generated
+// implicit_uses() hook surfaces a preserve-read of sdst via to_register_ref().
+// With an ordinary sdst that read is a real ordinary use; with a selector-encoded
+// special sdst (exec_lo) it collapses to a class-wide EXEC singleton and must be
+// dropped, or EXEC would be used-but-never-defined (the explicit dst path already
+// drops the selector-encoded def).
+TEST(SpecialEffectAnalysis, ImplicitPreserveReadDropsSelectorEncodedSpecial) {
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(decoder, nullptr);
+
+  // Ordinary destination: the implicit preserve-read of s4 is a real use.
+  {
+    const auto built = rdna4::build_sop1(rdna4::kSCvtF16F32Sop1, {.ssrc0 = 0, .sdst = 4});
+    const std::array<uint32_t, 2> words{built[0], 0u};
+    std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+    ASSERT_NE(inst, nullptr);
+    ASSERT_EQ(inst->mnemonic(), "s_cvt_f16_f32");
+
+    InstDefUse du(*inst);
+    EXPECT_TRUE(du.defs.contains({RegClass::SGPR, 4, 1}));
+    EXPECT_TRUE(du.uses.contains({RegClass::SGPR, 0, 1}));
+    EXPECT_TRUE(du.uses.contains({RegClass::SGPR, 4, 1})); // preserve-read via the hook
+    EXPECT_FALSE(du.defs.has_specials());
+    EXPECT_FALSE(du.uses.has_specials());
+  }
+
+  // Selector-encoded exec_lo destination (OPR_SDST value 126): the preserve-read
+  // decodes to a class-wide EXEC ref and must be dropped from uses, and the def
+  // is likewise dropped, leaving no special members and no ordinary destination.
+  {
+    const auto built = rdna4::build_sop1(rdna4::kSCvtF16F32Sop1, {.ssrc0 = 0, .sdst = 126});
+    const std::array<uint32_t, 2> words{built[0], 0u};
+    std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+    ASSERT_NE(inst, nullptr);
+    ASSERT_EQ(inst->mnemonic(), "s_cvt_f16_f32");
+
+    InstDefUse du(*inst);
+    EXPECT_FALSE(du.uses.has_specials());
+    EXPECT_FALSE(du.defs.has_specials());
+    EXPECT_EQ(du.defs.ordinary_size(), 0u); // selector-encoded dst dropped
+    EXPECT_EQ(du.uses.ordinary_size(), 1u); // only the ordinary ssrc0 (s0) remains
+    EXPECT_TRUE(du.uses.contains({RegClass::SGPR, 0, 1}));
+  }
+}
+
 TEST(SpecialEffectAnalysis, OrdinaryInstructionReportsNoSpecialEffects) {
   // A plain vector op with only ordinary register operands exposes no special
   // effects -- both special sets stay empty.

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -772,7 +772,7 @@ TEST(SpecialEffectAnalysis, CmpxWritesVccAndExecOnCdna) {
 }
 
 TEST(SpecialEffectAnalysis, CmpxWritesExecOnlyOnGfx1250) {
-  const auto built = gfx1250::build_vopc(gfx1250::kVCmpxEqF32Vopc, {.src0 = 256, .vsrc1 = 1});
+  const auto built = cdna5::build_vopc(cdna5::kVCmpxEqF32Vopc, {.src0 = 256, .vsrc1 = 1});
   const std::array<uint32_t, 2> words{built[0], 0u};
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
@@ -866,7 +866,7 @@ TEST(SpecialEffectAnalysis, Vop2CarryCdnaAddcUsesAndDefsVcc) {
 
 TEST(SpecialEffectAnalysis, Vop2CarryGfx1250AddCoCiUsesAndDefsVcc) {
   const auto built =
-      gfx1250::build_vop2(gfx1250::kVAddCoCiU32Vop2, {.src0 = 256, .vsrc1 = 1, .vdst = 2});
+      cdna5::build_vop2(cdna5::kVAddCoCiU32Vop2, {.src0 = 256, .vsrc1 = 1, .vdst = 2});
   const std::array<uint32_t, 2> words{built[0], 0u};
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
@@ -962,8 +962,7 @@ TEST(SpecialEffectAnalysis, SetGprIdxIdxReadsAndWritesM0) {
 // register class nor an ordinary register ref, so it contributes nothing to
 // defs/uses.
 TEST(SpecialEffectAnalysis, MemoryPseudoOperandProducesNoSpecialEffect) {
-  const auto words =
-      gfx1250::build_vbuffer(gfx1250::kBufferLoadB32Vbuffer, {.vdata = 1, .rsrc = 0});
+  const auto words = cdna5::build_vbuffer(cdna5::kBufferLoadB32Vbuffer, {.vdata = 1, .rsrc = 0});
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
   std::unique_ptr<Instruction> inst(decoder->decode(words.data()));

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -460,16 +460,22 @@ TEST(GeneratedInstDefUse, MubufCmpswapReturnUsesElementWidthAndTargetGate) {
   }
 }
 
-TEST(RegisterSetAnalysis, IgnoresSpecialRegisterClasses) {
+TEST(RegisterSetAnalysis, SpecialClassesAreHeldButCarryNoOrdinaryLanes) {
   RegisterSet set;
   set.expand({RegClass::EXEC, 0, 2});
   set.expand({RegClass::SCC, 0, 1});
   set.expand({RegClass::FLAT_SCRATCH, 0, 2});
 
-  EXPECT_TRUE(set.none());
-  EXPECT_FALSE(set.contains({RegClass::EXEC, 0, 1}));
-  EXPECT_FALSE(set.contains({RegClass::SCC, 0, 1}));
-  EXPECT_FALSE(set.contains({RegClass::FLAT_SCRATCH, 0, 2}));
+  // Special classes are singleton members, not dropped.
+  EXPECT_FALSE(set.none());
+  EXPECT_TRUE(set.has_specials());
+  EXPECT_TRUE(set.contains({RegClass::EXEC, 0, 1}));
+  EXPECT_TRUE(set.contains({RegClass::SCC, 0, 1}));
+  EXPECT_TRUE(set.contains({RegClass::FLAT_SCRATCH, 0, 2}));
+
+  // But they contribute no ordinary lanes and vanish under ordinary_only().
+  EXPECT_EQ(set.ordinary_size(), 0u);
+  EXPECT_TRUE(set.ordinary_only().none());
 }
 
 TEST(RegisterSetAnalysis, GeneratedCdna4OperandsMapTrackedRegisterRefs) {
@@ -500,6 +506,487 @@ TEST(RegisterSetAnalysis, Cdna4WritelaneDestinationIsUseAndDef) {
   EXPECT_TRUE(du.defs.contains({RegClass::VGPR, 141, 1}));
   EXPECT_TRUE(du.uses.contains({RegClass::VGPR, 141, 1}));
   EXPECT_TRUE(du.uses.contains({RegClass::SGPR, 4, 1}));
+}
+
+// ---------------------------------------------------------------------------
+// Architectural special-register + memory effect API. Special registers are
+// singleton members of the same RegisterSet as ordinary registers; consumers
+// that drive scratch-allocation liveness project them out with ordinary_only().
+// ---------------------------------------------------------------------------
+
+// Collect a set's special members in ascending RegClass order, so a test can
+// assert the *exact* set of special registers an instruction reads or writes,
+// not just membership.
+std::vector<RegClass> specials_in(const RegisterSet &set) {
+  std::vector<RegClass> classes;
+  set.for_each_special([&](RegClass c) { classes.push_back(c); });
+  return classes;
+}
+
+// Expected special-register list, sorted to match specials_in()'s ascending
+// iteration order.
+std::vector<RegClass> special_regs(std::initializer_list<RegClass> classes) {
+  std::vector<RegClass> sorted(classes);
+  std::ranges::sort(sorted);
+  return sorted;
+}
+
+TEST(RegisterSetSpecial, ClassifiesSpecialVersusOrdinaryClasses) {
+  EXPECT_FALSE(is_special_reg_class(RegClass::SGPR));
+  EXPECT_FALSE(is_special_reg_class(RegClass::VGPR));
+  EXPECT_FALSE(is_special_reg_class(RegClass::ACC_VGPR));
+  EXPECT_TRUE(is_special_reg_class(RegClass::EXEC));
+  EXPECT_TRUE(is_special_reg_class(RegClass::VCC));
+  EXPECT_TRUE(is_special_reg_class(RegClass::SCC));
+  EXPECT_TRUE(is_special_reg_class(RegClass::M0));
+  EXPECT_TRUE(is_special_reg_class(RegClass::FLAT_SCRATCH));
+  EXPECT_TRUE(is_special_reg_class(RegClass::TTMP));
+  EXPECT_TRUE(is_special_reg_class(RegClass::PC));
+}
+
+TEST(RegisterSetSpecial, OrdinaryAndSpecialInsertionCoexist) {
+  RegisterSet s;
+  s.expand({RegClass::SGPR, 4, 2});
+  s.expand({RegClass::EXEC, 0, 1});
+  s.expand({RegClass::VCC, 0, 1});
+
+  // size() counts ordinary lanes plus special singletons; ordinary_size() sees
+  // only the two SGPR lanes.
+  EXPECT_EQ(s.ordinary_size(), 2u);
+  EXPECT_EQ(s.size(), 4u);
+  EXPECT_TRUE(s.has_specials());
+  EXPECT_TRUE(s.contains({RegClass::SGPR, 4, 1}));
+  EXPECT_TRUE(s.contains({RegClass::EXEC, 0, 1}));
+  EXPECT_EQ(specials_in(s), special_regs({RegClass::EXEC, RegClass::VCC}));
+}
+
+TEST(RegisterSetSpecial, SpecialMembershipIgnoresIndexAndWidth) {
+  // Special classes are singletons: any index/width refers to the same member.
+  RegisterSet s;
+  s.expand({RegClass::EXEC, 42, 8});
+  EXPECT_TRUE(s.contains({RegClass::EXEC, 0, 1}));
+  EXPECT_TRUE(s.contains({RegClass::EXEC, 99, 2}));
+  EXPECT_EQ(s.size(), 1u);
+
+  s.erase({RegClass::EXEC, 7, 4});
+  EXPECT_FALSE(s.contains({RegClass::EXEC, 0, 1}));
+  EXPECT_TRUE(s.none());
+}
+
+TEST(RegisterSetSpecial, FullIterationEmitsCanonicalSpecialRefs) {
+  RegisterSet s;
+  s.expand({RegClass::VGPR, 1, 1});
+  s.expand({RegClass::PC, 5, 2});
+
+  // for_each visits the ordinary lane first, then the special as a canonical
+  // {cls, 0, 1} ref regardless of the index/width it was inserted with.
+  std::vector<RegisterRef> seen;
+  s.for_each([&](RegisterRef r) { seen.push_back(r); });
+  ASSERT_EQ(seen.size(), 2u);
+  EXPECT_EQ(seen[0], (RegisterRef{RegClass::VGPR, 1, 1}));
+  EXPECT_EQ(seen[1], (RegisterRef{RegClass::PC, 0, 1}));
+
+  // for_each_ordinary skips the special member entirely.
+  std::vector<RegisterRef> ordinary;
+  s.for_each_ordinary([&](RegisterRef r) { ordinary.push_back(r); });
+  EXPECT_EQ(ordinary, (std::vector<RegisterRef>{{RegClass::VGPR, 1, 1}}));
+}
+
+TEST(RegisterSetSpecial, OrdinaryOnlyDropsSpecialMembers) {
+  RegisterSet s;
+  s.expand({RegClass::SGPR, 3, 1});
+  s.expand({RegClass::SCC, 0, 1});
+
+  const RegisterSet ordinary = s.ordinary_only();
+  EXPECT_FALSE(ordinary.has_specials());
+  EXPECT_EQ(ordinary.size(), 1u);
+  EXPECT_TRUE(ordinary.contains({RegClass::SGPR, 3, 1}));
+  EXPECT_TRUE(s.has_specials()); // source unchanged
+}
+
+TEST(RegisterSetSpecial, SetAlgebraSpansOrdinaryAndSpecial) {
+  RegisterSet a;
+  a.expand({RegClass::SGPR, 0, 1});
+  a.expand({RegClass::EXEC, 0, 1});
+  RegisterSet b;
+  b.expand({RegClass::SGPR, 1, 1});
+  b.expand({RegClass::EXEC, 0, 1});
+  b.expand({RegClass::VCC, 0, 1});
+
+  EXPECT_TRUE(a.intersects(b)); // shared EXEC
+
+  const RegisterSet u = a | b;
+  EXPECT_EQ(u.size(), 4u); // s0, s1, EXEC, VCC
+  EXPECT_EQ(specials_in(u), special_regs({RegClass::EXEC, RegClass::VCC}));
+
+  const RegisterSet i = a & b;
+  EXPECT_EQ(specials_in(i), special_regs({RegClass::EXEC}));
+  EXPECT_FALSE(i.contains({RegClass::SGPR, 0, 1})); // s0 only in a
+
+  const RegisterSet d = b - a; // removes shared EXEC; keeps VCC and s1
+  EXPECT_EQ(specials_in(d), special_regs({RegClass::VCC}));
+  EXPECT_TRUE(d.contains({RegClass::SGPR, 1, 1}));
+
+  RegisterSet cleared = u;
+  cleared.clear_class(RegClass::EXEC);
+  EXPECT_EQ(specials_in(cleared), special_regs({RegClass::VCC}));
+  EXPECT_EQ(cleared.ordinary_size(), 2u); // clear_class(special) leaves ordinary intact
+}
+
+TEST(RegisterSetSpecial, EqualityDistinguishesSpecialMembership) {
+  RegisterSet a;
+  a.expand({RegClass::SGPR, 0, 1});
+  RegisterSet b = a;
+  EXPECT_EQ(a, b);
+  b.expand({RegClass::EXEC, 0, 1});
+  EXPECT_NE(a, b); // the special mask participates in equality
+}
+
+TEST(RegisterSetSpecial, HighValuedTtmpAndPcMaskBitsRoundTrip) {
+  // TTMP and PC are the highest RegClass values, where a mask-width bug would
+  // first surface.
+  RegisterSet s;
+  s.expand({RegClass::TTMP, 0, 1});
+  s.expand({RegClass::PC, 0, 1});
+  EXPECT_EQ(specials_in(s), special_regs({RegClass::TTMP, RegClass::PC}));
+  EXPECT_FALSE(s.contains({RegClass::SGPR, 0, 1})); // no aliasing onto bit 0
+}
+
+TEST(InstDefUseSpecialEffects, SpecialDefaultEmpty) {
+  // A decoded instruction with only ordinary operands reports no special
+  // members; ordinary def/use extraction is unchanged.
+  TestInstruction inst("test_sp", {{RegClass::SGPR, 4, 1}}, {{RegClass::VGPR, 0, 1}});
+  InstDefUse du(inst);
+
+  EXPECT_TRUE(du.defs.contains({RegClass::SGPR, 4, 1}));
+  EXPECT_TRUE(du.uses.contains({RegClass::VGPR, 0, 1}));
+  EXPECT_FALSE(du.defs.has_specials());
+  EXPECT_FALSE(du.uses.has_specials());
+}
+
+TEST(InstDefUseSpecialEffects, SpecialMembersStayOutOfOrdinaryProjection) {
+  // Special singletons live in defs/uses alongside ordinary registers, but the
+  // ordinary projection that drives scratch allocation is unaffected.
+  TestInstruction inst("test_sp", {{RegClass::SGPR, 4, 1}}, {});
+  InstDefUse du(inst);
+
+  du.defs.expand({RegClass::EXEC, 0, 1});
+  du.uses.expand({RegClass::VCC, 0, 1});
+
+  EXPECT_EQ(du.defs.ordinary_size(), 1u);
+  EXPECT_TRUE(du.defs.ordinary_only().contains({RegClass::SGPR, 4, 1}));
+  EXPECT_FALSE(du.defs.ordinary_only().has_specials());
+  EXPECT_TRUE(du.defs.contains({RegClass::EXEC, 0, 1}));
+  EXPECT_TRUE(du.uses.contains({RegClass::VCC, 0, 1}));
+}
+
+TEST(SpecialEffectAnalysis, SaveexecReportsExecAndSccFromDecodedOperands) {
+  // Real decoded instruction: s_and_saveexec_b64 s[0:1], s[0:1] (CDNA4). Its
+  // fieldless special operands become singleton members of defs/uses by
+  // direction:
+  //   dst EXEC + dst SCC  -> special members of defs
+  //   src EXEC (old exec) -> special member of uses
+  // while the ordinary sdst/ssrc0 SGPRs stay in the same sets as ordinary
+  // members. The ordinary projection (ordinary_only) sees only the SGPRs.
+  const uint32_t words[] = {0xBE802000u, 0x00000000u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "s_and_saveexec_b64");
+
+  InstDefUse du(*inst);
+
+  EXPECT_EQ(specials_in(du.defs), special_regs({RegClass::EXEC, RegClass::SCC}));
+  EXPECT_EQ(specials_in(du.uses), special_regs({RegClass::EXEC}));
+
+  // Ordinary sdst/ssrc0 (s[0:1]) still tracked as ordinary registers.
+  EXPECT_TRUE(du.defs.contains({RegClass::SGPR, 0, 2}));
+  EXPECT_TRUE(du.uses.contains({RegClass::SGPR, 0, 2}));
+
+  // EXEC/SCC are members of du.defs but stay out of the ordinary projection
+  // that feeds scratch allocation.
+  EXPECT_TRUE(du.defs.contains({RegClass::EXEC, 0, 1}));
+  EXPECT_FALSE(du.defs.ordinary_only().has_specials());
+}
+
+TEST(SpecialEffectAnalysis, OrdinaryInstructionReportsNoSpecialEffects) {
+  // A plain vector op with only ordinary register operands exposes no special
+  // effects -- both special sets stay empty.
+  constexpr std::array<uint32_t, 2> kWritelaneV141S4Lane2 = {0xd28a008du, 0x00010404u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(kWritelaneV141S4Lane2.data()));
+  ASSERT_NE(inst, nullptr);
+
+  InstDefUse du(*inst);
+  EXPECT_FALSE(du.defs.has_specials());
+  EXPECT_FALSE(du.uses.has_specials());
+}
+
+// Decode-time special-effect coverage for the hidden-side-effect instruction
+// families. Encodings are built through the generated per-ISA encoders so they
+// cannot silently drift, and each case locks the operand-driven special
+// defs/uses so a change elsewhere cannot alter them unnoticed.
+
+// V_CMPX writes EXEC on every ISA, and additionally VCC on CDNA/GFX9 (its
+// operand list carries a VCC destination). gfx1250 is EXEC-only, so the same
+// mnemonic has a genuinely different side-effect set across ISAs.
+TEST(SpecialEffectAnalysis, CmpxWritesVccAndExecOnCdna) {
+  const auto built = cdna3::build_vopc(cdna3::kVCmpxEqF32Vopc, {.src0 = 256, .vsrc1 = 1});
+  const std::array<uint32_t, 2> words{built[0], 0u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "v_cmpx_eq_f32_e32");
+
+  InstDefUse du(*inst);
+  EXPECT_EQ(specials_in(du.defs), special_regs({RegClass::EXEC, RegClass::VCC}));
+  EXPECT_FALSE(du.uses.has_specials());
+}
+
+TEST(SpecialEffectAnalysis, CmpxWritesExecOnlyOnGfx1250) {
+  const auto built = gfx1250::build_vopc(gfx1250::kVCmpxEqF32Vopc, {.src0 = 256, .vsrc1 = 1});
+  const std::array<uint32_t, 2> words{built[0], 0u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "v_cmpx_eq_f32_e32");
+
+  InstDefUse du(*inst);
+  EXPECT_EQ(specials_in(du.defs), special_regs({RegClass::EXEC}));
+  EXPECT_FALSE(du.uses.has_specials());
+}
+
+// RDNA CMPX is EXEC-only like gfx1250 (and unlike CDNA), tested directly on an
+// RDNA target rather than inferred from the CDNA-family gfx1250.
+TEST(SpecialEffectAnalysis, CmpxWritesExecOnlyOnRdna) {
+  const auto built = rdna4::build_vopc(rdna4::kVCmpxEqF32Vopc, {.src0 = 256, .vsrc1 = 1});
+  const std::array<uint32_t, 2> words{built[0], 0u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "v_cmpx_eq_f32_e32");
+
+  InstDefUse du(*inst);
+  EXPECT_EQ(specials_in(du.defs), special_regs({RegClass::EXEC}));
+  EXPECT_FALSE(du.uses.has_specials());
+}
+
+// s_cbranch_{scc,vcc,exec}* read a special condition register and branch. The
+// condition operand is a special use; nothing is defined.
+TEST(SpecialEffectAnalysis, CbranchSccIsSpecialSccUse) {
+  const uint32_t word = cdna3::build_sopp(cdna3::kSCbranchScc0Sopp, {.simm16 = 0})[0];
+  const std::array<uint32_t, 2> words{word, 0u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "s_cbranch_scc0");
+
+  InstDefUse du(*inst);
+  EXPECT_EQ(specials_in(du.uses), special_regs({RegClass::SCC}));
+  EXPECT_FALSE(du.defs.has_specials());
+}
+
+TEST(SpecialEffectAnalysis, CbranchVccIsSpecialVccUse) {
+  const uint32_t word = cdna3::build_sopp(cdna3::kSCbranchVcczSopp, {.simm16 = 0})[0];
+  const std::array<uint32_t, 2> words{word, 0u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "s_cbranch_vccz");
+
+  InstDefUse du(*inst);
+  EXPECT_EQ(specials_in(du.uses), special_regs({RegClass::VCC}));
+  EXPECT_FALSE(du.defs.has_specials());
+}
+
+TEST(SpecialEffectAnalysis, CbranchExecIsSpecialExecUse) {
+  const uint32_t word = cdna3::build_sopp(cdna3::kSCbranchExeczSopp, {.simm16 = 0})[0];
+  const std::array<uint32_t, 2> words{word, 0u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "s_cbranch_execz");
+
+  InstDefUse du(*inst);
+  EXPECT_EQ(specials_in(du.uses), special_regs({RegClass::EXEC}));
+  EXPECT_FALSE(du.defs.has_specials());
+}
+
+// VOP2 carry reads and writes VCC implicitly. The mnemonic differs by ISA
+// (CDNA/GFX9 v_addc_co_u32 vs RDNA/gfx1250 v_add_co_ci_u32) but both expose the
+// same VCC carry-in use and carry-out def.
+TEST(SpecialEffectAnalysis, Vop2CarryCdnaAddcUsesAndDefsVcc) {
+  const auto built =
+      cdna3::build_vop2(cdna3::kVAddcCoU32Vop2, {.src0 = 256, .vsrc1 = 1, .vdst = 2});
+  const std::array<uint32_t, 2> words{built[0], 0u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "v_addc_co_u32_e32");
+
+  InstDefUse du(*inst);
+  EXPECT_EQ(specials_in(du.defs), special_regs({RegClass::VCC}));
+  EXPECT_EQ(specials_in(du.uses), special_regs({RegClass::VCC}));
+  EXPECT_TRUE(du.defs.contains({RegClass::VGPR, 2, 1})); // ordinary vdst still tracked
+}
+
+TEST(SpecialEffectAnalysis, Vop2CarryGfx1250AddCoCiUsesAndDefsVcc) {
+  const auto built =
+      gfx1250::build_vop2(gfx1250::kVAddCoCiU32Vop2, {.src0 = 256, .vsrc1 = 1, .vdst = 2});
+  const std::array<uint32_t, 2> words{built[0], 0u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "v_add_co_ci_u32_e32");
+
+  InstDefUse du(*inst);
+  EXPECT_EQ(specials_in(du.defs), special_regs({RegClass::VCC}));
+  EXPECT_EQ(specials_in(du.uses), special_regs({RegClass::VCC}));
+}
+
+// PC family: getpc reads PC (writes an ordinary SGPR pair), setpc writes PC
+// (reads an ordinary SGPR pair), s_call does both.
+TEST(SpecialEffectAnalysis, GetpcReadsPc) {
+  const uint32_t word = cdna3::build_sop1(0x1c, {.ssrc0 = 0, .sdst = 8})[0]; // s_getpc_b64 s[8:9]
+  const std::array<uint32_t, 2> words{word, 0u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "s_getpc_b64");
+
+  InstDefUse du(*inst);
+  EXPECT_EQ(specials_in(du.uses), special_regs({RegClass::PC}));
+  EXPECT_FALSE(du.defs.has_specials());
+  EXPECT_TRUE(du.defs.contains({RegClass::SGPR, 8, 2}));
+}
+
+TEST(SpecialEffectAnalysis, SetpcWritesPc) {
+  const uint32_t word = cdna3::build_sop1(0x1d, {.ssrc0 = 8, .sdst = 0})[0]; // s_setpc_b64 s[8:9]
+  const std::array<uint32_t, 2> words{word, 0u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "s_setpc_b64");
+
+  InstDefUse du(*inst);
+  EXPECT_EQ(specials_in(du.defs), special_regs({RegClass::PC}));
+  EXPECT_FALSE(du.uses.has_specials());
+  EXPECT_TRUE(du.uses.contains({RegClass::SGPR, 8, 2}));
+}
+
+TEST(SpecialEffectAnalysis, ScallReadsAndWritesPc) {
+  const uint32_t word = build_s_call_b64(8, 0); // s_call_b64 s[8:9], <rel>
+  const std::array<uint32_t, 2> words{word, 0u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "s_call_b64");
+
+  InstDefUse du(*inst);
+  EXPECT_EQ(specials_in(du.defs), special_regs({RegClass::PC}));
+  EXPECT_EQ(specials_in(du.uses), special_regs({RegClass::PC}));
+  EXPECT_TRUE(du.defs.contains({RegClass::SGPR, 8, 2}));
+}
+
+// M0 family: s_movrels_b32 reads M0 as its relative index (special use), while
+// s_set_gpr_idx_idx both reads M0 and writes it back (special use and def). The
+// M0 operand is fieldless on both, so it surfaces only through the special path.
+TEST(SpecialEffectAnalysis, MovrelsReadsM0) {
+  const uint32_t word = cdna3::build_sop1(cdna3::kSMovrelsB32Sop1, {.ssrc0 = 0, .sdst = 8})[0];
+  const std::array<uint32_t, 2> words{word, 0u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "s_movrels_b32");
+
+  InstDefUse du(*inst);
+  EXPECT_EQ(specials_in(du.uses), special_regs({RegClass::M0}));
+  EXPECT_FALSE(du.defs.has_specials());
+  EXPECT_TRUE(du.defs.contains({RegClass::SGPR, 8, 1})); // ordinary sdst still tracked
+}
+
+TEST(SpecialEffectAnalysis, SetGprIdxIdxReadsAndWritesM0) {
+  const uint32_t word = cdna3::build_sop1(cdna3::kSSetGprIdxIdxSop1, {.ssrc0 = 0})[0];
+  const std::array<uint32_t, 2> words{word, 0u};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "s_set_gpr_idx_idx");
+
+  InstDefUse du(*inst);
+  EXPECT_EQ(specials_in(du.defs), special_regs({RegClass::M0}));
+  EXPECT_EQ(specials_in(du.uses), special_regs({RegClass::M0}));
+}
+
+// A buffer load's fieldless GPUMEM operand is inert: it yields neither a special
+// register class nor an ordinary register ref, so it contributes nothing to
+// defs/uses.
+TEST(SpecialEffectAnalysis, MemoryPseudoOperandProducesNoSpecialEffect) {
+  const auto words =
+      gfx1250::build_vbuffer(gfx1250::kBufferLoadB32Vbuffer, {.vdata = 1, .rsrc = 0});
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->mnemonic(), "buffer_load_b32");
+
+  InstDefUse du(*inst);
+  EXPECT_FALSE(du.defs.has_specials());
+  EXPECT_FALSE(du.uses.has_specials());
+}
+
+// Liveness models ordinary scratch registers only: an instruction's special
+// def/use appears in InstDefUse but must never reach BlockLiveness or
+// live_before(), which drive scratch allocation.
+TEST(SpecialEffectLiveness, SpecialEffectsAreAbsentFromOrdinaryLiveness) {
+  // s_and_saveexec_b64 s[0:1], s[0:1] defs {s[0:1], EXEC, SCC} and uses
+  // {s[0:1], EXEC}; s_endpgm terminates the single block.
+  std::vector<uint32_t> words = {
+      0xBE802000u, // s_and_saveexec_b64 s[0:1], s[0:1]
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),
+  };
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_FALSE(blocks.empty());
+
+  BasicBlock *entry = block_starting_at(blocks, 0);
+  ASSERT_NE(entry, nullptr);
+  auto &insts = entry->instructions();
+  ASSERT_NE(insts.begin(), insts.end());
+  const Instruction &saveexec = *insts.begin();
+  ASSERT_EQ(saveexec.mnemonic(), "s_and_saveexec_b64");
+
+  // InstDefUse records the special effects.
+  const InstDefUse du(saveexec);
+  EXPECT_TRUE(du.defs.contains({RegClass::EXEC, 0, 1}));
+  EXPECT_TRUE(du.defs.contains({RegClass::SCC, 0, 1}));
+  EXPECT_TRUE(du.uses.contains({RegClass::EXEC, 0, 1}));
+
+  // Liveness projects them out of every ordinary set.
+  const LivenessAnalysis liveness = analyze_scope(blocks);
+  const BlockLiveness &bl = liveness.block_liveness(*entry);
+  EXPECT_FALSE(bl.live_in.has_specials());
+  EXPECT_FALSE(bl.live_out.has_specials());
+  EXPECT_FALSE(bl.gen.has_specials());
+  EXPECT_FALSE(bl.kill.has_specials());
+  EXPECT_FALSE(liveness.live_before(saveexec).has_specials());
 }
 
 TEST(CfgAnalysis, LoopBackEdgeLinksPredecessor) {

--- a/emulation/rocjitsu/tests/decode_smoke_test.cpp
+++ b/emulation/rocjitsu/tests/decode_smoke_test.cpp
@@ -1076,6 +1076,15 @@ TEST(FieldlessOperandDecodeTest, SaveexecExposesInertExecAndSccOperands) {
   expect_inert_fieldless_operand(inst->dst_operand(2), 1, 253);  // SCC write.
   expect_inert_fieldless_operand(inst->src_operand(1), 64, 126); // EXEC read.
 
+  // The fieldless special operands are inert for ordinary register/SIMD access
+  // (asserted above), but each still reports its architectural special register
+  // through to_special_reg_class() -- the special-effect counterpart of
+  // to_register_ref(). The ordinary sdst carries no special class.
+  EXPECT_EQ(sdst->to_special_reg_class(), std::nullopt);
+  EXPECT_EQ(inst->dst_operand(1)->to_special_reg_class(), RegClass::EXEC);
+  EXPECT_EQ(inst->dst_operand(2)->to_special_reg_class(), RegClass::SCC);
+  EXPECT_EQ(inst->src_operand(1)->to_special_reg_class(), RegClass::EXEC);
+
   EXPECT_EQ(inst->disassemble(), "s_and_saveexec_b64 s[0:1], s[0:1]");
 }
 

--- a/emulation/rocjitsu/tests/patch/instrumentor_test.cpp
+++ b/emulation/rocjitsu/tests/patch/instrumentor_test.cpp
@@ -309,27 +309,6 @@ TEST(Validator, RejectsNegativeInstructionSize) {
   EXPECT_NE(err.find("size must be 4 or 8"), std::string::npos) << "error was: " << err;
 }
 
-TEST(SpillPolicy, EmptySpillSetPasses) {
-  RegisterSet spill_set;
-  std::string err;
-  EXPECT_TRUE(check_spill_policy(spill_set, SpillPolicy::NoSpillsSupported, &err));
-  EXPECT_TRUE(err.empty()) << err;
-}
-
-TEST(SpillPolicy, NamesSpecialRegistersInDiagnostic) {
-  // Spill sets are normally projected to ordinary registers before they reach
-  // check_spill_policy, but the diagnostic must still name any special member
-  // by its architectural name rather than emitting "?0".
-  RegisterSet spill_set;
-  spill_set.expand(RegisterRef{RegClass::EXEC, 0, 1});
-  spill_set.expand(RegisterRef{RegClass::SCC, 0, 1});
-  std::string err;
-  EXPECT_FALSE(check_spill_policy(spill_set, SpillPolicy::NoSpillsSupported, &err));
-  EXPECT_NE(err.find("exec"), std::string::npos) << err;
-  EXPECT_NE(err.find("scc"), std::string::npos) << err;
-  EXPECT_EQ(err.find('?'), std::string::npos) << err;
-}
-
 //==============================================================================
 // Section 1b: validate_inline_nop_plan
 //
@@ -1581,6 +1560,23 @@ TEST(InstrumentorSpill, PlanVgprSpillsRejectsNonVgpr) {
   EXPECT_FALSE(plan_vgpr_spills(spill, spills, ROCJITSU_CODE_ARCH_CDNA4, out, &err));
   EXPECT_TRUE(out.empty());
   EXPECT_NE(err.find("s7"), std::string::npos);
+}
+
+// A special register (EXEC/SCC/...) in the spill set is named by its
+// architectural name -- def/use surfaces special singletons, so a
+// consumer that forgets to project them out must still get a readable diagnostic.
+TEST(InstrumentorSpill, PlanVgprSpillsNamesSpecialRegisters) {
+  RegisterSet spill;
+  spill.expand(RegisterRef{RegClass::EXEC, 0, 1});
+  spill.expand(RegisterRef{RegClass::SCC, 0, 1});
+  SpillManager spills(0, 4096);
+  std::vector<SpillSlot> out;
+  std::string err;
+  EXPECT_FALSE(plan_vgpr_spills(spill, spills, ROCJITSU_CODE_ARCH_CDNA4, out, &err));
+  EXPECT_TRUE(out.empty());
+  EXPECT_NE(err.find("exec"), std::string::npos) << err;
+  EXPECT_NE(err.find("scc"), std::string::npos) << err;
+  EXPECT_EQ(err.find('?'), std::string::npos) << err;
 }
 
 // An offset past the CDNA4 12-bit FLAT field fails even within the scratch limit.

--- a/emulation/rocjitsu/tests/patch/instrumentor_test.cpp
+++ b/emulation/rocjitsu/tests/patch/instrumentor_test.cpp
@@ -309,6 +309,27 @@ TEST(Validator, RejectsNegativeInstructionSize) {
   EXPECT_NE(err.find("size must be 4 or 8"), std::string::npos) << "error was: " << err;
 }
 
+TEST(SpillPolicy, EmptySpillSetPasses) {
+  RegisterSet spill_set;
+  std::string err;
+  EXPECT_TRUE(check_spill_policy(spill_set, SpillPolicy::NoSpillsSupported, &err));
+  EXPECT_TRUE(err.empty()) << err;
+}
+
+TEST(SpillPolicy, NamesSpecialRegistersInDiagnostic) {
+  // Spill sets are normally projected to ordinary registers before they reach
+  // check_spill_policy, but the diagnostic must still name any special member
+  // by its architectural name rather than emitting "?0".
+  RegisterSet spill_set;
+  spill_set.expand(RegisterRef{RegClass::EXEC, 0, 1});
+  spill_set.expand(RegisterRef{RegClass::SCC, 0, 1});
+  std::string err;
+  EXPECT_FALSE(check_spill_policy(spill_set, SpillPolicy::NoSpillsSupported, &err));
+  EXPECT_NE(err.find("exec"), std::string::npos) << err;
+  EXPECT_NE(err.find("scc"), std::string::npos) << err;
+  EXPECT_EQ(err.find('?'), std::string::npos) << err;
+}
+
 //==============================================================================
 // Section 1b: validate_inline_nop_plan
 //

--- a/emulation/rocjitsu/tests/patch/probe_clobber_test.cpp
+++ b/emulation/rocjitsu/tests/patch/probe_clobber_test.cpp
@@ -178,10 +178,11 @@ TEST(ProbeClobber, DetectsExplicitFlatScratchWrite) {
   EXPECT_FALSE(summary->touches_m0);
 }
 
-// A body that writes both an ordinary SGPR (s5) and EXEC. InstDefUse now carries
-// EXEC as a singleton member of its def set, but ordinary_clobbers is built from
-// the ordinary projection, so s5 must appear there while no special member does.
-// The EXEC write is still surfaced separately via touches_exec.
+// A body that writes both an ordinary SGPR (s5) and EXEC (via the s_mov_b32
+// exec_lo selector). ordinary_clobbers is built from InstDefUse's ordinary
+// projection, so s5 appears there while no special member does. The
+// selector-encoded EXEC write is not surfaced by InstDefUse; it is caught
+// separately by scan_special_state and reported via touches_exec.
 TEST(ProbeClobber, SpecialWritesDoNotLeakIntoOrdinaryClobbers) {
   const auto callable = make_callable({kSMovS5_0, kSMovExecLo_0, kSSetpcS30S31});
   std::string err;

--- a/emulation/rocjitsu/tests/patch/probe_clobber_test.cpp
+++ b/emulation/rocjitsu/tests/patch/probe_clobber_test.cpp
@@ -178,5 +178,19 @@ TEST(ProbeClobber, DetectsExplicitFlatScratchWrite) {
   EXPECT_FALSE(summary->touches_m0);
 }
 
+// A body that writes both an ordinary SGPR (s5) and EXEC. InstDefUse now carries
+// EXEC as a singleton member of its def set, but ordinary_clobbers is built from
+// the ordinary projection, so s5 must appear there while no special member does.
+// The EXEC write is still surfaced separately via touches_exec.
+TEST(ProbeClobber, SpecialWritesDoNotLeakIntoOrdinaryClobbers) {
+  const auto callable = make_callable({kSMovS5_0, kSMovExecLo_0, kSSetpcS30S31});
+  std::string err;
+  const auto summary = build_probe_clobber_summary(callable, &err);
+  ASSERT_TRUE(summary.has_value()) << err;
+  EXPECT_TRUE(has_sgpr(summary->ordinary_clobbers, 5));
+  EXPECT_FALSE(summary->ordinary_clobbers.has_specials());
+  EXPECT_TRUE(summary->touches_exec);
+}
+
 } // namespace
 } // namespace rocjitsu

--- a/emulation/rocjitsu/tests/patch/spill_manager_test.cpp
+++ b/emulation/rocjitsu/tests/patch/spill_manager_test.cpp
@@ -362,6 +362,36 @@ TEST(SpillManager, ReserveSet_HandlesEmpty) {
   EXPECT_EQ(m.total_private_bytes(), before);
 }
 
+// A set containing a special singleton (EXEC/VCC/...) has no scratch slot, so
+// reserve must fail cleanly and reserve NOTHING — not even its ordinary members,
+// and without tripping the post-capacity-check assert on the special reg.
+TEST(SpillManager, ReserveSet_FailsCleanlyOnSpecialRegisters) {
+  RegisterSet set;
+  set.expand(sgpr(0));
+  set.expand(RegisterRef{RegClass::EXEC, 0, 1});
+
+  SpillManager m(0, kBigLimit);
+  EXPECT_FALSE(m.reserve(set));
+  EXPECT_EQ(m.total_private_bytes(), 0u);
+  EXPECT_EQ(m.offset_for(sgpr(0)), std::nullopt);
+}
+
+// The ordinary_only() projection of a set with specials is reservable — the
+// ordinary members allocate normally once the special is projected out.
+TEST(SpillManager, ReserveSet_OrdinaryProjectionIsReservable) {
+  RegisterSet set;
+  set.expand(sgpr(0));
+  set.expand(vgpr(3));
+  set.expand(RegisterRef{RegClass::VCC, 0, 1});
+
+  SpillManager m(0, kBigLimit);
+  ASSERT_FALSE(m.reserve(set)); // specials present -> clean fail
+  EXPECT_TRUE(m.reserve(set.ordinary_only()));
+  EXPECT_EQ(m.total_private_bytes(), 8u);
+  EXPECT_TRUE(m.offset_for(sgpr(0)).has_value());
+  EXPECT_TRUE(m.offset_for(vgpr(3)).has_value());
+}
+
 TEST(SpillManager, AllocateSlotReturnsNulloptOnOverflow) {
   SpillManager m(0, /*limit=*/8);
   EXPECT_TRUE(m.allocate_slot(sgpr(0)).has_value());

--- a/emulation/rocjitsu/tests/scalar_scc_test.cpp
+++ b/emulation/rocjitsu/tests/scalar_scc_test.cpp
@@ -312,6 +312,16 @@ void expect_wrexec_def_use(const ScalarSccProfile &profile, const WrexecPair &pa
         << profile.name << " " << mnemonic;
     EXPECT_EQ(def_use.defs.ordinary_size(), static_cast<size_t>(width))
         << profile.name << " " << mnemonic;
+
+    // wrexec reads and writes EXEC and sets SCC: these fieldless special
+    // operands are singleton members of the def/use sets (outside the ordinary
+    // projection asserted above).
+    EXPECT_TRUE(def_use.uses.contains(RegisterRef{RegClass::EXEC, 0, 1}))
+        << profile.name << " " << mnemonic;
+    EXPECT_TRUE(def_use.defs.contains(RegisterRef{RegClass::EXEC, 0, 1}))
+        << profile.name << " " << mnemonic;
+    EXPECT_TRUE(def_use.defs.contains(RegisterRef{RegClass::SCC, 0, 1}))
+        << profile.name << " " << mnemonic;
   }
 }
 
@@ -718,6 +728,8 @@ TEST(ScalarSccTest, AddkAndMulkRegisterDestinationRead) {
           << profile.name << " " << mnemonic;
       // The implicit SCC def is a special member of defs; the ordinary
       // projection is just the s4 read-modify-write.
+      EXPECT_EQ(def_use.defs.contains(RegisterRef{RegClass::SCC, 0, 1}), sets_scc)
+          << profile.name << " " << mnemonic;
       EXPECT_EQ(def_use.uses.ordinary_size(), 1u) << profile.name << " " << mnemonic;
       EXPECT_EQ(def_use.defs.ordinary_size(), 1u) << profile.name << " " << mnemonic;
     }

--- a/emulation/rocjitsu/tests/scalar_scc_test.cpp
+++ b/emulation/rocjitsu/tests/scalar_scc_test.cpp
@@ -285,10 +285,10 @@ void expect_wrexec_def_use(const ScalarSccProfile &profile, const WrexecPair &pa
 
     const RegisterRef source{RegClass::SGPR, kSourceSgpr, width};
     const RegisterRef destination{RegClass::SGPR, kDestSgpr, width};
-    // The implicit EXEC read/write and SCC def are modeled as inert fieldless
-    // operands (to_register_ref() == nullopt): they add to the operand counts
-    // but contribute nothing to def/use at this time. The field-bearing SGPR
-    // source/dest stay at index 0.
+    // The implicit EXEC read/write and SCC def are fieldless special operands
+    // (to_register_ref() == nullopt): they become singleton special members of
+    // the def/use sets, but stay out of the ordinary projection asserted below.
+    // The field-bearing SGPR source/dest stay at index 0.
     ASSERT_EQ(inst->num_src_operands(), 2) << profile.name << " " << mnemonic;
     ASSERT_EQ(inst->num_dst_operands(), 3) << profile.name << " " << mnemonic;
     EXPECT_EQ(inst->src_operand(0)->to_register_ref(), source) << profile.name << " " << mnemonic;
@@ -308,8 +308,10 @@ void expect_wrexec_def_use(const ScalarSccProfile &profile, const WrexecPair &pa
     EXPECT_FALSE(def_use.uses.contains(destination)) << profile.name << " " << mnemonic;
     EXPECT_TRUE(def_use.defs.contains(destination)) << profile.name << " " << mnemonic;
     EXPECT_FALSE(def_use.defs.contains(source)) << profile.name << " " << mnemonic;
-    EXPECT_EQ(def_use.uses.size(), static_cast<size_t>(width)) << profile.name << " " << mnemonic;
-    EXPECT_EQ(def_use.defs.size(), static_cast<size_t>(width)) << profile.name << " " << mnemonic;
+    EXPECT_EQ(def_use.uses.ordinary_size(), static_cast<size_t>(width))
+        << profile.name << " " << mnemonic;
+    EXPECT_EQ(def_use.defs.ordinary_size(), static_cast<size_t>(width))
+        << profile.name << " " << mnemonic;
   }
 }
 
@@ -689,8 +691,9 @@ TEST(ScalarSccTest, AddkAndMulkRegisterDestinationRead) {
       ASSERT_NE(inst, nullptr) << profile.name << " " << mnemonic;
       ASSERT_EQ(std::string_view(inst->mnemonic()), mnemonic) << profile.name;
 
-      // s_addk_i32 sets SCC, modeled as an inert fieldless dst operand;
-      // s_mulk_i32 does not touch SCC. SCC carries no def/use either way.
+      // s_addk_i32 sets SCC through a fieldless dst operand (no RegisterRef);
+      // s_mulk_i32 does not. InstDefUse records that SCC write as a singleton
+      // special member of defs, kept out of the ordinary projection below.
       const bool sets_scc = mnemonic != std::string_view{"s_mulk_i32"};
       ASSERT_EQ(inst->num_src_operands(), 2) << profile.name << " " << mnemonic;
       ASSERT_EQ(inst->num_dst_operands(), sets_scc ? 2 : 1) << profile.name << " " << mnemonic;
@@ -713,8 +716,10 @@ TEST(ScalarSccTest, AddkAndMulkRegisterDestinationRead) {
           << profile.name << " " << mnemonic;
       EXPECT_TRUE(def_use.defs.contains(RegisterRef{RegClass::SGPR, 4, 1}))
           << profile.name << " " << mnemonic;
-      EXPECT_EQ(def_use.uses.size(), 1u) << profile.name << " " << mnemonic;
-      EXPECT_EQ(def_use.defs.size(), 1u) << profile.name << " " << mnemonic;
+      // The implicit SCC def is a special member of defs; the ordinary
+      // projection is just the s4 read-modify-write.
+      EXPECT_EQ(def_use.uses.ordinary_size(), 1u) << profile.name << " " << mnemonic;
+      EXPECT_EQ(def_use.defs.ordinary_size(), 1u) << profile.name << " " << mnemonic;
     }
   }
 }


### PR DESCRIPTION
## Summary

Quick Note: This combines PR #9112 and PR #9230 into a single PR since it seemed that the original "split" design of #9112 was not necessary.  I have attempted to address the comments that are still relevant from those PRs in this one.

Fold the architectural special registers (EXEC/VCC/SCC/M0/FLAT_SCRATCH/ TTMP/PC) into `RegisterSet` as a compact singleton mask alongside the ordinary SGPR/VGPR/AccVGPR bitsets, and record them as def/use effects in `InstDefUse`. Fieldless special operands map to their `RegClass` via the generated `Operand::to_special_reg_class()`, driven by a shared fieldless operand policy table in the amdisa codegen.

Updated liveness consumers to use `RegisterSet::ordinary_only()` so special registers are not actually used yet.

Important note: special registers named as a generic operand (e.g. `exec_lo` on OPR_SDST) are *not* handled here yet. This is deferred for a follow-up. I expect to submit the follow-up as a stacked PR soon.

## Issue Tracking

This is the next step in Issue #8625.

## Test Plan

* Added a tests to verify that representative instructions have the correct special defs/uses

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
