### PR TITLE
fix(amdsmi): Count clock-gated XCDs in xcd_counter API

### DIFF
--- a/projects/amdsmi/rocm_smi/src/rocm_smi.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi.cc
@@ -7661,9 +7661,7 @@ rsmi_status_t rsmi_dev_metrics_xcd_counter_get(uint32_t dv_ind, uint16_t* xcd_co
       if (gfxclk == UINT16_MAX) {
         break;
       }
-      if ((gfxclk != 0) && (gfxclk != UINT16_MAX)) {
-        xcd_counter++;
-      }
+      xcd_counter++;
     }
   }
 

--- a/projects/amdsmi/tests/amd_smi_test/functional/gpu/metrics/gpu_metrics_read_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/gpu/metrics/gpu_metrics_read_test.cc
@@ -262,6 +262,20 @@ void TestGpuMetricsRead::Run(void) {
                   << "\n\t\t** XCD Counter Value: " << temp_xcd_counter_value << "\n";
       }
       CHK_ERR_ASRT(err);
+
+      // Verify XCD count is stable across multiple calls regardless of clock state
+      if (ret_xcd == AMDSMI_STATUS_SUCCESS && temp_xcd_counter_value > 0) {
+        auto xcd_count_verify = uint16_t(0);
+        auto ret_verify = amdsmi_get_gpu_xcd_counter(processor_handles_[i], &xcd_count_verify);
+        ASSERT_EQ(ret_verify, AMDSMI_STATUS_SUCCESS);
+        ASSERT_EQ(temp_xcd_counter_value, xcd_count_verify)
+            << "XCD count must be stable across calls (was " << temp_xcd_counter_value << ", now "
+            << xcd_count_verify << "). Count should not vary with GPU idle/clock-gated state.";
+        IF_VERB(STANDARD) {
+          std::cout << "\t\t** XCD counter stability verified: " << xcd_count_verify
+                    << " (current_gfxclk=" << smu.current_gfxclks[0] << " MHz)\n";
+        }
+      }
       amdsmi_asic_info_t asic_info = {};
       err = amdsmi_get_gpu_asic_info(processor_handles_[i], &asic_info);
       ASSERT_EQ(err, AMDSMI_STATUS_SUCCESS);


### PR DESCRIPTION

## Motivation

amdsmi_get_gpu_xcd_counter() returned 0 on idle GPUs (GFX clock gated at 0 MHz) instead of the actual XCD count.

## Technical Details

Changed rsmi_dev_metrics_xcd_counter_get() to count entries until the UINT16_MAX sentinel rather than skipping zero-clock entries, making the API return a power-state-independent count as callers expect.

## Issue Tracking

JIRA ID : ROCM-28766

## Test Plan

amd-smi metric -c
amd-smi metric -u
Confirm the gated state — GFX clock 0 MHz, GFX activi
python3 -c "import amdsmi; amdsmi.amdsmi_init(); \
print(amdsmi.amdsmi_get_gpu_xcd_counter(amdsmi.amdsmi_get_processor_handles()[0]))"

## Test Result

```
lsttdev1@lsttdev1:~$ python3 -c "import amdsmi; amdsmi.amdsmi_init(); \
print(amdsmi.amdsmi_get_gpu_xcd_counter(amdsmi.amdsmi_get_processor_handles()[0]))"
1
lsttdev1@lsttdev1:~$ amd-smi metric -u -c -g 0
GPU: 0
    USAGE:
        GFX_ACTIVITY: 0 %
        UMC_ACTIVITY: 0 %
        MM_ACTIVITY: 0 %
        VCN_ACTIVITY: [0 %, N/A, N/A, N/A]
        JPEG_ACTIVITY: [N/A, N/A, N/A, N/A, N/A, N/A, N/A, N/A, N/A, N/A, N/A, N/A, N/A, N/A, N/A, N/A, N/A, N/A, N/A, N/A, N/A, N/A, N/A, N/A, N/A, N/A, N/A, N/A, N/A, N/A, N/A, N/A]
        GFX_BUSY_INST: N/A
        JPEG_BUSY: N/A
        VCN_BUSY: 0 %
    CLOCK:
        GFX_0:
            CLK: 0 MHz
            MIN_CLK: 500 MHz
            MAX_CLK: 2500 MHz
            DEEP_SLEEP: ENABLED
        MEM_0:
            CLK: 96 MHz
            MIN_CLK: 100 MHz
            MAX_CLK: 200 MHz
            DEEP_SLEEP: ENABLED
        VCLK_0:
            CLK: 25 MHz
            MIN_CLK: 513 MHz
            MAX_CLK: 2934 MHz
            DEEP_SLEEP: ENABLED
        DCLK_0:
            CLK: 25 MHz
            MIN_CLK: 513 MHz
            MAX_CLK: 2200 MHz
            DEEP_SLEEP: ENABLED
        FCLK_0:
            CLK: 601 MHz
            MAX_CLK: 0 MHz
        SOCCLK_0:
            CLK: 500 MHz
            MIN_CLK: 500 MHz
            MAX_CLK: 1500 MHz
            DEEP_SLEEP: DISABLED

lsttdev1@lsttdev1:~$ python3 -c "import amdsmi; amdsmi.amdsmi_init(); \
print(amdsmi.amdsmi_get_gpu_xcd_counter(amdsmi.amdsmi_get_processor_handles()[0]))"
1

```
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
