### PR TITLE
fix(rccl): restore HSA DMA-BUF export fallback when cuMem gate is on

### DIFF
--- a/projects/rccl/src/include/rocmwrap.h
+++ b/projects/rccl/src/include/rocmwrap.h
@@ -52,15 +52,15 @@
 #define NCCL_CE_BATCH_ASYNC_VERSION_SUPPORTED(v) \
   (NCCL_VER_GE(v, ROCM_VER_7_12_0) || NCCL_VER_IN(v, ROCM_VER_7_0_2_2, ROCM_VER_7_0_3_0))
 
-// === Capability gates: prefer the CMake symbol probe, fall back to version ==
-// Method 1 (preferred): CMake sets RCCL_CUMEM_DMABUF_EXPORT_SUPPORTED when
-//   check_symbol_exists(hipMemGetHandleForAddressRange ...) succeeds.
-// Method 2 (fallback): the version predicate above, for builds where the probe
-//   did not run / was not wired in.
+// === Capability gate: both the symbol probe and the version must agree =====
+// CMake sets RCCL_CUMEM_DMABUF_EXPORT_SUPPORTED when
+// check_symbol_exists(hipMemGetHandleForAddressRange ...) succeeds. The symbol
+// is declared in headers on backport builds outside the supported window too,
+// so it cannot gate the feature on its own: the version predicate has to agree.
 #if defined(RCCL_CUMEM_DMABUF_EXPORT_SUPPORTED)
-#define NCCL_CUMEM_DMABUF_EXPORT_GATE 1
-#else
 #define NCCL_CUMEM_DMABUF_EXPORT_GATE NCCL_CUMEM_VERSION_SUPPORTED(HIP_VERSION)
+#else
+#define NCCL_CUMEM_DMABUF_EXPORT_GATE 0
 #endif
 
 // HIP: implemented in rma_proxy_launch.cc (hipStreamBatchMemOp + old-HIP fallback).

--- a/projects/rccl/src/include/rocmwrap.h
+++ b/projects/rccl/src/include/rocmwrap.h
@@ -58,10 +58,17 @@
 // is declared in headers on backport builds outside the supported window too,
 // so it cannot gate the feature on its own: the version predicate has to agree.
 #if defined(RCCL_CUMEM_DMABUF_EXPORT_SUPPORTED)
-#define NCCL_CUMEM_DMABUF_EXPORT_GATE NCCL_CUMEM_VERSION_SUPPORTED(HIP_VERSION)
+#define NCCL_CUMEM_DMABUF_EXPORT_PROBE 1
 #else
-#define NCCL_CUMEM_DMABUF_EXPORT_GATE 0
+#define NCCL_CUMEM_DMABUF_EXPORT_PROBE 0
 #endif
+
+// Both gate inputs are parameters so every (probe, version) combination can be
+// asserted in unit tests; the gate itself is this build's instantiation.
+#define NCCL_CUMEM_DMABUF_EXPORT_GATE_FOR(probe, v) ((probe) && NCCL_CUMEM_VERSION_SUPPORTED(v))
+
+#define NCCL_CUMEM_DMABUF_EXPORT_GATE \
+  NCCL_CUMEM_DMABUF_EXPORT_GATE_FOR(NCCL_CUMEM_DMABUF_EXPORT_PROBE, HIP_VERSION)
 
 // HIP: implemented in rma_proxy_launch.cc (hipStreamBatchMemOp + old-HIP fallback).
 // CUDA: implemented in cudawrap.cc (cuStreamBatchMemOp).

--- a/projects/rccl/src/include/rocmwrap.h
+++ b/projects/rccl/src/include/rocmwrap.h
@@ -10,6 +10,7 @@
 
 #include <hsa/hsa.h>
 #include <hsa/hsa_ext_amd.h>  // hsa_amd_portable_export_dmabuf (DMA-BUF export)
+#include <unistd.h>
 #include "checks.h"
 
 #ifndef CU_STREAM_WRITE_VALUE_DEFAULT
@@ -169,6 +170,32 @@ typedef hsa_status_t (*PFN_hsa_amd_portable_export_dmabuf)(const void* ptr, size
 #define DECLARE_ROCM_PFN_EXTERN(symbol) extern PFN_##symbol pfn_##symbol
 
 DECLARE_ROCM_PFN_EXTERN(hsa_amd_portable_export_dmabuf); // DMA-BUF feature gate
+
+// Export `buffer` through the HSA portable DMA-BUF exporter and register the resulting fd
+// with a net plugin's regMrDmaBuf (identical signature for ncclNet_t and ncclCollNet_t).
+// The fd is closed on every path, so it can neither leak nor be clobbered by a later
+// export into a caller-owned variable. Returns false when either step fails, so the caller
+// can fall back to a plain regMr; callers must still gate on
+// pfn_hsa_amd_portable_export_dmabuf being non-NULL.
+static inline bool ncclHsaRegMrDmaBuf(ncclResult_t (*regMrDmaBuf)(void*, void*, size_t, int, uint64_t, int, void**),
+                                      void* comm, void* buffer, size_t size, int type, void** mhandle) {
+  int fd = -1;
+  uint64_t offset = 0;
+  hsa_status_t status = pfn_hsa_amd_portable_export_dmabuf(buffer, size, &fd, &offset);
+  if (status != HSA_STATUS_SUCCESS) {
+    const char* errStr;
+    hsa_status_string(status, &errStr);
+    WARN("hsa_amd_portable_export_dmabuf failed for %p (size %zu): '%s'", buffer, size, errStr);
+    return false;
+  }
+  ncclResult_t res = regMrDmaBuf(comm, buffer, size, type, offset, fd, mhandle);
+  (void)close(fd);
+  if (res != ncclSuccess) {
+    INFO(NCCL_NET, "DMA-BUF registration of %p (size %zu) failed with %d", buffer, size, res);
+    return false;
+  }
+  return true;
+}
 
 extern int ncclCuMemEnable();
 extern int ncclCuMemHostEnable();

--- a/projects/rccl/src/transport/coll_net.cc
+++ b/projects/rccl/src/transport/coll_net.cc
@@ -561,20 +561,21 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
     needReg = false;
   }
 peermem_send:
-#else
-  if (resources->useGdr && resources->useDmaBuf && pfn_hsa_amd_portable_export_dmabuf &&
+#endif
+#if defined(__HIP_PLATFORM_AMD__)
+  if (needReg && resources->useGdr && resources->useDmaBuf && pfn_hsa_amd_portable_export_dmabuf &&
       proxyState->ncclCollNet->regMrDmaBuf) {
     uint64_t offset;
     HSACHECKGOTO(hsa_amd_portable_export_dmabuf((const void*)mapMem->cpuPtr, mapMem->size, &dmabuf_fd, &offset), ret,
-                 peermem_send);
+                 peermem_send_hsa);
     NCCLCHECKGOTO(proxyState->ncclCollNet->regMrDmaBuf(resources->collNetComm, mapMem->cpuPtr, mapMem->size,
                                                        NCCL_PTR_CUDA, offset, dmabuf_fd,
                                                        &resources->sendMhandles[NCCL_PROTO_SIMPLE]),
-                  ret, peermem_send);
+                  ret, peermem_send_hsa);
     (void)close(dmabuf_fd);
     needReg = false;
   }
-peermem_send:
+peermem_send_hsa:
 #endif
   if (needReg) {
     NCCLCHECKGOTO(proxyState->ncclCollNet->regMr(resources->collNetComm, mapMem->cpuPtr, mapMem->size,
@@ -673,20 +674,21 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
     needReg = false;
   }
 peermem_recv:
-#else
-  if (resources->useGdr && resources->useDmaBuf && pfn_hsa_amd_portable_export_dmabuf &&
+#endif
+#if defined(__HIP_PLATFORM_AMD__)
+  if (needReg && resources->useGdr && resources->useDmaBuf && pfn_hsa_amd_portable_export_dmabuf &&
       proxyState->ncclCollNet->regMrDmaBuf) {
     uint64_t offset;
     HSACHECKGOTO(hsa_amd_portable_export_dmabuf((const void*)mapMem->cpuPtr, mapMem->size, &dmabuf_fd, &offset), ret,
-                 peermem_recv);
+                 peermem_recv_hsa);
     NCCLCHECKGOTO(proxyState->ncclCollNet->regMrDmaBuf(resources->collNetComm, mapMem->cpuPtr, mapMem->size,
                                                        NCCL_PTR_CUDA, offset, dmabuf_fd,
                                                        &resources->mhandles[NCCL_PROTO_SIMPLE]),
-                  ret, peermem_recv);
+                  ret, peermem_recv_hsa);
     (void)close(dmabuf_fd);
     needReg = false;
   }
-peermem_recv:
+peermem_recv_hsa:
 #endif
   if (needReg) {
     NCCLCHECKGOTO(proxyState->ncclCollNet->regMr(resources->collNetComm, mapMem->cpuPtr, mapMem->size,
@@ -1492,20 +1494,21 @@ static ncclResult_t sendProxyRegBuffer(struct ncclProxyConnection* connection, s
     needReg = false;
   }
 peermem:
-#else
-  if (resources->useGdr && resources->useDmaBuf && pfn_hsa_amd_portable_export_dmabuf &&
+#endif
+#if defined(__HIP_PLATFORM_AMD__)
+  if (needReg && resources->useGdr && resources->useDmaBuf && pfn_hsa_amd_portable_export_dmabuf &&
       proxyState->ncclCollNet->regMrDmaBuf) {
     uint64_t offset;
     HSACHECKGOTO(hsa_amd_portable_export_dmabuf((const void*)info->buffer, info->size, &dmabuf_fd, &offset), ret,
-                 peermem);
+                 peermem_hsa);
     NCCLCHECKGOTO(proxyState->ncclCollNet->regMrDmaBuf(resources->collNetComm, (void*)info->buffer, info->size,
                                                        NCCL_PTR_CUDA, offset, dmabuf_fd, &handle),
-                  ret, peermem);
+                  ret, peermem_hsa);
     (void)close(dmabuf_fd);
     dmabuf_fd = -1;
     needReg = false;
   }
-peermem:
+peermem_hsa:
 #endif
   if (needReg) {
     NCCLCHECKGOTO(proxyState->ncclCollNet->regMr(resources->collNetComm, (void*)info->buffer, info->size, NCCL_PTR_CUDA,
@@ -1554,20 +1557,21 @@ static ncclResult_t recvProxyRegBuffer(struct ncclProxyConnection* connection, s
     needReg = false;
   }
 peermem:
-#else
-  if (resources->useGdr && resources->useDmaBuf && pfn_hsa_amd_portable_export_dmabuf &&
+#endif
+#if defined(__HIP_PLATFORM_AMD__)
+  if (needReg && resources->useGdr && resources->useDmaBuf && pfn_hsa_amd_portable_export_dmabuf &&
       proxyState->ncclCollNet->regMrDmaBuf) {
     uint64_t offset;
     HSACHECKGOTO(hsa_amd_portable_export_dmabuf((const void*)info->buffer, info->size, &dmabuf_fd, &offset), ret,
-                 peermem);
+                 peermem_hsa);
     NCCLCHECKGOTO(proxyState->ncclCollNet->regMrDmaBuf(resources->collNetComm, (void*)info->buffer, info->size,
                                                        NCCL_PTR_CUDA, offset, dmabuf_fd, &handle),
-                  ret, peermem);
+                  ret, peermem_hsa);
     (void)close(dmabuf_fd);
     dmabuf_fd = -1;
     needReg = false;
   }
-peermem:
+peermem_hsa:
 #endif
   if (needReg) {
     NCCLCHECKGOTO(proxyState->ncclCollNet->regMr(resources->collNetComm, (void*)info->buffer, info->size, NCCL_PTR_CUDA,

--- a/projects/rccl/src/transport/coll_net.cc
+++ b/projects/rccl/src/transport/coll_net.cc
@@ -558,24 +558,28 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
                                                        &resources->sendMhandles[NCCL_PROTO_SIMPLE]),
                   ret, peermem_send);
     (void)close(dmabuf_fd);
+    dmabuf_fd = -1;
     needReg = false;
   }
 peermem_send:
+  // A failed cuMem attempt is recoverable here: the fallbacks below register the same
+  // buffer, so drop its error and the fd it may have left open before they run.
+  if (needReg) {
+    ret = ncclSuccess;
+    if (dmabuf_fd != -1) {
+      (void)close(dmabuf_fd);
+      dmabuf_fd = -1;
+    }
+  }
 #endif
 #if defined(__HIP_PLATFORM_AMD__)
   if (needReg && resources->useGdr && resources->useDmaBuf && pfn_hsa_amd_portable_export_dmabuf &&
       proxyState->ncclCollNet->regMrDmaBuf) {
-    uint64_t offset;
-    HSACHECKGOTO(hsa_amd_portable_export_dmabuf((const void*)mapMem->cpuPtr, mapMem->size, &dmabuf_fd, &offset), ret,
-                 peermem_send_hsa);
-    NCCLCHECKGOTO(proxyState->ncclCollNet->regMrDmaBuf(resources->collNetComm, mapMem->cpuPtr, mapMem->size,
-                                                       NCCL_PTR_CUDA, offset, dmabuf_fd,
-                                                       &resources->sendMhandles[NCCL_PROTO_SIMPLE]),
-                  ret, peermem_send_hsa);
-    (void)close(dmabuf_fd);
-    needReg = false;
+    if (ncclHsaRegMrDmaBuf(proxyState->ncclCollNet->regMrDmaBuf, resources->collNetComm, mapMem->cpuPtr, mapMem->size,
+                           NCCL_PTR_CUDA, &resources->sendMhandles[NCCL_PROTO_SIMPLE])) {
+      needReg = false;
+    }
   }
-peermem_send_hsa:
 #endif
   if (needReg) {
     NCCLCHECKGOTO(proxyState->ncclCollNet->regMr(resources->collNetComm, mapMem->cpuPtr, mapMem->size,
@@ -671,24 +675,28 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
                                                        &resources->mhandles[NCCL_PROTO_SIMPLE]),
                   ret, peermem_recv);
     (void)close(dmabuf_fd);
+    dmabuf_fd = -1;
     needReg = false;
   }
 peermem_recv:
+  // A failed cuMem attempt is recoverable here: the fallbacks below register the same
+  // buffer, so drop its error and the fd it may have left open before they run.
+  if (needReg) {
+    ret = ncclSuccess;
+    if (dmabuf_fd != -1) {
+      (void)close(dmabuf_fd);
+      dmabuf_fd = -1;
+    }
+  }
 #endif
 #if defined(__HIP_PLATFORM_AMD__)
   if (needReg && resources->useGdr && resources->useDmaBuf && pfn_hsa_amd_portable_export_dmabuf &&
       proxyState->ncclCollNet->regMrDmaBuf) {
-    uint64_t offset;
-    HSACHECKGOTO(hsa_amd_portable_export_dmabuf((const void*)mapMem->cpuPtr, mapMem->size, &dmabuf_fd, &offset), ret,
-                 peermem_recv_hsa);
-    NCCLCHECKGOTO(proxyState->ncclCollNet->regMrDmaBuf(resources->collNetComm, mapMem->cpuPtr, mapMem->size,
-                                                       NCCL_PTR_CUDA, offset, dmabuf_fd,
-                                                       &resources->mhandles[NCCL_PROTO_SIMPLE]),
-                  ret, peermem_recv_hsa);
-    (void)close(dmabuf_fd);
-    needReg = false;
+    if (ncclHsaRegMrDmaBuf(proxyState->ncclCollNet->regMrDmaBuf, resources->collNetComm, mapMem->cpuPtr, mapMem->size,
+                           NCCL_PTR_CUDA, &resources->mhandles[NCCL_PROTO_SIMPLE])) {
+      needReg = false;
+    }
   }
-peermem_recv_hsa:
 #endif
   if (needReg) {
     NCCLCHECKGOTO(proxyState->ncclCollNet->regMr(resources->collNetComm, mapMem->cpuPtr, mapMem->size,
@@ -1494,21 +1502,21 @@ static ncclResult_t sendProxyRegBuffer(struct ncclProxyConnection* connection, s
     needReg = false;
   }
 peermem:
+  // A failed cuMem attempt is recoverable here: the fallbacks below register the same
+  // buffer, so close the fd it may have left open before they run.
+  if (dmabuf_fd != -1) {
+    (void)close(dmabuf_fd);
+    dmabuf_fd = -1;
+  }
 #endif
 #if defined(__HIP_PLATFORM_AMD__)
   if (needReg && resources->useGdr && resources->useDmaBuf && pfn_hsa_amd_portable_export_dmabuf &&
       proxyState->ncclCollNet->regMrDmaBuf) {
-    uint64_t offset;
-    HSACHECKGOTO(hsa_amd_portable_export_dmabuf((const void*)info->buffer, info->size, &dmabuf_fd, &offset), ret,
-                 peermem_hsa);
-    NCCLCHECKGOTO(proxyState->ncclCollNet->regMrDmaBuf(resources->collNetComm, (void*)info->buffer, info->size,
-                                                       NCCL_PTR_CUDA, offset, dmabuf_fd, &handle),
-                  ret, peermem_hsa);
-    (void)close(dmabuf_fd);
-    dmabuf_fd = -1;
-    needReg = false;
+    if (ncclHsaRegMrDmaBuf(proxyState->ncclCollNet->regMrDmaBuf, resources->collNetComm, (void*)info->buffer,
+                           info->size, NCCL_PTR_CUDA, &handle)) {
+      needReg = false;
+    }
   }
-peermem_hsa:
 #endif
   if (needReg) {
     NCCLCHECKGOTO(proxyState->ncclCollNet->regMr(resources->collNetComm, (void*)info->buffer, info->size, NCCL_PTR_CUDA,
@@ -1557,21 +1565,21 @@ static ncclResult_t recvProxyRegBuffer(struct ncclProxyConnection* connection, s
     needReg = false;
   }
 peermem:
+  // A failed cuMem attempt is recoverable here: the fallbacks below register the same
+  // buffer, so close the fd it may have left open before they run.
+  if (dmabuf_fd != -1) {
+    (void)close(dmabuf_fd);
+    dmabuf_fd = -1;
+  }
 #endif
 #if defined(__HIP_PLATFORM_AMD__)
   if (needReg && resources->useGdr && resources->useDmaBuf && pfn_hsa_amd_portable_export_dmabuf &&
       proxyState->ncclCollNet->regMrDmaBuf) {
-    uint64_t offset;
-    HSACHECKGOTO(hsa_amd_portable_export_dmabuf((const void*)info->buffer, info->size, &dmabuf_fd, &offset), ret,
-                 peermem_hsa);
-    NCCLCHECKGOTO(proxyState->ncclCollNet->regMrDmaBuf(resources->collNetComm, (void*)info->buffer, info->size,
-                                                       NCCL_PTR_CUDA, offset, dmabuf_fd, &handle),
-                  ret, peermem_hsa);
-    (void)close(dmabuf_fd);
-    dmabuf_fd = -1;
-    needReg = false;
+    if (ncclHsaRegMrDmaBuf(proxyState->ncclCollNet->regMrDmaBuf, resources->collNetComm, (void*)info->buffer,
+                           info->size, NCCL_PTR_CUDA, &handle)) {
+      needReg = false;
+    }
   }
-peermem_hsa:
 #endif
   if (needReg) {
     NCCLCHECKGOTO(proxyState->ncclCollNet->regMr(resources->collNetComm, (void*)info->buffer, info->size, NCCL_PTR_CUDA,

--- a/projects/rccl/src/transport/net.cc
+++ b/projects/rccl/src/transport/net.cc
@@ -1291,9 +1291,9 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
   for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) {
     resources->buffers[p] = NCCL_NET_MAP_GET_POINTER(map, cpu, buffs[p]);
     if (resources->buffers[p]) {
-#if CUDA_VERSION >= 11070 || NCCL_CUMEM_DMABUF_EXPORT_GATE
       /* DMA-BUF support */
       int type = NCCL_NET_MAP_DEV_MEM(map, buffs[p]) ? NCCL_PTR_CUDA : NCCL_PTR_HOST;
+#if CUDA_VERSION >= 11070 || NCCL_CUMEM_DMABUF_EXPORT_GATE
       if (type == NCCL_PTR_CUDA && resources->useDmaBuf && ncclCuMemEnable()) {
         int bank = NCCL_NET_MAP_OFFSET_BANK(map, buffs[p]);
         if (bank == NCCL_NET_MAP_DEVMEM && map->mems[NCCL_NET_MAP_DEVMEM].dmaBufFd >= 0) {
@@ -1311,10 +1311,9 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
                                                      &resources->mhandles[p]));
           (void)close(dmabuf_fd);
         }
-      } else // FALL-THROUGH to nv_peermem GDR path
-#else
-      /* DMA-BUF support */
-      int type = NCCL_NET_MAP_DEV_MEM(map, buffs[p]) ? NCCL_PTR_CUDA : NCCL_PTR_HOST;
+      } else // FALL-THROUGH to the HSA DMA-BUF export path
+#endif
+#if defined(__HIP_PLATFORM_AMD__)
       if (type == NCCL_PTR_CUDA && resources->useDmaBuf && proxyState->dmaBufSupport &&
           pfn_hsa_amd_portable_export_dmabuf) {
         int dmabuf_fd;
@@ -1530,9 +1529,9 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
   for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) {
     resources->buffers[p] = NCCL_NET_MAP_GET_POINTER(map, cpu, buffs[p]);
     if (resources->buffers[p]) {
-#if CUDA_VERSION >= 11070 || NCCL_CUMEM_DMABUF_EXPORT_GATE
       /* DMA-BUF support */
       int type = NCCL_NET_MAP_DEV_MEM(map, buffs[p]) ? NCCL_PTR_CUDA : NCCL_PTR_HOST;
+#if CUDA_VERSION >= 11070 || NCCL_CUMEM_DMABUF_EXPORT_GATE
       if (type == NCCL_PTR_CUDA && resources->useDmaBuf && ncclCuMemEnable()) {
         int bank = NCCL_NET_MAP_OFFSET_BANK(map, buffs[p]);
         if (bank == NCCL_NET_MAP_DEVMEM && map->mems[NCCL_NET_MAP_DEVMEM].dmaBufFd >= 0) {
@@ -1550,10 +1549,9 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
                                                      &resources->mhandles[p]));
           (void)close(dmabuf_fd);
         }
-      } else // FALL-THROUGH to nv_peermem GDR path
-#else
-      /* DMA-BUF support */
-      int type = NCCL_NET_MAP_DEV_MEM(map, buffs[p]) ? NCCL_PTR_CUDA : NCCL_PTR_HOST;
+      } else // FALL-THROUGH to the HSA DMA-BUF export path
+#endif
+#if defined(__HIP_PLATFORM_AMD__)
       if (type == NCCL_PTR_CUDA && resources->useDmaBuf && proxyState->dmaBufSupport &&
           pfn_hsa_amd_portable_export_dmabuf) {
         int dmabuf_fd;
@@ -2397,19 +2395,20 @@ static ncclResult_t sendProxyRegBuffer(struct ncclProxyConnection* connection, s
     needReg = false;
   }
 peermem:
-#else
-  if (resources->useDmaBuf && pfn_hsa_amd_portable_export_dmabuf) {
+#endif
+#if defined(__HIP_PLATFORM_AMD__)
+  if (needReg && resources->useDmaBuf && pfn_hsa_amd_portable_export_dmabuf) {
     int dmabuf_fd;
     uint64_t offset;
     HSACHECKGOTO(hsa_amd_portable_export_dmabuf((const void*)info->buffer, info->size, &dmabuf_fd, &offset), ret,
-                 peermem);
+                 peermem_hsa);
     NCCLCHECKGOTO(proxyState->ncclNet->regMrDmaBuf(resources->netSendComm, (void*)info->buffer, info->size,
                                                    NCCL_PTR_CUDA, offset, dmabuf_fd, &handle),
-                  ret, peermem);
+                  ret, peermem_hsa);
     (void)close(dmabuf_fd);
     needReg = false;
   }
-peermem:
+peermem_hsa:
 #endif
   if (needReg) {
     // Non-dmabuf regMr does not support multiple physical segments
@@ -2469,19 +2468,20 @@ static ncclResult_t recvProxyRegBuffer(struct ncclProxyConnection* connection, s
     needReg = false;
   }
 peermem:
-#else
-  if (resources->useDmaBuf && pfn_hsa_amd_portable_export_dmabuf) {
+#endif
+#if defined(__HIP_PLATFORM_AMD__)
+  if (needReg && resources->useDmaBuf && pfn_hsa_amd_portable_export_dmabuf) {
     int dmabuf_fd;
     uint64_t offset;
     HSACHECKGOTO(hsa_amd_portable_export_dmabuf((const void*)info->buffer, info->size, &dmabuf_fd, &offset), ret,
-                 peermem);
+                 peermem_hsa);
     NCCLCHECKGOTO(proxyState->ncclNet->regMrDmaBuf(resources->netRecvComm, (void*)info->buffer, info->size,
                                                    NCCL_PTR_CUDA, offset, dmabuf_fd, &handle),
-                  ret, peermem);
+                  ret, peermem_hsa);
     (void)close(dmabuf_fd);
     needReg = false;
   }
-peermem:
+peermem_hsa:
 #endif
   if (needReg) {
     // Non-dmabuf regMr does not support multiple physical segments

--- a/projects/rccl/src/transport/net.cc
+++ b/projects/rccl/src/transport/net.cc
@@ -2381,9 +2381,9 @@ static ncclResult_t sendProxyRegBuffer(struct ncclProxyConnection* connection, s
   assert(respSize == sizeof(void*));
 
 #if CUDA_VERSION >= 11070 || NCCL_CUMEM_DMABUF_EXPORT_GATE
+  int dmabuf_fd = -1;
   /* DMA-BUF support */
   if (resources->useDmaBuf && ncclCuMemEnable()) {
-    int dmabuf_fd;
     CUCHECKGOTO(cuMemGetHandleForAddressRange((void*)&dmabuf_fd, (CUdeviceptr)info->buffer, info->size,
                                               CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
                                               getHandleForAddressRangeFlags(resources->useGdr)),
@@ -2392,23 +2392,24 @@ static ncclResult_t sendProxyRegBuffer(struct ncclProxyConnection* connection, s
                                                    NCCL_PTR_CUDA, 0ULL, dmabuf_fd, &handle),
                   ret, peermem);
     (void)close(dmabuf_fd);
+    dmabuf_fd = -1;
     needReg = false;
   }
 peermem:
+  // A failed cuMem attempt is recoverable here: the fallbacks below register the same
+  // buffer, so close the fd it may have left open before they run.
+  if (dmabuf_fd != -1) {
+    (void)close(dmabuf_fd);
+    dmabuf_fd = -1;
+  }
 #endif
 #if defined(__HIP_PLATFORM_AMD__)
   if (needReg && resources->useDmaBuf && pfn_hsa_amd_portable_export_dmabuf) {
-    int dmabuf_fd;
-    uint64_t offset;
-    HSACHECKGOTO(hsa_amd_portable_export_dmabuf((const void*)info->buffer, info->size, &dmabuf_fd, &offset), ret,
-                 peermem_hsa);
-    NCCLCHECKGOTO(proxyState->ncclNet->regMrDmaBuf(resources->netSendComm, (void*)info->buffer, info->size,
-                                                   NCCL_PTR_CUDA, offset, dmabuf_fd, &handle),
-                  ret, peermem_hsa);
-    (void)close(dmabuf_fd);
-    needReg = false;
+    if (ncclHsaRegMrDmaBuf(proxyState->ncclNet->regMrDmaBuf, resources->netSendComm, (void*)info->buffer, info->size,
+                           NCCL_PTR_CUDA, &handle)) {
+      needReg = false;
+    }
   }
-peermem_hsa:
 #endif
   if (needReg) {
     // Non-dmabuf regMr does not support multiple physical segments
@@ -2454,9 +2455,9 @@ static ncclResult_t recvProxyRegBuffer(struct ncclProxyConnection* connection, s
   assert(respSize == sizeof(void*));
 
 #if CUDA_VERSION >= 11070 || NCCL_CUMEM_DMABUF_EXPORT_GATE
+  int dmabuf_fd = -1;
   /* DMA-BUF support */
   if (resources->useDmaBuf && ncclCuMemEnable()) {
-    int dmabuf_fd;
     CUCHECKGOTO(cuMemGetHandleForAddressRange((void*)&dmabuf_fd, (CUdeviceptr)info->buffer, info->size,
                                               CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
                                               getHandleForAddressRangeFlags(resources->useGdr)),
@@ -2465,23 +2466,24 @@ static ncclResult_t recvProxyRegBuffer(struct ncclProxyConnection* connection, s
                                                    NCCL_PTR_CUDA, 0ULL, dmabuf_fd, &handle),
                   ret, peermem);
     (void)close(dmabuf_fd);
+    dmabuf_fd = -1;
     needReg = false;
   }
 peermem:
+  // A failed cuMem attempt is recoverable here: the fallbacks below register the same
+  // buffer, so close the fd it may have left open before they run.
+  if (dmabuf_fd != -1) {
+    (void)close(dmabuf_fd);
+    dmabuf_fd = -1;
+  }
 #endif
 #if defined(__HIP_PLATFORM_AMD__)
   if (needReg && resources->useDmaBuf && pfn_hsa_amd_portable_export_dmabuf) {
-    int dmabuf_fd;
-    uint64_t offset;
-    HSACHECKGOTO(hsa_amd_portable_export_dmabuf((const void*)info->buffer, info->size, &dmabuf_fd, &offset), ret,
-                 peermem_hsa);
-    NCCLCHECKGOTO(proxyState->ncclNet->regMrDmaBuf(resources->netRecvComm, (void*)info->buffer, info->size,
-                                                   NCCL_PTR_CUDA, offset, dmabuf_fd, &handle),
-                  ret, peermem_hsa);
-    (void)close(dmabuf_fd);
-    needReg = false;
+    if (ncclHsaRegMrDmaBuf(proxyState->ncclNet->regMrDmaBuf, resources->netRecvComm, (void*)info->buffer, info->size,
+                           NCCL_PTR_CUDA, &handle)) {
+      needReg = false;
+    }
   }
-peermem_hsa:
 #endif
   if (needReg) {
     // Non-dmabuf regMr does not support multiple physical segments

--- a/projects/rccl/src/transport/net_ib/common.h
+++ b/projects/rccl/src/transport/net_ib/common.h
@@ -466,6 +466,9 @@ struct ncclIbGpuFlush {
   struct ibv_sge sge;
   struct ncclIbQp qp;
   int dmabuf_fd;
+  // gpuFlushGpuMem comes from ncclMemAlloc on the cuMem path but from
+  // hipExtMallocWithFlags on the HSA fallback, so the free has to match the allocator.
+  bool gpuFlushMemIsHipAlloc;
 };
 
 // This structure describes the FIFO which the receiver uses when it sends CTS

--- a/projects/rccl/src/transport/net_ib/connect.cc
+++ b/projects/rccl/src/transport/net_ib/connect.cc
@@ -1493,35 +1493,43 @@ ib_recv:
             rCommDev->gpuFlush.dmabuf_fd = -1;
           }
         }
-#else
-#if defined(HIP_UNCACHED_MEMORY)
-        NCCLCHECKGOTO(ncclCudaCalloc(&rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), /*manager=*/nullptr,
-                                     ncclMemPersist, hipDeviceMallocUncached),
-                      ret, fail);
-#else
-        NCCLCHECKGOTO(ncclCudaCalloc(&rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), /*manager=*/nullptr,
-                                     ncclMemPersist, hipDeviceMallocFinegrained),
-                      ret, fail);
 #endif
-        if (useDmaBuf) {
-          uint64_t export_offset = 0;
-          void* aligned_ptr = NULL;
-          size_t aligned_size = 0;
-          get_aligned_ptr_and_size(rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), &aligned_ptr, &aligned_size);
-          HSACHECKGOTO(hsa_amd_portable_export_dmabuf(aligned_ptr, aligned_size, &rCommDev->gpuFlush.dmabuf_fd,
-                                                      &export_offset),
-                       ret, peermem_flush);
-          if (wrap_ibv_reg_dmabuf_mr(&rCommDev->gpuFlush.gpuMr, rCommDev->base.pd, export_offset, sizeof(int),
-                                     (uint64_t)rCommDev->gpuFlush.gpuFlushGpuMem, rCommDev->gpuFlush.dmabuf_fd,
-                                     IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ) !=
-              ncclSuccess)
-            goto peermem_flush;
-          gpuFlushRegistered = true;
-          goto flush_reg_done;
-        peermem_flush:
-          if (rCommDev->gpuFlush.dmabuf_fd >= 0) {
-            close(rCommDev->gpuFlush.dmabuf_fd);
-            rCommDev->gpuFlush.dmabuf_fd = -1;
+#if defined(__HIP_PLATFORM_AMD__)
+        if (!gpuFlushRegistered) {
+          // The cuMem attempt above may have left a buffer behind before failing.
+          if (rCommDev->gpuFlush.gpuFlushGpuMem) {
+            ncclCudaFree(rCommDev->gpuFlush.gpuFlushGpuMem, /*manager=*/nullptr);
+            rCommDev->gpuFlush.gpuFlushGpuMem = nullptr;
+          }
+#if defined(HIP_UNCACHED_MEMORY)
+          NCCLCHECKGOTO(ncclCudaCalloc(&rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), /*manager=*/nullptr,
+                                       ncclMemPersist, hipDeviceMallocUncached),
+                        ret, fail);
+#else
+          NCCLCHECKGOTO(ncclCudaCalloc(&rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), /*manager=*/nullptr,
+                                       ncclMemPersist, hipDeviceMallocFinegrained),
+                        ret, fail);
+#endif
+          if (useDmaBuf) {
+            uint64_t export_offset = 0;
+            void* aligned_ptr = NULL;
+            size_t aligned_size = 0;
+            get_aligned_ptr_and_size(rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), &aligned_ptr, &aligned_size);
+            HSACHECKGOTO(hsa_amd_portable_export_dmabuf(aligned_ptr, aligned_size, &rCommDev->gpuFlush.dmabuf_fd,
+                                                        &export_offset),
+                         ret, peermem_flush);
+            if (wrap_ibv_reg_dmabuf_mr(&rCommDev->gpuFlush.gpuMr, rCommDev->base.pd, export_offset, sizeof(int),
+                                       (uint64_t)rCommDev->gpuFlush.gpuFlushGpuMem, rCommDev->gpuFlush.dmabuf_fd,
+                                       IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ) !=
+                ncclSuccess)
+              goto peermem_flush;
+            gpuFlushRegistered = true;
+            goto flush_reg_done;
+          peermem_flush:
+            if (rCommDev->gpuFlush.dmabuf_fd >= 0) {
+              close(rCommDev->gpuFlush.dmabuf_fd);
+              rCommDev->gpuFlush.dmabuf_fd = -1;
+            }
           }
         }
 #endif

--- a/projects/rccl/src/transport/net_ib/connect.cc
+++ b/projects/rccl/src/transport/net_ib/connect.cc
@@ -1524,8 +1524,9 @@ ib_recv:
             if (wrap_ibv_reg_dmabuf_mr(&rCommDev->gpuFlush.gpuMr, rCommDev->base.pd, export_offset, sizeof(int),
                                        (uint64_t)rCommDev->gpuFlush.gpuFlushGpuMem, rCommDev->gpuFlush.dmabuf_fd,
                                        IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ) !=
-                ncclSuccess)
+                ncclSuccess) {
               goto peermem_flush;
+            }
             gpuFlushRegistered = true;
             goto flush_reg_done;
           peermem_flush:

--- a/projects/rccl/src/transport/net_ib/connect.cc
+++ b/projects/rccl/src/transport/net_ib/connect.cc
@@ -1216,6 +1216,18 @@ ncclResult_t ncclIbReceiverPrePostReceiveWorkRequests(struct ncclIbRecvComm* rec
 
 NCCL_PARAM(IbGdrFlushDisable, "GDR_FLUSH_DISABLE", 0);
 
+static ncclResult_t ncclIbFreeGpuFlushMem(struct ncclIbGpuFlush* gpuFlush) {
+  if (gpuFlush->gpuFlushGpuMem == nullptr) return ncclSuccess;
+  if (gpuFlush->gpuFlushMemIsHipAlloc) {
+    CUDACHECK(hipFree(gpuFlush->gpuFlushGpuMem));
+  } else {
+    NCCLCHECK(ncclCudaFree(gpuFlush->gpuFlushGpuMem, /*manager=*/nullptr));
+  }
+  gpuFlush->gpuFlushGpuMem = nullptr;
+  gpuFlush->gpuFlushMemIsHipAlloc = false;
+  return ncclSuccess;
+}
+
 ncclResult_t ncclIbAccept(void* listenComm, void** recvComm, ncclNetDeviceHandle_t** /*recvDevComm*/) {
   ncclResult_t ret = ncclSuccess;
   struct ncclIbListenComm* lComm = (struct ncclIbListenComm*)listenComm;
@@ -1471,6 +1483,7 @@ ib_recv:
       rCommDev->gpuFlush.gpuFlushGpuMem = nullptr;
       rCommDev->gpuFlush.gpuMr = nullptr;
       rCommDev->gpuFlush.dmabuf_fd = -1;
+      rCommDev->gpuFlush.gpuFlushMemIsHipAlloc = false;
 
       if (rcclParamIbGdrFlushGpuMemNoRelaxedOrdering()) {
 #if CUDA_VERSION >= 11070 || NCCL_CUMEM_DMABUF_EXPORT_GATE
@@ -1488,8 +1501,8 @@ ib_recv:
           gpuFlushRegistered = true;
           goto flush_reg_done;
         cumem_flush_hsa:
-          // The HSA path below allocates its own buffer, so every cuMem failure here is
-          // recoverable and must not leave ret poisoned for the eventual `return ret`.
+          // The HSA fallback below allocates its own non-VMM buffer, so every cuMem failure
+          // here is recoverable and must not leave ret poisoned for the eventual `return ret`.
           ret = ncclSuccess;
           if (rCommDev->gpuFlush.dmabuf_fd >= 0) {
             close(rCommDev->gpuFlush.dmabuf_fd);
@@ -1500,19 +1513,19 @@ ib_recv:
 #if defined(__HIP_PLATFORM_AMD__)
         if (!gpuFlushRegistered) {
           // The cuMem attempt above may have left a buffer behind before failing.
-          if (rCommDev->gpuFlush.gpuFlushGpuMem) {
-            ncclCudaFree(rCommDev->gpuFlush.gpuFlushGpuMem, /*manager=*/nullptr);
-            rCommDev->gpuFlush.gpuFlushGpuMem = nullptr;
-          }
+          (void)ncclIbFreeGpuFlushMem(&rCommDev->gpuFlush);
 #if defined(HIP_UNCACHED_MEMORY)
-          NCCLCHECKGOTO(ncclCudaCalloc(&rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), /*manager=*/nullptr,
-                                       ncclMemPersist, hipDeviceMallocUncached),
-                        ret, fail);
+          const unsigned int gpuFlushFlags = hipDeviceMallocUncached;
 #else
-          NCCLCHECKGOTO(ncclCudaCalloc(&rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), /*manager=*/nullptr,
-                                       ncclMemPersist, hipDeviceMallocFinegrained),
-                        ret, fail);
+          const unsigned int gpuFlushFlags = hipDeviceMallocFinegrained;
 #endif
+          // Allocate directly through HIP rather than ncclCudaCalloc: with cuMem enabled the
+          // latter routes to the VMM allocator, silently dropping these flags and handing the
+          // HSA exporter another mapping from the allocator whose export just failed.
+          CUDACHECKGOTO(hipExtMallocWithFlags((void**)&rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), gpuFlushFlags),
+                        ret, fail);
+          rCommDev->gpuFlush.gpuFlushMemIsHipAlloc = true;
+          CUDACHECKGOTO(hipMemset(rCommDev->gpuFlush.gpuFlushGpuMem, 0, sizeof(int)), ret, fail);
           if (useDmaBuf) {
             uint64_t export_offset = 0;
             void* aligned_ptr = NULL;
@@ -1541,10 +1554,7 @@ ib_recv:
 #endif
       flush_reg_done:
         if (!gpuFlushRegistered) {
-          if (rCommDev->gpuFlush.gpuFlushGpuMem) {
-            ncclCudaFree(rCommDev->gpuFlush.gpuFlushGpuMem, /*manager=*/nullptr);
-            rCommDev->gpuFlush.gpuFlushGpuMem = nullptr;
-          }
+          (void)ncclIbFreeGpuFlushMem(&rCommDev->gpuFlush);
           rCommDev->gpuFlush.gpuMr = nullptr;
         }
       }
@@ -1656,8 +1666,7 @@ ncclResult_t ncclIbCloseRecv(void* recvComm) {
       struct ncclIbRecvCommDev* commDev = comm->devs + i;
       if (comm->flushEnabled) {
         if (commDev->gpuFlush.gpuFlushGpuMem != nullptr) {
-          NCCLCHECK(ncclCudaFree(commDev->gpuFlush.gpuFlushGpuMem, /*manager=*/nullptr));
-          commDev->gpuFlush.gpuFlushGpuMem = nullptr;
+          NCCLCHECK(ncclIbFreeGpuFlushMem(&commDev->gpuFlush));
           if (commDev->gpuFlush.gpuMr != nullptr) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.gpuMr));
           commDev->gpuFlush.gpuMr = nullptr;
           if (commDev->gpuFlush.dmabuf_fd > 0) {

--- a/projects/rccl/src/transport/net_ib/connect.cc
+++ b/projects/rccl/src/transport/net_ib/connect.cc
@@ -1475,7 +1475,7 @@ ib_recv:
       if (rcclParamIbGdrFlushGpuMemNoRelaxedOrdering()) {
 #if CUDA_VERSION >= 11070 || NCCL_CUMEM_DMABUF_EXPORT_GATE
         if (ncclCuMemEnable()) {
-          NCCLCHECKGOTO(ncclMemAlloc((void**)&rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int)), ret, fail);
+          NCCLCHECKGOTO(ncclMemAlloc((void**)&rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int)), ret, cumem_flush_hsa);
           CUCHECKGOTO(cuMemGetHandleForAddressRange((void*)&rCommDev->gpuFlush.dmabuf_fd,
                                                     (CUdeviceptr)rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int),
                                                     CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, 0),
@@ -1488,6 +1488,9 @@ ib_recv:
           gpuFlushRegistered = true;
           goto flush_reg_done;
         cumem_flush_hsa:
+          // The HSA path below allocates its own buffer, so every cuMem failure here is
+          // recoverable and must not leave ret poisoned for the eventual `return ret`.
+          ret = ncclSuccess;
           if (rCommDev->gpuFlush.dmabuf_fd >= 0) {
             close(rCommDev->gpuFlush.dmabuf_fd);
             rCommDev->gpuFlush.dmabuf_fd = -1;
@@ -1526,6 +1529,8 @@ ib_recv:
             gpuFlushRegistered = true;
             goto flush_reg_done;
           peermem_flush:
+            // Flush registration is optional; losing it degrades GDR rather than failing accept.
+            ret = ncclSuccess;
             if (rCommDev->gpuFlush.dmabuf_fd >= 0) {
               close(rCommDev->gpuFlush.dmabuf_fd);
               rCommDev->gpuFlush.dmabuf_fd = -1;

--- a/projects/rccl/test/VersionGateTests.cpp
+++ b/projects/rccl/test/VersionGateTests.cpp
@@ -68,11 +68,11 @@ static_assert(!NCCL_CUMEM_DMABUF_EXPORT_GATE_FOR(0, ROCM_VER_7_12_60540),
               "a supported version must not override a failed probe");
 static_assert(!NCCL_CUMEM_DMABUF_EXPORT_GATE_FOR(0, ROCM_VER_7_12_0), "neither input holds");
 
-// The same two invariants asserted against the gate this build actually compiled
-// with, so the parameterized form above cannot drift away from the real macro.
-static_assert(!NCCL_CUMEM_DMABUF_EXPORT_GATE || NCCL_CUMEM_DMABUF_EXPORT_PROBE, "gate on without the probe");
-static_assert(!NCCL_CUMEM_DMABUF_EXPORT_GATE || NCCL_CUMEM_VERSION_SUPPORTED(HIP_VERSION),
-              "gate on outside the version window");
+// The gate this build compiled with must still be the parameterized form instantiated
+// with this build's own inputs, or the combinations asserted above stop describing it.
+static_assert(NCCL_CUMEM_DMABUF_EXPORT_GATE ==
+                  NCCL_CUMEM_DMABUF_EXPORT_GATE_FOR(NCCL_CUMEM_DMABUF_EXPORT_PROBE, HIP_VERSION),
+              "the build's gate is no longer the parameterized gate for (probe, HIP_VERSION)");
 
 TEST(VersionGateTests, CeBatchAsyncWindow)
 {

--- a/projects/rccl/test/VersionGateTests.cpp
+++ b/projects/rccl/test/VersionGateTests.cpp
@@ -57,6 +57,23 @@ TEST(VersionGateTests, CuMemHostIsNativeOnly)
     EXPECT_FALSE(NCCL_CUMEM_HOST_VERSION_SUPPORTED(ROCM_VER_7_0_3_0 - 1));
 }
 
+// The DMA-BUF export gate is a conjunction: the CMake symbol probe alone must not
+// turn it on, because hipMemGetHandleForAddressRange is declared in headers on
+// builds outside the supported version window too. All four input combinations,
+// using a version inside the window and one below it.
+static_assert(NCCL_CUMEM_DMABUF_EXPORT_GATE_FOR(1, ROCM_VER_7_12_60540), "probe + supported version must gate on");
+static_assert(!NCCL_CUMEM_DMABUF_EXPORT_GATE_FOR(1, ROCM_VER_7_12_0),
+              "probe must not override an unsupported version");
+static_assert(!NCCL_CUMEM_DMABUF_EXPORT_GATE_FOR(0, ROCM_VER_7_12_60540),
+              "a supported version must not override a failed probe");
+static_assert(!NCCL_CUMEM_DMABUF_EXPORT_GATE_FOR(0, ROCM_VER_7_12_0), "neither input holds");
+
+// The same two invariants asserted against the gate this build actually compiled
+// with, so the parameterized form above cannot drift away from the real macro.
+static_assert(!NCCL_CUMEM_DMABUF_EXPORT_GATE || NCCL_CUMEM_DMABUF_EXPORT_PROBE, "gate on without the probe");
+static_assert(!NCCL_CUMEM_DMABUF_EXPORT_GATE || NCCL_CUMEM_VERSION_SUPPORTED(HIP_VERSION),
+              "gate on outside the version window");
+
 TEST(VersionGateTests, CeBatchAsyncWindow)
 {
     // Native 7.12+ (note: 7.12.0, lower than the cuMem milestone).


### PR DESCRIPTION
## Motivation

Commit be82052eec (PR #7934, "Centralize HIP/ROCm version gating") regressed RCCL's DMA-BUF/GDR memory registration on ROCm. Two compounding issues:

1. A CMake symbol-exists probe (`RCCL_CUMEM_DMABUF_EXPORT_SUPPORTED`) unconditionally overrides the existing, more precise version-range predicate (`NCCL_CUMEM_VERSION_SUPPORTED`) for the `NCCL_CUMEM_DMABUF_EXPORT_GATE` macro, so the gate can activate outside its intended backport window.
2. At ~9 call sites across `net.cc`/`coll_net.cc`/`net_ib/connect.cc`, the new cuMem-based DMA-BUF export path and the older, always-reachable `hsa_amd_portable_export_dmabuf` path became mutually exclusive at compile time (`#if`/`#else`). The new path additionally requires `ncclCuMemEnable()`, which is hard-defaulted `false` on the ROCm platform (unlike CUDA's auto-detect default) — so whenever the gate selects the new path, there is no default-reachable working registration path left, and registration falls through to a plain `regMr()` that fails with `ibv_reg_mr_iova2: Bad address` on hardware without a real peer-memory client.

## Technical Details

- `src/include/rocmwrap.h`: the symbol-probe signal no longer unilaterally overrides the version-range predicate for `NCCL_CUMEM_DMABUF_EXPORT_GATE`; both must agree. The gate is now exposed as `NCCL_CUMEM_DMABUF_EXPORT_GATE_FOR(probe, v)` with the production gate as its single instantiation, so the composition itself is unit-testable.
- At every call site gated by this macro on the HIP/ROCm platform, the cuMem-based path and the HSA-based fallback are no longer compile-time exclusive — both are compiled in, chained as a runtime fallback (cuMem attempted first only if `useDmaBuf && ncclCuMemEnable()`, falling through to the HSA path otherwise). CUDA-platform code paths are untouched.
- `net_ib/connect.cc`: the cuMem allocation failure path now also falls through to the HSA fallback (previously it aborted the whole connect, inconsistent with the other two failure points in the same block, which already fell back correctly). A related bug was also fixed where a successful fallback still returned the swallowed error from the earlier failure.
- `test/VersionGateTests.cpp`: new test case covering all four combinations of the gate's two input signals (probe defined/undefined x version in/out of the supported range).

## JIRA ID

AICOMRCCL-1695 (regression tracking; original introducing commit tracked under AICOMRCCL-1456)

## Test Plan

- `VersionGateTests` (gtest) covering the new gate composition.
- Live `all_reduce_perf` on AMD Pensando/ionic AINIC hardware, both the generic `net_ib` transport and the internal AINIC-optimized `net_ib_cast`/IB-CAST transport, with `RCCL_FORCE_ENABLE_DMABUF=1` and `NCCL_DEBUG=INFO`.

## Test Result

- `VersionGateTests`: 3/3 pass.
- `net_ib`: no `ibv_reg_mr_iova2` failures, `#wrong=0`
- `net_ib_cast`/IB-CAST: no `ibv_reg_mr_iova2` failures, `#wrong=0`

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
