### PR TITLE
fix(rocr): Export NUMA dependency regardless of BUILD_SHARED_LIBS

### DIFF
--- a/projects/rocr-runtime/libhsakmt/CMakeLists.txt
+++ b/projects/rocr-runtime/libhsakmt/CMakeLists.txt
@@ -248,18 +248,16 @@ else()
     find_package(NUMA)
     if(NUMA_FOUND)
       set(NUMA "${NUMA_LIBRARIES}")
-      # In BUILD_SHARED_LIBS mode hsakmt-config.cmake loads hsakmtTargets.cmake.
-      # Because hsakmt is static, its private imported dependencies are exported
-      # through LINK_ONLY and must be recreated by the package config. The
-      # staticdrm package path links the raw library name instead.
-      if(BUILD_SHARED_LIBS)
-        foreach(_numa_library IN LISTS NUMA_LIBRARIES)
-          if(TARGET "${_numa_library}")
-            set(HSAKMT_FIND_NUMA_DEPENDENCY ON)
-            break()
-          endif()
-        endforeach()
-      endif()
+      # When NUMA was found as a target, ensure consumers can find it too
+      # by having hsakmt-config.cmake call find_dependency(NUMA).
+      # This is needed regardless of BUILD_SHARED_LIBS because hsakmt's
+      # exported targets reference numa::numa.
+      foreach(_numa_library IN LISTS NUMA_LIBRARIES)
+        if(TARGET "${_numa_library}")
+          set(HSAKMT_FIND_NUMA_DEPENDENCY ON)
+          break()
+        endif()
+      endforeach()
     else()
       find_library(NUMA NAMES numa REQUIRED)
     endif()

--- a/projects/rocr-runtime/libhsakmt/hsakmt-config.cmake.in
+++ b/projects/rocr-runtime/libhsakmt/hsakmt-config.cmake.in
@@ -9,7 +9,8 @@ include( CMakeFindDependencyMacro )
 if(@HSAKMT_FIND_NUMA_DEPENDENCY@)
   # A ROCm distribution that bundles libnuma installs its package config under
   # lib/rocm_sysdeps, which is not on a consumer's default search path.
-  find_dependency(NUMA PATHS "${PACKAGE_PREFIX_DIR}/lib/rocm_sysdeps")
+  # Force CONFIG mode to ensure the imported target (numa::numa) is created.
+  find_dependency(NUMA CONFIG PATHS "${PACKAGE_PREFIX_DIR}/lib/rocm_sysdeps")
 endif()
 
 # If the option is ON link other dependent libraries dynamically


### PR DESCRIPTION
When NUMA is found as an imported target (e.g., numa::numa), hsakmt's exported targets reference it. The generated hsakmt-config.cmake must call find_dependency(NUMA) to make that target available to consumers, otherwise find_package(hsakmt) fails with:

  The link interface of target 'hsakmt::hsakmt' contains:
    numa::numa
  but the target was not found.

Previously, HSAKMT_FIND_NUMA_DEPENDENCY was only set ON when BUILD_SHARED_LIBS=ON. In standalone builds where BUILD_SHARED_LIBS may not be set, this caused the installed hsakmt-config.cmake to omit find_dependency(NUMA), breaking downstream consumers.

This fix removes the BUILD_SHARED_LIBS condition, ensuring the NUMA dependency is always exported when NUMA was found as a target, regardless of build configuration.

Also adds the find_dependency(NUMA) call to hsakmt-config.cmake.in with PATHS hint for bundled libnuma location.

Related to PR #9480 which fixed kfdtest's NUMA CONFIG mode handling.

JIRA ID: ROCM-28573

## Motivation

See PR #8221 and PR #9480 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
