### PR TITLE
[rocjitsu] Speed up indirect branch discovery

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
@@ -265,6 +265,11 @@ struct AnalysisContext {
   std::span<const uint8_t> text;
   rj_code_arch_t arch;
   std::vector<InstructionFacts> facts;
+
+  // Whole-text superset of every SGPR pair that a deferred cross-block
+  // consumer can name. Every PendingConsumer producer must originate from one
+  // of the setpc/swappc operands recorded here.
+  std::bitset<REGISTER_SET_MAX_SGPRS> consumer_pairs;
 };
 
 /// @brief Per-pair summary for one analysis block.
@@ -475,6 +480,21 @@ public:
     return false;
   }
 
+  /// @brief Visit dirty SGPR halves in ascending register order.
+  template <typename F> void for_each_dirty(F &&f) const {
+    uint64_t bits = dirty_lo_;
+    while (bits != 0) {
+      f(static_cast<uint16_t>(std::countr_zero(bits)));
+      bits &= bits - 1;
+    }
+
+    bits = dirty_hi_;
+    while (bits != 0) {
+      f(static_cast<uint16_t>(64 + std::countr_zero(bits)));
+      bits &= bits - 1;
+    }
+  }
+
   /// @brief Invalidate every builder overlapping @p sgpr.
   ///
   /// @details A write to sN can corrupt the pair s[N:N+1] when sN is the low
@@ -513,6 +533,7 @@ private:
 
   std::array<std::optional<PcValue>, REGISTER_SET_MAX_SGPRS> builders_;
   std::vector<uint16_t> active_pairs_;
+  static_assert(REGISTER_SET_MAX_SGPRS <= 128, "dirty set uses two 64-bit words");
   uint64_t dirty_lo_ = 0;
   uint64_t dirty_hi_ = 0;
 };
@@ -1178,6 +1199,10 @@ void join_lattice_value(LatticeValue &dst, const LatticeValue &src) {
     facts.getpc_sdst = scalar_pc_sreg(arch, inst, facts.word, ScalarPcOp::GetPc64);
     facts.setpc_ssrc = scalar_pc_sreg(arch, inst, facts.word, ScalarPcOp::SetPc64);
     facts.swappc_ssrc = scalar_pc_sreg(arch, inst, facts.word, ScalarPcOp::SwapPc64);
+    if (facts.setpc_ssrc && *facts.setpc_ssrc < kMaxTrackedSgprPair)
+      ctx.consumer_pairs.set(*facts.setpc_ssrc);
+    if (facts.swappc_ssrc && *facts.swappc_ssrc < kMaxTrackedSgprPair)
+      ctx.consumer_pairs.set(*facts.swappc_ssrc);
     if (facts.swappc_ssrc)
       facts.swappc_sdst = static_cast<uint16_t>((facts.word >> 16) & 0x7fu);
     facts.call_sdst = s_call_sdst(inst, facts.word);
@@ -1254,12 +1279,20 @@ build_analysis_blocks(const AnalysisContext &ctx, std::span<const uint64_t> extr
 
 [[nodiscard]] std::vector<uint8_t>
 explicit_external_entries(const std::vector<AnalysisBlock> &blocks,
-                          std::span<const uint64_t> extra_leaders) {
+                          std::span<const uint64_t> sorted_extra_leaders) {
   std::vector<uint8_t> entries(blocks.size(), 0);
   if (!entries.empty())
     entries[0] = 1;
+
+  // Analysis blocks are built from the ordered instruction stream. Both input
+  // sequences are therefore ascending and can be matched in one merge pass.
+  assert(std::ranges::is_sorted(blocks, {}, &AnalysisBlock::offset));
+  assert(std::ranges::is_sorted(sorted_extra_leaders));
+  auto leader = sorted_extra_leaders.begin();
   for (size_t block_index = 1; block_index < blocks.size(); ++block_index) {
-    if (std::ranges::find(extra_leaders, blocks[block_index].offset) != extra_leaders.end())
+    while (leader != sorted_extra_leaders.end() && *leader < blocks[block_index].offset)
+      ++leader;
+    if (leader != sorted_extra_leaders.end() && *leader == blocks[block_index].offset)
       entries[block_index] = 1;
   }
   return entries;
@@ -1284,15 +1317,18 @@ void set_kill_transfer(AnalysisBlock &block, uint16_t pair_lo) {
     transfer.kind = PairTransfer::Kind::Kill;
 }
 
-void finalize_block_transfers(AnalysisBlock &block, const BlockState &state) {
+void finalize_block_transfers(AnalysisBlock &block, const BlockState &state,
+                              const std::bitset<REGISTER_SET_MAX_SGPRS> &consumer_pairs) {
   // Phase 2 block-exit summary:
   //
-  // 1. Every still-live builder becomes SET. This overrides incoming facts for
-  //    the same pair in Phase 3.
-  // 2. Every dirty half that is not covered by a SET kills both possible pair
-  //    interpretations: s[N:N+1] and, when N > 0, s[N-1:N].
+  // 1. Every still-live builder for a consumer pair becomes SET. This
+  //    overrides incoming facts for the same pair in Phase 3.
+  // 2. Every dirty half overlapping a consumer pair that is not covered by a
+  //    SET kills that interpretation: s[N:N+1] or, when N > 0, s[N-1:N].
   // 3. Pairs never mentioned in transfers are implicit PASS.
   for (uint16_t pair_lo : state.active_pairs()) {
+    if (!consumer_pairs[pair_lo])
+      continue;
     const PcValue *value = state.builder(pair_lo);
     if (value == nullptr)
       continue;
@@ -1301,18 +1337,19 @@ void finalize_block_transfers(AnalysisBlock &block, const BlockState &state) {
     transfer.value = *value;
   }
 
-  for (uint16_t half = 0; half < REGISTER_SET_MAX_SGPRS; ++half) {
-    if (!state.dirty(half))
-      continue;
-    if (!block.transfers.contains(half) || block.transfers[half].kind != PairTransfer::Kind::Set)
+  const auto has_set_transfer = [&](uint16_t pair_lo) {
+    const auto transfer = block.transfers.find(pair_lo);
+    return transfer != block.transfers.end() && transfer->second.kind == PairTransfer::Kind::Set;
+  };
+  state.for_each_dirty([&](uint16_t half) {
+    if (consumer_pairs[half] && !has_set_transfer(half))
       set_kill_transfer(block, half);
     if (half > 0) {
       const uint16_t previous_pair = static_cast<uint16_t>(half - 1);
-      if (!block.transfers.contains(previous_pair) ||
-          block.transfers[previous_pair].kind != PairTransfer::Kind::Set)
+      if (consumer_pairs[previous_pair] && !has_set_transfer(previous_pair))
         set_kill_transfer(block, previous_pair);
     }
-  }
+  });
 }
 
 std::optional<size_t> try_apply_temp_delta_pattern(AnalysisContext &ctx, const AnalysisBlock &block,
@@ -1605,6 +1642,8 @@ void scan_block(AnalysisContext &ctx, size_t block_index, std::vector<AnalysisBl
         // predecessor blocks. Defer classification until the block-entry
         // lattice is available. Out-of-range selectors cannot name a tracked
         // SGPR pair and deliberately remain unresolved.
+        assert(ctx.consumer_pairs[*consumer_pair] &&
+               "deferred consumer pair must be in the whole-text consumer set");
         pending_consumers.push_back(PendingConsumer{
             .block_index = block_index,
             .inst_index = index,
@@ -1655,13 +1694,12 @@ void scan_block(AnalysisContext &ctx, size_t block_index, std::vector<AnalysisBl
   }
 
   note_live_pc_builders();
-  finalize_block_transfers(block, state);
+  finalize_block_transfers(block, state, ctx.consumer_pairs);
 }
 
-[[nodiscard]] std::vector<LatticeFacts>
-run_block_dataflow(const std::vector<AnalysisBlock> &blocks,
-                   std::span<const PendingConsumer> pending_consumers,
-                   std::span<const uint64_t> extra_leaders, ExternalEntryPolicy entry_policy) {
+[[nodiscard]] std::vector<LatticeFacts> run_block_dataflow(
+    const std::vector<AnalysisBlock> &blocks, std::span<const PendingConsumer> pending_consumers,
+    std::span<const uint64_t> sorted_extra_leaders, ExternalEntryPolicy entry_policy) {
   // Phase 3: compute block-entry facts to a fixed point.
   //
   // entry[B] = JOIN(exit[P]) for every predecessor P of B.
@@ -1676,7 +1714,8 @@ run_block_dataflow(const std::vector<AnalysisBlock> &blocks,
     for (size_t successor : blocks[block_index].successors)
       predecessors[successor].push_back(block_index);
   }
-  const std::vector<uint8_t> external_entries = explicit_external_entries(blocks, extra_leaders);
+  const std::vector<uint8_t> external_entries =
+      explicit_external_entries(blocks, sorted_extra_leaders);
 
   // Dataflow results are consumed only by pending cross-block branches. A pair
   // that is built or killed somewhere but never reaches such a consumer cannot
@@ -1950,7 +1989,7 @@ struct VectorLaneFlowState {
 
 void recover_vector_lane_stashed_pcs(AnalysisContext &ctx, const std::vector<AnalysisBlock> &blocks,
                                      std::vector<IndirectCallFixup> &recovered,
-                                     std::span<const uint64_t> extra_leaders,
+                                     std::span<const uint64_t> sorted_extra_leaders,
                                      ExternalEntryPolicy entry_policy) {
   // gfx1250 device functions sometimes keep a small static call set in one
   // VGPR: getpc-built low/high halves are written to fixed lanes, then read
@@ -1979,7 +2018,8 @@ void recover_vector_lane_stashed_pcs(AnalysisContext &ctx, const std::vector<Ana
 
   if (blocks.empty())
     return;
-  const std::vector<uint8_t> external_entries = explicit_external_entries(blocks, extra_leaders);
+  const std::vector<uint8_t> external_entries =
+      explicit_external_entries(blocks, sorted_extra_leaders);
 
   const auto changes_vgpr_msb_bank = [](std::string_view mnemonic) {
     return mnemonic == "s_set_vgpr_msb" || mnemonic == "s_setreg_b32" ||
@@ -2355,7 +2395,11 @@ std::optional<uint16_t> s_call_sdst(const Instruction &inst, uint32_t word) {
     std::vector<PcAddressBuilder> *pc_builders) {
   std::vector<IndirectCallFixup> recovered;
   AnalysisContext ctx = build_context(insts, text, arch);
-  std::vector<uint64_t> leaders(extra_leaders.begin(), extra_leaders.end());
+  std::vector<uint64_t> sorted_extra_leaders(extra_leaders.begin(), extra_leaders.end());
+  std::ranges::sort(sorted_extra_leaders);
+  sorted_extra_leaders.erase(std::ranges::unique(sorted_extra_leaders).begin(),
+                             sorted_extra_leaders.end());
+  std::vector<uint64_t> leaders(sorted_extra_leaders);
 
   PcAddressBuilderMap round_builders;
   for (size_t iteration = 0; iteration < kMaxIndirectDiscoveryIterations; ++iteration) {
@@ -2367,10 +2411,11 @@ std::optional<uint16_t> s_call_sdst(const Instruction &inst, uint32_t word) {
     std::vector<PendingConsumer> pending_consumers;
     std::vector<IndirectCallFixup> iteration_recovered;
     // Lane-stash recovery consumes the same graph as scalar recovery, including
-    // edges proven in earlier rounds. Keep extra_leaders separate from leaders:
-    // recovered targets become reachable through those edges, not by being
-    // promoted to external roots.
-    recover_vector_lane_stashed_pcs(ctx, blocks, iteration_recovered, extra_leaders, entry_policy);
+    // edges proven in earlier rounds. Keep the sorted explicit entries separate
+    // from leaders: recovered targets become reachable through those edges, not
+    // by being promoted to external roots.
+    recover_vector_lane_stashed_pcs(ctx, blocks, iteration_recovered, sorted_extra_leaders,
+                                    entry_policy);
     // Recovered leaders can split a block between rounds, which changes where a
     // builder's block-exit value is observed. Keep only the final round's view
     // so the published records are internally consistent with one CFG.
@@ -2381,7 +2426,7 @@ std::optional<uint16_t> s_call_sdst(const Instruction &inst, uint32_t word) {
 
     if (!pending_consumers.empty()) {
       const auto entry_facts =
-          run_block_dataflow(blocks, pending_consumers, extra_leaders, entry_policy);
+          run_block_dataflow(blocks, pending_consumers, sorted_extra_leaders, entry_policy);
       (void)classify_pending_consumers(ctx, blocks, entry_facts, pending_consumers,
                                        iteration_recovered);
     }

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -1059,37 +1059,42 @@ TEST(CfgAnalysis, SeedsTextEntryWithLoopBackedgeForCrossBlockPcBuilder) {
   EXPECT_FALSE(consumer->static_indirect_call_fixups()[0].source_incomplete);
 }
 
-TEST(CfgAnalysis, ExplicitKernelEntryMakesIncomingPcBuilderIncomplete) {
+TEST(CfgAnalysis, MultipleUnorderedExplicitEntriesMakeIncomingPcBuilderIncomplete) {
   constexpr uint16_t kPcSreg = 8;
   constexpr uint32_t kLiteralOperand = 255;
   constexpr uint32_t kInlineInt0 = 128;
 
-  // Entry A builds a static target and branches into entry B. B is also a
-  // separately launchable kernel, so its externally supplied s[8:9] value is
-  // unconstrained and must participate in the join with A's concrete builder.
+  // Entry A builds a static target and branches into entries B and C. Both are
+  // separately launchable kernels, so their externally supplied s[8:9] values
+  // must participate in the joins with A's concrete builder. Supply the entry
+  // offsets out of order with a duplicate to exercise the ordered merge.
   std::vector<uint32_t> words = {
       pack_sop1(0x1c, kPcSreg, 0),                         // 0x00: s_getpc_b64.
       pack_sop2(0, kPcSreg, kPcSreg, kLiteralOperand),     // 0x04: s_add_u32.
-      24,                                                  // 0x08: 0x04 + 24 = 0x1c.
+      32,                                                  // 0x08: 0x04 + 32 = 0x24.
       pack_sop2(4, kPcSreg + 1, kPcSreg + 1, kInlineInt0), // 0x0c: s_addc_u32.
-      build_s_branch(1, ROCJITSU_CODE_ARCH_CDNA4),         // 0x10 -> entry B at 0x18.
-      build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA4),            // 0x14: skipped.
+      pack_sopp(5, 2),                                     // 0x10: cbranch -> entry C at 0x1c.
+      build_s_branch(0, ROCJITSU_CODE_ARCH_CDNA4),         // 0x14 -> entry B at 0x18.
       pack_sop1(0x1d, 0, kPcSreg),                         // 0x18: entry B setpc.
-      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),            // 0x1c: A's target.
+      pack_sop1(0x1d, 0, kPcSreg),                         // 0x1c: entry C setpc.
+      build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA4),            // 0x20: not a target.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),            // 0x24: A's target.
   };
 
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
-  constexpr std::array<uint64_t, 1> extra_leaders{24};
+  constexpr std::array<uint64_t, 3> extra_leaders{28, 24, 28};
   auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, extra_leaders);
 
-  auto *consumer = block_starting_at(blocks, 24);
-  ASSERT_NE(consumer, nullptr);
-  ASSERT_EQ(consumer->static_indirect_call_fixups().size(), 1u);
-  EXPECT_EQ(consumer->static_indirect_call_fixups()[0].source_target_offset, 28u);
-  EXPECT_TRUE(consumer->static_indirect_call_fixups()[0].source_incomplete)
-      << "an independently launchable entry must include unconstrained external SGPR state";
+  for (uint64_t consumer_offset : {uint64_t{24}, uint64_t{28}}) {
+    auto *consumer = block_starting_at(blocks, consumer_offset);
+    ASSERT_NE(consumer, nullptr);
+    ASSERT_EQ(consumer->static_indirect_call_fixups().size(), 1u);
+    EXPECT_EQ(consumer->static_indirect_call_fixups()[0].source_target_offset, 36u);
+    EXPECT_TRUE(consumer->static_indirect_call_fixups()[0].source_incomplete)
+        << "each independently launchable entry must include unconstrained external SGPR state";
+  }
 }
 
 TEST(CfgAnalysis, RocrAbortTrapStopsTemporaryPcBuilderCfg) {
@@ -1572,7 +1577,7 @@ TEST(CfgAnalysis, DirectCallKillsCarriedPcBuilderFacts) {
   EXPECT_FALSE(has_successor_start(*continuation, stale_target->start_offset()));
 }
 
-TEST(CfgAnalysis, KillPredecessorPreventsRecoveredConsumer) {
+TEST(CfgAnalysis, EitherHalfKillPredecessorPreventsRecoveredConsumer) {
   constexpr uint16_t kPcSreg = 8;
   constexpr uint32_t kLiteralOperand = 255;
   constexpr uint32_t kInlineInt0 = 128;
@@ -1581,39 +1586,43 @@ TEST(CfgAnalysis, KillPredecessorPreventsRecoveredConsumer) {
   // Two paths reach the same setpc consumer:
   //
   //   * the fallthrough path builds a concrete PC target in s[8:9]
-  //   * the branch path writes s8 through ordinary scalar code, killing that
-  //     pair for this analysis
+  //   * the branch path writes either s8 or s9 through ordinary scalar code,
+  //     killing that pair for this analysis
   //
   // The concrete builder path alone is not enough to recover the consumer. A
   // real unmodeled write reaches the join, so the analysis must fail closed and
   // leave the setpc for the later DBT diagnostic.
-  std::vector<uint32_t> words = {
-      pack_sopp(5, 5),                                     // 0x00 -> kill path at 0x18.
-      pack_sop1(0x1c, kPcSreg, 0),                         // 0x04: s_getpc_b64.
-      pack_sop2(0, kPcSreg, kPcSreg, kLiteralOperand),     // 0x08: s_add_u32.
-      kOriginalGetpcDelta,                                 // 0x0c: target delta.
-      pack_sop2(4, kPcSreg + 1, kPcSreg + 1, kInlineInt0), // 0x10: s_addc_u32.
-      build_s_branch(2, ROCJITSU_CODE_ARCH_CDNA4),         // 0x14 -> consumer at 0x20.
-      pack_sop2(0, kPcSreg, kPcSreg, kInlineInt0),         // 0x18: unmodeled write.
-      build_s_branch(0, ROCJITSU_CODE_ARCH_CDNA4),         // 0x1c -> consumer at 0x20.
-      pack_sop1(0x1d, 0, kPcSreg),                         // 0x20: joined consumer.
-      build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA4),            // 0x24: not a target.
-      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),            // 0x28: builder target.
-  };
+  constexpr std::array<uint16_t, 2> clobbered_sregs{kPcSreg, kPcSreg + 1};
+  for (uint16_t clobbered_sreg : clobbered_sregs) {
+    SCOPED_TRACE(clobbered_sreg);
+    std::vector<uint32_t> words = {
+        pack_sopp(5, 5),                                           // 0x00 -> kill path at 0x18.
+        pack_sop1(0x1c, kPcSreg, 0),                               // 0x04: s_getpc_b64.
+        pack_sop2(0, kPcSreg, kPcSreg, kLiteralOperand),           // 0x08: s_add_u32.
+        kOriginalGetpcDelta,                                       // 0x0c: target delta.
+        pack_sop2(4, kPcSreg + 1, kPcSreg + 1, kInlineInt0),       // 0x10: s_addc_u32.
+        build_s_branch(2, ROCJITSU_CODE_ARCH_CDNA4),               // 0x14 -> consumer at 0x20.
+        pack_sop2(0, clobbered_sreg, clobbered_sreg, kInlineInt0), // 0x18: write.
+        build_s_branch(0, ROCJITSU_CODE_ARCH_CDNA4),               // 0x1c -> consumer.
+        pack_sop1(0x1d, 0, kPcSreg),                               // 0x20: consumer.
+        build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA4),                  // 0x24: not a target.
+        build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),                  // 0x28: target.
+    };
 
-  TestCodeObject co(std::move(words));
-  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
-  ASSERT_NE(decoder, nullptr);
-  constexpr std::array<uint64_t, 1> extra_leaders{40};
-  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, extra_leaders);
+    TestCodeObject co(std::move(words));
+    auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    ASSERT_NE(decoder, nullptr);
+    constexpr std::array<uint64_t, 1> extra_leaders{40};
+    auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_CDNA4, extra_leaders);
 
-  auto *consumer = block_starting_at(blocks, 32);
-  auto *target = block_starting_at(blocks, 40);
-  ASSERT_NE(consumer, nullptr);
-  ASSERT_NE(target, nullptr);
+    auto *consumer = block_starting_at(blocks, 32);
+    auto *target = block_starting_at(blocks, 40);
+    ASSERT_NE(consumer, nullptr);
+    ASSERT_NE(target, nullptr);
 
-  EXPECT_TRUE(consumer->static_indirect_call_fixups().empty());
-  EXPECT_FALSE(has_successor_start(*consumer, target->start_offset()));
+    EXPECT_TRUE(consumer->static_indirect_call_fixups().empty());
+    EXPECT_FALSE(has_successor_start(*consumer, target->start_offset()));
+  }
 }
 
 TEST(CfgAnalysis, RecoversSignedDeltaTemplateConsumers) {


### PR DESCRIPTION
Indirect branch discovery repeated two kinds of unnecessary work on large code objects. Explicit kernel-entry offsets were searched separately for every analysis block, and block transfer summaries retained SGPR pairs that no indirect control-transfer consumer could observe.

Sort and deduplicate explicit entries once per discovery, then match them against the ordered analysis blocks with a linear merge. Collect the SGPR pairs read by setpc and swappc while caching instruction facts, restrict transfer summaries to those pairs, and visit dirty register halves with bit scans instead of scanning the complete SGPR range.

Document and assert the ordering and consumer-set invariants. Cover unordered duplicate entries and writes that kill both the low and high halves of a consumed SGPR pair.

On the 224,676,512-byte RCCL object, CPU time falls from 185.44 s to 183.11 s (-1.26%) and peak RSS falls from 16,405,856 KiB to 15,977,972 KiB (-427,884 KiB).

Across the 20,000-object offline corpus, average CPU time falls from 0.0192485 s to 0.0188355 s (-2.15%). Average peak RSS changes from 20,294.200 KiB to 20,294.945 KiB (+0.745 KiB), while maximum peak RSS falls by 427,884 KiB. All translations succeed and all output SHA-256 values match the baseline.