### PR TITLE
Enable contrib/nccl_m2n M2N reshard on ROCm + AINIC CI (Group D)

### DIFF
--- a/.github/workflows/ainic_test_runner.yml
+++ b/.github/workflows/ainic_test_runner.yml
@@ -10,18 +10,30 @@
 #   Group A - NetIbMPI + GIN component/unit gtests (rccl-UnitTestsMPI binary).
 #   Group B - NCCL_NET plugin x knobs sweep on rccl-tests perf binaries.
 #   Group C - IONIC hardware counter validation.
+#   Group D - nccl_m2n M2N reshard (contrib/nccl_m2n binaries: reshard_bench
+#             and basic_api_test_{local,mpi}); single node.
 #
 # Triggers: manual (workflow_dispatch), nightly (schedule) against the default
 # branch, and label-gated on PRs -- add the "ainic-test" label to run a fast
-# smoke subset (Group A + selected B suites). Not a required merge gate.
+# smoke subset (Group A + selected B suites + the Group D functional reshard
+# matrices). Not a required merge gate.
 #
 # Build strategy: the runner is a SLURM submit node with no local GPUs, so
 # everything runs inside one SLURM batch job (sbatch --wait) on the GPU compute
 # nodes. Phase 0 builds RCCL fresh with --enable-mpi-tests from this run's own
 # checkout on the compute node (install.sh defaults -j to $(nproc), using all of
-# the node's cores). Both groups then run against that same fresh build: Group A
-# uses the freshly built rccl-UnitTestsMPI gtest binary; Group B/C uses prebuilt
-# rccl-tests perf binaries that load the fresh librccl.so via LD_LIBRARY_PATH.
+# the node's cores). It also builds contrib/nccl_m2n against that fresh librccl
+# via the rccl_tests_build_configuration hook (Group D binaries). All groups then
+# run against that same fresh build: Group A uses the freshly built
+# rccl-UnitTestsMPI gtest binary; Group B/C uses prebuilt rccl-tests perf binaries
+# that load the fresh librccl.so via LD_LIBRARY_PATH; Group D uses the freshly
+# built nccl_m2n binaries linked against the fresh librccl.so.
+#
+# Group D note: the reshard user-window path requires the AINIC/ionic runtime env
+# (RCCL_AINIC_ROCE / IONIC_LOCKFREE / NCCL_SOCKET_IFNAME), which --system ainic
+# applies; without it the reshard hangs. D1-D8 (basic_api_test_*) are gtest
+# binaries that only build when GTEST_DIR points at a prebuilt googletest tree;
+# D9-D16 (reshard_bench) need no gtest and always build.
 name: AINIC RCCL Test Runner
 
 on:
@@ -91,6 +103,11 @@ env:
   # Prebuilt rccl-tests perf binaries for Group B/C (they load librccl.so at
   # runtime via LD_LIBRARY_PATH; see the build-strategy note in the header).
   DEFAULT_RCCL_TESTS_BIN: /it-share/rccl-ci/rccl-tests-2.30.4/bin
+  # Googletest for the Group D functional tests (D1-D8 basic_api_test_*). Built
+  # once from this ROCm-mirrored tarball into GTEST_DIR and cached under the
+  # shared CI root (see the Phase -1 step). reshard_bench (D9-D16) needs no gtest.
+  GTEST_URL: https://rocm-third-party-deps.s3.us-east-2.amazonaws.com/googletest-1.16.0.tar.gz
+  GTEST_DIR_CACHE: /it-share/rccl-ci/gtest-prebuilt
   # SLURM allocation defaults (single source of truth; workflow_dispatch inputs
   # override them when non-empty).
   DEFAULT_SALLOC_PARTITION: amd-tw
@@ -101,8 +118,11 @@ env:
   DEFAULT_SALLOC_EXCLUDE: ''
   # PR subset for the label-gated path: Group A component gtests + selected B
   # suites (IB baseline, CAST full alltoall, autodetect on/off, ROCM-IB no
-  # offload, CTS force-override, and the full-range guard). Skips B3-B7 and C1.
-  SMOKE_SUITES: 'A*. Component*,B1.*,B2.*,B8.*,B9.*,B10.*,B11.*,B12.*'
+  # offload, CTS force-override, and the full-range guard) + the Group D
+  # functional reshard matrices D1-D4 (single-process local) and D5-D8 (MPI) --
+  # the 51-case (world 4) and 192-case (world 8) RING/DIRECT sweeps. Skips B3-B7,
+  # C1, and D9-D16 (the reshard_bench matrix runs nightly, not on the PR smoke).
+  SMOKE_SUITES: 'A*. Component*,B1.*,B2.*,B8.*,B9.*,B10.*,B11.*,B12.*,D1-D4.*,D5-D8.*'
 
 jobs:
   ainic-test-runner:
@@ -169,28 +189,34 @@ jobs:
         run: |
           set -o pipefail
 
-          # Split TEST_SUITES (or default to "everything") into a Group A glob
-          # and a Group B/C glob for --suite-name, since the two groups need
-          # different RCCL_BUILD_DIR/RCCL_TESTS_BIN and must run as separate
-          # test_runner.py invocations (its build dir is a single global value
-          # for the whole process). All Group A test_suites entries are named
-          # "A<n>. Component - ..." in ainic.json.
+          # Split TEST_SUITES (or default to "everything") into a Group A glob, a
+          # Group B/C glob, and a Group D glob for --suite-name, since the groups
+          # need different RCCL_BUILD_DIR/RCCL_TESTS_BIN/WORKDIR and must run as
+          # separate test_runner.py invocations (its build dir is a single global
+          # value for the whole process). All Group A test_suites entries are named
+          # "A<n>. Component - ..." and all Group D entries "D<n>..." in ainic.json.
+          # The B/C default excludes both A and D via negated globs.
           GROUP_A_FILTER="A*. Component*"
-          GROUP_BC_FILTER="-A*. Component*"
+          GROUP_BC_FILTER="-A*. Component*:-D*"
+          GROUP_D_FILTER="D*"
           RUN_GROUP_A=1
           RUN_GROUP_BC=1
+          RUN_GROUP_D=1
           if [ -n "${TEST_SUITES}" ]; then
             GROUP_A_LIST=""
             GROUP_BC_LIST=""
+            GROUP_D_LIST=""
             IFS=',' read -ra _suite_tokens <<< "${TEST_SUITES}"
             for tok in "${_suite_tokens[@]}"; do
               case "${tok}" in
                 A*". Component"*) GROUP_A_LIST="${GROUP_A_LIST:+${GROUP_A_LIST}:}${tok}" ;;
+                D*)               GROUP_D_LIST="${GROUP_D_LIST:+${GROUP_D_LIST}:}${tok}" ;;
                 *)                GROUP_BC_LIST="${GROUP_BC_LIST:+${GROUP_BC_LIST}:}${tok}" ;;
               esac
             done
             if [ -n "${GROUP_A_LIST}" ]; then GROUP_A_FILTER="${GROUP_A_LIST}"; else RUN_GROUP_A=0; fi
             if [ -n "${GROUP_BC_LIST}" ]; then GROUP_BC_FILTER="${GROUP_BC_LIST}"; else RUN_GROUP_BC=0; fi
+            if [ -n "${GROUP_D_LIST}" ]; then GROUP_D_FILTER="${GROUP_D_LIST}"; else RUN_GROUP_D=0; fi
           fi
 
           # Run inside a SLURM batch job (sbatch, not interactive salloc): it
@@ -213,11 +239,13 @@ jobs:
           fi
 
           # sbatch --export=ALL (default) forwards these to the batch job.
-          export RUN_GROUP_A RUN_GROUP_BC GROUP_A_FILTER GROUP_BC_FILTER \
+          export RUN_GROUP_A RUN_GROUP_BC RUN_GROUP_D \
+                 GROUP_A_FILTER GROUP_BC_FILTER GROUP_D_FILTER \
                  GROUP_A_RCCL_BUILD_DIR GROUP_BC_RCCL_BUILD_DIR GROUP_BC_RCCL_TESTS_BIN \
                  RCCL_BUILD_OVERRIDE \
                  GITHUB_WORKSPACE TEST_RUNNER_DIR RUNNER_TEMP \
-                 WORKDIR MPI_PATH ROCM_PATH
+                 WORKDIR MPI_PATH ROCM_PATH \
+                 RCCL_CI_ROOT GTEST_URL GTEST_DIR_CACHE
 
           BATCH_SCRIPT="${RUNNER_TEMP}/ainic_job.sbatch"
           SLURM_OUT="${RUNNER_TEMP}/ainic_slurm.out"
@@ -231,21 +259,68 @@ jobs:
           cd "${GITHUB_WORKSPACE}/${TEST_RUNNER_DIR}"
           overall_rc=0
 
+          # Phase -1: prepare GTEST_DIR for the Group D functional tests (D1-D8
+          # basic_api_test_*). Makefile.rocm's `tests` target needs a googletest
+          # tree (include/ + lib/libgtest.a, linked -no-pie); reshard_bench (D9-D16)
+          # needs none. Build libgtest.a once from the ROCm-mirrored tarball and
+          # cache it under the shared CI root so later runs reuse it. Only needed
+          # when Group D runs; export GTEST_DIR so the Phase 0
+          # rccl_tests_build_configuration hook (`make ... tests GTEST_DIR=...`)
+          # picks it up.
+          if [ "${RUN_GROUP_D}" = "1" ]; then
+            GTEST_DIR="${GTEST_DIR_CACHE}"
+            if [ ! -f "${GTEST_DIR}/lib/libgtest.a" ] || [ ! -f "${GTEST_DIR}/include/gtest/gtest.h" ]; then
+              echo "================================================================"
+              echo "Phase -1: build+cache googletest -> ${GTEST_DIR}"
+              echo "================================================================"
+              _gt_tmp="$(mktemp -d)"
+              if curl -fsSL "${GTEST_URL}" -o "${_gt_tmp}/gt.tgz" \
+                 && tar -xzf "${_gt_tmp}/gt.tgz" -C "${_gt_tmp}"; then
+                _gt_src="${_gt_tmp}/googletest-1.16.0/googletest"
+                mkdir -p "${GTEST_DIR}/lib"
+                if "${ROCM_PATH}/llvm/bin/clang++" -std=c++17 \
+                       -isystem "${_gt_src}/include" -I"${_gt_src}" \
+                       -c "${_gt_src}/src/gtest-all.cc" -o "${_gt_tmp}/gtest-all.o" \
+                   && ar rcs "${GTEST_DIR}/lib/libgtest.a" "${_gt_tmp}/gtest-all.o"; then
+                  cp -a "${_gt_src}/include" "${GTEST_DIR}/"
+                fi
+              fi
+              rm -rf "${_gt_tmp}"
+            fi
+            if [ -f "${GTEST_DIR}/lib/libgtest.a" ] && [ -f "${GTEST_DIR}/include/gtest/gtest.h" ]; then
+              export GTEST_DIR
+              echo "GTEST_DIR ready: ${GTEST_DIR}"
+            else
+              echo "WARNING: GTEST_DIR prep failed; Group D functional tests (D1-D8)"
+              echo "         will not build. Continuing (reshard_bench D9-D16 still builds)."
+              unset GTEST_DIR
+            fi
+          fi
+
           # Phase 0: build RCCL with --enable-mpi-tests on THIS compute node
           # rather than the 8-core submit node. No RCCL_BUILD_DIR here, so
           # test_runner.py invokes install.sh, which defaults -j to $(nproc) and
           # therefore uses ALL of the compute node's cores. WORKDIR points at this
-          # run's own checkout so install.sh and the build tree resolve there (on
-          # /it-share, shared with every node in the allocation).
+          # run's own checkout (=.../projects/rccl) so install.sh and the build tree
+          # resolve there (on /it-share, shared with every node in the allocation).
+          # This same invocation (no --no-build) also runs the
+          # rccl_tests_build_configuration hook, which builds contrib/nccl_m2n
+          # (Group D binaries) against the just-built librccl. --skip-tests only
+          # skips test execution, not the build steps.
           #
           # When to build:
           #   - Group A always needs a fresh --enable-mpi-tests build (that is
           #     where its rccl-UnitTestsMPI gtest binary comes from).
+          #   - Group D always needs a fresh build too: its nccl_m2n binaries are
+          #     produced by the rccl_tests_build_configuration hook, which only runs
+          #     during a build (non --no-build) invocation, and they must link the
+          #     version-matched fresh librccl.so (a stale prebuilt lib triggers an
+          #     "NCCL library version too old" abort).
           #   - Group B/C needs a build only when NO prebuilt override was given
           #     (RCCL_BUILD_OVERRIDE empty); with an override it loads that
           #     prebuilt librccl.so and the build is skipped.
           NEED_BUILD=0
-          if [ "${RUN_GROUP_A}" = "1" ]; then
+          if [ "${RUN_GROUP_A}" = "1" ] || [ "${RUN_GROUP_D}" = "1" ]; then
             NEED_BUILD=1
           elif [ "${RUN_GROUP_BC}" = "1" ] && [ -z "${RCCL_BUILD_OVERRIDE}" ]; then
             NEED_BUILD=1
@@ -305,6 +380,31 @@ jobs:
             [ "${rc}" -ne 0 ] && overall_rc=1
           else
             echo "SKIP: Group B/C (no matching suites in --suite-name selection)"
+          fi
+
+          if [ "${RUN_GROUP_D}" = "1" ]; then
+            echo "================================================================"
+            echo "Group D: nccl_m2n M2N reshard (fresh nccl_m2n + fresh librccl.so)"
+            echo "================================================================"
+            # WORKDIR mirrors Phase 0 (=.../projects/rccl) so the ${WORKDIR}-based
+            # nccl_m2n binary paths in ainic.json (contrib/nccl_m2n/build/bin/*)
+            # resolve to where the Phase 0 hook built them. RCCL_BUILD_DIR is the
+            # fresh build/debug so the runner loads the version-matched librccl.so
+            # (build dir goes first on LD_LIBRARY_PATH). --system ainic supplies the
+            # ionic runtime env the reshard user-window path requires.
+            WORKDIR="${GITHUB_WORKSPACE}/projects/rccl" \
+            RCCL_BUILD_DIR="${GROUP_A_RCCL_BUILD_DIR}" \
+            python3 test_runner.py \
+              --config configs/ainic.json \
+              --system ainic \
+              --no-build \
+              --suite-name "${GROUP_D_FILTER}" \
+              --report-suffix groupD \
+              2>&1 | tee "${RUNNER_TEMP}/ainic_run_groupD.log"
+            rc=$?
+            [ "${rc}" -ne 0 ] && overall_rc=1
+          else
+            echo "SKIP: Group D (no matching suites in --suite-name selection)"
           fi
 
           exit "${overall_rc}"

--- a/projects/rccl/contrib/nccl_m2n/Makefile.rocm
+++ b/projects/rccl/contrib/nccl_m2n/Makefile.rocm
@@ -1,0 +1,354 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# See LICENSE.txt for more license information.
+
+# ============================================================================
+# ROCm build for the NCCL M2N library (reshard release).
+# ============================================================================
+#
+# This is the AMD/ROCm counterpart of the upstream (NVIDIA) Makefile. It keeps
+# the exact same project structure, source lists and target names as the CUDA
+# build, but swaps the toolchain:
+#
+#   * CUDA -> HIP conversion is done at BUILD TIME with hipify-perl, exactly
+#     like the main RCCL build (cmake/src/CMakeLists.txt) and RCCL's own
+#     standalone tools (tools/topo_expl/Makefile). The upstream CUDA sources
+#     under src/, tests/ and benchmarks/ are NEVER edited in place -- they are
+#     copied into $(HIPIFY_DIR) and hipified there. No hand-hipified .cu/.cc
+#     files are committed to the repository.
+#   * nvcc            -> hipcc
+#   * -lnccl (NCCL)   -> -lrccl (RCCL, built from source)
+#   * nccl_device.h   comes from the RCCL build tree (RCCL_HOME/NCCL_HOME).
+#
+# Usage:
+#   make -f Makefile.rocm              - Build the shared library (default)
+#   make -f Makefile.rocm lib          - Build libnccl_m2n.so
+#   make -f Makefile.rocm tests        - Build basic_api_test_{mpi,local}
+#   make -f Makefile.rocm bench        - Build all benchmarks
+#   make -f Makefile.rocm hipify       - Stage + hipify sources only
+#   make -f Makefile.rocm install      - Install lib + header to PREFIX
+#   make -f Makefile.rocm clean        - Remove all build artifacts
+#   make -f Makefile.rocm help         - Show this help
+#
+# Required environment variables:
+#   NCCL_HOME (or RCCL_HOME) - Path to the RCCL build directory. Must contain
+#                              include/nccl_device.h and librccl.so.
+#
+# Optional environment variables:
+#   ROCM_PATH     - ROCm install (default: /opt/rocm)
+#   RCCL_LIBDIR   - Directory holding librccl.so (default: $(RCCL_HOME))
+#   OFFLOAD_ARCH  - GPU arch (default: gfx950)
+#   GTEST_DIR     - googletest tree with include/ and lib/ (for tests)
+#   MPI_HOME      - MPI install (benchmarks + MPI test); auto-detected via mpicc
+#   PREFIX        - Install prefix (default: /usr/local)
+#   DEBUG         - 1=-g, full=-g -O0
+#   BUILDDIR      - Override build/ output directory
+
+# ── Project root = directory containing this Makefile ──────────────────────
+NCCL_M2N_ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
+# ── Toolchain ──────────────────────────────────────────────────────────────
+ROCM_PATH   ?= /opt/rocm
+HIPCC       := $(ROCM_PATH)/bin/hipcc
+HIPIFY      := $(ROCM_PATH)/bin/hipify-perl
+HIPIFY_FLAGS := -quiet-warnings
+OFFLOAD_ARCH ?= gfx950
+
+# ── ROCm version ───────────────────────────────────────────────────────────
+# RCCL's device headers gate behaviour on ROCM_VERSION, which hipcc does NOT
+# predefine: RCCL's own CMake computes it from $(ROCM_PATH)/.info/version and
+# passes -DROCM_VERSION.  Consumers of those headers must do the same, or the
+# headers silently take their pre-7.0 fallbacks -- for warp-level coop syncs
+# that fallback is a whole-CTA __syncthreads(), which deadlocks any kernel that
+# calls ncclGin::waitSignal() from a subset of its waves.  Same arithmetic as
+# rccl/CMakeLists.txt: 10000*major + 100*minor + patch.
+ROCM_INFO_VERSION_FILE := $(firstword $(wildcard $(ROCM_PATH)/.info/version $(ROCM_PATH)/core/.info/version))
+ifneq ($(ROCM_INFO_VERSION_FILE),)
+    ROCM_VERSION_STRING := $(shell head -n1 $(ROCM_INFO_VERSION_FILE) | tr -d '[:space:]')
+    ROCM_MAJOR_VERSION := $(word 1,$(subst ., ,$(ROCM_VERSION_STRING)))
+    ROCM_MINOR_VERSION := $(word 2,$(subst ., ,$(ROCM_VERSION_STRING)))
+    ROCM_PATCH_VERSION := $(word 3,$(subst ., ,$(ROCM_VERSION_STRING)))
+    ROCM_VERSION ?= $(shell expr 10000 \* $(ROCM_MAJOR_VERSION) + 100 \* $(ROCM_MINOR_VERSION) + $(ROCM_PATCH_VERSION) 2>/dev/null)
+endif
+
+# ── RCCL dependency (device API headers + librccl) ─────────────────────────
+# Keep the upstream env-var name (NCCL_HOME) but point it at the RCCL build so
+# existing tooling/docs stay identical; RCCL_HOME is accepted as an alias.
+RCCL_HOME ?= $(NCCL_HOME)
+RCCL_LIBDIR ?= $(RCCL_HOME)
+
+# ── Required dependency checks (skipped for clean/help/hipify) ─────────────
+NO_DEPS_GOALS := clean help
+SKIP_DEP_CHECK := $(if $(MAKECMDGOALS),$(if $(filter-out $(NO_DEPS_GOALS),$(MAKECMDGOALS)),,1))
+ifeq ($(SKIP_DEP_CHECK),)
+ifeq ($(RCCL_HOME),)
+$(error NCCL_HOME/RCCL_HOME is not set. Point it at your RCCL build dir, e.g. /path/to/rccl/build/debug)
+endif
+ifeq ($(wildcard $(RCCL_HOME)/include/nccl_device.h),)
+$(error $(RCCL_HOME)/include/nccl_device.h not found. RCCL must be built from source (device API enabled).)
+endif
+ifeq ($(wildcard $(HIPCC)),)
+$(error hipcc not found at $(HIPCC). Set ROCM_PATH correctly.)
+endif
+ifeq ($(ROCM_VERSION),)
+$(error Could not determine ROCM_VERSION: no $(ROCM_PATH)/.info/version or $(ROCM_PATH)/core/.info/version. Pass ROCM_VERSION=<10000*major+100*minor+patch> explicitly.)
+endif
+endif
+
+# ── MPI (benchmarks + MPI test only; the library itself does not link MPI) ──
+MPICC ?= mpicc
+ifdef MPI_HOME
+MPI_CFLAGS  := -I$(MPI_HOME)/include
+MPI_LDFLAGS := -L$(MPI_HOME)/lib -lmpi
+else
+MPI_CFLAGS  := $(shell $(MPICC) --showme:compile 2>/dev/null)
+MPI_LDFLAGS := $(shell $(MPICC) --showme:link 2>/dev/null)
+ifeq ($(strip $(MPI_LDFLAGS)),)
+MPI_LDFLAGS := -lmpi
+endif
+endif
+
+# ── Output layout (single shared build/ at the project root) ───────────────
+BUILDDIR   ?= $(NCCL_M2N_ROOT)/build
+LIBDIR     := $(BUILDDIR)/lib
+BINDIR     := $(BUILDDIR)/bin
+INCDIR     := $(BUILDDIR)/include
+HIPIFY_DIR := $(BUILDDIR)/hipify
+
+M2N_LIBNAME       := libnccl_m2n.so
+M2N_LIBTARGET     := $(LIBDIR)/$(M2N_LIBNAME)
+M2N_HEADER_TARGET := $(INCDIR)/nccl_m2n.h
+
+# ── Pristine (CUDA) source trees — never modified in place ─────────────────
+SRCDIR   := $(NCCL_M2N_ROOT)/src
+TESTSDIR := $(NCCL_M2N_ROOT)/tests
+BENCHDIR := $(NCCL_M2N_ROOT)/benchmarks
+
+# ── Hipified (generated) source trees ──────────────────────────────────────
+HSRC   := $(HIPIFY_DIR)/src
+HTESTS := $(HIPIFY_DIR)/tests
+HBENCH := $(HIPIFY_DIR)/benchmarks
+
+# ── Compiler flags ─────────────────────────────────────────────────────────
+CXXSTD   := -std=c++17
+INCLUDES := -isystem $(RCCL_HOME)/include \
+            -isystem $(RCCL_HOME)/include/nccl_device \
+            -I$(HSRC) \
+            -isystem $(NCCL_M2N_ROOT)/third_party
+
+HIPFLAGS := $(CXXSTD) \
+            --offload-arch=$(OFFLOAD_ARCH) \
+            -D__HIP_PLATFORM_AMD__ \
+            -DNCCL_OS_LINUX \
+            -DROCM_VERSION=$(ROCM_VERSION) \
+            -fPIC -Wall -Wno-unused-result -O3 \
+            $(INCLUDES)
+
+ifeq ($(DEBUG),full)
+    HIPFLAGS += -g -O0
+    $(info [DEBUG] Full debug enabled (-g -O0))
+else ifeq ($(DEBUG),1)
+    HIPFLAGS += -g
+    $(info [DEBUG] Debug symbols enabled (-g))
+endif
+
+# Host-only flags (no --offload-arch): used for CUDA TUs that contain no device
+# code (e.g. reshard_model_bench.cu is a pure host JSON-config driver). nvcc
+# discards such host-only code from its device pass automatically; clang-HIP
+# would otherwise try to compile the host-only templates (nlohmann/json) for
+# the device and fail, so we force -x c++ for those TUs.
+HOSTFLAGS := $(CXXSTD) \
+             -D__HIP_PLATFORM_AMD__ \
+             -DNCCL_OS_LINUX \
+             -DROCM_VERSION=$(ROCM_VERSION) \
+             -fPIC -Wall -Wno-unused-result -O3 \
+             -isystem $(ROCM_PATH)/include \
+             $(INCLUDES)
+
+# ── Linker flags ───────────────────────────────────────────────────────────
+LIB_LDFLAGS      := -L$(RCCL_LIBDIR) -lrccl -Wl,-rpath,$(RCCL_LIBDIR)
+M2N_LIB_LDFLAGS  := $(LIB_LDFLAGS) -Wl,-rpath,'$$ORIGIN'
+M2N_CLIENT_LDFLAGS := -L$(LIBDIR) -lnccl_m2n -Wl,-rpath,'$$ORIGIN/../lib'
+BENCH_LDFLAGS    := $(LIB_LDFLAGS) $(MPI_LDFLAGS)
+
+# ── googletest (optional; prebuilt tree with include/ + lib/) ──────────────
+GTEST_DIR ?=
+ifneq ($(GTEST_DIR),)
+GTEST_INC   := $(GTEST_DIR)/include
+GTEST_LIB   := $(GTEST_DIR)/lib
+# Prebuilt libgtest.a is usually non-PIC -> link the test binaries -no-pie.
+GTEST_LDFLAGS := -L$(GTEST_LIB) -lgtest -no-pie
+GTEST_AVAILABLE := $(if $(wildcard $(GTEST_INC)/gtest/gtest.h),1,0)
+else
+GTEST_AVAILABLE := 0
+endif
+
+# ── Source lists (identical to the CUDA Makefiles) ─────────────────────────
+LIB_CC_NAMES := m2n_config.cc reshard_cache.cc reshard_mesh.cc \
+                reshard_loadbalance.cc reshard_prepare.cc reshard_transpose.cc \
+                m2n_init.cc
+LIB_CU_NAMES := reshard_user_window.cu
+LIB_SRC_NAMES := $(LIB_CC_NAMES) $(LIB_CU_NAMES)
+LIB_HDR_NAMES := nccl_m2n.h reshard_types.h reshard_limits.h m2n_checks.h \
+                 m2n_log.h reshard_internal.h reshard_kernels.cuh
+
+TEST_HELPERS_NAME := test_helpers.cu
+TEST_HDR_NAMES    := test_helpers.h basic_api_test_core.h
+TEST_MPI_NAMES    := basic_api_test_mpi.cc   $(TEST_HELPERS_NAME)
+TEST_LOCAL_NAMES  := basic_api_test_local.cc $(TEST_HELPERS_NAME)
+
+BENCH_KERNELS_NAME := bench_common_kernels.cu
+BENCH_NAMES        := reshard_bench.cc $(BENCH_KERNELS_NAME)
+BATCH_BENCH_NAMES  := reshard_batch_bench_user_window.cu
+MODEL_BENCH_NAMES  := reshard_model_bench.cu $(BENCH_KERNELS_NAME)
+
+# Staged (hipified) full paths.
+LIB_SRCS   := $(addprefix $(HSRC)/,$(LIB_SRC_NAMES))
+TEST_MPI_SRCS   := $(addprefix $(HTESTS)/,basic_api_test_mpi.cc) $(HTESTS)/$(TEST_HELPERS_NAME)
+TEST_LOCAL_SRCS := $(addprefix $(HTESTS)/,basic_api_test_local.cc) $(HTESTS)/$(TEST_HELPERS_NAME)
+BENCH_SRCS       := $(HBENCH)/reshard_bench.cc $(HBENCH)/$(BENCH_KERNELS_NAME)
+BATCH_BENCH_SRCS := $(HBENCH)/reshard_batch_bench_user_window.cu
+MODEL_BENCH_SRCS := $(HBENCH)/reshard_model_bench.cu $(HBENCH)/$(BENCH_KERNELS_NAME)
+
+# Sentinel that marks a completed hipify pass (all trees staged + converted).
+HIPIFY_STAMP := $(HIPIFY_DIR)/.hipify.stamp
+
+.PHONY: all lib tests bench basic_api_test_mpi basic_api_test_local \
+        reshard reshard_batch_user_window reshard_model \
+        hipify install clean help
+
+all: lib
+
+# ============================================================================
+# Build-time hipify (RCCL style): copy pristine CUDA sources into $(HIPIFY_DIR)
+# and convert them there with hipify-perl. Upstream sources stay untouched.
+# ============================================================================
+hipify: $(HIPIFY_STAMP)
+
+$(HIPIFY_STAMP): $(addprefix $(SRCDIR)/,$(LIB_SRC_NAMES) $(LIB_HDR_NAMES))
+	@printf ">>> Staging + hipifying sources into $(HIPIFY_DIR) ...\n"
+	@rm -rf $(HIPIFY_DIR)
+	@mkdir -p $(HSRC) $(HTESTS) $(HBENCH)
+	@cp -a $(SRCDIR)/. $(HSRC)/
+	@if [ -d $(TESTSDIR) ]; then cp -a $(TESTSDIR)/. $(HTESTS)/ ; fi
+	@if [ -d $(BENCHDIR) ]; then cp -a $(BENCHDIR)/. $(HBENCH)/ ; fi
+	@# Convert every CUDA TU/header in the staged trees. -inplace rewrites the
+	@# staged copy (leaving a .prehip backup); the originals are never touched.
+	@find $(HSRC) $(HTESTS) $(HBENCH) -type f \
+	    \( -name '*.cu' -o -name '*.cuh' -o -name '*.cc' -o -name '*.h' \) \
+	    -exec $(HIPIFY) -inplace $(HIPIFY_FLAGS) {} + >/dev/null 2>&1 || true
+	@# Drop the .prehip backups so the staged tree only holds HIP sources.
+	@find $(HIPIFY_DIR) -name '*.prehip' -delete
+	@touch $@
+	@printf ">>> Hipify complete.\n"
+
+# ============================================================================
+# Library
+# ============================================================================
+lib: $(M2N_LIBTARGET) $(M2N_HEADER_TARGET)
+
+$(M2N_LIBTARGET): $(HIPIFY_STAMP)
+	@printf "Building $(M2N_LIBNAME) (hipcc, arch=$(OFFLOAD_ARCH)) ...\n"
+	@mkdir -p $(LIBDIR)
+	$(HIPCC) -shared -o $@ $(HIPFLAGS) $(LIB_SRCS) $(M2N_LIB_LDFLAGS)
+	@printf "Done! Library at: $@\n"
+
+$(M2N_HEADER_TARGET): $(HIPIFY_STAMP)
+	@mkdir -p $(INCDIR)
+	cp $(HSRC)/nccl_m2n.h $@
+
+# ============================================================================
+# Tests (gtest)
+# ============================================================================
+ifeq ($(GTEST_AVAILABLE),1)
+tests: basic_api_test_mpi basic_api_test_local
+
+basic_api_test_mpi:   $(BINDIR)/basic_api_test_mpi   ; @:
+basic_api_test_local: $(BINDIR)/basic_api_test_local ; @:
+
+$(BINDIR)/basic_api_test_mpi: $(M2N_LIBTARGET)
+	@printf "Building basic_api_test_mpi (hipcc, gtest, MPI) ...\n"
+	@mkdir -p $(BINDIR)
+	$(HIPCC) -o $@ $(HIPFLAGS) $(MPI_CFLAGS) -I$(HTESTS) -isystem $(GTEST_INC) \
+	    $(TEST_MPI_SRCS) $(M2N_CLIENT_LDFLAGS) $(BENCH_LDFLAGS) $(GTEST_LDFLAGS) -lpthread
+	@printf "Done! Test binary at: $@\n"
+
+$(BINDIR)/basic_api_test_local: $(M2N_LIBTARGET)
+	@printf "Building basic_api_test_local (hipcc, gtest, no MPI) ...\n"
+	@mkdir -p $(BINDIR)
+	$(HIPCC) -o $@ $(HIPFLAGS) -I$(HTESTS) -isystem $(GTEST_INC) \
+	    $(TEST_LOCAL_SRCS) $(M2N_CLIENT_LDFLAGS) $(LIB_LDFLAGS) $(GTEST_LDFLAGS) -lpthread
+	@printf "Done! Test binary at: $@\n"
+else
+tests basic_api_test_mpi basic_api_test_local:
+	@echo "tests: googletest not found -- set GTEST_DIR=/path/to/googletest (with include/ + lib/)."
+endif
+
+# ============================================================================
+# Benchmarks
+# ============================================================================
+bench: reshard reshard_batch_user_window reshard_model
+
+reshard:                   $(BINDIR)/reshard_bench                   ; @:
+reshard_batch_user_window: $(BINDIR)/reshard_batch_bench_user_window ; @:
+reshard_model:             $(BINDIR)/reshard_model_bench             ; @:
+
+$(BINDIR)/reshard_bench: $(M2N_LIBTARGET)
+	@printf "Building reshard_bench ...\n"
+	@mkdir -p $(BINDIR)
+	$(HIPCC) -o $@ $(HIPFLAGS) $(MPI_CFLAGS) -I$(HBENCH) \
+	    $(BENCH_SRCS) $(M2N_CLIENT_LDFLAGS) $(BENCH_LDFLAGS)
+	@printf "Done! Benchmark binary at: $@\n"
+
+$(BINDIR)/reshard_batch_bench_user_window: $(M2N_LIBTARGET)
+	@printf "Building reshard_batch_bench_user_window ...\n"
+	@mkdir -p $(BINDIR)
+	$(HIPCC) -o $@ $(HIPFLAGS) $(MPI_CFLAGS) -I$(HBENCH) \
+	    $(BATCH_BENCH_SRCS) $(M2N_CLIENT_LDFLAGS) $(BENCH_LDFLAGS)
+	@printf "Done! Benchmark binary at: $@\n"
+
+# reshard_model_bench.cu is a host-only driver (JSON model/system configs, no
+# device code) -> compile it -x c++ so clang-HIP does not run a device pass on
+# the vendored nlohmann/json templates. The kernels live in the companion
+# bench_common_kernels.cu, which is compiled as HIP.
+$(BINDIR)/reshard_model_bench: $(M2N_LIBTARGET)
+	@printf "Building reshard_model_bench ...\n"
+	@mkdir -p $(BINDIR) $(BUILDDIR)/obj
+	$(HIPCC) -x c++ $(HOSTFLAGS) $(MPI_CFLAGS) -I$(HBENCH) \
+	    -c $(HBENCH)/reshard_model_bench.cu -o $(BUILDDIR)/obj/reshard_model_bench.o
+	$(HIPCC) $(HIPFLAGS) $(MPI_CFLAGS) -I$(HBENCH) \
+	    -c $(HBENCH)/$(BENCH_KERNELS_NAME) -o $(BUILDDIR)/obj/bench_common_kernels.model.o
+	$(HIPCC) -o $@ $(HIPFLAGS) \
+	    $(BUILDDIR)/obj/reshard_model_bench.o $(BUILDDIR)/obj/bench_common_kernels.model.o \
+	    $(M2N_CLIENT_LDFLAGS) $(BENCH_LDFLAGS)
+	@printf "Done! Benchmark binary at: $@\n"
+
+# ============================================================================
+# Install / clean / help
+# ============================================================================
+PREFIX ?= /usr/local
+install: lib
+	@printf "Installing to $(PREFIX) ...\n"
+	@mkdir -p $(PREFIX)/lib $(PREFIX)/include
+	cp $(M2N_LIBTARGET) $(PREFIX)/lib/
+	cp $(M2N_HEADER_TARGET) $(PREFIX)/include/
+	@printf "Done!\n"
+
+clean:
+	rm -rf $(BUILDDIR)
+
+help:
+	@echo "NCCL M2N library — ROCm build (build-time hipify + hipcc, links librccl)"
+	@echo ""
+	@echo "Targets:"
+	@echo "  all (default)        - Build shared library"
+	@echo "  lib                  - Build libnccl_m2n.so"
+	@echo "  hipify               - Stage + hipify sources into build/hipify only"
+	@echo "  tests                - Build basic_api_test_{mpi,local} (needs GTEST_DIR)"
+	@echo "  bench                - Build all benchmarks"
+	@echo "  install              - Install lib + header to PREFIX"
+	@echo "  clean                - Remove all build artifacts"
+	@echo ""
+	@echo "Required: NCCL_HOME (or RCCL_HOME) -> RCCL build dir with include/nccl_device.h + librccl.so"
+	@echo "Optional: ROCM_PATH, RCCL_LIBDIR, OFFLOAD_ARCH (default gfx950),"
+	@echo "          GTEST_DIR, MPI_HOME, PREFIX, DEBUG, BUILDDIR"

--- a/projects/rccl/contrib/nccl_m2n/src/reshard_cache.cc
+++ b/projects/rccl/contrib/nccl_m2n/src/reshard_cache.cc
@@ -7,6 +7,7 @@
 
 #include <cstdio>
 #include <cstring>
+#include <mutex>
 #include <vector>
 #include "nccl.h"
 
@@ -51,6 +52,15 @@ static int gDevcommCacheNextIdx = 0;
  * explicitly there before the vector is cleared. */
 static std::vector<StreamPoolEntry> gStreamPool;
 
+/* Guards all process-global caches above. In single-process / multi-rank
+ * (one host thread per rank, all sharing this address space) every rank thread
+ * hits these globals concurrently. Without this lock the non-atomic count and
+ * vector updates race, so ranks disagree on whether a cached devComm exists and
+ * a subset skips the COLLECTIVE ncclDevCommCreate -> deadlock. Recursive so the
+ * public helpers stay composable; never held across ncclDevCommCreate itself
+ * (that call happens outside these helpers, in the reshard hot path). */
+static std::recursive_mutex gCacheMutex;
+
 static ncclWindow_t* findCachedWindowByPtr(WindowCache* cache, ncclComm_t comm, void* buffer, size_t size) {
   for (int i = 0; i < cache->count; i++) {
     WindowCacheEntry& e = cache->entries[i];
@@ -81,17 +91,28 @@ static ncclResult_t cacheWindow(WindowCache* cache, ncclComm_t comm, void* windo
 }
 
 ncclWindow_t* findCachedInternalWindowByPtr(ncclComm_t comm, void* buffer, size_t size) {
+  std::lock_guard<std::recursive_mutex> lk(gCacheMutex);
   return findCachedWindowByPtr(&gInternalWindowCache, comm, buffer, size);
 }
 
 ncclResult_t cacheInternalWindow(ncclComm_t comm, void* buffer, size_t size, ncclWindow_t window) {
+  std::lock_guard<std::recursive_mutex> lk(gCacheMutex);
   return cacheWindow(&gInternalWindowCache, comm, buffer, size, window);
 }
 
 ncclDevComm* findCachedDevComm(ncclComm_t comm, int numCtas, int signalCount, cudaStream_t stream) {
+  std::lock_guard<std::recursive_mutex> lk(gCacheMutex);
   for (int i = 0; i < gDevcommCacheCount; i++) {
     DevCommCacheEntry& e = gDevcommCache[i];
-    if (e.valid && e.comm == comm && e.numCtas == numCtas && e.ginSignalCount == signalCount && e.stream == stream)
+    // NOTE: intentionally NOT keyed on `stream`. ncclDevCommCreate takes no
+    // stream and the devComm it returns is not stream-bound, so a raw
+    // cudaStream_t is a poor key: callers that destroy+recreate streams get
+    // recycled handle values that alias stale entries, and in single-process /
+    // multi-rank that aliasing diverges per rank -- some ranks hit and skip the
+    // COLLECTIVE ncclDevCommCreate while others miss and call it, deadlocking.
+    // Keying on (comm, numCtas, signalCount) keeps the create/reuse decision
+    // identical across ranks.
+    if (e.valid && e.comm == comm && e.numCtas == numCtas && e.ginSignalCount == signalCount)
       return &e.devComm;
   }
   return nullptr;
@@ -99,6 +120,7 @@ ncclDevComm* findCachedDevComm(ncclComm_t comm, int numCtas, int signalCount, cu
 
 ncclResult_t cacheDevComm(ncclComm_t comm, int numCtas, int signalCount, const ncclDevComm* devComm,
                           cudaStream_t stream) {
+  std::lock_guard<std::recursive_mutex> lk(gCacheMutex);
   int idx;
   if (gDevcommCacheCount >= MAX_DEVCOMM_CACHE_ENTRIES) {
     idx = gDevcommCacheNextIdx;
@@ -120,6 +142,7 @@ ncclResult_t cacheDevComm(ncclComm_t comm, int numCtas, int signalCount, const n
 }
 
 void cacheFinalize() {
+  std::lock_guard<std::recursive_mutex> lk(gCacheMutex);
   for (int i = 0; i < gInternalWindowCache.count; i++) {
     WindowCacheEntry& e = gInternalWindowCache.entries[i];
     if (e.valid) {
@@ -148,6 +171,7 @@ void cacheFinalize() {
 
 ncclResult_t streamPoolAcquire(ncclComm_t comm, int dev, cudaStream_t* outStream, cudaEvent_t* outEvent) {
   if (outStream == nullptr || outEvent == nullptr) return ncclInvalidArgument;
+  std::lock_guard<std::recursive_mutex> lk(gCacheMutex);
   /* Pool disabled (NCCL_RESHARD_STREAM_POOL_SIZE <= 0) — caller
    * should have gated on reshardGetStreamPoolSize() > 0; defend
    * anyway so a forgotten gate doesn't UB. */

--- a/projects/rccl/contrib/nccl_m2n/src/reshard_transpose.cc
+++ b/projects/rccl/contrib/nccl_m2n/src/reshard_transpose.cc
@@ -6,6 +6,8 @@
  ************************************************************************/
 
 #include <cstdio>
+#include <mutex>
+#include <vector>
 #include "cuda_runtime.h"
 #include "nccl.h"
 #include "reshard_types.h"
@@ -22,15 +24,32 @@
  *
  * Growth (high-water-mark): the old buffer is parked in gRetired and
  * freed only at finalization.  This avoids any cudaDeviceSynchronize
- * or cudaStreamSynchronize on the hot path.
+ * or cudaStreamSynchronize on the hot path.  In single-process /
+ * multi-rank every rank thread shares this one pool, so the retired
+ * list accumulates one entry per rank per growth; it is an unbounded
+ * vector rather than a fixed array so a legitimate run with many ranks
+ * and buffer growths never spuriously fails.  gRetired only holds
+ * pointers -- the backing VRAM is bounded by the high-water sizes and
+ * reclaimed together in transposeBufferFinalize.
  * ====================================================================*/
 
 static TransposeBufferEntry gPool[MAX_TRANSPOSE_BUFFER_ENTRIES];
 static int gPoolCount = 0;
 
-#define MAX_RETIRED_BUFFERS (MAX_TRANSPOSE_BUFFER_ENTRIES * 2)
-static void* gRetired[MAX_RETIRED_BUFFERS];
-static int gRetiredCount = 0;
+static std::vector<void*> gRetired;
+
+/* Guards the process-global transpose buffer pool. In single-process /
+ * multi-rank (one host thread per rank sharing this address space) every rank
+ * thread calls ensureTransposeBuffer / getTransposeBuffer* concurrently on the
+ * same globals. Without this lock the non-atomic gPoolCount++ and gPool[] /
+ * gRetired[] writes race: a rank can read a torn count or half-written slot,
+ * miss its own comm's entry, and end up with a wrong buffer/capacity. Since
+ * getTransposeBufferCapacity() feeds the internal-window cache key, that in
+ * turn makes ranks disagree on whether the transpose window is already
+ * registered -- a subset then skips the COLLECTIVE ncclCommWindowRegister and
+ * the reshard deadlocks. All allocation here is local (ncclMemAlloc), never a
+ * collective, so holding this lock across the body is deadlock-free. */
+static std::mutex gTransposeMutex;
 
 static TransposeBufferEntry* findPoolEntry(ncclComm_t comm) {
   for (int i = 0; i < gPoolCount; i++)
@@ -39,6 +58,7 @@ static TransposeBufferEntry* findPoolEntry(ncclComm_t comm) {
 }
 
 ncclResult_t ensureTransposeBuffer(ncclComm_t comm, size_t requiredBytes, cudaStream_t stream) {
+  std::lock_guard<std::mutex> lk(gTransposeMutex);
   TransposeBufferEntry* entry = findPoolEntry(comm);
 
   if (entry != nullptr) {
@@ -50,18 +70,11 @@ ncclResult_t ensureTransposeBuffer(ncclComm_t comm, size_t requiredBytes, cudaSt
     if (entry->capacity >= requiredBytes) return ncclSuccess;
 
     /* Growth: retire the old buffer and allocate a larger one. */
-    if (gRetiredCount >= MAX_RETIRED_BUFFERS) {
-      fprintf(stderr,
-              "[nccl-reshard] Transpose retired-buffer list full (%d); "
-              "too many buffer growths.\n",
-              MAX_RETIRED_BUFFERS);
-      return ncclInternalError;
-    }
     RESHARD_DEBUG(-1,
                   "Transpose buffer growing for comm %p: %zu -> %zu bytes "
                   "(retiring %p)",
                   (void*)comm, entry->capacity, requiredBytes, entry->buffer);
-    gRetired[gRetiredCount++] = entry->buffer;
+    gRetired.push_back(entry->buffer);
     entry->buffer = nullptr;
     entry->capacity = 0;
 
@@ -97,22 +110,26 @@ ncclResult_t ensureTransposeBuffer(ncclComm_t comm, size_t requiredBytes, cudaSt
 }
 
 void* getTransposeBuffer(ncclComm_t comm) {
+  std::lock_guard<std::mutex> lk(gTransposeMutex);
   TransposeBufferEntry* e = findPoolEntry(comm);
   return (e != nullptr) ? e->buffer : nullptr;
 }
 
 size_t getTransposeBufferCapacity(ncclComm_t comm) {
+  std::lock_guard<std::mutex> lk(gTransposeMutex);
   TransposeBufferEntry* e = findPoolEntry(comm);
   return (e != nullptr) ? e->capacity : 0;
 }
 
 ncclResult_t transposeBufferRecordEvent(ncclComm_t comm, cudaStream_t stream) {
+  std::lock_guard<std::mutex> lk(gTransposeMutex);
   TransposeBufferEntry* e = findPoolEntry(comm);
   if (e != nullptr) NCCL_M2N_CUDACHECK(cudaEventRecord(e->event, stream));
   return ncclSuccess;
 }
 
 void transposeBufferFinalize() {
+  std::lock_guard<std::mutex> lk(gTransposeMutex);
   for (int i = 0; i < gPoolCount; i++) {
     if (gPool[i].event != nullptr) cudaEventDestroy(gPool[i].event);
     if (gPool[i].buffer != nullptr) ncclMemFree(gPool[i].buffer);
@@ -120,13 +137,10 @@ void transposeBufferFinalize() {
   }
   gPoolCount = 0;
 
-  for (int i = 0; i < gRetiredCount; i++) {
-    if (gRetired[i] != nullptr) {
-      ncclMemFree(gRetired[i]);
-      gRetired[i] = nullptr;
-    }
+  for (void* buf : gRetired) {
+    if (buf != nullptr) ncclMemFree(buf);
   }
-  gRetiredCount = 0;
+  gRetired.clear();
 }
 
 bool shouldTransposeForCrossDim(const size_t* srcDimsBytes, const size_t* dstDimsBytes, int ndims, int srcShardDim,

--- a/projects/rccl/contrib/nccl_m2n/src/reshard_user_window.cu
+++ b/projects/rccl/contrib/nccl_m2n/src/reshard_user_window.cu
@@ -53,6 +53,20 @@
 #define NCCL_RESHARD_GIN_FINAL_FENCE ncclGinFenceLevel::Relaxed
 #endif
 
+/* The cooperative-group types used below (ncclCoopWarp, ncclCoopWarpSpan)
+ * account for threads in units of the target's native warp/wavefront: 64 lanes
+ * on AMD GFX9, 32 on NVIDIA.  The warp partitioning in these kernels must use
+ * that same unit.  A ncclCoopWarpSpan built from 32-thread warps on a 64-lane
+ * wave claims twice as many warps as the span actually holds leaders for, and
+ * its sync() then waits for arrivals that can never happen -> device-side
+ * deadlock on AMD.  Upstream hardcodes 32; use the target's real warp size.
+ */
+#if defined(WARP_SIZE)
+#define NCCL_RESHARD_WARP_SIZE WARP_SIZE
+#else
+#define NCCL_RESHARD_WARP_SIZE 32
+#endif
+
 // ============================================================================
 // Byte-level transpose kernel: [D0, D1, D2] -> [D0, D2, D1]  (row-major)
 // ============================================================================
@@ -99,8 +113,15 @@ __global__ __launch_bounds__(DEFAULT_KERNEL_MAX_NTHREADS, 1) void reshardKernelU
   ncclTeam world = ncclTeamWorld(devComm);
   ncclTeam lsa = ncclTeamLsa(devComm);
 
-  int warpId = threadIdx.x / 32;
-  int laneId = threadIdx.x % 32;
+  int warpId = threadIdx.x / NCCL_RESHARD_WARP_SIZE;
+  int laneId = threadIdx.x % NCCL_RESHARD_WARP_SIZE;
+
+  /* Required before the first ncclCoopWarpSpan::sync() below: where the target
+   * has no hardware named barriers the span is emulated with a shared
+   * sense-reversing barrier whose slots must be zeroed first.  No-op on targets
+   * that do have named barriers.
+   */
+  ncclCoopNamedBarrierInit();
 
   // [USER-WINDOW] Local pointer comes from the GLOBAL window.  Offset is
   // zero by contract but
@@ -130,7 +151,7 @@ __global__ __launch_bounds__(DEFAULT_KERNEL_MAX_NTHREADS, 1) void reshardKernelU
 
   // SOURCE: send data to targets
   if (params.isSource) {
-    int activeSrcWarps = min(MAX_SRC_WARPS, (int)(blockDim.x / 32));
+    int activeSrcWarps = min(MAX_SRC_WARPS, (int)(blockDim.x / NCCL_RESHARD_WARP_SIZE));
     if (warpId < activeSrcWarps) {
       for (int t = warpId; t < params.numTargets; t += activeSrcWarps) {
         ncclReshardTargetInfo& target = params.targets[t];
@@ -177,7 +198,7 @@ __global__ __launch_bounds__(DEFAULT_KERNEL_MAX_NTHREADS, 1) void reshardKernelU
 
   // DEST: receive and replicate
   if (params.isDest && params.numSources > 0) {
-    int warpsPerCta = blockDim.x / 32;
+    int warpsPerCta = blockDim.x / NCCL_RESHARD_WARP_SIZE;
     int activeSources = min(params.numSources, min(warpsPerCta, (int)MAX_WARP_GROUPS));
     int warpsPerSource = warpsPerCta / activeSources;
     if (warpsPerSource < 1) warpsPerSource = 1;
@@ -223,8 +244,8 @@ __global__ __launch_bounds__(DEFAULT_KERNEL_MAX_NTHREADS, 1) void reshardKernelU
         // [USER-WINDOW] LSA fan-out via the global window keyed by
         // world-rank arithmetic.
         if (params.numLocalFollowers > 0 && myStart < totalSize) {
-          int threadsInGroup = warpsPerSource * 32;
-          int threadInGroup = warpInGroup * 32 + laneId;
+          int threadsInGroup = warpsPerSource * NCCL_RESHARD_WARP_SIZE;
+          int threadInGroup = warpInGroup * NCCL_RESHARD_WARP_SIZE + laneId;
 
           char* srcPtr = localBuffer + plan.dstBaseOffset + myStart;
           size_t chunkSize = myEnd - myStart;
@@ -263,8 +284,8 @@ __global__ __launch_bounds__(DEFAULT_KERNEL_MAX_NTHREADS, 1) void reshardKernelU
           // [USER-WINDOW] LSA fan-out via the global window for
           // strided chunks.
           if (params.numLocalFollowers > 0 && thisBytes > 0) {
-            int threadsInGroup = warpsPerSource * 32;
-            int threadInGroup = warpInGroup * 32 + laneId;
+            int threadsInGroup = warpsPerSource * NCCL_RESHARD_WARP_SIZE;
+            int threadInGroup = warpInGroup * NCCL_RESHARD_WARP_SIZE + laneId;
 
             const size_t inner = plan.innerSize;
             size_t lsaIter = byteStart / inner;
@@ -327,8 +348,8 @@ directReshardKernelUserWindow(
 
   ncclTeam world = ncclTeamWorld(devComm);
 
-  int warpId = threadIdx.x / 32;
-  int laneId = threadIdx.x % 32;
+  int warpId = threadIdx.x / NCCL_RESHARD_WARP_SIZE;
+  int laneId = threadIdx.x % NCCL_RESHARD_WARP_SIZE;
 
   __shared__ uint64_t initialSignals[MAX_DIRECT_SOURCES];
   // Compile-time guard: shared-array dim must be at least the prep-side cap

--- a/projects/rccl/tools/scripts/test_runner/configs/ainic.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/ainic.json
@@ -1,7 +1,7 @@
 {
   "system_configurations": {
     "name": "RCCL-AINIC",
-    "description": "AINIC test plan. Group A: NetIbMPI + GIN component/unit tests (2 nodes x 1 GPU = 2 ranks). Group B: NCCL_NET plugin x knobs sweep on rccl-tests perf (2 nodes x 8 GPU = 16 ranks), including out-of-the-box autodetect. Group C: IONIC hardware counter validation. Run on the AINIC cluster with --system ainic."
+    "description": "AINIC test plan. Group A: NetIbMPI + GIN component/unit tests (2 nodes x 1 GPU = 2 ranks). Group B: NCCL_NET plugin x knobs sweep on rccl-tests perf (2 nodes x 8 GPU = 16 ranks), including out-of-the-box autodetect. Group C: IONIC hardware counter validation. Group D: nccl_m2n M2N reshard functional matrix (single node) - single-process (local) and multi-process (MPI), world 4 (51 cases) and world 8 (192 cases), RING and DIRECT, plus the reshard_bench --validate data-correctness matrix. Run on the AINIC cluster with --system ainic."
   },
   "paths": {
     "workdir": "${WORKDIR:-$PWD}",
@@ -28,6 +28,15 @@
   "build_configuration": {
     "install_flags": ["--debug", "-t", "--amdgpu_targets", "gfx950", "--log-trace", "--enable-mpi-tests", "--no_clean"],
     "cmake_options": "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
+  },
+
+  "rccl_tests_build_configuration": {
+    "enabled": true,
+    "source_dir": "${WORKDIR:-$PWD}/contrib/nccl_m2n",
+    "build_command": "make -f Makefile.rocm -j lib bench tests OFFLOAD_ARCH=gfx950 GTEST_DIR=${GTEST_DIR:-} MPICC=${MPI_PATH:-/it-share/ompi-5.0.8}/bin/mpicc",
+    "env_variables": {
+      "NCCL_M2N_BUILD_NOTE": "Builds contrib/nccl_m2n (libnccl_m2n.so + reshard_bench + basic_api_test_{local,mpi}) against the librccl built above via Makefile.rocm. RCCL_HOME/NCCL_HOME/ROCM_PATH/MPI_HOME are exported by the runner. reshard_bench needs no gtest; the functional tests (Group D D1-D8) need a prebuilt googletest - set GTEST_DIR in the CI environment (tree with include/ + lib/), otherwise the make 'tests' target no-ops and only the bench (D9-D16) binaries are produced. Output goes to contrib/nccl_m2n/build/bin (see Group D test_binary_dir)."
+    }
   },
 
   "test_configurations": {
@@ -435,6 +444,67 @@
         { "name": "C1_alltoall_counters_ROCMIB", "binary": "alltoall_perf", "command_args": "-b 1M -e 128M -f 2 -g 1", "env_variables": { "NCCL_NET": "ROCM-IB" }, "description": "IONIC counters (tx_rdma_ucast_bytes) non-zero and BW > 10 GB/s on the ROCM-IB backend. Capped at 128M to keep the counter run fast; large-size coverage lives in b_large_alltoall_repro." },
         { "name": "C1_allreduce_counters_ROCMIB", "binary": "all_reduce_perf", "command_args": "-b 1G -e 8G -f 2 -g 1", "env_variables": { "NCCL_NET": "ROCM-IB" }, "description": "IONIC counter validation on allreduce over the ROCM-IB backend." }
       ]
+    },
+
+    "d_m2n_base": {
+      "is_gtest": true,
+      "num_ranks": 1,
+      "num_nodes": 1,
+      "num_gpus": 8,
+      "timeout": 1200,
+      "description": "nccl_m2n M2N reshard base (single node). Binaries come from the contrib/nccl_m2n Makefile.rocm build (see rccl_tests_build_configuration); children set an absolute ${WORKDIR}-based binary path (build/bin) so the runner resolves them directly rather than from the rccl-tests dir. Symmetric-window RDMA path: keep CUMEM on and scratch-reclaim off. Children pin the world size via num_gpus (local, one thread per visible GPU) or num_ranks (MPI, one process per rank); the algorithm is a CLI flag, so no gtest filter is needed - each run executes the full parameterised case matrix (51 cases at world 4, 192 at world 8).",
+      "env_variables": {
+        "NCCL_CUMEM_ENABLE": "1",
+        "HSA_NO_SCRATCH_RECLAIM": "1"
+      }
+    },
+
+    "d_m2n_local": {
+      "extends": "d_m2n_base",
+      "binary": "${WORKDIR:-$PWD}/contrib/nccl_m2n/build/bin/basic_api_test_local",
+      "description": "D1-D4: single-process multi-rank (ncclCommInitAll, one host thread per GPU). World size = visible GPUs, so num_gpus selects the 192-case (8) or 51-case (4) matrix.",
+      "tests": [
+        { "name": "D1_local_ring_w8",   "command_args": "--algorithm ring",   "num_gpus": 8, "description": "Single-process 8-rank RING, full 192-case reshard matrix." },
+        { "name": "D2_local_direct_w8", "command_args": "--algorithm direct", "num_gpus": 8, "description": "Single-process 8-rank DIRECT, full 192-case reshard matrix." },
+        { "name": "D3_local_ring_w4",   "command_args": "--algorithm ring",   "num_gpus": 4, "description": "Single-process 4-rank RING, 51-case reshard matrix." },
+        { "name": "D4_local_direct_w4", "command_args": "--algorithm direct", "num_gpus": 4, "description": "Single-process 4-rank DIRECT, 51-case reshard matrix." }
+      ]
+    },
+
+    "d_m2n_mpi": {
+      "extends": "d_m2n_base",
+      "binary": "${WORKDIR:-$PWD}/contrib/nccl_m2n/build/bin/basic_api_test_mpi",
+      "description": "D5-D8: one rank per process (MPI). num_ranks selects the 192-case (8) or 51-case (4) matrix.",
+      "tests": [
+        { "name": "D5_mpi_ring_w8",   "command_args": "--algorithm ring",   "num_ranks": 8, "description": "MPI 8-rank RING, full 192-case reshard matrix." },
+        { "name": "D6_mpi_direct_w8", "command_args": "--algorithm direct", "num_ranks": 8, "description": "MPI 8-rank DIRECT, full 192-case reshard matrix." },
+        { "name": "D7_mpi_ring_w4",   "command_args": "--algorithm ring",   "num_ranks": 4, "description": "MPI 4-rank RING, 51-case reshard matrix." },
+        { "name": "D8_mpi_direct_w4", "command_args": "--algorithm direct", "num_ranks": 4, "description": "MPI 4-rank DIRECT, 51-case reshard matrix." }
+      ]
+    },
+
+    "d_m2n_bench": {
+      "is_gtest": false,
+      "binary": "${WORKDIR:-$PWD}/contrib/nccl_m2n/build/bin/reshard_bench",
+      "num_ranks": 6,
+      "num_nodes": 1,
+      "num_gpus": 8,
+      "timeout": 1200,
+      "description": "D9-D16: reshard_bench --validate data-correctness matrix (T4). Mesh 1,4 -> 1,2 (6 ranks), RING/DIRECT x same/cross-dim x 3D (256,128,64) / 2D (1024,1024). Fails on any byte mismatch.",
+      "env_variables": {
+        "NCCL_CUMEM_ENABLE": "1",
+        "HSA_NO_SCRATCH_RECLAIM": "1"
+      },
+      "tests": [
+        { "name": "D9_bench_ring_3D_same",     "command_args": "--src-mesh-dims 1,4 --dst-mesh-dims 1,2 --tensor-dims 256,128,64 --src-shard-dim 0 --dst-shard-dim 0 --algorithm ring   --validate --warmup 2 --iterations 3", "description": "RING 3D same-dim reshard, data validated." },
+        { "name": "D10_bench_ring_3D_cross",   "command_args": "--src-mesh-dims 1,4 --dst-mesh-dims 1,2 --tensor-dims 256,128,64 --src-shard-dim 0 --dst-shard-dim 1 --algorithm ring   --validate --warmup 2 --iterations 3", "description": "RING 3D cross-dim reshard, data validated." },
+        { "name": "D11_bench_ring_2D_same",    "command_args": "--src-mesh-dims 1,4 --dst-mesh-dims 1,2 --tensor-dims 1024,1024 --src-shard-dim 0 --dst-shard-dim 0 --algorithm ring   --validate --warmup 2 --iterations 3", "description": "RING 2D same-dim reshard, data validated." },
+        { "name": "D12_bench_ring_2D_cross",   "command_args": "--src-mesh-dims 1,4 --dst-mesh-dims 1,2 --tensor-dims 1024,1024 --src-shard-dim 0 --dst-shard-dim 1 --algorithm ring   --validate --warmup 2 --iterations 3", "description": "RING 2D cross-dim reshard, data validated." },
+        { "name": "D13_bench_direct_3D_same",  "command_args": "--src-mesh-dims 1,4 --dst-mesh-dims 1,2 --tensor-dims 256,128,64 --src-shard-dim 0 --dst-shard-dim 0 --algorithm direct --validate --warmup 2 --iterations 3", "description": "DIRECT 3D same-dim reshard, data validated." },
+        { "name": "D14_bench_direct_3D_cross", "command_args": "--src-mesh-dims 1,4 --dst-mesh-dims 1,2 --tensor-dims 256,128,64 --src-shard-dim 0 --dst-shard-dim 1 --algorithm direct --validate --warmup 2 --iterations 3", "description": "DIRECT 3D cross-dim reshard, data validated." },
+        { "name": "D15_bench_direct_2D_same",  "command_args": "--src-mesh-dims 1,4 --dst-mesh-dims 1,2 --tensor-dims 1024,1024 --src-shard-dim 0 --dst-shard-dim 0 --algorithm direct --validate --warmup 2 --iterations 3", "description": "DIRECT 2D same-dim reshard, data validated." },
+        { "name": "D16_bench_direct_2D_cross", "command_args": "--src-mesh-dims 1,4 --dst-mesh-dims 1,2 --tensor-dims 1024,1024 --src-shard-dim 0 --dst-shard-dim 1 --algorithm direct --validate --warmup 2 --iterations 3", "description": "DIRECT 2D cross-dim reshard, data validated." }
+      ]
     }
   },
 
@@ -462,6 +532,10 @@
     { "name": "B11. CTS force-override (PR#4657)",   "config": "b9_cts_force_override", "enabled": true },
     { "name": "B12. alltoall full-range guard",      "config": "b_large_alltoall_repro", "enabled": true },
 
-    { "name": "C1. IONIC counter validation",        "config": "c_counters",        "enabled": true }
+    { "name": "C1. IONIC counter validation",        "config": "c_counters",        "enabled": true },
+
+    { "name": "D1-D4. M2N reshard local (single-process, world 4/8)", "config": "d_m2n_local", "enabled": true },
+    { "name": "D5-D8. M2N reshard MPI (multi-process, world 4/8)",    "config": "d_m2n_mpi",   "enabled": true },
+    { "name": "D9-D16. M2N reshard_bench --validate matrix",          "config": "d_m2n_bench", "enabled": true }
   ]
 }


### PR DESCRIPTION
## Summary

Stacked on #9651 (which syncs the upstream `contrib/nccl_m2n` source from NVIDIA/nccl, source-only). This PR makes that source **build and run on ROCm** and wires it into the AINIC test runner.

- **ROCm build** (`Makefile.rocm`): build-time hipify + hipcc, links `librccl` instead of `libnccl`; upstream CUDA sources are never edited in place. Produces `libnccl_m2n.so`, `reshard_bench`, and `basic_api_test_{local,mpi}`.
- **AINIC CI (Group D)**: `ainic.json` adds the M2N reshard functional matrix (D1-D8, world 4/8, RING/DIRECT) and the `reshard_bench --validate` data-correctness matrix (D9-D16); `ainic_test_runner.yml` gains Group D routing, a Phase -1 googletest prep step, and a PR smoke subset (D1-D4 + D5-D8). Reuses the generic `rccl_tests_build_configuration` hook (no test_runner Python changes).
- **ROCm correctness fixes** on top of the upstream source:
  - *Reshard kernel warp size*: upstream hardcodes a 32-lane warp; on AMD GFX9 (wave64) a `ncclCoopWarpSpan` built from 32-thread warps deadlocks in `sync()`. Key the partitioning off the target's real `WARP_SIZE` and call `ncclCoopNamedBarrierInit()` before the first span sync.
  - *Process-global cache guards*: in single-process/multi-rank runs the DevComm/window/stream/transpose pools are shared; guard them with a mutex and key the DevComm cache on `(comm, numCtas, signalCount)` (not the recycled `cudaStream_t`) so all ranks make the same collective create/reuse decision.

## Test plan

Built and run on the AINIC cluster (gfx950, ROCm 7.14, librccl 2.30.7):

| Test | Clean upstream nccl_m2n | With ROCm fixes |
|---|---|---|
| D9 `reshard_bench` (MPI 6-rank, `--validate`) | hang at `devCommCreate` | PASS (~12 GB/s) |
| D1 `basic_api_test_local` ring w8 (196 cases) | hang at `case0000` | 192 PASSED, 4 skipped |
| D3 `basic_api_test_local` ring w4 (51 cases) | hang | pass (rc=0) |

- [ ] Full Group D matrix (incl. MPI D5-D8 and DIRECT w8) on a real 2-node topology via `workflow_dispatch` (single-node ionic loopback is CQE/timeout-limited, not a product issue).