### PR TITLE
[rocjitsu] Match the signed PC-delta template across prefetch padding

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
@@ -1495,26 +1495,42 @@ match_signed_delta_sub_consumer(const AnalysisContext &ctx, const AnalysisBlock 
     return dst != pair_lo && dst != static_cast<uint16_t>(pair_lo + 1u) && dst != tmp_sreg;
   };
 
-  size_t abs_index = block.first_index;
-  while (abs_index <= block.last_index && is_gfx1250_padding(abs_index))
-    ++abs_index;
-  if (abs_index + 3 > block.last_index)
+  // Padding is skipped before every step, not just before the first and the last.
+  // The compiler places the prefetch pair wherever it likes within the template,
+  // so stepping by a fixed +1/+2 through the middle stops matching the moment it
+  // lands between s_abs_i32 and the subtract -- which is exactly where gfx1250
+  // hipBLASLt kernels put it. The sibling add-half matcher already walks this
+  // way, and the two halves have to agree: recover_signed_delta_templates()
+  // discards a recovered add-half whenever the sub-half misses, so a gap matched
+  // by only one of them leaves BOTH setpcs unrecovered and refuses the kernel.
+  const auto skip_padding = [&](size_t index) {
+    while (index <= block.last_index && is_gfx1250_padding(index))
+      ++index;
+    return index;
+  };
+
+  const size_t abs_index = skip_padding(block.first_index);
+  if (abs_index > block.last_index)
     return std::nullopt;
-  const Instruction &abs_inst = *ctx.insts[abs_index];
-  const Instruction &low_inst = *ctx.insts[abs_index + 1];
-  const Instruction &high_inst = *ctx.insts[abs_index + 2];
-  size_t setpc_index = abs_index + 3;
-  while (setpc_index <= block.last_index && is_gfx1250_padding(setpc_index))
-    ++setpc_index;
+  const size_t low_index = skip_padding(abs_index + 1);
+  if (low_index > block.last_index)
+    return std::nullopt;
+  const size_t high_index = skip_padding(low_index + 1);
+  if (high_index > block.last_index)
+    return std::nullopt;
+  const size_t setpc_index = skip_padding(high_index + 1);
   if (setpc_index > block.last_index)
     return std::nullopt;
+  const Instruction &abs_inst = *ctx.insts[abs_index];
+  const Instruction &low_inst = *ctx.insts[low_index];
+  const Instruction &high_inst = *ctx.insts[high_index];
   const Instruction &setpc_inst = *ctx.insts[setpc_index];
   if (!sop1_same_sreg(abs_inst, ctx.facts[abs_index].word, "s_abs_i32", tmp_sreg))
     return std::nullopt;
-  if (!sop2_sreg_inline_to_sreg(low_inst, ctx.facts[abs_index + 1].word, *sub_u32_opcode, pair_lo,
+  if (!sop2_sreg_inline_to_sreg(low_inst, ctx.facts[low_index].word, *sub_u32_opcode, pair_lo,
                                 pair_lo, tmp_sreg))
     return std::nullopt;
-  if (!sop2_sreg_inline_zero_to_sreg(high_inst, ctx.facts[abs_index + 2].word, *subb_u32_opcode,
+  if (!sop2_sreg_inline_zero_to_sreg(high_inst, ctx.facts[high_index].word, *subb_u32_opcode,
                                      static_cast<uint16_t>(pair_lo + 1),
                                      static_cast<uint16_t>(pair_lo + 1)))
     return std::nullopt;

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -2694,6 +2694,76 @@ TEST(CfgAnalysis, Gfx1250DoesNotReuseStashFromSkippedFallthroughPredecessor) {
   EXPECT_TRUE(fixups.empty()) << "must-dataflow must not reuse a skipped-path stash";
 }
 
+// The signed PC-delta template with the gfx1250 instruction-prefetch pair sitting
+// between s_abs_i32 and the subtract. The encodings are lifted verbatim from a
+// hipBLASLt gfx1250 Tensile kernel, where this is what the compiler emits.
+//
+// Both halves have to recover together: the sub half proves the negative path and
+// the add half the positive one, and recover_signed_delta_templates() discards a
+// recovered add half whenever the sub half misses. Tolerating the padding in only
+// one matcher therefore leaves BOTH consumers unrecovered, and a kernel whose text
+// has to move is then refused outright -- which reached a user as a null kernel
+// handle and a segfault.
+TEST(CfgAnalysis, SignedDeltaTemplateToleratesPrefetchPaddingBeforeTheSubtract) {
+  std::vector<uint32_t> words = {
+      0xBE9C4700u, // 0x00: s_get_pc_i64 s[28:29].
+      0x811E84FFu, // 0x04: s_add_co_i32 s30, lit, 4.
+      0x00000034u, // 0x08: literal -> target 0x3c (getpc_next + lit + 4).
+      0xBF03801Eu, // 0x0c: s_cmp_ge_i32 s30, 0.
+      0xBFA20007u, // 0x10: s_cbranch_scc1 -> add half at 0x30.
+      0xBE9E151Eu, // 0x14: s_abs_i32 s30, s30.
+      0xBE8E009Fu, // 0x18: s_mov_b32 s14, 31        <- the prefetch-config move and
+      0xF404A000u, // 0x1c: s_prefetch_inst_pc_rel      prefetch that broke the match
+      0x1C000000u,
+      0x809C1E1Cu,                                // 0x24: s_sub_co_u32 s28, s28, s30.
+      0x829D801Du,                                // 0x28: s_sub_co_ci_u32 s29, s29, 0.
+      0xBE80481Cu,                                // 0x2c: s_set_pc_i64 s[28:29]  (negative path).
+      0x801C1E1Cu,                                // 0x30: s_add_co_u32 s28, s28, s30.
+      0x821D801Du,                                // 0x34: s_add_co_ci_u32 s29, s29, 0.
+      0xBE80481Cu,                                // 0x38: s_set_pc_i64 s[28:29]  (positive path).
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x3c: recovered target.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+
+  const auto *sec = co.text_sections().front();
+  const auto *inst_data = reinterpret_cast<const uint32_t *>(sec->data());
+  const size_t inst_data_size = sec->size() / sizeof(uint32_t);
+  std::vector<std::unique_ptr<Instruction>> owned;
+  for (size_t pc = 0, byte_offset = 0; pc < inst_data_size;) {
+    if (inst_data[pc] == 0) {
+      ++pc;
+      byte_offset += sizeof(uint32_t);
+      continue;
+    }
+    std::unique_ptr<Instruction> inst(decoder->decode(&inst_data[pc], byte_offset));
+    ASSERT_NE(inst, nullptr);
+    const uint32_t inst_words = static_cast<uint32_t>(inst->size()) / sizeof(uint32_t);
+    byte_offset += inst->size();
+    pc += inst_words;
+    owned.push_back(std::move(inst));
+  }
+  std::vector<const Instruction *> decoded_insts;
+  decoded_insts.reserve(owned.size());
+  for (const auto &inst : owned)
+    decoded_insts.push_back(inst.get());
+  const auto text =
+      std::span<const uint8_t>(reinterpret_cast<const uint8_t *>(sec->data()), sec->size());
+
+  const auto fixups = discover_indirect_branch_edges(
+      std::span<const Instruction *const>(decoded_insts.data(), decoded_insts.size()), text,
+      ROCJITSU_CODE_ARCH_GFX1250);
+
+  ASSERT_EQ(fixups.size(), 2u) << "both halves of the signed-delta template must recover";
+  for (const auto &fixup : fixups) {
+    EXPECT_EQ(fixup.source_target_offset, 0x3cu);
+    EXPECT_EQ(fixup.source_getpc_offset, 0x00u);
+    EXPECT_EQ(fixup.source_call_sreg, 28u);
+  }
+}
+
 TEST(CfgAnalysis, ReversePostOrderStraightLine) {
   auto blocks =
       build_test_blocks({TestOpcode::DefVgpr0, TestOpcode::UseVgpr0, TestOpcode::UseSgpr4});


### PR DESCRIPTION
The negative half of the signed PC-delta template walked s_abs_i32, the subtract and s_setpc at fixed offsets, stepping over gfx1250 instruction-prefetch padding only before the first and the last of them. gfx1250 hipBLASLt kernels place that padding between s_abs_i32 and the subtract, so the match failed there -- and because recover_signed_delta_templates() discards a recovered add half whenever the sub half misses, both consumers were left unrecovered. A kernel whose text has to move is then refused outright, the hook reports HSA_STATUS_ERROR_INVALID_CODE_OBJECT, and the caller dereferences the null kernel handle it gets back. The HSS MT256x128x64 solution that an FP16 NaN alpha/beta matmul selects was the only translation failure among the 191 hipBLASLt gfx1250 objects in this install.

Step over padding before every instruction the template looks for, as the sibling add-half matcher already does. The recovery range this half reports now spans the padding, which is sound because it feeds the indirect-call fixup path rather than patch_recovered_builder_fixups: that range already crosses a conditional branch into another block by construction, and the path that does erase a range fails closed on non-contiguous ones independently. The regression test carries the encodings verbatim from the affected kernel, and reverting either skip point restores the original diagnostic.