### PR TITLE
Rocprofv3: honor ROCPROF_ATT_LIBRARY_PATH instead of scanning "/"

### DIFF
--- a/projects/rocprofiler-sdk/source/bin/rocprofv3.py
+++ b/projects/rocprofiler-sdk/source/bin/rocprofv3.py
@@ -125,12 +125,6 @@ def warn_deprecated_output_formats(output_formats):
         )
 
 
-def info(msg, *args):
-    msg = patch_message(msg, *args)
-    sys.stderr.write(f"[rocprofv3] {msg}\n")
-    sys.stderr.flush()
-
-
 def format_help(formatter, w=120, h=40):
     """Return a wider HelpFormatter, if possible."""
     try:
@@ -388,11 +382,6 @@ def check_att_capability(args, att_lib_name="librocprof-trace-decoder.so"):
         for root, dirs, files in os.walk(path, topdown=True):
             for itr in files:
                 if att_lib_name in itr:
-                    info(
-                        "rocprof-trace-decoder library '{}' selected from '{}'".format(
-                            itr, root
-                        )
-                    )
                     args.att_library_path = resolve_library_path(
                         root, args, is_sdk_lib=False
                     )

--- a/projects/rocprofiler-sdk/source/bin/rocprofv3.py
+++ b/projects/rocprofiler-sdk/source/bin/rocprofv3.py
@@ -125,6 +125,12 @@ def warn_deprecated_output_formats(output_formats):
         )
 
 
+def info(msg, *args):
+    msg = patch_message(msg, *args)
+    sys.stderr.write(f"[rocprofv3] {msg}\n")
+    sys.stderr.flush()
+
+
 def format_help(formatter, w=120, h=40):
     """Return a wider HelpFormatter, if possible."""
     try:
@@ -352,7 +358,12 @@ def get_att_paths(args):
     if args.att_library_path:
         library_paths.extend(args.att_library_path)
     elif os.environ.get("ROCPROF_ATT_LIBRARY_PATH"):
-        return os.environ.get("ROCPROF_ATT_LIBRARY_PATH")
+        # Return a list (not a bare str) so the caller iterates over paths and
+        # not over the individual characters of the string. Support a
+        # colon-separated list for consistency with LD_LIBRARY_PATH.
+        for itr in os.environ["ROCPROF_ATT_LIBRARY_PATH"].split(":"):
+            if itr and itr not in library_paths:
+                library_paths += [itr]
     else:
         default_lib_path_env = os.environ.get("LD_LIBRARY_PATH", "").split(":") + [
             f"{ROCM_DIR}/lib"
@@ -369,9 +380,19 @@ def check_att_capability(args, att_lib_name="librocprof-trace-decoder.so"):
     library_paths = get_att_paths(args)
 
     for path in library_paths:
+        # Skip entries that are not existing directories so a stray value (e.g.
+        # an empty string, a file, or a bad path) cannot become an os.walk()
+        # root and silently trigger a full "/" scan.
+        if not path or not os.path.isdir(path):
+            continue
         for root, dirs, files in os.walk(path, topdown=True):
             for itr in files:
                 if att_lib_name in itr:
+                    info(
+                        "rocprof-trace-decoder library '{}' selected from '{}'".format(
+                            itr, root
+                        )
+                    )
                     args.att_library_path = resolve_library_path(
                         root, args, is_sdk_lib=False
                     )


### PR DESCRIPTION
## Motivation
Setting `ROCPROF_ATT_LIBRARY_PATH` — the documented way to point `rocprofv3 --att` at the trace decoder — currently has **no effect**. The value is discarded, the entire filesystem is walked starting at `/`, and the first `librocprof-trace-decoder.so*` found *anywhere on the machine* is used instead. Root cause is a return-type inconsistency in `get_att_paths()`: the env-var branch returns a `str` while every other branch returns a `list`. The only caller iterates the result as a sequence of paths:
```python
library_paths = get_att_paths(args)
for path in library_paths:            # iterates CHARACTERS when given a str
    for root, dirs, files in os.walk(path, topdown=True):
        ...
```
So each character of the path becomes an os.walk() root. The leading "/" turns this into a full-filesystem scan and the remaining characters match nothing; the directory finally used is effectively arbitrary — it can silently pick a decoder from an unrelated ROCm install/venv, and on a machine with no early match it scans the whole filesystem (including mounted network storage).

## Technical Details
- Return a list on the env-var branch, colon-split for LD_LIBRARY_PATH consistency, so the caller iterates over paths and not over individual characters.
- Guard the search: skip entries that are not existing directories, so a stray value (empty string, a file, a bad path, or a future type slip) can no longer become an os.walk() root and silently trigger a "/" scan.
- Log the selected decoder directory via a small info() helper, so library selection is visible to the user instead of invisible.

## Issue Tracking
JIRA ID: AIPROFSDK-1006

## Test Result
```
$ ROCPROF_ATT_LIBRARY_PATH=<venv>/_rocm_sdk_devel/lib rocprofv3 --att -- ./counter-collection-buffer
[rocprofv3] rocprof-trace-decoder library 'librocprof-trace-decoder.so.0.2.0' selected from '<venv>/_rocm_sdk_devel/lib'
HSA version 1.21.0 initialized
... shader_engine_0_1.att / _2.att / _10001.att ...
Run complete
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
