### PR TITLE
ci(hipfile): Ignore spelling in third-party code

### DIFF
--- a/.github/workflows/hipfile-codespell.yml
+++ b/.github/workflows/hipfile-codespell.yml
@@ -36,3 +36,4 @@ jobs:
         with:
           ignore_words_file: |
             projects/hipfile/.codespellignore
+          skip: "./projects/hipfile/third-party,./projects/hipfile/third-party/*"

--- a/projects/hipfile/.codespellignore
+++ b/projects/hipfile/.codespellignore
@@ -1,2 +1,1 @@
 hsa
-childRes


### PR DESCRIPTION
## Motivation

We don't need to fix spelling issues in third-party code. We currently suppress third-party spelling issues, but it would be better to just ignore the `third-party` directory completely.

## Technical Details

Exclude projects/hipfile/third-party from the codespell action

## Issue Tracking

JIRA ID: AIHIPFILE-65

## Test Plan

1. Remove the ignore entries for the third-party files (should cause CI to fail)
2. Update the GitHub action, which should pass now

## Test Result

Passes

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
