### PR TITLE
fix(rccl): set num_gpus to "auto" in nccl4py_build_smoke config

### DIFF
--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -2668,7 +2668,7 @@
       "test_dir": "test/nccl4py",
       "num_ranks": 1,
       "num_nodes": 1,
-      "num_gpus": 0,
+      "num_gpus": "auto",
       "timeout": 600,
       "tests": [
         {


### PR DESCRIPTION
## Motivation

The `nccl4py_build_smoke` test configuration in
`mi300x_mellanox_ib.json` had `"num_gpus": 0`, which fails JSON schema validation. The schema (`lib/schema.json`) requires `num_gpus` to be either an integer ≥ 1 or the string `"auto"`. Since `nccl4py_build_smoke` is a CPU-only pytest (`is_pytest: true`, `num_ranks: 1`), `"auto"` is the correct value — it resolves to the detected GPUs per node at runtime and does not impose an artificial GPU requirement.

## Technical Details

- `tools/scripts/test_runner/configs/mi300x_mellanox_ib.json`: change `"num_gpus": 0` to `"num_gpus": "auto"` in the `nccl4py_build_smoke` test configuration.

## Issue Tracking

JIRA ID: AICOMRCCL-1689

## Test Plan

1. Validate schema using jsonschema directly:
```
python3 -c "import json, jsonschema; schema = json.load(open('tools/scripts/test_runner/lib/schema.json')); config = json.load(open('tools/scripts/test_runner/configs/mi300x_mellanox_ib.json')); jsonschema.validate(config, schema); print('Schema validation passed')"
```
Expected output: `Schema validation passed`

2. Validate using the test runner:
```
python3 tools/scripts/test_runner/test_runner.py \
  --config tools/scripts/test_runner/configs/mi300x_mellanox_ib.json \
  --no-build --skip-tests
```
Expected output: `Configuration loaded and validated`

## Test Result

1. Schema validation using jsonschema directly:
```
$ python3 -c "import json, jsonschema; schema = json.load(open('tools/scripts/test_runner/lib/schema.json')); config = json.load(open('tools/scripts/test_runner/configs/mi300x_mellanox_ib.json')); jsonschema.validate(config, schema); print('Schema validation passed')"
Schema validation passed
```

2. Schema validation using test runner:
```
python3 tools/scripts/test_runner/test_runner.py  --config tools/scripts/test_runner/configs/mi300x_mellanox_ib.json --no-build --skip-tests
Configuration loaded and validated
WARNING: MPI path not found: /opt/ompi
ERROR: Environment check failed:
  - RCCL library not found: /home/sdarisal/workspace/rocm-systems/projects/rccl/build/debug/librccl.so
```

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
