### PR TITLE
[rocjitsu] Translate a code object once however often it is loaded

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/code/rj_gfx1250_b0_to_a0.h
+++ b/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/code/rj_gfx1250_b0_to_a0.h
@@ -38,9 +38,12 @@ typedef struct rj_gfx1250_b0_to_a0_translation_info_s {
 /// @param[out] translated_size Number of bytes in @p translated_elf.
 /// @retval ROCJITSU_STATUS_SUCCESS Translation succeeded.
 /// @retval ROCJITSU_STATUS_INVALID_ARGUMENT An input or output argument is invalid.
-/// @retval ROCJITSU_STATUS_INVALID_CODE_OBJECT The input is not a gfx1250 code object.
-/// @retval ROCJITSU_STATUS_OUT_OF_RESOURCES Output allocation failed.
-/// @retval ROCJITSU_STATUS_ERROR Translation failed or produced a non-dispatchable object.
+/// @retval ROCJITSU_STATUS_INVALID_CODE_OBJECT The input is not a gfx1250 code object, or
+///         translating it produced nothing dispatchable. Both are properties of the input, so
+///         repeating the call reaches the same verdict.
+/// @retval ROCJITSU_STATUS_OUT_OF_RESOURCES Output allocation failed. Environmental: the same
+///         input may translate on a later attempt.
+/// @retval ROCJITSU_STATUS_ERROR The translator threw. Carries no promise about the input.
 #ifdef __cplusplus
 [[nodiscard]]
 #endif

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/gfx1250_b0_to_a0_library.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/gfx1250_b0_to_a0_library.cpp
@@ -43,8 +43,14 @@ rj_status_t rj_gfx1250_b0_to_a0_translate_with_info(const void *source_elf, size
         ++info->changed_instruction_count;
     });
     auto result = translator.translate(source);
+    // A translation that ran to completion and produced nothing dispatchable is a
+    // statement about the input, not about this run: repeating it reaches the same
+    // conclusion. Reporting it as such is what lets a caller distinguish it from
+    // the environmental failures below and cache the verdict rather than
+    // rediscovering it. ROCJITSU_STATUS_ERROR is left to mean the translator threw,
+    // which carries no such promise.
     if (result.elf_bytes.empty() || !result.dispatchable())
-      return ROCJITSU_STATUS_ERROR;
+      return ROCJITSU_STATUS_INVALID_CODE_OBJECT;
 
     auto *output = static_cast<uint8_t *>(std::malloc(result.elf_bytes.size()));
     if (!output)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/gfx1250_b0_a0_hotswap.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/gfx1250_b0_a0_hotswap.cpp
@@ -3,22 +3,34 @@
 
 /// @file gfx1250_b0_a0_hotswap.cpp
 /// @brief Minimal eager-only HSA hook for gfx1250 B0-to-A0 translation.
+///
+/// @section env Environment controls
+///
+/// - `HSA_HOTSWAP_VERBOSE` -- debug logging to stderr. Changes what is reported,
+///   never what is done.
+///
+/// `HSA_HOTSWAP_DISABLE` belongs to CLR rather than this hook: it stops CLR
+/// forwarding anything here at all.
 
 #include "hsa/hsa_api_trace_minimal.h"
 #include "rocjitsu/code/amdgpu_elf.h"
 #include "rocjitsu/code/rj_gfx1250_b0_to_a0.h"
 
+#include <algorithm>
 #include <atomic>
 #include <cerrno>
 #include <cinttypes>
+#include <condition_variable>
 #include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <exception>
+#include <list>
 #include <memory>
 #include <mutex>
 #include <new>
+#include <span>
 #include <string>
 #include <string_view>
 #include <sys/stat.h>
@@ -134,6 +146,103 @@ struct OriginalApi {
   decltype(hsa_isa_get_info_alt) *isa_get_info = nullptr;
 };
 
+/// @brief Cheap selector narrowing the memo to a few candidate entries.
+///
+/// @details This only ever narrows: a candidate is confirmed by comparing the
+/// bytes outright, so the fingerprint has to be fast and reasonably spread, and
+/// does not have to be collision resistant. Reading every byte would be neither.
+/// Measured on the 212 MiB object RCCL loads: SHA-256 over it costs 586 ms
+/// (0.38 GB/s) while comparing it against a candidate costs 9 ms (24.5 GB/s), so
+/// hashing to avoid a comparison would cost sixty times what the comparison it
+/// replaces does. Sampling a fixed 4 KiB regardless of size keeps this in the
+/// microseconds and leaves the comparison to establish identity exactly.
+uint64_t sample_fingerprint(std::span<const uint8_t> bytes) noexcept {
+  constexpr uint64_t kOffsetBasis = 14695981039346656037ULL;
+  constexpr uint64_t kPrime = 1099511628211ULL;
+  constexpr size_t kWindows = 16;
+  constexpr size_t kWindowBytes = 256;
+
+  const size_t size = bytes.size();
+  uint64_t value = kOffsetBasis ^ size;
+  const size_t span = size <= kWindowBytes ? 0 : size - kWindowBytes;
+  for (size_t window = 0; window < kWindows; ++window) {
+    const size_t start = span * window / (kWindows - 1);
+    const size_t count = std::min(kWindowBytes, size - start);
+    for (size_t offset = 0; offset < count; ++offset) {
+      value ^= bytes[start + offset];
+      value *= kPrime;
+    }
+    if (span == 0)
+      break;
+  }
+  return value;
+}
+
+/// @brief The outcome of translating one exact code object.
+///
+/// @details `output` is null for a refusal, which is recorded deliberately: a
+/// caller that loads a bad object once loads it as many times as a good one, and
+/// re-running a translation that is known to fail is the same waste as re-running
+/// one that is known to succeed. `info` is kept so a reuse can reproduce the
+/// original translation record rather than logging a weaker one.
+struct TranslationRecord {
+  Blob output;
+  rj_gfx1250_b0_to_a0_translation_info_t info{};
+  rj_status_t status = ROCJITSU_STATUS_SUCCESS;
+};
+
+/// @brief One remembered translation, with the source that produced it.
+///
+/// @details The source is retained because identity is established by comparison
+/// rather than by a digest strong enough to trust on its own. That costs the
+/// object's size on top of the output, which is a small price beside what it
+/// buys: translating the object RCCL loads takes 197 s and peaks at 15.9 GB, so
+/// an entry costs a fraction of what merely reproducing it would.
+struct MemoEntry {
+  uint64_t fingerprint = 0;
+  Blob source;
+  TranslationRecord translation;
+};
+
+using MemoList = std::list<MemoEntry>;
+
+/// @brief A translation currently running, and the exact bytes it is running on.
+///
+/// @details The source is held rather than just its fingerprint because a
+/// fingerprint only narrows. Two same-sized objects that differ solely outside
+/// the sampled windows collide deterministically, and waiting on a fingerprint
+/// would park an unrelated object behind a translation that can take minutes.
+/// Whoever claims gets an @c id back so publication removes its own claim and no
+/// one else's.
+/// @details A finished translation too large for the memo is still handed to the
+/// cohort already waiting on it, through @c result, before the claim is torn
+/// down. Discarding it instead would wake every waiter to find neither a cached
+/// result nor a running claim, so each would translate the object again in turn:
+/// N concurrent loads of a 197 s object would cost N × 197 s, which is worse than
+/// switching the memo off. @c cohort counts the waiters still owed that result, so
+/// the bytes are released as soon as the last of them has taken a reference and
+/// never outlive the demand that justified keeping them.
+struct InFlightClaim {
+  uint64_t id = 0;
+  uint64_t fingerprint = 0;
+  Blob source;
+  TranslationRecord result;
+  bool completed = false;
+  size_t cohort = 0;
+};
+
+size_t memo_entry_bytes(const MemoEntry &entry) noexcept {
+  return (entry.source == nullptr ? 0 : entry.source->size()) +
+         (entry.translation.output == nullptr ? 0 : entry.translation.output->size());
+}
+
+// Strict ceiling on the payload the memo holds: every entry's source plus its
+// output, summed, stays at or below this. Nothing is exempt -- an entry that does
+// not fit is never admitted, and eviction runs to the ceiling rather than to the
+// last entry. The largest real object measured is 212 MiB, so the default holds a
+// couple of them, which is the shape the reported workload has.
+constexpr size_t kDefaultMemoCapacity = 1024u * 1024u * 1024u;
+
 struct HookState {
   std::mutex lifecycle_mutex;
   CoreApiTable *core = nullptr;
@@ -151,6 +260,28 @@ struct HookState {
   std::mutex storage_mutex;
   std::unordered_map<uint64_t, Blob> readers;
   std::unordered_map<uint64_t, std::vector<Blob>> executables;
+
+  // Translation memo. It has its own mutex rather than sharing storage_mutex
+  // because a thread that finds a translation already in flight sleeps here until
+  // it finishes, and it must not hold reader capture or executable teardown off
+  // while it sleeps.
+  //
+  // `recent` is the LRU list, most recently used at the front, and `index` maps a
+  // fingerprint to its candidate nodes -- several, since a fingerprint only
+  // narrows. Splicing within a list keeps iterators valid, so a hit can reorder
+  // the list without touching the index.
+  std::mutex memo_mutex;
+  std::condition_variable memo_ready;
+  MemoList recent;
+  std::unordered_multimap<uint64_t, MemoList::iterator> index;
+  // Bounded by the number of concurrent loads, so a scan costs less than the
+  // comparison each candidate needs anyway.
+  std::vector<InFlightClaim> in_flight;
+  uint64_t next_claim_id = 1;
+  size_t memo_bytes = 0;
+  size_t memo_capacity = kDefaultMemoCapacity;
+  size_t memo_waiters = 0;
+  std::atomic<uint64_t> translations{0};
 };
 
 // ROCr calls OnUnload before releasing this tool, so one DSO-local state owns the
@@ -236,6 +367,350 @@ void release(hsa_executable_t executable) noexcept {
   } catch (...) {
   }
 }
+
+#if defined(RJ_HOTSWAP_TEST_HOOKS)
+// Test-only: keep a completed claim alive after its cohort has drained. The
+// window in which a late load can take a ready transient result is normally over
+// in microseconds, so holding it open is the only way to observe what a load
+// arriving inside it does.
+std::atomic<bool> g_retain_completed_claims{false};
+bool retain_completed_claims_for_test() {
+  return g_retain_completed_claims.load(std::memory_order_relaxed);
+}
+
+// Test-only: fail one of the two allocations that admitting an entry needs, the
+// way a short allocation would. Nothing else can provoke that, and what becomes
+// of the cohort when it happens is the whole question. 1 is the list node, 2 the
+// index node; they fail at different points and have to be exercised separately.
+std::atomic<int> g_fail_next_admission{0};
+void fail_admission_if_armed_for_test(int stage) {
+  int armed = g_fail_next_admission.load(std::memory_order_relaxed);
+  if (armed == stage &&
+      g_fail_next_admission.compare_exchange_strong(armed, 0, std::memory_order_relaxed))
+    throw std::bad_alloc();
+}
+#else
+constexpr bool retain_completed_claims_for_test() { return false; }
+constexpr void fail_admission_if_armed_for_test(int) {}
+#endif
+
+/// @brief What the memo did while its lock was held, to be reported once it is
+/// released.
+///
+/// @details Fixed and scalar, so recording an event allocates nothing and cannot
+/// fail. That matters more than the detail it gives up: gathering these into a
+/// container put a throwing call in the middle of the very transitions this data
+/// describes. An allocation failure while noting a refusal would abandon the
+/// completed result its cohort was waiting for, and one while noting a
+/// displacement would abort eviction with the memo still over its ceiling and
+/// nothing left to retry it -- both at exactly the moment memory is scarce, which
+/// is when the ceiling and the single-flight guarantee are worth the most.
+/// Observing must never be able to change what is observed.
+struct MemoLogSummary {
+  bool refused = false;
+  size_t refused_bytes = 0;
+  size_t displaced_entries = 0;
+  size_t displaced_bytes = 0;
+  size_t held = 0;
+  size_t capacity = 0;
+  size_t remaining = 0;
+};
+
+void emit_memo_summary(const MemoLogSummary &summary) noexcept {
+  if (summary.refused)
+    log("memo refused entry bytes=%zu capacity=%zu: too large to hold", summary.refused_bytes,
+        summary.capacity);
+  if (summary.displaced_entries != 0)
+    log("memo displaced entries=%zu bytes=%zu held=%zu capacity=%zu remaining=%zu",
+        summary.displaced_entries, summary.displaced_bytes, summary.held, summary.capacity,
+        summary.remaining);
+}
+
+/// @brief Drop least-recently-used translations until the memo is under its cap.
+///
+/// @details Evicting is always safe: a caller that is using a translation holds
+/// its own reference, and a later load of the same object simply translates
+/// again. Only the memo's claim on the bytes is dropped, never the bytes
+/// themselves.
+/// @param summary Accumulates what happened, to be reported once the caller has
+/// let go of the memo. Writing to stderr here instead would hold every lookup,
+/// publication and waiter behind a synchronous write to a sink this process does
+/// not control -- and worse, invert against a thread that already holds the
+/// stderr lock and enters an intercepted load needing this mutex.
+void memo_evict_locked(MemoLogSummary &summary) {
+  // A memo that has been switched off has nothing to protect and releases
+  // everything, rather than sitting on one entry nothing will ever read.
+  if (g_state.memo_capacity == 0) {
+    g_state.recent.clear();
+    g_state.index.clear();
+    g_state.memo_bytes = 0;
+    return;
+  }
+  // Otherwise evict strictly to the ceiling. An entry too large to fit was never
+  // admitted (see memo_publish), so there is no case where holding one more entry
+  // than the cap allows is the lesser evil -- these bytes live until the process
+  // exits, and a limit that the largest entry is exempt from is not a limit.
+  while (g_state.memo_bytes > g_state.memo_capacity && !g_state.recent.empty()) {
+    const auto victim = std::prev(g_state.recent.end());
+    const auto range = g_state.index.equal_range(victim->fingerprint);
+    for (auto it = range.first; it != range.second; ++it) {
+      if (it->second == victim) {
+        g_state.index.erase(it);
+        break;
+      }
+    }
+    const size_t dropped = memo_entry_bytes(*victim);
+    g_state.memo_bytes -= dropped;
+    g_state.recent.erase(victim);
+    // Note it. Displacement is the one thing that silently reintroduces the cost
+    // this memo exists to remove, and an operator watching a slow start-up has no
+    // other way to tell a cold memo from one that is thrashing.
+    ++summary.displaced_entries;
+    summary.displaced_bytes += dropped;
+    summary.held = g_state.memo_bytes;
+    summary.capacity = g_state.memo_capacity;
+    summary.remaining = g_state.recent.size();
+  }
+}
+
+enum class MemoLookup {
+  kHit,        ///< @p out holds a previous outcome for these exact bytes.
+  kTranslate,  ///< The caller owns the digest and must publish or release it.
+  kUnavailable ///< The memo could not be consulted; translate without it.
+};
+
+/// @brief Look up a translation of exactly @p source, waiting out one in flight.
+///
+/// @details On @ref MemoLookup::kTranslate the caller holds a claim on
+/// @p fingerprint and owes exactly one @ref memo_publish or @ref memo_release;
+/// until then any other thread asking for the same bytes sleeps rather than
+/// duplicating the work. On @ref MemoLookup::kUnavailable nothing was claimed and
+/// nothing is owed, and the caller translates as if the memo did not exist -- the
+/// memo may only cost throughput, never correctness.
+///
+/// Candidates are compared with the lock held. That serialises other loads behind
+/// a comparison, which is 9 ms for the largest object seen and only happens when
+/// a fingerprint and a size both match, against a translation of minutes that the
+/// comparison exists to avoid. Comparing outside the lock would mean revalidating
+/// a node another thread may have evicted meanwhile, for no measurable gain.
+MemoLookup memo_acquire(uint64_t fingerprint, const Blob &source, TranslationRecord &out,
+                        uint64_t &claim) noexcept {
+  const auto same_bytes = [&source](const Blob &other) {
+    return other->size() == source->size() &&
+           std::memcmp(other->data(), source->data(), source->size()) == 0;
+  };
+  claim = 0;
+  try {
+    std::unique_lock lock(g_state.memo_mutex);
+    // A capacity of zero disables the memo: nothing is looked up, nothing is
+    // claimed, and every load translates as it did before this existed. Only a
+    // test sets that; production runs with a fixed ceiling.
+    if (g_state.memo_capacity == 0)
+      return MemoLookup::kUnavailable;
+    for (;;) {
+      const auto range = g_state.index.equal_range(fingerprint);
+      for (auto it = range.first; it != range.second; ++it) {
+        const MemoList::iterator node = it->second;
+        if (!same_bytes(node->source))
+          continue;
+        out = node->translation;
+        g_state.recent.splice(g_state.recent.begin(), g_state.recent, node);
+        return MemoLookup::kHit;
+      }
+      // A claim that finished but has not finished draining its cohort still
+      // holds exactly what this load wants. Take a copy of it: holding the memo
+      // lock makes that safe even if the last enrolled waiter erases the claim an
+      // instant later, since the copy carries its own reference to the bytes.
+      // Starting a fresh translation instead -- as skipping completed claims
+      // entirely would -- costs another 197 s and 15.9 GB for the object RCCL
+      // loads, purely because of when this load happened to arrive.
+      const auto finished = std::ranges::find_if(g_state.in_flight, [&](const InFlightClaim &e) {
+        return e.completed && e.fingerprint == fingerprint && same_bytes(e.source);
+      });
+      if (finished != g_state.in_flight.end()) {
+        out = finished->result;
+        return MemoLookup::kHit;
+      }
+
+      // Wait only for a translation of exactly these bytes. Matching on the
+      // fingerprint alone would park this load behind an unrelated object that
+      // merely samples the same, which for a large object is minutes of lost
+      // progress for work that could have run alongside it.
+      const auto running = std::ranges::find_if(g_state.in_flight, [&](const InFlightClaim &entry) {
+        return !entry.completed && entry.fingerprint == fingerprint && same_bytes(entry.source);
+      });
+      if (running == g_state.in_flight.end())
+        break;
+
+      // Enrol on that exact claim, so waking up means checking what became of it
+      // rather than re-deciding which translation this load belongs to.
+      const uint64_t enrolled = running->id;
+      ++running->cohort;
+      ++g_state.memo_waiters;
+      bool served = false;
+      for (;;) {
+        g_state.memo_ready.wait(lock);
+        const auto entry = std::ranges::find(g_state.in_flight, enrolled, &InFlightClaim::id);
+        if (entry == g_state.in_flight.end())
+          break; // Published to the memo, or abandoned. Either way, look again.
+        if (!entry->completed)
+          continue; // A different claim resolved; this one is still running.
+        out = entry->result;
+        served = true;
+        if (--entry->cohort == 0 && !retain_completed_claims_for_test())
+          g_state.in_flight.erase(entry);
+        break;
+      }
+      --g_state.memo_waiters;
+      if (served)
+        return MemoLookup::kHit;
+    }
+    claim = g_state.next_claim_id++;
+    g_state.in_flight.push_back(InFlightClaim{claim, fingerprint, source, {}, false, 0});
+    return MemoLookup::kTranslate;
+  } catch (...) {
+    claim = 0;
+    return MemoLookup::kUnavailable;
+  }
+}
+
+void erase_claim_locked(uint64_t claim) {
+  const auto it = std::ranges::find(g_state.in_flight, claim, &InFlightClaim::id);
+  if (it != g_state.in_flight.end())
+    g_state.in_flight.erase(it);
+}
+
+/// @brief Publish the outcome for a claimed fingerprint and wake anyone waiting.
+void memo_publish(uint64_t claim, uint64_t fingerprint, Blob source,
+                  TranslationRecord record) noexcept {
+  MemoLogSummary summary;
+  try {
+    {
+      std::lock_guard lock(g_state.memo_mutex);
+      const size_t bytes = source->size() + (record.output == nullptr ? 0 : record.output->size());
+      const auto held = std::ranges::find(g_state.in_flight, claim, &InFlightClaim::id);
+      const bool has_cohort = held != g_state.in_flight.end() && held->cohort != 0;
+
+      // Give the cohort something to wake onto before anything that can fail.
+      // Admitting an entry allocates twice, and if either allocation is short --
+      // most likely exactly when this translation has just peaked at 15.9 GB --
+      // the claim is all that stands between these waiters and translating the
+      // same object again one at a time. Copying the record here shares ownership
+      // of bytes that already exist and allocates nothing.
+      if (has_cohort) {
+        held->result = record;
+        held->completed = true;
+      }
+
+      // The ceiling is a promise about how much memory this takes and keeps, so an
+      // entry that does not fit is declined rather than admitted and then exempted
+      // from the rule. Say so: the alternative to holding it is paying the
+      // translation on every load, and an operator watching that has no other way
+      // to tell the two apart.
+      bool admitted = false;
+      if (bytes > g_state.memo_capacity) {
+        summary.refused = true;
+        summary.refused_bytes = bytes;
+        summary.capacity = g_state.memo_capacity;
+      } else {
+        try {
+          // The list, the index and the byte count commit together or not at all.
+          // A node the index cannot reach is worse than a missing entry: eviction
+          // would later subtract bytes that were never added, wrapping memo_bytes
+          // and leaving capacity enforcement broken for the life of the process.
+          fail_admission_if_armed_for_test(1);
+          g_state.recent.push_front(MemoEntry{fingerprint, source, record});
+          try {
+            fail_admission_if_armed_for_test(2);
+            g_state.index.emplace(fingerprint, g_state.recent.begin());
+          } catch (...) {
+            g_state.recent.pop_front();
+            throw;
+          }
+          g_state.memo_bytes += bytes;
+          memo_evict_locked(summary);
+          admitted = true;
+        } catch (...) {
+          // Could not take it. The cohort above still gets its answer; a later
+          // load translates again, which is the same cost as never having cached
+          // it and nothing like the cost of a convoy.
+        }
+      }
+
+      // Let the claim go once it has no one left to serve: either the memo now
+      // answers for these bytes, or nobody was waiting on them.
+      if (admitted || !has_cohort) {
+        const auto entry = std::ranges::find(g_state.in_flight, claim, &InFlightClaim::id);
+        if (entry != g_state.in_flight.end())
+          g_state.in_flight.erase(entry);
+      }
+    }
+  } catch (...) {
+    // A claim that never completed must not survive, or every later load of these
+    // bytes waits on a translation that is not coming. One that DID complete is
+    // holding a result its cohort has not collected yet, and erasing that is what
+    // creates the convoy -- so tell the two apart rather than dropping both.
+    try {
+      std::lock_guard lock(g_state.memo_mutex);
+      const auto entry = std::ranges::find(g_state.in_flight, claim, &InFlightClaim::id);
+      if (entry != g_state.in_flight.end() && !entry->completed)
+        g_state.in_flight.erase(entry);
+    } catch (...) {
+    }
+  }
+  g_state.memo_ready.notify_all();
+  emit_memo_summary(summary);
+}
+
+/// @brief Give up a claim without publishing, so waiters retry rather than hang.
+void memo_release(uint64_t claim) noexcept {
+  try {
+    std::lock_guard lock(g_state.memo_mutex);
+    erase_claim_locked(claim);
+  } catch (...) {
+  }
+  g_state.memo_ready.notify_all();
+}
+
+#if defined(RJ_HOTSWAP_TEST_HOOKS)
+// Test-only: hold a thread that has claimed a translation until it is let go.
+// Single-flight is only observable while a translation is in flight, and the test
+// fixture translates in under a millisecond, so without a way to stop the claimer
+// there the waiters have nothing to wait for and the case would pass whether or
+// not they ever blocked.
+std::mutex g_gate_mutex;
+std::condition_variable g_gate_open;
+bool g_gate_closed = false;
+
+// Test-only: replace the next translation's status, to reach the paths that
+// depend on WHICH failure occurred. An environmental failure cannot be provoked
+// on demand, and the difference between remembering one and not is the difference
+// between a transient fault and a permanent refusal of valid bytes.
+std::mutex g_forced_status_mutex;
+bool g_forced_status_armed = false;
+rj_status_t g_forced_status = ROCJITSU_STATUS_SUCCESS;
+
+void hold_claimed_translation_for_test() {
+  std::unique_lock lock(g_gate_mutex);
+  g_gate_open.wait(lock, [] { return !g_gate_closed; });
+}
+
+void override_translation_status_for_test(rj_status_t &status, uint8_t *&data, size_t &size) {
+  std::lock_guard lock(g_forced_status_mutex);
+  if (!g_forced_status_armed)
+    return;
+  g_forced_status_armed = false;
+  status = g_forced_status;
+  if (status == ROCJITSU_STATUS_SUCCESS)
+    return;
+  rj_gfx1250_b0_to_a0_free(data);
+  data = nullptr;
+  size = 0;
+}
+#else
+void hold_claimed_translation_for_test() {}
+void override_translation_status_for_test(rj_status_t &, uint8_t *&, size_t &) {}
+#endif // RJ_HOTSWAP_TEST_HOOKS
 
 bool install(HsaApiTable *table) {
   std::lock_guard lock(g_state.lifecycle_mutex);
@@ -669,33 +1144,94 @@ hsa_status_t HSA_API load_agent_code_object(hsa_executable_t executable, hsa_age
     // gfx1250 A0 and B0 code objects carry the same machine identity. Mode 2 is
     // a B0-input environment, so gfx1250 input targeting an A0 agent uses the
     // fixed B0-to-A0 profile.
+    //
+    // Translation is a pure function of these bytes, so a caller that registers
+    // the same object repeatedly -- which is exactly what a kernel-attribute walk
+    // over a large device library does, once per registration and once per device
+    // -- should pay for it once. RCCL's gfx1250 device image is 212 MiB and takes
+    // 197 s to translate, so a repeat that translates again does not merely run
+    // slowly; it exhausts the caller's whole startup budget.
+    const uint64_t fingerprint = sample_fingerprint(*source);
+
+    TranslationRecord translation;
+    uint64_t claim = 0;
+    const MemoLookup lookup = memo_acquire(fingerprint, source, translation, claim);
+
+    // A claim taken by memo_acquire() must be given back exactly once. Anything
+    // that leaves this scope without resolving it would leave every later load of
+    // these bytes waiting on a translation that is never coming.
+    bool claim_resolved = lookup != MemoLookup::kTranslate;
+    const auto claim_guard = make_scope_guard([&] {
+      if (!claim_resolved)
+        memo_release(claim);
+    });
+    const auto remember = [&](const TranslationRecord &outcome) {
+      if (claim_resolved)
+        return;
+      claim_resolved = true;
+      memo_publish(claim, fingerprint, source, outcome);
+    };
+
+    // Serve a remembered outcome, whichever way it went. Reporting it through the
+    // same record as a fresh translation keeps every load attributable to its
+    // source object; a reuse that logged less would blind that linkage precisely
+    // when almost every load is a reuse.
+    if (lookup == MemoLookup::kHit) {
+      if (translation.output == nullptr) {
+        log_translation(translation.info.source_code_object_id, "reused_failure",
+                        translation.info.changed_instruction_count, source->size(), 0,
+                        translation.status, HSA_STATUS_ERROR_INVALID_CODE_OBJECT);
+        return HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
+      }
+      const hsa_status_t reused_status = load_owned_bytes(executable, agent, translation.output,
+                                                          options, loaded, *api, original_load);
+      log_translation(translation.info.source_code_object_id, "reused",
+                      translation.info.changed_instruction_count, source->size(),
+                      translation.output->size(), translation.status, reused_status);
+      return reused_status;
+    }
+
     uint8_t *translated_data = nullptr;
     size_t translated_size = 0;
-    rj_gfx1250_b0_to_a0_translation_info_t info{};
-    const rj_status_t translate_status = rj_gfx1250_b0_to_a0_translate_with_info(
-        source->data(), source->size(), &translated_data, &translated_size, &info);
-    if (translate_status != ROCJITSU_STATUS_SUCCESS || translated_data == nullptr ||
+    g_state.translations.fetch_add(1, std::memory_order_relaxed);
+    hold_claimed_translation_for_test();
+    translation.status = rj_gfx1250_b0_to_a0_translate_with_info(
+        source->data(), source->size(), &translated_data, &translated_size, &translation.info);
+    override_translation_status_for_test(translation.status, translated_data, translated_size);
+    if (translation.status != ROCJITSU_STATUS_SUCCESS || translated_data == nullptr ||
         translated_size == 0) {
       rj_gfx1250_b0_to_a0_free(translated_data);
-      log_translation(info.source_code_object_id, "translation_failed",
-                      info.changed_instruction_count, source->size(), 0, translate_status,
-                      HSA_STATUS_ERROR_INVALID_CODE_OBJECT);
+      // Remember a refusal only when it is a verdict on the bytes. The translator
+      // reports an environmental failure -- an allocation it could not make, an
+      // exception it could not attribute -- with a status that promises nothing
+      // about the input, and recording one of those would turn a single bad moment
+      // into a permanent refusal of an object that translates perfectly well.
+      if (translation.status == ROCJITSU_STATUS_INVALID_CODE_OBJECT)
+        remember(translation);
+      log_translation(translation.info.source_code_object_id, "translation_failed",
+                      translation.info.changed_instruction_count, source->size(), 0,
+                      translation.status, HSA_STATUS_ERROR_INVALID_CODE_OBJECT);
       return HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
     }
 
-    Blob translated = copy_bytes(translated_data, translated_size);
+    translation.output = copy_bytes(translated_data, translated_size);
     rj_gfx1250_b0_to_a0_free(translated_data);
-    if (translated == nullptr) {
-      log_translation(info.source_code_object_id, "output_copy_failed",
-                      info.changed_instruction_count, source->size(), translated_size,
-                      translate_status, HSA_STATUS_ERROR_OUT_OF_RESOURCES);
+    if (translation.output == nullptr) {
+      // Deliberately NOT remembered: running out of memory says nothing about
+      // these bytes, and recording it would turn one bad moment into a permanent
+      // refusal of an object that translates perfectly well.
+      log_translation(translation.info.source_code_object_id, "output_copy_failed",
+                      translation.info.changed_instruction_count, source->size(), translated_size,
+                      translation.status, HSA_STATUS_ERROR_OUT_OF_RESOURCES);
       return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
     }
 
-    const hsa_status_t load_status =
-        load_owned_bytes(executable, agent, translated, options, loaded, *api, original_load);
-    log_translation(info.source_code_object_id, "translated", info.changed_instruction_count,
-                    source->size(), translated_size, translate_status, load_status);
+    remember(translation);
+    const hsa_status_t load_status = load_owned_bytes(executable, agent, translation.output,
+                                                      options, loaded, *api, original_load);
+    log_translation(translation.info.source_code_object_id, "translated",
+                    translation.info.changed_instruction_count, source->size(), translated_size,
+                    translation.status, load_status);
     return load_status;
   });
 }
@@ -784,13 +1320,117 @@ extern "C" RJ_HOOK_EXPORT size_t rj_test_retained_executable_buffer_count() {
   return count;
 }
 
-// Test-only: drop all retained storage. Production storage is process-lifetime (not
-// cleared on reinstall), so a test fixture needs this to isolate the retention
-// lifecycle between test cases; production never calls it.
+// Test-only: drop all retained storage and every remembered translation.
+// Production storage is process-lifetime (not cleared on reinstall), so a test
+// fixture needs this to isolate the retention lifecycle between test cases;
+// production never calls it. The memo is cleared here too, because a test that
+// expects to observe a translation cannot do so once an earlier case has already
+// paid for the same bytes.
 extern "C" RJ_HOOK_EXPORT void rj_test_clear_retained_storage() {
-  std::lock_guard lock(g_state.storage_mutex);
-  g_state.readers.clear();
-  g_state.executables.clear();
+  {
+    std::lock_guard lock(g_state.storage_mutex);
+    g_state.readers.clear();
+    g_state.executables.clear();
+  }
+  // Release anything a previous case armed. A gate left closed or a status left
+  // forced would wedge or corrupt every case that followed, which is a far more
+  // confusing failure than the one that set it.
+  {
+    std::lock_guard lock(g_gate_mutex);
+    g_gate_closed = false;
+  }
+  g_gate_open.notify_all();
+  g_retain_completed_claims.store(false, std::memory_order_relaxed);
+  g_fail_next_admission.store(0, std::memory_order_relaxed);
+  {
+    std::lock_guard lock(g_forced_status_mutex);
+    g_forced_status_armed = false;
+  }
+  std::lock_guard lock(g_state.memo_mutex);
+  g_state.recent.clear();
+  g_state.index.clear();
+  // Claims too. A completed one left behind would answer a later case's load from
+  // an earlier case's translation, which is exactly the confusion this exists to
+  // prevent. No production caller can reach here with a claim outstanding.
+  g_state.in_flight.clear();
+  g_state.memo_bytes = 0;
+  g_state.memo_capacity = kDefaultMemoCapacity;
+  g_state.translations.store(0, std::memory_order_relaxed);
+}
+
+// Test-only: number of translations actually performed. The point of the memo is
+// that this stays at the number of DISTINCT code objects however many times they
+// are loaded, and two loads agreeing is also true when both translated -- only
+// this distinguishes reuse from repetition.
+extern "C" RJ_HOOK_EXPORT uint64_t rj_test_translation_count() {
+  return g_state.translations.load(std::memory_order_relaxed);
+}
+
+// Test-only: set the memo's byte cap, so displacement is reachable without
+// allocating the working set the production cap is sized for. Zero disables the
+// memo. Production takes no configuration; the ceiling is fixed.
+extern "C" RJ_HOOK_EXPORT void rj_test_set_translation_memo_capacity(uint64_t bytes) {
+  MemoLogSummary summary;
+  {
+    std::lock_guard lock(g_state.memo_mutex);
+    g_state.memo_capacity = static_cast<size_t>(bytes);
+    memo_evict_locked(summary);
+  }
+  emit_memo_summary(summary);
+}
+
+// Test-only: stop the next thread that claims a translation, so a test can hold a
+// translation in flight and observe that its peers block rather than duplicate it.
+extern "C" RJ_HOOK_EXPORT void rj_test_close_translation_gate() {
+  std::lock_guard lock(g_gate_mutex);
+  g_gate_closed = true;
+}
+
+extern "C" RJ_HOOK_EXPORT void rj_test_open_translation_gate() {
+  {
+    std::lock_guard lock(g_gate_mutex);
+    g_gate_closed = false;
+  }
+  g_gate_open.notify_all();
+}
+
+// Test-only: the fingerprint of @p bytes. A test that wants two objects which
+// collide has to be able to confirm they do; constructing a pair by hand and
+// assuming the sampling misses the difference would silently stop testing the
+// collision the day the window layout changes.
+extern "C" RJ_HOOK_EXPORT uint64_t rj_test_sample_fingerprint(const void *bytes, size_t size) {
+  return sample_fingerprint({static_cast<const uint8_t *>(bytes), size});
+}
+
+// Test-only: hold completed claims open past their cohort, so a test can submit a
+// load into the window where a finished result is still available to be taken.
+extern "C" RJ_HOOK_EXPORT void rj_test_retain_completed_claims(bool retain) {
+  g_retain_completed_claims.store(retain, std::memory_order_relaxed);
+}
+
+// Test-only: make the next admission to the memo fail as a short allocation
+// would. Stage 1 is the LRU list node, stage 2 the index node; zero disarms.
+extern "C" RJ_HOOK_EXPORT void rj_test_fail_next_memo_admission(int stage) {
+  g_fail_next_admission.store(stage, std::memory_order_relaxed);
+}
+
+// Test-only: threads currently asleep waiting for an in-flight translation.
+extern "C" RJ_HOOK_EXPORT uint64_t rj_test_translation_waiters() {
+  std::lock_guard lock(g_state.memo_mutex);
+  return g_state.memo_waiters;
+}
+
+// Test-only: make the next translation report @p status instead of its own.
+extern "C" RJ_HOOK_EXPORT void rj_test_force_next_translation_status(int status) {
+  std::lock_guard lock(g_forced_status_mutex);
+  g_forced_status_armed = true;
+  g_forced_status = static_cast<rj_status_t>(status);
+}
+
+// Test-only: bytes the memo is currently holding, sources and outputs together.
+extern "C" RJ_HOOK_EXPORT uint64_t rj_test_translation_memo_bytes() {
+  std::lock_guard lock(g_state.memo_mutex);
+  return g_state.memo_bytes;
 }
 
 // Test-only: emit a deterministic translation record so concurrent logger tests

--- a/emulation/rocjitsu/tests/dbt/hsa_hotswap_rocjitsu_unit_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/hsa_hotswap_rocjitsu_unit_test.cpp
@@ -8,6 +8,7 @@
 
 #include <array>
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -15,6 +16,7 @@
 #include <fstream>
 #include <iomanip>
 #include <iterator>
+#include <mutex>
 #include <new>
 #include <regex>
 #include <sstream>
@@ -28,6 +30,16 @@ extern "C" void OnUnload();
 extern "C" size_t rj_test_retained_executable_buffer_count();
 extern "C" void rj_test_clear_retained_storage();
 extern "C" void rj_test_log_translation(uint64_t source_id, size_t changed);
+extern "C" uint64_t rj_test_translation_count();
+extern "C" uint64_t rj_test_translation_memo_bytes();
+extern "C" void rj_test_set_translation_memo_capacity(uint64_t bytes);
+extern "C" void rj_test_close_translation_gate();
+extern "C" void rj_test_open_translation_gate();
+extern "C" uint64_t rj_test_translation_waiters();
+extern "C" void rj_test_force_next_translation_status(int status);
+extern "C" uint64_t rj_test_sample_fingerprint(const void *bytes, size_t size);
+extern "C" void rj_test_retain_completed_claims(bool retain);
+extern "C" void rj_test_fail_next_memo_admission(int stage);
 
 namespace {
 
@@ -128,9 +140,15 @@ hsa_status_t HSA_API fake_isa_get_info(hsa_isa_t isa, hsa_isa_info_t attribute, 
   return HSA_STATUS_ERROR_INVALID_ARGUMENT;
 }
 
+// Serialises the loader fakes' shared bookkeeping. Only the concurrency cases call
+// them from more than one thread, but the state they touch is plain globals, so
+// without this those cases would be racing rather than testing.
+std::mutex g_fake_mutex;
+
 hsa_status_t HSA_API fake_create_file(hsa_file_t, hsa_code_object_reader_t *reader) {
   if (reader == nullptr)
     return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  std::lock_guard fake_lock(g_fake_mutex);
   *reader = hsa_code_object_reader_t{g_next_reader++};
   return HSA_STATUS_SUCCESS;
 }
@@ -139,12 +157,14 @@ hsa_status_t HSA_API fake_create_memory(const void *bytes, size_t size,
                                         hsa_code_object_reader_t *reader) {
   if (bytes == nullptr || size == 0 || reader == nullptr)
     return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  std::lock_guard fake_lock(g_fake_mutex);
   *reader = hsa_code_object_reader_t{g_next_reader++};
   g_readers.emplace(reader->handle, ReaderView{static_cast<const uint8_t *>(bytes), size});
   return HSA_STATUS_SUCCESS;
 }
 
 hsa_status_t HSA_API fake_destroy_reader(hsa_code_object_reader_t reader) {
+  std::lock_guard fake_lock(g_fake_mutex);
   ++g_reader_destroy_calls;
   if (g_reader_destroy_status == HSA_STATUS_SUCCESS)
     g_readers.erase(reader.handle);
@@ -157,6 +177,7 @@ hsa_status_t HSA_API fake_destroy_executable(hsa_executable_t) {
 
 hsa_status_t HSA_API fake_load_agent(hsa_executable_t, hsa_agent_t, hsa_code_object_reader_t reader,
                                      const char *, hsa_loaded_code_object_t *loaded) {
+  std::lock_guard fake_lock(g_fake_mutex);
   ++g_load_agent_calls;
   g_loaded_reader = reader;
   if (g_load_agent_status != HSA_STATUS_SUCCESS)
@@ -696,5 +717,647 @@ TEST_F(HsaHotswapHookTest, CallbackApiSnapshotIsSafeDuringUnload) {
 
   EXPECT_EQ(unexpected_statuses.load(std::memory_order_relaxed), 0);
 }
+
+// Translation is a pure function of the source bytes, so a caller that registers
+// the same object repeatedly should pay for it once. The cases below assert on the
+// number of translations actually performed rather than on elapsed time: two loads
+// producing equal bytes is also true when both translated, and only the count
+// distinguishes reuse from repetition.
+class HsaHotswapMemoTest : public HsaHotswapHookTest {
+protected:
+  // Loads @p source through a fresh reader, the way a caller that re-registers the
+  // same object does -- a new handle every time, so nothing but the content itself
+  // can connect one load to the next.
+  // Spin until @p expected threads are asleep on an in-flight translation, or a
+  // generous deadline passes. Returns what was actually observed so the caller can
+  // release the gate before asserting on it.
+  static uint64_t wait_for_memo_waiters(uint64_t expected) {
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+    uint64_t waiters = rj_test_translation_waiters();
+    while (waiters < expected && std::chrono::steady_clock::now() < deadline) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      waiters = rj_test_translation_waiters();
+    }
+    return waiters;
+  }
+
+  // Build a second object of the SAME size as @p base whose sampled windows are
+  // identical but whose bytes are not, by disturbing one byte of trailing padding
+  // that the sampling happens to miss. Returns empty if no such byte exists, so a
+  // caller can fail loudly rather than quietly test something weaker. The
+  // fingerprint is queried rather than assumed: hand-picking an offset would stop
+  // testing a collision the day the window layout changed.
+  static std::vector<uint8_t> make_fingerprint_twin(const std::vector<uint8_t> &base) {
+    constexpr size_t kPadding = 4096;
+    std::vector<uint8_t> original = base;
+    original.resize(base.size() + kPadding, 0);
+    const uint64_t target = rj_test_sample_fingerprint(original.data(), original.size());
+    for (size_t offset = base.size(); offset < original.size(); ++offset) {
+      std::vector<uint8_t> twin = original;
+      twin[offset] = 0x5a;
+      if (rj_test_sample_fingerprint(twin.data(), twin.size()) == target)
+        return twin;
+    }
+    return {};
+  }
+
+  // Overwrite the first instruction of @p base with @p word. The result is still a
+  // structurally valid gfx1250 object, so it reaches translation rather than being
+  // rejected up front -- which is how the two ways a translation can fail are told
+  // apart: a body the translator cannot render dispatchable, versus one that makes
+  // it throw. Returns empty if .text cannot be located.
+  static std::vector<uint8_t> patch_first_instruction(const std::vector<uint8_t> &base,
+                                                      uint32_t word) {
+    if (base.size() < sizeof(rocjitsu::Elf64_Ehdr))
+      return {};
+    rocjitsu::Elf64_Ehdr header{};
+    std::memcpy(&header, base.data(), sizeof(header));
+    // Bounds-check what the fixture claims before believing it. A truncated or
+    // malformed one should fail the case, not read past the buffer and take the
+    // whole test process down with it.
+    const size_t table_bytes = size_t{header.e_shnum} * sizeof(rocjitsu::Elf64_Shdr);
+    if (header.e_shoff > base.size() || table_bytes > base.size() - header.e_shoff ||
+        header.e_shstrndx >= header.e_shnum)
+      return {};
+    const auto *sections =
+        reinterpret_cast<const rocjitsu::Elf64_Shdr *>(base.data() + header.e_shoff);
+    const size_t names_offset = sections[header.e_shstrndx].sh_offset;
+    if (names_offset >= base.size())
+      return {};
+    const char *names = reinterpret_cast<const char *>(base.data() + names_offset);
+    const size_t names_limit = base.size() - names_offset;
+    for (uint16_t index = 0; index < header.e_shnum; ++index) {
+      if (sections[index].sh_name >= names_limit)
+        return {};
+      const char *name = names + sections[index].sh_name;
+      const size_t name_limit = names_limit - sections[index].sh_name;
+      if (std::memchr(name, '\0', name_limit) == nullptr)
+        return {}; // Unterminated: comparing it would run off the end.
+      if (std::strcmp(name, ".text") != 0)
+        continue;
+      if (sections[index].sh_offset + sizeof(word) > base.size())
+        return {};
+      std::vector<uint8_t> patched = base;
+      std::memcpy(patched.data() + sections[index].sh_offset, &word, sizeof(word));
+      return patched;
+    }
+    return {};
+  }
+
+  hsa_status_t load_through_new_reader(const std::vector<uint8_t> &source,
+                                       hsa_executable_t executable = kExecutable) {
+    hsa_code_object_reader_t reader{};
+    const hsa_status_t create_status = api.core.hsa_code_object_reader_create_from_memory_fn(
+        source.data(), source.size(), &reader);
+    if (create_status != HSA_STATUS_SUCCESS)
+      return create_status;
+    return api.core.hsa_executable_load_agent_code_object_fn(executable, kA0Agent, reader, nullptr,
+                                                             nullptr);
+  }
+};
+
+// The ticket this exists for: a caller registered two distinct code objects 509
+// times each across four devices and paid for 2036 translations.
+TEST_F(HsaHotswapMemoTest, RemembersARefusalInsteadOfRepeatingIt) {
+  ASSERT_TRUE(OnLoad(&api.table, 0, 0, nullptr));
+  const std::vector<uint8_t> source = make_invalid_gfx1250_elf();
+  constexpr size_t kLoads = 256;
+
+  for (size_t load = 0; load < kLoads; ++load)
+    ASSERT_EQ(load_through_new_reader(source), HSA_STATUS_ERROR_INVALID_CODE_OBJECT) << load;
+
+  // A refusal is a property of the bytes: reaching it once is enough, and every
+  // later load must reach the same answer without re-deriving it.
+  EXPECT_EQ(rj_test_translation_count(), 1u);
+  EXPECT_EQ(g_load_agent_calls, 0);
+  EXPECT_EQ(rj_test_retained_executable_buffer_count(), 0u);
+}
+
+#ifdef GFX1250_B0_TO_A0_FIXTURE
+TEST_F(HsaHotswapMemoTest, RepeatedLoadsOfOneObjectTranslateOnce) {
+  ASSERT_TRUE(OnLoad(&api.table, 0, 0, nullptr));
+  const std::vector<uint8_t> source = read_translation_fixture();
+  ASSERT_FALSE(source.empty()) << GFX1250_B0_TO_A0_FIXTURE;
+  constexpr size_t kLoads = 256;
+
+  ASSERT_EQ(load_through_new_reader(source), HSA_STATUS_SUCCESS);
+  const std::vector<uint8_t> first_output = g_loaded_bytes;
+  ASSERT_NE(first_output, source);
+  ASSERT_EQ(rj_test_translation_count(), 1u);
+
+  for (size_t load = 1; load < kLoads; ++load) {
+    g_loaded_bytes.clear();
+    ASSERT_EQ(load_through_new_reader(source), HSA_STATUS_SUCCESS) << load;
+    ASSERT_EQ(g_loaded_bytes, first_output) << load;
+  }
+
+  EXPECT_EQ(rj_test_translation_count(), 1u);
+  EXPECT_EQ(g_load_agent_calls, static_cast<int>(kLoads));
+  // One entry is held, not one per load: the reuses shared that buffer rather
+  // than each taking a copy of it. An entry is its source plus its output,
+  // because identity is settled by comparing bytes rather than trusting a digest.
+  EXPECT_EQ(rj_test_translation_memo_bytes(), source.size() + first_output.size());
+}
+
+// Identity is exact. Two objects that a sampled fingerprint could plausibly place
+// in the same bucket -- same size, differing in one interior byte -- must not be
+// mistaken for each other, because the consequence is running the wrong code.
+TEST_F(HsaHotswapMemoTest, ObjectsDifferingInOneInteriorByteAreNotConfused) {
+  ASSERT_TRUE(OnLoad(&api.table, 0, 0, nullptr));
+  const std::vector<uint8_t> base = read_translation_fixture();
+  ASSERT_FALSE(base.empty()) << GFX1250_B0_TO_A0_FIXTURE;
+
+  std::vector<uint8_t> altered = base;
+  ASSERT_GT(altered.size(), 2048u);
+  altered[altered.size() / 2] = static_cast<uint8_t>(altered[altered.size() / 2] ^ 0xff);
+
+  ASSERT_EQ(load_through_new_reader(base), HSA_STATUS_SUCCESS);
+  const std::vector<uint8_t> base_output = g_loaded_bytes;
+
+  g_loaded_bytes.clear();
+  const hsa_status_t altered_status = load_through_new_reader(altered);
+  // Whatever the altered object translates to, it must not be served the entry
+  // that belongs to the original.
+  if (altered_status == HSA_STATUS_SUCCESS) {
+    EXPECT_NE(g_loaded_bytes, base_output);
+  }
+  EXPECT_EQ(rj_test_translation_count(), 2u);
+}
+
+TEST_F(HsaHotswapMemoTest, DistinctObjectsAreTranslatedOncePerContent) {
+  ASSERT_TRUE(OnLoad(&api.table, 0, 0, nullptr));
+  const std::vector<uint8_t> base = read_translation_fixture();
+  ASSERT_FALSE(base.empty()) << GFX1250_B0_TO_A0_FIXTURE;
+
+  // Trailing bytes past the end of the ELF change the content without changing
+  // what translation makes of it, which is what a second distinct object needs to
+  // be here: different bytes, same outcome.
+  std::vector<std::vector<uint8_t>> objects{base, base};
+  objects[1].push_back(0x5a);
+  constexpr size_t kLoadsPerObject = 64;
+
+  for (size_t load = 0; load < kLoadsPerObject; ++load)
+    for (const auto &object : objects)
+      ASSERT_EQ(load_through_new_reader(object), HSA_STATUS_SUCCESS) << load;
+
+  EXPECT_EQ(rj_test_translation_count(), objects.size());
+}
+
+// A control for the case above: without the memo these loads would each translate,
+// so the count must follow the number of DISTINCT objects and not the number of
+// loads. Clearing the memo mid-run makes the same object translate again, which
+// shows the count is measuring translation rather than being pinned at one.
+TEST_F(HsaHotswapMemoTest, ClearingTheMemoMakesTheSameObjectTranslateAgain) {
+  ASSERT_TRUE(OnLoad(&api.table, 0, 0, nullptr));
+  const std::vector<uint8_t> source = read_translation_fixture();
+  ASSERT_FALSE(source.empty()) << GFX1250_B0_TO_A0_FIXTURE;
+
+  ASSERT_EQ(load_through_new_reader(source), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(load_through_new_reader(source), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(rj_test_translation_count(), 1u);
+
+  rj_test_clear_retained_storage();
+  // Without this the case proves nothing: the clear also resets the counter, so
+  // the final 1 below would read the same whether a translation happened or not.
+  ASSERT_EQ(rj_test_translation_count(), 0u);
+
+  ASSERT_EQ(load_through_new_reader(source), HSA_STATUS_SUCCESS);
+  EXPECT_EQ(rj_test_translation_count(), 1u);
+}
+
+TEST_F(HsaHotswapMemoTest, ConcurrentLoadsOfOneObjectTranslateOnce) {
+  ASSERT_TRUE(OnLoad(&api.table, 0, 0, nullptr));
+  const std::vector<uint8_t> source = read_translation_fixture();
+  ASSERT_FALSE(source.empty()) << GFX1250_B0_TO_A0_FIXTURE;
+  constexpr size_t kThreadCount = 8;
+
+  // Hold the first translation open. The fixture translates in well under a
+  // millisecond, so left to itself the claimer would publish before its peers
+  // even reached the memo, and the count below would read 1 whether or not
+  // single-flight waiting works at all.
+  rj_test_close_translation_gate();
+
+  std::atomic<int> failures{0};
+  std::vector<std::thread> workers;
+  workers.reserve(kThreadCount);
+  for (size_t thread_index = 0; thread_index < kThreadCount; ++thread_index) {
+    workers.emplace_back([&] {
+      if (load_through_new_reader(source) != HSA_STATUS_SUCCESS)
+        failures.fetch_add(1, std::memory_order_relaxed);
+    });
+  }
+
+  // Exactly one thread claims and is held at the gate; the rest must be asleep
+  // inside the memo rather than translating alongside it. Sample before opening
+  // the gate, and open it whatever the sample said -- an assertion that fired
+  // here while threads were still held would abort the process instead of failing
+  // the case.
+  const uint64_t waiters = wait_for_memo_waiters(kThreadCount - 1);
+  const uint64_t translations_while_held = rj_test_translation_count();
+  rj_test_open_translation_gate();
+  for (auto &worker : workers)
+    worker.join();
+
+  EXPECT_EQ(waiters, kThreadCount - 1);
+  EXPECT_EQ(translations_while_held, 1u);
+
+  EXPECT_EQ(failures.load(std::memory_order_relaxed), 0);
+  EXPECT_EQ(rj_test_translation_waiters(), 0u);
+  // The waiters resumed onto the published entry rather than each translating.
+  EXPECT_EQ(rj_test_translation_count(), 1u);
+}
+
+// Two objects that merely sample alike must translate side by side. The
+// fingerprint only narrows, so waiting on it would park an independent object
+// behind a translation that for the image RCCL loads runs for 197 s -- and
+// because the sampling is deterministic, so is the stall.
+TEST_F(HsaHotswapMemoTest, ObjectsThatShareAFingerprintDoNotWaitForEachOther) {
+  ASSERT_TRUE(OnLoad(&api.table, 0, 0, nullptr));
+  const std::vector<uint8_t> base = read_translation_fixture();
+  ASSERT_FALSE(base.empty()) << GFX1250_B0_TO_A0_FIXTURE;
+
+  const std::vector<uint8_t> first = [&] {
+    std::vector<uint8_t> padded = base;
+    padded.resize(base.size() + 4096, 0);
+    return padded;
+  }();
+  const std::vector<uint8_t> second = make_fingerprint_twin(base);
+  ASSERT_FALSE(second.empty()) << "no colliding twin found; the sampling changed";
+  ASSERT_EQ(first.size(), second.size());
+  ASSERT_NE(first, second);
+  ASSERT_EQ(rj_test_sample_fingerprint(first.data(), first.size()),
+            rj_test_sample_fingerprint(second.data(), second.size()));
+
+  // Hold both translations open. If the claim were keyed on the fingerprint, the
+  // second object would be asleep in the memo instead of translating.
+  rj_test_close_translation_gate();
+  std::atomic<int> failures{0};
+  std::vector<std::thread> workers;
+  for (const std::vector<uint8_t> *object : {&first, &second}) {
+    workers.emplace_back([&, object] {
+      if (load_through_new_reader(*object) != HSA_STATUS_SUCCESS)
+        failures.fetch_add(1, std::memory_order_relaxed);
+    });
+  }
+
+  // Both should reach the gate, so two translations are in flight and nobody is
+  // waiting. Sample, then release regardless of what was seen.
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+  while (rj_test_translation_count() < 2 && std::chrono::steady_clock::now() < deadline)
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  const uint64_t translations_while_held = rj_test_translation_count();
+  const uint64_t waiters = rj_test_translation_waiters();
+  rj_test_open_translation_gate();
+  for (auto &worker : workers)
+    worker.join();
+
+  EXPECT_EQ(failures.load(std::memory_order_relaxed), 0);
+  EXPECT_EQ(translations_while_held, 2u) << "a colliding object was serialised behind the other";
+  EXPECT_EQ(waiters, 0u);
+}
+
+// The other way a claim ends. A claimer that gives up without publishing must
+// release its waiters, and one of them must then go on to do the work -- if the
+// claim leaked instead, every later load of these bytes would sleep forever.
+TEST_F(HsaHotswapMemoTest, WaitersResumeWhenAClaimIsReleasedWithoutPublishing) {
+  ASSERT_TRUE(OnLoad(&api.table, 0, 0, nullptr));
+  const std::vector<uint8_t> source = read_translation_fixture();
+  ASSERT_FALSE(source.empty()) << GFX1250_B0_TO_A0_FIXTURE;
+  constexpr size_t kThreadCount = 4;
+
+  // The first translation reports an environmental failure, which is not
+  // remembered, so its claim is released rather than published.
+  rj_test_force_next_translation_status(3 /* ROCJITSU_STATUS_OUT_OF_RESOURCES */);
+  rj_test_close_translation_gate();
+
+  std::atomic<int> succeeded{0};
+  std::vector<std::thread> workers;
+  workers.reserve(kThreadCount);
+  for (size_t thread_index = 0; thread_index < kThreadCount; ++thread_index) {
+    workers.emplace_back([&] {
+      if (load_through_new_reader(source) == HSA_STATUS_SUCCESS)
+        succeeded.fetch_add(1, std::memory_order_relaxed);
+    });
+  }
+
+  const uint64_t waiters = wait_for_memo_waiters(kThreadCount - 1);
+  rj_test_open_translation_gate();
+  for (auto &worker : workers)
+    worker.join();
+
+  EXPECT_EQ(waiters, kThreadCount - 1);
+  // One load hit the forced failure; the rest resumed and one of them translated
+  // for real, so the object is usable again despite the transient fault.
+  EXPECT_EQ(succeeded.load(std::memory_order_relaxed), static_cast<int>(kThreadCount) - 1);
+  EXPECT_EQ(rj_test_translation_waiters(), 0u);
+  EXPECT_GE(rj_test_translation_count(), 2u);
+}
+
+// The two ways a real translation fails, told apart by what they imply about the
+// input. A body the translator renders non-dispatchable is a verdict on the bytes
+// and is remembered; a body that makes it throw promises nothing and is not. The
+// header-only object used above never reaches translation at all, so it cannot
+// exercise either.
+TEST_F(HsaHotswapMemoTest, ANonDispatchableObjectIsRememberedButAThrowingOneIsNot) {
+  ASSERT_TRUE(OnLoad(&api.table, 0, 0, nullptr));
+  const std::vector<uint8_t> base = read_translation_fixture();
+  ASSERT_FALSE(base.empty()) << GFX1250_B0_TO_A0_FIXTURE;
+
+  // A zero opcode translates to completion but yields nothing dispatchable.
+  const std::vector<uint8_t> non_dispatchable = patch_first_instruction(base, 0x00000000u);
+  ASSERT_FALSE(non_dispatchable.empty()) << "could not locate .text";
+  for (size_t load = 0; load < 4; ++load)
+    ASSERT_EQ(load_through_new_reader(non_dispatchable), HSA_STATUS_ERROR_INVALID_CODE_OBJECT)
+        << load;
+  EXPECT_EQ(rj_test_translation_count(), 1u) << "a verdict on the bytes was re-derived";
+
+  // An all-ones opcode makes the translator throw, which says nothing about the
+  // input, so every load has to try again.
+  rj_test_clear_retained_storage();
+  const std::vector<uint8_t> throwing = patch_first_instruction(base, 0xffffffffu);
+  ASSERT_FALSE(throwing.empty());
+  for (size_t load = 0; load < 4; ++load)
+    ASSERT_EQ(load_through_new_reader(throwing), HSA_STATUS_ERROR_INVALID_CODE_OBJECT) << load;
+  EXPECT_EQ(rj_test_translation_count(), 4u) << "an unattributable failure was remembered";
+}
+
+// A failure that says nothing about the bytes must not become a verdict on them.
+// The translator reports an allocation it could not make with the same kind of
+// status as a real refusal, and remembering one would refuse a perfectly valid
+// object for the life of the process.
+TEST_F(HsaHotswapMemoTest, ATransientFailureIsNotRememberedAndTheNextLoadSucceeds) {
+  ASSERT_TRUE(OnLoad(&api.table, 0, 0, nullptr));
+  const std::vector<uint8_t> source = read_translation_fixture();
+  ASSERT_FALSE(source.empty()) << GFX1250_B0_TO_A0_FIXTURE;
+
+  rj_test_force_next_translation_status(3 /* ROCJITSU_STATUS_OUT_OF_RESOURCES */);
+  EXPECT_EQ(load_through_new_reader(source), HSA_STATUS_ERROR_INVALID_CODE_OBJECT);
+  EXPECT_EQ(rj_test_translation_count(), 1u);
+  EXPECT_EQ(rj_test_translation_memo_bytes(), 0u) << "a transient failure was remembered";
+
+  // The control: the same bytes, and nothing was learned from the bad moment.
+  EXPECT_EQ(load_through_new_reader(source), HSA_STATUS_SUCCESS);
+  EXPECT_EQ(rj_test_translation_count(), 2u);
+  EXPECT_GT(rj_test_translation_memo_bytes(), 0u);
+}
+
+// A ceiling of zero switches the memo off entirely: nothing is looked up and
+// nothing is kept, so every load translates exactly as it did before the memo
+// existed.
+TEST_F(HsaHotswapMemoTest, ACapacityOfZeroDisablesTheMemo) {
+  ASSERT_TRUE(OnLoad(&api.table, 0, 0, nullptr));
+  const std::vector<uint8_t> source = read_translation_fixture();
+  ASSERT_FALSE(source.empty()) << GFX1250_B0_TO_A0_FIXTURE;
+
+  rj_test_set_translation_memo_capacity(0);
+  constexpr size_t kLoads = 4;
+  for (size_t load = 0; load < kLoads; ++load)
+    ASSERT_EQ(load_through_new_reader(source), HSA_STATUS_SUCCESS) << load;
+
+  EXPECT_EQ(rj_test_translation_count(), kLoads);
+  EXPECT_EQ(rj_test_translation_memo_bytes(), 0u);
+}
+
+TEST_F(HsaHotswapMemoTest, DisplacedTranslationsAreTranslatedAgainRatherThanLost) {
+  ASSERT_TRUE(OnLoad(&api.table, 0, 0, nullptr));
+  const std::vector<uint8_t> base = read_translation_fixture();
+  ASSERT_FALSE(base.empty()) << GFX1250_B0_TO_A0_FIXTURE;
+
+  // Two objects of identical size, so one entry's worth of room holds exactly one
+  // of them and the second must displace the first.
+  const std::vector<uint8_t> other = make_fingerprint_twin(base);
+  ASSERT_FALSE(other.empty());
+  std::vector<uint8_t> first = base;
+  first.resize(base.size() + 4096, 0);
+  ASSERT_EQ(first.size(), other.size());
+
+  ASSERT_EQ(load_through_new_reader(first), HSA_STATUS_SUCCESS);
+  const uint64_t one_entry = rj_test_translation_memo_bytes();
+  ASSERT_GT(one_entry, 0u);
+
+  rj_test_set_translation_memo_capacity(one_entry);
+  ASSERT_EQ(load_through_new_reader(other), HSA_STATUS_SUCCESS);
+  EXPECT_EQ(rj_test_translation_memo_bytes(), one_entry) << "both entries were held";
+  ASSERT_EQ(rj_test_translation_count(), 2u);
+
+  // Displacement costs throughput and nothing else: the object still loads, it is
+  // simply translated again.
+  ASSERT_EQ(load_through_new_reader(first), HSA_STATUS_SUCCESS);
+  EXPECT_EQ(rj_test_translation_count(), 3u);
+}
+
+// Declining to cache an oversized result must not turn its waiters into a convoy.
+// They asked for these exact bytes and the work is done, so the cohort is served
+// from it before it is dropped; waking them to find nothing would make each
+// translate the object again in turn -- N x 197 s for the image RCCL loads, worse
+// than switching the memo off.
+TEST_F(HsaHotswapMemoTest, AnOversizedResultStillServesTheWaitersItAlreadyHas) {
+  ASSERT_TRUE(OnLoad(&api.table, 0, 0, nullptr));
+  const std::vector<uint8_t> source = read_translation_fixture();
+  ASSERT_FALSE(source.empty()) << GFX1250_B0_TO_A0_FIXTURE;
+  constexpr size_t kThreadCount = 8;
+
+  rj_test_set_translation_memo_capacity(1); // Nothing can be admitted.
+  rj_test_close_translation_gate();
+
+  std::atomic<int> failures{0};
+  std::vector<std::thread> workers;
+  workers.reserve(kThreadCount);
+  for (size_t thread_index = 0; thread_index < kThreadCount; ++thread_index) {
+    workers.emplace_back([&] {
+      if (load_through_new_reader(source) != HSA_STATUS_SUCCESS)
+        failures.fetch_add(1, std::memory_order_relaxed);
+    });
+  }
+
+  const uint64_t waiters = wait_for_memo_waiters(kThreadCount - 1);
+  rj_test_open_translation_gate();
+  for (auto &worker : workers)
+    worker.join();
+
+  EXPECT_EQ(failures.load(std::memory_order_relaxed), 0);
+  EXPECT_EQ(waiters, kThreadCount - 1);
+  // One translation for the whole cohort, and not a byte kept afterwards.
+  EXPECT_EQ(rj_test_translation_count(), 1u);
+  EXPECT_LE(rj_test_translation_memo_bytes(), 1u);
+
+  // The result really was transient: a load arriving after the cohort drained
+  // finds nothing and translates again.
+  ASSERT_EQ(load_through_new_reader(source), HSA_STATUS_SUCCESS);
+  EXPECT_EQ(rj_test_translation_count(), 2u);
+  EXPECT_LE(rj_test_translation_memo_bytes(), 1u);
+}
+
+// A load arriving while a finished result is still draining its cohort must take
+// it rather than start again. The window is normally microseconds, but an
+// enrolled waiter can be descheduled for arbitrarily long, and the duplicate
+// costs another 197 s and 15.9 GB for the object RCCL loads.
+TEST_F(HsaHotswapMemoTest, ALateLoadTakesAResultThatIsStillDraining) {
+  ASSERT_TRUE(OnLoad(&api.table, 0, 0, nullptr));
+  const std::vector<uint8_t> source = read_translation_fixture();
+  ASSERT_FALSE(source.empty()) << GFX1250_B0_TO_A0_FIXTURE;
+
+  // Oversized, so the result is handed to the cohort rather than cached; and held
+  // open afterwards, so the window this is about does not close before the late
+  // load can enter it.
+  rj_test_set_translation_memo_capacity(1);
+  rj_test_retain_completed_claims(true);
+  rj_test_close_translation_gate();
+
+  std::atomic<int> failures{0};
+  std::vector<std::thread> workers;
+  workers.reserve(2);
+  for (size_t thread_index = 0; thread_index < 2; ++thread_index) {
+    workers.emplace_back([&] {
+      if (load_through_new_reader(source) != HSA_STATUS_SUCCESS)
+        failures.fetch_add(1, std::memory_order_relaxed);
+    });
+  }
+  const uint64_t waiters = wait_for_memo_waiters(1);
+  rj_test_open_translation_gate();
+  for (auto &worker : workers)
+    worker.join();
+
+  EXPECT_EQ(failures.load(std::memory_order_relaxed), 0);
+  EXPECT_EQ(waiters, 1u);
+  ASSERT_EQ(rj_test_translation_count(), 1u);
+
+  // Arriving inside the drain window: the answer is right there.
+  EXPECT_EQ(load_through_new_reader(source), HSA_STATUS_SUCCESS);
+  EXPECT_EQ(rj_test_translation_count(), 1u) << "a ready result was ignored";
+}
+
+// Admitting an entry allocates twice, and either allocation can come up short --
+// most plausibly right after a translation that peaked at 15.9 GB. Neither
+// failure may cost the waiters their answer: they would translate the same object
+// one at a time, N x 197 s, which is the convoy in a new place.
+class HsaHotswapAdmissionFaultTest : public HsaHotswapMemoTest,
+                                     public ::testing::WithParamInterface<int> {};
+
+TEST_P(HsaHotswapAdmissionFaultTest, AFailedAdmissionStillServesTheCohort) {
+  ASSERT_TRUE(OnLoad(&api.table, 0, 0, nullptr));
+  const std::vector<uint8_t> source = read_translation_fixture();
+  ASSERT_FALSE(source.empty()) << GFX1250_B0_TO_A0_FIXTURE;
+  constexpr size_t kThreadCount = 6;
+
+  // Room to spare, so the entry would be admitted if the allocation succeeded.
+  rj_test_close_translation_gate();
+  rj_test_fail_next_memo_admission(GetParam());
+
+  std::atomic<int> failures{0};
+  std::vector<std::thread> workers;
+  workers.reserve(kThreadCount);
+  for (size_t thread_index = 0; thread_index < kThreadCount; ++thread_index) {
+    workers.emplace_back([&] {
+      if (load_through_new_reader(source) != HSA_STATUS_SUCCESS)
+        failures.fetch_add(1, std::memory_order_relaxed);
+    });
+  }
+  const uint64_t waiters = wait_for_memo_waiters(kThreadCount - 1);
+  rj_test_open_translation_gate();
+  for (auto &worker : workers)
+    worker.join();
+
+  EXPECT_EQ(waiters, kThreadCount - 1);
+  // Every load succeeded, and exactly one translation served all of them.
+  EXPECT_EQ(failures.load(std::memory_order_relaxed), 0);
+  EXPECT_EQ(rj_test_translation_count(), 1u) << "the cohort was made to translate again";
+  // Nothing was cached, which is the cost of the failed admission and all of it.
+  EXPECT_EQ(rj_test_translation_memo_bytes(), 0u);
+
+  // A later load finds no entry and translates, confirming the memo really is
+  // empty rather than holding something unreachable.
+  ASSERT_EQ(load_through_new_reader(source), HSA_STATUS_SUCCESS);
+  EXPECT_EQ(rj_test_translation_count(), 2u);
+}
+
+INSTANTIATE_TEST_SUITE_P(ListNodeAndIndexNode, HsaHotswapAdmissionFaultTest,
+                         ::testing::Values(1, 2));
+
+// Eviction has to run to the ceiling in one go, however many entries that takes.
+// Stopping part way -- as it would if anything in the loop could fail -- leaves
+// the memo over its limit with nothing that will ever retry it, because a hit
+// does not evict.
+TEST_F(HsaHotswapMemoTest, ShrinkingTheCeilingDisplacesEveryEntryItHasTo) {
+  ASSERT_TRUE(OnLoad(&api.table, 0, 0, nullptr));
+  const std::vector<uint8_t> base = read_translation_fixture();
+  ASSERT_FALSE(base.empty()) << GFX1250_B0_TO_A0_FIXTURE;
+  constexpr size_t kObjects = 5;
+
+  // Distinct objects of the same shape: trailing bytes past the ELF change the
+  // content without changing what translation makes of it.
+  uint64_t one_entry = 0;
+  for (size_t index = 0; index < kObjects; ++index) {
+    std::vector<uint8_t> object = base;
+    object.resize(base.size() + 64 + index, 0x11);
+    ASSERT_EQ(load_through_new_reader(object), HSA_STATUS_SUCCESS) << index;
+    if (index == 0)
+      one_entry = rj_test_translation_memo_bytes();
+  }
+  ASSERT_EQ(rj_test_translation_count(), kObjects);
+  const uint64_t all_entries = rj_test_translation_memo_bytes();
+  ASSERT_GT(all_entries, 2 * one_entry) << "the objects did not all stay resident";
+
+  // Room for roughly one of them, so four have to go at once.
+  rj_test_set_translation_memo_capacity(one_entry + 8);
+  EXPECT_LE(rj_test_translation_memo_bytes(), one_entry + 8) << "eviction stopped short";
+}
+
+// The ceiling is a promise about resident memory, and these bytes are never
+// reclaimed, so an entry that does not fit is declined rather than admitted and
+// exempted. The cost is a retranslation per load, which is the operator's to
+// weigh -- the log names the variable that would buy the entry back.
+TEST_F(HsaHotswapMemoTest, AnObjectLargerThanTheCapIsNotRemembered) {
+  ASSERT_TRUE(OnLoad(&api.table, 0, 0, nullptr));
+  const std::vector<uint8_t> source = read_translation_fixture();
+  ASSERT_FALSE(source.empty()) << GFX1250_B0_TO_A0_FIXTURE;
+
+  rj_test_set_translation_memo_capacity(1);
+  constexpr size_t kLoads = 4;
+  for (size_t load = 0; load < kLoads; ++load)
+    ASSERT_EQ(load_through_new_reader(source), HSA_STATUS_SUCCESS) << load;
+
+  // Never over the ceiling, and never a failed load -- only slower ones.
+  EXPECT_LE(rj_test_translation_memo_bytes(), 1u);
+  EXPECT_EQ(rj_test_translation_count(), kLoads);
+}
+
+TEST_F(HsaHotswapMemoTest, ReuseIsReportedAgainstTheSameSourceObject) {
+  ASSERT_TRUE(OnLoad(&api.table, 0, 0, nullptr));
+  const std::vector<uint8_t> source = read_translation_fixture();
+  ASSERT_FALSE(source.empty()) << GFX1250_B0_TO_A0_FIXTURE;
+
+  ASSERT_EQ(setenv("HSA_HOTSWAP_VERBOSE", "1", 1), 0);
+  testing::internal::CaptureStderr();
+  ASSERT_EQ(load_through_new_reader(source), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(load_through_new_reader(source), HSA_STATUS_SUCCESS);
+  const std::string log_text = testing::internal::GetCapturedStderr();
+  ASSERT_EQ(unsetenv("HSA_HOTSWAP_VERBOSE"), 0);
+
+  uint64_t identity = 14695981039346656037ULL;
+  for (uint8_t byte : source) {
+    identity ^= byte;
+    identity *= 1099511628211ULL;
+  }
+  std::ostringstream expected_identity;
+  expected_identity << "source_id=fnv1a64:" << std::hex << std::setfill('0') << std::setw(16)
+                    << identity;
+
+  // A reuse must stay attributable to its source object. Almost every load becomes
+  // a reuse once the memo is warm, so a reuse that reported less would blind the
+  // translation record exactly when it carries the most traffic.
+  EXPECT_NE(log_text.find(" outcome=translated changed="), std::string::npos) << log_text;
+  EXPECT_NE(log_text.find(" outcome=reused changed="), std::string::npos) << log_text;
+  std::istringstream lines(log_text);
+  std::string line;
+  size_t reuse_records = 0;
+  while (std::getline(lines, line)) {
+    EXPECT_NE(line.find(expected_identity.str()), std::string::npos) << line;
+    if (line.find(" outcome=reused ") != std::string::npos)
+      ++reuse_records;
+  }
+  EXPECT_EQ(reuse_records, 1u);
+}
+#endif
 
 } // namespace


### PR DESCRIPTION
The hook keyed everything it remembered on an HSA handle, so a caller that registered the same object under a new reader each time looked like a caller with a new object each time. A kernel-attribute walk over a large device library does exactly that -- once per registration and once per device -- and paid for a full translation on every one of them. RCCL's gfx1250 image is 212 MiB and takes 197s to translate, so a repeat did not merely run slowly; it exhausted the caller's     whole startup budget.

Remember translations by their source bytes instead. A fingerprint over a fixed sample narrows the memo to a few candidates and a comparison of the whole object decides between them, which is exact and far cheaper than a digest strong enough to be trusted alone: 9 ms against 586 ms for SHA-256 over that image. Concurrent loads of the same bytes wait for the one translation rather than repeating it, while loads that merely share a fingerprint proceed independently. A failure is remembered only when it is a verdict on the bytes, so a translation that completes without producing anything dispatchable now reports ROCJITSU_STATUS_INVALID_CODE_OBJECT and ROCJITSU_STATUS_ERROR is left to mean the
translator threw. What is kept stays under a strict source-plus-output ceiling that HSA_HOTSWAP_TRANSLATION_MEMO_BYTES moves and zero switches off, and a result too large to admit is still handed to the waiters already enrolled on it rather than leaving each of them to translate it again.