### PR TITLE
[rocjitsu] Report gfx1250 hotswap translation failures

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/code/rj_gfx1250_b0_to_a0.h
+++ b/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/code/rj_gfx1250_b0_to_a0.h
@@ -30,6 +30,13 @@ typedef struct rj_gfx1250_b0_to_a0_translation_info_s {
 /// All string pointers are valid only for the duration of the callback. A
 /// required-work item is delivered as a separate view with @c required_work set;
 /// its kind and source location identify the diagnostic it belongs to.
+///
+/// @c severity and @c kind are stable matching keys, not display strings. Severity
+/// is currently @c warning or @c error. Kind values distinguish translator
+/// diagnostics from API, input, translation-result, allocation, and exception
+/// failures. Consumers
+/// must accept unknown future keys. @c mnemonic, @c message, and required-work
+/// text are human-readable and may change.
 typedef struct rj_gfx1250_b0_to_a0_diagnostic_s {
   const char *severity;
   const char *kind;
@@ -73,13 +80,10 @@ typedef void (*rj_gfx1250_b0_to_a0_diagnostic_callback_t)(
 #ifdef __cplusplus
 [[nodiscard]]
 #endif
-RJ_API_EXPORT rj_status_t rj_gfx1250_b0_to_a0_translate(const void *source_elf, size_t source_size,
-                                                        uint8_t **translated_elf,
-                                                        size_t *translated_size,
-                                                        rj_gfx1250_b0_to_a0_translation_info_t *info,
-                                                        rj_gfx1250_b0_to_a0_diagnostic_callback_t
-                                                            diagnostic_callback,
-                                                        void *user_data);
+RJ_API_EXPORT rj_status_t rj_gfx1250_b0_to_a0_translate(
+    const void *source_elf, size_t source_size, uint8_t **translated_elf, size_t *translated_size,
+    rj_gfx1250_b0_to_a0_translation_info_t *info,
+    rj_gfx1250_b0_to_a0_diagnostic_callback_t diagnostic_callback, void *user_data);
 
 /// Release storage returned by rj_gfx1250_b0_to_a0_translate().
 /// @param[in] translated_elf Allocation to release; NULL is accepted.

--- a/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/code/rj_gfx1250_b0_to_a0.h
+++ b/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/code/rj_gfx1250_b0_to_a0.h
@@ -25,6 +25,25 @@ typedef struct rj_gfx1250_b0_to_a0_translation_info_s {
   size_t changed_instruction_count;
 } rj_gfx1250_b0_to_a0_translation_info_t;
 
+/// Borrowed view of one diagnostic produced by a failed translation.
+///
+/// All string pointers are valid only for the duration of the callback. A
+/// required-work item is delivered as a separate view with @c required_work set;
+/// its kind and source location identify the diagnostic it belongs to.
+typedef struct rj_gfx1250_b0_to_a0_diagnostic_s {
+  const char *severity;
+  const char *kind;
+  int has_guest_offset;
+  uint64_t guest_offset;
+  const char *mnemonic;
+  const char *message;
+  int required_work;
+} rj_gfx1250_b0_to_a0_diagnostic_t;
+
+/// Synchronous sink for diagnostics from a failed translation.
+typedef void (*rj_gfx1250_b0_to_a0_diagnostic_callback_t)(
+    const rj_gfx1250_b0_to_a0_diagnostic_t *diagnostic, void *user_data);
+
 /// Translate one gfx1250 B0 AMDGPU code-object ELF for execution on gfx1250 A0.
 ///
 /// The input must be a standalone gfx1250 AMDGPU code object. On success, the
@@ -36,6 +55,13 @@ typedef struct rj_gfx1250_b0_to_a0_translation_info_s {
 /// @param[in] source_size Number of bytes in @p source_elf.
 /// @param[out] translated_elf Newly allocated translated code-object bytes.
 /// @param[out] translated_size Number of bytes in @p translated_elf.
+/// @param[out] info Stable source identity and changed-instruction count. This
+///             is cleared before argument validation. When all arguments are
+///             valid, source_code_object_id is populated before parsing.
+/// @param[in] diagnostic_callback Optional synchronous sink for diagnostics
+///            when the result is not dispatchable. The callback receives the
+///            complete diagnostic set, including required-work items.
+/// @param[in] user_data Opaque value passed to @p diagnostic_callback.
 /// @retval ROCJITSU_STATUS_SUCCESS Translation succeeded.
 /// @retval ROCJITSU_STATUS_INVALID_ARGUMENT An input or output argument is invalid.
 /// @retval ROCJITSU_STATUS_INVALID_CODE_OBJECT The input is not a gfx1250 code object, or
@@ -49,27 +75,11 @@ typedef struct rj_gfx1250_b0_to_a0_translation_info_s {
 #endif
 RJ_API_EXPORT rj_status_t rj_gfx1250_b0_to_a0_translate(const void *source_elf, size_t source_size,
                                                         uint8_t **translated_elf,
-                                                        size_t *translated_size);
-
-/// Translate one gfx1250 B0 code object and report source provenance.
-///
-/// This is the provenance-reporting form of rj_gfx1250_b0_to_a0_translate().
-/// @p info is cleared before argument validation. When all arguments are valid,
-/// source_code_object_id is populated before parsing, so failed translation
-/// attempts can still be associated with their exact input.
-///
-/// @param[in] source_elf Source code-object bytes.
-/// @param[in] source_size Number of bytes in @p source_elf.
-/// @param[out] translated_elf Newly allocated translated code-object bytes.
-/// @param[out] translated_size Number of bytes in @p translated_elf.
-/// @param[out] info Stable source identity and changed-instruction count.
-/// @return The same status values as rj_gfx1250_b0_to_a0_translate().
-#ifdef __cplusplus
-[[nodiscard]]
-#endif
-RJ_API_EXPORT rj_status_t rj_gfx1250_b0_to_a0_translate_with_info(
-    const void *source_elf, size_t source_size, uint8_t **translated_elf, size_t *translated_size,
-    rj_gfx1250_b0_to_a0_translation_info_t *info);
+                                                        size_t *translated_size,
+                                                        rj_gfx1250_b0_to_a0_translation_info_t *info,
+                                                        rj_gfx1250_b0_to_a0_diagnostic_callback_t
+                                                            diagnostic_callback,
+                                                        void *user_data);
 
 /// Release storage returned by rj_gfx1250_b0_to_a0_translate().
 /// @param[in] translated_elf Allocation to release; NULL is accepted.

--- a/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/code/rj_gfx1250_b0_to_a0.h
+++ b/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/code/rj_gfx1250_b0_to_a0.h
@@ -65,9 +65,13 @@ typedef void (*rj_gfx1250_b0_to_a0_diagnostic_callback_t)(
 /// @param[out] info Stable source identity and changed-instruction count. This
 ///             is cleared before argument validation. When all arguments are
 ///             valid, source_code_object_id is populated before parsing.
-/// @param[in] diagnostic_callback Optional synchronous sink for diagnostics
-///            when the result is not dispatchable. The callback receives the
-///            complete diagnostic set, including required-work items.
+/// @param[in] diagnostic_callback Optional synchronous sink invoked for every
+///            non-success return, including an invalid argument, an input that
+///            is not a gfx1250 code object, a non-dispatchable result, a failed
+///            allocation, and a translator exception. Only a failure that came
+///            from translation delivers the complete translator diagnostic set
+///            with its required-work items; the other paths report one
+///            diagnostic describing the failure itself.
 /// @param[in] user_data Opaque value passed to @p diagnostic_callback.
 /// @retval ROCJITSU_STATUS_SUCCESS Translation succeeded.
 /// @retval ROCJITSU_STATUS_INVALID_ARGUMENT An input or output argument is invalid.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/gfx1250_b0_to_a0_library.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/gfx1250_b0_to_a0_library.cpp
@@ -16,12 +16,30 @@
 
 namespace {
 
+constexpr char kSeverityWarning[] = "warning";
+constexpr char kSeverityError[] = "error";
+constexpr char kKindApiInvalidArgument[] = "api-invalid-argument";
+constexpr char kKindInputInvalidCodeObject[] = "input-invalid-code-object";
+constexpr char kKindResultNotDispatchable[] = "result-not-dispatchable";
+constexpr char kKindOutputAllocationFailed[] = "output-allocation-failed";
+constexpr char kKindTranslationOutOfMemory[] = "translation-out-of-memory";
+constexpr char kKindTranslationException[] = "translation-exception";
+constexpr char kKindTranslatorUnsupportedGuestArch[] = "translator-unsupported-guest-arch";
+constexpr char kKindTranslatorKernelDescriptor[] = "translator-kernel-descriptor";
+constexpr char kKindTranslatorLegalization[] = "translator-legalization";
+constexpr char kKindTranslatorExpandMissing[] = "translator-expand-missing";
+constexpr char kKindTranslatorExpandFailed[] = "translator-expand-failed";
+constexpr char kKindTranslatorDataOnly[] = "translator-data-only";
+constexpr char kKindTranslatorNothingToTranslate[] = "translator-nothing-to-translate";
+constexpr char kKindTranslatorResourceLimit[] = "translator-resource-limit";
+constexpr char kKindTranslatorKernelSkipped[] = "translator-kernel-skipped";
+
 const char *diagnostic_severity_name(rocjitsu::DiagnosticSeverity severity) noexcept {
   switch (severity) {
   case rocjitsu::DiagnosticSeverity::Warning:
-    return "warning";
+    return kSeverityWarning;
   case rocjitsu::DiagnosticSeverity::Error:
-    return "error";
+    return kSeverityError;
   }
   return "unknown";
 }
@@ -29,23 +47,23 @@ const char *diagnostic_severity_name(rocjitsu::DiagnosticSeverity severity) noex
 const char *diagnostic_kind_name(rocjitsu::DiagnosticKind kind) noexcept {
   switch (kind) {
   case rocjitsu::DiagnosticKind::UnsupportedGuestArch:
-    return "unsupported-guest-arch";
+    return kKindTranslatorUnsupportedGuestArch;
   case rocjitsu::DiagnosticKind::KernelDescriptor:
-    return "kernel-descriptor";
+    return kKindTranslatorKernelDescriptor;
   case rocjitsu::DiagnosticKind::Legalization:
-    return "legalization";
+    return kKindTranslatorLegalization;
   case rocjitsu::DiagnosticKind::ExpandMissing:
-    return "expand-missing";
+    return kKindTranslatorExpandMissing;
   case rocjitsu::DiagnosticKind::ExpandFailed:
-    return "expand-failed";
+    return kKindTranslatorExpandFailed;
   case rocjitsu::DiagnosticKind::DataOnly:
-    return "data-only";
+    return kKindTranslatorDataOnly;
   case rocjitsu::DiagnosticKind::NothingToTranslate:
-    return "nothing-to-translate";
+    return kKindTranslatorNothingToTranslate;
   case rocjitsu::DiagnosticKind::ResourceLimit:
-    return "resource-limit";
+    return kKindTranslatorResourceLimit;
   case rocjitsu::DiagnosticKind::KernelSkipped:
-    return "kernel-skipped";
+    return kKindTranslatorKernelSkipped;
   }
   return "unknown";
 }
@@ -91,7 +109,7 @@ void emit_diagnostics(rj_gfx1250_b0_to_a0_diagnostic_callback_t callback, void *
     for (const std::string &item : diagnostic.required_work) {
       const rj_gfx1250_b0_to_a0_diagnostic_t required{
           view.severity, view.kind, view.has_guest_offset, view.guest_offset, view.mnemonic,
-          item.c_str(), 1,
+          item.c_str(),  1,
       };
       invoke_diagnostic_callback(callback, required, user_data);
     }
@@ -100,10 +118,11 @@ void emit_diagnostics(rj_gfx1250_b0_to_a0_diagnostic_callback_t callback, void *
 
 } // namespace
 
-rj_status_t rj_gfx1250_b0_to_a0_translate(
-    const void *source_elf, size_t source_size, uint8_t **translated_elf, size_t *translated_size,
-    rj_gfx1250_b0_to_a0_translation_info_t *info,
-    rj_gfx1250_b0_to_a0_diagnostic_callback_t diagnostic_callback, void *user_data) {
+rj_status_t
+rj_gfx1250_b0_to_a0_translate(const void *source_elf, size_t source_size, uint8_t **translated_elf,
+                              size_t *translated_size, rj_gfx1250_b0_to_a0_translation_info_t *info,
+                              rj_gfx1250_b0_to_a0_diagnostic_callback_t diagnostic_callback,
+                              void *user_data) {
   if (translated_elf)
     *translated_elf = nullptr;
   if (translated_size)
@@ -112,7 +131,7 @@ rj_status_t rj_gfx1250_b0_to_a0_translate(
     *info = {};
 
   if (!source_elf || source_size == 0 || !translated_elf || !translated_size || !info) {
-    emit_diagnostic(diagnostic_callback, user_data, "error", "invalid-argument",
+    emit_diagnostic(diagnostic_callback, user_data, kSeverityError, kKindApiInvalidArgument,
                     "translation received an invalid input or output argument");
     return ROCJITSU_STATUS_INVALID_ARGUMENT;
   }
@@ -123,7 +142,7 @@ rj_status_t rj_gfx1250_b0_to_a0_translate(
     const auto *source_bytes = static_cast<const uint8_t *>(source_elf);
     rocjitsu::AmdGpuCodeObject source(source_bytes, source_size);
     if (!source.is_valid() || source.target_id() != ROCJITSU_CODE_TARGET_GFX1250) {
-      emit_diagnostic(diagnostic_callback, user_data, "error", "invalid-code-object",
+      emit_diagnostic(diagnostic_callback, user_data, kSeverityError, kKindInputInvalidCodeObject,
                       "source is not a valid gfx1250 AMDGPU code object");
       return ROCJITSU_STATUS_INVALID_CODE_OBJECT;
     }
@@ -147,14 +166,14 @@ rj_status_t rj_gfx1250_b0_to_a0_translate(
     if (result.elf_bytes.empty() || !result.dispatchable()) {
       emit_diagnostics(diagnostic_callback, user_data, result.diagnostics);
       if (result.diagnostics.empty())
-        emit_diagnostic(diagnostic_callback, user_data, "error", "nothing-to-translate",
+        emit_diagnostic(diagnostic_callback, user_data, kSeverityError, kKindResultNotDispatchable,
                         "translation produced no dispatchable code object");
       return ROCJITSU_STATUS_INVALID_CODE_OBJECT;
     }
 
     auto *output = static_cast<uint8_t *>(std::malloc(result.elf_bytes.size()));
     if (!output) {
-      emit_diagnostic(diagnostic_callback, user_data, "error", "resource-limit",
+      emit_diagnostic(diagnostic_callback, user_data, kSeverityError, kKindOutputAllocationFailed,
                       "could not allocate the translated code object");
       return ROCJITSU_STATUS_OUT_OF_RESOURCES;
     }
@@ -164,14 +183,15 @@ rj_status_t rj_gfx1250_b0_to_a0_translate(
     *translated_size = result.elf_bytes.size();
     return ROCJITSU_STATUS_SUCCESS;
   } catch (const std::bad_alloc &) {
-    emit_diagnostic(diagnostic_callback, user_data, "error", "resource-limit",
+    emit_diagnostic(diagnostic_callback, user_data, kSeverityError, kKindTranslationOutOfMemory,
                     "translation ran out of memory");
     return ROCJITSU_STATUS_OUT_OF_RESOURCES;
   } catch (const std::exception &error) {
-    emit_diagnostic(diagnostic_callback, user_data, "error", "exception", error.what());
+    emit_diagnostic(diagnostic_callback, user_data, kSeverityError, kKindTranslationException,
+                    error.what());
     return ROCJITSU_STATUS_ERROR;
   } catch (...) {
-    emit_diagnostic(diagnostic_callback, user_data, "error", "exception",
+    emit_diagnostic(diagnostic_callback, user_data, kSeverityError, kKindTranslationException,
                     "translation threw an unknown exception");
     return ROCJITSU_STATUS_ERROR;
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/gfx1250_b0_to_a0_library.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/gfx1250_b0_to_a0_library.cpp
@@ -9,12 +9,101 @@
 
 #include <cstdlib>
 #include <cstring>
+#include <exception>
 #include <new>
+#include <string>
+#include <vector>
 
-rj_status_t rj_gfx1250_b0_to_a0_translate_with_info(const void *source_elf, size_t source_size,
-                                                    uint8_t **translated_elf,
-                                                    size_t *translated_size,
-                                                    rj_gfx1250_b0_to_a0_translation_info_t *info) {
+namespace {
+
+const char *diagnostic_severity_name(rocjitsu::DiagnosticSeverity severity) noexcept {
+  switch (severity) {
+  case rocjitsu::DiagnosticSeverity::Warning:
+    return "warning";
+  case rocjitsu::DiagnosticSeverity::Error:
+    return "error";
+  }
+  return "unknown";
+}
+
+const char *diagnostic_kind_name(rocjitsu::DiagnosticKind kind) noexcept {
+  switch (kind) {
+  case rocjitsu::DiagnosticKind::UnsupportedGuestArch:
+    return "unsupported-guest-arch";
+  case rocjitsu::DiagnosticKind::KernelDescriptor:
+    return "kernel-descriptor";
+  case rocjitsu::DiagnosticKind::Legalization:
+    return "legalization";
+  case rocjitsu::DiagnosticKind::ExpandMissing:
+    return "expand-missing";
+  case rocjitsu::DiagnosticKind::ExpandFailed:
+    return "expand-failed";
+  case rocjitsu::DiagnosticKind::DataOnly:
+    return "data-only";
+  case rocjitsu::DiagnosticKind::NothingToTranslate:
+    return "nothing-to-translate";
+  case rocjitsu::DiagnosticKind::ResourceLimit:
+    return "resource-limit";
+  case rocjitsu::DiagnosticKind::KernelSkipped:
+    return "kernel-skipped";
+  }
+  return "unknown";
+}
+
+void invoke_diagnostic_callback(rj_gfx1250_b0_to_a0_diagnostic_callback_t callback,
+                                const rj_gfx1250_b0_to_a0_diagnostic_t &diagnostic,
+                                void *user_data) noexcept {
+  if (callback == nullptr)
+    return;
+  try {
+    callback(&diagnostic, user_data);
+  } catch (...) {
+    // A reporting sink must not let an exception cross the C API boundary or
+    // change the translation result it is observing.
+  }
+}
+
+void emit_diagnostic(rj_gfx1250_b0_to_a0_diagnostic_callback_t callback, void *user_data,
+                     const char *severity, const char *kind, const char *message) noexcept {
+  if (callback == nullptr)
+    return;
+  const rj_gfx1250_b0_to_a0_diagnostic_t view{
+      severity, kind, 0, 0, "", message, 0,
+  };
+  invoke_diagnostic_callback(callback, view, user_data);
+}
+
+void emit_diagnostics(rj_gfx1250_b0_to_a0_diagnostic_callback_t callback, void *user_data,
+                      const std::vector<rocjitsu::TranslationDiagnostic> &diagnostics) noexcept {
+  if (callback == nullptr)
+    return;
+  for (const rocjitsu::TranslationDiagnostic &diagnostic : diagnostics) {
+    const rj_gfx1250_b0_to_a0_diagnostic_t view{
+        diagnostic_severity_name(diagnostic.severity),
+        diagnostic_kind_name(diagnostic.kind),
+        diagnostic.guest_offset.has_value() ? 1 : 0,
+        diagnostic.guest_offset.value_or(0),
+        diagnostic.mnemonic.c_str(),
+        diagnostic.message.c_str(),
+        0,
+    };
+    invoke_diagnostic_callback(callback, view, user_data);
+    for (const std::string &item : diagnostic.required_work) {
+      const rj_gfx1250_b0_to_a0_diagnostic_t required{
+          view.severity, view.kind, view.has_guest_offset, view.guest_offset, view.mnemonic,
+          item.c_str(), 1,
+      };
+      invoke_diagnostic_callback(callback, required, user_data);
+    }
+  }
+}
+
+} // namespace
+
+rj_status_t rj_gfx1250_b0_to_a0_translate(
+    const void *source_elf, size_t source_size, uint8_t **translated_elf, size_t *translated_size,
+    rj_gfx1250_b0_to_a0_translation_info_t *info,
+    rj_gfx1250_b0_to_a0_diagnostic_callback_t diagnostic_callback, void *user_data) {
   if (translated_elf)
     *translated_elf = nullptr;
   if (translated_size)
@@ -22,16 +111,22 @@ rj_status_t rj_gfx1250_b0_to_a0_translate_with_info(const void *source_elf, size
   if (info)
     *info = {};
 
-  if (!source_elf || source_size == 0 || !translated_elf || !translated_size || !info)
+  if (!source_elf || source_size == 0 || !translated_elf || !translated_size || !info) {
+    emit_diagnostic(diagnostic_callback, user_data, "error", "invalid-argument",
+                    "translation received an invalid input or output argument");
     return ROCJITSU_STATUS_INVALID_ARGUMENT;
+  }
 
   info->source_code_object_id = rocjitsu::stable_code_object_id(source_elf, source_size);
 
   try {
     const auto *source_bytes = static_cast<const uint8_t *>(source_elf);
     rocjitsu::AmdGpuCodeObject source(source_bytes, source_size);
-    if (!source.is_valid() || source.target_id() != ROCJITSU_CODE_TARGET_GFX1250)
+    if (!source.is_valid() || source.target_id() != ROCJITSU_CODE_TARGET_GFX1250) {
+      emit_diagnostic(diagnostic_callback, user_data, "error", "invalid-code-object",
+                      "source is not a valid gfx1250 AMDGPU code object");
       return ROCJITSU_STATUS_INVALID_CODE_OBJECT;
+    }
 
     rocjitsu::BinaryTranslatorOptions options;
     options.input_revision = rocjitsu::ProcessorRevision::Gfx1250B0;
@@ -49,29 +144,37 @@ rj_status_t rj_gfx1250_b0_to_a0_translate_with_info(const void *source_elf, size
     // the environmental failures below and cache the verdict rather than
     // rediscovering it. ROCJITSU_STATUS_ERROR is left to mean the translator threw,
     // which carries no such promise.
-    if (result.elf_bytes.empty() || !result.dispatchable())
+    if (result.elf_bytes.empty() || !result.dispatchable()) {
+      emit_diagnostics(diagnostic_callback, user_data, result.diagnostics);
+      if (result.diagnostics.empty())
+        emit_diagnostic(diagnostic_callback, user_data, "error", "nothing-to-translate",
+                        "translation produced no dispatchable code object");
       return ROCJITSU_STATUS_INVALID_CODE_OBJECT;
+    }
 
     auto *output = static_cast<uint8_t *>(std::malloc(result.elf_bytes.size()));
-    if (!output)
+    if (!output) {
+      emit_diagnostic(diagnostic_callback, user_data, "error", "resource-limit",
+                      "could not allocate the translated code object");
       return ROCJITSU_STATUS_OUT_OF_RESOURCES;
+    }
 
     std::memcpy(output, result.elf_bytes.data(), result.elf_bytes.size());
     *translated_elf = output;
     *translated_size = result.elf_bytes.size();
     return ROCJITSU_STATUS_SUCCESS;
   } catch (const std::bad_alloc &) {
+    emit_diagnostic(diagnostic_callback, user_data, "error", "resource-limit",
+                    "translation ran out of memory");
     return ROCJITSU_STATUS_OUT_OF_RESOURCES;
+  } catch (const std::exception &error) {
+    emit_diagnostic(diagnostic_callback, user_data, "error", "exception", error.what());
+    return ROCJITSU_STATUS_ERROR;
   } catch (...) {
+    emit_diagnostic(diagnostic_callback, user_data, "error", "exception",
+                    "translation threw an unknown exception");
     return ROCJITSU_STATUS_ERROR;
   }
-}
-
-rj_status_t rj_gfx1250_b0_to_a0_translate(const void *source_elf, size_t source_size,
-                                          uint8_t **translated_elf, size_t *translated_size) {
-  rj_gfx1250_b0_to_a0_translation_info_t info{};
-  return rj_gfx1250_b0_to_a0_translate_with_info(source_elf, source_size, translated_elf,
-                                                 translated_size, &info);
 }
 
 void rj_gfx1250_b0_to_a0_free(void *translated_elf) { std::free(translated_elf); }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/gfx1250_b0_a0_hotswap.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/gfx1250_b0_a0_hotswap.cpp
@@ -8,6 +8,18 @@
 ///
 /// - `HSA_HOTSWAP_VERBOSE` -- debug logging to stderr. Changes what is reported,
 ///   never what is done. Errors are always reported, independently of this flag.
+/// - `HSA_HOTSWAP_DUMP_SOURCE` -- when set to anything but `0`, a translation
+///   that fails writes the source code object it refused to disk. Off by
+///   default: these objects reach 212 MiB, and a failure the memo declines to
+///   remember recurs on every load of the same bytes.
+/// - `HSA_HOTSWAP_DUMP_DIR` -- where those artifacts go, falling back to
+///   `TMPDIR` and then `/tmp`. Naming a destination does not enable capture;
+///   `HSA_HOTSWAP_DUMP_SOURCE` does that.
+///
+/// Capture writes at most one artifact per source identity and covers at most 32
+/// distinct sources per process. An out-of-resources failure is never captured:
+/// copying a large input adds pressure to a system that just ran out, and the
+/// bytes are not what failed.
 ///
 /// `HSA_HOTSWAP_DISABLE` belongs to CLR rather than this hook: it stops CLR
 /// forwarding anything here at all.
@@ -68,12 +80,27 @@ void log(const char *format, ...) noexcept;
 void log_error(const char *format, ...) noexcept;
 
 #if defined(RJ_HOTSWAP_TEST_HOOKS)
-std::mutex g_test_dump_mutex;
-std::vector<std::string> g_test_dump_paths;
+// The state and its lock live in ordinary functions, not in the template below:
+// a function-local static inside a template belongs to one instantiation, so a
+// second call site with a different callable type would get its own copy.
+std::mutex &test_dump_mutex() {
+  static std::mutex mutex;
+  return mutex;
+}
+std::vector<std::string> &test_dump_paths() {
+  static std::vector<std::string> paths;
+  return paths;
+}
+
+/// @brief Run @p fn against the recorded capture paths under their own lock.
+template <typename Fn> decltype(auto) with_test_dump_paths(Fn &&fn) {
+  std::lock_guard lock(test_dump_mutex());
+  return fn(test_dump_paths());
+}
+
 void remember_test_dump(const char *path) noexcept {
   try {
-    std::lock_guard lock(g_test_dump_mutex);
-    g_test_dump_paths.emplace_back(path);
+    with_test_dump_paths([&](std::vector<std::string> &paths) { paths.emplace_back(path); });
   } catch (...) {
   }
 }
@@ -106,74 +133,129 @@ const char *source_capture_directory() {
 // produced enough material to diagnose whatever is wrong.
 constexpr size_t kMaxCapturedSources = 32;
 
-std::mutex g_captured_sources_mutex;
-/// Source identity -> whether its artifact was completely written. An entry that
-/// is present but false is a capture in flight on another thread.
-std::unordered_map<uint64_t, bool> g_captured_sources;
-/// Sources the disabled-capture hint has already named. Kept apart from the
-/// capture registry so the hint does not consume the artifact's one slot: an
-/// operator who reads it, exports the variable and retries must get the file.
-std::unordered_set<uint64_t> g_hinted_sources;
+/// @brief Everything the capture policy remembers for the life of the process.
+struct SourceCaptureState {
+  /// Source identity -> whether its artifact was completely written. An entry
+  /// present but false is a capture in flight on another thread.
+  std::unordered_map<uint64_t, bool> captures;
+  /// Sources the disabled-capture hint has already named. Kept apart from
+  /// @ref captures so the hint does not consume the artifact's one slot: an
+  /// operator who reads it, exports the variable and retries must get the file.
+  std::unordered_set<uint64_t> hinted;
+  /// Sources whose write failure has been reported. A failed write is retried,
+  /// so without this a permanently unwritable destination would report itself on
+  /// every load of the same bytes.
+  std::unordered_set<uint64_t> reported_write_failures;
+  /// Whether the registry has already explained that it is full.
+  bool reported_capacity = false;
+};
 
-/// @returns True when @p seen did not already hold @p source_id and has room.
-bool claim_once(std::unordered_set<uint64_t> &seen, uint64_t source_id) noexcept {
+// Held in ordinary functions for the reason given above test_dump_mutex().
+std::mutex &capture_state_mutex() {
+  static std::mutex mutex;
+  return mutex;
+}
+SourceCaptureState &capture_state() {
+  static SourceCaptureState state;
+  return state;
+}
+
+/// @brief Run @p fn against the capture state under its own lock.
+template <typename Fn> decltype(auto) with_capture_state(Fn &&fn) {
+  std::lock_guard lock(capture_state_mutex());
+  return fn(capture_state());
+}
+
+/// @returns True the first time @p source_id is offered, up to the registry cap.
+bool claim_once(std::unordered_set<uint64_t> SourceCaptureState::*member,
+                uint64_t source_id) noexcept {
   try {
-    std::lock_guard lock(g_captured_sources_mutex);
-    if (seen.size() >= kMaxCapturedSources)
-      return false;
-    return seen.insert(source_id).second;
+    return with_capture_state([&](SourceCaptureState &state) {
+      auto &seen = state.*member;
+      if (seen.size() >= kMaxCapturedSources)
+        return false;
+      return seen.insert(source_id).second;
+    });
   } catch (...) {
     return false;
   }
 }
 
+/// @brief What became of an attempt to claim the capture slot for one source.
+enum class CaptureClaim : uint8_t {
+  Granted,        ///< This call owns the write and must settle it.
+  AlreadyHandled, ///< Captured already, or being written by another thread.
+  RegistryFull,   ///< The per-process source cap is reached.
+};
+
 /// @brief Begin the one capture allowed for @p source_id.
 ///
-/// @returns False when another thread is already writing this source, when it
-/// has been captured, or when the registry is full. A claim taken here is
-/// released by finish_source_capture(), so a capture that could not be written
-/// -- an unwritable directory, a full filesystem -- can be retried once the
-/// operator fixes it rather than being refused for the life of the process.
-bool begin_source_capture(uint64_t source_id) noexcept {
+/// @details A granted claim is settled by finish_source_capture(), so a capture
+/// that could not be written -- an unwritable directory, a full filesystem --
+/// can be retried once the operator fixes it rather than being refused for the
+/// life of the process.
+CaptureClaim begin_source_capture(uint64_t source_id) noexcept {
   try {
-    std::lock_guard lock(g_captured_sources_mutex);
-    if (g_captured_sources.size() >= kMaxCapturedSources && !g_captured_sources.contains(source_id))
-      return false;
-    return g_captured_sources.emplace(source_id, false).second;
+    return with_capture_state([&](SourceCaptureState &state) {
+      if (state.captures.contains(source_id))
+        return CaptureClaim::AlreadyHandled;
+      if (state.captures.size() >= kMaxCapturedSources)
+        return CaptureClaim::RegistryFull;
+      state.captures.emplace(source_id, false);
+      return CaptureClaim::Granted;
+    });
   } catch (...) {
-    return false;
+    return CaptureClaim::AlreadyHandled;
   }
 }
 
 /// @brief Settle a claim taken by begin_source_capture().
 void finish_source_capture(uint64_t source_id, bool written) noexcept {
-  std::lock_guard lock(g_captured_sources_mutex);
-  if (written)
-    g_captured_sources[source_id] = true;
-  else
-    g_captured_sources.erase(source_id);
+  with_capture_state([&](SourceCaptureState &state) {
+    if (written)
+      state.captures[source_id] = true;
+    else
+      state.captures.erase(source_id);
+  });
+}
+
+/// @returns True the one time the full registry should explain itself.
+bool claim_capacity_report() noexcept {
+  return with_capture_state(
+      [](SourceCaptureState &state) { return !std::exchange(state.reported_capacity, true); });
 }
 
 /// @brief Write @p bytes to a fresh file in the configured directory.
 ///
 /// @returns True only once the artifact is completely written and closed.
 bool write_captured_source(uint64_t source_id, std::span<const uint8_t> bytes) noexcept {
+  // The write is retried until it succeeds, so its failure is reported once per
+  // source: a destination that stays unwritable would otherwise repeat itself on
+  // every load of the same bytes.
+  const auto report_failure = [source_id] {
+    return claim_once(&SourceCaptureState::reported_write_failures, source_id);
+  };
   char path[PATH_MAX];
   const int length =
       std::snprintf(path, sizeof(path), "%s/rocjitsu-gfx1250-b0-to-a0-%016" PRIx64 "-XXXXXX.elf",
                     source_capture_directory(), source_id);
   if (length < 0 || static_cast<size_t>(length) >= sizeof(path)) {
-    log_error("translation failed and its source code object could not be saved: path is too long "
-              "source_id=fnv1a64:%016" PRIx64 "; please file a bug report",
-              source_id);
+    if (report_failure()) {
+      log_error(
+          "translation failed and its source code object could not be saved: path is too long "
+          "source_id=fnv1a64:%016" PRIx64 "; please file a bug report",
+          source_id);
+    }
     return false;
   }
 
   const int descriptor = mkstemps(path, 4);
   if (descriptor < 0) {
-    log_error("translation failed and its source code object could not be saved "
-              "source_id=fnv1a64:%016" PRIx64 " errno=%d; please file a bug report",
-              source_id, errno);
+    if (report_failure()) {
+      log_error("translation failed and its source code object could not be saved "
+                "source_id=fnv1a64:%016" PRIx64 " errno=%d; please file a bug report",
+                source_id, errno);
+    }
     return false;
   }
   FILE *output = fdopen(descriptor, "wb");
@@ -181,9 +263,11 @@ bool write_captured_source(uint64_t source_id, std::span<const uint8_t> bytes) n
     const int saved_errno = errno;
     close(descriptor);
     unlink(path);
-    log_error("translation failed and its source code object could not be saved "
-              "source_id=fnv1a64:%016" PRIx64 " path=%s errno=%d; please file a bug report",
-              source_id, path, saved_errno);
+    if (report_failure()) {
+      log_error("translation failed and its source code object could not be saved "
+                "source_id=fnv1a64:%016" PRIx64 " path=%s errno=%d; please file a bug report",
+                source_id, path, saved_errno);
+    }
     return false;
   }
   const size_t written = std::fwrite(bytes.data(), 1, bytes.size(), output);
@@ -191,10 +275,12 @@ bool write_captured_source(uint64_t source_id, std::span<const uint8_t> bytes) n
   if (written != bytes.size() || close_status != 0) {
     const int saved_errno = errno;
     unlink(path);
-    log_error("translation failed and its source code object could not be saved "
-              "source_id=fnv1a64:%016" PRIx64
-              " path=%s written=%zu expected=%zu errno=%d; please file a bug report",
-              source_id, path, written, bytes.size(), saved_errno);
+    if (report_failure()) {
+      log_error("translation failed and its source code object could not be saved "
+                "source_id=fnv1a64:%016" PRIx64
+                " path=%s written=%zu expected=%zu errno=%d; please file a bug report",
+                source_id, path, written, bytes.size(), saved_errno);
+    }
     return false;
   }
   log_error("translation failed; source code object saved source_id=fnv1a64:%016" PRIx64
@@ -206,16 +292,30 @@ bool write_captured_source(uint64_t source_id, std::span<const uint8_t> bytes) n
 
 void dump_failed_source(uint64_t source_id, std::span<const uint8_t> bytes) noexcept {
   if (!source_capture_enabled()) {
-    if (claim_once(g_hinted_sources, source_id)) {
+    if (claim_once(&SourceCaptureState::hinted, source_id)) {
       log_error("translation failed; set HSA_HOTSWAP_DUMP_SOURCE=1 to save the source code object "
                 "source_id=fnv1a64:%016" PRIx64 " input_bytes=%zu; please file a bug report",
                 source_id, bytes.size());
     }
     return;
   }
-  if (!begin_source_capture(source_id))
+  switch (begin_source_capture(source_id)) {
+  case CaptureClaim::Granted:
+    finish_source_capture(source_id, write_captured_source(source_id, bytes));
     return;
-  finish_source_capture(source_id, write_captured_source(source_id, bytes));
+  case CaptureClaim::AlreadyHandled:
+    return;
+  case CaptureClaim::RegistryFull:
+    // Silence here would look identical to a successful capture the operator
+    // then cannot find.
+    if (claim_capacity_report()) {
+      log_error("translation failed; no source code object was saved because %zu distinct sources "
+                "have already been captured source_id=fnv1a64:%016" PRIx64
+                "; please file a bug report",
+                kMaxCapturedSources, source_id);
+    }
+    return;
+  }
 }
 
 void write_log(bool enabled, const char *level, const char *format, va_list args) noexcept {
@@ -1578,19 +1678,12 @@ extern "C" RJ_HOOK_EXPORT size_t rj_test_retained_executable_buffer_count() {
 // paid for the same bytes.
 extern "C" RJ_HOOK_EXPORT void rj_test_clear_retained_storage() {
   std::vector<std::string> dump_paths;
-  {
-    std::lock_guard lock(g_test_dump_mutex);
-    dump_paths.swap(g_test_dump_paths);
-  }
+  with_test_dump_paths([&](std::vector<std::string> &paths) { dump_paths.swap(paths); });
   for (const std::string &path : dump_paths)
     (void)unlink(path.c_str());
-  // The capture claim is process-wide, so a case that leaves its source claimed
-  // would silently suppress the artifact every later case expects.
-  {
-    std::lock_guard lock(g_captured_sources_mutex);
-    g_captured_sources.clear();
-    g_hinted_sources.clear();
-  }
+  // The capture state is process-wide, so a case that leaves its source claimed
+  // or its capacity message spent would silently change what a later one sees.
+  with_capture_state([](SourceCaptureState &state) { state = {}; });
   {
     std::lock_guard lock(g_state.storage_mutex);
     g_state.readers.clear();
@@ -1693,8 +1786,8 @@ extern "C" RJ_HOOK_EXPORT void rj_test_force_next_translation_status(int status)
 
 // Test-only: how many source captures this process has written.
 extern "C" RJ_HOOK_EXPORT uint64_t rj_test_dump_path_count() {
-  std::lock_guard lock(g_test_dump_mutex);
-  return g_test_dump_paths.size();
+  return with_test_dump_paths(
+      [](const std::vector<std::string> &paths) { return static_cast<uint64_t>(paths.size()); });
 }
 
 // Test-only: bytes the memo is currently holding, sources and outputs together.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/gfx1250_b0_a0_hotswap.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/gfx1250_b0_a0_hotswap.cpp
@@ -14,13 +14,13 @@
 
 #include "hsa/hsa_api_trace_minimal.h"
 #include "rocjitsu/code/amdgpu_elf.h"
-#include "rocjitsu/code/code_object_identity.h"
 #include "rocjitsu/code/rj_gfx1250_b0_to_a0.h"
 
 #include <algorithm>
 #include <atomic>
 #include <cerrno>
 #include <cinttypes>
+#include <climits>
 #include <condition_variable>
 #include <cstdarg>
 #include <cstdio>
@@ -37,6 +37,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -80,11 +81,56 @@ void remember_test_dump(const char *path) noexcept {
 void remember_test_dump(const char *) noexcept {}
 #endif
 
-void dump_failed_source(std::span<const uint8_t> bytes) noexcept {
-  const uint64_t source_id = rocjitsu::stable_code_object_id(bytes.data(), bytes.size());
-  char path[256];
-  const int length = std::snprintf(
-      path, sizeof(path), "/tmp/rocjitsu-gfx1250-b0-to-a0-%016" PRIx64 "-XXXXXX.elf", source_id);
+/// @brief Whether the operator asked for failing inputs to be written to disk.
+///
+/// @details Capture is opt-in because the objects are large -- RCCL's gfx1250
+/// device image is 212 MiB -- and an environmental failure is deliberately not
+/// memoized, so it repeats on every load of the same bytes.
+bool source_capture_enabled() {
+  const char *value = std::getenv("HSA_HOTSWAP_DUMP_SOURCE");
+  return value != nullptr && value[0] != '\0' && std::strcmp(value, "0") != 0;
+}
+
+/// @brief Directory that receives captured sources, most specific setting first.
+const char *source_capture_directory() {
+  for (const char *name : {"HSA_HOTSWAP_DUMP_DIR", "TMPDIR"}) {
+    const char *value = std::getenv(name);
+    if (value != nullptr && value[0] != '\0')
+      return value;
+  }
+  return "/tmp";
+}
+
+std::mutex g_captured_sources_mutex;
+std::unordered_set<uint64_t> g_captured_sources;
+
+/// @brief Take the single capture slot for @p source_id.
+///
+/// @returns False when this source was already reported, so a failure repeating
+/// on every load of the same bytes leaves one artifact, not one per attempt.
+bool claim_source_capture(uint64_t source_id) noexcept {
+  try {
+    std::lock_guard lock(g_captured_sources_mutex);
+    return g_captured_sources.insert(source_id).second;
+  } catch (...) {
+    return false;
+  }
+}
+
+void dump_failed_source(uint64_t source_id, std::span<const uint8_t> bytes) noexcept {
+  if (!claim_source_capture(source_id))
+    return;
+  if (!source_capture_enabled()) {
+    log_error("translation failed; set HSA_HOTSWAP_DUMP_SOURCE=1 to save the source code object "
+              "source_id=fnv1a64:%016" PRIx64 " input_bytes=%zu; please file a bug report",
+              source_id, bytes.size());
+    return;
+  }
+
+  char path[PATH_MAX];
+  const int length =
+      std::snprintf(path, sizeof(path), "%s/rocjitsu-gfx1250-b0-to-a0-%016" PRIx64 "-XXXXXX.elf",
+                    source_capture_directory(), source_id);
   if (length < 0 || static_cast<size_t>(length) >= sizeof(path)) {
     log_error("translation failed and its source code object could not be saved: path is too long "
               "source_id=fnv1a64:%016" PRIx64 "; please file a bug report",
@@ -152,12 +198,19 @@ void log_error(const char *format, ...) noexcept {
   va_end(args);
 }
 
+/// @brief Report one load attempt.
+///
+/// @param replay True when the outcome is a remembered verdict rather than a
+///        fresh one. A refusal is reported unconditionally the one time it is
+///        reached, but the reuses that follow are not new failures: a device
+///        library registered once per kernel and per device replays the same
+///        verdict hundreds of times, and reporting each one buries the original.
 void log_translation(uint64_t source_id, const char *outcome, size_t changed, size_t input_bytes,
-                     size_t output_bytes, rj_status_t translation_status,
-                     hsa_status_t load_status) noexcept {
+                     size_t output_bytes, rj_status_t translation_status, hsa_status_t load_status,
+                     bool replay = false) noexcept {
   const bool failed =
       translation_status != ROCJITSU_STATUS_SUCCESS || load_status != HSA_STATUS_SUCCESS;
-  if (!failed && !verbose_logging())
+  if ((!failed || replay) && !verbose_logging())
     return;
   flockfile(stderr);
   std::fputs("[hsa-hotswap-rj] ", stderr);
@@ -1303,15 +1356,16 @@ hsa_status_t HSA_API load_agent_code_object(hsa_executable_t executable, hsa_age
       memo_publish(claim, fingerprint, source, outcome);
     };
 
-    // Serve a remembered outcome, whichever way it went. Reporting it through the
-    // same record as a fresh translation keeps every load attributable to its
-    // source object; a reuse that logged less would blind that linkage precisely
-    // when almost every load is a reuse.
+    // Serve a remembered outcome, whichever way it went. Both reuses carry the
+    // same record as a fresh translation so every load stays attributable to its
+    // source object, but only the verbose channel sees them: the reuse itself is
+    // not news, and almost every load is a reuse.
     if (lookup == MemoLookup::kHit) {
       if (translation.output == nullptr) {
         log_translation(translation.info.source_code_object_id, "reused_failure",
                         translation.info.changed_instruction_count, source->size(), 0,
-                        translation.status, HSA_STATUS_ERROR_INVALID_CODE_OBJECT);
+                        translation.status, HSA_STATUS_ERROR_INVALID_CODE_OBJECT,
+                        /*replay=*/true);
         return HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
       }
       const hsa_status_t reused_status = load_owned_bytes(executable, agent, translation.output,
@@ -1337,7 +1391,10 @@ hsa_status_t HSA_API load_agent_code_object(hsa_executable_t executable, hsa_age
     if (translation.status != ROCJITSU_STATUS_SUCCESS || translated_data == nullptr ||
         translated_size == 0) {
       rj_gfx1250_b0_to_a0_free(translated_data);
-      dump_failed_source(*source);
+      // Copying a large input to disk after an allocation failure adds pressure
+      // to a system that just ran out, and the bytes are not what failed.
+      if (translation.status != ROCJITSU_STATUS_OUT_OF_RESOURCES)
+        dump_failed_source(translation.info.source_code_object_id, *source);
       // Remember a refusal only when it is a verdict on the bytes. The translator
       // reports an environmental failure -- an allocation it could not make, an
       // exception it could not attribute -- with a status that promises nothing
@@ -1481,6 +1538,12 @@ extern "C" RJ_HOOK_EXPORT void rj_test_clear_retained_storage() {
   }
   for (const std::string &path : dump_paths)
     (void)unlink(path.c_str());
+  // The capture claim is process-wide, so a case that leaves its source claimed
+  // would silently suppress the artifact every later case expects.
+  {
+    std::lock_guard lock(g_captured_sources_mutex);
+    g_captured_sources.clear();
+  }
   {
     std::lock_guard lock(g_state.storage_mutex);
     g_state.readers.clear();
@@ -1579,6 +1642,12 @@ extern "C" RJ_HOOK_EXPORT void rj_test_force_next_translation_status(int status)
   std::lock_guard lock(g_forced_status_mutex);
   g_forced_status_armed = true;
   g_forced_status = static_cast<rj_status_t>(status);
+}
+
+// Test-only: how many source captures this process has written.
+extern "C" RJ_HOOK_EXPORT uint64_t rj_test_dump_path_count() {
+  std::lock_guard lock(g_test_dump_mutex);
+  return g_test_dump_paths.size();
 }
 
 // Test-only: bytes the memo is currently holding, sources and outputs together.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/gfx1250_b0_a0_hotswap.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/gfx1250_b0_a0_hotswap.cpp
@@ -7,7 +7,12 @@
 /// @section env Environment controls
 ///
 /// - `HSA_HOTSWAP_VERBOSE` -- debug logging to stderr. Changes what is reported,
-///   never what is done.
+///   never what is done. Errors are always reported, independently of this flag.
+/// - `HSA_HOTSWAP_DUMP_DIR` -- write each intercepted source code object to this
+///   existing directory for offline diagnosis.
+/// - `HSA_HOTSWAP_DUMP_ONLY` -- when nonzero, dump intercepted code objects and
+///   pass them to the lower loader without translation. Intended only for
+///   collecting an input for offline translation.
 ///
 /// `HSA_HOTSWAP_DISABLE` belongs to CLR rather than this hook: it stops CLR
 /// forwarding anything here at all.
@@ -62,35 +67,142 @@ bool verbose_logging() {
   return value != nullptr && value[0] != '\0' && std::strcmp(value, "0") != 0;
 }
 
-void log(const char *format, ...) {
-  if (!verbose_logging())
+bool dump_only() {
+  const char *value = std::getenv("HSA_HOTSWAP_DUMP_ONLY");
+  return value != nullptr && value[0] != '\0' && std::strcmp(value, "0") != 0;
+}
+
+void log(const char *format, ...) noexcept;
+void log_error(const char *format, ...) noexcept;
+
+uint64_t exact_source_id(std::span<const uint8_t> bytes) noexcept {
+  constexpr uint64_t kOffsetBasis = 14695981039346656037ULL;
+  constexpr uint64_t kPrime = 1099511628211ULL;
+  uint64_t value = kOffsetBasis;
+  for (const uint8_t byte : bytes) {
+    value ^= byte;
+    value *= kPrime;
+  }
+  return value;
+}
+
+void dump_source_for_diagnostics(std::span<const uint8_t> bytes) noexcept {
+  const char *directory = std::getenv("HSA_HOTSWAP_DUMP_DIR");
+  if (directory == nullptr || directory[0] == '\0')
+    return;
+
+  char path[4096];
+  const uint64_t source_id = exact_source_id(bytes);
+  const int length = std::snprintf(path, sizeof(path), "%s/gfx1250-%016" PRIx64 "-%zu.elf",
+                                   directory, source_id, bytes.size());
+  if (length < 0 || static_cast<size_t>(length) >= sizeof(path)) {
+    log_error("diagnostic dump path is too long source_id=fnv1a64:%016" PRIx64, source_id);
+    return;
+  }
+
+  FILE *output = std::fopen(path, "wb");
+  if (output == nullptr) {
+    log_error("diagnostic dump open failed source_id=fnv1a64:%016" PRIx64 " path=%s errno=%d",
+              source_id, path, errno);
+    return;
+  }
+  const size_t written = std::fwrite(bytes.data(), 1, bytes.size(), output);
+  const int close_status = std::fclose(output);
+  if (written != bytes.size() || close_status != 0) {
+    log_error("diagnostic dump write failed source_id=fnv1a64:%016" PRIx64
+              " path=%s written=%zu expected=%zu errno=%d",
+              source_id, path, written, bytes.size(), errno);
+    return;
+  }
+  log("diagnostic dump source_id=fnv1a64:%016" PRIx64 " input_bytes=%zu path=%s", source_id,
+      bytes.size(), path);
+}
+
+void write_log(bool enabled, const char *level, const char *format, va_list args) noexcept {
+  if (!enabled)
     return;
   flockfile(stderr);
   std::fputs("[hsa-hotswap-rj] ", stderr);
-  va_list args;
-  va_start(args, format);
+  if (level != nullptr)
+    std::fprintf(stderr, "%s: ", level);
   std::vfprintf(stderr, format, args);
-  va_end(args);
   std::fputc('\n', stderr);
   funlockfile(stderr);
 }
 
-void log_translation(uint64_t source_id, const char *outcome, size_t changed, size_t input_bytes,
-                     size_t output_bytes, rj_status_t translation_status,
-                     hsa_status_t load_status) {
-  log("eager translation source_id=fnv1a64:%016" PRIx64
-      " input_revision=b0 output_revision=a0 outcome=%s changed=%zu"
-      " input_bytes=%zu output_bytes=%zu translation_status=%d status=%d",
-      source_id, outcome, changed, input_bytes, output_bytes, static_cast<int>(translation_status),
-      static_cast<int>(load_status));
+void log(const char *format, ...) noexcept {
+  va_list args;
+  va_start(args, format);
+  write_log(verbose_logging(), nullptr, format, args);
+  va_end(args);
 }
 
-template <typename Fn> hsa_status_t hsa_boundary(Fn &&fn) noexcept {
+void log_error(const char *format, ...) noexcept {
+  va_list args;
+  va_start(args, format);
+  write_log(true, "error", format, args);
+  va_end(args);
+}
+
+void log_translation(uint64_t source_id, const char *outcome, size_t changed, size_t input_bytes,
+                     size_t output_bytes, rj_status_t translation_status,
+                     hsa_status_t load_status) noexcept {
+  const bool failed = translation_status != ROCJITSU_STATUS_SUCCESS ||
+                      load_status != HSA_STATUS_SUCCESS;
+  if (!failed && !verbose_logging())
+    return;
+  flockfile(stderr);
+  std::fputs("[hsa-hotswap-rj] ", stderr);
+  if (failed)
+    std::fputs("error: ", stderr);
+  std::fprintf(stderr,
+               "eager translation source_id=fnv1a64:%016" PRIx64
+               " input_revision=b0 output_revision=a0 outcome=%s changed=%zu"
+               " input_bytes=%zu output_bytes=%zu translation_status=%d status=%d\n",
+               source_id, outcome, changed, input_bytes, output_bytes,
+               static_cast<int>(translation_status), static_cast<int>(load_status));
+  funlockfile(stderr);
+}
+
+void log_translation_diagnostic(
+    uint64_t source_id, const rj_gfx1250_b0_to_a0_diagnostic_t *diagnostic) noexcept {
+  if (diagnostic == nullptr)
+    return;
+  const char *severity = diagnostic->severity != nullptr ? diagnostic->severity : "unknown";
+  const char *kind = diagnostic->kind != nullptr ? diagnostic->kind : "unknown";
+  const char *mnemonic = diagnostic->mnemonic != nullptr ? diagnostic->mnemonic : "";
+  const char *message = diagnostic->message != nullptr ? diagnostic->message : "";
+
+  flockfile(stderr);
+  std::fprintf(stderr,
+               "[hsa-hotswap-rj] error: translation diagnostic "
+               "source_id=fnv1a64:%016" PRIx64 " severity=%s kind=%s",
+               source_id, severity, kind);
+  if (diagnostic->has_guest_offset)
+    std::fprintf(stderr, " guest_offset=.text+0x%" PRIx64, diagnostic->guest_offset);
+  if (mnemonic[0] != '\0')
+    std::fprintf(stderr, " mnemonic=%s", mnemonic);
+  if (diagnostic->required_work)
+    std::fprintf(stderr, " required=%s\n", message);
+  else
+    std::fprintf(stderr, " message=%s\n", message);
+  funlockfile(stderr);
+}
+
+template <typename Fn> hsa_status_t hsa_boundary(const char *operation, Fn &&fn) noexcept {
   try {
     return fn();
   } catch (const std::bad_alloc &) {
+    log_error("operation=%s exception=std::bad_alloc status=%d", operation,
+              static_cast<int>(HSA_STATUS_ERROR_OUT_OF_RESOURCES));
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+  } catch (const std::exception &error) {
+    log_error("operation=%s exception=std::exception what=%s status=%d", operation, error.what(),
+              static_cast<int>(HSA_STATUS_ERROR));
+    return HSA_STATUS_ERROR;
   } catch (...) {
+    log_error("operation=%s exception=unknown status=%d", operation,
+              static_cast<int>(HSA_STATUS_ERROR));
     return HSA_STATUS_ERROR;
   }
 }
@@ -714,15 +826,24 @@ void override_translation_status_for_test(rj_status_t &, uint8_t *&, size_t &) {
 
 bool install(HsaApiTable *table) {
   std::lock_guard lock(g_state.lifecycle_mutex);
-  if (g_state.core != nullptr || table == nullptr || table->core_ == nullptr)
+  if (g_state.core != nullptr) {
+    log_error("OnLoad refused: hook is already installed");
     return false;
+  }
+  if (table == nullptr || table->core_ == nullptr) {
+    log_error("OnLoad refused: missing HSA API table");
+    return false;
+  }
 
   CoreApiTable *core = table->core_;
   constexpr size_t required_size =
       offsetof(CoreApiTable, hsa_executable_load_agent_code_object_fn) +
       sizeof(CoreApiTable::hsa_executable_load_agent_code_object_fn);
-  if (core->version.minor_id < required_size)
+  if (core->version.minor_id < required_size) {
+    log_error("OnLoad refused: HSA core API table is too small size=%u required=%zu",
+              core->version.minor_id, required_size);
     return false;
+  }
 
   OriginalApi original{
       core->hsa_code_object_reader_create_from_file_fn,
@@ -743,8 +864,10 @@ bool install(HsaApiTable *table) {
       original.load_agent == nullptr || original.load_program == nullptr ||
       original.load_deprecated == nullptr || original.get_extension_table == nullptr ||
       original.iterate_agents == nullptr || original.agent_get_info == nullptr ||
-      original.agent_iterate_isas == nullptr || original.isa_get_info == nullptr)
+      original.agent_iterate_isas == nullptr || original.isa_get_info == nullptr) {
+    log_error("OnLoad refused: HSA core API table has a missing required entry");
     return false;
+  }
 
   // Do NOT free the previous generation's translated backing storage here. Those
   // buffers can still be referenced by consumers whose lifetime is NOT bounded by
@@ -859,8 +982,11 @@ Blob read_file_region(hsa_file_t file, size_t offset, size_t requested_size) {
 }
 
 hsa_status_t capture_reader(const OriginalApi &api, hsa_code_object_reader_t *reader, Blob bytes) {
-  if (bytes != nullptr && store_reader(*reader, std::move(bytes)))
-    return HSA_STATUS_SUCCESS;
+  if (bytes != nullptr) {
+    dump_source_for_diagnostics(*bytes);
+    if (store_reader(*reader, std::move(bytes)))
+      return HSA_STATUS_SUCCESS;
+  }
   (void)api.destroy_reader(*reader);
   *reader = {};
   return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
@@ -1012,7 +1138,7 @@ hsa_status_t load_owned_bytes(hsa_executable_t executable, hsa_agent_t agent, co
 
 hsa_status_t HSA_API reader_create_from_memory(const void *code_object, size_t size,
                                                hsa_code_object_reader_t *reader) {
-  return hsa_boundary([&] {
+  return hsa_boundary("hsa_code_object_reader_create_from_memory", [&] {
     // Reject a null output pointer before forwarding: the lower/vendor API may write
     // through it without checking, so fail fast the way ROCr's own layer does.
     if (reader == nullptr)
@@ -1031,7 +1157,7 @@ hsa_status_t HSA_API reader_create_from_memory(const void *code_object, size_t s
 }
 
 hsa_status_t HSA_API reader_create_from_file(hsa_file_t file, hsa_code_object_reader_t *reader) {
-  return hsa_boundary([&] {
+  return hsa_boundary("hsa_code_object_reader_create_from_file", [&] {
     if (reader == nullptr)
       return HSA_STATUS_ERROR_INVALID_ARGUMENT;
     const std::shared_ptr<const OriginalApi> api =
@@ -1048,7 +1174,7 @@ hsa_status_t HSA_API reader_create_from_file(hsa_file_t file, hsa_code_object_re
 
 hsa_status_t vendor_reader_create(hsa_file_t file, size_t offset, size_t size,
                                   hsa_code_object_reader_t *reader) {
-  return hsa_boundary([&] {
+  return hsa_boundary("amd_loader_code_object_reader_create_from_file", [&] {
     if (reader == nullptr)
       return HSA_STATUS_ERROR_INVALID_ARGUMENT;
     const std::shared_ptr<const OriginalApi> api =
@@ -1067,7 +1193,7 @@ hsa_status_t vendor_reader_create(hsa_file_t file, size_t offset, size_t size,
 
 hsa_status_t HSA_API system_get_major_extension_table(uint16_t extension, uint16_t version_major,
                                                       size_t table_length, void *table) {
-  return hsa_boundary([&] {
+  return hsa_boundary("hsa_system_get_major_extension_table", [&] {
     const std::shared_ptr<const OriginalApi> api =
         g_state.active_api.load(std::memory_order_acquire);
     if (api == nullptr)
@@ -1092,7 +1218,7 @@ hsa_status_t HSA_API system_get_major_extension_table(uint16_t extension, uint16
 }
 
 hsa_status_t HSA_API reader_destroy(hsa_code_object_reader_t reader) {
-  return hsa_boundary([&] {
+  return hsa_boundary("hsa_code_object_reader_destroy", [&] {
     const std::shared_ptr<const OriginalApi> api =
         g_state.active_api.load(std::memory_order_acquire);
     if (api == nullptr)
@@ -1106,7 +1232,7 @@ hsa_status_t HSA_API reader_destroy(hsa_code_object_reader_t reader) {
 }
 
 hsa_status_t HSA_API executable_destroy(hsa_executable_t executable) {
-  return hsa_boundary([&] {
+  return hsa_boundary("hsa_executable_destroy", [&] {
     const std::shared_ptr<const OriginalApi> api =
         g_state.active_api.load(std::memory_order_acquire);
     if (api == nullptr)
@@ -1122,7 +1248,7 @@ hsa_status_t HSA_API executable_destroy(hsa_executable_t executable) {
 hsa_status_t HSA_API load_agent_code_object(hsa_executable_t executable, hsa_agent_t agent,
                                             hsa_code_object_reader_t reader, const char *options,
                                             hsa_loaded_code_object_t *loaded) {
-  return hsa_boundary([&] {
+  return hsa_boundary("hsa_executable_load_agent_code_object", [&] {
     const std::shared_ptr<const OriginalApi> api =
         g_state.active_api.load(std::memory_order_acquire);
     if (api == nullptr)
@@ -1138,6 +1264,10 @@ hsa_status_t HSA_API load_agent_code_object(hsa_executable_t executable, hsa_age
     Blob source = lookup_reader(reader);
     if (source == nullptr)
       return HSA_STATUS_ERROR_INVALID_CODE_OBJECT_READER;
+    if (dump_only()) {
+      log("diagnostic dump-only pass-through input_bytes=%zu", source->size());
+      return original_load(executable, agent, reader, options, loaded);
+    }
     if (!is_gfx1250(source))
       return load_owned_bytes(executable, agent, source, options, loaded, *api, original_load);
 
@@ -1195,8 +1325,14 @@ hsa_status_t HSA_API load_agent_code_object(hsa_executable_t executable, hsa_age
     size_t translated_size = 0;
     g_state.translations.fetch_add(1, std::memory_order_relaxed);
     hold_claimed_translation_for_test();
-    translation.status = rj_gfx1250_b0_to_a0_translate_with_info(
-        source->data(), source->size(), &translated_data, &translated_size, &translation.info);
+    translation.status = rj_gfx1250_b0_to_a0_translate(
+        source->data(), source->size(), &translated_data, &translated_size, &translation.info,
+        [](const rj_gfx1250_b0_to_a0_diagnostic_t *diagnostic, void *user_data) noexcept {
+          const auto *info =
+              static_cast<const rj_gfx1250_b0_to_a0_translation_info_t *>(user_data);
+          log_translation_diagnostic(info->source_code_object_id, diagnostic);
+        },
+        &translation.info);
     override_translation_status_for_test(translation.status, translated_data, translated_size);
     if (translation.status != ROCJITSU_STATUS_SUCCESS || translated_data == nullptr ||
         translated_size == 0) {
@@ -1239,7 +1375,7 @@ hsa_status_t HSA_API load_agent_code_object(hsa_executable_t executable, hsa_age
 hsa_status_t HSA_API load_program_code_object(hsa_executable_t executable,
                                               hsa_code_object_reader_t reader, const char *options,
                                               hsa_loaded_code_object_t *loaded) {
-  return hsa_boundary([&] {
+  return hsa_boundary("hsa_executable_load_program_code_object", [&] {
     const std::shared_ptr<const OriginalApi> api =
         g_state.active_api.load(std::memory_order_acquire);
     if (api == nullptr)
@@ -1261,7 +1397,7 @@ hsa_status_t HSA_API load_program_code_object(hsa_executable_t executable,
 
 hsa_status_t HSA_API load_code_object(hsa_executable_t executable, hsa_agent_t agent,
                                       hsa_code_object_t code_object, const char *options) {
-  return hsa_boundary([&] {
+  return hsa_boundary("hsa_executable_load_code_object", [&] {
     const std::shared_ptr<const OriginalApi> api =
         g_state.active_api.load(std::memory_order_acquire);
     if (api == nullptr)
@@ -1290,7 +1426,14 @@ extern "C" RJ_HOOK_EXPORT bool OnLoad(HsaApiTable *table, uint64_t runtime_versi
   (void)failed_tool_names;
   try {
     return install(table);
+  } catch (const std::bad_alloc &) {
+    log_error("OnLoad failed: exception=std::bad_alloc");
+    return false;
+  } catch (const std::exception &error) {
+    log_error("OnLoad failed: exception=std::exception what=%s", error.what());
+    return false;
   } catch (...) {
+    log_error("OnLoad failed: exception=unknown");
     return false;
   }
 }
@@ -1298,7 +1441,10 @@ extern "C" RJ_HOOK_EXPORT bool OnLoad(HsaApiTable *table, uint64_t runtime_versi
 extern "C" RJ_HOOK_EXPORT void OnUnload() {
   try {
     uninstall();
+  } catch (const std::exception &error) {
+    log_error("OnUnload failed: exception=std::exception what=%s", error.what());
   } catch (...) {
+    log_error("OnUnload failed: exception=unknown");
   }
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/gfx1250_b0_a0_hotswap.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/gfx1250_b0_a0_hotswap.cpp
@@ -8,17 +8,13 @@
 ///
 /// - `HSA_HOTSWAP_VERBOSE` -- debug logging to stderr. Changes what is reported,
 ///   never what is done. Errors are always reported, independently of this flag.
-/// - `HSA_HOTSWAP_DUMP_DIR` -- write each intercepted source code object to this
-///   existing directory for offline diagnosis.
-/// - `HSA_HOTSWAP_DUMP_ONLY` -- when nonzero, dump intercepted code objects and
-///   pass them to the lower loader without translation. Intended only for
-///   collecting an input for offline translation.
 ///
 /// `HSA_HOTSWAP_DISABLE` belongs to CLR rather than this hook: it stops CLR
 /// forwarding anything here at all.
 
 #include "hsa/hsa_api_trace_minimal.h"
 #include "rocjitsu/code/amdgpu_elf.h"
+#include "rocjitsu/code/code_object_identity.h"
 #include "rocjitsu/code/rj_gfx1250_b0_to_a0.h"
 
 #include <algorithm>
@@ -67,55 +63,67 @@ bool verbose_logging() {
   return value != nullptr && value[0] != '\0' && std::strcmp(value, "0") != 0;
 }
 
-bool dump_only() {
-  const char *value = std::getenv("HSA_HOTSWAP_DUMP_ONLY");
-  return value != nullptr && value[0] != '\0' && std::strcmp(value, "0") != 0;
-}
-
 void log(const char *format, ...) noexcept;
 void log_error(const char *format, ...) noexcept;
 
-uint64_t exact_source_id(std::span<const uint8_t> bytes) noexcept {
-  constexpr uint64_t kOffsetBasis = 14695981039346656037ULL;
-  constexpr uint64_t kPrime = 1099511628211ULL;
-  uint64_t value = kOffsetBasis;
-  for (const uint8_t byte : bytes) {
-    value ^= byte;
-    value *= kPrime;
+#if defined(RJ_HOTSWAP_TEST_HOOKS)
+std::mutex g_test_dump_mutex;
+std::vector<std::string> g_test_dump_paths;
+void remember_test_dump(const char *path) noexcept {
+  try {
+    std::lock_guard lock(g_test_dump_mutex);
+    g_test_dump_paths.emplace_back(path);
+  } catch (...) {
   }
-  return value;
 }
+#else
+void remember_test_dump(const char *) noexcept {}
+#endif
 
-void dump_source_for_diagnostics(std::span<const uint8_t> bytes) noexcept {
-  const char *directory = std::getenv("HSA_HOTSWAP_DUMP_DIR");
-  if (directory == nullptr || directory[0] == '\0')
-    return;
-
-  char path[4096];
-  const uint64_t source_id = exact_source_id(bytes);
-  const int length = std::snprintf(path, sizeof(path), "%s/gfx1250-%016" PRIx64 "-%zu.elf",
-                                   directory, source_id, bytes.size());
+void dump_failed_source(std::span<const uint8_t> bytes) noexcept {
+  const uint64_t source_id = rocjitsu::stable_code_object_id(bytes.data(), bytes.size());
+  char path[256];
+  const int length = std::snprintf(
+      path, sizeof(path), "/tmp/rocjitsu-gfx1250-b0-to-a0-%016" PRIx64 "-XXXXXX.elf", source_id);
   if (length < 0 || static_cast<size_t>(length) >= sizeof(path)) {
-    log_error("diagnostic dump path is too long source_id=fnv1a64:%016" PRIx64, source_id);
+    log_error("translation failed and its source code object could not be saved: path is too long "
+              "source_id=fnv1a64:%016" PRIx64 "; please file a bug report",
+              source_id);
     return;
   }
 
-  FILE *output = std::fopen(path, "wb");
+  const int descriptor = mkstemps(path, 4);
+  if (descriptor < 0) {
+    log_error("translation failed and its source code object could not be saved "
+              "source_id=fnv1a64:%016" PRIx64 " errno=%d; please file a bug report",
+              source_id, errno);
+    return;
+  }
+  FILE *output = fdopen(descriptor, "wb");
   if (output == nullptr) {
-    log_error("diagnostic dump open failed source_id=fnv1a64:%016" PRIx64 " path=%s errno=%d",
-              source_id, path, errno);
+    const int saved_errno = errno;
+    close(descriptor);
+    unlink(path);
+    log_error("translation failed and its source code object could not be saved "
+              "source_id=fnv1a64:%016" PRIx64 " path=%s errno=%d; please file a bug report",
+              source_id, path, saved_errno);
     return;
   }
   const size_t written = std::fwrite(bytes.data(), 1, bytes.size(), output);
   const int close_status = std::fclose(output);
   if (written != bytes.size() || close_status != 0) {
-    log_error("diagnostic dump write failed source_id=fnv1a64:%016" PRIx64
-              " path=%s written=%zu expected=%zu errno=%d",
-              source_id, path, written, bytes.size(), errno);
+    const int saved_errno = errno;
+    unlink(path);
+    log_error("translation failed and its source code object could not be saved "
+              "source_id=fnv1a64:%016" PRIx64
+              " path=%s written=%zu expected=%zu errno=%d; please file a bug report",
+              source_id, path, written, bytes.size(), saved_errno);
     return;
   }
-  log("diagnostic dump source_id=fnv1a64:%016" PRIx64 " input_bytes=%zu path=%s", source_id,
-      bytes.size(), path);
+  log_error("translation failed; source code object saved source_id=fnv1a64:%016" PRIx64
+            " input_bytes=%zu path=%s; please file a bug report and attach this code object",
+            source_id, bytes.size(), path);
+  remember_test_dump(path);
 }
 
 void write_log(bool enabled, const char *level, const char *format, va_list args) noexcept {
@@ -147,8 +155,8 @@ void log_error(const char *format, ...) noexcept {
 void log_translation(uint64_t source_id, const char *outcome, size_t changed, size_t input_bytes,
                      size_t output_bytes, rj_status_t translation_status,
                      hsa_status_t load_status) noexcept {
-  const bool failed = translation_status != ROCJITSU_STATUS_SUCCESS ||
-                      load_status != HSA_STATUS_SUCCESS;
+  const bool failed =
+      translation_status != ROCJITSU_STATUS_SUCCESS || load_status != HSA_STATUS_SUCCESS;
   if (!failed && !verbose_logging())
     return;
   flockfile(stderr);
@@ -164,8 +172,8 @@ void log_translation(uint64_t source_id, const char *outcome, size_t changed, si
   funlockfile(stderr);
 }
 
-void log_translation_diagnostic(
-    uint64_t source_id, const rj_gfx1250_b0_to_a0_diagnostic_t *diagnostic) noexcept {
+void log_translation_diagnostic(uint64_t source_id,
+                                const rj_gfx1250_b0_to_a0_diagnostic_t *diagnostic) noexcept {
   if (diagnostic == nullptr)
     return;
   const char *severity = diagnostic->severity != nullptr ? diagnostic->severity : "unknown";
@@ -175,9 +183,9 @@ void log_translation_diagnostic(
 
   flockfile(stderr);
   std::fprintf(stderr,
-               "[hsa-hotswap-rj] error: translation diagnostic "
+               "[hsa-hotswap-rj] %s: translation diagnostic "
                "source_id=fnv1a64:%016" PRIx64 " severity=%s kind=%s",
-               source_id, severity, kind);
+               severity, source_id, severity, kind);
   if (diagnostic->has_guest_offset)
     std::fprintf(stderr, " guest_offset=.text+0x%" PRIx64, diagnostic->guest_offset);
   if (mnemonic[0] != '\0')
@@ -982,11 +990,8 @@ Blob read_file_region(hsa_file_t file, size_t offset, size_t requested_size) {
 }
 
 hsa_status_t capture_reader(const OriginalApi &api, hsa_code_object_reader_t *reader, Blob bytes) {
-  if (bytes != nullptr) {
-    dump_source_for_diagnostics(*bytes);
-    if (store_reader(*reader, std::move(bytes)))
-      return HSA_STATUS_SUCCESS;
-  }
+  if (bytes != nullptr && store_reader(*reader, std::move(bytes)))
+    return HSA_STATUS_SUCCESS;
   (void)api.destroy_reader(*reader);
   *reader = {};
   return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
@@ -1264,10 +1269,6 @@ hsa_status_t HSA_API load_agent_code_object(hsa_executable_t executable, hsa_age
     Blob source = lookup_reader(reader);
     if (source == nullptr)
       return HSA_STATUS_ERROR_INVALID_CODE_OBJECT_READER;
-    if (dump_only()) {
-      log("diagnostic dump-only pass-through input_bytes=%zu", source->size());
-      return original_load(executable, agent, reader, options, loaded);
-    }
     if (!is_gfx1250(source))
       return load_owned_bytes(executable, agent, source, options, loaded, *api, original_load);
 
@@ -1328,8 +1329,7 @@ hsa_status_t HSA_API load_agent_code_object(hsa_executable_t executable, hsa_age
     translation.status = rj_gfx1250_b0_to_a0_translate(
         source->data(), source->size(), &translated_data, &translated_size, &translation.info,
         [](const rj_gfx1250_b0_to_a0_diagnostic_t *diagnostic, void *user_data) noexcept {
-          const auto *info =
-              static_cast<const rj_gfx1250_b0_to_a0_translation_info_t *>(user_data);
+          const auto *info = static_cast<const rj_gfx1250_b0_to_a0_translation_info_t *>(user_data);
           log_translation_diagnostic(info->source_code_object_id, diagnostic);
         },
         &translation.info);
@@ -1337,6 +1337,7 @@ hsa_status_t HSA_API load_agent_code_object(hsa_executable_t executable, hsa_age
     if (translation.status != ROCJITSU_STATUS_SUCCESS || translated_data == nullptr ||
         translated_size == 0) {
       rj_gfx1250_b0_to_a0_free(translated_data);
+      dump_failed_source(*source);
       // Remember a refusal only when it is a verdict on the bytes. The translator
       // reports an environmental failure -- an allocation it could not make, an
       // exception it could not attribute -- with a status that promises nothing
@@ -1473,6 +1474,13 @@ extern "C" RJ_HOOK_EXPORT size_t rj_test_retained_executable_buffer_count() {
 // expects to observe a translation cannot do so once an earlier case has already
 // paid for the same bytes.
 extern "C" RJ_HOOK_EXPORT void rj_test_clear_retained_storage() {
+  std::vector<std::string> dump_paths;
+  {
+    std::lock_guard lock(g_test_dump_mutex);
+    dump_paths.swap(g_test_dump_paths);
+  }
+  for (const std::string &path : dump_paths)
+    (void)unlink(path.c_str());
   {
     std::lock_guard lock(g_state.storage_mutex);
     g_state.readers.clear();
@@ -1584,5 +1592,13 @@ extern "C" RJ_HOOK_EXPORT uint64_t rj_test_translation_memo_bytes() {
 extern "C" RJ_HOOK_EXPORT void rj_test_log_translation(uint64_t source_id, size_t changed) {
   log_translation(source_id, "translated", changed, 64, 96, ROCJITSU_STATUS_SUCCESS,
                   HSA_STATUS_SUCCESS);
+}
+
+// Test-only: render one diagnostic without arranging a translator result solely
+// to select its severity.
+extern "C" RJ_HOOK_EXPORT void
+rj_test_log_translation_diagnostic(uint64_t source_id,
+                                   const rj_gfx1250_b0_to_a0_diagnostic_t *diagnostic) {
+  log_translation_diagnostic(source_id, diagnostic);
 }
 #endif // RJ_HOTSWAP_TEST_HOOKS

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/gfx1250_b0_a0_hotswap.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/gfx1250_b0_a0_hotswap.cpp
@@ -101,32 +101,63 @@ const char *source_capture_directory() {
   return "/tmp";
 }
 
-std::mutex g_captured_sources_mutex;
-std::unordered_set<uint64_t> g_captured_sources;
+// A distinct failing object is rare, but nothing about a process guarantees it:
+// cap what the registries below can grow to, and stop capturing once a run has
+// produced enough material to diagnose whatever is wrong.
+constexpr size_t kMaxCapturedSources = 32;
 
-/// @brief Take the single capture slot for @p source_id.
-///
-/// @returns False when this source was already reported, so a failure repeating
-/// on every load of the same bytes leaves one artifact, not one per attempt.
-bool claim_source_capture(uint64_t source_id) noexcept {
+std::mutex g_captured_sources_mutex;
+/// Source identity -> whether its artifact was completely written. An entry that
+/// is present but false is a capture in flight on another thread.
+std::unordered_map<uint64_t, bool> g_captured_sources;
+/// Sources the disabled-capture hint has already named. Kept apart from the
+/// capture registry so the hint does not consume the artifact's one slot: an
+/// operator who reads it, exports the variable and retries must get the file.
+std::unordered_set<uint64_t> g_hinted_sources;
+
+/// @returns True when @p seen did not already hold @p source_id and has room.
+bool claim_once(std::unordered_set<uint64_t> &seen, uint64_t source_id) noexcept {
   try {
     std::lock_guard lock(g_captured_sources_mutex);
-    return g_captured_sources.insert(source_id).second;
+    if (seen.size() >= kMaxCapturedSources)
+      return false;
+    return seen.insert(source_id).second;
   } catch (...) {
     return false;
   }
 }
 
-void dump_failed_source(uint64_t source_id, std::span<const uint8_t> bytes) noexcept {
-  if (!claim_source_capture(source_id))
-    return;
-  if (!source_capture_enabled()) {
-    log_error("translation failed; set HSA_HOTSWAP_DUMP_SOURCE=1 to save the source code object "
-              "source_id=fnv1a64:%016" PRIx64 " input_bytes=%zu; please file a bug report",
-              source_id, bytes.size());
-    return;
+/// @brief Begin the one capture allowed for @p source_id.
+///
+/// @returns False when another thread is already writing this source, when it
+/// has been captured, or when the registry is full. A claim taken here is
+/// released by finish_source_capture(), so a capture that could not be written
+/// -- an unwritable directory, a full filesystem -- can be retried once the
+/// operator fixes it rather than being refused for the life of the process.
+bool begin_source_capture(uint64_t source_id) noexcept {
+  try {
+    std::lock_guard lock(g_captured_sources_mutex);
+    if (g_captured_sources.size() >= kMaxCapturedSources && !g_captured_sources.contains(source_id))
+      return false;
+    return g_captured_sources.emplace(source_id, false).second;
+  } catch (...) {
+    return false;
   }
+}
 
+/// @brief Settle a claim taken by begin_source_capture().
+void finish_source_capture(uint64_t source_id, bool written) noexcept {
+  std::lock_guard lock(g_captured_sources_mutex);
+  if (written)
+    g_captured_sources[source_id] = true;
+  else
+    g_captured_sources.erase(source_id);
+}
+
+/// @brief Write @p bytes to a fresh file in the configured directory.
+///
+/// @returns True only once the artifact is completely written and closed.
+bool write_captured_source(uint64_t source_id, std::span<const uint8_t> bytes) noexcept {
   char path[PATH_MAX];
   const int length =
       std::snprintf(path, sizeof(path), "%s/rocjitsu-gfx1250-b0-to-a0-%016" PRIx64 "-XXXXXX.elf",
@@ -135,7 +166,7 @@ void dump_failed_source(uint64_t source_id, std::span<const uint8_t> bytes) noex
     log_error("translation failed and its source code object could not be saved: path is too long "
               "source_id=fnv1a64:%016" PRIx64 "; please file a bug report",
               source_id);
-    return;
+    return false;
   }
 
   const int descriptor = mkstemps(path, 4);
@@ -143,7 +174,7 @@ void dump_failed_source(uint64_t source_id, std::span<const uint8_t> bytes) noex
     log_error("translation failed and its source code object could not be saved "
               "source_id=fnv1a64:%016" PRIx64 " errno=%d; please file a bug report",
               source_id, errno);
-    return;
+    return false;
   }
   FILE *output = fdopen(descriptor, "wb");
   if (output == nullptr) {
@@ -153,7 +184,7 @@ void dump_failed_source(uint64_t source_id, std::span<const uint8_t> bytes) noex
     log_error("translation failed and its source code object could not be saved "
               "source_id=fnv1a64:%016" PRIx64 " path=%s errno=%d; please file a bug report",
               source_id, path, saved_errno);
-    return;
+    return false;
   }
   const size_t written = std::fwrite(bytes.data(), 1, bytes.size(), output);
   const int close_status = std::fclose(output);
@@ -164,12 +195,27 @@ void dump_failed_source(uint64_t source_id, std::span<const uint8_t> bytes) noex
               "source_id=fnv1a64:%016" PRIx64
               " path=%s written=%zu expected=%zu errno=%d; please file a bug report",
               source_id, path, written, bytes.size(), saved_errno);
-    return;
+    return false;
   }
   log_error("translation failed; source code object saved source_id=fnv1a64:%016" PRIx64
             " input_bytes=%zu path=%s; please file a bug report and attach this code object",
             source_id, bytes.size(), path);
   remember_test_dump(path);
+  return true;
+}
+
+void dump_failed_source(uint64_t source_id, std::span<const uint8_t> bytes) noexcept {
+  if (!source_capture_enabled()) {
+    if (claim_once(g_hinted_sources, source_id)) {
+      log_error("translation failed; set HSA_HOTSWAP_DUMP_SOURCE=1 to save the source code object "
+                "source_id=fnv1a64:%016" PRIx64 " input_bytes=%zu; please file a bug report",
+                source_id, bytes.size());
+    }
+    return;
+  }
+  if (!begin_source_capture(source_id))
+    return;
+  finish_source_capture(source_id, write_captured_source(source_id, bytes));
 }
 
 void write_log(bool enabled, const char *level, const char *format, va_list args) noexcept {
@@ -1543,6 +1589,7 @@ extern "C" RJ_HOOK_EXPORT void rj_test_clear_retained_storage() {
   {
     std::lock_guard lock(g_captured_sources_mutex);
     g_captured_sources.clear();
+    g_hinted_sources.clear();
   }
   {
     std::lock_guard lock(g_state.storage_mutex);

--- a/emulation/rocjitsu/tests/dbt/gfx1250_b0_to_a0_library_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/gfx1250_b0_to_a0_library_test.cpp
@@ -5,6 +5,9 @@
 /// @brief Tests the fixed-profile gfx1250 B0-to-A0 shared-library API.
 
 #include "rocjitsu/code/rj_gfx1250_b0_to_a0.h"
+#include "rocjitsu/isa/arch/amdgpu/gfx1250/builders.h"
+#include "rocjitsu/isa/arch/amdgpu/gfx1250/opcodes.h"
+#include "support/gfx1250_test_code_object.h"
 
 #include <gtest/gtest.h>
 
@@ -21,8 +24,21 @@ namespace {
 struct CapturedDiagnostic {
   std::string severity;
   std::string kind;
+  bool has_guest_offset = false;
+  uint64_t guest_offset = 0;
+  std::string mnemonic;
   std::string message;
+  bool required_work = false;
 };
+
+void capture_diagnostic(const rj_gfx1250_b0_to_a0_diagnostic_t *diagnostic, void *user_data) {
+  auto *captured = static_cast<std::vector<CapturedDiagnostic> *>(user_data);
+  captured->push_back(
+      {diagnostic->severity != nullptr ? diagnostic->severity : "",
+       diagnostic->kind != nullptr ? diagnostic->kind : "", diagnostic->has_guest_offset != 0,
+       diagnostic->guest_offset, diagnostic->mnemonic != nullptr ? diagnostic->mnemonic : "",
+       diagnostic->message != nullptr ? diagnostic->message : "", diagnostic->required_work != 0});
+}
 
 #ifdef GFX1250_B0_TO_A0_FIXTURE
 uint64_t source_identity(const std::vector<uint8_t> &bytes) {
@@ -41,8 +57,9 @@ TEST(Gfx1250B0ToA0Library, RejectsInvalidArgumentsAndClearsOutputs) {
   auto *output = reinterpret_cast<uint8_t *>(0x1);
   size_t output_size = 1;
   rj_gfx1250_b0_to_a0_translation_info_t info{1, 1};
-  EXPECT_EQ(rj_gfx1250_b0_to_a0_translate(nullptr, 0, &output, &output_size, &info, nullptr, nullptr),
-            ROCJITSU_STATUS_INVALID_ARGUMENT);
+  EXPECT_EQ(
+      rj_gfx1250_b0_to_a0_translate(nullptr, 0, &output, &output_size, &info, nullptr, nullptr),
+      ROCJITSU_STATUS_INVALID_ARGUMENT);
   EXPECT_EQ(output, nullptr);
   EXPECT_EQ(output_size, 0u);
   EXPECT_EQ(info.source_code_object_id, 0u);
@@ -50,7 +67,7 @@ TEST(Gfx1250B0ToA0Library, RejectsInvalidArgumentsAndClearsOutputs) {
 
   constexpr std::array<uint8_t, 64> kNotElf = {'N', 'O', 'T', 'E', 'L', 'F'};
   EXPECT_EQ(rj_gfx1250_b0_to_a0_translate(kNotElf.data(), kNotElf.size(), &output, &output_size,
-                                         &info, nullptr, nullptr),
+                                          &info, nullptr, nullptr),
             ROCJITSU_STATUS_INVALID_CODE_OBJECT);
   EXPECT_EQ(output, nullptr);
   EXPECT_EQ(output_size, 0u);
@@ -67,19 +84,53 @@ TEST(Gfx1250B0ToA0Library, ReportsInvalidCodeObjectDiagnostic) {
   rj_gfx1250_b0_to_a0_translation_info_t info{};
   std::vector<CapturedDiagnostic> diagnostics;
 
-  EXPECT_EQ(
-      rj_gfx1250_b0_to_a0_translate(
-          kNotElf.data(), kNotElf.size(), &output, &output_size, &info,
-          [](const rj_gfx1250_b0_to_a0_diagnostic_t *diagnostic, void *user_data) {
-            auto *captured = static_cast<std::vector<CapturedDiagnostic> *>(user_data);
-            captured->push_back({diagnostic->severity, diagnostic->kind, diagnostic->message});
-          },
-          &diagnostics),
-      ROCJITSU_STATUS_INVALID_CODE_OBJECT);
-  ASSERT_EQ(diagnostics.size(), 1u);
-  EXPECT_EQ(diagnostics[0].severity, "error");
-  EXPECT_EQ(diagnostics[0].kind, "invalid-code-object");
-  EXPECT_NE(diagnostics[0].message.find("valid gfx1250"), std::string::npos);
+  EXPECT_EQ(rj_gfx1250_b0_to_a0_translate(kNotElf.data(), kNotElf.size(), &output, &output_size,
+                                          &info, capture_diagnostic, &diagnostics),
+            ROCJITSU_STATUS_INVALID_CODE_OBJECT);
+  ASSERT_FALSE(diagnostics.empty());
+  const auto matching = std::find_if(diagnostics.begin(), diagnostics.end(), [](const auto &item) {
+    return item.severity == "error" && item.kind == "input-invalid-code-object" &&
+           item.message.find("valid gfx1250") != std::string::npos;
+  });
+  EXPECT_NE(matching, diagnostics.end());
+}
+
+TEST(Gfx1250B0ToA0Library, ReportsTranslatorDiagnosticsAndRequiredWork) {
+  constexpr auto conversion =
+      rocjitsu::gfx1250::build_vop3(rocjitsu::gfx1250::kVCvtPkFp8F32Vop3,
+                                    {.vdst = 30, .clamp = 1, .src0 = 256 + 22, .src1 = 256 + 2});
+  constexpr uint32_t kEndpgm = 0xBFB00000u;
+  const std::array<uint32_t, 3> text = {conversion[0], conversion[1], kEndpgm};
+  const auto source = rocjitsu::test_support::make_gfx1250_code_object(text);
+  uint8_t *output = nullptr;
+  size_t output_size = 0;
+  rj_gfx1250_b0_to_a0_translation_info_t info{};
+  std::vector<CapturedDiagnostic> diagnostics;
+
+  EXPECT_EQ(rj_gfx1250_b0_to_a0_translate(source.data(), source.size(), &output, &output_size,
+                                          &info, capture_diagnostic, &diagnostics),
+            ROCJITSU_STATUS_INVALID_CODE_OBJECT);
+  EXPECT_EQ(output, nullptr);
+  EXPECT_EQ(output_size, 0u);
+  ASSERT_GE(diagnostics.size(), 2u);
+
+  const auto primary = std::find_if(diagnostics.begin(), diagnostics.end(), [](const auto &item) {
+    return !item.required_work && item.severity == "error" &&
+           item.kind == "translator-expand-missing";
+  });
+  ASSERT_NE(primary, diagnostics.end());
+  EXPECT_TRUE(primary->has_guest_offset);
+  EXPECT_EQ(primary->guest_offset, 0u);
+  EXPECT_EQ(primary->mnemonic, "v_cvt_pk_fp8_f32");
+
+  const auto required = std::find_if(diagnostics.begin(), diagnostics.end(), [](const auto &item) {
+    return item.required_work && item.kind == "translator-expand-missing";
+  });
+  ASSERT_NE(required, diagnostics.end());
+  EXPECT_TRUE(required->has_guest_offset);
+  EXPECT_EQ(required->guest_offset, 0u);
+  EXPECT_EQ(required->mnemonic, "v_cvt_pk_fp8_f32");
+  EXPECT_NE(required->message.find("semantic expansion rule"), std::string::npos);
 }
 
 #ifdef GFX1250_B0_TO_A0_FIXTURE
@@ -93,8 +144,8 @@ TEST(Gfx1250B0ToA0Library, TranslatesRealGfx1250CodeObject) {
   uint8_t *output = nullptr;
   size_t output_size = 0;
   rj_gfx1250_b0_to_a0_translation_info_t info{};
-  ASSERT_EQ(rj_gfx1250_b0_to_a0_translate(source.data(), source.size(), &output, &output_size, &info,
-                                         nullptr, nullptr),
+  ASSERT_EQ(rj_gfx1250_b0_to_a0_translate(source.data(), source.size(), &output, &output_size,
+                                          &info, nullptr, nullptr),
             ROCJITSU_STATUS_SUCCESS);
   ASSERT_NE(output, nullptr);
   EXPECT_EQ(info.source_code_object_id, source_identity(source));

--- a/emulation/rocjitsu/tests/dbt/gfx1250_b0_to_a0_library_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/gfx1250_b0_to_a0_library_test.cpp
@@ -18,6 +18,12 @@
 
 namespace {
 
+struct CapturedDiagnostic {
+  std::string severity;
+  std::string kind;
+  std::string message;
+};
+
 #ifdef GFX1250_B0_TO_A0_FIXTURE
 uint64_t source_identity(const std::vector<uint8_t> &bytes) {
   constexpr uint64_t kOffsetBasis = 14695981039346656037ULL;
@@ -35,7 +41,7 @@ TEST(Gfx1250B0ToA0Library, RejectsInvalidArgumentsAndClearsOutputs) {
   auto *output = reinterpret_cast<uint8_t *>(0x1);
   size_t output_size = 1;
   rj_gfx1250_b0_to_a0_translation_info_t info{1, 1};
-  EXPECT_EQ(rj_gfx1250_b0_to_a0_translate_with_info(nullptr, 0, &output, &output_size, &info),
+  EXPECT_EQ(rj_gfx1250_b0_to_a0_translate(nullptr, 0, &output, &output_size, &info, nullptr, nullptr),
             ROCJITSU_STATUS_INVALID_ARGUMENT);
   EXPECT_EQ(output, nullptr);
   EXPECT_EQ(output_size, 0u);
@@ -43,8 +49,8 @@ TEST(Gfx1250B0ToA0Library, RejectsInvalidArgumentsAndClearsOutputs) {
   EXPECT_EQ(info.changed_instruction_count, 0u);
 
   constexpr std::array<uint8_t, 64> kNotElf = {'N', 'O', 'T', 'E', 'L', 'F'};
-  EXPECT_EQ(rj_gfx1250_b0_to_a0_translate_with_info(kNotElf.data(), kNotElf.size(), &output,
-                                                    &output_size, &info),
+  EXPECT_EQ(rj_gfx1250_b0_to_a0_translate(kNotElf.data(), kNotElf.size(), &output, &output_size,
+                                         &info, nullptr, nullptr),
             ROCJITSU_STATUS_INVALID_CODE_OBJECT);
   EXPECT_EQ(output, nullptr);
   EXPECT_EQ(output_size, 0u);
@@ -52,6 +58,28 @@ TEST(Gfx1250B0ToA0Library, RejectsInvalidArgumentsAndClearsOutputs) {
   EXPECT_EQ(info.changed_instruction_count, 0u);
 
   rj_gfx1250_b0_to_a0_free(nullptr);
+}
+
+TEST(Gfx1250B0ToA0Library, ReportsInvalidCodeObjectDiagnostic) {
+  constexpr std::array<uint8_t, 64> kNotElf = {'N', 'O', 'T', 'E', 'L', 'F'};
+  uint8_t *output = nullptr;
+  size_t output_size = 0;
+  rj_gfx1250_b0_to_a0_translation_info_t info{};
+  std::vector<CapturedDiagnostic> diagnostics;
+
+  EXPECT_EQ(
+      rj_gfx1250_b0_to_a0_translate(
+          kNotElf.data(), kNotElf.size(), &output, &output_size, &info,
+          [](const rj_gfx1250_b0_to_a0_diagnostic_t *diagnostic, void *user_data) {
+            auto *captured = static_cast<std::vector<CapturedDiagnostic> *>(user_data);
+            captured->push_back({diagnostic->severity, diagnostic->kind, diagnostic->message});
+          },
+          &diagnostics),
+      ROCJITSU_STATUS_INVALID_CODE_OBJECT);
+  ASSERT_EQ(diagnostics.size(), 1u);
+  EXPECT_EQ(diagnostics[0].severity, "error");
+  EXPECT_EQ(diagnostics[0].kind, "invalid-code-object");
+  EXPECT_NE(diagnostics[0].message.find("valid gfx1250"), std::string::npos);
 }
 
 #ifdef GFX1250_B0_TO_A0_FIXTURE
@@ -65,8 +93,8 @@ TEST(Gfx1250B0ToA0Library, TranslatesRealGfx1250CodeObject) {
   uint8_t *output = nullptr;
   size_t output_size = 0;
   rj_gfx1250_b0_to_a0_translation_info_t info{};
-  ASSERT_EQ(rj_gfx1250_b0_to_a0_translate_with_info(source.data(), source.size(), &output,
-                                                    &output_size, &info),
+  ASSERT_EQ(rj_gfx1250_b0_to_a0_translate(source.data(), source.size(), &output, &output_size, &info,
+                                         nullptr, nullptr),
             ROCJITSU_STATUS_SUCCESS);
   ASSERT_NE(output, nullptr);
   EXPECT_EQ(info.source_code_object_id, source_identity(source));

--- a/emulation/rocjitsu/tests/dbt/hsa_hotswap_rocjitsu_unit_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/hsa_hotswap_rocjitsu_unit_test.cpp
@@ -438,11 +438,26 @@ TEST_F(HsaHotswapHookTest, TranslationFailureDoesNotLoadOrRetain) {
   ASSERT_EQ(
       api.core.hsa_code_object_reader_create_from_memory_fn(source.data(), source.size(), &reader),
       HSA_STATUS_SUCCESS);
+  ASSERT_EQ(unsetenv("HSA_HOTSWAP_VERBOSE"), 0);
+  testing::internal::CaptureStderr();
   EXPECT_EQ(api.core.hsa_executable_load_agent_code_object_fn(kExecutable, kA0Agent, reader,
                                                               nullptr, nullptr),
             HSA_STATUS_ERROR_INVALID_CODE_OBJECT);
+  const std::string log_text = testing::internal::GetCapturedStderr();
   EXPECT_EQ(g_load_agent_calls, 0);
   EXPECT_EQ(rj_test_retained_executable_buffer_count(), 0u);
+  EXPECT_NE(log_text.find("[hsa-hotswap-rj] error: eager translation "), std::string::npos)
+      << log_text;
+  EXPECT_NE(log_text.find("[hsa-hotswap-rj] error: translation diagnostic "), std::string::npos)
+      << log_text;
+  EXPECT_NE(log_text.find(" severity=error kind=invalid-code-object "), std::string::npos)
+      << log_text;
+  EXPECT_NE(log_text.find(" message=source is not a valid gfx1250 AMDGPU code object"),
+            std::string::npos)
+      << log_text;
+  EXPECT_NE(log_text.find(" outcome=translation_failed "), std::string::npos) << log_text;
+  EXPECT_NE(log_text.find(" translation_status="), std::string::npos) << log_text;
+  EXPECT_NE(log_text.find(" status="), std::string::npos) << log_text;
 }
 
 // The translated backing storage retained for an A0 load must SURVIVE OnUnload()
@@ -686,10 +701,18 @@ TEST_F(HsaHotswapHookTest, ContainsExceptionsAtTheHsaBoundary) {
   ASSERT_TRUE(OnLoad(&api.table, 0, 0, nullptr));
   g_asic_revision = 1;
   g_throw_from_deprecated_load = true;
+  ASSERT_EQ(unsetenv("HSA_HOTSWAP_VERBOSE"), 0);
+  testing::internal::CaptureStderr();
   EXPECT_EQ(api.core.hsa_executable_load_code_object_fn(kExecutable, kA0Agent, hsa_code_object_t{1},
                                                         nullptr),
             HSA_STATUS_ERROR_OUT_OF_RESOURCES);
+  const std::string log_text = testing::internal::GetCapturedStderr();
   EXPECT_EQ(g_load_deprecated_calls, 1);
+  EXPECT_NE(log_text.find("[hsa-hotswap-rj] error: "), std::string::npos) << log_text;
+  EXPECT_NE(log_text.find("operation=hsa_executable_load_code_object"), std::string::npos)
+      << log_text;
+  EXPECT_NE(log_text.find("exception=std::bad_alloc"), std::string::npos) << log_text;
+  EXPECT_NE(log_text.find("status="), std::string::npos) << log_text;
 }
 
 TEST_F(HsaHotswapHookTest, CallbackApiSnapshotIsSafeDuringUnload) {

--- a/emulation/rocjitsu/tests/dbt/hsa_hotswap_rocjitsu_unit_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/hsa_hotswap_rocjitsu_unit_test.cpp
@@ -26,6 +26,7 @@
 #include <regex>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <unistd.h>
 #include <unordered_map>
@@ -46,6 +47,7 @@ extern "C" void rj_test_close_translation_gate();
 extern "C" void rj_test_open_translation_gate();
 extern "C" uint64_t rj_test_translation_waiters();
 extern "C" void rj_test_force_next_translation_status(int status);
+extern "C" uint64_t rj_test_dump_path_count();
 extern "C" uint64_t rj_test_sample_fingerprint(const void *bytes, size_t size);
 extern "C" void rj_test_retain_completed_claims(bool retain);
 extern "C" void rj_test_fail_next_memo_admission(int stage);
@@ -249,6 +251,36 @@ std::vector<uint8_t> make_invalid_gfx1250_elf() {
   return image;
 }
 
+/// @brief A directory that exists for one test case.
+class ScopedTempDirectory {
+public:
+  ScopedTempDirectory() {
+    char pattern[] = "/tmp/rocjitsu-hotswap-dump-XXXXXX";
+    const char *created = mkdtemp(pattern);
+    if (created != nullptr)
+      path_ = created;
+  }
+  ScopedTempDirectory(const ScopedTempDirectory &) = delete;
+  ScopedTempDirectory &operator=(const ScopedTempDirectory &) = delete;
+  ~ScopedTempDirectory() {
+    if (!path_.empty())
+      (void)rmdir(path_.c_str());
+  }
+
+  const std::string &path() const { return path_; }
+
+private:
+  std::string path_;
+};
+
+size_t count_occurrences(const std::string &text, std::string_view needle) {
+  size_t count = 0;
+  for (size_t at = text.find(needle); at != std::string::npos;
+       at = text.find(needle, at + needle.size()))
+    ++count;
+  return count;
+}
+
 void expect_failure_dump(const std::string &log_text, const std::vector<uint8_t> &source) {
   std::smatch match;
   const std::regex path_pattern(
@@ -300,9 +332,12 @@ struct FakeApi {
 class HsaHotswapHookTest : public ::testing::Test {
 protected:
   void SetUp() override {
-    const char *verbose = std::getenv("HSA_HOTSWAP_VERBOSE");
-    if (verbose != nullptr)
-      saved_verbose_ = verbose;
+    for (const char *name : kIsolatedEnvironment) {
+      const char *value = std::getenv(name);
+      saved_environment_.emplace_back(name, value != nullptr ? std::optional<std::string>(value)
+                                                             : std::nullopt);
+      (void)unsetenv(name);
+    }
     OnUnload();
     // Production storage is process-lifetime (not freed on reinstall), so clear it
     // here to isolate the retention lifecycle between test cases.
@@ -312,14 +347,22 @@ protected:
   void TearDown() override {
     OnUnload();
     rj_test_clear_retained_storage();
-    if (saved_verbose_)
-      (void)setenv("HSA_HOTSWAP_VERBOSE", saved_verbose_->c_str(), 1);
-    else
-      (void)unsetenv("HSA_HOTSWAP_VERBOSE");
+    for (const auto &[name, value] : saved_environment_) {
+      if (value)
+        (void)setenv(name, value->c_str(), 1);
+      else
+        (void)unsetenv(name);
+    }
+    saved_environment_.clear();
   }
 
+  // Every case runs with these cleared and gets whatever the process had back,
+  // so one case cannot decide what a later one observes.
+  static constexpr std::array<const char *, 3> kIsolatedEnvironment = {
+      "HSA_HOTSWAP_VERBOSE", "HSA_HOTSWAP_DUMP_SOURCE", "HSA_HOTSWAP_DUMP_DIR"};
+
   FakeApi api;
-  std::optional<std::string> saved_verbose_;
+  std::vector<std::pair<const char *, std::optional<std::string>>> saved_environment_;
 };
 
 TEST_F(HsaHotswapHookTest, InstallsOnlyTheEightEntryEagerSurface) {
@@ -473,7 +516,7 @@ TEST_F(HsaHotswapHookTest, TranslationFailureDoesNotLoadOrRetain) {
   ASSERT_EQ(
       api.core.hsa_code_object_reader_create_from_memory_fn(source.data(), source.size(), &reader),
       HSA_STATUS_SUCCESS);
-  ASSERT_EQ(unsetenv("HSA_HOTSWAP_VERBOSE"), 0);
+  ASSERT_EQ(setenv("HSA_HOTSWAP_DUMP_SOURCE", "1", 1), 0);
   testing::internal::CaptureStderr();
   EXPECT_EQ(api.core.hsa_executable_load_agent_code_object_fn(kExecutable, kA0Agent, reader,
                                                               nullptr, nullptr),
@@ -509,7 +552,7 @@ TEST_F(HsaHotswapHookTest, RendersTranslatorDiagnosticsAndDumpsFailedSource) {
       api.core.hsa_code_object_reader_create_from_memory_fn(source.data(), source.size(), &reader),
       HSA_STATUS_SUCCESS);
 
-  ASSERT_EQ(unsetenv("HSA_HOTSWAP_VERBOSE"), 0);
+  ASSERT_EQ(setenv("HSA_HOTSWAP_DUMP_SOURCE", "1", 1), 0);
   testing::internal::CaptureStderr();
   EXPECT_EQ(api.core.hsa_executable_load_agent_code_object_fn(kExecutable, kA0Agent, reader,
                                                               nullptr, nullptr),
@@ -550,6 +593,106 @@ TEST_F(HsaHotswapHookTest, DiagnosticPrefixMatchesWarningSeverity) {
 // atexit -- can still reference these bytes, so a reinstall must not free them. They
 // are released only at executable destroy (or process exit). Regression guard for
 // the process-lifetime storage-retention lifecycle.
+TEST_F(HsaHotswapHookTest, FailedTranslationWritesNothingByDefault) {
+  ASSERT_TRUE(OnLoad(&api.table, 0, 0, nullptr));
+  const std::vector<uint8_t> source = make_invalid_gfx1250_elf();
+
+  hsa_code_object_reader_t reader{};
+  ASSERT_EQ(
+      api.core.hsa_code_object_reader_create_from_memory_fn(source.data(), source.size(), &reader),
+      HSA_STATUS_SUCCESS);
+  testing::internal::CaptureStderr();
+  EXPECT_EQ(api.core.hsa_executable_load_agent_code_object_fn(kExecutable, kA0Agent, reader,
+                                                              nullptr, nullptr),
+            HSA_STATUS_ERROR_INVALID_CODE_OBJECT);
+  const std::string log_text = testing::internal::GetCapturedStderr();
+
+  // Nothing was written, and the report says how to ask for the artifact.
+  EXPECT_EQ(log_text.find("; please file a bug report and attach this code object"),
+            std::string::npos)
+      << log_text;
+  EXPECT_NE(log_text.find("set HSA_HOTSWAP_DUMP_SOURCE=1 to save the source code object"),
+            std::string::npos)
+      << log_text;
+  EXPECT_EQ(rj_test_dump_path_count(), 0u);
+}
+
+TEST_F(HsaHotswapHookTest, CapturedSourceHonorsTheConfiguredDirectory) {
+  ASSERT_TRUE(OnLoad(&api.table, 0, 0, nullptr));
+  const std::vector<uint8_t> source = make_invalid_gfx1250_elf();
+  ScopedTempDirectory directory;
+  ASSERT_FALSE(directory.path().empty());
+  ASSERT_EQ(setenv("HSA_HOTSWAP_DUMP_SOURCE", "1", 1), 0);
+  ASSERT_EQ(setenv("HSA_HOTSWAP_DUMP_DIR", directory.path().c_str(), 1), 0);
+
+  hsa_code_object_reader_t reader{};
+  ASSERT_EQ(
+      api.core.hsa_code_object_reader_create_from_memory_fn(source.data(), source.size(), &reader),
+      HSA_STATUS_SUCCESS);
+  testing::internal::CaptureStderr();
+  EXPECT_EQ(api.core.hsa_executable_load_agent_code_object_fn(kExecutable, kA0Agent, reader,
+                                                              nullptr, nullptr),
+            HSA_STATUS_ERROR_INVALID_CODE_OBJECT);
+  const std::string log_text = testing::internal::GetCapturedStderr();
+
+  std::smatch match;
+  const std::regex path_pattern(
+      R"(path=([^;\s]+); please file a bug report and attach this code object)");
+  ASSERT_TRUE(std::regex_search(log_text, match, path_pattern)) << log_text;
+  EXPECT_EQ(match[1].str().rfind(directory.path() + "/", 0), 0u) << match[1].str();
+  expect_failure_dump(log_text, source);
+}
+
+TEST_F(HsaHotswapHookTest, RepeatedEnvironmentalFailuresCaptureOneArtifact) {
+  ASSERT_TRUE(OnLoad(&api.table, 0, 0, nullptr));
+  const std::vector<uint8_t> source = make_invalid_gfx1250_elf();
+  ASSERT_EQ(setenv("HSA_HOTSWAP_DUMP_SOURCE", "1", 1), 0);
+  constexpr size_t kLoads = 8;
+
+  // A throwing translator is not remembered, so every load translates again.
+  // Capture must still leave exactly one file behind.
+  for (size_t load = 0; load < kLoads; ++load) {
+    rj_test_force_next_translation_status(1 /* ROCJITSU_STATUS_ERROR */);
+    hsa_code_object_reader_t reader{};
+    ASSERT_EQ(api.core.hsa_code_object_reader_create_from_memory_fn(source.data(), source.size(),
+                                                                    &reader),
+              HSA_STATUS_SUCCESS);
+    EXPECT_EQ(api.core.hsa_executable_load_agent_code_object_fn(kExecutable, kA0Agent, reader,
+                                                                nullptr, nullptr),
+              HSA_STATUS_ERROR_INVALID_CODE_OBJECT)
+        << load;
+  }
+
+  // The point of the case: every load really did translate again, and the eight
+  // attempts still left one artifact.
+  EXPECT_EQ(rj_test_translation_count(), kLoads);
+  EXPECT_EQ(rj_test_dump_path_count(), 1u);
+}
+
+TEST_F(HsaHotswapHookTest, AnOutOfResourcesFailureCapturesNothing) {
+  ASSERT_TRUE(OnLoad(&api.table, 0, 0, nullptr));
+  const std::vector<uint8_t> source = make_invalid_gfx1250_elf();
+  ASSERT_EQ(setenv("HSA_HOTSWAP_DUMP_SOURCE", "1", 1), 0);
+  rj_test_force_next_translation_status(3 /* ROCJITSU_STATUS_OUT_OF_RESOURCES */);
+
+  hsa_code_object_reader_t reader{};
+  ASSERT_EQ(
+      api.core.hsa_code_object_reader_create_from_memory_fn(source.data(), source.size(), &reader),
+      HSA_STATUS_SUCCESS);
+  testing::internal::CaptureStderr();
+  EXPECT_EQ(api.core.hsa_executable_load_agent_code_object_fn(kExecutable, kA0Agent, reader,
+                                                              nullptr, nullptr),
+            HSA_STATUS_ERROR_INVALID_CODE_OBJECT);
+  const std::string log_text = testing::internal::GetCapturedStderr();
+
+  // Copying a large input after an allocation failure adds pressure without
+  // diagnosing anything: the bytes are not why it failed.
+  EXPECT_EQ(rj_test_dump_path_count(), 0u);
+  EXPECT_EQ(log_text.find("; please file a bug report and attach this code object"),
+            std::string::npos)
+      << log_text;
+}
+
 TEST_F(HsaHotswapHookTest, RetainedStorageSurvivesUnloadAndReinstall) {
   ASSERT_TRUE(OnLoad(&api.table, 0, 0, nullptr));
   ASSERT_EQ(rj_test_retained_executable_buffer_count(), 0u);
@@ -925,6 +1068,7 @@ protected:
 // times each across four devices and paid for 2036 translations.
 TEST_F(HsaHotswapMemoTest, RemembersARefusalInsteadOfRepeatingIt) {
   ASSERT_TRUE(OnLoad(&api.table, 0, 0, nullptr));
+  ASSERT_EQ(unsetenv("HSA_HOTSWAP_VERBOSE"), 0);
   const std::vector<uint8_t> source = make_invalid_gfx1250_elf();
   constexpr size_t kLoads = 256;
 
@@ -938,8 +1082,25 @@ TEST_F(HsaHotswapMemoTest, RemembersARefusalInsteadOfRepeatingIt) {
   EXPECT_EQ(rj_test_translation_count(), 1u);
   EXPECT_EQ(g_load_agent_calls, 0);
   EXPECT_EQ(rj_test_retained_executable_buffer_count(), 0u);
-  EXPECT_NE(log_text.find(" outcome=translation_failed "), std::string::npos) << log_text;
-  EXPECT_NE(log_text.find(" outcome=reused_failure "), std::string::npos) << log_text;
+  // The refusal is reported the once it is reached. The 255 reuses that follow
+  // are the memo working, not new failures, so they stay on the verbose channel.
+  EXPECT_EQ(count_occurrences(log_text, " outcome=translation_failed "), 1u) << log_text;
+  EXPECT_EQ(count_occurrences(log_text, " outcome=reused_failure "), 0u) << log_text;
+}
+
+TEST_F(HsaHotswapMemoTest, VerboseLoggingStillShowsEveryRememberedRefusal) {
+  ASSERT_TRUE(OnLoad(&api.table, 0, 0, nullptr));
+  ASSERT_EQ(setenv("HSA_HOTSWAP_VERBOSE", "1", 1), 0);
+  const std::vector<uint8_t> source = make_invalid_gfx1250_elf();
+  constexpr size_t kLoads = 4;
+
+  testing::internal::CaptureStderr();
+  for (size_t load = 0; load < kLoads; ++load)
+    EXPECT_EQ(load_through_new_reader(source), HSA_STATUS_ERROR_INVALID_CODE_OBJECT) << load;
+  const std::string log_text = testing::internal::GetCapturedStderr();
+
+  EXPECT_EQ(count_occurrences(log_text, " outcome=translation_failed "), 1u) << log_text;
+  EXPECT_EQ(count_occurrences(log_text, " outcome=reused_failure "), kLoads - 1) << log_text;
 }
 
 #ifdef GFX1250_B0_TO_A0_FIXTURE

--- a/emulation/rocjitsu/tests/dbt/hsa_hotswap_rocjitsu_unit_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/hsa_hotswap_rocjitsu_unit_test.cpp
@@ -17,6 +17,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <filesystem>
 #include <fstream>
 #include <iomanip>
 #include <iterator>
@@ -263,8 +264,10 @@ public:
   ScopedTempDirectory(const ScopedTempDirectory &) = delete;
   ScopedTempDirectory &operator=(const ScopedTempDirectory &) = delete;
   ~ScopedTempDirectory() {
-    if (!path_.empty())
-      (void)rmdir(path_.c_str());
+    if (path_.empty())
+      return;
+    std::error_code error;
+    std::filesystem::remove_all(path_, error);
   }
 
   const std::string &path() const { return path_; }
@@ -279,6 +282,13 @@ size_t count_occurrences(const std::string &text, std::string_view needle) {
        at = text.find(needle, at + needle.size()))
     ++count;
   return count;
+}
+
+/// @brief An invalid object whose identity differs from every other salt.
+std::vector<uint8_t> make_invalid_gfx1250_elf(uint8_t salt) {
+  std::vector<uint8_t> image = make_invalid_gfx1250_elf();
+  image.push_back(salt);
+  return image;
 }
 
 void expect_failure_dump(const std::string &log_text, const std::vector<uint8_t> &source) {
@@ -372,8 +382,8 @@ protected:
 
   // Every case runs with these cleared and gets whatever the process had back,
   // so one case cannot decide what a later one observes.
-  static constexpr std::array<const char *, 3> kIsolatedEnvironment = {
-      "HSA_HOTSWAP_VERBOSE", "HSA_HOTSWAP_DUMP_SOURCE", "HSA_HOTSWAP_DUMP_DIR"};
+  static constexpr std::array<const char *, 4> kIsolatedEnvironment = {
+      "HSA_HOTSWAP_VERBOSE", "HSA_HOTSWAP_DUMP_SOURCE", "HSA_HOTSWAP_DUMP_DIR", "TMPDIR"};
 
   FakeApi api;
   std::vector<std::pair<const char *, std::optional<std::string>>> saved_environment_;
@@ -530,7 +540,10 @@ TEST_F(HsaHotswapHookTest, TranslationFailureDoesNotLoadOrRetain) {
   ASSERT_EQ(
       api.core.hsa_code_object_reader_create_from_memory_fn(source.data(), source.size(), &reader),
       HSA_STATUS_SUCCESS);
+  ScopedTempDirectory capture_directory;
+  ASSERT_FALSE(capture_directory.path().empty());
   ASSERT_EQ(setenv("HSA_HOTSWAP_DUMP_SOURCE", "1", 1), 0);
+  ASSERT_EQ(setenv("HSA_HOTSWAP_DUMP_DIR", capture_directory.path().c_str(), 1), 0);
   testing::internal::CaptureStderr();
   EXPECT_EQ(api.core.hsa_executable_load_agent_code_object_fn(kExecutable, kA0Agent, reader,
                                                               nullptr, nullptr),
@@ -566,7 +579,10 @@ TEST_F(HsaHotswapHookTest, RendersTranslatorDiagnosticsAndDumpsFailedSource) {
       api.core.hsa_code_object_reader_create_from_memory_fn(source.data(), source.size(), &reader),
       HSA_STATUS_SUCCESS);
 
+  ScopedTempDirectory capture_directory;
+  ASSERT_FALSE(capture_directory.path().empty());
   ASSERT_EQ(setenv("HSA_HOTSWAP_DUMP_SOURCE", "1", 1), 0);
+  ASSERT_EQ(setenv("HSA_HOTSWAP_DUMP_DIR", capture_directory.path().c_str(), 1), 0);
   testing::internal::CaptureStderr();
   EXPECT_EQ(api.core.hsa_executable_load_agent_code_object_fn(kExecutable, kA0Agent, reader,
                                                               nullptr, nullptr),
@@ -660,7 +676,10 @@ TEST_F(HsaHotswapHookTest, CapturedSourceHonorsTheConfiguredDirectory) {
 TEST_F(HsaHotswapHookTest, RepeatedEnvironmentalFailuresCaptureOneArtifact) {
   ASSERT_TRUE(OnLoad(&api.table, 0, 0, nullptr));
   const std::vector<uint8_t> source = make_invalid_gfx1250_elf();
+  ScopedTempDirectory capture_directory;
+  ASSERT_FALSE(capture_directory.path().empty());
   ASSERT_EQ(setenv("HSA_HOTSWAP_DUMP_SOURCE", "1", 1), 0);
+  ASSERT_EQ(setenv("HSA_HOTSWAP_DUMP_DIR", capture_directory.path().c_str(), 1), 0);
   constexpr size_t kLoads = 8;
 
   // A throwing translator is not remembered, so every load translates again.
@@ -686,7 +705,10 @@ TEST_F(HsaHotswapHookTest, RepeatedEnvironmentalFailuresCaptureOneArtifact) {
 TEST_F(HsaHotswapHookTest, AnOutOfResourcesFailureCapturesNothing) {
   ASSERT_TRUE(OnLoad(&api.table, 0, 0, nullptr));
   const std::vector<uint8_t> source = make_invalid_gfx1250_elf();
+  ScopedTempDirectory capture_directory;
+  ASSERT_FALSE(capture_directory.path().empty());
   ASSERT_EQ(setenv("HSA_HOTSWAP_DUMP_SOURCE", "1", 1), 0);
+  ASSERT_EQ(setenv("HSA_HOTSWAP_DUMP_DIR", capture_directory.path().c_str(), 1), 0);
   rj_test_force_next_translation_status(3 /* ROCJITSU_STATUS_OUT_OF_RESOURCES */);
 
   hsa_code_object_reader_t reader{};
@@ -725,7 +747,10 @@ TEST_F(HsaHotswapHookTest, EnablingCaptureAfterAHintStillProducesTheArtifact) {
       << hint_text;
   ASSERT_EQ(rj_test_dump_path_count(), 0u);
 
+  ScopedTempDirectory capture_directory;
+  ASSERT_FALSE(capture_directory.path().empty());
   ASSERT_EQ(setenv("HSA_HOTSWAP_DUMP_SOURCE", "1", 1), 0);
+  ASSERT_EQ(setenv("HSA_HOTSWAP_DUMP_DIR", capture_directory.path().c_str(), 1), 0);
   rj_test_force_next_translation_status(1 /* ROCJITSU_STATUS_ERROR */);
   testing::internal::CaptureStderr();
   EXPECT_EQ(load_through_new_reader(source), HSA_STATUS_ERROR_INVALID_CODE_OBJECT);
@@ -741,12 +766,18 @@ TEST_F(HsaHotswapHookTest, CorrectingTheCaptureDirectoryRetriesTheArtifact) {
   ASSERT_EQ(setenv("HSA_HOTSWAP_DUMP_SOURCE", "1", 1), 0);
   ASSERT_EQ(setenv("HSA_HOTSWAP_DUMP_DIR", "/nonexistent-rocjitsu-hotswap-dump", 1), 0);
 
-  // Forced so the memo does not remember it: the retry below has to translate.
-  rj_test_force_next_translation_status(1 /* ROCJITSU_STATUS_ERROR */);
+  // Forced so the memo does not remember it: every load below translates again
+  // and retries the write, which is what makes the reporting bound matter.
+  constexpr size_t kFailedLoads = 4;
   testing::internal::CaptureStderr();
-  EXPECT_EQ(load_through_new_reader(source), HSA_STATUS_ERROR_INVALID_CODE_OBJECT);
+  for (size_t load = 0; load < kFailedLoads; ++load) {
+    rj_test_force_next_translation_status(1 /* ROCJITSU_STATUS_ERROR */);
+    EXPECT_EQ(load_through_new_reader(source), HSA_STATUS_ERROR_INVALID_CODE_OBJECT) << load;
+  }
   const std::string failed_text = testing::internal::GetCapturedStderr();
-  ASSERT_NE(failed_text.find("could not be saved"), std::string::npos) << failed_text;
+  // The destination stays broken, so the write keeps being retried -- but the
+  // operator is told about it once, not once per load.
+  EXPECT_EQ(count_occurrences(failed_text, "could not be saved"), 1u) << failed_text;
   ASSERT_EQ(rj_test_dump_path_count(), 0u);
 
   // A capture that could not be written must not spend the source's slot: the
@@ -761,6 +792,50 @@ TEST_F(HsaHotswapHookTest, CorrectingTheCaptureDirectoryRetriesTheArtifact) {
 
   EXPECT_EQ(rj_test_dump_path_count(), 1u);
   expect_failure_dump(capture_text, source);
+}
+
+TEST_F(HsaHotswapHookTest, CaptureFallsBackToTmpdirWhenNoDirectoryIsNamed) {
+  ASSERT_TRUE(OnLoad(&api.table, 0, 0, nullptr));
+  const std::vector<uint8_t> source = make_invalid_gfx1250_elf();
+  ScopedTempDirectory directory;
+  ASSERT_FALSE(directory.path().empty());
+  // HSA_HOTSWAP_DUMP_DIR stays unset: TMPDIR is the next choice, and /tmp only
+  // after that.
+  ASSERT_EQ(setenv("HSA_HOTSWAP_DUMP_SOURCE", "1", 1), 0);
+  ASSERT_EQ(setenv("TMPDIR", directory.path().c_str(), 1), 0);
+
+  testing::internal::CaptureStderr();
+  EXPECT_EQ(load_through_new_reader(source), HSA_STATUS_ERROR_INVALID_CODE_OBJECT);
+  const std::string log_text = testing::internal::GetCapturedStderr();
+
+  std::smatch match;
+  const std::regex path_pattern(
+      R"(path=([^;\s]+); please file a bug report and attach this code object)");
+  ASSERT_TRUE(std::regex_search(log_text, match, path_pattern)) << log_text;
+  EXPECT_EQ(match[1].str().rfind(directory.path() + "/", 0), 0u) << match[1].str();
+  expect_failure_dump(log_text, source);
+}
+
+TEST_F(HsaHotswapHookTest, CaptureStopsAtTheSourceCapAndSaysWhy) {
+  ASSERT_TRUE(OnLoad(&api.table, 0, 0, nullptr));
+  ScopedTempDirectory capture_directory;
+  ASSERT_FALSE(capture_directory.path().empty());
+  ASSERT_EQ(setenv("HSA_HOTSWAP_DUMP_SOURCE", "1", 1), 0);
+  ASSERT_EQ(setenv("HSA_HOTSWAP_DUMP_DIR", capture_directory.path().c_str(), 1), 0);
+  // kMaxCapturedSources in the hook. One more source than the registry holds.
+  constexpr size_t kCap = 32;
+
+  testing::internal::CaptureStderr();
+  for (size_t index = 0; index <= kCap; ++index) {
+    const std::vector<uint8_t> source = make_invalid_gfx1250_elf(static_cast<uint8_t>(index));
+    EXPECT_EQ(load_through_new_reader(source), HSA_STATUS_ERROR_INVALID_CODE_OBJECT) << index;
+  }
+  const std::string log_text = testing::internal::GetCapturedStderr();
+
+  // Refusing silently would be indistinguishable from a capture the operator
+  // then cannot find, so the cap explains itself -- once.
+  EXPECT_EQ(rj_test_dump_path_count(), kCap);
+  EXPECT_EQ(count_occurrences(log_text, "have already been captured"), 1u) << log_text;
 }
 
 TEST_F(HsaHotswapHookTest, RetainedStorageSurvivesUnloadAndReinstall) {

--- a/emulation/rocjitsu/tests/dbt/hsa_hotswap_rocjitsu_unit_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/hsa_hotswap_rocjitsu_unit_test.cpp
@@ -5,6 +5,10 @@
 
 #include "hsa/hsa_api_trace_minimal.h"
 #include "rocjitsu/code/amdgpu_elf.h"
+#include "rocjitsu/code/rj_gfx1250_b0_to_a0.h"
+#include "rocjitsu/isa/arch/amdgpu/gfx1250/builders.h"
+#include "rocjitsu/isa/arch/amdgpu/gfx1250/opcodes.h"
+#include "support/gfx1250_test_code_object.h"
 
 #include <array>
 #include <atomic>
@@ -18,10 +22,12 @@
 #include <iterator>
 #include <mutex>
 #include <new>
+#include <optional>
 #include <regex>
 #include <sstream>
 #include <string>
 #include <thread>
+#include <unistd.h>
 #include <unordered_map>
 #include <vector>
 
@@ -30,6 +36,9 @@ extern "C" void OnUnload();
 extern "C" size_t rj_test_retained_executable_buffer_count();
 extern "C" void rj_test_clear_retained_storage();
 extern "C" void rj_test_log_translation(uint64_t source_id, size_t changed);
+extern "C" void
+rj_test_log_translation_diagnostic(uint64_t source_id,
+                                   const rj_gfx1250_b0_to_a0_diagnostic_t *diagnostic);
 extern "C" uint64_t rj_test_translation_count();
 extern "C" uint64_t rj_test_translation_memo_bytes();
 extern "C" void rj_test_set_translation_memo_capacity(uint64_t bytes);
@@ -240,6 +249,21 @@ std::vector<uint8_t> make_invalid_gfx1250_elf() {
   return image;
 }
 
+void expect_failure_dump(const std::string &log_text, const std::vector<uint8_t> &source) {
+  std::smatch match;
+  const std::regex path_pattern(
+      R"(path=([^;\s]+); please file a bug report and attach this code object)");
+  ASSERT_TRUE(std::regex_search(log_text, match, path_pattern)) << log_text;
+  const std::string path = match[1].str();
+  std::ifstream input(path, std::ios::binary);
+  ASSERT_TRUE(input) << path;
+  const std::vector<uint8_t> dumped((std::istreambuf_iterator<char>(input)),
+                                    std::istreambuf_iterator<char>());
+  EXPECT_EQ(dumped, source);
+  input.close();
+  EXPECT_EQ(unlink(path.c_str()), 0) << path;
+}
+
 #ifdef GFX1250_B0_TO_A0_FIXTURE
 std::vector<uint8_t> read_translation_fixture() {
   std::ifstream input(GFX1250_B0_TO_A0_FIXTURE, std::ios::binary);
@@ -276,15 +300,26 @@ struct FakeApi {
 class HsaHotswapHookTest : public ::testing::Test {
 protected:
   void SetUp() override {
+    const char *verbose = std::getenv("HSA_HOTSWAP_VERBOSE");
+    if (verbose != nullptr)
+      saved_verbose_ = verbose;
     OnUnload();
     // Production storage is process-lifetime (not freed on reinstall), so clear it
     // here to isolate the retention lifecycle between test cases.
     rj_test_clear_retained_storage();
     reset_fakes();
   }
-  void TearDown() override { OnUnload(); }
+  void TearDown() override {
+    OnUnload();
+    rj_test_clear_retained_storage();
+    if (saved_verbose_)
+      (void)setenv("HSA_HOTSWAP_VERBOSE", saved_verbose_->c_str(), 1);
+    else
+      (void)unsetenv("HSA_HOTSWAP_VERBOSE");
+  }
 
   FakeApi api;
+  std::optional<std::string> saved_verbose_;
 };
 
 TEST_F(HsaHotswapHookTest, InstallsOnlyTheEightEntryEagerSurface) {
@@ -450,7 +485,7 @@ TEST_F(HsaHotswapHookTest, TranslationFailureDoesNotLoadOrRetain) {
       << log_text;
   EXPECT_NE(log_text.find("[hsa-hotswap-rj] error: translation diagnostic "), std::string::npos)
       << log_text;
-  EXPECT_NE(log_text.find(" severity=error kind=invalid-code-object "), std::string::npos)
+  EXPECT_NE(log_text.find(" severity=error kind=input-invalid-code-object "), std::string::npos)
       << log_text;
   EXPECT_NE(log_text.find(" message=source is not a valid gfx1250 AMDGPU code object"),
             std::string::npos)
@@ -458,6 +493,53 @@ TEST_F(HsaHotswapHookTest, TranslationFailureDoesNotLoadOrRetain) {
   EXPECT_NE(log_text.find(" outcome=translation_failed "), std::string::npos) << log_text;
   EXPECT_NE(log_text.find(" translation_status="), std::string::npos) << log_text;
   EXPECT_NE(log_text.find(" status="), std::string::npos) << log_text;
+  expect_failure_dump(log_text, source);
+}
+
+TEST_F(HsaHotswapHookTest, RendersTranslatorDiagnosticsAndDumpsFailedSource) {
+  ASSERT_TRUE(OnLoad(&api.table, 0, 0, nullptr));
+  constexpr auto conversion =
+      rocjitsu::gfx1250::build_vop3(rocjitsu::gfx1250::kVCvtPkFp8F32Vop3,
+                                    {.vdst = 30, .clamp = 1, .src0 = 256 + 22, .src1 = 256 + 2});
+  constexpr uint32_t kEndpgm = 0xBFB00000u;
+  const std::array<uint32_t, 3> text = {conversion[0], conversion[1], kEndpgm};
+  const auto source = rocjitsu::test_support::make_gfx1250_code_object(text);
+  hsa_code_object_reader_t reader{};
+  ASSERT_EQ(
+      api.core.hsa_code_object_reader_create_from_memory_fn(source.data(), source.size(), &reader),
+      HSA_STATUS_SUCCESS);
+
+  ASSERT_EQ(unsetenv("HSA_HOTSWAP_VERBOSE"), 0);
+  testing::internal::CaptureStderr();
+  EXPECT_EQ(api.core.hsa_executable_load_agent_code_object_fn(kExecutable, kA0Agent, reader,
+                                                              nullptr, nullptr),
+            HSA_STATUS_ERROR_INVALID_CODE_OBJECT);
+  const std::string log_text = testing::internal::GetCapturedStderr();
+  EXPECT_EQ(g_load_agent_calls, 0);
+  EXPECT_NE(log_text.find("[hsa-hotswap-rj] error: translation diagnostic "), std::string::npos)
+      << log_text;
+  EXPECT_NE(log_text.find(" severity=error kind=translator-expand-missing "), std::string::npos)
+      << log_text;
+  EXPECT_NE(log_text.find(" guest_offset=.text+0x0 mnemonic=v_cvt_pk_fp8_f32 "), std::string::npos)
+      << log_text;
+  EXPECT_NE(log_text.find(" required=Add a semantic expansion rule for this mnemonic."),
+            std::string::npos)
+      << log_text;
+  expect_failure_dump(log_text, source);
+}
+
+TEST_F(HsaHotswapHookTest, DiagnosticPrefixMatchesWarningSeverity) {
+  const rj_gfx1250_b0_to_a0_diagnostic_t diagnostic{
+      "warning", "translator-data-only", 0, 0, "", "test warning", 0,
+  };
+  testing::internal::CaptureStderr();
+  rj_test_log_translation_diagnostic(0x1234, &diagnostic);
+  const std::string log_text = testing::internal::GetCapturedStderr();
+  EXPECT_NE(log_text.find("[hsa-hotswap-rj] warning: translation diagnostic "), std::string::npos)
+      << log_text;
+  EXPECT_NE(log_text.find(" severity=warning kind=translator-data-only "), std::string::npos)
+      << log_text;
+  EXPECT_EQ(log_text.find("[hsa-hotswap-rj] error:"), std::string::npos) << log_text;
 }
 
 // The translated backing storage retained for an A0 load must SURVIVE OnUnload()
@@ -846,14 +928,18 @@ TEST_F(HsaHotswapMemoTest, RemembersARefusalInsteadOfRepeatingIt) {
   const std::vector<uint8_t> source = make_invalid_gfx1250_elf();
   constexpr size_t kLoads = 256;
 
+  testing::internal::CaptureStderr();
   for (size_t load = 0; load < kLoads; ++load)
-    ASSERT_EQ(load_through_new_reader(source), HSA_STATUS_ERROR_INVALID_CODE_OBJECT) << load;
+    EXPECT_EQ(load_through_new_reader(source), HSA_STATUS_ERROR_INVALID_CODE_OBJECT) << load;
+  const std::string log_text = testing::internal::GetCapturedStderr();
 
   // A refusal is a property of the bytes: reaching it once is enough, and every
   // later load must reach the same answer without re-deriving it.
   EXPECT_EQ(rj_test_translation_count(), 1u);
   EXPECT_EQ(g_load_agent_calls, 0);
   EXPECT_EQ(rj_test_retained_executable_buffer_count(), 0u);
+  EXPECT_NE(log_text.find(" outcome=translation_failed "), std::string::npos) << log_text;
+  EXPECT_NE(log_text.find(" outcome=reused_failure "), std::string::npos) << log_text;
 }
 
 #ifdef GFX1250_B0_TO_A0_FIXTURE

--- a/emulation/rocjitsu/tests/dbt/hsa_hotswap_rocjitsu_unit_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/hsa_hotswap_rocjitsu_unit_test.cpp
@@ -356,6 +356,20 @@ protected:
     saved_environment_.clear();
   }
 
+  // Loads @p source through a fresh reader, the way a caller that re-registers
+  // the same object does -- a new handle every time, so nothing but the content
+  // itself can connect one load to the next.
+  hsa_status_t load_through_new_reader(const std::vector<uint8_t> &source,
+                                       hsa_executable_t executable = kExecutable) {
+    hsa_code_object_reader_t reader{};
+    const hsa_status_t create_status = api.core.hsa_code_object_reader_create_from_memory_fn(
+        source.data(), source.size(), &reader);
+    if (create_status != HSA_STATUS_SUCCESS)
+      return create_status;
+    return api.core.hsa_executable_load_agent_code_object_fn(executable, kA0Agent, reader, nullptr,
+                                                             nullptr);
+  }
+
   // Every case runs with these cleared and gets whatever the process had back,
   // so one case cannot decide what a later one observes.
   static constexpr std::array<const char *, 3> kIsolatedEnvironment = {
@@ -693,6 +707,62 @@ TEST_F(HsaHotswapHookTest, AnOutOfResourcesFailureCapturesNothing) {
       << log_text;
 }
 
+TEST_F(HsaHotswapHookTest, EnablingCaptureAfterAHintStillProducesTheArtifact) {
+  ASSERT_TRUE(OnLoad(&api.table, 0, 0, nullptr));
+  const std::vector<uint8_t> source = make_invalid_gfx1250_elf();
+
+  // The hint names the variable that turns capture on. Acting on it inside the
+  // same process must work: a hint that consumed the source's one capture slot
+  // would tell the operator to do something that then cannot succeed. Both
+  // attempts force a status the memo refuses to remember, so the second load
+  // really translates again instead of replaying the first verdict.
+  rj_test_force_next_translation_status(1 /* ROCJITSU_STATUS_ERROR */);
+  testing::internal::CaptureStderr();
+  EXPECT_EQ(load_through_new_reader(source), HSA_STATUS_ERROR_INVALID_CODE_OBJECT);
+  const std::string hint_text = testing::internal::GetCapturedStderr();
+  ASSERT_NE(hint_text.find("set HSA_HOTSWAP_DUMP_SOURCE=1 to save the source code object"),
+            std::string::npos)
+      << hint_text;
+  ASSERT_EQ(rj_test_dump_path_count(), 0u);
+
+  ASSERT_EQ(setenv("HSA_HOTSWAP_DUMP_SOURCE", "1", 1), 0);
+  rj_test_force_next_translation_status(1 /* ROCJITSU_STATUS_ERROR */);
+  testing::internal::CaptureStderr();
+  EXPECT_EQ(load_through_new_reader(source), HSA_STATUS_ERROR_INVALID_CODE_OBJECT);
+  const std::string capture_text = testing::internal::GetCapturedStderr();
+
+  EXPECT_EQ(rj_test_dump_path_count(), 1u);
+  expect_failure_dump(capture_text, source);
+}
+
+TEST_F(HsaHotswapHookTest, CorrectingTheCaptureDirectoryRetriesTheArtifact) {
+  ASSERT_TRUE(OnLoad(&api.table, 0, 0, nullptr));
+  const std::vector<uint8_t> source = make_invalid_gfx1250_elf();
+  ASSERT_EQ(setenv("HSA_HOTSWAP_DUMP_SOURCE", "1", 1), 0);
+  ASSERT_EQ(setenv("HSA_HOTSWAP_DUMP_DIR", "/nonexistent-rocjitsu-hotswap-dump", 1), 0);
+
+  // Forced so the memo does not remember it: the retry below has to translate.
+  rj_test_force_next_translation_status(1 /* ROCJITSU_STATUS_ERROR */);
+  testing::internal::CaptureStderr();
+  EXPECT_EQ(load_through_new_reader(source), HSA_STATUS_ERROR_INVALID_CODE_OBJECT);
+  const std::string failed_text = testing::internal::GetCapturedStderr();
+  ASSERT_NE(failed_text.find("could not be saved"), std::string::npos) << failed_text;
+  ASSERT_EQ(rj_test_dump_path_count(), 0u);
+
+  // A capture that could not be written must not spend the source's slot: the
+  // operator fixes the destination and the next failure produces the artifact.
+  ScopedTempDirectory directory;
+  ASSERT_FALSE(directory.path().empty());
+  ASSERT_EQ(setenv("HSA_HOTSWAP_DUMP_DIR", directory.path().c_str(), 1), 0);
+  rj_test_force_next_translation_status(1 /* ROCJITSU_STATUS_ERROR */);
+  testing::internal::CaptureStderr();
+  EXPECT_EQ(load_through_new_reader(source), HSA_STATUS_ERROR_INVALID_CODE_OBJECT);
+  const std::string capture_text = testing::internal::GetCapturedStderr();
+
+  EXPECT_EQ(rj_test_dump_path_count(), 1u);
+  expect_failure_dump(capture_text, source);
+}
+
 TEST_F(HsaHotswapHookTest, RetainedStorageSurvivesUnloadAndReinstall) {
   ASSERT_TRUE(OnLoad(&api.table, 0, 0, nullptr));
   ASSERT_EQ(rj_test_retained_executable_buffer_count(), 0u);
@@ -973,9 +1043,6 @@ TEST_F(HsaHotswapHookTest, CallbackApiSnapshotIsSafeDuringUnload) {
 // distinguishes reuse from repetition.
 class HsaHotswapMemoTest : public HsaHotswapHookTest {
 protected:
-  // Loads @p source through a fresh reader, the way a caller that re-registers the
-  // same object does -- a new handle every time, so nothing but the content itself
-  // can connect one load to the next.
   // Spin until @p expected threads are asleep on an in-flight translation, or a
   // generous deadline passes. Returns what was actually observed so the caller can
   // release the gate before asserting on it.
@@ -1050,17 +1117,6 @@ protected:
       return patched;
     }
     return {};
-  }
-
-  hsa_status_t load_through_new_reader(const std::vector<uint8_t> &source,
-                                       hsa_executable_t executable = kExecutable) {
-    hsa_code_object_reader_t reader{};
-    const hsa_status_t create_status = api.core.hsa_code_object_reader_create_from_memory_fn(
-        source.data(), source.size(), &reader);
-    if (create_status != HSA_STATUS_SUCCESS)
-      return create_status;
-    return api.core.hsa_executable_load_agent_code_object_fn(executable, kA0Agent, reader, nullptr,
-                                                             nullptr);
   }
 };
 

--- a/emulation/rocjitsu/tests/dbt/support/gfx1250_test_code_object.h
+++ b/emulation/rocjitsu/tests/dbt/support/gfx1250_test_code_object.h
@@ -1,0 +1,154 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "rocjitsu/code/amdgpu_elf.h"
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <span>
+#include <string_view>
+#include <vector>
+
+namespace rocjitsu::test_support {
+namespace detail {
+
+inline uint64_t align_up(uint64_t value, uint64_t alignment) {
+  const uint64_t remainder = value % alignment;
+  return remainder == 0 ? value : value + alignment - remainder;
+}
+
+inline uint32_t add_name(std::vector<uint8_t> &table, std::string_view name) {
+  const uint32_t offset = static_cast<uint32_t>(table.size());
+  table.insert(table.end(), name.begin(), name.end());
+  table.push_back('\0');
+  return offset;
+}
+
+} // namespace detail
+
+/// Build a small, valid gfx1250 code object with one kernel descriptor.
+inline std::vector<uint8_t> make_gfx1250_code_object(std::span<const uint32_t> text_words) {
+  constexpr uint64_t kTextOffset = 0x100;
+  constexpr uint64_t kTextVaddr = 0x1100;
+  constexpr uint64_t kLoadAlignment = 0x1000;
+  constexpr uint64_t kKernelDescriptorSize = 64;
+  constexpr uint64_t kKernelEntryOffsetField = 16;
+  const uint64_t text_size = text_words.size_bytes();
+
+  std::vector<uint8_t> section_names{'\0'};
+  const uint32_t text_name = detail::add_name(section_names, ".text");
+  const uint32_t rodata_name = detail::add_name(section_names, ".rodata");
+  const uint32_t symtab_name = detail::add_name(section_names, ".symtab");
+  const uint32_t strtab_name = detail::add_name(section_names, ".strtab");
+  const uint32_t shstrtab_name = detail::add_name(section_names, ".shstrtab");
+
+  std::vector<uint8_t> symbol_names{'\0'};
+  const uint32_t descriptor_symbol_name = detail::add_name(symbol_names, "kernel.kd");
+
+  const uint64_t rodata_offset = detail::align_up(kTextOffset + text_size, 8);
+  const uint64_t rodata_vaddr = detail::align_up(kTextVaddr + text_size, 8) + kLoadAlignment;
+  const uint64_t strtab_offset = rodata_offset + kKernelDescriptorSize;
+  const uint64_t symtab_offset = detail::align_up(strtab_offset + symbol_names.size(), 8);
+  constexpr size_t kSymbolCount = 2;
+  const uint64_t shstrtab_offset = symtab_offset + kSymbolCount * sizeof(Elf64_Sym);
+  const uint64_t section_headers_offset =
+      detail::align_up(shstrtab_offset + section_names.size(), 8);
+  constexpr uint16_t kSectionCount = 6;
+
+  std::vector<uint8_t> image(section_headers_offset + kSectionCount * sizeof(Elf64_Shdr), 0);
+
+  Elf64_Ehdr header{};
+  std::memcpy(header.e_ident, EI_MAGIC, EI_MAGIC_SIZE);
+  header.e_ident[EI_CLASS] = ELFCLASS64;
+  header.e_ident[EI_OSABI] = ELFOSABI_AMDGPU_HSA;
+  header.e_type = ET_DYN;
+  header.e_machine = EM_AMDGPU;
+  header.e_version = 1;
+  header.e_phoff = sizeof(Elf64_Ehdr);
+  header.e_shoff = section_headers_offset;
+  header.e_flags = EF_AMDGPU_MACH_AMDGCN_GFX1250;
+  header.e_ehsize = sizeof(Elf64_Ehdr);
+  header.e_phentsize = sizeof(Elf64_Phdr);
+  header.e_phnum = 2;
+  header.e_shentsize = sizeof(Elf64_Shdr);
+  header.e_shnum = kSectionCount;
+  header.e_shstrndx = 5;
+  std::memcpy(image.data(), &header, sizeof(header));
+
+  std::array<Elf64_Phdr, 2> program_headers{};
+  program_headers[0].p_type = PT_LOAD;
+  program_headers[0].p_flags = 0x5;
+  program_headers[0].p_offset = kTextOffset;
+  program_headers[0].p_vaddr = kTextVaddr;
+  program_headers[0].p_paddr = kTextVaddr;
+  program_headers[0].p_filesz = text_size;
+  program_headers[0].p_memsz = text_size;
+  program_headers[0].p_align = kLoadAlignment;
+  program_headers[1].p_type = PT_LOAD;
+  program_headers[1].p_flags = 0x4;
+  program_headers[1].p_offset = rodata_offset;
+  program_headers[1].p_vaddr = rodata_vaddr;
+  program_headers[1].p_paddr = rodata_vaddr;
+  program_headers[1].p_filesz = kKernelDescriptorSize;
+  program_headers[1].p_memsz = kKernelDescriptorSize;
+  program_headers[1].p_align = kLoadAlignment;
+  std::memcpy(image.data() + header.e_phoff, program_headers.data(), sizeof(program_headers));
+
+  std::memcpy(image.data() + kTextOffset, text_words.data(), text_size);
+  const int64_t entry_offset =
+      static_cast<int64_t>(kTextVaddr) - static_cast<int64_t>(rodata_vaddr);
+  std::memcpy(image.data() + rodata_offset + kKernelEntryOffsetField, &entry_offset,
+              sizeof(entry_offset));
+  std::memcpy(image.data() + strtab_offset, symbol_names.data(), symbol_names.size());
+
+  std::array<Elf64_Sym, kSymbolCount> symbols{};
+  symbols[1].st_name = descriptor_symbol_name;
+  symbols[1].st_info = elf_symbol_info(kElfSymbolBindGlobal, kElfSymbolTypeObject);
+  symbols[1].st_shndx = 2;
+  symbols[1].st_value = rodata_vaddr;
+  symbols[1].st_size = kKernelDescriptorSize;
+  std::memcpy(image.data() + symtab_offset, symbols.data(), sizeof(symbols));
+  std::memcpy(image.data() + shstrtab_offset, section_names.data(), section_names.size());
+
+  std::array<Elf64_Shdr, kSectionCount> section_headers{};
+  section_headers[1].sh_name = text_name;
+  section_headers[1].sh_type = SHT_PROGBITS;
+  section_headers[1].sh_flags = SHF_ALLOC | SHF_EXECINSTR;
+  section_headers[1].sh_addr = kTextVaddr;
+  section_headers[1].sh_offset = kTextOffset;
+  section_headers[1].sh_size = text_size;
+  section_headers[1].sh_addralign = sizeof(uint32_t);
+  section_headers[2].sh_name = rodata_name;
+  section_headers[2].sh_type = SHT_PROGBITS;
+  section_headers[2].sh_flags = SHF_ALLOC;
+  section_headers[2].sh_addr = rodata_vaddr;
+  section_headers[2].sh_offset = rodata_offset;
+  section_headers[2].sh_size = kKernelDescriptorSize;
+  section_headers[2].sh_addralign = 64;
+  section_headers[3].sh_name = symtab_name;
+  section_headers[3].sh_type = SHT_SYMTAB;
+  section_headers[3].sh_offset = symtab_offset;
+  section_headers[3].sh_size = sizeof(symbols);
+  section_headers[3].sh_link = 4;
+  section_headers[3].sh_info = 1;
+  section_headers[3].sh_addralign = 8;
+  section_headers[3].sh_entsize = sizeof(Elf64_Sym);
+  section_headers[4].sh_name = strtab_name;
+  section_headers[4].sh_type = SHT_STRTAB;
+  section_headers[4].sh_offset = strtab_offset;
+  section_headers[4].sh_size = symbol_names.size();
+  section_headers[4].sh_addralign = 1;
+  section_headers[5].sh_name = shstrtab_name;
+  section_headers[5].sh_type = SHT_STRTAB;
+  section_headers[5].sh_offset = shstrtab_offset;
+  section_headers[5].sh_size = section_names.size();
+  section_headers[5].sh_addralign = 1;
+  std::memcpy(image.data() + section_headers_offset, section_headers.data(),
+              sizeof(section_headers));
+  return image;
+}
+
+} // namespace rocjitsu::test_support


### PR DESCRIPTION
## Motivation

When the gfx1250 B0→A0 hotswap hook failed to translate a code object, it said nothing. Every translation record, success and failure alike, went through the verbose-only log(), and the HSA boundary swallowed exceptions and returned a status with no message at all — so an operator without HSA_HOTSWAP_VERBOSE saw a bare HSA_STATUS_ERROR_INVALID_CODE_OBJECT with no indication of which code object was refused or why. That matters because callers do not always check: hipBLASLt dereferences a null kernel handle after a rejected load and segfaults, turning a diagnosable translation gap into an unattributable crash. The translation library made this worse by discarding what it knew — the translator produces per-instruction diagnostics naming the offset, mnemonic and the work required to support it, and none of that reached the hook.

##  Technical details

rj_gfx1250_b0_to_a0_translate() now takes the provenance info out-parameter (folding in the old _with_info entry point) plus an optional synchronous diagnostic callback, invoked on every non-success return; translator failures deliver the complete diagnostic set including required-work items, while argument, input, allocation and exception failures report one diagnostic describing themselves. Diagnostics carry severity and kind as stable matching keys with distinct names per failure source, so a consumer can tell a translator resource limit from an output-allocation failure. The hook reports failures unconditionally at error level, derives each diagnostic's line prefix from its carried severity, and names the failing operation when an exception crosses the HSA boundary; a memoized refusal being replayed stays on the verbose channel, since a device library registered once per kernel and per device replays one verdict hundreds of times and would otherwise bury the original. Capturing the failing source to disk is opt-in through HSA_HOTSWAP_DUMP_SOURCE, writing to HSA_HOTSWAP_DUMP_DIR, else TMPDIR, else /tmp — these objects reach 212 MiB and an environmental failure is deliberately not memoized, so an always-on capture would rewrite the same bytes on every load. One artifact is kept per source identity, the claim is released whenever the write does not complete so a corrected directory can be retried, out-of-resources failures are skipped, and both registries are bounded.