### PR TITLE
ci(hipfile): Bump DOCKERFILE ROCm version to 7.14.0

### DIFF
--- a/projects/hipfile/util/docker/DOCKERFILE.ais_ci_rocky
+++ b/projects/hipfile/util/docker/DOCKERFILE.ais_ci_rocky
@@ -9,7 +9,7 @@ LABEL org.opencontainers.image.source=https://github.com/ROCm/hipFile
 # Brings ROCKY_VERSION in-scope
 ARG ROCKY_MAJOR_VERSION
 ARG ROCKY_VERSION
-ARG ROCM_VERSION=7.2.2
+ARG ROCM_VERSION=7.14.0
 
 # If the target ROCm Version on the package repository is non-standard, you can forcibly
 # set the ROCm version used in the package repo URL.

--- a/projects/hipfile/util/docker/DOCKERFILE.ais_ci_rocky8
+++ b/projects/hipfile/util/docker/DOCKERFILE.ais_ci_rocky8
@@ -9,7 +9,7 @@ LABEL org.opencontainers.image.source=https://github.com/ROCm/hipFile
 # Brings ROCKY_VERSION in-scope
 ARG ROCKY_MAJOR_VERSION
 ARG ROCKY_VERSION
-ARG ROCM_VERSION=7.2.2
+ARG ROCM_VERSION=7.14.0
 
 # If the target ROCm Version on the package repository is non-standard, you can forcibly
 # set the ROCm version used in the package repo URL.

--- a/projects/hipfile/util/docker/DOCKERFILE.ais_ci_suse
+++ b/projects/hipfile/util/docker/DOCKERFILE.ais_ci_suse
@@ -8,7 +8,7 @@ FROM opensuse/leap:${SUSE_MAJOR_VERSION}.${SUSE_MINOR_VERSION} AS base
 LABEL org.opencontainers.image.source=https://github.com/ROCm/hipFile
 ARG SUSE_MAJOR_VERSION
 ARG SUSE_MINOR_VERSION
-ARG ROCM_VERSION=7.2.2
+ARG ROCM_VERSION=7.14.0
 
 # If the target ROCm Version on the package repository is non-standard, you can forcibly
 # set the ROCm version used in the package repo URL.

--- a/projects/hipfile/util/docker/DOCKERFILE.ais_ci_ubuntu
+++ b/projects/hipfile/util/docker/DOCKERFILE.ais_ci_ubuntu
@@ -8,7 +8,7 @@ LABEL org.opencontainers.image.source=https://github.com/ROCm/hipFile
 ARG UBUNTU_CODENAME
 ARG UBUNTU_MAJOR_VERSION=24
 ARG UBUNTU_MINOR_VERSION=04
-ARG ROCM_VERSION=7.2.2
+ARG ROCM_VERSION=7.14.0
 
 # If the target ROCm Version on the package repository is non-standard, you can forcibly
 # set the ROCm version used in the package repo URL.


### PR DESCRIPTION
## Motivation

The CI ROCm version needs to be kept current

## Technical Details

Bump the ROCm version in DOCKERFILE files to 7.14.0

## Issue Tracking

JIRA ID: AIHIPFILE-252

## Test Plan

CI passes

## Test Result

Success

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
