### PR TITLE
test(rccl): gate the NIC merge GID check on RoCE and say why a merge failed

### DIFF
--- a/projects/rccl/test/transport/NetIbMPI/GeneralTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/GeneralTests.cpp
@@ -655,9 +655,9 @@ TEST_F(NetIbMPITest, ListenCloseListen) {
 
     ASSERT_EQ(InitNetIb(), ncclSuccess);
 
-    int mergedDev = CreateMergedDevice(4, rank);
+    int mergedDev = CreateMergedDevice(4);
     if (mergedDev == -1) {
-        GTEST_SKIP() << "Failed to create merged device";
+        GTEST_SKIP() << mergeSkipReason_;
     }
 
     for (int iter = 0; iter < 3; iter++) {
@@ -756,10 +756,13 @@ TEST_F(NetIbMPITest, MultipleSimultaneousListens) {
     for (int d : physDevs)
         if (props[d].speed == targetSpeed) compat.push_back(d);
 
-    int mergedDevA = CreateMergedDevice(2, rank);
-    int mergedDevB = CreateMergedDevice(3, rank, 2);
-    if (mergedDevA == -1 || mergedDevB == -1) {
-        GTEST_SKIP() << "Failed to create merged device";
+    int mergedDevA = CreateMergedDevice(2);
+    if (mergedDevA == -1) {
+        GTEST_SKIP() << mergeSkipReason_;
+    }
+    int mergedDevB = CreateMergedDevice(3, /*speedGroupStart=*/2);
+    if (mergedDevB == -1) {
+        GTEST_SKIP() << mergeSkipReason_;
     }
 
     // Physical device = first NIC from merged A's group
@@ -971,9 +974,9 @@ TEST_F(NetIbMPITest, RapidConnectDisconnect) {
     }
     ASSERT_FALSE(physDevs.empty()) << "No physical devices found";
 
-    int mergedDev = CreateMergedDevice(3, rank);
+    int mergedDev = CreateMergedDevice(3);
     if (mergedDev == -1) {
-        GTEST_SKIP() << "Failed to create merged device";
+        GTEST_SKIP() << mergeSkipReason_;
     }
 
 

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
@@ -470,14 +470,30 @@ protected:
         ASSERT_EQ(PostRecv(recvComm, 1, bufs, sizes, tags, handles, request), ncclSuccess);
     }
 
-    // Returns true if the IB device has at least one routable GID (non-zero IPv4-mapped
-    // or global-scope IPv6). NICs with only link-local GIDs cannot do cross-node RDMA.
-    static bool HasRoutableGid(const char* devName) {
+    // Returns true unless the port is RoCE with no routable GID: such a port completes QP
+    // setup and then silently drops cross-node RDMA traffic. On InfiniBand every GID is
+    // link-local, so the GID table says nothing about routability there. When the port
+    // cannot be inspected, assume it is usable rather than dropping the NIC.
+    static bool CanRouteCrossNode(const char* devName, int port) {
         char path[PATH_MAX];
-        if (snprintf(path, sizeof(path), "/sys/class/infiniband/%s/ports/1/gids", devName) >= PATH_MAX)
-            return false;
+        if (snprintf(path, sizeof(path), "/sys/class/infiniband/%s/ports/%d/link_layer",
+                     devName, port) >= PATH_MAX)
+            return true;
+
+        FILE* linkLayerFile = fopen(path, "r");
+        if (!linkLayerFile) return true;
+
+        char linkLayer[32] = {};
+        fscanf(linkLayerFile, "%31s", linkLayer);
+        fclose(linkLayerFile);
+
+        if (strcmp(linkLayer, "Ethernet") != 0) return true;
+
+        snprintf(path, sizeof(path), "/sys/class/infiniband/%s/ports/%d/gids", devName, port);
+
         DIR* d = opendir(path);
-        if (!d) return false;
+        if (!d) return true;
+
         struct dirent* ent;
         bool found = false;
         while ((ent = readdir(d)) != nullptr) {
@@ -501,8 +517,8 @@ protected:
     // Helper: create a merged device from N physical NICs.
     // Returns merged device index, or -1 if no suitable group found.
     // Iterates speed groups (fastest-first by enumeration order). Within each
-    // group, slides a window of nNicsToMerge; skips windows containing a NIC
-    // without a routable GID (those can set up QPs but drop RDMA traffic cross-node).
+    // group, slides a window of nNicsToMerge; skips windows containing a NIC that
+    // cannot carry cross-node RDMA traffic.
     // speedGroupStart: index into physDevs indicating which speed group to try first.
     // rank: MPI rank of this process
     int CreateMergedDevice(int nNicsToMerge, int rank, int speedGroupStart = 0)
@@ -539,8 +555,8 @@ protected:
         for (int w = 0; w + nNicsToMerge <= (int)compat.size(); w++) {
             bool routable = true;
             for (int i = 0; i < nNicsToMerge; i++) {
-                const char* name = props[compat[w + i]].name;
-                if (name && !HasRoutableGid(name)) { routable = false; break; }
+                const ncclNetProperties_t& dev = props[compat[w + i]];
+                if (dev.name && !CanRouteCrossNode(dev.name, dev.port)) { routable = false; break; }
             }
             if (!routable) continue;
 

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
@@ -470,36 +470,36 @@ protected:
         ASSERT_EQ(PostRecv(recvComm, 1, bufs, sizes, tags, handles, request), ncclSuccess);
     }
 
-    // Returns true unless the port is RoCE with no routable GID: such a port completes QP
-    // setup and then silently drops cross-node RDMA traffic. On InfiniBand every GID is
-    // link-local, so the GID table says nothing about routability there. When the port
-    // cannot be inspected, assume it is usable rather than dropping the NIC.
-    static bool CanRouteCrossNode(const char* devName, int port) {
+    static bool PortIsEthernet(const char* portsPath, const char* port) {
         char path[PATH_MAX];
-        if (snprintf(path, sizeof(path), "/sys/class/infiniband/%s/ports/%d/link_layer",
-                     devName, port) >= PATH_MAX)
-            return true;
+        if (snprintf(path, sizeof(path), "%s/%s/link_layer", portsPath, port) >= (int)sizeof(path))
+            return false;
 
         FILE* linkLayerFile = fopen(path, "r");
-        if (!linkLayerFile) return true;
+        if (!linkLayerFile) return false;
 
         char linkLayer[32] = {};
         bool linkLayerRead = (fscanf(linkLayerFile, "%31s", linkLayer) == 1);
         fclose(linkLayerFile);
 
-        if (!linkLayerRead || strcmp(linkLayer, "Ethernet") != 0) return true;
+        return linkLayerRead && strcmp(linkLayer, "Ethernet") == 0;
+    }
 
-        snprintf(path, sizeof(path), "/sys/class/infiniband/%s/ports/%d/gids", devName, port);
+    static bool PortHasRoutableGid(const char* portsPath, const char* port) {
+        char path[PATH_MAX];
+        if (snprintf(path, sizeof(path), "%s/%s/gids", portsPath, port) >= (int)sizeof(path))
+            return false;
 
-        DIR* d = opendir(path);
-        if (!d) return true;
+        DIR* gidDir = opendir(path);
+        if (!gidDir) return false;
 
         struct dirent* ent;
         bool found = false;
-        while ((ent = readdir(d)) != nullptr) {
+        while (!found && (ent = readdir(gidDir)) != nullptr) {
             if (ent->d_name[0] == '.') continue;
             char gidPath[PATH_MAX];
-            snprintf(gidPath, sizeof(gidPath), "%s/%s", path, ent->d_name);
+            if (snprintf(gidPath, sizeof(gidPath), "%s/%s", path, ent->d_name) >= (int)sizeof(gidPath))
+                continue;
             FILE* f = fopen(gidPath, "r");
             if (!f) continue;
             char gid[64] = {};
@@ -509,10 +509,41 @@ protected:
             // Skip all-zero GIDs and link-local (fe80::) GIDs
             bool allZero = (strcmp(gid, "0000:0000:0000:0000:0000:0000:0000:0000") == 0);
             bool linkLocal = (strncmp(gid, "fe80:", 5) == 0);
-            if (!allZero && !linkLocal) { found = true; break; }
+            found = !allZero && !linkLocal;
         }
-        closedir(d);
+        closedir(gidDir);
         return found;
+    }
+
+    // Returns true unless the device is RoCE with no routable GID on any port: such a port
+    // completes QP setup and then silently drops cross-node RDMA traffic. On InfiniBand every
+    // GID is link-local, so the GID table says nothing about routability there. When the device
+    // cannot be inspected, assume it is usable rather than dropping the NIC.
+    //
+    // The ports come from the device directory rather than ncclNetProperties_t::port, which the
+    // plugin sets to portNum + realPort. realPort counts VF siblings on one PCI path, so for
+    // every VF past the first it names a port that does not exist in sysfs.
+    static bool CanRouteCrossNode(const char* devName) {
+        char portsPath[PATH_MAX];
+        if (snprintf(portsPath, sizeof(portsPath), "/sys/class/infiniband/%s/ports", devName)
+            >= (int)sizeof(portsPath))
+            return true;
+
+        DIR* portsDir = opendir(portsPath);
+        if (!portsDir) return true;
+
+        int ethernetPorts = 0;
+        bool routable = false;
+        struct dirent* ent;
+        while (!routable && (ent = readdir(portsDir)) != nullptr) {
+            if (ent->d_name[0] == '.') continue;
+            if (!PortIsEthernet(portsPath, ent->d_name)) continue;
+            ethernetPorts++;
+            routable = PortHasRoutableGid(portsPath, ent->d_name);
+        }
+        closedir(portsDir);
+
+        return routable || ethernetPorts == 0;
     }
 
     // What CreateMergedDevice() tried before giving up. Empty after a success.
@@ -528,9 +559,9 @@ protected:
     // Helper: create a merged device from N physical NICs.
     // Returns merged device index, or -1 if no suitable group found, in which case
     // mergeSkipReason_ describes the attempt.
-    // Iterates speed groups (fastest-first by enumeration order). Within each
-    // group, slides a window of nNicsToMerge; skips windows containing a NIC that
-    // cannot carry cross-node RDMA traffic.
+    // Iterates speed groups in order of first appearance. Within each group, slides
+    // a window of nNicsToMerge; skips windows containing a NIC that cannot carry
+    // cross-node RDMA traffic.
     // speedGroupStart: index into physDevs indicating which speed group to try first.
     int CreateMergedDevice(int nNicsToMerge, int speedGroupStart = 0)
     {
@@ -546,6 +577,8 @@ protected:
         if (mergedDev < 0)
             mergeSkipReason_ = "no group of " + std::to_string(nNicsToMerge) +
                                " mergeable NICs: " + mergeSkipReason_;
+        else
+            mergeSkipReason_.clear();
         return mergedDev;
     }
 
@@ -568,69 +601,69 @@ protected:
         }
 
         if (speedGroupStart >= (int)physDevs.size()) {
-            if (mergeSkipReason_.empty())
-                AppendMergeSkipReason(std::to_string(physDevs.size()) +
-                                      " physical NICs, none from index " +
-                                      std::to_string(speedGroupStart) + " on");
+            AppendMergeSkipReason(std::to_string(physDevs.size()) +
+                                  " physical NICs, none from index " +
+                                  std::to_string(speedGroupStart) + " on");
             return -1;
         }
 
-        // Build the speed group starting at speedGroupStart
-        int targetSpeed = props[physDevs[speedGroupStart]].speed;
-        std::vector<int> compat;
-        for (int d : physDevs)
-            if (props[d].speed == targetSpeed) compat.push_back(d);
+        // A speed group is every NIC at that speed, wherever it sits in physDevs, so walking the
+        // start index would revisit a group whose members are not contiguous.
+        std::set<int> triedSpeeds;
 
-        int windowsTried = 0;
-        int windowsUnroutable = 0;
-        int windowsRefused = 0;
-        std::string firstUnroutableNic;
+        for (int start = speedGroupStart; start < (int)physDevs.size(); start++) {
+            int targetSpeed = props[physDevs[start]].speed;
+            if (!triedSpeeds.insert(targetSpeed).second) continue;
 
-        // Try each consecutive window of nNicsToMerge within this speed group
-        for (int w = 0; w + nNicsToMerge <= (int)compat.size(); w++) {
-            windowsTried++;
-            bool routable = true;
-            for (int i = 0; i < nNicsToMerge; i++) {
-                const ncclNetProperties_t& dev = props[compat[w + i]];
-                if (dev.name && !CanRouteCrossNode(dev.name, dev.port)) {
-                    routable = false;
-                    if (firstUnroutableNic.empty()) firstUnroutableNic = dev.name;
-                    break;
+            std::vector<int> compat;
+            for (int d : physDevs)
+                if (props[d].speed == targetSpeed) compat.push_back(d);
+
+            int windowsTried = 0;
+            int windowsUnroutable = 0;
+            int windowsRefused = 0;
+            std::string firstUnroutableNic;
+
+            // Try each consecutive window of nNicsToMerge within this speed group
+            for (int w = 0; w + nNicsToMerge <= (int)compat.size(); w++) {
+                windowsTried++;
+                bool routable = true;
+                for (int i = 0; i < nNicsToMerge; i++) {
+                    const ncclNetProperties_t& dev = props[compat[w + i]];
+                    if (dev.name && !CanRouteCrossNode(dev.name)) {
+                        routable = false;
+                        if (firstUnroutableNic.empty()) firstUnroutableNic = dev.name;
+                        break;
+                    }
                 }
+                if (!routable) { windowsUnroutable++; continue; }
+
+                ncclNetVDeviceProps_t vProps;
+                memset(&vProps, 0, sizeof(vProps));
+                vProps.ndevs = nNicsToMerge;
+                for (int i = 0; i < nNicsToMerge; i++)
+                    vProps.devs[i] = compat[w + i];
+
+                int outMergedDev = -1;
+                if (MakeVirtualDevice(&outMergedDev, &vProps) == ncclSuccess && outMergedDev >= 0)
+                    return outMergedDev;
+                windowsRefused++;
             }
-            if (!routable) { windowsUnroutable++; continue; }
 
-            ncclNetVDeviceProps_t vProps;
-            memset(&vProps, 0, sizeof(vProps));
-            vProps.ndevs = nNicsToMerge;
-            for (int i = 0; i < nNicsToMerge; i++)
-                vProps.devs[i] = compat[w + i];
-
-            int outMergedDev = -1;
-            if (MakeVirtualDevice(&outMergedDev, &vProps) == ncclSuccess && outMergedDev >= 0)
-                return outMergedDev;
-            windowsRefused++;
+            std::ostringstream clause;
+            if (windowsTried == 0) {
+                clause << compat.size() << " of the " << nNicsToMerge
+                       << " NICs required at speed " << targetSpeed;
+            } else {
+                clause << compat.size() << " NICs at speed " << targetSpeed << ": "
+                       << windowsTried << " windows tried, " << windowsUnroutable << " unroutable";
+                if (!firstUnroutableNic.empty()) clause << " (" << firstUnroutableNic << ")";
+                clause << ", " << windowsRefused << " refused by makeVDevice";
+            }
+            AppendMergeSkipReason(clause.str());
         }
 
-        std::ostringstream clause;
-        if (windowsTried == 0) {
-            clause << compat.size() << " of the " << nNicsToMerge
-                   << " NICs required at speed " << targetSpeed;
-        } else {
-            clause << compat.size() << " NICs at speed " << targetSpeed << ": "
-                   << windowsTried << " windows tried, " << windowsUnroutable << " unroutable";
-            if (!firstUnroutableNic.empty()) clause << " (" << firstUnroutableNic << ")";
-            clause << ", " << windowsRefused << " refused by makeVDevice";
-        }
-        AppendMergeSkipReason(clause.str());
-
-        // This speed group exhausted — advance to the next one
-        int nextStart = speedGroupStart;
-        while (nextStart < (int)physDevs.size() &&
-               props[physDevs[nextStart]].speed == targetSpeed)
-            nextStart++;
-
-        return CreateMergedDeviceFromSpeedGroup(nNicsToMerge, nextStart);
+        return -1;
     }
 
 

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
@@ -484,10 +484,10 @@ protected:
         if (!linkLayerFile) return true;
 
         char linkLayer[32] = {};
-        fscanf(linkLayerFile, "%31s", linkLayer);
+        bool linkLayerRead = (fscanf(linkLayerFile, "%31s", linkLayer) == 1);
         fclose(linkLayerFile);
 
-        if (strcmp(linkLayer, "Ethernet") != 0) return true;
+        if (!linkLayerRead || strcmp(linkLayer, "Ethernet") != 0) return true;
 
         snprintf(path, sizeof(path), "/sys/class/infiniband/%s/ports/%d/gids", devName, port);
 
@@ -503,8 +503,9 @@ protected:
             FILE* f = fopen(gidPath, "r");
             if (!f) continue;
             char gid[64] = {};
-            fscanf(f, "%63s", gid);
+            bool gidRead = (fscanf(f, "%63s", gid) == 1);
             fclose(f);
+            if (!gidRead) continue;
             // Skip all-zero GIDs and link-local (fe80::) GIDs
             bool allZero = (strcmp(gid, "0000:0000:0000:0000:0000:0000:0000:0000") == 0);
             bool linkLocal = (strncmp(gid, "fe80:", 5) == 0);

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
@@ -514,25 +514,48 @@ protected:
         return found;
     }
 
+    // What CreateMergedDevice() tried before giving up. Empty after a success.
+    // Callers put it in their GTEST_SKIP() message, so a skip states which speed
+    // groups existed and why each one was rejected.
+    std::string mergeSkipReason_;
+
+    void AppendMergeSkipReason(const std::string& clause) {
+        if (!mergeSkipReason_.empty()) mergeSkipReason_ += "; ";
+        mergeSkipReason_ += clause;
+    }
+
     // Helper: create a merged device from N physical NICs.
-    // Returns merged device index, or -1 if no suitable group found.
+    // Returns merged device index, or -1 if no suitable group found, in which case
+    // mergeSkipReason_ describes the attempt.
     // Iterates speed groups (fastest-first by enumeration order). Within each
     // group, slides a window of nNicsToMerge; skips windows containing a NIC that
     // cannot carry cross-node RDMA traffic.
     // speedGroupStart: index into physDevs indicating which speed group to try first.
-    // rank: MPI rank of this process
-    int CreateMergedDevice(int nNicsToMerge, int rank, int speedGroupStart = 0)
+    int CreateMergedDevice(int nNicsToMerge, int speedGroupStart = 0)
     {
+        mergeSkipReason_.clear();
+
         if (nNicsToMerge <= 0 || nNicsToMerge > NCCL_NET_MAX_DEVS_PER_NIC) {
-            fprintf(stderr,
-                    "Rank %d requested invalid merge size %d (valid range: 1..%d)\n",
-                    rank, nNicsToMerge, NCCL_NET_MAX_DEVS_PER_NIC);
+            mergeSkipReason_ = "invalid merge size " + std::to_string(nNicsToMerge) +
+                               " (valid range: 1.." + std::to_string(NCCL_NET_MAX_DEVS_PER_NIC) + ")";
             return -1;
         }
 
+        int mergedDev = CreateMergedDeviceFromSpeedGroup(nNicsToMerge, speedGroupStart);
+        if (mergedDev < 0)
+            mergeSkipReason_ = "no group of " + std::to_string(nNicsToMerge) +
+                               " mergeable NICs: " + mergeSkipReason_;
+        return mergedDev;
+    }
+
+    int CreateMergedDeviceFromSpeedGroup(int nNicsToMerge, int speedGroupStart)
+    {
         int ndev = 0;
         RCCL_TEST_CHECK(GetDeviceCount(&ndev));
-        if (ndev <= 0) return -1;
+        if (ndev <= 0) {
+            AppendMergeSkipReason("the plugin reports no devices");
+            return -1;
+        }
 
         std::vector<ncclNetProperties_t> props(ndev);
         std::vector<int> physDevs;
@@ -543,7 +566,13 @@ protected:
                 physDevs.push_back(i);
         }
 
-        if (speedGroupStart >= (int)physDevs.size()) return -1;
+        if (speedGroupStart >= (int)physDevs.size()) {
+            if (mergeSkipReason_.empty())
+                AppendMergeSkipReason(std::to_string(physDevs.size()) +
+                                      " physical NICs, none from index " +
+                                      std::to_string(speedGroupStart) + " on");
+            return -1;
+        }
 
         // Build the speed group starting at speedGroupStart
         int targetSpeed = props[physDevs[speedGroupStart]].speed;
@@ -551,14 +580,24 @@ protected:
         for (int d : physDevs)
             if (props[d].speed == targetSpeed) compat.push_back(d);
 
+        int windowsTried = 0;
+        int windowsUnroutable = 0;
+        int windowsRefused = 0;
+        std::string firstUnroutableNic;
+
         // Try each consecutive window of nNicsToMerge within this speed group
         for (int w = 0; w + nNicsToMerge <= (int)compat.size(); w++) {
+            windowsTried++;
             bool routable = true;
             for (int i = 0; i < nNicsToMerge; i++) {
                 const ncclNetProperties_t& dev = props[compat[w + i]];
-                if (dev.name && !CanRouteCrossNode(dev.name, dev.port)) { routable = false; break; }
+                if (dev.name && !CanRouteCrossNode(dev.name, dev.port)) {
+                    routable = false;
+                    if (firstUnroutableNic.empty()) firstUnroutableNic = dev.name;
+                    break;
+                }
             }
-            if (!routable) continue;
+            if (!routable) { windowsUnroutable++; continue; }
 
             ncclNetVDeviceProps_t vProps;
             memset(&vProps, 0, sizeof(vProps));
@@ -569,7 +608,20 @@ protected:
             int outMergedDev = -1;
             if (MakeVirtualDevice(&outMergedDev, &vProps) == ncclSuccess && outMergedDev >= 0)
                 return outMergedDev;
+            windowsRefused++;
         }
+
+        std::ostringstream clause;
+        if (windowsTried == 0) {
+            clause << compat.size() << " of the " << nNicsToMerge
+                   << " NICs required at speed " << targetSpeed;
+        } else {
+            clause << compat.size() << " NICs at speed " << targetSpeed << ": "
+                   << windowsTried << " windows tried, " << windowsUnroutable << " unroutable";
+            if (!firstUnroutableNic.empty()) clause << " (" << firstUnroutableNic << ")";
+            clause << ", " << windowsRefused << " refused by makeVDevice";
+        }
+        AppendMergeSkipReason(clause.str());
 
         // This speed group exhausted — advance to the next one
         int nextStart = speedGroupStart;
@@ -577,7 +629,7 @@ protected:
                props[physDevs[nextStart]].speed == targetSpeed)
             nextStart++;
 
-        return CreateMergedDevice(nNicsToMerge, rank, nextStart);
+        return CreateMergedDeviceFromSpeedGroup(nNicsToMerge, nextStart);
     }
 
 

--- a/projects/rccl/test/transport/NetIbMPI/NicFusionTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/NicFusionTests.cpp
@@ -1195,7 +1195,7 @@ TEST_F(NetIbMPITest, SequentialTransfers_VNic) {
 // =============================================================================
 // Test: SendRecvDifferentMemoryTypes
 //
-// Creates a 2-NIC merged virtual device per rank (CreateMergedDevice(2, rank)).
+// Creates a 2-NIC merged virtual device per rank (CreateMergedDevice(2)).
 // Rank 0 (receiver) and Rank 1 (sender) each use their own merged device.
 // Tests all four memory type combinations: host→host, host→GPU, GPU→host, GPU→GPU.
 //
@@ -1216,9 +1216,9 @@ TEST_F(NetIbMPITest, SendRecvDifferentMemoryTypes) {
 
     ASSERT_EQ(InitNetIb(), ncclSuccess);
 
-    int mergedDev = CreateMergedDevice(2, rank);
+    int mergedDev = CreateMergedDevice(2);
     if (mergedDev == -1) {
-        GTEST_SKIP() << "Failed to create merged device";
+        GTEST_SKIP() << mergeSkipReason_;
     }
 
     ncclNetProperties_t mProps;
@@ -1345,9 +1345,9 @@ TEST_F(NetIbMPITest, SendRecvMultipleSizesFusion) {
 
     ASSERT_EQ(InitNetIb(), ncclSuccess);
 
-    int mergedDev = CreateMergedDevice(3, rank);
+    int mergedDev = CreateMergedDevice(3);
     if (mergedDev == -1) {
-        GTEST_SKIP() << "Failed to create merged device";
+        GTEST_SKIP() << mergeSkipReason_;
     }
 
     // Build test size list
@@ -1470,9 +1470,9 @@ TEST_F(NetIbMPITest, MultidirectionalTransfer) {
 
     ASSERT_EQ(InitNetIb(), ncclSuccess);
 
-    int mergedSendDev = CreateMergedDevice(4, rank);
+    int mergedSendDev = CreateMergedDevice(4);
     if (mergedSendDev == -1) {
-        GTEST_SKIP() << "Failed to create merged device";
+        GTEST_SKIP() << mergeSkipReason_;
     }
     int mergedRecvDev = mergedSendDev;
 
@@ -1610,9 +1610,9 @@ TEST_F(NetIbMPITest, MultipleOutstandingSendRecv) {
     // --- Init and discover devices ---
     ASSERT_EQ(InitNetIb(), ncclSuccess);
 
-    int mergedDev = CreateMergedDevice(2, rank);
+    int mergedDev = CreateMergedDevice(2);
     if (mergedDev == -1) {
-        GTEST_SKIP() << "Failed to create merged device";
+        GTEST_SKIP() << mergeSkipReason_;
     }
 
     // --- Parameters ---
@@ -2080,9 +2080,9 @@ TEST_F(NetIbMPITest, MultiRecvGPUShuffled) {
 
     ASSERT_EQ(InitNetIb(), ncclSuccess);
 
-    int dev = CreateMergedDevice(3, rank);
+    int dev = CreateMergedDevice(3);
     if (dev == -1) {
-        GTEST_SKIP() << "Failed to create 3-NIC merged device";
+        GTEST_SKIP() << mergeSkipReason_;
     }
 
     {


### PR DESCRIPTION
## Motivation

On a cluster with InfiniBand `ListenCloseListen`, `MultipleSimultaneousListens` and `MultiRecvGPUShuffled` skip themselves with `Failed to create merged device`, while `MergeMultipleDevices` fuses the same physical NICs seconds later in the same run.

Two problems follow. The merge API itself stays covered on IB, but everything downstream of it is lost, since these three are the tests that take a fused NIC through cross-node QP setup and teardown, concurrent listens, and multi-receive GPU transfers. And because all nine call sites printed one constant string, a skip could not be told apart from a genuine fusion failure.

## Technical Details

**The GID filter was RoCE semantics applied to every fabric.** `CreateMergedDevice()` dropped any NIC whose GID table held only link-local entries. On RoCE that is a real defect, since such a port completes QP setup and then silently discards cross-node traffic. On InfiniBand it is the normal state: routing goes by LID/FLID and index 0 is always `fe80::`, which is exactly the entry `ncclIbGetGidIndex()` selects. The filter removed every candidate before `MakeVirtualDevice()` was ever called, and `MergeMultipleDevices` passed only because it never consulted it. The helper was therefore stricter than the code under test: `ncclIbMakeVDeviceInternal()` has no such requirement. The check now reads `link_layer` first and runs the GID scan on Ethernet ports only.

**The port was hardcoded, and `props.port` is not the port either.** The check addressed `ports/1` regardless of device, so on a multi-port NIC it inspected the wrong port. Reading `ncclNetProperties_t::port` is not a fix: the plugin sets it to `portNum + realPort`, and `realPort` counts earlier devices sharing a VF pci path, so past the first VF it names a sysfs port that does not exist, `fopen` fails, and the assume-usable default drops the filter entirely, which is worse than the hardcoded `ports/1` it replaced. `portNum` is not reachable through the public plugin API, so the check enumerates `/sys/class/infiniband/<dev>/ports/*` instead and rejects a NIC only when it has an Ethernet port and none of its ports carries a routable GID. An unreadable device or port still means assume-usable rather than silently dropping the NIC. Both sysfs reads check their `fscanf` result instead of letting an empty buffer decide, which also removes a disagreement in the GID loop where an unreadable entry counted as routable while an unopenable one was skipped.

**Skips now explain themselves.** Each speed group contributes a clause naming how many windows were tried, how many held a NIC that cannot route cross-node and which one, and how many `makeVDevice` itself refused:

```
no group of 4 mergeable NICs: 8 NICs at speed 400000: 5 windows tried, 5 unroutable (mlx5_0), 0 refused by makeVDevice
no group of 4 mergeable NICs: 1 of the 4 NICs required at speed 400000
```

The string is cleared when a merge does succeed, and each speed group is visited once even when its NICs are not contiguous in the enumeration, so a clause cannot repeat. Selection behavior is unchanged: the same groups are tried in the same order and the same value is returned.

## Issue Tracking

JIRA ID : ROCM-28935

## Test Plan

Validated on two nodes with MI300X:
- ConnectX-7 InfiniBand: the four affected tests go from 1 passed / 3 skipped to 4 passed, with `MultiRecvGPUShuffled` moving from 0 ms to 5.5 s of real cross-node GPU traffic.
- Broadcom Thor2 RoCE: 4 passed before and after, and the built vNICs still name only the eight ACTIVE `bnxt_re` ports, confirming the check is honored rather than bypassed there.
- Full `NetIbMPITest.*` shows no new failures on either fabric: on InfiniBand 115 tests, 64 passed, 46 skipped and the same five `-np 2` failures the stock code produces.
- Restricting the run to one HCA produces `1 of the N NICs required at speed 400000`.
- Temporarily disabling the link-layer gate on the InfiniBand nodes makes all eight `mlx5` devices come back as `5 windows tried, 5 unroutable (mlx5_0)`. That both reproduces the original skip with its cause now stated, and is the evidence that the port walk reaches each device's GID table rather than falling through to assume-usable, since "no ports found" would report the NICs as usable instead.

## Test Result

CI tests result:
***NetIB_Conn_RapidConnectDisconnect***
[ RUN      ] NetIbMPITest.RapidConnectDisconnect
init_tmp.cc:331 NCCL WARN NET/IB : Merging NICs across PCIe Root Complexes (mlx5_0 root=0000:00, mlx5_2 root=0000:40).
connect_tmp.cc:1424 NCCL WARN NET/IB: Peermem not available, falling back to GPU Direct RDMA (DMAbuf) for device 6
   ... эта строка повторяется 100 раз, по одной на цикл connect/disconnect ...
[       OK ] NetIbMPITest.RapidConnectDisconnect (4863 ms)
  Result: PASSED (6.480 seconds)

***NetIB_Xfer_DifferentMemoryTypes***
NCCL WARN NET/IB : Merging NICs across PCIe Root Complexes (mlx5_0 root=0000:00, mlx5_2 root=0000:40).
NCCL INFO NET/IB : Made virtual device [6] name=mlx5_0+mlx5_2 speed=800000 ndevs=2
[       OK ] NetIbMPITest.SendRecvDifferentMemoryTypes (121 ms)
  Result: PASSED (1.870 seconds)

***NetIB_Xfer_MultipleSizesFusion***
build 5:  NCCL INFO NET/IB : Made virtual device [6] name=mlx5_0+mlx5_2+mlx5_3 speed=1200000 ndevs=3
          [       OK ] NetIbMPITest.SendRecvMultipleSizesFusion (760 ms)
          Result: PASSED (2.471 seconds)

***NetIB_Xfer_MultipleOutstanding***
build 5:  NCCL INFO NET/IB : Made virtual device [6] name=mlx5_0+mlx5_2 speed=800000 ndevs=2
          [       OK ] NetIbMPITest.MultipleOutstandingSendRecv (541 ms)
          Result: PASSED (2.171 seconds)

***NetIB_VNic_MergeMultipleDevices***
[0] TEST INFO Only 6 same-speed NICs available; the ndevs == 8 boundary was not exercised
init_tmp.cc:261 NCCL WARN NET/IB : Can't make virtual NIC with 9 devices, max 8
[       OK ] NetIbMPITest.MergeMultipleDevices (56 ms)
  Result: PASSED (7.135 seconds)

***NetIB_VNic_DisjointRailLocal***
NCCL WARN NET/IB : Merging NICs across PCIe Root Complexes (mlx5_0 root=0000:00, mlx5_2 root=0000:40).
NCCL WARN NET/IB: Peermem not available, falling back to GPU Direct RDMA (DMAbuf) for device 6
[       OK ] NetIbMPITest.DisjointMergeRailLocal_VNic (96 ms)
  Result: PASSED (6.933 seconds)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.

**(AI Asist)**

