### PR TITLE
fix(rocprof-sys-python): stop loading the runtime on import

### DIFF
--- a/projects/rocprofiler-systems/cmake/Templates/console-script.in
+++ b/projects/rocprofiler-systems/cmake/Templates/console-script.in
@@ -10,7 +10,7 @@ set -e
 
 run-script()
 {
-    echo -e "\n##### ${PROJECT_NAME} :: executing '${@}'... #####\n"
+    echo -e "\n##### @PROJECT_NAME@ :: executing '${@}'... #####\n"
     eval $@
 }
 

--- a/projects/rocprofiler-systems/source/python/libpyrocprofsys.cpp
+++ b/projects/rocprofiler-systems/source/python/libpyrocprofsys.cpp
@@ -106,8 +106,13 @@ PYBIND11_MODULE(libpyrocprofsys, omni)
         }
         return _use_mpi;
     };
-    rocprofsys_external_register_pause_callbacks(&pyrocprofsys_pause_callback,
-                                                 &pyrocprofsys_resume_callback);
+    // Deferred out of module init: this is the first call into the dl layer and it
+    // dlopens librocprof-sys.so, so registering here would load the whole runtime on
+    // `import rocprofsys`.
+    static auto _register_pause_callbacks = []() {
+        rocprofsys_external_register_pause_callbacks(&pyrocprofsys_pause_callback,
+                                                     &pyrocprofsys_resume_callback);
+    };
 
     omni.def("is_initialized", []() { return _is_initialized; }, "Initialization state");
 
@@ -119,6 +124,7 @@ PYBIND11_MODULE(libpyrocprofsys, omni)
             if(_is_initialized)
                 throw std::runtime_error("Error! rocprofsys is already initialized");
             _is_initialized = true;
+            _register_pause_callbacks();
             rocprofsys_set_mpi(_get_use_mpi());
             rocprofsys_init("trace", false, _v.c_str());
         },
@@ -130,6 +136,7 @@ PYBIND11_MODULE(libpyrocprofsys, omni)
             if(_is_initialized)
                 throw std::runtime_error("Error! rocprofsys is already initialized");
             _is_initialized = true;
+            _register_pause_callbacks();
             rocprofsys_set_instrumented(
                 static_cast<int>(rocprofsys::dl::InstrumentMode::PythonProfile));
             rocprofsys_set_mpi(_get_use_mpi());

--- a/projects/rocprofiler-systems/source/python/rocprofsys/__init__.py
+++ b/projects/rocprofiler-systems/source/python/rocprofsys/__init__.py
@@ -19,17 +19,21 @@ try:
     import os
     from pathlib import Path
 
-    # Set up ROCPROFSYS environment variables
+    # Set up ROCPROFSYS environment variables. The package sits at
+    # <root>/@CMAKE_INSTALL_PYTHONDIR@/rocprofsys in both the build and install trees;
+    # export nothing rather than a wrong path if the package was relocated.
     rocprofsys_root = Path(__file__).resolve().parents[4]
-    os.environ.update(
-        {
-            "ROCPROFSYS_ROOT": str(rocprofsys_root),
-            "ROCPROFSYS_PATH": str(rocprofsys_root / "lib"),
-            "ROCPROFSYS_SCRIPT_PATH": str(
-                rocprofsys_root / "libexec/rocprofiler-systems"
-            ),
-        }
-    )
+    rocprofsys_libdir = rocprofsys_root / "@CMAKE_INSTALL_LIBDIR@"
+    if (rocprofsys_libdir / "librocprof-sys-dl.so").exists():
+        os.environ.update(
+            {
+                "ROCPROFSYS_ROOT": str(rocprofsys_root),
+                "ROCPROFSYS_PATH": str(rocprofsys_libdir),
+                "ROCPROFSYS_SCRIPT_PATH": str(
+                    rocprofsys_root / "libexec/rocprofiler-systems"
+                ),
+            }
+        )
 
     from .libpyrocprofsys import coverage
     from . import user
@@ -70,7 +74,7 @@ try:
     import atexit
 
     def _finalize_at_exit():
-        if not is_finalized():
+        if is_initialized() and not is_finalized():
             finalize()
 
     atexit.register(_finalize_at_exit)

--- a/projects/rocprofiler-systems/source/python/rocprofsys/__main__.py
+++ b/projects/rocprofiler-systems/source/python/rocprofsys/__main__.py
@@ -274,6 +274,13 @@ def main(main_args=sys.argv):
                     "python -m rocprofsys -- ./script.py".format(" ".join(argv))
                 )
 
+    if not argv:
+        raise RuntimeError(
+            "Could not determine input script. Use '--' before the script and its "
+            "arguments to ensure correct parsing. \nE.g. "
+            "python -m rocprofsys -- ./script.py"
+        )
+
     if len(argv) > 1:
         if argv[0] == "-m":
             argv = argv[1:]
@@ -338,7 +345,6 @@ def main(main_args=sys.argv):
     # Make sure the script's directory is on sys.path
     sys.path.insert(0, os.path.dirname(script_file))
 
-    _ROCPROFSYS_PYTHON_SCRIPT_FILE = script_file
     os.environ["ROCPROFSYS_PYTHON_SCRIPT_FILE"] = script_file
 
     prof = Profiler()

--- a/projects/rocprofiler-systems/tests/pytest/test_python.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_python.py
@@ -6,6 +6,9 @@ Python tests.
 """
 
 from __future__ import annotations
+import os
+import subprocess
+import sys
 import pytest
 from conftest import RocprofsysTest
 from pathlib import Path
@@ -310,3 +313,91 @@ class TestPython(RocprofsysTest):
             result,
             rules_files=python_source_rocpd_rules,
         )
+
+
+# =============================================================================
+# Frontend regressions
+# =============================================================================
+
+
+class TestPythonFrontend:
+    """CLI-level regressions in the rocprof-sys-python wrapper and package."""
+
+    TIMEOUT_SEC = 120
+
+    def _python_executable(self, rocprof_config) -> str:
+        """Interpreter the bindings were built for.
+
+        The wrapper otherwise falls back to whatever `python3` resolves to, which
+        on some distributions is a system Python with no libpyrocprofsys module.
+        """
+        executables = rocprof_config.capabilities.supported_python_executables
+        return str(executables[0]) if executables else sys.executable
+
+    def _run_wrapper(
+        self,
+        rocprof_config,
+        args: list[str],
+        extra_env: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [str(rocprof_config.rocprofsys_python), *args],
+            capture_output=True,
+            text=True,
+            env={
+                **os.environ,
+                "PYTHON_EXECUTABLE": self._python_executable(rocprof_config),
+                **(extra_env or {}),
+            },
+            timeout=self.TIMEOUT_SEC,
+        )
+
+    def _run_probe(
+        self, rocprof_config, source: str, extra_env: dict[str, str] | None = None
+    ) -> str:
+        result = subprocess.run(
+            [self._python_executable(rocprof_config), "-c", source],
+            capture_output=True,
+            text=True,
+            env={
+                **os.environ,
+                "PYTHONPATH": str(rocprof_config.rocprofsys_site_packages),
+                **(extra_env or {}),
+            },
+            timeout=self.TIMEOUT_SEC,
+        )
+        assert result.returncode == 0, result.stderr
+        return result.stdout.splitlines()[-1]
+
+    @pytest.mark.parametrize("log_level", ["debug", "trace"])
+    def test_help_survives_verbose_logging(self, rocprof_config, log_level: str) -> None:
+        result = self._run_wrapper(
+            rocprof_config, ["--help"], {"ROCPROFSYS_LOG_LEVEL": log_level}
+        )
+        assert result.returncode == 0, result.stderr
+
+    def test_import_does_not_load_profiling_runtime(self, rocprof_config) -> None:
+        loaded = self._run_probe(
+            rocprof_config,
+            "import rocprofsys\n"
+            "with open('/proc/self/maps') as maps:\n"
+            "    print(sum('librocprof-sys.so' in line for line in maps))\n",
+            {"ROCPROFSYS_LOG_LEVEL": "debug"},
+        )
+        assert loaded == "0", "importing rocprofsys loaded the profiling runtime"
+
+    def test_missing_script_is_reported(self, rocprof_config) -> None:
+        result = self._run_wrapper(rocprof_config, ["--"])
+        assert result.returncode != 0
+        assert "Could not determine input script" in result.stderr
+
+    def test_banner_names_the_project(self, rocprof_config) -> None:
+        result = self._run_wrapper(rocprof_config, ["--help"])
+        assert "rocprofiler-systems :: executing" in result.stdout
+
+    def test_library_path_points_at_the_runtime(self, rocprof_config) -> None:
+        library_path = self._run_probe(
+            rocprof_config,
+            "import os, rocprofsys\nprint(os.environ.get('ROCPROFSYS_PATH', ''))\n",
+        )
+        assert (Path(library_path) / "librocprof-sys-dl.so").exists()

--- a/projects/rocprofiler-systems/tests/pytest/test_python.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_python.py
@@ -366,8 +366,9 @@ class TestPythonFrontend:
             },
             timeout=self.TIMEOUT_SEC,
         )
-        assert result.returncode == 0, result.stderr
-        return result.stdout.splitlines()[-1]
+        lines = result.stdout.splitlines()
+        assert lines, f"probe produced no stdout; stderr:\n{result.stderr}"
+        return lines[-1]
 
     @pytest.mark.parametrize("log_level", ["debug", "trace"])
     def test_help_survives_verbose_logging(self, rocprof_config, log_level: str) -> None:
@@ -393,6 +394,7 @@ class TestPythonFrontend:
 
     def test_banner_names_the_project(self, rocprof_config) -> None:
         result = self._run_wrapper(rocprof_config, ["--help"])
+        assert result.returncode == 0, result.stderr
         assert "rocprofiler-systems :: executing" in result.stdout
 
     def test_library_path_points_at_the_runtime(self, rocprof_config) -> None:
@@ -400,4 +402,5 @@ class TestPythonFrontend:
             rocprof_config,
             "import os, rocprofsys\nprint(os.environ.get('ROCPROFSYS_PATH', ''))\n",
         )
+        assert library_path, "rocprofsys did not export ROCPROFSYS_PATH"
         assert (Path(library_path) / "librocprof-sys-dl.so").exists()


### PR DESCRIPTION
## Motivation

- Importing the rocprofsys module registered the pause/resume callbacks from the pybind11 module body. That is the first call into the dl layer, so it dlopened librocprof-sys.so as a side effect, pulling the entire profiling stack into any process that merely imported the package. The atexit finalizer did the same at shutdown even when nothing had been initialized. 

- Register the callbacks in initialize(), where profiling is actually requested, and skip the atexit finalize when the library was never initialized - matching the existing guard in common.py. 

Four smaller defects found alongside it:

- `rocprof-sys-python --` left argv empty and indexed argv[0] unguarded, raising IndexError instead of the usage error the no-separator path already produces.
- The console-script template used shell ${PROJECT_NAME}, which is unset at run time, so the banner printed an empty project name.
- The package hardcoded "lib" and exported ROCPROFSYS_PATH unconditionally, so a relocated package silently pointed at a directory holding no runtime.
- main() assigned _ROCPROFSYS_PYTHON_SCRIPT_FILE with no `global`, binding a local; the environment variable beside it is what the re-entry path reads.

## Technical Details

- `libpyrocprofsys.cpp` called `rocprofsys_external_register_pause_callbacks()` from the `PYBIND11_MODULE` body. That is the first call into the dl layer, and it `dlopen`s `librocprof-sys.so` as a side effect:
```
    PyInit_libpyrocprofsys                           
     -> pybind11_init_libpyrocprofsys                  
       -> rocprofsys_external_register_pause_callbacks 
         -> get_indirect()                            
           -> dlopen("librocprof-sys.so")
```

- `__init__.py`'s `atexit` handler was a second, independent trigger: it called `finalize()` whenever the library was not finalized, including when it had never been *initialized*, and `finalize()` is itself a dl trampoline, so it loaded the runtime during interpreter shutdown.
- Register the pause/resume callbacks in both `initialize()` overloads instead of at module load, i.e. where profiling is actually requested.
- Skip the `atexit` finalize when the library was never initialized.
- `rocprof-sys-python --` left `argv` empty and indexed `argv[0]` unguarded, raising `IndexError`. It now raises the same usage `RuntimeError` the no-separator path already produces.
- `console-script.in` used shell `${PROJECT_NAME}`, unset at run time, so the banner printed an empty project name. Now uses CMake's `@PROJECT_NAME@`.
- `__init__.py` hardcoded `"lib"` and exported `ROCPROFSYS_PATH` unconditionally, so a relocated package silently pointed at a directory containing no runtime. The directory now comes from `@CMAKE_INSTALL_LIBDIR@` and is only exported when the runtime is actually present.
- Removed a dead store: `main()` assigned `_ROCPROFSYS_PYTHON_SCRIPT_FILE` with no `global`, binding a local. The environment variable beside it is what the re-entry path at module scope reads.

## Issue Tracking

JIRA ID: AIPROFSYST-708
JIRA ID: AIPROFSYST-675

## Test Plan

New `TestPythonFrontend` class in `tests/pytest/test_python.py` (6 tests). Five of the six failed before the fix:

| Test | Asserts | Before |
|---|---|---|
| `help_survives_verbose_logging[debug]` | `--help` exits 0 at `LOG_LEVEL=debug` | exit 139 |
| `help_survives_verbose_logging[trace]` | same at `trace` | exit 139 |
| `import_does_not_load_profiling_runtime` | no `librocprof-sys.so` mapping after import | SIGSEGV |
| `missing_script_is_reported` | `--` exits non-zero with usage message | IndexError |
| `banner_names_the_project` | banner contains the project name | empty name |
| `library_path_points_at_the_runtime` | `ROCPROFSYS_PATH` holds `librocprof-sys-dl.so` | passed (guard) |

## Test Result

- New regression tests: **6 passed**
- Full `test_python.py`: **15 passed, 22 subtests passed**
- `rocprof-sys-unit-tests`: **1248 passed**

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
