### PR TITLE
fix(amdsmi): harden the packaging test suite and cover scriptlet isolation

### DIFF
--- a/.github/workflows/amdsmi-python-versions.yml
+++ b/.github/workflows/amdsmi-python-versions.yml
@@ -37,6 +37,7 @@ jobs:
   python-version-tests:
     name: Python ${{matrix.python-version}}
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     # 3.6/3.7 run inside official python images because actions/setup-python no
     # longer provides those EOL interpreters on a supported hosted runner (they
     # were only on ubuntu-20.04, itself being retired). The images are archived,
@@ -65,7 +66,7 @@ jobs:
           apt-get update
           apt-get install -y --no-install-recommends git ca-certificates
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # rocm-systems is a large monorepo; only the amdsmi tests are needed.
           sparse-checkout: |

--- a/.github/workflows/amdsmi-upgrade-downgrade.yml
+++ b/.github/workflows/amdsmi-upgrade-downgrade.yml
@@ -24,6 +24,7 @@ on:
       - 'projects/amdsmi/RPM/**'
       - 'projects/amdsmi/py-interface/**'
       - 'projects/amdsmi/CMakeLists.txt'
+      - 'projects/amdsmi/tests/run_amdsmi_component_removal_test.py'
       - 'projects/amdsmi/tests/run_amdsmi_upgrade_downgrade_test.py'
       - '.github/workflows/amdsmi-upgrade-downgrade.yml'
   push:
@@ -33,6 +34,7 @@ on:
       - 'projects/amdsmi/RPM/**'
       - 'projects/amdsmi/py-interface/**'
       - 'projects/amdsmi/CMakeLists.txt'
+      - 'projects/amdsmi/tests/run_amdsmi_component_removal_test.py'
       - 'projects/amdsmi/tests/run_amdsmi_upgrade_downgrade_test.py'
       - '.github/workflows/amdsmi-upgrade-downgrade.yml'
   workflow_dispatch:
@@ -133,4 +135,18 @@ jobs:
           python3 tests/run_amdsmi_upgrade_downgrade_test.py \
             --old-package /tmp/pkgs/old.${{matrix.ext}} \
             --new-package /tmp/pkgs/new.${{matrix.ext}} \
+            --package-manager ${{matrix.manager}}
+
+      - name: Remove tests component without removing main package state
+        working-directory: projects/amdsmi
+        run: |
+          set -e
+          # The tests package depends on the main package. Removing that optional
+          # component must not run main-package removal scripts or delete its state.
+          tests_pkg=$(find "$BUILD_DIR" -maxdepth 1 \
+            -name "amd-smi-lib-tests[-_]*.${{matrix.ext}}" | sort -V | tail -1)
+          cp "$tests_pkg" /tmp/pkgs/tests.${{matrix.ext}}
+          python3 tests/run_amdsmi_component_removal_test.py \
+            --main-package /tmp/pkgs/new.${{matrix.ext}} \
+            --tests-package /tmp/pkgs/tests.${{matrix.ext}} \
             --package-manager ${{matrix.manager}}

--- a/.github/workflows/amdsmi-upgrade-downgrade.yml
+++ b/.github/workflows/amdsmi-upgrade-downgrade.yml
@@ -46,6 +46,7 @@ jobs:
   upgrade-downgrade:
     name: ${{matrix.name}}
     runs-on: ubuntu-22.04
+    timeout-minutes: 45
     container: ${{matrix.container}}
     strategy:
       fail-fast: false
@@ -88,7 +89,7 @@ jobs:
             git gcc gcc-c++ cmake make rpm-build file \
             libdrm-devel libnl3-devel libmnl-devel python3 sudo
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # rocm-systems is a large monorepo; only the amdsmi project is needed.
           sparse-checkout: |

--- a/projects/amdsmi/DEBIAN/postinst.in
+++ b/projects/amdsmi/DEBIAN/postinst.in
@@ -71,6 +71,36 @@ do_ldconfig() {
   fi
 }
 
+# Pip-era package removal is best-effort, so a stale /usr/local amdsmi may
+# remain after upgrade and shadow the module installed in the system sitelib.
+do_warn_shadowed_python_module() {
+  local packaged_sitelib="@AMDSMI_SYSTEM_PYTHON_SITELIB@"
+  local imported_sitelib
+
+  if [ -z "${packaged_sitelib}" ]; then
+    return 0
+  fi
+
+  if ! command -v python3 &>/dev/null; then
+    return 0
+  fi
+
+  imported_sitelib="$(python3 -c 'import amdsmi, os; print(os.path.dirname(os.path.dirname(os.path.realpath(amdsmi.__file__))))' 2>/dev/null)" || return 0
+  if [ -z "${imported_sitelib}" ]; then
+    return 0
+  fi
+
+  if [ "${imported_sitelib}" != "${packaged_sitelib}" ]; then
+    cat << EOF
+[WARNING] A pip-installed amdsmi copy at ${imported_sitelib} takes precedence over
+the packaged module at ${packaged_sitelib} for plain 'import amdsmi'.
+Remove the shadowing copy with: python3 -m pip uninstall amdsmi
+EOF
+  fi
+
+  return 0
+}
+
 do_activate_argcomplete() {
   # python3-argcomplete is recommended but optional; activate global bash
   # completion when its helper is present, otherwise continue gracefully.
@@ -89,6 +119,7 @@ do_activate_argcomplete() {
 case "$1" in
   ( configure )
     do_ldconfig
+    do_warn_shadowed_python_module
     do_activate_argcomplete
     do_configureLogrotate || exit 0
   ;;

--- a/projects/amdsmi/RPM/post.in
+++ b/projects/amdsmi/RPM/post.in
@@ -71,6 +71,36 @@ do_ldconfig() {
   fi
 }
 
+# Pip-era package removal is best-effort, so a stale /usr/local amdsmi may
+# remain after upgrade and shadow the module installed in the system sitelib.
+do_warn_shadowed_python_module() {
+  local packaged_sitelib="@AMDSMI_SYSTEM_PYTHON_SITELIB@"
+  local imported_sitelib
+
+  if [ -z "${packaged_sitelib}" ]; then
+    return 0
+  fi
+
+  if ! command -v python3 &>/dev/null; then
+    return 0
+  fi
+
+  imported_sitelib="$(python3 -c 'import amdsmi, os; print(os.path.dirname(os.path.dirname(os.path.realpath(amdsmi.__file__))))' 2>/dev/null)" || return 0
+  if [ -z "${imported_sitelib}" ]; then
+    return 0
+  fi
+
+  if [ "${imported_sitelib}" != "${packaged_sitelib}" ]; then
+    cat << EOF
+[WARNING] A pip-installed amdsmi copy at ${imported_sitelib} takes precedence over
+the packaged module at ${packaged_sitelib} for plain 'import amdsmi'.
+Remove the shadowing copy with: python3 -m pip uninstall amdsmi
+EOF
+  fi
+
+  return 0
+}
+
 do_activate_argcomplete() {
   # python3-argcomplete is recommended but optional; activate global bash
   # completion when its helper is present, otherwise continue gracefully.
@@ -91,6 +121,7 @@ do_activate_argcomplete() {
 # post install or upgrade, $i is 1 or 2 -> do these actions
 if [ "$1" -ge 1 ]; then
   do_ldconfig
+  do_warn_shadowed_python_module
   do_activate_argcomplete
   do_configureLogrotate || exit 0
 fi

--- a/projects/amdsmi/tests/amdsmi_build/run_amdsmi_build.py
+++ b/projects/amdsmi/tests/amdsmi_build/run_amdsmi_build.py
@@ -1147,7 +1147,7 @@ def parse_args() -> RunnerConfig:
         "--python-interpreters",
         default=None,
         help="Comma-separated interpreters for the Python-version loader tests "
-        "(default: discovered python3.6..3.13)",
+        "(default: discovered python3.6..3.14)",
     )
     parser.add_argument(
         "--no-autodetect",

--- a/projects/amdsmi/tests/amdsmi_build/run_amdsmi_build.py
+++ b/projects/amdsmi/tests/amdsmi_build/run_amdsmi_build.py
@@ -1437,6 +1437,26 @@ def main() -> None:
         report_and_raise("PYTHON VERSIONS", exc)
     _write_result(cfg.test_results_dir, "python_versions_result.txt", "PYTHON VERSIONS PASSED")
 
+    # 5d. Upgrade/downgrade from a prior package (only when one is provided).
+    # Deliberately ahead of the install/wheel stages: `pip install` puts the
+    # wheel under /usr/local, which precedes the deb/rpm site-packages path for
+    # `import amdsmi`, so running this afterwards would verify the wheel on
+    # every transition instead of the package actually being upgraded.
+    if not cfg.skip_install and cfg.upgrade_from:
+        try:
+            verify_upgrade_downgrade(cfg, artifact)
+        except CommandError as exc:
+            _write_result(
+                cfg.test_results_dir,
+                "upgrade_downgrade_result.txt",
+                f"UPGRADE/DOWNGRADE FAILED: {exc.name} exited {exc.code}\n\n"
+                f"Log ({exc.log_path}):\n{read_log(exc.log_path)}",
+            )
+            report_and_raise("UPGRADE/DOWNGRADE", exc)
+        _write_result(
+            cfg.test_results_dir, "upgrade_downgrade_result.txt", "UPGRADE/DOWNGRADE PASSED"
+        )
+
     # 6. Install
     if not cfg.skip_install:
         try:
@@ -1494,22 +1514,6 @@ def main() -> None:
             )
             report_and_raise("DUAL COPY CHECK", exc)
         _write_result(cfg.test_results_dir, "dual_copy_result.txt", "DUAL COPY CHECK PASSED")
-
-    # 10. Upgrade/downgrade from a prior package (only when one is provided)
-    if not cfg.skip_install and cfg.upgrade_from:
-        try:
-            verify_upgrade_downgrade(cfg, artifact)
-        except CommandError as exc:
-            _write_result(
-                cfg.test_results_dir,
-                "upgrade_downgrade_result.txt",
-                f"UPGRADE/DOWNGRADE FAILED: {exc.name} exited {exc.code}\n\n"
-                f"Log ({exc.log_path}):\n{read_log(exc.log_path)}",
-            )
-            report_and_raise("UPGRADE/DOWNGRADE", exc)
-        _write_result(
-            cfg.test_results_dir, "upgrade_downgrade_result.txt", "UPGRADE/DOWNGRADE PASSED"
-        )
 
     print("AMDSMI workflow complete")
 

--- a/projects/amdsmi/tests/amdsmi_build/test_run_amdsmi_build.py
+++ b/projects/amdsmi/tests/amdsmi_build/test_run_amdsmi_build.py
@@ -23,6 +23,9 @@ def _load_module():
         "run_amdsmi_build", here / "run_amdsmi_build.py"
     )
     mod = importlib.util.module_from_spec(spec)
+    # Register before exec: @dataclass resolves its module via sys.modules on
+    # Python 3.12+, so a module loaded outside sys.modules fails to import.
+    sys.modules[spec.name] = mod
     # Bootstrap is a no-op on Python 3.7+ which the test env always satisfies.
     spec.loader.exec_module(mod)
     return mod

--- a/projects/amdsmi/tests/python/test_cpack_path_guard.py
+++ b/projects/amdsmi/tests/python/test_cpack_path_guard.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) Advanced Micro Devices. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""Unit tests for the CPack Python module path guard."""
+
+import importlib.util
+import os
+import site
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_guard():
+    # In the source tree the guard lives at tests/run_amdsmi_cpack_path_test.py;
+    # in the installed tests layout REPO_ROOT is share/amd_smi and it lives at
+    # tests/run_amdsmi_cpack_path_test.py there too.
+    for cand in (
+        REPO_ROOT / "tests" / "run_amdsmi_cpack_path_test.py",
+        REPO_ROOT / "run_amdsmi_cpack_path_test.py",
+    ):
+        if cand.is_file():
+            spec = importlib.util.spec_from_file_location("amdsmi_cpack_path_guard", cand)
+            mod = importlib.util.module_from_spec(spec)
+            sys.modules[spec.name] = mod
+            spec.loader.exec_module(mod)
+            return mod
+    raise unittest.SkipTest("run_amdsmi_cpack_path_test.py not found")
+
+
+class SelectModulePathsTest(unittest.TestCase):
+    def setUp(self):
+        self.guard = _load_guard()
+
+    def test_accepts_canonical_debian_and_rpm_roots(self):
+        site_dirs = [
+            "/usr/lib/python3/dist-packages",
+            "/usr/lib64/python3.9/site-packages",
+            "/usr/lib/python3.9/site-packages",
+        ]
+        paths = [site_dir + "/amdsmi/amdsmi_interface.py" for site_dir in site_dirs]
+        self.assertEqual(self.guard.select_module_paths(paths, site_dirs), paths)
+
+    def test_rejects_non_import_paths(self):
+        site_dirs = ["/usr/lib/python3.10/dist-packages", "/usr/lib/python3/dist-packages"]
+        rejected = [
+            "/usr/lib/python3.11/dist-packages/amdsmi/amdsmi_interface.py",
+            "/usr/lib/python3/not-site-packages/amdsmi/amdsmi_interface.py",
+            "/usr/lib/python3/not-dist-packages/amdsmi/amdsmi_interface.py",
+            "/opt/acme/site-packages/amdsmi/amdsmi_interface.py",
+            "/usr/share/site-packages/amdsmi/amdsmi_interface.py",
+            "/usr/lib/python3/dist-packages-old/amdsmi/amdsmi_interface.py",
+            "/usr/lib/python3.10/dist-packages/../../amdsmi/amdsmi_interface.py",
+        ]
+        for path in rejected:
+            with self.subTest(path=path):
+                self.assertEqual(self.guard.select_module_paths([path], site_dirs), [])
+
+
+class ParseDpkgListingTest(unittest.TestCase):
+    def setUp(self):
+        self.guard = _load_guard()
+
+    def test_symlink_target_is_ignored_and_spaces_are_preserved(self):
+        listing = (
+            "lrwxrwxrwx root/root 0 2026-08-04 12:00 "
+            "./usr/lib/python3/dist-packages/amdsmi/link.py -> target.py\n"
+            "-rw-r--r-- root/root 10 2026-08-04 12:00 "
+            "./usr/lib/python3/dist-packages/amdsmi/path with space.py\n"
+        )
+        self.assertEqual(
+            self.guard.parse_dpkg_listing(listing),
+            [
+                "/usr/lib/python3/dist-packages/amdsmi/link.py",
+                "/usr/lib/python3/dist-packages/amdsmi/path with space.py",
+            ],
+        )
+
+
+class MainTest(unittest.TestCase):
+    def setUp(self):
+        self.guard = _load_guard()
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.base = Path(self._tmp.name)
+        self.dpkg = self.base / "dpkg"
+        self.dpkg.write_text("#!/bin/sh\nprintf '%s\\n' \"$DPKG_LISTING\"\n", encoding="utf-8")
+        self.dpkg.chmod(0o755)
+        old_path = os.environ.get("PATH")
+        os.environ["PATH"] = str(self.base) + os.pathsep + (old_path or "")
+        if old_path is None:
+            self.addCleanup(os.environ.pop, "PATH", None)
+        else:
+            self.addCleanup(os.environ.__setitem__, "PATH", old_path)
+        self.pkg = self.base / "pkg.deb"
+        self.pkg.touch()
+
+    def test_main_rejects_substring_false_positive(self):
+        site_dir = "/usr/lib/python3/dist-packages"
+        os.environ["DPKG_LISTING"] = (
+            "-rw-r--r-- root/root 10 2026-08-04 12:00 "
+            "./usr/lib/python3/dist-packages/amdsmi/amdsmi_interface.py"
+        )
+        self.addCleanup(os.environ.pop, "DPKG_LISTING", None)
+        self.assertEqual(self.guard.main(["--site-dir", site_dir, str(self.pkg)]), 0)
+
+        os.environ["DPKG_LISTING"] = (
+            "-rw-r--r-- root/root 10 2026-08-04 12:00 "
+            "./usr/lib/python3/not-site-packages/amdsmi/amdsmi_interface.py"
+        )
+        with self.assertRaises(SystemExit) as raised:
+            self.guard.main(["--site-dir", site_dir, str(self.pkg)])
+        self.assertNotEqual(raised.exception.code, 0)
+
+
+class SubprocessMainTest(unittest.TestCase):
+    def setUp(self):
+        self.guard = _load_guard()
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.base = Path(self._tmp.name)
+        dpkg = self.base / "dpkg"
+        dpkg.write_text("#!/bin/sh\nprintf '%s\\n' \"$DPKG_LISTING\"\n", encoding="utf-8")
+        dpkg.chmod(0o755)
+        self.pkg = self.base / "pkg.deb"
+        self.pkg.touch()
+
+    def _run(self, listing, *extra_args):
+        env = os.environ.copy()
+        env["PATH"] = str(self.base) + os.pathsep + env.get("PATH", "")
+        env["DPKG_LISTING"] = listing
+        return subprocess.run(
+            [sys.executable, str(Path(self.guard.__file__)), str(self.pkg)] + list(extra_args),
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+        )
+
+    def test_legacy_cli_rejects_substring_false_positive(self):
+        result = self._run(
+            "-rw-r--r-- root/root 10 2026-08-04 12:00 "
+            "./usr/lib/python3/not-site-packages/amdsmi/amdsmi_interface.py"
+        )
+        output = result.stdout + result.stderr
+        self.assertNotEqual(result.returncode, 0, output)
+        self.assertIn("expected site directories", output)
+
+    def test_accepts_the_site_directory_of_the_named_interpreter(self):
+        getsitepackages = getattr(site, "getsitepackages", None)
+        if getsitepackages is None:
+            raise unittest.SkipTest("site.getsitepackages is unavailable")
+        site_dirs = getsitepackages()
+        if not site_dirs:
+            raise unittest.SkipTest("site.getsitepackages returned no directories")
+        site_dir = next((path for path in site_dirs if Path(path).exists()), site_dirs[0])
+        listing = "-rw-r--r-- root/root 10 2026-08-04 12:00 .{}/amdsmi/amdsmi_interface.py".format(
+            site_dir
+        )
+        result = self._run(listing, "--python", sys.executable)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_legacy_cli_rejects_package_without_amdsmi(self):
+        result = self._run(
+            "-rw-r--r-- root/root 10 2026-08-04 12:00 ./usr/share/doc/example/README"
+        )
+        output = result.stdout + result.stderr
+        self.assertNotEqual(result.returncode, 0, output)
+        self.assertIn("expected site directories", output)
+
+
+class DefaultPythonTest(unittest.TestCase):
+    """The guard must inspect the same interpreter the packaging targeted."""
+
+    def setUp(self):
+        self.guard = _load_guard()
+
+    def _with_existing(self, existing):
+        real_exists = self.guard.os.path.exists
+        self.guard.os.path.exists = lambda path: path in existing or real_exists(path)
+        self.addCleanup(setattr, self.guard.os.path, "exists", real_exists)
+
+    def test_prefers_platform_python(self):
+        self._with_existing({"/usr/libexec/platform-python", "/usr/bin/python3"})
+        self.assertEqual(self.guard.default_python(), "/usr/libexec/platform-python")
+
+    def test_falls_back_to_usr_bin_python3(self):
+        real_exists = self.guard.os.path.exists
+        self.guard.os.path.exists = lambda path: path == "/usr/bin/python3"
+        self.addCleanup(setattr, self.guard.os.path, "exists", real_exists)
+        self.assertEqual(self.guard.default_python(), "/usr/bin/python3")
+
+    def test_falls_back_to_the_running_interpreter(self):
+        real_exists = self.guard.os.path.exists
+        self.guard.os.path.exists = lambda path: False
+        self.addCleanup(setattr, self.guard.os.path, "exists", real_exists)
+        self.assertEqual(self.guard.default_python(), sys.executable)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/projects/amdsmi/tests/python/test_packaging_scriptlets.py
+++ b/projects/amdsmi/tests/python/test_packaging_scriptlets.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) Advanced Micro Devices. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""Guard maintainer-script ownership boundaries between component packages.
+
+amd-smi-lib-tests depends on amd-smi-lib, so removing or upgrading the tests
+package must never disturb the main package's state. These tests assert that
+invariant against the packaging templates themselves, deliberately without
+prescribing HOW it is achieved: the tests component may be given its own
+scriptlets, or simply be left without the main package's, and either satisfies
+the contract.
+
+Static assertions on the templates, so they need no root, package manager or
+container. run_amdsmi_component_removal_test.py proves the same invariant at
+runtime against real packages.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# State that belongs to the main package. The tests package must never touch
+# any of it, on any transition.
+MAIN_PACKAGE_STATE = (
+    "/etc/ld.so.conf.d",
+    "ldconfig",
+    "/var/log/amd_smi_lib",
+    "logrotate",
+    "egg-info",
+    "gpuv-smi",
+)
+
+RPM_SCRIPTLETS = (
+    "POST_INSTALL_SCRIPT_FILE",
+    "PRE_UNINSTALL_SCRIPT_FILE",
+    "POST_UNINSTALL_SCRIPT_FILE",
+)
+
+
+def _read_template(relative_path):
+    path = REPO_ROOT / relative_path
+    if not path.is_file():
+        raise unittest.SkipTest("{} not found".format(relative_path))
+    return path.read_text(encoding="utf-8")
+
+
+def _executable_lines(script):
+    # The contract is about what a script RUNS, not what it documents, so a
+    # maintainer can name the paths that must never be touched in a comment.
+    return "\n".join(line for line in script.splitlines() if not line.lstrip().startswith("#"))
+
+
+def _case_branches(script):
+    """Map each `case "$1"` branch label to its body."""
+    branches = {}
+    pattern = re.compile(r"^\s*\(?\s*([a-z|* \t]+?)\s*\)\s*$(?P<body>.*?)^\s*;;", re.M | re.S)
+    for match in pattern.finditer(script):
+        branches[match.group(1).strip()] = match.group("body")
+    return branches
+
+
+def _removal_commands(script):
+    # Matches both a plain `rm -rf ...` and a `find ... -exec rm -rf {} +`.
+    return [line for line in script.splitlines() if re.search(r"\brm\b", line)]
+
+
+class TestsPackageOwnershipTest(unittest.TestCase):
+    """The tests package must confine itself to files it owns."""
+
+    def setUp(self):
+        self.script = _executable_lines(_read_template("DEBIAN/amd-smi-lib-tests/prerm.in"))
+
+    def test_never_touches_main_package_state(self):
+        for value in MAIN_PACKAGE_STATE:
+            with self.subTest(state=value):
+                self.assertNotIn(value, self.script)
+
+    def test_removals_are_confined_to_the_tests_tree(self):
+        # Every removal must name the tests or tools tree, either directly or
+        # through a variable holding it, so nothing else can be swept up.
+        for command in _removal_commands(self.script):
+            with self.subTest(command=command.strip()):
+                target = command.lower()
+                self.assertTrue(
+                    "test" in target or "tool" in target, "removes something outside the tests tree"
+                )
+
+    def test_nothing_destructive_on_upgrade(self):
+        for label, body in _case_branches(self.script).items():
+            if "upgrade" in label:
+                with self.subTest(branch=label):
+                    self.assertEqual(_removal_commands(body), [])
+
+
+class MainPackageScriptletTest(unittest.TestCase):
+    """The main package may only tear down its own state on a real removal."""
+
+    def test_debian_prerm_removes_ldconfig_only_on_remove(self):
+        script = _read_template("DEBIAN/prerm.in")
+        calls = re.findall(r"^\s*rm_ldconfig\s*$", script, re.MULTILINE)
+        self.assertEqual(calls, ["  rm_ldconfig"])
+        body = re.search(
+            r'if \[ "\$1" = "remove" \]; then(?P<body>.*?)^fi$', script, re.DOTALL | re.MULTILINE
+        )
+        self.assertIsNotNone(body, "final remove branch not found")
+        self.assertIn("rm_ldconfig", body.group("body"))
+
+    def test_rpm_teardown_is_final_erase_only(self):
+        postun = _read_template("RPM/postun.in")
+        guard = re.search(
+            r'if \[ "\$1" -eq 0 \].*?; then(?P<body>.*?)^fi$', postun, re.DOTALL | re.MULTILINE
+        )
+        self.assertIsNotNone(guard, "postun is not guarded by an erase check")
+        self.assertIn("/etc/ld.so.conf.d", guard.group("body"))
+
+        preun = _read_template("RPM/preun.in")
+        guard = re.search(
+            r'if \[ "\$1" -eq 0 \]; then(?P<body>.*?)^fi$', preun, re.DOTALL | re.MULTILINE
+        )
+        self.assertIsNotNone(guard, "preun is not guarded by an erase check")
+        for helper in ("rm_leftovers", "rm_logFolder", "rm_rocm_tests_dir", "rm_logrotateConfig"):
+            with self.subTest(helper=helper):
+                self.assertEqual(len(re.findall(r"^\s*{}\s*$".format(helper), preun, re.M)), 1)
+                self.assertIn(helper, guard.group("body"))
+
+
+class ComponentScopingTest(unittest.TestCase):
+    """Scriptlets must name the component that owns the state they touch.
+
+    An unprefixed CPACK_RPM_<KIND>_SCRIPT_FILE is copied into every component
+    RPM, and on Debian a component with no control-extra of its own inherits
+    the generic CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA. Verified with CPack 3.28.3:
+    naming the component (CPACK_RPM_<COMPONENT>_<KIND>) confines the scriptlet
+    to it, and a component named nowhere ships none.
+
+    The state at stake -- /etc/ld.so.conf.d, /var/log/amd_smi_lib,
+    /etc/logrotate.d -- sits at absolute paths every variant shares, so an
+    inheriting component damages the main package even from another prefix.
+    """
+
+    def setUp(self):
+        self.cmake = _executable_lines(_read_template("CMakeLists.txt"))
+
+    def _is_set(self, name):
+        return re.search(r"set\s*\(\s*{}[\s\n]".format(name), self.cmake) is not None
+
+    def test_no_unprefixed_rpm_scriptlet_reaches_every_component(self):
+        for kind in RPM_SCRIPTLETS:
+            with self.subTest(scriptlet=kind):
+                self.assertFalse(
+                    self._is_set("CPACK_RPM_{}".format(kind)),
+                    "CPACK_RPM_{0} is copied into EVERY component RPM, including asan and "
+                    "any component added later. Name the owning component group instead: "
+                    "CPACK_RPM_RUNTIME_{0}.".format(kind),
+                )
+
+    def test_no_generic_debian_control_extra(self):
+        self.assertFalse(
+            self._is_set("CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA"),
+            "a component without its own control-extra inherits the generic one; "
+            "set CPACK_DEBIAN_<COMPONENT>_PACKAGE_CONTROL_EXTRA per component instead",
+        )
+
+    def test_the_owning_group_still_declares_its_scriptlets(self):
+        # Guards the other direction: scoping must not quietly drop the main
+        # package's own ldconfig registration and cleanup.
+        #
+        # The name is the component GROUP, not the component:
+        # generic_package_post() puts dev into the "runtime" group, so CPack
+        # emits one package per group and looks up CPACK_*_RUNTIME_*. A
+        # CPACK_*_DEV_* variable is accepted by CMake and silently ignored by
+        # CPack, which ships a main package with no maintainer scripts at all.
+        for kind in RPM_SCRIPTLETS:
+            with self.subTest(scriptlet=kind):
+                self.assertTrue(
+                    self._is_set("CPACK_RPM_RUNTIME_{}".format(kind)),
+                    "the main package lost its {}".format(kind),
+                )
+        self.assertTrue(self._is_set("CPACK_DEBIAN_RUNTIME_PACKAGE_CONTROL_EXTRA"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/projects/amdsmi/tests/python/test_upgrade_downgrade_guard.py
+++ b/projects/amdsmi/tests/python/test_upgrade_downgrade_guard.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) Advanced Micro Devices. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""Unit tests for the package upgrade and downgrade guard."""
+
+import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class _Result:
+    def __init__(self, stdout):
+        self.stdout = stdout
+
+
+class _FakeSubprocess:
+    PIPE = object()
+    STDOUT = object()
+
+    def __init__(self, module_file, owner_output):
+        self.module_file = module_file
+        self.owner_output = owner_output
+
+    def check_output(self, cmd, **kwargs):
+        return self.module_file
+
+    def run(self, cmd, **kwargs):
+        return _Result(self.owner_output)
+
+
+def _load_guard():
+    # Probe both the source-tree and installed-tests layouts.
+    for cand in (
+        REPO_ROOT / "tests" / "run_amdsmi_upgrade_downgrade_test.py",
+        REPO_ROOT / "run_amdsmi_upgrade_downgrade_test.py",
+    ):
+        if cand.is_file():
+            spec = importlib.util.spec_from_file_location("amdsmi_upgrade_downgrade_guard", cand)
+            mod = importlib.util.module_from_spec(spec)
+            sys.modules[spec.name] = mod
+            spec.loader.exec_module(mod)
+            return mod
+    raise unittest.SkipTest("run_amdsmi_upgrade_downgrade_test.py not found")
+
+
+class InstallCommandTest(unittest.TestCase):
+    def setUp(self):
+        self.guard = _load_guard()
+
+    def test_commands(self):
+        cases = (
+            (
+                "apt",
+                False,
+                ["apt-get", "install", "-y", "--allow-downgrades", "--reinstall", "pkg"],
+            ),
+            ("apt", True, ["apt-get", "install", "-y", "--allow-downgrades", "--reinstall", "pkg"]),
+            ("dnf", False, ["dnf", "install", "-y", "pkg"]),
+            ("dnf", True, ["dnf", "downgrade", "-y", "pkg"]),
+            (
+                "zypper",
+                False,
+                ["zypper", "--non-interactive", "install", "--allow-downgrade", "pkg"],
+            ),
+            (
+                "zypper",
+                True,
+                ["zypper", "--non-interactive", "install", "--allow-downgrade", "pkg"],
+            ),
+        )
+        for manager, downgrade, expected in cases:
+            with self.subTest(manager=manager, downgrade=downgrade):
+                self.assertEqual(
+                    self.guard.install_command(manager, "pkg", downgrade=downgrade), expected
+                )
+
+    def test_unknown_manager(self):
+        with self.assertRaises(ValueError):
+            self.guard.install_command("unknown", "pkg")
+
+
+class DistinctPackagesTest(unittest.TestCase):
+    def setUp(self):
+        self.guard = _load_guard()
+
+    def test_identical_packages_fail(self):
+        with self.assertRaises(SystemExit):
+            self.guard.assert_distinct_packages("amd-smi-lib-1", "amd-smi-lib-1")
+
+    def test_different_packages_pass(self):
+        self.assertIsNone(self.guard.assert_distinct_packages("amd-smi-lib-1", "amd-smi-lib-2"))
+
+
+class ImportProvenanceTest(unittest.TestCase):
+    """The imported module must belong to the package under test."""
+
+    def setUp(self):
+        self.guard = _load_guard()
+
+    def test_ownership_is_matched_exactly(self):
+        cases = (
+            ("amd-smi-lib: /usr/lib/python3/dist-packages/amdsmi/__init__.py", "apt", True),
+            # A sibling package's name CONTAINS the main package's, so a
+            # substring test would wrongly accept it.
+            ("amd-smi-lib-tests: /usr/lib/python3/dist-packages/amdsmi/__init__.py", "apt", False),
+            (
+                "dpkg-query: no path found matching pattern "
+                "/usr/local/lib/python3.10/dist-packages/amdsmi/__init__.py",
+                "apt",
+                False,
+            ),
+            ("", "apt", False),
+            ("amd-smi-lib", "dnf", True),
+            ("amd-smi-lib-tests", "dnf", False),
+            ("file /x is not owned by any package", "dnf", False),
+        )
+        for output, manager, owned in cases:
+            with self.subTest(output=output[:48], manager=manager):
+                self.assertEqual(
+                    self.guard.import_is_package_owned(output, manager, "amd-smi-lib"), owned
+                )
+
+    def test_verify_rejects_unowned_wheel_path(self):
+        wheel = "/usr/local/lib/python3.10/dist-packages/amdsmi/__init__.py"
+        self.guard.subprocess = _FakeSubprocess(
+            wheel, "dpkg-query: no path found matching pattern " + wheel
+        )
+        with self.assertRaises(SystemExit) as raised:
+            self.guard._verify("apt", "amd-smi-lib")
+        self.assertIn(wheel, str(raised.exception))
+
+    def test_verify_rejects_a_sibling_package(self):
+        path = "/usr/lib/python3/dist-packages/amdsmi/__init__.py"
+        self.guard.subprocess = _FakeSubprocess(path, "amd-smi-lib-tests: " + path)
+        with self.assertRaises(SystemExit) as raised:
+            self.guard._verify("apt", "amd-smi-lib")
+        self.assertIn("amd-smi-lib-tests", str(raised.exception))
+
+    def test_verify_owned_import_reaches_cli_check(self):
+        path = "/usr/lib/python3/dist-packages/amdsmi/__init__.py"
+        self.guard.subprocess = _FakeSubprocess(path, "amd-smi-lib: " + path)
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        old = os.environ.get("ROCM_PATH")
+        os.environ["ROCM_PATH"] = tmp.name
+        if old is None:
+            self.addCleanup(os.environ.pop, "ROCM_PATH", None)
+        else:
+            self.addCleanup(os.environ.__setitem__, "ROCM_PATH", old)
+        with self.assertRaises(SystemExit) as raised:
+            self.guard._verify("apt", "amd-smi-lib")
+        self.assertIn("amd-smi", str(raised.exception))
+        self.assertNotIn("owned by", str(raised.exception))
+
+
+class TransitionSequenceTest(unittest.TestCase):
+    def setUp(self):
+        self.guard = _load_guard()
+        self.commands = []
+        original_run = self.guard._run
+        original_verify = self.guard._verify
+        original_identity = self.guard.read_package_identity
+        self.guard._run = self.commands.append
+        self.guard._verify = lambda manager, expected: None
+        self.guard.read_package_identity = lambda pkg, manager: (
+            "old" if "old" in str(pkg) else "new"
+        )
+        original_name = self.guard.read_package_name
+        self.guard.read_package_name = lambda pkg, manager: "amd-smi-lib"
+        self.addCleanup(setattr, self.guard, "read_package_name", original_name)
+        self.addCleanup(setattr, self.guard, "_run", original_run)
+        self.addCleanup(setattr, self.guard, "_verify", original_verify)
+        self.addCleanup(setattr, self.guard, "read_package_identity", original_identity)
+
+    def _run_main(self, manager):
+        with tempfile.TemporaryDirectory() as tmp:
+            old = Path(tmp) / "old.pkg"
+            new = Path(tmp) / "new.pkg"
+            old.touch()
+            new.touch()
+            result = self.guard.main(
+                ["--old-package", str(old), "--new-package", str(new), "--package-manager", manager]
+            )
+            self.assertEqual(result, 0)
+            return str(old), str(new)
+
+    def test_dnf_sequence(self):
+        old, new = self._run_main("dnf")
+        self.assertEqual(
+            self.commands,
+            [
+                ["dnf", "install", "-y", old],
+                ["dnf", "install", "-y", new],
+                ["dnf", "downgrade", "-y", old],
+            ],
+        )
+
+    def test_apt_sequence(self):
+        old, new = self._run_main("apt")
+        self.assertEqual(
+            self.commands,
+            [
+                ["apt-get", "install", "-y", "--allow-downgrades", "--reinstall", old],
+                ["apt-get", "install", "-y", "--allow-downgrades", "--reinstall", new],
+                ["apt-get", "install", "-y", "--allow-downgrades", "--reinstall", old],
+            ],
+        )
+
+    def test_identical_packages_fail_before_install(self):
+        self.guard.read_package_identity = lambda pkg, manager: "same-package"
+        with tempfile.TemporaryDirectory() as tmp:
+            old = Path(tmp) / "old.pkg"
+            new = Path(tmp) / "new.pkg"
+            old.touch()
+            new.touch()
+            with self.assertRaises(SystemExit):
+                self.guard.main(
+                    [
+                        "--old-package",
+                        str(old),
+                        "--new-package",
+                        str(new),
+                        "--package-manager",
+                        "dnf",
+                    ]
+                )
+        self.assertEqual(self.commands, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/projects/amdsmi/tests/run_amdsmi_component_removal_test.py
+++ b/projects/amdsmi/tests/run_amdsmi_component_removal_test.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) Advanced Micro Devices. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""
+run_amdsmi_component_removal_test.py
+====================================
+
+The amd-smi-lib-tests package depends on amd-smi-lib, but removing that optional
+component must not run the main package's removal scripts. A packaging regression
+did exactly that, deleting the main package's linker registration and, on RPM
+systems, its log directory and logrotate configuration while amd-smi-lib remained
+installed.
+
+This test installs the main and tests packages, snapshots the main installation,
+removes only the tests package, and proves the main package, Python module, linker
+configuration, and any pre-existing logging paths survive intact.
+
+Requires root and is intended to run only in the CI distro container.
+"""
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+LINKER_CONFIG = Path("/etc/ld.so.conf.d/x86_64-libamd_smi_lib.conf")
+OPTIONAL_PATHS = (Path("/var/log/amd_smi_lib"), Path("/etc/logrotate.d/amd_smi.conf"))
+
+
+def _run(cmd: list) -> None:
+    print("+ " + " ".join(cmd))
+    subprocess.run(cmd, check=True)
+
+
+def install_command(manager: str, package: str) -> list:
+    if manager == "apt":
+        return ["apt-get", "install", "-y", "--reinstall", package]
+    if manager == "dnf":
+        return ["dnf", "install", "-y", package]
+    if manager == "zypper":
+        return ["zypper", "--non-interactive", "install", package]
+    raise ValueError(f"unsupported package manager: {manager}")
+
+
+def remove_command(manager: str, package_name: str) -> list:
+    if manager == "apt":
+        return ["apt-get", "remove", "-y", package_name]
+    if manager == "dnf":
+        return ["dnf", "remove", "-y", package_name]
+    if manager == "zypper":
+        return ["zypper", "--non-interactive", "remove", package_name]
+    raise ValueError(f"unsupported package manager: {manager}")
+
+
+def read_package_name(package: Path, manager: str) -> str:
+    if manager == "apt":
+        cmd = ["dpkg-deb", "-f", str(package), "Package"]
+    elif manager in ("dnf", "zypper"):
+        cmd = ["rpm", "-qp", "--qf", "%{NAME}", str(package)]
+    else:
+        raise ValueError(f"unsupported package manager: {manager}")
+    return subprocess.check_output(cmd, universal_newlines=True).strip()
+
+
+def package_is_installed(manager: str, package_name: str) -> bool:
+    if manager == "apt":
+        cmd = ["dpkg-query", "-W", "-f=${Status}", package_name]
+        expected = "install ok installed"
+    elif manager in ("dnf", "zypper"):
+        cmd = ["rpm", "-q", package_name]
+        expected = None
+    else:
+        raise ValueError(f"unsupported package manager: {manager}")
+    result = subprocess.run(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, universal_newlines=True
+    )
+    return result.returncode == 0 and (expected is None or result.stdout.strip() == expected)
+
+
+def module_owner(manager: str, module_file: str) -> str:
+    if manager == "apt":
+        cmd = ["dpkg", "-S", module_file]
+    elif manager in ("dnf", "zypper"):
+        cmd = ["rpm", "-qf", "--qf", "%{NAME}", module_file]
+    else:
+        raise ValueError(f"unsupported package manager: {manager}")
+    print("+ " + " ".join(cmd))
+    result = subprocess.run(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True
+    )
+    print(result.stdout, end="")
+    if result.returncode != 0:
+        return ""
+    if manager == "apt":
+        return result.stdout.partition(":")[0].strip()
+    return result.stdout.strip()
+
+
+def import_module_file() -> str:
+    cmd = ["python3", "-c", "import amdsmi; print(amdsmi.__file__)"]
+    print("+ " + " ".join(cmd))
+    return subprocess.check_output(cmd, universal_newlines=True).strip()
+
+
+def linker_library_directory(config_text: str) -> Path:
+    lines = [line.strip() for line in config_text.splitlines() if line.strip()]
+    if not lines:
+        raise ValueError("linker registration is empty")
+    return Path(lines[0])
+
+
+def _detect_manager() -> str:
+    for mgr in ("apt-get", "dnf", "zypper"):
+        if shutil.which(mgr):
+            return {"apt-get": "apt", "dnf": "dnf", "zypper": "zypper"}[mgr]
+    sys.exit("no supported package manager found")
+
+
+def snapshot_main_state(manager: str, main_package_name: str) -> dict:
+    if not package_is_installed(manager, main_package_name):
+        sys.exit(f"main package {main_package_name} is not installed before component removal")
+    if not LINKER_CONFIG.is_file():
+        sys.exit(f"main package linker registration {LINKER_CONFIG} is missing before removal")
+    config_text = LINKER_CONFIG.read_text()
+    try:
+        libdir = linker_library_directory(config_text)
+    except ValueError as error:
+        sys.exit(f"main package {error} before component removal")
+    if not list(libdir.glob("libamd_smi.so*")):
+        sys.exit(f"main package linker registration points at {libdir} without libamd_smi.so")
+    try:
+        module_file = import_module_file()
+    except subprocess.CalledProcessError:
+        sys.exit("main package Python module does not import before component removal")
+    if module_owner(manager, module_file) != main_package_name:
+        sys.exit(
+            f"main package Python module {module_file} is not owned by {main_package_name} "
+            "before component removal"
+        )
+    return {
+        "config_text": config_text,
+        "module_file": module_file,
+        "optional_paths": {path: path.exists() for path in OPTIONAL_PATHS},
+    }
+
+
+def verify_main_survived(manager: str, main_package_name: str, snapshot: dict) -> None:
+    if not LINKER_CONFIG.is_file():
+        sys.exit(f"tests-package removal destroyed linker registration {LINKER_CONFIG}")
+    config_text = LINKER_CONFIG.read_text()
+    if config_text != snapshot["config_text"]:
+        sys.exit(f"tests-package removal changed linker registration {LINKER_CONFIG}")
+    try:
+        libdir = linker_library_directory(config_text)
+    except ValueError:
+        sys.exit(f"tests-package removal emptied linker registration {LINKER_CONFIG}")
+    if not list(libdir.glob("libamd_smi.so*")):
+        sys.exit(
+            f"tests-package removal left linker registration pointing at {libdir}, "
+            "but destroyed libamd_smi.so"
+        )
+    if not package_is_installed(manager, main_package_name):
+        sys.exit(f"tests-package removal uninstalled main package {main_package_name}")
+    try:
+        module_file = import_module_file()
+    except subprocess.CalledProcessError:
+        sys.exit("tests-package removal destroyed the main package's Python module import")
+    if module_file != snapshot["module_file"]:
+        sys.exit(
+            f"tests-package removal changed the main package Python module from "
+            f"{snapshot['module_file']} to {module_file}"
+        )
+    if module_owner(manager, module_file) != main_package_name:
+        sys.exit(
+            f"tests-package removal left Python module {module_file} no longer owned by "
+            f"main package {main_package_name}"
+        )
+    for path, existed in snapshot["optional_paths"].items():
+        if existed and not path.exists():
+            sys.exit(f"tests-package removal destroyed main package path {path}")
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--main-package", type=Path, required=True, help="Main .deb/.rpm package.")
+    parser.add_argument(
+        "--tests-package", type=Path, required=True, help="Matching tests .deb/.rpm package."
+    )
+    parser.add_argument(
+        "--package-manager",
+        choices=("apt", "dnf", "zypper"),
+        default=None,
+        help="apt / dnf / zypper (default: auto).",
+    )
+    args = parser.parse_args(argv)
+
+    if os.geteuid() != 0:
+        sys.exit("this package installation test requires root")
+    for package in (args.main_package, args.tests_package):
+        if not package.is_file():
+            sys.exit(f"package not found: {package}")
+
+    manager = args.package_manager or _detect_manager()
+    main_package_name = read_package_name(args.main_package, manager)
+    tests_package_name = read_package_name(args.tests_package, manager)
+
+    print("=== 1. install main package ===")
+    _run(install_command(manager, str(args.main_package)))
+    print("=== 2. install tests package ===")
+    _run(install_command(manager, str(args.tests_package)))
+    snapshot = snapshot_main_state(manager, main_package_name)
+    print("=== 3. remove tests package only ===")
+    _run(remove_command(manager, tests_package_name))
+    verify_main_survived(manager, main_package_name, snapshot)
+
+    print("PASS: removing the tests package left the main package intact.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/projects/amdsmi/tests/run_amdsmi_cpack_path_test.py
+++ b/projects/amdsmi/tests/run_amdsmi_cpack_path_test.py
@@ -32,14 +32,25 @@ directory, before the package is ever installed.
 """
 
 import argparse
-import re
+import json
+import os
 import subprocess
 import sys
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
-# amdsmi_interface.py is a stable module file the package must ship; matching it
-# under a site/dist-packages path proves the module landed on an import path.
-MODULE_MARKER = re.compile(r"(site-packages|dist-packages)/amdsmi/amdsmi_interface\.py$")
+
+def parse_dpkg_listing(text: str) -> list:
+    paths = []
+    for line in text.splitlines():
+        member = line.split(" -> ", 1)[0]
+        fields = member.split(None, 5)
+        if len(fields) != 6:
+            continue
+        path = fields[5]
+        if path.startswith("./"):
+            path = path[1:]
+        paths.append(path)
+    return paths
 
 
 def _list_deb(pkg: Path) -> list:
@@ -50,13 +61,7 @@ def _list_deb(pkg: Path) -> list:
         universal_newlines=True,
         check=True,
     )
-    # dpkg -c lines end with the path (may be "./usr/lib/..."); take the last field.
-    paths = []
-    for line in out.stdout.splitlines():
-        parts = line.split()
-        if parts:
-            paths.append(parts[-1].lstrip("."))
-    return paths
+    return parse_dpkg_listing(out.stdout)
 
 
 def _list_rpm(pkg: Path) -> list:
@@ -79,21 +84,84 @@ def list_package(pkg: Path) -> list:
     sys.exit(f"unsupported package type: {pkg}")
 
 
-def main() -> int:
+def select_module_paths(paths, site_dirs) -> list:
+    expected = {
+        PurePosixPath(
+            os.path.normpath(str(PurePosixPath(site_dir) / "amdsmi" / "amdsmi_interface.py"))
+        )
+        for site_dir in site_dirs
+    }
+    return [path for path in paths if PurePosixPath(os.path.normpath(path)) in expected]
+
+
+def default_python() -> str:
+    """Pick the interpreter the package install path was derived from.
+
+    py-interface/CMakeLists.txt detects the module destination with
+    /usr/libexec/platform-python when it exists (the stable RHEL/Fedora handle
+    on the default interpreter) and /usr/bin/python3 otherwise. Mirror that
+    order rather than using sys.executable: on the RHEL family the two can be
+    different minors, and checking the wrong one reports a correctly packaged
+    module as misplaced.
+    """
+    for candidate in ("/usr/libexec/platform-python", "/usr/bin/python3"):
+        if os.path.exists(candidate):
+            return candidate
+    return sys.executable
+
+
+def discover_site_dirs(python_exe) -> list:
+    command = "import site, json; print(json.dumps(site.getsitepackages()))"
+    try:
+        out = subprocess.run(
+            [python_exe, "-c", command],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+            check=True,
+        )
+        site_dirs = json.loads(out.stdout)
+    except (OSError, subprocess.CalledProcessError, ValueError) as error:
+        detail = getattr(error, "stderr", None) or str(error)
+        sys.exit(
+            "failed to discover site directories with {}: {}".format(python_exe, detail.strip())
+        )
+    if not isinstance(site_dirs, list):
+        sys.exit(
+            "failed to discover site directories with {}: expected a JSON list".format(python_exe)
+        )
+    return site_dirs
+
+
+def main(argv=None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("package", type=Path, help="Built .deb or .rpm to inspect.")
-    args = parser.parse_args()
+    parser.add_argument(
+        "--site-dir",
+        action="append",
+        dest="site_dirs",
+        help="Expected interpreter site directory (repeatable; skips discovery).",
+    )
+    parser.add_argument(
+        "--python",
+        default=None,
+        help="Python interpreter used to discover site directories "
+        "(default: the interpreter the package install path was derived from).",
+    )
+    args = parser.parse_args(argv)
     pkg = args.package
     if not pkg.is_file():
         sys.exit(f"package not found: {pkg}")
 
+    site_dirs = args.site_dirs or discover_site_dirs(args.python or default_python())
     paths = list_package(pkg)
-    matches = [p for p in paths if MODULE_MARKER.search(p)]
+    matches = select_module_paths(paths, site_dirs)
     if not matches:
         sample = "\n  ".join(p for p in paths if "amdsmi" in p) or "(no amdsmi paths at all)"
+        expected = "\n  ".join(site_dirs) or "(no site directories reported)"
         sys.exit(
-            "amdsmi module not found under a site-packages/dist-packages path in "
-            f"{pkg.name}.\namdsmi-related entries:\n  {sample}"
+            f"amdsmi module not found under an expected site directory in {pkg.name}.\n"
+            f"expected site directories:\n  {expected}\namdsmi-related entries:\n  {sample}"
         )
 
     print(f"PASS: {pkg.name} ships the amdsmi module at:")
@@ -103,4 +171,4 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    sys.exit(main())

--- a/projects/amdsmi/tests/run_amdsmi_python_versions_test.py
+++ b/projects/amdsmi/tests/run_amdsmi_python_versions_test.py
@@ -76,7 +76,11 @@ def _import_smoke(interp: str) -> None:
 
 
 def _run_unit_tests(interp: str) -> None:
-    for test in ("test_abi_compat.py", "test_dual_copy_guard.py"):
+    for test in (
+        "test_abi_compat.py",
+        "test_dual_copy_guard.py",
+        "test_cpack_path_guard.py",
+    ):
         subprocess.run([interp, str(TEST_DIR / test)], check=True)
 
 

--- a/projects/amdsmi/tests/run_amdsmi_python_versions_test.py
+++ b/projects/amdsmi/tests/run_amdsmi_python_versions_test.py
@@ -80,6 +80,8 @@ def _run_unit_tests(interp: str) -> None:
         "test_abi_compat.py",
         "test_dual_copy_guard.py",
         "test_cpack_path_guard.py",
+        "test_upgrade_downgrade_guard.py",
+        "test_packaging_scriptlets.py",
     ):
         subprocess.run([interp, str(TEST_DIR / test)], check=True)
 

--- a/projects/amdsmi/tests/run_amdsmi_python_versions_test.py
+++ b/projects/amdsmi/tests/run_amdsmi_python_versions_test.py
@@ -21,8 +21,7 @@
 
 """
 run_amdsmi_python_versions_test.py
-==================================
-
+===========================
 The amdsmi loader and wrapper must behave identically across the range of
 CPython versions AMD SMI supports (3.6.8 through the latest release). This
 harness runs the version-independent loader contract tests under each

--- a/projects/amdsmi/tests/run_amdsmi_python_versions_test.py
+++ b/projects/amdsmi/tests/run_amdsmi_python_versions_test.py
@@ -48,9 +48,14 @@ PY_INTERFACE = REPO_ROOT / "py-interface"
 TEST_DIR = REPO_ROOT / "tests" / "python"
 
 
+# Highest CPython minor AMD SMI claims support for; keep in sync with the
+# matrix in .github/workflows/amdsmi-python-versions.yml.
+NEWEST_SUPPORTED_MINOR = 14
+
+
 def _discover_default_interpreters() -> list:
     found = []
-    for minor in range(6, 14):
+    for minor in range(6, NEWEST_SUPPORTED_MINOR + 1):
         exe = shutil.which(f"python3.{minor}")
         if exe:
             found.append(exe)
@@ -82,7 +87,7 @@ def main() -> int:
         "--interpreters",
         nargs="*",
         default=None,
-        help="Python interpreters to test (default: discovered python3.6..3.13).",
+        help="Python interpreters to test (default: discovered python3.6..3.14).",
     )
     args = parser.parse_args()
     interpreters = args.interpreters or _discover_default_interpreters()

--- a/projects/amdsmi/tests/run_amdsmi_upgrade_downgrade_test.py
+++ b/projects/amdsmi/tests/run_amdsmi_upgrade_downgrade_test.py
@@ -61,7 +61,9 @@ def _run_cli_version(amd_smi: str) -> None:
     cmd = [amd_smi, "version"]
     print("+ " + " ".join(cmd))
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True)
+        result = subprocess.run(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True
+        )
     except OSError as e:
         sys.exit(f"CLI {amd_smi} could not be executed: {e}")
     print(result.stdout, end="")
@@ -70,25 +72,93 @@ def _run_cli_version(amd_smi: str) -> None:
         sys.exit(f"CLI {amd_smi} version failed with exit {result.returncode}")
 
 
-def _install(pkg: Path, manager: str, downgrade: bool = False) -> None:
+def install_command(manager: str, pkg: str, downgrade: bool = False) -> list:
     if manager == "apt":
-        _run(["apt-get", "install", "-y", "--allow-downgrades", "--reinstall", str(pkg)])
-    elif manager == "dnf":
+        return ["apt-get", "install", "-y", "--allow-downgrades", "--reinstall", pkg]
+    if manager == "dnf":
         # dnf install refuses to downgrade; use dnf downgrade for that direction.
         # apt and zypper handle both directions with their existing flags.
         if downgrade:
-            _run(["dnf", "downgrade", "-y", str(pkg)])
-        else:
-            _run(["dnf", "install", "-y", str(pkg)])
-    elif manager == "zypper":
-        _run(["zypper", "--non-interactive", "install", "--allow-downgrade", str(pkg)])
+            return ["dnf", "downgrade", "-y", pkg]
+        return ["dnf", "install", "-y", pkg]
+    if manager == "zypper":
+        return ["zypper", "--non-interactive", "install", "--allow-downgrade", pkg]
+    raise ValueError(f"unsupported package manager: {manager}")
+
+
+def _install(pkg: Path, manager: str, downgrade: bool = False) -> None:
+    _run(install_command(manager, str(pkg), downgrade))
+
+
+def read_package_name(pkg: Path, manager: str) -> str:
+    if manager == "apt":
+        cmd = ["dpkg-deb", "-f", str(pkg), "Package"]
+    elif manager in ("dnf", "zypper"):
+        cmd = ["rpm", "-qp", "--qf", "%{NAME}", str(pkg)]
     else:
-        sys.exit(f"unsupported package manager: {manager}")
+        raise ValueError(f"unsupported package manager: {manager}")
+    return subprocess.check_output(cmd, universal_newlines=True).strip()
 
 
-def _verify() -> None:
+def read_package_identity(pkg: Path, manager: str) -> str:
+    if manager == "apt":
+        cmd = ["dpkg-deb", "-f", str(pkg), "Package", "Version"]
+    elif manager in ("dnf", "zypper"):
+        cmd = ["rpm", "-qp", "--qf", "%{NAME}-%{EVR}", str(pkg)]
+    else:
+        raise ValueError(f"unsupported package manager: {manager}")
+    return subprocess.check_output(cmd, universal_newlines=True).strip()
+
+
+def assert_distinct_packages(old_id: str, new_id: str) -> None:
+    if old_id == new_id:
+        sys.exit(f"OLD and NEW packages have the same identity: {old_id}")
+
+
+def owner_package_name(owner_query_output: str, manager: str) -> str:
+    """Exact name of the package owning a file, or "" when nothing owns it."""
+    text = owner_query_output.strip()
+    lowered = text.lower()
+    if not text or "no path found" in lowered or "not owned by any package" in lowered:
+        return ""
+    first = text.splitlines()[0].strip()
+    # `dpkg -S` answers "<package>: <path>"; the rpm query below asks for the
+    # bare %{NAME}, so it needs no further parsing.
+    return first.split(":", 1)[0].strip() if manager == "apt" else first
+
+
+def import_is_package_owned(owner_query_output: str, manager: str, expected_package: str) -> bool:
+    """Whether the imported module belongs to the package under test.
+
+    Compares the owning package name exactly: a substring test would accept a
+    sibling such as amd-smi-lib-tests, whose name contains the main package's.
+    """
+    return owner_package_name(owner_query_output, manager) == expected_package
+
+
+def _verify(manager: str, expected_package: str) -> None:
     # Module imports and resolves a library path.
-    _run(["python3", "-c", "import amdsmi; print('import OK from', amdsmi.__file__)"])
+    import_cmd = ["python3", "-c", "import amdsmi; print(amdsmi.__file__)"]
+    print("+ " + " ".join(import_cmd))
+    module_file = subprocess.check_output(import_cmd, universal_newlines=True).strip()
+    print(f"import OK from {module_file}")
+    if manager == "apt":
+        owner_cmd = ["dpkg", "-S", module_file]
+    elif manager in ("dnf", "zypper"):
+        owner_cmd = ["rpm", "-qf", "--qf", "%{NAME}", module_file]
+    else:
+        raise ValueError(f"unsupported package manager: {manager}")
+    print("+ " + " ".join(owner_cmd))
+    owner = subprocess.run(
+        owner_cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True
+    ).stdout
+    print(owner, end="")
+    if not import_is_package_owned(owner, manager, expected_package):
+        sys.exit(
+            f"amdsmi import resolved to {module_file}, owned by "
+            f"'{owner_package_name(owner, manager) or 'nothing'}' rather than "
+            f"'{expected_package}' (for example, a pip wheel under /usr/local)"
+        )
     # CLI runs. The package installs amd-smi to <ROCM_PATH>/bin, which is not
     # on PATH in the CI container, so resolve it there directly rather than via
     # `which` (which would silently skip the check and let a broken CLI pass).
@@ -105,7 +175,10 @@ def _verify() -> None:
     conf = Path("/etc/ld.so.conf.d/x86_64-libamd_smi_lib.conf")
     if not conf.is_file():
         sys.exit(f"linker registration {conf} is missing after install/upgrade")
-    libdir = conf.read_text().strip().splitlines()[0].strip()
+    conf_lines = [line.strip() for line in conf.read_text().splitlines() if line.strip()]
+    if not conf_lines:
+        sys.exit("linker registration {} is empty; postinst wrote no library path".format(conf))
+    libdir = conf_lines[0]
     if not list(Path(libdir).glob("libamd_smi.so*")):
         sys.exit(f"ld.so.conf.d points at {libdir} but no libamd_smi.so is there")
 
@@ -117,36 +190,42 @@ def _detect_manager() -> str:
     sys.exit("no supported package manager found")
 
 
-def main() -> int:
+def main(argv=None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--old-package", type=Path, required=True, help="Prior-version .deb/.rpm.")
     parser.add_argument("--new-package", type=Path, required=True, help="New .deb/.rpm to test.")
     parser.add_argument(
         "--package-manager", default=None, help="apt / dnf / zypper (default: auto)."
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     for p in (args.old_package, args.new_package):
         if not p.is_file():
             sys.exit(f"package not found: {p}")
 
     manager = args.package_manager or _detect_manager()
+    assert_distinct_packages(
+        read_package_identity(args.old_package, manager),
+        read_package_identity(args.new_package, manager),
+    )
+
+    expected_package = read_package_name(args.new_package, manager)
 
     print("=== 1. install OLD ===")
     _install(args.old_package, manager)
-    _verify()
+    _verify(manager, expected_package)
 
     print("=== 2. upgrade to NEW ===")
     _install(args.new_package, manager)
-    _verify()
+    _verify(manager, expected_package)
 
     print("=== 3. downgrade to OLD ===")
     _install(args.old_package, manager, downgrade=True)
-    _verify()
+    _verify(manager, expected_package)
 
     print("PASS: upgrade and downgrade keep the module, CLI, and linker config consistent.")
     return 0
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    sys.exit(main())


### PR DESCRIPTION
Stacked on #9110 — this targets that branch, not `develop`.

```
develop
└─ #9034 packaging install-path and multi-Python coverage
   └─ #9035 SLES RPM interpreter dependency check
      └─ #9110 component scriptlet isolation
         └─ #9695 (this PR)
```

## What this is

The regression tests #9110 didn't ship with, plus fixes for several unrelated defects in the packaging test suite that let real breakage through. Nothing here changes #9110's fix — this PR adds tests and CI only, apart from the two behavior changes called out at the bottom.

## Regression coverage for #9110

#9110 stops `amd-smi-lib-tests` from tearing down the still-installed `amd-smi-lib`. Two tests pin it:

- **`test_packaging_scriptlets.py`** — static guard on the templates and the CPack wiring. Written against the *invariant* rather than one particular remedy, so it accepts either "give the tests component its own scriptlets" or "scope the globals to the owner".
- **`run_amdsmi_component_removal_test.py`** + a workflow step — installs both packages in the distro container, removes only the tests package, and asserts the main package survives: still installed, linker registration intact, module still importable and still owned by the main package, log directory and logrotate config untouched.

The static guard alone is not sufficient. It can only confirm which CPack variables were *written*, never that CPack *honors* them, so it passes against packaging that is genuinely broken. The container test is what closes that gap.

## Also fixed — the test oracles themselves

- **CPack path check** accepted any path merely *containing* `site-packages`. Verified false positives on real synthetic packages: `/usr/lib/python3/not-site-packages/…`, `/opt/acme/site-packages/…`, and a wrong Python minor. It now matches against the target interpreter's `site.getsitepackages()`, and picks that interpreter the way packaging does (`/usr/libexec/platform-python`, then `/usr/bin/python3`) rather than `sys.executable`, which differs on the RHEL family. It also parses `dpkg -c` without mangling symlink entries or paths containing spaces.
- **Upgrade round trip** verified a bare `import amdsmi`. A pip wheel under `/usr/local` shadows the packaged module, so all three phases could validate the *same unchanged wheel* while the system package really did change — reproduced on Ubuntu 22.04 and AlmaLinux 9. It now requires the imported module to be owned by the package under test, comparing the owning package name **exactly**: a substring test accepts `amd-smi-lib-tests`, whose name contains the main package's. OLD and NEW must also differ, so equal versions can't no-op past the test.
- **Build harness** ran that round trip *after* installing the wheel; moved ahead of the install and wheel stages.
- **Post-install** now warns, non-fatally and destroying nothing, when a pip-installed `amdsmi` shadows the packaged module.
- **`test_run_amdsmi_build.py`** never registered the module in `sys.modules` before `exec_module`, which `@dataclass` requires on Python 3.12+. All 16 of its tests were uncollectable.

## Testing

The new unit tests are hermetic — no root, Docker, network or GPU — and run on Python 3.6 through 3.14 via the version harness. Both new guards fail on the pre-fix code for the right reason, not merely because a helper is missing: the scriptlet guard fails on the pre-fix templates, and the CPack path guard drives the old CLI through a fake `dpkg` shim and reports the unimportable path it used to accept.

Each commit is self-contained and was verified individually, so the stack bisects cleanly.

## Notes for review

- Two behavior changes only: the post-install warning, which deletes nothing and always exits 0, and stage ordering inside a test harness. Everything else is test coverage or CI.
- The upgrade-round-trip ownership check uses exact package-name comparison rather than the `"amd-smi-lib"` prefix suggested in review, because that string is also a prefix of `amd-smi-lib-tests`. The sibling case is covered by a test.

## JIRA ID

ROCM-3941
