### PR TITLE
feature(rocdbgapi): Use flat_scratch to get the scratch base when available

### DIFF
--- a/projects/rocdbgapi/src/architecture.cpp
+++ b/projects/rocdbgapi/src/architecture.cpp
@@ -2589,6 +2589,9 @@ public:
     const agent_t &agent, uint32_t compute_tmpring_size_register,
     const architecture_t::cwsr_record_t &cwsr_record) const override;
 
+  amd_dbgapi_size_t
+  scratch_memory_size (uint32_t compute_tmpring_size_register) const override;
+
   std::vector<agent_t::aperture_t>
   get_apertures (const os_agent_info_t &info) const override;
 
@@ -3411,7 +3414,7 @@ gfx9_architecture_t::scratch_memory_region (
     = utils::bit_extract (compute_tmpring_size_register, 0, 11);
   /* Amount of space in bytes used by each wave.  */
   amd_dbgapi_size_t wavesize
-    = utils::bit_extract (compute_tmpring_size_register, 12, 24) * 1024;
+    = scratch_memory_size (compute_tmpring_size_register);
 
   auto shader_engine_count = utils::narrow<uint32_t> (
     agent.os_info ().shader_engine_count / agent.os_info ().xcc_count);
@@ -3440,6 +3443,13 @@ gfx9_architecture_t::scratch_memory_region (
     = waves * wavesize * cwsr_record.xcc_id ();
 
   return { xcc_scratch_base + offset, wavesize };
+}
+
+amd_dbgapi_size_t
+gfx9_architecture_t::scratch_memory_size (
+  uint32_t compute_tmpring_size_register) const
+{
+  return utils::bit_extract (compute_tmpring_size_register, 12, 24) * 1024;
 }
 
 std::vector<agent_t::aperture_t>
@@ -5579,6 +5589,8 @@ public:
   scratch_memory_region (
     const agent_t &agent, uint32_t compute_tmpring_size_register,
     const architecture_t::cwsr_record_t &cwsr_record) const override;
+  amd_dbgapi_size_t
+  scratch_memory_size (uint32_t compute_tmpring_size_register) const override;
 
   bool can_halt_at_endpgm () const override { return true; }
   virtual bool can_halt_at_sendmsg_dealloc_vgprs () const
@@ -6127,30 +6139,17 @@ gfx11_architecture_t::can_simulate (wave_t &wave,
 
 std::pair<amd_dbgapi_size_t /* offset  */, amd_dbgapi_size_t /* size  */>
 gfx11_architecture_t::scratch_memory_region (
-  const agent_t &agent, uint32_t compute_tmpring_size_register,
-  const architecture_t::cwsr_record_t &cwsr_record) const
+  const agent_t & /* agent */, uint32_t /* compute_tmpring_size_register */,
+  const architecture_t::cwsr_record_t & /* cwsr_record */) const
 {
-  /* Total size of allocated scratch memory in number of waves.  */
-  amd_dbgapi_size_t waves
-    = utils::bit_extract (compute_tmpring_size_register, 0, 11);
-  /* Amount of space in bytes used by each wave.  */
-  amd_dbgapi_size_t wavesize
-    = utils::bit_extract (compute_tmpring_size_register, 12, 26) * 256;
+  dbgapi_assert_not_reached ("scratch_memory_region must not be called");
+}
 
-  /* For gfx11, the number of waves is per shader engine instead of total.  */
-  amd_dbgapi_size_t offset = (waves * cwsr_record.shader_engine_id ()
-                              + cwsr_record.scratch_scoreboard_id ())
-                             * wavesize;
-
-  auto shader_engine_count = utils::narrow<uint32_t> (
-    agent.os_info ().shader_engine_count / agent.os_info ().xcc_count);
-
-  /* The scratch memory is evenly divided between all XCCs, so each XCC has its
-     own scratch base.  */
-  amd_dbgapi_size_t xcc_scratch_base
-    = waves * shader_engine_count * wavesize * cwsr_record.xcc_id ();
-
-  return { xcc_scratch_base + offset, wavesize };
+amd_dbgapi_size_t
+gfx11_architecture_t::scratch_memory_size (
+  uint32_t compute_tmpring_size_register) const
+{
+  return utils::bit_extract (compute_tmpring_size_register, 12, 26) * 256;
 }
 
 /* Generic gfx11 architecture.  */
@@ -6446,10 +6445,8 @@ protected:
   wave_disable_traps (wave_t &wave,
                       os_wave_launch_trap_mask_t mask) const override final;
 
-  std::pair<amd_dbgapi_size_t /* offset  */, amd_dbgapi_size_t /* size  */>
-  scratch_memory_region (
-    const agent_t &agent, uint32_t compute_tmpring_size_register,
-    const architecture_t::cwsr_record_t &cwsr_record) const override;
+  amd_dbgapi_size_t
+  scratch_memory_size (uint32_t compute_tmpring_size_register) const override;
 };
 
 gfx12_architecture_t::gfx12_architecture_t (elf_amdgpu_machine_t e_machine,
@@ -7572,33 +7569,11 @@ gfx12_architecture_t::is_sequential (const instruction_t &instruction) const
     && !is_sopk_encoding<20> (instruction);
 }
 
-std::pair<amd_dbgapi_size_t /* offset  */, amd_dbgapi_size_t /* size  */>
-gfx12_architecture_t::scratch_memory_region (
-  const agent_t &agent, uint32_t compute_tmpring_size_register,
-  const architecture_t::cwsr_record_t &cwsr_record) const
+amd_dbgapi_size_t
+gfx12_architecture_t::scratch_memory_size (
+  uint32_t compute_tmpring_size_register) const
 {
-  /* Total size of allocated scratch memory in number of waves.  */
-  amd_dbgapi_size_t waves
-    = utils::bit_extract (compute_tmpring_size_register, 0, 11);
-  /* Amount of space in bytes used by each wave.
-     This is unit of 64 dwords.  */
-  amd_dbgapi_size_t wavesize
-    = utils::bit_extract (compute_tmpring_size_register, 12, 29) * 256;
-
-  /* The number of waves is per shader engine instead of total.  */
-  amd_dbgapi_size_t offset = (waves * cwsr_record.shader_engine_id ()
-                              + cwsr_record.scratch_scoreboard_id ())
-                             * wavesize;
-
-  auto shader_engine_count = utils::narrow<uint32_t> (
-    agent.os_info ().shader_engine_count / agent.os_info ().xcc_count);
-
-  /* The scratch memory is evenly divided between all XCCs, so each XCC has its
-     own scratch base.  */
-  amd_dbgapi_size_t xcc_scratch_base
-    = waves * shader_engine_count * wavesize * cwsr_record.xcc_id ();
-
-  return { xcc_scratch_base + offset, wavesize };
+  return utils::bit_extract (compute_tmpring_size_register, 12, 29) * 256;
 }
 
 /* Generic gfx12 architecture.  */

--- a/projects/rocdbgapi/src/architecture.h
+++ b/projects/rocdbgapi/src/architecture.h
@@ -299,6 +299,11 @@ public:
                          const cwsr_record_t &cwsr_record) const
     = 0;
 
+  /* Size, in bytes, of the scratch memory allocated per wave.  */
+  virtual amd_dbgapi_size_t
+  scratch_memory_size (uint32_t compute_tmpring_size_register) const
+    = 0;
+
   virtual bool
   is_address_space_supported (const address_space_t &address_space) const
     = 0;

--- a/projects/rocdbgapi/src/queue.cpp
+++ b/projects/rocdbgapi/src/queue.cpp
@@ -1017,10 +1017,25 @@ std::pair<agent_address_t /* address */, amd_dbgapi_size_t /* size */>
 aql_queue_t::scratch_memory_region (
   const architecture_t::cwsr_record_t &cwsr_record) const
 {
-  auto [offset, size] = architecture ().scratch_memory_region (
-    agent (), m_compute_tmpring_size, cwsr_record);
+  if (architecture ().has_architected_flat_scratch ())
+    {
+      agent_address_t flat_scratch;
+      auto flat_scratch_address
+        = cwsr_record.register_address (amdgpu_regnum_t::flat_scratch);
+      dbgapi_assert (flat_scratch_address.has_value ());
+      agent ().read_agent_memory (flat_scratch_address.value (),
+                                  &flat_scratch);
 
-  return { m_scratch_backing_memory_address + offset, size };
+      return { flat_scratch,
+               architecture ().scratch_memory_size (m_compute_tmpring_size) };
+    }
+  else
+    {
+      auto [offset, size] = architecture ().scratch_memory_region (
+        agent (), m_compute_tmpring_size, cwsr_record);
+
+      return { m_scratch_backing_memory_address + offset, size };
+    }
 }
 
 void

--- a/projects/rocdbgapi/src/wave.cpp
+++ b/projects/rocdbgapi/src/wave.cpp
@@ -790,30 +790,7 @@ wave_t::write_register (amdgpu_regnum_t regnum, size_t offset,
 std::pair<agent_address_t /* address */, amd_dbgapi_size_t /* size */>
 wave_t::scratch_memory_region () const
 {
-  auto [address, size]
-    = queue ().scratch_memory_region (*m_cwsr_record.get ());
-
-  /* On architectures with an architected flat_scratch register, check that the
-     computed slot scratch address matches the content of the register.  */
-  if (architecture ().has_architected_flat_scratch ())
-    {
-      agent_address_t flat_scratch;
-      read_register (amdgpu_regnum_t::flat_scratch, &flat_scratch);
-
-      if (address != flat_scratch && size != 0)
-        {
-          warning ("flat_scratch may be corrupted, "
-                   "private memory access is disabled");
-
-          /* If the computed scratch address differs from the content of the
-             flat_scratch register, either the calculation is incorrect or the
-             register is corrupted.  Disable access to the scratch memory
-             region by returning a 0 size.  */
-          size = 0;
-        }
-    }
-
-  return { address, size };
+  return queue ().scratch_memory_region (*m_cwsr_record.get ());
 }
 
 size_t


### PR DESCRIPTION
For architectures where we have the flat_scratch register, there is no need to fully compute the scratch base address from the wave relaunch data.  It is easier to just read the flat_scratch register.

We still need to decode the compute_tmpringsize register to know how many bytes of scratch is allocated per wave, but the rest is not really necessary.

## Motivation

Simplify the code and remove the need for adding new calculations for new architectures.

## Technical Details

The `flat_scratch` reg has the calculated address we need. No need to compute anymore.

## Issue Tracking

AIROCGDB-1337

## Test Plan

Run ROCgdb test.

## Test Result
```
FAIL: gdb.rocm/runtime-core.exp: fault=abort: faulty_wave: frame function abort_kernel
FAIL: gdb.rocm/runtime-core.exp: fault=abort: faulty_wave: p local
FAIL: gdb.rocm/runtime-core.exp: fault=abort: faulty_wave: p some_global
FAIL: gdb.rocm/runtime-core.exp: fault=abort: faulty_wave: p data
FAIL: gdb.rocm/runtime-core.exp: fault=abort: faulty_wave: p data[12]
...
FAIL: gdb.rocm/runtime-core.exp: fault=assert: faulty_wave: frame function assert_kernel
FAIL: gdb.rocm/runtime-core.exp: fault=assert: faulty_wave: p local
FAIL: gdb.rocm/runtime-core.exp: fault=assert: faulty_wave: p some_global
FAIL: gdb.rocm/runtime-core.exp: fault=assert: faulty_wave: p data
FAIL: gdb.rocm/runtime-core.exp: fault=assert: faulty_wave: p data[12]
...
		=== gdb Summary ===

# of unexpected core files	16
# of expected passes		2490
# of unexpected failures	10
# of expected failures		7
# of known failures		7
# of unsupported tests		1
```
Those failures are related to AIROCGDB-646.