### PR TITLE
docs(hip): Updated HIP environment variable GPU_MAX_HW_QUEUES

### DIFF
--- a/projects/clr/CHANGELOG.md
+++ b/projects/clr/CHANGELOG.md
@@ -2,12 +2,24 @@
 
 Full documentation for HIP is available at [rocm.docs.amd.com](https://rocm.docs.amd.com/projects/HIP/en/latest/index.html)
 
-## HIP 7.15 for ROCm 7.15
+## HIP 10.0.0 for ROCm 10.0.0
 
 ### Added
 * New HIP APIs
-    - Stream Ordered Memory Allocator: Support for the following APIs for parity with corresponding CUDA APIs.
+    - Stream Ordered Memory Allocator: support for the API for parity with corresponding CUDA API.
       * `hipMemGetDefaultMemPool` returns the default memory pool for the specified location and allocation type
+    - Cooperative Groups scan functions are now supported, providing feature parity with CUDA.
+      * `cooperative_groups::exclusive_scan` performs an exclusive prefix scan across the threads in a cooperative group. For each thread, the result is computed from the values of all preceding threads using a binary operation (addition by default), excluding the current thread's own value.
+      * `cooperative_groups::inclusive_scan` performs an inclusive prefix scan across the threads in a cooperative group. For each thread, the result includes the current thread's value in addition to the values of all preceding threads.
+* HIP Record and Replay (HRR) is now available as an initial implementation. HRR captures HIP API calls made by an application and stores them in a binary archive (.hrr). The recorded workload can then be replayed on a GPU, reproducing application behavior, including multi-threaded execution, graph launches, and GPU memory transfers.
+This capability enables efficient bug reproduction, performance regression testing, and kernel benchmarking without requiring access to the original application. To help developers get started, documentation is provided that describes HRR's architecture, design, implementation details, and replay workflow, along with a comprehensive readme guide.
+* Added stream capture support for the following APIs, enabling `BatchMemOp` operations to be captured as graph nodes instead of executing immediately. Also improved `BatchMemOp` graph replay reliability through fixes to parameter handling and operation ordering, aligning behavior more closely with CUDA.
+    - `hipStreamWaitValue32`
+    - `hipStreamWaitValue64`
+    - `hipStreamWriteValue32`
+    - `hipStreamWriteValue64`
+    - `hipStreamBatchMemOp`
+* Support NUMA in `hipMemCreate` related APIs. HIP runtime added virtual memory support for `hipMemLocationTypeHostNuma` and `hipMemLocationTypeHostNumaCurrent` APIs. This enables NUMA-aware memory allocations backed by host CPU NUMA pools and aligns HIP virtual memory management behavior with CUDA host and host-NUMA VMM expectations.
 
 ### Resolved issues
 
@@ -16,6 +28,10 @@ since it is not available in the dynamic linker search path. Since `rocminfo` al
 enabling successful ROCm initialization, HSA agent discovery, and subsequent ROCm operations.
 * Fixed a segmentation fault in HIP queue idle detection caused by referencing a recycled completion signal. Idle state is now derived from a queue-owned signal with a safe lifetime.
 * Resolved incorrect NaN handling in the ordered not-equal comparison intrinsics `__hne` (for `__half`) and `__hne` (for `__hip_bfloat16`), along with their vector forms. Being *ordered* predicates, they now correctly return `false` when either operand is NaN.
+* Resolved memory-safety issues in the ROCm code object and ELF loader by adding validation checks during code object module loading, preventing segmentation faults and improving runtime stability.
+* Resolved a memory leak affecting mipmapped arrays when using `hipMemcpy2DToArray` with levels obtained via `hipGetMipmappedArrayLevel`. Mipmap level references are now properly released, ensuring that memory is correctly freed when `hipFreeMipmappedArray` is called.
+* Fixed a deadlock that could occur when using rocprofiler-sdk with ROCm-aware MVAPICH and MPICH. HIP runtime now performs profiler registration after dispatch table initialization, ensuring proper initialization ordering and guard release. This prevents hangs caused by reentrant initialization during profiler startup.
+* Fixed a deadlock caused by `hipMemMap`/`hipMemUnmap` operations on the null stream that could lead to hangs. The HIP runtime now implements proper synchronization to all devices with access to a mapped pointer before unmapping it.
 
 ### Optimized
 
@@ -24,6 +40,12 @@ Previously, non-4-byte-aligned row or slice pitches could cause the runtime to i
 performance degradation for workloads such as 1-byte-wide transfers with millions of rows.
 These transfers are now handled using a single shader-based copy operation, dramatically reducing transfer times.
 Copy operations at or below the 256-row threshold are unchanged.
+* Improved `hipEventRecord` performance by using the `hipEventDisableTiming` flag to avoid unnecessary profiling when timing information is not required. Event operations are now coalesced to eliminate redundant barrier submissions, reducing runtime overhead and improving execution efficiency.
+* Improved batch copy performance: optimized `hipMemcpyBatchAsync` by splitting batch operations into per-device commands.
+    - Simplified `rocrCopyBufferBatch` by using a single `src_agent` per engine group (H2D, D2H, and D2D).
+    - Streamlined batch grouping:
+      * Removed the `AgentGroup/src_agent` mapping for D2D broadcasts.
+      * Processed `H2D` and `D2H` LINEAR operations directly, bypassing the broadcast map.
 
 ## HIP 7.14 for ROCm 7.14
 

--- a/projects/hip/docs/data/env_variables_hip.rst
+++ b/projects/hip/docs/data/env_variables_hip.rst
@@ -146,11 +146,12 @@ The debugging environment variables in HIP are collected in the following table.
     * - | ``GPU_MAX_HW_QUEUES``
         | The maximum number of hardware queues allocated per device.
       - ``4``
-      - The variable controls how many independent hardware queues HIP runtime can create per process,
-        per device. If an application allocates more HIP streams than this number, then HIP runtime reuses
-        the same hardware queues for the new streams in a round-robin manner. Note that this maximum
-        number does not apply to hardware queues that are created for CU-masked HIP streams, or
-        cooperative queues for HIP Cooperative Groups (single queue per device).
+      - | ``GPU number-1``: If GPU number is greater than 4. 
+        | The variable controls how many independent hardware queues HIP runtime can create per process,
+        | per device. If an application allocates more HIP streams than this number, then HIP runtime reuses
+        | the same hardware queues for the new streams in a round-robin manner. Note that this maximum
+        | number does not apply to hardware queues that are created for CU-masked HIP streams, or
+        | cooperative queues for HIP Cooperative Groups (single queue per device).
 
 HIP memory management related variables
 --------------------------------------------------------------------------------

--- a/projects/hip/docs/reference/env_variables/debug_hip_env.rst
+++ b/projects/hip/docs/reference/env_variables/debug_hip_env.rst
@@ -95,8 +95,9 @@ and :doc:`GPU isolation <rocm:conceptual/gpu-isolation>`.
     * - | ``GPU_MAX_HW_QUEUES``
         | The maximum number of hardware queues allocated per device.
       - ``4``
-      - The variable controls how many independent hardware queues HIP runtime can create per process,
-        per device. If an application allocates more HIP streams than this number, then HIP runtime reuses
-        the same hardware queues for the new streams in a round-robin manner. Note that this maximum
-        number does not apply to hardware queues that are created for CU-masked HIP streams, or
-        cooperative queues for HIP Cooperative Groups (single queue per device).
+      - | ``GPU number-1``: If GPU number is greater than 4.
+        | The variable controls how many independent hardware queues HIP runtime can create per process,
+        | per device. If an application allocates more HIP streams than this number, then HIP runtime reuses
+        | the same hardware queues for the new streams in a round-robin manner. Note that this maximum
+        | number does not apply to hardware queues that are created for CU-masked HIP streams, or
+        | cooperative queues for HIP Cooperative Groups (single queue per device).


### PR DESCRIPTION
## Motivation

AIRUNTIME-2591: Update HIP documents for env GPU_MAX_HW_QUEUES

## Technical Details

Update HIP documents for env GPU_MAX_HW_QUEUES, adding the max number setting

## Issue Tracking

AIRUNTIME-2591

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
