### PR TITLE
WIP TEST - test: dynamic baseline_run_id selection for external repos

### DIFF
--- a/.github/scripts/ci_utils.py
+++ b/.github/scripts/ci_utils.py
@@ -74,3 +74,13 @@ def set_github_output(outputs: Mapping[str, str]):
     with open(output_file, "a") as f:
         for k, v in outputs.items():
             f.write(f"{k}={v}\n")
+
+
+def append_step_summary(summary: str):
+    """Appends markdown to GITHUB_STEP_SUMMARY (or prints if not in CI)."""
+    summary_file = os.environ.get("GITHUB_STEP_SUMMARY", "")
+    if not summary_file:
+        print(summary)
+        return
+    with open(summary_file, "a", encoding="utf-8") as f:
+        f.write(summary)

--- a/.github/scripts/resolve_therock_ref.py
+++ b/.github/scripts/resolve_therock_ref.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+"""Resolve the ROCm/TheRock commit a multi-arch CI run should build against.
+
+Policy (see the "Merge-base-time TheRock ref" design):
+
+- On a ``pull_request`` event, pin TheRock to the tip of ``main`` as it existed
+  at the time of the PR branch's merge-base with its base branch. The pin stays
+  frozen while the author pushes new commits and only advances when they merge
+  or rebase the base branch back in. This keeps the ROCm build underneath a PR
+  stable during authoring and debugging.
+- A caller-supplied override short-circuits everything (manual pin).
+- On any other event (push / workflow_dispatch / schedule) there is no
+  merge-base, so use the live tip of ``main`` (equivalent to the prior
+  behavior).
+
+The merge-base is computed server-side by GitHub's compare API, so no deep
+clone of this repository is required. Staleness is warn-only: if the resolved
+TheRock commit is older than the threshold we surface a warning but still use
+the commit.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Optional, Protocol
+
+import requests
+
+from ci_utils import append_step_summary, retry, set_github_output
+
+GITHUB_API = "https://api.github.com"
+DEFAULT_THEROCK_REPO = "ROCm/TheRock"
+DEFAULT_THEROCK_BRANCH = "main"
+DEFAULT_STALENESS_DAYS = 14
+
+MODE_OVERRIDE = "override"
+MODE_MERGE_BASE = "pull-request merge-base"
+MODE_MERGE_BASE_FALLBACK = "pull-request merge-base (fell back to live tip of main)"
+MODE_LIVE_TIP = "live-tip (push/dispatch/schedule)"
+
+
+def parse_github_time(value: str) -> datetime:
+    """Parse a GitHub ISO-8601 timestamp (``...Z``) into an aware datetime."""
+    # datetime.fromisoformat only accepts the "Z" suffix on Python 3.11+, so
+    # normalize it explicitly for portability.
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def iso_utc(dt: datetime) -> str:
+    """Render an aware datetime as a compact UTC ISO-8601 string."""
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def humanize_delta(seconds: float) -> str:
+    """Render a duration in seconds as a coarse human string (e.g. '3 days')."""
+    seconds = abs(seconds)
+    minutes = seconds / 60
+    hours = minutes / 60
+    days = hours / 24
+    if days >= 1:
+        value = int(round(days))
+        return f"{value} day{'s' if value != 1 else ''}"
+    if hours >= 1:
+        value = int(round(hours))
+        return f"{value} hour{'s' if value != 1 else ''}"
+    if minutes >= 1:
+        value = int(round(minutes))
+        return f"{value} minute{'s' if value != 1 else ''}"
+    value = int(round(seconds))
+    return f"{value} second{'s' if value != 1 else ''}"
+
+
+def humanize_age(dt: datetime, now: datetime) -> str:
+    """Render how long ago ``dt`` was relative to ``now``."""
+    return f"{humanize_delta((now - dt).total_seconds())} ago"
+
+
+@dataclass
+class Commit:
+    """A resolved commit: its SHA and committer timestamp."""
+
+    sha: str
+    committed_at: datetime
+
+
+@dataclass
+class Resolution:
+    """The outcome of resolving which TheRock commit to build against."""
+
+    therock_ref: str
+    therock_repo: str
+    mode: str
+    therock_commit: Optional[Commit] = None
+    merge_base: Optional[Commit] = None
+    source_repo: str = ""
+    warnings: list[str] = field(default_factory=list)
+    staleness_days: int = DEFAULT_STALENESS_DAYS
+
+
+class GitHubClient(Protocol):
+    """Minimal GitHub read surface the resolver depends on (for testability)."""
+
+    def get_merge_base(self, repo: str, base_sha: str, head_sha: str) -> Commit: ...
+
+    def get_commit_at_or_before(
+        self, repo: str, branch: str, until: datetime
+    ) -> Optional[Commit]: ...
+
+    def get_live_tip(self, repo: str, branch: str) -> Commit: ...
+
+    def get_commit(self, repo: str, ref: str) -> Commit: ...
+
+
+class RestGitHubClient:
+    """GitHub REST client used at runtime. Read-only; retries transient errors."""
+
+    def __init__(self, token: str, api_url: str = GITHUB_API):
+        self._api_url = api_url
+        self._session = requests.Session()
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        self._session.headers.update(headers)
+
+    @retry(max_attempts=3, delay_seconds=2, exceptions=(requests.RequestException,))
+    def _get(self, path: str, params: Optional[dict] = None):
+        response = self._session.get(
+            f"{self._api_url}{path}", params=params, timeout=30
+        )
+        response.raise_for_status()
+        return response.json()
+
+    @staticmethod
+    def _commit_from_payload(payload: dict) -> Commit:
+        return Commit(
+            sha=payload["sha"],
+            committed_at=parse_github_time(payload["commit"]["committer"]["date"]),
+        )
+
+    def get_merge_base(self, repo: str, base_sha: str, head_sha: str) -> Commit:
+        payload = self._get(f"/repos/{repo}/compare/{base_sha}...{head_sha}")
+        return self._commit_from_payload(payload["merge_base_commit"])
+
+    def get_commit_at_or_before(
+        self, repo: str, branch: str, until: datetime
+    ) -> Optional[Commit]:
+        payload = self._get(
+            f"/repos/{repo}/commits",
+            params={"sha": branch, "until": iso_utc(until), "per_page": 1},
+        )
+        if not payload:
+            return None
+        return self._commit_from_payload(payload[0])
+
+    def get_live_tip(self, repo: str, branch: str) -> Commit:
+        payload = self._get(
+            f"/repos/{repo}/commits", params={"sha": branch, "per_page": 1}
+        )
+        if not payload:
+            raise ValueError(f"No commits found on {repo}@{branch}")
+        return self._commit_from_payload(payload[0])
+
+    def get_commit(self, repo: str, ref: str) -> Commit:
+        payload = self._get(f"/repos/{repo}/commits/{ref}")
+        return self._commit_from_payload(payload)
+
+
+def resolve_ref(
+    client: GitHubClient,
+    *,
+    event_name: str,
+    source_repo: str,
+    base_sha: str,
+    head_sha: str,
+    override: str,
+    therock_repo: str = DEFAULT_THEROCK_REPO,
+    therock_branch: str = DEFAULT_THEROCK_BRANCH,
+    staleness_days: int = DEFAULT_STALENESS_DAYS,
+    now: Optional[datetime] = None,
+) -> Resolution:
+    """Resolve which TheRock commit to build against for this run."""
+    now = now or datetime.now(timezone.utc)
+    warnings: list[str] = []
+
+    if override:
+        commit = client.get_commit(therock_repo, override)
+        resolution = Resolution(
+            therock_ref=commit.sha,
+            therock_repo=therock_repo,
+            mode=MODE_OVERRIDE,
+            therock_commit=commit,
+            warnings=warnings,
+            staleness_days=staleness_days,
+        )
+    elif event_name == "pull_request" and base_sha and head_sha:
+        merge_base = client.get_merge_base(source_repo, base_sha, head_sha)
+        commit = client.get_commit_at_or_before(
+            therock_repo, therock_branch, merge_base.committed_at
+        )
+        if commit is None:
+            commit = client.get_live_tip(therock_repo, therock_branch)
+            warnings.append(
+                "No "
+                f"{therock_repo}@{therock_branch} commit found at or before the "
+                "merge-base time; fell back to the live tip of the branch."
+            )
+            mode = MODE_MERGE_BASE_FALLBACK
+        else:
+            mode = MODE_MERGE_BASE
+        resolution = Resolution(
+            therock_ref=commit.sha,
+            therock_repo=therock_repo,
+            mode=mode,
+            therock_commit=commit,
+            merge_base=merge_base,
+            warnings=warnings,
+            staleness_days=staleness_days,
+        )
+    else:
+        commit = client.get_live_tip(therock_repo, therock_branch)
+        resolution = Resolution(
+            therock_ref=commit.sha,
+            therock_repo=therock_repo,
+            mode=MODE_LIVE_TIP,
+            therock_commit=commit,
+            warnings=warnings,
+            staleness_days=staleness_days,
+        )
+
+    resolution.source_repo = source_repo
+    _check_staleness(resolution, now)
+    return resolution
+
+
+def _is_merge_base_mode(resolution: Resolution) -> bool:
+    """True when the ref was pinned from a PR merge-base (vs. override/live-tip)."""
+    return resolution.merge_base is not None
+
+
+def _check_staleness(resolution: Resolution, now: datetime) -> None:
+    commit = resolution.therock_commit
+    if commit is None:
+        return
+    age_days = (now - commit.committed_at).total_seconds() / 86400
+    if age_days > resolution.staleness_days:
+        if _is_merge_base_mode(resolution):
+            hint = (
+                "consider syncing your base branch (merge or rebase) to pick up "
+                "a newer TheRock."
+            )
+        else:
+            hint = (
+                "consider building against a newer TheRock (for example via the "
+                "`therock_ref_override` input)."
+            )
+        resolution.warnings.append(
+            f"This TheRock commit is {int(age_days)} days old "
+            f"(threshold {resolution.staleness_days} days); {hint}"
+        )
+
+
+def build_summary(resolution: Resolution, now: Optional[datetime] = None) -> str:
+    """Render the verbose, self-explaining GitHub step-summary card."""
+    now = now or datetime.now(timezone.utc)
+    repo = resolution.therock_repo
+    commit = resolution.therock_commit
+
+    lines: list[str] = []
+    lines.append("### TheRock version locked for this run")
+    lines.append("")
+    if _is_merge_base_mode(resolution):
+        intro = (
+            "This PR is built against a fixed TheRock commit chosen from the "
+            "point where your branch last synced with its base branch (the "
+            "merge-base). It stays frozen while you push new commits, and only "
+            "moves when you merge or rebase the base branch back into your "
+            "branch. This keeps the ROCm build underneath you stable while you "
+            "author and debug."
+        )
+    elif resolution.mode == MODE_OVERRIDE:
+        intro = (
+            "This run is built against an explicitly pinned TheRock ref supplied "
+            "via the `therock_ref_override` input."
+        )
+    else:
+        intro = (
+            "This run is built against the live tip of "
+            f"{repo}@{DEFAULT_THEROCK_BRANCH}. Merge-base pinning only applies to "
+            "`pull_request` events; other events (push, workflow_dispatch, "
+            "schedule) use the current tip."
+        )
+    lines.append(intro)
+    lines.append("")
+
+    if commit is not None:
+        commit_url = f"https://github.com/{repo}/commit/{commit.sha}"
+        lines.append(
+            f"- **Resolved TheRock commit:** [`{commit.sha[:12]}`]({commit_url}) "
+            f"(committed {iso_utc(commit.committed_at)}, "
+            f"{humanize_age(commit.committed_at, now)})"
+        )
+
+    merge_base = resolution.merge_base
+    if merge_base is not None:
+        if resolution.source_repo:
+            mb_url = (
+                f"https://github.com/{resolution.source_repo}/commit/{merge_base.sha}"
+            )
+            mb_label = f"[`{merge_base.sha[:12]}`]({mb_url})"
+        else:
+            mb_label = f"`{merge_base.sha[:12]}`"
+        lines.append(
+            f"- **Merge-base commit (this repo):** {mb_label} "
+            f"(committed {iso_utc(merge_base.committed_at)}, "
+            f"{humanize_age(merge_base.committed_at, now)}) - the base-branch "
+            "state your branch is built on."
+        )
+        lines.append(
+            "- **Mapping rule:** chose the newest "
+            f"{repo}@{DEFAULT_THEROCK_BRANCH} commit at or before the merge-base "
+            "time."
+        )
+        if commit is not None:
+            skew = (merge_base.committed_at - commit.committed_at).total_seconds()
+            direction = "older than" if skew >= 0 else "newer than"
+            lines.append(
+                f"- **Repo skew:** the TheRock commit is {humanize_delta(skew)} "
+                f"{direction} the merge-base, a rough gauge of how well-aligned "
+                "the two repos were at that moment."
+            )
+
+    lines.append(f"- **Resolution mode:** {resolution.mode}")
+    if resolution.merge_base is None and resolution.mode != MODE_OVERRIDE:
+        lines.append(
+            "  - Merge-base pinning only applies to `pull_request` events; this "
+            "run used the live tip instead."
+        )
+    lines.append("")
+    if _is_merge_base_mode(resolution):
+        how_to_change = (
+            "**How to change this:** merge or rebase your base branch into this "
+            "PR to advance the TheRock version, or set the `therock_ref_override` "
+            "input on a manual run to pin an explicit ref."
+        )
+    else:
+        how_to_change = (
+            "**How to change this:** set the `therock_ref_override` input on a "
+            "manual run to pin an explicit ref."
+        )
+    lines.append(how_to_change)
+
+    for warning in resolution.warnings:
+        lines.append("")
+        lines.append("> [!WARNING]")
+        lines.append(f"> {warning}")
+
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    token = os.environ.get("GITHUB_TOKEN", "")
+    event_name = os.environ.get("GITHUB_EVENT_NAME", "")
+    source_repo = os.environ.get("GITHUB_REPOSITORY", "")
+    base_sha = os.environ.get("BASE_SHA", "")
+    head_sha = os.environ.get("HEAD_SHA", "")
+    override = os.environ.get("THEROCK_REF_OVERRIDE", "").strip()
+    therock_repo = os.environ.get("THEROCK_REPO", DEFAULT_THEROCK_REPO)
+    therock_branch = os.environ.get("THEROCK_BRANCH", DEFAULT_THEROCK_BRANCH)
+    staleness_days = int(
+        os.environ.get("STALENESS_THRESHOLD_DAYS", str(DEFAULT_STALENESS_DAYS))
+    )
+
+    client = RestGitHubClient(token)
+    resolution = resolve_ref(
+        client,
+        event_name=event_name,
+        source_repo=source_repo,
+        base_sha=base_sha,
+        head_sha=head_sha,
+        override=override,
+        therock_repo=therock_repo,
+        therock_branch=therock_branch,
+        staleness_days=staleness_days,
+    )
+
+    set_github_output({"therock_ref": resolution.therock_ref})
+    append_step_summary(build_summary(resolution))
+
+
+if __name__ == "__main__":
+    main()
+

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -1,16 +1,19 @@
 name: TheRock CI
 
+# DISABLED for testing multi-arch CI with dynamic baseline_run_id
+# TODO: Re-enable pull_request trigger after testing
+
 on:
   push:
     branches:
       - develop
       - release/therock-*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - labeled
+  # pull_request:
+  #   types:
+  #     - opened
+  #     - synchronize
+  #     - reopened
+  #     - labeled
   workflow_dispatch:
     inputs:
       projects:

--- a/.github/workflows/therock-multi-arch-ci.yml
+++ b/.github/workflows/therock-multi-arch-ci.yml
@@ -12,22 +12,19 @@
 # - Supports prebuilt stages to skip certain build stages
 # - Better parallelization across GPU architectures
 
-# TheRock ref: using main until full migration, then switch to pinned SHA (TheRock#3343)
-# NOTE: update all `@<ref>` refs and `ref:` inputs together when switching
-
-# =============================================================================
-# TEMPORARY: MI455 (gfx125X) bringup configuration
-# TODO(geomin12): Remove this block once MI455 is fully enabled in therock-ci-config
-#
-# The gfx125x_family_overrides JSON configures MI455-specific test settings:
-# - test-runs-on: Custom runner label for MI455 hardware
-# - test_labels_for_family: Limit tests to hip-tests, rocrtst (sanity always runs)
-# - Container options with ulimit for RCCL compatibility
-# =============================================================================
+# TEST BRANCH: users/geomin12/dynamic-determination-stage
+# Testing dynamic baseline_run_id selection for external repos
+# NOTE: rocm-systems changes affect compiler-runtime which cascades to ALL stages,
+# so no stages will be reusable. This is expected behavior.
 
 name: TheRock Multi-Arch CI
 
 on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
   workflow_dispatch:
     inputs:
       linux_amdgpu_families:
@@ -74,6 +71,9 @@ jobs:
       changed_projects: ${{ steps.configure.outputs.changed_projects }}
       run_all_tests: ${{ steps.configure.outputs.run_all_tests }}
       skip_tests: ${{ steps.configure.outputs.skip_tests }}
+      reusable_stages: ${{ steps.configure.outputs.reusable_stages }}
+      rebuild_stages: ${{ steps.configure.outputs.rebuild_stages }}
+      baseline_run_id: ${{ steps.configure.outputs.baseline_run_id }}
     steps:
       - name: Checkout repository config
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -85,53 +85,55 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ROCm/TheRock
-          ref: main
+          ref: users/geomin12/dynamic-determination-stage
           path: _therock
-          sparse-checkout: build_tools/github_actions
-          sparse-checkout-cone-mode: true
+          sparse-checkout: |
+            build_tools
+            BUILD_TOPOLOGY.toml
+          sparse-checkout-cone-mode: false
 
       - name: Configure CI
         id: configure
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           python3 _therock/build_tools/github_actions/configure_external_repo_ci.py \
             --event-name "${{ github.event_name }}" \
             --github-repo "${{ github.repository }}" \
             --base-sha "${{ github.event.pull_request.base.sha }}" \
             --head-sha "${{ github.event.pull_request.head.sha }}" \
-            --config-path ".github/repos-config.json"
+            --config-path ".github/repos-config.json" \
+            --enable-stage-reuse \
+            --ignore-ci-triggers
+
+      - name: Debug outputs
+        run: |
+          echo "=== Configure Outputs ==="
+          echo "changed_projects: ${{ steps.configure.outputs.changed_projects }}"
+          echo "run_all_tests: ${{ steps.configure.outputs.run_all_tests }}"
+          echo "skip_tests: ${{ steps.configure.outputs.skip_tests }}"
+          echo "reusable_stages: ${{ steps.configure.outputs.reusable_stages }}"
+          echo "rebuild_stages: ${{ steps.configure.outputs.rebuild_stages }}"
+          echo "baseline_run_id: ${{ steps.configure.outputs.baseline_run_id }}"
 
   setup:
     needs: configure
-    uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@main
+    uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@users/geomin12/dynamic-determination-stage
     with:
       build_variant: "release"
       # Limit GPU families for rocm-systems CI
-      # Note: gfx125X is added for MI455 bringup with limited tests (hip-tests, rocrtst, sanity)
-      linux_amdgpu_families: ${{ inputs.linux_amdgpu_families || 'gfx94X,gfx950,gfx125X' }}
-      windows_amdgpu_families: ${{ inputs.windows_amdgpu_families || 'gfx1151' }}
+      linux_amdgpu_families: ${{ inputs.linux_amdgpu_families || 'gfx94X' }}
+      windows_amdgpu_families: ${{ inputs.windows_amdgpu_families || '' }}
       linux_test_labels: ${{ inputs.linux_test_labels || '' }}
       windows_test_labels: ${{ inputs.windows_test_labels || '' }}
-      prebuilt_stages: ${{ inputs.prebuilt_stages || '' }}
-      baseline_run_id: ${{ inputs.baseline_run_id || '' }}
+      # Use dynamically determined prebuilt_stages and baseline_run_id
+      # NOTE: For rocm-systems, reusable_stages will likely be empty since changes
+      # affect compiler-runtime which cascades to all stages
+      prebuilt_stages: ${{ inputs.prebuilt_stages || needs.configure.outputs.reusable_stages }}
+      baseline_run_id: ${{ inputs.baseline_run_id || needs.configure.outputs.baseline_run_id }}
       repository: ROCm/TheRock
-      ref: main
-      # TEMPORARY: MI455 bringup - pass family_overrides to configure test runner and limited tests
-      # TODO(geomin12): Remove family_overrides once MI455 is in therock-ci-config
-      # NOTE: MI455 machine is down - test-runs-on set to "" until back online (was: linux-mi455-gpu-rocm)
-      external_repo: >-
-        {
-          "repository": "${{ github.repository }}",
-          "ref": "${{ github.sha }}",
-          "family_overrides": {
-            "gfx125x": {
-              "linux": {
-                "test-runs-on": "",
-                "test_labels_for_family": ["test:hip-tests", "test:rocrtst"],
-                "fetch-gfx-targets": ["gfx1250"]
-              }
-            }
-          }
-        }
+      ref: users/geomin12/dynamic-determination-stage
+      external_repo: '{"repository":"${{ github.repository }}","ref":"${{ github.sha }}"}'
 
   linux_build_and_test:
     name: Linux::${{ fromJSON(needs.setup.outputs.linux_build_config || '{}').build_variant_label || 'skip' }}
@@ -142,7 +144,7 @@ jobs:
         needs.setup.outputs.enable_build_jobs == 'true' &&
         needs.configure.outputs.skip_tests != 'true'
       }}
-    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@main
+    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@users/geomin12/dynamic-determination-stage
     secrets: inherit
     with:
       build_config: ${{ needs.setup.outputs.linux_build_config }}
@@ -153,7 +155,7 @@ jobs:
       # Empty string when run_all_tests=true triggers full test run in downstream workflow
       changed_projects: ${{ needs.configure.outputs.run_all_tests == 'true' && '' || needs.configure.outputs.changed_projects }}
       repository: ROCm/TheRock
-      ref: main
+      ref: users/geomin12/dynamic-determination-stage
     permissions:
       contents: read
       id-token: write
@@ -167,7 +169,7 @@ jobs:
         needs.setup.outputs.enable_build_jobs == 'true' &&
         needs.configure.outputs.skip_tests != 'true'
       }}
-    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_windows.yml@main
+    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_windows.yml@users/geomin12/dynamic-determination-stage
     secrets: inherit
     with:
       build_config: ${{ needs.setup.outputs.windows_build_config }}
@@ -178,7 +180,7 @@ jobs:
       # Empty string when run_all_tests=true triggers full test run in downstream workflow
       changed_projects: ${{ needs.configure.outputs.run_all_tests == 'true' && '' || needs.configure.outputs.changed_projects }}
       repository: ROCm/TheRock
-      ref: main
+      ref: users/geomin12/dynamic-determination-stage
     permissions:
       contents: read
       id-token: write
@@ -196,7 +198,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "ROCm/TheRock"
-          ref: main
+          ref: users/geomin12/dynamic-determination-stage
           sparse-checkout: build_tools/github_actions
           sparse-checkout-cone-mode: true
 

--- a/.github/workflows/therock-multi-arch-ci.yml
+++ b/.github/workflows/therock-multi-arch-ci.yml
@@ -7,15 +7,11 @@
 # TheRock's reusable workflows directly. It provides sharded, multi-stage
 # builds with per-architecture testing.
 #
-# Key differences from therock-ci.yml:
-# - Uses TheRock's multi-arch sharded build pipeline (foundation -> compiler-runtime -> math-libs)
-# - Supports prebuilt stages to skip certain build stages
-# - Better parallelization across GPU architectures
-
-# TEST BRANCH: users/geomin12/dynamic-determination-stage
-# Testing skip path filter for external repos
-# NOTE: rocm-systems changes affect compiler-runtime which cascades to ALL stages,
-# so no stages will be reusable. This is expected behavior.
+# TheRock ref: the resolve_therock_ref job picks one concrete ROCm/TheRock SHA
+# for the whole run. On pull_request events it pins to the tip of TheRock@main
+# as it existed at the PR branch's merge-base time, so the pin stays stable
+# while a PR is authored and only advances when the base branch is merged/
+# rebased in. This enables commit-compatible stage reuse.
 
 name: TheRock Multi-Arch CI
 
@@ -51,6 +47,10 @@ on:
         type: string
         default: ""
         description: "Workflow run ID to copy prebuilt stage artifacts from; required when prebuilt_stages is set"
+      therock_ref_override:
+        type: string
+        default: ""
+        description: "Optional explicit TheRock ref (branch/tag/SHA) to build against. Empty resolves the ref per event (merge-base time for PRs, live tip of main otherwise)."
 
 permissions:
   contents: read
@@ -71,9 +71,8 @@ jobs:
       changed_projects: ${{ steps.configure.outputs.changed_projects }}
       run_all_tests: ${{ steps.configure.outputs.run_all_tests }}
       skip_tests: ${{ steps.configure.outputs.skip_tests }}
-      reusable_stages: ${{ steps.configure.outputs.reusable_stages }}
       rebuild_stages: ${{ steps.configure.outputs.rebuild_stages }}
-      baseline_run_id: ${{ steps.configure.outputs.baseline_run_id }}
+      reusable_stages: ${{ steps.configure.outputs.reusable_stages }}
     steps:
       - name: Checkout repository config
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -87,10 +86,8 @@ jobs:
           repository: ROCm/TheRock
           ref: users/geomin12/dynamic-determination-stage
           path: _therock
-          sparse-checkout: |
-            build_tools
-            BUILD_TOPOLOGY.toml
-          sparse-checkout-cone-mode: false
+          sparse-checkout: build_tools/github_actions
+          sparse-checkout-cone-mode: true
 
       - name: Configure CI
         id: configure
@@ -110,12 +107,40 @@ jobs:
           echo "changed_projects: ${{ steps.configure.outputs.changed_projects }}"
           echo "run_all_tests: ${{ steps.configure.outputs.run_all_tests }}"
           echo "skip_tests: ${{ steps.configure.outputs.skip_tests }}"
-          echo "reusable_stages: ${{ steps.configure.outputs.reusable_stages }}"
           echo "rebuild_stages: ${{ steps.configure.outputs.rebuild_stages }}"
-          echo "baseline_run_id: ${{ steps.configure.outputs.baseline_run_id }}"
+          echo "reusable_stages: ${{ steps.configure.outputs.reusable_stages }}"
+
+  resolve_therock_ref:
+    name: Resolve TheRock ref
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      therock_ref: ${{ steps.resolve.outputs.therock_ref }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github
+          sparse-checkout-cone-mode: true
+
+      - name: Install dependencies
+        run: pip install requests
+
+      # Picks one concrete TheRock SHA for the whole run. See the header comment
+      # and .github/scripts/resolve_therock_ref.py for the policy. Uses the REST
+      # API only, so no deep clone of this repository is required.
+      - name: Resolve TheRock ref
+        id: resolve
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          THEROCK_REF_OVERRIDE: ${{ inputs.therock_ref_override || '' }}
+        run: python .github/scripts/resolve_therock_ref.py
 
   setup:
-    needs: configure
+    needs: [configure, resolve_therock_ref]
     uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@users/geomin12/dynamic-determination-stage
     with:
       build_variant: "release"
@@ -125,14 +150,15 @@ jobs:
       # TEST: Only run rocprofiler tests
       linux_test_labels: ${{ inputs.linux_test_labels || 'test:rocprofiler' }}
       windows_test_labels: ${{ inputs.windows_test_labels || '' }}
-      # Use dynamically determined reusable stages, or manual override if provided
-      prebuilt_stages: ${{ inputs.prebuilt_stages || needs.configure.outputs.reusable_stages }}
-      # Use dynamically found baseline run ID, or manual override if provided
-      baseline_run_id: ${{ inputs.baseline_run_id || needs.configure.outputs.baseline_run_id }}
-      # Disable automatic stage reuse since we're passing prebuilt_stages directly
-      stage_reuse_mode: dry-run
+      # Manual override for prebuilt stages
+      prebuilt_stages: ${{ inputs.prebuilt_stages || '' }}
+      baseline_run_id: ${{ inputs.baseline_run_id || '' }}
+      # Enable automatic stage reuse - TheRock will find commit-compatible baselines
+      stage_reuse_mode: reuse-stage
       repository: ROCm/TheRock
-      ref: users/geomin12/dynamic-determination-stage
+      # Concrete SHA resolved once by resolve_therock_ref; setup re-exports the
+      # checked-out commit as needs.setup.outputs.ref for downstream jobs.
+      ref: ${{ needs.resolve_therock_ref.outputs.therock_ref }}
       external_repo: '{"repository":"${{ github.repository }}","ref":"${{ github.sha }}"}'
 
   linux_build_and_test:
@@ -152,10 +178,9 @@ jobs:
       rocm_package_version: ${{ needs.setup.outputs.rocm_package_version }}
       test_type: ${{ needs.setup.outputs.test_type }}
       external_repo_config: ${{ needs.setup.outputs.external_repo_config }}
-      # TEST: Always pass changed_projects (ignore run_all_tests for testing)
-      changed_projects: ${{ needs.configure.outputs.changed_projects || 'projects/rocprofiler' }}
+      changed_projects: ${{ needs.configure.outputs.run_all_tests == 'true' && '' || needs.configure.outputs.changed_projects }}
       repository: ROCm/TheRock
-      ref: users/geomin12/dynamic-determination-stage
+      ref: ${{ needs.setup.outputs.ref }}
     permissions:
       contents: read
       id-token: write
@@ -177,10 +202,9 @@ jobs:
       rocm_package_version: ${{ needs.setup.outputs.rocm_package_version }}
       test_type: ${{ needs.setup.outputs.test_type }}
       external_repo_config: ${{ needs.setup.outputs.external_repo_config }}
-      # TEST: Always pass changed_projects (ignore run_all_tests for testing)
-      changed_projects: ${{ needs.configure.outputs.changed_projects || 'projects/rocprofiler' }}
+      changed_projects: ${{ needs.configure.outputs.run_all_tests == 'true' && '' || needs.configure.outputs.changed_projects }}
       repository: ROCm/TheRock
-      ref: users/geomin12/dynamic-determination-stage
+      ref: ${{ needs.setup.outputs.ref }}
     permissions:
       contents: read
       id-token: write
@@ -198,7 +222,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "ROCm/TheRock"
-          ref: users/geomin12/dynamic-determination-stage
+          ref: ${{ needs.setup.outputs.ref }}
           sparse-checkout: build_tools/github_actions
           sparse-checkout-cone-mode: true
 

--- a/.github/workflows/therock-multi-arch-ci.yml
+++ b/.github/workflows/therock-multi-arch-ci.yml
@@ -130,13 +130,16 @@ jobs:
       # Picks one concrete TheRock SHA for the whole run. See the header comment
       # and .github/scripts/resolve_therock_ref.py for the policy. Uses the REST
       # API only, so no deep clone of this repository is required.
+      #
+      # TEST: Override to use the test branch for development
       - name: Resolve TheRock ref
         id: resolve
         env:
           GITHUB_TOKEN: ${{ github.token }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          THEROCK_REF_OVERRIDE: ${{ inputs.therock_ref_override || '' }}
+          # TEST: Force use of test branch for testing
+          THEROCK_REF_OVERRIDE: ${{ inputs.therock_ref_override || 'users/geomin12/dynamic-determination-stage' }}
         run: python .github/scripts/resolve_therock_ref.py
 
   setup:

--- a/.github/workflows/therock-multi-arch-ci.yml
+++ b/.github/workflows/therock-multi-arch-ci.yml
@@ -13,7 +13,7 @@
 # - Better parallelization across GPU architectures
 
 # TEST BRANCH: users/geomin12/dynamic-determination-stage
-# Testing dynamic baseline_run_id selection for external repos
+# Testing skip path filter for external repos
 # NOTE: rocm-systems changes affect compiler-runtime which cascades to ALL stages,
 # so no stages will be reusable. This is expected behavior.
 

--- a/.github/workflows/therock-multi-arch-ci.yml
+++ b/.github/workflows/therock-multi-arch-ci.yml
@@ -71,8 +71,6 @@ jobs:
       changed_projects: ${{ steps.configure.outputs.changed_projects }}
       run_all_tests: ${{ steps.configure.outputs.run_all_tests }}
       skip_tests: ${{ steps.configure.outputs.skip_tests }}
-      rebuild_stages: ${{ steps.configure.outputs.rebuild_stages }}
-      reusable_stages: ${{ steps.configure.outputs.reusable_stages }}
     steps:
       - name: Checkout repository config
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -107,8 +105,6 @@ jobs:
           echo "changed_projects: ${{ steps.configure.outputs.changed_projects }}"
           echo "run_all_tests: ${{ steps.configure.outputs.run_all_tests }}"
           echo "skip_tests: ${{ steps.configure.outputs.skip_tests }}"
-          echo "rebuild_stages: ${{ steps.configure.outputs.rebuild_stages }}"
-          echo "reusable_stages: ${{ steps.configure.outputs.reusable_stages }}"
 
   resolve_therock_ref:
     name: Resolve TheRock ref

--- a/.github/workflows/therock-multi-arch-ci.yml
+++ b/.github/workflows/therock-multi-arch-ci.yml
@@ -110,6 +110,9 @@ jobs:
           echo "changed_projects: ${{ steps.configure.outputs.changed_projects }}"
           echo "run_all_tests: ${{ steps.configure.outputs.run_all_tests }}"
           echo "skip_tests: ${{ steps.configure.outputs.skip_tests }}"
+          echo "reusable_stages: ${{ steps.configure.outputs.reusable_stages }}"
+          echo "rebuild_stages: ${{ steps.configure.outputs.rebuild_stages }}"
+          echo "baseline_run_id: ${{ steps.configure.outputs.baseline_run_id }}"
 
   setup:
     needs: configure
@@ -122,13 +125,12 @@ jobs:
       # TEST: Only run rocprofiler tests
       linux_test_labels: ${{ inputs.linux_test_labels || 'test:rocprofiler' }}
       windows_test_labels: ${{ inputs.windows_test_labels || '' }}
-      # Manual override for prebuilt stages
-      prebuilt_stages: ${{ inputs.prebuilt_stages || '' }}
-      baseline_run_id: ${{ inputs.baseline_run_id || '' }}
-      # Enable automatic stage reuse
-      # NOTE: For rocm-systems, stages will likely require rebuild since changes
-      # affect compiler-runtime which cascades to all stages
-      stage_reuse_mode: reuse-stage
+      # Use dynamically determined reusable stages, or manual override if provided
+      prebuilt_stages: ${{ inputs.prebuilt_stages || needs.configure.outputs.reusable_stages }}
+      # Use dynamically found baseline run ID, or manual override if provided
+      baseline_run_id: ${{ inputs.baseline_run_id || needs.configure.outputs.baseline_run_id }}
+      # Disable automatic stage reuse since we're passing prebuilt_stages directly
+      stage_reuse_mode: dry-run
       repository: ROCm/TheRock
       ref: users/geomin12/dynamic-determination-stage
       external_repo: '{"repository":"${{ github.repository }}","ref":"${{ github.sha }}"}'

--- a/.github/workflows/therock-multi-arch-ci.yml
+++ b/.github/workflows/therock-multi-arch-ci.yml
@@ -102,9 +102,7 @@ jobs:
             --github-repo "${{ github.repository }}" \
             --base-sha "${{ github.event.pull_request.base.sha }}" \
             --head-sha "${{ github.event.pull_request.head.sha }}" \
-            --config-path ".github/repos-config.json" \
-            --enable-stage-reuse \
-            --ignore-ci-triggers
+            --config-path ".github/repos-config.json"
 
       - name: Debug outputs
         run: |
@@ -112,9 +110,6 @@ jobs:
           echo "changed_projects: ${{ steps.configure.outputs.changed_projects }}"
           echo "run_all_tests: ${{ steps.configure.outputs.run_all_tests }}"
           echo "skip_tests: ${{ steps.configure.outputs.skip_tests }}"
-          echo "reusable_stages: ${{ steps.configure.outputs.reusable_stages }}"
-          echo "rebuild_stages: ${{ steps.configure.outputs.rebuild_stages }}"
-          echo "baseline_run_id: ${{ steps.configure.outputs.baseline_run_id }}"
 
   setup:
     needs: configure
@@ -126,11 +121,13 @@ jobs:
       windows_amdgpu_families: ${{ inputs.windows_amdgpu_families || '' }}
       linux_test_labels: ${{ inputs.linux_test_labels || '' }}
       windows_test_labels: ${{ inputs.windows_test_labels || '' }}
-      # Use dynamically determined prebuilt_stages and baseline_run_id
-      # NOTE: For rocm-systems, reusable_stages will likely be empty since changes
+      # Manual override for prebuilt stages
+      prebuilt_stages: ${{ inputs.prebuilt_stages || '' }}
+      baseline_run_id: ${{ inputs.baseline_run_id || '' }}
+      # Enable automatic stage reuse
+      # NOTE: For rocm-systems, stages will likely require rebuild since changes
       # affect compiler-runtime which cascades to all stages
-      prebuilt_stages: ${{ inputs.prebuilt_stages || needs.configure.outputs.reusable_stages }}
-      baseline_run_id: ${{ inputs.baseline_run_id || needs.configure.outputs.baseline_run_id }}
+      stage_reuse_mode: reuse-stage
       repository: ROCm/TheRock
       ref: users/geomin12/dynamic-determination-stage
       external_repo: '{"repository":"${{ github.repository }}","ref":"${{ github.sha }}"}'

--- a/.github/workflows/therock-multi-arch-ci.yml
+++ b/.github/workflows/therock-multi-arch-ci.yml
@@ -119,7 +119,8 @@ jobs:
       # Limit GPU families for rocm-systems CI
       linux_amdgpu_families: ${{ inputs.linux_amdgpu_families || 'gfx94X' }}
       windows_amdgpu_families: ${{ inputs.windows_amdgpu_families || '' }}
-      linux_test_labels: ${{ inputs.linux_test_labels || '' }}
+      # TEST: Only run rocprofiler tests
+      linux_test_labels: ${{ inputs.linux_test_labels || 'test:rocprofiler' }}
       windows_test_labels: ${{ inputs.windows_test_labels || '' }}
       # Manual override for prebuilt stages
       prebuilt_stages: ${{ inputs.prebuilt_stages || '' }}
@@ -149,8 +150,8 @@ jobs:
       rocm_package_version: ${{ needs.setup.outputs.rocm_package_version }}
       test_type: ${{ needs.setup.outputs.test_type }}
       external_repo_config: ${{ needs.setup.outputs.external_repo_config }}
-      # Empty string when run_all_tests=true triggers full test run in downstream workflow
-      changed_projects: ${{ needs.configure.outputs.run_all_tests == 'true' && '' || needs.configure.outputs.changed_projects }}
+      # TEST: Always pass changed_projects (ignore run_all_tests for testing)
+      changed_projects: ${{ needs.configure.outputs.changed_projects || 'projects/rocprofiler' }}
       repository: ROCm/TheRock
       ref: users/geomin12/dynamic-determination-stage
     permissions:
@@ -174,8 +175,8 @@ jobs:
       rocm_package_version: ${{ needs.setup.outputs.rocm_package_version }}
       test_type: ${{ needs.setup.outputs.test_type }}
       external_repo_config: ${{ needs.setup.outputs.external_repo_config }}
-      # Empty string when run_all_tests=true triggers full test run in downstream workflow
-      changed_projects: ${{ needs.configure.outputs.run_all_tests == 'true' && '' || needs.configure.outputs.changed_projects }}
+      # TEST: Always pass changed_projects (ignore run_all_tests for testing)
+      changed_projects: ${{ needs.configure.outputs.changed_projects || 'projects/rocprofiler' }}
       repository: ROCm/TheRock
       ref: users/geomin12/dynamic-determination-stage
     permissions:

--- a/projects/rocprofiler/CMakeLists.txt
+++ b/projects/rocprofiler/CMakeLists.txt
@@ -1,4 +1,6 @@
 # ##############################################################################
+# TEST: Dynamic baseline_run_id selection test change
+# ##############################################################################
 # Copyright (c) 2018 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/projects/rocprofiler/README.md
+++ b/projects/rocprofiler/README.md
@@ -596,3 +596,5 @@ Please report in the Github Issues.
 - gfx10xx ([Navi2x] AMD Radeon(TM) Graphics)
 - gfx11xx ([Navi3x] AMD Radeon(TM) Graphics)
 
+
+<!-- Test change for CI stage reuse -->

--- a/projects/rocprofiler/TEST_STAGE_REUSE.txt
+++ b/projects/rocprofiler/TEST_STAGE_REUSE.txt
@@ -1,0 +1,1 @@
+# Test change for stage reuse validation


### PR DESCRIPTION
Test TheRock branch users/geomin12/dynamic-determination-stage which adds dynamic baseline_run_id selection for external repos.

Changes:
- Update therock-multi-arch-ci.yml to use TheRock test branch
- Enable --enable-stage-reuse flag to test dynamic baseline selection
- Add pull_request trigger to multi-arch CI
- Disable pull_request trigger on therock-ci.yml to avoid conflicts
- Add test change to rocprofiler/README.md to trigger stage impact analysis

NOTE: rocm-systems changes affect compiler-runtime which cascades to ALL downstream stages, so no stages will be reusable. This is expected behavior. The test is more meaningful for rocm-libraries.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
