### PR TITLE
[rocjitsu][CI] Publish offline translation hashes

### DIFF
--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -12,7 +12,7 @@ on:
       - ".github/workflows/rocjitsu-*.yml"
   push:
     branches:
-      - main
+      - develop
     paths:
       - "emulation/rocjitsu/**"
       - ".github/workflows/rocjitsu-*.yml"
@@ -36,7 +36,10 @@ on:
         required: true
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Preserve every non-PR run, including manual reruns of one develop commit.
+  # This intentionally prevents back-to-back develop pushes from cancelling
+  # the full lane so each can publish. PR updates still supersede old revisions.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions:
@@ -49,6 +52,9 @@ env:
   ROCJITSU_DBT_CORPUS_DIR: ${{ github.workspace }}/rocjitsu-dbt-test-corpus
   ROCJITSU_DBT_VENV: ${{ github.workspace }}/gfx1250-dbt-venv-${{ github.run_id }}-${{ github.run_attempt }}
   ROCJITSU_HSACO_CORPUS: ${{ github.workspace }}/gfx1250-packaged-hsacos-${{ github.run_id }}-${{ github.run_attempt }}
+  ROCJITSU_DBT_CORPUS_REF: 42944a3ff37490441dcd0f1838e289a419af082d
+  ROCJITSU_DBT_SHA_FRAGMENTS: ${{ github.workspace }}/gfx1250-dbt-sha-pairs-${{ github.run_id }}-${{ github.run_attempt }}/fragments
+  ROCJITSU_DBT_SHA_MANIFEST: ${{ github.workspace }}/gfx1250-dbt-sha-pairs-${{ github.run_id }}-${{ github.run_attempt }}/gfx1250-b0-a0-sha-pairs.json
   ROCM_SDK_VERSION: 7.15.0a20260728
   UV_VERSION: 0.9.26
 
@@ -166,7 +172,7 @@ jobs:
         with:
           repository: ${{ github.event.inputs.corpus_repository || 'ROCm/rocjitsu-test-corpus' }}
           # Last updated on 2026/07/29.
-          ref: ${{ github.event.inputs.corpus_ref || '42944a3ff37490441dcd0f1838e289a419af082d' }}
+          ref: ${{ github.event.inputs.corpus_ref || env.ROCJITSU_DBT_CORPUS_REF }}
           path: rocjitsu-dbt-test-corpus
 
       - name: Set up Python
@@ -178,6 +184,12 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: ${{ env.UV_VERSION }}
+
+      - name: Test DBT SHA-pair tooling
+        if: matrix.name == 'release'
+        run: |
+          python3 \
+            "${ROCJITSU_SOURCE_DIR}/tests/corpus/test-record-gfx1250-dbt-sha-pairs.py"
 
       - name: Install ROCm SDK
         run: |
@@ -425,6 +437,7 @@ jobs:
             --destination "${ROCJITSU_HSACO_CORPUS}"
 
       - name: Run gfx1250 DBT corpus tests
+        id: run_dbt
         if: ${{ !cancelled() && matrix.enable_tsan == 0 && steps.extract_dbt.outcome == 'success' }}
         timeout-minutes: ${{ matrix.dbt_job_timeout }}
         working-directory: ${{ env.ROCJITSU_DBT_CORPUS_DIR }}
@@ -462,6 +475,68 @@ jobs:
             -q \
             -rxX \
             --tb=short
+
+      - name: Collect gfx1250 B0-to-A0 SHA pairs
+        id: collect_dbt_sha_pairs
+        if: >-
+          matrix.name == 'release' &&
+          steps.run_dbt.outcome == 'success' &&
+          (github.event_name == 'pull_request' ||
+           (github.ref == 'refs/heads/develop' &&
+            (github.event_name == 'push' ||
+             (github.event_name == 'workflow_dispatch' &&
+              github.event.inputs.corpus_repository == 'ROCm/rocjitsu-test-corpus' &&
+              github.event.inputs.corpus_ref == env.ROCJITSU_DBT_CORPUS_REF))))
+        timeout-minutes: 15
+        working-directory: ${{ env.ROCJITSU_DBT_CORPUS_DIR }}
+        shell: bash
+        run: |
+          DBT_WORKERS="$(nproc)"
+          if (( DBT_WORKERS > 16 )); then
+            DBT_WORKERS=16
+          fi
+          python3 \
+            "${ROCJITSU_SOURCE_DIR}/tests/corpus/record-gfx1250-dbt-sha-pairs.py" \
+            collect \
+            --translator "${ROCJITSU_BUILD_DIR}/tools/rj_dbt_translate" \
+            --corpus "${ROCJITSU_HSACO_CORPUS}" \
+            --input-manifest "${ROCJITSU_HSACO_CORPUS}/manifests/SHA256SUMS" \
+            --expected-failures "${ROCJITSU_SOURCE_DIR}/tests/corpus/dbt/gfx1250_b0_a0_expected_failures.json" \
+            --fragments "${ROCJITSU_DBT_SHA_FRAGMENTS}" \
+            --workers "${DBT_WORKERS}" \
+            --timeout "${{ matrix.dbt_timeout }}"
+
+      - name: Finalize gfx1250 B0-to-A0 SHA pairs
+        id: finalize_dbt_sha_pairs
+        if: matrix.name == 'release' && steps.collect_dbt_sha_pairs.outcome == 'success'
+        timeout-minutes: 2
+        working-directory: ${{ env.ROCJITSU_DBT_CORPUS_DIR }}
+        shell: bash
+        run: |
+          python3 \
+            "${ROCJITSU_SOURCE_DIR}/tests/corpus/record-gfx1250-dbt-sha-pairs.py" \
+            finalize \
+            --fragments "${ROCJITSU_DBT_SHA_FRAGMENTS}" \
+            --output "${ROCJITSU_DBT_SHA_MANIFEST}" \
+            --input-manifest "${ROCJITSU_HSACO_CORPUS}/manifests/SHA256SUMS" \
+            --expected-failures "${ROCJITSU_SOURCE_DIR}/tests/corpus/dbt/gfx1250_b0_a0_expected_failures.json" \
+            --expected-rewrites "${ROCJITSU_SOURCE_DIR}/tests/corpus/dbt/gfx1250_b0_a0_expected_rewrites.json" \
+            --package-lock "${ROCJITSU_SOURCE_DIR}/tests/corpus/dbt/gfx1250_20260726_package_lock.json" \
+            --source-commit "${GITHUB_SHA}" \
+            --corpus-commit "$(git rev-parse HEAD)" \
+            --rocm-sdk-version "${ROCM_SDK_VERSION}"
+
+      - name: Upload develop gfx1250 B0-to-A0 SHA pairs
+        if: >-
+          matrix.name == 'release' &&
+          steps.finalize_dbt_sha_pairs.outcome == 'success' &&
+          github.event_name != 'pull_request'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gfx1250-b0-a0-sha-pairs
+          path: ${{ env.ROCJITSU_DBT_SHA_MANIFEST }}
+          if-no-files-found: error
+          retention-days: 90
 
       # Debugging aid only. The pinned extraction is reproducible, so retain
       # translator logs but never upload the extracted HSACOs.

--- a/emulation/rocjitsu/tests/corpus/README.md
+++ b/emulation/rocjitsu/tests/corpus/README.md
@@ -15,3 +15,34 @@ until their translations are implemented:
 
 The offline translator currently rejects those forms as unsupported. They are
 not silently accepted or treated as passing translations.
+
+## Offline translation SHA baseline
+
+The `rocjitsu-test-corpus` workflow records the SHA-256 of every successful
+gfx1250 B0-to-A0 input and translated output after the release-lane corpus
+tests succeed. Pull requests exercise collection and finalization but do not
+upload an artifact. A develop push uploads the canonical manifest as the
+`gfx1250-b0-a0-sha-pairs` workflow artifact. A manual workflow dispatch on the
+`develop` branch also refreshes the baseline when the official corpus
+repository and pinned gfx1250 corpus ref are left unchanged. The manifest
+includes the fixed translation profile, pinned corpus commit, input-manifest
+hash, package-lock hash, ROCm SDK version, and source commit; it never contains
+the code objects themselves.
+
+The follow-up PR advisory flow will select the newest completed, unexpired
+artifact from a successful develop push or canonical manual run. It will
+compare output hashes only when the corpus, input manifest, package lock, and
+SDK provenance match, and will report changed outputs in a non-blocking PR
+comment. Input-set or provenance changes are incompatible comparisons rather
+than translation changes.
+
+`record-gfx1250-dbt-sha-pairs.py` runs a bounded, translation-only collection
+pass after the corpus tests and validates the resulting manifest. The external
+corpus harness does not expose the translated bytes, so keeping collection
+separate avoids coupling its interface to this workflow. The preceding
+harness run qualifies the included input set under its timeout and memory
+policy; the collector repeats the per-object timeout and does not rerun
+declared exclusions. It streams each output through a temporary file and
+retains only its size and SHA-256. Its `finalize` command requires every pinned
+corpus input to have either a successful pair or a matching declared
+exclusion, which prevents partial runs from becoming a develop baseline.

--- a/emulation/rocjitsu/tests/corpus/record-gfx1250-dbt-sha-pairs.py
+++ b/emulation/rocjitsu/tests/corpus/record-gfx1250-dbt-sha-pairs.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Record deterministic gfx1250 B0-to-A0 translation hashes."""
+
+from __future__ import annotations
+
+import argparse
+from concurrent.futures import as_completed, ThreadPoolExecutor
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+
+SHA256_RE = re.compile(r"[0-9a-f]{64}")
+# Provenance is later rendered into a trusted PR comment. Keep these values
+# single-token and canonical at the artifact boundary.
+GIT_SHA_RE = re.compile(r"(?:[0-9a-f]{40}|[0-9a-f]{64})")
+SDK_VERSION_RE = re.compile(r"[0-9A-Za-z][0-9A-Za-z.+_-]{0,127}")
+SHA256SUM_RE = re.compile(r"(?P<digest>[0-9a-f]{64})  objects/(?P=digest)\.hsaco")
+PROFILE = {
+    "target": "gfx1250",
+    "input_revision": "b0",
+    "output_revision": "a0",
+    "output_mode": "code-object",
+    "verify_idempotence": True,
+}
+ERROR = 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        if args.command == "collect":
+            collect_pairs(args)
+            return 0
+        if args.command == "finalize":
+            finalize_manifest(args)
+            return 0
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return ERROR
+    raise AssertionError(f"unhandled command: {args.command}")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    collect_parser = commands.add_parser(
+        "collect", help="translate successful corpus inputs and record SHA-256 pairs"
+    )
+    collect_parser.add_argument("--translator", type=Path, required=True)
+    collect_parser.add_argument("--corpus", type=Path, required=True)
+    collect_parser.add_argument("--input-manifest", type=Path, required=True)
+    collect_parser.add_argument("--expected-failures", type=Path, required=True)
+    collect_parser.add_argument("--fragments", type=Path, required=True)
+    collect_parser.add_argument("--workers", type=int, required=True)
+    collect_parser.add_argument("--timeout", type=float, required=True)
+
+    finalize_parser = commands.add_parser(
+        "finalize", help="validate fragments and write one canonical manifest"
+    )
+    finalize_parser.add_argument("--fragments", type=Path, required=True)
+    finalize_parser.add_argument("--output", type=Path, required=True)
+    finalize_parser.add_argument("--input-manifest", type=Path, required=True)
+    finalize_parser.add_argument("--expected-failures", type=Path, required=True)
+    finalize_parser.add_argument("--expected-rewrites", type=Path, required=True)
+    finalize_parser.add_argument("--package-lock", type=Path, required=True)
+    finalize_parser.add_argument("--source-commit", required=True)
+    finalize_parser.add_argument("--corpus-commit", required=True)
+    finalize_parser.add_argument("--rocm-sdk-version", required=True)
+
+    return parser.parse_args(argv)
+
+
+def collect_pairs(args: argparse.Namespace) -> None:
+    translator = args.translator.resolve()
+    if not translator.is_file() or not os.access(translator, os.X_OK):
+        raise ValueError(f"translator is not executable: {args.translator}")
+    args.translator = translator
+    if args.workers <= 0:
+        raise ValueError("--workers must be greater than zero")
+    if args.timeout <= 0:
+        raise ValueError("--timeout must be greater than zero")
+    if args.fragments.exists():
+        if not args.fragments.is_dir():
+            raise ValueError(
+                f"translation fragment path is not a directory: {args.fragments}"
+            )
+        if any(args.fragments.iterdir()):
+            raise ValueError(
+                f"translation fragment directory is not empty: {args.fragments}"
+            )
+    args.fragments.mkdir(parents=True, exist_ok=True)
+    corpus_inputs = _load_input_manifest(args.input_manifest)
+    expected_failures = _load_expected_failures(args.expected_failures)
+    unknown_failures = expected_failures - corpus_inputs
+    if unknown_failures:
+        raise ValueError(
+            f"expected-failure manifest names {len(unknown_failures)} input(s) "
+            f"absent from the corpus: {_shown(unknown_failures)}"
+        )
+    successful_inputs = sorted(corpus_inputs - expected_failures)
+
+    errors = []
+    completed = 0
+    with ThreadPoolExecutor(max_workers=args.workers) as executor:
+        futures = {
+            executor.submit(_translate_and_hash, args, digest): digest
+            for digest in successful_inputs
+        }
+        for future in as_completed(futures):
+            digest = futures[future]
+            try:
+                _record_fragment(args.fragments, future.result())
+            except (OSError, ValueError) as error:
+                errors.append(f"{digest}: {error}")
+            completed += 1
+            if completed % 1000 == 0 or completed == len(successful_inputs):
+                print(f"collected {completed}/{len(successful_inputs)} SHA-256 pairs")
+    if errors:
+        shown = "\n".join(errors[:20])
+        suffix = f"\n... and {len(errors) - 20} more" if len(errors) > 20 else ""
+        raise ValueError(
+            f"{len(errors)} translation hash collection(s) failed:\n{shown}{suffix}"
+        )
+
+
+def _translate_and_hash(args: argparse.Namespace, input_sha256: str) -> dict:
+    source = args.corpus / "objects" / f"{input_sha256}.hsaco"
+    if not source.is_file():
+        raise ValueError(f"translation input is not a file: {source}")
+    actual_input_sha256, input_size = _hash_and_size(source)
+    if actual_input_sha256 != input_sha256:
+        raise ValueError(
+            f"input SHA-256 mismatch: expected {input_sha256}, got {actual_input_sha256}"
+        )
+    command = [
+        str(args.translator),
+        "--verify-idempotence",
+        str(source),
+        "--input-target",
+        PROFILE["target"],
+        "--output-target",
+        PROFILE["target"],
+        "--input-revision",
+        PROFILE["input_revision"],
+        "--output-revision",
+        PROFILE["output_revision"],
+        "--output-mode",
+        PROFILE["output_mode"],
+    ]
+    with tempfile.TemporaryFile() as output, tempfile.TemporaryFile() as error_output:
+        process = subprocess.Popen(command, stdout=output, stderr=error_output)
+        try:
+            returncode = process.wait(timeout=args.timeout)
+        except subprocess.TimeoutExpired as error:
+            process.kill()
+            process.wait()
+            raise ValueError(
+                f"translation timed out after {args.timeout:g} seconds"
+            ) from error
+        if returncode:
+            error_output.seek(0)
+            stderr = error_output.read(64 * 1024).decode("utf-8", errors="replace")
+            raise ValueError(
+                f"translation failed with status {returncode}: {stderr.strip() or '<empty>'}"
+            )
+        output.seek(0)
+        output_sha256 = hashlib.sha256()
+        output_size = 0
+        while chunk := output.read(1024 * 1024):
+            output_sha256.update(chunk)
+            output_size += len(chunk)
+    if output_size == 0:
+        raise ValueError("translation produced an empty output")
+    return {
+        "input_bytes": input_size,
+        "input_sha256": input_sha256,
+        "output_bytes": output_size,
+        "output_sha256": output_sha256.hexdigest(),
+    }
+
+
+def finalize_manifest(args: argparse.Namespace) -> None:
+    _validate_git_sha(args.source_commit, "source commit")
+    _validate_git_sha(args.corpus_commit, "corpus commit")
+    _validate_sdk_version(args.rocm_sdk_version, "ROCm SDK version")
+
+    pairs = _load_fragments(args.fragments)
+    corpus_inputs = _load_input_manifest(args.input_manifest)
+    expected_failures = _load_expected_failures(args.expected_failures)
+    unknown_failures = expected_failures - corpus_inputs
+    if unknown_failures:
+        raise ValueError(
+            f"expected-failure manifest names {len(unknown_failures)} input(s) "
+            f"absent from the corpus: {_shown(unknown_failures)}"
+        )
+
+    expected_pairs = corpus_inputs - expected_failures
+    actual_pairs = set(pairs)
+    missing = expected_pairs - actual_pairs
+    extra = actual_pairs - expected_pairs
+    if missing or extra:
+        raise ValueError(
+            "translation fragments do not cover the successful corpus inputs: "
+            f"missing={len(missing)} [{_shown(missing)}], "
+            f"extra={len(extra)} [{_shown(extra)}]"
+        )
+
+    payload = {
+        "excluded_inputs": sorted(expected_failures),
+        "pairs": [pairs[digest] for digest in sorted(pairs)],
+        "profile": PROFILE,
+        "provenance": {
+            "corpus_commit": args.corpus_commit,
+            "expected_failures_sha256": _sha256_file(args.expected_failures),
+            "expected_rewrites_sha256": _sha256_file(args.expected_rewrites),
+            "input_manifest_sha256": _sha256_file(args.input_manifest),
+            "package_lock_sha256": _sha256_file(args.package_lock),
+            "rocm_sdk_version": args.rocm_sdk_version,
+            "rocm_systems_commit": args.source_commit,
+        },
+        "schema_version": 1,
+    }
+    _write_json(args.output, payload)
+    print(
+        f"wrote {len(pairs)} gfx1250 B0-to-A0 SHA-256 pairs to {args.output} "
+        f"({len(expected_failures)} expected failure(s) excluded)"
+    )
+
+
+def _record_fragment(directory: Path, record: dict) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    destination = directory / f"{record['input_sha256']}.json"
+    fd, temporary_name = tempfile.mkstemp(prefix=".pair-", dir=directory)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as output:
+            json.dump(record, output, sort_keys=True, separators=(",", ":"))
+            output.write("\n")
+        try:
+            os.link(temporary, destination)
+        except FileExistsError:
+            existing = json.loads(destination.read_text(encoding="utf-8"))
+            if existing != record:
+                raise ValueError(
+                    f"conflicting translation outputs for {record['input_sha256']}"
+                )
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _load_fragments(directory: Path) -> dict[str, dict]:
+    if not directory.is_dir():
+        raise ValueError(f"translation fragment directory does not exist: {directory}")
+    pairs = {}
+    for path in sorted(directory.glob("*.json")):
+        record = json.loads(path.read_text(encoding="utf-8"))
+        _validate_pair_record(record, str(path))
+        digest = record["input_sha256"]
+        if path.name != f"{digest}.json":
+            raise ValueError(f"{path} name does not match its input SHA-256")
+        if digest in pairs:
+            raise ValueError(f"duplicate translation fragment for {digest}")
+        pairs[digest] = record
+    return pairs
+
+
+def _load_input_manifest(path: Path) -> set[str]:
+    inputs = set()
+    for line_number, line in enumerate(
+        path.read_text(encoding="ascii").splitlines(), start=1
+    ):
+        match = SHA256SUM_RE.fullmatch(line)
+        if match is None:
+            raise ValueError(
+                f"{path}:{line_number} is not a canonical SHA256SUMS entry"
+            )
+        digest = match.group("digest")
+        if digest in inputs:
+            raise ValueError(f"{path}:{line_number} repeats {digest}")
+        inputs.add(digest)
+    if not inputs:
+        raise ValueError(f"{path} must not be empty")
+    return inputs
+
+
+def _load_expected_failures(path: Path) -> set[str]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    failures = payload.get("expected_failures")
+    if not isinstance(failures, dict):
+        raise ValueError(f"{path} field 'expected_failures' must be an object")
+    invalid = [
+        digest
+        for digest in failures
+        if not isinstance(digest, str) or not SHA256_RE.fullmatch(digest)
+    ]
+    if invalid:
+        raise ValueError(f"{path} contains an invalid expected-failure SHA-256")
+    return set(failures)
+
+
+def _validate_pair_record(record: dict, description: str) -> None:
+    expected_fields = {
+        "input_bytes",
+        "input_sha256",
+        "output_bytes",
+        "output_sha256",
+    }
+    if not isinstance(record, dict) or set(record) != expected_fields:
+        raise ValueError(
+            f"{description} must contain exactly {sorted(expected_fields)}"
+        )
+    for field in ("input_sha256", "output_sha256"):
+        if not isinstance(record[field], str) or not SHA256_RE.fullmatch(record[field]):
+            raise ValueError(f"{description} field {field!r} must be lowercase SHA-256")
+    for field in ("input_bytes", "output_bytes"):
+        if (
+            isinstance(record[field], bool)
+            or not isinstance(record[field], int)
+            or record[field] <= 0
+        ):
+            raise ValueError(
+                f"{description} field {field!r} must be a positive integer"
+            )
+
+
+def _hash_and_size(path: Path) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    size = 0
+    with path.open("rb") as source:
+        while chunk := source.read(1024 * 1024):
+            digest.update(chunk)
+            size += len(chunk)
+    return digest.hexdigest(), size
+
+
+def _sha256_file(path: Path) -> str:
+    return _hash_and_size(path)[0]
+
+
+def _validate_git_sha(value: str, description: str) -> None:
+    if not isinstance(value, str) or GIT_SHA_RE.fullmatch(value) is None:
+        raise ValueError(f"{description} must be a full lowercase Git SHA")
+
+
+def _validate_sdk_version(value: str, description: str) -> None:
+    if not isinstance(value, str) or SDK_VERSION_RE.fullmatch(value) is None:
+        raise ValueError(f"{description} contains unsupported characters")
+
+
+def _shown(digests: set[str]) -> str:
+    ordered = sorted(digests)
+    shown = ", ".join(ordered[:3])
+    return f"{shown}, ..." if len(ordered) > 3 else shown
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/emulation/rocjitsu/tests/corpus/test-record-gfx1250-dbt-sha-pairs.py
+++ b/emulation/rocjitsu/tests/corpus/test-record-gfx1250-dbt-sha-pairs.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+import contextlib
+import hashlib
+import importlib.util
+import io
+import json
+import os
+from pathlib import Path
+import tempfile
+import unittest
+
+TOOL_PATH = Path(__file__).with_name("record-gfx1250-dbt-sha-pairs.py")
+SPEC = importlib.util.spec_from_file_location("gfx1250_dbt_sha_pairs", TOOL_PATH)
+assert SPEC is not None and SPEC.loader is not None
+TOOL = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(TOOL)
+
+
+class CollectionTest(unittest.TestCase):
+    def test_collects_successes_and_skips_expected_failures(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            corpus = root / "corpus"
+            objects = corpus / "objects"
+            objects.mkdir(parents=True)
+            source = b"ELF input bytes"
+            excluded_source = b"known large input"
+            input_sha256 = hashlib.sha256(source).hexdigest()
+            excluded_sha256 = hashlib.sha256(excluded_source).hexdigest()
+            (objects / f"{input_sha256}.hsaco").write_bytes(source)
+            (objects / f"{excluded_sha256}.hsaco").write_bytes(excluded_source)
+            input_manifest = corpus / "SHA256SUMS"
+            input_manifest.write_text(
+                f"{input_sha256}  objects/{input_sha256}.hsaco\n"
+                f"{excluded_sha256}  objects/{excluded_sha256}.hsaco\n",
+                encoding="ascii",
+            )
+            expected_failures = corpus / "expected-failures.json"
+            expected_failures.write_text(
+                json.dumps({"expected_failures": {excluded_sha256: {}}}),
+                encoding="utf-8",
+            )
+            translator = self._write_translator(root, mode="success")
+            fragments = root / "fragments"
+
+            self.assertEqual(
+                TOOL.main(
+                    self._collect_args(
+                        translator,
+                        corpus,
+                        input_manifest,
+                        expected_failures,
+                        fragments,
+                    )
+                ),
+                0,
+            )
+
+            record = json.loads(
+                (fragments / f"{input_sha256}.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(record["input_sha256"], input_sha256)
+            self.assertEqual(
+                record["output_sha256"], hashlib.sha256(source[::-1]).hexdigest()
+            )
+            self.assertEqual(record["input_bytes"], len(source))
+            self.assertEqual(record["output_bytes"], len(source))
+            self.assertFalse((fragments / f"{excluded_sha256}.json").exists())
+
+    def test_rejects_translation_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            corpus = root / "corpus"
+            objects = corpus / "objects"
+            objects.mkdir(parents=True)
+            source = b"bad input"
+            input_sha256 = hashlib.sha256(source).hexdigest()
+            (objects / f"{input_sha256}.hsaco").write_bytes(source)
+            input_manifest = corpus / "SHA256SUMS"
+            input_manifest.write_text(
+                f"{input_sha256}  objects/{input_sha256}.hsaco\n",
+                encoding="ascii",
+            )
+            expected_failures = corpus / "expected-failures.json"
+            expected_failures.write_text(
+                json.dumps({"expected_failures": {}}), encoding="utf-8"
+            )
+            translator = self._write_translator(root, mode="failure")
+            fragments = root / "fragments"
+
+            diagnostics = io.StringIO()
+            with contextlib.redirect_stderr(diagnostics):
+                status = TOOL.main(
+                    self._collect_args(
+                        translator,
+                        corpus,
+                        input_manifest,
+                        expected_failures,
+                        fragments,
+                    )
+                )
+            self.assertEqual(status, TOOL.ERROR)
+            self.assertIn("translation failed with status 7", diagnostics.getvalue())
+            self.assertEqual(list(fragments.glob("*.json")), [])
+
+    def test_rejects_translation_timeout(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            corpus, input_manifest, expected_failures = self._write_single_input(root)
+            translator = self._write_translator(root, mode="timeout")
+            arguments = self._collect_args(
+                translator,
+                corpus,
+                input_manifest,
+                expected_failures,
+                root / "fragments",
+            )
+            timeout_index = arguments.index("--timeout") + 1
+            arguments[timeout_index] = "0.05"
+
+            diagnostics = io.StringIO()
+            with contextlib.redirect_stderr(diagnostics):
+                status = TOOL.main(arguments)
+
+            self.assertEqual(status, TOOL.ERROR)
+            self.assertIn("translation timed out", diagnostics.getvalue())
+
+    def test_rejects_empty_translation(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            corpus, input_manifest, expected_failures = self._write_single_input(root)
+            translator = self._write_translator(root, mode="empty")
+
+            diagnostics = io.StringIO()
+            with contextlib.redirect_stderr(diagnostics):
+                status = TOOL.main(
+                    self._collect_args(
+                        translator,
+                        corpus,
+                        input_manifest,
+                        expected_failures,
+                        root / "fragments",
+                    )
+                )
+
+            self.assertEqual(status, TOOL.ERROR)
+            self.assertIn(
+                "translation produced an empty output", diagnostics.getvalue()
+            )
+
+    def test_accepts_relative_translator_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            corpus, input_manifest, expected_failures = self._write_single_input(root)
+            self._write_translator(root, mode="success")
+            previous_directory = Path.cwd()
+            try:
+                os.chdir(root)
+                status = TOOL.main(
+                    self._collect_args(
+                        Path("translator.py"),
+                        corpus,
+                        input_manifest,
+                        expected_failures,
+                        root / "fragments",
+                    )
+                )
+            finally:
+                os.chdir(previous_directory)
+
+            self.assertEqual(status, 0)
+
+    def test_rejects_nonempty_fragment_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            corpus, input_manifest, expected_failures = self._write_single_input(root)
+            translator = self._write_translator(root, mode="success")
+            fragments = root / "fragments"
+            fragments.mkdir()
+            (fragments / "stale.json").write_text("{}", encoding="utf-8")
+
+            diagnostics = io.StringIO()
+            with contextlib.redirect_stderr(diagnostics):
+                status = TOOL.main(
+                    self._collect_args(
+                        translator,
+                        corpus,
+                        input_manifest,
+                        expected_failures,
+                        fragments,
+                    )
+                )
+
+            self.assertEqual(status, TOOL.ERROR)
+            self.assertIn("fragment directory is not empty", diagnostics.getvalue())
+
+    def test_record_fragment_rejects_conflicting_output(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            fragments = Path(temporary_directory)
+            record = {
+                "input_bytes": 64,
+                "input_sha256": "1" * 64,
+                "output_bytes": 96,
+                "output_sha256": "2" * 64,
+            }
+            TOOL._record_fragment(fragments, record)
+            conflicting = {**record, "output_sha256": "3" * 64}
+
+            with self.assertRaisesRegex(ValueError, "conflicting translation outputs"):
+                TOOL._record_fragment(fragments, conflicting)
+
+    @staticmethod
+    def _write_translator(root: Path, *, mode: str) -> Path:
+        translator = root / "translator.py"
+        translator.write_text(
+            "#!/usr/bin/env python3\n"
+            "from pathlib import Path\n"
+            "import sys\n"
+            "import time\n"
+            "if '--verify-idempotence' not in sys.argv:\n"
+            "    print('missing extra argument', file=sys.stderr)\n"
+            "    sys.exit(9)\n"
+            "source = next(Path(arg) for arg in sys.argv[1:] if arg.endswith('.hsaco'))\n"
+            f"mode = {mode!r}\n"
+            "if mode == 'timeout':\n"
+            "    time.sleep(60)\n"
+            "if mode == 'failure':\n"
+            "    print('expected failure', file=sys.stderr)\n"
+            "    sys.exit(7)\n"
+            "if mode == 'success':\n"
+            "    sys.stdout.buffer.write(source.read_bytes()[::-1])\n"
+            "sys.exit(0)\n",
+            encoding="utf-8",
+        )
+        translator.chmod(0o755)
+        return translator
+
+    @staticmethod
+    def _write_single_input(root: Path) -> tuple[Path, Path, Path]:
+        corpus = root / "corpus"
+        objects = corpus / "objects"
+        objects.mkdir(parents=True)
+        source = b"single input"
+        input_sha256 = hashlib.sha256(source).hexdigest()
+        (objects / f"{input_sha256}.hsaco").write_bytes(source)
+        input_manifest = corpus / "SHA256SUMS"
+        input_manifest.write_text(
+            f"{input_sha256}  objects/{input_sha256}.hsaco\n", encoding="ascii"
+        )
+        expected_failures = corpus / "expected-failures.json"
+        expected_failures.write_text(
+            json.dumps({"expected_failures": {}}), encoding="utf-8"
+        )
+        return corpus, input_manifest, expected_failures
+
+    @staticmethod
+    def _collect_args(
+        translator: Path,
+        corpus: Path,
+        input_manifest: Path,
+        expected_failures: Path,
+        fragments: Path,
+    ) -> list[str]:
+        return [
+            "collect",
+            "--translator",
+            str(translator),
+            "--corpus",
+            str(corpus),
+            "--input-manifest",
+            str(input_manifest),
+            "--expected-failures",
+            str(expected_failures),
+            "--fragments",
+            str(fragments),
+            "--workers",
+            "2",
+            "--timeout",
+            "5",
+        ]
+
+
+class ManifestTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name)
+        self.fragments = self.root / "fragments"
+        self.fragments.mkdir()
+        self.success_input = "1" * 64
+        self.failed_input = "2" * 64
+        self.output_digest = "3" * 64
+        self._write_fragment(self.success_input, self.output_digest)
+
+        self.input_manifest = self.root / "SHA256SUMS"
+        self.input_manifest.write_text(
+            f"{self.success_input}  objects/{self.success_input}.hsaco\n"
+            f"{self.failed_input}  objects/{self.failed_input}.hsaco\n",
+            encoding="ascii",
+        )
+        self.expected_failures = self.root / "expected-failures.json"
+        self.expected_failures.write_text(
+            json.dumps(
+                {
+                    "expected_failures": {
+                        self.failed_input: {
+                            "kind": "memory-limit",
+                            "reason": "fixture",
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        self.expected_rewrites = self.root / "expected-rewrites.json"
+        self.expected_rewrites.write_text(
+            json.dumps({"expected_rewrites": {}}), encoding="utf-8"
+        )
+        self.package_lock = self.root / "package-lock.json"
+        self.package_lock.write_text(
+            json.dumps({"schema_version": 1}), encoding="utf-8"
+        )
+
+    def tearDown(self) -> None:
+        self.temporary_directory.cleanup()
+
+    def test_finalize_is_deterministic_and_complete(self) -> None:
+        first = self.root / "first.json"
+        second = self.root / "second.json"
+
+        self.assertEqual(TOOL.main(self._finalize_args(first)), 0)
+        self.assertEqual(TOOL.main(self._finalize_args(second)), 0)
+
+        self.assertEqual(first.read_bytes(), second.read_bytes())
+        manifest = json.loads(first.read_text(encoding="utf-8"))
+        self.assertEqual(manifest["excluded_inputs"], [self.failed_input])
+        self.assertEqual(len(manifest["pairs"]), 1)
+        self.assertEqual(manifest["profile"], TOOL.PROFILE)
+        self.assertTrue(manifest["profile"]["verify_idempotence"])
+        self.assertEqual(manifest["provenance"]["rocm_systems_commit"], "a" * 40)
+
+    def test_finalize_rejects_missing_successful_input(self) -> None:
+        (self.fragments / f"{self.success_input}.json").unlink()
+
+        diagnostics = io.StringIO()
+        with contextlib.redirect_stderr(diagnostics):
+            status = TOOL.main(self._finalize_args(self.root / "bad.json"))
+        self.assertEqual(status, TOOL.ERROR)
+        self.assertIn("missing=1", diagnostics.getvalue())
+
+    def test_finalize_rejects_extra_input(self) -> None:
+        self._write_fragment("4" * 64, "5" * 64)
+
+        diagnostics = io.StringIO()
+        with contextlib.redirect_stderr(diagnostics):
+            status = TOOL.main(self._finalize_args(self.root / "bad.json"))
+
+        self.assertEqual(status, TOOL.ERROR)
+        self.assertIn("extra=1", diagnostics.getvalue())
+
+    def test_finalize_rejects_intermediate_git_sha_length(self) -> None:
+        arguments = self._finalize_args(self.root / "bad.json")
+        source_index = arguments.index("--source-commit") + 1
+        arguments[source_index] = "a" * 41
+
+        diagnostics = io.StringIO()
+        with contextlib.redirect_stderr(diagnostics):
+            status = TOOL.main(arguments)
+
+        self.assertEqual(status, TOOL.ERROR)
+        self.assertIn("full lowercase Git SHA", diagnostics.getvalue())
+
+    def test_finalize_rejects_unsafe_sdk_version(self) -> None:
+        arguments = self._finalize_args(self.root / "bad.json")
+        version_index = arguments.index("--rocm-sdk-version") + 1
+        arguments[version_index] = "7.15.0 | @reviewers"
+
+        diagnostics = io.StringIO()
+        with contextlib.redirect_stderr(diagnostics):
+            status = TOOL.main(arguments)
+
+        self.assertEqual(status, TOOL.ERROR)
+        self.assertIn("unsupported characters", diagnostics.getvalue())
+
+    def _write_fragment(
+        self,
+        input_digest: str,
+        output_digest: str,
+    ) -> None:
+        path = self.fragments / f"{input_digest}.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "input_bytes": 64,
+                    "input_sha256": input_digest,
+                    "output_bytes": 96,
+                    "output_sha256": output_digest,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def _finalize_args(self, output: Path) -> list[str]:
+        return [
+            "finalize",
+            "--fragments",
+            str(self.fragments),
+            "--output",
+            str(output),
+            "--input-manifest",
+            str(self.input_manifest),
+            "--expected-failures",
+            str(self.expected_failures),
+            "--expected-rewrites",
+            str(self.expected_rewrites),
+            "--package-lock",
+            str(self.package_lock),
+            "--source-commit",
+            "a" * 40,
+            "--corpus-commit",
+            "b" * 40,
+            "--rocm-sdk-version",
+            "7.15.0a20260728",
+        ]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Publish a canonical input/output SHA-256 manifest from each develop push or canonical manual rerun that executes the pinned gfx1250 B0-to-A0 corpus. Include corpus, package, SDK, and source provenance without retaining code objects.

Collect hashes in a separate bounded translation pass so the corpus harness remains responsible for translator timeout, memory, idempotence, and expected-failure handling. Require complete corpus coverage before uploading the 90-day baseline artifact.

Validated producer unit tests, deterministic finalization of all 19,999 successful inputs, workflow YAML and shell syntax, and pre-commit hooks.