### PR TITLE
fix(rocr): tune SDMA fan-out for large RCCL copy sizes

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_blit_sdma.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_blit_sdma.h
@@ -104,15 +104,15 @@ class BlitSdmaBase : public core::Blit {
   /// @brief Maximum byte count a single linear copy packet can describe
   /// (the 30-bit count field, ~1 GiB).  Larger copies are split into multiple
   /// chunked packets; both the plain (BuildCopyCommand) and fused WaitSignal
-  /// builders chunk internally.  The indirect WaitSignal packet is the lone
+  /// WaitSignal builders chunk internally. The indirect WaitSignal packet is the lone
   /// exception - it has no offset field, so callers must reject indirect copies
   /// larger than this limit.
   virtual size_t MaxSingleLinearCopySize() const = 0;
 
-  /// @brief Single-doorbell fused WaitSignal copy for gfx125+ single copies.
-  /// Emits GCR invalidate + dep polls + N fused WaitSignal+Copy packets +
+  /// @brief Single-doorbell WaitSignal copy for gfx125+ single copies.
+  /// Emits GCR invalidate + dep polls + N WaitSignal copy packets +
   /// GCR writeback + mailbox/trap — all in one ring reservation.
-  /// Each chunk carries wait+copy+signal dec inline; no prologue signal needed.
+  /// Only the first packet waits and only the final packet signals.
   /// When profiling is enabled, start/end SDMA timestamp commands are emitted
   /// around the copy packets (after dep polls and after copies respectively).
   virtual hsa_status_t SubmitLinearCopyBodyWaitSignal(
@@ -124,9 +124,10 @@ class BlitSdmaBase : public core::Blit {
   /// @brief Unified prologue: dep polls, HDP flush, start timestamp, GCR
   /// invalidate, and prologue_signal decrement — emitted conditionally based on
   /// @p fused_bodies and the internal profiling_enabled() state.
-  ///   fused + !profiling: only GCR invalidate + prologue_signal dec (bodies WAIT
-  ///     on deps themselves).
-  ///   !fused or profiling: dep polls + HDP flush + [start timestamp] + GCR + dec.
+  ///   WaitSignal + !profiling: only GCR invalidate + prologue_signal dec
+  ///     (bodies WAIT on deps themselves).
+  ///   Classic packets or profiling: dep polls + HDP flush +
+  ///     [start timestamp] + GCR + dec.
   virtual hsa_status_t SubmitPrologue(
       const std::vector<core::Signal*>& dep_signals,
       core::Signal& out_signal,
@@ -156,7 +157,6 @@ class BlitSdmaBase : public core::Blit {
       const std::vector<core::Signal*>& dep_signals,
       core::Signal& out_signal,
       core::Signal* prologue_signal,
-      bool fused_bodies,
       hsa_amd_memory_copy_op_type_t op,
       const std::vector<void*>& dsts,
       const std::vector<const void*>& srcs,
@@ -167,10 +167,9 @@ class BlitSdmaBase : public core::Blit {
 
   /// @brief Unified body submission: one ring reservation (one doorbell) for all
   /// entries in an engine group.  Dispatches internally to copy / swap / indirect
-  /// packet builders based on @p op.  Every chunk waits on dep_signals[0] and
-  /// decrements out_signal via fused WaitSignal packets; dep_signals[1..] are
-  /// leading 64b polls.  Arms out_signal for chunk extras:
-  /// AddRelaxed(total_chunks - num_entries).
+  /// packet builders based on @p op. The first packet waits on dep_signals[0],
+  /// the final packet decrements out_signal, and middle packets carry neither
+  /// WAIT nor SIGNAL; dep_signals[1..] are leading 64b polls.
   ///
   /// Entries are gathered directly from the caller's master @p dst_list /
   /// @p src_list / @p size_list arrays via @p indices, avoiding per-engine
@@ -316,7 +315,6 @@ template <bool useGCR, bool scopeFields> class BlitSdma : public BlitSdmaBase {
       const std::vector<core::Signal*>& dep_signals,
       core::Signal& out_signal,
       core::Signal* prologue_signal,
-      bool fused_bodies,
       hsa_amd_memory_copy_op_type_t op,
       const std::vector<void*>& dsts,
       const std::vector<const void*>& srcs,
@@ -422,7 +420,8 @@ template <bool useGCR, bool scopeFields> class BlitSdma : public BlitSdmaBase {
   void BuildWaitSignalCopyCommand(char* cmd_addr, uint32_t num_copy_command,
                                   void* dst, const void* src, size_t size,
                                   const core::Signal* wait_signal,
-                                  core::Signal* signal_signal);
+                                  core::Signal* signal_signal,
+                                  bool boundary_wait_signal);
 
   void BuildWaitSignalSwapCommand(char* cmd_addr, uint32_t num_copy_command,
                                   void* addr_a, void* addr_b,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_sdma.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_sdma.cpp
@@ -756,7 +756,7 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitLinearCopyBodyWaitSignal(
   const core::Signal* wait_sig = dep_signals.empty() ? nullptr : dep_signals[0];
   BuildWaitSignalCopyCommand(command_addr, num_copy_command,
                              dst, src, size,
-                             wait_sig, &out_signal);
+                             wait_sig, &out_signal, false);
   bytes_written_.fill(wrapped_index, wrapped_index + copy_bytes, prior_bytes);
   bytes_written_[wrapped_index + copy_bytes - sizeof(uint32_t)] = post_bytes;
   command_addr += copy_bytes;
@@ -1077,7 +1077,6 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitFusedCoordinator(
     const std::vector<core::Signal*>& dep_signals,
     core::Signal& out_signal,
     core::Signal* prologue_signal,
-    bool fused_bodies,
     hsa_amd_memory_copy_op_type_t op,
     const std::vector<void*>& dsts,
     const std::vector<const void*>& srcs,
@@ -1096,11 +1095,9 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitFusedCoordinator(
   // Epilogue fast path: the epilogue exists to (a) raise the completion
   // interrupt (fence+trap) once all engines finish, (b) order a GCR cache
   // writeback before signalling, and (c) emit the profiling end-timestamp.
-  // When none of those apply, the poll+fence are redundant: every body packet's
-  // SIGNAL stage already atomically subtracts 1 from out_signal *after* its copy
-  // (SDMA executes in-order per engine), so the last chunk's sub is the correct
-  // completion edge on its own.  We drop the whole epilogue and shift the signal
-  // target down by one (below) so that final sub lands on the done value.
+  // When none of those apply, the poll+fence are redundant: the final body
+  // packet decrements out_signal after its copy. We drop the whole epilogue and
+  // shift the signal target down by one so that decrement lands on the done value.
   const bool skip_epilogue = !useGCR && !profiling_enabled && !has_mailbox;
 
   // --- Prologue size computation ---
@@ -1109,7 +1106,7 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitFusedCoordinator(
   uint64_t dep_signals_value[HSA_MAX_DEP_SIGNALS];
 
   if (need_prologue) {
-    const bool emit_deps = !fused_bodies || profiling_enabled;
+    const bool emit_deps = profiling_enabled;
     if (emit_deps) {
       for (size_t i = 0; i < dep_signals.size(); ++i) {
         dep_signals_value[i] = dep_signals[i]->LoadRelaxed();
@@ -1128,13 +1125,15 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitFusedCoordinator(
     prologue_size += fence_64b_command_size_;
   }
 
-  // --- Body size computation (gfx125+ fused WaitSignal path) ---
+  // --- Body size computation ---
   const size_t max_copy_size = is_swap
       ? SDMA_PKT_COPY_LINEAR_SWAP_WAITSIGNAL_GFX1250::kMaxSize_
       : (max_single_linear_copy_size_ ? max_single_linear_copy_size_ : kMaxSingleCopySize);
 
-  const uint32_t wait_dws = body_deps.empty() ? 0 : 7;
-  const uint32_t per_pkt_dws = 1 + wait_dws + 6 + 5;
+  const uint32_t wait_dws =
+      (!body_deps.empty() && num_entries != 0) ? 7 : 0;
+  const uint32_t signal_dws = num_entries != 0 ? 5 : 0;
+  constexpr uint32_t kPacketCoreDws = 1 + 6;
 
   std::vector<uint32_t> chunks(num_entries);
   uint32_t total_chunks = 0;
@@ -1147,9 +1146,11 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitFusedCoordinator(
     total_chunks += chunks[i];
     total_bytes += entry_size;
   }
-  const uint32_t body_copy_bytes = total_chunks * per_pkt_dws * sizeof(uint32_t);
+  const uint32_t body_copy_dws =
+      total_chunks * kPacketCoreDws + wait_dws + signal_dws;
+  const uint32_t body_copy_bytes = body_copy_dws * sizeof(uint32_t);
 
-  const uint32_t body_extra_polls = (body_deps.size() > 1)
+  const uint32_t body_extra_polls = (num_entries != 0 && body_deps.size() > 1)
       ? static_cast<uint32_t>(body_deps.size() - 1) : 0;
   const uint32_t body_extra_poll_bytes = body_extra_polls * poll_64b_command_size_;
 
@@ -1190,18 +1191,14 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitFusedCoordinator(
   }
   uint32_t wrapped_index = WrapIntoRing(curr_index);
 
-  // Arm out_signal for multi-chunk body entries (same as SubmitBodies).
-  if (total_chunks > num_entries)
-    out_signal.AddRelaxed(total_chunks - num_entries);
-
   // With no epilogue fence to perform the final completion decrement, the body
-  // SIGNAL subs must reach the done value themselves: drop the target by one.
+  // SIGNAL must reach the done value itself: drop the target by one.
   if (skip_epilogue)
     out_signal.SubRelaxed(1);
 
   // === PROLOGUE SECTION ===
   if (need_prologue) {
-    const bool emit_deps = !fused_bodies || profiling_enabled;
+    const bool emit_deps = profiling_enabled;
 
     if (emit_deps) {
       for (size_t i = 0; i < dep_signals.size(); ++i) {
@@ -1244,43 +1241,56 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitFusedCoordinator(
     wrapped_index += fence_64b_command_size_;
   }
 
-  // === BODY SECTION (fused WaitSignal path) ===
-  for (uint32_t i = 1; i < body_deps.size(); ++i) {
-    BuildPoll64bCommand(command_addr, body_deps[i]->ValueLocation(), 0);
-    command_addr += poll_64b_command_size_;
-    bytes_written_[wrapped_index] = prior_bytes;
-    wrapped_index += poll_64b_command_size_;
+  // === BODY SECTION ===
+  if (num_entries != 0) {
+    for (uint32_t i = 1; i < body_deps.size(); ++i) {
+      BuildPoll64bCommand(command_addr, body_deps[i]->ValueLocation(), 0);
+      command_addr += poll_64b_command_size_;
+      bytes_written_[wrapped_index] = prior_bytes;
+      wrapped_index += poll_64b_command_size_;
+    }
   }
-
-  const core::Signal* wait_sig = body_deps.empty() ? nullptr : body_deps[0];
   const uint32_t copy_start = wrapped_index;
 
+  const core::Signal* wait_sig = body_deps.empty() ? nullptr : body_deps[0];
   for (size_t i = 0; i < num_entries; ++i) {
+    const bool is_first_entry = i == 0;
+    const bool is_last_entry = i + 1 == num_entries;
+    const core::Signal* wait_signal =
+        is_first_entry ? wait_sig : nullptr;
+    core::Signal* signal_signal = is_last_entry ? &out_signal : nullptr;
+
     if (is_indirect) {
       BuildWaitSignalIndirectCopyCommand(command_addr,
           dsts[i], srcs[i], sizes_a[i],
           indirect_src, indirect_dst,
-          wait_sig, &out_signal);
+          wait_signal, signal_signal);
     } else if (is_swap) {
       BuildWaitSignalSwapCommand(command_addr, chunks[i],
           dsts[i], const_cast<void*>(srcs[i]),
           sizes_a[i], sizes_b[i],
-          wait_sig, &out_signal);
+          wait_signal, signal_signal);
     } else {
       BuildWaitSignalCopyCommand(command_addr, chunks[i],
           dsts[i], srcs[i], sizes_a[i],
-          wait_sig, &out_signal);
+          wait_signal, signal_signal, true);
     }
-    const uint32_t entry_bytes = chunks[i] * per_pkt_dws * sizeof(uint32_t);
+    const uint32_t entry_dws =
+        chunks[i] * kPacketCoreDws +
+        (is_first_entry ? wait_dws : 0) +
+        (is_last_entry ? signal_dws : 0);
+    const uint32_t entry_bytes = entry_dws * sizeof(uint32_t);
     command_addr += entry_bytes;
     wrapped_index += entry_bytes;
   }
-  bytes_written_.fill(copy_start, copy_start + body_copy_bytes, prior_bytes);
-  bytes_written_[copy_start + body_copy_bytes - sizeof(uint32_t)] = post_bytes;
+  if (body_copy_bytes) {
+    bytes_written_.fill(copy_start, copy_start + body_copy_bytes, prior_bytes);
+    bytes_written_[copy_start + body_copy_bytes - sizeof(uint32_t)] = post_bytes;
+  }
 
   // === EPILOGUE SECTION ===
-  // Skipped entirely on the fast path: the body SIGNAL subs are the completion
-  // edge (see skip_epilogue above).
+  // Skipped entirely on the fast path: the final packet's SIGNAL is the
+  // completion edge (see skip_epilogue above).
   if (!skip_epilogue) {
     BuildPoll64bCommand(command_addr, out_signal.ValueLocation(), 1);
     command_addr += poll_64b_command_size_;
@@ -1364,9 +1374,10 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitBodies(
       : (max_single_linear_copy_size_ ? max_single_linear_copy_size_ : kMaxSingleCopySize);
 
   if (is_gfx125plus_) {
-    // --- Fused WaitSignal path: every chunk carries wait+copy+signal in one packet ---
+    // --- WaitSignal path: WAIT on first packet, SIGNAL on final packet ---
     const uint32_t wait_dws = dep_signals.empty() ? 0 : 7;
-    const uint32_t per_pkt_dws = 1 + wait_dws + 6 + 5;
+    constexpr uint32_t kPacketCoreDws = 1 + 6;
+    constexpr uint32_t kSignalDws = 5;
 
     std::vector<uint32_t> chunks(num_entries);
     uint32_t total_chunks = 0;
@@ -1380,7 +1391,8 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitBodies(
       total_chunks += chunks[i];
       total_bytes += entry_size;
     }
-    const uint32_t total_copy_dws = total_chunks * per_pkt_dws;
+    const uint32_t total_copy_dws =
+        total_chunks * kPacketCoreDws + wait_dws + kSignalDws;
     const uint32_t copy_bytes = total_copy_dws * sizeof(uint32_t);
 
     const uint32_t extra_polls = (dep_signals.size() > 1)
@@ -1406,9 +1418,6 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitBodies(
     }
     uint32_t wrapped_index = WrapIntoRing(curr_index);
 
-    if (total_chunks > num_entries)
-      out_signal.AddRelaxed(total_chunks - num_entries);
-
     for (uint32_t i = 1; i < dep_signals.size(); ++i) {
       BuildPoll64bCommand(command_addr, dep_signals[i]->ValueLocation(), 0);
       command_addr += poll_64b_command_size_;
@@ -1421,22 +1430,32 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitBodies(
 
     for (size_t i = 0; i < num_entries; ++i) {
       const uint32_t d = indices[i];
+      const bool is_first_entry = i == 0;
+      const bool is_last_entry = i + 1 == num_entries;
+      const core::Signal* wait_signal =
+          is_first_entry ? wait_sig : nullptr;
+      core::Signal* signal_signal = is_last_entry ? &out_signal : nullptr;
+
       if (is_indirect) {
         BuildWaitSignalIndirectCopyCommand(command_addr,
             dst_list[d], src_list[d], size_list[d],
             indirect_src, indirect_dst,
-            wait_sig, &out_signal);
+            wait_signal, signal_signal);
       } else if (is_swap) {
         BuildWaitSignalSwapCommand(command_addr, chunks[i],
             dst_list[d], const_cast<void*>(src_list[d]),
             size_list[d], size_list[d],
-            wait_sig, &out_signal);
+            wait_signal, signal_signal);
       } else {
         BuildWaitSignalCopyCommand(command_addr, chunks[i],
             dst_list[d], src_list[d], size_list[d],
-            wait_sig, &out_signal);
+            wait_signal, signal_signal, true);
       }
-      const uint32_t entry_bytes = chunks[i] * per_pkt_dws * sizeof(uint32_t);
+      const uint32_t entry_dws =
+          chunks[i] * kPacketCoreDws +
+          (is_first_entry ? wait_dws : 0) +
+          (is_last_entry ? kSignalDws : 0);
+      const uint32_t entry_bytes = entry_dws * sizeof(uint32_t);
       command_addr += entry_bytes;
       wrapped_index += entry_bytes;
     }
@@ -2695,7 +2714,8 @@ void BlitSdma<useGCR, scopeFields>::BuildWaitSignalCopyCommand(
     char* cmd_addr, uint32_t num_copy_command,
     void* dst, const void* src, size_t size,
     const core::Signal* wait_signal,
-    core::Signal* signal_signal) {
+    core::Signal* signal_signal,
+    bool boundary_wait_signal) {
 
   size_t cur_size = 0;
   const size_t max_copy_size = max_single_linear_copy_size_ ? max_single_linear_copy_size_
@@ -2705,13 +2725,10 @@ void BlitSdma<useGCR, scopeFields>::BuildWaitSignalCopyCommand(
     const uint32_t copy_size =
         static_cast<uint32_t>(std::min(size - cur_size, max_copy_size));
 
-    // Option (b) chunk synchronization: every chunk waits on the same input
-    // signal and decrements the same output signal.  This is correct even when
-    // the HW overlaps chunk copies, since out_signal only reaches 0 once all
-    // chunks have signalled (the caller pre-loads it by N-1).  A scheme that
-    // signals only on the last chunk could complete early under overlap.
-    const bool do_wait = (wait_signal != nullptr);
-    const bool do_signal = (signal_signal != nullptr);
+    const bool do_wait =
+        wait_signal != nullptr && (!boundary_wait_signal || i == 0);
+    const bool do_signal = signal_signal != nullptr &&
+        (!boundary_wait_signal || i + 1 == num_copy_command);
 
     // The WaitSignal packet is variable length: per the MAS, the 7 WAIT DWs
     // (DW1-7) and 5 SIGNAL DWs (DW14-18) are present in the buffer only when
@@ -2854,11 +2871,9 @@ void BlitSdma<useGCR, scopeFields>::BuildWaitSignalSwapCommand(
   const size_t max_copy_size = SDMA_PKT_COPY_LINEAR_SWAP_WAITSIGNAL_GFX1250::kMaxSize_;
 
   for (uint32_t i = 0; i < num_copy_command; ++i) {
-    // Option (b) chunk synchronization: every chunk waits on the same input
-    // signal and decrements the same output signal, so completion is correct
-    // even if the HW overlaps chunk copies (caller pre-loads out_signal by N-1).
-    const bool do_wait = (wait_signal != nullptr);
-    const bool do_signal = (signal_signal != nullptr);
+    const bool do_wait = wait_signal != nullptr && i == 0;
+    const bool do_signal =
+        signal_signal != nullptr && i + 1 == num_copy_command;
 
     const uint32_t chunk_a = static_cast<uint32_t>(std::min(size_a - cur_a, max_copy_size));
     const uint32_t chunk_b = static_cast<uint32_t>(std::min(size_b - cur_b, max_copy_size));

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -1346,7 +1346,7 @@ hsa_status_t GpuAgent::DmaCopyOnEngine(void* dst, core::Agent& dst_agent,
     out_signal.async_copy_agent(core::Agent::Convert(this->public_handle()));
   }
 
-  // gfx125+ fast path: single fused WaitSignal packet (one doorbell).
+  // gfx125+ fast path: WaitSignal packets in one doorbell submission.
   // Each chunk carries wait+copy+signal inline; no prologue signal needed.
   if (blit->isSDMA()) {
     BlitSdmaBase* sdma_blit = static_cast<BlitSdmaBase*>((*blit).get());
@@ -1516,25 +1516,32 @@ hsa_status_t GpuAgent::DmaCopyFanOutOp(
 
   std::fill(engines.begin(), engines.end(), EngineSlot{coordinator, coord_idx});
 
+  constexpr size_t kLargeCopyMinSize = 1ull << 30;
+  constexpr uint32_t kMaxCopiesPerEngine = 8;
+  const bool use_large_copy_grouping =
+      std::all_of(size_list, size_list + num_entries,
+                  [](size_t size) { return size >= kLargeCopyMinSize; });
+
   // Fan out body entries across multiple engines unless capped to 1.
   if (!max_engines || max_engines > 1) {
-    if ((coordinator->IsGfx125Plus()) && total_sdma > 0) {
+    if (coordinator->IsGfx125Plus() && total_sdma > 0 && dst_agent_list &&
+        use_large_copy_grouping) {
+      // gfx125+ copies at or above 1 GiB: pack up to eight copies per engine,
+      // then move to the next engine. Smaller copies use the per-entry
+      // multi-engine fan-out path below.
       uint32_t eng_mask = 0;
       DmaPreferredEngine(*this, *this, &eng_mask);
-      uint32_t assigned = 0;
+
+      uint32_t num_engines = rocr::os::Popcount(eng_mask);
+      if (max_engines) num_engines = std::min(num_engines, max_engines);
       for (uint32_t d = 0; d < num_entries; ++d) {
-        // Rotate across engines within THIS copy (local index d), so entry 0
-        // lands on the coordinator and successive entries spread across the
-        // mask -- deterministic per call, no marching across API calls.
-        uint32_t eng_idx = NthSdmaEngine(eng_mask, d);
-        if (eng_idx) {
-          lazy_ptr<core::Blit>& blit = GetBlitObject(eng_idx);
-          if (blit->isSDMA()) {
-            engines[d] = {static_cast<BlitSdmaBase*>((*blit).get()), eng_idx};
-            ++assigned;
-          }
+        const uint32_t engine_slot =
+            (d / kMaxCopiesPerEngine) % num_engines;
+        const uint32_t eng_idx = NthSdmaEngine(eng_mask, engine_slot);
+        lazy_ptr<core::Blit>& blit = GetBlitObject(eng_idx);
+        if (blit->isSDMA()) {
+          engines[d] = {static_cast<BlitSdmaBase*>((*blit).get()), eng_idx};
         }
-        if (max_engines && assigned >= max_engines) break;
       }
     } else if (dst_agent_list) {
       std::set<uint32_t> usedEngines;
@@ -1643,9 +1650,9 @@ hsa_status_t GpuAgent::DmaCopyFanOutOp(
   }
 
   // Body deps:
-  // - fused + profiling: prologue waited on user deps, bodies just wait on prologue_signal.
-  // - fused + !profiling: no prologue, bodies wait on user dep_signals directly.
-  // - classic (!fused): bodies poll prologue_signal + user deps (classic only reads [0]).
+  // - gfx125+ with profiling: first body packet waits on prologue_signal.
+  // - gfx125+ without profiling: first body packet waits on user dep_signals directly.
+  // - classic: bodies poll prologue_signal + user deps (classic only reads [0]).
   std::vector<core::Signal*> body_deps;
   if (need_prologue) {
     if (fused) {
@@ -1674,10 +1681,10 @@ hsa_status_t GpuAgent::DmaCopyFanOutOp(
   hsa_status_t stat;
 
   if (fused) {
-    // === gfx125+ fused path: SubmitFusedCoordinator (1 doorbell for coord) ===
+    // === gfx125+ WaitSignal path (1 doorbell for coordinator) ===
 
-    // Arm: each entry decrements out_signal independently.
-    out_signal.AddRelaxed(num_entries);
+    // One final packet per engine group decrements out_signal.
+    out_signal.AddRelaxed(static_cast<uint32_t>(engine_groups.size()));
 
     // Gather coordinator group entries.
     std::vector<void*> coord_dsts;
@@ -1716,9 +1723,9 @@ hsa_status_t GpuAgent::DmaCopyFanOutOp(
       if (stat != HSA_STATUS_SUCCESS) return stat;
     }
 
-    // Fused coordinator: prologue + coord bodies + epilogue in one doorbell.
+    // Coordinator: prologue + coord bodies + epilogue in one doorbell.
     LogPrint(HSA_AMD_LOG_FLAG_SDMA,
-             "SDMA FanOut(%s) FusedCoord: engine %02u, coord_entries=%zu, "
+             "SDMA FanOut(%s) Coordinator: engine %02u, coord_entries=%zu, "
              "other_groups=%zu, completion_signal=0x%zx, prologue_signal=%p",
              op_name, coord_idx, coord_dsts.size(),
              engine_groups.size() - (engine_groups.count(coord_idx) ? 1 : 0),
@@ -1726,7 +1733,7 @@ hsa_status_t GpuAgent::DmaCopyFanOutOp(
              prologue_signal ? prologue_signal.get() : nullptr);
     stat = coordinator->SubmitFusedCoordinator(
         dep_signals, out_signal,
-        prologue_signal.get(), fused,
+        prologue_signal.get(),
         op, coord_dsts, coord_srcs, coord_sizes_a, coord_sizes_b,
         ind_src, ind_dst, body_deps);
     if (stat != HSA_STATUS_SUCCESS) return stat;
@@ -1848,11 +1855,9 @@ hsa_status_t GpuAgent::DmaCopyBroadcast(
 
   // Size thresholds for multi-destination copy path selection.
   // kMulticastMaxSize: gfx125+ multicast/fan-out crossover (256 KB).
-  //   At/below this the single-engine multicast packet wins; above it fan-out
-  //   across multiple SDMA engines delivers higher aggregate bandwidth. A
-  //   single-engine multicast serialises the writes to all destinations, so it
-  //   becomes bandwidth-bound well before 8 MB -- keep the crossover low so
-  //   larger multi-destination copies parallelise across engines.
+  //   At/below this the single-engine multicast packet wins. Above it,
+  //   DmaCopyFanOutOp uses per-entry multi-engine fan-out below 1 GiB and
+  //   packs up to eight copies per engine at or above 1 GiB.
   // kB2BMinSize/kB2BMaxSize: per-copy size window for linearB2B on non-gfx125+.
   //   Below kB2BMinSize the broadcast packet (2-dst) is used instead; above
   //   kB2BMaxSize fan-out parallelises across engines. Kept consistent with
@@ -1885,7 +1890,7 @@ hsa_status_t GpuAgent::DmaCopyBroadcast(
         const bool use_multicast = (mc_flag == Flag::SDMA_ENABLE) ||
             (mc_flag == Flag::SDMA_DEFAULT && op.size <= kMulticastMaxSize);
         if (use_multicast) {
-          // SubmitLinearCopyMulticastCommand picks the fused wait/signal packet
+          // SubmitLinearCopyMulticastCommand picks the WaitSignal packet
           // when profiling is off and the timestamp-capable plain packet when on.
           std::vector<void*> dsts(op.dst_list, op.dst_list + num_entries);
           LogPrint(HSA_AMD_LOG_FLAG_SDMA,


### PR DESCRIPTION
Use boundary WaitSignal packets on gfx125+ fan-out so only the first packet waits and only the final packet signals, reducing packet overhead while keeping completion on one decrement per engine group.

Add size-aware engine assignment for multi-destination copies: multicast at or below 256 KiB, per-entry multi-engine fan-out below 1 GiB, and pack up to eight copies per engine at or above 1 GiB.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

JIRA ID: AIRUNTIME-1

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
