### PR TITLE
clr/hip-tests: fix __hip_bfloat16 operator!= to be unordered

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_bf16.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_bf16.h
@@ -1563,7 +1563,7 @@ __BF16_HOST_DEVICE_STATIC__ bool operator==(const __hip_bfloat16& l, const __hip
  * \brief Operator to perform a not equal on two __hip_bfloat16 numbers
  */
 __BF16_HOST_DEVICE_STATIC__ bool operator!=(const __hip_bfloat16& l, const __hip_bfloat16& r) {
-  return __hne(l, r);
+  return __hneu(l, r);
 }
 
 /**

--- a/projects/hip-tests/catch/unit/deviceLib/bfloat16.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/bfloat16.cc
@@ -197,6 +197,27 @@ __global__ void bf16_compare_nan(const float* a, const float* b, unsigned* res, 
   }
 }
 
+// Order of scalar operator results written by bf16_nan_operators().
+enum Bf16NanOp {
+  kOpNeQnan, kOpNeSnan,  // operator!= : unordered -> true for NaN
+  kOpEqQnan, kOpEqSnan,  // operator== : ordered   -> false for NaN
+  kOpNeOne, kOpEqOne,    // sanity: normal value
+  kBf16NanOpCount
+};
+
+__global__ void bf16_nan_operators(unsigned* out) {
+  const __hip_bfloat16 qnan = __ushort_as_bfloat16((unsigned short)0x7FC0U);  // quiet NaN
+  const __hip_bfloat16 snan = __ushort_as_bfloat16((unsigned short)0x7FA0U);  // signaling NaN
+  const __hip_bfloat16 one = __ushort_as_bfloat16((unsigned short)0x3F80U);   // 1.0
+
+  out[kOpNeQnan] = bool_to_unsigned(qnan != qnan);
+  out[kOpNeSnan] = bool_to_unsigned(snan != snan);
+  out[kOpEqQnan] = bool_to_unsigned(qnan == qnan);
+  out[kOpEqSnan] = bool_to_unsigned(snan == snan);
+  out[kOpNeOne] = bool_to_unsigned(one != one);
+  out[kOpEqOne] = bool_to_unsigned(one == one);
+}
+
 // Convert to bits
 __global__ void bf16_conv_bits(float* val, unsigned short* res, size_t size) {
   auto i = threadIdx.x;
@@ -404,6 +425,33 @@ HIP_TEST_CASE(Unit_bf16_basic) {
 
     HIP_CHECK(hipFree(d_a));
     HIP_CHECK(hipFree(d_b));
+    HIP_CHECK(hipFree(d_res));
+  }
+
+  SECTION("NaN operator semantics") {
+    struct OpCase {
+      const char* name;
+      unsigned expected;
+    };
+    static const OpCase kOps[kBf16NanOpCount] = {
+        {"qnan != qnan", 1}, {"snan != snan", 1},
+        {"qnan == qnan", 0}, {"snan == snan", 0},
+        {"one != one", 0},   {"one == one", 1}};
+
+    unsigned* d_res;
+    HIP_CHECK(hipMalloc(&d_res, sizeof(unsigned) * kBf16NanOpCount));
+
+    bf16_nan_operators<<<1, 1>>>(d_res);
+
+    std::vector<unsigned> res(kBf16NanOpCount, 0);
+    HIP_CHECK(hipMemcpy(res.data(), d_res, sizeof(unsigned) * res.size(),
+                        hipMemcpyDeviceToHost));
+
+    for (int p = 0; p < kBf16NanOpCount; p++) {
+      CAPTURE(kOps[p].name);
+      CHECK(res[p] == kOps[p].expected);
+    }
+
     HIP_CHECK(hipFree(d_res));
   }
 


### PR DESCRIPTION
## Motivation

The scalar `__hip_bfloat16 operator!=` returned the wrong result when an operand is NaN: `NaN != NaN` evaluated to `false`. This violates C++/IEEE semantics and breaks the common `x != x` NaN-detection idiom. It was reported via Kokkos `bhalf` qNaN/sNaN test failures (a regression in ROCm 10 that is not present in 7.14 or earlier).

## Technical Details

`operator!=` delegated to the `__hne` intrinsic. `__hne` was (correctly) changed to the *ordered* not-equal (`NaN -> false`) in #8920, but the `operator!=` overload must be the *unordered* not-equal (`NaN != x -> true`). This routes `operator!=` to `__hneu`, matching CUDA, where `__nv_bfloat16 operator!=` maps to `__hneu`. The ordered `__hne` intrinsic fix from #8920 is preserved, and `operator==` continues to use the ordered `__heq`.

Scope is narrow: only the scalar `__hip_bfloat16 operator!=` was affected. The fp16 scalar/vector operators and the `__hip_bfloat162` vector operator already implement `!=` as `!(l == r)` and were correct; all `__hne`/`__hneu` intrinsics were correct.

A regression test is added in `bfloat16.cc` (`bf16_nan_operators` kernel + `NaN operator semantics` section) that exercises the scalar `!=`/`==` operators on qNaN and sNaN. The NaN values are built by bit pattern (`__ushort_as_bfloat16(0x7FC0/0x7FA0)`) so a signaling NaN is not quieted by a `float -> bfloat16` conversion. The pre-existing `Neq Operation` test skipped NaN inputs and only exercised the `__hip_bfloat162` vector operator, which is why this path was uncovered.

## Issue Tracking

JIRA ID: ROCM-29004
Related: #8920 (introduced the ordered `__hne` intrinsic that this PR completes for the operator path).

## Test Plan

- Build hip-tests and run `Unit_bf16_basic`, in particular the new `NaN operator semantics` section.
- Confirm parity with the Kokkos/LLNL reproducer attached to ROCM-29004.

## Test Result

The new `NaN operator semantics` section asserts the target behavior:
`qnan != qnan == 1`, `snan != snan == 1`, `qnan == qnan == 0`, `snan == snan == 0`, plus normal-value sanity (`one != one == 0`, `one == one == 1`).
As verified on ROCM-29004, routing `operator!=` to `__hneu` yields `qnan!=qnan=1` while keeping `__hne(qnan,qnan)=0` and `__hneu(qnan,qnan)=1` (i.e. it fixes the operator without regressing the intrinsic).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
