### PR TITLE
limit unroll 8,16,32 to gfx1250

### DIFF
--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -38,7 +38,7 @@ jobs:
     # Skipped when artifact_run_id is provided (reuse mode). Downstream jobs
     # use `!cancelled()` in their `if:` so they still run when this is skipped.
     if: ${{ inputs.artifact_run_id == '' }}
-    runs-on: aws-linux-rocm-large-dev
+    runs-on: aws-linux-scale-rocm-prod
     permissions:
       id-token: write
     container:

--- a/projects/rccl/src/device/generate.py
+++ b/projects/rccl/src/device/generate.py
@@ -372,14 +372,16 @@ def custom_sort_key(fn: Fn):
 def get_arch_guard(fn):
   cond = None
 
-  if fn.proto == "LL128" and fn.acc == "1":
+  if fn.unroll in ("8", "16", "32"):
+      cond = "defined(__gfx1250__)"
+  elif fn.proto == "LL128" and fn.acc == "1":
       cond = "(defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1250__)) && defined(ENABLE_LL128)"
   elif fn.proto == "LL128":
       cond = "(defined(__gfx90a__) || defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1250__)) && defined(ENABLE_LL128)"
   elif fn.acc == "1":
       cond = "defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1250__)"
-  elif fn.unroll in ("8", "16", "32"):
-      cond = "defined(__gfx1250__)"
+  elif fn.ty in ("f8e4m3", "f8e5m2"):
+      cond = "defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1200__) || defined(__gfx1201__) || defined(__gfx1250__)"
 
   return cond
 
@@ -693,7 +695,7 @@ with open(os.path.join(gensrc, "specialized_files.txt"), "w") as f:
   for filename, func_name, guard, fn in specialized_filelist:
     if fn.unroll in ("8", "16", "32"):
       cmake_guard = "defined(__gfx1250__)"
-      if guard and "ENABLE_LL128" in guard:
+      if fn.proto == "LL128":
         cmake_guard += " && defined(ENABLE_LL128)"
     else:
       cmake_guard = guard or ""

--- a/projects/rccl/src/device/generate.py
+++ b/projects/rccl/src/device/generate.py
@@ -378,6 +378,8 @@ def get_arch_guard(fn):
       cond = "(defined(__gfx90a__) || defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1250__)) && defined(ENABLE_LL128)"
   elif fn.acc == "1":
       cond = "defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1250__)"
+  elif fn.unroll in ("8", "16", "32"):
+      cond = "defined(__gfx1250__)"
 
   return cond
 
@@ -688,7 +690,13 @@ specialized_filelist.sort(key=_compile_cost_key)
 
 # Write the list of specialized files for CMake consumption
 with open(os.path.join(gensrc, "specialized_files.txt"), "w") as f:
-  for filename, func_name, guard, _ in specialized_filelist:
-    f.write("%s %s %s\n" % (filename, func_name, guard or ""))
+  for filename, func_name, guard, fn in specialized_filelist:
+    if fn.unroll in ("8", "16", "32"):
+      cmake_guard = "defined(__gfx1250__)"
+      if guard and "ENABLE_LL128" in guard:
+        cmake_guard += " && defined(ENABLE_LL128)"
+    else:
+      cmake_guard = guard or ""
+    f.write("%s %s %s\n" % (filename, func_name, cmake_guard))
 
 print("-- Generated %d specialized kernel files in %s" % (len(specialized_filelist), specialized_dir))


### PR DESCRIPTION
## Motivation

Address CI failure related to building all unrolls for all architectures.

## Technical Details

Limit unroll 8,16,32 to gfx1250

## Issue Tracking

JIRA ID AICOMRCCL-1666

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
