### PR TITLE
fix(rocprofiler-compute): Harden formula eval with AST node allowlist

### DIFF
--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
@@ -30,6 +30,7 @@ from utils.file_io import (
 )
 from utils.logger import (
     console_debug,
+    console_error,
     console_warning,
     demarcate,
 )
@@ -587,8 +588,11 @@ class db_analysis(OmniAnalyze_Base):
                 value,
             )
             ast_node = ast.parse(value)
-            transformer = CodeTransformer()
-            transformer.visit(ast_node)
+            try:
+                transformer = CodeTransformer()
+                transformer.visit(ast_node)
+            except ValueError as exc:
+                console_error(f"Invalid metric expression '{value}': {exc}")
             value = astunparse.unparse(ast_node)
             value = value.replace("raw_pmc_df", "pmc_df")
             value = value.replace("pmc_df['sys_info']", "sys_info")
@@ -605,7 +609,7 @@ class db_analysis(OmniAnalyze_Base):
                 warnings.simplefilter("always", RuntimeWarning)
                 eval_result = eval(
                     compile(value, "<string>", "eval"),
-                    {},  # no globals
+                    {"__builtins__": {}},
                     {
                         # only locals
                         "pmc_df": pmc_df,

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
@@ -30,7 +30,6 @@ from utils.file_io import (
 )
 from utils.logger import (
     console_debug,
-    console_error,
     console_warning,
     demarcate,
 )
@@ -49,7 +48,7 @@ from utils.metrics.aggregation import (
     to_sum,
 )
 from utils.metrics.common import ValuDualIssueDetector
-from utils.metrics.expression import CodeTransformer
+from utils.metrics.expression import transform_expression
 from utils.metrics.noise_clamper import (
     clear_noise_clamp_warnings,
     get_noise_clamp_warnings,
@@ -582,17 +581,15 @@ class db_analysis(OmniAnalyze_Base):
         emit_variance_warnings: bool = False,
     ) -> Any:  # noqa ANN401
         if parse:
+            original_value = value
             value = re.sub(
                 r"\$([0-9A-Za-z_]+)",
                 lambda m: f'sys_info["{m.group(1)}"]',
                 value,
             )
             ast_node = ast.parse(value)
-            try:
-                transformer = CodeTransformer()
-                transformer.visit(ast_node)
-            except ValueError as exc:
-                console_error(f"Invalid metric expression '{value}': {exc}")
+            if not transform_expression(ast_node, original_value):
+                return None
             value = astunparse.unparse(ast_node)
             value = value.replace("raw_pmc_df", "pmc_df")
             value = value.replace("pmc_df['sys_info']", "sys_info")

--- a/projects/rocprofiler-compute/src/utils/metrics/expression.py
+++ b/projects/rocprofiler-compute/src/utils/metrics/expression.py
@@ -10,8 +10,47 @@ import re
 
 import astunparse
 
+from utils.logger import console_error
 from utils.utils_common import SUPPORTED_FIELD
 from utils.utils_counter_defs import SUPPORTED_DENOM
+
+ALLOWED_AST_NODES: frozenset[type] = frozenset({
+    ast.Module,
+    ast.Expr,
+    ast.Expression,
+    ast.Constant,
+    ast.Name,
+    ast.Tuple,
+    ast.List,
+    ast.BinOp,
+    ast.UnaryOp,
+    ast.Compare,
+    ast.BoolOp,
+    ast.IfExp,
+    ast.Call,
+    ast.Subscript,
+    ast.Slice,
+    ast.Index,
+    ast.Load,
+    ast.Add,
+    ast.Sub,
+    ast.Mult,
+    ast.Div,
+    ast.FloorDiv,
+    ast.Mod,
+    ast.Pow,
+    ast.USub,
+    ast.UAdd,
+    ast.Not,
+    ast.Eq,
+    ast.NotEq,
+    ast.Lt,
+    ast.Gt,
+    ast.LtE,
+    ast.GtE,
+    ast.And,
+    ast.Or,
+})
 
 SUPPORTED_CALL: dict[str, str] = {
     # If the below has a single arg, like(expr), it is an aggr,
@@ -39,6 +78,11 @@ SUPPORTED_CALL: dict[str, str] = {
 
 class CodeTransformer(ast.NodeTransformer):
     """Python AST visitor to transform user equation strings to df format."""
+
+    def generic_visit(self, node: ast.AST) -> ast.AST:
+        if type(node) not in ALLOWED_AST_NODES:
+            raise ValueError(f"Disallowed expression element: {type(node).__name__}")
+        return super().generic_visit(node)
 
     def visit_Call(self, node: ast.Call) -> ast.Call:
         self.generic_visit(node)
@@ -142,8 +186,11 @@ def build_eval_string(equation: str) -> str:
 
     # convert equation string to intermediate expression in df array format
     ast_node = ast.parse(equation_string)
-    transformer = CodeTransformer()
-    transformer.visit(ast_node)
+    try:
+        transformer = CodeTransformer()
+        transformer.visit(ast_node)
+    except ValueError as exc:
+        console_error(f"Invalid metric expression '{equation}': {exc}")
 
     equation_string = astunparse.unparse(ast_node)
 

--- a/projects/rocprofiler-compute/src/utils/metrics/expression.py
+++ b/projects/rocprofiler-compute/src/utils/metrics/expression.py
@@ -10,10 +10,16 @@ import re
 
 import astunparse
 
-from utils.logger import console_error
+from utils.logger import console_warning
 from utils.utils_common import SUPPORTED_FIELD
 from utils.utils_counter_defs import SUPPORTED_DENOM
 
+
+class InvalidExpressionError(ValueError):
+    """Raised when a metric formula contains disallowed AST constructs."""
+
+
+# ast.Attribute is deliberately omitted — it enables dunder-chain escapes.
 ALLOWED_AST_NODES: frozenset[type] = frozenset({
     ast.Module,
     ast.Expr,
@@ -28,9 +34,9 @@ ALLOWED_AST_NODES: frozenset[type] = frozenset({
     ast.BoolOp,
     ast.IfExp,
     ast.Call,
+    ast.keyword,
     ast.Subscript,
     ast.Slice,
-    ast.Index,
     ast.Load,
     ast.Add,
     ast.Sub,
@@ -39,6 +45,12 @@ ALLOWED_AST_NODES: frozenset[type] = frozenset({
     ast.FloorDiv,
     ast.Mod,
     ast.Pow,
+    ast.BitOr,
+    ast.BitAnd,
+    ast.BitXor,
+    ast.LShift,
+    ast.RShift,
+    ast.Invert,
     ast.USub,
     ast.UAdd,
     ast.Not,
@@ -48,6 +60,10 @@ ALLOWED_AST_NODES: frozenset[type] = frozenset({
     ast.Gt,
     ast.LtE,
     ast.GtE,
+    ast.In,
+    ast.NotIn,
+    ast.Is,
+    ast.IsNot,
     ast.And,
     ast.Or,
 })
@@ -81,25 +97,27 @@ class CodeTransformer(ast.NodeTransformer):
 
     def generic_visit(self, node: ast.AST) -> ast.AST:
         if type(node) not in ALLOWED_AST_NODES:
-            raise ValueError(f"Disallowed expression element: {type(node).__name__}")
+            raise InvalidExpressionError(
+                f"Disallowed expression element: {type(node).__name__}"
+            )
         return super().generic_visit(node)
 
     def visit_Call(self, node: ast.Call) -> ast.Call:
-        self.generic_visit(node)
         if isinstance(node.func, ast.Name):
-            if node.func.id in SUPPORTED_CALL:
-                node.func.id = SUPPORTED_CALL[node.func.id]
-            else:
-                raise Exception("Unknown call:", node.func.id)
+            if node.func.id not in SUPPORTED_CALL:
+                raise InvalidExpressionError(f"Unsupported call: {node.func.id}")
+            self.generic_visit(node)
+            node.func.id = SUPPORTED_CALL[node.func.id]
+        else:
+            self.generic_visit(node)
         return node
 
     def visit_IfExp(self, node: ast.IfExp) -> ast.Expr:
         self.generic_visit(node)
 
         if isinstance(node.body, ast.Constant):
-            raise Exception(
-                "Don't support body of IF with number only! Has to be expr with "
-                "df['column']."
+            raise InvalidExpressionError(
+                "IF body must contain a df['column'] expression, not a literal"
             )
 
         new_node = ast.Expr(
@@ -130,6 +148,23 @@ class CodeTransformer(ast.NodeTransformer):
                 ctx=ast.Load(),
             )
         return node
+
+
+def transform_expression(
+    ast_node: ast.AST,
+    source: str,
+) -> bool:
+    """Run CodeTransformer on *ast_node*, warning on invalid formulas.
+
+    Returns True on success, False when the expression was rejected.
+    """
+    transformer = CodeTransformer()
+    try:
+        transformer.visit(ast_node)
+    except InvalidExpressionError as exc:
+        console_warning(f"Invalid metric expression '{source}': {exc}")
+        return False
+    return True
 
 
 def build_eval_string(equation: str) -> str:
@@ -186,11 +221,8 @@ def build_eval_string(equation: str) -> str:
 
     # convert equation string to intermediate expression in df array format
     ast_node = ast.parse(equation_string)
-    try:
-        transformer = CodeTransformer()
-        transformer.visit(ast_node)
-    except ValueError as exc:
-        console_error(f"Invalid metric expression '{equation}': {exc}")
+    if not transform_expression(ast_node, equation):
+        return ""
 
     equation_string = astunparse.unparse(ast_node)
 

--- a/projects/rocprofiler-compute/src/utils/metrics/metric_evaluator.py
+++ b/projects/rocprofiler-compute/src/utils/metrics/metric_evaluator.py
@@ -70,7 +70,7 @@ class MetricEvaluator:
                 warnings.simplefilter("always", RuntimeWarning)
                 eval_result = eval(
                     compile(expr, "<string>", "eval"),
-                    {},
+                    {"__builtins__": {}},
                     local_expr_context,
                 )
             # RuntimeWarnings (e.g. divide-by-zero) are surfaced only under --verbose

--- a/projects/rocprofiler-compute/tests/test_metric_utils.py
+++ b/projects/rocprofiler-compute/tests/test_metric_utils.py
@@ -30,6 +30,7 @@ from utils.metrics.evaluation_pipeline import (
 )
 from utils.metrics.expression import (
     CodeTransformer,
+    InvalidExpressionError,
     build_eval_string,
     gen_counter_list,
     update_denominator_string,
@@ -189,15 +190,11 @@ class TestExpression:
         assert update_denominator_string("", "per_wave") == ""
 
     def test_visit_call_raises_for_unknown_function(self):
-        """CodeTransformer.visit_Call raises for unknown function names."""
+        """CodeTransformer rejects unsupported function calls."""
+        tree = ast.parse("UNKNOWN_FUNC(5)")
         transformer = CodeTransformer()
-        unknown_call = ast.Call(
-            func=ast.Name(id="ammolite__UNKNOWN", ctx=ast.Load()),
-            args=[ast.Constant(value=5)],
-            keywords=[],
-        )
-        with pytest.raises(Exception, match="Unknown call"):
-            transformer.visit_Call(unknown_call)
+        with pytest.raises(InvalidExpressionError, match="Unsupported call"):
+            transformer.visit(tree)
 
     def test_visit_call_translates_supported_function_to_helper_name(self):
         """CodeTransformer.visit_Call rewrites MIN to the to_min helper name."""
@@ -325,13 +322,15 @@ class TestExpression:
         """CodeTransformer.generic_visit raises for disallowed AST node types."""
         tree = ast.parse(formula)
         transformer = CodeTransformer()
-        with pytest.raises(ValueError, match=blocked_node):
+        with pytest.raises(InvalidExpressionError, match=blocked_node):
             transformer.visit(tree)
 
-    def test_build_eval_string_exits_on_unsafe_formula(self) -> None:
-        """build_eval_string exits via console_error for unsafe formulas."""
-        with pytest.raises(SystemExit):
-            build_eval_string('"".__class__')
+    def test_build_eval_string_warns_on_unsafe_formula(self) -> None:
+        """build_eval_string warns and returns empty for unsafe formulas."""
+        with patch("utils.metrics.expression.console_warning") as mock_warning:
+            result = build_eval_string('"".__class__')
+        assert result == ""
+        assert mock_warning.called
 
 
 # =============================================================================
@@ -793,6 +792,14 @@ class TestEvaluationPipeline:
 
 class TestMetricEvaluator:
     """Tests for utils.metrics.metric_evaluator."""
+
+    def test_eval_expression_cannot_reach_builtins(self):
+        """Builtins are suppressed at the eval site."""
+        evaluator = MetricEvaluator(pd.DataFrame(), {}, {})
+        with patch("utils.metrics.metric_evaluator.console_warning") as mock_warning:
+            result = evaluator.eval_expression("__import__('os')")
+        assert result == "N/A"
+        assert mock_warning.called
 
     def test_eval_expression_returns_na_when_eval_returns_none(self):
         """eval_expression returns 'N/A' when the evaluated expression yields None."""

--- a/projects/rocprofiler-compute/tests/test_metric_utils.py
+++ b/projects/rocprofiler-compute/tests/test_metric_utils.py
@@ -282,6 +282,57 @@ class TestExpression:
         """
         assert update_normal_unit_string(equation, normal_unit) == expected
 
+    @pytest.mark.parametrize(
+        "formula",
+        [
+            (
+                "100 * SUM(SQ_ACTIVE_INST_SCA)"
+                " / SUM(ammolite__GRBM_GUI_ACTIVE_PER_XCD"
+                " * ammolite__cu_per_gpu)"
+            ),
+            (
+                "TCC_EA_RDREQ_LEVEL_31 / TCC_EA_RDREQ_31"
+                " if (TCC_EA_RDREQ_31 != 0) else TCC_EA_RDREQ_31"
+            ),
+            "ROUND(AVG(4 * SQ_BUSY_CU_CYCLES), 0)",
+        ],
+    )
+    def test_code_transformer_accepts_legitimate_formulas(
+        self,
+        formula: str,
+    ) -> None:
+        """CodeTransformer.generic_visit passes for real metric formulas."""
+        tree = ast.parse(formula)
+        transformer = CodeTransformer()
+        transformer.visit(tree)
+
+    @pytest.mark.parametrize(
+        "formula, blocked_node",
+        [
+            ('"".__class__', "Attribute"),
+            ("(lambda: 1)()", "Lambda"),
+            ("[x for x in (1,)]", "ListComp"),
+            ("(x for x in (1,))", "GeneratorExp"),
+            ("{x: 1 for x in (1,)}", "DictComp"),
+            ("{x for x in (1,)}", "SetComp"),
+        ],
+    )
+    def test_code_transformer_rejects_unsafe_node_types(
+        self,
+        formula: str,
+        blocked_node: str,
+    ) -> None:
+        """CodeTransformer.generic_visit raises for disallowed AST node types."""
+        tree = ast.parse(formula)
+        transformer = CodeTransformer()
+        with pytest.raises(ValueError, match=blocked_node):
+            transformer.visit(tree)
+
+    def test_build_eval_string_exits_on_unsafe_formula(self) -> None:
+        """build_eval_string exits via console_error for unsafe formulas."""
+        with pytest.raises(SystemExit):
+            build_eval_string('"".__class__')
+
 
 # =============================================================================
 # Tests for utils.metrics.evaluation_pipeline


### PR DESCRIPTION
## Motivation

Add deny-by-default AST node validation to the metric formula evaluation pipeline. YAML config formula strings reach `eval()` through `CodeTransformer` without restriction on AST node types, allowing attribute chains `("".__class__.__mro__)` and other constructs to bypass the existing function call allowlist. Users can supply arbitrary YAML configs via `--config-dir`.

## Technical Details

- Add `ALLOWED_AST_NODES` frozenset and a `generic_visit` override to `CodeTransformer` that rejects any AST node type not on the allowlist
- Introduce `InvalidExpressionError(ValueError)` to avoid catching unrelated `ValueErrors` from inside the visitor
- Use `console_warning` + graceful `return ("" / None)` instead of `console_error (which calls sys.exit)`, matching the existing degradation pattern where one bad metric does not abort the entire run
- Suppress `__builtins__` at both `eval()` sites by passing `{"__builtins__": {}}` as globals instead of `{}`
- Remove dead `ast.Index` entry (not emitted since Python 3.9, which is the project minimum)

## Issue Tracking

JIRA ID: ROCM-26855

## Test Plan

- Legitimate formulas (arithmetic, aggregation calls, ternaries) accepted
- Unsafe AST node types (Attribute, Lambda, ListComp, GeneratorExp, DictComp, SetComp) raise InvalidExpressionError
- `build_eval_string` warns and returns `""` on unsafe input (no sys.exit)

## Test Result

- [x] Legitimate formulas (arithmetic, aggregation calls, ternaries) accepted
- [x] Unsafe AST node types (Attribute, Lambda, ListComp, GeneratorExp, DictComp, SetComp) raise InvalidExpressionError
- [x] `build_eval_string` warns and returns `""` on unsafe input (no sys.exit)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
