### PR TITLE
fix(rccl): reject collectives issued on a suspended communicator

### DIFF
--- a/projects/rccl/docs/how-to/rccl-usage-tips.rst
+++ b/projects/rccl/docs/how-to/rccl-usage-tips.rst
@@ -304,7 +304,8 @@ The relevant functions, declared in ``rccl.h``, are described in full in
 - ``ncclCommSuspend`` releases the resources selected by its ``flags``
   argument. Pass ``NCCL_SUSPEND_MEM`` to release dynamic GPU memory
   allocations. After this call, the communicator can't be used until it's
-  resumed.
+  resumed: a collective issued while it's suspended is rejected with
+  ``ncclInvalidUsage``.
 - ``ncclCommResume`` reacquires every resource that the matching
   ``ncclCommSuspend`` call released, after which the communicator can run
   collectives again.

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -3851,6 +3851,22 @@ ncclResult_t ncclEnqueueCheck(struct ncclInfo* info) {
     goto fail;
   }
 
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+  // RCCL: a collective must not be issued on a suspended communicator. The queues cover a suspend or resume still
+  // pending in this group, which the group drains before launching.
+  if (info->comm->memManager) {
+    bool commIsSuspended = ncclIntruQueueEmpty(&info->comm->resumeTaskQueue) &&
+                           (!ncclIntruQueueEmpty(&info->comm->suspendTaskQueue) ||
+                            __atomic_load_n(&info->comm->memManager->released, __ATOMIC_ACQUIRE));
+    if (commIsSuspended) {
+      WARN("%s: communicator %p is suspended; call ncclCommResume before issuing collectives", info->opName,
+           info->comm);
+      ret = ncclInvalidUsage;
+      goto fail;
+    }
+  }
+#endif
+
   if (info->comm->checkMode != ncclCheckModeDefault) {
     CUDACHECKGOTO(cudaGetDevice(&devOld), ret, fail);
     CUDACHECKGOTO(cudaSetDevice(info->comm->cudaDev), ret, fail);

--- a/projects/rccl/src/nccl.h.in
+++ b/projects/rccl/src/nccl.h.in
@@ -514,7 +514,8 @@ ncclResult_t pncclCommDeregister(const ncclComm_t comm, void* handle);
 
 /*! @brief      Suspend communicator operations to free resources.
     @details    Releases the resources selected by @p flags. The communicator
-                cannot be used until @ref ncclCommResume is called.
+                cannot be used until @ref ncclCommResume is called; a collective
+                issued in the meantime returns ncclInvalidUsage.
     @return     Result code. See @ref rccl_result_code for more details.
 
     @param[in]  comm          Communicator to suspend

--- a/projects/rccl/test/mem_manager/SuspendResumeMPITests.cpp
+++ b/projects/rccl/test/mem_manager/SuspendResumeMPITests.cpp
@@ -1879,6 +1879,69 @@ TEST_F(SuspendResumeGroup, MixedSuspendResume)
         << "After Suspend+Resume in the same group, comm must be active";
 }
 
+TEST_F(SuspendResumeGroup, CollectiveAfterResumeInSameGroup)
+{
+    // Resume and a collective in one group is legal: the comm is active by the
+    // time the kernel runs, so the guard must not reject it on the released flag
+    // that is still set when the collective is enqueued.
+    if (!ncclCuMemEnable()) {
+        GTEST_SKIP() << "NCCL_CUMEM_ENABLE=0 — nothing is tracked, so Suspend "
+                        "releases no memory and there is nothing to guard";
+    }
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t  comm   = getActiveCommunicator();
+    hipStream_t stream = getActiveStream();
+
+    // Suspend must release live connections, so run a collective first.
+    EXPECT_TRUE(runAllReduceAndVerify(comm, stream)) << "AllReduce baseline before Suspend";
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommSuspend(comm, NCCL_SUSPEND_MEM));
+
+    void* sendbuf = nullptr;
+    void* recvbuf = nullptr;
+    ASSERT_EQ(hipSuccess, hipMalloc(&sendbuf, kAllReduceCount * sizeof(float)));
+    auto sendGuard = makeDeviceBufferAutoGuard(sendbuf);
+    ASSERT_EQ(hipSuccess, hipMalloc(&recvbuf, kAllReduceCount * sizeof(float)));
+    auto recvGuard = makeDeviceBufferAutoGuard(recvbuf);
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclGroupStart());
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommResume(comm));
+    ASSERT_MPI_EQ(ncclSuccess,
+                  ncclAllReduce(sendbuf, recvbuf, kAllReduceCount, ncclFloat32,
+                                ncclSum, comm, stream));
+    ASSERT_MPI_EQ(ncclSuccess, ncclGroupEnd());
+    ASSERT_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+    EXPECT_EQ(0u, readStat(comm, ncclStatGpuMemSuspended));
+}
+
+TEST_F(SuspendResumeGroup, CollectiveAfterSuspendInSameGroup)
+{
+    // Mirror image of the case above and not legal: the comm is suspended by the
+    // time the kernel runs, so the guard must reject even though the released
+    // flag is still 0 when the collective is enqueued.
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t  comm   = getActiveCommunicator();
+    hipStream_t stream = getActiveStream();
+
+    void* sendbuf = nullptr;
+    void* recvbuf = nullptr;
+    ASSERT_EQ(hipSuccess, hipMalloc(&sendbuf, kAllReduceCount * sizeof(float)));
+    auto sendGuard = makeDeviceBufferAutoGuard(sendbuf);
+    ASSERT_EQ(hipSuccess, hipMalloc(&recvbuf, kAllReduceCount * sizeof(float)));
+    auto recvGuard = makeDeviceBufferAutoGuard(recvbuf);
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclGroupStart());
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommSuspend(comm, NCCL_SUSPEND_MEM));
+    ASSERT_MPI_EQ(ncclInvalidUsage,
+                  ncclAllReduce(sendbuf, recvbuf, kAllReduceCount, ncclFloat32,
+                                ncclSum, comm, stream));
+    // ncclGroupEnd reports the first error raised inside the group.
+    ASSERT_MPI_EQ(ncclInvalidUsage, ncclGroupEnd());
+}
+
 // ----------------------------------------------------------------------------
 // 6. Argument validation / corner cases
 //
@@ -1960,6 +2023,41 @@ TEST_F(SuspendResumeArgValidation, DoubleResume)
     ASSERT_MPI_EQ(ncclInvalidUsage, ncclCommResume(comm));
 
     EXPECT_EQ(0u, readStat(comm, ncclStatGpuMemSuspended));
+}
+
+TEST_F(SuspendResumeArgValidation, CollectiveWhileSuspended)
+{
+    // A collective on a suspended comm must be rejected instead of faulting the
+    // GPU, and the rejection must leave the comm usable after Resume. Only cuMem
+    // unmaps the buffers, so this is the configuration the fault was reported on.
+    if (!ncclCuMemEnable()) {
+        GTEST_SKIP() << "NCCL_CUMEM_ENABLE=0 — nothing is tracked, so Suspend "
+                        "releases no memory and there is nothing to guard";
+    }
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t  comm   = getActiveCommunicator();
+    hipStream_t stream = getActiveStream();
+
+    // Suspend must release live connections, so run a collective first.
+    EXPECT_TRUE(runAllReduceAndVerify(comm, stream)) << "AllReduce baseline before Suspend";
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommSuspend(comm, NCCL_SUSPEND_MEM));
+
+    void* sendbuf = nullptr;
+    void* recvbuf = nullptr;
+    ASSERT_EQ(hipSuccess, hipMalloc(&sendbuf, kAllReduceCount * sizeof(float)));
+    auto sendGuard = makeDeviceBufferAutoGuard(sendbuf);
+    ASSERT_EQ(hipSuccess, hipMalloc(&recvbuf, kAllReduceCount * sizeof(float)));
+    auto recvGuard = makeDeviceBufferAutoGuard(recvbuf);
+
+    ASSERT_MPI_EQ(ncclInvalidUsage,
+                  ncclAllReduce(sendbuf, recvbuf, kAllReduceCount, ncclFloat32,
+                                ncclSum, comm, stream));
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommResume(comm));
+    EXPECT_TRUE(runAllReduceAndVerify(comm, stream))
+        << "a rejected collective must leave the comm usable";
 }
 
 // ----- ncclCommMemStats validation --------------------------------------


### PR DESCRIPTION
## Motivation

A collective enqueued on a suspended communicator runs against VMM regions that Suspend has unmapped, so with NCCL_CUMEM_ENABLE=1 it faults the GPU in ncclDevKernel_Generic_1 instead of reporting a usage error. 

## Technical Details

ncclEnqueueCheck now rejects suspended comm with ncclInvalidUsage, the same way it already rejects a revoked communicator.

The predicate is queue-aware because a group drains its suspend and resume tasks before it launches: a Resume pending in the same group leaves the communicator active by launch time, while a pending Suspend suspends it even though the released flag is still clear at enqueue.

Three tests cover those states, plus a sentence each in the doxygen block for ncclCommSuspend and in the usage tips. The two tests that end with an active communicator run under NCCL_CUMEM_ENABLE=1 only

## Issue Tracking

JIRA ID : ROCM-28711

## Test Plan

MI355X (gfx950), ROCm 7.14, 2 and 8 ranks:

```
  mpirun -np 2 ... rccl-UnitTestsMPI \
    --gtest_filter='SuspendResume*:MemManagerAnyRanks.*:MemManagerTwoRank.*'
```

## Test Result

NCCL_CUMEM_ENABLE=1: 40 tests passed at np=2, and the 3 new tests passed at np=8

CI:
```
Test: SuspendResume_Group_CuMem1
================================================================================
  Description: Atomic Suspend/Resume inside ncclGroupStart/End (NCCL_CUMEM_ENABLE=1)
  Filter:  SuspendResumeGroup.*
  Ranks:   2      Nodes: 1      GPUs/node: 2
  Environment variables (5):
    HSA_NO_SCRATCH_RECLAIM=1
    NCCL_SOCKET_IFNAME=eth0,eth1
    NCCL_IB_HCA=^mlx5_1,mlx5_6
    NCCL_DEBUG=
    NCCL_CUMEM_ENABLE=1
  Started: 2026-08-07 13:20:08
[==========] Running 5 tests from 1 test suite.
[ RUN      ] SuspendResumeGroup.AtomicSuspend
[       OK ] SuspendResumeGroup.AtomicSuspend (4434 ms)
[ RUN      ] SuspendResumeGroup.AtomicResume
[       OK ] SuspendResumeGroup.AtomicResume (1350 ms)
[ RUN      ] SuspendResumeGroup.MixedSuspendResume
[       OK ] SuspendResumeGroup.MixedSuspendResume (1350 ms)
[ RUN      ] SuspendResumeGroup.CollectiveAfterResumeInSameGroup
[       OK ] SuspendResumeGroup.CollectiveAfterResumeInSameGroup (1333 ms)
[ RUN      ] SuspendResumeGroup.CollectiveAfterSuspendInSameGroup
[       OK ] SuspendResumeGroup.CollectiveAfterSuspendInSameGroup (1007 ms)
[----------] 5 tests from SuspendResumeGroup (9475 ms total)
[==========] 5 tests from 1 test suite ran. (9795 ms total)
[  PASSED  ] 5 tests.
  Result: PASSED (16.960 seconds)


Test: SuspendResume_ArgValidation_CuMem1
================================================================================
  Description: Argument validation: zero/unknown flags, double-Suspend/Resume (NCCL_CUMEM_ENABLE=1)
  Filter:  SuspendResumeArgValidation.*
  Ranks:   2      Nodes: 1      GPUs/node: 2
  Environment variables (5):
    HSA_NO_SCRATCH_RECLAIM=1
    NCCL_SOCKET_IFNAME=eth0,eth1
    NCCL_IB_HCA=^mlx5_1,mlx5_6
    NCCL_DEBUG=
    NCCL_CUMEM_ENABLE=1
  Started: 2026-08-07 13:20:25
[==========] Running 6 tests from 1 test suite.
[ RUN      ] SuspendResumeArgValidation.ZeroFlags
[       OK ] SuspendResumeArgValidation.ZeroFlags (4420 ms)
[ RUN      ] SuspendResumeArgValidation.UnknownFlagsRejected
[       OK ] SuspendResumeArgValidation.UnknownFlagsRejected (1330 ms)
[ RUN      ] SuspendResumeArgValidation.DoubleSuspend
[       OK ] SuspendResumeArgValidation.DoubleSuspend (1314 ms)
[ RUN      ] SuspendResumeArgValidation.ResumeWhenActive
[       OK ] SuspendResumeArgValidation.ResumeWhenActive (1028 ms)
[ RUN      ] SuspendResumeArgValidation.DoubleResume
[       OK ] SuspendResumeArgValidation.DoubleResume (1340 ms)
[ RUN      ] SuspendResumeArgValidation.CollectiveWhileSuspended
[       OK ] SuspendResumeArgValidation.CollectiveWhileSuspended (1307 ms)
[----------] 6 tests from SuspendResumeArgValidation (10742 ms total)
[==========] 6 tests from 1 test suite ran. (11060 ms total)
[  PASSED  ] 6 tests.
  Result: PASSED (17.609 seconds)
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
