### PR TITLE
[RCCL] Update hierarchical AG thresholds (#9473)

### DIFF
--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -2719,8 +2719,9 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
         comm->forcePatEnable = !userDisabledPat && !rcclUseAinic();
         NCCLCHECKGOTO(ncclCommSplit(comm, local_rank, node_id, &comm->hierarchicalInterComm, NULL), res, fail);
         comm->forcePatEnable = false;
-        size_t tempBufSize =
-          (comm->nNodes >= 16) ? HIERARCHICAL_AG_TEMP_BUFFER_SIZE : HIERARCHICAL_AG_TEMP_BUFFER_SIZE / 2;
+        size_t tempBufSize = (comm->nNodes >= 32) ? HIERARCHICAL_AG_TEMP_BUFFER_SIZE
+                             : (comm->nNodes >= 16) ? HIERARCHICAL_AG_TEMP_BUFFER_SIZE / 2
+                                                    : HIERARCHICAL_AG_TEMP_BUFFER_SIZE / 4;
         NCCLCHECKGOTO(ncclCudaMalloc(&(comm->hierarchicalAGTempBuffer), tempBufSize, comm->memManager), res, fail);
         comm->hierarchicalCommsInitialized = true;
         INFO(NCCL_INIT, "Hierarchical AllGather: intraComm (nRanks=%d) and interComm (nRanks=%d) Initialized",

--- a/projects/rccl/src/rccl_wrap.cc
+++ b/projects/rccl/src/rccl_wrap.cc
@@ -525,10 +525,12 @@ bool rcclUseHierarchicalAllGather(struct ncclComm* comm, size_t msgSize) {
   if (!comm->hierarchicalCommsInitialized) return false;
 
   size_t threshold = 0;
-  if (comm->nNodes >= 16) {
-    threshold = HIERARCHICAL_AG_TEMP_BUFFER_SIZE;
+  if (comm->nNodes >= 32) {
+    threshold = HIERARCHICAL_AG_TEMP_BUFFER_SIZE; // 128MB
+  } else if (comm->nNodes >= 16) {
+    threshold = HIERARCHICAL_AG_TEMP_BUFFER_SIZE / 2; // 64MB
   } else if (comm->nNodes >= 8) {
-    threshold = HIERARCHICAL_AG_TEMP_BUFFER_SIZE / 2;
+    threshold = HIERARCHICAL_AG_TEMP_BUFFER_SIZE / 4; // 32MB
   }
 
   return threshold > 0 && msgSize <= threshold;

--- a/projects/rccl/test/RcclWrapTests.cpp
+++ b/projects/rccl/test/RcclWrapTests.cpp
@@ -1472,19 +1472,31 @@ TEST(Rcclwrap, RcclUseHierarchicalAllGatherTests)
     };
 
     const size_t HALF = HIERARCHICAL_AG_TEMP_BUFFER_SIZE / 2;
+    const size_t QUARTER = HIERARCHICAL_AG_TEMP_BUFFER_SIZE / 4;
     const size_t FULL = HIERARCHICAL_AG_TEMP_BUFFER_SIZE;
 
     std::vector<HierAGCase> testCases = {
         // nNodes < 8 --> disabled
-        {"LessThan8Nodes",            4,  true,  1ULL << 20, false, {}},
+        {"LessThan8Nodes",               4,  true,  1ULL << 20,  false, {}},
         // sub-comms not initialized --> disabled
-        {"CommsNotInitialized",       16, false, 1ULL << 20, false, {}},
-        // 8 node size > 64MB --> disabled
-        {"Disabled_8Nodes_AboveHalf", 8,  true,  HALF + 1,   false, {}},
-        // 16 node size > 128MB --> disabled
-        {"Disabled_16N_AboveFull",    16, true,  FULL + 1,   false, {}},
+        {"CommsNotInitialized",          16, false, 1ULL << 20,  false, {}},
+        // 8-15 nodes --> limit is 32MB
+        {"Enabled_8Nodes_AtQuarter",     8,  true,  QUARTER,     true,  {}},
+        {"Disabled_8Nodes_AboveQuarter", 8,  true,  QUARTER + 1, false, {}},
+        {"Enabled_15Nodes_AtQuarter",    15, true,  QUARTER,     true,  {}},
+        {"Disabled_15Nodes_AtHalf",      15, true,  HALF,        false, {}},
+        // 16-31 nodes --> limit is 64MB
+        {"Enabled_16Nodes_AtHalf",       16, true,  HALF,        true,  {}},
+        {"Disabled_16Nodes_AboveHalf",   16, true,  HALF + 1,    false, {}},
+        {"Enabled_31Nodes_AtHalf",       31, true,  HALF,        true,  {}},
+        {"Disabled_31Nodes_AtFull",      31, true,  FULL,        false, {}},
+        // 32+ nodes --> limit is 128MB
+        {"Enabled_32Nodes_AtHalf",       32, true,  HALF,        true,  {}},
+        {"Enabled_32Nodes_AtFull",       32, true,  FULL,        true,  {}},
+        {"Disabled_32Nodes_AboveFull",   32, true,  FULL + 1,    false, {}},
+        {"Enabled_64Nodes_AtFull",       64, true,  FULL,        true,  {}},
         // env var forces off --> disabled
-        {"DisabledByEnvVar",          16, true,  1ULL << 20, false, {{"RCCL_HIERARCHICAL_ALLGATHER", "0"}}},
+        {"DisabledByEnvVar",             16, true,  1ULL << 20,  false, {{"RCCL_HIERARCHICAL_ALLGATHER", "0"}}},
     };
 
     // Base environment shared by every case


### PR DESCRIPTION
Cherry-picks cf65ebc into the ROCm 10.0 release branch.

---

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Updated the thresholds for hierarchical AG as gfx950 shows regression on 8 and 16 nodes with datatype bf16.
New thresholds for hierarchical AG:
 -   `>= 32` nodes up to 128MB
 -  `>= 16` nodes up to 64MB
 -  `>= 8` nodes up to 32MB 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->
JIRA ID: AICOMRCCL-1639
## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.

