### PR TITLE
rccl: add NIC fusion varibles to env-variables.rst

### DIFF
--- a/projects/rccl/docs/api-reference/env-variables.rst
+++ b/projects/rccl/docs/api-reference/env-variables.rst
@@ -212,14 +212,38 @@ in the following table.
       - | ``0``: Fail initialization with ``ncclSystemError`` and a warning on the mismatch (default).
         | ``1``: Detect and continue, logging the mismatch at ``INFO`` level.
 
+    * - | ``NCCL_IB_MERGE_NICS``
+        | Enables RCCL to combine several physical IB NICs that are close to the
+          same GPU into a single logical network device (NIC Fusion). This allows
+          RCCL to aggregate the bandwidth of those NICs. Use
+          ``NCCL_NET_MERGE_LEVEL`` and ``NCCL_NET_FORCE_MERGE`` to control which
+          NICs are combined.
+      - | ``1``: Enabled (default).
+        | ``0``: Disabled.
+        | On AINIC with the ``IB-CAST`` transport, merging is off unless this
+          variable is explicitly set to ``1``.
+
     * - | ``NCCL_NET_MERGE_LEVEL``
-        | Controls network device merging behavior.
-      - | Integer value specifying merge level
-        | Default: ``PATH_PORT``
+        | Sets the maximum topological distance between two NICs that can be
+          merged into a single logical device. NICs farther apart than this level
+          are left separate.
+      - | ``LOC``: Same device only, which disables merging.
+        | ``PORT``: Two ports of the same NIC (default).
+        | ``PIX``: Under the same PCIe switch.
+        | ``PXB``: Multiple PCIe bridges, without crossing the PCIe host bridge.
+        | ``P2C``, ``PXN``: Accepted, with the same effect as ``PXB`` for NIC pairs.
+        | ``PHB``: Under the same CPU socket.
+        | ``SYS``: Anywhere in the node, including across NUMA nodes.
+        | The value is a string, so ``PATH_PORT`` is not valid. An unrecognized
+          value falls back to ``LOC`` and disables merging.
 
     * - | ``NCCL_NET_FORCE_MERGE``
-        | Forces merging of network devices.
-      - | String specifying forced merge configuration
+        | Merges the listed groups of NICs regardless of
+          ``NCCL_NET_MERGE_LEVEL``. NICs that are not listed are then merged
+          automatically.
+      - | Semicolon-separated list of groups, each a comma-separated list of
+          device names in ``NCCL_IB_HCA`` notation.
+        | Default: unset.
 
     * - | ``NCCL_NETDEVS_POLICY``
         | Controls how many of a GPU's locally reachable NICs are used on the


### PR DESCRIPTION
## Motivation

This pull request updates the environment variable documentation for RCCL's network device merging (NIC Fusion) features. The changes clarify how NIC merging is controlled and introduce more detailed explanations and options for configuring NIC merging behavior.

**New NIC Fusion feature and improved configuration:**

* Added documentation for the new `NCCL_IB_MERGE_NICS` variable, which enables RCCL to combine multiple physical IB NICs near the same GPU into a single logical device, allowing bandwidth aggregation.
* Expanded and clarified the `NCCL_NET_MERGE_LEVEL` variable, listing all supported topology levels for NIC merging (e.g., `LOC`, `PORT`, `PIX`, `PXB`, `PHB`, `SYS`) and explaining their effects.
* Improved the description of `NCCL_NET_FORCE_MERGE`, specifying its format as a semicolon-separated list of comma-separated NIC device names, and clarifying its interaction with `NCCL_NET_MERGE_LEVEL`.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

AICOMNET-154

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
