### PR TITLE
fix(rocdbgapi): exit early if accessing nullptr

### DIFF
--- a/projects/rocdbgapi/src/memory.cpp
+++ b/projects/rocdbgapi/src/memory.cpp
@@ -1451,6 +1451,10 @@ xfer_memory (amd_dbgapi_process_id_t process_id, amd_dbgapi_wave_id_t wave_id,
             ? address_space->lower (wave->agent (), segment_address)
             : std::make_pair (std::cref (*address_space), segment_address);
 
+      /* Exit early if accessing a nullptr.  */
+      if (lowered_address == lowered_address_space.null_address ())
+        throw memory_access_error_t (lowered_address_space, lowered_address);
+
       switch (lowered_address_space.address_dependency (lowered_address))
         {
         case AMD_DBGAPI_SEGMENT_ADDRESS_DEPENDENCE_PROCESS:


### PR DESCRIPTION
## Motivation

Check for nullptr access and do not attempt to access memory. Give a proper error.

## Technical Details

When accessing the memory, check if accessing the nullptr and if so, exit early with an error, so that we don't go into lower layers.

## Issue Tracking

Bug: AIROCGDB-645

## Test Plan

A new test to be included in ROCgdb.

## Test Result

Passes with this patch, fails without.
