### PR TITLE
fix(rocprofiler-sdk): do not propagate host register library path to target in rocattach

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
@@ -174,7 +174,7 @@ build_environment_buffer()
             // only take envvars starting with ROCP
             continue;
         }
-        constexpr char register_library_env[] = "ROCPROFILER_REGISTER_LIBRARY=";
+        constexpr auto register_library_env = "ROCPROFILER_REGISTER_LIBRARY=";
         if(strncmp(register_library_env, var, sizeof(register_library_env) - 1) == 0)
         {
             // ROCPROFILER_REGISTER_LIBRARY is set by the attaching process's SDK and may

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
@@ -174,6 +174,14 @@ build_environment_buffer()
             // only take envvars starting with ROCP
             continue;
         }
+        constexpr auto register_library_env = "ROCPROFILER_REGISTER_LIBRARY=";
+        if(strncmp(register_library_env, var, sizeof(register_library_env) - 1) == 0)
+        {
+            // ROCPROFILER_REGISTER_LIBRARY is set by the attaching process's SDK and may
+            // contain a host-only, fully versioned path. Do not propagate it to the target;
+            // let rocprofiler-register resolve the SDK in the target environment.
+            continue;
+        }
 
         var_count++;
         ROCP_TRACE << "[rocprofiler-sdk-rocattach] Adding to environment buffer: " << var;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
@@ -174,7 +174,7 @@ build_environment_buffer()
             // only take envvars starting with ROCP
             continue;
         }
-        constexpr auto register_library_env = "ROCPROFILER_REGISTER_LIBRARY=";
+        constexpr char register_library_env[] = "ROCPROFILER_REGISTER_LIBRARY=";
         if(strncmp(register_library_env, var, sizeof(register_library_env) - 1) == 0)
         {
             // ROCPROFILER_REGISTER_LIBRARY is set by the attaching process's SDK and may

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
@@ -175,7 +175,7 @@ build_environment_buffer()
             continue;
         }
         constexpr auto register_library_env = "ROCPROFILER_REGISTER_LIBRARY=";
-        if(strncmp(register_library_env, var, sizeof(register_library_env) - 1) == 0)
+        if(std::string_view{var}.find(register_library_env) == 0)
         {
             // ROCPROFILER_REGISTER_LIBRARY is set by the attaching process's SDK and may
             // contain a host-only, fully versioned path. Do not propagate it to the target;

--- a/projects/rocprofiler-sdk/tests/bin/attachment-test/attachment_test.cpp
+++ b/projects/rocprofiler-sdk/tests/bin/attachment-test/attachment_test.cpp
@@ -270,6 +270,11 @@ main(int argc, char** argv)
         std::cout << "Attachment test process " << getpid() << " received signal " << SIGWINCH
                   << "\n";
     }
+    if(const auto* forwarding_test = std::getenv("ROCPROFILER_TEST_FORWARDING"))
+    {
+        std::cout << "Attachment test observed ROCPROFILER_TEST_FORWARDING=" << forwarding_test
+                  << "\n";
+    }
     std::cout << "Attachment test app finished" << std::endl;
 
     if(child_pid > 0)

--- a/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
@@ -158,7 +158,8 @@ rocprofiler_add_integration_execute_test(
     ENVIRONMENT "${rocattach-test-env}"
     DISABLED ${IS_DISABLED}
     PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
-    PASS_REGULAR_EXPRESSION "Test C tool \\(priority=0\\) is using rocprofiler-sdk v"
+    PASS_REGULAR_EXPRESSION
+        "Attachment adding environment variable: ROCPROFILER_TEST_FORWARDING=preserved"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")
 
 # Verify absolute tool library paths fail early when target-side dlopen could not resolve

--- a/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
@@ -148,6 +148,19 @@ rocprofiler_add_integration_execute_test(
     PASS_REGULAR_EXPRESSION "Test C tool \\(priority=0\\) is using rocprofiler-sdk v"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")
 
+rocprofiler_add_integration_execute_test(
+    rocattach-stale-register-library-test-execute
+    COMMAND $<TARGET_FILE:rocattach-parallel-attach-test> $<TARGET_FILE:attachment-test>
+            $<TARGET_FILE:rocprofiler-sdk-c-tool> --stale-register-library
+    DEPENDS rocattach-parallel-attach-test
+    TIMEOUT 45
+    LABELS "attachment"
+    ENVIRONMENT "${rocattach-test-env}"
+    DISABLED ${IS_DISABLED}
+    PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
+    PASS_REGULAR_EXPRESSION "Test C tool \\(priority=0\\) is using rocprofiler-sdk v"
+    FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")
+
 # Verify absolute tool library paths fail early when target-side dlopen could not resolve
 # them from the target mount namespace.
 rocprofiler_add_integration_execute_test(

--- a/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
@@ -159,7 +159,7 @@ rocprofiler_add_integration_execute_test(
     DISABLED ${IS_DISABLED}
     PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
     PASS_REGULAR_EXPRESSION
-        "Attachment adding environment variable: ROCPROFILER_TEST_FORWARDING=preserved"
+        "Attachment test observed ROCPROFILER_TEST_FORWARDING=preserved"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")
 
 # Verify absolute tool library paths fail early when target-side dlopen could not resolve

--- a/projects/rocprofiler-sdk/tests/rocattach/main.cpp
+++ b/projects/rocprofiler-sdk/tests/rocattach/main.cpp
@@ -133,7 +133,10 @@ main(int argc, char** argv)
         // Child process
         if(poison_register_library_env)
         {
+            // These values should reach the target only through rocattach's injected
+            // environment buffer, not through normal fork/exec inheritance.
             unsetenv("ROCPROFILER_REGISTER_LIBRARY");
+            unsetenv("ROCPROFILER_TEST_FORWARDING");
         }
         std::cout << "child executing " << argv[1] << std::endl;
         int ret = execl(argv[1], argv[1], nullptr);
@@ -167,9 +170,12 @@ main(int argc, char** argv)
         setenv("ROCPROF_ATTACH_TOOL_LIBRARY", argv[2], true);
         if(poison_register_library_env)
         {
+            // Model a stale host SDK path in the attaching process. The sentinel verifies
+            // that other ROCPROFILER_* variables are still forwarded to the target.
             setenv("ROCPROFILER_REGISTER_LIBRARY",
                    "/tmp/rocattach-missing-librocprofiler-sdk.so.999.999.999",
                    true);
+            setenv("ROCPROFILER_TEST_FORWARDING", "preserved", true);
         }
 
         {

--- a/projects/rocprofiler-sdk/tests/rocattach/main.cpp
+++ b/projects/rocprofiler-sdk/tests/rocattach/main.cpp
@@ -88,6 +88,26 @@ main(int argc, char** argv)
         return 1;
     }
 
+    bool send_signal                 = false;
+    bool poison_register_library_env = false;
+    for(int i = 3; i < argc; ++i)
+    {
+        std::string arg{argv[i]};
+        if(arg == "--send-signal")
+        {
+            send_signal = true;
+        }
+        else if(arg == "--stale-register-library")
+        {
+            poison_register_library_env = true;
+        }
+        else
+        {
+            std::cout << "error: unknown argument " << arg << "\n";
+            return 1;
+        }
+    }
+
     pid_t pid1 = fork();
     if(pid1 < 0)
     {
@@ -111,6 +131,10 @@ main(int argc, char** argv)
     if(pid1 == 0 || pid2 == 0)
     {
         // Child process
+        if(poison_register_library_env)
+        {
+            unsetenv("ROCPROFILER_REGISTER_LIBRARY");
+        }
         std::cout << "child executing " << argv[1] << std::endl;
         int ret = execl(argv[1], argv[1], nullptr);
         if(ret == -1)
@@ -141,6 +165,12 @@ main(int argc, char** argv)
         }
 
         setenv("ROCPROF_ATTACH_TOOL_LIBRARY", argv[2], true);
+        if(poison_register_library_env)
+        {
+            setenv("ROCPROFILER_REGISTER_LIBRARY",
+                   "/tmp/rocattach-missing-librocprofiler-sdk.so.999.999.999",
+                   true);
+        }
 
         {
             std::cout << "starting call to rocattach_attach(pid1)" << std::endl;
@@ -168,21 +198,17 @@ main(int argc, char** argv)
         }
 
         // Send signal to child processes after attaching
-        if(argc >= 4)
+        if(send_signal)
         {
-            std::string signal_arg{argv[3]};
-            if(signal_arg == "--send-signal")
+            std::cout << "Sending SIGWINCH to PID " << pid1 << "\n";
+            if(kill(pid1, SIGWINCH) == -1)
             {
-                std::cout << "Sending SIGWINCH to PID " << pid1 << "\n";
-                if(kill(pid1, SIGWINCH) == -1)
-                {
-                    std::cout << "error: Failed to send SIGWINCH signal to pid1\n";
-                }
-                std::cout << "Sending SIGWINCH to PID " << pid2 << "\n";
-                if(kill(pid2, SIGWINCH) == -1)
-                {
-                    std::cout << "error: Failed to send SIGWINCH signal to pid2\n";
-                }
+                std::cout << "error: Failed to send SIGWINCH signal to pid1\n";
+            }
+            std::cout << "Sending SIGWINCH to PID " << pid2 << "\n";
+            if(kill(pid2, SIGWINCH) == -1)
+            {
+                std::cout << "error: Failed to send SIGWINCH signal to pid2\n";
             }
         }
 


### PR DESCRIPTION
## Motivation

`ROCPROFILER_REGISTER_LIBRARY` is set by the host-side rocprofiler SDK constructor and may contain an absolute, fully versioned path to the host SDK, for example:

```text
/rocm/lib/librocprofiler-sdk.so.1.3.5
```

When attaching to a process in a container or another mount namespace with a different ROCm installation, that path may not exist. The target-side `rocprofiler-register` attempts to `dlopen` the forwarded path and aborts the target when loading fails.

This PR prevents `rocattach` from forwarding `ROCPROFILER_REGISTER_LIBRARY` from the attaching process into the target process. Attaching to a process that uses a different ROCm installation should no longer cause the target to abort because of a host-specific SDK path. The target instead loads the rocprofiler SDK available in its own environment.

## Technical Details

Exclude `ROCPROFILER_REGISTER_LIBRARY` from the environment buffer constructed by `rocattach` to allow the target-side `rocprofiler-register` to resolve the SDK available in the target environment.

`ROCPROFILER_REGISTER_LIBRARY` identifies the SDK selected by the attaching process. It is process-local implementation state rather than target profiling configuration and should not cross the attach boundary.


## Issue Tracking

JIRA ID: AIPROFSDK-1011

## Test Plan

Added `rocattach-stale-register-library-test-execute`, which simulates the version-mismatch failure by setting the attaching process’s `ROCPROFILER_REGISTER_LIBRARY` to a nonexistent fully versioned SDK path before attach.

## Test Result

- Ran `rocattach-stale-register-library-test-execute` successfully.
- Verified the same test fails without the fix because the stale `ROCPROFILER_REGISTER_LIBRARY` reaches the target and triggers the fatal `dlopen` path.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
