### PR TITLE
fix(rocdecode,rocjpeg): restrict VA/DRM cmake find modules to TheRock sysdeps only

### DIFF
--- a/projects/rocdecode/CMakeLists.txt
+++ b/projects/rocdecode/CMakeLists.txt
@@ -116,16 +116,6 @@ find_package(Libdrm_amdgpu QUIET)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads QUIET)
 
-# Check Libva version compatibility: requires libva >= 1.22
-if(Libva_FOUND)
-  if("${Libva_VERSION}" VERSION_GREATER_EQUAL "1.22")
-    message("-- ${White}\tLibva Version Supported${ColourReset}")
-  else()
-    set(Libva_FOUND FALSE)
-    message("-- ${Yellow}\tLibva Version Not Supported (found ${Libva_VERSION}, need >= 1.22)${ColourReset}")
-  endif()
-endif()
-
 if(ROCDECODE_ENABLE_ROCPROFILER_REGISTER)
   find_package(rocprofiler-register QUIET
     HINTS $ENV{rocprofiler_register_ROOT} $ENV{ROCPROFILER_REGISTER_ROOT} ${CMAKE_INSTALL_PREFIX}

--- a/projects/rocdecode/cmake/FindLibdrm_amdgpu.cmake
+++ b/projects/rocdecode/cmake/FindLibdrm_amdgpu.cmake
@@ -26,8 +26,8 @@ if(DEFINED THEROCK_SUPERPROJECT_INCLUDE_DIRS)
   list(APPEND _libdrm_amdgpu_include_hints ${THEROCK_SUPERPROJECT_INCLUDE_DIRS})
 endif()
 
-find_library(LIBDRM_AMDGPU_LIBRARY NAMES drm_amdgpu HINTS ${ROCM_PATH}/lib/rocm_sysdeps/lib /opt/amdgpu/lib/x86_64-linux-gnu /opt/amdgpu/lib64 /usr/lib/x86_64-linux-gnu /usr/lib64)
-find_path(LIBDRM_AMDGPU_INCLUDE_DIR NAMES libdrm/amdgpu.h libdrm/amdgpu_drm.h PATHS ${_libdrm_amdgpu_include_hints} ${ROCM_PATH}/lib/rocm_sysdeps/include /opt/amdgpu/include /usr/include /usr/ /usr/local/include NO_DEFAULT_PATH)
+find_library(LIBDRM_AMDGPU_LIBRARY NAMES drm_amdgpu HINTS ${ROCM_PATH}/lib/rocm_sysdeps/lib)
+find_path(LIBDRM_AMDGPU_INCLUDE_DIR NAMES libdrm/amdgpu.h libdrm/amdgpu_drm.h PATHS ${_libdrm_amdgpu_include_hints} ${ROCM_PATH}/lib/rocm_sysdeps/include NO_DEFAULT_PATH)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Libdrm_amdgpu DEFAULT_MSG LIBDRM_AMDGPU_INCLUDE_DIR LIBDRM_AMDGPU_LIBRARY)

--- a/projects/rocdecode/cmake/FindLibdrm_amdgpu.cmake
+++ b/projects/rocdecode/cmake/FindLibdrm_amdgpu.cmake
@@ -24,9 +24,10 @@
 # Search super-project (e.g. libdrm) sysdeps first when building in TheRock
 if(DEFINED THEROCK_SUPERPROJECT_INCLUDE_DIRS)
   list(APPEND _libdrm_amdgpu_include_hints ${THEROCK_SUPERPROJECT_INCLUDE_DIRS})
+  list(APPEND _libdrm_amdgpu_library_hints ${CMAKE_LIBRARY_PATH})
 endif()
 
-find_library(LIBDRM_AMDGPU_LIBRARY NAMES drm_amdgpu HINTS ${ROCM_PATH}/lib/rocm_sysdeps/lib NO_DEFAULT_PATH)
+find_library(LIBDRM_AMDGPU_LIBRARY NAMES drm_amdgpu HINTS ${_libdrm_amdgpu_library_hints} ${ROCM_PATH}/lib/rocm_sysdeps/lib NO_DEFAULT_PATH)
 find_path(LIBDRM_AMDGPU_INCLUDE_DIR NAMES libdrm/amdgpu.h libdrm/amdgpu_drm.h PATHS ${_libdrm_amdgpu_include_hints} ${ROCM_PATH}/lib/rocm_sysdeps/include NO_DEFAULT_PATH)
 
 include(FindPackageHandleStandardArgs)

--- a/projects/rocdecode/cmake/FindLibdrm_amdgpu.cmake
+++ b/projects/rocdecode/cmake/FindLibdrm_amdgpu.cmake
@@ -26,7 +26,7 @@ if(DEFINED THEROCK_SUPERPROJECT_INCLUDE_DIRS)
   list(APPEND _libdrm_amdgpu_include_hints ${THEROCK_SUPERPROJECT_INCLUDE_DIRS})
 endif()
 
-find_library(LIBDRM_AMDGPU_LIBRARY NAMES drm_amdgpu HINTS ${ROCM_PATH}/lib/rocm_sysdeps/lib)
+find_library(LIBDRM_AMDGPU_LIBRARY NAMES drm_amdgpu HINTS ${ROCM_PATH}/lib/rocm_sysdeps/lib NO_DEFAULT_PATH)
 find_path(LIBDRM_AMDGPU_INCLUDE_DIR NAMES libdrm/amdgpu.h libdrm/amdgpu_drm.h PATHS ${_libdrm_amdgpu_include_hints} ${ROCM_PATH}/lib/rocm_sysdeps/include NO_DEFAULT_PATH)
 
 include(FindPackageHandleStandardArgs)

--- a/projects/rocdecode/cmake/FindLibva.cmake
+++ b/projects/rocdecode/cmake/FindLibva.cmake
@@ -26,12 +26,12 @@ if(DEFINED THEROCK_SUPERPROJECT_INCLUDE_DIRS)
   list(APPEND _libva_include_hints ${THEROCK_SUPERPROJECT_INCLUDE_DIRS})
 endif()
 
-find_library(LIBVA_LIBRARY NAMES va HINTS ${ROCM_PATH}/lib/rocm_sysdeps/lib)
-find_library(LIBVA_DRM_LIBRARY NAMES va-drm HINTS ${ROCM_PATH}/lib/rocm_sysdeps/lib)
+find_library(LIBVA_LIBRARY NAMES va HINTS ${ROCM_PATH}/lib/rocm_sysdeps/lib NO_DEFAULT_PATH)
+find_library(LIBVA_DRM_LIBRARY NAMES va-drm HINTS ${ROCM_PATH}/lib/rocm_sysdeps/lib NO_DEFAULT_PATH)
 find_path(LIBVA_INCLUDE_DIR NAMES va/va.h PATHS ${_libva_include_hints} ${ROCM_PATH}/lib/rocm_sysdeps/include NO_DEFAULT_PATH)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(Libva DEFAULT_MSG LIBVA_INCLUDE_DIR LIBVA_LIBRARY)
+find_package_handle_standard_args(Libva DEFAULT_MSG LIBVA_INCLUDE_DIR LIBVA_LIBRARY LIBVA_DRM_LIBRARY)
 mark_as_advanced(LIBVA_INCLUDE_DIR LIBVA_LIBRARY LIBVA_DRM_LIBRARY)
 
 if(Libva_FOUND)

--- a/projects/rocdecode/cmake/FindLibva.cmake
+++ b/projects/rocdecode/cmake/FindLibva.cmake
@@ -26,9 +26,9 @@ if(DEFINED THEROCK_SUPERPROJECT_INCLUDE_DIRS)
   list(APPEND _libva_include_hints ${THEROCK_SUPERPROJECT_INCLUDE_DIRS})
 endif()
 
-find_library(LIBVA_LIBRARY NAMES va HINTS ${ROCM_PATH}/lib/rocm_sysdeps/lib /opt/amdgpu/lib/x86_64-linux-gnu /opt/amdgpu/lib64 /usr/lib/x86_64-linux-gnu /usr/lib64)
-find_library(LIBVA_DRM_LIBRARY NAMES va-drm HINTS ${ROCM_PATH}/lib/rocm_sysdeps/lib /opt/amdgpu/lib/x86_64-linux-gnu /opt/amdgpu/lib64 /usr/lib/x86_64-linux-gnu /usr/lib64)
-find_path(LIBVA_INCLUDE_DIR NAMES va/va.h PATHS ${_libva_include_hints} ${ROCM_PATH}/lib/rocm_sysdeps/include /opt/amdgpu/include /usr/include NO_DEFAULT_PATH)
+find_library(LIBVA_LIBRARY NAMES va HINTS ${ROCM_PATH}/lib/rocm_sysdeps/lib)
+find_library(LIBVA_DRM_LIBRARY NAMES va-drm HINTS ${ROCM_PATH}/lib/rocm_sysdeps/lib)
+find_path(LIBVA_INCLUDE_DIR NAMES va/va.h PATHS ${_libva_include_hints} ${ROCM_PATH}/lib/rocm_sysdeps/include NO_DEFAULT_PATH)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Libva DEFAULT_MSG LIBVA_INCLUDE_DIR LIBVA_LIBRARY)

--- a/projects/rocdecode/cmake/FindLibva.cmake
+++ b/projects/rocdecode/cmake/FindLibva.cmake
@@ -24,10 +24,11 @@
 # Search super-project (e.g. amd-mesa) sysdeps first when building in TheRock
 if(DEFINED THEROCK_SUPERPROJECT_INCLUDE_DIRS)
   list(APPEND _libva_include_hints ${THEROCK_SUPERPROJECT_INCLUDE_DIRS})
+  list(APPEND _libva_library_hints ${CMAKE_LIBRARY_PATH})
 endif()
 
-find_library(LIBVA_LIBRARY NAMES va HINTS ${ROCM_PATH}/lib/rocm_sysdeps/lib NO_DEFAULT_PATH)
-find_library(LIBVA_DRM_LIBRARY NAMES va-drm HINTS ${ROCM_PATH}/lib/rocm_sysdeps/lib NO_DEFAULT_PATH)
+find_library(LIBVA_LIBRARY NAMES va HINTS ${_libva_library_hints} ${ROCM_PATH}/lib/rocm_sysdeps/lib NO_DEFAULT_PATH)
+find_library(LIBVA_DRM_LIBRARY NAMES va-drm HINTS ${_libva_library_hints} ${ROCM_PATH}/lib/rocm_sysdeps/lib NO_DEFAULT_PATH)
 find_path(LIBVA_INCLUDE_DIR NAMES va/va.h PATHS ${_libva_include_hints} ${ROCM_PATH}/lib/rocm_sysdeps/include NO_DEFAULT_PATH)
 
 include(FindPackageHandleStandardArgs)

--- a/projects/rocjpeg/CMakeLists.txt
+++ b/projects/rocjpeg/CMakeLists.txt
@@ -149,16 +149,6 @@ find_package(Libva QUIET)
 find_package(Libdrm_amdgpu QUIET)
 find_package(Threads QUIET)
 
-# Check Libva version compatibility: requires libva >= 1.22
-if(Libva_FOUND)
-  if("${Libva_VERSION}" VERSION_GREATER_EQUAL "1.22")
-    message("-- ${White}\tLibva Version Supported${ColourReset}")
-  else()
-    set(Libva_FOUND FALSE)
-    message("-- ${Yellow}\tLibva Version Not Supported (found ${Libva_VERSION}, need >= 1.22)${ColourReset}")
-  endif()
-endif()
-
 if(ROCJPEG_ENABLE_ROCPROFILER_REGISTER)
   find_package(rocprofiler-register QUIET
     HINTS $ENV{rocprofiler_register_ROOT} $ENV{ROCPROFILER_REGISTER_ROOT} ${CMAKE_INSTALL_PREFIX}

--- a/projects/rocjpeg/cmake/FindLibdrm_amdgpu.cmake
+++ b/projects/rocjpeg/cmake/FindLibdrm_amdgpu.cmake
@@ -26,8 +26,8 @@ if(DEFINED THEROCK_SUPERPROJECT_INCLUDE_DIRS)
   list(APPEND _libdrm_amdgpu_include_hints ${THEROCK_SUPERPROJECT_INCLUDE_DIRS})
 endif()
 
-find_library(LIBDRM_AMDGPU_LIBRARY NAMES drm_amdgpu HINTS ${ROCM_PATH}/lib/rocm_sysdeps/lib /opt/amdgpu/lib/x86_64-linux-gnu /opt/amdgpu/lib64 /usr/lib/x86_64-linux-gnu /usr/lib64)
-find_path(LIBDRM_AMDGPU_INCLUDE_DIR NAMES libdrm/amdgpu.h libdrm/amdgpu_drm.h PATHS ${_libdrm_amdgpu_include_hints} ${ROCM_PATH}/lib/rocm_sysdeps/include /opt/amdgpu/include /usr/include /usr/ /usr/local/include NO_DEFAULT_PATH)
+find_library(LIBDRM_AMDGPU_LIBRARY NAMES drm_amdgpu HINTS ${ROCM_PATH}/lib/rocm_sysdeps/lib)
+find_path(LIBDRM_AMDGPU_INCLUDE_DIR NAMES libdrm/amdgpu.h libdrm/amdgpu_drm.h PATHS ${_libdrm_amdgpu_include_hints} ${ROCM_PATH}/lib/rocm_sysdeps/include NO_DEFAULT_PATH)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Libdrm_amdgpu DEFAULT_MSG LIBDRM_AMDGPU_INCLUDE_DIR LIBDRM_AMDGPU_LIBRARY)

--- a/projects/rocjpeg/cmake/FindLibdrm_amdgpu.cmake
+++ b/projects/rocjpeg/cmake/FindLibdrm_amdgpu.cmake
@@ -24,9 +24,10 @@
 # Search super-project (e.g. libdrm) sysdeps first when building in TheRock
 if(DEFINED THEROCK_SUPERPROJECT_INCLUDE_DIRS)
   list(APPEND _libdrm_amdgpu_include_hints ${THEROCK_SUPERPROJECT_INCLUDE_DIRS})
+  list(APPEND _libdrm_amdgpu_library_hints ${CMAKE_LIBRARY_PATH})
 endif()
 
-find_library(LIBDRM_AMDGPU_LIBRARY NAMES drm_amdgpu HINTS ${ROCM_PATH}/lib/rocm_sysdeps/lib NO_DEFAULT_PATH)
+find_library(LIBDRM_AMDGPU_LIBRARY NAMES drm_amdgpu HINTS ${_libdrm_amdgpu_library_hints} ${ROCM_PATH}/lib/rocm_sysdeps/lib NO_DEFAULT_PATH)
 find_path(LIBDRM_AMDGPU_INCLUDE_DIR NAMES libdrm/amdgpu.h libdrm/amdgpu_drm.h PATHS ${_libdrm_amdgpu_include_hints} ${ROCM_PATH}/lib/rocm_sysdeps/include NO_DEFAULT_PATH)
 
 include(FindPackageHandleStandardArgs)

--- a/projects/rocjpeg/cmake/FindLibdrm_amdgpu.cmake
+++ b/projects/rocjpeg/cmake/FindLibdrm_amdgpu.cmake
@@ -26,7 +26,7 @@ if(DEFINED THEROCK_SUPERPROJECT_INCLUDE_DIRS)
   list(APPEND _libdrm_amdgpu_include_hints ${THEROCK_SUPERPROJECT_INCLUDE_DIRS})
 endif()
 
-find_library(LIBDRM_AMDGPU_LIBRARY NAMES drm_amdgpu HINTS ${ROCM_PATH}/lib/rocm_sysdeps/lib)
+find_library(LIBDRM_AMDGPU_LIBRARY NAMES drm_amdgpu HINTS ${ROCM_PATH}/lib/rocm_sysdeps/lib NO_DEFAULT_PATH)
 find_path(LIBDRM_AMDGPU_INCLUDE_DIR NAMES libdrm/amdgpu.h libdrm/amdgpu_drm.h PATHS ${_libdrm_amdgpu_include_hints} ${ROCM_PATH}/lib/rocm_sysdeps/include NO_DEFAULT_PATH)
 
 include(FindPackageHandleStandardArgs)

--- a/projects/rocjpeg/cmake/FindLibva.cmake
+++ b/projects/rocjpeg/cmake/FindLibva.cmake
@@ -26,12 +26,12 @@ if(DEFINED THEROCK_SUPERPROJECT_INCLUDE_DIRS)
   list(APPEND _libva_include_hints ${THEROCK_SUPERPROJECT_INCLUDE_DIRS})
 endif()
 
-find_library(LIBVA_LIBRARY NAMES va HINTS ${ROCM_PATH}/lib/rocm_sysdeps/lib)
-find_library(LIBVA_DRM_LIBRARY NAMES va-drm HINTS ${ROCM_PATH}/lib/rocm_sysdeps/lib)
+find_library(LIBVA_LIBRARY NAMES va HINTS ${ROCM_PATH}/lib/rocm_sysdeps/lib NO_DEFAULT_PATH)
+find_library(LIBVA_DRM_LIBRARY NAMES va-drm HINTS ${ROCM_PATH}/lib/rocm_sysdeps/lib NO_DEFAULT_PATH)
 find_path(LIBVA_INCLUDE_DIR NAMES va/va.h PATHS ${_libva_include_hints} ${ROCM_PATH}/lib/rocm_sysdeps/include NO_DEFAULT_PATH)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(Libva DEFAULT_MSG LIBVA_INCLUDE_DIR LIBVA_LIBRARY)
+find_package_handle_standard_args(Libva DEFAULT_MSG LIBVA_INCLUDE_DIR LIBVA_LIBRARY LIBVA_DRM_LIBRARY)
 mark_as_advanced(LIBVA_INCLUDE_DIR LIBVA_LIBRARY LIBVA_DRM_LIBRARY)
 
 if(Libva_FOUND)

--- a/projects/rocjpeg/cmake/FindLibva.cmake
+++ b/projects/rocjpeg/cmake/FindLibva.cmake
@@ -26,9 +26,9 @@ if(DEFINED THEROCK_SUPERPROJECT_INCLUDE_DIRS)
   list(APPEND _libva_include_hints ${THEROCK_SUPERPROJECT_INCLUDE_DIRS})
 endif()
 
-find_library(LIBVA_LIBRARY NAMES va HINTS ${ROCM_PATH}/lib/rocm_sysdeps/lib /opt/amdgpu/lib/x86_64-linux-gnu /opt/amdgpu/lib64 /usr/lib/x86_64-linux-gnu /usr/lib64)
-find_library(LIBVA_DRM_LIBRARY NAMES va-drm HINTS ${ROCM_PATH}/lib/rocm_sysdeps/lib /opt/amdgpu/lib/x86_64-linux-gnu /opt/amdgpu/lib64 /usr/lib/x86_64-linux-gnu /usr/lib64)
-find_path(LIBVA_INCLUDE_DIR NAMES va/va.h PATHS ${_libva_include_hints} ${ROCM_PATH}/lib/rocm_sysdeps/include /opt/amdgpu/include /usr/include NO_DEFAULT_PATH)
+find_library(LIBVA_LIBRARY NAMES va HINTS ${ROCM_PATH}/lib/rocm_sysdeps/lib)
+find_library(LIBVA_DRM_LIBRARY NAMES va-drm HINTS ${ROCM_PATH}/lib/rocm_sysdeps/lib)
+find_path(LIBVA_INCLUDE_DIR NAMES va/va.h PATHS ${_libva_include_hints} ${ROCM_PATH}/lib/rocm_sysdeps/include NO_DEFAULT_PATH)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Libva DEFAULT_MSG LIBVA_INCLUDE_DIR LIBVA_LIBRARY)

--- a/projects/rocjpeg/cmake/FindLibva.cmake
+++ b/projects/rocjpeg/cmake/FindLibva.cmake
@@ -24,10 +24,11 @@
 # Search super-project (e.g. amd-mesa) sysdeps first when building in TheRock
 if(DEFINED THEROCK_SUPERPROJECT_INCLUDE_DIRS)
   list(APPEND _libva_include_hints ${THEROCK_SUPERPROJECT_INCLUDE_DIRS})
+  list(APPEND _libva_library_hints ${CMAKE_LIBRARY_PATH})
 endif()
 
-find_library(LIBVA_LIBRARY NAMES va HINTS ${ROCM_PATH}/lib/rocm_sysdeps/lib NO_DEFAULT_PATH)
-find_library(LIBVA_DRM_LIBRARY NAMES va-drm HINTS ${ROCM_PATH}/lib/rocm_sysdeps/lib NO_DEFAULT_PATH)
+find_library(LIBVA_LIBRARY NAMES va HINTS ${_libva_library_hints} ${ROCM_PATH}/lib/rocm_sysdeps/lib NO_DEFAULT_PATH)
+find_library(LIBVA_DRM_LIBRARY NAMES va-drm HINTS ${_libva_library_hints} ${ROCM_PATH}/lib/rocm_sysdeps/lib NO_DEFAULT_PATH)
 find_path(LIBVA_INCLUDE_DIR NAMES va/va.h PATHS ${_libva_include_hints} ${ROCM_PATH}/lib/rocm_sysdeps/include NO_DEFAULT_PATH)
 
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
## Motivation

Both rocdecode and rocjpeg are built and shipped exclusively within TheRock, where libva, libva-drm, and libdrm_amdgpu are provided under ${ROCM_PATH}/lib/rocm_sysdeps/. The previous Find modules listed multiple fallback search paths (/opt/amdgpu/lib*, /usr/lib*, /usr/include, etc.) that are irrelevant in the TheRock build context and risked accidentally resolving to a system-installed copy of these libraries.

## Technical Details

Changes in FindLibva.cmake and FindLibdrm_amdgpu.cmake (rocdecode and rocjpeg):
- Remove all non-sysdeps fallback paths from find_library() HINTS and find_path() PATHS, leaving only ${ROCM_PATH}/lib/rocm_sysdeps/lib and ${ROCM_PATH}/lib/rocm_sysdeps/include respectively.
- Retain the THEROCK_SUPERPROJECT_INCLUDE_DIRS block so that an in-tree TheRock superproject build can still inject its include directories ahead of the installed sysdeps path.

Changes in CMakeLists.txt (rocdecode and rocjpeg):
- Remove the post-find libva version compatibility check (>= 1.22). TheRock controls the libva version it ships; the version gate is redundant and would incorrectly block builds if TheRock ever ships a libva with a different version string format.


## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
