### PR TITLE
[rocjitsu] Collect relocation pair results in one dataflow pass

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -1609,15 +1609,15 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
                                   ExternalEntryPolicy::ExplicitOnly);
   const BlockOffsetIndex block_index = build_block_offset_index(blocks);
   const uint64_t text_vaddr = obj.text_sections().front()->vaddr();
-  const auto relocation_table_dispatches =
-      discover_relocation_table_dispatches(blocks, relocation_function_tables, text_vaddr);
+  const auto relocation_pair_analysis =
+      analyze_relocation_pairs(blocks, relocation_function_tables, text_vaddr);
+  const auto &relocation_table_dispatches = relocation_pair_analysis.dispatches;
   const auto relocation_table_calls = attach_relocation_table_call_edges(
       block_index, relocation_function_tables, relocation_table_dispatches);
 
   // Address materializations that must survive relocation. See the use sites for how a data target
   // and a code target are each rewritten.
-  const auto pc_relative_address_builders =
-      discover_pc_relative_address_builders(blocks, text_vaddr);
+  const auto &pc_relative_address_builders = relocation_pair_analysis.address_builders;
 
   // Whether every code address this object can produce is one this translation will relocate.
   //

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/relocation_function_table.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/relocation_function_table.cpp
@@ -115,7 +115,7 @@ table_at_address(std::span<const RelocationFunctionTable> tables, uint64_t vaddr
 void transfer_instruction(PairState &state, const Instruction &inst,
                           std::span<const RelocationFunctionTable> tables, uint64_t text_vaddr,
                           std::vector<RelocationTableDispatch> *dispatches,
-                          std::vector<PcRelativeAddressBuilder> *address_builders = nullptr) {
+                          std::vector<PcRelativeAddressBuilder> *address_builders) {
   const std::string_view mnemonic = inst.mnemonic();
   // Only getpc can create a tracked fact from an empty state. Large linked
   // objects contain millions of unrelated instructions, so avoid decoding
@@ -257,8 +257,7 @@ meet_predecessors(const BasicBlock &block,
   return nullptr;
 }
 
-/// @brief Shared getpc/add fixed point. Both public entry points need the same lattice; only what
-/// they collect from the final pass differs, so the worklist itself is written once.
+/// @brief Shared getpc/add fixed point that collects both result kinds after convergence.
 void run_pair_dataflow(std::span<const std::unique_ptr<BasicBlock>> blocks,
                        std::span<const RelocationFunctionTable> tables, uint64_t text_vaddr,
                        std::vector<RelocationTableDispatch> *dispatches,
@@ -398,42 +397,35 @@ discover_relocation_function_tables(const AmdGpuCodeObject &object) {
   return tables;
 }
 
-std::vector<RelocationTableDispatch>
-discover_relocation_table_dispatches(std::span<const std::unique_ptr<BasicBlock>> blocks,
-                                     std::span<const RelocationFunctionTable> tables,
-                                     uint64_t text_vaddr) {
-  if (blocks.empty() || tables.empty())
-    return {};
-  std::vector<RelocationTableDispatch> dispatches;
-  run_pair_dataflow(blocks, tables, text_vaddr, &dispatches, nullptr);
-  std::ranges::sort(dispatches, [](const auto &lhs, const auto &rhs) {
+RelocationPairAnalysis analyze_relocation_pairs(std::span<const std::unique_ptr<BasicBlock>> blocks,
+                                                std::span<const RelocationFunctionTable> tables,
+                                                uint64_t text_vaddr) {
+  RelocationPairAnalysis result;
+  if (blocks.empty())
+    return result;
+
+  run_pair_dataflow(blocks, tables, text_vaddr, &result.dispatches, &result.address_builders);
+  std::ranges::sort(result.dispatches, [](const auto &lhs, const auto &rhs) {
     if (lhs.source_call_offset != rhs.source_call_offset)
       return lhs.source_call_offset < rhs.source_call_offset;
     return lhs.table_index < rhs.table_index;
   });
-  dispatches.erase(std::ranges::unique(dispatches, {},
-                                       [](const RelocationTableDispatch &item) {
-                                         return std::pair{item.source_call_offset,
-                                                          item.table_index};
-                                       })
-                       .begin(),
-                   dispatches.end());
-  return dispatches;
-}
+  result.dispatches.erase(std::ranges::unique(result.dispatches, {},
+                                              [](const RelocationTableDispatch &item) {
+                                                return std::pair{item.source_call_offset,
+                                                                 item.table_index};
+                                              })
+                              .begin(),
+                          result.dispatches.end());
 
-std::vector<PcRelativeAddressBuilder>
-discover_pc_relative_address_builders(std::span<const std::unique_ptr<BasicBlock>> blocks,
-                                      uint64_t text_vaddr) {
-  if (blocks.empty())
-    return {};
-  std::vector<PcRelativeAddressBuilder> builders;
-  run_pair_dataflow(blocks, {}, text_vaddr, nullptr, &builders);
-  std::ranges::sort(builders, {}, &PcRelativeAddressBuilder::source_address_add_offset);
-  builders.erase(
-      std::ranges::unique(builders, {}, &PcRelativeAddressBuilder::source_address_add_offset)
+  std::ranges::sort(result.address_builders, {},
+                    &PcRelativeAddressBuilder::source_address_add_offset);
+  result.address_builders.erase(
+      std::ranges::unique(result.address_builders, {},
+                          &PcRelativeAddressBuilder::source_address_add_offset)
           .begin(),
-      builders.end());
-  return builders;
+      result.address_builders.end());
+  return result;
 }
 
 namespace {
@@ -481,7 +473,7 @@ void run_pair_dataflow(std::span<const std::unique_ptr<BasicBlock>> blocks,
     PairState next_in = meet_predecessors(*block, positions, out, initialized);
     PairState next_out = next_in;
     for (const Instruction &inst : block->instructions())
-      transfer_instruction(next_out, inst, tables, text_vaddr, nullptr);
+      transfer_instruction(next_out, inst, tables, text_vaddr, nullptr, nullptr);
 
     const bool changed = !initialized[index] || next_in != in[index] || next_out != out[index];
     initialized[index] = true;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/relocation_function_table.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/relocation_function_table.h
@@ -64,7 +64,7 @@ struct RelocationFunctionTable {
 /// the call and the PC-relative address builder that must remain pointed at the
 /// same data object after `.text` grows.
 struct RelocationTableDispatch {
-  /// Index into the table vector passed to `discover_relocation_table_dispatches()`.
+  /// Index into the table span passed to `analyze_relocation_pairs()`.
   size_t table_index = 0;
 
   /// Original `.text`-relative offset of the `s_swap_pc_i64` call instruction.
@@ -105,15 +105,28 @@ struct PcRelativeAddressBuilder {
   uint64_t target_vaddr = 0;
 };
 
-/// @brief Discover every proven `s_get_pc_i64` + literal-add address materialization.
+/// @brief Results collected by the shared SGPR-pair dataflow.
+struct RelocationPairAnalysis {
+  /// Dispatches sorted by `(source_call_offset, table_index)` and unique on that key.
+  std::vector<RelocationTableDispatch> dispatches;
+
+  /// Address builders sorted and unique by `source_address_add_offset`.
+  /// This complete set is independent of the supplied relocation tables.
+  std::vector<PcRelativeAddressBuilder> address_builders;
+};
+
+/// @brief Discover table dispatches and address builders in one dataflow pass.
 ///
-/// @details Shares the dataflow that resolves table dispatches, so the same guarantees apply: a
-/// chained second add, a write to either half, or a CFG join whose predecessors disagree all leave
-/// the pair untracked rather than reported. Callers decide what a target means; this reports the
-/// address arithmetic only.
-[[nodiscard]] std::vector<PcRelativeAddressBuilder>
-discover_pc_relative_address_builders(std::span<const std::unique_ptr<BasicBlock>> blocks,
-                                      uint64_t text_vaddr);
+/// @details The analysis propagates a small SGPR-pair lattice. An
+/// `s_get_pc_i64` plus literal add produces an address builder; a builder is
+/// reported before its value can be reclassified as a known table base, so
+/// `tables` affects only `dispatches`. A chained second add, a write to either
+/// half, or a CFG join whose predecessors disagree leaves the pair unreported.
+/// A table or GOT address followed by an indexed load and `s_swap_pc_i64`
+/// produces a dispatch only when every step is proven.
+[[nodiscard]] RelocationPairAnalysis
+analyze_relocation_pairs(std::span<const std::unique_ptr<BasicBlock>> blocks,
+                         std::span<const RelocationFunctionTable> tables, uint64_t text_vaddr);
 
 /// @brief Discover finite device-call tables from ELF symbols and relocations.
 ///
@@ -130,20 +143,5 @@ discover_pc_relative_address_builders(std::span<const std::unique_ptr<BasicBlock
 /// not returned.
 [[nodiscard]] std::vector<RelocationFunctionTable>
 discover_relocation_function_tables(const AmdGpuCodeObject &object);
-
-/// @brief Resolve decoded dynamic calls back to relocation-discovered tables.
-///
-/// @details The analysis propagates only a small SGPR-pair lattice:
-/// `s_get_pc_i64 + s_add_nc_u64 literal64` produces an address. That address
-/// may name the table directly or a GOT slot whose zero-offset load produces
-/// the table base. A subsequent indexed `s_load_b64` produces an entry value,
-/// and a dispatch is reported only when that value reaches `s_swap_pc_i64`.
-/// Writes to either SGPR half kill the fact, and CFG joins retain only facts
-/// that agree on every initialized predecessor, so unproven calls remain
-/// unresolved rather than acquiring speculative table edges.
-[[nodiscard]] std::vector<RelocationTableDispatch>
-discover_relocation_table_dispatches(std::span<const std::unique_ptr<BasicBlock>> blocks,
-                                     std::span<const RelocationFunctionTable> tables,
-                                     uint64_t text_vaddr);
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/tests/code/relocation_function_table_test.cpp
+++ b/emulation/rocjitsu/tests/code/relocation_function_table_test.cpp
@@ -489,7 +489,7 @@ TEST(RelocationFunctionTable, ResolvesDynamicDispatchThroughGotAndTableLoads) {
   ASSERT_NE(decoder, nullptr);
   std::array<uint64_t, 1> leaders{40};
   const auto blocks = BasicBlock::build(object, *decoder, ROCJITSU_CODE_ARCH_GFX1250, leaders);
-  const auto dispatches = discover_relocation_table_dispatches(blocks, tables, 0x1000);
+  const auto dispatches = analyze_relocation_pairs(blocks, tables, 0x1000).dispatches;
   ASSERT_EQ(dispatches.size(), 1u);
   EXPECT_EQ(dispatches[0].table_index, 0u);
   EXPECT_EQ(dispatches[0].source_call_offset, 32u);
@@ -514,7 +514,8 @@ TEST(RelocationFunctionTable, ResolvesRcclDirectIndexedTableDispatch) {
   ASSERT_NE(decoder, nullptr);
   std::array<uint64_t, 1> leaders{32};
   const auto blocks = BasicBlock::build(object, *decoder, ROCJITSU_CODE_ARCH_GFX1250, leaders);
-  const auto dispatches = discover_relocation_table_dispatches(blocks, tables, 0x1000);
+  const auto analysis = analyze_relocation_pairs(blocks, tables, 0x1000);
+  const auto &dispatches = analysis.dispatches;
   ASSERT_EQ(dispatches.size(), 1u);
   EXPECT_EQ(dispatches[0].table_index, 0u);
   EXPECT_EQ(dispatches[0].source_call_offset, 24u);
@@ -522,6 +523,20 @@ TEST(RelocationFunctionTable, ResolvesRcclDirectIndexedTableDispatch) {
   EXPECT_EQ(dispatches[0].source_getpc_offset, 0u);
   EXPECT_EQ(dispatches[0].source_address_add_offset, 4u);
   EXPECT_EQ(dispatches[0].source_table_address_vaddr, 0x2000u);
+
+  ASSERT_EQ(analysis.address_builders.size(), 1u);
+  EXPECT_EQ(analysis.address_builders[0].source_getpc_offset, 0u);
+  EXPECT_EQ(analysis.address_builders[0].source_address_add_offset, 4u);
+  EXPECT_EQ(analysis.address_builders[0].target_vaddr, 0x2000u);
+
+  const auto table_free_analysis = analyze_relocation_pairs(blocks, {}, 0x1000);
+  ASSERT_EQ(table_free_analysis.address_builders.size(), 1u);
+  EXPECT_EQ(table_free_analysis.address_builders[0].source_getpc_offset,
+            analysis.address_builders[0].source_getpc_offset);
+  EXPECT_EQ(table_free_analysis.address_builders[0].source_address_add_offset,
+            analysis.address_builders[0].source_address_add_offset);
+  EXPECT_EQ(table_free_analysis.address_builders[0].target_vaddr,
+            analysis.address_builders[0].target_vaddr);
 }
 
 TEST(RelocationFunctionTable, RejectsChainedAddressAddDispatch) {
@@ -538,7 +553,7 @@ TEST(RelocationFunctionTable, RejectsChainedAddressAddDispatch) {
   ASSERT_NE(decoder, nullptr);
   std::array<uint64_t, 1> leaders{44};
   const auto blocks = BasicBlock::build(object, *decoder, ROCJITSU_CODE_ARCH_GFX1250, leaders);
-  const auto dispatches = discover_relocation_table_dispatches(blocks, tables, 0x1000);
+  const auto dispatches = analyze_relocation_pairs(blocks, tables, 0x1000).dispatches;
   // The base is built with two literal adds; only one add offset can be relocated,
   // so the dispatch must fail closed rather than resolve to a value whose first
   // addend would still execute.
@@ -567,7 +582,7 @@ TEST(RelocationFunctionTable, ResolvesBackwardTableAddress) {
   ASSERT_NE(decoder, nullptr);
   std::array<uint64_t, 1> leaders{32};
   const auto blocks = BasicBlock::build(object, *decoder, ROCJITSU_CODE_ARCH_GFX1250, leaders);
-  const auto dispatches = discover_relocation_table_dispatches(blocks, tables, kAssumedTextVaddr);
+  const auto dispatches = analyze_relocation_pairs(blocks, tables, kAssumedTextVaddr).dispatches;
   ASSERT_EQ(dispatches.size(), 1u);
   EXPECT_EQ(dispatches[0].table_index, 0u);
   EXPECT_EQ(dispatches[0].source_table_address_vaddr, 0x2000u);

--- a/emulation/rocjitsu/tests/dbt/relocation_function_table_hip_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/relocation_function_table_hip_test.cpp
@@ -62,8 +62,9 @@ TEST(RelocationFunctionTableHip, TranslatesEightWayDeviceDispatch) {
   ASSERT_NE(decoder, nullptr);
   const auto blocks =
       rocjitsu::BasicBlock::build(*source, *decoder, ROCJITSU_CODE_ARCH_GFX1250, source_targets);
-  const auto dispatches = rocjitsu::discover_relocation_table_dispatches(
-      blocks, source_tables, source->text_sections()[0]->vaddr());
+  const auto dispatches =
+      rocjitsu::analyze_relocation_pairs(blocks, source_tables, source->text_sections()[0]->vaddr())
+          .dispatches;
   ASSERT_EQ(dispatches.size(), 1u);
   EXPECT_EQ(dispatches[0].table_index, 0u);
 


### PR DESCRIPTION
Collect relocation-backed dispatches and PC-relative address builders during one shared SGPR-pair fixed point instead of traversing the CFG twice. Keep a single documented analysis entry point and directly test that known tables do not change the address-builder result.

On the 224,676,512-byte RCCL object, this changes CPU time from 189.83 s to 174.25 s (-8.21%) and wall time from 189.91 s to 174.33 s (-8.20%), with peak RSS changing from 16,408,748 KiB to 16,409,172 KiB (+424 KiB).

Across the 20,000-object offline corpus, average CPU time changes from 0.0192485 s to 0.0185885 s (-3.43%) and average peak RSS from 20,294.200 KiB to 20,301.058 KiB (+6.858 KiB, +0.034%). Maximum peak RSS falls by 4,276 KiB, with zero translation failures and zero output SHA-256 mismatches.