### PR TITLE
test(rccl): add unit test for net_ib peer-memory client detection

### DIFF
--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -433,6 +433,8 @@ set(SRC_FILES
   transport/net_ib/connect.cc
   transport/net_ib/connect.h
   transport/net_ib/gdr.cc
+  transport/net_ib/gdr_peermem.cc
+  transport/net_ib/gdr_peermem.h
   transport/net_ib/gin.cc
   transport/net_ib/gin.h
   transport/net_ib/init.cc

--- a/projects/rccl/src/transport/net_ib/gdr.cc
+++ b/projects/rccl/src/transport/net_ib/gdr.cc
@@ -7,8 +7,7 @@
 
 #include "common.h"
 #include "graph/xml.h"
-
-#include <dirent.h>
+#include "gdr_peermem.h"
 
 // Detect whether GDR can work on a given NIC with the current CUDA device
 // Returns :
@@ -42,19 +41,7 @@ static void ibGdrSupportInitOnce() {
     const char* memory_peers_paths[] = {"/sys/kernel/mm/memory_peers", "/sys/kernel/memory_peers",
                                         "/sys/memory_peers", NULL};
 
-    for (int i = 0; memory_peers_paths[i] && ncclIbGdrModuleLoaded == 0; ++i) {
-      DIR* dir = opendir(memory_peers_paths[i]);
-      if (dir == NULL) continue;
-      struct dirent* entry;
-      while ((entry = readdir(dir)) != NULL) {
-        if (entry->d_name[0] == '.') continue;
-        if (entry->d_type != DT_DIR && entry->d_type != DT_UNKNOWN) continue;
-        ncclIbGdrModuleLoaded = 1;
-        INFO(NCCL_INIT, "Found peer memory client %s/%s", memory_peers_paths[i], entry->d_name);
-        break;
-      }
-      closedir(dir);
-    }
+    if (ncclIbScanPeerMemClients(memory_peers_paths)) ncclIbGdrModuleLoaded = 1;
 
     char strValue[MAX_STR_LEN];
     (void)ncclTopoGetStrFromSys("/sys/devices/virtual/dmi/id", "bios_version", strValue);

--- a/projects/rccl/src/transport/net_ib/gdr_peermem.cc
+++ b/projects/rccl/src/transport/net_ib/gdr_peermem.cc
@@ -1,0 +1,29 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See LICENSE.txt for more license information
+ *************************************************************************/
+
+#include "gdr_peermem.h"
+#include "debug.h"
+
+#include <dirent.h>
+
+int ncclIbScanPeerMemClients(const char* const* basePaths) {
+  int found = 0;
+  for (int i = 0; basePaths[i] && found == 0; ++i) {
+    DIR* dir = opendir(basePaths[i]);
+    if (dir == NULL) continue;
+    struct dirent* entry;
+    while ((entry = readdir(dir)) != NULL) {
+      if (entry->d_name[0] == '.') continue;
+      if (entry->d_type != DT_DIR && entry->d_type != DT_UNKNOWN) continue;
+      found = 1;
+      INFO(NCCL_INIT, "Found peer memory client %s/%s", basePaths[i], entry->d_name);
+      break;
+    }
+    closedir(dir);
+  }
+  return found;
+}

--- a/projects/rccl/src/transport/net_ib/gdr_peermem.h
+++ b/projects/rccl/src/transport/net_ib/gdr_peermem.h
@@ -1,0 +1,20 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See LICENSE.txt for more license information
+ *************************************************************************/
+
+#ifndef NCCL_GDR_PEERMEM_H_
+#define NCCL_GDR_PEERMEM_H_
+
+// Scan a NULL-terminated list of `memory_peers` base directories for a registered
+// peer-memory client. A real client registers itself as a named subdirectory (e.g.
+// `amdkfd`), so the presence of any such subdirectory means a client is loaded.
+//
+// The base-path list is passed in (rather than hardcoded) so the detection can be
+// exercised against a mock sysfs tree in unit tests. Returns 1 if a client
+// subdirectory is found in any of the given paths, 0 otherwise.
+int ncclIbScanPeerMemClients(const char* const* basePaths);
+
+#endif  // NCCL_GDR_PEERMEM_H_

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -428,6 +428,24 @@ if(BUILD_TESTS)
     endif()
   endif()
 
+  # rccl-UnitTestsGdr: Compiles the net_ib peer-memory detection helper
+  # (gdr_peermem.cc) directly so the sysfs scan can be exercised against a mock
+  # `memory_peers` tree in a temp directory. The helper is pure (no HIP, no
+  # librccl.so symbols, no GPU), so this target builds in Release and Debug.
+  list(APPEND RCCL_TEST_EXECUTABLES rccl-UnitTestsGdr)
+
+  set(TEST_GDR_SOURCE_FILES
+    GdrPeerMemTests.cpp
+    ../src/transport/net_ib/gdr_peermem.cc
+    common/main_altrsmi.cpp
+  )
+
+  add_executable(rccl-UnitTestsGdr ${TEST_GDR_SOURCE_FILES})
+
+  # GdrPeerMemTests.cpp and gdr_peermem.cc include the helper header from its
+  # source directory (net_ib is not on the default test include path).
+  target_include_directories(rccl-UnitTestsGdr PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src/transport/net_ib)
+
   # Create separate MPI test binary if MPI tests are enabled
   if(ENABLE_MPI_TESTS)
     set(MPI_TEST_SOURCE_FILES

--- a/projects/rccl/test/GdrPeerMemTests.cpp
+++ b/projects/rccl/test/GdrPeerMemTests.cpp
@@ -1,0 +1,133 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#include "gdr_peermem.h"
+#include "debug.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <filesystem>
+#include <string>
+#include <system_error>
+#include <unistd.h>
+
+// Weak stub for ncclDebugLog, required because gdr_peermem.cc uses the debug.h
+// INFO() macro. Debug builds: ncclDebugLog is exported from librccl.so
+// (-fvisibility=default), so the strong shared-library definition wins at link
+// time and this stub is unused. Release builds: ncclDebugLog is hidden in
+// librccl.so (-fvisibility=hidden), so this stub provides the symbol and drops logs.
+// Mirrors the pattern in test/AltRsmiTests.cpp.
+void __attribute__((weak)) ncclDebugLog(ncclDebugLogLevel, unsigned long, const char*, int, const char*, ...) {}
+
+namespace RcclUnitTesting {
+
+namespace {
+namespace fs = std::filesystem;
+
+// Each test gets its own PID-scoped sandbox directory so parallel CI runs and
+// leftover state from a previous run cannot collide.
+class GdrPeerMem : public ::testing::Test {
+ protected:
+  std::string root_;
+
+  void SetUp() override {
+    const char* name = ::testing::UnitTest::GetInstance()->current_test_info()->name();
+    root_ = (fs::temp_directory_path() / ("gdr_peermem_test_" + std::to_string(getpid())) / name).string();
+    std::error_code ec;
+    fs::remove_all(root_, ec);
+    fs::create_directories(root_);
+  }
+
+  void TearDown() override {
+    std::error_code ec;
+    fs::remove_all(root_, ec);
+  }
+
+  // Absolute path to `rel` inside this test's sandbox.
+  std::string Path(const std::string& rel) { return (fs::path(root_) / rel).string(); }
+
+  void MakeDir(const std::string& rel) { fs::create_directories(Path(rel)); }
+
+  void MakeFile(const std::string& rel) {
+    std::FILE* f = std::fopen(Path(rel).c_str(), "w");
+    ASSERT_NE(f, nullptr) << "failed to create " << Path(rel);
+    std::fclose(f);
+  }
+};
+
+}  // namespace
+
+// A registered client (named subdirectory) is detected.
+TEST_F(GdrPeerMem, ClientPresent_SubdirDetected) {
+  MakeDir("memory_peers/amdkfd");
+  const std::string base = Path("memory_peers");
+  const char* paths[] = {base.c_str(), nullptr};
+  EXPECT_EQ(ncclIbScanPeerMemClients(paths), 1);
+}
+
+// An existing but empty memory_peers directory means no client is loaded. This
+// is the false-positive case the sysfs approach fixes relative to the kallsyms scan.
+TEST_F(GdrPeerMem, NoClient_EmptyDir) {
+  MakeDir("memory_peers");
+  const std::string base = Path("memory_peers");
+  const char* paths[] = {base.c_str(), nullptr};
+  EXPECT_EQ(ncclIbScanPeerMemClients(paths), 0);
+}
+
+// opendir() returns NULL for an absent base path; detection must simply skip it.
+TEST_F(GdrPeerMem, NoClient_AbsentPath) {
+  const std::string base = Path("does_not_exist");
+  const char* paths[] = {base.c_str(), nullptr};
+  EXPECT_EQ(ncclIbScanPeerMemClients(paths), 0);
+}
+
+// A regular file in memory_peers (e.g. a stray `version`) is not a client and
+// must not trigger detection.
+TEST_F(GdrPeerMem, FilesOnly_NotDetected) {
+  MakeDir("memory_peers");
+  MakeFile("memory_peers/version");
+  const std::string base = Path("memory_peers");
+  const char* paths[] = {base.c_str(), nullptr};
+  EXPECT_EQ(ncclIbScanPeerMemClients(paths), 0);
+}
+
+// A hidden subdirectory (leading dot) is skipped, proving the dotfile filter
+// rejects real entries and not just "." / "..".
+TEST_F(GdrPeerMem, HiddenSubdirIgnored) {
+  MakeDir("memory_peers/.hidden");
+  const std::string base = Path("memory_peers");
+  const char* paths[] = {base.c_str(), nullptr};
+  EXPECT_EQ(ncclIbScanPeerMemClients(paths), 0);
+}
+
+// The scan walks the list in order: a client found in a later base path is
+// detected even when earlier ones are absent.
+TEST_F(GdrPeerMem, MultipleBasePaths_SecondHasClient) {
+  MakeDir("second/amdkfd");
+  const std::string p0 = Path("first_absent");
+  const std::string p1 = Path("second");
+  const char* paths[] = {p0.c_str(), p1.c_str(), nullptr};
+  EXPECT_EQ(ncclIbScanPeerMemClients(paths), 1);
+}
+
+// A match in the first base path short-circuits: detection succeeds without
+// requiring the remaining paths to exist.
+TEST_F(GdrPeerMem, FirstMatchShortCircuits) {
+  MakeDir("first/amdkfd");
+  const std::string p0 = Path("first");
+  const std::string p1 = Path("second_absent");
+  const char* paths[] = {p0.c_str(), p1.c_str(), nullptr};
+  EXPECT_EQ(ncclIbScanPeerMemClients(paths), 1);
+}
+
+// NOTE: the DT_UNKNOWN acceptance branch (a dirent whose type the filesystem
+// does not report) cannot be forced deterministically here — tmpfs/ext4 fill
+// d_type with concrete values (DT_DIR/DT_REG), so readdir never returns
+// DT_UNKNOWN for these sandbox entries. The DT_DIR-accept and DT_REG-reject
+// paths above cover the behavior that matters in practice.
+
+}  // namespace RcclUnitTesting

--- a/projects/rccl/tools/scripts/test_runner/configs/ci-precheckin.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/ci-precheckin.json
@@ -183,6 +183,17 @@
         {"name": "VersionInfoTests", "description": "HIP/ROCm version string formatting tests", "test_filter": "VersionInfoTests.*"},
         {"name": "GinDeviceTest", "description": "GIN proxy backend device-leaf tests", "test_filter": "GinDeviceTest.*"}
       ]
+    },
+    "unit_tests_gdr": {
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsGdr",
+      "num_ranks": 1,
+      "num_nodes": 1,
+      "num_gpus": 1,
+      "timeout": 60,
+      "tests": [
+        {"name": "GdrPeerMem", "description": "net_ib peer-memory client sysfs detection (mock memory_peers tree)", "test_filter": "GdrPeerMem.*"}
+      ]
     }
   },
   "test_suites": [
@@ -196,6 +207,12 @@
       "name": "RCCL Unit Tests - Fixtures",
       "description": "rccl-UnitTestsFixtures (header-level tests including MiscTests.Sorter)",
       "config": "unit_tests_fixtures",
+      "enabled": true
+    },
+    {
+      "name": "RCCL Unit Tests - GDR Peer-Memory Detection",
+      "description": "rccl-UnitTestsGdr (net_ib memory_peers sysfs scan, CPU-only)",
+      "config": "unit_tests_gdr",
       "enabled": true
     }
   ]


### PR DESCRIPTION
## Motivation

PR #9540 replaces the unreliable `/proc/kallsyms` peer-memory detection in
`net_ib/gdr.cc` with a `memory_peers` sysfs scan, but it merged with **no unit
test** (the policy bot flagged "source changed without an accompanying unit
test"). This PR adds that coverage.

It targets the PR #9540 branch so the test lands together with the fix.

## Technical Details

The detection was previously an inline `opendir`/`readdir` loop inside
`ibGdrSupportInitOnce()`, coupled to a `static` global and `std::call_once` —
not directly testable. This extracts the scan into a small, pure helper that
takes the base-path list as a parameter:

```c
int ncclIbScanPeerMemClients(const char* const* basePaths);
```

`gdr.cc` now calls it with the production sysfs paths; the test passes paths to
a mock `memory_peers` tree in a temp directory. This also starts on the helper
extraction @amd-arozanov requested in review (scoped to `net_ib` here;
`net_ib_cast` still has its own copy).

A standalone gtest target, `rccl-UnitTestsGdr`, compiles the helper directly
(no HIP, no `librccl.so` symbols, no GPU), following the existing
`rccl-UnitTestsAltRsmi` precedent for sysfs-probing code.

## Issue Tracking

JIRA ID : AICOMRCCL-1662

## Test Plan

Built RCCL with tests on the MI300X (gfx942) / ROCm 7.0.2 cluster and ran the
new suite:

```
./install.sh -t --amdgpu_targets=gfx942
./build/release/test/rccl-UnitTestsGdr --gtest_filter=GdrPeerMem.*
```

Cases: client present (subdir detected), empty dir, absent path, files-only
(no false positive), hidden subdir ignored, client in a later base path, and
first-match short-circuit.

## Test Result

`librccl` builds cleanly with the refactor and all 7 cases pass:

```
[==========] Running 7 tests from 1 test suite.
[----------] 7 tests from GdrPeerMem
[       OK ] GdrPeerMem.ClientPresent_SubdirDetected
[       OK ] GdrPeerMem.NoClient_EmptyDir
[       OK ] GdrPeerMem.NoClient_AbsentPath
[       OK ] GdrPeerMem.FilesOnly_NotDetected
[       OK ] GdrPeerMem.HiddenSubdirIgnored
[       OK ] GdrPeerMem.MultipleBasePaths_SecondHasClient
[       OK ] GdrPeerMem.FirstMatchShortCircuits
[  PASSED  ] 7 tests.
```

Note: the `DT_UNKNOWN` acceptance branch isn't deterministically reproducible on
tmpfs/ext4 (they populate `d_type`), so it's documented in the test rather than
asserted.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
