### PR TITLE
[rocjitsu] Fixes for gfx1250 B0 -> A0 hipblastlt workloads

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
@@ -1409,20 +1409,21 @@ std::optional<size_t> try_apply_temp_delta_pattern(AnalysisContext &ctx, const A
   // this block. We deliberately do not add that temporary to the general
   // lattice; this helper is only for the complete signed-delta template where
   // the sibling subtract block proves both paths are the same static target.
-  if (block.first_index + 2 > block.last_index)
-    return std::nullopt;
-
   const auto add_u32_opcode = scalar_sop2_opcode(ctx.arch, ScalarSop2Op::AddU32);
   const auto addc_u32_opcode = scalar_sop2_opcode(ctx.arch, ScalarSop2Op::AddcU32);
   if (!add_u32_opcode || !addc_u32_opcode)
     return std::nullopt;
 
-  const Instruction &low_inst = *ctx.insts[block.first_index];
   const auto is_gfx1250_padding = [&](size_t index) {
     if (ctx.arch != ROCJITSU_CODE_ARCH_GFX1250)
       return false;
     const Instruction &inst = *ctx.insts[index];
-    if (inst.mnemonic() == "s_prefetch_inst_pc_rel")
+    // The gfx1250 sequence drains XCNT before an instruction prefetch. The
+    // shader manual defines S_WAIT_XCNT as a counter wait, so neither it nor
+    // the prefetch changes the PC pair or the signed-delta temporary. Keep both
+    // instructions in the translated body; this predicate only skips them
+    // while locating the arithmetic and set-PC consumer.
+    if (inst.mnemonic() == "s_wait_xcnt" || inst.mnemonic() == "s_prefetch_inst_pc_rel")
       return true;
     // The compiler also emits a scalar immediate move to configure the
     // prefetch. It is safe to skip only when its destination is outside the
@@ -1435,7 +1436,14 @@ std::optional<size_t> try_apply_temp_delta_pattern(AnalysisContext &ctx, const A
     return dst != pair_lo && dst != static_cast<uint16_t>(pair_lo + 1u) && dst != tmp_sreg;
   };
 
-  size_t high_index = block.first_index + 1;
+  size_t low_index = block.first_index;
+  while (low_index <= block.last_index && is_gfx1250_padding(low_index))
+    ++low_index;
+  if (low_index > block.last_index)
+    return std::nullopt;
+  const Instruction &low_inst = *ctx.insts[low_index];
+
+  size_t high_index = low_index + 1;
   while (high_index <= block.last_index && is_gfx1250_padding(high_index))
     ++high_index;
   if (high_index > block.last_index)
@@ -1448,7 +1456,7 @@ std::optional<size_t> try_apply_temp_delta_pattern(AnalysisContext &ctx, const A
   if (setpc_index > block.last_index)
     return std::nullopt;
   const Instruction &setpc_inst = *ctx.insts[setpc_index];
-  if (!sop2_sreg_inline_to_sreg(low_inst, ctx.facts[block.first_index].word, *add_u32_opcode,
+  if (!sop2_sreg_inline_to_sreg(low_inst, ctx.facts[low_index].word, *add_u32_opcode,
                                 pair_lo, pair_lo, tmp_sreg))
     return std::nullopt;
   if (!sop2_sreg_inline_zero_to_sreg(high_inst, ctx.facts[high_index].word, *addc_u32_opcode,
@@ -1485,7 +1493,7 @@ match_signed_delta_sub_consumer(const AnalysisContext &ctx, const AnalysisBlock 
     if (ctx.arch != ROCJITSU_CODE_ARCH_GFX1250)
       return false;
     const Instruction &inst = *ctx.insts[index];
-    if (inst.mnemonic() == "s_prefetch_inst_pc_rel")
+    if (inst.mnemonic() == "s_wait_xcnt" || inst.mnemonic() == "s_prefetch_inst_pc_rel")
       return true;
     // Skip a prefetch-config move only when it clobbers neither the getpc pair
     // nor tmp_sreg (whose value s_abs_i32/s_sub_u32 below consume).

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
@@ -1420,9 +1420,12 @@ std::optional<size_t> try_apply_temp_delta_pattern(AnalysisContext &ctx, const A
     const Instruction &inst = *ctx.insts[index];
     // The gfx1250 sequence drains XCNT before an instruction prefetch. The
     // shader manual defines S_WAIT_XCNT as a counter wait, so neither it nor
-    // the prefetch changes the PC pair or the signed-delta temporary. Keep both
-    // instructions in the translated body; this predicate only skips them
-    // while locating the arithmetic and set-PC consumer.
+    // the prefetch changes the PC pair or the signed-delta temporary. This
+    // block is the conditional branch target, so it lies past the recovery
+    // range and keeps both instructions verbatim; the predicate only skips them
+    // while locating the arithmetic and set-PC consumer. The subtract half sits
+    // inside the range and has to reproduce its drain -- see
+    // match_signed_delta_sub_consumer.
     if (inst.mnemonic() == "s_wait_xcnt" || inst.mnemonic() == "s_prefetch_inst_pc_rel")
       return true;
     // The compiler also emits a scalar immediate move to configure the
@@ -1456,8 +1459,8 @@ std::optional<size_t> try_apply_temp_delta_pattern(AnalysisContext &ctx, const A
   if (setpc_index > block.last_index)
     return std::nullopt;
   const Instruction &setpc_inst = *ctx.insts[setpc_index];
-  if (!sop2_sreg_inline_to_sreg(low_inst, ctx.facts[low_index].word, *add_u32_opcode,
-                                pair_lo, pair_lo, tmp_sreg))
+  if (!sop2_sreg_inline_to_sreg(low_inst, ctx.facts[low_index].word, *add_u32_opcode, pair_lo,
+                                pair_lo, tmp_sreg))
     return std::nullopt;
   if (!sop2_sreg_inline_zero_to_sreg(high_inst, ctx.facts[high_index].word, *addc_u32_opcode,
                                      static_cast<uint16_t>(pair_lo + 1),
@@ -1470,7 +1473,14 @@ std::optional<size_t> try_apply_temp_delta_pattern(AnalysisContext &ctx, const A
   return setpc_index;
 }
 
-[[nodiscard]] std::optional<std::pair<size_t, uint64_t>>
+/// @brief Negative half of the signed PC-delta template, as matched in one block.
+struct SignedDeltaSubMatch {
+  size_t setpc_index = 0;    ///< Index of the subtract half's set-PC consumer.
+  uint64_t recovery_end = 0; ///< One-past-end source byte of the recovery range.
+  bool skipped_xcnt = false; ///< The range holds an `s_wait_xcnt` the rewrite must reproduce.
+};
+
+[[nodiscard]] std::optional<SignedDeltaSubMatch>
 match_signed_delta_sub_consumer(const AnalysisContext &ctx, const AnalysisBlock &block,
                                 uint16_t pair_lo, uint16_t tmp_sreg) {
   // Match the negative half of the same signed PC-delta template:
@@ -1503,9 +1513,17 @@ match_signed_delta_sub_consumer(const AnalysisContext &ctx, const AnalysisBlock 
     return dst != pair_lo && dst != static_cast<uint16_t>(pair_lo + 1u) && dst != tmp_sreg;
   };
 
+  // Padding skipped ahead of the subtract half lies inside the recovery range,
+  // which patch_recovered_builder_fixups overwrites with the canonical builder
+  // and NOP-fills. Losing the prefetch and its configuration move only costs a
+  // hint, but the canonical builder writes the same pair the XCNT drain orders,
+  // so the rewrite has to reproduce the drain.
   size_t abs_index = block.first_index;
-  while (abs_index <= block.last_index && is_gfx1250_padding(abs_index))
+  bool skipped_xcnt = false;
+  while (abs_index <= block.last_index && is_gfx1250_padding(abs_index)) {
+    skipped_xcnt = skipped_xcnt || ctx.insts[abs_index]->mnemonic() == "s_wait_xcnt";
     ++abs_index;
+  }
   if (abs_index + 3 > block.last_index)
     return std::nullopt;
   const Instruction &abs_inst = *ctx.insts[abs_index];
@@ -1530,7 +1548,11 @@ match_signed_delta_sub_consumer(const AnalysisContext &ctx, const AnalysisBlock 
       scalar_pc_sreg(ctx.arch, setpc_inst, ctx.facts[setpc_index].word, ScalarPcOp::SetPc64);
   if (!setpc_sreg || *setpc_sreg != pair_lo)
     return std::nullopt;
-  return std::pair{setpc_index, high_inst.src_loc() + static_cast<uint64_t>(high_inst.size())};
+  return SignedDeltaSubMatch{
+      .setpc_index = setpc_index,
+      .recovery_end = high_inst.src_loc() + static_cast<uint64_t>(high_inst.size()),
+      .skipped_xcnt = skipped_xcnt,
+  };
 }
 
 bool try_apply_pair_update(AnalysisContext &ctx, size_t index, BlockState &state) {
@@ -2379,13 +2401,20 @@ void recover_signed_delta_templates(const AnalysisContext &ctx,
                   static_cast<int64_t>(static_cast<int32_t>(literal)) + 4,
         .source_getpc_offset = getpc_inst.src_loc(),
         .source_recovery_begin_offset = getpc_next,
-        .source_recovery_end_offset = sub_consumer->second,
+        .source_recovery_end_offset = sub_consumer->recovery_end,
     };
 
-    if (auto fixup = fixup_for_value(ctx, sub_consumer->first, *pair_lo, value))
+    // Both consumers name the same range, so both must ask for the same
+    // replacement: patch_recovered_builder_fixups rewrites it once and requires
+    // the duplicate to agree.
+    if (auto fixup = fixup_for_value(ctx, sub_consumer->setpc_index, *pair_lo, value)) {
+      fixup->source_requires_xcnt_drain = sub_consumer->skipped_xcnt;
       append_unique(recovered, *fixup);
-    if (auto fixup = fixup_for_value(ctx, *add_consumer, *pair_lo, value))
+    }
+    if (auto fixup = fixup_for_value(ctx, *add_consumer, *pair_lo, value)) {
+      fixup->source_requires_xcnt_drain = sub_consumer->skipped_xcnt;
       append_unique(recovered, *fixup);
+    }
   }
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
@@ -1136,12 +1136,18 @@ bool append_unique(std::vector<IndirectCallFixup> &out, IndirectCallFixup fixup)
            existing.source_recovery_end_offset == fixup.source_recovery_end_offset;
   });
   if (duplicate != out.end()) {
-    // Incompleteness is monotonic: if any iteration observes this fixup as
-    // incomplete, the merged record must stay incomplete. Otherwise a later
-    // fixed-point pass that rediscovers an earlier-complete fact as incomplete
-    // would be dropped here, leaving the consumer wrongly eligible for a direct
-    // window.
+    // Both flags below are monotonic and must survive the merge, because only
+    // the first record of a duplicate group is kept. Incompleteness: if any
+    // iteration observes this fixup as incomplete, the merged record must stay
+    // incomplete, or a later fixed-point pass that rediscovers an
+    // earlier-complete fact as incomplete would be dropped here and leave the
+    // consumer wrongly eligible for a direct window. A drain requirement is the
+    // same shape -- it is a demand on the replacement, so a producer that needs
+    // it cannot be outvoted by one that does not. Any future requirement that
+    // changes the bytes relocation emits belongs here too.
     duplicate->source_incomplete = duplicate->source_incomplete || fixup.source_incomplete;
+    duplicate->source_requires_xcnt_drain =
+        duplicate->source_requires_xcnt_drain || fixup.source_requires_xcnt_drain;
     return false;
   }
   out.push_back(fixup);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.h
@@ -51,6 +51,11 @@ struct IndirectCallFixup {
   /// be replaced with a direct transfer window — an unconstrained path would be
   /// redirected to a concrete target it never dynamically reaches.
   bool source_incomplete = false;
+  /// @brief True when the recovery range contains an `s_wait_xcnt` the replacement
+  /// must reproduce. The canonical builder overwrites the whole range and writes
+  /// the same SGPR pair the drain was ordering, so dropping the wait would let the
+  /// pair be rewritten while an operation still has the old value in flight.
+  bool source_requires_xcnt_drain = false;
   uint16_t source_return_sreg = 0;           ///< Low SGPR receiving the return PC for calls.
   uint64_t target_getpc_offset = 0;          ///< Relocated offset of the s_getpc_b64 producer.
   uint64_t target_recovery_begin_offset = 0; ///< Relocated first byte of replaceable builder code.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
@@ -50,6 +50,7 @@ constexpr uint16_t kWmmaScaleSrc2PrefixOp = 0x35;
 constexpr uint16_t kWmmaScale16PrefixOp = 0x3a;
 constexpr uint16_t kGfx1250InlineZero = 128;
 constexpr uint32_t kGfx1250ScratchMaxDwordOffset = 0x7ffffcu;
+constexpr uint16_t kGfx1250ModeFp16OvflHwreg = 1u | (23u << 6);
 
 /// @brief Diagnose control fields that are invalid for floating-point WMMA.
 ///
@@ -1361,10 +1362,9 @@ ExpandResult expand_gfx1250_ds_addtid(const Instruction &inst, uint32_t, uint64_
 }
 
 /// @brief Emulate one RNE F32-to-UE5M3 conversion into a low byte.
-void append_gfx1250_f32_to_e5m3(std::vector<uint32_t> &words, uint16_t source,
-                                uint8_t source_abs, uint8_t source_neg, uint8_t source_bank,
-                                uint16_t out, uint16_t temp, uint16_t top_byte,
-                                uint16_t nan_mask, uint16_t top_mask, uint16_t round_mask,
+void append_gfx1250_f32_to_e5m3(std::vector<uint32_t> &words, uint16_t source, uint8_t source_bank,
+                                uint16_t out, uint16_t temp, uint16_t top_byte, uint16_t nan_mask,
+                                uint16_t subnormal_mask, uint16_t overflow_mask, uint16_t fp16_ovfl,
                                 uint8_t &current_mode) {
   const auto append_literal = [&](uint16_t opcode, gfx1250::Vop3BuilderFields fields,
                                   uint32_t literal) {
@@ -1373,107 +1373,81 @@ void append_gfx1250_f32_to_e5m3(std::vector<uint32_t> &words, uint16_t source,
   };
   const auto append_compare_literal = [&](uint16_t opcode, uint16_t mask, uint16_t src1,
                                           uint32_t literal) {
-    append_words(words, gfx1250::build_vop3(
-                            opcode, {.vdst = static_cast<uint8_t>(mask), .src0 = 255, .src1 = src1}));
+    append_words(words,
+                 gfx1250::build_vop3(
+                     opcode, {.vdst = static_cast<uint8_t>(mask), .src0 = 255, .src1 = src1}));
     words.push_back(literal);
   };
   const uint8_t source_mode = source >= 256u ? static_cast<uint8_t>(source_bank << 2) : 0;
 
-  // NaN classification uses the unmodified magnitude. NEG and ABS cannot
-  // change whether an F32 value is NaN.
+  // E5M3 is an unsigned scale format. Taking the magnitude also makes the
+  // unsupported source ABS/NEG encodings immaterial, matching the execution
+  // model's conversion helper.
   append_gfx1250_vgpr_msb_transition(words, current_mode, source_mode);
   append_literal(gfx1250::kVAndB32Vop3,
-                 {.vdst = static_cast<uint8_t>(temp), .src0 = 255, .src1 = source},
-                 0x7fffffffu);
+                 {.vdst = static_cast<uint8_t>(out), .src0 = 255, .src1 = source}, 0x7fffffffu);
   append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
-  append_compare_literal(gfx1250::kVCmpLtU32Vop3, nan_mask, gfx1250_vgpr_src(temp),
-                         0x7f800000u);
+  append_compare_literal(gfx1250::kVCmpLtU32Vop3, nan_mask, gfx1250_vgpr_src(out), 0x7f800000u);
+  append_compare_literal(gfx1250::kVCmpGtU32Vop3, subnormal_mask, gfx1250_vgpr_src(out),
+                         0x38800000u);
 
-  // UE5M3 is unsigned, so first clamp the modified source to non-negative.
-  append_gfx1250_vgpr_msb_transition(words, current_mode, source_mode);
-  append_words(words, gfx1250::build_vop3(
-                          gfx1250::kVMaxNumF32Vop3,
-                          {.vdst = static_cast<uint8_t>(out),
-                           .abs = static_cast<uint8_t>(source_abs != 0 ? 2u : 0u),
-                           .src0 = gfx1250_inline_u32(0),
-                           .src1 = source,
-                           .neg = static_cast<uint8_t>(source_neg != 0 ? 2u : 0u)}));
-  append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
-
-  // Values at and above the 0xf7/0xf8 midpoint need a direct exponent-31
-  // path because an F16 intermediate cannot represent that finite octave.
-  append_compare_literal(gfx1250::kVCmpLeF32Vop3, top_mask, gfx1250_vgpr_src(out),
-                         0x47780000u);
-  append_literal(gfx1250::kVMulF32Vop3,
-                 {.vdst = static_cast<uint8_t>(top_byte),
-                  .src0 = 255,
-                  .src1 = gfx1250_vgpr_src(out)},
-                 0x39000000u);
+  // For normal E5M3 values, round the F32 bit pattern at bit 20 and then
+  // remove the exponent-bias delta: (127 - 15) * 8 == 0x380.
   append_words(words,
-               gfx1250::build_vop3(gfx1250::kVCvtNearestI32F32Vop3,
-                                    {.vdst = static_cast<uint8_t>(top_byte),
-                                     .src0 = gfx1250_vgpr_src(top_byte)}));
-  append_literal(gfx1250::kVAddNcU32Vop3,
-                 {.vdst = static_cast<uint8_t>(top_byte),
-                  .src0 = 255,
-                  .src1 = gfx1250_vgpr_src(top_byte)},
-                 0xf0u);
-  append_literal(gfx1250::kVMinU32Vop3,
-                 {.vdst = static_cast<uint8_t>(top_byte),
-                  .src0 = 255,
-                  .src1 = gfx1250_vgpr_src(top_byte)},
-                 0xfeu);
-
-  append_words(words, gfx1250::build_vop3(gfx1250::kVCvtF16F32Vop3,
-                                          {.vdst = static_cast<uint8_t>(out),
-                                           .src0 = gfx1250_vgpr_src(out)}));
+               gfx1250::build_vop3(gfx1250::kVLshrrevB32Vop3, {.vdst = static_cast<uint8_t>(temp),
+                                                               .src0 = gfx1250_inline_u32(20),
+                                                               .src1 = gfx1250_vgpr_src(out)}));
   append_literal(gfx1250::kVAndB32Vop3,
-                 {.vdst = static_cast<uint8_t>(temp),
-                  .src0 = 255,
-                  .src1 = gfx1250_vgpr_src(out)},
-                 0x7fu);
-  append_words(words, gfx1250::build_vop3(gfx1250::kVBfeU32Vop3,
-                                          {.vdst = static_cast<uint8_t>(out),
-                                           .src0 = gfx1250_vgpr_src(out),
-                                           .src1 = gfx1250_inline_u32(7),
-                                           .src2 = gfx1250_inline_u32(9)}));
-  append_words(words, gfx1250::build_vop3(gfx1250::kVLshlrevB32Vop3,
-                                          {.vdst = static_cast<uint8_t>(temp),
-                                           .src0 = gfx1250_inline_u32(1),
-                                           .src1 = gfx1250_vgpr_src(temp)}));
-  append_literal(gfx1250::kVBfiB32Vop3,
-                 {.vdst = static_cast<uint8_t>(temp),
-                  .src0 = 255,
-                  .src1 = gfx1250_vgpr_src(temp),
-                  .src2 = gfx1250_vgpr_src(out)},
-                 0xfffffffeu);
-  append_compare_literal(gfx1250::kVCmpLtU32Vop3, round_mask, gfx1250_vgpr_src(temp), 0x80u);
-  append_words(words, gfx1250::build_vop3(gfx1250::kVCndmaskB32Vop3,
-                                          {.vdst = static_cast<uint8_t>(temp),
-                                           .src0 = gfx1250_inline_u32(0),
-                                           .src1 = gfx1250_inline_u32(1),
-                                           .src2 = round_mask}));
-  append_words(words, gfx1250::build_vop3(gfx1250::kVAddNcU32Vop3,
-                                          {.vdst = static_cast<uint8_t>(out),
-                                           .src0 = gfx1250_vgpr_src(out),
-                                           .src1 = gfx1250_vgpr_src(temp)}));
-  append_literal(gfx1250::kVMinU32Vop3,
-                 {.vdst = static_cast<uint8_t>(out),
-                  .src0 = 255,
-                  .src1 = gfx1250_vgpr_src(out)},
-                 0xfeu);
-  append_words(words, gfx1250::build_vop3(gfx1250::kVCndmaskB32Vop3,
-                                          {.vdst = static_cast<uint8_t>(out),
-                                           .src0 = gfx1250_vgpr_src(out),
-                                           .src1 = gfx1250_vgpr_src(top_byte),
-                                           .src2 = top_mask}));
-  append_literal(gfx1250::kVMovB32Vop3,
-                 {.vdst = static_cast<uint8_t>(temp), .src0 = 255}, 0xffu);
-  append_words(words, gfx1250::build_vop3(gfx1250::kVCndmaskB32Vop3,
-                                          {.vdst = static_cast<uint8_t>(out),
-                                           .src0 = gfx1250_vgpr_src(out),
-                                           .src1 = gfx1250_vgpr_src(temp),
-                                           .src2 = nan_mask}));
+                 {.vdst = static_cast<uint8_t>(temp), .src0 = 255, .src1 = gfx1250_vgpr_src(temp)},
+                 1u);
+  append_literal(
+      gfx1250::kVAddNcU32Vop3,
+      {.vdst = static_cast<uint8_t>(top_byte), .src0 = 255, .src1 = gfx1250_vgpr_src(out)},
+      0x7ffffu);
+  append_words(words,
+               gfx1250::build_vop3(gfx1250::kVAddNcU32Vop3, {.vdst = static_cast<uint8_t>(top_byte),
+                                                             .src0 = gfx1250_vgpr_src(top_byte),
+                                                             .src1 = gfx1250_vgpr_src(temp)}));
+  append_words(
+      words, gfx1250::build_vop3(gfx1250::kVLshrrevB32Vop3, {.vdst = static_cast<uint8_t>(top_byte),
+                                                             .src0 = gfx1250_inline_u32(20),
+                                                             .src1 = gfx1250_vgpr_src(top_byte)}));
+  append_literal(
+      gfx1250::kVSubNcU32Vop3,
+      {.vdst = static_cast<uint8_t>(top_byte), .src0 = gfx1250_vgpr_src(top_byte), .src1 = 255},
+      0x380u);
+
+  // E5M3 subnormals have a constant 2^-17 quantum. Scaling by 2^17 is exact
+  // in F32, so a direct nearest-integer conversion implements RNE without an
+  // intermediate-format rounding step.
+  append_literal(gfx1250::kVMulF32Vop3,
+                 {.vdst = static_cast<uint8_t>(temp), .src0 = 255, .src1 = gfx1250_vgpr_src(out)},
+                 0x48000000u);
+  append_words(words, gfx1250::build_vop3(
+                          gfx1250::kVCvtNearestI32F32Vop3,
+                          {.vdst = static_cast<uint8_t>(temp), .src0 = gfx1250_vgpr_src(temp)}));
+  append_words(words,
+               gfx1250::build_vop3(gfx1250::kVCndmaskB32Vop3, {.vdst = static_cast<uint8_t>(out),
+                                                               .src0 = gfx1250_vgpr_src(top_byte),
+                                                               .src1 = gfx1250_vgpr_src(temp),
+                                                               .src2 = subnormal_mask}));
+
+  append_compare_literal(gfx1250::kVCmpLtU32Vop3, overflow_mask, gfx1250_vgpr_src(out), 0xfeu);
+  // MODE.FP16_OVFL is either zero or one. XOR maps it branchlessly to the
+  // required terminal encoding: mode 0 -> 0xff, mode 1 -> 0xfe.
+  append_literal(gfx1250::kVXorB32Vop3,
+                 {.vdst = static_cast<uint8_t>(temp), .src0 = 255, .src1 = fp16_ovfl}, 0xffu);
+  append_words(words,
+               gfx1250::build_vop3(gfx1250::kVCndmaskB32Vop3, {.vdst = static_cast<uint8_t>(out),
+                                                               .src0 = gfx1250_vgpr_src(out),
+                                                               .src1 = gfx1250_vgpr_src(temp),
+                                                               .src2 = overflow_mask}));
+  append_literal(gfx1250::kVMovB32Vop3, {.vdst = static_cast<uint8_t>(temp), .src0 = 255}, 0xffu);
+  append_words(words,
+               gfx1250::build_vop3(gfx1250::kVCndmaskB32Vop3, {.vdst = static_cast<uint8_t>(out),
+                                                               .src0 = gfx1250_vgpr_src(out),
+                                                               .src1 = gfx1250_vgpr_src(temp),
+                                                               .src2 = nan_mask}));
 }
 
 /// @brief Emulate B0 CLAMP=1 packed F32-to-UE5M3 conversion on A0.
@@ -1490,12 +1464,14 @@ ExpandResult expand_gfx1250_cvt_pk_fp8_f32_e5m3(const Instruction &inst, uint32_
   std::memcpy(&source, inst.raw_encoding(), sizeof(source));
   if (source.clamp == 0)
     return ExpandResult::not_handled();
+  if (source.src0 == 233u || source.src0 == 234u || source.src0 == 250u)
+    return ExpandResult::failed("gfx1250 E5M3 pack does not support DPP");
   const bool has_literal = source.src0 == 255u || source.src1 == 255u;
   if (has_literal && inst.size() < 3 * static_cast<int>(sizeof(uint32_t)))
     return ExpandResult::failed("gfx1250 E5M3 pack literal word is missing");
   uint32_t literal = 0;
   if (has_literal)
-    std::memcpy(&literal, inst.raw_encoding() + 2 * sizeof(uint32_t), sizeof(literal));
+    std::memcpy(&literal, inst.raw_encoding() + 2, sizeof(literal));
 
   SemanticScratchAllocator allocator(
       inst, liveness, context,
@@ -1515,13 +1491,13 @@ ExpandResult expand_gfx1250_cvt_pk_fp8_f32_e5m3(const Instruction &inst, uint32_
   const uint16_t top_byte = static_cast<uint16_t>(out0 + 3u);
 
   Gfx1250SgprScratchRequest mask_request;
-  mask_request.count = 3;
+  mask_request.count = 4;
   mask_request.forbidden = request.forbidden;
   mask_request.forbidden.expand(scratch.lease->registers());
   mask_request.carrier_mode = Gfx1250SgprCarrierMode::ExecMasked;
   const auto masks = acquire_gfx1250_sgprs(inst, liveness, context, &allocator, mask_request);
   if (!masks)
-    return ExpandResult::failed("gfx1250 E5M3 pack could not allocate three SGPR masks");
+    return ExpandResult::failed("gfx1250 E5M3 pack could not allocate four scratch SGPRs");
 
   const auto src0_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Src0);
   const auto src1_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Src1);
@@ -1530,8 +1506,7 @@ ExpandResult expand_gfx1250_cvt_pk_fp8_f32_e5m3(const Instruction &inst, uint32_
   if (!src0_bank || !src1_bank || !src2_bank || !dst_bank)
     return ExpandResult::failed("gfx1250 E5M3 pack cannot prove the VGPR-MSB mode");
   const uint8_t original_mode =
-      static_cast<uint8_t>(*src0_bank | (*src1_bank << 2) | (*src2_bank << 4) |
-                           (*dst_bank << 6));
+      static_cast<uint8_t>(*src0_bank | (*src1_bank << 2) | (*src2_bank << 4) | (*dst_bank << 6));
 
   std::vector<uint32_t> words;
   words.reserve(160);
@@ -1544,6 +1519,10 @@ ExpandResult expand_gfx1250_cvt_pk_fp8_f32_e5m3(const Instruction &inst, uint32_
       return ExpandResult::failed("gfx1250 E5M3 pack could not preserve scratch registers");
     }
   }
+  const uint16_t fp16_ovfl = static_cast<uint16_t>(masks->base + 3u);
+  append_words(words, gfx1250::build_sopk(gfx1250::kSGetregB32Sopk,
+                                          {.simm16 = kGfx1250ModeFp16OvflHwreg,
+                                           .sdst = static_cast<uint8_t>(fp16_ovfl)}));
 
   uint16_t effective_src0 = source.src0;
   if (source.src0 == 255u) {
@@ -1553,10 +1532,9 @@ ExpandResult expand_gfx1250_cvt_pk_fp8_f32_e5m3(const Instruction &inst, uint32_
     words.push_back(literal);
     effective_src0 = gfx1250_vgpr_src(out0);
   }
-  append_gfx1250_f32_to_e5m3(words, effective_src0, source.abs & 1u, source.neg & 1u,
-                              *src0_bank, out0, temp, top_byte, masks->base,
-                              static_cast<uint16_t>(masks->base + 2u),
-                              static_cast<uint16_t>(masks->base + 1u), current_mode);
+  append_gfx1250_f32_to_e5m3(words, effective_src0, *src0_bank, out0, temp, top_byte, masks->base,
+                             static_cast<uint16_t>(masks->base + 1u),
+                             static_cast<uint16_t>(masks->base + 2u), fp16_ovfl, current_mode);
   uint16_t effective_src1 = source.src1;
   if (source.src1 == 255u) {
     append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
@@ -1565,30 +1543,29 @@ ExpandResult expand_gfx1250_cvt_pk_fp8_f32_e5m3(const Instruction &inst, uint32_
     words.push_back(literal);
     effective_src1 = gfx1250_vgpr_src(out1);
   }
-  append_gfx1250_f32_to_e5m3(words, effective_src1, source.abs & 2u, source.neg & 2u,
-                              *src1_bank, out1, temp, top_byte,
-                              static_cast<uint16_t>(masks->base + 1u),
-                              static_cast<uint16_t>(masks->base + 2u), masks->base, current_mode);
+  append_gfx1250_f32_to_e5m3(words, effective_src1, *src1_bank, out1, temp, top_byte, masks->base,
+                             static_cast<uint16_t>(masks->base + 1u),
+                             static_cast<uint16_t>(masks->base + 2u), fp16_ovfl, current_mode);
   append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
-  append_words(words, gfx1250::build_vop3(gfx1250::kVLshlOrB32Vop3,
-                                          {.vdst = static_cast<uint8_t>(out0),
-                                           .src0 = gfx1250_vgpr_src(out1),
-                                           .src1 = gfx1250_inline_u32(8),
-                                           .src2 = gfx1250_vgpr_src(out0)}));
+  append_words(words,
+               gfx1250::build_vop3(gfx1250::kVLshlOrB32Vop3, {.vdst = static_cast<uint8_t>(out0),
+                                                              .src0 = gfx1250_vgpr_src(out1),
+                                                              .src1 = gfx1250_inline_u32(8),
+                                                              .src2 = gfx1250_vgpr_src(out0)}));
   const bool write_high = (source.opsel & 8u) != 0;
   if (write_high) {
-    append_words(words, gfx1250::build_vop3(gfx1250::kVLshlrevB32Vop3,
-                                            {.vdst = static_cast<uint8_t>(out0),
-                                             .src0 = gfx1250_inline_u32(16),
-                                             .src1 = gfx1250_vgpr_src(out0)}));
+    append_words(words,
+                 gfx1250::build_vop3(gfx1250::kVLshlrevB32Vop3, {.vdst = static_cast<uint8_t>(out0),
+                                                                 .src0 = gfx1250_inline_u32(16),
+                                                                 .src1 = gfx1250_vgpr_src(out0)}));
   }
   const uint8_t merge_mode = static_cast<uint8_t>((*dst_bank << 4) | (*dst_bank << 6));
   append_gfx1250_vgpr_msb_transition(words, current_mode, merge_mode);
-  append_words(words, gfx1250::build_vop3(gfx1250::kVBfiB32Vop3,
-                                          {.vdst = static_cast<uint8_t>(source.vdst),
-                                           .src0 = 255,
-                                           .src1 = gfx1250_vgpr_src(out0),
-                                           .src2 = gfx1250_vgpr_src(source.vdst)}));
+  append_words(
+      words, gfx1250::build_vop3(gfx1250::kVBfiB32Vop3, {.vdst = static_cast<uint8_t>(source.vdst),
+                                                         .src0 = 255,
+                                                         .src1 = gfx1250_vgpr_src(out0),
+                                                         .src2 = gfx1250_vgpr_src(source.vdst)}));
   words.push_back(write_high ? 0xffff0000u : 0x0000ffffu);
 
   if (scratch.lease->spilled || masks->has_carrier()) {
@@ -1612,45 +1589,51 @@ ExpandResult expand_gfx1250_cvt_sr_fp8_f32_e5m3(const Instruction &inst, uint32_
                                                 const LaneLayout *) {
   if (inst.mnemonic() != "v_cvt_sr_fp8_f32" || inst.raw_encoding() == nullptr ||
       inst.size() < static_cast<int>(sizeof(gfx1250::Vop3MachineInst))) {
-    return ExpandResult::failed(
-        "gfx1250 stochastic E5M3 rule received an unsupported instruction");
+    return ExpandResult::failed("gfx1250 stochastic E5M3 rule received an unsupported instruction");
   }
   gfx1250::Vop3MachineInst source{};
   std::memcpy(&source, inst.raw_encoding(), sizeof(source));
   if (source.clamp == 0)
     return ExpandResult::not_handled();
+  if (source.src0 == 233u || source.src0 == 234u || source.src0 == 250u)
+    return ExpandResult::failed("gfx1250 stochastic E5M3 does not support DPP");
   const bool has_literal = source.src0 == 255u || source.src1 == 255u;
   if (has_literal && inst.size() < 3 * static_cast<int>(sizeof(uint32_t)))
     return ExpandResult::failed("gfx1250 stochastic E5M3 literal word is missing");
   uint32_t literal = 0;
   if (has_literal)
-    std::memcpy(&literal, inst.raw_encoding() + 2 * sizeof(uint32_t), sizeof(literal));
+    std::memcpy(&literal, inst.raw_encoding() + 2, sizeof(literal));
 
   SemanticScratchAllocator allocator(
       inst, liveness, context,
       SemanticScratchPolicy{.max_vgprs = 256,
                             .max_spill_dword_offset = kGfx1250ScratchMaxDwordOffset});
   SemanticScratchRequest request;
-  request.count = 3;
+  request.count = 5;
   request.forbidden = gfx1250_instruction_registers(inst);
   request.allow_spill = true;
   const SemanticScratchResult scratch = allocator.acquire_vgprs(request);
   if (!scratch)
-    return ExpandResult::failed("gfx1250 stochastic E5M3 could not allocate three scratch VGPRs");
+    return ExpandResult::failed("gfx1250 stochastic E5M3 could not allocate five scratch VGPRs");
   const uint16_t out = scratch.lease->base;
   const uint16_t temp = static_cast<uint16_t>(out + 1u);
-  const uint16_t top_byte = static_cast<uint16_t>(out + 2u);
+  const uint16_t normal = static_cast<uint16_t>(out + 2u);
+  const uint16_t aux = static_cast<uint16_t>(out + 3u);
+  const uint16_t shift = static_cast<uint16_t>(out + 4u);
 
   Gfx1250SgprScratchRequest mask_request;
-  mask_request.count = 2;
+  mask_request.count = 5;
   mask_request.forbidden = request.forbidden;
   mask_request.forbidden.expand(scratch.lease->registers());
   mask_request.carrier_mode = Gfx1250SgprCarrierMode::ExecMasked;
   const auto masks = acquire_gfx1250_sgprs(inst, liveness, context, &allocator, mask_request);
   if (!masks)
-    return ExpandResult::failed("gfx1250 stochastic E5M3 could not allocate two SGPR masks");
+    return ExpandResult::failed("gfx1250 stochastic E5M3 could not allocate five scratch SGPRs");
   const uint16_t nan_mask = masks->base;
-  const uint16_t top_mask = static_cast<uint16_t>(masks->base + 1u);
+  const uint16_t subnormal_mask = static_cast<uint16_t>(masks->base + 1u);
+  const uint16_t overflow_mask = static_cast<uint16_t>(masks->base + 2u);
+  const uint16_t tiny_mask = static_cast<uint16_t>(masks->base + 3u);
+  const uint16_t fp16_ovfl = static_cast<uint16_t>(masks->base + 4u);
 
   const auto src0_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Src0);
   const auto src1_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Src1);
@@ -1659,8 +1642,7 @@ ExpandResult expand_gfx1250_cvt_sr_fp8_f32_e5m3(const Instruction &inst, uint32_
   if (!src0_bank || !src1_bank || !src2_bank || !dst_bank)
     return ExpandResult::failed("gfx1250 stochastic E5M3 cannot prove the VGPR-MSB mode");
   const uint8_t original_mode =
-      static_cast<uint8_t>(*src0_bank | (*src1_bank << 2) | (*src2_bank << 4) |
-                           (*dst_bank << 6));
+      static_cast<uint8_t>(*src0_bank | (*src1_bank << 2) | (*src2_bank << 4) | (*dst_bank << 6));
 
   const auto append_literal = [](std::vector<uint32_t> &output, uint16_t opcode,
                                  gfx1250::Vop3BuilderFields fields, uint32_t value) {
@@ -1669,8 +1651,9 @@ ExpandResult expand_gfx1250_cvt_sr_fp8_f32_e5m3(const Instruction &inst, uint32_
   };
   const auto append_compare_literal = [](std::vector<uint32_t> &output, uint16_t opcode,
                                          uint16_t mask, uint16_t src1, uint32_t value) {
-    append_words(output, gfx1250::build_vop3(
-                             opcode, {.vdst = static_cast<uint8_t>(mask), .src0 = 255, .src1 = src1}));
+    append_words(output,
+                 gfx1250::build_vop3(
+                     opcode, {.vdst = static_cast<uint8_t>(mask), .src0 = 255, .src1 = src1}));
     output.push_back(value);
   };
 
@@ -1682,105 +1665,139 @@ ExpandResult expand_gfx1250_cvt_sr_fp8_f32_e5m3(const Instruction &inst, uint32_
     append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
     if (!append_gfx1250_scratch_preservation(words, *scratch.lease, false) ||
         !append_gfx1250_sgpr_preservation(words, *masks, false)) {
-      return ExpandResult::failed(
-          "gfx1250 stochastic E5M3 could not preserve scratch registers");
+      return ExpandResult::failed("gfx1250 stochastic E5M3 could not preserve scratch registers");
     }
   }
+  append_words(words, gfx1250::build_sopk(gfx1250::kSGetregB32Sopk,
+                                          {.simm16 = kGfx1250ModeFp16OvflHwreg,
+                                           .sdst = static_cast<uint8_t>(fp16_ovfl)}));
 
   uint16_t value_source = source.src0;
   if (source.src0 == 255u) {
     append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
-    append_literal(words, gfx1250::kVMovB32Vop3,
-                   {.vdst = static_cast<uint8_t>(out), .src0 = 255}, literal);
+    append_literal(words, gfx1250::kVMovB32Vop3, {.vdst = static_cast<uint8_t>(out), .src0 = 255},
+                   literal);
     value_source = gfx1250_vgpr_src(out);
   }
   uint16_t noise_source = source.src1;
-  if (source.src1 == 255u) {
-    append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
-    append_literal(words, gfx1250::kVMovB32Vop3,
-                   {.vdst = static_cast<uint8_t>(top_byte), .src0 = 255}, literal);
-    noise_source = gfx1250_vgpr_src(top_byte);
-  }
-  const uint8_t value_mode = value_source >= 256u && source.src0 != 255u
-                                 ? static_cast<uint8_t>(*src0_bank << 2)
-                                 : 0;
+  const uint8_t value_mode =
+      value_source >= 256u && source.src0 != 255u ? static_cast<uint8_t>(*src0_bank << 2) : 0;
   append_gfx1250_vgpr_msb_transition(words, current_mode, value_mode);
   append_literal(words, gfx1250::kVAndB32Vop3,
-                 {.vdst = static_cast<uint8_t>(temp), .src0 = 255, .src1 = value_source},
+                 {.vdst = static_cast<uint8_t>(out), .src0 = 255, .src1 = value_source},
                  0x7fffffffu);
   append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
-  append_compare_literal(words, gfx1250::kVCmpLtU32Vop3, nan_mask,
-                         gfx1250_vgpr_src(temp), 0x7f800000u);
-  append_gfx1250_vgpr_msb_transition(words, current_mode, value_mode);
-  append_words(words, gfx1250::build_vop3(
-                          gfx1250::kVMaxNumF32Vop3,
-                          {.vdst = static_cast<uint8_t>(out),
-                           .abs = static_cast<uint8_t>((source.abs & 1u) != 0 ? 2u : 0u),
-                           .src0 = gfx1250_inline_u32(0),
-                           .src1 = value_source,
-                           .neg = static_cast<uint8_t>((source.neg & 1u) != 0 ? 2u : 0u)}));
+  append_compare_literal(words, gfx1250::kVCmpLtU32Vop3, nan_mask, gfx1250_vgpr_src(out),
+                         0x7f800000u);
+  append_compare_literal(words, gfx1250::kVCmpGtU32Vop3, subnormal_mask, gfx1250_vgpr_src(out),
+                         0x38800000u);
+  append_compare_literal(words, gfx1250::kVCmpGtU32Vop3, tiny_mask, gfx1250_vgpr_src(out),
+                         0x36800000u);
 
-  const uint8_t noise_mode = noise_source >= 256u && source.src1 != 255u
-                                 ? static_cast<uint8_t>(*src1_bank << 2)
-                                 : 0;
+  const uint8_t noise_mode =
+      noise_source >= 256u && source.src1 != 255u ? static_cast<uint8_t>(*src1_bank << 2) : 0;
   append_gfx1250_vgpr_msb_transition(words, current_mode, noise_mode);
-  append_words(words, gfx1250::build_vop3(gfx1250::kVLshrrevB32Vop3,
-                                          {.vdst = static_cast<uint8_t>(temp),
-                                           .src0 = gfx1250_inline_u32(12),
-                                           .src1 = noise_source}));
+  if (source.src1 == 255u) {
+    append_literal(
+        words, gfx1250::kVLshrrevB32Vop3,
+        {.vdst = static_cast<uint8_t>(temp), .src0 = gfx1250_inline_u32(12), .src1 = 255}, literal);
+  } else {
+    append_words(words,
+                 gfx1250::build_vop3(gfx1250::kVLshrrevB32Vop3, {.vdst = static_cast<uint8_t>(temp),
+                                                                 .src0 = gfx1250_inline_u32(12),
+                                                                 .src1 = noise_source}));
+  }
   append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
-  append_words(words, gfx1250::build_vop3(gfx1250::kVAddNcU32Vop3,
-                                          {.vdst = static_cast<uint8_t>(out),
-                                           .src0 = gfx1250_vgpr_src(out),
-                                           .src1 = gfx1250_vgpr_src(temp)}));
-
-  append_compare_literal(words, gfx1250::kVCmpLeF32Vop3, top_mask,
-                         gfx1250_vgpr_src(out), 0x47800000u);
-  append_literal(words, gfx1250::kVMulF32Vop3,
-                 {.vdst = static_cast<uint8_t>(top_byte),
-                  .src0 = 255,
-                  .src1 = gfx1250_vgpr_src(out)},
-                 0x39000000u);
   append_words(words,
-               gfx1250::build_vop3(gfx1250::kVCvtFloorI32F32Vop3,
-                                    {.vdst = static_cast<uint8_t>(top_byte),
-                                     .src0 = gfx1250_vgpr_src(top_byte)}));
-  append_literal(words, gfx1250::kVAddNcU32Vop3,
-                 {.vdst = static_cast<uint8_t>(top_byte),
-                  .src0 = 255,
-                  .src1 = gfx1250_vgpr_src(top_byte)},
-                 0xf0u);
-  append_literal(words, gfx1250::kVMinU32Vop3,
-                 {.vdst = static_cast<uint8_t>(top_byte),
-                  .src0 = 255,
-                  .src1 = gfx1250_vgpr_src(top_byte)},
-                 0xfeu);
-  append_words(words, gfx1250::build_vop3(gfx1250::kVCvtF16F32Vop3,
-                                          {.vdst = static_cast<uint8_t>(out),
-                                           .src0 = gfx1250_vgpr_src(out)}));
-  append_words(words, gfx1250::build_vop3(gfx1250::kVBfeU32Vop3,
-                                          {.vdst = static_cast<uint8_t>(out),
-                                           .src0 = gfx1250_vgpr_src(out),
-                                           .src1 = gfx1250_inline_u32(7),
-                                           .src2 = gfx1250_inline_u32(9)}));
-  append_literal(words, gfx1250::kVMinU32Vop3,
-                 {.vdst = static_cast<uint8_t>(out),
-                  .src0 = 255,
-                  .src1 = gfx1250_vgpr_src(out)},
-                 0xfeu);
-  append_words(words, gfx1250::build_vop3(gfx1250::kVCndmaskB32Vop3,
-                                          {.vdst = static_cast<uint8_t>(out),
-                                           .src0 = gfx1250_vgpr_src(out),
-                                           .src1 = gfx1250_vgpr_src(top_byte),
-                                           .src2 = top_mask}));
-  append_literal(words, gfx1250::kVMovB32Vop3,
-                 {.vdst = static_cast<uint8_t>(temp), .src0 = 255}, 0xffu);
-  append_words(words, gfx1250::build_vop3(gfx1250::kVCndmaskB32Vop3,
-                                          {.vdst = static_cast<uint8_t>(out),
-                                           .src0 = gfx1250_vgpr_src(out),
-                                           .src1 = gfx1250_vgpr_src(temp),
-                                           .src2 = nan_mask}));
-
+               gfx1250::build_vop3(gfx1250::kVAddNcU32Vop3, {.vdst = static_cast<uint8_t>(normal),
+                                                             .src0 = gfx1250_vgpr_src(out),
+                                                             .src1 = gfx1250_vgpr_src(temp)}));
+  append_words(words,
+               gfx1250::build_vop3(gfx1250::kVLshrrevB32Vop3, {.vdst = static_cast<uint8_t>(normal),
+                                                               .src0 = gfx1250_inline_u32(20),
+                                                               .src1 = gfx1250_vgpr_src(normal)}));
+  append_literal(
+      words, gfx1250::kVSubNcU32Vop3,
+      {.vdst = static_cast<uint8_t>(normal), .src0 = gfx1250_vgpr_src(normal), .src1 = 255},
+      0x380u);
+  // Subnormal stochastic rounding follows the execution model exactly. The
+  // discarded significand and the high `shift` seed bits are added as
+  // integers; shifting their sum yields the stochastic carry.
+  append_literal(words, gfx1250::kVAndB32Vop3,
+                 {.vdst = static_cast<uint8_t>(aux), .src0 = 255, .src1 = gfx1250_vgpr_src(out)},
+                 0x7fffffu);
+  append_literal(words, gfx1250::kVOrB32Vop3,
+                 {.vdst = static_cast<uint8_t>(aux), .src0 = 255, .src1 = gfx1250_vgpr_src(aux)},
+                 0x800000u);
+  append_words(words,
+               gfx1250::build_vop3(gfx1250::kVLshrrevB32Vop3, {.vdst = static_cast<uint8_t>(shift),
+                                                               .src0 = gfx1250_inline_u32(23),
+                                                               .src1 = gfx1250_vgpr_src(out)}));
+  append_literal(
+      words, gfx1250::kVSubNcU32Vop3,
+      {.vdst = static_cast<uint8_t>(shift), .src0 = 255, .src1 = gfx1250_vgpr_src(shift)}, 133u);
+  append_words(words,
+               gfx1250::build_vop3(gfx1250::kVLshrrevB32Vop3, {.vdst = static_cast<uint8_t>(out),
+                                                               .src0 = gfx1250_vgpr_src(shift),
+                                                               .src1 = gfx1250_vgpr_src(aux)}));
+  append_words(words,
+               gfx1250::build_vop3(gfx1250::kVBfeU32Vop3, {.vdst = static_cast<uint8_t>(aux),
+                                                           .src0 = gfx1250_vgpr_src(aux),
+                                                           .src1 = gfx1250_inline_u32(0),
+                                                           .src2 = gfx1250_vgpr_src(shift)}));
+  append_literal(words, gfx1250::kVSubNcU32Vop3,
+                 {.vdst = static_cast<uint8_t>(temp), .src0 = 255, .src1 = gfx1250_vgpr_src(shift)},
+                 32u);
+  append_gfx1250_vgpr_msb_transition(words, current_mode, noise_mode);
+  if (source.src1 == 255u) {
+    append_literal(
+        words, gfx1250::kVLshrrevB32Vop3,
+        {.vdst = static_cast<uint8_t>(temp), .src0 = gfx1250_vgpr_src(temp), .src1 = 255}, literal);
+  } else {
+    append_words(words,
+                 gfx1250::build_vop3(gfx1250::kVLshrrevB32Vop3, {.vdst = static_cast<uint8_t>(temp),
+                                                                 .src0 = gfx1250_vgpr_src(temp),
+                                                                 .src1 = noise_source}));
+  }
+  append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
+  append_words(words,
+               gfx1250::build_vop3(gfx1250::kVAddNcU32Vop3, {.vdst = static_cast<uint8_t>(aux),
+                                                             .src0 = gfx1250_vgpr_src(aux),
+                                                             .src1 = gfx1250_vgpr_src(temp)}));
+  append_words(words,
+               gfx1250::build_vop3(gfx1250::kVLshrrevB32Vop3, {.vdst = static_cast<uint8_t>(aux),
+                                                               .src0 = gfx1250_vgpr_src(shift),
+                                                               .src1 = gfx1250_vgpr_src(aux)}));
+  append_words(words,
+               gfx1250::build_vop3(gfx1250::kVAddNcU32Vop3, {.vdst = static_cast<uint8_t>(out),
+                                                             .src0 = gfx1250_vgpr_src(out),
+                                                             .src1 = gfx1250_vgpr_src(aux)}));
+  append_words(words,
+               gfx1250::build_vop3(gfx1250::kVCndmaskB32Vop3, {.vdst = static_cast<uint8_t>(out),
+                                                               .src0 = gfx1250_vgpr_src(out),
+                                                               .src1 = gfx1250_inline_u32(0),
+                                                               .src2 = tiny_mask}));
+  append_words(words,
+               gfx1250::build_vop3(gfx1250::kVCndmaskB32Vop3, {.vdst = static_cast<uint8_t>(out),
+                                                               .src0 = gfx1250_vgpr_src(normal),
+                                                               .src1 = gfx1250_vgpr_src(out),
+                                                               .src2 = subnormal_mask}));
+  append_compare_literal(words, gfx1250::kVCmpLtU32Vop3, overflow_mask, gfx1250_vgpr_src(out),
+                         0xfeu);
+  append_literal(words, gfx1250::kVXorB32Vop3,
+                 {.vdst = static_cast<uint8_t>(temp), .src0 = 255, .src1 = fp16_ovfl}, 0xffu);
+  append_words(words,
+               gfx1250::build_vop3(gfx1250::kVCndmaskB32Vop3, {.vdst = static_cast<uint8_t>(out),
+                                                               .src0 = gfx1250_vgpr_src(out),
+                                                               .src1 = gfx1250_vgpr_src(temp),
+                                                               .src2 = overflow_mask}));
+  append_literal(words, gfx1250::kVMovB32Vop3, {.vdst = static_cast<uint8_t>(temp), .src0 = 255},
+                 0xffu);
+  append_words(words,
+               gfx1250::build_vop3(gfx1250::kVCndmaskB32Vop3, {.vdst = static_cast<uint8_t>(out),
+                                                               .src0 = gfx1250_vgpr_src(out),
+                                                               .src1 = gfx1250_vgpr_src(temp),
+                                                               .src2 = nan_mask}));
   const uint8_t byte_sel = static_cast<uint8_t>((source.opsel >> 2u) & 3u);
   if (byte_sel != 0) {
     append_words(words, gfx1250::build_vop3(gfx1250::kVLshlrevB32Vop3,
@@ -1788,8 +1805,8 @@ ExpandResult expand_gfx1250_cvt_sr_fp8_f32_e5m3(const Instruction &inst, uint32_
                                              .src0 = gfx1250_inline_u32(byte_sel * 8u),
                                              .src1 = gfx1250_vgpr_src(out)}));
   }
-  constexpr std::array<uint32_t, 4> kByteMasks = {
-      0x000000ffu, 0x0000ff00u, 0x00ff0000u, 0xff000000u};
+  constexpr std::array<uint32_t, 4> kByteMasks = {0x000000ffu, 0x0000ff00u, 0x00ff0000u,
+                                                  0xff000000u};
   const uint8_t merge_mode = static_cast<uint8_t>((*dst_bank << 4) | (*dst_bank << 6));
   append_gfx1250_vgpr_msb_transition(words, current_mode, merge_mode);
   append_literal(words, gfx1250::kVBfiB32Vop3,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
@@ -1525,26 +1525,35 @@ ExpandResult expand_gfx1250_cvt_pk_fp8_f32_e5m3(const Instruction &inst, uint32_
                                            .sdst = static_cast<uint8_t>(fp16_ovfl)}));
 
   uint16_t effective_src0 = source.src0;
+  // The bank travels with the operand, not with the instruction. Once a literal
+  // has been materialized into out0 the effective operand is that scratch VGPR,
+  // which is allocated in the low bank -- forwarding the guest operand's bank
+  // would make the helper address a different physical register under a nonzero
+  // VGPR-MSB mode.
+  uint8_t effective_src0_bank = *src0_bank;
   if (source.src0 == 255u) {
     append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
     append_words(words, gfx1250::build_vop3(gfx1250::kVMovB32Vop3,
                                             {.vdst = static_cast<uint8_t>(out0), .src0 = 255}));
     words.push_back(literal);
     effective_src0 = gfx1250_vgpr_src(out0);
+    effective_src0_bank = 0;
   }
-  append_gfx1250_f32_to_e5m3(words, effective_src0, *src0_bank, out0, temp, top_byte, masks->base,
-                             static_cast<uint16_t>(masks->base + 1u),
+  append_gfx1250_f32_to_e5m3(words, effective_src0, effective_src0_bank, out0, temp, top_byte,
+                             masks->base, static_cast<uint16_t>(masks->base + 1u),
                              static_cast<uint16_t>(masks->base + 2u), fp16_ovfl, current_mode);
   uint16_t effective_src1 = source.src1;
+  uint8_t effective_src1_bank = *src1_bank;
   if (source.src1 == 255u) {
     append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
     append_words(words, gfx1250::build_vop3(gfx1250::kVMovB32Vop3,
                                             {.vdst = static_cast<uint8_t>(out1), .src0 = 255}));
     words.push_back(literal);
     effective_src1 = gfx1250_vgpr_src(out1);
+    effective_src1_bank = 0;
   }
-  append_gfx1250_f32_to_e5m3(words, effective_src1, *src1_bank, out1, temp, top_byte, masks->base,
-                             static_cast<uint16_t>(masks->base + 1u),
+  append_gfx1250_f32_to_e5m3(words, effective_src1, effective_src1_bank, out1, temp, top_byte,
+                             masks->base, static_cast<uint16_t>(masks->base + 1u),
                              static_cast<uint16_t>(masks->base + 2u), fp16_ovfl, current_mode);
   append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
   append_words(words,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
@@ -1466,6 +1466,11 @@ ExpandResult expand_gfx1250_cvt_pk_fp8_f32_e5m3(const Instruction &inst, uint32_
     return ExpandResult::not_handled();
   if (source.src0 == 233u || source.src0 == 234u || source.src0 == 250u)
     return ExpandResult::failed("gfx1250 E5M3 pack does not support DPP");
+  // SRC_LITERAL64 carries a two-word payload, and the expansion has no free
+  // literal slot to re-encode it: the generated helpers already spend selector
+  // 255 on their own mask literals.
+  if (source.src0 == 254u || source.src1 == 254u)
+    return ExpandResult::failed("gfx1250 E5M3 pack does not support SRC_LITERAL64");
   const bool has_literal = source.src0 == 255u || source.src1 == 255u;
   if (has_literal && inst.size() < 3 * static_cast<int>(sizeof(uint32_t)))
     return ExpandResult::failed("gfx1250 E5M3 pack literal word is missing");
@@ -1606,6 +1611,8 @@ ExpandResult expand_gfx1250_cvt_sr_fp8_f32_e5m3(const Instruction &inst, uint32_
     return ExpandResult::not_handled();
   if (source.src0 == 233u || source.src0 == 234u || source.src0 == 250u)
     return ExpandResult::failed("gfx1250 stochastic E5M3 does not support DPP");
+  if (source.src0 == 254u || source.src1 == 254u)
+    return ExpandResult::failed("gfx1250 stochastic E5M3 does not support SRC_LITERAL64");
   const bool has_literal = source.src0 == 255u || source.src1 == 255u;
   if (has_literal && inst.size() < 3 * static_cast<int>(sizeof(uint32_t)))
     return ExpandResult::failed("gfx1250 stochastic E5M3 literal word is missing");

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
@@ -1360,6 +1360,458 @@ ExpandResult expand_gfx1250_ds_addtid(const Instruction &inst, uint32_t, uint64_
   return ExpandResult::success(std::move(words));
 }
 
+/// @brief Emulate one RNE F32-to-UE5M3 conversion into a low byte.
+void append_gfx1250_f32_to_e5m3(std::vector<uint32_t> &words, uint16_t source,
+                                uint8_t source_abs, uint8_t source_neg, uint8_t source_bank,
+                                uint16_t out, uint16_t temp, uint16_t top_byte,
+                                uint16_t nan_mask, uint16_t top_mask, uint16_t round_mask,
+                                uint8_t &current_mode) {
+  const auto append_literal = [&](uint16_t opcode, gfx1250::Vop3BuilderFields fields,
+                                  uint32_t literal) {
+    append_words(words, gfx1250::build_vop3(opcode, fields));
+    words.push_back(literal);
+  };
+  const auto append_compare_literal = [&](uint16_t opcode, uint16_t mask, uint16_t src1,
+                                          uint32_t literal) {
+    append_words(words, gfx1250::build_vop3(
+                            opcode, {.vdst = static_cast<uint8_t>(mask), .src0 = 255, .src1 = src1}));
+    words.push_back(literal);
+  };
+  const uint8_t source_mode = source >= 256u ? static_cast<uint8_t>(source_bank << 2) : 0;
+
+  // NaN classification uses the unmodified magnitude. NEG and ABS cannot
+  // change whether an F32 value is NaN.
+  append_gfx1250_vgpr_msb_transition(words, current_mode, source_mode);
+  append_literal(gfx1250::kVAndB32Vop3,
+                 {.vdst = static_cast<uint8_t>(temp), .src0 = 255, .src1 = source},
+                 0x7fffffffu);
+  append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
+  append_compare_literal(gfx1250::kVCmpLtU32Vop3, nan_mask, gfx1250_vgpr_src(temp),
+                         0x7f800000u);
+
+  // UE5M3 is unsigned, so first clamp the modified source to non-negative.
+  append_gfx1250_vgpr_msb_transition(words, current_mode, source_mode);
+  append_words(words, gfx1250::build_vop3(
+                          gfx1250::kVMaxNumF32Vop3,
+                          {.vdst = static_cast<uint8_t>(out),
+                           .abs = static_cast<uint8_t>(source_abs != 0 ? 2u : 0u),
+                           .src0 = gfx1250_inline_u32(0),
+                           .src1 = source,
+                           .neg = static_cast<uint8_t>(source_neg != 0 ? 2u : 0u)}));
+  append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
+
+  // Values at and above the 0xf7/0xf8 midpoint need a direct exponent-31
+  // path because an F16 intermediate cannot represent that finite octave.
+  append_compare_literal(gfx1250::kVCmpLeF32Vop3, top_mask, gfx1250_vgpr_src(out),
+                         0x47780000u);
+  append_literal(gfx1250::kVMulF32Vop3,
+                 {.vdst = static_cast<uint8_t>(top_byte),
+                  .src0 = 255,
+                  .src1 = gfx1250_vgpr_src(out)},
+                 0x39000000u);
+  append_words(words,
+               gfx1250::build_vop3(gfx1250::kVCvtNearestI32F32Vop3,
+                                    {.vdst = static_cast<uint8_t>(top_byte),
+                                     .src0 = gfx1250_vgpr_src(top_byte)}));
+  append_literal(gfx1250::kVAddNcU32Vop3,
+                 {.vdst = static_cast<uint8_t>(top_byte),
+                  .src0 = 255,
+                  .src1 = gfx1250_vgpr_src(top_byte)},
+                 0xf0u);
+  append_literal(gfx1250::kVMinU32Vop3,
+                 {.vdst = static_cast<uint8_t>(top_byte),
+                  .src0 = 255,
+                  .src1 = gfx1250_vgpr_src(top_byte)},
+                 0xfeu);
+
+  append_words(words, gfx1250::build_vop3(gfx1250::kVCvtF16F32Vop3,
+                                          {.vdst = static_cast<uint8_t>(out),
+                                           .src0 = gfx1250_vgpr_src(out)}));
+  append_literal(gfx1250::kVAndB32Vop3,
+                 {.vdst = static_cast<uint8_t>(temp),
+                  .src0 = 255,
+                  .src1 = gfx1250_vgpr_src(out)},
+                 0x7fu);
+  append_words(words, gfx1250::build_vop3(gfx1250::kVBfeU32Vop3,
+                                          {.vdst = static_cast<uint8_t>(out),
+                                           .src0 = gfx1250_vgpr_src(out),
+                                           .src1 = gfx1250_inline_u32(7),
+                                           .src2 = gfx1250_inline_u32(9)}));
+  append_words(words, gfx1250::build_vop3(gfx1250::kVLshlrevB32Vop3,
+                                          {.vdst = static_cast<uint8_t>(temp),
+                                           .src0 = gfx1250_inline_u32(1),
+                                           .src1 = gfx1250_vgpr_src(temp)}));
+  append_literal(gfx1250::kVBfiB32Vop3,
+                 {.vdst = static_cast<uint8_t>(temp),
+                  .src0 = 255,
+                  .src1 = gfx1250_vgpr_src(temp),
+                  .src2 = gfx1250_vgpr_src(out)},
+                 0xfffffffeu);
+  append_compare_literal(gfx1250::kVCmpLtU32Vop3, round_mask, gfx1250_vgpr_src(temp), 0x80u);
+  append_words(words, gfx1250::build_vop3(gfx1250::kVCndmaskB32Vop3,
+                                          {.vdst = static_cast<uint8_t>(temp),
+                                           .src0 = gfx1250_inline_u32(0),
+                                           .src1 = gfx1250_inline_u32(1),
+                                           .src2 = round_mask}));
+  append_words(words, gfx1250::build_vop3(gfx1250::kVAddNcU32Vop3,
+                                          {.vdst = static_cast<uint8_t>(out),
+                                           .src0 = gfx1250_vgpr_src(out),
+                                           .src1 = gfx1250_vgpr_src(temp)}));
+  append_literal(gfx1250::kVMinU32Vop3,
+                 {.vdst = static_cast<uint8_t>(out),
+                  .src0 = 255,
+                  .src1 = gfx1250_vgpr_src(out)},
+                 0xfeu);
+  append_words(words, gfx1250::build_vop3(gfx1250::kVCndmaskB32Vop3,
+                                          {.vdst = static_cast<uint8_t>(out),
+                                           .src0 = gfx1250_vgpr_src(out),
+                                           .src1 = gfx1250_vgpr_src(top_byte),
+                                           .src2 = top_mask}));
+  append_literal(gfx1250::kVMovB32Vop3,
+                 {.vdst = static_cast<uint8_t>(temp), .src0 = 255}, 0xffu);
+  append_words(words, gfx1250::build_vop3(gfx1250::kVCndmaskB32Vop3,
+                                          {.vdst = static_cast<uint8_t>(out),
+                                           .src0 = gfx1250_vgpr_src(out),
+                                           .src1 = gfx1250_vgpr_src(temp),
+                                           .src2 = nan_mask}));
+}
+
+/// @brief Emulate B0 CLAMP=1 packed F32-to-UE5M3 conversion on A0.
+ExpandResult expand_gfx1250_cvt_pk_fp8_f32_e5m3(const Instruction &inst, uint32_t, uint64_t,
+                                                std::span<const uint8_t>,
+                                                const LivenessAnalysis &liveness,
+                                                TranslationContext &context, const LaneLayout *,
+                                                const LaneLayout *) {
+  if (inst.mnemonic() != "v_cvt_pk_fp8_f32" || inst.raw_encoding() == nullptr ||
+      inst.size() < static_cast<int>(sizeof(gfx1250::Vop3MachineInst))) {
+    return ExpandResult::failed("gfx1250 E5M3 pack rule received an unsupported instruction");
+  }
+  gfx1250::Vop3MachineInst source{};
+  std::memcpy(&source, inst.raw_encoding(), sizeof(source));
+  if (source.clamp == 0)
+    return ExpandResult::not_handled();
+  const bool has_literal = source.src0 == 255u || source.src1 == 255u;
+  if (has_literal && inst.size() < 3 * static_cast<int>(sizeof(uint32_t)))
+    return ExpandResult::failed("gfx1250 E5M3 pack literal word is missing");
+  uint32_t literal = 0;
+  if (has_literal)
+    std::memcpy(&literal, inst.raw_encoding() + 2 * sizeof(uint32_t), sizeof(literal));
+
+  SemanticScratchAllocator allocator(
+      inst, liveness, context,
+      SemanticScratchPolicy{.max_vgprs = 256,
+                            .max_spill_dword_offset = kGfx1250ScratchMaxDwordOffset});
+  SemanticScratchRequest request;
+  request.count = 4;
+  request.forbidden = gfx1250_instruction_registers(inst);
+  request.allow_spill = true;
+  const SemanticScratchResult scratch = allocator.acquire_vgprs(request);
+  if (!scratch) {
+    return ExpandResult::failed("gfx1250 E5M3 pack could not allocate four scratch VGPRs");
+  }
+  const uint16_t out0 = scratch.lease->base;
+  const uint16_t out1 = static_cast<uint16_t>(out0 + 1u);
+  const uint16_t temp = static_cast<uint16_t>(out0 + 2u);
+  const uint16_t top_byte = static_cast<uint16_t>(out0 + 3u);
+
+  Gfx1250SgprScratchRequest mask_request;
+  mask_request.count = 3;
+  mask_request.forbidden = request.forbidden;
+  mask_request.forbidden.expand(scratch.lease->registers());
+  mask_request.carrier_mode = Gfx1250SgprCarrierMode::ExecMasked;
+  const auto masks = acquire_gfx1250_sgprs(inst, liveness, context, &allocator, mask_request);
+  if (!masks)
+    return ExpandResult::failed("gfx1250 E5M3 pack could not allocate three SGPR masks");
+
+  const auto src0_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Src0);
+  const auto src1_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Src1);
+  const auto src2_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Src2);
+  const auto dst_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Dst);
+  if (!src0_bank || !src1_bank || !src2_bank || !dst_bank)
+    return ExpandResult::failed("gfx1250 E5M3 pack cannot prove the VGPR-MSB mode");
+  const uint8_t original_mode =
+      static_cast<uint8_t>(*src0_bank | (*src1_bank << 2) | (*src2_bank << 4) |
+                           (*dst_bank << 6));
+
+  std::vector<uint32_t> words;
+  words.reserve(160);
+  append_gfx1250_scratch_dependency_barrier(words);
+  uint8_t current_mode = original_mode;
+  if (scratch.lease->spilled || masks->has_carrier()) {
+    append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
+    if (!append_gfx1250_scratch_preservation(words, *scratch.lease, false) ||
+        !append_gfx1250_sgpr_preservation(words, *masks, false)) {
+      return ExpandResult::failed("gfx1250 E5M3 pack could not preserve scratch registers");
+    }
+  }
+
+  uint16_t effective_src0 = source.src0;
+  if (source.src0 == 255u) {
+    append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
+    append_words(words, gfx1250::build_vop3(gfx1250::kVMovB32Vop3,
+                                            {.vdst = static_cast<uint8_t>(out0), .src0 = 255}));
+    words.push_back(literal);
+    effective_src0 = gfx1250_vgpr_src(out0);
+  }
+  append_gfx1250_f32_to_e5m3(words, effective_src0, source.abs & 1u, source.neg & 1u,
+                              *src0_bank, out0, temp, top_byte, masks->base,
+                              static_cast<uint16_t>(masks->base + 2u),
+                              static_cast<uint16_t>(masks->base + 1u), current_mode);
+  uint16_t effective_src1 = source.src1;
+  if (source.src1 == 255u) {
+    append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
+    append_words(words, gfx1250::build_vop3(gfx1250::kVMovB32Vop3,
+                                            {.vdst = static_cast<uint8_t>(out1), .src0 = 255}));
+    words.push_back(literal);
+    effective_src1 = gfx1250_vgpr_src(out1);
+  }
+  append_gfx1250_f32_to_e5m3(words, effective_src1, source.abs & 2u, source.neg & 2u,
+                              *src1_bank, out1, temp, top_byte,
+                              static_cast<uint16_t>(masks->base + 1u),
+                              static_cast<uint16_t>(masks->base + 2u), masks->base, current_mode);
+  append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
+  append_words(words, gfx1250::build_vop3(gfx1250::kVLshlOrB32Vop3,
+                                          {.vdst = static_cast<uint8_t>(out0),
+                                           .src0 = gfx1250_vgpr_src(out1),
+                                           .src1 = gfx1250_inline_u32(8),
+                                           .src2 = gfx1250_vgpr_src(out0)}));
+  const bool write_high = (source.opsel & 8u) != 0;
+  if (write_high) {
+    append_words(words, gfx1250::build_vop3(gfx1250::kVLshlrevB32Vop3,
+                                            {.vdst = static_cast<uint8_t>(out0),
+                                             .src0 = gfx1250_inline_u32(16),
+                                             .src1 = gfx1250_vgpr_src(out0)}));
+  }
+  const uint8_t merge_mode = static_cast<uint8_t>((*dst_bank << 4) | (*dst_bank << 6));
+  append_gfx1250_vgpr_msb_transition(words, current_mode, merge_mode);
+  append_words(words, gfx1250::build_vop3(gfx1250::kVBfiB32Vop3,
+                                          {.vdst = static_cast<uint8_t>(source.vdst),
+                                           .src0 = 255,
+                                           .src1 = gfx1250_vgpr_src(out0),
+                                           .src2 = gfx1250_vgpr_src(source.vdst)}));
+  words.push_back(write_high ? 0xffff0000u : 0x0000ffffu);
+
+  if (scratch.lease->spilled || masks->has_carrier()) {
+    append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
+    if (!append_gfx1250_sgpr_preservation(words, *masks, true) ||
+        !append_gfx1250_scratch_preservation(words, *scratch.lease, true)) {
+      return ExpandResult::failed("gfx1250 E5M3 pack could not restore scratch registers");
+    }
+  }
+  append_gfx1250_vgpr_msb_transition(words, current_mode, original_mode);
+  if (!prepend_gfx1250_execz_guard_for_masked_replacement(words, masks->has_carrier()))
+    return ExpandResult::failed("gfx1250 E5M3 pack SGPR-carrier guard is too large");
+  return ExpandResult::success(std::move(words));
+}
+
+/// @brief Emulate B0 CLAMP=1 stochastic F32-to-UE5M3 conversion on A0.
+ExpandResult expand_gfx1250_cvt_sr_fp8_f32_e5m3(const Instruction &inst, uint32_t, uint64_t,
+                                                std::span<const uint8_t>,
+                                                const LivenessAnalysis &liveness,
+                                                TranslationContext &context, const LaneLayout *,
+                                                const LaneLayout *) {
+  if (inst.mnemonic() != "v_cvt_sr_fp8_f32" || inst.raw_encoding() == nullptr ||
+      inst.size() < static_cast<int>(sizeof(gfx1250::Vop3MachineInst))) {
+    return ExpandResult::failed(
+        "gfx1250 stochastic E5M3 rule received an unsupported instruction");
+  }
+  gfx1250::Vop3MachineInst source{};
+  std::memcpy(&source, inst.raw_encoding(), sizeof(source));
+  if (source.clamp == 0)
+    return ExpandResult::not_handled();
+  const bool has_literal = source.src0 == 255u || source.src1 == 255u;
+  if (has_literal && inst.size() < 3 * static_cast<int>(sizeof(uint32_t)))
+    return ExpandResult::failed("gfx1250 stochastic E5M3 literal word is missing");
+  uint32_t literal = 0;
+  if (has_literal)
+    std::memcpy(&literal, inst.raw_encoding() + 2 * sizeof(uint32_t), sizeof(literal));
+
+  SemanticScratchAllocator allocator(
+      inst, liveness, context,
+      SemanticScratchPolicy{.max_vgprs = 256,
+                            .max_spill_dword_offset = kGfx1250ScratchMaxDwordOffset});
+  SemanticScratchRequest request;
+  request.count = 3;
+  request.forbidden = gfx1250_instruction_registers(inst);
+  request.allow_spill = true;
+  const SemanticScratchResult scratch = allocator.acquire_vgprs(request);
+  if (!scratch)
+    return ExpandResult::failed("gfx1250 stochastic E5M3 could not allocate three scratch VGPRs");
+  const uint16_t out = scratch.lease->base;
+  const uint16_t temp = static_cast<uint16_t>(out + 1u);
+  const uint16_t top_byte = static_cast<uint16_t>(out + 2u);
+
+  Gfx1250SgprScratchRequest mask_request;
+  mask_request.count = 2;
+  mask_request.forbidden = request.forbidden;
+  mask_request.forbidden.expand(scratch.lease->registers());
+  mask_request.carrier_mode = Gfx1250SgprCarrierMode::ExecMasked;
+  const auto masks = acquire_gfx1250_sgprs(inst, liveness, context, &allocator, mask_request);
+  if (!masks)
+    return ExpandResult::failed("gfx1250 stochastic E5M3 could not allocate two SGPR masks");
+  const uint16_t nan_mask = masks->base;
+  const uint16_t top_mask = static_cast<uint16_t>(masks->base + 1u);
+
+  const auto src0_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Src0);
+  const auto src1_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Src1);
+  const auto src2_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Src2);
+  const auto dst_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Dst);
+  if (!src0_bank || !src1_bank || !src2_bank || !dst_bank)
+    return ExpandResult::failed("gfx1250 stochastic E5M3 cannot prove the VGPR-MSB mode");
+  const uint8_t original_mode =
+      static_cast<uint8_t>(*src0_bank | (*src1_bank << 2) | (*src2_bank << 4) |
+                           (*dst_bank << 6));
+
+  const auto append_literal = [](std::vector<uint32_t> &output, uint16_t opcode,
+                                 gfx1250::Vop3BuilderFields fields, uint32_t value) {
+    append_words(output, gfx1250::build_vop3(opcode, fields));
+    output.push_back(value);
+  };
+  const auto append_compare_literal = [](std::vector<uint32_t> &output, uint16_t opcode,
+                                         uint16_t mask, uint16_t src1, uint32_t value) {
+    append_words(output, gfx1250::build_vop3(
+                             opcode, {.vdst = static_cast<uint8_t>(mask), .src0 = 255, .src1 = src1}));
+    output.push_back(value);
+  };
+
+  std::vector<uint32_t> words;
+  words.reserve(96);
+  append_gfx1250_scratch_dependency_barrier(words);
+  uint8_t current_mode = original_mode;
+  if (scratch.lease->spilled || masks->has_carrier()) {
+    append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
+    if (!append_gfx1250_scratch_preservation(words, *scratch.lease, false) ||
+        !append_gfx1250_sgpr_preservation(words, *masks, false)) {
+      return ExpandResult::failed(
+          "gfx1250 stochastic E5M3 could not preserve scratch registers");
+    }
+  }
+
+  uint16_t value_source = source.src0;
+  if (source.src0 == 255u) {
+    append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
+    append_literal(words, gfx1250::kVMovB32Vop3,
+                   {.vdst = static_cast<uint8_t>(out), .src0 = 255}, literal);
+    value_source = gfx1250_vgpr_src(out);
+  }
+  uint16_t noise_source = source.src1;
+  if (source.src1 == 255u) {
+    append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
+    append_literal(words, gfx1250::kVMovB32Vop3,
+                   {.vdst = static_cast<uint8_t>(top_byte), .src0 = 255}, literal);
+    noise_source = gfx1250_vgpr_src(top_byte);
+  }
+  const uint8_t value_mode = value_source >= 256u && source.src0 != 255u
+                                 ? static_cast<uint8_t>(*src0_bank << 2)
+                                 : 0;
+  append_gfx1250_vgpr_msb_transition(words, current_mode, value_mode);
+  append_literal(words, gfx1250::kVAndB32Vop3,
+                 {.vdst = static_cast<uint8_t>(temp), .src0 = 255, .src1 = value_source},
+                 0x7fffffffu);
+  append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
+  append_compare_literal(words, gfx1250::kVCmpLtU32Vop3, nan_mask,
+                         gfx1250_vgpr_src(temp), 0x7f800000u);
+  append_gfx1250_vgpr_msb_transition(words, current_mode, value_mode);
+  append_words(words, gfx1250::build_vop3(
+                          gfx1250::kVMaxNumF32Vop3,
+                          {.vdst = static_cast<uint8_t>(out),
+                           .abs = static_cast<uint8_t>((source.abs & 1u) != 0 ? 2u : 0u),
+                           .src0 = gfx1250_inline_u32(0),
+                           .src1 = value_source,
+                           .neg = static_cast<uint8_t>((source.neg & 1u) != 0 ? 2u : 0u)}));
+
+  const uint8_t noise_mode = noise_source >= 256u && source.src1 != 255u
+                                 ? static_cast<uint8_t>(*src1_bank << 2)
+                                 : 0;
+  append_gfx1250_vgpr_msb_transition(words, current_mode, noise_mode);
+  append_words(words, gfx1250::build_vop3(gfx1250::kVLshrrevB32Vop3,
+                                          {.vdst = static_cast<uint8_t>(temp),
+                                           .src0 = gfx1250_inline_u32(12),
+                                           .src1 = noise_source}));
+  append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
+  append_words(words, gfx1250::build_vop3(gfx1250::kVAddNcU32Vop3,
+                                          {.vdst = static_cast<uint8_t>(out),
+                                           .src0 = gfx1250_vgpr_src(out),
+                                           .src1 = gfx1250_vgpr_src(temp)}));
+
+  append_compare_literal(words, gfx1250::kVCmpLeF32Vop3, top_mask,
+                         gfx1250_vgpr_src(out), 0x47800000u);
+  append_literal(words, gfx1250::kVMulF32Vop3,
+                 {.vdst = static_cast<uint8_t>(top_byte),
+                  .src0 = 255,
+                  .src1 = gfx1250_vgpr_src(out)},
+                 0x39000000u);
+  append_words(words,
+               gfx1250::build_vop3(gfx1250::kVCvtFloorI32F32Vop3,
+                                    {.vdst = static_cast<uint8_t>(top_byte),
+                                     .src0 = gfx1250_vgpr_src(top_byte)}));
+  append_literal(words, gfx1250::kVAddNcU32Vop3,
+                 {.vdst = static_cast<uint8_t>(top_byte),
+                  .src0 = 255,
+                  .src1 = gfx1250_vgpr_src(top_byte)},
+                 0xf0u);
+  append_literal(words, gfx1250::kVMinU32Vop3,
+                 {.vdst = static_cast<uint8_t>(top_byte),
+                  .src0 = 255,
+                  .src1 = gfx1250_vgpr_src(top_byte)},
+                 0xfeu);
+  append_words(words, gfx1250::build_vop3(gfx1250::kVCvtF16F32Vop3,
+                                          {.vdst = static_cast<uint8_t>(out),
+                                           .src0 = gfx1250_vgpr_src(out)}));
+  append_words(words, gfx1250::build_vop3(gfx1250::kVBfeU32Vop3,
+                                          {.vdst = static_cast<uint8_t>(out),
+                                           .src0 = gfx1250_vgpr_src(out),
+                                           .src1 = gfx1250_inline_u32(7),
+                                           .src2 = gfx1250_inline_u32(9)}));
+  append_literal(words, gfx1250::kVMinU32Vop3,
+                 {.vdst = static_cast<uint8_t>(out),
+                  .src0 = 255,
+                  .src1 = gfx1250_vgpr_src(out)},
+                 0xfeu);
+  append_words(words, gfx1250::build_vop3(gfx1250::kVCndmaskB32Vop3,
+                                          {.vdst = static_cast<uint8_t>(out),
+                                           .src0 = gfx1250_vgpr_src(out),
+                                           .src1 = gfx1250_vgpr_src(top_byte),
+                                           .src2 = top_mask}));
+  append_literal(words, gfx1250::kVMovB32Vop3,
+                 {.vdst = static_cast<uint8_t>(temp), .src0 = 255}, 0xffu);
+  append_words(words, gfx1250::build_vop3(gfx1250::kVCndmaskB32Vop3,
+                                          {.vdst = static_cast<uint8_t>(out),
+                                           .src0 = gfx1250_vgpr_src(out),
+                                           .src1 = gfx1250_vgpr_src(temp),
+                                           .src2 = nan_mask}));
+
+  const uint8_t byte_sel = static_cast<uint8_t>((source.opsel >> 2u) & 3u);
+  if (byte_sel != 0) {
+    append_words(words, gfx1250::build_vop3(gfx1250::kVLshlrevB32Vop3,
+                                            {.vdst = static_cast<uint8_t>(out),
+                                             .src0 = gfx1250_inline_u32(byte_sel * 8u),
+                                             .src1 = gfx1250_vgpr_src(out)}));
+  }
+  constexpr std::array<uint32_t, 4> kByteMasks = {
+      0x000000ffu, 0x0000ff00u, 0x00ff0000u, 0xff000000u};
+  const uint8_t merge_mode = static_cast<uint8_t>((*dst_bank << 4) | (*dst_bank << 6));
+  append_gfx1250_vgpr_msb_transition(words, current_mode, merge_mode);
+  append_literal(words, gfx1250::kVBfiB32Vop3,
+                 {.vdst = static_cast<uint8_t>(source.vdst),
+                  .src0 = 255,
+                  .src1 = gfx1250_vgpr_src(out),
+                  .src2 = gfx1250_vgpr_src(source.vdst)},
+                 kByteMasks[byte_sel]);
+
+  if (scratch.lease->spilled || masks->has_carrier()) {
+    append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
+    if (!append_gfx1250_sgpr_preservation(words, *masks, true) ||
+        !append_gfx1250_scratch_preservation(words, *scratch.lease, true)) {
+      return ExpandResult::failed("gfx1250 stochastic E5M3 could not restore scratch registers");
+    }
+  }
+  append_gfx1250_vgpr_msb_transition(words, current_mode, original_mode);
+  if (!prepend_gfx1250_execz_guard_for_masked_replacement(words, masks->has_carrier()))
+    return ExpandResult::failed("gfx1250 stochastic E5M3 SGPR-carrier guard is too large");
+  return ExpandResult::success(std::move(words));
+}
+
 /// @brief Emulate B0 CLAMP=1 UE5M3 unpack on A0.
 ExpandResult expand_gfx1250_cvt_f32_fp8_e5m3(const Instruction &inst, uint32_t, uint64_t,
                                              std::span<const uint8_t>,
@@ -1642,7 +2094,7 @@ ExpandResult expand_gfx1250_k128_wmma(const Instruction &inst, uint32_t, uint64_
 // The semantic translator binary-searches this table, so entries must stay
 // sorted by the full encoding ID and then opcode. VDS encoding IDs include the
 // high opcode bits, hence the four consecutive kVdsOpHi* groups below.
-inline constexpr std::array<TranslationRule, 39> kGfx1250B0ToA0ExpandRules = {{
+inline constexpr std::array<TranslationRule, 41> kGfx1250B0ToA0ExpandRules = {{
     {gfx1250::encoding::kSop1, gfx1250::kSBarrierSignalIsfirstSop1, RuleAction::Expand, 0, 0,
      nullptr, expand_gfx1250_barrier_signal_isfirst, nullptr, nullptr, false},
     {gfx1250::encoding::kSopp, gfx1250::kSClauseSopp, RuleAction::Expand, 0, 0, nullptr,
@@ -1679,6 +2131,10 @@ inline constexpr std::array<TranslationRule, 39> kGfx1250B0ToA0ExpandRules = {{
      expand_gfx1250_tensor_load_to_lds, nullptr, nullptr},
     {gfx1250::encoding::kVop3OpHi3, gfx1250::kVCvtF32Fp8Vop3, RuleAction::Expand, 0, 0, nullptr,
      expand_gfx1250_cvt_f32_fp8_e5m3, nullptr, nullptr},
+    {gfx1250::encoding::kVop3OpHi6, gfx1250::kVCvtPkFp8F32Vop3, RuleAction::Expand, 0, 0, nullptr,
+     expand_gfx1250_cvt_pk_fp8_f32_e5m3, nullptr, nullptr},
+    {gfx1250::encoding::kVop3OpHi6, gfx1250::kVCvtSrFp8F32Vop3, RuleAction::Expand, 0, 0, nullptr,
+     expand_gfx1250_cvt_sr_fp8_f32_e5m3, nullptr, nullptr},
     {gfx1250::encoding::kVds, gfx1250::kDsStore2addrB32Vds, RuleAction::Expand, 0, 0, nullptr,
      expand_gfx1250_ds2, nullptr, nullptr},
     {gfx1250::encoding::kVds, gfx1250::kDsStore2addrStride64B32Vds, RuleAction::Expand, 0, 0,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
@@ -1488,6 +1488,10 @@ ExpandResult expand_gfx1250_cvt_pk_fp8_f32_e5m3(const Instruction &inst, uint32_
   request.allow_spill = true;
   const SemanticScratchResult scratch = allocator.acquire_vgprs(request);
   if (!scratch) {
+    if (scratch.failure == SemanticScratchFailure::DynamicStackUnsupported) {
+      return ExpandResult::failed(
+          "gfx1250 E5M3 pack cannot use private-memory spills in a dynamic-stack kernel");
+    }
     return ExpandResult::failed("gfx1250 E5M3 pack could not allocate four scratch VGPRs");
   }
   const uint16_t out0 = scratch.lease->base;
@@ -1629,8 +1633,13 @@ ExpandResult expand_gfx1250_cvt_sr_fp8_f32_e5m3(const Instruction &inst, uint32_
   request.forbidden = gfx1250_instruction_registers(inst);
   request.allow_spill = true;
   const SemanticScratchResult scratch = allocator.acquire_vgprs(request);
-  if (!scratch)
+  if (!scratch) {
+    if (scratch.failure == SemanticScratchFailure::DynamicStackUnsupported) {
+      return ExpandResult::failed(
+          "gfx1250 stochastic E5M3 cannot use private-memory spills in a dynamic-stack kernel");
+    }
     return ExpandResult::failed("gfx1250 stochastic E5M3 could not allocate five scratch VGPRs");
+  }
   const uint16_t out = scratch.lease->base;
   const uint16_t temp = static_cast<uint16_t>(out + 1u);
   const uint16_t normal = static_cast<uint16_t>(out + 2u);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instruction_builder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instruction_builder.h
@@ -651,6 +651,16 @@ build_s_nop(uint16_t cycles = 0, rj_code_arch_t arch = ROCJITSU_CODE_ARCH_RDNA4)
   return build_sopp_encoding(arch, sopp_op_delay_alu(arch), simm16);
 }
 
+/// @brief Encode `s_wait_xcnt 0` for the given target ISA.
+///
+/// @returns std::nullopt on an ISA that has no XCNT counter, where nothing can
+/// have required the drain in the first place.
+[[nodiscard]] inline constexpr std::optional<uint32_t> build_s_wait_xcnt(rj_code_arch_t arch) {
+  if (arch != ROCJITSU_CODE_ARCH_GFX1250)
+    return std::nullopt;
+  return build_sopp_encoding(arch, gfx1250::kSWaitXcntSopp, 0);
+}
+
 /// @brief Encode s_mov_b32 for the given target ISA.
 [[nodiscard]] inline constexpr uint32_t build_s_mov_b32(uint16_t sdst, uint16_t ssrc0,
                                                         rj_code_arch_t arch) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/kernel_text_layout.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/kernel_text_layout.cpp
@@ -997,6 +997,19 @@ TextRelocationResult patch_recovered_builder_fixups(std::vector<uint8_t> &text,
     const int64_t base = static_cast<int64_t>(fixup.target_getpc_offset + sizeof(uint32_t));
     const int64_t delta = static_cast<int64_t>(*target_target) - base;
     std::vector<uint32_t> replacement_words;
+    if (fixup.source_requires_xcnt_drain) {
+      // The drain the source range held ordered the writes to this same SGPR
+      // pair, so it has to come before the builder rather than be NOP-filled
+      // away with the rest of the range.
+      const auto drain = build_s_wait_xcnt(arch);
+      if (!drain) {
+        return relocation_error(
+            fixup.source_call_offset,
+            "target ISA cannot encode the XCNT drain the recovered builder requires",
+            TextLayoutFailureCategory::ResourceLimit);
+      }
+      replacement_words.push_back(*drain);
+    }
     if (!append_pc_delta_builder(replacement_words, arch, fixup.source_call_sreg, delta)) {
       return relocation_error(
           fixup.source_call_offset,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/kernel_text_layout.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/kernel_text_layout.cpp
@@ -13,6 +13,7 @@
 #include <limits>
 #include <sstream>
 #include <string_view>
+#include <tuple>
 #include <unordered_map>
 #include <utility>
 
@@ -950,7 +951,7 @@ TextRelocationResult patch_recovered_indirect_fixups(std::vector<uint8_t> &text,
 TextRelocationResult patch_recovered_builder_fixups(std::vector<uint8_t> &text,
                                                     const KernelTextLayout &layout,
                                                     rj_code_arch_t arch) {
-  std::unordered_map<uint64_t, std::pair<uint64_t, uint64_t>> rewritten_regions;
+  std::unordered_map<uint64_t, std::tuple<uint64_t, uint64_t, bool>> rewritten_regions;
   for (const IndirectCallFixup &fixup : layout.recovered_builder_fixups) {
     auto target_target = target_for_source_offset(layout, fixup.source_target_offset);
     if (!target_target) {
@@ -970,18 +971,20 @@ TextRelocationResult patch_recovered_builder_fixups(std::vector<uint8_t> &text,
                               "recovered indirect branch builder points outside translated .text");
     }
 
-    // One source-side builder may feed multiple consumers. Rewriting the same
-    // builder more than once is valid only when every consumer agrees on the
-    // final relocated target and byte range.
+    // One source-side builder may feed multiple consumers. Only the first one
+    // rewrites the range, so reuse is valid only when every consumer asks for
+    // the same replacement -- same target, same byte range, and the same drain
+    // requirement, which changes the words emitted.
     const auto rewrite_key =
-        std::pair{fixup.target_recovery_end_offset, static_cast<uint64_t>(*target_target)};
+        std::tuple{fixup.target_recovery_end_offset, static_cast<uint64_t>(*target_target),
+                   fixup.source_requires_xcnt_drain};
     auto [rewrite_it, inserted] =
         rewritten_regions.emplace(fixup.target_recovery_begin_offset, rewrite_key);
     if (!inserted) {
       if (rewrite_it->second != rewrite_key) {
         return relocation_error(
             fixup.source_call_offset,
-            "recovered indirect branch builder is reused for incompatible targets");
+            "recovered indirect branch builder is reused for incompatible replacements");
       }
       continue;
     }

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -1867,10 +1867,12 @@ TEST(CfgAnalysis, Gfx1250RecoversSignedDeltaTemplateWithPrefetch) {
   ASSERT_EQ(sub_consumer->static_indirect_call_fixups().size(), 1u);
   EXPECT_EQ(sub_consumer->static_indirect_call_fixups()[0].source_target_offset, 76u);
   EXPECT_TRUE(has_successor_start(*sub_consumer, target->start_offset()));
+  EXPECT_FALSE(sub_consumer->static_indirect_call_fixups()[0].source_requires_xcnt_drain);
 
   ASSERT_EQ(add_consumer->static_indirect_call_fixups().size(), 1u);
   EXPECT_EQ(add_consumer->static_indirect_call_fixups()[0].source_target_offset, 76u);
   EXPECT_TRUE(has_successor_start(*add_consumer, target->start_offset()));
+  EXPECT_FALSE(add_consumer->static_indirect_call_fixups()[0].source_requires_xcnt_drain);
 }
 
 TEST(CfgAnalysis, Gfx1250RecoversSignedDeltaTemplateWithXcntWaitAndPrefetch) {
@@ -1945,6 +1947,11 @@ TEST(CfgAnalysis, Gfx1250RecoversSignedDeltaTemplateWithXcntWaitAndPrefetch) {
   ASSERT_EQ(add_consumer->static_indirect_call_fixups().size(), 1u);
   EXPECT_EQ(add_consumer->static_indirect_call_fixups()[0].source_target_offset, 76u);
   EXPECT_TRUE(has_successor_start(*add_consumer, target->start_offset()));
+
+  // The subtract half's drain is inside the range relocation overwrites, so
+  // both consumers of that shared range must ask the rewrite to reproduce it.
+  EXPECT_TRUE(sub_consumer->static_indirect_call_fixups()[0].source_requires_xcnt_drain);
+  EXPECT_TRUE(add_consumer->static_indirect_call_fixups()[0].source_requires_xcnt_drain);
 }
 
 TEST(CfgAnalysis, Gfx1250SignedDeltaRejectsMoveClobberingTemporary) {

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -1873,6 +1873,80 @@ TEST(CfgAnalysis, Gfx1250RecoversSignedDeltaTemplateWithPrefetch) {
   EXPECT_TRUE(has_successor_start(*add_consumer, target->start_offset()));
 }
 
+TEST(CfgAnalysis, Gfx1250RecoversSignedDeltaTemplateWithXcntWaitAndPrefetch) {
+  constexpr uint16_t kPcSreg = 8;
+  constexpr uint16_t kTmpSreg = 12;
+  constexpr uint32_t kLiteralOperand = 255;
+  constexpr uint32_t kInlineInt0 = 128;
+  constexpr uint32_t kInlineInt4 = 132;
+  constexpr uint32_t kSignedDeltaLiteral = 68;
+
+  // gfx1250 compiler output drains XCNT immediately before each instruction
+  // prefetch. These waits and prefetches do not modify the PC pair or temporary,
+  // and must remain in the translated body while the two set-PC consumers are
+  // recovered to their common static target.
+  std::vector<uint32_t> words = {
+      gfx1250::build_sop1(gfx1250::kSGetPcI64Sop1,
+                          {.ssrc0 = 0, .sdst = kPcSreg})[0], // 0x00: s_get_pc_i64 s[8:9].
+      gfx1250::build_sop2(gfx1250::kSAddCoI32Sop2,
+                          {.ssrc0 = kLiteralOperand, .ssrc1 = kInlineInt4, .sdst = kTmpSreg})[0],
+      // 0x04: s_add_co_i32.
+      kSignedDeltaLiteral, // 0x08: literal.
+      gfx1250::build_sopc(gfx1250::kSCmpGeI32Sopc,
+                          {.ssrc0 = kTmpSreg, .ssrc1 = kInlineInt0})[0], // 0x0c: s_cmp_ge_i32.
+      gfx1250::build_sopp(gfx1250::kSCbranchScc1Sopp, {.simm16 = 7})[0],
+      // 0x10 -> add half at 0x30.
+      gfx1250::build_sopp(gfx1250::kSWaitXcntSopp, {.simm16 = 0})[0],
+      // 0x14: s_wait_xcnt 0.
+      0xF404A000u,
+      0x1C000000u, // 0x18: s_prefetch_inst_pc_rel.
+      gfx1250::build_sop1(gfx1250::kSAbsI32Sop1,
+                          {.ssrc0 = kTmpSreg, .sdst = kTmpSreg})[0], // 0x20: s_abs_i32.
+      gfx1250::build_sop2(gfx1250::kSSubCoU32Sop2,
+                          {.ssrc0 = kPcSreg, .ssrc1 = kTmpSreg, .sdst = kPcSreg})[0],
+      // 0x24: s_sub_co_u32.
+      gfx1250::build_sop2(gfx1250::kSSubCoCiU32Sop2,
+                          {.ssrc0 = kPcSreg + 1, .ssrc1 = kInlineInt0, .sdst = kPcSreg + 1})[0],
+      // 0x28: s_sub_co_ci_u32.
+      gfx1250::build_sop1(gfx1250::kSSetPcI64Sop1,
+                          {.ssrc0 = kPcSreg, .sdst = 0})[0], // 0x2c: subtract consumer.
+      gfx1250::build_sopp(gfx1250::kSWaitXcntSopp, {.simm16 = 0})[0],
+      // 0x30: s_wait_xcnt 0.
+      0xF404A000u,
+      0x1C000000u, // 0x34: s_prefetch_inst_pc_rel.
+      gfx1250::build_sop2(gfx1250::kSAddCoU32Sop2,
+                          {.ssrc0 = kPcSreg, .ssrc1 = kTmpSreg, .sdst = kPcSreg})[0],
+      // 0x3c: s_add_co_u32.
+      gfx1250::build_sop2(gfx1250::kSAddCoCiU32Sop2,
+                          {.ssrc0 = kPcSreg + 1, .ssrc1 = kInlineInt0, .sdst = kPcSreg + 1})[0],
+      // 0x40: s_add_co_ci_u32.
+      gfx1250::build_sop1(gfx1250::kSSetPcI64Sop1,
+                          {.ssrc0 = kPcSreg, .sdst = 0})[0], // 0x44: add consumer.
+      build_s_nop(0, ROCJITSU_CODE_ARCH_GFX1250),            // 0x48: not a target.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250),            // 0x4c: shared target.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+
+  auto *sub_consumer = block_starting_at(blocks, 44);
+  auto *add_consumer = block_starting_at(blocks, 68);
+  auto *target = block_starting_at(blocks, 76);
+  ASSERT_NE(sub_consumer, nullptr);
+  ASSERT_NE(add_consumer, nullptr);
+  ASSERT_NE(target, nullptr);
+
+  ASSERT_EQ(sub_consumer->static_indirect_call_fixups().size(), 1u);
+  EXPECT_EQ(sub_consumer->static_indirect_call_fixups()[0].source_target_offset, 76u);
+  EXPECT_TRUE(has_successor_start(*sub_consumer, target->start_offset()));
+
+  ASSERT_EQ(add_consumer->static_indirect_call_fixups().size(), 1u);
+  EXPECT_EQ(add_consumer->static_indirect_call_fixups()[0].source_target_offset, 76u);
+  EXPECT_TRUE(has_successor_start(*add_consumer, target->start_offset()));
+}
+
 TEST(CfgAnalysis, Gfx1250SignedDeltaRejectsMoveClobberingTemporary) {
   // Same signed-delta template as above, but the "prefetch padding" move on the
   // subtract half writes the temporary (s12) instead of an unrelated register

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -9878,24 +9878,39 @@ TEST(BinaryTranslatorE2E, Gfx1250EmulatesCvtSrFp8F32ClampSetForA0) {
             1);
 }
 
+/// @brief What executing one translated E5M3 replacement left behind.
+struct Gfx1250E5m3Execution {
+  uint32_t vdst = 0;          ///< Destination VGPR of the operand's own bank.
+  uint8_t final_msb_mode = 0; ///< VGPR-MSB mode the replacement left in effect.
+};
+
 /// @brief Run one translated gfx1250 E5M3 replacement on the emulated CU.
 ///
 /// @details The B0 conversion is translated on its own and every instruction of
 /// the A0 replacement then executes in order on a single-lane wavefront. That
 /// makes the emitted sequence comparable against the execution model's own
 /// conversion helpers, which mnemonic-counting tests cannot check.
-std::optional<uint32_t> run_gfx1250_e5m3_replacement(uint16_t opcode, uint8_t opsel,
-                                                     uint32_t src0_value, uint32_t src1_value,
-                                                     uint32_t vdst_initial, bool fp16_ovfl,
-                                                     uint8_t vgpr_msb_mode = 0) {
+///
+/// @param vgpr_msb_mode Incoming S_SET_VGPR_MSB layout. Each operand is read and
+///        written through its own role's bank, so a lowering that forwards the
+///        wrong role's bank addresses a register the test never wrote.
+std::optional<Gfx1250E5m3Execution>
+run_gfx1250_e5m3_replacement(uint16_t opcode, uint8_t opsel, uint32_t src0_value,
+                             uint32_t src1_value, uint32_t vdst_initial, bool fp16_ovfl,
+                             uint8_t vgpr_msb_mode = 0) {
   constexpr uint16_t kSrc0Vgpr = 22;
   constexpr uint16_t kSrc1Vgpr = 2;
   constexpr uint16_t kDstVgpr = 30;
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  const uint32_t src0_bank = vgpr_msb_mode & 0x3u;
+  const uint32_t src1_bank = (vgpr_msb_mode >> 2) & 0x3u;
+  const uint32_t dst_bank = (vgpr_msb_mode >> 6) & 0x3u;
 
   std::vector<uint32_t> source_words;
-  if (vgpr_msb_mode != 0)
-    source_words.push_back(gfx1250::build_sopp(gfx1250::kSSetVgprMsbSopp, {.simm16 = 0})[0]);
+  if (vgpr_msb_mode != 0) {
+    source_words.push_back(
+        gfx1250::build_sopp(gfx1250::kSSetVgprMsbSopp, {.simm16 = vgpr_msb_mode})[0]);
+  }
   const auto conversion = gfx1250::build_vop3(opcode, {.vdst = kDstVgpr,
                                                        .opsel = opsel,
                                                        .clamp = 1,
@@ -9930,7 +9945,8 @@ std::optional<uint32_t> run_gfx1250_e5m3_replacement(uint16_t opcode, uint8_t op
   cfg.arch = ROCJITSU_CODE_ARCH_GFX1250;
   cfg.num_wf_slots = 1;
   cfg.sgprs_per_wf = 106;
-  cfg.vgprs_per_wf = 256;
+  // Both banks must be addressable: a banked operand resolves to reg + 256.
+  cfg.vgprs_per_wf = 512;
   cfg.lds_size_kb = 64;
   auto cu = rocjitsu::amdgpu::ComputeUnitCore::create("gfx1250_e5m3", cfg, &gpu_mem, &l2);
   if (cu == nullptr) {
@@ -9945,9 +9961,9 @@ std::optional<uint32_t> run_gfx1250_e5m3_replacement(uint16_t opcode, uint8_t op
   wf->set_exec(0x1u);
   wf->set_mode_raw(fp16_ovfl ? rocjitsu::amdgpu::Wavefront::FP16_OVFL_BIT : 0u);
   const uint32_t vb = wf->vgpr_alloc().base;
-  cu->write_vgpr(vb + kSrc0Vgpr, 0, src0_value);
-  cu->write_vgpr(vb + kSrc1Vgpr, 0, src1_value);
-  cu->write_vgpr(vb + kDstVgpr, 0, vdst_initial);
+  cu->write_vgpr(vb + (src0_bank << 8) + kSrc0Vgpr, 0, src0_value);
+  cu->write_vgpr(vb + (src1_bank << 8) + kSrc1Vgpr, 0, src1_value);
+  cu->write_vgpr(vb + (dst_bank << 8) + kDstVgpr, 0, vdst_initial);
 
   auto decoder = rocjitsu::Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   if (!decoder) {
@@ -9973,7 +9989,8 @@ std::optional<uint32_t> run_gfx1250_e5m3_replacement(uint16_t opcode, uint8_t op
     cu->execute_instruction(inst.get(), *wf);
     index += static_cast<size_t>(inst->size()) / sizeof(uint32_t);
   }
-  return cu->read_vgpr(vb + kDstVgpr, 0);
+  return Gfx1250E5m3Execution{cu->read_vgpr(vb + (dst_bank << 8) + kDstVgpr, 0),
+                              wf->vgpr_msb_mode()};
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250E5m3PackReplacementMatchesReferenceConversion) {
@@ -10002,7 +10019,7 @@ TEST(BinaryTranslatorE2E, Gfx1250E5m3PackReplacementMatchesReferenceConversion) 
              << 8);
         const uint32_t expected = write_high ? ((kDstInitial & 0x0000ffffu) | (packed << 16))
                                              : ((kDstInitial & 0xffff0000u) | packed);
-        EXPECT_EQ(*produced, expected)
+        EXPECT_EQ(produced->vdst, expected)
             << "src0=" << std::hex << src0 << " src1=" << src1 << " fp16_ovfl=" << std::dec
             << fp16_ovfl << " write_high=" << write_high;
       }
@@ -10031,10 +10048,57 @@ TEST(BinaryTranslatorE2E, Gfx1250E5m3StochasticReplacementMatchesReferenceConver
               util::f32_to_fp8_e5m3_sr_mode(std::bit_cast<float>(value), seed, fp16_ovfl);
           const uint32_t shift = static_cast<uint32_t>(dst_byte) * 8u;
           const uint32_t expected = (kDstInitial & ~(0xffu << shift)) | (byte << shift);
-          EXPECT_EQ(*produced, expected)
+          EXPECT_EQ(produced->vdst, expected)
               << "value=" << std::hex << value << " seed=" << seed << std::dec
               << " fp16_ovfl=" << fp16_ovfl << " dst_byte=" << static_cast<unsigned>(dst_byte);
         }
+      }
+    }
+  }
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250E5m3ReplacementsHonorPerRoleVgprBanks) {
+  // Only two banks are addressable, so no single mode can separate all three
+  // roles. Raising each role's bank on its own does: whichever pair a lowering
+  // confuses, one of these modes has them differ, and the operand then resolves
+  // to a register nothing wrote instead of one that happens to hold the answer.
+  static constexpr std::array<uint8_t, 3> modes = {
+      1u,      // src0 in the high bank.
+      1u << 2, // src1 in the high bank.
+      1u << 6, // destination in the high bank.
+  };
+  static constexpr std::array<uint32_t, 6> kValues = {0x00000000u, 0x37000000u, 0x3F800000u,
+                                                      0x47E00000u, 0x47F80000u, 0x7FC00000u};
+  constexpr uint32_t kDstInitial = 0x5a5a5a5au;
+
+  for (const uint8_t mode : modes) {
+    for (const bool fp16_ovfl : {false, true}) {
+      for (size_t index = 0; index < kValues.size(); ++index) {
+        const uint32_t src0 = kValues[index];
+        const uint32_t src1 = kValues[(index + 2) % kValues.size()];
+
+        const auto packed_run = run_gfx1250_e5m3_replacement(gfx1250::kVCvtPkFp8F32Vop3, 0, src0,
+                                                             src1, kDstInitial, fp16_ovfl, mode);
+        ASSERT_TRUE(packed_run.has_value());
+        const uint32_t packed =
+            util::f32_to_fp8_e5m3_rne_mode(std::bit_cast<float>(src0), fp16_ovfl) |
+            (static_cast<uint32_t>(
+                 util::f32_to_fp8_e5m3_rne_mode(std::bit_cast<float>(src1), fp16_ovfl))
+             << 8);
+        EXPECT_EQ(packed_run->vdst, (kDstInitial & 0xffff0000u) | packed)
+            << "src0=" << std::hex << src0 << " src1=" << src1 << std::dec
+            << " fp16_ovfl=" << fp16_ovfl << " mode=" << static_cast<unsigned>(mode);
+        EXPECT_EQ(packed_run->final_msb_mode, mode) << "the incoming mode must be restored";
+
+        const auto stochastic_run = run_gfx1250_e5m3_replacement(
+            gfx1250::kVCvtSrFp8F32Vop3, 2u << 2, src0, src1, kDstInitial, fp16_ovfl, mode);
+        ASSERT_TRUE(stochastic_run.has_value());
+        const uint32_t byte =
+            util::f32_to_fp8_e5m3_sr_mode(std::bit_cast<float>(src0), src1, fp16_ovfl);
+        EXPECT_EQ(stochastic_run->vdst, (kDstInitial & ~(0xffu << 16)) | (byte << 16))
+            << "value=" << std::hex << src0 << " seed=" << src1 << std::dec
+            << " fp16_ovfl=" << fp16_ovfl << " mode=" << static_cast<unsigned>(mode);
+        EXPECT_EQ(stochastic_run->final_msb_mode, mode) << "the incoming mode must be restored";
       }
     }
   }

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -9753,7 +9753,7 @@ TEST(BinaryTranslatorE2E, Gfx1250CopiesCvtPkFp8F32WhenClampIsClear) {
   EXPECT_EQ(target_words[2], kGfx1250SEndpgm);
 }
 
-TEST(BinaryTranslatorE2E, Gfx1250CvtPkFp8F32ClampSetStillFailsClosed) {
+TEST(BinaryTranslatorE2E, Gfx1250EmulatesCvtPkFp8F32ClampSetForA0) {
   constexpr auto source_cvt = gfx1250::build_vop3(
       gfx1250::kVCvtPkFp8F32Vop3, {.vdst = 30, .clamp = 1, .src0 = 256 + 22, .src1 = 256 + 2});
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
@@ -9767,16 +9767,22 @@ TEST(BinaryTranslatorE2E, Gfx1250CvtPkFp8F32ClampSetStillFailsClosed) {
                                rocjitsu::ProcessorRevision::Gfx1250A0));
   auto result = translator.translate(source);
 
-  EXPECT_FALSE(result.ok());
-  const auto diagnostic = std::ranges::find_if(result.diagnostics, [](const auto &item) {
-    return item.severity == rocjitsu::DiagnosticSeverity::Error &&
-           item.kind == rocjitsu::DiagnosticKind::ExpandMissing;
-  });
-  ASSERT_NE(diagnostic, result.diagnostics.end());
-  EXPECT_EQ(diagnostic->mnemonic, "v_cvt_pk_fp8_f32");
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  EXPECT_EQ(std::ranges::count_if(decoded, [](const auto &item) {
+              return item->mnemonic() == "v_cvt_pk_fp8_f32";
+            }),
+            0);
+  EXPECT_GE(std::ranges::count_if(decoded, [](const auto &item) {
+              return item->mnemonic() == "v_cndmask_b32";
+            }),
+            6);
 }
 
-TEST(BinaryTranslatorE2E, Gfx1250LiteralCvtPkFp8F32ClampSetFailsClosed) {
+TEST(BinaryTranslatorE2E, Gfx1250EmulatesLiteralCvtPkFp8F32ClampSetForA0) {
   constexpr auto source_cvt = gfx1250::build_vop3(
       gfx1250::kVCvtPkFp8F32Vop3, {.vdst = 30, .clamp = 1, .src0 = 255, .src1 = 256 + 2});
   constexpr uint32_t kLiteral = 0x3F800000u;
@@ -9791,13 +9797,45 @@ TEST(BinaryTranslatorE2E, Gfx1250LiteralCvtPkFp8F32ClampSetFailsClosed) {
                                rocjitsu::ProcessorRevision::Gfx1250A0));
   auto result = translator.translate(source);
 
-  EXPECT_FALSE(result.ok());
-  const auto diagnostic = std::ranges::find_if(result.diagnostics, [](const auto &item) {
-    return item.severity == rocjitsu::DiagnosticSeverity::Error &&
-           item.kind == rocjitsu::DiagnosticKind::ExpandMissing;
-  });
-  ASSERT_NE(diagnostic, result.diagnostics.end());
-  EXPECT_EQ(diagnostic->mnemonic, "v_cvt_pk_fp8_f32");
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  EXPECT_EQ(std::ranges::count_if(decoded, [](const auto &item) {
+              return item->mnemonic() == "v_cvt_pk_fp8_f32";
+            }),
+            0);
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250EmulatesCvtSrFp8F32ClampSetForA0) {
+  constexpr auto source_cvt = gfx1250::build_vop3(
+      gfx1250::kVCvtSrFp8F32Vop3,
+      {.vdst = 30, .opsel = 12, .clamp = 1, .src0 = 256 + 22, .src1 = 256 + 2});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {source_cvt[0], source_cvt[1], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  auto result = translator.translate(source);
+
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  EXPECT_EQ(std::ranges::count_if(decoded, [](const auto &item) {
+              return item->mnemonic() == "v_cvt_sr_fp8_f32";
+            }),
+            0);
+  EXPECT_EQ(std::ranges::count_if(decoded, [](const auto &item) {
+              return item->mnemonic() == "v_cvt_floor_i32_f32";
+            }),
+            1);
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250CopiesLiteralCvtF32Fp8E32WithoutClampEmulation) {
@@ -10405,7 +10443,7 @@ TEST(BinaryTranslatorE2E, Gfx1250UsesNeutralScaledK128Fp8Bf8Wmma) {
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
   constexpr auto completion_wait = kGfx1250WmmaCompletionWait;
 
-  EXPECT_EQ(rocjitsu::semantic_expand_rules_gfx1250_b0_to_a0().size(), 39u);
+  EXPECT_EQ(rocjitsu::semantic_expand_rules_gfx1250_b0_to_a0().size(), 41u);
   for (const WmmaCase &test_case : cases) {
     SCOPED_TRACE(test_case.name);
     auto source_wmma = gfx1250::build_vop3p(test_case.source_opcode, fields);

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -9805,6 +9805,47 @@ TEST(BinaryTranslatorE2E, Gfx1250EmulatesLiteralCvtPkFp8F32ClampSetForA0) {
             0);
 }
 
+TEST(BinaryTranslatorE2E, Gfx1250MaterializedE5m3LiteralIgnoresTheGuestSourceBank) {
+  // Src0 is a literal and its guest bank is 1; src1, src2 and the destination
+  // stay in bank 0. The literal is materialized into a low-bank scratch VGPR,
+  // so no helper may run under a src-bank-1 mode (0x04) -- doing so would read
+  // a different physical register than the one the v_mov just wrote.
+  constexpr auto set_vgpr_msb = gfx1250::build_sopp(gfx1250::kSSetVgprMsbSopp, {.simm16 = 0x01});
+  constexpr auto source_cvt = gfx1250::build_vop3(
+      gfx1250::kVCvtPkFp8F32Vop3, {.vdst = 30, .clamp = 1, .src0 = 255, .src1 = 256 + 2});
+  constexpr uint32_t kLiteral = 0x3F800000u;
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {set_vgpr_msb[0], source_cvt[0], source_cvt[1], kLiteral, kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  EXPECT_EQ(std::ranges::count_if(
+                decoded, [](const auto &inst) { return inst->mnemonic() == "v_cvt_pk_fp8_f32"; }),
+            0);
+  std::vector<uint8_t> modes;
+  for (const auto &inst : decoded) {
+    if (inst->mnemonic() == "s_set_vgpr_msb") {
+      ASSERT_NE(inst->raw_encoding(), nullptr);
+      modes.push_back(static_cast<uint8_t>(inst->raw_encoding()[0] & 0xffu));
+    }
+  }
+  ASSERT_FALSE(modes.empty());
+  EXPECT_EQ(std::ranges::find(modes, 0x04u), modes.end())
+      << "materialized literal must be read from the low bank";
+  EXPECT_EQ(modes.back(), 0x01u) << "expansion must restore the incoming VGPR-MSB mode";
+}
+
 TEST(BinaryTranslatorE2E, Gfx1250EmulatesCvtSrFp8F32ClampSetForA0) {
   constexpr auto source_cvt =
       gfx1250::build_vop3(gfx1250::kVCvtSrFp8F32Vop3,
@@ -9863,6 +9904,37 @@ TEST(BinaryTranslatorE2E, Gfx1250E5m3PackRejectsDpp) {
     ASSERT_FALSE(result.ok());
     ASSERT_FALSE(result.diagnostics.empty());
     EXPECT_NE(result.diagnostics.front().message.find("does not support DPP"), std::string::npos);
+  }
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250E5m3PackRejectsLiteral64) {
+  constexpr uint32_t kEndpgm = 0xBFB00000u;
+  constexpr uint32_t kLiteralLow = 0x3F800000u;
+  // The gfx1250 VOP3 decoder reports only the first literal word, so the second
+  // one is decoded on its own. Keep it an s_nop rather than undecodable bytes,
+  // which would fail the kernel before the expansion rule is consulted.
+  constexpr uint32_t kLiteralHigh = 0xBF800000u;
+  for (const uint16_t opcode : {gfx1250::kVCvtPkFp8F32Vop3, gfx1250::kVCvtSrFp8F32Vop3}) {
+    for (const bool literal_in_src0 : {true, false}) {
+      const auto conversion = gfx1250::build_vop3(
+          opcode, {.vdst = 30,
+                   .clamp = 1,
+                   .src0 = static_cast<uint16_t>(literal_in_src0 ? 254 : 256 + 22),
+                   .src1 = static_cast<uint16_t>(literal_in_src0 ? 256 + 2 : 254)});
+      auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+          {conversion[0], conversion[1], kLiteralLow, kLiteralHigh, kEndpgm});
+      rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+      rocjitsu::BinaryTranslator translator(
+          ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+          gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                                   rocjitsu::ProcessorRevision::Gfx1250A0));
+      const auto result = translator.translate(source);
+      ASSERT_FALSE(result.ok());
+      ASSERT_FALSE(result.diagnostics.empty());
+      EXPECT_NE(result.diagnostics.front().message.find("does not support SRC_LITERAL64"),
+                std::string::npos)
+          << result.diagnostics.front().message;
+    }
   }
 }
 
@@ -14034,6 +14106,73 @@ TEST(BinaryTranslatorE2E, Gfx1250RecoversAddNcU64PcBuilder) {
 
   EXPECT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
                                                           : result.diagnostics.front().message);
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250RecoveredBuilderRewriteKeepsTheXcntDrain) {
+  // A recovered gfx1250 signed-delta range holds the s_wait_xcnt the compiler
+  // put ahead of the pair writes. The canonical builder overwrites the whole
+  // range and writes that same pair, so the drain has to be re-emitted in front
+  // of it instead of being NOP-filled away with the rest of the range.
+  constexpr uint64_t kWord = sizeof(uint32_t);
+  constexpr uint16_t kPcSreg = 8;
+  std::vector<uint8_t> text(8 * kWord, 0);
+  rocjitsu::KernelTextLayout layout;
+  layout.body_end = text.size();
+  layout.blocks.push_back(
+      {.source_start = 0, .source_end = 4 * kWord, .target_start = 0, .target_end = 4 * kWord});
+  layout.blocks.push_back({.source_start = 4 * kWord,
+                           .source_end = 8 * kWord,
+                           .target_start = 4 * kWord,
+                           .target_end = 8 * kWord});
+  layout.recovered_builder_fixups.push_back({.source_target_offset = 4 * kWord,
+                                             .source_call_sreg = kPcSreg,
+                                             .source_requires_xcnt_drain = true,
+                                             .target_getpc_offset = 0,
+                                             .target_recovery_begin_offset = kWord,
+                                             .target_recovery_end_offset = 4 * kWord});
+
+  const auto patched =
+      rocjitsu::patch_recovered_builder_fixups(text, layout, ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_TRUE(patched.ok) << patched.message;
+
+  std::array<uint32_t, 3> replacement{};
+  std::memcpy(replacement.data(), text.data() + kWord, replacement.size() * sizeof(uint32_t));
+  EXPECT_EQ(replacement[0], rocjitsu::build_s_wait_xcnt(ROCJITSU_CODE_ARCH_GFX1250).value());
+  const auto builder = rocjitsu::decode_one(replacement[1], ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(builder, nullptr);
+  EXPECT_EQ(builder->mnemonic(), "s_add_nc_u64");
+  // s_get_pc_i64 leaves the address of the next instruction, and the target is
+  // the block at 4 * kWord.
+  EXPECT_EQ(replacement[2], 3 * kWord);
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250RecoveredBuilderRewriteOmitsAnUnneededXcntDrain) {
+  constexpr uint64_t kWord = sizeof(uint32_t);
+  constexpr uint16_t kPcSreg = 8;
+  std::vector<uint8_t> text(8 * kWord, 0);
+  rocjitsu::KernelTextLayout layout;
+  layout.body_end = text.size();
+  layout.blocks.push_back(
+      {.source_start = 0, .source_end = 4 * kWord, .target_start = 0, .target_end = 4 * kWord});
+  layout.blocks.push_back({.source_start = 4 * kWord,
+                           .source_end = 8 * kWord,
+                           .target_start = 4 * kWord,
+                           .target_end = 8 * kWord});
+  layout.recovered_builder_fixups.push_back({.source_target_offset = 4 * kWord,
+                                             .source_call_sreg = kPcSreg,
+                                             .target_getpc_offset = 0,
+                                             .target_recovery_begin_offset = kWord,
+                                             .target_recovery_end_offset = 4 * kWord});
+
+  const auto patched =
+      rocjitsu::patch_recovered_builder_fixups(text, layout, ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_TRUE(patched.ok) << patched.message;
+
+  uint32_t first = 0;
+  std::memcpy(&first, text.data() + kWord, sizeof(first));
+  const auto builder = rocjitsu::decode_one(first, ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(builder, nullptr);
+  EXPECT_EQ(builder->mnemonic(), "s_add_nc_u64");
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250IgnoresUndecodablePaddingAfterTerminator) {

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -86,6 +86,7 @@
 #include "rocjitsu/vm/amdgpu/l2_cache.h"
 #include "rocjitsu/vm/amdgpu/wavefront.h"
 #include "support/elf_test_support.h"
+#include "util/data_types.h"
 
 #include "rocjitsu/base/rj_compiler.h"
 RJ_DIAGNOSTIC_PUSH
@@ -9877,6 +9878,168 @@ TEST(BinaryTranslatorE2E, Gfx1250EmulatesCvtSrFp8F32ClampSetForA0) {
             1);
 }
 
+/// @brief Run one translated gfx1250 E5M3 replacement on the emulated CU.
+///
+/// @details The B0 conversion is translated on its own and every instruction of
+/// the A0 replacement then executes in order on a single-lane wavefront. That
+/// makes the emitted sequence comparable against the execution model's own
+/// conversion helpers, which mnemonic-counting tests cannot check.
+std::optional<uint32_t> run_gfx1250_e5m3_replacement(uint16_t opcode, uint8_t opsel,
+                                                     uint32_t src0_value, uint32_t src1_value,
+                                                     uint32_t vdst_initial, bool fp16_ovfl,
+                                                     uint8_t vgpr_msb_mode = 0) {
+  constexpr uint16_t kSrc0Vgpr = 22;
+  constexpr uint16_t kSrc1Vgpr = 2;
+  constexpr uint16_t kDstVgpr = 30;
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+
+  std::vector<uint32_t> source_words;
+  if (vgpr_msb_mode != 0)
+    source_words.push_back(gfx1250::build_sopp(gfx1250::kSSetVgprMsbSopp, {.simm16 = 0})[0]);
+  const auto conversion = gfx1250::build_vop3(opcode, {.vdst = kDstVgpr,
+                                                       .opsel = opsel,
+                                                       .clamp = 1,
+                                                       .src0 = 256 + kSrc0Vgpr,
+                                                       .src1 = 256 + kSrc1Vgpr});
+  source_words.push_back(conversion[0]);
+  source_words.push_back(conversion[1]);
+  source_words.push_back(kGfx1250SEndpgm);
+
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(source_words);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  if (!result.ok()) {
+    ADD_FAILURE() << (result.diagnostics.empty() ? "" : result.diagnostics.front().message);
+    return std::nullopt;
+  }
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  if (translated.text_sections().empty()) {
+    ADD_FAILURE() << "translated code object has no .text";
+    return std::nullopt;
+  }
+  const auto *text = reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+  const size_t word_count = translated.text_sections()[0]->size() / sizeof(uint32_t);
+
+  rocjitsu::amdgpu::GpuMemory gpu_mem("gfx1250_e5m3_mem");
+  rocjitsu::amdgpu::L2Cache l2("gfx1250_e5m3_l2");
+  rocjitsu::amdgpu::ComputeUnitCore::Config cfg{};
+  cfg.arch = ROCJITSU_CODE_ARCH_GFX1250;
+  cfg.num_wf_slots = 1;
+  cfg.sgprs_per_wf = 106;
+  cfg.vgprs_per_wf = 256;
+  cfg.lds_size_kb = 64;
+  auto cu = rocjitsu::amdgpu::ComputeUnitCore::create("gfx1250_e5m3", cfg, &gpu_mem, &l2);
+  if (cu == nullptr) {
+    ADD_FAILURE() << "could not create a gfx1250 compute unit";
+    return std::nullopt;
+  }
+  auto *wf = cu->dispatch_wf(0, 0, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
+  if (wf == nullptr) {
+    ADD_FAILURE() << "could not dispatch a wavefront";
+    return std::nullopt;
+  }
+  wf->set_exec(0x1u);
+  wf->set_mode_raw(fp16_ovfl ? rocjitsu::amdgpu::Wavefront::FP16_OVFL_BIT : 0u);
+  const uint32_t vb = wf->vgpr_alloc().base;
+  cu->write_vgpr(vb + kSrc0Vgpr, 0, src0_value);
+  cu->write_vgpr(vb + kSrc1Vgpr, 0, src1_value);
+  cu->write_vgpr(vb + kDstVgpr, 0, vdst_initial);
+
+  auto decoder = rocjitsu::Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  if (!decoder) {
+    ADD_FAILURE() << "no gfx1250 decoder";
+    return std::nullopt;
+  }
+  const std::string_view source_mnemonic =
+      opcode == gfx1250::kVCvtPkFp8F32Vop3 ? "v_cvt_pk_fp8_f32" : "v_cvt_sr_fp8_f32";
+  for (size_t index = 0; index < word_count;) {
+    std::unique_ptr<rocjitsu::Instruction> inst(decoder->decode(text + index));
+    if (inst == nullptr) {
+      ADD_FAILURE() << "undecodable replacement word at " << index;
+      return std::nullopt;
+    }
+    if (std::string_view(inst->mnemonic()) == "s_endpgm")
+      break;
+    // Executing the untranslated conversion would compare the model against
+    // itself and pass no matter what the expansion emits.
+    if (std::string_view(inst->mnemonic()) == source_mnemonic) {
+      ADD_FAILURE() << "the source conversion survived translation";
+      return std::nullopt;
+    }
+    cu->execute_instruction(inst.get(), *wf);
+    index += static_cast<size_t>(inst->size()) / sizeof(uint32_t);
+  }
+  return cu->read_vgpr(vb + kDstVgpr, 0);
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250E5m3PackReplacementMatchesReferenceConversion) {
+  // Deliberately spans the encoding's discontinuities: signed zeros, the tiny
+  // and subnormal quanta, the normal boundary, a rounding tie, max finite, the
+  // rounded and exponent overflow cases, infinity and NaN.
+  static constexpr std::array<uint32_t, 19> kValues = {
+      0x00000000u, 0x80000000u, 0x00000001u, 0x36800000u, 0x37000000u, 0x37800000u, 0x38800000u,
+      0x3F800000u, 0x3FC00000u, 0x3F900000u, 0x47C00000u, 0x47D00000u, 0x47E00000u, 0x47E80000u,
+      0x47F00000u, 0x47F80000u, 0x7F000000u, 0x7F800000u, 0x7FC00000u};
+  constexpr uint32_t kDstInitial = 0xa5a5a5a5u;
+
+  for (const bool fp16_ovfl : {false, true}) {
+    for (const bool write_high : {false, true}) {
+      for (size_t index = 0; index < kValues.size(); ++index) {
+        const uint32_t src0 = kValues[index];
+        const uint32_t src1 = kValues[(index + 5) % kValues.size()];
+        const auto produced = run_gfx1250_e5m3_replacement(gfx1250::kVCvtPkFp8F32Vop3,
+                                                           static_cast<uint8_t>(write_high ? 8 : 0),
+                                                           src0, src1, kDstInitial, fp16_ovfl);
+        ASSERT_TRUE(produced.has_value());
+        const uint32_t packed =
+            util::f32_to_fp8_e5m3_rne_mode(std::bit_cast<float>(src0), fp16_ovfl) |
+            (static_cast<uint32_t>(
+                 util::f32_to_fp8_e5m3_rne_mode(std::bit_cast<float>(src1), fp16_ovfl))
+             << 8);
+        const uint32_t expected = write_high ? ((kDstInitial & 0x0000ffffu) | (packed << 16))
+                                             : ((kDstInitial & 0xffff0000u) | packed);
+        EXPECT_EQ(*produced, expected)
+            << "src0=" << std::hex << src0 << " src1=" << src1 << " fp16_ovfl=" << std::dec
+            << fp16_ovfl << " write_high=" << write_high;
+      }
+    }
+  }
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250E5m3StochasticReplacementMatchesReferenceConversion) {
+  static constexpr std::array<uint32_t, 14> kValues = {
+      0x00000000u, 0x80000000u, 0x00000001u, 0x36800000u, 0x37000000u, 0x38800000u, 0x3F800000u,
+      0x3FC00000u, 0x47D00000u, 0x47E00000u, 0x47F00000u, 0x47F80000u, 0x7F800000u, 0x7FC00000u};
+  // Both seed extremes plus one interior value: stochastic rounding must round
+  // down at seed 0 and up at UINT32_MAX for every representable magnitude.
+  static constexpr std::array<uint32_t, 3> kSeeds = {0u, 0x0f0f0f0fu, 0xffffffffu};
+  constexpr uint32_t kDstInitial = 0xa5a5a5a5u;
+
+  for (const bool fp16_ovfl : {false, true}) {
+    for (uint8_t dst_byte = 0; dst_byte < 4; ++dst_byte) {
+      for (const uint32_t seed : kSeeds) {
+        for (const uint32_t value : kValues) {
+          const auto produced = run_gfx1250_e5m3_replacement(gfx1250::kVCvtSrFp8F32Vop3,
+                                                             static_cast<uint8_t>(dst_byte << 2),
+                                                             value, seed, kDstInitial, fp16_ovfl);
+          ASSERT_TRUE(produced.has_value());
+          const uint32_t byte =
+              util::f32_to_fp8_e5m3_sr_mode(std::bit_cast<float>(value), seed, fp16_ovfl);
+          const uint32_t shift = static_cast<uint32_t>(dst_byte) * 8u;
+          const uint32_t expected = (kDstInitial & ~(0xffu << shift)) | (byte << shift);
+          EXPECT_EQ(*produced, expected)
+              << "value=" << std::hex << value << " seed=" << seed << std::dec
+              << " fp16_ovfl=" << fp16_ovfl << " dst_byte=" << static_cast<unsigned>(dst_byte);
+        }
+      }
+    }
+  }
+}
+
 TEST(BinaryTranslatorE2E, Gfx1250E5m3PackRejectsDpp) {
   constexpr uint32_t kEndpgm = 0xBFB00000u;
   for (const uint16_t opcode : {gfx1250::kVCvtPkFp8F32Vop3, gfx1250::kVCvtSrFp8F32Vop3}) {
@@ -14115,6 +14278,7 @@ TEST(BinaryTranslatorE2E, Gfx1250RecoveredBuilderRewriteKeepsTheXcntDrain) {
   // of it instead of being NOP-filled away with the rest of the range.
   constexpr uint64_t kWord = sizeof(uint32_t);
   constexpr uint16_t kPcSreg = 8;
+  constexpr uint16_t kLiteralOperand = 255;
   std::vector<uint8_t> text(8 * kWord, 0);
   rocjitsu::KernelTextLayout layout;
   layout.body_end = text.size();
@@ -14138,9 +14302,9 @@ TEST(BinaryTranslatorE2E, Gfx1250RecoveredBuilderRewriteKeepsTheXcntDrain) {
   std::array<uint32_t, 3> replacement{};
   std::memcpy(replacement.data(), text.data() + kWord, replacement.size() * sizeof(uint32_t));
   EXPECT_EQ(replacement[0], rocjitsu::build_s_wait_xcnt(ROCJITSU_CODE_ARCH_GFX1250).value());
-  const auto builder = rocjitsu::decode_one(replacement[1], ROCJITSU_CODE_ARCH_GFX1250);
-  ASSERT_NE(builder, nullptr);
-  EXPECT_EQ(builder->mnemonic(), "s_add_nc_u64");
+  EXPECT_EQ(replacement[1],
+            rocjitsu::build_sop2_encoding(ROCJITSU_CODE_ARCH_GFX1250, gfx1250::kSAddNcU64Sop2,
+                                          kPcSreg, kPcSreg, kLiteralOperand));
   // s_get_pc_i64 leaves the address of the next instruction, and the target is
   // the block at 4 * kWord.
   EXPECT_EQ(replacement[2], 3 * kWord);
@@ -14149,6 +14313,7 @@ TEST(BinaryTranslatorE2E, Gfx1250RecoveredBuilderRewriteKeepsTheXcntDrain) {
 TEST(BinaryTranslatorE2E, Gfx1250RecoveredBuilderRewriteOmitsAnUnneededXcntDrain) {
   constexpr uint64_t kWord = sizeof(uint32_t);
   constexpr uint16_t kPcSreg = 8;
+  constexpr uint16_t kLiteralOperand = 255;
   std::vector<uint8_t> text(8 * kWord, 0);
   rocjitsu::KernelTextLayout layout;
   layout.body_end = text.size();
@@ -14170,9 +14335,42 @@ TEST(BinaryTranslatorE2E, Gfx1250RecoveredBuilderRewriteOmitsAnUnneededXcntDrain
 
   uint32_t first = 0;
   std::memcpy(&first, text.data() + kWord, sizeof(first));
-  const auto builder = rocjitsu::decode_one(first, ROCJITSU_CODE_ARCH_GFX1250);
-  ASSERT_NE(builder, nullptr);
-  EXPECT_EQ(builder->mnemonic(), "s_add_nc_u64");
+  EXPECT_EQ(first,
+            rocjitsu::build_sop2_encoding(ROCJITSU_CODE_ARCH_GFX1250, gfx1250::kSAddNcU64Sop2,
+                                          kPcSreg, kPcSreg, kLiteralOperand));
+}
+
+TEST(BinaryTranslatorE2E, RecoveredBuilderReuseRejectsDisagreeingXcntDrain) {
+  // Only the first consumer of a shared range writes the replacement, so a
+  // second consumer that wants different words must not be silently dropped.
+  constexpr uint64_t kWord = sizeof(uint32_t);
+  constexpr uint16_t kPcSreg = 8;
+  std::vector<uint8_t> text(8 * kWord, 0);
+  rocjitsu::KernelTextLayout layout;
+  layout.body_end = text.size();
+  layout.blocks.push_back(
+      {.source_start = 0, .source_end = 4 * kWord, .target_start = 0, .target_end = 4 * kWord});
+  layout.blocks.push_back({.source_start = 4 * kWord,
+                           .source_end = 8 * kWord,
+                           .target_start = 4 * kWord,
+                           .target_end = 8 * kWord});
+  layout.recovered_builder_fixups.push_back({.source_target_offset = 4 * kWord,
+                                             .source_call_sreg = kPcSreg,
+                                             .target_getpc_offset = 0,
+                                             .target_recovery_begin_offset = kWord,
+                                             .target_recovery_end_offset = 4 * kWord});
+  layout.recovered_builder_fixups.push_back({.source_target_offset = 4 * kWord,
+                                             .source_call_sreg = kPcSreg,
+                                             .source_requires_xcnt_drain = true,
+                                             .target_getpc_offset = 0,
+                                             .target_recovery_begin_offset = kWord,
+                                             .target_recovery_end_offset = 4 * kWord});
+
+  const auto patched =
+      rocjitsu::patch_recovered_builder_fixups(text, layout, ROCJITSU_CODE_ARCH_GFX1250);
+  EXPECT_FALSE(patched.ok);
+  EXPECT_NE(patched.message.find("incompatible replacements"), std::string::npos)
+      << patched.message;
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250IgnoresUndecodablePaddingAfterTerminator) {

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -9729,29 +9729,34 @@ TEST(BinaryTranslatorE2E, Gfx1250CopiesUnaffectedLiteralOperandsForB0ToA0) {
   EXPECT_EQ(target_words[2], kGfx1250SEndpgm);
 }
 
-TEST(BinaryTranslatorE2E, Gfx1250CopiesCvtPkFp8F32WhenClampIsClear) {
-  constexpr auto source_cvt = gfx1250::build_vop3(
-      gfx1250::kVCvtPkFp8F32Vop3, {.vdst = 30, .clamp = 0, .src0 = 256 + 22, .src1 = 256 + 2});
+TEST(BinaryTranslatorE2E, Gfx1250CopiesFp8ConversionsWhenClampIsClear) {
+  // CLAMP selects the E5M3 encoding these rules exist for. With it clear the
+  // instruction already runs on A0, so both rules must decline rather than
+  // rewrite it.
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
-  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
-      {source_cvt[0], source_cvt[1], kGfx1250SEndpgm});
-  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  for (const uint16_t opcode : {gfx1250::kVCvtPkFp8F32Vop3, gfx1250::kVCvtSrFp8F32Vop3}) {
+    const auto source_cvt =
+        gfx1250::build_vop3(opcode, {.vdst = 30, .clamp = 0, .src0 = 256 + 22, .src1 = 256 + 2});
+    auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+        {source_cvt[0], source_cvt[1], kGfx1250SEndpgm});
+    rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
 
-  rocjitsu::BinaryTranslator translator(
-      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
-      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
-                               rocjitsu::ProcessorRevision::Gfx1250A0));
-  auto result = translator.translate(source);
+    rocjitsu::BinaryTranslator translator(
+        ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+        gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                                 rocjitsu::ProcessorRevision::Gfx1250A0));
+    auto result = translator.translate(source);
 
-  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
-                                                          : result.diagnostics.front().message);
-  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
-  ASSERT_FALSE(translated.text_sections().empty());
-  const auto *target_words =
-      reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
-  EXPECT_EQ(target_words[0], source_cvt[0]);
-  EXPECT_EQ(target_words[1], source_cvt[1]);
-  EXPECT_EQ(target_words[2], kGfx1250SEndpgm);
+    ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                            : result.diagnostics.front().message);
+    rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+    ASSERT_FALSE(translated.text_sections().empty());
+    const auto *target_words =
+        reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+    EXPECT_EQ(target_words[0], source_cvt[0]);
+    EXPECT_EQ(target_words[1], source_cvt[1]);
+    EXPECT_EQ(target_words[2], kGfx1250SEndpgm);
+  }
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250EmulatesCvtPkFp8F32ClampSetForA0) {
@@ -9884,6 +9889,27 @@ struct Gfx1250E5m3Execution {
   uint8_t final_msb_mode = 0; ///< VGPR-MSB mode the replacement left in effect.
 };
 
+/// @brief One source of a conversion under test, and where its value lives.
+///
+/// @details The expansions materialize a literal into scratch and read a scalar
+/// through a different operand path than a VGPR, so each kind reaches different
+/// code. VOP3 carries at most one literal, so at most one source may be one.
+struct Gfx1250E5m3Operand {
+  enum class Kind : uint8_t { Vgpr, Sgpr, Literal };
+  Kind kind = Kind::Vgpr;
+  uint32_t value = 0;
+};
+
+constexpr Gfx1250E5m3Operand e5m3_vgpr(uint32_t value) {
+  return {Gfx1250E5m3Operand::Kind::Vgpr, value};
+}
+constexpr Gfx1250E5m3Operand e5m3_sgpr(uint32_t value) {
+  return {Gfx1250E5m3Operand::Kind::Sgpr, value};
+}
+constexpr Gfx1250E5m3Operand e5m3_literal(uint32_t value) {
+  return {Gfx1250E5m3Operand::Kind::Literal, value};
+}
+
 /// @brief Run one translated gfx1250 E5M3 replacement on the emulated CU.
 ///
 /// @details The B0 conversion is translated on its own and every instruction of
@@ -9895,29 +9921,59 @@ struct Gfx1250E5m3Execution {
 ///        written through its own role's bank, so a lowering that forwards the
 ///        wrong role's bank addresses a register the test never wrote.
 std::optional<Gfx1250E5m3Execution>
-run_gfx1250_e5m3_replacement(uint16_t opcode, uint8_t opsel, uint32_t src0_value,
-                             uint32_t src1_value, uint32_t vdst_initial, bool fp16_ovfl,
-                             uint8_t vgpr_msb_mode = 0) {
+run_gfx1250_e5m3_replacement(uint16_t opcode, uint8_t opsel, Gfx1250E5m3Operand src0,
+                             Gfx1250E5m3Operand src1, uint32_t vdst_initial, bool fp16_ovfl,
+                             uint8_t vgpr_msb_mode = 0, uint16_t live_sgprs = 0) {
   constexpr uint16_t kSrc0Vgpr = 22;
   constexpr uint16_t kSrc1Vgpr = 2;
   constexpr uint16_t kDstVgpr = 30;
+  constexpr uint16_t kSrc0Sgpr = 8;
+  constexpr uint16_t kSrc1Sgpr = 9;
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  constexpr uint16_t kM0Operand = 125;
+  using Kind = Gfx1250E5m3Operand::Kind;
+  if (src0.kind == Kind::Literal && src1.kind == Kind::Literal) {
+    ADD_FAILURE() << "VOP3 carries at most one literal";
+    return std::nullopt;
+  }
   const uint32_t src0_bank = vgpr_msb_mode & 0x3u;
   const uint32_t src1_bank = (vgpr_msb_mode >> 2) & 0x3u;
   const uint32_t dst_bank = (vgpr_msb_mode >> 6) & 0x3u;
+  const auto selector = [](Gfx1250E5m3Operand operand, uint16_t vgpr, uint16_t sgpr) -> uint16_t {
+    switch (operand.kind) {
+    case Kind::Vgpr:
+      return static_cast<uint16_t>(256 + vgpr);
+    case Kind::Sgpr:
+      return sgpr;
+    case Kind::Literal:
+      break;
+    }
+    return 255;
+  };
 
   std::vector<uint32_t> source_words;
   if (vgpr_msb_mode != 0) {
     source_words.push_back(
         gfx1250::build_sopp(gfx1250::kSSetVgprMsbSopp, {.simm16 = vgpr_msb_mode})[0]);
   }
-  const auto conversion = gfx1250::build_vop3(opcode, {.vdst = kDstVgpr,
-                                                       .opsel = opsel,
-                                                       .clamp = 1,
-                                                       .src0 = 256 + kSrc0Vgpr,
-                                                       .src1 = 256 + kSrc1Vgpr});
+  const auto conversion =
+      gfx1250::build_vop3(opcode, {.vdst = kDstVgpr,
+                                   .opsel = opsel,
+                                   .clamp = 1,
+                                   .src0 = selector(src0, kSrc0Vgpr, kSrc0Sgpr),
+                                   .src1 = selector(src1, kSrc1Vgpr, kSrc1Sgpr)});
   source_words.push_back(conversion[0]);
   source_words.push_back(conversion[1]);
+  if (src0.kind == Kind::Literal)
+    source_words.push_back(src0.value);
+  else if (src1.kind == Kind::Literal)
+    source_words.push_back(src1.value);
+  // Readers that keep every ordinary SGPR live, so the expansion has to borrow
+  // VGPR carriers and guard them instead of taking scratch SGPRs outright.
+  for (uint16_t sgpr = 0; sgpr < live_sgprs; ++sgpr) {
+    source_words.push_back(gfx1250::build_sop1(
+        gfx1250::kSMovB32Sop1, {.ssrc0 = static_cast<uint8_t>(sgpr), .sdst = kM0Operand})[0]);
+  }
   source_words.push_back(kGfx1250SEndpgm);
 
   auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(source_words);
@@ -9962,8 +10018,15 @@ run_gfx1250_e5m3_replacement(uint16_t opcode, uint8_t opsel, uint32_t src0_value
   wf->set_exec(0x1u);
   wf->set_mode_raw(fp16_ovfl ? rocjitsu::amdgpu::Wavefront::FP16_OVFL_BIT : 0u);
   const uint32_t vb = wf->vgpr_alloc().base;
-  cu->write_vgpr(vb + (src0_bank << 8) + kSrc0Vgpr, 0, src0_value);
-  cu->write_vgpr(vb + (src1_bank << 8) + kSrc1Vgpr, 0, src1_value);
+  const uint32_t sb = wf->sgpr_alloc().base;
+  const auto place = [&](Gfx1250E5m3Operand operand, uint32_t bank, uint16_t vgpr, uint16_t sgpr) {
+    if (operand.kind == Kind::Vgpr)
+      cu->write_vgpr(vb + (bank << 8) + vgpr, 0, operand.value);
+    else if (operand.kind == Kind::Sgpr)
+      cu->write_sgpr(sb + sgpr, operand.value);
+  };
+  place(src0, src0_bank, kSrc0Vgpr, kSrc0Sgpr);
+  place(src1, src1_bank, kSrc1Vgpr, kSrc1Sgpr);
   cu->write_vgpr(vb + (dst_bank << 8) + kDstVgpr, 0, vdst_initial);
 
   auto decoder = rocjitsu::Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
@@ -9973,6 +10036,7 @@ run_gfx1250_e5m3_replacement(uint16_t opcode, uint8_t opsel, uint32_t src0_value
   }
   const std::string_view source_mnemonic =
       opcode == gfx1250::kVCvtPkFp8F32Vop3 ? "v_cvt_pk_fp8_f32" : "v_cvt_sr_fp8_f32";
+  bool borrowed_a_carrier = false;
   for (size_t index = 0; index < word_count;) {
     std::unique_ptr<rocjitsu::Instruction> inst(decoder->decode(text + index));
     if (inst == nullptr) {
@@ -9987,8 +10051,17 @@ run_gfx1250_e5m3_replacement(uint16_t opcode, uint8_t opsel, uint32_t src0_value
       ADD_FAILURE() << "the source conversion survived translation";
       return std::nullopt;
     }
+    borrowed_a_carrier =
+        borrowed_a_carrier || std::string_view(inst->mnemonic()) == "v_readfirstlane_b32_e32";
     cu->execute_instruction(inst.get(), *wf);
     index += static_cast<size_t>(inst->size()) / sizeof(uint32_t);
+  }
+  // A caller that walled off the SGPRs asked for the carrier path. Without this
+  // the shape could quietly degenerate into the ordinary one and still compare
+  // equal, testing nothing it was written for.
+  if (live_sgprs != 0 && !borrowed_a_carrier) {
+    ADD_FAILURE() << "the SGPR-pressure shape did not borrow a VGPR carrier";
+    return std::nullopt;
   }
   return Gfx1250E5m3Execution{cu->read_vgpr(vb + (dst_bank << 8) + kDstVgpr, 0),
                               wf->vgpr_msb_mode()};
@@ -10009,9 +10082,9 @@ TEST(BinaryTranslatorE2E, Gfx1250E5m3PackReplacementMatchesReferenceConversion) 
       for (size_t index = 0; index < kValues.size(); ++index) {
         const uint32_t src0 = kValues[index];
         const uint32_t src1 = kValues[(index + 5) % kValues.size()];
-        const auto produced = run_gfx1250_e5m3_replacement(gfx1250::kVCvtPkFp8F32Vop3,
-                                                           static_cast<uint8_t>(write_high ? 8 : 0),
-                                                           src0, src1, kDstInitial, fp16_ovfl);
+        const auto produced = run_gfx1250_e5m3_replacement(
+            gfx1250::kVCvtPkFp8F32Vop3, static_cast<uint8_t>(write_high ? 8 : 0), e5m3_vgpr(src0),
+            e5m3_vgpr(src1), kDstInitial, fp16_ovfl);
         ASSERT_TRUE(produced.has_value());
         const uint32_t packed =
             util::f32_to_fp8_e5m3_rne_mode(std::bit_cast<float>(src0), fp16_ovfl) |
@@ -10041,9 +10114,9 @@ TEST(BinaryTranslatorE2E, Gfx1250E5m3StochasticReplacementMatchesReferenceConver
     for (uint8_t dst_byte = 0; dst_byte < 4; ++dst_byte) {
       for (const uint32_t seed : kSeeds) {
         for (const uint32_t value : kValues) {
-          const auto produced = run_gfx1250_e5m3_replacement(gfx1250::kVCvtSrFp8F32Vop3,
-                                                             static_cast<uint8_t>(dst_byte << 2),
-                                                             value, seed, kDstInitial, fp16_ovfl);
+          const auto produced = run_gfx1250_e5m3_replacement(
+              gfx1250::kVCvtSrFp8F32Vop3, static_cast<uint8_t>(dst_byte << 2), e5m3_vgpr(value),
+              e5m3_vgpr(seed), kDstInitial, fp16_ovfl);
           ASSERT_TRUE(produced.has_value());
           const uint32_t byte =
               util::f32_to_fp8_e5m3_sr_mode(std::bit_cast<float>(value), seed, fp16_ovfl);
@@ -10079,8 +10152,9 @@ TEST(BinaryTranslatorE2E, Gfx1250E5m3ReplacementsHonorPerRoleVgprBanks) {
         const uint32_t src0 = kValues[index];
         const uint32_t src1 = kValues[(index + 2) % kValues.size()];
 
-        const auto packed_run = run_gfx1250_e5m3_replacement(gfx1250::kVCvtPkFp8F32Vop3, 0, src0,
-                                                             src1, kDstInitial, fp16_ovfl, mode);
+        const auto packed_run =
+            run_gfx1250_e5m3_replacement(gfx1250::kVCvtPkFp8F32Vop3, 0, e5m3_vgpr(src0),
+                                         e5m3_vgpr(src1), kDstInitial, fp16_ovfl, mode);
         ASSERT_TRUE(packed_run.has_value());
         const uint32_t packed =
             util::f32_to_fp8_e5m3_rne_mode(std::bit_cast<float>(src0), fp16_ovfl) |
@@ -10092,8 +10166,9 @@ TEST(BinaryTranslatorE2E, Gfx1250E5m3ReplacementsHonorPerRoleVgprBanks) {
             << " fp16_ovfl=" << fp16_ovfl << " mode=" << static_cast<unsigned>(mode);
         EXPECT_EQ(packed_run->final_msb_mode, mode) << "the incoming mode must be restored";
 
-        const auto stochastic_run = run_gfx1250_e5m3_replacement(
-            gfx1250::kVCvtSrFp8F32Vop3, 2u << 2, src0, src1, kDstInitial, fp16_ovfl, mode);
+        const auto stochastic_run =
+            run_gfx1250_e5m3_replacement(gfx1250::kVCvtSrFp8F32Vop3, 2u << 2, e5m3_vgpr(src0),
+                                         e5m3_vgpr(src1), kDstInitial, fp16_ovfl, mode);
         ASSERT_TRUE(stochastic_run.has_value());
         const uint32_t byte =
             util::f32_to_fp8_e5m3_sr_mode(std::bit_cast<float>(src0), src1, fp16_ovfl);
@@ -10101,6 +10176,71 @@ TEST(BinaryTranslatorE2E, Gfx1250E5m3ReplacementsHonorPerRoleVgprBanks) {
             << "value=" << std::hex << src0 << " seed=" << src1 << std::dec
             << " fp16_ovfl=" << fp16_ovfl << " mode=" << static_cast<unsigned>(mode);
         EXPECT_EQ(stochastic_run->final_msb_mode, mode) << "the incoming mode must be restored";
+      }
+    }
+  }
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250E5m3ReplacementsMatchForNonVgprSources) {
+  // Each source kind reaches different code: a literal is materialized into
+  // scratch first, a scalar is read through the operand's scalar path, and the
+  // SGPR-pressure shape forces VGPR carriers behind an execz guard. All three
+  // must still produce what the reference conversion does.
+  static constexpr std::array<uint32_t, 5> kValues = {0x00000000u, 0x37000000u, 0x3F800000u,
+                                                      0x47E00000u, 0x7FC00000u};
+  constexpr uint32_t kDstInitial = 0xa5a5a5a5u;
+  constexpr uint32_t kSeed = 0x0f0f0f0fu;
+
+  const auto expect_packed = [&](const std::optional<Gfx1250E5m3Execution> &run, uint32_t src0,
+                                 uint32_t src1, bool fp16_ovfl, const char *shape) {
+    ASSERT_TRUE(run.has_value()) << shape;
+    const uint32_t packed = util::f32_to_fp8_e5m3_rne_mode(std::bit_cast<float>(src0), fp16_ovfl) |
+                            (static_cast<uint32_t>(util::f32_to_fp8_e5m3_rne_mode(
+                                 std::bit_cast<float>(src1), fp16_ovfl))
+                             << 8);
+    EXPECT_EQ(run->vdst, (kDstInitial & 0xffff0000u) | packed)
+        << shape << " src0=" << std::hex << src0 << " src1=" << src1 << std::dec
+        << " fp16_ovfl=" << fp16_ovfl;
+  };
+
+  for (const bool fp16_ovfl : {false, true}) {
+    for (size_t index = 0; index < kValues.size(); ++index) {
+      const uint32_t src0 = kValues[index];
+      const uint32_t src1 = kValues[(index + 3) % kValues.size()];
+
+      expect_packed(run_gfx1250_e5m3_replacement(gfx1250::kVCvtPkFp8F32Vop3, 0, e5m3_literal(src0),
+                                                 e5m3_vgpr(src1), kDstInitial, fp16_ovfl),
+                    src0, src1, fp16_ovfl, "literal src0");
+      expect_packed(run_gfx1250_e5m3_replacement(gfx1250::kVCvtPkFp8F32Vop3, 0, e5m3_vgpr(src0),
+                                                 e5m3_literal(src1), kDstInitial, fp16_ovfl),
+                    src0, src1, fp16_ovfl, "literal src1");
+      expect_packed(run_gfx1250_e5m3_replacement(gfx1250::kVCvtPkFp8F32Vop3, 0, e5m3_sgpr(src0),
+                                                 e5m3_vgpr(src1), kDstInitial, fp16_ovfl),
+                    src0, src1, fp16_ovfl, "scalar src0");
+      expect_packed(run_gfx1250_e5m3_replacement(gfx1250::kVCvtPkFp8F32Vop3, 0, e5m3_vgpr(src0),
+                                                 e5m3_sgpr(src1), kDstInitial, fp16_ovfl),
+                    src0, src1, fp16_ovfl, "scalar src1");
+      expect_packed(run_gfx1250_e5m3_replacement(gfx1250::kVCvtPkFp8F32Vop3, 0, e5m3_vgpr(src0),
+                                                 e5m3_vgpr(src1), kDstInitial, fp16_ovfl, 0,
+                                                 rocjitsu::REGISTER_SET_MAX_SGPRS),
+                    src0, src1, fp16_ovfl, "sgpr pressure");
+
+      // The stochastic lowering reads the seed through the same operand paths.
+      for (const auto &[seed, shape] :
+           std::initializer_list<std::pair<Gfx1250E5m3Operand, const char *>>{
+               {e5m3_literal(kSeed), "literal seed"},
+               {e5m3_sgpr(kSeed), "scalar seed"},
+               {e5m3_vgpr(kSeed), "sgpr pressure seed"}}) {
+        const uint16_t live_sgprs =
+            std::string_view(shape) == "sgpr pressure seed" ? rocjitsu::REGISTER_SET_MAX_SGPRS : 0;
+        const auto run =
+            run_gfx1250_e5m3_replacement(gfx1250::kVCvtSrFp8F32Vop3, 0, e5m3_vgpr(src0), seed,
+                                         kDstInitial, fp16_ovfl, 0, live_sgprs);
+        ASSERT_TRUE(run.has_value()) << shape;
+        const uint32_t byte =
+            util::f32_to_fp8_e5m3_sr_mode(std::bit_cast<float>(src0), kSeed, fp16_ovfl);
+        EXPECT_EQ(run->vdst, (kDstInitial & 0xffffff00u) | byte)
+            << shape << " value=" << std::hex << src0 << std::dec << " fp16_ovfl=" << fp16_ovfl;
       }
     }
   }
@@ -12288,6 +12428,17 @@ TEST(BinaryTranslatorE2E, Gfx1250SpillBackedRulesFailClosedForDynamicStackKernel
                                             {.vdst = 30, .opsel = 2, .clamp = 1, .src0 = 256 + 22});
   expect_failure({e5m3[0], e5m3[1]},
                  "gfx1250 E5M3 unpack cannot use private-memory spills in a dynamic-stack kernel");
+
+  constexpr auto pack = gfx1250::build_vop3(
+      gfx1250::kVCvtPkFp8F32Vop3, {.vdst = 30, .clamp = 1, .src0 = 256 + 22, .src1 = 256 + 2});
+  expect_failure({pack[0], pack[1]},
+                 "gfx1250 E5M3 pack cannot use private-memory spills in a dynamic-stack kernel");
+
+  constexpr auto stochastic = gfx1250::build_vop3(
+      gfx1250::kVCvtSrFp8F32Vop3, {.vdst = 30, .clamp = 1, .src0 = 256 + 22, .src1 = 256 + 2});
+  expect_failure(
+      {stochastic[0], stochastic[1]},
+      "gfx1250 stochastic E5M3 cannot use private-memory spills in a dynamic-stack kernel");
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250SpillWaitsForOutstandingVgprProducer) {

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -9772,13 +9772,11 @@ TEST(BinaryTranslatorE2E, Gfx1250EmulatesCvtPkFp8F32ClampSetForA0) {
   rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
   const auto decoded =
       decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
-  EXPECT_EQ(std::ranges::count_if(decoded, [](const auto &item) {
-              return item->mnemonic() == "v_cvt_pk_fp8_f32";
-            }),
+  EXPECT_EQ(std::ranges::count_if(
+                decoded, [](const auto &item) { return item->mnemonic() == "v_cvt_pk_fp8_f32"; }),
             0);
-  EXPECT_GE(std::ranges::count_if(decoded, [](const auto &item) {
-              return item->mnemonic() == "v_cndmask_b32";
-            }),
+  EXPECT_GE(std::ranges::count_if(
+                decoded, [](const auto &item) { return item->mnemonic() == "v_cndmask_b32"; }),
             6);
 }
 
@@ -9802,16 +9800,15 @@ TEST(BinaryTranslatorE2E, Gfx1250EmulatesLiteralCvtPkFp8F32ClampSetForA0) {
   rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
   const auto decoded =
       decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
-  EXPECT_EQ(std::ranges::count_if(decoded, [](const auto &item) {
-              return item->mnemonic() == "v_cvt_pk_fp8_f32";
-            }),
+  EXPECT_EQ(std::ranges::count_if(
+                decoded, [](const auto &item) { return item->mnemonic() == "v_cvt_pk_fp8_f32"; }),
             0);
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250EmulatesCvtSrFp8F32ClampSetForA0) {
-  constexpr auto source_cvt = gfx1250::build_vop3(
-      gfx1250::kVCvtSrFp8F32Vop3,
-      {.vdst = 30, .opsel = 12, .clamp = 1, .src0 = 256 + 22, .src1 = 256 + 2});
+  constexpr auto source_cvt =
+      gfx1250::build_vop3(gfx1250::kVCvtSrFp8F32Vop3,
+                          {.vdst = 30, .opsel = 12, .clamp = 1, .src0 = 256 + 22, .src1 = 256 + 2});
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
   auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
       {source_cvt[0], source_cvt[1], kGfx1250SEndpgm});
@@ -9828,14 +9825,72 @@ TEST(BinaryTranslatorE2E, Gfx1250EmulatesCvtSrFp8F32ClampSetForA0) {
   rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
   const auto decoded =
       decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
-  EXPECT_EQ(std::ranges::count_if(decoded, [](const auto &item) {
-              return item->mnemonic() == "v_cvt_sr_fp8_f32";
-            }),
+  EXPECT_EQ(std::ranges::count_if(
+                decoded, [](const auto &item) { return item->mnemonic() == "v_cvt_sr_fp8_f32"; }),
             0);
-  EXPECT_EQ(std::ranges::count_if(decoded, [](const auto &item) {
-              return item->mnemonic() == "v_cvt_floor_i32_f32";
-            }),
+  EXPECT_EQ(std::ranges::count_if(
+                decoded, [](const auto &item) { return item->mnemonic() == "v_cvt_f16_f32"; }),
+            0);
+  EXPECT_EQ(std::ranges::count_if(
+                decoded, [](const auto &item) { return item->mnemonic() == "s_getreg_b32"; }),
             1);
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250E5m3PackRejectsDpp) {
+  constexpr uint32_t kEndpgm = 0xBFB00000u;
+  for (const uint16_t opcode : {gfx1250::kVCvtPkFp8F32Vop3, gfx1250::kVCvtSrFp8F32Vop3}) {
+    gfx1250::Vop3VopDpp16MachineInst dpp{};
+    dpp.vdst = 30;
+    dpp.clamp = 1;
+    dpp.op = opcode;
+    dpp.encoding = 0x35;
+    dpp.src0 = 250;
+    dpp.src1 = 256 + 2;
+    dpp.vsrc0 = 22;
+    dpp.fi = 1;
+    dpp.bank_mask = 0xf;
+    dpp.row_mask = 0xf;
+    std::array<uint32_t, 3> words{};
+    std::memcpy(words.data(), &dpp, sizeof(dpp));
+    auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+        {words[0], words[1], words[2], kEndpgm});
+    rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+    rocjitsu::BinaryTranslator translator(
+        ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+        gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                                 rocjitsu::ProcessorRevision::Gfx1250A0));
+    const auto result = translator.translate(source);
+    ASSERT_FALSE(result.ok());
+    ASSERT_FALSE(result.diagnostics.empty());
+    EXPECT_NE(result.diagnostics.front().message.find("does not support DPP"), std::string::npos);
+  }
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250E5m3PackUsesCarriersUnderSgprPressure) {
+  for (const uint16_t opcode : {gfx1250::kVCvtPkFp8F32Vop3, gfx1250::kVCvtSrFp8F32Vop3}) {
+    const auto conversion =
+        gfx1250::build_vop3(opcode, {.vdst = 30, .clamp = 1, .src0 = 256 + 22, .src1 = 256 + 23});
+    auto image =
+        rocjitsu::make_gfx1250_image_with_live_sgprs(conversion, rocjitsu::REGISTER_SET_MAX_SGPRS);
+    rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+    rocjitsu::BinaryTranslator translator(
+        ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+        gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                                 rocjitsu::ProcessorRevision::Gfx1250A0));
+    const auto result = translator.translate(source);
+    ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                            : result.diagnostics.front().message);
+    rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+    const auto decoded =
+        decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+    EXPECT_EQ(std::ranges::count_if(
+                  decoded, [](const auto &inst) { return inst->mnemonic() == "s_cbranch_execz"; }),
+              1);
+    EXPECT_GE(std::ranges::count_if(
+                  decoded,
+                  [](const auto &inst) { return inst->mnemonic() == "v_readfirstlane_b32_e32"; }),
+              4);
+  }
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250CopiesLiteralCvtF32Fp8E32WithoutClampEmulation) {

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -9945,8 +9945,9 @@ run_gfx1250_e5m3_replacement(uint16_t opcode, uint8_t opsel, uint32_t src0_value
   cfg.arch = ROCJITSU_CODE_ARCH_GFX1250;
   cfg.num_wf_slots = 1;
   cfg.sgprs_per_wf = 106;
-  // Both banks must be addressable: a banked operand resolves to reg + 256.
-  cfg.vgprs_per_wf = 512;
+  // Every bank must be addressable: a role's two-bit selector resolves an
+  // operand to reg + 256 * selector, so the file has to span all four.
+  cfg.vgprs_per_wf = 1024;
   cfg.lds_size_kb = 64;
   auto cu = rocjitsu::amdgpu::ComputeUnitCore::create("gfx1250_e5m3", cfg, &gpu_mem, &l2);
   if (cu == nullptr) {
@@ -10058,14 +10059,15 @@ TEST(BinaryTranslatorE2E, Gfx1250E5m3StochasticReplacementMatchesReferenceConver
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250E5m3ReplacementsHonorPerRoleVgprBanks) {
-  // Only two banks are addressable, so no single mode can separate all three
-  // roles. Raising each role's bank on its own does: whichever pair a lowering
-  // confuses, one of these modes has them differ, and the operand then resolves
-  // to a register nothing wrote instead of one that happens to hold the answer.
+  // Every mode gives src0, src1 and the destination three different banks, so a
+  // lowering that forwards one role's selector in place of another's resolves to
+  // a register nothing wrote rather than one that happens to hold the answer.
+  // Rotating through them puts each role on each of selectors 1, 2 and 3, which
+  // is what catches a selector whose high bit is dropped.
   static constexpr std::array<uint8_t, 3> modes = {
-      1u,      // src0 in the high bank.
-      1u << 2, // src1 in the high bank.
-      1u << 6, // destination in the high bank.
+      0xC9u, // src0 bank 1, src1 bank 2, destination bank 3.
+      0x87u, // src0 bank 3, src1 bank 1, destination bank 2.
+      0x4Eu, // src0 bank 2, src1 bank 3, destination bank 1.
   };
   static constexpr std::array<uint32_t, 6> kValues = {0x00000000u, 0x37000000u, 0x3F800000u,
                                                       0x47E00000u, 0x47F80000u, 0x7FC00000u};


### PR DESCRIPTION
## Motivation

hipBLASLt's gfx1250 kernels could not be translated for A0 for two independent reasons. First, they use the FP8 conversions v_cvt_pk_fp8_f32, v_cvt_sr_fp8_f32 and v_cvt_f32_fp8 with CLAMP=1, which on B0 selects the unsigned E5M3 scale format — an encoding A0 does not implement, so the instruction cannot simply be copied through. Second, LLVM emits the signed PC-delta indirect-branch template with an s_wait_xcnt drain ahead of its instruction prefetch, a shape the recovery matcher did not recognize; without a recovered target the branch stayed dynamic and the object was refused. A refusal here is not a graceful degradation in practice — hipBLASLt does not check the load status and segfaults on a null kernel handle — so both gaps presented as crashes rather than diagnostics.

## Technical details

The three CLAMP=1 conversions gain software expansions that reproduce the B0 E5M3 semantics on A0 out of ordinary VALU work: magnitude extraction, an RNE round at the F32 mantissa boundary with the exponent-bias delta removed, an exact 2^17-scaled path for the constant subnormal quantum, stochastic rounding driven by the seed's high bits, MODE.FP16_OVFL read through s_getreg_b32 and mapped branchlessly to the right terminal encoding, and a destination merge that preserves the untouched half or bytes. Each expansion allocates scratch VGPRs and SGPRs through the existing spill-capable allocators, tracks the VGPR-MSB bank per operand role, and fails closed on DPP and SRC_LITERAL64 operands it cannot re-encode. Indirect-branch recovery now treats s_wait_xcnt as skippable padding in both halves of the signed-delta template; because the subtract half lies inside the byte range the canonical builder overwrites and NOP-fills, a source_requires_xcnt_drain flag rides the fixup through relocation so the rewrite re-emits s_wait_xcnt 0 ahead of the writes it ordered, and a replacement mismatch on a shared range fails closed. Correctness is pinned by executing the emitted A0 sequences on the emulated gfx1250 compute unit and comparing against the execution model's own f32_to_fp8_e5m3_rne_mode / _sr_mode helpers across the format's discontinuities, both FP16_OVFL settings, every destination half and byte, and all four VGPR-MSB bank selectors.