### PR TITLE
fix(rccl): skip WindowRegister non-sym test on gfx908, bump CI timeout

### DIFF
--- a/projects/rccl/test/RegisterTests.cpp
+++ b/projects/rccl/test/RegisterTests.cpp
@@ -557,6 +557,15 @@ static void testDeregisterNullHandle() {
 static void testWindowRegisterSingleRankNonSymTeardown() {
     SKIP_IF_NO_GPU();
 
+    hipDeviceProp_t prop;
+    HIPCALL(hipGetDeviceProperties(&prop, 0));
+    if (!isArchSupportedForP2pCollTest(prop.gcnArchName)) {
+        GTEST_SKIP() << "Non-symmetric window register path hangs on "
+                     << prop.gcnArchName
+                     << "; test requires gfx942 / gfx950.";
+        return;
+    }
+
     HIPCALL(hipSetDevice(0));
 
     ncclComm_t comm;

--- a/projects/rccl/test/RegisterTests.cpp
+++ b/projects/rccl/test/RegisterTests.cpp
@@ -47,6 +47,23 @@ static bool isArchSupportedForP2pCollTest(const char* gcnArchName) {
     return false;
 }
 
+// cuMem VMM (Virtual Memory Management) is required by the symmetric window
+// register path and also by the non-symmetric fallback exercised with
+// NCCL_CUMEM_ENABLE=0.  On architectures that lack VMM support in the HIP/ROCr
+// driver stack (e.g. gfx908 / MI100), the non-symmetric window register path
+// hangs indefinitely during ncclCommWindowRegister.
+static bool deviceSupportsCuMemVmm(int deviceId = 0) {
+    hipDeviceProp_t prop;
+    if (hipGetDeviceProperties(&prop, deviceId) != hipSuccess)
+        return false;
+    static const char* kVmmArchs[] = {"gfx942", "gfx950", "gfx1250"};
+    for (const char* arch : kVmmArchs) {
+        if (strncmp(prop.gcnArchName, arch, strlen(arch)) == 0)
+            return true;
+    }
+    return false;
+}
+
 // Queries every visible device and returns true only if all of them are a
 // supported architecture for the P2P+collective registration test.
 static bool allDevicesSupportP2pCollTest(int numDevices, char* unsupportedArchOut,
@@ -557,12 +574,9 @@ static void testDeregisterNullHandle() {
 static void testWindowRegisterSingleRankNonSymTeardown() {
     SKIP_IF_NO_GPU();
 
-    hipDeviceProp_t prop;
-    HIPCALL(hipGetDeviceProperties(&prop, 0));
-    if (!isArchSupportedForP2pCollTest(prop.gcnArchName)) {
-        GTEST_SKIP() << "Non-symmetric window register path hangs on "
-                     << prop.gcnArchName
-                     << "; test requires gfx942 / gfx950.";
+    if (!deviceSupportsCuMemVmm(0)) {
+        GTEST_SKIP() << "Non-symmetric window register path requires cuMem VMM "
+                        "support; skipping on this GPU.";
         return;
     }
 

--- a/projects/rccl/tools/scripts/test_runner/configs/ci-precheckin.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/ci-precheckin.json
@@ -140,7 +140,7 @@
         {"name": "AllReduce.BiasFloat64_Min", "description": "AllReduce bias float64 min", "test_filter": "AllReduce.BiasFloat64_Min"},
         {"name": "AllReduce.BiasFloat64_Prod", "description": "AllReduce bias float64 prod", "test_filter": "AllReduce.BiasFloat64_Prod"},
         {"name": "AlltoAll.Channels", "description": "AlltoAll with channels", "test_filter": "AlltoAll.Channels", "timeout": 1000},
-        {"name": "Register.ProcessIsolatedRegisterTests", "description": "Process isolated buffer registration tests", "test_filter": "Register.ProcessIsolatedRegisterTests"},
+        {"name": "Register.ProcessIsolatedRegisterTests", "description": "Process isolated buffer registration tests", "test_filter": "Register.ProcessIsolatedRegisterTests", "timeout": 300},
         {"name": "Recorder.ParseBinary", "description": "Recorder parse binary tests", "test_filter": "Recorder.ParseBinary"},
         {"name": "Recorder.ParseJson", "description": "Recorder parse JSON tests", "test_filter": "Recorder.ParseJson"},
         {"name": "Recorder.VerifyMultithread", "description": "Recorder multithread verification tests", "test_filter": "Recorder.VerifyMultithread"},


### PR DESCRIPTION
## Summary

- Skips `WindowRegisterSingleRankNonSymTeardown` on GPUs without cuMem VMM support (e.g. gfx908 / MI100) where the non-symmetric window register path hangs indefinitely
- Bumps the CI precheckin timeout for `Register.ProcessIsolatedRegisterTests` from 90s to 300s as defense in depth

## Root Cause

`WindowRegisterSingleRankNonSymTeardown` was added in PR #7888 (Jun 29) and always hung on gfx908. The test sets `NCCL_CUMEM_ENABLE=0` which forces the non-symmetric `windowRegisterNonSym` code path — on gfx908 this path hangs during `ncclCommWindowRegister` (the child process emits zero output before being killed).

The hang was masked until **PR #8341** (Jul 17, `44cf4c2b18`) bumped `kDefaultTestTimeoutSeconds` from **30s to 300s** for DPX+NPS2 gfx1250 tests. Before that change, the process-isolated runner killed the hanging sub-test after 30s, keeping total test time at ~54s (under the 90s CI limit). After the bump, the hang runs for 300s, pushing total time to ~324s and triggering the CI timeout.

Per-sub-test timing from CI (gfx908 MI100):

| Sub-test | Duration |
|----------|----------|
| CommRegisterDeregister_Disabled | 2.80s |
| CommRegisterDeregister_Enabled | 2.78s |
| MultipleBufferRegistration_Disabled | 2.77s |
| MultipleBufferRegistration_Enabled | 2.77s |
| VariableSizeBuffers_Disabled | 2.75s |
| VariableSizeBuffers_Enabled | 2.75s |
| DeregisterNullHandle | 2.71s |
| P2pThenCollective_SameBuffer | 0.40s (SKIP) |
| **WindowRegisterSingleRankNonSymTeardown** | **>300s HANG** |

A bisect across 7 commits (Jun 25 – Jul 24, 3 runs each on ruby MI350 8-GPU) confirms no RCCL code PR caused a timing regression — execution time is flat at 34-37s on gfx950.

## Changes

1. **`RegisterTests.cpp`**: Add `deviceSupportsCuMemVmm()` helper that checks whether the GPU architecture supports cuMem Virtual Memory Management (allowlists gfx942/gfx950/gfx1250). Guard `testWindowRegisterSingleRankNonSymTeardown` with this check, using `GTEST_SKIP()` on unsupported architectures.

2. **`ci-precheckin.json`**: Add `"timeout": 300` override for `Register.ProcessIsolatedRegisterTests`. The test legitimately needs >90s because `P2pThenCollective_SameBuffer` has a 120s internal timeout.

JIRA ID : AICOMRCCL-1706

## Test Plan

- [x] Bisect timing data: 7 commits, 21 runs, 0 failures on gfx950
- [x] Identified hanging sub-test from CI logs (gfx908)
- [x] Root-caused to PR #8341 default timeout bump exposing pre-existing gfx908 hang
- [ ] Verify precheckin pipeline passes with arch skip