### PR TITLE
fix(rocjitsu):  Fix scratch allocation for unmapped GPU addresses

### DIFF
--- a/emulation/rocjitsu/docs/rocjitsu-cli.md
+++ b/emulation/rocjitsu/docs/rocjitsu-cli.md
@@ -159,9 +159,12 @@ Memfds are passed via `sendmsg()`/`recvmsg()` with `SCM_RIGHTS` ancillary
 data. This is the standard Unix mechanism for cross-process file descriptor
 sharing (same pattern as QEMU vhost-user and CRIU).
 
-Two RPC operations carry memfds:
-- `RPC_IOCTL` (ALLOC_MEMORY response) --- allocation backing memfd
-- `RPC_MMAP` (response) --- doorbell and event page memfds
+RPC carries memfds in both directions:
+- `RPC_IOCTL` request for `DBG_TRAP ENABLE` --- debugger notifier and target-process authorization fds
+- `RPC_IOCTL` request for `GET_DMABUF_INFO` and `IMPORT_DMABUF` --- the client dmabuf fd
+- `RPC_IOCTL` response for `ALLOC_MEMORY` and `IPC_IMPORT_HANDLE` --- allocation backing memfd
+- `RPC_IOCTL` response for `EXPORT_DMABUF` --- exported duplicate fd
+- `RPC_MMAP` response --- doorbell and event page memfds
 
 ### Thread Safety
 
@@ -169,15 +172,38 @@ ROCR is heavily multithreaded. The `rpc_mutex_` in `RemoteDriver` serializes
 all send+recv pairs. `WAIT_EVENTS` uses client-side polling with `ppoll` on
 a shutdown `eventfd` between daemon timeout=0 polls, avoiding mutex starvation.
 
-## Memory Sharing (Same-VA Architecture)
+## Memory Sharing
 
-Both client and daemon map every memfd at the **same virtual address** using
-MAP_FIXED. GPU VAs are in the GPUVM aperture (`0x1000000000` - `0x3FFFFFFFFFFF`),
-which doesn't collide with either process's normal address space.
+Ordinary GPU allocations use GPUVM addresses chosen inside the reported
+aperture. The daemon backs them with memfds and publishes process page-table
+entries so GPU accesses translate through the simulated KFD process state. In
+daemon mode the daemon maps each backing at a daemon-local host address; the
+client maps the received memfd at ROCR's requested address with `MAP_FIXED` when
+CPU access is required. The daemon does not rely on direct
+`reinterpret_cast<void *>(gpu_va)` dereferences for shared allocations.
 
-This means `reinterpret_cast<void*>(gpu_va)` works in both processes ---
-AQL packets, kernarg pointers, signal handles, ring buffers, and rptr/wptr
-all resolve correctly without VA translation.
+USERPTR is intentionally different. `va_addr` is the GPU VA, while
+`mmap_offset` is the caller's CPU VMA. In daemon mode the client stages that CPU
+range into the daemon-created memfd and replaces the caller VMA only after the
+staging copy succeeds. The daemon may use a different host address internally;
+GPU access still goes through the process page table rather than by
+reinterpret-casting every GPU VA as a host pointer.
+
+DMABUF imports also use the daemon's local fd namespace. The client sends the
+dmabuf with the request, the daemon duplicates and maps it locally, and the
+client-visible fd number is restored in the response. Imports with a nonzero
+`va_addr` publish GPU PTEs immediately. Imports with `va_addr == 0` are
+handle-only graphics registrations: the daemon retains the backing under the
+returned KFD handle but does not map GPU address zero.
+
+Scratch backing follows libhsakmt's split address model. The advertised scratch
+aperture is the logical shader/debugger private-address window, while
+`SET_SCRATCH_BACKING_VA` carries a GPUVM/SVM backing address. When the runtime
+has not programmed backing, the simulator uses a per-GPU fallback reserve near
+the top of GPUVM rather than the logical scratch aperture. These fallback
+windows are reserved from process creation: ordinary driver-selected
+allocations skip them, explicit allocations/imports reject overlap, and
+fallback dispatches require the simulator-owned scratch pool for that GPU.
 
 ### Allocation Flow
 
@@ -190,29 +216,32 @@ Client                                     Daemon
 2. ROCR: hsaKmtAllocMemory()
    RemoteDriver::send_ioctl(ALLOC)  ---->  alloc_memory_ioctl()
                                             memfd_create + ftruncate + fallocate
-                                            MAP_FIXED memfd at VA (proactive)
+                                            mmap memfd at daemon-local host VA
+                                            publish GPUVA -> host PTEs
                                     <----  response + memfd (SCM_RIGHTS)
-   [USERPTR: mincore+copy, MAP_FIXED]
+   [USERPTR: copy mmap_offset CPU range, MAP_FIXED only after staging succeeds]
 
 3. ROCR: fmm_map_to_cpu()
    mmap(drm_fd, MAP_FIXED, offset)
-   interposer routes DRM fd     ---->     mmap() -> already mapped, return
-                                    <----  response
+   RemoteDriver maps memfd locally at requested VA
 ```
 
-### Proactive Mapping
+### Daemon-Local Backing
 
-The daemon MAP_FIXED maps all allocations at ALLOC_MEMORY time, not at
-mmap time. This prevents a race where the CP thread dereferences kernarg
-pointers before the client's fmm_map_to_cpu RPC arrives.
+The daemon creates and maps ordinary allocation backing during ALLOC_MEMORY, but
+the mapping is daemon-local. GPU-visible addresses are resolved through the
+process page table. Client `MAP_FIXED` mappings are created later by the
+RemoteDriver when ROCR asks for CPU access, or by the anonymous-MAP_FIXED
+interception path for already registered daemon-shared ranges.
 
 ### USERPTR Sharing
 
 For USERPTR allocations (ring buffer, rptr/wptr), the client receives the
-daemon's memfd, copies committed pages via mincore, then MAP_FIXED replaces
-the anonymous pages with the shared memfd. The interposer suppresses
-MADV_HUGEPAGE and MADV_DONTFORK on GPUVM addresses to prevent kernel 6.17
-shmem fault failures.
+daemon's memfd, copies the full valid CPU range named by `mmap_offset`, then
+MAP_FIXED replaces those CPU pages with the shared memfd. If promotion fails,
+the client rolls back the daemon allocation and leaves the original VMA in
+place. The interposer suppresses MADV_HUGEPAGE and MADV_DONTFORK on GPUVM
+addresses to prevent kernel 6.17 shmem fault failures.
 
 ### Trust Model
 

--- a/emulation/rocjitsu/docs/vm-design.md
+++ b/emulation/rocjitsu/docs/vm-design.md
@@ -426,15 +426,43 @@ ROCm application
 | `GET_VERSION` | `get_version_ioctl` | Returns KFD_IOCTL_MAJOR/MINOR_VERSION |
 | `GET_PROCESS_APERTURES_NEW` | `get_process_apertures_ioctl` | Returns `gpu_apertures(ordinal)` — LDS/scratch shifted by `kApertureStride` per GPU, with per-instance `gpu_id` |
 | `ACQUIRE_VM` | `acquire_vm_ioctl` | No-op (VM is always acquired) |
-| `ALLOC_MEMORY_OF_GPU` | `alloc_memory_ioctl` | Allocates host memory, assigns GPU VA from a linear bump allocator |
-| `FREE_MEMORY_OF_GPU` | `free_memory_ioctl` | Frees host memory, removes VA mapping |
-| `MAP_MEMORY_TO_GPU` / `UNMAP` | map/unmap ioctls | No-op (host pointers serve as GPU VAs) |
+| `ALLOC_MEMORY_OF_GPU` | `alloc_memory_ioctl` | Allocates host memory; caller-provided GPU VAs must be in the reported GPUVM aperture and must not overlap live allocations, and driver-selected GPU VAs search forward from the cursor to the next free aligned range |
+| `FREE_MEMORY_OF_GPU` | `free_memory_ioctl` | Releases allocation ownership and removes only the freed allocation's VA mapping |
+| `MAP_MEMORY_TO_GPU` / `UNMAP` | map/unmap ioctls | Publishes/removes PTEs for the allocation's tracked backing; caller-owned USERPTR VMAs are never unmapped by the driver |
+| `IMPORT_DMABUF` / `IPC_IMPORT_HANDLE` | import ioctls | Publish imported backing after a nonzero requested GPU VA range is proven in-aperture and non-overlapping; zero-VA DMABUF imports are handle-only for graphics/GEM paths; IPC imports can also allocate the next free driver-selected VA |
 | `CREATE_QUEUE` | `create_queue_ioctl` | Registers an AQL ring with the CP; deferred until doorbell page is mapped |
 | `DESTROY_QUEUE` | `destroy_queue_ioctl` | Unregisters the ring from the CP |
 | `CREATE_EVENT` | `create_event_ioctl` | Allocates a slot in the memfd-backed signal page |
 | `DESTROY_EVENT` | `destroy_event_ioctl` | Removes event slot; wakes any WAIT_EVENTS callers |
 | `SET_EVENT` | `set_event_ioctl` | Marks slot non-zero with `memory_order_release`; notifies waiters |
 | `WAIT_EVENTS` | `wait_events_ioctl` | Waits up to 100ms then returns; simulates `wake_up_interruptible` |
+
+Scratch has two address domains. `GET_PROCESS_APERTURES_NEW` reports the
+logical LDS/scratch apertures used for shader private-address and debugger
+semantics. `SET_SCRATCH_BACKING_VA`, however, programs the physical backing
+GPUVA that libhsakmt allocated from the GPUVM/SVM domain. rocjitsu validates
+that backing in GPUVM, not in the logical scratch aperture. If a dispatch needs
+scratch before the runtime programs backing, the simulator uses a per-GPU
+fallback reserve near the top of GPUVM. The backing pool lives outside the
+user-visible KFD allocation handle table, and the reserved windows are excluded
+from ordinary explicit/imported and driver-selected allocations. Fallback
+dispatches require the simulator-owned scratch pool for that GPU; ordinary host
+PTEs at the same address do not satisfy scratch backing. Growth preserves
+internal backing identity, maps only newly exposed tail pages, and checks exact
+byte-range host backing rather than PTE presence alone. The legacy scratch path
+sizes through the highest logical workgroup slot including `workgroup_id_offset`;
+CDNA5 sizes to the complete physical XCC/SE/scoreboard scratch capacity required
+by the device model.
+
+USERPTR allocations keep the caller's CPU VA distinct from the GPU VA:
+`mmap_offset` names the CPU VMA to share, while `va_addr` names the GPUVM
+address. Local mode maps GPU PTEs directly to the caller VMA and leaves the VMA
+owned by the caller on free. Daemon mode first stages the CPU contents into a
+memfd and only then replaces the caller VMA with shared backing; if staging or
+replacement fails, the daemon allocation is freed and the original ioctl result
+is not reported as success. IPC export rejects USERPTR allocations and any
+non-USERPTR allocation without shareable memfd backing instead of creating a
+snapshot that would sever the CPU/GPU alias.
 
 ### Signal event page
 

--- a/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/vm/rj_vm.h
+++ b/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/vm/rj_vm.h
@@ -54,12 +54,20 @@ typedef enum rj_vm_mode_t {
 
 /// @brief Device command descriptor for rj_vm_execute.
 typedef struct rj_vm_cmd_t {
-  uint32_t cmd;               ///< Platform-specific command number.
-  void *buf;                  ///< Command arguments buffer (with inlined arrays).
-  size_t buf_size;            ///< Total size of the arguments buffer.
-  int32_t result;             ///< [out] Return code (0 on success, negative errno on failure).
-  rj_handle_t shared_handle;  ///< [out] Borrowed backing handle, or -1; owned by the VM.
-  rj_handle_t in_handle;      ///< [in,out] Client-provided fd (e.g. debugger notifier), or -1.
+  uint32_t cmd;    ///< Platform-specific command number.
+  void *buf;       ///< Command arguments buffer (with inlined arrays).
+  size_t buf_size; ///< Total size of the arguments buffer.
+  int32_t result;  ///< [out] Return code (0 on success, negative errno on failure).
+  /// @brief Response fd returned by command execution, or -1.
+  /// @details When shared backing exists, successful ALLOC_MEMORY and
+  /// IPC_IMPORT_HANDLE return a VM-owned borrowed backing fd that callers must
+  /// not close and may use only while the allocation/process remains alive.
+  /// Local explicit-VA ALLOC_MEMORY can succeed without shared backing and
+  /// therefore leaves this field as -1. Successful EXPORT_DMABUF returns a
+  /// one-shot duplicate that the caller owns and should close after
+  /// transfer/use. Other commands leave this field as -1.
+  rj_handle_t shared_handle;
+  rj_handle_t in_handle;      ///< [in,out] Request fd such as DBG_TRAP notifier or dmabuf, or -1.
   rj_handle_t in_mem_handle;  ///< [in,out] Debugger-authorized target /proc/pid/mem fd, or -1.
   rj_handle_t in_proc_handle; ///< [in] Pinned target /proc/pid directory fd, or -1.
 } rj_vm_cmd_t;
@@ -264,12 +272,13 @@ RJ_API_EXPORT rj_status_t rj_vm_execute(rj_vm_t *vm, rj_vm_cmd_t *cmd);
 /// @brief Execute a device command for a specific process (daemon mode).
 ///
 /// @details In daemon mode, if @p cmd carries a client-provided input fd in
-/// cmd->in_handle (e.g. the debugger's notifier pipe for AMDKFD_IOC_DBG_TRAP
-/// ENABLE), the VM substitutes it into the command payload and, on success,
-/// adopts it — clearing cmd->in_handle to -1 so the caller does not close the
-/// descriptor. If the command does not consume the fd, cmd->in_handle is left
-/// unchanged for the caller to reclaim. Set cmd->in_handle to -1 when there is
-/// no fd to transfer.
+/// cmd->in_handle, the VM substitutes it into ioctl payloads whose descriptor
+/// fields are process-local. DBG_TRAP ENABLE consumes and adopts the notifier,
+/// clearing cmd->in_handle to -1 so the caller does not close it. GET_DMABUF_INFO
+/// and IMPORT_DMABUF borrow the fd only long enough for the KFD layer to inspect
+/// or duplicate it, leaving cmd->in_handle unchanged for the caller to reclaim.
+/// See rj_vm_cmd_t::shared_handle for response-fd ownership. Set
+/// cmd->in_handle to -1 when there is no fd to transfer.
 /// @param[in] vm VM handle.
 /// @param[in] process_id The target process ID.
 /// @param[in,out] cmd Command descriptor.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
@@ -44,6 +44,17 @@ namespace rocjitsu {
 /// routes ioctls to the correct KfdProcess.
 class KfdProcess {
 public:
+  /// @brief Log2 of the simulated KFD GPU page size.
+  static constexpr uint64_t kPageShift = 12;
+  /// @brief Simulated KFD GPU page size in bytes.
+  static constexpr uint64_t kPageSize = 1ULL << kPageShift;
+  /// @brief Lowest address in the GPUVM aperture reported to userspace.
+  static constexpr uint64_t kGpuVmBase = 0x10000ULL;
+  /// @brief Inclusive highest address in the GPUVM aperture reported to userspace.
+  static constexpr uint64_t kGpuVmLimit = 0x7FFFFFFFFFFFULL;
+  /// @brief First GPUVA considered for allocations selected by the simulated driver.
+  static constexpr uint64_t kGpuVmAllocationBase = 0x1000000000ULL;
+
   /// @brief Per-GPU state within a process.
   struct PerGpuState {
     /// @brief One live client mapping of the canonical doorbell backing.
@@ -70,7 +81,7 @@ public:
   /// @param process_id Unique identifier (analogous to PASID) for CP routing.
   /// @param num_gpus Number of GPU devices (sizes per-GPU state vector).
   explicit KfdProcess(uint32_t process_id, uint32_t num_gpus = 1)
-      : process_id_(process_id), next_gpu_va_(0x1000000000ULL), gpu_state_(num_gpus) {}
+      : process_id_(process_id), next_gpu_va_(kGpuVmAllocationBase), gpu_state_(num_gpus) {}
 
   /// @brief Get the process ID (PASID analog).
   uint32_t process_id() const { return process_id_; }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
@@ -301,11 +301,6 @@ public:
     }
   };
 
-  // GPUVM uses the simulator's fixed 4 KiB translation granule. This models
-  // the GPU page table and is intentionally independent of the host page size.
-  static constexpr uint64_t kPageShift = 12;
-  static constexpr uint64_t kPageSize = 1ULL << kPageShift;
-
   /// @brief One host-backed interval within a GPU page.
   struct HostExtent {
     uint8_t *host_ptr = nullptr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
@@ -23,6 +23,7 @@
 #include <atomic>
 #include <cassert>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
@@ -47,11 +48,16 @@ public:
   /// @brief Log2 of the simulated KFD GPU page size.
   static constexpr uint64_t kPageShift = 12;
   /// @brief Simulated KFD GPU page size in bytes.
+  /// @details This is the simulator's GPU translation granule. It is kept at
+  /// 4 KiB to match KFD page-table contracts and is intentionally independent
+  /// of the host system page size.
   static constexpr uint64_t kPageSize = 1ULL << kPageShift;
   /// @brief Lowest address in the GPUVM aperture reported to userspace.
   static constexpr uint64_t kGpuVmBase = 0x10000ULL;
   /// @brief Inclusive highest address in the GPUVM aperture reported to userspace.
   static constexpr uint64_t kGpuVmLimit = 0x7FFFFFFFFFFFULL;
+  /// @brief Per-GPU high-GPUVM reserve used for simulator fallback scratch backing.
+  static constexpr uint64_t kFallbackScratchReserveSize = 0x100000000ULL;
   /// @brief First GPUVA considered for allocations selected by the simulated driver.
   static constexpr uint64_t kGpuVmAllocationBase = 0x1000000000ULL;
 
@@ -301,6 +307,73 @@ public:
     }
   };
 
+  /// @brief Driver-owned storage that can move without changing PTE identity.
+  class BackingStore {
+  public:
+    using ResizeContentionHook = std::function<void()>;
+
+    BackingStore() = default;
+    explicit BackingStore(size_t size) : storage_(size) {}
+
+    BackingStore(const BackingStore &) = delete;
+    BackingStore &operator=(const BackingStore &) = delete;
+
+    [[nodiscard]] size_t size() const {
+      std::shared_lock lock(mutex_);
+      return storage_.size();
+    }
+
+    [[nodiscard]] bool resize(size_t size) {
+      std::unique_lock<std::shared_mutex> lock(mutex_, std::defer_lock);
+      if (resize_contention_hook_) {
+        if (!lock.try_lock()) {
+          (*resize_contention_hook_)();
+          lock.lock();
+        }
+      } else {
+        lock.lock();
+      }
+      if (size <= storage_.size())
+        return true;
+      try {
+        storage_.resize(size);
+      } catch (...) {
+        return false;
+      }
+      return true;
+    }
+
+    /// @brief Run @p fn with a stable pointer into this backing store.
+    /// @details Holds a shared lock for the full callback. The supplied pointer
+    /// is borrowed and becomes invalid when the callback returns; callers must
+    /// not store it or use it while another thread may resize the backing.
+    template <typename F> bool with_span(size_t offset, size_t size, F &&fn) {
+      if (size == 0)
+        return false;
+      std::shared_lock lock(mutex_);
+      if (offset > storage_.size() || size > storage_.size() - offset)
+        return false;
+      fn(storage_.data() + offset);
+      return true;
+    }
+
+    /// @brief Install a borrowed test hook called when resize waits on a live span.
+    /// @details The hook pointer is not owned and must outlive this BackingStore
+    /// or be reset to nullptr before the pointed-to callable is destroyed.
+    void set_resize_contention_hook_for_testing(ResizeContentionHook *hook) {
+      resize_contention_hook_ = hook;
+    }
+
+    [[nodiscard]] uintptr_t atomic_key(size_t offset) const {
+      return reinterpret_cast<uintptr_t>(this) ^ offset;
+    }
+
+  private:
+    mutable std::shared_mutex mutex_;
+    std::vector<uint8_t> storage_;
+    ResizeContentionHook *resize_contention_hook_ = nullptr;
+  };
+
   /// @brief One host-backed interval within a GPU page.
   struct HostExtent {
     uint8_t *host_ptr = nullptr;
@@ -308,6 +381,18 @@ public:
     size_t host_backed_bytes = 0;
     /// GPU-page offset that corresponds to host_ptr.
     size_t gpu_page_offset = 0;
+    /// Stable internal backing for driver-owned memory such as fallback scratch.
+    std::shared_ptr<BackingStore> backing;
+    /// Byte offset within backing that corresponds to gpu_page_offset.
+    size_t backing_offset = 0;
+
+    [[nodiscard]] bool has_backing() const { return host_ptr != nullptr || backing != nullptr; }
+    [[nodiscard]] bool has_raw_host_ptr() const {
+      return host_ptr != nullptr && backing == nullptr;
+    }
+    [[nodiscard]] bool has_backing_store() const {
+      return host_ptr == nullptr && backing != nullptr;
+    }
 
     bool operator==(const HostExtent &) const = default;
   };
@@ -461,16 +546,43 @@ public:
   struct PageTableEntry {
     PageTableEntry() = default;
     PageTableEntry(uint8_t *host_ptr, amdgpu::Mtype page_mtype)
-        : mtype(page_mtype), host_extents{{host_ptr, kPageSize, 0}} {}
+        : mtype(page_mtype), host_extents{{host_ptr, kPageSize, 0, nullptr, 0}} {}
     PageTableEntry(uint8_t *host_ptr, amdgpu::Mtype page_mtype, size_t host_backed_bytes,
                    size_t gpu_page_offset)
-        : mtype(page_mtype), host_extents{{host_ptr, host_backed_bytes, gpu_page_offset}} {}
+        : mtype(page_mtype),
+          host_extents{{host_ptr, host_backed_bytes, gpu_page_offset, nullptr, 0}} {}
 
     amdgpu::Mtype mtype = amdgpu::Mtype::RW;
     HostExtentList host_extents;
 
     bool operator==(const PageTableEntry &) const = default;
   };
+
+  /// @brief Process-local scratch pool key.
+  struct ScratchPoolKey {
+    uint32_t gpu_ordinal = 0;
+    uint64_t gpu_va = 0;
+
+    bool operator==(const ScratchPoolKey &) const = default;
+  };
+
+  struct ScratchPoolKeyHash {
+    size_t operator()(const ScratchPoolKey &key) const {
+      size_t hash_value = std::hash<uint32_t>{}(key.gpu_ordinal);
+      hash_value ^= std::hash<uint64_t>{}(key.gpu_va) + 0x9e3779b97f4a7c15ULL + (hash_value << 6) +
+                    (hash_value >> 2);
+      return hash_value;
+    }
+  };
+
+  /// @brief Internal scratch pool keyed by GPU ordinal and base VA.
+  struct ScratchPool {
+    uint64_t gpu_va = 0;
+    size_t size = 0;
+    std::shared_ptr<BackingStore> backing;
+  };
+
+  using ScratchPoolMap = std::unordered_map<ScratchPoolKey, ScratchPool, ScratchPoolKeyHash>;
 
   /// @brief Per-process GPU page table (GPU VA page number → PTE).
   /// @details Managed by the driver's mmap/munmap handlers. GpuMemory holds a
@@ -495,7 +607,8 @@ public:
                                                       mtype, host_backed_bytes, gpu_page_offset);
       if (!inserted) {
         page->second.mtype = mtype;
-        replace_host_extent(page->second, {base + host_offset, host_backed_bytes, gpu_page_offset});
+        replace_host_extent(page->second,
+                            {base + host_offset, host_backed_bytes, gpu_page_offset, nullptr, 0});
       }
       mapped_va += host_backed_bytes;
       host_offset += host_backed_bytes;
@@ -503,6 +616,31 @@ public:
     // Keep publication in the page-table critical section. Cached readers
     // validate this generation while holding the shared side of the same lock;
     // publishing after unlock would permit a stale-cache hit in between.
+    publish_page_table_mutation_locked();
+  }
+
+  /// @brief Map driver-owned backing into this process's GPU page table.
+  void map_backing_pages(uint64_t gpu_va, const std::shared_ptr<BackingStore> &backing,
+                         size_t backing_offset, size_t size,
+                         amdgpu::Mtype mtype = amdgpu::Mtype::RW) {
+    assert(backing != nullptr);
+    std::unique_lock request_lock(*page_table_request_mutex_);
+    std::unique_lock lock(page_table_mutex_);
+    uint64_t mapped_va = gpu_va;
+    size_t mapped_bytes = 0;
+    while (mapped_bytes < size) {
+      const size_t gpu_page_offset = mapped_va & (kPageSize - 1);
+      const size_t host_backed_bytes =
+          std::min<size_t>(kPageSize - gpu_page_offset, size - mapped_bytes);
+      std::pair<PageTable::iterator, bool> insertion =
+          page_table_.try_emplace(mapped_va >> kPageShift);
+      PageTable::iterator page = insertion.first;
+      page->second.mtype = mtype;
+      replace_host_extent(page->second, {nullptr, host_backed_bytes, gpu_page_offset, backing,
+                                         backing_offset + mapped_bytes});
+      mapped_va += host_backed_bytes;
+      mapped_bytes += host_backed_bytes;
+    }
     publish_page_table_mutation_locked();
   }
 
@@ -614,14 +752,15 @@ public:
   mutable std::mutex alloc_mutex_;
   /// @brief Serializes scratch-pool backing allocation for this process.
   /// @details Every XCD of a fanned-out dispatch independently finds the same
-  /// process-wide pool VA unbacked and races to map it; remapping a pool that
-  /// already has live waves spilling into it would drop their data. Per-process
-  /// rather than driver-wide so daemon clients do not serialize against each
-  /// other. Lock order: hw_queue_mutex_ (held by the calling command processor)
-  /// -> scratch_backing_mutex_ -> {alloc_mutex_, owned_fds_mutex_,
-  /// page_table_mutex_}; nothing taken under it reaches a command processor.
+  /// process-wide pool VA unbacked and races to map it. Per-process rather
+  /// than driver-wide so daemon clients do not serialize against each other.
+  /// Lock order: hw_queue_mutex_ (held by the calling command processor) ->
+  /// scratch_backing_mutex_ -> {alloc_mutex_, page_table_mutex_}; backing-store
+  /// resize takes only the backing's internal mutex and never calls back into a
+  /// command processor.
   std::mutex scratch_backing_mutex_;
   std::unordered_map<uint64_t, GpuAllocation> allocations_;
+  ScratchPoolMap scratch_pools_;
   uint64_t next_handle_ = 1;
   uint64_t next_gpu_va_;
 
@@ -680,6 +819,33 @@ public:
   RuntimeState runtime_state_;
 
 private:
+  static HostExtent slice_host_extent(const HostExtent &extent, size_t slice_begin,
+                                      size_t slice_end) {
+    assert(slice_begin >= extent.gpu_page_offset);
+    assert(slice_end >= slice_begin);
+    assert(slice_end <= extent.gpu_page_offset + extent.host_backed_bytes);
+    HostExtent sliced = extent;
+    const size_t delta = slice_begin - extent.gpu_page_offset;
+    sliced.host_backed_bytes = slice_end - slice_begin;
+    sliced.gpu_page_offset = slice_begin;
+    if (sliced.host_ptr)
+      sliced.host_ptr += delta;
+    if (sliced.backing)
+      sliced.backing_offset += delta;
+    return sliced;
+  }
+
+  static bool can_merge_host_extents(const HostExtent &previous, const HostExtent &current) {
+    if (previous.gpu_page_offset + previous.host_backed_bytes != current.gpu_page_offset)
+      return false;
+    if (previous.has_raw_host_ptr() && current.has_raw_host_ptr())
+      return previous.host_ptr + previous.host_backed_bytes == current.host_ptr;
+    if (previous.has_backing_store() && current.has_backing_store())
+      return previous.backing == current.backing &&
+             previous.backing_offset + previous.host_backed_bytes == current.backing_offset;
+    return false;
+  }
+
   static void normalize_host_extents(PageTableEntry &page) {
     auto &extents = page.host_extents;
     if (extents.size() > 1)
@@ -688,12 +854,11 @@ private:
       });
     size_t out = 0;
     for (const auto &extent : extents) {
-      if (extent.host_ptr == nullptr || extent.host_backed_bytes == 0)
+      if (!extent.has_backing() || extent.host_backed_bytes == 0)
         continue;
       if (out > 0) {
         auto &previous = extents[out - 1];
-        if (previous.gpu_page_offset + previous.host_backed_bytes == extent.gpu_page_offset &&
-            previous.host_ptr + previous.host_backed_bytes == extent.host_ptr) {
+        if (can_merge_host_extents(previous, extent)) {
           previous.host_backed_bytes += extent.host_backed_bytes;
           continue;
         }
@@ -720,10 +885,9 @@ private:
         continue;
       }
       if (extent_begin < replacement_begin)
-        updated.push_back({extent.host_ptr, replacement_begin - extent_begin, extent_begin});
+        updated.push_back(slice_host_extent(extent, extent_begin, replacement_begin));
       if (replacement_end < extent_end)
-        updated.push_back({extent.host_ptr + (replacement_end - extent_begin),
-                           extent_end - replacement_end, replacement_end});
+        updated.push_back(slice_host_extent(extent, replacement_end, extent_end));
     }
     updated.push_back(replacement);
     page.host_extents = std::move(updated);
@@ -742,10 +906,9 @@ private:
         continue;
       }
       if (extent_begin < erased_begin)
-        updated.push_back({extent.host_ptr, erased_begin - extent_begin, extent_begin});
+        updated.push_back(slice_host_extent(extent, extent_begin, erased_begin));
       if (erased_end < extent_end)
-        updated.push_back(
-            {extent.host_ptr + (erased_end - extent_begin), extent_end - erased_end, erased_end});
+        updated.push_back(slice_host_extent(extent, erased_end, extent_end));
     }
     page.host_extents = std::move(updated);
     normalize_host_extents(page);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/remote_driver.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/remote_driver.cpp
@@ -11,11 +11,14 @@
 #include "util/unique_handle.h"
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <cerrno>
 #include <chrono>
+#include <cstdio>
 #include <cstring>
 #include <fcntl.h>
+#include <limits>
 #include <linux/mman.h>
 #ifndef MADV_POPULATE_WRITE
 #define MADV_POPULATE_WRITE 23
@@ -28,6 +31,7 @@
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/syscall.h>
+#include <sys/uio.h>
 #include <sys/un.h>
 #include <thread>
 #include <unistd.h>
@@ -42,6 +46,7 @@ constexpr bool has_embedded_pointers(unsigned long request) {
   case AMDKFD_IOC_MAP_MEMORY_TO_GPU:
   case AMDKFD_IOC_UNMAP_MEMORY_FROM_GPU:
   case AMDKFD_IOC_GET_PROCESS_APERTURES_NEW:
+  case AMDKFD_IOC_GET_DMABUF_INFO:
   case AMDKFD_IOC_DBG_TRAP:
     return true;
   case AMDKFD_IOC_SVM:
@@ -220,6 +225,66 @@ uint32_t clamp_snapshot_entries(uint32_t count, uint32_t entry_size, size_t arg_
   return static_cast<uint32_t>(std::min<size_t>(count, max_entries));
 }
 
+bool self_range_readable(uint64_t start, size_t size) {
+  if (size == 0 || start > std::numeric_limits<uint64_t>::max() - size)
+    return false;
+  const uint64_t limit = start + size;
+
+  FILE *maps = std::fopen("/proc/self/maps", "r");
+  if (maps == nullptr)
+    return false;
+
+  bool readable = false;
+  uint64_t cursor = start;
+  char line[512];
+  while (std::fgets(line, sizeof(line), maps) != nullptr) {
+    unsigned long long map_start = 0;
+    unsigned long long map_limit = 0;
+    char perms[5] = {};
+    if (std::sscanf(line, "%llx-%llx %4s", &map_start, &map_limit, perms) != 3)
+      continue;
+    if (map_limit <= cursor)
+      continue;
+    if (map_start > cursor)
+      break;
+    if (perms[0] != 'r')
+      break;
+
+    if (map_limit >= limit) {
+      readable = true;
+      break;
+    }
+    cursor = map_limit;
+  }
+
+  std::fclose(maps);
+  return readable;
+}
+
+int copy_from_self_userptr(void *dst, const void *src, size_t size) {
+  iovec local{dst, size};
+  iovec remote{const_cast<void *>(src), size};
+  const ssize_t copied = process_vm_readv(getpid(), &local, 1, &remote, 1, 0);
+  if (copied == static_cast<ssize_t>(size))
+    return 0;
+  if (copied >= 0)
+    return -EFAULT;
+
+  const int copy_errno = errno;
+  if (copy_errno != EPERM)
+    return -copy_errno;
+
+  // Some sandboxed test environments deny process_vm_readv(self) with EPERM.
+  // The pointer is still in this process, so fall back to a normal copy after
+  // checking /proc/self/maps so PROT_NONE or unmapped userptrs still fail like
+  // a kernel copy_from_user() rather than crashing or silently succeeding.
+  const uint64_t src_addr = reinterpret_cast<uint64_t>(src);
+  if (!self_range_readable(src_addr, size))
+    return -EFAULT;
+  std::memcpy(dst, src, size);
+  return 0;
+}
+
 } // namespace
 
 RemoteDriver::MemfdLookup RemoteDriver::find_memfd_for_addr(void *addr, size_t length,
@@ -281,6 +346,50 @@ int RemoteDriver::poison_stream() {
   if (sock_ >= 0)
     syscall(SYS_shutdown, sock_, SHUT_RDWR);
   return -EPROTO;
+}
+
+int RemoteDriver::rollback_remote_allocation(uint64_t handle) {
+  if (handle == 0)
+    return 0;
+
+  kfd_ioctl_free_memory_of_gpu_args free_args{};
+  free_args.handle = handle;
+
+  constexpr size_t prefix = sizeof(RpcHeader) + sizeof(RpcIoctlRequest);
+  std::array<uint8_t, prefix + sizeof(free_args)> buffer{};
+  auto *hdr = reinterpret_cast<RpcHeader *>(buffer.data());
+  hdr->opcode = RPC_IOCTL;
+  hdr->request_id = next_id_++;
+  hdr->payload_bytes = sizeof(RpcIoctlRequest) + sizeof(free_args);
+
+  auto *request = reinterpret_cast<RpcIoctlRequest *>(buffer.data() + sizeof(RpcHeader));
+  request->ioctl_cmd = AMDKFD_IOC_FREE_MEMORY_OF_GPU;
+  request->args_bytes = sizeof(free_args);
+  std::memcpy(buffer.data() + prefix, &free_args, sizeof(free_args));
+
+  size_t sent = 0;
+  if (!rpc_send_exact(sock_, buffer.data(), buffer.size(), &sent)) {
+    if (sent > 0)
+      return poison_stream();
+    return transport_errno();
+  }
+
+  RpcHeader response{};
+  int received_fds[1] = {-1};
+  size_t num_fds = 1;
+  const ssize_t bytes = rpc_recv_msg(sock_, &response, sizeof(response), received_fds, &num_fds);
+  if (num_fds > 0 && received_fds[0] >= 0)
+    syscall(SYS_close, received_fds[0]);
+  if (bytes <= 0 || static_cast<size_t>(bytes) != sizeof(response))
+    return poison_stream();
+  if (response.payload_bytes > kMaxPayloadBytes)
+    return poison_stream();
+  if (response.payload_bytes > 0) {
+    std::vector<uint8_t> payload(response.payload_bytes);
+    if (!rpc_recv_exact(sock_, payload.data(), payload.size()))
+      return poison_stream();
+  }
+  return response.result;
 }
 
 int RemoteDriver::open() {
@@ -539,6 +648,25 @@ int RemoteDriver::send_ioctl(unsigned long request, void *arg) {
   if (!validate_ioctl_arg_size(request, arg, arg_size))
     return -EINVAL;
 
+  kfd_ioctl_alloc_memory_of_gpu_args original_alloc_args{};
+  const bool saved_alloc_args =
+      canonical_ioctl_request(request) == AMDKFD_IOC_ALLOC_MEMORY_OF_GPU &&
+      arg_size >= sizeof(original_alloc_args);
+  if (saved_alloc_args)
+    original_alloc_args = *static_cast<kfd_ioctl_alloc_memory_of_gpu_args *>(arg);
+
+  uint32_t saved_dmabuf_fd = KFD_INVALID_FD;
+  uint64_t saved_dmabuf_metadata_ptr = 0;
+  uint32_t saved_dmabuf_metadata_size = 0;
+  if (canonical_ioctl_request(request) == AMDKFD_IOC_IMPORT_DMABUF) {
+    saved_dmabuf_fd = static_cast<kfd_ioctl_import_dmabuf_args *>(arg)->dmabuf_fd;
+  } else if (canonical_ioctl_request(request) == AMDKFD_IOC_GET_DMABUF_INFO) {
+    auto *info = static_cast<kfd_ioctl_get_dmabuf_info_args *>(arg);
+    saved_dmabuf_fd = info->dmabuf_fd;
+    saved_dmabuf_metadata_ptr = info->metadata_ptr;
+    saved_dmabuf_metadata_size = info->metadata_size;
+  }
+
   // Save original embedded pointers before serialization. The daemon rewrites
   // these to point at its own buffer; we must restore the client-side originals
   // before copying inline response data back.
@@ -667,6 +795,16 @@ int RemoteDriver::send_ioctl(unsigned long request, void *arg) {
       buf.resize(buf.size() + aperture_args->num_of_nodes * sizeof(kfd_process_device_apertures));
       break;
     }
+    case AMDKFD_IOC_GET_DMABUF_INFO: {
+      auto *info_args = reinterpret_cast<kfd_ioctl_get_dmabuf_info_args *>(args_base);
+      const size_t inline_size =
+          info_args->metadata_ptr != 0 ? static_cast<size_t>(info_args->metadata_size) : 0;
+      const size_t payload_so_far = buf.size() - sizeof(RpcHeader);
+      if (payload_so_far >= kMaxPayloadBytes || inline_size > kMaxPayloadBytes - payload_so_far)
+        return -E2BIG;
+      buf.resize(buf.size() + inline_size);
+      break;
+    }
     case AMDKFD_IOC_DBG_TRAP: {
       auto *dbg = reinterpret_cast<kfd_ioctl_dbg_trap_args *>(args_base);
       size_t inline_size = 0;
@@ -756,12 +894,10 @@ int RemoteDriver::send_ioctl(unsigned long request, void *arg) {
   ireq->ioctl_cmd = static_cast<uint32_t>(request);
   ireq->args_bytes = static_cast<uint32_t>(buf.size() - prefix);
 
-  // For DBG_TRAP ENABLE, hand the debugger's notifier pipe write-end to the
-  // daemon as an SCM_RIGHTS fd. The daemon substitutes it into the ioctl's
-  // dbg_fd so the driver can wake the debugger when a wave stops — the same fd
-  // the real kernel would receive through the ioctl. KFD_INVALID_FD (0xffffffff)
-  // casts to -1 and is not sent.
-  int send_fds[3] = {-1, -1, -1};
+  // For ioctls whose fd arguments are process-local integers, hand the actual
+  // object to the daemon over SCM_RIGHTS. The daemon substitutes the received fd
+  // before dispatching so client fd numbers are never trusted in daemon space.
+  int send_fds[kRpcMaxFds] = {-1, -1, -1, -1};
   size_t num_send_fds = 0;
   // Owned only for the duration of the send: SCM_RIGHTS installs the daemon's
   // own copies, so ours are released on every path out of here, including the
@@ -796,6 +932,14 @@ int RemoteDriver::send_ioctl(unsigned long request, void *arg) {
       send_fds[num_send_fds++] = target_mem_fd.get();
       send_fds[num_send_fds++] = target_proc_fd.get();
     }
+  } else if (request == AMDKFD_IOC_IMPORT_DMABUF || request == AMDKFD_IOC_GET_DMABUF_INFO) {
+    const int dmabuf_fd =
+        request == AMDKFD_IOC_IMPORT_DMABUF
+            ? static_cast<int>(static_cast<kfd_ioctl_import_dmabuf_args *>(arg)->dmabuf_fd)
+            : static_cast<int>(static_cast<kfd_ioctl_get_dmabuf_info_args *>(arg)->dmabuf_fd);
+    if (::fcntl(dmabuf_fd, F_GETFD) < 0)
+      return transport_errno();
+    send_fds[num_send_fds++] = dmabuf_fd;
   }
   // A send that fails without putting a byte on the wire is recoverable: the
   // daemon never saw a frame, so the stream is still aligned and the caller just
@@ -827,10 +971,28 @@ int RemoteDriver::send_ioctl(unsigned long request, void *arg) {
 
   // Receive response — may include a memfd via SCM_RIGHTS for ALLOC_MEMORY.
   uint8_t resp_header_buf[sizeof(RpcHeader)];
-  int received_fds[1] = {-1};
-  size_t num_fds = 1;
+  std::array<int, kRpcMaxFds> received_fds{};
+  received_fds.fill(-1);
+  size_t num_fds = received_fds.size();
   auto bytes =
-      rpc_recv_msg(sock_, resp_header_buf, sizeof(resp_header_buf), received_fds, &num_fds);
+      rpc_recv_msg(sock_, resp_header_buf, sizeof(resp_header_buf), received_fds.data(), &num_fds);
+
+  auto close_received_fds = [&] {
+    for (size_t i = 0; i < num_fds; ++i) {
+      if (received_fds[i] >= 0) {
+        syscall(SYS_close, received_fds[i]);
+        received_fds[i] = -1;
+      }
+    }
+  };
+
+  auto take_received_fd = [&](size_t index) {
+    int fd = received_fds[index];
+    received_fds[index] = -1;
+    return fd;
+  };
+
+  auto has_exactly_one_received_fd = [&] { return num_fds == 1 && received_fds[0] >= 0; };
 
   // Every reply byte we decline to read leaves the stream misaligned: the next
   // call would parse its header out of this one's remains, silently returning a
@@ -839,8 +1001,7 @@ int RemoteDriver::send_ioctl(unsigned long request, void *arg) {
   // in on the doomed reply is dropped here — nothing downstream runs to adopt
   // it.
   auto poison_reply = [&] {
-    if (num_fds > 0 && received_fds[0] >= 0)
-      syscall(SYS_close, received_fds[0]);
+    close_received_fds();
     return poison_stream();
   };
 
@@ -885,6 +1046,11 @@ int RemoteDriver::send_ioctl(unsigned long request, void *arg) {
       case AMDKFD_IOC_GET_PROCESS_APERTURES_NEW:
         static_cast<kfd_ioctl_get_process_apertures_new_args *>(arg)
             ->kfd_process_device_apertures_ptr = saved_apertures_ptr;
+        break;
+      case AMDKFD_IOC_GET_DMABUF_INFO:
+        static_cast<kfd_ioctl_get_dmabuf_info_args *>(arg)->metadata_ptr =
+            saved_dmabuf_metadata_ptr;
+        static_cast<kfd_ioctl_get_dmabuf_info_args *>(arg)->dmabuf_fd = saved_dmabuf_fd;
         break;
       case AMDKFD_IOC_MAP_MEMORY_TO_GPU:
       case AMDKFD_IOC_UNMAP_MEMORY_FROM_GPU:
@@ -943,6 +1109,8 @@ int RemoteDriver::send_ioctl(unsigned long request, void *arg) {
         break;
       }
     }
+    if (request == AMDKFD_IOC_IMPORT_DMABUF)
+      static_cast<kfd_ioctl_import_dmabuf_args *>(arg)->dmabuf_fd = saved_dmabuf_fd;
 
     if (has_embedded_pointers(request) && resp->payload_bytes > arg_size) {
       size_t extra = resp->payload_bytes - arg_size;
@@ -959,6 +1127,14 @@ int RemoteDriver::send_ioctl(unsigned long request, void *arg) {
             reinterpret_cast<void *>(aperture_args->kfd_process_device_apertures_ptr),
             payload.data() + arg_size,
             std::min(aperture_args->num_of_nodes * sizeof(kfd_process_device_apertures), extra));
+        break;
+      }
+      case AMDKFD_IOC_GET_DMABUF_INFO: {
+        if (resp->result == 0 && saved_dmabuf_metadata_ptr != 0 && saved_dmabuf_metadata_size > 0) {
+          std::memcpy(reinterpret_cast<void *>(saved_dmabuf_metadata_ptr),
+                      payload.data() + arg_size,
+                      std::min(static_cast<size_t>(saved_dmabuf_metadata_size), extra));
+        }
         break;
       }
       case AMDKFD_IOC_DBG_TRAP: {
@@ -1074,67 +1250,94 @@ int RemoteDriver::send_ioctl(unsigned long request, void *arg) {
       alloc_ranges_.push_back({va_addr, size, memfd});
   };
 
-  auto promote_userptr = [&](uint64_t va_addr, uint64_t size, int memfd) {
-    auto *va = reinterpret_cast<void *>(va_addr);
+  auto rollback_failed_allocation = [&](kfd_ioctl_alloc_memory_of_gpu_args *alloc_args,
+                                        int primary_error, int received_fd) -> int {
+    if (received_fd >= 0)
+      syscall(SYS_close, received_fd);
+    const int rollback_result = rollback_remote_allocation(alloc_args->handle);
+    if (saved_alloc_args)
+      *alloc_args = original_alloc_args;
+    if (rollback_result != 0)
+      return rollback_result == -EPROTO ? rollback_result : poison_stream();
+    if (primary_error == -EPROTO)
+      return poison_stream();
+    return primary_error;
+  };
+
+  auto promote_userptr = [&](uint64_t cpu_va, uint64_t size, int memfd) -> int {
+    if (size == 0 || size > static_cast<uint64_t>(std::numeric_limits<size_t>::max()) ||
+        size > static_cast<uint64_t>(std::numeric_limits<ssize_t>::max()))
+      return -EINVAL;
+    auto *va = reinterpret_cast<void *>(cpu_va);
     auto length = static_cast<size_t>(size);
 
-    [[maybe_unused]] auto ft_rc = ftruncate(memfd, static_cast<off_t>(length));
-    fallocate(memfd, 0, 0, static_cast<off_t>(length));
+    if (ftruncate(memfd, static_cast<off_t>(length)) != 0)
+      return -errno;
+    if (fallocate(memfd, 0, 0, static_cast<off_t>(length)) != 0)
+      return -errno;
 
-    constexpr size_t page_size = 4096;
-    size_t num_pages = (length + page_size - 1) / page_size;
-    std::vector<uint8_t> resident(num_pages);
-    auto mc_rc = syscall(SYS_mincore, va, length, resident.data());
+    auto *temp = static_cast<uint8_t *>(
+        safe_mmap(nullptr, length, PROT_READ | PROT_WRITE, MAP_SHARED, memfd, 0));
+    if (temp == MAP_FAILED)
+      return -errno;
 
-    auto *temp =
-        static_cast<uint8_t *>(safe_mmap(nullptr, length, PROT_WRITE, MAP_SHARED, memfd, 0));
-    if (temp != MAP_FAILED) {
-      if (mc_rc == 0) {
-        auto *src = static_cast<uint8_t *>(va);
-        for (size_t i = 0; i < num_pages; ++i) {
-          if (resident[i] & 1) {
-            size_t off = i * page_size;
-            size_t n = std::min(page_size, length - off);
-            std::memcpy(temp + off, src + off, n);
-          }
-        }
-      }
+    const int copy_result = copy_from_self_userptr(temp, va, length);
+    if (copy_result != 0) {
       syscall(SYS_munmap, temp, length);
+      return copy_result;
     }
+    if (syscall(SYS_munmap, temp, length) != 0)
+      return -errno;
 
     auto *mapped = safe_mmap(va, length, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED, memfd, 0);
-    if (mapped != MAP_FAILED)
-      syscall(SYS_madvise, mapped, length, MADV_POPULATE_WRITE);
+    if (mapped == MAP_FAILED)
+      return -errno;
+    return 0;
   };
 
   // Store memfd received from ALLOC_MEMORY for use in the subsequent mmap().
   // Also register the address range for anonymous MAP_FIXED interception.
   if (request == AMDKFD_IOC_ALLOC_MEMORY_OF_GPU && resp->result == 0) {
     auto *alloc_args = static_cast<kfd_ioctl_alloc_memory_of_gpu_args *>(arg);
-    if (num_fds > 0 && received_fds[0] >= 0) {
-      register_allocation(alloc_args->handle, alloc_args->va_addr, alloc_args->size,
-                          received_fds[0]);
-
-      if (alloc_args->flags & KFD_IOC_ALLOC_MEM_FLAGS_USERPTR)
-        promote_userptr(alloc_args->va_addr, alloc_args->size, received_fds[0]);
+    if (!has_exactly_one_received_fd()) {
+      close_received_fds();
+      return rollback_failed_allocation(alloc_args, -EPROTO, -1);
     }
+    const int allocation_fd = take_received_fd(0);
+    if (alloc_args->flags & KFD_IOC_ALLOC_MEM_FLAGS_USERPTR) {
+      const int promotion_result =
+          promote_userptr(alloc_args->mmap_offset, alloc_args->size, allocation_fd);
+      if (promotion_result != 0) {
+        return rollback_failed_allocation(alloc_args, promotion_result, allocation_fd);
+      }
+    }
+    register_allocation(alloc_args->handle, alloc_args->va_addr, alloc_args->size, allocation_fd);
   }
 
   if (request == AMDKFD_IOC_IPC_IMPORT_HANDLE && resp->result == 0) {
     auto *import_args = static_cast<kfd_ioctl_ipc_import_handle_args *>(arg);
-    if (num_fds > 0 && received_fds[0] >= 0) {
+    if (has_exactly_one_received_fd()) {
+      const int import_fd = take_received_fd(0);
       uint64_t size = 0;
       struct stat st {};
-      if (fstat(received_fds[0], &st) == 0)
+      if (fstat(import_fd, &st) == 0)
         size = static_cast<uint64_t>(st.st_size);
-      register_allocation(import_args->handle, import_args->va_addr, size, received_fds[0]);
+      register_allocation(import_args->handle, import_args->va_addr, size, import_fd);
+    } else {
+      close_received_fds();
+      const int rollback_result = rollback_remote_allocation(import_args->handle);
+      return rollback_result == -EPROTO ? rollback_result : poison_stream();
     }
   }
 
   if (request == AMDKFD_IOC_EXPORT_DMABUF && resp->result == 0) {
     auto *export_args = static_cast<kfd_ioctl_export_dmabuf_args *>(arg);
-    if (num_fds > 0 && received_fds[0] >= 0)
-      export_args->dmabuf_fd = received_fds[0];
+    if (has_exactly_one_received_fd()) {
+      export_args->dmabuf_fd = take_received_fd(0);
+    } else {
+      close_received_fds();
+      return poison_stream();
+    }
   }
 
   if (request == AMDKFD_IOC_FREE_MEMORY_OF_GPU && resp->result == 0) {
@@ -1148,6 +1351,7 @@ int RemoteDriver::send_ioctl(unsigned long request, void *arg) {
     }
   }
 
+  close_received_fds();
   return resp->result;
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/remote_driver.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/remote_driver.h
@@ -125,6 +125,7 @@ public:
 
 private:
   int send_ioctl(unsigned long request, void *arg);
+  int rollback_remote_allocation(uint64_t handle);
   int send_mmap(void *addr, size_t length, int prot, int flags, off_t offset, int *memfd_out);
 
   /// @brief Mark the RPC stream unusable and make the connection terminal.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/rj_daemon.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/rj_daemon.cpp
@@ -85,6 +85,11 @@ bool validate_ioctl_payload(uint32_t command, const void *buffer, size_t buffer_
       return false;
     break;
   }
+  case AMDKFD_IOC_GET_DMABUF_INFO: {
+    const auto *args = static_cast<const kfd_ioctl_get_dmabuf_info_args *>(buffer);
+    inline_size = args->metadata_ptr != 0 ? static_cast<size_t>(args->metadata_size) : 0;
+    break;
+  }
   case AMDKFD_IOC_DBG_TRAP: {
     // Every op the client reserves an inline tail for has to appear here, or
     // the exact-length test below rejects a well-formed request and the
@@ -148,11 +153,11 @@ bool send_with_fd_exact(int socket, const void *data, size_t size, int fd) {
 /// @details DBG_TRAP ENABLE sends three: the debugger's notifier, and the
 /// authorization the daemon needs to reach the debuggee's address space --
 /// /proc/<pid>/mem, plus the /proc/<pid> directory that pins the identity that
-/// fd belongs to. Every other request sends at most the notifier. Ownership is
-/// RAII, so descriptors the VM declines to adopt are released with the request
-/// rather than leaked for the life of the connection.
+/// fd belongs to. DMABUF ioctls send their dmabuf in the first slot. Ownership
+/// is RAII, so descriptors the VM declines to adopt are released with the
+/// request rather than leaked for the life of the connection.
 struct ReceivedFds {
-  util::UniqueHandle notifier;
+  util::UniqueHandle request_handle;
   util::UniqueHandle target_mem;
   util::UniqueHandle target_proc;
 };
@@ -165,7 +170,7 @@ bool receive_header_with_fds(int socket, RpcHeader *header, ReceivedFds *fds) {
     header_bytes = rpc_recv_msg(socket, header, sizeof(*header), received_fds, &received_fd_count);
   } while (header_bytes < 0 && errno == EINTR);
   if (received_fd_count > 0)
-    fds->notifier.reset(received_fds[0]);
+    fds->request_handle.reset(received_fds[0]);
   if (received_fd_count > 1)
     fds->target_mem.reset(received_fds[1]);
   if (received_fd_count > 2)
@@ -273,7 +278,7 @@ private:
   }
 
   RequestDisposition handle_handshake(const RpcHeader &header, const ReceivedFds &input_fds) {
-    if (process_id_ != 0 || header.payload_bytes != 0 || input_fds.notifier)
+    if (process_id_ != 0 || header.payload_bytes != 0 || input_fds.request_handle)
       return RequestDisposition::Disconnect;
 
     if (rj_vm_device_open(daemon_->vm, client_pid_, &process_id_) != ROCJITSU_STATUS_SUCCESS) {
@@ -322,7 +327,7 @@ private:
   }
 
   RequestDisposition handle_close(const RpcHeader &header, const ReceivedFds &input_fds) {
-    if (process_id_ == 0 || header.payload_bytes != 0 || input_fds.notifier)
+    if (process_id_ == 0 || header.payload_bytes != 0 || input_fds.request_handle)
       return RequestDisposition::Disconnect;
 
     close_device();
@@ -334,7 +339,8 @@ private:
   }
 
   RequestDisposition handle_mmap(const RpcHeader &header, const ReceivedFds &input_fds) {
-    if (process_id_ == 0 || header.payload_bytes != sizeof(RpcMmapRequest) || input_fds.notifier) {
+    if (process_id_ == 0 || header.payload_bytes != sizeof(RpcMmapRequest) ||
+        input_fds.request_handle) {
       return RequestDisposition::Disconnect;
     }
     RpcMmapRequest request{};
@@ -374,7 +380,7 @@ private:
 
   RequestDisposition handle_munmap(const RpcHeader &header, const ReceivedFds &input_fds) {
     if (process_id_ == 0 || header.payload_bytes != sizeof(RpcMunmapRequest) ||
-        input_fds.notifier) {
+        input_fds.request_handle) {
       return RequestDisposition::Disconnect;
     }
     RpcMunmapRequest request{};
@@ -411,7 +417,7 @@ private:
     command.buf = arguments;
     command.buf_size = request->args_bytes;
     command.shared_handle = -1;
-    command.in_handle = input_fds.notifier.get();
+    command.in_handle = input_fds.request_handle.get();
     command.in_mem_handle = input_fds.target_mem.get();
     // Borrowed, not adopted: the driver dups it if the session needs to keep it
     // (rj_vm.cpp passes it by value), so this side always closes its own copy.
@@ -421,7 +427,7 @@ private:
     // The VM clears each handle it took ownership of; drop ours to match, so
     // RAII does not close a descriptor the debug session now owns.
     if (command.in_handle < 0)
-      static_cast<void>(input_fds.notifier.release());
+      static_cast<void>(input_fds.request_handle.release());
     if (command.in_mem_handle < 0)
       static_cast<void>(input_fds.target_mem.release());
     if (command.buf_size > available_arguments)
@@ -442,6 +448,8 @@ private:
       }
       sent = send_with_fd_exact(client_fd_, response_buffer.data(), response_buffer.size(),
                                 command.shared_handle);
+      if (command.cmd == AMDKFD_IOC_EXPORT_DMABUF)
+        ::close(command.shared_handle);
     } else {
       sent = rpc_send_exact(client_fd_, &response, sizeof(response)) &&
              (command.buf_size == 0 || rpc_send_exact(client_fd_, command.buf, command.buf_size));

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/rpc.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/rpc.h
@@ -49,7 +49,7 @@ struct RpcHeader {
 };
 
 /// @brief RPC protocol version. Increment when making breaking changes.
-inline constexpr uint32_t kRpcProtocolVersion = 3;
+inline constexpr uint32_t kRpcProtocolVersion = 4;
 
 /// @brief Largest payload the daemon accepts after an RpcHeader.
 /// @details The daemon rejects — and disconnects — any client whose header

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
@@ -1797,8 +1797,8 @@ kfd_process_device_apertures SimulatedKfd::gpu_apertures(uint32_t ordinal) const
       .scratch_limit = scratch_base + 0xFFFFFFFFULL,
       // rocjitsu maps GPU VAs directly to host pointers, so the aperture must
       // cover the host addresses accepted by the runtime.
-      .gpuvm_base = 0x10000ULL,
-      .gpuvm_limit = 0x7FFFFFFFFFFFULL,
+      .gpuvm_base = KfdProcess::kGpuVmBase,
+      .gpuvm_limit = KfdProcess::kGpuVmLimit,
       .gpu_id = ordinal < gpus_.size() ? gpus_[ordinal].gpu_id : 0,
       .pad = 0,
   };
@@ -2075,7 +2075,7 @@ int SimulatedKfd::free_memory_ioctl(KfdProcess &proc, void *arg) {
         proc.imported_dmabufs_.erase(dmabuf_it);
       }
     }
-    if (alloc.host_ptr && !alloc.user_va)
+    if (alloc.host_ptr)
       unmap_from_gpu(proc, alloc.gpu_va, alloc.size);
     if (alloc.memfd >= 0) {
       {
@@ -2122,6 +2122,14 @@ int SimulatedKfd::map_memory_ioctl(KfdProcess &proc, void *arg) {
                       alloc.handle, alloc.gpu_va, alloc.size, args->n_devices,
                       alloc.host_ptr != nullptr);
   });
+  if (!daemon_mode_ && alloc.user_va && alloc.host_ptr == nullptr &&
+      !(alloc.flags & (KFD_IOC_ALLOC_MEM_FLAGS_USERPTR | KFD_IOC_ALLOC_MEM_FLAGS_DOORBELL))) {
+    auto *host_ptr = reinterpret_cast<void *>(alloc.gpu_va);
+    if (libc_passthrough().mprotect(host_ptr, alloc.size, PROT_READ | PROT_WRITE) == 0)
+      alloc.host_ptr = host_ptr;
+    else
+      return -errno;
+  }
   if (alloc.host_ptr)
     map_to_gpu(proc, alloc.gpu_va, alloc.host_ptr, alloc.size, pte_mtype_for_flags(alloc.flags));
   args->n_success = args->n_devices;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
@@ -1886,6 +1886,12 @@ int SimulatedKfd::unmap_memory_ioctl(void *arg) {
 int SimulatedKfd::alloc_memory_ioctl(KfdProcess &proc, void *arg) {
   auto *args = static_cast<kfd_ioctl_alloc_memory_of_gpu_args *>(arg);
 
+  if (args->size == 0)
+    return -EINVAL;
+  if (args->va_addr != 0 && ((args->va_addr & (KfdProcess::kPageSize - 1)) != 0 ||
+                             (args->size & (KfdProcess::kPageSize - 1)) != 0))
+    return -EINVAL;
+
   std::lock_guard<std::mutex> lock(proc.alloc_mutex_);
 
   bool user_provided_va = (args->va_addr != 0);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
@@ -34,6 +34,7 @@ RJ_DIAGNOSTIC_POP
 #include <fcntl.h>
 #include <format>
 #include <iterator>
+#include <limits>
 #include <linux/types.h>
 #include <poll.h>
 #include <sstream>
@@ -125,6 +126,206 @@ bool ranges_overlap(const void *lhs, size_t lhs_size, const void *rhs, size_t rh
   const auto lhs_base = reinterpret_cast<uintptr_t>(lhs);
   const auto rhs_base = reinterpret_cast<uintptr_t>(rhs);
   return lhs_base <= rhs_base ? rhs_base - lhs_base < lhs_size : lhs_base - rhs_base < rhs_size;
+}
+
+bool gpu_ranges_overlap(uint64_t lhs_va, uint64_t lhs_size, uint64_t rhs_va, uint64_t rhs_size) {
+  if (lhs_size == 0 || rhs_size == 0)
+    return false;
+  return lhs_va <= rhs_va ? rhs_va - lhs_va < lhs_size : lhs_va - rhs_va < rhs_size;
+}
+
+bool gpu_range_contains(uint64_t outer_va, uint64_t outer_size, uint64_t inner_va,
+                        uint64_t inner_size) {
+  if (outer_size == 0 || inner_size == 0)
+    return false;
+  if (inner_va < outer_va)
+    return false;
+  const uint64_t offset = inner_va - outer_va;
+  return offset <= outer_size && inner_size <= outer_size - offset;
+}
+
+bool gpu_range_overflows(uint64_t gpu_va, uint64_t size) {
+  return size != 0 && gpu_va > std::numeric_limits<uint64_t>::max() - size;
+}
+
+bool gpuvm_range_contains(uint64_t gpu_va, uint64_t size) {
+  if (size == 0 || gpu_va < KfdProcess::kGpuVmBase)
+    return false;
+  constexpr uint64_t kApertureSize = KfdProcess::kGpuVmLimit - KfdProcess::kGpuVmBase + 1;
+  const uint64_t offset = gpu_va - KfdProcess::kGpuVmBase;
+  return offset < kApertureSize && size <= kApertureSize - offset;
+}
+
+bool fallback_scratch_base(uint32_t gpu_ordinal, uint64_t *gpu_va) {
+  constexpr uint64_t kGpuVmEnd = KfdProcess::kGpuVmLimit + 1;
+  constexpr uint64_t kReserveSize = KfdProcess::kFallbackScratchReserveSize;
+  const uint64_t ordinal_count = static_cast<uint64_t>(gpu_ordinal) + 1;
+  if (kReserveSize == 0 || ordinal_count > kGpuVmEnd / kReserveSize)
+    return false;
+  const uint64_t base = kGpuVmEnd - ordinal_count * kReserveSize;
+  if (!gpuvm_range_contains(base, KfdProcess::kPageSize))
+    return false;
+  *gpu_va = base;
+  return true;
+}
+
+bool fallback_scratch_window(uint32_t gpu_ordinal, uint64_t *gpu_va, uint64_t *size) {
+  if (!fallback_scratch_base(gpu_ordinal, gpu_va))
+    return false;
+  *size = KfdProcess::kFallbackScratchReserveSize;
+  return gpuvm_range_contains(*gpu_va, *size);
+}
+
+bool decode_scratch_base(uint64_t encoded_va, uint64_t *gpu_va) {
+  if (encoded_va > (std::numeric_limits<uint64_t>::max() >> 16))
+    return false;
+  *gpu_va = encoded_va << 16;
+  return true;
+}
+
+bool allocation_overlaps_gpu_range(const KfdProcess::GpuAllocation &alloc, uint64_t gpu_va,
+                                   uint64_t size) {
+  if (alloc.gpu_va == 0)
+    return false;
+  return gpu_ranges_overlap(alloc.gpu_va, alloc.size, gpu_va, size);
+}
+
+bool scratch_pool_overlaps_gpu_range(const KfdProcess::ScratchPool &pool, uint64_t gpu_va,
+                                     uint64_t size) {
+  if (pool.gpu_va == 0)
+    return false;
+  return gpu_ranges_overlap(pool.gpu_va, pool.size, gpu_va, size);
+}
+
+bool scratch_pool_contains_gpu_range(const KfdProcess::ScratchPool &pool, uint64_t gpu_va,
+                                     uint64_t size) {
+  if (pool.gpu_va == 0)
+    return false;
+  return gpu_range_contains(pool.gpu_va, pool.size, gpu_va, size);
+}
+
+bool gpu_va_align_up(uint64_t gpu_va, uint64_t *aligned) {
+  constexpr uint64_t kMask = KfdProcess::kPageSize - 1;
+  if (gpu_va > std::numeric_limits<uint64_t>::max() - kMask)
+    return false;
+  *aligned = (gpu_va + kMask) & ~kMask;
+  return true;
+}
+
+bool allocations_overlap_gpu_range(const KfdProcess &proc, uint64_t gpu_va, uint64_t size,
+                                   uint64_t allowed_handle = 0) {
+  for (const std::pair<const uint64_t, KfdProcess::GpuAllocation> &entry : proc.allocations_) {
+    const uint64_t handle = entry.first;
+    const KfdProcess::GpuAllocation &existing = entry.second;
+    if (handle == allowed_handle)
+      continue;
+    if (allocation_overlaps_gpu_range(existing, gpu_va, size))
+      return true;
+  }
+  return false;
+}
+
+constexpr uint32_t kNoScratchGpuOrdinal = std::numeric_limits<uint32_t>::max();
+
+bool fallback_reservations_overlap_gpu_range(
+    const KfdProcess &proc, uint64_t gpu_va, uint64_t size,
+    uint32_t allowed_fallback_ordinal = kNoScratchGpuOrdinal) {
+  for (uint32_t ordinal = 0; ordinal < proc.gpu_state_.size(); ++ordinal) {
+    if (ordinal == allowed_fallback_ordinal)
+      continue;
+    uint64_t reserve_base = 0;
+    uint64_t reserve_size = 0;
+    if (fallback_scratch_window(ordinal, &reserve_base, &reserve_size) &&
+        gpu_ranges_overlap(reserve_base, reserve_size, gpu_va, size)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool fallback_window_contains_gpu_range(uint32_t gpu_ordinal, uint64_t gpu_va, uint64_t size) {
+  uint64_t reserve_base = 0;
+  uint64_t reserve_size = 0;
+  return fallback_scratch_window(gpu_ordinal, &reserve_base, &reserve_size) &&
+         gpu_range_contains(reserve_base, reserve_size, gpu_va, size);
+}
+
+bool process_ranges_overlap_gpu_range(const KfdProcess &proc, uint64_t gpu_va, uint64_t size,
+                                      uint64_t allowed_handle = 0,
+                                      uint32_t allowed_scratch_ordinal = kNoScratchGpuOrdinal,
+                                      uint64_t allowed_scratch_base = 0,
+                                      uint32_t allowed_fallback_ordinal = kNoScratchGpuOrdinal) {
+  if (allocations_overlap_gpu_range(proc, gpu_va, size, allowed_handle))
+    return true;
+  if (fallback_reservations_overlap_gpu_range(proc, gpu_va, size, allowed_fallback_ordinal))
+    return true;
+  for (const std::pair<const KfdProcess::ScratchPoolKey, KfdProcess::ScratchPool> &entry :
+       proc.scratch_pools_) {
+    const KfdProcess::ScratchPoolKey &key = entry.first;
+    const KfdProcess::ScratchPool &pool = entry.second;
+    if (key.gpu_ordinal == allowed_scratch_ordinal && key.gpu_va == allowed_scratch_base)
+      continue;
+    if (scratch_pool_overlaps_gpu_range(pool, gpu_va, size))
+      return true;
+  }
+  return false;
+}
+
+bool find_available_gpu_range(KfdProcess &proc, uint64_t size, uint64_t *gpu_va) {
+  if (!gpuvm_range_contains(KfdProcess::kGpuVmBase, size))
+    return false;
+
+  uint64_t candidate = std::max(proc.next_gpu_va_, KfdProcess::kGpuVmBase);
+  for (;;) {
+    if (!gpu_va_align_up(candidate, &candidate) || gpu_range_overflows(candidate, size))
+      return false;
+    if (!gpuvm_range_contains(candidate, size))
+      return false;
+
+    bool overlapped = false;
+    for (const std::pair<const uint64_t, KfdProcess::GpuAllocation> &entry : proc.allocations_) {
+      const KfdProcess::GpuAllocation &existing = entry.second;
+      if (!allocation_overlaps_gpu_range(existing, candidate, size))
+        continue;
+      if (gpu_range_overflows(existing.gpu_va, existing.size))
+        return false;
+      candidate = existing.gpu_va + existing.size;
+      overlapped = true;
+      break;
+    }
+    if (overlapped)
+      continue;
+    for (const std::pair<const KfdProcess::ScratchPoolKey, KfdProcess::ScratchPool> &entry :
+         proc.scratch_pools_) {
+      const KfdProcess::ScratchPool &existing = entry.second;
+      if (!scratch_pool_overlaps_gpu_range(existing, candidate, size))
+        continue;
+      if (gpu_range_overflows(existing.gpu_va, existing.size))
+        return false;
+      candidate = existing.gpu_va + existing.size;
+      overlapped = true;
+      break;
+    }
+    if (overlapped)
+      continue;
+    for (uint32_t ordinal = 0; ordinal < proc.gpu_state_.size(); ++ordinal) {
+      uint64_t reserve_base = 0;
+      uint64_t reserve_size = 0;
+      if (!fallback_scratch_window(ordinal, &reserve_base, &reserve_size) ||
+          !gpu_ranges_overlap(reserve_base, reserve_size, candidate, size)) {
+        continue;
+      }
+      if (gpu_range_overflows(reserve_base, reserve_size))
+        return false;
+      candidate = reserve_base + reserve_size;
+      overlapped = true;
+      break;
+    }
+    if (!overlapped) {
+      *gpu_va = candidate;
+      return true;
+    }
+  }
 }
 
 /// @brief Return whether one non-empty address range fully contains another.
@@ -653,7 +854,8 @@ void SimulatedKfd::init_command_processors_locked() {
     // must be what the runtime and the debugger were told.
     const kfd_process_device_apertures ap = gpu_apertures(static_cast<uint32_t>(i));
     g.soc->set_apertures(ap.lds_base, ap.lds_limit, ap.scratch_base, ap.scratch_limit);
-    g.soc->for_each_cp([this, i](amdgpu::CommandProcessor *cp) {
+    const uint32_t gpu_ordinal = static_cast<uint32_t>(i);
+    g.soc->for_each_cp([this, gpu_ordinal](amdgpu::CommandProcessor *cp) {
       cp->set_interrupt_callback([this](uint32_t process_id, uint32_t event_id) {
         std::lock_guard<std::mutex> ilk(interrupt_mutex_);
         auto it = event_dispatch_.find(process_id);
@@ -666,24 +868,38 @@ void SimulatedKfd::init_command_processors_locked() {
                            " found=false");
         }
       });
-      cp->set_scratch_backing_resolver([this](uint32_t process_id) -> uint64_t {
-        std::lock_guard<std::mutex> plk(process_mutex_);
-        for (auto &[fd, proc] : processes_) {
-          if (proc->process_id() == process_id) {
-            for (auto &gs : proc->gpu_state_) {
-              if (gs.scratch_backing_va != 0)
-                return gs.scratch_backing_va << 16;
+      cp->set_scratch_backing_resolver(
+          [this, gpu_ordinal](uint32_t process_id) -> amdgpu::CommandProcessor::ScratchBacking {
+            std::lock_guard<std::mutex> plk(process_mutex_);
+            for (const std::pair<const uint32_t, std::shared_ptr<KfdProcess>> &entry : processes_) {
+              const std::shared_ptr<KfdProcess> &proc = entry.second;
+              if (proc->process_id() == process_id) {
+                if (gpu_ordinal >= proc->gpu_state_.size())
+                  return {};
+                uint64_t scratch_base = 0;
+                if (!decode_scratch_base(proc->gpu(gpu_ordinal).scratch_backing_va, &scratch_base))
+                  return {};
+                if (scratch_base == 0) {
+                  uint64_t fallback = 0;
+                  if (!fallback_scratch_base(gpu_ordinal, &fallback))
+                    return {};
+                  return {.gpu_va = fallback, .requires_owned_pool = true};
+                }
+                return {.gpu_va = scratch_base, .requires_owned_pool = false};
+              }
             }
-          }
-        }
-        return 0;
+            return {};
+          });
+      cp->set_scratch_backing_allocator([this, gpu_ordinal](uint32_t process_id, uint64_t gpu_va,
+                                                            size_t size,
+                                                            bool requires_owned_pool) -> bool {
+        return allocate_scratch_backing(gpu_ordinal, process_id, gpu_va, size, requires_owned_pool);
       });
-      cp->set_scratch_backing_allocator(
-          [this](uint32_t process_id, uint64_t gpu_va, size_t size) -> bool {
-            return allocate_scratch_backing(process_id, gpu_va, size);
+      cp->set_scratch_backing_verifier(
+          [this, gpu_ordinal](uint32_t process_id, uint64_t gpu_va, size_t size) -> bool {
+            return is_scratch_backing_owned(gpu_ordinal, process_id, gpu_va, size);
           });
       for (auto *cu : cp->compute_units()) {
-        const uint32_t gpu_ordinal = static_cast<uint32_t>(i);
         cu->set_trap_handler_resolver([this, gpu_ordinal](const amdgpu::Wavefront &wf) {
           return resolve_trap_handler(wf, gpu_ordinal);
         });
@@ -1013,16 +1229,6 @@ int SimulatedKfd::close(uint32_t process_id) {
   proc.event_state_.notify_closing();
   proc.event_state_.signal_page_shutdown();
 
-  {
-    std::lock_guard<std::mutex> ilk(interrupt_mutex_);
-    event_dispatch_.erase(process_id);
-  }
-
-  for (auto &g : gpus_) {
-    if (auto *mem = g.soc ? g.soc->memory() : nullptr)
-      mem->unregister_process(process_id);
-  }
-
   const bool trace_enabled = vm_trace_enabled();
   size_t leaked_allocations = 0;
   uint64_t leaked_bytes = 0;
@@ -1034,7 +1240,23 @@ int SimulatedKfd::close(uint32_t process_id) {
     queue_ids.assign(proc.active_queue_ids_.begin(), proc.active_queue_ids_.end());
     proc.active_queue_ids_.clear();
     proc.queue_snapshot_map_.clear();
+  }
 
+  for (uint32_t qid : queue_ids) {
+    for (GpuDevice &g : gpus_)
+      if (g.soc)
+        g.soc->for_each_cp([qid, process_id](amdgpu::CommandProcessor *cp) {
+          cp->unregister_queue(qid, process_id);
+        });
+  }
+
+  {
+    std::lock_guard<std::mutex> ilk(interrupt_mutex_);
+    event_dispatch_.erase(process_id);
+  }
+
+  {
+    std::lock_guard<std::mutex> alk(proc.alloc_mutex_);
     if (trace_enabled)
       leaked_handles.reserve(proc.allocations_.size());
     for (auto &[handle, alloc] : proc.allocations_) {
@@ -1043,7 +1265,8 @@ int SimulatedKfd::close(uint32_t process_id) {
       if (trace_enabled)
         leaked_handles.push_back(handle);
       if (alloc.host_ptr && alloc.host_ptr_owned) {
-        unmap_from_gpu(proc, alloc.gpu_va, alloc.size);
+        if (alloc.gpu_va != 0)
+          unmap_from_gpu(proc, alloc.gpu_va, alloc.size);
         libc_passthrough().munmap(alloc.host_ptr, alloc.size);
         alloc.host_ptr = nullptr;
         alloc.host_ptr_owned = false;
@@ -1060,12 +1283,16 @@ int SimulatedKfd::close(uint32_t process_id) {
     proc.allocations_.clear();
   }
 
-  for (uint32_t qid : queue_ids) {
-    for (auto &g : gpus_)
-      if (g.soc)
-        g.soc->for_each_cp([qid, process_id](amdgpu::CommandProcessor *cp) {
-          cp->unregister_queue(qid, process_id);
-        });
+  {
+    std::lock_guard<std::mutex> scratch_lock(proc.scratch_backing_mutex_);
+    std::lock_guard<std::mutex> alk(proc.alloc_mutex_);
+    for (const std::pair<const KfdProcess::ScratchPoolKey, KfdProcess::ScratchPool> &entry :
+         proc.scratch_pools_) {
+      const KfdProcess::ScratchPool &pool = entry.second;
+      if (pool.size != 0)
+        unmap_from_gpu(proc, pool.gpu_va, pool.size);
+    }
+    proc.scratch_pools_.clear();
   }
 
   // Doorbell mappings live in gpu_state_, not allocations_. Snapshot and clear
@@ -1103,6 +1330,12 @@ int SimulatedKfd::close(uint32_t process_id) {
       }
       libc_passthrough().close(doorbell_memfd);
     }
+  }
+
+  for (GpuDevice &g : gpus_) {
+    amdgpu::GpuMemory *mem = g.soc ? g.soc->memory() : nullptr;
+    if (mem != nullptr)
+      mem->unregister_process(process_id);
   }
 
   leaked_queues = queue_ids.size();
@@ -1236,7 +1469,18 @@ int SimulatedKfd::dispatch_ioctl(KfdProcess &proc, unsigned long request, void *
       return debug_trap_ioctl(proc, arg, target_mem_fd, target_proc_fd);
     case AMDKFD_IOC_SET_SCRATCH_BACKING_VA: {
       auto *a = static_cast<kfd_ioctl_set_scratch_backing_va_args *>(arg);
+      if (!find_gpu(a->gpu_id))
+        return -EINVAL;
       uint32_t ord = gpu_ordinal(a->gpu_id);
+      uint64_t scratch_base = 0;
+      if (!decode_scratch_base(a->va_addr, &scratch_base))
+        return -EINVAL;
+      if (scratch_base != 0) {
+        if (!gpuvm_range_contains(scratch_base, KfdProcess::kPageSize) ||
+            fallback_reservations_overlap_gpu_range(proc, scratch_base, KfdProcess::kPageSize)) {
+          return -EINVAL;
+        }
+      }
       {
         std::lock_guard<std::mutex> plk(process_mutex_);
         proc.gpu(ord).scratch_backing_va = a->va_addr;
@@ -1888,71 +2132,102 @@ int SimulatedKfd::alloc_memory_ioctl(KfdProcess &proc, void *arg) {
 
   if (args->size == 0)
     return -EINVAL;
+  if (args->size > std::numeric_limits<uint64_t>::max() - (KfdProcess::kPageSize - 1))
+    return -EINVAL;
+  const uint64_t aligned_size =
+      (args->size + KfdProcess::kPageSize - 1) & ~(KfdProcess::kPageSize - 1);
   if (args->va_addr != 0 && ((args->va_addr & (KfdProcess::kPageSize - 1)) != 0 ||
                              (args->size & (KfdProcess::kPageSize - 1)) != 0))
     return -EINVAL;
 
   std::lock_guard<std::mutex> lock(proc.alloc_mutex_);
 
-  bool user_provided_va = (args->va_addr != 0);
+  const bool user_provided_va = (args->va_addr != 0);
   uint64_t va = args->va_addr;
   if (va == 0) {
-    va = proc.next_gpu_va_;
-    proc.next_gpu_va_ += (args->size + 0xFFF) & ~0xFFFULL;
+    if (!find_available_gpu_range(proc, aligned_size, &va))
+      return -ENOMEM;
+  } else if (gpu_range_overflows(va, args->size)) {
+    return -EINVAL;
+  } else if (!gpuvm_range_contains(va, aligned_size)) {
+    return -EINVAL;
   }
 
+  if (process_ranges_overlap_gpu_range(proc, va, aligned_size)) {
+    util::Logger::cp([&](auto &os) {
+      os << std::format("ALLOC_MEMORY_FAIL gpu_va={:#x} size={:#x} overlaps existing GPUVA range",
+                        va, aligned_size);
+    });
+    return user_provided_va ? -EINVAL : -ENOMEM;
+  }
   KfdProcess::GpuAllocation alloc{};
   alloc.gpu_va = va;
   alloc.size = args->size;
   alloc.flags = args->flags;
-  alloc.handle = proc.next_handle_++;
   alloc.host_ptr = nullptr;
   alloc.gpu_id = args->gpu_id;
   alloc.user_va = user_provided_va;
 
-  auto alloc_mtype = pte_mtype_for_flags(args->flags);
-  bool is_userptr = (args->flags & KFD_IOC_ALLOC_MEM_FLAGS_USERPTR) != 0;
-  bool is_doorbell = (args->flags & KFD_IOC_ALLOC_MEM_FLAGS_DOORBELL) != 0;
+  const amdgpu::Mtype alloc_mtype = pte_mtype_for_flags(args->flags);
+  const bool is_userptr = (args->flags & KFD_IOC_ALLOC_MEM_FLAGS_USERPTR) != 0;
+  const bool is_doorbell = (args->flags & KFD_IOC_ALLOC_MEM_FLAGS_DOORBELL) != 0;
+  if (is_userptr && args->mmap_offset == 0)
+    args->mmap_offset = va;
   if (is_userptr && !daemon_mode_) {
-    alloc.host_ptr = reinterpret_cast<void *>(va);
-    map_to_gpu(proc, va, reinterpret_cast<void *>(va), args->size, alloc_mtype);
+    const uint64_t cpu_va = args->mmap_offset;
+    if ((cpu_va & (KfdProcess::kPageSize - 1)) != 0 || gpu_range_overflows(cpu_va, args->size))
+      return -EINVAL;
+    void *host_ptr = reinterpret_cast<void *>(cpu_va);
+    if (libc_passthrough().mprotect(host_ptr, args->size, PROT_READ | PROT_WRITE) != 0)
+      return -errno;
+    alloc.host_ptr = host_ptr;
+    map_to_gpu(proc, va, host_ptr, args->size, alloc_mtype);
   } else if (daemon_mode_ || !user_provided_va) {
-    auto raw_fd = memfd_create("rocjitsu_alloc", MFD_CLOEXEC | MFD_ALLOW_SEALING);
-    if (raw_fd >= 0) {
-      alloc.memfd = safe_fcntl(raw_fd, F_DUPFD_CLOEXEC, 4096);
-      if (alloc.memfd < 0)
-        alloc.memfd = raw_fd;
-      else
-        libc_passthrough().close(raw_fd);
-      {
-        std::lock_guard<std::mutex> lk(owned_fds_mutex_);
-        owned_fds_.insert(alloc.memfd);
-      }
-      if (alloc.memfd >= 0) {
-        [[maybe_unused]] auto ft_rc = ftruncate(alloc.memfd, static_cast<off_t>(alloc.size));
-        fallocate(alloc.memfd, 0, 0, static_cast<off_t>(alloc.size));
-        safe_fcntl(alloc.memfd, F_ADD_SEALS, F_SEAL_SHRINK);
+    int raw_fd = memfd_create("rocjitsu_alloc", MFD_CLOEXEC | MFD_ALLOW_SEALING);
+    if (raw_fd < 0)
+      return -errno;
+    UniqueDriverFd backing_fd(raw_fd);
+    int high_fd = safe_fcntl(backing_fd.get(), F_DUPFD_CLOEXEC, 4096);
+    if (high_fd >= 0)
+      backing_fd.reset(high_fd);
 
-        if (daemon_mode_ && !is_doorbell) {
-          auto *mapped =
-              safe_mmap(nullptr, alloc.size, PROT_READ | PROT_WRITE, MAP_SHARED, alloc.memfd, 0);
-          if (mapped != MAP_FAILED) {
-            alloc.host_ptr = mapped;
-            alloc.host_ptr_owned = true;
-            map_to_gpu(proc, va, alloc.host_ptr, alloc.size, alloc_mtype);
-          }
-        }
-      }
+    if (ftruncate(backing_fd.get(), static_cast<off_t>(alloc.size)) != 0)
+      return -errno;
+    if (fallocate(backing_fd.get(), 0, 0, static_cast<off_t>(alloc.size)) != 0)
+      return -errno;
+    safe_fcntl(backing_fd.get(), F_ADD_SEALS, F_SEAL_SHRINK);
+
+    UniqueMapping daemon_mapping;
+    if (daemon_mode_ && !is_doorbell) {
+      void *mapped =
+          safe_mmap(nullptr, alloc.size, PROT_READ | PROT_WRITE, MAP_SHARED, backing_fd.get(), 0);
+      if (mapped == MAP_FAILED)
+        return errno > 0 ? -errno : -ENOMEM;
+      daemon_mapping.reset(mapped, static_cast<size_t>(alloc.size));
+      alloc.host_ptr = mapped;
+      alloc.host_ptr_owned = true;
+      map_to_gpu(proc, va, alloc.host_ptr, alloc.size, alloc_mtype);
     }
+
+    alloc.memfd = backing_fd.get();
+    {
+      std::lock_guard<std::mutex> lk(owned_fds_mutex_);
+      owned_fds_.insert(alloc.memfd);
+    }
+    static_cast<void>(backing_fd.release());
+    static_cast<void>(daemon_mapping.release());
   }
 
+  alloc.handle = proc.next_handle_++;
   proc.allocations_[alloc.handle] = alloc;
+  if (!user_provided_va)
+    proc.next_gpu_va_ = va + aligned_size;
 
   args->handle = alloc.handle;
   args->va_addr = va;
   if (args->flags & KFD_IOC_ALLOC_MEM_FLAGS_DOORBELL) {
     args->mmap_offset = KFD_MMAP_TYPE_DOORBELL | kfd_mmap_gpu_id(args->gpu_id);
-  } else {
+  } else if (!is_userptr) {
     args->mmap_offset = alloc.handle << 12;
   }
 
@@ -1970,16 +2245,22 @@ int SimulatedKfd::alloc_memory_ioctl(KfdProcess &proc, void *arg) {
   return 0;
 }
 
-bool SimulatedKfd::allocate_scratch_backing(uint32_t process_id, uint64_t gpu_va, size_t size) {
+bool SimulatedKfd::allocate_scratch_backing(uint32_t gpu_ordinal, uint32_t process_id,
+                                            uint64_t gpu_va, size_t size,
+                                            bool requires_owned_pool) {
   if (size == 0)
+    return false;
+  if (gpu_ordinal >= gpus_.size())
     return false;
 
   std::shared_ptr<KfdProcess> proc;
   {
     std::lock_guard<std::mutex> plk(process_mutex_);
-    for (auto &[fd, p] : processes_) {
-      if (p->process_id() == process_id) {
-        proc = p;
+    for (std::unordered_map<uint32_t, std::shared_ptr<KfdProcess>>::const_iterator it =
+             processes_.begin();
+         it != processes_.end(); ++it) {
+      if (it->second->process_id() == process_id) {
+        proc = it->second;
         break;
       }
     }
@@ -1987,83 +2268,89 @@ bool SimulatedKfd::allocate_scratch_backing(uint32_t process_id, uint64_t gpu_va
   if (!proc)
     return false;
 
-  size_t aligned_size = (size + 0xFFF) & ~0xFFFULL;
+  constexpr size_t kPageSize = static_cast<size_t>(KfdProcess::kPageSize);
+  if (size > std::numeric_limits<size_t>::max() - (kPageSize - 1))
+    return false;
+  const size_t aligned_size = (size + kPageSize - 1) & ~(kPageSize - 1);
+  if (gpu_range_overflows(gpu_va, aligned_size))
+    return false;
+  if (!gpuvm_range_contains(gpu_va, aligned_size))
+    return false;
+  if (requires_owned_pool && !fallback_window_contains_gpu_range(gpu_ordinal, gpu_va, aligned_size))
+    return false;
 
   // Every XCD of a fanned-out dispatch races here for the same process-wide pool
   // VA, each having independently found it unbacked. Only the first may map it:
   // mapping again would repoint the pool underneath waves the first XCD already
-  // launched and leak the original. The requested size is grid-scale and therefore
-  // identical for every XCD of one grid, so a pool already at least that large
-  // satisfies all of them and this covers the whole fan-out race.
-  //
-  // A later dispatch in the same process needing a LARGER pool still falls through
-  // and remaps, as it did before fan-out existed. That path is unchanged here.
+  // launched. Keep the GPUVA and PTE backing identity stable; growth resizes the
+  // internal backing and maps only the newly exposed tail.
   std::lock_guard<std::mutex> scratch_lock(proc->scratch_backing_mutex_);
-  {
-    std::lock_guard<std::mutex> lk(proc->alloc_mutex_);
-    for (const auto &[handle, alloc] : proc->allocations_) {
-      if (alloc.gpu_va == gpu_va && alloc.size >= aligned_size)
-        return true;
-    }
-  }
+  std::lock_guard<std::mutex> lk(proc->alloc_mutex_);
 
-  auto raw_fd = memfd_create("rocjitsu_scratch", MFD_CLOEXEC);
-  if (raw_fd < 0)
+  const KfdProcess::ScratchPoolKey key{.gpu_ordinal = gpu_ordinal, .gpu_va = gpu_va};
+  KfdProcess::ScratchPoolMap::iterator existing = proc->scratch_pools_.find(key);
+  if (existing != proc->scratch_pools_.end() && existing->second.size >= aligned_size)
+    return true;
+  const uint32_t allowed_fallback_ordinal =
+      requires_owned_pool ? gpu_ordinal : kNoScratchGpuOrdinal;
+  if (process_ranges_overlap_gpu_range(*proc, gpu_va, aligned_size, 0, gpu_ordinal, gpu_va,
+                                       allowed_fallback_ordinal))
     return false;
 
-  int memfd = safe_fcntl(raw_fd, F_DUPFD_CLOEXEC, 4096);
-  if (memfd < 0)
-    memfd = raw_fd;
-  else
-    libc_passthrough().close(raw_fd);
-  {
-    std::lock_guard<std::mutex> lk(owned_fds_mutex_);
-    owned_fds_.insert(memfd);
-  }
-
-  if (ftruncate(memfd, static_cast<off_t>(aligned_size)) != 0) {
-    {
-      std::lock_guard<std::mutex> lk(owned_fds_mutex_);
-      owned_fds_.erase(memfd);
+  std::shared_ptr<KfdProcess::BackingStore> backing;
+  size_t old_size = 0;
+  if (existing != proc->scratch_pools_.end()) {
+    backing = existing->second.backing;
+    old_size = static_cast<size_t>(existing->second.size);
+  } else {
+    try {
+      backing = std::make_shared<KfdProcess::BackingStore>();
+    } catch (const std::bad_alloc &) {
+      return false;
     }
-    libc_passthrough().close(memfd);
+  }
+  if (!backing || !backing->resize(aligned_size))
     return false;
-  }
-  auto *host_ptr = safe_mmap(nullptr, aligned_size, PROT_READ | PROT_WRITE, MAP_SHARED, memfd, 0);
-  if (host_ptr == MAP_FAILED) {
-    {
-      std::lock_guard<std::mutex> lk(owned_fds_mutex_);
-      owned_fds_.erase(memfd);
-    }
-    libc_passthrough().close(memfd);
-    return false;
-  }
-  {
-    std::lock_guard<std::mutex> lk(owned_fds_mutex_);
-    owned_fds_.erase(memfd);
-  }
-  libc_passthrough().close(memfd);
-  std::memset(host_ptr, 0, aligned_size);
-  proc->map_pages(gpu_va, host_ptr, aligned_size);
 
-  {
-    std::lock_guard<std::mutex> lk(proc->alloc_mutex_);
-    KfdProcess::GpuAllocation alloc{};
-    alloc.gpu_va = gpu_va;
-    alloc.size = aligned_size;
-    alloc.host_ptr = host_ptr;
-    alloc.host_ptr_owned = true;
-    alloc.handle = proc->next_handle_++;
-    alloc.memfd = -1;
-    proc->allocations_[alloc.handle] = alloc;
+  if (old_size == 0) {
+    proc->map_backing_pages(gpu_va, backing, 0, aligned_size);
+    KfdProcess::ScratchPool pool{};
+    pool.gpu_va = gpu_va;
+    pool.size = aligned_size;
+    pool.backing = backing;
+    proc->scratch_pools_[key] = std::move(pool);
+  } else {
+    proc->map_backing_pages(gpu_va + old_size, backing, old_size, aligned_size - old_size);
+    existing->second.size = aligned_size;
   }
 
   util::Logger::vm([&](auto &os) {
-    os << "SCRATCH_BACKING pid=" << process_id << " gpu_va=0x" << std::hex << gpu_va << " size=0x"
-       << aligned_size << std::dec << " host=" << host_ptr;
+    os << "SCRATCH_BACKING pid=" << process_id << " gpu_va=0x" << std::hex << gpu_va
+       << " old_size=0x" << old_size << " size=0x" << aligned_size << std::dec
+       << " backing=" << backing.get();
   });
 
   return true;
+}
+
+bool SimulatedKfd::is_scratch_backing_owned(uint32_t gpu_ordinal, uint32_t process_id,
+                                            uint64_t gpu_va, size_t size) const {
+  if (size == 0)
+    return false;
+  std::shared_ptr<KfdProcess> proc = find_process(process_id);
+  if (!proc)
+    return false;
+
+  std::lock_guard<std::mutex> scratch_lock(proc->scratch_backing_mutex_);
+  std::lock_guard<std::mutex> lk(proc->alloc_mutex_);
+  for (const std::pair<const KfdProcess::ScratchPoolKey, KfdProcess::ScratchPool> &entry :
+       proc->scratch_pools_) {
+    const KfdProcess::ScratchPoolKey &key = entry.first;
+    const KfdProcess::ScratchPool &pool = entry.second;
+    if (key.gpu_ordinal == gpu_ordinal && scratch_pool_contains_gpu_range(pool, gpu_va, size))
+      return true;
+  }
+  return false;
 }
 
 int SimulatedKfd::free_memory_ioctl(KfdProcess &proc, void *arg) {
@@ -2081,8 +2368,12 @@ int SimulatedKfd::free_memory_ioctl(KfdProcess &proc, void *arg) {
         proc.imported_dmabufs_.erase(dmabuf_it);
       }
     }
-    if (alloc.host_ptr)
-      unmap_from_gpu(proc, alloc.gpu_va, alloc.size);
+    if (alloc.host_ptr) {
+      if (alloc.gpu_va != 0)
+        unmap_from_gpu(proc, alloc.gpu_va, alloc.size);
+      if (alloc.host_ptr_owned)
+        libc_passthrough().munmap(alloc.host_ptr, alloc.size);
+    }
     if (alloc.memfd >= 0) {
       {
         std::lock_guard<std::mutex> lk(owned_fds_mutex_);
@@ -2123,6 +2414,10 @@ int SimulatedKfd::map_memory_ioctl(KfdProcess &proc, void *arg) {
     return -EINVAL;
   }
   auto &alloc = it->second;
+  if (alloc.gpu_va == 0) {
+    args->n_success = 0;
+    return -EINVAL;
+  }
   util::Logger::cp([&](auto &os) {
     os << std::format("MAP_MEMORY handle={} gpu_va={:#x} size={:#x} n_devices={} host_ptr={}",
                       alloc.handle, alloc.gpu_va, alloc.size, args->n_devices,
@@ -2133,8 +2428,10 @@ int SimulatedKfd::map_memory_ioctl(KfdProcess &proc, void *arg) {
     auto *host_ptr = reinterpret_cast<void *>(alloc.gpu_va);
     if (libc_passthrough().mprotect(host_ptr, alloc.size, PROT_READ | PROT_WRITE) == 0)
       alloc.host_ptr = host_ptr;
-    else
+    else {
+      args->n_success = 0;
       return -errno;
+    }
   }
   if (alloc.host_ptr)
     map_to_gpu(proc, alloc.gpu_va, alloc.host_ptr, alloc.size, pte_mtype_for_flags(alloc.flags));
@@ -2152,7 +2449,7 @@ int SimulatedKfd::unmap_memory_ioctl(KfdProcess &proc, void *arg) {
     // releases it. Erasing here would leak those fds and make a later FREE a
     // no-op for this handle.
     auto &alloc = it->second;
-    if (alloc.host_ptr)
+    if (alloc.host_ptr && alloc.gpu_va != 0)
       unmap_from_gpu(proc, alloc.gpu_va, alloc.size);
   }
   args->n_success = args->n_devices;
@@ -2385,40 +2682,58 @@ int SimulatedKfd::import_dmabuf_ioctl(KfdProcess &proc, void *arg) {
   struct stat st {};
   if (safe_fstat(args->dmabuf_fd, &st) != 0)
     return -errno;
+  if (st.st_size <= 0)
+    return -EINVAL;
   uint64_t size = static_cast<uint64_t>(st.st_size);
+  if (size > static_cast<uint64_t>(std::numeric_limits<size_t>::max()))
+    return -EOVERFLOW;
+  if (args->va_addr != 0 && gpu_range_overflows(args->va_addr, size))
+    return -EINVAL;
+  if (args->va_addr != 0 && !gpuvm_range_contains(args->va_addr, size))
+    return -EINVAL;
 
   int dupfd = safe_fcntl(args->dmabuf_fd, F_DUPFD_CLOEXEC, 0);
   if (dupfd < 0)
     return -errno;
+  UniqueDriverFd imported_fd(dupfd);
+  void *mapped = safe_mmap(nullptr, static_cast<size_t>(size), PROT_READ | PROT_WRITE, MAP_SHARED,
+                           imported_fd.get(), 0);
+  if (mapped == MAP_FAILED)
+    return errno > 0 ? -errno : -ENOMEM;
+  UniqueMapping imported_mapping(mapped, static_cast<size_t>(size));
 
   uint64_t handle;
   {
     std::lock_guard<std::mutex> lk(proc.alloc_mutex_);
+    if (args->va_addr != 0 && process_ranges_overlap_gpu_range(proc, args->va_addr, size))
+      return -EINVAL;
+
     handle = proc.next_handle_++;
     KfdProcess::GpuAllocation alloc{};
     alloc.gpu_va = args->va_addr;
     alloc.size = size;
     alloc.flags = KFD_IOC_ALLOC_MEM_FLAGS_GTT | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
     alloc.handle = handle;
-    alloc.user_va = true;
+    alloc.user_va = args->va_addr != 0;
     alloc.imported = true;
-    alloc.dmabuf_fd = dupfd;
-    alloc.host_ptr = reinterpret_cast<void *>(args->va_addr);
+    alloc.dmabuf_fd = imported_fd.get();
+    alloc.host_ptr = mapped;
+    alloc.host_ptr_owned = true;
+    if (args->va_addr)
+      map_to_gpu(proc, args->va_addr, mapped, size, amdgpu::Mtype::UC);
     proc.allocations_[handle] = alloc;
 
     KfdProcess::ImportedDmabuf info{};
     info.handle = handle;
-    info.fd = dupfd;
+    info.fd = imported_fd.get();
     info.size = size;
     info.va = args->va_addr;
     info.gpu_id = args->gpu_id;
     proc.imported_dmabufs_[handle] = info;
-    proc.fd_to_import_handle_[dupfd] = handle;
+    proc.fd_to_import_handle_[imported_fd.get()] = handle;
+    static_cast<void>(imported_mapping.release());
+    (void)imported_fd.release();
   }
-
-  if (args->va_addr)
-    map_to_gpu(proc, args->va_addr, reinterpret_cast<void *>(args->va_addr), size,
-               amdgpu::Mtype::UC);
 
   args->handle = handle;
   return 0;
@@ -2455,54 +2770,10 @@ int SimulatedKfd::ipc_export_handle_ioctl(KfdProcess &proc, void *arg) {
     if (it == proc.allocations_.end())
       return -EINVAL;
     auto &alloc = it->second;
-
-    if (alloc.memfd < 0 && alloc.host_ptr) {
-      int promoted_fd = memfd_create("rocjitsu_ipc_promote", MFD_CLOEXEC | MFD_ALLOW_SEALING);
-      if (promoted_fd < 0)
-        return -errno;
-      if (ftruncate(promoted_fd, static_cast<off_t>(alloc.size)) != 0) {
-        libc_passthrough().close(promoted_fd);
-        return -errno;
-      }
-      auto *new_host_ptr =
-          safe_mmap(nullptr, alloc.size, PROT_READ | PROT_WRITE, MAP_SHARED, promoted_fd, 0);
-      if (new_host_ptr == MAP_FAILED) {
-        libc_passthrough().close(promoted_fd);
-        return -ENOMEM;
-      }
-      std::memcpy(new_host_ptr, alloc.host_ptr, alloc.size);
-
-      if (alloc.flags & KFD_IOC_ALLOC_MEM_FLAGS_USERPTR) {
-        util::Logger::vm("ipc_export: promoting USERPTR to memfd-backed (snapshot copy, not "
-                         "true sharing)");
-      }
-
-      proc.remap_page_host_ptrs(alloc.gpu_va, alloc.host_ptr, new_host_ptr, alloc.size);
-
-      if (alloc.host_ptr_owned)
-        libc_passthrough().munmap(alloc.host_ptr, alloc.size);
-
-      alloc.host_ptr = new_host_ptr;
-      alloc.host_ptr_owned = true;
-      alloc.memfd = promoted_fd;
-      {
-        std::lock_guard<std::mutex> flk(owned_fds_mutex_);
-        owned_fds_.insert(promoted_fd);
-      }
-    } else if (alloc.memfd < 0) {
-      int new_fd = memfd_create("rocjitsu_ipc_lazy", MFD_CLOEXEC | MFD_ALLOW_SEALING);
-      if (new_fd < 0)
-        return -errno;
-      if (ftruncate(new_fd, static_cast<off_t>(alloc.size)) != 0) {
-        libc_passthrough().close(new_fd);
-        return -errno;
-      }
-      alloc.memfd = new_fd;
-      {
-        std::lock_guard<std::mutex> flk(owned_fds_mutex_);
-        owned_fds_.insert(new_fd);
-      }
-    }
+    if (alloc.flags & KFD_IOC_ALLOC_MEM_FLAGS_USERPTR)
+      return -EINVAL;
+    if (alloc.memfd < 0)
+      return -EINVAL;
 
     // Upgrade the exporter's PTE mtype to CC (cache coherent) so that
     // the local GPU sees writes from the importing GPU.  On real hardware
@@ -2576,30 +2847,31 @@ int SimulatedKfd::ipc_import_handle_ioctl(KfdProcess &proc, void *arg) {
   if (dup_fd < 0)
     return -errno;
 
-  {
-    std::lock_guard<std::mutex> flk(owned_fds_mutex_);
-    owned_fds_.insert(dup_fd);
-  }
+  UniqueDriverFd imported_fd(dup_fd);
 
-  auto *host_ptr = safe_mmap(nullptr, alloc_size, PROT_READ | PROT_WRITE, MAP_SHARED, dup_fd, 0);
-  if (host_ptr == MAP_FAILED) {
-    {
-      std::lock_guard<std::mutex> flk(owned_fds_mutex_);
-      owned_fds_.erase(dup_fd);
-    }
-    libc_passthrough().close(dup_fd);
+  void *host_ptr =
+      safe_mmap(nullptr, alloc_size, PROT_READ | PROT_WRITE, MAP_SHARED, imported_fd.get(), 0);
+  if (host_ptr == MAP_FAILED)
     return -ENOMEM;
-  }
+  UniqueMapping imported_mapping(host_ptr, static_cast<size_t>(alloc_size));
 
   uint64_t gpu_va;
   uint64_t handle;
   {
     std::lock_guard<std::mutex> lk(proc.alloc_mutex_);
-    if (args->va_addr != 0)
+    if (args->va_addr != 0) {
+      if (gpu_range_overflows(args->va_addr, alloc_size) ||
+          !gpuvm_range_contains(args->va_addr, alloc_size) ||
+          process_ranges_overlap_gpu_range(proc, args->va_addr, alloc_size)) {
+        return -EINVAL;
+      }
       gpu_va = args->va_addr;
-    else {
-      gpu_va = proc.next_gpu_va_;
-      proc.next_gpu_va_ += (alloc_size + 0xFFF) & ~0xFFFULL;
+    } else {
+      if (!find_available_gpu_range(proc, alloc_size, &gpu_va))
+        return -ENOMEM;
+      const uint64_t aligned_size =
+          (alloc_size + KfdProcess::kPageSize - 1) & ~(KfdProcess::kPageSize - 1);
+      proc.next_gpu_va_ = gpu_va + aligned_size;
     }
     handle = proc.next_handle_++;
 
@@ -2610,17 +2882,18 @@ int SimulatedKfd::ipc_import_handle_ioctl(KfdProcess &proc, void *arg) {
     alloc.handle = handle;
     alloc.host_ptr = host_ptr;
     alloc.host_ptr_owned = true;
-    alloc.memfd = dup_fd;
+    alloc.memfd = imported_fd.get();
     alloc.gpu_id = source_gpu_id;
     alloc.imported = true;
+    map_to_gpu(proc, gpu_va, host_ptr, alloc_size, amdgpu::Mtype::CC);
+    {
+      std::lock_guard<std::mutex> flk(owned_fds_mutex_);
+      owned_fds_.insert(imported_fd.get());
+    }
     proc.allocations_[handle] = alloc;
+    (void)imported_mapping.release();
+    (void)imported_fd.release();
   }
-
-  // IPC-imported memory uses CC (cache coherent) mtype to emulate the
-  // cross-GPU coherence that real hardware provides via xGMI snoops.
-  // Without this, the importing GPU's L2 cache serves stale data when
-  // the exporting GPU writes to the shared buffer.
-  map_to_gpu(proc, gpu_va, host_ptr, alloc_size, amdgpu::Mtype::CC);
 
   args->handle = handle;
   args->mmap_offset = handle << 12;
@@ -2660,12 +2933,7 @@ int SimulatedKfd::get_dmabuf_info_ioctl(KfdProcess &proc, void *arg) {
   args->size = size;
   args->gpu_id = gpu_id;
   args->flags = KFD_IOC_ALLOC_MEM_FLAGS_GTT;
-  // metadata_ptr is a client-process address that cannot be dereferenced in
-  // daemon mode. ROCR currently queries with metadata_size == 0; reject
-  // metadata-bearing calls rather than risk a cross-process pointer deref.
-  if (args->metadata_size > 0 && daemon_mode_)
-    return -EINVAL;
-  if (args->metadata_ptr && args->metadata_size && !daemon_mode_) {
+  if (args->metadata_ptr && args->metadata_size) {
     std::memset(reinterpret_cast<void *>(args->metadata_ptr), 0,
                 static_cast<size_t>(args->metadata_size));
   }
@@ -4853,6 +5121,13 @@ int SimulatedKfd::get_mmap_memfd(uint32_t process_id, off_t offset) const {
   return dispatch_get_mmap_memfd(*p, offset);
 }
 
+int SimulatedKfd::get_allocation_memfd(uint32_t process_id, uint64_t handle) const {
+  std::shared_ptr<KfdProcess> p = find_process(process_id);
+  if (!p)
+    return -1;
+  return dispatch_get_allocation_memfd(*p, handle);
+}
+
 int SimulatedKfd::dispatch_get_mmap_memfd(KfdProcess &proc, off_t offset) const {
   uint64_t type = static_cast<uint64_t>(offset) & KFD_MMAP_TYPE_MASK;
 
@@ -4894,6 +5169,15 @@ int SimulatedKfd::dispatch_get_mmap_memfd(KfdProcess &proc, off_t offset) const 
     return it->second.memfd;
 
   return -1;
+}
+
+int SimulatedKfd::dispatch_get_allocation_memfd(KfdProcess &proc, uint64_t handle) const {
+  std::lock_guard<std::mutex> lock(proc.alloc_mutex_);
+  std::unordered_map<uint64_t, KfdProcess::GpuAllocation>::iterator it =
+      proc.allocations_.find(handle);
+  if (it == proc.allocations_.end())
+    return -1;
+  return it->second.memfd;
 }
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.h
@@ -138,6 +138,7 @@ public:
   void close_all_processes();
 
   [[nodiscard]] int get_mmap_memfd(uint32_t process_id, off_t offset) const;
+  [[nodiscard]] int get_allocation_memfd(uint32_t process_id, uint64_t handle) const;
   /// @}
 
   /// @brief Local-mode get_mmap_memfd (uses local process).
@@ -286,6 +287,7 @@ private:
                       off_t offset);
   int dispatch_munmap(KfdProcess &proc, void *addr, size_t length);
   int dispatch_get_mmap_memfd(KfdProcess &proc, off_t offset) const;
+  int dispatch_get_allocation_memfd(KfdProcess &proc, uint64_t handle) const;
 
   int get_process_apertures_ioctl(void *arg) override;
   int acquire_vm_ioctl(void *arg) override;
@@ -442,7 +444,10 @@ private:
   kfd_process_device_apertures gpu_apertures(uint32_t ordinal) const;
   int set_xnack_mode_ioctl(void *arg);
   int get_tile_config_ioctl(void *arg);
-  bool allocate_scratch_backing(uint32_t process_id, uint64_t gpu_va, size_t size);
+  bool allocate_scratch_backing(uint32_t gpu_ordinal, uint32_t process_id, uint64_t gpu_va,
+                                size_t size, bool requires_owned_pool);
+  bool is_scratch_backing_owned(uint32_t gpu_ordinal, uint32_t process_id, uint64_t gpu_va,
+                                size_t size) const;
 
   /// @brief Lazily create the backing memfd exactly once across racing opens.
   /// @details CAS-publishes fd_ so concurrent open()/open_process() callers agree
@@ -478,7 +483,7 @@ private:
   ///   op_mutex_ < debug_sessions_mutex_ < runtime_mutex_ (debug_trap_ioctl)
   ///   process_mutex_ < interrupt_mutex_                (open()/open_process())
   ///   hw_queue_mutex_ (CP) < scratch_backing_mutex_ (KfdProcess) < alloc_mutex_
-  ///                                                    (allocate_scratch_backing)
+  ///                                                    (scratch pool reservation)
   /// The op_mutex_ in the debug rule is always the CALLER's, while runtime_mutex_
   /// may belong to a DIFFERENT process (the debug target resolved by client pid).
   /// debug_trap_ioctl holds only the caller's op_mutex_ and never acquires the
@@ -487,10 +492,9 @@ private:
   /// descends into EventState::mutex_, and close() takes it only after releasing
   /// process_mutex_, so there is no cycle.
   /// The CP engine thread acquires hw_queue_mutex_ first, then reaches
-  /// process_mutex_ (scratch resolver) or alloc_mutex_ (scratch allocator) through
-  /// the callbacks — hw_queue_mutex_ -> process_mutex_ and, separately,
-  /// hw_queue_mutex_ -> alloc_mutex_ (never both nested). To avoid an ABBA against
-  /// that thread, an ioctl MUST NOT hold a per-process lock (alloc_mutex_) across a
+  /// process_mutex_ (scratch resolver) or scratch_backing_mutex_/alloc_mutex_
+  /// (scratch allocator) through callbacks. To avoid an ABBA against that thread,
+  /// an ioctl MUST NOT hold a per-process lock (alloc_mutex_) across a
   /// CommandProcessor call that takes hw_queue_mutex_ (e.g. register_queue) — build
   /// state under alloc_mutex_, release it, then call the CP.
   mutable std::mutex process_mutex_;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -493,8 +493,8 @@ void CommandProcessor::init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf,
     }
     uint64_t wave_scratch = scratch_pool + scratch_slot * per_wave_size;
 
-    if (memory_ && memory_->resolve_host_ptr(wave_scratch, pkt.process_id) == nullptr &&
-        scratch_allocator_) {
+    if (memory_ && scratch_allocator_ &&
+        !memory_->has_page_table_mapping(wave_scratch, pkt.process_id)) {
       // Size against the whole grid, not this XCD's share: every XCD of a
       // fanned-out dispatch shares the allocation. CDNA5 uses the complete
       // physical XCC/SE/scoreboard address space instead of logical grid slots.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -521,12 +521,11 @@ void CommandProcessor::init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf,
       cu->write_sgpr(sbase + 33, 0);
     }
     util::Logger::cp([&](auto &os) {
-      os << std::format(
-          "SCRATCH wf{} pool={:#x} wave_scratch={:#x} per_wave={} priv_size={} "
-          "backing_addr={:#x} mapped={}",
-          wf->wf_id(), scratch_pool, wave_scratch, per_wave_size, pkt.private_segment_fixed_size,
-          pkt.scratch_backing_addr,
-          memory_ ? (memory_->resolve_host_ptr(wave_scratch, pkt.process_id) != nullptr) : false);
+      os << std::format("SCRATCH wf{} pool={:#x} wave_scratch={:#x} per_wave={} priv_size={} "
+                        "backing_addr={:#x} mapped={}",
+                        wf->wf_id(), scratch_pool, wave_scratch, per_wave_size,
+                        pkt.private_segment_fixed_size, pkt.scratch_backing_addr,
+                        memory_ ? memory_->is_mapped(wave_scratch, pkt.process_id) : false);
     });
 
     if (flat_scratch_init_sgpr >= 0) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -462,19 +462,34 @@ void CommandProcessor::init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf,
   // across all CUs and workgroups in the dispatch.
   if (pkt.private_segment_fixed_size > 0) {
     uint64_t scratch_pool = pkt.scratch_backing_addr;
+    bool scratch_requires_owned_pool = pkt.scratch_requires_owned_pool;
+    if (scratch_pool == 0 && scratch_resolver_) {
+      const ScratchBacking resolved = scratch_resolver_(pkt.process_id);
+      scratch_pool = resolved.gpu_va;
+      scratch_requires_owned_pool = resolved.requires_owned_pool;
+    }
     if (scratch_pool == 0)
       scratch_pool = 0x1'0000'0000ULL;
     // Round the per-wave region to the 1 KB COMPUTE_TMPRING_SIZE.WAVESIZE granule
     // so that each wave's base equals scratch_pool + scoreboard_id * wavesize,
     // which is exactly what rocm-dbgapi computes to locate a wave's private
     // memory (rocdbgapi architecture.cpp scratch_memory_region).
-    uint64_t raw_per_wave = static_cast<uint64_t>(pkt.private_segment_fixed_size) * wf->wf_size();
-    uint64_t per_wave_size = ((raw_per_wave + 1023) / 1024) * 1024;
-    uint32_t wg_total_size = static_cast<uint32_t>(pkt.workgroup_size_x) *
-                             std::max<uint16_t>(1, pkt.workgroup_size_y) *
-                             std::max<uint16_t>(1, pkt.workgroup_size_z);
-    uint32_t waves_per_wg = (wg_total_size + wf->wf_size() - 1) / wf->wf_size();
-    uint64_t global_wave_idx = static_cast<uint64_t>(global_wg_id) * waves_per_wg + wf_index_in_wg;
+    const uint64_t raw_per_wave =
+        static_cast<uint64_t>(pkt.private_segment_fixed_size) * wf->wf_size();
+    if (raw_per_wave > std::numeric_limits<uint64_t>::max() - 1023)
+      throw std::runtime_error("scratch backing size overflow");
+    const uint64_t per_wave_size = ((raw_per_wave + 1023) / 1024) * 1024;
+    const uint64_t wg_total_size = static_cast<uint64_t>(pkt.workgroup_size_x) *
+                                   std::max<uint16_t>(1, pkt.workgroup_size_y) *
+                                   std::max<uint16_t>(1, pkt.workgroup_size_z);
+    const uint64_t waves_per_wg = (wg_total_size + wf->wf_size() - 1) / wf->wf_size();
+    if (waves_per_wg != 0 &&
+        static_cast<uint64_t>(global_wg_id) > std::numeric_limits<uint64_t>::max() / waves_per_wg)
+      throw std::runtime_error("scratch wave index overflow");
+    const uint64_t global_wave_base = static_cast<uint64_t>(global_wg_id) * waves_per_wg;
+    const uint64_t global_wave_idx = global_wave_base + wf_index_in_wg;
+    if (global_wave_idx < global_wave_base)
+      throw std::runtime_error("scratch wave index overflow");
     uint64_t scratch_slot = global_wave_idx;
     if (cu->arch() == ROCJITSU_CODE_ARCH_CDNA5) {
       const uint32_t shader_engine_count =
@@ -491,22 +506,82 @@ void CommandProcessor::init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf,
       // Legacy CWSR records use the dispatch-wide logical scratch slot.
       wf->set_scratch_scoreboard_id(static_cast<uint32_t>(global_wave_idx));
     }
-    uint64_t wave_scratch = scratch_pool + scratch_slot * per_wave_size;
+    if (per_wave_size != 0 && scratch_slot > std::numeric_limits<uint64_t>::max() / per_wave_size)
+      throw std::runtime_error("scratch wave address overflow");
+    const uint64_t scratch_offset = scratch_slot * per_wave_size;
+    if (scratch_pool > std::numeric_limits<uint64_t>::max() - scratch_offset)
+      throw std::runtime_error("scratch wave address overflow");
+    const uint64_t wave_scratch = scratch_pool + scratch_offset;
+    auto scratch_range_backed = [&](uint64_t addr, size_t size) {
+      if (scratch_requires_owned_pool) {
+        return scratch_verifier_ && scratch_verifier_(pkt.process_id, addr, size) &&
+               memory_->is_range_host_backed(addr, size, pkt.process_id);
+      }
+      if (pkt.process_id != 0)
+        return memory_->is_range_host_backed(addr, size, pkt.process_id);
+      if (size == 0 || size - 1 > std::numeric_limits<uint64_t>::max() - addr)
+        return false;
+      size_t offset = 0;
+      while (offset < size) {
+        const uint64_t ea = addr + offset;
+        if (!memory_->has_page(ea))
+          return false;
+        offset += std::min(size - offset,
+                           GpuMemory::PAGE_SIZE - static_cast<size_t>(ea & GpuMemory::PAGE_MASK));
+      }
+      return true;
+    };
+    auto scratch_allocator_needed = [&]() {
+      if (pkt.process_id == 0)
+        return memory_->resolve_host_ptr(wave_scratch, pkt.process_id, per_wave_size) == nullptr;
+      return !scratch_range_backed(wave_scratch, per_wave_size);
+    };
 
-    if (memory_ && scratch_allocator_ &&
-        !memory_->has_page_table_mapping(wave_scratch, pkt.process_id)) {
+    if (memory_ && scratch_allocator_ && scratch_allocator_needed()) {
       // Size against the whole grid, not this XCD's share: every XCD of a
       // fanned-out dispatch shares the allocation. CDNA5 uses the complete
       // physical XCC/SE/scoreboard address space instead of logical grid slots.
-      uint64_t scratch_slots = static_cast<uint64_t>(pkt.grid_total_wgs()) * waves_per_wg;
+      uint64_t scratch_slots = 0;
       if (cu->arch() == ROCJITSU_CODE_ARCH_CDNA5) {
         const uint32_t shader_engine_count =
             std::max(scratch_wave_divisor_, scratch_shader_engine_count_);
-        scratch_slots =
-            static_cast<uint64_t>(scratch_xcc_count_) * shader_engine_count * scratch_waves_per_se_;
+        const uint64_t xcc_se_slots =
+            static_cast<uint64_t>(scratch_xcc_count_) * shader_engine_count;
+        if (scratch_waves_per_se_ != 0 &&
+            xcc_se_slots > std::numeric_limits<uint64_t>::max() / scratch_waves_per_se_)
+          throw std::runtime_error("scratch backing size overflow");
+        scratch_slots = xcc_se_slots * scratch_waves_per_se_;
+      } else {
+        const uint64_t highest_exclusive_wg =
+            static_cast<uint64_t>(pkt.workgroup_id_offset) + pkt.total_wgs;
+        if (highest_exclusive_wg < pkt.workgroup_id_offset)
+          throw std::runtime_error("scratch backing size overflow");
+        const uint64_t scratch_wgs = std::max<uint64_t>(pkt.grid_total_wgs(), highest_exclusive_wg);
+        if (scratch_wgs != 0 && waves_per_wg > std::numeric_limits<uint64_t>::max() / scratch_wgs)
+          throw std::runtime_error("scratch backing size overflow");
+        scratch_slots = scratch_wgs * waves_per_wg;
       }
-      uint64_t total_scratch = per_wave_size * scratch_slots;
-      scratch_allocator_(pkt.process_id, scratch_pool, static_cast<size_t>(total_scratch));
+      if (per_wave_size != 0 &&
+          scratch_slots > std::numeric_limits<uint64_t>::max() / per_wave_size)
+        throw std::runtime_error("scratch backing size overflow");
+      const uint64_t total_scratch = per_wave_size * scratch_slots;
+      if (scratch_pool > std::numeric_limits<uint64_t>::max() - total_scratch)
+        throw std::runtime_error("scratch backing address overflow");
+      if (total_scratch > std::numeric_limits<size_t>::max())
+        throw std::runtime_error("scratch backing size overflow");
+      const bool allocated =
+          scratch_allocator_(pkt.process_id, scratch_pool, static_cast<size_t>(total_scratch),
+                             scratch_requires_owned_pool);
+      if (!allocated || !scratch_range_backed(wave_scratch, per_wave_size)) {
+        throw std::runtime_error(
+            std::format("scratch backing allocation failed for range {:#x}+{:#x}", wave_scratch,
+                        per_wave_size));
+      }
+    }
+    if (memory_ && scratch_requires_owned_pool &&
+        !scratch_range_backed(wave_scratch, per_wave_size)) {
+      throw std::runtime_error(std::format(
+          "scratch backing allocation failed for range {:#x}+{:#x}", wave_scratch, per_wave_size));
     }
 
     wf->set_scratch_base(wave_scratch);
@@ -525,7 +600,7 @@ void CommandProcessor::init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf,
                         "backing_addr={:#x} mapped={}",
                         wf->wf_id(), scratch_pool, wave_scratch, per_wave_size,
                         pkt.private_segment_fixed_size, pkt.scratch_backing_addr,
-                        memory_ ? memory_->is_mapped(wave_scratch, pkt.process_id) : false);
+                        memory_ ? scratch_range_backed(wave_scratch, per_wave_size) : false);
     });
 
     if (flat_scratch_init_sgpr >= 0) {
@@ -1944,8 +2019,15 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
       uint64_t scratch_loc_va =
           dp.queue_ptr + offsetof(amd_queue_t, scratch_backing_memory_location);
       dp.scratch_backing_addr = read_gpu_u64(scratch_loc_va, queue.process_id);
-      if (dp.scratch_backing_addr == 0 && scratch_resolver_)
-        dp.scratch_backing_addr = scratch_resolver_(queue.process_id);
+      if (scratch_resolver_) {
+        const ScratchBacking resolved = scratch_resolver_(queue.process_id);
+        if (dp.scratch_backing_addr == 0) {
+          dp.scratch_backing_addr = resolved.gpu_va;
+          dp.scratch_requires_owned_pool = resolved.requires_owned_pool;
+        } else if (resolved.requires_owned_pool && dp.scratch_backing_addr == resolved.gpu_va) {
+          dp.scratch_requires_owned_pool = true;
+        }
+      }
 
       // Publish the scratch backing location and COMPUTE_TMPRING_SIZE into the
       // ABI-stable part of amd_queue_t so rocm-dbgapi can compute each wave's
@@ -1978,7 +2060,10 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
           // Older debugger layouts interpret WAVES as a device-wide count and
           // require it to be divisible by the shader-engine count.
           uint32_t se = std::max(1u, scratch_wave_divisor_);
-          uint64_t total_waves = static_cast<uint64_t>(total_wgs) * wfs_per_wg;
+          if (workgroup_id_offset_ > std::numeric_limits<uint32_t>::max() - total_wgs)
+            throw std::runtime_error("scratch backing wave count overflow");
+          uint64_t scratch_wgs = static_cast<uint64_t>(workgroup_id_offset_) + total_wgs;
+          uint64_t total_waves = scratch_wgs * wfs_per_wg;
           waves_field =
               static_cast<uint32_t>(((std::max<uint64_t>(1, total_waves) + se - 1) / se) * se);
         }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
@@ -148,15 +148,26 @@ public:
   using InterruptCallback = std::function<void(uint32_t process_id, uint32_t event_id)>;
   void set_interrupt_callback(InterruptCallback cb) { interrupt_cb_ = std::move(cb); }
 
-  using ScratchBackingResolver = std::function<uint64_t(uint32_t process_id)>;
+  struct ScratchBacking {
+    uint64_t gpu_va = 0;
+    bool requires_owned_pool = false;
+  };
+
+  using ScratchBackingResolver = std::function<ScratchBacking(uint32_t process_id)>;
   void set_scratch_backing_resolver(ScratchBackingResolver cb) {
     scratch_resolver_ = std::move(cb);
   }
 
-  using ScratchBackingAllocator =
-      std::function<bool(uint32_t process_id, uint64_t gpu_va, size_t size)>;
+  using ScratchBackingAllocator = std::function<bool(uint32_t process_id, uint64_t gpu_va,
+                                                     size_t size, bool requires_owned_pool)>;
   void set_scratch_backing_allocator(ScratchBackingAllocator cb) {
     scratch_allocator_ = std::move(cb);
+  }
+
+  using ScratchBackingVerifier =
+      std::function<bool(uint32_t process_id, uint64_t gpu_va, size_t size)>;
+  void set_scratch_backing_verifier(ScratchBackingVerifier cb) {
+    scratch_verifier_ = std::move(cb);
   }
 
   /// @brief Number of shader engines per XCC (array_count / simd_arrays_per_engine).
@@ -690,6 +701,7 @@ private:
   InterruptCallback interrupt_cb_;
   ScratchBackingResolver scratch_resolver_;
   ScratchBackingAllocator scratch_allocator_;
+  ScratchBackingVerifier scratch_verifier_;
   uint32_t scratch_wave_divisor_ = 1;
   uint32_t scratch_shader_engine_count_ = 1;
   uint32_t scratch_waves_per_se_ = 1;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
@@ -150,6 +150,7 @@ struct DispatchEntry {
   uint16_t workgroup_size_y = 1;
   uint16_t workgroup_size_z = 1;
   uint64_t scratch_backing_addr = 0;
+  bool scratch_requires_owned_pool = false;
   uint32_t private_segment_fixed_size = 0;
   uint32_t group_segment_fixed_size = 0;
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
@@ -284,7 +284,7 @@ public:
     for_each_page_chunk(addr, size, [&](uint64_t ea, size_t offset, size_t chunk) {
       if (!contiguous)
         return;
-      auto *host_ptr = translate(ea, vmid, chunk);
+      uint8_t *host_ptr = translate(ea, vmid, chunk);
       if (!host_ptr || (first_host_ptr && host_ptr != first_host_ptr + offset)) {
         contiguous = false;
         return;
@@ -316,6 +316,38 @@ public:
   /// A zero size, or a range that wraps the address space, is not mapped.
   bool is_range_mapped(uint64_t addr, size_t size, uint32_t vmid = 0) const {
     return every_page(addr, size, [&](uint64_t page_addr) { return is_mapped(page_addr, vmid); });
+  }
+
+  /// @brief Return whether every byte in a process VMID range has host backing.
+  /// @details Unlike is_range_mapped(), this verifies the clipped HostExtent
+  /// intervals inside each mapped page. A page-table entry whose live host
+  /// extent is disjoint from the requested bytes does not satisfy this predicate.
+  /// Passthrough is deliberately ignored for vmid != 0.
+  bool is_range_host_backed(uint64_t addr, size_t size, uint32_t vmid = 0) const {
+    if (size == 0 || size - 1 > std::numeric_limits<uint64_t>::max() - addr)
+      return false;
+    if (vmid == 0)
+      return resolve_host_ptr(addr, vmid, size) != nullptr;
+
+    std::shared_lock vmid_lock(vmid_mutex_);
+    std::unordered_map<uint32_t, VmidEntry>::const_iterator vmid_entry = vmid_table_.find(vmid);
+    if (vmid_entry == vmid_table_.end())
+      return false;
+
+    const VmidEntry &entry = vmid_entry->second;
+    std::shared_lock page_table_lock(*entry.mutex);
+    bool backed = true;
+    for_each_page_chunk(addr, size, [&](uint64_t ea, size_t, size_t chunk) {
+      if (!backed)
+        return;
+      KfdProcess::PageTable::const_iterator page = entry.page_table->find(ea >> PAGE_SHIFT);
+      if (page == entry.page_table->end()) {
+        backed = false;
+        return;
+      }
+      backed = page_range_host_backed(page->second, ea & PAGE_MASK, chunk);
+    });
+    return backed;
   }
 
   /// @brief Look up PTE MTYPE for a GPU VA in the given VMID's page table.
@@ -512,7 +544,7 @@ public:
 
       const size_t page_offset = addr & PAGE_MASK;
       const auto *current_extent = host_extent_at(page_entry->second, page_offset);
-      if (!current_extent)
+      if (!current_extent || !current_extent->has_raw_host_ptr())
         return {0, 0};
 
       uint64_t first_page = page;
@@ -523,7 +555,7 @@ public:
         if (previous_page_entry == page_table->end())
           break;
         const auto *previous_extent = host_extent_ending_at_page(previous_page_entry->second);
-        if (!previous_extent ||
+        if (!previous_extent || !previous_extent->has_raw_host_ptr() ||
             previous_extent->host_ptr + previous_extent->host_backed_bytes != first_host_byte)
           break;
         --first_page;
@@ -538,7 +570,7 @@ public:
         if (next_page_entry == page_table->end())
           break;
         const auto *next_extent = host_extent_starting_at_page(next_page_entry->second);
-        if (!next_extent ||
+        if (!next_extent || !next_extent->has_raw_host_ptr() ||
             next_extent->host_ptr != last_extent->host_ptr + last_extent->host_backed_bytes)
           break;
         ++last_page;
@@ -673,21 +705,27 @@ public:
           (void)passthrough_page; // Passthrough pages keep the addressability-checked copy.
           if (!pte)
             return;
-          uint8_t *whole = nullptr;
-          size_t spans = 0;
-          const size_t mapped_bytes =
-              for_each_mapped_span(*pte, addr & PAGE_MASK, kLen,
-                                   [&](size_t value_offset, uint8_t *host_ptr, size_t span_size) {
-                                     ++spans;
-                                     if (value_offset == 0 && span_size == kLen)
-                                       whole = host_ptr;
-                                   });
-          if (mapped_bytes != kLen || spans != 1 || whole == nullptr ||
-              reinterpret_cast<uintptr_t>(whole) % alignof(uint64_t) != 0)
+          const size_t page_offset = addr & PAGE_MASK;
+          const KfdProcess::HostExtent *extent = host_extent_at(*pte, page_offset);
+          if (!extent || kLen > extent->host_backed_bytes - (page_offset - extent->gpu_page_offset))
             return;
-          *out = std::atomic_ref<uint64_t>(*reinterpret_cast<uint64_t *>(whole))
-                     .load(std::memory_order_acquire);
-          loaded = true;
+          const size_t extent_offset = page_offset - extent->gpu_page_offset;
+          auto load_atomic = [&](uint8_t *whole) {
+            if (reinterpret_cast<uintptr_t>(whole) % alignof(uint64_t) != 0)
+              return;
+            *out = std::atomic_ref<uint64_t>(*reinterpret_cast<uint64_t *>(whole))
+                       .load(std::memory_order_acquire);
+            loaded = true;
+          };
+          if (extent->has_raw_host_ptr()) {
+            uint8_t *whole = extent->host_ptr + extent_offset;
+            if (addressable_prefix(whole, kLen) == kLen)
+              load_atomic(whole);
+            return;
+          }
+          if (extent->has_backing_store())
+            (void)extent->backing->with_span(extent->backing_offset + extent_offset, kLen,
+                                             load_atomic);
         });
     return mapped && loaded;
   }
@@ -811,12 +849,26 @@ private:
   template <typename F>
   static bool atomic_rmw_mapped_page(const KfdProcess::PageTableEntry &pte, size_t page_offset,
                                      size_t size, F &fn) {
-    const auto *extent = host_extent_at(pte, page_offset);
+    const KfdProcess::HostExtent *extent = host_extent_at(pte, page_offset);
     if (extent && size <= extent->host_backed_bytes - (page_offset - extent->gpu_page_offset)) {
-      auto *target = extent->host_ptr + (page_offset - extent->gpu_page_offset);
-      if (addressable_prefix(target, size) == size) {
-        atomic_rmw_mapped(target, fn);
-        return true;
+      const size_t extent_offset = page_offset - extent->gpu_page_offset;
+      if (extent->has_raw_host_ptr()) {
+        uint8_t *target = extent->host_ptr + extent_offset;
+        if (addressable_prefix(target, size) == size) {
+          atomic_rmw_mapped(target, fn);
+          return true;
+        }
+      }
+      if (extent->has_backing_store()) {
+        bool ran = false;
+        (void)extent->backing->with_span(
+            extent->backing_offset + extent_offset, size, [&](uint8_t *target) {
+              std::lock_guard lock(backing_atomic_mutex(
+                  extent->backing->atomic_key(extent->backing_offset + extent_offset)));
+              fn(target);
+              ran = true;
+            });
+        return ran;
       }
     }
 
@@ -827,6 +879,21 @@ private:
     };
     std::array<AtomicSpan, sizeof(uint64_t)> spans{};
     size_t span_count = 0;
+    bool saw_indirect_span = false;
+    const size_t access_end = page_offset + size;
+    for (const KfdProcess::HostExtent &candidate : pte.host_extents) {
+      const size_t extent_begin = candidate.gpu_page_offset;
+      const size_t extent_end = extent_begin + candidate.host_backed_bytes;
+      if (std::max(page_offset, extent_begin) < std::min(access_end, extent_end) &&
+          candidate.has_backing_store()) {
+        saw_indirect_span = true;
+        break;
+      }
+    }
+    if (saw_indirect_span) {
+      atomic_rmw_discarded(fn);
+      return false;
+    }
     const size_t mapped_bytes = for_each_mapped_span(
         pte, page_offset, size, [&](size_t value_offset, uint8_t *host_ptr, size_t span_size) {
           assert(span_count < spans.size());
@@ -1094,24 +1161,51 @@ private:
     return extent.gpu_page_offset + extent.host_backed_bytes == PAGE_SIZE ? &extent : nullptr;
   }
 
+  static bool page_range_host_backed(const KfdProcess::PageTableEntry &pte, size_t access_begin,
+                                     size_t len) {
+    const size_t access_end = access_begin + len;
+    size_t cursor = access_begin;
+    while (cursor < access_end) {
+      const KfdProcess::HostExtent *extent = host_extent_at(pte, cursor);
+      if (!extent)
+        return false;
+      const size_t extent_end = extent->gpu_page_offset + extent->host_backed_bytes;
+      cursor = std::min(access_end, extent_end);
+    }
+    return true;
+  }
+
   template <typename F>
   static size_t for_each_mapped_span(const KfdProcess::PageTableEntry &pte, size_t access_begin,
                                      size_t len, F &&fn) {
     const size_t access_end = access_begin + len;
     size_t mapped_bytes = 0;
-    for (const auto &extent : pte.host_extents) {
+    for (const KfdProcess::HostExtent &extent : pte.host_extents) {
       const size_t extent_begin = extent.gpu_page_offset;
       const size_t extent_end = extent_begin + extent.host_backed_bytes;
       const size_t overlap_begin = std::max(access_begin, extent_begin);
       const size_t overlap_end = std::min(access_end, extent_end);
       if (overlap_begin >= overlap_end)
         continue;
-      auto *host_begin = extent.host_ptr + (overlap_begin - extent_begin);
-      for_each_bounded_addressable_span(
-          host_begin, overlap_end - overlap_begin, [&](size_t span_offset, size_t span_size) {
-            mapped_bytes += span_size;
-            fn(overlap_begin - access_begin + span_offset, host_begin + span_offset, span_size);
-          });
+      const size_t overlap_size = overlap_end - overlap_begin;
+      const size_t extent_offset = overlap_begin - extent_begin;
+      if (extent.has_raw_host_ptr()) {
+        uint8_t *host_begin = extent.host_ptr + extent_offset;
+        for_each_bounded_addressable_span(
+            host_begin, overlap_size, [&](size_t span_offset, size_t span_size) {
+              mapped_bytes += span_size;
+              fn(overlap_begin - access_begin + span_offset, host_begin + span_offset, span_size);
+            });
+        continue;
+      }
+      if (extent.has_backing_store()) {
+        if (extent.backing->with_span(extent.backing_offset + extent_offset, overlap_size,
+                                      [&](uint8_t *host_begin) {
+                                        mapped_bytes += overlap_size;
+                                        fn(overlap_begin - access_begin, host_begin, overlap_size);
+                                      }))
+          continue;
+      }
     }
     return mapped_bytes;
   }
@@ -1208,9 +1302,11 @@ private:
       page_table_lock.unlock();
       vmid_lock.unlock();
       run_asan_page_table_unlocked_hook();
-      for (auto &extent : candidate.host_extents)
-        extent.host_backed_bytes =
-            heap_allocation_bounded_length(extent.host_ptr, extent.host_backed_bytes);
+      for (KfdProcess::HostExtent &extent : candidate.host_extents) {
+        if (extent.has_raw_host_ptr())
+          extent.host_backed_bytes =
+              heap_allocation_bounded_length(extent.host_ptr, extent.host_backed_bytes);
+      }
 
       vmid_lock.lock();
       if (vmid_registry_generation_ != registry_generation) {
@@ -1361,38 +1457,46 @@ private:
         });
   }
 
-  /// @brief Run @p fn over a fully-backed, page-bounded host span with the
-  /// page-table lock held for the duration.
+  /// @brief Run @p fn over a fully-backed, page-bounded mapped span.
   /// @details Applies exactly translate()'s resolution rules -- the range must
-  /// be contiguous, host-backed and addressable -- but hands the pointer to a
-  /// callback instead of returning it, so a concurrent unmap or VMID
-  /// unregistration cannot free the storage between resolution and use.
+  /// be contiguous, host-backed and addressable for raw host mappings -- but
+  /// hands the pointer to a callback instead of returning it, so a concurrent
+  /// unmap, VMID unregistration, or backing-store resize cannot free or move the
+  /// storage between resolution and use.
   /// @return true if the span resolved and @p fn ran.
   template <typename F>
   bool with_translated_span(uint64_t addr, uint32_t vmid, size_t size, F &&fn) const {
     if (size == 0 || (addr & PAGE_MASK) + size > PAGE_SIZE)
       return false;
     bool copied = false;
-    with_page_mapping(addr, vmid,
-                      [&](const KfdProcess::PageTableEntry *pte, uint8_t *passthrough_page) {
-                        const size_t page_offset = addr & PAGE_MASK;
-                        uint8_t *candidate = nullptr;
-                        if (pte) {
-                          const auto *extent = host_extent_at(*pte, page_offset);
-                          if (!extent || size > extent->host_backed_bytes -
-                                                    (page_offset - extent->gpu_page_offset))
-                            return;
-                          candidate = extent->host_ptr + (page_offset - extent->gpu_page_offset);
-                        } else {
-                          if (addr >= kUserSpaceLimit || size > kUserSpaceLimit - addr)
-                            return;
-                          candidate = passthrough_page + page_offset;
-                        }
-                        if (addressable_prefix(candidate, size) != size)
-                          return;
-                        fn(candidate);
-                        copied = true;
-                      });
+    with_page_mapping(
+        addr, vmid, [&](const KfdProcess::PageTableEntry *pte, uint8_t *passthrough_page) {
+          const size_t page_offset = addr & PAGE_MASK;
+          uint8_t *candidate = nullptr;
+          if (pte) {
+            const KfdProcess::HostExtent *extent = host_extent_at(*pte, page_offset);
+            if (!extent ||
+                size > extent->host_backed_bytes - (page_offset - extent->gpu_page_offset))
+              return;
+            const size_t extent_offset = page_offset - extent->gpu_page_offset;
+            if (extent->has_backing_store()) {
+              copied = extent->backing->with_span(extent->backing_offset + extent_offset, size,
+                                                  [&](uint8_t *ptr) { fn(ptr); });
+              return;
+            }
+            if (!extent->has_raw_host_ptr())
+              return;
+            candidate = extent->host_ptr + extent_offset;
+          } else {
+            if (addr >= kUserSpaceLimit || size > kUserSpaceLimit - addr)
+              return;
+            candidate = passthrough_page + page_offset;
+          }
+          if (addressable_prefix(candidate, size) != size)
+            return;
+          fn(candidate);
+          copied = true;
+        });
     return copied;
   }
 
@@ -1416,11 +1520,13 @@ private:
         addr, vmid, [&](const KfdProcess::PageTableEntry *pte, uint8_t *passthrough_page) {
           const size_t page_offset = addr & PAGE_MASK;
           if (pte) {
-            const auto *extent = host_extent_at(*pte, page_offset);
+            const KfdProcess::HostExtent *extent = host_extent_at(*pte, page_offset);
             if (!extent ||
                 size > extent->host_backed_bytes - (page_offset - extent->gpu_page_offset))
               return;
-            auto *candidate = extent->host_ptr + (page_offset - extent->gpu_page_offset);
+            if (!extent->has_raw_host_ptr())
+              return;
+            uint8_t *candidate = extent->host_ptr + (page_offset - extent->gpu_page_offset);
             if (addressable_prefix(candidate, size) == size)
               host_ptr = candidate;
             return;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
@@ -318,6 +318,19 @@ public:
     return every_page(addr, size, [&](uint64_t page_addr) { return is_mapped(page_addr, vmid); });
   }
 
+  /// @brief Return whether a GPU VA has host backing in a VMID page table.
+  /// @details Unlike resolve_host_ptr(), this query never falls back to identity
+  /// passthrough. Callers use it when they need to distinguish explicit backing
+  /// from an otherwise valid host virtual address.
+  bool has_page_table_mapping(uint64_t addr, uint32_t vmid) const {
+    if (vmid == 0)
+      return false;
+    static thread_local PteCache cache;
+    return cached_walk(addr, vmid, cache, [](const KfdProcess::PageTableEntry *pte) {
+      return pte && pte->host_ptr != nullptr;
+    });
+  }
+
   /// @brief Look up PTE MTYPE for a GPU VA in the given VMID's page table.
   /// @details This reads only the page-wide policy. It deliberately avoids the
   /// host-extent copy, addressability checks, and external allocator queries

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
@@ -318,19 +318,6 @@ public:
     return every_page(addr, size, [&](uint64_t page_addr) { return is_mapped(page_addr, vmid); });
   }
 
-  /// @brief Return whether a GPU VA has host backing in a VMID page table.
-  /// @details Unlike resolve_host_ptr(), this query never falls back to identity
-  /// passthrough. Callers use it when they need to distinguish explicit backing
-  /// from an otherwise valid host virtual address.
-  bool has_page_table_mapping(uint64_t addr, uint32_t vmid) const {
-    if (vmid == 0)
-      return false;
-    static thread_local PteCache cache;
-    return cached_walk(addr, vmid, cache, [](const KfdProcess::PageTableEntry *pte) {
-      return pte && pte->host_ptr != nullptr;
-    });
-  }
-
   /// @brief Look up PTE MTYPE for a GPU VA in the given VMID's page table.
   /// @details This reads only the page-wide policy. It deliberately avoids the
   /// host-extent copy, addressability checks, and external allocator queries

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/rj_vm.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/rj_vm.cpp
@@ -188,6 +188,14 @@ bool reconstruct_embedded_pointers(uint32_t cmd, void *arg, size_t arg_size, siz
       args->kfd_process_device_apertures_ptr = reinterpret_cast<uint64_t>(extra);
     break;
   }
+  case AMDKFD_IOC_GET_DMABUF_INFO: {
+    auto *args = static_cast<kfd_ioctl_get_dmabuf_info_args *>(arg);
+    if (args->metadata_ptr != 0 && args->metadata_size > inline_size)
+      return false;
+    if (args->metadata_ptr != 0 && args->metadata_size > 0)
+      args->metadata_ptr = reinterpret_cast<uint64_t>(extra);
+    break;
+  }
   case AMDKFD_IOC_DBG_TRAP: {
     auto *args = static_cast<kfd_ioctl_dbg_trap_args *>(arg);
     switch (args->op) {
@@ -378,23 +386,22 @@ rj_status_t execute_impl(SimulatedKfd *driver, uint32_t process_id, rj_vm_cmd_t 
     return ROCJITSU_STATUS_SUCCESS;
   }
 
-  // For DBG_TRAP ENABLE the debugger's notifier pipe arrives as an SCM_RIGHTS
-  // fd in cmd->in_handle (already in the daemon's fd space). Substitute it for
-  // the client-side fd number in the payload so the driver signals the right
-  // pipe when a wave stops (the kernel receives the same fd via the ioctl). On
-  // success the debug session takes ownership (cmd->in_handle cleared so the
-  // transport does not close it); otherwise the transport reclaims it. Only
-  // daemon mode transfers the fd; local mode passes the debugger's own fd
-  // through the interposer and leaves cmd->in_handle at -1.
+  // Daemon-mode fd arguments arrive as SCM_RIGHTS descriptors in cmd->in_handle,
+  // already in the daemon's fd space. Substitute that descriptor for payload
+  // fields that would otherwise be client-local fd numbers; local mode passes
+  // the caller's own descriptors through the interposer and leaves
+  // cmd->in_handle at -1.
   //
-  // The client-supplied dbg_fd is a number in the *client's* fd table and is
-  // never trusted in the daemon's namespace. Overwrite it unconditionally for
-  // ENABLE: with the transferred fd when one arrived via SCM_RIGHTS, otherwise
-  // with KFD_INVALID_FD so the handler's fcntl() check rejects it. Leaving the
-  // client's integer in place would let a client that omits the ancillary fd
-  // point the session at an arbitrary daemon-owned descriptor (a confused-deputy
-  // fd substitution).
+  // The client-supplied dbg_fd and dmabuf_fd values are numbers in the client's
+  // fd table and are never trusted in the daemon namespace. Overwrite them with
+  // the transferred fd when one arrived, otherwise with an invalid fd so the
+  // handler's fcntl()/fstat() check rejects the ioctl. DBG_TRAP ENABLE is the
+  // only command here that adopts cmd->in_handle on success; DMABUF ioctls only
+  // borrow the transferred fd and restore the client-visible fd field before
+  // the response is sent.
   bool adopting_notifier = false;
+  bool restore_dmabuf_fd = false;
+  uint32_t saved_dmabuf_fd = KFD_INVALID_FD;
   if (driver->daemon_mode() && cmd->cmd == AMDKFD_IOC_DBG_TRAP) {
     auto *dbg = static_cast<kfd_ioctl_dbg_trap_args *>(cmd->buf);
     if (dbg->op == KFD_IOC_DBG_TRAP_ENABLE) {
@@ -405,6 +412,18 @@ rj_status_t execute_impl(SimulatedKfd *driver, uint32_t process_id, rj_vm_cmd_t 
         dbg->enable.dbg_fd = KFD_INVALID_FD;
       }
     }
+  } else if (driver->daemon_mode() && cmd->cmd == AMDKFD_IOC_IMPORT_DMABUF) {
+    auto *import = static_cast<kfd_ioctl_import_dmabuf_args *>(cmd->buf);
+    saved_dmabuf_fd = import->dmabuf_fd;
+    restore_dmabuf_fd = true;
+    import->dmabuf_fd =
+        cmd->in_handle >= 0 ? static_cast<uint32_t>(cmd->in_handle) : static_cast<uint32_t>(-1);
+  } else if (driver->daemon_mode() && cmd->cmd == AMDKFD_IOC_GET_DMABUF_INFO) {
+    auto *info = static_cast<kfd_ioctl_get_dmabuf_info_args *>(cmd->buf);
+    saved_dmabuf_fd = info->dmabuf_fd;
+    restore_dmabuf_fd = true;
+    info->dmabuf_fd =
+        cmd->in_handle >= 0 ? static_cast<uint32_t>(cmd->in_handle) : static_cast<uint32_t>(-1);
   }
 
   cmd->result =
@@ -412,15 +431,23 @@ rj_status_t execute_impl(SimulatedKfd *driver, uint32_t process_id, rj_vm_cmd_t 
   cmd->shared_handle = -1;
   if (adopting_notifier && cmd->result == 0)
     cmd->in_handle = -1;
+  if (restore_dmabuf_fd) {
+    if (cmd->cmd == AMDKFD_IOC_IMPORT_DMABUF)
+      static_cast<kfd_ioctl_import_dmabuf_args *>(cmd->buf)->dmabuf_fd = saved_dmabuf_fd;
+    else if (cmd->cmd == AMDKFD_IOC_GET_DMABUF_INFO)
+      static_cast<kfd_ioctl_get_dmabuf_info_args *>(cmd->buf)->dmabuf_fd = saved_dmabuf_fd;
+  }
 
   if (cmd->cmd == AMDKFD_IOC_ALLOC_MEMORY_OF_GPU && cmd->result == 0) {
     auto *alloc_args = static_cast<kfd_ioctl_alloc_memory_of_gpu_args *>(cmd->buf);
-    cmd->shared_handle =
-        driver->get_mmap_memfd(process_id, static_cast<off_t>(alloc_args->mmap_offset));
+    cmd->shared_handle = driver->get_allocation_memfd(process_id, alloc_args->handle);
   } else if (cmd->cmd == AMDKFD_IOC_IPC_IMPORT_HANDLE && cmd->result == 0) {
     auto *import_args = static_cast<kfd_ioctl_ipc_import_handle_args *>(cmd->buf);
     cmd->shared_handle =
         driver->get_mmap_memfd(process_id, static_cast<off_t>(import_args->mmap_offset));
+  } else if (cmd->cmd == AMDKFD_IOC_EXPORT_DMABUF && cmd->result == 0) {
+    auto *export_args = static_cast<kfd_ioctl_export_dmabuf_args *>(cmd->buf);
+    cmd->shared_handle = static_cast<rj_handle_t>(export_args->dmabuf_fd);
   }
 
   return ROCJITSU_STATUS_SUCCESS;

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -261,7 +261,7 @@ TEST(ComputeUnitConfigTest, RejectsVgprSpanAboveIsaMaximum) {
 // kernel is complete once every listed CU reports idle. Waves that need their final
 // register state inspected should capture it via HaltSnapshotPlugin, which snapshots
 // at halt regardless of where this loop stops.
-void step_until_halted(simdojo::SimulationEngine &engine,
+bool step_until_halted(simdojo::SimulationEngine &engine,
                        std::initializer_list<amdgpu::ComputeUnitCore *> cus,
                        uint32_t max_steps = 10000) {
   auto any_active = [&]() {
@@ -275,8 +275,9 @@ void step_until_halted(simdojo::SimulationEngine &engine,
     if (any_active())
       saw_work = true;
     else if (saw_work)
-      break;
+      return true;
   }
+  return saw_work && !any_active();
 }
 
 TEST(LdsAllocationTest, ZeroLdsDispatchKeepsCuBackingUnmaterialized) {
@@ -404,12 +405,12 @@ TEST(AqlQueueTest, DefaultProcessKeepsQueueStateInSparseMemoryWithPassthrough) {
 TEST(CommandProcessorScratchBackingTest, ExplicitPteControlsAllocatorWithPassthrough) {
   constexpr uint32_t kVmid = 44;
   constexpr uint64_t kScratchPool = 0x1'0000'0000ULL;
-  constexpr uint32_t kPrivateSegmentSize = 4;
+  constexpr uint32_t kPrivateSegmentSize = 65;
   constexpr size_t kRawScratchSize = kPrivateSegmentSize * 64;
   constexpr size_t kExpectedScratchSize = ((kRawScratchSize + 1023) / 1024) * 1024;
 
   KfdProcess proc(kVmid);
-  alignas(KfdProcess::kPageSize) std::array<uint8_t, KfdProcess::kPageSize> scratch_backing{};
+  alignas(KfdProcess::kPageSize) std::array<uint8_t, KfdProcess::kPageSize * 2> scratch_backing{};
   alignas(KfdProcess::kPageSize) std::array<uint8_t, KfdProcess::kPageSize> ring{};
   alignas(KfdProcess::kPageSize) std::array<uint8_t, KfdProcess::kPageSize> kernel{};
   alignas(uint64_t) uint64_t read_ptr = 0;
@@ -420,13 +421,18 @@ TEST(CommandProcessorScratchBackingTest, ExplicitPteControlsAllocatorWithPassthr
   f.mem()->register_process(kVmid, &proc.page_table_, &proc.page_table_mutex_);
 
   size_t allocator_calls = 0;
-  f.cp()->set_scratch_backing_allocator([&](uint32_t process_id, uint64_t gpu_va, size_t size) {
-    EXPECT_EQ(process_id, kVmid);
-    EXPECT_EQ(gpu_va, kScratchPool);
-    EXPECT_EQ(size, kExpectedScratchSize);
-    ++allocator_calls;
-    return true;
-  });
+  f.cp()->set_scratch_backing_allocator(
+      [&](uint32_t process_id, uint64_t gpu_va, size_t size, bool requires_owned_pool) {
+        EXPECT_EQ(process_id, kVmid);
+        EXPECT_EQ(gpu_va, kScratchPool);
+        EXPECT_EQ(size, kExpectedScratchSize);
+        EXPECT_FALSE(requires_owned_pool);
+        if (size > scratch_backing.size())
+          return false;
+        proc.map_pages(gpu_va, scratch_backing.data(), size);
+        ++allocator_calls;
+        return true;
+      });
 
   using namespace rocr::llvm::amdhsa;
   kernel_descriptor_t descriptor{};
@@ -452,15 +458,231 @@ TEST(CommandProcessorScratchBackingTest, ExplicitPteControlsAllocatorWithPassthr
     pkt.private_segment_size = kPrivateSegmentSize;
     pkt.kernel_object = kernel_object;
     queue.submit(pkt);
-    step_until_halted(*f.engine, {f.cu()});
+    return step_until_halted(*f.engine, {f.cu()});
   };
 
-  dispatch();
+  ASSERT_TRUE(dispatch());
   EXPECT_EQ(allocator_calls, 1u);
 
-  proc.map_pages(kScratchPool, scratch_backing.data(), scratch_backing.size());
-  dispatch();
+  proc.unmap_pages(kScratchPool, kExpectedScratchSize);
+  proc.map_pages(kScratchPool + 2048, scratch_backing.data() + 2048, 2048);
+  proc.map_pages(kScratchPool + KfdProcess::kPageSize,
+                 scratch_backing.data() + KfdProcess::kPageSize,
+                 kExpectedScratchSize - KfdProcess::kPageSize);
+  ASSERT_TRUE(f.mem()->is_range_mapped(kScratchPool, kExpectedScratchSize, kVmid));
+  ASSERT_FALSE(f.mem()->is_range_host_backed(kScratchPool, kExpectedScratchSize, kVmid));
+  ASSERT_TRUE(dispatch());
+  EXPECT_EQ(allocator_calls, 2u);
+
+  proc.unmap_pages(kScratchPool, kExpectedScratchSize);
+  proc.map_pages(kScratchPool, scratch_backing.data(), KfdProcess::kPageSize);
+  ASSERT_TRUE(dispatch());
+  EXPECT_EQ(allocator_calls, 3u);
+
+  proc.unmap_pages(kScratchPool, kExpectedScratchSize);
+  proc.map_pages(kScratchPool, scratch_backing.data(), kExpectedScratchSize);
+  ASSERT_TRUE(dispatch());
+  EXPECT_EQ(allocator_calls, 3u);
+}
+
+TEST(CommandProcessorScratchBackingTest, FallbackResolverRequiresOwnedPoolEvenWhenRawPteExists) {
+  constexpr uint32_t kVmid = 47;
+  constexpr uint64_t kScratchPool = 0x1'0000'0000ULL;
+  constexpr uint32_t kPrivateSegmentSize = 64;
+  constexpr size_t kExpectedScratchSize = KfdProcess::kPageSize;
+
+  KfdProcess proc(kVmid);
+  alignas(KfdProcess::kPageSize) std::array<uint8_t, KfdProcess::kPageSize> stray_backing{};
+  std::shared_ptr<KfdProcess::BackingStore> owned_backing =
+      std::make_shared<KfdProcess::BackingStore>();
+  alignas(KfdProcess::kPageSize) std::array<uint8_t, KfdProcess::kPageSize> ring{};
+  alignas(KfdProcess::kPageSize) std::array<uint8_t, KfdProcess::kPageSize> kernel{};
+  alignas(uint64_t) uint64_t read_ptr = 0;
+  alignas(uint64_t) uint64_t write_ptr = 0;
+  alignas(uint64_t) uint64_t doorbell = 0;
+  VmFixture f;
+  f.mem()->set_passthrough(true);
+  f.mem()->register_process(kVmid, &proc.page_table_, &proc.page_table_mutex_);
+  proc.map_pages(kScratchPool, stray_backing.data(), kExpectedScratchSize);
+  ASSERT_EQ(f.mem()->resolve_host_ptr(kScratchPool, kVmid), stray_backing.data());
+
+  bool owns_pool = false;
+  size_t allocator_calls = 0;
+  f.cp()->set_scratch_backing_resolver([](uint32_t) -> amdgpu::CommandProcessor::ScratchBacking {
+    return {.gpu_va = kScratchPool, .requires_owned_pool = true};
+  });
+  f.cp()->set_scratch_backing_verifier([&](uint32_t process_id, uint64_t gpu_va, size_t size) {
+    EXPECT_EQ(process_id, kVmid);
+    if (!owns_pool)
+      return false;
+    return gpu_va >= kScratchPool && (gpu_va - kScratchPool) <= owned_backing->size() &&
+           size <= owned_backing->size() - (gpu_va - kScratchPool);
+  });
+  f.cp()->set_scratch_backing_allocator(
+      [&](uint32_t process_id, uint64_t gpu_va, size_t size, bool requires_owned_pool) {
+        EXPECT_EQ(process_id, kVmid);
+        EXPECT_EQ(gpu_va, kScratchPool);
+        EXPECT_EQ(size, kExpectedScratchSize);
+        EXPECT_TRUE(requires_owned_pool);
+        if (!owned_backing->resize(size))
+          return false;
+        proc.map_backing_pages(gpu_va, owned_backing, 0, size);
+        owns_pool = true;
+        ++allocator_calls;
+        return true;
+      });
+
+  using namespace rocr::llvm::amdhsa;
+  kernel_descriptor_t descriptor{};
+  descriptor.kernel_code_entry_byte_offset = sizeof(descriptor);
+  std::memcpy(kernel.data(), &descriptor, sizeof(descriptor));
+  std::memcpy(kernel.data() + sizeof(descriptor), &SOPP_S_ENDPGM, sizeof(SOPP_S_ENDPGM));
+
+  test::AqlQueue queue(f.mem(), f.cp(), reinterpret_cast<uint64_t>(ring.data()), ring.size(),
+                       reinterpret_cast<uint64_t>(&read_ptr),
+                       reinterpret_cast<uint64_t>(&write_ptr),
+                       reinterpret_cast<uint64_t>(&doorbell), kVmid);
+
+  hsa_kernel_dispatch_packet_t pkt{};
+  pkt.header = HSA_PACKET_TYPE_KERNEL_DISPATCH;
+  pkt.setup = 1;
+  pkt.workgroup_size_x = 64;
+  pkt.workgroup_size_y = 1;
+  pkt.workgroup_size_z = 1;
+  pkt.grid_size_x = 64;
+  pkt.grid_size_y = 1;
+  pkt.grid_size_z = 1;
+  pkt.private_segment_size = kPrivateSegmentSize;
+  pkt.kernel_object = reinterpret_cast<uint64_t>(kernel.data());
+  queue.submit(pkt);
+  EXPECT_TRUE(step_until_halted(*f.engine, {f.cu()}));
+
   EXPECT_EQ(allocator_calls, 1u);
+  EXPECT_TRUE(owns_pool);
+  EXPECT_EQ(f.mem()->resolve_host_ptr(kScratchPool, kVmid), nullptr);
+  EXPECT_TRUE(f.mem()->is_range_host_backed(kScratchPool, kExpectedScratchSize, kVmid));
+}
+
+TEST(CommandProcessorScratchBackingTest, FallbackBackingCoversWorkgroupOffset) {
+  constexpr uint32_t kVmid = 46;
+  constexpr uint64_t kScratchPool = 0x1'0000'0000ULL;
+  constexpr uint32_t kWorkgroupOffset = 3;
+  constexpr uint32_t kPrivateSegmentSize = 65;
+  constexpr size_t kRawScratchSize = kPrivateSegmentSize * 64;
+  constexpr size_t kExpectedWaveSize = ((kRawScratchSize + 1023) / 1024) * 1024;
+  constexpr size_t kExpectedScratchSize = (kWorkgroupOffset + 1) * kExpectedWaveSize;
+
+  KfdProcess proc(kVmid);
+  std::vector<uint8_t> scratch_backing(kExpectedScratchSize);
+  alignas(KfdProcess::kPageSize) std::array<uint8_t, KfdProcess::kPageSize> ring{};
+  alignas(KfdProcess::kPageSize) std::array<uint8_t, KfdProcess::kPageSize> kernel{};
+  alignas(uint64_t) uint64_t read_ptr = 0;
+  alignas(uint64_t) uint64_t write_ptr = 0;
+  alignas(uint64_t) uint64_t doorbell = 0;
+  VmFixture f;
+  f.mem()->set_passthrough(true);
+  f.mem()->register_process(kVmid, &proc.page_table_, &proc.page_table_mutex_);
+  f.cp()->set_workgroup_id_offset(kWorkgroupOffset);
+
+  size_t allocator_calls = 0;
+  f.cp()->set_scratch_backing_allocator(
+      [&](uint32_t process_id, uint64_t gpu_va, size_t size, bool requires_owned_pool) {
+        EXPECT_EQ(process_id, kVmid);
+        EXPECT_EQ(gpu_va, kScratchPool);
+        EXPECT_EQ(size, kExpectedScratchSize);
+        EXPECT_FALSE(requires_owned_pool);
+        if (size > scratch_backing.size())
+          return false;
+        proc.map_pages(gpu_va, scratch_backing.data(), size);
+        ++allocator_calls;
+        return true;
+      });
+
+  using namespace rocr::llvm::amdhsa;
+  kernel_descriptor_t descriptor{};
+  descriptor.kernel_code_entry_byte_offset = sizeof(descriptor);
+  std::memcpy(kernel.data(), &descriptor, sizeof(descriptor));
+  std::memcpy(kernel.data() + sizeof(descriptor), &SOPP_S_ENDPGM, sizeof(SOPP_S_ENDPGM));
+
+  test::AqlQueue queue(f.mem(), f.cp(), reinterpret_cast<uint64_t>(ring.data()), ring.size(),
+                       reinterpret_cast<uint64_t>(&read_ptr),
+                       reinterpret_cast<uint64_t>(&write_ptr),
+                       reinterpret_cast<uint64_t>(&doorbell), kVmid);
+
+  hsa_kernel_dispatch_packet_t pkt{};
+  pkt.header = HSA_PACKET_TYPE_KERNEL_DISPATCH;
+  pkt.setup = 1;
+  pkt.workgroup_size_x = 64;
+  pkt.workgroup_size_y = 1;
+  pkt.workgroup_size_z = 1;
+  pkt.grid_size_x = 64;
+  pkt.grid_size_y = 1;
+  pkt.grid_size_z = 1;
+  pkt.private_segment_size = kPrivateSegmentSize;
+  pkt.kernel_object = reinterpret_cast<uint64_t>(kernel.data());
+  queue.submit(pkt);
+  step_until_halted(*f.engine, {f.cu()});
+
+  EXPECT_EQ(allocator_calls, 1u);
+  EXPECT_TRUE(f.mem()->is_range_mapped(kScratchPool + kWorkgroupOffset * kExpectedWaveSize,
+                                       kExpectedWaveSize, kVmid));
+}
+
+TEST(CommandProcessorScratchBackingTest, AllocatorFailureFailsDispatchSetup) {
+  constexpr uint32_t kVmid = 45;
+  constexpr uint64_t kScratchPool = 0x1'0000'0000ULL;
+  constexpr uint32_t kPrivateSegmentSize = 65;
+  constexpr size_t kRawScratchSize = kPrivateSegmentSize * 64;
+  constexpr size_t kExpectedScratchSize = ((kRawScratchSize + 1023) / 1024) * 1024;
+
+  KfdProcess proc(kVmid);
+  alignas(KfdProcess::kPageSize) std::array<uint8_t, KfdProcess::kPageSize> ring{};
+  alignas(KfdProcess::kPageSize) std::array<uint8_t, KfdProcess::kPageSize> kernel{};
+  alignas(uint64_t) uint64_t read_ptr = 0;
+  alignas(uint64_t) uint64_t write_ptr = 0;
+  alignas(uint64_t) uint64_t doorbell = 0;
+  VmFixture f;
+  f.mem()->set_passthrough(true);
+  f.mem()->register_process(kVmid, &proc.page_table_, &proc.page_table_mutex_);
+
+  size_t allocator_calls = 0;
+  f.cp()->set_scratch_backing_allocator(
+      [&](uint32_t process_id, uint64_t gpu_va, size_t size, bool requires_owned_pool) {
+        EXPECT_EQ(process_id, kVmid);
+        EXPECT_EQ(gpu_va, kScratchPool);
+        EXPECT_EQ(size, kExpectedScratchSize);
+        EXPECT_FALSE(requires_owned_pool);
+        ++allocator_calls;
+        return false;
+      });
+
+  using namespace rocr::llvm::amdhsa;
+  kernel_descriptor_t descriptor{};
+  descriptor.kernel_code_entry_byte_offset = sizeof(descriptor);
+  std::memcpy(kernel.data(), &descriptor, sizeof(descriptor));
+  std::memcpy(kernel.data() + sizeof(descriptor), &SOPP_S_ENDPGM, sizeof(SOPP_S_ENDPGM));
+  uint64_t kernel_object = reinterpret_cast<uint64_t>(kernel.data());
+  test::AqlQueue queue(f.mem(), f.cp(), reinterpret_cast<uint64_t>(ring.data()), ring.size(),
+                       reinterpret_cast<uint64_t>(&read_ptr),
+                       reinterpret_cast<uint64_t>(&write_ptr),
+                       reinterpret_cast<uint64_t>(&doorbell), kVmid);
+
+  hsa_kernel_dispatch_packet_t pkt{};
+  pkt.header = HSA_PACKET_TYPE_KERNEL_DISPATCH;
+  pkt.setup = 1;
+  pkt.workgroup_size_x = 64;
+  pkt.workgroup_size_y = 1;
+  pkt.workgroup_size_z = 1;
+  pkt.grid_size_x = 64;
+  pkt.grid_size_y = 1;
+  pkt.grid_size_z = 1;
+  pkt.private_segment_size = kPrivateSegmentSize;
+  pkt.kernel_object = kernel_object;
+  queue.submit(pkt);
+
+  EXPECT_THROW((void)step_until_halted(*f.engine, {f.cu()}), std::runtime_error);
+  EXPECT_EQ(allocator_calls, 1u);
+  EXPECT_FALSE(f.cu()->has_active_wfs());
 }
 
 std::vector<uint8_t> make_loaded_kernel_symbol_elf(uint64_t kernel_descriptor_offset,
@@ -932,6 +1154,9 @@ TEST(GpuMemoryTest, PartialMappedPageReadsZeroFillAndWritesClipToAllocation) {
             allocation.data() + kAllocationSize - 1);
   EXPECT_EQ(memory.resolve_host_ptr(kBaseVa + kAllocationSize - 1, kPid, 2), nullptr);
   EXPECT_EQ(memory.resolve_host_ptr(kBaseVa + kAllocationSize, kPid), nullptr);
+  EXPECT_TRUE(memory.is_range_mapped(kBaseVa, KfdProcess::kPageSize, kPid));
+  EXPECT_TRUE(memory.is_range_host_backed(kBaseVa, kAllocationSize, kPid));
+  EXPECT_FALSE(memory.is_range_host_backed(kBaseVa, KfdProcess::kPageSize, kPid));
   EXPECT_EQ(memory.find_host_range(kBaseVa + kAllocationSize - 1, kPid),
             std::make_pair(reinterpret_cast<uint64_t>(allocation.data()),
                            static_cast<uint64_t>(kAllocationSize)));
@@ -991,6 +1216,108 @@ TEST(GpuMemoryTest, PartialMappedPageReadsZeroFillAndWritesClipToAllocation) {
   memory.write_block(kBaseVa, std::span<const uint8_t>(replacement), kPid);
   EXPECT_TRUE(std::all_of(allocation.begin(), allocation.end(),
                           [](uint8_t value) { return value == 0xa5; }));
+}
+
+TEST(GpuMemoryTest, IndirectBackingExtentsResizeWithoutRawPointerEscape) {
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kPid = 7;
+  constexpr uint64_t kBaseVa = 0x50000000;
+  constexpr uint64_t kSecondPageVa = kBaseVa + KfdProcess::kPageSize;
+  constexpr uint32_t kSentinel = 0x51A7CAFEu;
+  constexpr uint32_t kTailSentinel = 0xFEED1250u;
+
+  KfdProcess process(kPid);
+  std::shared_ptr<KfdProcess::BackingStore> backing =
+      std::make_shared<KfdProcess::BackingStore>(KfdProcess::kPageSize);
+  process.map_backing_pages(kBaseVa, backing, 0, KfdProcess::kPageSize);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  EXPECT_TRUE(memory.is_range_mapped(kBaseVa, KfdProcess::kPageSize, kPid));
+  EXPECT_TRUE(memory.is_range_host_backed(kBaseVa, KfdProcess::kPageSize, kPid));
+  EXPECT_EQ(memory.resolve_host_ptr(kBaseVa, kPid), nullptr);
+  EXPECT_EQ(memory.find_host_range(kBaseVa, kPid), (std::pair<uint64_t, uint64_t>{0, 0}));
+
+  memory.write32(kBaseVa, kSentinel, kPid);
+  EXPECT_EQ(memory.read32(kBaseVa, kPid), kSentinel);
+
+  constexpr uint64_t kAtomicVa = kBaseVa + 8;
+  memory.write64(kAtomicVa, 7, kPid);
+  uint64_t loaded = 0;
+  EXPECT_TRUE(memory.try_read_u64_atomic(kAtomicVa, &loaded, kPid));
+  EXPECT_EQ(loaded, 7u);
+  memory.atomic_rmw(
+      kAtomicVa, sizeof(uint64_t),
+      [](uint8_t *storage) {
+        uint64_t value = 0;
+        std::memcpy(&value, storage, sizeof(value));
+        ++value;
+        std::memcpy(storage, &value, sizeof(value));
+      },
+      kPid);
+  EXPECT_EQ(memory.read64(kAtomicVa, kPid), 8u);
+
+  ASSERT_TRUE(backing->resize(KfdProcess::kPageSize * 2));
+  process.map_backing_pages(kSecondPageVa, backing, KfdProcess::kPageSize, KfdProcess::kPageSize);
+
+  EXPECT_TRUE(memory.is_range_host_backed(kBaseVa, KfdProcess::kPageSize * 2, kPid));
+  EXPECT_EQ(memory.resolve_host_ptr(kSecondPageVa, kPid), nullptr);
+  EXPECT_EQ(memory.read32(kBaseVa, kPid), kSentinel);
+  EXPECT_EQ(memory.read32(kSecondPageVa, kPid), 0u);
+  memory.write32(kSecondPageVa + 16, kTailSentinel, kPid);
+  EXPECT_EQ(memory.read32(kSecondPageVa + 16, kPid), kTailSentinel);
+}
+
+TEST(GpuMemoryTest, BackingStoreResizeWaitsForScopedAccess) {
+  std::shared_ptr<KfdProcess::BackingStore> backing =
+      std::make_shared<KfdProcess::BackingStore>(KfdProcess::kPageSize);
+  std::atomic<bool> span_entered{false};
+  std::atomic<bool> release_span{false};
+  std::atomic<bool> resize_contended{false};
+  std::atomic<bool> resize_done{false};
+  std::atomic<bool> resize_ok{false};
+  KfdProcess::BackingStore::ResizeContentionHook resize_contention_hook = [&] {
+    resize_contended.store(true, std::memory_order_release);
+  };
+  backing->set_resize_contention_hook_for_testing(&resize_contention_hook);
+
+  std::jthread holder([&] {
+    (void)backing->with_span(0, sizeof(uint32_t), [&](uint8_t *storage) {
+      uint32_t value = 0xA17ECAFEu;
+      std::memcpy(storage, &value, sizeof(value));
+      span_entered.store(true, std::memory_order_release);
+      while (!release_span.load(std::memory_order_acquire))
+        std::this_thread::yield();
+    });
+  });
+  while (!span_entered.load(std::memory_order_acquire))
+    std::this_thread::yield();
+
+  std::jthread grower([&] {
+    resize_ok.store(backing->resize(KfdProcess::kPageSize * 2), std::memory_order_release);
+    resize_done.store(true, std::memory_order_release);
+  });
+  const std::chrono::steady_clock::time_point wait_deadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds(2);
+  while (std::chrono::steady_clock::now() < wait_deadline &&
+         !resize_contended.load(std::memory_order_acquire) &&
+         !resize_done.load(std::memory_order_acquire)) {
+    std::this_thread::yield();
+  }
+  EXPECT_TRUE(resize_contended.load(std::memory_order_acquire));
+  EXPECT_FALSE(resize_done.load(std::memory_order_acquire));
+
+  release_span.store(true, std::memory_order_release);
+  holder.join();
+  grower.join();
+  backing->set_resize_contention_hook_for_testing(nullptr);
+  EXPECT_TRUE(resize_done.load(std::memory_order_acquire));
+  EXPECT_TRUE(resize_ok.load(std::memory_order_acquire));
+  uint32_t preserved = 0;
+  ASSERT_TRUE(backing->with_span(0, sizeof(preserved), [&](uint8_t *storage) {
+    std::memcpy(&preserved, storage, sizeof(preserved));
+  }));
+  EXPECT_EQ(preserved, 0xA17ECAFEu);
 }
 
 TEST(GpuMemoryTest, SamePageMappingsRemainIndependent) {

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -109,7 +109,7 @@ TEST(GpuMemoryPassthroughTest, PageTableMappingQueryIgnoresHostPassthrough) {
   KfdProcess proc(kVmid);
   mem.register_process(kVmid, &proc.page_table_, &proc.page_table_mutex_);
 
-  EXPECT_FALSE(mem.has_page_table_mapping(kGpuVa, kVmid));
+  EXPECT_FALSE(mem.is_mapped(kGpuVa, kVmid));
   EXPECT_EQ(mem.resolve_host_ptr(kGpuVa, kVmid), reinterpret_cast<uint8_t *>(kGpuVa));
 
   mem.unregister_process(kVmid);
@@ -128,7 +128,7 @@ TEST(GpuMemoryPassthroughTest, MappedGpuVmApertureStillUsesProcessPageTable) {
   proc.map_pages(kGpuVa, backing.data(), backing.size());
   mem.register_process(kVmid, &proc.page_table_, &proc.page_table_mutex_);
 
-  EXPECT_TRUE(mem.has_page_table_mapping(kGpuVa, kVmid));
+  EXPECT_TRUE(mem.is_mapped(kGpuVa, kVmid));
   ASSERT_EQ(mem.resolve_host_ptr(kGpuVa, kVmid), backing.data());
   mem.write32(kGpuVa, kValue, kVmid);
   uint32_t observed = 0;
@@ -405,7 +405,8 @@ TEST(CommandProcessorScratchBackingTest, ExplicitPteControlsAllocatorWithPassthr
   constexpr uint32_t kVmid = 44;
   constexpr uint64_t kScratchPool = 0x1'0000'0000ULL;
   constexpr uint32_t kPrivateSegmentSize = 4;
-  constexpr size_t kExpectedScratchSize = kPrivateSegmentSize * 64;
+  constexpr size_t kRawScratchSize = kPrivateSegmentSize * 64;
+  constexpr size_t kExpectedScratchSize = ((kRawScratchSize + 1023) / 1024) * 1024;
 
   KfdProcess proc(kVmid);
   alignas(KfdProcess::kPageSize) std::array<uint8_t, KfdProcess::kPageSize> scratch_backing{};

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -99,6 +99,42 @@ constexpr uint32_t SOPP_S_TRAP_1 = 0xBF920001;
 
 using namespace rocjitsu;
 
+TEST(GpuMemoryPassthroughTest, DoesNotTreatUnmappedGpuVmApertureAsHostPointer) {
+  constexpr uint32_t kVmid = 42;
+  constexpr uint64_t kGpuVa = KfdProcess::kGpuVmBase + 0x45000;
+  constexpr uint32_t kValue = 0x12345678u;
+
+  amdgpu::GpuMemory mem("test.vram");
+  mem.set_passthrough(true);
+
+  EXPECT_EQ(mem.resolve_host_ptr(kGpuVa, kVmid), nullptr);
+  mem.write32(kGpuVa, kValue, kVmid);
+  EXPECT_EQ(mem.read32(kGpuVa, kVmid), kValue);
+  EXPECT_EQ(mem.resolve_host_ptr(kGpuVa, kVmid), nullptr);
+}
+
+TEST(GpuMemoryPassthroughTest, MappedGpuVmApertureStillUsesProcessPageTable) {
+  constexpr uint32_t kVmid = 43;
+  constexpr uint64_t kGpuVa = KfdProcess::kGpuVmBase + 0x46000;
+  constexpr uint32_t kValue = 0xA5A55A5Au;
+
+  amdgpu::GpuMemory mem("test.vram");
+  mem.set_passthrough(true);
+
+  KfdProcess proc(kVmid);
+  alignas(KfdProcess::kPageSize) std::array<uint8_t, KfdProcess::kPageSize> backing{};
+  proc.map_pages(kGpuVa, backing.data(), backing.size());
+  mem.register_process(kVmid, &proc.page_table_, &proc.page_table_mutex_);
+
+  ASSERT_EQ(mem.resolve_host_ptr(kGpuVa, kVmid), backing.data());
+  mem.write32(kGpuVa, kValue, kVmid);
+  uint32_t observed = 0;
+  std::memcpy(&observed, backing.data(), sizeof(observed));
+  EXPECT_EQ(observed, kValue);
+
+  mem.unregister_process(kVmid);
+}
+
 struct VmFixture {
   std::unique_ptr<simdojo::SimulationEngine> engine;
   SoC *soc_ptr = nullptr;

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -99,18 +99,20 @@ constexpr uint32_t SOPP_S_TRAP_1 = 0xBF920001;
 
 using namespace rocjitsu;
 
-TEST(GpuMemoryPassthroughTest, DoesNotTreatUnmappedGpuVmApertureAsHostPointer) {
+TEST(GpuMemoryPassthroughTest, PageTableMappingQueryIgnoresHostPassthrough) {
   constexpr uint32_t kVmid = 42;
   constexpr uint64_t kGpuVa = KfdProcess::kGpuVmBase + 0x45000;
-  constexpr uint32_t kValue = 0x12345678u;
 
   amdgpu::GpuMemory mem("test.vram");
   mem.set_passthrough(true);
 
-  EXPECT_EQ(mem.resolve_host_ptr(kGpuVa, kVmid), nullptr);
-  mem.write32(kGpuVa, kValue, kVmid);
-  EXPECT_EQ(mem.read32(kGpuVa, kVmid), kValue);
-  EXPECT_EQ(mem.resolve_host_ptr(kGpuVa, kVmid), nullptr);
+  KfdProcess proc(kVmid);
+  mem.register_process(kVmid, &proc.page_table_, &proc.page_table_mutex_);
+
+  EXPECT_FALSE(mem.has_page_table_mapping(kGpuVa, kVmid));
+  EXPECT_EQ(mem.resolve_host_ptr(kGpuVa, kVmid), reinterpret_cast<uint8_t *>(kGpuVa));
+
+  mem.unregister_process(kVmid);
 }
 
 TEST(GpuMemoryPassthroughTest, MappedGpuVmApertureStillUsesProcessPageTable) {
@@ -126,6 +128,7 @@ TEST(GpuMemoryPassthroughTest, MappedGpuVmApertureStillUsesProcessPageTable) {
   proc.map_pages(kGpuVa, backing.data(), backing.size());
   mem.register_process(kVmid, &proc.page_table_, &proc.page_table_mutex_);
 
+  EXPECT_TRUE(mem.has_page_table_mapping(kGpuVa, kVmid));
   ASSERT_EQ(mem.resolve_host_ptr(kGpuVa, kVmid), backing.data());
   mem.write32(kGpuVa, kValue, kVmid);
   uint32_t observed = 0;
@@ -367,6 +370,96 @@ TEST(RdnaDispatchTest, DescriptorSelectsCoherentWaveWidthAndVgprGranule) {
       EXPECT_EQ(snapshots->snapshots().front().vgpr(0, 43), 43u);
     }
   }
+}
+
+TEST(AqlQueueTest, DefaultProcessKeepsQueueStateInSparseMemoryWithPassthrough) {
+  constexpr uint64_t kHostSentinel = 0xA5A5A5A5A5A5A5A5ULL;
+  alignas(64) std::array<uint8_t, test::AqlQueue::DEFAULT_RING_SIZE> ring{};
+  ring.fill(0xA5);
+  uint64_t read_ptr = kHostSentinel;
+  uint64_t write_ptr = kHostSentinel;
+  uint64_t doorbell = kHostSentinel;
+  VmFixture f;
+  f.mem()->set_passthrough(true);
+
+  test::AqlQueue queue(f.mem(), f.cp(), reinterpret_cast<uint64_t>(ring.data()), ring.size(),
+                       reinterpret_cast<uint64_t>(&read_ptr),
+                       reinterpret_cast<uint64_t>(&write_ptr),
+                       reinterpret_cast<uint64_t>(&doorbell));
+  hsa_kernel_dispatch_packet_t pkt{};
+  pkt.header = HSA_PACKET_TYPE_KERNEL_DISPATCH;
+  queue.submit(pkt);
+
+  EXPECT_TRUE(std::all_of(ring.begin(), ring.end(), [](uint8_t byte) { return byte == 0xA5; }));
+  EXPECT_EQ(read_ptr, kHostSentinel);
+  EXPECT_EQ(write_ptr, kHostSentinel);
+  EXPECT_EQ(doorbell, kHostSentinel);
+
+  f.mem()->set_passthrough(false);
+  EXPECT_EQ(f.mem()->read64(reinterpret_cast<uint64_t>(&read_ptr)), 0u);
+  EXPECT_EQ(f.mem()->read64(reinterpret_cast<uint64_t>(&write_ptr)), 1u);
+  EXPECT_EQ(f.mem()->read64(reinterpret_cast<uint64_t>(&doorbell)), 1u);
+}
+
+TEST(CommandProcessorScratchBackingTest, ExplicitPteControlsAllocatorWithPassthrough) {
+  constexpr uint32_t kVmid = 44;
+  constexpr uint64_t kScratchPool = 0x1'0000'0000ULL;
+  constexpr uint32_t kPrivateSegmentSize = 4;
+  constexpr size_t kExpectedScratchSize = kPrivateSegmentSize * 64;
+
+  KfdProcess proc(kVmid);
+  alignas(KfdProcess::kPageSize) std::array<uint8_t, KfdProcess::kPageSize> scratch_backing{};
+  alignas(KfdProcess::kPageSize) std::array<uint8_t, KfdProcess::kPageSize> ring{};
+  alignas(KfdProcess::kPageSize) std::array<uint8_t, KfdProcess::kPageSize> kernel{};
+  alignas(uint64_t) uint64_t read_ptr = 0;
+  alignas(uint64_t) uint64_t write_ptr = 0;
+  alignas(uint64_t) uint64_t doorbell = 0;
+  VmFixture f;
+  f.mem()->set_passthrough(true);
+  f.mem()->register_process(kVmid, &proc.page_table_, &proc.page_table_mutex_);
+
+  size_t allocator_calls = 0;
+  f.cp()->set_scratch_backing_allocator([&](uint32_t process_id, uint64_t gpu_va, size_t size) {
+    EXPECT_EQ(process_id, kVmid);
+    EXPECT_EQ(gpu_va, kScratchPool);
+    EXPECT_EQ(size, kExpectedScratchSize);
+    ++allocator_calls;
+    return true;
+  });
+
+  using namespace rocr::llvm::amdhsa;
+  kernel_descriptor_t descriptor{};
+  descriptor.kernel_code_entry_byte_offset = sizeof(descriptor);
+  std::memcpy(kernel.data(), &descriptor, sizeof(descriptor));
+  std::memcpy(kernel.data() + sizeof(descriptor), &SOPP_S_ENDPGM, sizeof(SOPP_S_ENDPGM));
+  uint64_t kernel_object = reinterpret_cast<uint64_t>(kernel.data());
+  test::AqlQueue queue(f.mem(), f.cp(), reinterpret_cast<uint64_t>(ring.data()), ring.size(),
+                       reinterpret_cast<uint64_t>(&read_ptr),
+                       reinterpret_cast<uint64_t>(&write_ptr),
+                       reinterpret_cast<uint64_t>(&doorbell), kVmid);
+
+  auto dispatch = [&]() {
+    hsa_kernel_dispatch_packet_t pkt{};
+    pkt.header = HSA_PACKET_TYPE_KERNEL_DISPATCH;
+    pkt.setup = 1;
+    pkt.workgroup_size_x = 64;
+    pkt.workgroup_size_y = 1;
+    pkt.workgroup_size_z = 1;
+    pkt.grid_size_x = 64;
+    pkt.grid_size_y = 1;
+    pkt.grid_size_z = 1;
+    pkt.private_segment_size = kPrivateSegmentSize;
+    pkt.kernel_object = kernel_object;
+    queue.submit(pkt);
+    step_until_halted(*f.engine, {f.cu()});
+  };
+
+  dispatch();
+  EXPECT_EQ(allocator_calls, 1u);
+
+  proc.map_pages(kScratchPool, scratch_backing.data(), scratch_backing.size());
+  dispatch();
+  EXPECT_EQ(allocator_calls, 1u);
 }
 
 std::vector<uint8_t> make_loaded_kernel_symbol_elf(uint64_t kernel_descriptor_offset,

--- a/emulation/rocjitsu/tests/aql_queue.h
+++ b/emulation/rocjitsu/tests/aql_queue.h
@@ -21,6 +21,7 @@ RJ_DIAGNOSTIC_POP
 #include <cstdint>
 #include <cstring>
 #include <memory>
+#include <span>
 #include <thread>
 
 namespace rocjitsu::test {
@@ -55,17 +56,18 @@ public:
            uint64_t ring_addr = DEFAULT_RING_ADDR, uint32_t ring_size = DEFAULT_RING_SIZE,
            uint64_t read_ptr_addr = DEFAULT_READ_PTR_ADDR,
            uint64_t write_ptr_addr = DEFAULT_WRITE_PTR_ADDR,
-           uint64_t doorbell_addr = DEFAULT_DOORBELL_ADDR, bool xcd_fanout = false,
-           uint32_t queue_id = 1)
+           uint64_t doorbell_addr = DEFAULT_DOORBELL_ADDR, uint32_t process_id = 0,
+           bool xcd_fanout = false, uint32_t queue_id = 1)
       : memory_(memory), cp_(cp), ring_addr_(ring_addr), ring_size_(ring_size),
         read_ptr_addr_(read_ptr_addr), write_ptr_addr_(write_ptr_addr),
-        doorbell_addr_(doorbell_addr) {
+        doorbell_addr_(doorbell_addr), process_id_(process_id) {
     uint64_t zero = 0;
-    memory_->load_image(reinterpret_cast<const uint8_t *>(&zero), 8, read_ptr_addr_);
-    memory_->load_image(reinterpret_cast<const uint8_t *>(&zero), 8, write_ptr_addr_);
-    memory_->load_image(reinterpret_cast<const uint8_t *>(&zero), 8, doorbell_addr_);
+    write_block(read_ptr_addr_, &zero, sizeof(zero));
+    write_block(write_ptr_addr_, &zero, sizeof(zero));
+    write_block(doorbell_addr_, &zero, sizeof(zero));
 
     amdgpu::HwQueue hw{};
+    hw.process_id = process_id;
     hw.queue_id = queue_id;
     hw.ring_base_va = ring_addr_;
     hw.ring_size = ring_size_;
@@ -76,14 +78,20 @@ public:
     cp_->register_queue(std::move(hw));
   }
 
+  AqlQueue(amdgpu::GpuMemory *memory, amdgpu::CommandProcessor *cp, uint64_t ring_addr,
+           uint32_t ring_size, uint64_t read_ptr_addr, uint64_t write_ptr_addr,
+           uint64_t doorbell_addr, bool xcd_fanout, uint32_t queue_id = 1)
+      : AqlQueue(memory, cp, ring_addr, ring_size, read_ptr_addr, write_ptr_addr, doorbell_addr,
+                 /*process_id=*/0, xcd_fanout, queue_id) {}
+
   /// Write an AQL dispatch packet and ring the doorbell via GPU memory.
   void submit(const hsa_kernel_dispatch_packet_t &pkt) {
     uint32_t slot = static_cast<uint32_t>(write_idx_ % (ring_size_ / 64));
     uint64_t pkt_addr = ring_addr_ + slot * 64;
-    memory_->load_image(reinterpret_cast<const uint8_t *>(&pkt), 64, pkt_addr);
+    write_block(pkt_addr, &pkt, sizeof(pkt));
     ++write_idx_;
-    memory_->load_image(reinterpret_cast<const uint8_t *>(&write_idx_), 8, write_ptr_addr_);
-    memory_->load_image(reinterpret_cast<const uint8_t *>(&write_idx_), 8, doorbell_addr_);
+    write_block(write_ptr_addr_, &write_idx_, sizeof(write_idx_));
+    write_block(doorbell_addr_, &write_idx_, sizeof(write_idx_));
     // Inject a doorbell event so the engine processes it on the next drain.
     cp_->engine()->schedule_event_now(cp_->doorbell_event());
   }
@@ -186,6 +194,15 @@ public:
   }
 
 private:
+  void write_block(uint64_t address, const void *source, size_t size) {
+    auto *bytes = static_cast<const uint8_t *>(source);
+    if (process_id_ == 0) {
+      memory_->load_image(bytes, size, address);
+      return;
+    }
+    memory_->write_block(address, std::span<const uint8_t>(bytes, size), process_id_);
+  }
+
   amdgpu::GpuMemory *memory_;
   amdgpu::CommandProcessor *cp_;
   uint64_t ring_addr_;
@@ -193,6 +210,7 @@ private:
   uint64_t read_ptr_addr_;
   uint64_t write_ptr_addr_;
   uint64_t doorbell_addr_;
+  uint32_t process_id_;
   uint64_t write_idx_ = 0;
 };
 

--- a/emulation/rocjitsu/tests/aql_queue.h
+++ b/emulation/rocjitsu/tests/aql_queue.h
@@ -46,6 +46,7 @@ public:
   /// @param read_ptr_addr Address of the read pointer.
   /// @param write_ptr_addr Address of the write pointer.
   /// @param doorbell_addr Address of the doorbell.
+  /// @param process_id VM process that owns the queue and its ring pointers.
   /// @param xcd_fanout Spread each dispatch over every XCD, as the KFD create-queue
   /// ioctl now does for compute queues on a multi-XCD part. Off by default so a test
   /// that binds a queue to one command processor keeps its CUs to itself.
@@ -78,6 +79,7 @@ public:
     cp_->register_queue(std::move(hw));
   }
 
+  /// @brief Compatibility overload for the older positional xcd_fanout signature.
   AqlQueue(amdgpu::GpuMemory *memory, amdgpu::CommandProcessor *cp, uint64_t ring_addr,
            uint32_t ring_size, uint64_t read_ptr_addr, uint64_t write_ptr_addr,
            uint64_t doorbell_addr, bool xcd_fanout, uint32_t queue_id = 1)

--- a/emulation/rocjitsu/tests/kfd_ioctl_test.cpp
+++ b/emulation/rocjitsu/tests/kfd_ioctl_test.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
+#include "aql_queue.h"
+
 #include "rocjitsu/config/config_loader.h"
 #include "rocjitsu/kmd/linux/cwsr.h"
 #include "rocjitsu/kmd/linux/kfd_ioctl_utils.h"
@@ -10,13 +12,20 @@
 #include "rocjitsu/vm/amdgpu/command_processor.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/rj_vm.h"
+#include "rocjitsu/vm/rj_vm_impl.h"
 #include "rocjitsu/vm/virtual_machine.h"
 
 #include "embedded_schema.h"
+#include "rocjitsu/base/rj_compiler.h"
 #include "rocjitsu/kmd/linux/amdgpu_properties.h"
 #include "rocjitsu/kmd/linux/kfd_topology.h"
 #include "simdojo/sim/simulation.h"
 #include "util/unique_handle.h"
+
+RJ_DIAGNOSTIC_PUSH
+RJ_DIAGNOSTIC_IGNORE_PEDANTIC
+#include "hsa/AMDHSAKernelDescriptor.h"
+RJ_DIAGNOSTIC_POP
 
 #include <gtest/gtest.h>
 
@@ -40,7 +49,10 @@
 #include <cstring>
 #include <functional>
 #include <limits>
+#include <memory>
+#include <mutex>
 #include <thread>
+#include <unordered_map>
 #include <vector>
 
 #ifndef MAP_FIXED_NOREPLACE
@@ -50,15 +62,121 @@
 namespace {
 
 const std::string CONFIG_PATH = std::string(CONFIG_DIR) + "/gfx950_mi355x.json";
+const std::string MULTIGPU_CONFIG_PATH = std::string(CONFIG_DIR) + "/gfx950_mi355x_kmd_2gpu.json";
 constexpr uint32_t kGpuId = 38144;
 const std::string CDNA5_CONFIG_PATH = std::string(CONFIG_DIR) + "/gfx1250_mi455x.json";
 constexpr uint32_t kCdna5GpuId = 1250;
+constexpr uint32_t kSoppSEndpgm = 0xBF810000;
 
 // A part with no modelled CWSR record layout. gfx1100 is not a debug target:
 // kmd::cwsr_layout_modelled() covers gfx942/gfx950/gfx1250, and the driver has to
 // decline stops there rather than publish a record rocm-dbgapi would misparse.
 const std::string RDNA3_CONFIG_PATH = std::string(CONFIG_DIR) + "/gfx1100_w7900.json";
 constexpr uint32_t kRdna3GpuId = 7019;
+
+struct ScratchPoolSnapshot {
+  size_t count = 0;
+  size_t size = 0;
+  const rocjitsu::KfdProcess::BackingStore *backing = nullptr;
+};
+
+ScratchPoolSnapshot scratch_pool_at(rocjitsu::KfdProcess &proc, uint32_t gpu_ordinal,
+                                    uint64_t gpu_va) {
+  ScratchPoolSnapshot snapshot;
+  std::lock_guard<std::mutex> scratch_lock(proc.scratch_backing_mutex_);
+  std::lock_guard<std::mutex> lk(proc.alloc_mutex_);
+  rocjitsu::KfdProcess::ScratchPoolMap::iterator it = proc.scratch_pools_.find(
+      rocjitsu::KfdProcess::ScratchPoolKey{.gpu_ordinal = gpu_ordinal, .gpu_va = gpu_va});
+  if (it == proc.scratch_pools_.end())
+    return snapshot;
+  snapshot.count = 1;
+  snapshot.size = it->second.size;
+  snapshot.backing = it->second.backing.get();
+  return snapshot;
+}
+
+constexpr uint64_t fallback_scratch_base(uint32_t gpu_ordinal) {
+  return (rocjitsu::KfdProcess::kGpuVmLimit + 1) -
+         (static_cast<uint64_t>(gpu_ordinal) + 1) *
+             rocjitsu::KfdProcess::kFallbackScratchReserveSize;
+}
+
+constexpr uint64_t fallback_scratch_limit(uint32_t gpu_ordinal) {
+  return fallback_scratch_base(gpu_ordinal) + rocjitsu::KfdProcess::kFallbackScratchReserveSize - 1;
+}
+
+[[nodiscard]] bool step_process_until_idle(simdojo::SimulationEngine &engine,
+                                           const rocjitsu::SoC &soc, uint32_t process_id,
+                                           uint32_t max_steps = 10000) {
+  bool saw_work = false;
+  for (uint32_t i = 0; i < max_steps && engine.step(); ++i) {
+    if (soc.has_active_wfs_for_process(process_id))
+      saw_work = true;
+    else if (saw_work)
+      return true;
+  }
+  return saw_work && !soc.has_active_wfs_for_process(process_id);
+}
+
+util::UniqueHandle make_sized_memfd(const char *name, size_t size) {
+  util::UniqueHandle fd(static_cast<int>(syscall(SYS_memfd_create, name, MFD_CLOEXEC)));
+  if (!fd)
+    return {};
+  if (ftruncate(fd.get(), static_cast<off_t>(size)) != 0)
+    return {};
+  return fd;
+}
+
+class ScopedMapping {
+public:
+  ScopedMapping(void *address, size_t size) : address_(address), size_(size) {}
+  ~ScopedMapping() { reset(); }
+
+  ScopedMapping(const ScopedMapping &) = delete;
+  ScopedMapping &operator=(const ScopedMapping &) = delete;
+
+  void *get() const { return address_; }
+
+  void release() {
+    address_ = nullptr;
+    size_ = 0;
+  }
+
+  void reset() {
+    if (address_ != nullptr && address_ != MAP_FAILED)
+      munmap(address_, size_);
+    release();
+  }
+
+private:
+  void *address_;
+  size_t size_;
+};
+
+class ScopedGpuAllocation {
+public:
+  ScopedGpuAllocation(rocjitsu::SimulatedKfd *driver, uint64_t handle)
+      : driver_(driver), handle_(handle) {}
+  ~ScopedGpuAllocation() { reset(); }
+
+  ScopedGpuAllocation(const ScopedGpuAllocation &) = delete;
+  ScopedGpuAllocation &operator=(const ScopedGpuAllocation &) = delete;
+
+  void release() { handle_ = 0; }
+
+  void reset() {
+    if (handle_ == 0)
+      return;
+    kfd_ioctl_free_memory_of_gpu_args args{};
+    args.handle = handle_;
+    driver_->ioctl(AMDKFD_IOC_FREE_MEMORY_OF_GPU, &args);
+    release();
+  }
+
+private:
+  rocjitsu::SimulatedKfd *driver_;
+  uint64_t handle_;
+};
 
 class ChildProcessGuard {
 public:
@@ -680,22 +798,23 @@ TEST(KfdIoctlStandaloneTest, GetTileConfigReportsRdnaGbAddrConfig) {
 
 TEST_F(KfdIoctlTest, ImportDmabufAndQueryInfo) {
   constexpr size_t kSize = 4096;
+  constexpr uint64_t kGpuVa = rocjitsu::KfdProcess::kGpuVmBase + 0x3200000;
+  constexpr uint32_t kSentinel = 0xABCD1234u;
   int memfd = static_cast<int>(syscall(SYS_memfd_create, "kfd_dmabuf_test", MFD_CLOEXEC));
   ASSERT_GE(memfd, 0);
   ASSERT_EQ(ftruncate(memfd, kSize), 0);
-
-  void *addr = mmap(nullptr, kSize, PROT_READ | PROT_WRITE, MAP_SHARED, memfd, 0);
-  ASSERT_NE(addr, MAP_FAILED);
-  std::memset(addr, 0xAB, kSize);
+  ASSERT_EQ(::pwrite(memfd, &kSentinel, sizeof(kSentinel), 0),
+            static_cast<ssize_t>(sizeof(kSentinel)));
 
   kfd_ioctl_import_dmabuf_args import_args{};
   import_args.dmabuf_fd = memfd;
   import_args.gpu_id = kGpuId;
-  import_args.va_addr = reinterpret_cast<uint64_t>(addr);
+  import_args.va_addr = kGpuVa;
 
   int rc = driver_->ioctl(AMDKFD_IOC_IMPORT_DMABUF, &import_args);
   EXPECT_EQ(rc, 0);
   EXPECT_NE(import_args.handle, 0u);
+  EXPECT_EQ(soc_->memory()->read32(kGpuVa, driver_->local_process_id()), kSentinel);
 
   kfd_ioctl_get_dmabuf_info_args info_args{};
   info_args.dmabuf_fd = memfd;
@@ -712,8 +831,209 @@ TEST_F(KfdIoctlTest, ImportDmabufAndQueryInfo) {
   free_args.handle = import_args.handle;
   EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_FREE_MEMORY_OF_GPU, &free_args), 0);
 
-  munmap(addr, kSize);
   close(memfd);
+}
+
+TEST_F(KfdIoctlTest, ImportDmabufAllowsHandleOnlyZeroVa) {
+  constexpr size_t kSize = rocjitsu::KfdProcess::kPageSize;
+  constexpr uint32_t kSentinel = 0xD1AB0000u;
+  util::UniqueHandle dmabuf = make_sized_memfd("kfd_dmabuf_zero_va", kSize);
+  ASSERT_TRUE(dmabuf);
+  ASSERT_EQ(::pwrite(dmabuf.get(), &kSentinel, sizeof(kSentinel), 0),
+            static_cast<ssize_t>(sizeof(kSentinel)));
+
+  kfd_ioctl_import_dmabuf_args import{};
+  import.dmabuf_fd = dmabuf.get();
+  import.gpu_id = kGpuId;
+  import.va_addr = 0;
+  EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_IMPORT_DMABUF, &import), 0);
+  ASSERT_NE(import.handle, 0u);
+  EXPECT_EQ(import.va_addr, 0u);
+
+  std::shared_ptr<rocjitsu::KfdProcess> process =
+      driver_->find_process(driver_->local_process_id());
+  ASSERT_NE(process, nullptr);
+  {
+    std::lock_guard<std::mutex> lk(process->alloc_mutex_);
+    std::unordered_map<uint64_t, rocjitsu::KfdProcess::GpuAllocation>::iterator allocation_it =
+        process->allocations_.find(import.handle);
+    ASSERT_NE(allocation_it, process->allocations_.end());
+    rocjitsu::KfdProcess::GpuAllocation &allocation = allocation_it->second;
+    EXPECT_EQ(allocation.gpu_va, 0u);
+    EXPECT_TRUE(allocation.imported);
+    EXPECT_NE(allocation.host_ptr, nullptr);
+    EXPECT_TRUE(allocation.host_ptr_owned);
+  }
+  EXPECT_FALSE(soc_->memory()->is_mapped(0, driver_->local_process_id()));
+
+  kfd_ioctl_map_memory_to_gpu_args map{};
+  map.handle = import.handle;
+  map.n_devices = 1;
+  EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_MAP_MEMORY_TO_GPU, &map), -EINVAL);
+  EXPECT_EQ(map.n_success, 0u);
+
+  kfd_ioctl_free_memory_of_gpu_args free_args{};
+  free_args.handle = import.handle;
+  EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_FREE_MEMORY_OF_GPU, &free_args), 0);
+}
+
+TEST_F(KfdIoctlTest, ImportDmabufRejectsOverlapAndFreeKeepsAdjacentImport) {
+  constexpr size_t kSize = rocjitsu::KfdProcess::kPageSize;
+  util::UniqueHandle first_fd = make_sized_memfd("kfd_dmabuf_first", kSize);
+  util::UniqueHandle second_fd = make_sized_memfd("kfd_dmabuf_second", kSize);
+  ASSERT_TRUE(first_fd);
+  ASSERT_TRUE(second_fd);
+
+  constexpr uint64_t first_addr = rocjitsu::KfdProcess::kGpuVmBase + 0x3310000;
+  constexpr uint64_t second_addr = first_addr + kSize;
+
+  kfd_ioctl_import_dmabuf_args first{};
+  first.dmabuf_fd = first_fd.get();
+  first.gpu_id = kGpuId;
+  first.va_addr = first_addr;
+  ASSERT_EQ(driver_->ioctl(AMDKFD_IOC_IMPORT_DMABUF, &first), 0);
+  ScopedGpuAllocation first_allocation(driver_, first.handle);
+  ASSERT_NE(first.handle, 0u);
+
+  kfd_ioctl_import_dmabuf_args overlap{};
+  overlap.dmabuf_fd = second_fd.get();
+  overlap.gpu_id = kGpuId;
+  overlap.va_addr = first_addr + kSize / 2;
+  EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_IMPORT_DMABUF, &overlap), -EINVAL);
+  EXPECT_EQ(overlap.handle, 0u);
+  EXPECT_TRUE(soc_->memory()->is_range_mapped(first_addr, kSize, driver_->local_process_id()));
+
+  kfd_ioctl_import_dmabuf_args adjacent{};
+  adjacent.dmabuf_fd = second_fd.get();
+  adjacent.gpu_id = kGpuId;
+  adjacent.va_addr = second_addr;
+  ASSERT_EQ(driver_->ioctl(AMDKFD_IOC_IMPORT_DMABUF, &adjacent), 0);
+  ScopedGpuAllocation adjacent_allocation(driver_, adjacent.handle);
+  ASSERT_NE(adjacent.handle, 0u);
+
+  first_allocation.reset();
+  constexpr uint32_t kSentinel = 0x5EA1CAFEu;
+  soc_->memory()->write32(second_addr, kSentinel, driver_->local_process_id());
+  uint32_t observed = 0;
+  EXPECT_EQ(::pread(second_fd.get(), &observed, sizeof(observed), 0),
+            static_cast<ssize_t>(sizeof(observed)));
+  EXPECT_EQ(observed, kSentinel);
+  EXPECT_TRUE(soc_->memory()->is_range_mapped(second_addr, kSize, driver_->local_process_id()));
+}
+
+TEST_F(KfdIoctlTest, IpcImportRejectsOverlapAndSurvivesExporterFree) {
+  constexpr uint64_t kPageSize = rocjitsu::KfdProcess::kPageSize;
+  constexpr uint32_t kFlags = KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+
+  kfd_ioctl_alloc_memory_of_gpu_args source{};
+  source.size = kPageSize;
+  source.gpu_id = kGpuId;
+  source.flags = kFlags;
+  ASSERT_EQ(driver_->ioctl(AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &source), 0);
+  ScopedGpuAllocation source_allocation(driver_, source.handle);
+  ASSERT_NE(source.handle, 0u);
+
+  kfd_ioctl_ipc_export_handle_args export_args{};
+  export_args.handle = source.handle;
+  export_args.gpu_id = kGpuId;
+  ASSERT_EQ(driver_->ioctl(AMDKFD_IOC_IPC_EXPORT_HANDLE, &export_args), 0);
+
+  kfd_ioctl_ipc_import_handle_args overlap{};
+  std::memcpy(overlap.share_handle, export_args.share_handle, sizeof(overlap.share_handle));
+  overlap.gpu_id = kGpuId;
+  overlap.va_addr = source.va_addr;
+  EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_IPC_IMPORT_HANDLE, &overlap), -EINVAL);
+  EXPECT_EQ(overlap.handle, 0u);
+
+  kfd_ioctl_ipc_import_handle_args adjacent{};
+  std::memcpy(adjacent.share_handle, export_args.share_handle, sizeof(adjacent.share_handle));
+  adjacent.gpu_id = kGpuId;
+  adjacent.va_addr = source.va_addr + kPageSize;
+  ASSERT_EQ(driver_->ioctl(AMDKFD_IOC_IPC_IMPORT_HANDLE, &adjacent), 0);
+  ScopedGpuAllocation adjacent_allocation(driver_, adjacent.handle);
+  ASSERT_NE(adjacent.handle, 0u);
+  EXPECT_TRUE(
+      soc_->memory()->is_range_mapped(adjacent.va_addr, kPageSize, driver_->local_process_id()));
+
+  source_allocation.reset();
+  constexpr uint32_t kSentinel = 0x1CA11D00u;
+  soc_->memory()->write32(adjacent.va_addr, kSentinel, driver_->local_process_id());
+  EXPECT_EQ(soc_->memory()->read32(adjacent.va_addr, driver_->local_process_id()), kSentinel);
+  EXPECT_TRUE(
+      soc_->memory()->is_range_mapped(adjacent.va_addr, kPageSize, driver_->local_process_id()));
+}
+
+TEST_F(KfdIoctlTest, UserptrIpcExportIsRejectedAndKeepsCpuGpuAlias) {
+  constexpr uint64_t kGpuVa = rocjitsu::KfdProcess::kGpuVmBase + 0x3280000;
+  constexpr size_t kSize = rocjitsu::KfdProcess::kPageSize;
+  constexpr uint32_t kBefore = 0xA11A5001u;
+  constexpr uint32_t kAfter = 0xA11A5002u;
+
+  void *mapping = mmap(nullptr, kSize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE(mapping, MAP_FAILED);
+  ScopedMapping scoped_mapping(mapping, kSize);
+
+  kfd_ioctl_alloc_memory_of_gpu_args alloc{};
+  alloc.va_addr = kGpuVa;
+  alloc.mmap_offset = reinterpret_cast<uint64_t>(mapping);
+  alloc.size = kSize;
+  alloc.gpu_id = kGpuId;
+  alloc.flags = KFD_IOC_ALLOC_MEM_FLAGS_USERPTR | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+  ASSERT_EQ(driver_->ioctl(AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &alloc), 0);
+  ScopedGpuAllocation allocation(driver_, alloc.handle);
+  ASSERT_NE(alloc.handle, 0u);
+
+  soc_->memory()->write32(kGpuVa, kBefore, driver_->local_process_id());
+  EXPECT_EQ(*reinterpret_cast<volatile uint32_t *>(mapping), kBefore);
+
+  kfd_ioctl_ipc_export_handle_args export_args{};
+  export_args.handle = alloc.handle;
+  export_args.gpu_id = kGpuId;
+  EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_IPC_EXPORT_HANDLE, &export_args), -EINVAL);
+
+  *reinterpret_cast<volatile uint32_t *>(mapping) = kAfter;
+  EXPECT_EQ(soc_->memory()->read32(kGpuVa, driver_->local_process_id()), kAfter);
+}
+
+TEST_F(KfdIoctlTest, CallerOwnedNonUserptrIpcExportIsRejectedAndKeepsCpuGpuAlias) {
+  constexpr uint64_t kGpuVa = rocjitsu::KfdProcess::kGpuVmBase + 0x3290000;
+  constexpr size_t kSize = rocjitsu::KfdProcess::kPageSize;
+  constexpr uint32_t kBefore = 0xA11A6001u;
+  constexpr uint32_t kAfter = 0xA11A6002u;
+  constexpr uint32_t kFlags = KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+
+  void *reserved = mmap(reinterpret_cast<void *>(kGpuVa), kSize, PROT_NONE,
+                        MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED_NOREPLACE | MAP_NORESERVE, -1, 0);
+  if (reserved == MAP_FAILED && errno == EEXIST)
+    GTEST_SKIP() << "test GPUVA reservation is already occupied";
+  ASSERT_EQ(reserved, reinterpret_cast<void *>(kGpuVa)) << std::strerror(errno);
+  ScopedMapping reservation(reserved, kSize);
+
+  kfd_ioctl_alloc_memory_of_gpu_args alloc{};
+  alloc.va_addr = kGpuVa;
+  alloc.size = kSize;
+  alloc.gpu_id = kGpuId;
+  alloc.flags = kFlags;
+  ASSERT_EQ(driver_->ioctl(AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &alloc), 0);
+  ScopedGpuAllocation allocation(driver_, alloc.handle);
+  ASSERT_NE(alloc.handle, 0u);
+
+  kfd_ioctl_map_memory_to_gpu_args map{};
+  map.handle = alloc.handle;
+  map.n_devices = 1;
+  ASSERT_EQ(driver_->ioctl(AMDKFD_IOC_MAP_MEMORY_TO_GPU, &map), 0);
+  EXPECT_EQ(map.n_success, 1u);
+
+  soc_->memory()->write32(kGpuVa, kBefore, driver_->local_process_id());
+  EXPECT_EQ(*reinterpret_cast<volatile uint32_t *>(kGpuVa), kBefore);
+
+  kfd_ioctl_ipc_export_handle_args export_args{};
+  export_args.handle = alloc.handle;
+  export_args.gpu_id = kGpuId;
+  EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_IPC_EXPORT_HANDLE, &export_args), -EINVAL);
+
+  *reinterpret_cast<volatile uint32_t *>(kGpuVa) = kAfter;
+  EXPECT_EQ(soc_->memory()->read32(kGpuVa, driver_->local_process_id()), kAfter);
 }
 
 TEST_F(KfdIoctlTest, MapMemoryToGpuMapsLocalUserVaAllocation) {
@@ -726,11 +1046,7 @@ TEST_F(KfdIoctlTest, MapMemoryToGpuMapsLocalUserVaAllocation) {
   if (reserved == MAP_FAILED && errno == EEXIST)
     GTEST_SKIP() << "test GPUVA reservation is already occupied";
   ASSERT_EQ(reserved, reinterpret_cast<void *>(kGpuVa)) << std::strerror(errno);
-  struct ScopedReservation {
-    void *address;
-    size_t size;
-    ~ScopedReservation() { munmap(address, size); }
-  } reservation{reserved, kSize};
+  ScopedMapping reservation(reserved, kSize);
 
   kfd_ioctl_alloc_memory_of_gpu_args alloc{};
   alloc.va_addr = kGpuVa;
@@ -738,17 +1054,7 @@ TEST_F(KfdIoctlTest, MapMemoryToGpuMapsLocalUserVaAllocation) {
   alloc.gpu_id = kGpuId;
   alloc.flags = KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
   ASSERT_EQ(driver_->ioctl(AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &alloc), 0);
-  struct ScopedAllocation {
-    rocjitsu::SimulatedKfd *driver;
-    uint64_t handle;
-    ~ScopedAllocation() {
-      if (handle != 0) {
-        kfd_ioctl_free_memory_of_gpu_args args{};
-        args.handle = handle;
-        driver->ioctl(AMDKFD_IOC_FREE_MEMORY_OF_GPU, &args);
-      }
-    }
-  } allocation{driver_, alloc.handle};
+  ScopedGpuAllocation allocation(driver_, alloc.handle);
   ASSERT_NE(alloc.handle, 0u);
   EXPECT_FALSE(soc_->memory()->is_mapped(kGpuVa, driver_->local_process_id()));
 
@@ -768,8 +1074,311 @@ TEST_F(KfdIoctlTest, MapMemoryToGpuMapsLocalUserVaAllocation) {
   kfd_ioctl_free_memory_of_gpu_args free_args{};
   free_args.handle = alloc.handle;
   EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_FREE_MEMORY_OF_GPU, &free_args), 0);
-  allocation.handle = 0;
+  allocation.release();
   EXPECT_FALSE(soc_->memory()->is_mapped(kGpuVa, driver_->local_process_id()));
+}
+
+TEST_F(KfdIoctlTest, UserptrAllocMapsGpuVaToCpuBackingAndFreeKeepsVma) {
+  constexpr uint64_t kGpuVa = rocjitsu::KfdProcess::kGpuVmBase + 0x3240000;
+  constexpr size_t kSize = rocjitsu::KfdProcess::kPageSize;
+  constexpr uint32_t kExpected = 0xA17ECAFEu;
+  constexpr uint32_t kAfterFree = 0x600DF00Du;
+
+  void *mapping = mmap(nullptr, kSize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE(mapping, MAP_FAILED);
+  ScopedMapping scoped_mapping(mapping, kSize);
+
+  const uint64_t cpu_va = reinterpret_cast<uint64_t>(mapping);
+  ASSERT_NE(cpu_va, kGpuVa);
+  kfd_ioctl_alloc_memory_of_gpu_args alloc{};
+  alloc.va_addr = kGpuVa;
+  alloc.mmap_offset = cpu_va;
+  alloc.size = kSize;
+  alloc.gpu_id = kGpuId;
+  alloc.flags = KFD_IOC_ALLOC_MEM_FLAGS_USERPTR | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+  ASSERT_EQ(driver_->ioctl(AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &alloc), 0);
+  ScopedGpuAllocation allocation(driver_, alloc.handle);
+  ASSERT_NE(alloc.handle, 0u);
+  EXPECT_EQ(alloc.va_addr, kGpuVa);
+  EXPECT_EQ(alloc.mmap_offset, cpu_va);
+  EXPECT_TRUE(soc_->memory()->is_mapped(kGpuVa, driver_->local_process_id()));
+  EXPECT_EQ(soc_->memory()->resolve_host_ptr(kGpuVa, driver_->local_process_id()),
+            static_cast<uint8_t *>(mapping));
+
+  soc_->memory()->write32(kGpuVa, kExpected, driver_->local_process_id());
+  EXPECT_EQ(*reinterpret_cast<volatile uint32_t *>(mapping), kExpected);
+
+  kfd_ioctl_free_memory_of_gpu_args free_args{};
+  free_args.handle = alloc.handle;
+  EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_FREE_MEMORY_OF_GPU, &free_args), 0);
+  allocation.release();
+  EXPECT_FALSE(soc_->memory()->is_mapped(kGpuVa, driver_->local_process_id()));
+  *reinterpret_cast<volatile uint32_t *>(mapping) = kAfterFree;
+  EXPECT_EQ(*reinterpret_cast<volatile uint32_t *>(mapping), kAfterFree);
+}
+
+TEST_F(KfdIoctlTest, MapMemoryToGpuFailsWithoutCoveringUserVma) {
+  constexpr size_t kSize = rocjitsu::KfdProcess::kPageSize;
+
+  void *reserved =
+      mmap(nullptr, kSize, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0);
+  ASSERT_NE(reserved, MAP_FAILED) << std::strerror(errno);
+  const uint64_t kGpuVa = reinterpret_cast<uint64_t>(reserved);
+  if (kGpuVa < rocjitsu::KfdProcess::kGpuVmBase ||
+      kGpuVa > rocjitsu::KfdProcess::kGpuVmLimit - kSize) {
+    ASSERT_EQ(munmap(reserved, kSize), 0);
+    GTEST_SKIP() << "dynamic GPUVA reservation is outside the simulated GPUVM aperture";
+  }
+  ASSERT_EQ(munmap(reserved, kSize), 0);
+
+  kfd_ioctl_alloc_memory_of_gpu_args alloc{};
+  alloc.va_addr = kGpuVa;
+  alloc.size = kSize;
+  alloc.gpu_id = kGpuId;
+  alloc.flags = KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+  ASSERT_EQ(driver_->ioctl(AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &alloc), 0);
+  ScopedGpuAllocation allocation(driver_, alloc.handle);
+  ASSERT_NE(alloc.handle, 0u);
+  EXPECT_FALSE(soc_->memory()->is_mapped(kGpuVa, driver_->local_process_id()));
+
+  kfd_ioctl_map_memory_to_gpu_args map{};
+  map.handle = alloc.handle;
+  map.n_devices = 1;
+  map.n_success = 0xFFFFu;
+  EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_MAP_MEMORY_TO_GPU, &map), -ENOMEM);
+  EXPECT_EQ(map.n_success, 0u);
+  EXPECT_FALSE(soc_->memory()->is_mapped(kGpuVa, driver_->local_process_id()));
+
+  reserved = mmap(reinterpret_cast<void *>(kGpuVa), kSize, PROT_NONE,
+                  MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED_NOREPLACE | MAP_NORESERVE, -1, 0);
+  if (reserved == MAP_FAILED && errno == EEXIST)
+    GTEST_SKIP() << "test GPUVA retry reservation is already occupied";
+  ASSERT_EQ(reserved, reinterpret_cast<void *>(kGpuVa)) << std::strerror(errno);
+  ScopedMapping reservation(reserved, kSize);
+
+  map.n_success = 0xFFFFu;
+  EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_MAP_MEMORY_TO_GPU, &map), 0);
+  EXPECT_EQ(map.n_success, 1u);
+  EXPECT_TRUE(soc_->memory()->is_mapped(kGpuVa, driver_->local_process_id()));
+}
+
+TEST_F(KfdIoctlTest, ScratchBackingGrowthKeepsInternalPoolStable) {
+  constexpr uint32_t kSmallPrivateSegment = 64;
+  constexpr uint32_t kLargePrivateSegment = 65;
+  constexpr uint64_t kSmallBackingSize = rocjitsu::KfdProcess::kPageSize;
+  constexpr uint64_t kLargeWaveSize = 5120;
+  constexpr uint64_t kLargeBackingSize = rocjitsu::KfdProcess::kPageSize * 2;
+  constexpr uint32_t kSentinel = 0x51A7CAFEu;
+
+  rocjitsu::amdgpu::CommandProcessor *cp = soc_->xcd(0)->command_processor();
+  ASSERT_NE(cp, nullptr);
+  std::shared_ptr<rocjitsu::KfdProcess> process =
+      driver_->find_process(driver_->local_process_id());
+  ASSERT_NE(process, nullptr);
+
+  constexpr uint64_t kScratchPool = fallback_scratch_base(0);
+  static_assert((kScratchPool & 0xFFFFu) == 0);
+
+  alignas(64) std::array<uint8_t, rocjitsu::test::AqlQueue::DEFAULT_RING_SIZE> ring{};
+  alignas(rocjitsu::KfdProcess::kPageSize) std::array<uint8_t, rocjitsu::KfdProcess::kPageSize>
+      kernel{};
+  alignas(uint64_t) uint64_t read_ptr = 0;
+  alignas(uint64_t) uint64_t write_ptr = 0;
+  alignas(uint64_t) uint64_t doorbell = 0;
+
+  using namespace rocr::llvm::amdhsa;
+  kernel_descriptor_t descriptor{};
+  descriptor.kernel_code_entry_byte_offset = sizeof(descriptor);
+  std::memcpy(kernel.data(), &descriptor, sizeof(descriptor));
+  std::memcpy(kernel.data() + sizeof(descriptor), &kSoppSEndpgm, sizeof(kSoppSEndpgm));
+
+  rocjitsu::test::AqlQueue queue(
+      soc_->memory(), cp, reinterpret_cast<uint64_t>(ring.data()), ring.size(),
+      reinterpret_cast<uint64_t>(&read_ptr), reinterpret_cast<uint64_t>(&write_ptr),
+      reinterpret_cast<uint64_t>(&doorbell), driver_->local_process_id());
+
+  auto dispatch_with_scratch = [&](uint32_t private_segment_size) {
+    const uint64_t read_before_submit = read_ptr;
+    const uint64_t write_before_submit = write_ptr;
+    hsa_kernel_dispatch_packet_t pkt{};
+    pkt.header = HSA_PACKET_TYPE_KERNEL_DISPATCH;
+    pkt.setup = 1;
+    pkt.workgroup_size_x = 64;
+    pkt.workgroup_size_y = 1;
+    pkt.workgroup_size_z = 1;
+    pkt.grid_size_x = 64;
+    pkt.grid_size_y = 1;
+    pkt.grid_size_z = 1;
+    pkt.private_segment_size = private_segment_size;
+    pkt.kernel_object = reinterpret_cast<uint64_t>(kernel.data());
+    queue.submit(pkt);
+    const bool retired = step_process_until_idle(*engine_, *soc_, driver_->local_process_id());
+    return retired && write_ptr == write_before_submit + 1 && read_ptr == read_before_submit + 1 &&
+           read_ptr == write_ptr && !soc_->has_active_wfs_for_process(driver_->local_process_id());
+  };
+
+  ASSERT_TRUE(dispatch_with_scratch(kSmallPrivateSegment));
+  ScratchPoolSnapshot first = scratch_pool_at(*process, 0, kScratchPool);
+  ASSERT_EQ(first.count, 1u);
+  EXPECT_EQ(first.size, kSmallBackingSize);
+  ASSERT_NE(first.backing, nullptr);
+  {
+    std::lock_guard<std::mutex> lk(process->alloc_mutex_);
+    EXPECT_TRUE(process->allocations_.empty());
+  }
+  EXPECT_EQ(soc_->memory()->resolve_host_ptr(kScratchPool, driver_->local_process_id()), nullptr);
+  EXPECT_EQ(soc_->memory()->find_host_range(kScratchPool, driver_->local_process_id()),
+            (std::pair<uint64_t, uint64_t>{0, 0}));
+
+  soc_->memory()->write32(kScratchPool, kSentinel, driver_->local_process_id());
+  constexpr uint32_t kTailSentinel = 0xBACCAB1Eu;
+  const uint64_t old_tail_va = kScratchPool + kSmallBackingSize - sizeof(uint32_t);
+  soc_->memory()->write32(old_tail_va, kTailSentinel, driver_->local_process_id());
+
+  ASSERT_TRUE(dispatch_with_scratch(kSmallPrivateSegment));
+  ScratchPoolSnapshot reused = scratch_pool_at(*process, 0, kScratchPool);
+  ASSERT_EQ(reused.count, 1u);
+  EXPECT_EQ(reused.backing, first.backing);
+  EXPECT_EQ(reused.size, kSmallBackingSize);
+
+  ASSERT_TRUE(dispatch_with_scratch(kLargePrivateSegment));
+  ScratchPoolSnapshot grown = scratch_pool_at(*process, 0, kScratchPool);
+  ASSERT_EQ(grown.count, 1u);
+  EXPECT_EQ(grown.backing, first.backing);
+  EXPECT_EQ(grown.size, kLargeBackingSize);
+  {
+    std::lock_guard<std::mutex> lk(process->alloc_mutex_);
+    EXPECT_TRUE(process->allocations_.empty());
+  }
+  EXPECT_TRUE(
+      soc_->memory()->is_range_mapped(kScratchPool, kLargeWaveSize, driver_->local_process_id()));
+  EXPECT_TRUE(soc_->memory()->is_range_host_backed(kScratchPool, kLargeWaveSize,
+                                                   driver_->local_process_id()));
+  EXPECT_EQ(soc_->memory()->read32(kScratchPool, driver_->local_process_id()), kSentinel);
+  EXPECT_EQ(soc_->memory()->read32(old_tail_va, driver_->local_process_id()), kTailSentinel);
+
+  constexpr uint32_t kUpperPageSentinel = 0xFEED1250u;
+  const uint64_t upper_page_va = kScratchPool + kSmallBackingSize + 16;
+  soc_->memory()->write32(upper_page_va, kUpperPageSentinel, driver_->local_process_id());
+  EXPECT_EQ(soc_->memory()->read32(upper_page_va, driver_->local_process_id()), kUpperPageSentinel);
+
+  kfd_ioctl_free_memory_of_gpu_args free_old{};
+  free_old.handle = 0x12345678;
+  EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_FREE_MEMORY_OF_GPU, &free_old), 0);
+  EXPECT_TRUE(
+      soc_->memory()->is_range_mapped(kScratchPool, kLargeWaveSize, driver_->local_process_id()));
+  EXPECT_EQ(soc_->memory()->read32(kScratchPool, driver_->local_process_id()), kSentinel);
+  EXPECT_EQ(soc_->memory()->read32(old_tail_va, driver_->local_process_id()), kTailSentinel);
+  EXPECT_EQ(soc_->memory()->read32(upper_page_va, driver_->local_process_id()), kUpperPageSentinel);
+
+  constexpr uint32_t kFlags = KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+  kfd_ioctl_alloc_memory_of_gpu_args overlap{};
+  overlap.va_addr = kScratchPool;
+  overlap.size = kSmallBackingSize;
+  overlap.gpu_id = kGpuId;
+  overlap.flags = kFlags;
+  EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &overlap), -EINVAL);
+  EXPECT_EQ(overlap.handle, 0u);
+
+  kfd_ioctl_alloc_memory_of_gpu_args ordinary{};
+  ordinary.size = rocjitsu::KfdProcess::kPageSize;
+  ordinary.gpu_id = kGpuId;
+  ordinary.flags = kFlags;
+  ASSERT_EQ(driver_->ioctl(AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &ordinary), 0);
+  ScopedGpuAllocation ordinary_allocation(driver_, ordinary.handle);
+  ASSERT_NE(ordinary.handle, 0u);
+}
+
+TEST_F(KfdIoctlTest, FallbackScratchReservationsRejectLocalAndDaemonAllocations) {
+  constexpr uint64_t kPageSize = rocjitsu::KfdProcess::kPageSize;
+  constexpr uint64_t kScratchPool = fallback_scratch_base(0);
+  constexpr uint32_t kFlags = KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+
+  kfd_ioctl_alloc_memory_of_gpu_args local_alloc{};
+  local_alloc.va_addr = kScratchPool;
+  local_alloc.size = kPageSize;
+  local_alloc.gpu_id = kGpuId;
+  local_alloc.flags = kFlags;
+  EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &local_alloc), -EINVAL);
+  EXPECT_EQ(local_alloc.handle, 0u);
+
+  rocjitsu::SimulatedKfd daemon_driver(*soc_, /*daemon_mode=*/true);
+  const uint32_t process_id = daemon_driver.open_process(getpid());
+  ASSERT_NE(process_id, 0u);
+
+  kfd_ioctl_alloc_memory_of_gpu_args daemon_alloc{};
+  daemon_alloc.va_addr = kScratchPool;
+  daemon_alloc.size = kPageSize;
+  daemon_alloc.gpu_id = kGpuId;
+  daemon_alloc.flags = kFlags;
+  EXPECT_EQ(daemon_driver.ioctl(process_id, AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &daemon_alloc),
+            -EINVAL);
+  EXPECT_EQ(daemon_alloc.handle, 0u);
+
+  util::UniqueHandle daemon_fd = make_sized_memfd("kfd_daemon_dmabuf_fallback", kPageSize);
+  ASSERT_TRUE(daemon_fd);
+  kfd_ioctl_import_dmabuf_args daemon_import{};
+  daemon_import.dmabuf_fd = daemon_fd.get();
+  daemon_import.gpu_id = kGpuId;
+  daemon_import.va_addr = kScratchPool;
+  EXPECT_EQ(daemon_driver.ioctl(process_id, AMDKFD_IOC_IMPORT_DMABUF, &daemon_import), -EINVAL);
+  EXPECT_EQ(daemon_import.handle, 0u);
+
+  EXPECT_EQ(daemon_driver.close(process_id), 0);
+}
+
+TEST_F(KfdIoctlTest, DriverSelectedAllocationSkipsFallbackScratchReservationAtCursor) {
+  constexpr uint64_t kPageSize = rocjitsu::KfdProcess::kPageSize;
+  constexpr uint64_t kScratchPool = fallback_scratch_base(0);
+  constexpr uint32_t kFlags = KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+
+  std::shared_ptr<rocjitsu::KfdProcess> process =
+      driver_->find_process(driver_->local_process_id());
+  ASSERT_NE(process, nullptr);
+  {
+    std::lock_guard<std::mutex> lk(process->alloc_mutex_);
+    process->next_gpu_va_ = kScratchPool - kPageSize;
+  }
+
+  kfd_ioctl_alloc_memory_of_gpu_args before_reserve{};
+  before_reserve.size = kPageSize;
+  before_reserve.gpu_id = kGpuId;
+  before_reserve.flags = kFlags;
+  ASSERT_EQ(driver_->ioctl(AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &before_reserve), 0);
+  ScopedGpuAllocation first_allocation(driver_, before_reserve.handle);
+  EXPECT_EQ(before_reserve.va_addr, kScratchPool - kPageSize);
+
+  kfd_ioctl_alloc_memory_of_gpu_args selected{};
+  selected.size = kPageSize;
+  selected.gpu_id = kGpuId;
+  selected.flags = kFlags;
+  EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &selected), -ENOMEM);
+  EXPECT_EQ(selected.handle, 0u);
+}
+
+TEST_F(KfdIoctlTest, DmabufImportRejectsFallbackScratchReservationButAllowsZeroVa) {
+  constexpr uint64_t kPageSize = rocjitsu::KfdProcess::kPageSize;
+  constexpr uint64_t kScratchPool = fallback_scratch_base(0);
+
+  util::UniqueHandle explicit_fd = make_sized_memfd("kfd_dmabuf_fallback_explicit", kPageSize);
+  ASSERT_TRUE(explicit_fd);
+  kfd_ioctl_import_dmabuf_args explicit_import{};
+  explicit_import.dmabuf_fd = explicit_fd.get();
+  explicit_import.gpu_id = kGpuId;
+  explicit_import.va_addr = kScratchPool;
+  EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_IMPORT_DMABUF, &explicit_import), -EINVAL);
+  EXPECT_EQ(explicit_import.handle, 0u);
+
+  util::UniqueHandle zero_fd = make_sized_memfd("kfd_dmabuf_fallback_zero", kPageSize);
+  ASSERT_TRUE(zero_fd);
+  kfd_ioctl_import_dmabuf_args zero_import{};
+  zero_import.dmabuf_fd = zero_fd.get();
+  zero_import.gpu_id = kGpuId;
+  zero_import.va_addr = 0;
+  ASSERT_EQ(driver_->ioctl(AMDKFD_IOC_IMPORT_DMABUF, &zero_import), 0);
+  ScopedGpuAllocation imported(driver_, zero_import.handle);
+  EXPECT_NE(zero_import.handle, 0u);
+  EXPECT_EQ(zero_import.va_addr, 0u);
 }
 
 TEST_F(KfdIoctlTest, AllocMemoryRejectsInvalidUserVaRanges) {
@@ -792,6 +1401,441 @@ TEST_F(KfdIoctlTest, AllocMemoryRejectsInvalidUserVaRanges) {
   expect_invalid(kGpuVa, 0, kFlags);
   expect_invalid(kGpuVa + 1, kSize,
                  KFD_IOC_ALLOC_MEM_FLAGS_USERPTR | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE);
+}
+
+TEST_F(KfdIoctlTest, AllocMemoryHonorsAdvertisedGpuVmAperture) {
+  constexpr uint64_t kPageSize = rocjitsu::KfdProcess::kPageSize;
+  constexpr uint32_t kFlags = KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+  constexpr uint64_t kLastOrdinaryPage = fallback_scratch_base(0) - kPageSize;
+
+  auto expect_alloc = [&](uint64_t va, uint64_t size, int expected) {
+    kfd_ioctl_alloc_memory_of_gpu_args alloc{};
+    alloc.va_addr = va;
+    alloc.size = size;
+    alloc.gpu_id = kGpuId;
+    alloc.flags = kFlags;
+    EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &alloc), expected);
+    if (expected == 0) {
+      ScopedGpuAllocation allocation(driver_, alloc.handle);
+      EXPECT_NE(alloc.handle, 0u);
+    } else {
+      EXPECT_EQ(alloc.handle, 0u);
+    }
+  };
+
+  expect_alloc(rocjitsu::KfdProcess::kGpuVmBase - kPageSize, kPageSize, -EINVAL);
+  expect_alloc(kLastOrdinaryPage, kPageSize, 0);
+  expect_alloc(kLastOrdinaryPage, kPageSize * 2, -EINVAL);
+}
+
+TEST_F(KfdIoctlTest, ImportDmabufHonorsAdvertisedGpuVmAperture) {
+  constexpr uint64_t kPageSize = rocjitsu::KfdProcess::kPageSize;
+  constexpr uint64_t kLastPage = rocjitsu::KfdProcess::kGpuVmLimit + 1 - kPageSize;
+
+  util::UniqueHandle one_page = make_sized_memfd("kfd_dmabuf_aperture_one", kPageSize);
+  ASSERT_TRUE(one_page);
+  kfd_ioctl_import_dmabuf_args below_base{};
+  below_base.dmabuf_fd = one_page.get();
+  below_base.gpu_id = kGpuId;
+  below_base.va_addr = rocjitsu::KfdProcess::kGpuVmBase - kPageSize;
+  EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_IMPORT_DMABUF, &below_base), -EINVAL);
+  EXPECT_EQ(below_base.handle, 0u);
+
+  util::UniqueHandle two_pages = make_sized_memfd("kfd_dmabuf_aperture_two", kPageSize * 2);
+  ASSERT_TRUE(two_pages);
+  kfd_ioctl_import_dmabuf_args crosses_limit{};
+  crosses_limit.dmabuf_fd = two_pages.get();
+  crosses_limit.gpu_id = kGpuId;
+  crosses_limit.va_addr = kLastPage;
+  EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_IMPORT_DMABUF, &crosses_limit), -EINVAL);
+  EXPECT_EQ(crosses_limit.handle, 0u);
+}
+
+TEST_F(KfdIoctlTest, IpcImportHonorsAdvertisedGpuVmAperture) {
+  constexpr uint64_t kPageSize = rocjitsu::KfdProcess::kPageSize;
+  constexpr uint64_t kLastPage = rocjitsu::KfdProcess::kGpuVmLimit + 1 - kPageSize;
+  constexpr uint32_t kFlags = KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+
+  kfd_ioctl_alloc_memory_of_gpu_args source{};
+  source.size = kPageSize * 2;
+  source.gpu_id = kGpuId;
+  source.flags = kFlags;
+  ASSERT_EQ(driver_->ioctl(AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &source), 0);
+  ScopedGpuAllocation source_allocation(driver_, source.handle);
+  ASSERT_NE(source.handle, 0u);
+
+  kfd_ioctl_ipc_export_handle_args export_args{};
+  export_args.handle = source.handle;
+  export_args.gpu_id = kGpuId;
+  ASSERT_EQ(driver_->ioctl(AMDKFD_IOC_IPC_EXPORT_HANDLE, &export_args), 0);
+
+  kfd_ioctl_ipc_import_handle_args below_base{};
+  std::memcpy(below_base.share_handle, export_args.share_handle, sizeof(below_base.share_handle));
+  below_base.gpu_id = kGpuId;
+  below_base.va_addr = rocjitsu::KfdProcess::kGpuVmBase - kPageSize;
+  EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_IPC_IMPORT_HANDLE, &below_base), -EINVAL);
+  EXPECT_EQ(below_base.handle, 0u);
+
+  kfd_ioctl_ipc_import_handle_args crosses_limit{};
+  std::memcpy(crosses_limit.share_handle, export_args.share_handle,
+              sizeof(crosses_limit.share_handle));
+  crosses_limit.gpu_id = kGpuId;
+  crosses_limit.va_addr = kLastPage;
+  EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_IPC_IMPORT_HANDLE, &crosses_limit), -EINVAL);
+  EXPECT_EQ(crosses_limit.handle, 0u);
+
+  kfd_ioctl_ipc_import_handle_args fallback_reserve{};
+  std::memcpy(fallback_reserve.share_handle, export_args.share_handle,
+              sizeof(fallback_reserve.share_handle));
+  fallback_reserve.gpu_id = kGpuId;
+  fallback_reserve.va_addr = fallback_scratch_base(0);
+  EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_IPC_IMPORT_HANDLE, &fallback_reserve), -EINVAL);
+  EXPECT_EQ(fallback_reserve.handle, 0u);
+}
+
+TEST_F(KfdIoctlTest, DriverSelectedAllocationStopsBeforeFallbackScratchReserve) {
+  constexpr uint64_t kPageSize = rocjitsu::KfdProcess::kPageSize;
+  constexpr uint32_t kFlags = KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+  constexpr uint64_t kLastOrdinaryPage = fallback_scratch_base(0) - kPageSize;
+
+  std::shared_ptr<rocjitsu::KfdProcess> process =
+      driver_->find_process(driver_->local_process_id());
+  ASSERT_NE(process, nullptr);
+  {
+    std::lock_guard<std::mutex> lk(process->alloc_mutex_);
+    process->next_gpu_va_ = kLastOrdinaryPage;
+  }
+
+  kfd_ioctl_alloc_memory_of_gpu_args first{};
+  first.size = kPageSize;
+  first.gpu_id = kGpuId;
+  first.flags = kFlags;
+  ASSERT_EQ(driver_->ioctl(AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &first), 0);
+  ScopedGpuAllocation first_allocation(driver_, first.handle);
+  EXPECT_EQ(first.va_addr, kLastOrdinaryPage);
+
+  kfd_ioctl_alloc_memory_of_gpu_args second{};
+  second.size = kPageSize;
+  second.gpu_id = kGpuId;
+  second.flags = kFlags;
+  EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &second), -ENOMEM);
+  EXPECT_EQ(second.handle, 0u);
+}
+
+TEST_F(KfdIoctlTest, AllocMemoryRejectsOverlappingGpuVaRanges) {
+  constexpr uint64_t kGpuVa = rocjitsu::KfdProcess::kGpuVmBase + 0x3260000;
+  constexpr uint64_t kPageSize = rocjitsu::KfdProcess::kPageSize;
+  constexpr uint64_t kSize = kPageSize * 2;
+  constexpr uint32_t kFlags = KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+
+  kfd_ioctl_alloc_memory_of_gpu_args first{};
+  first.va_addr = kGpuVa;
+  first.size = kSize;
+  first.gpu_id = kGpuId;
+  first.flags = kFlags;
+  ASSERT_EQ(driver_->ioctl(AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &first), 0);
+  ScopedGpuAllocation first_allocation(driver_, first.handle);
+  ASSERT_NE(first.handle, 0u);
+
+  auto expect_overlap = [&](uint64_t va, uint64_t size) {
+    kfd_ioctl_alloc_memory_of_gpu_args alloc{};
+    alloc.va_addr = va;
+    alloc.size = size;
+    alloc.gpu_id = kGpuId;
+    alloc.flags = kFlags;
+    EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &alloc), -EINVAL);
+    EXPECT_EQ(alloc.handle, 0u);
+  };
+
+  expect_overlap(kGpuVa, kPageSize);
+  expect_overlap(kGpuVa + kPageSize, kPageSize);
+
+  kfd_ioctl_alloc_memory_of_gpu_args adjacent{};
+  adjacent.va_addr = kGpuVa + kSize;
+  adjacent.size = kPageSize;
+  adjacent.gpu_id = kGpuId;
+  adjacent.flags = kFlags;
+  ASSERT_EQ(driver_->ioctl(AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &adjacent), 0);
+  ScopedGpuAllocation adjacent_allocation(driver_, adjacent.handle);
+  ASSERT_NE(adjacent.handle, 0u);
+}
+
+TEST_F(KfdIoctlTest, DriverSelectedAllocationSkipsExplicitRangeAtCursor) {
+  constexpr uint64_t kPageSize = rocjitsu::KfdProcess::kPageSize;
+  constexpr uint32_t kFlags = KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+
+  std::shared_ptr<rocjitsu::KfdProcess> process =
+      driver_->find_process(driver_->local_process_id());
+  ASSERT_NE(process, nullptr);
+
+  uint64_t cursor = 0;
+  {
+    std::lock_guard<std::mutex> lk(process->alloc_mutex_);
+    cursor = process->next_gpu_va_;
+  }
+
+  kfd_ioctl_alloc_memory_of_gpu_args explicit_alloc{};
+  explicit_alloc.va_addr = cursor;
+  explicit_alloc.size = kPageSize;
+  explicit_alloc.gpu_id = kGpuId;
+  explicit_alloc.flags = kFlags;
+  ASSERT_EQ(driver_->ioctl(AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &explicit_alloc), 0);
+  ScopedGpuAllocation explicit_allocation(driver_, explicit_alloc.handle);
+  ASSERT_NE(explicit_alloc.handle, 0u);
+
+  kfd_ioctl_alloc_memory_of_gpu_args selected{};
+  selected.size = kPageSize;
+  selected.gpu_id = kGpuId;
+  selected.flags = kFlags;
+  ASSERT_EQ(driver_->ioctl(AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &selected), 0);
+  ScopedGpuAllocation selected_allocation(driver_, selected.handle);
+  ASSERT_NE(selected.handle, 0u);
+  EXPECT_EQ(selected.va_addr, cursor + kPageSize);
+}
+
+TEST_F(KfdIoctlTest, SetScratchBackingVaValidatesGpuAndGpuVmBacking) {
+  std::array<kfd_process_device_apertures, 1> apertures{};
+  kfd_ioctl_get_process_apertures_new_args aperture_args{};
+  aperture_args.kfd_process_device_apertures_ptr = reinterpret_cast<uint64_t>(apertures.data());
+  aperture_args.num_of_nodes = apertures.size();
+  ASSERT_EQ(driver_->ioctl(AMDKFD_IOC_GET_PROCESS_APERTURES_NEW, &aperture_args), 0);
+  ASSERT_EQ(aperture_args.num_of_nodes, 1u);
+
+  kfd_ioctl_set_scratch_backing_va_args valid{};
+  valid.gpu_id = kGpuId;
+  valid.va_addr = rocjitsu::KfdProcess::kGpuVmAllocationBase >> 16;
+  EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_SET_SCRATCH_BACKING_VA, &valid), 0);
+
+  kfd_ioctl_set_scratch_backing_va_args unknown = valid;
+  unknown.gpu_id = 0xDEADu;
+  EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_SET_SCRATCH_BACKING_VA, &unknown), -EINVAL);
+
+  kfd_ioctl_set_scratch_backing_va_args logical_scratch = valid;
+  logical_scratch.va_addr = apertures[0].scratch_base >> 16;
+  EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_SET_SCRATCH_BACKING_VA, &logical_scratch), -EINVAL);
+
+  kfd_ioctl_set_scratch_backing_va_args fallback_reserve = valid;
+  fallback_reserve.va_addr = fallback_scratch_base(0) >> 16;
+  EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_SET_SCRATCH_BACKING_VA, &fallback_reserve), -EINVAL);
+
+  kfd_ioctl_set_scratch_backing_va_args overflow = valid;
+  overflow.va_addr = std::numeric_limits<uint64_t>::max();
+  EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_SET_SCRATCH_BACKING_VA, &overflow), -EINVAL);
+
+  kfd_ioctl_set_scratch_backing_va_args clear{};
+  clear.gpu_id = kGpuId;
+  clear.va_addr = 0;
+  EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_SET_SCRATCH_BACKING_VA, &clear), 0);
+}
+
+TEST_F(KfdIoctlTest, ScratchBackingRejectsPoolCrossingFallbackReserve) {
+  constexpr uint32_t kPrivateSegmentSize = 2048;
+  constexpr uint64_t scratch_pool = fallback_scratch_base(0) - 0x10000u;
+  ASSERT_EQ(scratch_pool & 0xFFFFu, 0u);
+  kfd_ioctl_set_scratch_backing_va_args scratch{};
+  scratch.gpu_id = kGpuId;
+  scratch.va_addr = scratch_pool >> 16;
+  ASSERT_EQ(driver_->ioctl(AMDKFD_IOC_SET_SCRATCH_BACKING_VA, &scratch), 0);
+
+  std::shared_ptr<rocjitsu::KfdProcess> process =
+      driver_->find_process(driver_->local_process_id());
+  ASSERT_NE(process, nullptr);
+
+  rocjitsu::amdgpu::CommandProcessor *cp = soc_->xcd(0)->command_processor();
+  ASSERT_NE(cp, nullptr);
+
+  alignas(64) std::array<uint8_t, rocjitsu::test::AqlQueue::DEFAULT_RING_SIZE> ring{};
+  alignas(rocjitsu::KfdProcess::kPageSize) std::array<uint8_t, rocjitsu::KfdProcess::kPageSize>
+      kernel{};
+  alignas(uint64_t) uint64_t read_ptr = 0;
+  alignas(uint64_t) uint64_t write_ptr = 0;
+  alignas(uint64_t) uint64_t doorbell = 0;
+
+  using namespace rocr::llvm::amdhsa;
+  kernel_descriptor_t descriptor{};
+  descriptor.kernel_code_entry_byte_offset = sizeof(descriptor);
+  std::memcpy(kernel.data(), &descriptor, sizeof(descriptor));
+  std::memcpy(kernel.data() + sizeof(descriptor), &kSoppSEndpgm, sizeof(kSoppSEndpgm));
+
+  rocjitsu::test::AqlQueue queue(
+      soc_->memory(), cp, reinterpret_cast<uint64_t>(ring.data()), ring.size(),
+      reinterpret_cast<uint64_t>(&read_ptr), reinterpret_cast<uint64_t>(&write_ptr),
+      reinterpret_cast<uint64_t>(&doorbell), driver_->local_process_id());
+
+  hsa_kernel_dispatch_packet_t pkt{};
+  pkt.header = HSA_PACKET_TYPE_KERNEL_DISPATCH;
+  pkt.setup = 1;
+  pkt.workgroup_size_x = 64;
+  pkt.workgroup_size_y = 1;
+  pkt.workgroup_size_z = 1;
+  pkt.grid_size_x = 64;
+  pkt.grid_size_y = 1;
+  pkt.grid_size_z = 1;
+  pkt.private_segment_size = kPrivateSegmentSize;
+  pkt.kernel_object = reinterpret_cast<uint64_t>(kernel.data());
+  queue.submit(pkt);
+
+  auto step = [&]() {
+    (void)step_process_until_idle(*engine_, *soc_, driver_->local_process_id());
+  };
+  EXPECT_THROW(step(), std::runtime_error);
+  EXPECT_FALSE(soc_->memory()->is_mapped(scratch_pool, driver_->local_process_id()));
+  EXPECT_EQ(scratch_pool_at(*process, 0, scratch_pool).count, 0u);
+
+  kfd_ioctl_set_scratch_backing_va_args clear{};
+  clear.gpu_id = kGpuId;
+  clear.va_addr = 0;
+  EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_SET_SCRATCH_BACKING_VA, &clear), 0);
+}
+
+TEST(KfdIoctlStandaloneTest, ScratchBackingResolverUsesOwningGpuBase) {
+  constexpr uint32_t kPrivateSegmentSize = 64;
+
+  rj_vm_t *vm = nullptr;
+  ASSERT_EQ(rj_vm_create(MULTIGPU_CONFIG_PATH.c_str(), RJ_VM_MODE_LOCAL, &vm),
+            ROCJITSU_STATUS_SUCCESS);
+  ASSERT_NE(vm, nullptr);
+  std::unique_ptr<rj_vm_t, decltype(&rj_vm_destroy)> vm_guard(vm, rj_vm_destroy);
+
+  rocjitsu::SimulatedKfd *driver = vm->vm->driver();
+  ASSERT_NE(driver, nullptr);
+  const uint32_t process_id = driver->local_process_id();
+  ASSERT_NE(process_id, 0u);
+
+  std::array<kfd_process_device_apertures, 2> apertures{};
+  kfd_ioctl_get_process_apertures_new_args aperture_args{};
+  aperture_args.kfd_process_device_apertures_ptr = reinterpret_cast<uint64_t>(apertures.data());
+  aperture_args.num_of_nodes = apertures.size();
+  ASSERT_EQ(driver->ioctl(AMDKFD_IOC_GET_PROCESS_APERTURES_NEW, &aperture_args), 0);
+  ASSERT_EQ(aperture_args.num_of_nodes, 2u);
+  ASSERT_NE(apertures[0].scratch_base, apertures[1].scratch_base);
+  ASSERT_GT(apertures[0].scratch_base, rocjitsu::KfdProcess::kGpuVmLimit);
+  ASSERT_GT(apertures[1].scratch_base, rocjitsu::KfdProcess::kGpuVmLimit);
+
+  constexpr std::array<uint64_t, 2> backing_bases = {
+      rocjitsu::KfdProcess::kGpuVmAllocationBase + 0x7100000ULL,
+      rocjitsu::KfdProcess::kGpuVmAllocationBase + 0x7200000ULL,
+  };
+  for (size_t idx = 0; idx < apertures.size(); ++idx) {
+    kfd_ioctl_set_scratch_backing_va_args scratch{};
+    scratch.gpu_id = apertures[idx].gpu_id;
+    scratch.va_addr = backing_bases[idx] >> 16;
+    ASSERT_EQ(driver->ioctl(AMDKFD_IOC_SET_SCRATCH_BACKING_VA, &scratch), 0);
+  }
+
+  rocjitsu::SoC *gpu1 = vm->vm->soc(1);
+  ASSERT_NE(gpu1, nullptr);
+  rocjitsu::amdgpu::CommandProcessor *cp = gpu1->xcd(0)->command_processor();
+  ASSERT_NE(cp, nullptr);
+  std::shared_ptr<rocjitsu::KfdProcess> process = driver->find_process(process_id);
+  ASSERT_NE(process, nullptr);
+
+  alignas(64) std::array<uint8_t, rocjitsu::test::AqlQueue::DEFAULT_RING_SIZE> ring{};
+  alignas(rocjitsu::KfdProcess::kPageSize) std::array<uint8_t, rocjitsu::KfdProcess::kPageSize>
+      kernel{};
+  alignas(uint64_t) uint64_t read_ptr = 0;
+  alignas(uint64_t) uint64_t write_ptr = 0;
+  alignas(uint64_t) uint64_t doorbell = 0;
+
+  using namespace rocr::llvm::amdhsa;
+  kernel_descriptor_t descriptor{};
+  descriptor.kernel_code_entry_byte_offset = sizeof(descriptor);
+  std::memcpy(kernel.data(), &descriptor, sizeof(descriptor));
+  std::memcpy(kernel.data() + sizeof(descriptor), &kSoppSEndpgm, sizeof(kSoppSEndpgm));
+
+  rocjitsu::test::AqlQueue queue(gpu1->memory(), cp, reinterpret_cast<uint64_t>(ring.data()),
+                                 ring.size(), reinterpret_cast<uint64_t>(&read_ptr),
+                                 reinterpret_cast<uint64_t>(&write_ptr),
+                                 reinterpret_cast<uint64_t>(&doorbell), process_id);
+
+  hsa_kernel_dispatch_packet_t pkt{};
+  pkt.header = HSA_PACKET_TYPE_KERNEL_DISPATCH;
+  pkt.setup = 1;
+  pkt.workgroup_size_x = 64;
+  pkt.workgroup_size_y = 1;
+  pkt.workgroup_size_z = 1;
+  pkt.grid_size_x = 64;
+  pkt.grid_size_y = 1;
+  pkt.grid_size_z = 1;
+  pkt.private_segment_size = kPrivateSegmentSize;
+  pkt.kernel_object = reinterpret_cast<uint64_t>(kernel.data());
+  queue.submit(pkt);
+  ASSERT_TRUE(step_process_until_idle(*vm->engine, *gpu1, process_id));
+  EXPECT_EQ(read_ptr, 1u);
+  EXPECT_EQ(write_ptr, 1u);
+
+  ScratchPoolSnapshot gpu0_pool = scratch_pool_at(*process, 0, backing_bases[0]);
+  ScratchPoolSnapshot gpu1_pool = scratch_pool_at(*process, 1, backing_bases[1]);
+  EXPECT_EQ(gpu0_pool.count, 0u);
+  ASSERT_EQ(gpu1_pool.count, 1u);
+  EXPECT_EQ(gpu1_pool.size, rocjitsu::KfdProcess::kPageSize);
+  EXPECT_NE(gpu1_pool.backing, nullptr);
+}
+
+TEST(KfdIoctlStandaloneTest, FallbackScratchRejectsGrowthPastOwningGpuWindow) {
+  constexpr uint32_t kPrivateSegmentSize = 65536;
+
+  rj_vm_t *vm = nullptr;
+  ASSERT_EQ(rj_vm_create(MULTIGPU_CONFIG_PATH.c_str(), RJ_VM_MODE_LOCAL, &vm),
+            ROCJITSU_STATUS_SUCCESS);
+  ASSERT_NE(vm, nullptr);
+  std::unique_ptr<rj_vm_t, decltype(&rj_vm_destroy)> vm_guard(vm, rj_vm_destroy);
+
+  rocjitsu::SimulatedKfd *driver = vm->vm->driver();
+  ASSERT_NE(driver, nullptr);
+  const uint32_t process_id = driver->local_process_id();
+  ASSERT_NE(process_id, 0u);
+
+  std::array<kfd_process_device_apertures, 2> apertures{};
+  kfd_ioctl_get_process_apertures_new_args aperture_args{};
+  aperture_args.kfd_process_device_apertures_ptr = reinterpret_cast<uint64_t>(apertures.data());
+  aperture_args.num_of_nodes = apertures.size();
+  ASSERT_EQ(driver->ioctl(AMDKFD_IOC_GET_PROCESS_APERTURES_NEW, &aperture_args), 0);
+  ASSERT_EQ(aperture_args.num_of_nodes, 2u);
+  EXPECT_EQ(fallback_scratch_limit(1) + 1, fallback_scratch_base(0));
+
+  rocjitsu::SoC *gpu1 = vm->vm->soc(1);
+  ASSERT_NE(gpu1, nullptr);
+  rocjitsu::amdgpu::CommandProcessor *cp = gpu1->xcd(0)->command_processor();
+  ASSERT_NE(cp, nullptr);
+  std::shared_ptr<rocjitsu::KfdProcess> process = driver->find_process(process_id);
+  ASSERT_NE(process, nullptr);
+
+  alignas(64) std::array<uint8_t, rocjitsu::test::AqlQueue::DEFAULT_RING_SIZE> ring{};
+  alignas(rocjitsu::KfdProcess::kPageSize) std::array<uint8_t, rocjitsu::KfdProcess::kPageSize>
+      kernel{};
+  alignas(uint64_t) uint64_t read_ptr = 0;
+  alignas(uint64_t) uint64_t write_ptr = 0;
+  alignas(uint64_t) uint64_t doorbell = 0;
+
+  using namespace rocr::llvm::amdhsa;
+  kernel_descriptor_t descriptor{};
+  descriptor.kernel_code_entry_byte_offset = sizeof(descriptor);
+  std::memcpy(kernel.data(), &descriptor, sizeof(descriptor));
+  std::memcpy(kernel.data() + sizeof(descriptor), &kSoppSEndpgm, sizeof(kSoppSEndpgm));
+
+  rocjitsu::test::AqlQueue queue(gpu1->memory(), cp, reinterpret_cast<uint64_t>(ring.data()),
+                                 ring.size(), reinterpret_cast<uint64_t>(&read_ptr),
+                                 reinterpret_cast<uint64_t>(&write_ptr),
+                                 reinterpret_cast<uint64_t>(&doorbell), process_id);
+
+  hsa_kernel_dispatch_packet_t pkt{};
+  pkt.header = HSA_PACKET_TYPE_KERNEL_DISPATCH;
+  pkt.setup = 1;
+  pkt.workgroup_size_x = 64;
+  pkt.workgroup_size_y = 1;
+  pkt.workgroup_size_z = 1;
+  pkt.grid_size_x = 64 * 1025;
+  pkt.grid_size_y = 1;
+  pkt.grid_size_z = 1;
+  pkt.private_segment_size = kPrivateSegmentSize;
+  pkt.kernel_object = reinterpret_cast<uint64_t>(kernel.data());
+  queue.submit(pkt);
+
+  auto step = [&]() { (void)step_process_until_idle(*vm->engine, *gpu1, process_id); };
+  EXPECT_THROW(step(), std::runtime_error);
+  EXPECT_EQ(scratch_pool_at(*process, 1, fallback_scratch_base(1)).count, 0u);
+  EXPECT_FALSE(gpu1->memory()->is_mapped(fallback_scratch_base(1), process_id));
 }
 
 TEST_F(KfdIoctlTest, SvmSetAndGetAttributes) {
@@ -1783,16 +2827,14 @@ TEST(RemoteDriverEmbeddedArrayTest, WaitEventsSerializesEventsAcrossBufferGrowth
   EXPECT_EQ(driver.ioctl(AMDKFD_IOC_WAIT_EVENTS, &args), -EINVAL);
 }
 
-// --- Daemon-mode DBG_TRAP notifier-fd transfer via SCM_RIGHTS ---
+// --- Daemon-mode ioctl fd transfer via rj_vm_execute_as() ---
 //
-// In daemon mode the debugger's dbg_fd is a number in the *client's* fd table
-// and is meaningless to the daemon. The client hands the real fd over
-// out-of-band as SCM_RIGHTS ancillary data; the daemon receives it in its own
-// fd space and the rj_vm_execute_as() glue substitutes it into DBG_TRAP
-// ENABLE's dbg_fd so the debug session can later signal it, releasing it on
-// DISABLE. These tests exercise the real rj_vm_execute_as() dispatch path
-// (where the substitution and adoption live), not the raw driver ioctl.
-class DbgTrapDaemonTest : public ::testing::Test {
+// In daemon mode request fds are numbers in the *client's* fd table and are
+// meaningless to the daemon. The client hands real fds over out-of-band as
+// SCM_RIGHTS ancillary data; the daemon receives them in its own fd space and
+// rj_vm_execute_as() substitutes/adopts them for the ioctl being replayed. These
+// tests exercise that real dispatch path, not the raw driver ioctl.
+class DaemonIoctlTest : public ::testing::Test {
 protected:
   void SetUp() override {
     ASSERT_EQ(rj_vm_create(CONFIG_PATH.c_str(), RJ_VM_MODE_DAEMON, &vm_), ROCJITSU_STATUS_SUCCESS);
@@ -1869,6 +2911,10 @@ protected:
   uint32_t process_id_ = 0;
   std::string mem_mismatch_path_;
 };
+
+// DBG_TRAP-specific daemon fd-transfer behavior layered on the common daemon
+// ioctl harness.
+class DbgTrapDaemonTest : public DaemonIoctlTest {};
 
 // The transferred mem fd becomes authoritative for guest reads and CWSR writes,
 // so O_RDWR is not enough to accept it -- it also has to name the memory of the
@@ -2021,6 +3067,73 @@ TEST_F(DbgTrapDaemonTest, EnableWithClientChosenFdNumberIsNotTrustedInDaemonName
   // The daemon's own descriptor was left untouched: not adopted, not closed.
   EXPECT_NE(fcntl(daemon_fd, F_GETFD), -1);
   ::close(daemon_fd);
+}
+
+TEST_F(DaemonIoctlTest, ImportDmabufBorrowsTransferredFdAndRestoresClientFd) {
+  constexpr size_t kSize = rocjitsu::KfdProcess::kPageSize;
+  constexpr uint64_t kGpuVa = rocjitsu::KfdProcess::kGpuVmBase + 0x6400000;
+  util::UniqueHandle dmabuf = make_sized_memfd("daemon_import_dmabuf", kSize);
+  ASSERT_TRUE(dmabuf);
+
+  kfd_ioctl_import_dmabuf_args import{};
+  import.dmabuf_fd = 0x0BADF00D; // client-side number; daemon must replace it
+  import.gpu_id = kGpuId;
+  import.va_addr = kGpuVa;
+
+  int in_handle_out = -2;
+  ASSERT_EQ(
+      execute(AMDKFD_IOC_IMPORT_DMABUF, &import, sizeof(import), dmabuf.get(), &in_handle_out), 0);
+  EXPECT_EQ(import.dmabuf_fd, 0x0BADF00Du);
+  EXPECT_EQ(in_handle_out, dmabuf.get());
+  ASSERT_NE(import.handle, 0u);
+
+  kfd_ioctl_free_memory_of_gpu_args free_args{};
+  free_args.handle = import.handle;
+  EXPECT_EQ(execute(AMDKFD_IOC_FREE_MEMORY_OF_GPU, &free_args, sizeof(free_args), -1, nullptr), 0);
+}
+
+TEST_F(DaemonIoctlTest, ImportDmabufDoesNotTrustClientChosenFdNumber) {
+  constexpr size_t kSize = rocjitsu::KfdProcess::kPageSize;
+  constexpr uint64_t kGpuVa = rocjitsu::KfdProcess::kGpuVmBase + 0x6410000;
+  util::UniqueHandle daemon_fd = make_sized_memfd("daemon_import_confused_fd", kSize);
+  ASSERT_TRUE(daemon_fd);
+
+  kfd_ioctl_import_dmabuf_args import{};
+  import.dmabuf_fd = static_cast<uint32_t>(daemon_fd.get());
+  import.gpu_id = kGpuId;
+  import.va_addr = kGpuVa;
+
+  int in_handle_out = -2;
+  EXPECT_EQ(execute(AMDKFD_IOC_IMPORT_DMABUF, &import, sizeof(import), -1, &in_handle_out), -EBADF);
+  EXPECT_EQ(import.dmabuf_fd, static_cast<uint32_t>(daemon_fd.get()));
+  EXPECT_EQ(import.handle, 0u);
+  EXPECT_EQ(in_handle_out, -1);
+  EXPECT_NE(fcntl(daemon_fd.get(), F_GETFD), -1);
+}
+
+TEST_F(DaemonIoctlTest, GetDmabufInfoBorrowsTransferredFdAndFillsInlineMetadata) {
+  constexpr size_t kSize = rocjitsu::KfdProcess::kPageSize;
+  util::UniqueHandle dmabuf = make_sized_memfd("daemon_get_dmabuf_info", kSize);
+  ASSERT_TRUE(dmabuf);
+
+  std::array<uint8_t, sizeof(kfd_ioctl_get_dmabuf_info_args) + 64> payload{};
+  auto *info = reinterpret_cast<kfd_ioctl_get_dmabuf_info_args *>(payload.data());
+  auto *metadata = payload.data() + sizeof(*info);
+  std::fill(metadata, payload.data() + payload.size(), 0xAB);
+  info->dmabuf_fd = 0x0BADF00D; // client-side number; daemon must replace it
+  info->metadata_ptr = 0xFEEDFACE;
+  info->metadata_size = static_cast<uint32_t>(payload.size() - sizeof(*info));
+
+  int in_handle_out = -2;
+  ASSERT_EQ(execute(AMDKFD_IOC_GET_DMABUF_INFO, info, payload.size(), dmabuf.get(), &in_handle_out),
+            0);
+  EXPECT_EQ(info->dmabuf_fd, 0x0BADF00Du);
+  EXPECT_EQ(info->size, kSize);
+  EXPECT_EQ(info->metadata_ptr, reinterpret_cast<uint64_t>(metadata));
+  EXPECT_EQ(info->metadata_size, 0u);
+  EXPECT_TRUE(std::all_of(metadata, payload.data() + payload.size(),
+                          [](uint8_t byte) { return byte == 0; }));
+  EXPECT_EQ(in_handle_out, dmabuf.get());
 }
 
 // End-to-end: the RemoteDriver client hands the debugger's notifier fd to an
@@ -2505,6 +3618,61 @@ TEST_F(DbgTrapDaemonTest, QueueControlReconstructsRequestedIdsAndReportsInvalidQ
   EXPECT_EQ(disable(), 0);
 }
 
+// Closes an fd however the enclosing scope exits. A daemon stand-in that
+// returns early without closing leaves the client blocked in rpc_recv_msg()
+// waiting for an EOF that never arrives, which hangs the run instead of
+// failing the test. util::UniqueHandle already owns a POSIX fd exactly this
+// way, so there is nothing to hand-roll.
+using CloseOnScopeExit = util::UniqueHandle;
+
+// --- RemoteDriver RPC handshake ---
+
+void serve_handshake_with_version(int server_fd, uint32_t version,
+                                  std::atomic<bool> *saw_handshake) {
+  const CloseOnScopeExit closer{server_fd};
+  rocjitsu::RpcHeader request{};
+  int in_fds[1] = {-1};
+  size_t num_in = 1;
+  ASSERT_GT(rocjitsu::rpc_recv_msg(server_fd, &request, sizeof(request), in_fds, &num_in), 0);
+  if (in_fds[0] >= 0)
+    ::close(in_fds[0]);
+  EXPECT_EQ(request.opcode, rocjitsu::RPC_HANDSHAKE);
+  EXPECT_EQ(request.payload_bytes, 0u);
+  saw_handshake->store(true, std::memory_order_release);
+
+  rocjitsu::RpcHandshakeResponse handshake{};
+  handshake.version = version;
+  rocjitsu::RpcHeader response{};
+  response.opcode = rocjitsu::RPC_HANDSHAKE;
+  response.request_id = request.request_id;
+  response.payload_bytes = sizeof(handshake);
+  ASSERT_TRUE(rocjitsu::rpc_send_exact(server_fd, &response, sizeof(response)));
+  ASSERT_TRUE(rocjitsu::rpc_send_exact(server_fd, &handshake, sizeof(handshake)));
+}
+
+void expect_remote_open_rejects_protocol_version(uint32_t version) {
+  int sv[2];
+  ASSERT_EQ(::socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0) << ::strerror(errno);
+
+  std::atomic<bool> saw_handshake{false};
+  std::jthread server(
+      [&, server_fd = sv[1]] { serve_handshake_with_version(server_fd, version, &saw_handshake); });
+
+  rocjitsu::RemoteDriver rd(sv[0]);
+  EXPECT_EQ(rd.open(), -1);
+  server.join();
+  EXPECT_TRUE(saw_handshake.load(std::memory_order_acquire));
+}
+
+TEST(RemoteDriverHandshakeTest, RejectsOlderProtocolVersionBeforeIoctl) {
+  static_assert(rocjitsu::kRpcProtocolVersion > 0);
+  expect_remote_open_rejects_protocol_version(rocjitsu::kRpcProtocolVersion - 1);
+}
+
+TEST(RemoteDriverHandshakeTest, RejectsNewerProtocolVersionBeforeIoctl) {
+  expect_remote_open_rejects_protocol_version(rocjitsu::kRpcProtocolVersion + 1);
+}
+
 // --- RemoteDriver DBG_TRAP snapshot response copy-back ---
 //
 // The client saves the caller's snapshot buffer pointer and capacity
@@ -2512,13 +3680,6 @@ TEST_F(DbgTrapDaemonTest, QueueControlReconstructsRequestedIdsAndReportsInvalidQ
 // writes it back on success, clamped to that capacity. This guards daemon mode
 // against a failed op (e.g. -ENOSYS) mutating caller memory and against a
 // daemon-returned count larger than the caller's buffer.
-
-// Closes an fd however the enclosing scope exits. A daemon stand-in that
-// returns early without closing leaves the client blocked in rpc_recv_msg()
-// waiting for an EOF that never arrives, which hangs the run instead of
-// failing the test. util::UniqueHandle already owns a POSIX fd exactly this
-// way, so there is nothing to hand-roll.
-using CloseOnScopeExit = util::UniqueHandle;
 
 // Inspect the request header and rewrite the arg struct the reply echoes back,
 // so one stand-in can model a daemon that reports different outputs than the
@@ -2571,6 +3732,625 @@ void serve_one_ioctl_reply(int server_fd, int32_t result, size_t arg_struct_size
   resp.payload_bytes = static_cast<uint32_t>(out.size());
   rocjitsu::rpc_send_exact(server_fd, &resp, sizeof(resp));
   rocjitsu::rpc_send_exact(server_fd, out.data(), out.size());
+}
+
+using DaemonIoctlObserver =
+    std::function<void(const rocjitsu::RpcIoctlRequest &request, const rj_vm_cmd_t &command)>;
+
+void serve_daemon_ioctl_loop(int server_fd, rj_vm_t *vm, uint32_t process_id,
+                             const DaemonIoctlObserver &observer = {}) {
+  const CloseOnScopeExit closer{server_fd};
+  for (;;) {
+    rocjitsu::RpcHeader hdr{};
+    std::array<int, rocjitsu::kRpcMaxFds> in_fds{};
+    in_fds.fill(-1);
+    size_t num_in = in_fds.size();
+    if (rocjitsu::rpc_recv_msg(server_fd, &hdr, sizeof(hdr), in_fds.data(), &num_in) <= 0)
+      break;
+
+    auto close_input_fds = [&] {
+      for (size_t i = 0; i < num_in; ++i) {
+        if (in_fds[i] >= 0) {
+          ::close(in_fds[i]);
+          in_fds[i] = -1;
+        }
+      }
+    };
+
+    if (hdr.opcode == rocjitsu::RPC_CLOSE) {
+      rocjitsu::RpcHeader resp{};
+      resp.opcode = hdr.opcode;
+      resp.request_id = hdr.request_id;
+      rocjitsu::rpc_send_exact(server_fd, &resp, sizeof(resp));
+      close_input_fds();
+      break;
+    }
+    if (hdr.opcode != rocjitsu::RPC_IOCTL ||
+        hdr.payload_bytes < sizeof(rocjitsu::RpcIoctlRequest) ||
+        hdr.payload_bytes > rocjitsu::kMaxPayloadBytes) {
+      close_input_fds();
+      break;
+    }
+
+    std::vector<uint8_t> payload(hdr.payload_bytes);
+    if (!rocjitsu::rpc_recv_exact(server_fd, payload.data(), payload.size())) {
+      close_input_fds();
+      break;
+    }
+    auto *ireq = reinterpret_cast<rocjitsu::RpcIoctlRequest *>(payload.data());
+    if (ireq->args_bytes != payload.size() - sizeof(*ireq)) {
+      close_input_fds();
+      break;
+    }
+
+    rj_vm_cmd_t cmd{};
+    cmd.cmd = ireq->ioctl_cmd;
+    cmd.buf = payload.data() + sizeof(*ireq);
+    cmd.buf_size = ireq->args_bytes;
+    cmd.shared_handle = -1;
+    cmd.in_handle = num_in > 0 ? in_fds[0] : -1;
+    cmd.in_mem_handle = num_in > 1 ? in_fds[1] : -1;
+    cmd.in_proc_handle = num_in > 2 ? in_fds[2] : -1;
+    if (rj_vm_execute_as(vm, process_id, &cmd) != ROCJITSU_STATUS_SUCCESS) {
+      close_input_fds();
+      break;
+    }
+
+    if (cmd.in_handle < 0 && num_in > 0)
+      in_fds[0] = -1;
+    if (cmd.in_mem_handle < 0 && num_in > 1)
+      in_fds[1] = -1;
+    if (observer)
+      observer(*ireq, cmd);
+    if (cmd.buf_size > ireq->args_bytes) {
+      close_input_fds();
+      break;
+    }
+
+    rocjitsu::RpcHeader resp{};
+    resp.opcode = rocjitsu::RPC_IOCTL;
+    resp.request_id = hdr.request_id;
+    resp.result = cmd.result;
+    resp.payload_bytes = static_cast<uint32_t>(cmd.buf_size);
+
+    std::vector<uint8_t> response(sizeof(resp) + cmd.buf_size);
+    std::memcpy(response.data(), &resp, sizeof(resp));
+    if (cmd.buf_size > 0)
+      std::memcpy(response.data() + sizeof(resp), cmd.buf, cmd.buf_size);
+
+    bool sent = false;
+    if (cmd.shared_handle >= 0) {
+      int response_fd = cmd.shared_handle;
+      ssize_t bytes =
+          rocjitsu::rpc_send_msg(server_fd, response.data(), response.size(), &response_fd, 1);
+      sent = bytes > 0 &&
+             (static_cast<size_t>(bytes) == response.size() ||
+              rocjitsu::rpc_send_exact(server_fd, response.data() + static_cast<size_t>(bytes),
+                                       response.size() - static_cast<size_t>(bytes)));
+      if (cmd.cmd == AMDKFD_IOC_EXPORT_DMABUF)
+        ::close(cmd.shared_handle);
+    } else {
+      sent = rocjitsu::rpc_send_exact(server_fd, response.data(), response.size());
+    }
+    close_input_fds();
+    if (!sent)
+      break;
+  }
+}
+
+TEST_F(DaemonIoctlTest, UserptrAllocationSharesMmapOffsetCpuVaOverDaemonRpc) {
+  constexpr size_t kSize = rocjitsu::KfdProcess::kPageSize;
+  constexpr uint64_t kGpuVa = rocjitsu::KfdProcess::kGpuVmBase + 0x6500000;
+  constexpr uint32_t kBefore = 0x51504D41u;
+  constexpr uint32_t kAfterCpu = 0x51504D42u;
+  constexpr uint32_t kAfterGpu = 0x51504D43u;
+
+  void *cpu_addr = mmap(nullptr, kSize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE(cpu_addr, MAP_FAILED) << std::strerror(errno);
+  ScopedMapping cpu_mapping(cpu_addr, kSize);
+  *static_cast<uint32_t *>(cpu_addr) = kBefore;
+
+  int sv[2];
+  ASSERT_EQ(::socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0) << ::strerror(errno);
+  std::jthread server(
+      [&, server_fd = sv[1]] { serve_daemon_ioctl_loop(server_fd, vm_, process_id_); });
+
+  rocjitsu::RemoteDriver driver(sv[0]);
+  kfd_ioctl_alloc_memory_of_gpu_args alloc{};
+  alloc.va_addr = kGpuVa;
+  alloc.mmap_offset = reinterpret_cast<uint64_t>(cpu_addr);
+  alloc.size = kSize;
+  alloc.gpu_id = kGpuId;
+  alloc.flags = KFD_IOC_ALLOC_MEM_FLAGS_USERPTR | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+  ASSERT_EQ(driver.ioctl(AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &alloc), 0);
+  ASSERT_NE(alloc.handle, 0u);
+  EXPECT_EQ(alloc.va_addr, kGpuVa);
+  EXPECT_EQ(alloc.mmap_offset, reinterpret_cast<uint64_t>(cpu_addr));
+  EXPECT_EQ(vm_->vm->memory()->read32(kGpuVa, process_id_), kBefore);
+
+  *static_cast<volatile uint32_t *>(cpu_addr) = kAfterCpu;
+  EXPECT_EQ(vm_->vm->memory()->read32(kGpuVa, process_id_), kAfterCpu);
+
+  vm_->vm->memory()->write32(kGpuVa, kAfterGpu, process_id_);
+  EXPECT_EQ(*static_cast<volatile uint32_t *>(cpu_addr), kAfterGpu);
+
+  kfd_ioctl_free_memory_of_gpu_args free_args{};
+  free_args.handle = alloc.handle;
+  EXPECT_EQ(driver.ioctl(AMDKFD_IOC_FREE_MEMORY_OF_GPU, &free_args), 0);
+
+  driver.close();
+  server.join();
+}
+
+TEST_F(DaemonIoctlTest, GetInfoAndImportDmabufShareBackingOverDaemonRpc) {
+  constexpr size_t kSize = rocjitsu::KfdProcess::kPageSize;
+  constexpr uint64_t kGpuVa = rocjitsu::KfdProcess::kGpuVmBase + 0x6510000;
+  constexpr uint32_t kBefore = 0xD1AB0101u;
+  constexpr uint32_t kAfterGpu = 0xD1AB0102u;
+  util::UniqueHandle dmabuf = make_sized_memfd("remote_daemon_dmabuf", kSize);
+  ASSERT_TRUE(dmabuf);
+  ASSERT_EQ(::pwrite(dmabuf.get(), &kBefore, sizeof(kBefore), 0),
+            static_cast<ssize_t>(sizeof(kBefore)));
+
+  int sv[2];
+  ASSERT_EQ(::socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0) << ::strerror(errno);
+  std::jthread server(
+      [&, server_fd = sv[1]] { serve_daemon_ioctl_loop(server_fd, vm_, process_id_); });
+
+  rocjitsu::RemoteDriver driver(sv[0]);
+
+  std::array<uint8_t, 64> metadata{};
+  metadata.fill(0xAB);
+  kfd_ioctl_get_dmabuf_info_args info{};
+  info.dmabuf_fd = static_cast<uint32_t>(dmabuf.get());
+  info.metadata_ptr = reinterpret_cast<uint64_t>(metadata.data());
+  info.metadata_size = static_cast<uint32_t>(metadata.size());
+  ASSERT_EQ(driver.ioctl(AMDKFD_IOC_GET_DMABUF_INFO, &info), 0);
+  EXPECT_EQ(info.dmabuf_fd, static_cast<uint32_t>(dmabuf.get()));
+  EXPECT_EQ(info.size, kSize);
+  EXPECT_EQ(info.gpu_id, kGpuId);
+  EXPECT_EQ(info.metadata_ptr, reinterpret_cast<uint64_t>(metadata.data()));
+  EXPECT_EQ(info.metadata_size, 0u);
+  EXPECT_TRUE(
+      std::all_of(metadata.begin(), metadata.end(), [](uint8_t byte) { return byte == 0; }));
+
+  kfd_ioctl_import_dmabuf_args import{};
+  import.dmabuf_fd = static_cast<uint32_t>(dmabuf.get());
+  import.gpu_id = kGpuId;
+  import.va_addr = kGpuVa;
+  ASSERT_EQ(driver.ioctl(AMDKFD_IOC_IMPORT_DMABUF, &import), 0);
+  ASSERT_NE(import.handle, 0u);
+  EXPECT_EQ(import.dmabuf_fd, static_cast<uint32_t>(dmabuf.get()));
+  EXPECT_EQ(vm_->vm->memory()->read32(kGpuVa, process_id_), kBefore);
+
+  vm_->vm->memory()->write32(kGpuVa, kAfterGpu, process_id_);
+  uint32_t observed = 0;
+  EXPECT_EQ(::pread(dmabuf.get(), &observed, sizeof(observed), 0),
+            static_cast<ssize_t>(sizeof(observed)));
+  EXPECT_EQ(observed, kAfterGpu);
+
+  kfd_ioctl_free_memory_of_gpu_args free_args{};
+  free_args.handle = import.handle;
+  EXPECT_EQ(driver.ioctl(AMDKFD_IOC_FREE_MEMORY_OF_GPU, &free_args), 0);
+
+  driver.close();
+  server.join();
+}
+
+TEST_F(DaemonIoctlTest, GetInfoAndImportDmabufHandleOnlyZeroVaOverDaemonRpc) {
+  constexpr size_t kSize = rocjitsu::KfdProcess::kPageSize;
+  constexpr uint32_t kBefore = 0xD1AB0000u;
+  util::UniqueHandle dmabuf = make_sized_memfd("remote_daemon_zero_va_dmabuf", kSize);
+  ASSERT_TRUE(dmabuf);
+  ASSERT_EQ(::pwrite(dmabuf.get(), &kBefore, sizeof(kBefore), 0),
+            static_cast<ssize_t>(sizeof(kBefore)));
+
+  int sv[2];
+  ASSERT_EQ(::socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0) << ::strerror(errno);
+  std::jthread server(
+      [&, server_fd = sv[1]] { serve_daemon_ioctl_loop(server_fd, vm_, process_id_); });
+
+  rocjitsu::RemoteDriver driver(sv[0]);
+
+  std::array<uint8_t, 64> metadata{};
+  metadata.fill(0xAB);
+  kfd_ioctl_get_dmabuf_info_args info{};
+  info.dmabuf_fd = static_cast<uint32_t>(dmabuf.get());
+  info.metadata_ptr = reinterpret_cast<uint64_t>(metadata.data());
+  info.metadata_size = static_cast<uint32_t>(metadata.size());
+  ASSERT_EQ(driver.ioctl(AMDKFD_IOC_GET_DMABUF_INFO, &info), 0);
+  EXPECT_EQ(info.dmabuf_fd, static_cast<uint32_t>(dmabuf.get()));
+  EXPECT_EQ(info.size, kSize);
+  EXPECT_EQ(info.gpu_id, kGpuId);
+  EXPECT_EQ(info.metadata_ptr, reinterpret_cast<uint64_t>(metadata.data()));
+  EXPECT_EQ(info.metadata_size, 0u);
+  EXPECT_TRUE(
+      std::all_of(metadata.begin(), metadata.end(), [](uint8_t byte) { return byte == 0; }));
+
+  kfd_ioctl_import_dmabuf_args import{};
+  import.dmabuf_fd = static_cast<uint32_t>(dmabuf.get());
+  import.gpu_id = kGpuId;
+  import.va_addr = 0;
+  ASSERT_EQ(driver.ioctl(AMDKFD_IOC_IMPORT_DMABUF, &import), 0);
+  ASSERT_NE(import.handle, 0u);
+  EXPECT_EQ(import.dmabuf_fd, static_cast<uint32_t>(dmabuf.get()));
+  EXPECT_EQ(import.va_addr, 0u);
+  EXPECT_FALSE(vm_->vm->memory()->is_mapped(0, process_id_));
+
+  std::shared_ptr<rocjitsu::KfdProcess> process = vm_->vm->driver()->find_process(process_id_);
+  ASSERT_NE(process, nullptr);
+  {
+    std::lock_guard<std::mutex> lk(process->alloc_mutex_);
+    std::unordered_map<uint64_t, rocjitsu::KfdProcess::GpuAllocation>::iterator allocation_it =
+        process->allocations_.find(import.handle);
+    ASSERT_NE(allocation_it, process->allocations_.end());
+    rocjitsu::KfdProcess::GpuAllocation &allocation = allocation_it->second;
+    EXPECT_EQ(allocation.gpu_va, 0u);
+    EXPECT_TRUE(allocation.imported);
+    EXPECT_NE(allocation.host_ptr, nullptr);
+    EXPECT_TRUE(allocation.host_ptr_owned);
+  }
+
+  kfd_ioctl_map_memory_to_gpu_args map{};
+  map.handle = import.handle;
+  std::array<uint32_t, 1> device_ids{kGpuId};
+  map.device_ids_array_ptr = reinterpret_cast<uint64_t>(device_ids.data());
+  map.n_devices = 1;
+  EXPECT_EQ(driver.ioctl(AMDKFD_IOC_MAP_MEMORY_TO_GPU, &map), -EINVAL);
+  EXPECT_EQ(map.n_success, 0u);
+
+  kfd_ioctl_free_memory_of_gpu_args free_args{};
+  free_args.handle = import.handle;
+  EXPECT_EQ(driver.ioctl(AMDKFD_IOC_FREE_MEMORY_OF_GPU, &free_args), 0);
+
+  driver.close();
+  server.join();
+}
+
+TEST_F(DaemonIoctlTest, ExportDmabufReturnsSharedBackingOverDaemonRpc) {
+  constexpr size_t kSize = rocjitsu::KfdProcess::kPageSize;
+  constexpr uint32_t kSentinel = 0xE9B0017u;
+
+  int sv[2];
+  ASSERT_EQ(::socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0) << ::strerror(errno);
+  std::jthread server(
+      [&, server_fd = sv[1]] { serve_daemon_ioctl_loop(server_fd, vm_, process_id_); });
+
+  rocjitsu::RemoteDriver driver(sv[0]);
+  kfd_ioctl_alloc_memory_of_gpu_args alloc{};
+  alloc.size = kSize;
+  alloc.gpu_id = kGpuId;
+  alloc.flags = KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+  ASSERT_EQ(driver.ioctl(AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &alloc), 0);
+  ASSERT_NE(alloc.handle, 0u);
+  ASSERT_NE(alloc.va_addr, 0u);
+
+  kfd_ioctl_export_dmabuf_args export_args{};
+  export_args.handle = alloc.handle;
+  ASSERT_EQ(driver.ioctl(AMDKFD_IOC_EXPORT_DMABUF, &export_args), 0);
+  util::UniqueHandle exported_dmabuf(static_cast<int>(export_args.dmabuf_fd));
+  ASSERT_TRUE(exported_dmabuf);
+
+  vm_->vm->memory()->write32(alloc.va_addr, kSentinel, process_id_);
+  uint32_t observed = 0;
+  EXPECT_EQ(::pread(exported_dmabuf.get(), &observed, sizeof(observed), 0),
+            static_cast<ssize_t>(sizeof(observed)));
+  EXPECT_EQ(observed, kSentinel);
+
+  kfd_ioctl_free_memory_of_gpu_args free_args{};
+  free_args.handle = alloc.handle;
+  EXPECT_EQ(driver.ioctl(AMDKFD_IOC_FREE_MEMORY_OF_GPU, &free_args), 0);
+
+  driver.close();
+  server.join();
+}
+
+TEST(RemoteDriverMemoryTest, UserptrPromotionUsesMmapOffsetCpuVa) {
+  constexpr size_t kSize = rocjitsu::KfdProcess::kPageSize;
+  constexpr uint8_t kFirstByte = 0x5Au;
+  constexpr uint8_t kLastByte = 0x6Bu;
+  constexpr uint8_t kUpdatedByte = 0xA5u;
+
+  void *cpu_addr = mmap(nullptr, kSize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE(cpu_addr, MAP_FAILED) << std::strerror(errno);
+  ScopedMapping cpu_mapping(cpu_addr, kSize);
+  auto *cpu_bytes = static_cast<uint8_t *>(cpu_addr);
+  cpu_bytes[0] = kFirstByte;
+  cpu_bytes[kSize - 1] = kLastByte;
+
+  void *gpu_addr =
+      mmap(nullptr, kSize, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0);
+  ASSERT_NE(gpu_addr, MAP_FAILED) << std::strerror(errno);
+  ScopedMapping gpu_mapping(gpu_addr, kSize);
+  ASSERT_NE(cpu_addr, gpu_addr);
+
+  util::UniqueHandle backing_fd = make_sized_memfd("remote_userptr_backing", kSize);
+  ASSERT_TRUE(backing_fd);
+
+  int sv[2];
+  ASSERT_EQ(::socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0) << ::strerror(errno);
+
+  std::jthread server([&, server_fd = sv[1]] {
+    const CloseOnScopeExit closer{server_fd};
+
+    rocjitsu::RpcHeader hdr{};
+    int in_fds[1] = {-1};
+    size_t num_in = 1;
+    ASSERT_GT(rocjitsu::rpc_recv_msg(server_fd, &hdr, sizeof(hdr), in_fds, &num_in), 0);
+    if (num_in > 0 && in_fds[0] >= 0)
+      ::close(in_fds[0]);
+    ASSERT_EQ(hdr.opcode, rocjitsu::RPC_IOCTL);
+
+    std::vector<uint8_t> request(hdr.payload_bytes);
+    ASSERT_TRUE(rocjitsu::rpc_recv_exact(server_fd, request.data(), request.size()));
+    auto *ireq = reinterpret_cast<rocjitsu::RpcIoctlRequest *>(request.data());
+    ASSERT_EQ(ireq->ioctl_cmd, AMDKFD_IOC_ALLOC_MEMORY_OF_GPU);
+    ASSERT_EQ(ireq->args_bytes, sizeof(kfd_ioctl_alloc_memory_of_gpu_args));
+
+    kfd_ioctl_alloc_memory_of_gpu_args echoed{};
+    std::memcpy(&echoed, request.data() + sizeof(rocjitsu::RpcIoctlRequest), sizeof(echoed));
+    EXPECT_EQ(echoed.va_addr, reinterpret_cast<uint64_t>(gpu_addr));
+    EXPECT_EQ(echoed.mmap_offset, reinterpret_cast<uint64_t>(cpu_addr));
+    echoed.handle = 0x1234;
+
+    std::vector<uint8_t> response(sizeof(rocjitsu::RpcHeader) + sizeof(echoed));
+    auto *resp = reinterpret_cast<rocjitsu::RpcHeader *>(response.data());
+    resp->opcode = rocjitsu::RPC_IOCTL;
+    resp->request_id = hdr.request_id;
+    resp->result = 0;
+    resp->payload_bytes = sizeof(echoed);
+    std::memcpy(response.data() + sizeof(rocjitsu::RpcHeader), &echoed, sizeof(echoed));
+
+    int sent_fd = backing_fd.get();
+    ASSERT_GT(rocjitsu::rpc_send_msg(server_fd, response.data(), response.size(), &sent_fd, 1), 0);
+  });
+
+  rocjitsu::RemoteDriver driver(sv[0]);
+  kfd_ioctl_alloc_memory_of_gpu_args alloc{};
+  alloc.va_addr = reinterpret_cast<uint64_t>(gpu_addr);
+  alloc.mmap_offset = reinterpret_cast<uint64_t>(cpu_addr);
+  alloc.size = kSize;
+  alloc.gpu_id = kGpuId;
+  alloc.flags = KFD_IOC_ALLOC_MEM_FLAGS_USERPTR | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+  ASSERT_EQ(driver.ioctl(AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &alloc), 0);
+  EXPECT_EQ(alloc.va_addr, reinterpret_cast<uint64_t>(gpu_addr));
+  EXPECT_EQ(alloc.mmap_offset, reinterpret_cast<uint64_t>(cpu_addr));
+
+  cpu_bytes[0] = kUpdatedByte;
+  uint8_t fd_byte = 0;
+  ASSERT_EQ(::pread(backing_fd.get(), &fd_byte, sizeof(fd_byte), 0), 1);
+  EXPECT_EQ(fd_byte, kUpdatedByte);
+  ASSERT_EQ(::pread(backing_fd.get(), &fd_byte, sizeof(fd_byte), static_cast<off_t>(kSize - 1)), 1);
+  EXPECT_EQ(fd_byte, kLastByte);
+
+  server.join();
+}
+
+TEST(RemoteDriverMemoryTest, SuccessfulAllocWithoutFdRollsBackAndPoisonsConnection) {
+  constexpr size_t kSize = rocjitsu::KfdProcess::kPageSize;
+  constexpr uint64_t kGpuVa = rocjitsu::KfdProcess::kGpuVmBase + 0x6520000;
+  constexpr uint64_t kHandle = 0x3579;
+
+  int sv[2];
+  ASSERT_EQ(::socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0) << ::strerror(errno);
+
+  std::atomic<bool> saw_free{false};
+  std::jthread server([&, server_fd = sv[1]] {
+    const CloseOnScopeExit closer{server_fd};
+
+    rocjitsu::RpcHeader hdr{};
+    int in_fds[1] = {-1};
+    size_t num_in = 1;
+    ASSERT_GT(rocjitsu::rpc_recv_msg(server_fd, &hdr, sizeof(hdr), in_fds, &num_in), 0);
+    if (num_in > 0 && in_fds[0] >= 0)
+      ::close(in_fds[0]);
+    ASSERT_EQ(hdr.opcode, rocjitsu::RPC_IOCTL);
+
+    std::vector<uint8_t> request(hdr.payload_bytes);
+    ASSERT_TRUE(rocjitsu::rpc_recv_exact(server_fd, request.data(), request.size()));
+    auto *ireq = reinterpret_cast<rocjitsu::RpcIoctlRequest *>(request.data());
+    ASSERT_EQ(ireq->ioctl_cmd, AMDKFD_IOC_ALLOC_MEMORY_OF_GPU);
+
+    kfd_ioctl_alloc_memory_of_gpu_args echoed{};
+    std::memcpy(&echoed, request.data() + sizeof(rocjitsu::RpcIoctlRequest), sizeof(echoed));
+    echoed.handle = kHandle;
+    echoed.mmap_offset = kHandle << 12;
+
+    rocjitsu::RpcHeader resp{};
+    resp.opcode = rocjitsu::RPC_IOCTL;
+    resp.request_id = hdr.request_id;
+    resp.result = 0;
+    resp.payload_bytes = sizeof(echoed);
+    ASSERT_TRUE(rocjitsu::rpc_send_exact(server_fd, &resp, sizeof(resp)));
+    ASSERT_TRUE(rocjitsu::rpc_send_exact(server_fd, &echoed, sizeof(echoed)));
+
+    rocjitsu::RpcHeader free_hdr{};
+    num_in = 1;
+    ASSERT_GT(rocjitsu::rpc_recv_msg(server_fd, &free_hdr, sizeof(free_hdr), in_fds, &num_in), 0);
+    if (num_in > 0 && in_fds[0] >= 0)
+      ::close(in_fds[0]);
+    ASSERT_EQ(free_hdr.opcode, rocjitsu::RPC_IOCTL);
+    std::vector<uint8_t> free_request(free_hdr.payload_bytes);
+    ASSERT_TRUE(rocjitsu::rpc_recv_exact(server_fd, free_request.data(), free_request.size()));
+    auto *free_req = reinterpret_cast<rocjitsu::RpcIoctlRequest *>(free_request.data());
+    ASSERT_EQ(free_req->ioctl_cmd, AMDKFD_IOC_FREE_MEMORY_OF_GPU);
+    kfd_ioctl_free_memory_of_gpu_args free_args{};
+    std::memcpy(&free_args, free_request.data() + sizeof(rocjitsu::RpcIoctlRequest),
+                sizeof(free_args));
+    EXPECT_EQ(free_args.handle, kHandle);
+    saw_free.store(true, std::memory_order_release);
+
+    rocjitsu::RpcHeader free_resp{};
+    free_resp.opcode = rocjitsu::RPC_IOCTL;
+    free_resp.request_id = free_hdr.request_id;
+    free_resp.result = 0;
+    ASSERT_TRUE(rocjitsu::rpc_send_exact(server_fd, &free_resp, sizeof(free_resp)));
+  });
+
+  rocjitsu::RemoteDriver driver(sv[0]);
+  kfd_ioctl_alloc_memory_of_gpu_args alloc{};
+  alloc.va_addr = kGpuVa;
+  alloc.size = kSize;
+  alloc.gpu_id = kGpuId;
+  alloc.flags = KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+  EXPECT_EQ(driver.ioctl(AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &alloc), -EPROTO);
+  EXPECT_EQ(alloc.handle, 0u);
+  EXPECT_EQ(alloc.va_addr, kGpuVa);
+  EXPECT_TRUE(saw_free.load(std::memory_order_acquire));
+
+  kfd_ioctl_get_version_args version{};
+  EXPECT_EQ(driver.ioctl(AMDKFD_IOC_GET_VERSION, &version), -EPROTO);
+  server.join();
+}
+
+TEST(RemoteDriverMemoryTest, FailedUserptrPromotionRollsBackDaemonAllocation) {
+  constexpr size_t kSize = rocjitsu::KfdProcess::kPageSize;
+  constexpr uint64_t kGpuVa = rocjitsu::KfdProcess::kGpuVmBase + 0x6000000;
+  constexpr uint64_t kHandle = 0x5678;
+
+  void *cpu_addr = mmap(nullptr, kSize, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE(cpu_addr, MAP_FAILED) << std::strerror(errno);
+  ScopedMapping cpu_mapping(cpu_addr, kSize);
+
+  util::UniqueHandle backing_fd = make_sized_memfd("remote_userptr_rollback", kSize);
+  ASSERT_TRUE(backing_fd);
+
+  int sv[2];
+  ASSERT_EQ(::socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0) << ::strerror(errno);
+
+  std::atomic<bool> saw_free{false};
+  std::jthread server([&, server_fd = sv[1]] {
+    const CloseOnScopeExit closer{server_fd};
+
+    rocjitsu::RpcHeader hdr{};
+    int in_fds[1] = {-1};
+    size_t num_in = 1;
+    ASSERT_GT(rocjitsu::rpc_recv_msg(server_fd, &hdr, sizeof(hdr), in_fds, &num_in), 0);
+    if (num_in > 0 && in_fds[0] >= 0)
+      ::close(in_fds[0]);
+    ASSERT_EQ(hdr.opcode, rocjitsu::RPC_IOCTL);
+
+    std::vector<uint8_t> request(hdr.payload_bytes);
+    ASSERT_TRUE(rocjitsu::rpc_recv_exact(server_fd, request.data(), request.size()));
+    auto *ireq = reinterpret_cast<rocjitsu::RpcIoctlRequest *>(request.data());
+    ASSERT_EQ(ireq->ioctl_cmd, AMDKFD_IOC_ALLOC_MEMORY_OF_GPU);
+
+    kfd_ioctl_alloc_memory_of_gpu_args echoed{};
+    std::memcpy(&echoed, request.data() + sizeof(rocjitsu::RpcIoctlRequest), sizeof(echoed));
+    echoed.handle = kHandle;
+
+    std::vector<uint8_t> response(sizeof(rocjitsu::RpcHeader) + sizeof(echoed));
+    auto *resp = reinterpret_cast<rocjitsu::RpcHeader *>(response.data());
+    resp->opcode = rocjitsu::RPC_IOCTL;
+    resp->request_id = hdr.request_id;
+    resp->result = 0;
+    resp->payload_bytes = sizeof(echoed);
+    std::memcpy(response.data() + sizeof(rocjitsu::RpcHeader), &echoed, sizeof(echoed));
+
+    int sent_fd = backing_fd.get();
+    ASSERT_GT(rocjitsu::rpc_send_msg(server_fd, response.data(), response.size(), &sent_fd, 1), 0);
+
+    rocjitsu::RpcHeader free_hdr{};
+    num_in = 1;
+    ASSERT_GT(rocjitsu::rpc_recv_msg(server_fd, &free_hdr, sizeof(free_hdr), in_fds, &num_in), 0);
+    if (num_in > 0 && in_fds[0] >= 0)
+      ::close(in_fds[0]);
+    ASSERT_EQ(free_hdr.opcode, rocjitsu::RPC_IOCTL);
+    std::vector<uint8_t> free_request(free_hdr.payload_bytes);
+    ASSERT_TRUE(rocjitsu::rpc_recv_exact(server_fd, free_request.data(), free_request.size()));
+    auto *free_req = reinterpret_cast<rocjitsu::RpcIoctlRequest *>(free_request.data());
+    ASSERT_EQ(free_req->ioctl_cmd, AMDKFD_IOC_FREE_MEMORY_OF_GPU);
+    kfd_ioctl_free_memory_of_gpu_args free_args{};
+    std::memcpy(&free_args, free_request.data() + sizeof(rocjitsu::RpcIoctlRequest),
+                sizeof(free_args));
+    EXPECT_EQ(free_args.handle, kHandle);
+    saw_free.store(true, std::memory_order_release);
+
+    rocjitsu::RpcHeader free_resp{};
+    free_resp.opcode = rocjitsu::RPC_IOCTL;
+    free_resp.request_id = free_hdr.request_id;
+    free_resp.result = 0;
+    ASSERT_TRUE(rocjitsu::rpc_send_exact(server_fd, &free_resp, sizeof(free_resp)));
+  });
+
+  rocjitsu::RemoteDriver driver(sv[0]);
+  kfd_ioctl_alloc_memory_of_gpu_args alloc{};
+  alloc.va_addr = kGpuVa;
+  alloc.mmap_offset = reinterpret_cast<uint64_t>(cpu_addr);
+  alloc.size = kSize;
+  alloc.gpu_id = kGpuId;
+  alloc.flags = KFD_IOC_ALLOC_MEM_FLAGS_USERPTR | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+  EXPECT_EQ(driver.ioctl(AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &alloc), -EFAULT);
+  EXPECT_EQ(alloc.handle, 0u);
+  EXPECT_EQ(alloc.va_addr, kGpuVa);
+  EXPECT_EQ(alloc.mmap_offset, reinterpret_cast<uint64_t>(cpu_addr));
+
+  ASSERT_EQ(mprotect(cpu_addr, kSize, PROT_READ | PROT_WRITE), 0);
+  auto *cpu_bytes = static_cast<uint8_t *>(cpu_addr);
+  cpu_bytes[0] = 0xA5;
+  EXPECT_EQ(cpu_bytes[0], 0xA5);
+
+  server.join();
+  EXPECT_TRUE(saw_free.load(std::memory_order_acquire));
+}
+
+TEST(RemoteDriverMemoryTest, ImportDmabufSendsFdOverScmRights) {
+  constexpr size_t kSize = rocjitsu::KfdProcess::kPageSize;
+  constexpr uint32_t kSentinel = 0xD1A0B00Fu;
+  util::UniqueHandle dmabuf = make_sized_memfd("remote_import_dmabuf", kSize);
+  ASSERT_TRUE(dmabuf);
+  ASSERT_EQ(::pwrite(dmabuf.get(), &kSentinel, sizeof(kSentinel), 0),
+            static_cast<ssize_t>(sizeof(kSentinel)));
+
+  int sv[2];
+  ASSERT_EQ(::socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0) << ::strerror(errno);
+
+  std::atomic<bool> saw_fd{false};
+  std::jthread server([&, server_fd = sv[1]] {
+    const CloseOnScopeExit closer{server_fd};
+
+    rocjitsu::RpcHeader hdr{};
+    int in_fds[1] = {-1};
+    size_t num_in = 1;
+    ASSERT_GT(rocjitsu::rpc_recv_msg(server_fd, &hdr, sizeof(hdr), in_fds, &num_in), 0);
+    ASSERT_EQ(num_in, 1u);
+    ASSERT_GE(in_fds[0], 0);
+    util::UniqueHandle received{in_fds[0]};
+
+    uint32_t observed = 0;
+    ASSERT_EQ(::pread(received.get(), &observed, sizeof(observed), 0),
+              static_cast<ssize_t>(sizeof(observed)));
+    EXPECT_EQ(observed, kSentinel);
+    saw_fd.store(true, std::memory_order_release);
+
+    std::vector<uint8_t> request(hdr.payload_bytes);
+    ASSERT_TRUE(rocjitsu::rpc_recv_exact(server_fd, request.data(), request.size()));
+    auto *ireq = reinterpret_cast<rocjitsu::RpcIoctlRequest *>(request.data());
+    ASSERT_EQ(ireq->ioctl_cmd, AMDKFD_IOC_IMPORT_DMABUF);
+
+    kfd_ioctl_import_dmabuf_args echoed{};
+    std::memcpy(&echoed, request.data() + sizeof(rocjitsu::RpcIoctlRequest), sizeof(echoed));
+    echoed.handle = 0x2468;
+
+    rocjitsu::RpcHeader resp{};
+    resp.opcode = rocjitsu::RPC_IOCTL;
+    resp.request_id = hdr.request_id;
+    resp.result = 0;
+    resp.payload_bytes = sizeof(echoed);
+    ASSERT_TRUE(rocjitsu::rpc_send_exact(server_fd, &resp, sizeof(resp)));
+    ASSERT_TRUE(rocjitsu::rpc_send_exact(server_fd, &echoed, sizeof(echoed)));
+  });
+
+  rocjitsu::RemoteDriver driver(sv[0]);
+  kfd_ioctl_import_dmabuf_args import{};
+  import.dmabuf_fd = static_cast<uint32_t>(dmabuf.get());
+  import.gpu_id = kGpuId;
+  import.va_addr = rocjitsu::KfdProcess::kGpuVmBase + 0x6100000;
+  EXPECT_EQ(driver.ioctl(AMDKFD_IOC_IMPORT_DMABUF, &import), 0);
+  EXPECT_EQ(import.handle, 0x2468u);
+
+  server.join();
+  EXPECT_TRUE(saw_fd.load(std::memory_order_acquire));
 }
 
 TEST(RemoteDriverDbgQueueControlTest, QueueIdsAndStatusBitsRoundTripInline) {

--- a/emulation/rocjitsu/tests/kfd_ioctl_test.cpp
+++ b/emulation/rocjitsu/tests/kfd_ioctl_test.cpp
@@ -726,6 +726,11 @@ TEST_F(KfdIoctlTest, MapMemoryToGpuMapsLocalUserVaAllocation) {
   if (reserved == MAP_FAILED && errno == EEXIST)
     GTEST_SKIP() << "test GPUVA reservation is already occupied";
   ASSERT_EQ(reserved, reinterpret_cast<void *>(kGpuVa)) << std::strerror(errno);
+  struct ScopedReservation {
+    void *address;
+    size_t size;
+    ~ScopedReservation() { munmap(address, size); }
+  } reservation{reserved, kSize};
 
   kfd_ioctl_alloc_memory_of_gpu_args alloc{};
   alloc.va_addr = kGpuVa;
@@ -733,6 +738,17 @@ TEST_F(KfdIoctlTest, MapMemoryToGpuMapsLocalUserVaAllocation) {
   alloc.gpu_id = kGpuId;
   alloc.flags = KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
   ASSERT_EQ(driver_->ioctl(AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &alloc), 0);
+  struct ScopedAllocation {
+    rocjitsu::SimulatedKfd *driver;
+    uint64_t handle;
+    ~ScopedAllocation() {
+      if (handle != 0) {
+        kfd_ioctl_free_memory_of_gpu_args args{};
+        args.handle = handle;
+        driver->ioctl(AMDKFD_IOC_FREE_MEMORY_OF_GPU, &args);
+      }
+    }
+  } allocation{driver_, alloc.handle};
   ASSERT_NE(alloc.handle, 0u);
 
   kfd_ioctl_map_memory_to_gpu_args map{};
@@ -741,7 +757,7 @@ TEST_F(KfdIoctlTest, MapMemoryToGpuMapsLocalUserVaAllocation) {
   ASSERT_EQ(driver_->ioctl(AMDKFD_IOC_MAP_MEMORY_TO_GPU, &map), 0);
   EXPECT_EQ(map.n_success, 1u);
 
-  auto *page = soc_->memory()->resolve_host_ptr(kGpuVa, driver_->local_process_id());
+  uint8_t *page = soc_->memory()->resolve_host_ptr(kGpuVa, driver_->local_process_id());
   ASSERT_EQ(page, reinterpret_cast<uint8_t *>(kGpuVa));
 
   soc_->memory()->write32(kGpuVa, kExpected, driver_->local_process_id());
@@ -750,7 +766,8 @@ TEST_F(KfdIoctlTest, MapMemoryToGpuMapsLocalUserVaAllocation) {
   kfd_ioctl_free_memory_of_gpu_args free_args{};
   free_args.handle = alloc.handle;
   EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_FREE_MEMORY_OF_GPU, &free_args), 0);
-  munmap(reserved, kSize);
+  allocation.handle = 0;
+  EXPECT_FALSE(soc_->memory()->has_page_table_mapping(kGpuVa, driver_->local_process_id()));
 }
 
 TEST_F(KfdIoctlTest, SvmSetAndGetAttributes) {

--- a/emulation/rocjitsu/tests/kfd_ioctl_test.cpp
+++ b/emulation/rocjitsu/tests/kfd_ioctl_test.cpp
@@ -750,12 +750,14 @@ TEST_F(KfdIoctlTest, MapMemoryToGpuMapsLocalUserVaAllocation) {
     }
   } allocation{driver_, alloc.handle};
   ASSERT_NE(alloc.handle, 0u);
+  EXPECT_FALSE(soc_->memory()->is_mapped(kGpuVa, driver_->local_process_id()));
 
   kfd_ioctl_map_memory_to_gpu_args map{};
   map.handle = alloc.handle;
   map.n_devices = 1;
   ASSERT_EQ(driver_->ioctl(AMDKFD_IOC_MAP_MEMORY_TO_GPU, &map), 0);
   EXPECT_EQ(map.n_success, 1u);
+  EXPECT_TRUE(soc_->memory()->is_mapped(kGpuVa, driver_->local_process_id()));
 
   uint8_t *page = soc_->memory()->resolve_host_ptr(kGpuVa, driver_->local_process_id());
   ASSERT_EQ(page, reinterpret_cast<uint8_t *>(kGpuVa));
@@ -767,7 +769,29 @@ TEST_F(KfdIoctlTest, MapMemoryToGpuMapsLocalUserVaAllocation) {
   free_args.handle = alloc.handle;
   EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_FREE_MEMORY_OF_GPU, &free_args), 0);
   allocation.handle = 0;
-  EXPECT_FALSE(soc_->memory()->has_page_table_mapping(kGpuVa, driver_->local_process_id()));
+  EXPECT_FALSE(soc_->memory()->is_mapped(kGpuVa, driver_->local_process_id()));
+}
+
+TEST_F(KfdIoctlTest, AllocMemoryRejectsInvalidUserVaRanges) {
+  constexpr uint64_t kGpuVa = rocjitsu::KfdProcess::kGpuVmBase + 0x3220000;
+  constexpr uint64_t kSize = rocjitsu::KfdProcess::kPageSize;
+  constexpr uint32_t kFlags = KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+
+  auto expect_invalid = [&](uint64_t va, uint64_t size, uint32_t flags) {
+    kfd_ioctl_alloc_memory_of_gpu_args alloc{};
+    alloc.va_addr = va;
+    alloc.size = size;
+    alloc.gpu_id = kGpuId;
+    alloc.flags = flags;
+    EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &alloc), -EINVAL);
+    EXPECT_EQ(alloc.handle, 0u);
+  };
+
+  expect_invalid(kGpuVa + 1, kSize, kFlags);
+  expect_invalid(kGpuVa, kSize - 1, kFlags);
+  expect_invalid(kGpuVa, 0, kFlags);
+  expect_invalid(kGpuVa + 1, kSize,
+                 KFD_IOC_ALLOC_MEM_FLAGS_USERPTR | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE);
 }
 
 TEST_F(KfdIoctlTest, SvmSetAndGetAttributes) {

--- a/emulation/rocjitsu/tests/kfd_ioctl_test.cpp
+++ b/emulation/rocjitsu/tests/kfd_ioctl_test.cpp
@@ -43,6 +43,10 @@
 #include <thread>
 #include <vector>
 
+#ifndef MAP_FIXED_NOREPLACE
+#define MAP_FIXED_NOREPLACE 0x100000
+#endif
+
 namespace {
 
 const std::string CONFIG_PATH = std::string(CONFIG_DIR) + "/gfx950_mi355x.json";
@@ -710,6 +714,43 @@ TEST_F(KfdIoctlTest, ImportDmabufAndQueryInfo) {
 
   munmap(addr, kSize);
   close(memfd);
+}
+
+TEST_F(KfdIoctlTest, MapMemoryToGpuMapsLocalUserVaAllocation) {
+  constexpr uint64_t kGpuVa = rocjitsu::KfdProcess::kGpuVmBase + 0x3210000;
+  constexpr size_t kSize = 4096;
+  constexpr uint32_t kExpected = 0xC001CAFEu;
+
+  void *reserved = mmap(reinterpret_cast<void *>(kGpuVa), kSize, PROT_NONE,
+                        MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED_NOREPLACE | MAP_NORESERVE, -1, 0);
+  if (reserved == MAP_FAILED && errno == EEXIST)
+    GTEST_SKIP() << "test GPUVA reservation is already occupied";
+  ASSERT_EQ(reserved, reinterpret_cast<void *>(kGpuVa)) << std::strerror(errno);
+
+  kfd_ioctl_alloc_memory_of_gpu_args alloc{};
+  alloc.va_addr = kGpuVa;
+  alloc.size = kSize;
+  alloc.gpu_id = kGpuId;
+  alloc.flags = KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+  ASSERT_EQ(driver_->ioctl(AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &alloc), 0);
+  ASSERT_NE(alloc.handle, 0u);
+
+  kfd_ioctl_map_memory_to_gpu_args map{};
+  map.handle = alloc.handle;
+  map.n_devices = 1;
+  ASSERT_EQ(driver_->ioctl(AMDKFD_IOC_MAP_MEMORY_TO_GPU, &map), 0);
+  EXPECT_EQ(map.n_success, 1u);
+
+  auto *page = soc_->memory()->resolve_host_ptr(kGpuVa, driver_->local_process_id());
+  ASSERT_EQ(page, reinterpret_cast<uint8_t *>(kGpuVa));
+
+  soc_->memory()->write32(kGpuVa, kExpected, driver_->local_process_id());
+  EXPECT_EQ(*reinterpret_cast<volatile uint32_t *>(kGpuVa), kExpected);
+
+  kfd_ioctl_free_memory_of_gpu_args free_args{};
+  free_args.handle = alloc.handle;
+  EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_FREE_MEMORY_OF_GPU, &free_args), 0);
+  munmap(reserved, kSize);
 }
 
 TEST_F(KfdIoctlTest, SvmSetAndGetAttributes) {

--- a/emulation/rocjitsu/tests/xcd_distribution_test.cpp
+++ b/emulation/rocjitsu/tests/xcd_distribution_test.cpp
@@ -877,7 +877,7 @@ TEST(XcdDistributionTest, FanoutSizesScratchForTheWholeGridNotOneShare) {
   std::mutex requests_mutex;
   for (uint32_t xi = 0; xi < kTotalXcds; ++xi) {
     fx.soc->xcd(xi)->command_processor()->set_scratch_backing_allocator(
-        [&](uint32_t, uint64_t gpu_va, size_t size) -> bool {
+        [&](uint32_t, uint64_t gpu_va, size_t size, bool) -> bool {
           {
             std::lock_guard<std::mutex> lock(requests_mutex);
             requests.push_back({gpu_va, size});

--- a/emulation/rocjitsu/tests/xcd_fanout_kfd_test.cpp
+++ b/emulation/rocjitsu/tests/xcd_fanout_kfd_test.cpp
@@ -13,14 +13,10 @@
 ///
 /// What that reaches, and what it does not: the scratch *addressing* contract is
 /// covered here, because a wave's slot is indexed by its grid-wide workgroup id
-/// and the high-rank peers run the top of the grid. The driver's on-demand
-/// scratch-backing allocator is not, and cannot be from a local-mode test:
-/// opening a process turns GpuMemory passthrough on, so a wave's scratch address
-/// always resolves and the command processor never asks the driver to back it.
-/// That allocator -- and the existing-allocation check that keeps eight XCDs of
-/// one grid from each mapping the same pool -- is a daemon-mode path, where the
-/// guest's addresses are not the daemon's and passthrough stays off. Covering it
-/// needs a daemon-mode regression, not this fixture.
+/// and the high-rank peers run the top of the grid. This fixture deliberately
+/// programs USERPTR scratch with SET_SCRATCH_BACKING_VA, so it does not exercise
+/// the driver's no-SET fallback allocator. The local ScratchBackingGrowth test
+/// covers fallback pool stability and growth through the process page table.
 
 #include "test_paths.h"
 


### PR DESCRIPTION
## Motivation

When a kernel dispatch needs more simulated scratch than the initial allocation, scratch growth is skipped because passthrough resolution makes the unmapped GPU VA look valid. The simulator then accesses an unallocated host address and segfaults.

## Technical Details

 - Add explicit page-table mapping query that does not fall back to host passthrough.
 - Map local user-VA KFD allocations into the process page table.
 - Centralize the simulated GPUVM aperture constants.

## Issue Tracking

N/A

## Test Plan

Add allocation tests, run tests

## Test Result

Tests pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
