### PR TITLE
[rocjitsu][CI] Warn about offline translation changes

### DIFF
--- a/.github/scripts/rocjitsu_corpus_translation_comment.py
+++ b/.github/scripts/rocjitsu_corpus_translation_comment.py
@@ -1,0 +1,541 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Plan a trusted corpus comparison and maintain its sticky PR comment."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+from typing import Any
+import urllib.parse
+import urllib.request
+
+BASELINE_ARTIFACT = "gfx1250-b0-a0-sha-pairs"
+CANDIDATE_ARTIFACT = "gfx1250-b0-a0-sha-pairs-candidate"
+COMMENT_MARKER = "<!-- rocjitsu-gfx1250-b0-a0-translation -->"
+COMPARISON_TIMEOUT_SECONDS = 60
+MAXIMUM_ARTIFACT_BYTES = 20 * 1024 * 1024
+MAXIMUM_MANIFEST_BYTES = 10 * 1024 * 1024
+GIT_SHA_RE = re.compile(r"(?:[0-9a-f]{40}|[0-9a-f]{64})")
+REPOSITORY_RE = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
+TRUSTED_BASE = "develop"
+WORKFLOW_FILE = "rocjitsu-corpus-tests.yml"
+TRUSTED_WORKFLOW_PATH = f".github/workflows/{WORKFLOW_FILE}"
+
+
+@dataclass(frozen=True)
+class ComparisonPlan:
+    ready: bool
+    reason: str
+    pull_number: int | None = None
+    candidate_run_id: int | None = None
+    baseline_run_id: int | None = None
+    candidate_head_sha: str | None = None
+
+
+class GitHubApi:
+    def __init__(self, repository: str, token: str, api_url: str) -> None:
+        if REPOSITORY_RE.fullmatch(repository) is None:
+            raise ValueError(f"invalid GitHub repository: {repository!r}")
+        if not token:
+            raise ValueError("GH_TOKEN must not be empty")
+        if not api_url.startswith("https://"):
+            raise ValueError("GITHUB_API_URL must use HTTPS")
+        self.repository = repository
+        self._token = token
+        self._api_url = api_url.rstrip("/")
+
+    def get(self, path: str) -> Any:
+        return self._request("GET", path)
+
+    def paginate(self, path: str, key: str | None = None) -> list[Any]:
+        items = []
+        page = 1
+        separator = "&" if "?" in path else "?"
+        while True:
+            payload = self.get(f"{path}{separator}per_page=100&page={page}")
+            if key is None:
+                batch = payload
+            else:
+                if not isinstance(payload, dict):
+                    raise ValueError(f"GitHub response for {path!r} is not an object")
+                batch = payload.get(key)
+            if not isinstance(batch, list):
+                raise ValueError(f"GitHub response for {path!r} is not a list")
+            items.extend(batch)
+            if len(batch) < 100:
+                return items
+            page += 1
+
+    def create(self, path: str, payload: dict[str, Any]) -> Any:
+        return self._request("POST", path, payload)
+
+    def update(self, path: str, payload: dict[str, Any]) -> Any:
+        return self._request("PATCH", path, payload)
+
+    def delete(self, path: str) -> Any:
+        return self._request("DELETE", path)
+
+    def _request(
+        self, method: str, path: str, payload: dict[str, Any] | None = None
+    ) -> Any:
+        body = None
+        if payload is not None:
+            body = json.dumps(payload).encode("utf-8")
+        request = urllib.request.Request(
+            f"{self._api_url}{path}",
+            data=body,
+            method=method,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self._token}",
+                "Content-Type": "application/json",
+                "User-Agent": "rocjitsu-corpus-translation-comment",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        with urllib.request.urlopen(request, timeout=30) as response:
+            response_body = response.read()
+        return json.loads(response_body) if response_body else None
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        repository = _environment("GITHUB_REPOSITORY")
+        api = GitHubApi(
+            repository,
+            _environment("GH_TOKEN"),
+            os.environ.get("GITHUB_API_URL", "https://api.github.com"),
+        )
+        if args.command == "plan":
+            event = json.loads(args.event.read_text(encoding="utf-8"))
+            plan = resolve_plan(event, api, repository)
+            write_plan_outputs(args.output, plan)
+            print(plan.reason)
+            return 0
+        if args.command == "comment":
+            baseline_found = _environment_boolean("BASELINE_FOUND")
+            candidate_head_sha = _environment_git_sha("CANDIDATE_HEAD_SHA")
+            pull_number = _environment_integer("PR_NUMBER")
+            source_run_id = _environment_integer("SOURCE_RUN_ID")
+            status, report = compare_candidate(
+                args.comparison_tool,
+                args.baseline,
+                args.candidate,
+                baseline_found,
+            )
+            body = render_comment(
+                repository,
+                source_run_id,
+                candidate_head_sha,
+                baseline_found,
+                status,
+                report,
+                os.environ.get("GITHUB_SERVER_URL", "https://github.com"),
+            )
+            synchronize_comment(api, repository, pull_number, candidate_head_sha, body)
+            return 0
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    raise AssertionError(f"unhandled command: {args.command}")
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    plan = commands.add_parser("plan", help="resolve the PR and artifact run IDs")
+    plan.add_argument("--event", type=Path, required=True)
+    plan.add_argument("--output", type=Path, required=True)
+    comment = commands.add_parser("comment", help="compare and synchronize the comment")
+    comment.add_argument("--candidate", type=Path, required=True)
+    comment.add_argument("--baseline", type=Path, required=True)
+    comment.add_argument("--comparison-tool", type=Path, required=True)
+    return parser.parse_args(argv)
+
+
+def resolve_plan(event: dict[str, Any], api: Any, repository: str) -> ComparisonPlan:
+    run = event.get("workflow_run")
+    if not isinstance(run, dict) or run.get("event") != "pull_request":
+        return ComparisonPlan(False, "Source workflow was not a pull-request run.")
+    if run.get("conclusion") != "success":
+        return ComparisonPlan(False, "Source pull-request workflow did not succeed.")
+    if run.get("path") != TRUSTED_WORKFLOW_PATH:
+        return ComparisonPlan(
+            False,
+            f"Source workflow path was not {TRUSTED_WORKFLOW_PATH}.",
+        )
+    head_repository = run.get("head_repository")
+    if (
+        not isinstance(head_repository, dict)
+        or head_repository.get("full_name") != repository
+    ):
+        return ComparisonPlan(
+            False,
+            f"Source workflow did not run from {repository}.",
+        )
+    head_sha = run.get("head_sha")
+    if not isinstance(head_sha, str) or GIT_SHA_RE.fullmatch(head_sha) is None:
+        return ComparisonPlan(False, "Source workflow has an invalid head SHA.")
+    run_id = _positive_integer(run.get("id"), "workflow run ID")
+    pull_numbers = {
+        pull.get("number")
+        for pull in run.get("pull_requests", [])
+        if isinstance(pull, dict) and _is_positive_integer(pull.get("number"))
+    }
+    if not pull_numbers:
+        associated = api.paginate(
+            f"/repos/{repository}/commits/{urllib.parse.quote(head_sha, safe='')}/pulls"
+        )
+        pull_numbers = {
+            pull.get("number")
+            for pull in associated
+            if isinstance(pull, dict)
+            and pull.get("base", {}).get("repo", {}).get("full_name") == repository
+            and _is_positive_integer(pull.get("number"))
+        }
+    if len(pull_numbers) != 1:
+        return ComparisonPlan(
+            False,
+            f"Expected one pull request for workflow run {run_id}, found "
+            f"{len(pull_numbers)}.",
+        )
+    pull_number = next(iter(pull_numbers))
+    pull = api.get(f"/repos/{repository}/pulls/{pull_number}")
+    if not isinstance(pull, dict):
+        raise ValueError(f"GitHub response for PR #{pull_number} is not an object")
+    head = pull.get("head")
+    if (
+        not isinstance(head, dict)
+        or head.get("sha") != head_sha
+        or not isinstance(head.get("repo"), dict)
+        or head["repo"].get("full_name") != repository
+    ):
+        return ComparisonPlan(
+            False,
+            f"Workflow run {run_id} does not match the current same-repository "
+            f"head of PR #{pull_number}.",
+        )
+    base = pull.get("base", {})
+    if (
+        base.get("repo", {}).get("full_name") != repository
+        or base.get("ref") != TRUSTED_BASE
+    ):
+        return ComparisonPlan(
+            False,
+            f"PR #{pull_number} does not target {repository}:{TRUSTED_BASE}.",
+        )
+
+    artifacts = api.paginate(
+        f"/repos/{repository}/actions/runs/{run_id}/artifacts", "artifacts"
+    )
+    candidates = _named_artifacts(artifacts, CANDIDATE_ARTIFACT)
+    if len(candidates) != 1:
+        return ComparisonPlan(
+            False,
+            f"Expected one candidate artifact for workflow run {run_id}, found "
+            f"{len(candidates)}.",
+        )
+    _validate_artifact_size(candidates[0], "candidate")
+
+    baseline_run_id = find_baseline_run(api, repository)
+    message = f"Resolved PR #{pull_number} and candidate workflow run {run_id}."
+    if baseline_run_id is None:
+        message += " No canonical develop baseline is available."
+    else:
+        message += f" Baseline workflow run is {baseline_run_id}."
+    return ComparisonPlan(
+        ready=True,
+        reason=message,
+        pull_number=pull_number,
+        candidate_run_id=run_id,
+        baseline_run_id=baseline_run_id,
+        candidate_head_sha=head_sha,
+    )
+
+
+def find_baseline_run(api: Any, repository: str) -> int | None:
+    runs = api.paginate(
+        f"/repos/{repository}/actions/workflows/{WORKFLOW_FILE}/runs"
+        f"?branch={TRUSTED_BASE}&status=completed",
+        "workflow_runs",
+    )
+    for run in runs:
+        if (
+            not isinstance(run, dict)
+            or run.get("event") not in {"push", "workflow_dispatch"}
+            or run.get("conclusion") != "success"
+        ):
+            continue
+        run_id = _positive_integer(run.get("id"), "baseline workflow run ID")
+        artifacts = api.paginate(
+            f"/repos/{repository}/actions/runs/{run_id}/artifacts", "artifacts"
+        )
+        baselines = _named_artifacts(artifacts, BASELINE_ARTIFACT)
+        if len(baselines) != 1:
+            continue
+        try:
+            _validate_artifact_size(baselines[0], "baseline")
+        except ValueError as error:
+            print(f"Ignoring workflow run {run_id}: {error}")
+            continue
+        return run_id
+    return None
+
+
+def write_plan_outputs(path: Path, plan: ComparisonPlan) -> None:
+    lines = [f"ready={'true' if plan.ready else 'false'}"]
+    if plan.ready:
+        if plan.candidate_head_sha is None:
+            raise ValueError("ready comparison plan has no candidate head SHA")
+        lines.extend(
+            [
+                f"pull-number={plan.pull_number}",
+                f"candidate-run-id={plan.candidate_run_id}",
+                f"candidate-head-sha={plan.candidate_head_sha}",
+                f"baseline-found={'true' if plan.baseline_run_id else 'false'}",
+            ]
+        )
+        if plan.baseline_run_id is not None:
+            lines.append(f"baseline-run-id={plan.baseline_run_id}")
+    with path.open("a", encoding="utf-8") as output:
+        output.write("\n".join(lines) + "\n")
+
+
+def compare_candidate(
+    comparison_tool: Path,
+    baseline: Path,
+    candidate: Path,
+    baseline_found: bool,
+) -> tuple[int | None, str | None]:
+    _validate_manifest_file(candidate, "candidate")
+    if not baseline_found:
+        return None, None
+    _validate_manifest_file(baseline, "baseline")
+    if not comparison_tool.is_file():
+        raise ValueError(f"comparison tool is not a file: {comparison_tool}")
+    with tempfile.TemporaryDirectory() as temporary_directory:
+        report = Path(temporary_directory) / "comparison.md"
+        try:
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(comparison_tool),
+                    "compare",
+                    "--baseline",
+                    str(baseline),
+                    "--candidate",
+                    str(candidate),
+                    "--markdown",
+                    str(report),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=COMPARISON_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired as error:
+            raise ValueError(
+                "manifest comparison exceeded " f"{COMPARISON_TIMEOUT_SECONDS} seconds"
+            ) from error
+        if result.returncode not in {0, 2, 3}:
+            diagnostic = result.stderr.strip() or result.stdout.strip() or "<empty>"
+            raise ValueError(
+                f"manifest comparison failed with status {result.returncode}: "
+                f"{diagnostic[-4096:]}"
+            )
+        return result.returncode, report.read_text(encoding="utf-8")
+
+
+def render_comment(
+    repository: str,
+    source_run_id: int,
+    candidate_head_sha: str,
+    baseline_found: bool,
+    comparison_status: int | None,
+    report: str | None,
+    server_url: str,
+) -> str | None:
+    if not server_url.startswith("https://"):
+        raise ValueError("GITHUB_SERVER_URL must use HTTPS")
+    _validate_git_sha(candidate_head_sha, "candidate head SHA")
+    footer = (
+        f"<sub>Compared PR head [`{candidate_head_sha}`]"
+        f"({server_url.rstrip('/')}/{repository}/commit/{candidate_head_sha}) using "
+        f"[rocjitsu-test-corpus run {source_run_id}]"
+        f"({server_url.rstrip('/')}/{repository}/actions/runs/{source_run_id}).</sub>"
+    )
+    if not baseline_found:
+        return "\n".join(
+            [
+                COMMENT_MARKER,
+                "## gfx1250 B0-to-A0 translation baseline",
+                "",
+                "> [!WARNING]",
+                "> No canonical develop baseline is available, so this PR could not be compared.",
+                "",
+                footer,
+            ]
+        )
+    if comparison_status == 0:
+        return None
+    if comparison_status not in {2, 3} or not report:
+        raise ValueError("changed comparison must provide a warning report")
+    return f"{COMMENT_MARKER}\n{report.strip()}\n\n{footer}"
+
+
+def synchronize_comment(
+    api: Any,
+    repository: str,
+    pull_number: int,
+    candidate_head_sha: str,
+    body: str | None,
+) -> None:
+    _validate_git_sha(candidate_head_sha, "candidate head SHA")
+    comments = api.paginate(f"/repos/{repository}/issues/{pull_number}/comments")
+    existing = [
+        comment
+        for comment in comments
+        if isinstance(comment, dict)
+        and isinstance(comment.get("user"), dict)
+        and comment["user"].get("login") == "github-actions[bot]"
+        and isinstance(comment.get("body"), str)
+        and COMMENT_MARKER in comment["body"]
+    ]
+    if body is None:
+        for comment in existing:
+            if not _pull_head_matches(api, repository, pull_number, candidate_head_sha):
+                return
+            api.delete(f"/repos/{repository}/issues/comments/{comment['id']}")
+        print(f"Removed {len(existing)} resolved translation comment(s).")
+        return
+    if not existing:
+        if not _pull_head_matches(api, repository, pull_number, candidate_head_sha):
+            return
+        api.create(f"/repos/{repository}/issues/{pull_number}/comments", {"body": body})
+        print(f"Created translation comment on PR #{pull_number}.")
+        return
+    if not _pull_head_matches(api, repository, pull_number, candidate_head_sha):
+        return
+    api.update(
+        f"/repos/{repository}/issues/comments/{existing[0]['id']}", {"body": body}
+    )
+    for duplicate in existing[1:]:
+        if not _pull_head_matches(api, repository, pull_number, candidate_head_sha):
+            return
+        api.delete(f"/repos/{repository}/issues/comments/{duplicate['id']}")
+    print(f"Updated translation comment on PR #{pull_number}.")
+
+
+def _pull_head_matches(
+    api: Any, repository: str, pull_number: int, candidate_head_sha: str
+) -> bool:
+    pull = api.get(f"/repos/{repository}/pulls/{pull_number}")
+    if not isinstance(pull, dict):
+        raise ValueError(f"GitHub response for PR #{pull_number} is not an object")
+    head = pull.get("head")
+    current_head_sha = head.get("sha") if isinstance(head, dict) else None
+    if (
+        not isinstance(current_head_sha, str)
+        or GIT_SHA_RE.fullmatch(current_head_sha) is None
+    ):
+        raise ValueError(
+            f"GitHub response for PR #{pull_number} has an invalid head SHA"
+        )
+    if current_head_sha == candidate_head_sha:
+        return True
+    print(
+        f"Skipped stale translation comment for PR #{pull_number}: "
+        f"compared {candidate_head_sha}, current head is {current_head_sha}."
+    )
+    return False
+
+
+def _named_artifacts(artifacts: list[Any], name: str) -> list[dict[str, Any]]:
+    return [
+        artifact
+        for artifact in artifacts
+        if isinstance(artifact, dict)
+        and artifact.get("name") == name
+        and not artifact.get("expired", False)
+    ]
+
+
+def _validate_artifact_size(artifact: dict[str, Any], description: str) -> None:
+    size = artifact.get("size_in_bytes")
+    if not _is_positive_integer(size):
+        raise ValueError(f"{description} artifact has an invalid size")
+    if size > MAXIMUM_ARTIFACT_BYTES:
+        raise ValueError(
+            f"{description} artifact is {size} bytes; limit is "
+            f"{MAXIMUM_ARTIFACT_BYTES}"
+        )
+
+
+def _validate_manifest_file(path: Path, description: str) -> None:
+    if not path.is_file():
+        raise ValueError(f"{description} manifest is not a file: {path}")
+    size = path.stat().st_size
+    if size <= 0 or size > MAXIMUM_MANIFEST_BYTES:
+        raise ValueError(
+            f"{description} manifest is {size} bytes; expected 1 to "
+            f"{MAXIMUM_MANIFEST_BYTES}"
+        )
+
+
+def _environment(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise ValueError(f"{name} must not be empty")
+    return value
+
+
+def _environment_boolean(name: str) -> bool:
+    value = _environment(name)
+    if value not in {"true", "false"}:
+        raise ValueError(f"{name} must be 'true' or 'false'")
+    return value == "true"
+
+
+def _environment_integer(name: str) -> int:
+    value = _environment(name)
+    try:
+        parsed = int(value)
+    except ValueError as error:
+        raise ValueError(f"{name} must be an integer") from error
+    return _positive_integer(parsed, name)
+
+
+def _environment_git_sha(name: str) -> str:
+    value = _environment(name)
+    _validate_git_sha(value, name)
+    return value
+
+
+def _validate_git_sha(value: str, description: str) -> None:
+    if GIT_SHA_RE.fullmatch(value) is None:
+        raise ValueError(f"{description} must be a lowercase Git SHA")
+
+
+def _positive_integer(value: Any, description: str) -> int:
+    if not _is_positive_integer(value):
+        raise ValueError(f"{description} must be a positive integer")
+    return value
+
+
+def _is_positive_integer(value: Any) -> bool:
+    return not isinstance(value, bool) and isinstance(value, int) and value > 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test-rocjitsu-corpus-translation-comment.py
+++ b/.github/scripts/test-rocjitsu-corpus-translation-comment.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+
+import rocjitsu_corpus_translation_comment as HELPER
+
+REPOSITORY = "ROCm/rocm-systems"
+HEAD_SHA = "a" * 40
+NEW_HEAD_SHA = "b" * 40
+
+
+class FakeApi:
+    def __init__(self) -> None:
+        self.pull = {
+            "base": {"ref": "develop", "repo": {"full_name": REPOSITORY}},
+            "head": {
+                "repo": {"full_name": REPOSITORY},
+                "sha": HEAD_SHA,
+            },
+        }
+        self.runs = [{"conclusion": "success", "event": "push", "id": 200}]
+        self.artifacts = {
+            100: [self._artifact(HELPER.CANDIDATE_ARTIFACT)],
+            200: [self._artifact(HELPER.BASELINE_ARTIFACT)],
+        }
+        self.comments = []
+        self.calls = []
+
+    def get(self, path):
+        if path == f"/repos/{REPOSITORY}/pulls/7":
+            return self.pull
+        raise AssertionError(path)
+
+    def paginate(self, path, key=None):
+        if path.endswith(f"/commits/{HEAD_SHA}/pulls"):
+            return []
+        if path.endswith("/runs?branch=develop&status=completed"):
+            self.assert_key(key, "workflow_runs")
+            return self.runs
+        if path.endswith("/comments"):
+            self.assert_key(key, None)
+            return self.comments
+        if "/actions/runs/" in path and path.endswith("/artifacts"):
+            self.assert_key(key, "artifacts")
+            run_id = int(path.split("/actions/runs/")[1].split("/")[0])
+            return self.artifacts.get(run_id, [])
+        raise AssertionError(path)
+
+    def create(self, path, payload):
+        self.calls.append(("create", path, payload))
+
+    def update(self, path, payload):
+        self.calls.append(("update", path, payload))
+
+    def delete(self, path):
+        self.calls.append(("delete", path, None))
+
+    @staticmethod
+    def _artifact(name):
+        return {"expired": False, "name": name, "size_in_bytes": 5_000_000}
+
+    @staticmethod
+    def assert_key(actual, expected):
+        if actual != expected:
+            raise AssertionError((actual, expected))
+
+
+class PlanTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.api = FakeApi()
+        self.event = {
+            "workflow_run": {
+                "event": "pull_request",
+                "conclusion": "success",
+                "head_repository": {"full_name": REPOSITORY},
+                "head_sha": HEAD_SHA,
+                "id": 100,
+                "path": HELPER.TRUSTED_WORKFLOW_PATH,
+                "pull_requests": [{"number": 7}],
+            }
+        }
+
+    def test_resolves_candidate_and_latest_baseline(self) -> None:
+        plan = HELPER.resolve_plan(self.event, self.api, REPOSITORY)
+
+        self.assertTrue(plan.ready)
+        self.assertEqual(plan.pull_number, 7)
+        self.assertEqual(plan.candidate_run_id, 100)
+        self.assertEqual(plan.baseline_run_id, 200)
+        self.assertEqual(plan.candidate_head_sha, HEAD_SHA)
+
+    def test_allows_bootstrap_without_baseline(self) -> None:
+        self.api.runs = []
+
+        plan = HELPER.resolve_plan(self.event, self.api, REPOSITORY)
+
+        self.assertTrue(plan.ready)
+        self.assertIsNone(plan.baseline_run_id)
+
+    def test_skips_unsuccessful_source_run(self) -> None:
+        self.event["workflow_run"]["conclusion"] = "failure"
+
+        plan = HELPER.resolve_plan(self.event, self.api, REPOSITORY)
+
+        self.assertFalse(plan.ready)
+        self.assertIn("did not succeed", plan.reason)
+
+    def test_skips_untrusted_source_workflow_path(self) -> None:
+        self.event["workflow_run"]["path"] = ".github/workflows/untrusted.yml"
+
+        plan = HELPER.resolve_plan(self.event, self.api, REPOSITORY)
+
+        self.assertFalse(plan.ready)
+        self.assertIn("workflow path", plan.reason)
+
+    def test_skips_source_run_from_fork(self) -> None:
+        self.event["workflow_run"]["head_repository"]["full_name"] = "someone/fork"
+
+        plan = HELPER.resolve_plan(self.event, self.api, REPOSITORY)
+
+        self.assertFalse(plan.ready)
+        self.assertIn("did not run from", plan.reason)
+
+    def test_skips_stale_pull_request_revision(self) -> None:
+        self.api.pull["head"]["sha"] = NEW_HEAD_SHA
+
+        plan = HELPER.resolve_plan(self.event, self.api, REPOSITORY)
+
+        self.assertFalse(plan.ready)
+        self.assertIn("does not match", plan.reason)
+
+    def test_skips_pull_request_from_fork(self) -> None:
+        self.api.pull["head"]["repo"]["full_name"] = "someone/fork"
+
+        plan = HELPER.resolve_plan(self.event, self.api, REPOSITORY)
+
+        self.assertFalse(plan.ready)
+        self.assertIn("same-repository", plan.reason)
+
+    def test_ignores_unsuccessful_baseline_run(self) -> None:
+        self.api.runs.insert(0, {"conclusion": "failure", "event": "push", "id": 201})
+        self.api.artifacts[201] = [self.api._artifact(HELPER.BASELINE_ARTIFACT)]
+
+        plan = HELPER.resolve_plan(self.event, self.api, REPOSITORY)
+
+        self.assertEqual(plan.baseline_run_id, 200)
+
+    def test_skips_pull_request_with_different_base(self) -> None:
+        self.api.pull["base"]["ref"] = "release/7.0"
+
+        plan = HELPER.resolve_plan(self.event, self.api, REPOSITORY)
+
+        self.assertFalse(plan.ready)
+        self.assertIn("does not target", plan.reason)
+
+    def test_rejects_oversized_candidate(self) -> None:
+        self.api.artifacts[100][0]["size_in_bytes"] = HELPER.MAXIMUM_ARTIFACT_BYTES + 1
+
+        with self.assertRaisesRegex(ValueError, "candidate artifact"):
+            HELPER.resolve_plan(self.event, self.api, REPOSITORY)
+
+    def test_writes_canonical_outputs(self) -> None:
+        plan = HELPER.resolve_plan(self.event, self.api, REPOSITORY)
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            output = Path(temporary_directory) / "outputs"
+
+            HELPER.write_plan_outputs(output, plan)
+
+            self.assertEqual(
+                output.read_text(encoding="utf-8"),
+                "ready=true\n"
+                "pull-number=7\n"
+                "candidate-run-id=100\n"
+                f"candidate-head-sha={HEAD_SHA}\n"
+                "baseline-found=true\n"
+                "baseline-run-id=200\n",
+            )
+
+
+class GitHubApiTest(unittest.TestCase):
+    def test_paginate_rejects_non_object_keyed_response(self) -> None:
+        api = HELPER.GitHubApi(REPOSITORY, "token", "https://api.github.com")
+        with mock.patch.object(api, "get", return_value=[]):
+            with self.assertRaisesRegex(ValueError, "is not an object"):
+                api.paginate("/artifacts", "artifacts")
+
+
+class CommentTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.api = FakeApi()
+
+    def test_renders_warning_and_resolution(self) -> None:
+        warning = HELPER.render_comment(
+            REPOSITORY,
+            100,
+            HEAD_SHA,
+            True,
+            2,
+            "## report\n\n> [!WARNING]\n> changed\n",
+            "https://github.com",
+        )
+
+        self.assertIn(HELPER.COMMENT_MARKER, warning)
+        self.assertIn("[!WARNING]", warning)
+        self.assertIn(HEAD_SHA, warning)
+        self.assertIsNone(
+            HELPER.render_comment(
+                REPOSITORY,
+                100,
+                HEAD_SHA,
+                True,
+                0,
+                "## clean",
+                "https://github.com",
+            )
+        )
+
+    def test_renders_missing_baseline_warning(self) -> None:
+        body = HELPER.render_comment(
+            REPOSITORY, 100, HEAD_SHA, False, None, None, "https://github.com"
+        )
+
+        self.assertIn("No canonical develop baseline", body)
+
+    def test_creates_updates_and_removes_sticky_comment(self) -> None:
+        HELPER.synchronize_comment(self.api, REPOSITORY, 7, HEAD_SHA, "warning")
+        self.assertEqual(self.api.calls[0][0], "create")
+
+        self.api.calls.clear()
+        self.api.comments = [
+            {
+                "body": HELPER.COMMENT_MARKER,
+                "id": 41,
+                "user": {"login": "github-actions[bot]"},
+            },
+            {
+                "body": HELPER.COMMENT_MARKER,
+                "id": 42,
+                "user": {"login": "github-actions[bot]"},
+            },
+        ]
+        HELPER.synchronize_comment(self.api, REPOSITORY, 7, HEAD_SHA, "new warning")
+        self.assertEqual([call[0] for call in self.api.calls], ["update", "delete"])
+
+        self.api.calls.clear()
+        HELPER.synchronize_comment(self.api, REPOSITORY, 7, HEAD_SHA, None)
+        self.assertEqual([call[0] for call in self.api.calls], ["delete", "delete"])
+
+    def test_ignores_comment_with_null_body(self) -> None:
+        self.api.comments = [
+            {
+                "body": None,
+                "id": 41,
+                "user": {"login": "github-actions[bot]"},
+            }
+        ]
+
+        HELPER.synchronize_comment(self.api, REPOSITORY, 7, HEAD_SHA, "warning")
+
+        self.assertEqual([call[0] for call in self.api.calls], ["create"])
+
+    def test_stale_head_cannot_create_update_or_delete_comment(self) -> None:
+        existing = {
+            "body": HELPER.COMMENT_MARKER,
+            "id": 41,
+            "user": {"login": "github-actions[bot]"},
+        }
+        for body, comments in (
+            ("warning", []),
+            ("new warning", [existing]),
+            (None, [existing]),
+        ):
+            with self.subTest(body=body):
+                self.api.calls.clear()
+                self.api.comments = comments
+                self.api.pull["head"]["sha"] = NEW_HEAD_SHA
+
+                HELPER.synchronize_comment(self.api, REPOSITORY, 7, HEAD_SHA, body)
+
+                self.assertEqual(self.api.calls, [])
+
+    def test_rechecks_head_before_removing_duplicate_after_update(self) -> None:
+        self.api.comments = [
+            {
+                "body": HELPER.COMMENT_MARKER,
+                "id": 41,
+                "user": {"login": "github-actions[bot]"},
+            },
+            {
+                "body": HELPER.COMMENT_MARKER,
+                "id": 42,
+                "user": {"login": "github-actions[bot]"},
+            },
+        ]
+        current_pull = self.api.pull
+        stale_pull = {
+            **self.api.pull,
+            "head": {**self.api.pull["head"], "sha": NEW_HEAD_SHA},
+        }
+        with mock.patch.object(self.api, "get", side_effect=[current_pull, stale_pull]):
+            HELPER.synchronize_comment(self.api, REPOSITORY, 7, HEAD_SHA, "new warning")
+
+        self.assertEqual([call[0] for call in self.api.calls], ["update"])
+
+    def test_comparison_timeout_is_reported(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            directory = Path(temporary_directory)
+            baseline = directory / "baseline.json"
+            candidate = directory / "candidate.json"
+            baseline.write_text("{}", encoding="utf-8")
+            candidate.write_text("{}", encoding="utf-8")
+            timeout = HELPER.subprocess.TimeoutExpired(
+                "compare", HELPER.COMPARISON_TIMEOUT_SECONDS
+            )
+            with mock.patch.object(
+                HELPER.subprocess, "run", side_effect=timeout
+            ) as run:
+                with self.assertRaisesRegex(ValueError, "exceeded 60 seconds"):
+                    HELPER.compare_candidate(
+                        Path(__file__), baseline, candidate, baseline_found=True
+                    )
+
+            self.assertEqual(
+                run.call_args.kwargs["timeout"], HELPER.COMPARISON_TIMEOUT_SECONDS
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     paths:
       - "emulation/rocjitsu/**"
+      - ".github/scripts/rocjitsu_corpus_translation_comment*.py"
       - ".github/workflows/rocjitsu-*.yml"
   push:
     branches:
@@ -190,6 +191,8 @@ jobs:
         run: |
           python3 \
             "${ROCJITSU_SOURCE_DIR}/tests/corpus/test-record-gfx1250-dbt-sha-pairs.py"
+          python3 \
+            "${GITHUB_WORKSPACE}/rocm-systems/.github/scripts/test-rocjitsu-corpus-translation-comment.py"
 
       - name: Install ROCm SDK
         run: |
@@ -536,7 +539,21 @@ jobs:
           name: gfx1250-b0-a0-sha-pairs
           path: ${{ env.ROCJITSU_DBT_SHA_MANIFEST }}
           if-no-files-found: error
-          retention-days: 90
+          retention-days: 45
+
+      # PR jobs intentionally have no write token. They publish only data here;
+      # the trusted workflow_run job downloads it and maintains the PR comment.
+      - name: Upload PR gfx1250 B0-to-A0 SHA pairs
+        if: >-
+          matrix.name == 'release' &&
+          steps.finalize_dbt_sha_pairs.outcome == 'success' &&
+          github.event_name == 'pull_request'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gfx1250-b0-a0-sha-pairs-candidate
+          path: ${{ env.ROCJITSU_DBT_SHA_MANIFEST }}
+          if-no-files-found: error
+          retention-days: 7
 
       # Debugging aid only. The pinned extraction is reproducible, so retain
       # translator logs but never upload the extracted HSACOs.

--- a/.github/workflows/rocjitsu-corpus-translation-comment.yml
+++ b/.github/workflows/rocjitsu-corpus-translation-comment.yml
@@ -1,0 +1,74 @@
+name: "rocjitsu-corpus-translation-comment"
+
+on:
+  workflow_run:
+    workflows: ["rocjitsu-test-corpus"]
+    types: [completed]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_repository.id }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+
+jobs:
+  comment:
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-24.04
+    steps:
+      # This job has a write token. Check out only trusted develop content;
+      # candidate data is downloaded separately and is never executed.
+      - name: Checkout trusted comparison helper
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: develop
+          sparse-checkout: |
+            .github/scripts
+            emulation/rocjitsu/tests/corpus
+
+      - name: Resolve comparison inputs
+        id: plan
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python3 .github/scripts/rocjitsu_corpus_translation_comment.py plan \
+            --event "${GITHUB_EVENT_PATH}" \
+            --output "${GITHUB_OUTPUT}"
+
+      - name: Download PR gfx1250 B0-to-A0 SHA pairs
+        if: steps.plan.outputs.ready == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: gfx1250-b0-a0-sha-pairs-candidate
+          path: ${{ github.workspace }}/candidate
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.plan.outputs.candidate-run-id }}
+
+      - name: Download develop gfx1250 B0-to-A0 baseline
+        if: steps.plan.outputs.baseline-found == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: gfx1250-b0-a0-sha-pairs
+          path: ${{ github.workspace }}/baseline
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.plan.outputs.baseline-run-id }}
+
+      - name: Update PR translation comment
+        if: steps.plan.outputs.ready == 'true'
+        env:
+          BASELINE_FOUND: ${{ steps.plan.outputs.baseline-found }}
+          CANDIDATE_HEAD_SHA: ${{ steps.plan.outputs.candidate-head-sha }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.plan.outputs.pull-number }}
+          SOURCE_RUN_ID: ${{ steps.plan.outputs.candidate-run-id }}
+        run: |
+          python3 .github/scripts/rocjitsu_corpus_translation_comment.py comment \
+            --candidate "${GITHUB_WORKSPACE}/candidate/gfx1250-b0-a0-sha-pairs.json" \
+            --baseline "${GITHUB_WORKSPACE}/baseline/gfx1250-b0-a0-sha-pairs.json" \
+            --comparison-tool \
+              emulation/rocjitsu/tests/corpus/record-gfx1250-dbt-sha-pairs.py

--- a/emulation/rocjitsu/tests/corpus/README.md
+++ b/emulation/rocjitsu/tests/corpus/README.md
@@ -20,21 +20,23 @@ not silently accepted or treated as passing translations.
 
 The `rocjitsu-test-corpus` workflow records the SHA-256 of every successful
 gfx1250 B0-to-A0 input and translated output after the release-lane corpus
-tests succeed. Pull requests exercise collection and finalization but do not
-upload an artifact. A develop push uploads the canonical manifest as the
-`gfx1250-b0-a0-sha-pairs` workflow artifact. A manual workflow dispatch on the
-`develop` branch also refreshes the baseline when the official corpus
-repository and pinned gfx1250 corpus ref are left unchanged. The manifest
-includes the fixed translation profile, pinned corpus commit, input-manifest
-hash, package-lock hash, ROCm SDK version, and source commit; it never contains
-the code objects themselves.
+tests succeed. A develop push uploads the canonical manifest as the
+`gfx1250-b0-a0-sha-pairs` workflow artifact for 45 days. A manual workflow
+dispatch on the `develop` branch also refreshes the baseline when the official
+corpus repository and pinned gfx1250 corpus ref are left unchanged. The
+manifest includes the fixed translation profile, pinned corpus commit,
+input-manifest hash, package-lock hash, ROCm SDK version, and source commit; it
+never contains the code objects themselves.
 
-The follow-up PR advisory flow will select the newest completed, unexpired
-artifact from a successful develop push or canonical manual run. It will
-compare output hashes only when the corpus, input manifest, package lock, and
-SDK provenance match, and will report changed outputs in a non-blocking PR
-comment. Input-set or provenance changes are incompatible comparisons rather
-than translation changes.
+Pull-request runs upload a seven-day candidate manifest without receiving
+write access. A separate trusted workflow selects the newest completed,
+unexpired artifact from a successful develop push or canonical manual run,
+then compares output hashes only when the corpus, input manifest, package lock,
+and SDK provenance match. Before using a candidate artifact, the trusted
+workflow also requires the expected source workflow path and an exact match to
+the current head of a same-repository PR. Changed outputs or incompatible
+provenance create or update one non-blocking warning comment on the PR. When a
+later run matches, the workflow removes its stale comment.
 
 `record-gfx1250-dbt-sha-pairs.py` runs a bounded, translation-only collection
 pass after the corpus tests and validates the resulting manifest. The external

--- a/emulation/rocjitsu/tests/corpus/record-gfx1250-dbt-sha-pairs.py
+++ b/emulation/rocjitsu/tests/corpus/record-gfx1250-dbt-sha-pairs.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2026 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-"""Record deterministic gfx1250 B0-to-A0 translation hashes."""
+"""Record and compare deterministic gfx1250 B0-to-A0 translation hashes."""
 
 from __future__ import annotations
 
@@ -31,7 +31,10 @@ PROFILE = {
     "output_mode": "code-object",
     "verify_idempotence": True,
 }
+COMPARE_UNCHANGED = 0
 ERROR = 1
+COMPARE_CHANGED = 2
+COMPARE_INCOMPATIBLE = 3
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -43,6 +46,8 @@ def main(argv: list[str] | None = None) -> int:
         if args.command == "finalize":
             finalize_manifest(args)
             return 0
+        if args.command == "compare":
+            return compare_manifests(args)
     except (OSError, ValueError, json.JSONDecodeError) as error:
         print(f"error: {error}", file=sys.stderr)
         return ERROR
@@ -76,6 +81,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     finalize_parser.add_argument("--source-commit", required=True)
     finalize_parser.add_argument("--corpus-commit", required=True)
     finalize_parser.add_argument("--rocm-sdk-version", required=True)
+
+    compare_parser = commands.add_parser(
+        "compare", help="compare a candidate manifest to a develop manifest"
+    )
+    compare_parser.add_argument("--baseline", type=Path, required=True)
+    compare_parser.add_argument("--candidate", type=Path, required=True)
+    compare_parser.add_argument("--markdown", type=Path, required=True)
+    compare_parser.add_argument("--max-details", type=int, default=50)
 
     return parser.parse_args(argv)
 
@@ -237,6 +250,117 @@ def finalize_manifest(args: argparse.Namespace) -> None:
     )
 
 
+def compare_manifests(args: argparse.Namespace) -> int:
+    if args.max_details <= 0:
+        raise ValueError("--max-details must be greater than zero")
+    baseline = _load_pair_manifest(args.baseline)
+    candidate = _load_pair_manifest(args.candidate)
+
+    compatibility_fields = (
+        "corpus_commit",
+        "input_manifest_sha256",
+        "package_lock_sha256",
+        "rocm_sdk_version",
+    )
+    incompatible = [
+        field
+        for field in compatibility_fields
+        if baseline["provenance"][field] != candidate["provenance"][field]
+    ]
+    baseline_pairs = _pairs_by_input(baseline)
+    candidate_pairs = _pairs_by_input(candidate)
+    removed = sorted(set(baseline_pairs) - set(candidate_pairs))
+    added = sorted(set(candidate_pairs) - set(baseline_pairs))
+
+    if incompatible or removed or added:
+        lines = [
+            "## gfx1250 B0-to-A0 translation baseline",
+            "",
+            "> [!WARNING]",
+            "> The PR result is not directly comparable to the latest develop baseline.",
+            "",
+        ]
+        if incompatible:
+            lines.extend(
+                [
+                    "Changed provenance:",
+                    "",
+                    "| Field | develop | PR |",
+                    "| --- | --- | --- |",
+                ]
+            )
+            for field in incompatible:
+                lines.append(
+                    f"| `{field}` | `{baseline['provenance'][field]}` | "
+                    f"`{candidate['provenance'][field]}` |"
+                )
+            lines.append("")
+        if removed or added:
+            lines.extend(
+                [
+                    f"Input-set difference: {len(removed)} removed, {len(added)} added.",
+                    "",
+                ]
+            )
+        _write_markdown(args.markdown, lines)
+        return COMPARE_INCOMPATIBLE
+
+    changed = [
+        digest
+        for digest in sorted(baseline_pairs)
+        if baseline_pairs[digest]["output_sha256"]
+        != candidate_pairs[digest]["output_sha256"]
+    ]
+    baseline_commit = baseline["provenance"]["rocm_systems_commit"]
+    candidate_commit = candidate["provenance"]["rocm_systems_commit"]
+    if not changed:
+        _write_markdown(
+            args.markdown,
+            [
+                "## gfx1250 B0-to-A0 translation baseline",
+                "",
+                f"No translated output SHA-256 changes across {len(baseline_pairs)} "
+                "successful corpus inputs.",
+                "",
+                f"- develop source: `{baseline_commit}`",
+                f"- PR source: `{candidate_commit}`",
+                "",
+            ],
+        )
+        return COMPARE_UNCHANGED
+
+    lines = [
+        "## gfx1250 B0-to-A0 translation baseline",
+        "",
+        "> [!WARNING]",
+        f"> This PR changes {len(changed)} translated output SHA-256 value(s).",
+        "",
+        f"Compared `{candidate_commit}` against develop baseline `{baseline_commit}`.",
+        "",
+        "| Input SHA-256 | Input bytes | develop output | develop bytes | "
+        "PR output | PR bytes |",
+        "| --- | ---: | --- | ---: | --- | ---: |",
+    ]
+    for digest in changed[: args.max_details]:
+        lines.append(
+            f"| `{digest}` | {baseline_pairs[digest]['input_bytes']:,} | "
+            f"`{baseline_pairs[digest]['output_sha256']}` | "
+            f"{baseline_pairs[digest]['output_bytes']:,} | "
+            f"`{candidate_pairs[digest]['output_sha256']}` | "
+            f"{candidate_pairs[digest]['output_bytes']:,} |"
+        )
+    if len(changed) > args.max_details:
+        lines.extend(
+            [
+                "",
+                f"Showing the first {args.max_details} of {len(changed)} changes.",
+            ]
+        )
+    lines.append("")
+    _write_markdown(args.markdown, lines)
+    return COMPARE_CHANGED
+
+
 def _record_fragment(directory: Path, record: dict) -> None:
     directory.mkdir(parents=True, exist_ok=True)
     destination = directory / f"{record['input_sha256']}.json"
@@ -308,6 +432,82 @@ def _load_expected_failures(path: Path) -> set[str]:
     return set(failures)
 
 
+def _load_pair_manifest(path: Path) -> dict:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    required = {
+        "excluded_inputs",
+        "pairs",
+        "profile",
+        "provenance",
+        "schema_version",
+    }
+    if not isinstance(payload, dict) or set(payload) != required:
+        raise ValueError(f"{path} must contain exactly {sorted(required)}")
+    if payload["schema_version"] != 1:
+        raise ValueError(f"{path} field 'schema_version' must be 1")
+    if payload["profile"] != PROFILE:
+        raise ValueError(f"{path} does not describe the gfx1250 B0-to-A0 profile")
+    provenance_fields = {
+        "corpus_commit",
+        "expected_failures_sha256",
+        "expected_rewrites_sha256",
+        "input_manifest_sha256",
+        "package_lock_sha256",
+        "rocm_sdk_version",
+        "rocm_systems_commit",
+    }
+    provenance = payload["provenance"]
+    if not isinstance(provenance, dict) or set(provenance) != provenance_fields:
+        raise ValueError(f"{path} has invalid provenance fields")
+    for field in (
+        "expected_failures_sha256",
+        "expected_rewrites_sha256",
+        "input_manifest_sha256",
+        "package_lock_sha256",
+    ):
+        if not isinstance(provenance[field], str) or not SHA256_RE.fullmatch(
+            provenance[field]
+        ):
+            raise ValueError(f"{path} provenance field {field!r} is not SHA-256")
+    for field in ("corpus_commit", "rocm_systems_commit"):
+        _validate_git_sha(provenance[field], f"{path} provenance field {field!r}")
+    _validate_sdk_version(
+        provenance["rocm_sdk_version"],
+        f"{path} provenance field 'rocm_sdk_version'",
+    )
+    excluded = payload["excluded_inputs"]
+    if (
+        not isinstance(excluded, list)
+        or excluded != sorted(set(excluded))
+        or any(
+            not isinstance(digest, str) or not SHA256_RE.fullmatch(digest)
+            for digest in excluded
+        )
+    ):
+        raise ValueError(f"{path} field 'excluded_inputs' is not canonical")
+    pairs = _pairs_by_input(payload)
+    if list(pairs) != sorted(pairs):
+        raise ValueError(f"{path} field 'pairs' is not sorted by input SHA-256")
+    overlap = set(excluded) & set(pairs)
+    if overlap:
+        raise ValueError(f"{path} both excludes and records {_shown(overlap)}")
+    return payload
+
+
+def _pairs_by_input(manifest: dict) -> dict[str, dict]:
+    records = manifest["pairs"]
+    if not isinstance(records, list):
+        raise ValueError("manifest field 'pairs' must be a list")
+    pairs = {}
+    for record in records:
+        _validate_pair_record(record, "manifest pair")
+        digest = record.get("input_sha256")
+        if digest in pairs:
+            raise ValueError(f"manifest repeats input SHA-256 {digest}")
+        pairs[digest] = record
+    return pairs
+
+
 def _validate_pair_record(record: dict, description: str) -> None:
     expected_fields = {
         "input_bytes",
@@ -369,6 +569,11 @@ def _write_json(path: Path, payload: dict) -> None:
         json.dumps(payload, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
     )
+
+
+def _write_markdown(path: Path, lines: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines), encoding="utf-8")
 
 
 if __name__ == "__main__":

--- a/emulation/rocjitsu/tests/corpus/test-record-gfx1250-dbt-sha-pairs.py
+++ b/emulation/rocjitsu/tests/corpus/test-record-gfx1250-dbt-sha-pairs.py
@@ -385,10 +385,94 @@ class ManifestTest(unittest.TestCase):
         self.assertEqual(status, TOOL.ERROR)
         self.assertIn("unsupported characters", diagnostics.getvalue())
 
+    def test_compare_reports_changed_outputs(self) -> None:
+        baseline = self.root / "baseline.json"
+        candidate = self.root / "candidate.json"
+        report = self.root / "report.md"
+        self.assertEqual(TOOL.main(self._finalize_args(baseline)), 0)
+
+        self._write_fragment(self.success_input, "4" * 64, output_bytes=128)
+        candidate_args = self._finalize_args(candidate)
+        source_index = candidate_args.index("--source-commit") + 1
+        candidate_args[source_index] = "c" * 40
+        self.assertEqual(TOOL.main(candidate_args), 0)
+
+        status = TOOL.main(
+            [
+                "compare",
+                "--baseline",
+                str(baseline),
+                "--candidate",
+                str(candidate),
+                "--markdown",
+                str(report),
+            ]
+        )
+
+        self.assertEqual(status, TOOL.COMPARE_CHANGED)
+        rendered = report.read_text(encoding="utf-8")
+        self.assertIn("changes 1 translated output", rendered)
+        self.assertIn("| Input SHA-256 | Input bytes |", rendered)
+        self.assertIn("| 64 |", rendered)
+        self.assertIn("| 96 |", rendered)
+        self.assertIn("| 128 |", rendered)
+
+    def test_compare_accepts_unchanged_outputs(self) -> None:
+        baseline = self.root / "baseline.json"
+        candidate = self.root / "candidate.json"
+        report = self.root / "report.md"
+        self.assertEqual(TOOL.main(self._finalize_args(baseline)), 0)
+        candidate_args = self._finalize_args(candidate)
+        source_index = candidate_args.index("--source-commit") + 1
+        candidate_args[source_index] = "c" * 40
+        self.assertEqual(TOOL.main(candidate_args), 0)
+
+        status = TOOL.main(
+            [
+                "compare",
+                "--baseline",
+                str(baseline),
+                "--candidate",
+                str(candidate),
+                "--markdown",
+                str(report),
+            ]
+        )
+
+        self.assertEqual(status, TOOL.COMPARE_UNCHANGED)
+        self.assertIn("No translated output", report.read_text(encoding="utf-8"))
+
+    def test_compare_rejects_incompatible_provenance(self) -> None:
+        baseline = self.root / "baseline.json"
+        candidate = self.root / "candidate.json"
+        report = self.root / "report.md"
+        self.assertEqual(TOOL.main(self._finalize_args(baseline)), 0)
+        candidate_args = self._finalize_args(candidate)
+        corpus_index = candidate_args.index("--corpus-commit") + 1
+        candidate_args[corpus_index] = "d" * 40
+        self.assertEqual(TOOL.main(candidate_args), 0)
+
+        status = TOOL.main(
+            [
+                "compare",
+                "--baseline",
+                str(baseline),
+                "--candidate",
+                str(candidate),
+                "--markdown",
+                str(report),
+            ]
+        )
+
+        self.assertEqual(status, TOOL.COMPARE_INCOMPATIBLE)
+        self.assertIn("not directly comparable", report.read_text(encoding="utf-8"))
+
     def _write_fragment(
         self,
         input_digest: str,
         output_digest: str,
+        *,
+        output_bytes: int = 96,
     ) -> None:
         path = self.fragments / f"{input_digest}.json"
         path.write_text(
@@ -396,7 +480,7 @@ class ManifestTest(unittest.TestCase):
                 {
                     "input_bytes": 64,
                     "input_sha256": input_digest,
-                    "output_bytes": 96,
+                    "output_bytes": output_bytes,
                     "output_sha256": output_digest,
                 }
             ),


### PR DESCRIPTION
Upload a short-lived candidate manifest for pull requests and compare it with the latest successful develop baseline from a trusted workflow. Post, update, or remove a sticky pull-request comment with changed SHA pairs and byte sizes after validating artifact provenance.

Align canonical baseline retention with the 45-day repository policy.