### PR TITLE
test(rccl): validate RMA and GIN finalize NULL access fix

### DIFF
--- a/projects/rccl/test/CommMPITests.cpp
+++ b/projects/rccl/test/CommMPITests.cpp
@@ -594,7 +594,7 @@ TEST_F(GinRmaContextMPITest, RmaAndGinFinalizeWithSplitComm)
     ASSERT_MPI_TRUE(parent != nullptr);
     ASSERT_MPI_TRUE(parent->sharedRes != nullptr);
 
-    if(parent->sharedRes->ginState.ncclGin == nullptr || parent->rmaState.rmaProxyState.ncclGin == nullptr)
+    if(parent->sharedRes->ginState.ncclGin == nullptr || parent->rmaState.rmaProxyState.ncclRma == nullptr)
     {
         GTEST_SKIP() << "Requires both the GIN and RMA plugins enabled on this host";
     }
@@ -602,8 +602,8 @@ TEST_F(GinRmaContextMPITest, RmaAndGinFinalizeWithSplitComm)
     // One internal backend serves both roles, so the contexts are distinct
     // only when RMA owns a separate field.
     ASSERT_MPI_TRUE(parent->ginContext != nullptr);
-    ASSERT_MPI_TRUE(parent->rmaGinContext != nullptr);
-    ASSERT_MPI_TRUE(parent->ginContext != parent->rmaGinContext);
+    ASSERT_MPI_TRUE(parent->rmaContext != nullptr);
+    ASSERT_MPI_TRUE(parent->ginContext != parent->rmaContext);
 
     // The parent shares its resources, so the child inherits both contexts
     // instead of initializing the plugins again.
@@ -614,7 +614,7 @@ TEST_F(GinRmaContextMPITest, RmaAndGinFinalizeWithSplitComm)
     struct ncclComm* child = splitComm;
     ASSERT_MPI_TRUE(child->sharedRes == parent->sharedRes);
     ASSERT_MPI_TRUE(child->ginContext == parent->ginContext);
-    ASSERT_MPI_TRUE(child->rmaGinContext == parent->rmaGinContext);
+    ASSERT_MPI_TRUE(child->rmaContext == parent->rmaContext);
 
     // Destroy the parent first so the child holds the last reference and
     // finalizes both plugins against the contexts it inherited.

--- a/projects/rccl/test/CommMPITests.cpp
+++ b/projects/rccl/test/CommMPITests.cpp
@@ -11,6 +11,8 @@
 #include "TestChecks.hpp"
 #include "ResourceGuards.hpp"
 
+#include "comm.h"
+
 #include <cstdlib>
 #include <string>
 
@@ -549,6 +551,75 @@ TEST_F(DestroySubsysMPITest, DestroySubsys_IncludesDestroyNoise)
 
     ASSERT_MPI_TRUE(hit_comm_free);
     ASSERT_MPI_TRUE(hit_colltrace);
+}
+
+/**
+ * @class GinRmaContextMPITest
+ * @brief Inspects the GIN and RMA plugin contexts bound at communicator init
+ *        time. No data path is stood up, only the plugin state is read.
+ */
+class GinRmaContextMPITest : public ConfigCommMPITestBase
+{
+protected:
+    // ncclCommInitChildComm() derives shareResources from the parent config, not
+    // from the config handed to ncclCommSplit(), so splitShare has to be set here.
+    void applyConfig(ncclConfig_t& config) override
+    {
+        config.splitShare = 1;
+    }
+
+    std::string configLabel() const override
+    {
+        return "splitShare=1";
+    }
+
+    struct ncclComm* ActiveComm()
+    {
+        return reinterpret_cast<struct ncclComm*>(getActiveCommunicator());
+    }
+};
+
+/**
+ * @test GinRmaContextMPITest.RmaAndGinFinalizeWithSplitComm
+ * @brief With both plugins initialized, RMA and GIN must hold separate
+ *        contexts that a split child inherits and finalize can release.
+ */
+TEST_F(GinRmaContextMPITest, RmaAndGinFinalizeWithSplitComm)
+{
+    ASSERT_MPI_TRUE(validateTestPrerequisites(kMinProcessesForMPI));
+
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+
+    struct ncclComm* parent = ActiveComm();
+    ASSERT_MPI_TRUE(parent != nullptr);
+    ASSERT_MPI_TRUE(parent->sharedRes != nullptr);
+
+    if(parent->sharedRes->ginState.ncclGin == nullptr || parent->rmaState.rmaProxyState.ncclGin == nullptr)
+    {
+        GTEST_SKIP() << "Requires both the GIN and RMA plugins enabled on this host";
+    }
+
+    // One internal backend serves both roles, so the contexts are distinct
+    // only when RMA owns a separate field.
+    ASSERT_MPI_TRUE(parent->ginContext != nullptr);
+    ASSERT_MPI_TRUE(parent->rmaGinContext != nullptr);
+    ASSERT_MPI_TRUE(parent->ginContext != parent->rmaGinContext);
+
+    // The parent shares its resources, so the child inherits both contexts
+    // instead of initializing the plugins again.
+    ncclComm_t splitComm = nullptr;
+    ASSERT_MPI_EQ(ncclSuccess,
+                  ncclCommSplit(getActiveCommunicator(), 0, getTestMpiRank(), &splitComm, nullptr));
+
+    struct ncclComm* child = reinterpret_cast<struct ncclComm*>(splitComm);
+    ASSERT_MPI_TRUE(child->sharedRes == parent->sharedRes);
+    ASSERT_MPI_TRUE(child->ginContext == parent->ginContext);
+    ASSERT_MPI_TRUE(child->rmaGinContext == parent->rmaGinContext);
+
+    // Destroy the parent first so the child holds the last reference and
+    // finalizes both plugins against the contexts it inherited.
+    ASSERT_MPI_EQ(ncclSuccess, cleanupTestCommunicator());
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommDestroy(splitComm));
 }
 
 #endif // MPI_TESTS_ENABLED

--- a/projects/rccl/test/CommMPITests.cpp
+++ b/projects/rccl/test/CommMPITests.cpp
@@ -575,7 +575,7 @@ protected:
 
     struct ncclComm* ActiveComm()
     {
-        return reinterpret_cast<struct ncclComm*>(getActiveCommunicator());
+        return getActiveCommunicator();
     }
 };
 
@@ -611,7 +611,7 @@ TEST_F(GinRmaContextMPITest, RmaAndGinFinalizeWithSplitComm)
     ASSERT_MPI_EQ(ncclSuccess,
                   ncclCommSplit(getActiveCommunicator(), 0, getTestMpiRank(), &splitComm, nullptr));
 
-    struct ncclComm* child = reinterpret_cast<struct ncclComm*>(splitComm);
+    struct ncclComm* child = splitComm;
     ASSERT_MPI_TRUE(child->sharedRes == parent->sharedRes);
     ASSERT_MPI_TRUE(child->ginContext == parent->ginContext);
     ASSERT_MPI_TRUE(child->rmaGinContext == parent->rmaGinContext);

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -1207,6 +1207,11 @@
             "NCCL_MIN_CTAS": "0",
             "NCCL_MAX_CTAS": "0"
           }
+        },
+        {
+          "name": "CommMPITests_GinRmaFinalizeWithSplitComm",
+          "description": "RMA and GIN hold separate contexts that a shared split child inherits and finalizes without a NULL access",
+          "test_filter": "GinRmaContextMPITest.RmaAndGinFinalizeWithSplitComm"
         }
       ]
     },


### PR DESCRIPTION
## Motivation

NCCL fixed a NULL access during finalize when RMA and GIN are both initialized (released in NCCL 2.30.3, inherited by RCCL via the 2.30 sync)

## Technical Details

RMA initializes into its own `comm->rmaGinContext` instead of aliasing `comm->ginContext`, finalize is NULL-guarded and runs before GIN, and a resource-sharing split child inherits both contexts from its parent.

## Issue Tracking

JIRA ID: AICOMRCCL-1519

## Test Plan

Add a test that executes the path end to end

## Test Result

`GinRmaContextMPITest.RmaAndGinFinalizeWithSplitComm` added and passes 

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
