### PR TITLE
fix(clr): fall back to the default thread stack when glibc rejects th…

### DIFF
--- a/projects/clr/rocclr/os/os_posix.cpp
+++ b/projects/clr/rocclr/os/os_posix.cpp
@@ -482,8 +482,12 @@ const void* Os::createOsThread(amd::Thread* thread) {
             thread->name().c_str());
 
     // A stack size cannot be unset, so rebuild the attributes from scratch.
-    ::pthread_attr_destroy(&threadAttr);
-    ::pthread_attr_init(&threadAttr);
+    if (0 != ::pthread_attr_destroy(&threadAttr)) {
+      fatal("pthread_attr_destroy() failed");
+    }
+    if (0 != ::pthread_attr_init(&threadAttr)) {
+      fatal("pthread_attr_init() failed");
+    }
     if (0 != ::pthread_attr_setdetachstate(&threadAttr, PTHREAD_CREATE_DETACHED)) {
       fatal("pthread_attr_setdetachstate() failed");
     }

--- a/projects/clr/rocclr/os/os_posix.cpp
+++ b/projects/clr/rocclr/os/os_posix.cpp
@@ -450,19 +450,22 @@ bool Os::isThreadAlive(const Thread& thread) {
   return ::pthread_kill((pthread_t)thread.handle(), 0) == 0;
 }
 
-const void* Os::createOsThread(amd::Thread* thread) {
+//! Spawns a detached thread, sizing its stack only when stackSize is non-zero.
+//! Returns the pthread_create() status.
+static int createDetachedThread(pthread_t* handle, size_t stackSize, void* (*entry)(void*),
+                                void* arg) {
   pthread_attr_t threadAttr;
-  ::pthread_attr_init(&threadAttr);
+  if (0 != ::pthread_attr_init(&threadAttr)) {
+    fatal("pthread_attr_init() failed");
+  }
 
-  size_t stackSize = 0;
-  if (thread->stackSize_ != 0) {
+  if (stackSize != 0) {
     size_t guardsize = 0;
     if (0 != ::pthread_attr_getguardsize(&threadAttr, &guardsize)) {
       fatal("pthread_attr_getguardsize() failed");
     }
 
-    stackSize = thread->stackSize_ + guardsize;
-    if (0 != ::pthread_attr_setstacksize(&threadAttr, stackSize)) {
+    if (0 != ::pthread_attr_setstacksize(&threadAttr, stackSize + guardsize)) {
       fatal("pthread_attr_setstacksize() failed");
     }
   }
@@ -472,39 +475,35 @@ const void* Os::createOsThread(amd::Thread* thread) {
     fatal("pthread_attr_setdetachstate() failed");
   }
 
+  int status = ::pthread_create(handle, &threadAttr, entry, arg);
+
+  if (0 != ::pthread_attr_destroy(&threadAttr)) {
+    fatal("pthread_attr_destroy() failed");
+  }
+  return status;
+}
+
+const void* Os::createOsThread(amd::Thread* thread) {
+  auto entry = (void* (*)(void*)) & Thread::entry;
+
   pthread_t handle = 0;
-  int status = ::pthread_create(&handle, &threadAttr, (void* (*)(void*)) & Thread::entry, thread);
+  int status = createDetachedThread(&handle, thread->stackSize_, entry, thread);
 
-  // If the stack size is rejected, use the default stack size, which always accounts for static TLS.
-  if (status == EINVAL && stackSize != 0) {
+  // glibc carves a thread's static TLS out of the requested stack, so an undersized request is
+  // refused. The default stack size always accounts for static TLS.
+  if (status == EINVAL && thread->stackSize_ != 0) {
     ClPrint(amd::LOG_WARNING, amd::LOG_INIT,
-            "%zu byte stack rejected for \"%s\"; using the default stack size instead", stackSize,
-            thread->name().c_str());
-
-    // A stack size cannot be unset, so rebuild the attributes from scratch.
-    if (0 != ::pthread_attr_destroy(&threadAttr)) {
-      fatal("pthread_attr_destroy() failed");
-    }
-    if (0 != ::pthread_attr_init(&threadAttr)) {
-      fatal("pthread_attr_init() failed");
-    }
-    if (0 != ::pthread_attr_setdetachstate(&threadAttr, PTHREAD_CREATE_DETACHED)) {
-      fatal("pthread_attr_setdetachstate() failed");
-    }
-    status = ::pthread_create(&handle, &threadAttr, (void* (*)(void*)) & Thread::entry, thread);
+            "%zu byte stack rejected for \"%s\"; using the default stack size instead",
+            thread->stackSize_, thread->name().c_str());
+    status = createDetachedThread(&handle, 0, entry, thread);
   }
 
   if (status != 0) {
     thread->setState(Thread::FAILED);
     ClPrint(amd::LOG_ERROR, amd::LOG_INIT, "pthread_create() failed for \"%s\": %s (%d)",
             thread->name().c_str(), strerror(status), status);
-    ::pthread_attr_destroy(&threadAttr);
     return nullptr;
   }
-
-  if (0 != ::pthread_attr_destroy(&threadAttr)) {
-    fatal("pthread_attr_destroy() failed");
-  };
   return reinterpret_cast<const void*>(handle);
 }
 

--- a/projects/clr/rocclr/os/os_posix.cpp
+++ b/projects/clr/rocclr/os/os_posix.cpp
@@ -39,6 +39,7 @@
 #include <string>
 #include <sstream>
 #include <cstring>  // for strncmp
+#include <cerrno>
 #include <cstdlib>
 #include <cstdio>  // for tempnam
 #include <limits.h>
@@ -453,13 +454,15 @@ const void* Os::createOsThread(amd::Thread* thread) {
   pthread_attr_t threadAttr;
   ::pthread_attr_init(&threadAttr);
 
+  size_t stackSize = 0;
   if (thread->stackSize_ != 0) {
     size_t guardsize = 0;
     if (0 != ::pthread_attr_getguardsize(&threadAttr, &guardsize)) {
       fatal("pthread_attr_getguardsize() failed");
     }
 
-    if (0 != ::pthread_attr_setstacksize(&threadAttr, thread->stackSize_ + guardsize)) {
+    stackSize = thread->stackSize_ + guardsize;
+    if (0 != ::pthread_attr_setstacksize(&threadAttr, stackSize)) {
       fatal("pthread_attr_setstacksize() failed");
     }
   }
@@ -470,9 +473,29 @@ const void* Os::createOsThread(amd::Thread* thread) {
   }
 
   pthread_t handle = 0;
-  if (0 != ::pthread_create(&handle, &threadAttr, (void* (*)(void*)) & Thread::entry, thread)) {
+  int status = ::pthread_create(&handle, &threadAttr, (void* (*)(void*)) & Thread::entry, thread);
+
+  // If the stack size is rejected, use the default stack size, which always accounts for static TLS.
+  if (status == EINVAL && stackSize != 0) {
+    ClPrint(amd::LOG_WARNING, amd::LOG_INIT,
+            "%zu byte stack rejected for \"%s\"; using the default stack size instead", stackSize,
+            thread->name().c_str());
+
+    // A stack size cannot be unset, so rebuild the attributes from scratch.
+    ::pthread_attr_destroy(&threadAttr);
+    ::pthread_attr_init(&threadAttr);
+    if (0 != ::pthread_attr_setdetachstate(&threadAttr, PTHREAD_CREATE_DETACHED)) {
+      fatal("pthread_attr_setdetachstate() failed");
+    }
+    status = ::pthread_create(&handle, &threadAttr, (void* (*)(void*)) & Thread::entry, thread);
+  }
+
+  if (status != 0) {
     thread->setState(Thread::FAILED);
-    guarantee(false, "pthread_create() failed");
+    ClPrint(amd::LOG_ERROR, amd::LOG_INIT, "pthread_create() failed for \"%s\": %s (%d)",
+            thread->name().c_str(), strerror(status), status);
+    ::pthread_attr_destroy(&threadAttr);
+    return nullptr;
   }
 
   if (0 != ::pthread_attr_destroy(&threadAttr)) {

--- a/projects/hip-tests/catch/config/configs/unit/printf.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/printf.yaml
@@ -25,3 +25,5 @@ printf:
   Unit_Printf_PrintfWidthPrecision: *level_2
   Unit_Printf_PrintfBasicTsts: *level_2
   Unit_Printf_PrintfAltFormsTsts: *level_2
+  Unit_Printf_HostcallLargeStaticTls_Positive: *level_2
+  Unit_Printf_HostcallUndersizedStackRequest_Positive: *level_2

--- a/projects/hip-tests/catch/unit/printf/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/printf/CMakeLists.txt
@@ -19,6 +19,7 @@ endif()
 
 if(UNIX)
   set(AMD_TEST_SRC
+    hostcallStackSize.cc
     printfNonHost.cc
     hipPrintfManyDevices.cc
     hipPrintfStar.cc
@@ -82,4 +83,13 @@ add_dependencies(build_tests printfLength_exe)
 add_dependencies(build_tests printfSpecifiers_exe)
 add_dependencies(build_tests printfFlagsNonHost_exe)
 add_dependencies(build_tests printfSpecifiersNonHost_exe)
+
+# The hostcall listener stack test needs the static TLS block in a process of its own, so it
+# cannot be linked into the shared test binary.
+if(UNIX AND HIP_PLATFORM MATCHES "amd")
+  add_executable(hostcallStackSize_exe EXCLUDE_FROM_ALL hostcallStackSize_exe.cc)
+  set_source_files_properties(hostcallStackSize_exe.cc PROPERTIES LANGUAGE ${GPGPU_LANGUAGE})
+  set_property(GLOBAL APPEND PROPERTY G_INSTALL_EXE_TARGETS hostcallStackSize_exe)
+  add_dependencies(build_tests hostcallStackSize_exe)
+endif()
 

--- a/projects/hip-tests/catch/unit/printf/hostcallStackSize.cc
+++ b/projects/hip-tests/catch/unit/printf/hostcallStackSize.cc
@@ -25,12 +25,6 @@ std::string expectedOutput() {
   }
   return reference;
 }
-
-bool hostcallSupported() {
-  int pcieAtomic = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
-  return pcieAtomic != 0;
-}
 }  // namespace
 
 /**
@@ -49,9 +43,7 @@ bool hostcallSupported() {
  *    - HIP_VERSION >= 5.2
  */
 HIP_TEST_CASE(Unit_Printf_HostcallLargeStaticTls_Positive) {
-  if (!hostcallSupported()) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-  }
+  CHECK_PCIE_ATOMIC_SUPPORT
 
   hip::SpawnProc proc("hostcallStackSize_exe", true);
   REQUIRE(proc.run() == 0);
@@ -75,9 +67,7 @@ HIP_TEST_CASE(Unit_Printf_HostcallLargeStaticTls_Positive) {
  *    - HIP_VERSION >= 5.2
  */
 HIP_TEST_CASE(Unit_Printf_HostcallUndersizedStackRequest_Positive) {
-  if (!hostcallSupported()) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-  }
+  CHECK_PCIE_ATOMIC_SUPPORT
 
   hip::SpawnProc proc("hostcallStackSize_exe", true);
   proc.setEnv("CQ_THREAD_STACK_SIZE", "32768");

--- a/projects/hip-tests/catch/unit/printf/hostcallStackSize.cc
+++ b/projects/hip-tests/catch/unit/printf/hostcallStackSize.cc
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <hip_test_common.hh>
+#include <hip_test_process.hh>
+
+/**
+ * @addtogroup printf printf
+ * @{
+ * @ingroup PrintfTest
+ * `int printf()` -
+ * Method to print the content on output device.
+ */
+
+namespace {
+constexpr int kGreetLines = 4;
+
+std::string expectedOutput() {
+  std::string reference;
+  for (int i = 0; i < kGreetLines; ++i) {
+    reference += "hostcall serviced\n";
+  }
+  return reference;
+}
+
+bool hostcallSupported() {
+  int pcieAtomic = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
+  return pcieAtomic != 0;
+}
+}  // namespace
+
+/**
+ * Test Description
+ * ------------------------
+ *    - Dispatches a printf kernel from a process holding a large static TLS block, which forces
+ *      the hostcall listener's stack request to be smaller than the process' static TLS.
+ *      glibc refuses such a request with EINVAL, which used to abort the process.
+ *
+ * Test source
+ * ------------------------
+ *    - unit/printf/hostcallStackSize.cc
+ * Test requirements
+ * ------------------------
+ *    - Host specific (LINUX)
+ *    - HIP_VERSION >= 5.2
+ */
+HIP_TEST_CASE(Unit_Printf_HostcallLargeStaticTls_Positive) {
+  if (!hostcallSupported()) {
+    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+  }
+
+  hip::SpawnProc proc("hostcallStackSize_exe", true);
+  REQUIRE(proc.run() == 0);
+  REQUIRE(proc.getOutput() == expectedOutput());
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *    - Same dispatch, but the listener's stack request is shrunk below the static TLS of even a
+ *      minimal process. This keeps the coverage independent of how much static TLS the runtime's
+ *      own dependencies contribute. The request stays above PTHREAD_STACK_MIN so that it is
+ *      pthread_create() that rejects it, rather than pthread_attr_setstacksize().
+ *
+ * Test source
+ * ------------------------
+ *    - unit/printf/hostcallStackSize.cc
+ * Test requirements
+ * ------------------------
+ *    - Host specific (LINUX)
+ *    - HIP_VERSION >= 5.2
+ */
+HIP_TEST_CASE(Unit_Printf_HostcallUndersizedStackRequest_Positive) {
+  if (!hostcallSupported()) {
+    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+  }
+
+  hip::SpawnProc proc("hostcallStackSize_exe", true);
+  proc.setEnv("CQ_THREAD_STACK_SIZE", "32768");
+  REQUIRE(proc.run() == 0);
+  REQUIRE(proc.getOutput() == expectedOutput());
+}
+
+/**
+ * End doxygen group PrintfTest.
+ * @}
+ */

--- a/projects/hip-tests/catch/unit/printf/hostcallStackSize_exe.cc
+++ b/projects/hip-tests/catch/unit/printf/hostcallStackSize_exe.cc
@@ -10,8 +10,8 @@
 //
 // glibc allocates a thread's static TLS out of the stack mapping requested through
 // pthread_attr_setstacksize(), so a request that cannot also hold the process' static TLS is
-// refused with EINVAL. TLS_PAD_KIB bytes of initial-exec TLS put this process in the same
-// position as an application that links libraries with large PT_TLS segments.
+// refused with EINVAL. The initial-exec TLS below puts this process in the same position as an
+// application that links libraries with large PT_TLS segments.
 //
 // The device printf() makes the compiler declare hidden_hostcall_buffer, so dispatching the
 // kernel creates the listener thread.
@@ -20,12 +20,9 @@
 
 #include <cstdio>
 
-#ifndef TLS_PAD_KIB
-#define TLS_PAD_KIB 512
-#endif
-
 namespace {
-constexpr size_t kTlsPadBytes = static_cast<size_t>(TLS_PAD_KIB) * 1024;
+// Comfortably above the 256 KiB (CQ_THREAD_STACK_SIZE) stack the listener used to request.
+constexpr size_t kTlsPadBytes = 512 * 1024;
 constexpr int kThreads = 4;
 }  // namespace
 

--- a/projects/hip-tests/catch/unit/printf/hostcallStackSize_exe.cc
+++ b/projects/hip-tests/catch/unit/printf/hostcallStackSize_exe.cc
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+// Companion executable for hostcallStackSize.cc. It must be a standalone exe because the static
+// TLS block below has to belong to the process that creates the hostcall listener, and because
+// the driving test needs a process whose stack size flag can be set before runtime init.
+//
+// glibc allocates a thread's static TLS out of the stack mapping requested through
+// pthread_attr_setstacksize(), so a request that cannot also hold the process' static TLS is
+// refused with EINVAL. TLS_PAD_KIB bytes of initial-exec TLS put this process in the same
+// position as an application that links libraries with large PT_TLS segments.
+//
+// The device printf() makes the compiler declare hidden_hostcall_buffer, so dispatching the
+// kernel creates the listener thread.
+
+#include <hip/hip_runtime.h>
+
+#include <cstdio>
+
+#ifndef TLS_PAD_KIB
+#define TLS_PAD_KIB 512
+#endif
+
+namespace {
+constexpr size_t kTlsPadBytes = static_cast<size_t>(TLS_PAD_KIB) * 1024;
+constexpr int kThreads = 4;
+}  // namespace
+
+// External linkage plus initial-exec keeps this in the executable's PT_TLS segment so that it is
+// accounted for in the process' static TLS size at startup.
+__thread char tlsPad[kTlsPadBytes] __attribute__((tls_model("initial-exec")));
+
+__global__ void greet() { printf("hostcall serviced\n"); }
+
+int main() {
+  // Touch both ends so the whole block is committed and cannot be elided.
+  tlsPad[0] = 1;
+  tlsPad[kTlsPadBytes - 1] = 2;
+
+  greet<<<1, kThreads>>>();
+
+  hipError_t err = hipDeviceSynchronize();
+  if (err != hipSuccess) {
+    std::fprintf(stderr, "hipDeviceSynchronize failed: %s\n", hipGetErrorString(err));
+    return 1;
+  }
+
+  if (tlsPad[0] != 1 || tlsPad[kTlsPadBytes - 1] != 2) {
+    std::fprintf(stderr, "TLS block was corrupted\n");
+    return 1;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
…e requested size

## Motivation
glibc places a thread's static TLS block inside the stack mapping requested via pthread_attr_setstacksize(), so pthread_create() refuses any request smaller than guard size + static TLS + a minimal reserve, with EINVAL. A process that links libraries with large PT_TLS segments can exceed the 256 KiB CQ_THREAD_STACK_SIZE request on its own, in which case creating the hostcall listener aborts the process. Blender 5.2 hits this on Linux: its bundled USD library brings the static TLS footprint to ~313 KB, and its HIP kernels are built with device asserts, so they declare hidden_hostcall_buffer and spawn the listener. The guessTlsSize() heuristic used to mask this by inflating every stack request.

Retry once with the default stack size, which always accounts for static TLS, and warn when doing so. Also report the pthread_create() status, which was previously discarded (it is returned rather than reported via errno), and return nullptr instead of aborting, so the existing failure handling in HostcallListener::init() and the HostQueue constructor can surface the error as a failed dispatch rather than a core dump.

## Technical Details
Regression introduced by: [#6147](https://github.com/ROCm/rocm-systems/pull/6147)

## Issue Tracking

ROCM-28942

## Test Plan

Blender test

## Test Result

Blender test pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
