### PR TITLE
fix(rocprofiler-sdk) increase pc sampling buffer size

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/utils.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/utils.cpp
@@ -70,11 +70,24 @@ get_matching_hsa_pcs_units(rocprofiler_pc_sampling_unit_t unit)
     ROCP_FATAL << "Illegal pc sampling unit " << unit;
 }
 
-size_t get_hsa_pcs_buffer_size(uint32_t /*gfx_target_version*/)
+size_t
+get_hsa_pcs_buffer_size(uint32_t gfx_target_version)
 {
-    // Small buffers result in dropped samples on actual silicon.
-    // ROCM-22213 further splits the buffer per XCC, so we use a large size.
-    return 1024 * 1024 * sizeof(perf_sample_hosttrap_v1_t);  // 64MB
+    // gfx_target_version encodes major*10000 + minor*100 + patch
+    const uint32_t major = (gfx_target_version / 10000) % 100;
+    const uint32_t minor = (gfx_target_version / 100) % 100;
+
+    // Since ROCM-22213, the buffer is split per XCC, so we need larger buffers for these GPUs.
+    // Right now, just enable for MI300/350/400 series chips.
+    const bool is_multi_xcc = (major == 9 && (minor == 4 || minor == 5)) ||
+                              (major == 12 && minor == 5);
+
+    if(is_multi_xcc)
+    {
+        return 1024 * 1024 * sizeof(perf_sample_hosttrap_v1_t);  // 64MB
+    }
+
+    return 64 * 1024 * sizeof(perf_sample_hosttrap_v1_t);  // 4MB
 }
 }  // namespace utils
 }  // namespace pc_sampling

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/utils.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/utils.cpp
@@ -72,8 +72,9 @@ get_matching_hsa_pcs_units(rocprofiler_pc_sampling_unit_t unit)
 
 size_t get_hsa_pcs_buffer_size(uint32_t /*gfx_target_version*/)
 {
-    // Use bigger buffer to reduce number of dropped samples on actual silicon
-    return 64 * 1024 * sizeof(perf_sample_hosttrap_v1_t);  // 4MB
+    // Small buffers result in dropped samples on actual silicon.
+    // ROCM-22213 further splits the buffer per XCC, so we use a large size.
+    return 1024 * 1024 * sizeof(perf_sample_hosttrap_v1_t);  // 64MB
 }
 }  // namespace utils
 }  // namespace pc_sampling

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/utils.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/utils.cpp
@@ -79,8 +79,8 @@ get_hsa_pcs_buffer_size(uint32_t gfx_target_version)
 
     // Since ROCM-22213, the buffer is split per XCC, so we need larger buffers for these GPUs.
     // Right now, just enable for MI300/350/400 series chips.
-    const bool is_multi_xcc = (major == 9 && (minor == 4 || minor == 5)) ||
-                              (major == 12 && minor == 5);
+    const bool is_multi_xcc =
+        (major == 9 && (minor == 4 || minor == 5)) || (major == 12 && minor == 5);
 
     if(is_multi_xcc)
     {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/utils.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/utils.cpp
@@ -73,8 +73,9 @@ get_matching_hsa_pcs_units(rocprofiler_pc_sampling_unit_t unit)
 size_t
 get_hsa_pcs_buffer_size(uint32_t gfx_target_version)
 {
-    // To increase the throughput and reduce the number of dropped samples, ROCr allocates a buffer per XCC.
-    // Thus, we increase the overall ROCr PC sampling buffer size for the multi-chiplet architectures like gfx942 and gfx1250.
+    // To increase the throughput and reduce the number of dropped samples, ROCr allocates a buffer
+    // per XCC. Thus, we increase the overall ROCr PC sampling buffer size for the multi-chiplet
+    // architectures like gfx942 and gfx1250.
     const auto is_multi_xcc = [](uint32_t gfx_version) -> bool {
         // gfx_target_version encodes major*10000 + minor*100 + patch
         switch(gfx_version / 100)

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/utils.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/utils.cpp
@@ -73,8 +73,8 @@ get_matching_hsa_pcs_units(rocprofiler_pc_sampling_unit_t unit)
 size_t
 get_hsa_pcs_buffer_size(uint32_t gfx_target_version)
 {
-    // Since ROCM-22213, the buffer is split per XCC, so we need larger buffers for these GPUs.
-    // For now, just enable for MI300/350/400 series chips.
+    // To increase the throughput and reduce the number of dropped samples, ROCr allocates a buffer per XCC.
+    // Thus, we increase the overall ROCr PC sampling buffer size for the multi-chiplet architectures like gfx942 and gfx1250.
     const auto is_multi_xcc = [](uint32_t gfx_version) -> bool {
         // gfx_target_version encodes major*10000 + minor*100 + patch
         switch(gfx_version / 100)

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/utils.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/utils.cpp
@@ -75,9 +75,9 @@ get_hsa_pcs_buffer_size(uint32_t gfx_target_version)
 {
     // Since ROCM-22213, the buffer is split per XCC, so we need larger buffers for these GPUs.
     // For now, just enable for MI300/350/400 series chips.
-    const auto is_multi_xcc = [](uint32_t gfx_target_version) -> bool {
+    const auto is_multi_xcc = [](uint32_t gfx_version) -> bool {
         // gfx_target_version encodes major*10000 + minor*100 + patch
-        switch(gfx_target_version / 100)
+        switch(gfx_version / 100)
         {
             case 904:
             case 905:

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/utils.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/utils.cpp
@@ -73,21 +73,33 @@ get_matching_hsa_pcs_units(rocprofiler_pc_sampling_unit_t unit)
 size_t
 get_hsa_pcs_buffer_size(uint32_t gfx_target_version)
 {
-    // gfx_target_version encodes major*10000 + minor*100 + patch
-    const uint32_t major = (gfx_target_version / 10000) % 100;
-    const uint32_t minor = (gfx_target_version / 100) % 100;
-
     // Since ROCM-22213, the buffer is split per XCC, so we need larger buffers for these GPUs.
-    // Right now, just enable for MI300/350/400 series chips.
-    const bool is_multi_xcc =
-        (major == 9 && (minor == 4 || minor == 5)) || (major == 12 && minor == 5);
+    // For now, just enable for MI300/350/400 series chips.
+    const auto is_multi_xcc = [](uint32_t gfx_target_version) -> bool {
+        // gfx_target_version encodes major*10000 + minor*100 + patch
+        switch(gfx_target_version / 100)
+        {
+            case 904:
+            case 905:
+            case 1205: return true;
+            default: return false;
+        }
+    };
 
-    if(is_multi_xcc)
+    static_assert(sizeof(perf_sample_hosttrap_v1_t) == 64,
+                  "update size comments below and reevaluate buffer size");
+    size_t num_elems{};
+
+    if(is_multi_xcc(gfx_target_version))
     {
-        return 1024 * 1024 * sizeof(perf_sample_hosttrap_v1_t);  // 64MB
+        num_elems = 1024 * 1024;  // 64mb
+    }
+    else
+    {
+        num_elems = 64 * 1024;  // 4mb
     }
 
-    return 64 * 1024 * sizeof(perf_sample_hosttrap_v1_t);  // 4MB
+    return num_elems * sizeof(perf_sample_hosttrap_v1_t);
 }
 }  // namespace utils
 }  // namespace pc_sampling


### PR DESCRIPTION
## Motivation

High percentage of dropped or invalid samples were observed with reasonable sampling rates on MI300 series cards.

## Technical Details

Increasing the buffer size mitigates the issue.

## Issue Tracking

JIRA ID: AIPROFSDK-1007

## Test Plan

build the repo

## Test Result

it built :)

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
