### PR TITLE
feat(rocprofiler-compute): Show profile mode warning message for compute/memory partition mode

### DIFF
--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -15,6 +15,10 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 * Redesigned the standalone roofline HTML to improve user experience and interactivity.
 
+* Added a profile-mode warning reporting the active compute and memory partition
+  modes on partition-capable accelerators, noting that analysis derives logical
+  XCD, L2 channel, and HBM channel counts from them.
+
 ### Changed
 
 * ML API tracing options (--torch-trace/--triton-trace/--ml-api-trace) are no longer allowed with PC-sampling-only profiling; the run now fails with an error telling the user to drop the ML API tracing flag or add a counter block, since without counters there is nothing to correlate the markers against.

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -268,7 +268,7 @@ class RocProfCompute:
     def generate_machine_specs(self) -> None:
         """Generate MachineSpecs for RocProfCompute"""
         self.__mspec = generate_machine_specs(self.__args)
-        
+
         if self.__mode == "profile":
             compute_partition = self.__mspec.compute_partition
             if compute_partition and compute_partition.strip().lower() != "n/a":

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -268,14 +268,23 @@ class RocProfCompute:
     def generate_machine_specs(self) -> None:
         """Generate MachineSpecs for RocProfCompute"""
         self.__mspec = generate_machine_specs(self.__args)
-        if (
-            self.__mode == "profile"
-            and self.__mspec.compute_partition.strip().lower() == "cpx"
-        ):
-            console_warning(
-                "Compute partition detected as CPX mode - metrics calculated are "
-                "based on number of XCDs derived from CPX"
-            )
+        
+        if self.__mode == "profile":
+            compute_partition = self.__mspec.compute_partition
+            if compute_partition and compute_partition.strip().lower() != "n/a":
+                console_warning(
+                    f"Compute partition detected as {compute_partition} mode - metrics "
+                    f"calculated are based on number of XCDs derived from "
+                    f"{compute_partition}"
+                )
+
+            memory_partition = self.__mspec.memory_partition
+            if memory_partition and memory_partition.strip().lower() != "n/a":
+                console_warning(
+                    f"Memory partition detected as {memory_partition} mode - metrics "
+                    f"calculated are based on number of HBM channels derived from "
+                    f"{memory_partition}"
+                )
 
     @demarcate
     def load_soc_specs(self, sysinfo: Optional[dict] = None) -> None:

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -268,6 +268,14 @@ class RocProfCompute:
     def generate_machine_specs(self) -> None:
         """Generate MachineSpecs for RocProfCompute"""
         self.__mspec = generate_machine_specs(self.__args)
+        if (
+            self.__mode == "profile"
+            and self.__mspec.compute_partition.strip().lower() == "cpx"
+        ):
+            console_warning(
+                "Compute partition detected as CPX mode - metrics calculated are "
+                "based on number of XCDs derived from CPX"
+            )
 
     @demarcate
     def load_soc_specs(self, sysinfo: Optional[dict] = None) -> None:

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -270,7 +270,7 @@ class RocProfCompute:
         self.__mspec = generate_machine_specs(self.__args)
 
         if self.__mode == "profile":
-            compute_partition = self.__mspec.compute_partition
+            compute_partition = getattr(self.__mspec, "compute_partition", None)
             if compute_partition and compute_partition.strip().lower() != "n/a":
                 console_warning(
                     f"Compute partition detected as {compute_partition} mode - metrics "
@@ -278,7 +278,7 @@ class RocProfCompute:
                     f"{compute_partition}"
                 )
 
-            memory_partition = self.__mspec.memory_partition
+            memory_partition = getattr(self.__mspec, "memory_partition", None)
             if memory_partition and memory_partition.strip().lower() != "n/a":
                 console_warning(
                     f"Memory partition detected as {memory_partition} mode - metrics "

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -269,23 +269,6 @@ class RocProfCompute:
         """Generate MachineSpecs for RocProfCompute"""
         self.__mspec = generate_machine_specs(self.__args)
 
-        if self.__mode == "profile":
-            compute_partition = getattr(self.__mspec, "compute_partition", None)
-            if compute_partition and compute_partition.strip().lower() != "n/a":
-                console_warning(
-                    f"Compute partition detected as {compute_partition} mode - metrics "
-                    f"calculated are based on number of XCDs derived from "
-                    f"{compute_partition}"
-                )
-
-            memory_partition = getattr(self.__mspec, "memory_partition", None)
-            if memory_partition and memory_partition.strip().lower() != "n/a":
-                console_warning(
-                    f"Memory partition detected as {memory_partition} mode - metrics "
-                    f"calculated are based on number of HBM channels derived from "
-                    f"{memory_partition}"
-                )
-
     @demarcate
     def load_soc_specs(self, sysinfo: Optional[dict] = None) -> None:
         """

--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
@@ -21,7 +21,9 @@ from utils.logger import (
     console_warning,
     demarcate,
 )
+from utils.mi_gpu_spec import mi_gpu_specs
 from utils.native_tool_finder import NativeToolFinder
+from utils.specs import MachineSpecs
 from utils.utils_common import (
     PROFILE_OUTPUT_FORMAT,
     format_time,
@@ -43,6 +45,28 @@ _FLAG_TO_FRAMEWORKS: dict[str, tuple[str, ...]] = {
     "triton_trace": ("triton",),
     "ml_api_trace": KNOWN_ML_API_BACKENDS,
 }
+
+
+def _partition_warning_messages(mspec: MachineSpecs) -> list[str]:
+    """Return notices on how active partition modes shape analysis metrics."""
+    if not mi_gpu_specs.is_partition_supported(
+        getattr(mspec, "gpu_arch", None), getattr(mspec, "gpu_model", None)
+    ):
+        return []
+
+    messages = []
+    for label, attribute, derived in (
+        ("Compute", "compute_partition", "logical XCDs and L2 channels"),
+        ("Memory", "memory_partition", "HBM channels"),
+    ):
+        partition = getattr(mspec, attribute, None)
+        if not partition or partition.strip().lower() == "n/a":
+            continue
+        messages.append(
+            f"{label} partition: {partition}. Analysis mode will calculate metrics "
+            f"based on the number of {derived} derived for this partition mode."
+        )
+    return messages
 
 
 def _compute_selected_frameworks(args: argparse.Namespace) -> set[str]:
@@ -319,6 +343,9 @@ class RocProfCompute_Base:
             mspec=self._soc._mspec,
             soc=self._soc,
         )
+
+        for message in _partition_warning_messages(self._soc._mspec):
+            console_warning(message)
 
     def profile(
         self,

--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
@@ -21,7 +21,7 @@ from utils.logger import (
     console_warning,
     demarcate,
 )
-from utils.mi_gpu_spec import mi_gpu_specs
+from utils.mi_gpu_spec import MIGPUSpecs
 from utils.native_tool_finder import NativeToolFinder
 from utils.specs import MachineSpecs
 from utils.utils_common import (
@@ -49,7 +49,7 @@ _FLAG_TO_FRAMEWORKS: dict[str, tuple[str, ...]] = {
 
 def _partition_warning_messages(mspec: MachineSpecs) -> list[str]:
     """Return notices on how active partition modes shape analysis metrics."""
-    if not mi_gpu_specs.is_partition_supported(
+    if not MIGPUSpecs.is_partition_supported(
         getattr(mspec, "gpu_arch", None), getattr(mspec, "gpu_model", None)
     ):
         return []

--- a/projects/rocprofiler-compute/tests/test_profiler_base.py
+++ b/projects/rocprofiler-compute/tests/test_profiler_base.py
@@ -12,7 +12,10 @@ import yaml
 
 from pc_sampling.pc_sampling_profile import PCSamplingLimits
 from rocprof_compute_base import RocProfCompute
-from rocprof_compute_profile.profiler_base import RocProfCompute_Base
+from rocprof_compute_profile.profiler_base import (
+    RocProfCompute_Base,
+    _partition_warning_messages,
+)
 from rocprof_compute_profile.profiler_rocprof_v3 import rocprof_v3_profiler
 from rocprof_compute_profile.profiler_rocprofiler_sdk import rocprofiler_sdk_profiler
 from utils.utils_common import PROFILE_OUTPUT_FORMAT
@@ -65,6 +68,30 @@ def _setup_test_files(tmp_path, remaining, setup):
         binary.chmod(0o755)
         return [s.replace("{binary}", str(binary)) for s in remaining]
     return remaining
+
+
+@pytest.mark.parametrize(
+    "gpu_arch, compute_partition, memory_partition, expected",
+    [
+        pytest.param("gfx942", "CPX", "NPS4", 2, id="both_partitions"),
+        pytest.param("gfx942", "SPX", None, 1, id="memory_partition_missing"),
+        pytest.param("gfx942", "SPX", "N/A", 1, id="memory_partition_na"),
+        pytest.param("gfx90a", "N/A", "N/A", 0, id="cdna_without_partitions"),
+        pytest.param("gfx1151", None, None, 0, id="rdna"),
+    ],
+)
+def test_partition_warning_messages(
+    gpu_arch, compute_partition, memory_partition, expected
+):
+    """Partition notices only apply to supported partitioned GPUs."""
+    mspec = SimpleNamespace(
+        gpu_arch=gpu_arch,
+        gpu_model=None,
+        compute_partition=compute_partition,
+        memory_partition=memory_partition,
+    )
+
+    assert len(_partition_warning_messages(mspec)) == expected
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Motivation
rocprof-compute adjusts several metric calculations according to the active accelerator compute and memory partition configuration. Previously, profile runs did not explicitly tell users when these derived partition values affected analysis results.

This change adds profile-time notices for supported partitioned GPUs. The notices identify the active compute partition, such as SPX, DPX, QPX, or CPX, and memory partition, such as NPS1 or NPS4, and explain how they affect subsequent analysis metrics.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Added [_partition_warning_messages()](vscode-file://vscode-app/c:/Users/ywang103/AppData/Local/Programs/Microsoft%20VS%20Code/df53daabb1/resources/app/out/vs/code/electron-browser/workbench/workbench.html) in src/rocprof_compute_profile/profiler_base.py.

Produces separate notices for compute and memory partition modes.
Uses [mi_gpu_specs.is_partition_supported(gpu_arch, gpu_model)](vscode-file://vscode-app/c:/Users/ywang103/AppData/Local/Programs/Microsoft%20VS%20Code/df53daabb1/resources/app/out/vs/code/electron-browser/workbench/workbench.html) so messages are emitted only on GPU families that support partitioning.
Handles absent partition attributes safely with [getattr()](vscode-file://vscode-app/c:/Users/ywang103/AppData/Local/Programs/Microsoft%20VS%20Code/df53daabb1/resources/app/out/vs/code/electron-browser/workbench/workbench.html), preventing failures on architectures such as RDNA gfx1151.
Skips missing or unsupported partition values, including None and N/A.
Moved notice emission to [RocProfCompute_Base.pre_processing()](vscode-file://vscode-app/c:/Users/ywang103/AppData/Local/Programs/Microsoft%20VS%20Code/df53daabb1/resources/app/out/vs/code/electron-browser/workbench/workbench.html), immediately after [gen_sysinfo(...)](vscode-file://vscode-app/c:/Users/ywang103/AppData/Local/Programs/Microsoft%20VS%20Code/df53daabb1/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

Keeps this behavior profile-only.
Applies consistently to both rocprofv3 and rocprofiler-sdk through their shared base class.
Avoids notices for analysis-mode runs, list/spec commands that exit before preprocessing, and profiler compatibility failures.
Removed the original warning logic from [RocProfCompute.generate_machine_specs()](vscode-file://vscode-app/c:/Users/ywang103/AppData/Local/Programs/Microsoft%20VS%20Code/df53daabb1/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

Added parameterized unit coverage in tests/test_profiler_base.py for:

Compute and memory notices together: gfx942 / CPX / NPS4.
Missing memory partition mode.
N/A memory partition mode.
Non-partitioned CDNA architecture: gfx90a.
RDNA gfx1151, ensuring missing partition fields do not cause a regression.

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking
AIPROFCOMP-740

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.


[AIPROFCOMP-740]: https://amd-hub.atlassian.net/browse/AIPROFCOMP-740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ