### PR TITLE
feat(rccl): add DDA fabric allreduce LL two-shot

### DIFF
--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -124,6 +124,7 @@ set(SRC_FILES
   include/algorithms/CollCommon_ll128.h
   include/algorithms/all_reduce/all_reduce_dda.h
   include/algorithms/all_reduce/all_reduce_dda_ll.h
+  include/algorithms/all_reduce/all_reduce_dda_ll_twoshot.h
   include/algorithms/all_reduce/all_reduce_dda_fabric_ll128.h
   include/algorithms/reduce_scatter/reduce_scatter_dda.h
   include/algorithms/all_gather/all_gather_dda.h

--- a/projects/rccl/src/dda_all_gather_fabric_ll.cu
+++ b/projects/rccl/src/dda_all_gather_fabric_ll.cu
@@ -131,7 +131,8 @@ bool ncclAllGatherDdaFabricLLEligible(ncclComm* comm, const void* sendbuff, void
   if (perRankBytes % 16 != 0) {
     return false;
   }
-  if (perRankBytes > kDdaLLMaxBytes) {
+  // expand from 8B to 16B
+  if (perRankBytes * 2 > kDdaLLMaxBytes) {
     return false;
   }
   if (ddaLLAgScratchSize(comm->nRanks) > comm->ddaScratchBytes) {

--- a/projects/rccl/src/dda_all_gather_fabric_ll.cu
+++ b/projects/rccl/src/dda_all_gather_fabric_ll.cu
@@ -22,8 +22,8 @@
 
 namespace {
 
-using meta::comms::kDdaLLAgMaxPerRankBytes;
 using meta::comms::kDdaLLAgSlotStridePkts;
+using meta::comms::kDdaLLMaxBytes;
 using meta::comms::LLPacket16;
 using nccl_dda_detail::kDdaLLAgMaxBlocksPerPeer;
 
@@ -131,7 +131,7 @@ bool ncclAllGatherDdaFabricLLEligible(ncclComm* comm, const void* sendbuff, void
   if (perRankBytes % 16 != 0) {
     return false;
   }
-  if (perRankBytes > kDdaLLAgMaxPerRankBytes) {
+  if (perRankBytes > kDdaLLMaxBytes) {
     return false;
   }
   if (ddaLLAgScratchSize(comm->nRanks) > comm->ddaScratchBytes) {

--- a/projects/rccl/src/dda_all_reduce_fabric_ll.cu
+++ b/projects/rccl/src/dda_all_reduce_fabric_ll.cu
@@ -62,17 +62,17 @@ static inline size_t ddaLLArScratchSize(int nRanks) {
   return (size_t)2 * (size_t)nRanks * kDdaLLArSlotStridePkts * sizeof(LLPacket16);
 }
 
-// Two-shot footprint, sized off that tier's own slot constant so it tracks the
-// tier it guards rather than the one-shot's.
+// Two-shot footprint, 2 banks * nRanks slots * slotStride packets * 16B  * 2 phases.
 static inline size_t ddaLLArTwoShotScratchSize(int nRanks) {
-  return (size_t)2 * (size_t)nRanks * kDdaLLArTwoShotSlotStridePkts * sizeof(LLPacket16);
+  return (size_t)2 * (size_t)nRanks * kDdaLLArTwoShotSlotStridePkts * sizeof(LLPacket16) * 2;
 }
 
 // The two tiers stage through one scratch under one epoch, so bank 1 has to
 // start at the same offset for both; otherwise a launch of one could write over
 // lines the other is still polling an epoch later.
 static_assert(kDdaLLArTwoShotSlotStridePkts == kDdaLLArSlotStridePkts / 2,
-              "LL all-reduce tiers share one scratch and epoch; keep LL-ts slot half of LL");
+              "LL all-reduce tiers share one scratch and epoch; \
+              keep LL-ts slot half of LL becuase the scratch is used in two phases");
 
 // Single source of the launch geometry: 1-D grid over 8-byte LL packets, capped
 // low (LL serves tiny messages where latency, not occupancy, dominates).
@@ -221,9 +221,8 @@ static bool ddaLLArOneShotEligible(ncclComm* comm, const void* sendbuff, void* r
   }
 
   const size_t bytes = count * ncclTypeSize(datatype);
-  // Payload is staged as 8-byte LL packets, so it must be a whole number of
-  // packets.
-  if (bytes % 8 != 0) {
+
+  if (bytes % 16 != 0) {
     return false;
   }
   if (bytes > kDdaLLArMaxBytes) {
@@ -262,19 +261,22 @@ static bool ddaLLArTwoShotEligible(ncclComm* comm, const void* sendbuff, void* r
   }
 
   const size_t bytes = count * ncclTypeSize(datatype);
-  // Payload is staged as 8-byte LL packets per rank,
-  // so it must be a whole number of packets.
-  if (bytes % (8 * (size_t)comm->nRanks) != 0) {
-    return false;
-  }
-  if (bytes > kDdaLLArTwoShotMaxBytes) {
-    return false;
-  }
-  if (ddaLLArTwoShotScratchSize(comm->nRanks) > comm->ddaScratchBytes) {
+
+  if (bytes % (size_t)comm->nRanks != 0) {
     return false;
   }
 
-  if ((bytes >> 3) / (size_t)comm->nRanks > kDdaLLArTwoShotSlotStridePkts) {
+  const size_t bytesPerRank = bytes / (size_t)comm->nRanks;
+
+  if (bytesPerRank % 16 != 0) {
+    return false;
+  }
+
+  if (bytesPerRank > kDdaLLArTwoShotMaxBytes) {
+    return false;
+  }
+
+  if (ddaLLArTwoShotScratchSize(comm->nRanks) > comm->ddaScratchBytes) {
     return false;
   }
 

--- a/projects/rccl/src/dda_all_reduce_fabric_ll.cu
+++ b/projects/rccl/src/dda_all_reduce_fabric_ll.cu
@@ -51,8 +51,8 @@ static inline size_t ddaLLArTwoShotScratchSize(int nRanks) {
 // The two tiers stage through one scratch under one epoch, so bank 1 has to
 // start at the same offset for both; otherwise a launch of one could write over
 // lines the other is still polling an epoch later.
-static_assert(kDdaLLArTwoShotSlotStridePkts == kDdaLLArSlotStridePkts,
-              "LL all-reduce tiers share one scratch and epoch; keep their slot strides equal");
+static_assert(kDdaLLArTwoShotSlotStridePkts == kDdaLLArSlotStridePkts / 2,
+              "LL all-reduce tiers share one scratch and epoch; keep LL-ts slot half of LL");
 
 // Single source of the launch geometry: 1-D grid over 8-byte LL packets, capped
 // low (LL serves tiny messages where latency, not occupancy, dominates).
@@ -129,7 +129,7 @@ static ncclResult_t ncclAllReduceDdaFabricLLTwoShotTyped(const void* sendbuff, v
                                                          ncclComm* comm, cudaStream_t stream) {
   const int nRanks = comm->nRanks;
   const size_t bytes = count * sizeof(T);
-  const size_t nPk = bytes >> 3; // 8 payload bytes per packet
+  const size_t nPk = (bytes >> 3 ) / (size_t)nRanks; // 8 payload bytes per packet
 
   const unsigned threads = 256;
   int nBlocksMax = std::min(comm->ddaFabricMaxBlocks, nccl_dda_detail::kDdaFabricLLArMaxBlocks);
@@ -256,15 +256,19 @@ bool ncclAllReduceDdaFabricLLTwoShotEligible(ncclComm* comm, const void* sendbuf
   }
 
   const size_t bytes = count * ncclTypeSize(datatype);
-  // Payload is staged as 8-byte LL packets, so it must be a whole number of
-  // packets.
-  if (bytes % 8 != 0) {
+  // Payload is staged as 8-byte LL packets per rank,
+  // so it must be a whole number of packets.
+  if (bytes % (8 * (size_t)comm->nRanks) != 0) {
     return false;
   }
   if (bytes > kDdaLLArTwoShotMaxBytes) {
     return false;
   }
   if (ddaLLArTwoShotScratchSize(comm->nRanks) > comm->ddaScratchBytes) {
+    return false;
+  }
+
+  if ((bytes >> 3) / (size_t)comm->nRanks > kDdaLLArTwoShotSlotStridePkts) {
     return false;
   }
 

--- a/projects/rccl/src/dda_all_reduce_fabric_ll.cu
+++ b/projects/rccl/src/dda_all_reduce_fabric_ll.cu
@@ -22,6 +22,7 @@
 #include "dda_init_detail.h" // nccl_dda_detail::kDdaFabricLLArMaxBlocks
 #include "debug.h"
 #include "fabric_gpu_barrier.h" // meta::comms::kDdaMaxNranks
+#include "param.h"
 
 #include <cuda_runtime.h>
 
@@ -29,6 +30,24 @@
 #include <cstddef>
 #include <cstdint>
 #include <utility>
+
+// Tier selection for the LL AllReduce lives here rather than in collectives.cc,
+// so that file has a single call site (ncclAllReduceDdaFabricLL) and does not
+// need to know that the tier has two variants.
+//
+// DDA_LL / DDA_LL_THRESHOLD are shared with the AllGather, AllToAll and
+// ReduceScatter LL tiers, so they stay defined in collectives.cc and are only
+// declared here. The two-shot knobs are AllReduce-only and are defined here.
+RCCL_PARAM_DECLARE(DdaLL);
+RCCL_PARAM_DECLARE(DdaLLThreshold);
+
+// Two-shot LL tier: transports one shard per rank instead of the whole message.
+// Left inert by default (threshold 0 matches no message) until its range is
+// tuned. Raising DDA_LL_TWOSHOT_THRESHOLD is what opts a run into it; setting
+// DDA_LL_THRESHOLD=0 alongside is what hands the same sizes over from the
+// one-shot tier.
+RCCL_PARAM(DdaLLTwoShot, "DDA_LL_TWOSHOT", 1);
+RCCL_PARAM(DdaLLTwoShotThreshold, "DDA_LL_TWOSHOT_THRESHOLD", (size_t)(0));
 
 namespace {
 
@@ -175,10 +194,10 @@ static ncclResult_t ncclAllReduceDdaFabricLLTwoShotTyped(const void* sendbuff, v
   return ncclSuccess;
 }
 
-} // namespace
-
-bool ncclAllReduceDdaFabricLLEligible(ncclComm* comm, const void* sendbuff, void* recvbuff, size_t count,
-                                      ncclDataType_t datatype, ncclRedOp_t op) {
+// Shape/resource eligibility for the one-shot variant, independent of whether
+// the tier is switched on for this size.
+static bool ddaLLArOneShotEligible(ncclComm* comm, const void* sendbuff, void* recvbuff, size_t count,
+                                   ncclDataType_t datatype, ncclRedOp_t op) {
   (void)sendbuff;
   (void)recvbuff;
   if (comm == nullptr || comm->bootstrap == nullptr) {
@@ -217,23 +236,9 @@ bool ncclAllReduceDdaFabricLLEligible(ncclComm* comm, const void* sendbuff, void
   return true;
 }
 
-ncclResult_t ncclAllReduceDdaFabricLL(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
-                                      ncclRedOp_t op, ncclComm* comm, cudaStream_t stream) {
-  (void)op;
-  switch (datatype) {
-  case ncclFloat32:
-    return ncclAllReduceDdaFabricLLTyped<float>(sendbuff, recvbuff, count, comm, stream);
-  case ncclFloat16:
-    return ncclAllReduceDdaFabricLLTyped<half>(sendbuff, recvbuff, count, comm, stream);
-  case ncclBfloat16:
-    return ncclAllReduceDdaFabricLLTyped<bf16>(sendbuff, recvbuff, count, comm, stream);
-  default:
-    return ncclInvalidArgument;
-  }
-}
-
-bool ncclAllReduceDdaFabricLLTwoShotEligible(ncclComm* comm, const void* sendbuff, void* recvbuff, size_t count,
-                                             ncclDataType_t datatype, ncclRedOp_t op) {
+// Shape/resource eligibility for the two-shot variant.
+static bool ddaLLArTwoShotEligible(ncclComm* comm, const void* sendbuff, void* recvbuff, size_t count,
+                                   ncclDataType_t datatype, ncclRedOp_t op) {
   (void)sendbuff;
   (void)recvbuff;
   if (comm == nullptr || comm->bootstrap == nullptr) {
@@ -276,20 +281,70 @@ bool ncclAllReduceDdaFabricLLTwoShotEligible(ncclComm* comm, const void* sendbuf
   return true;
 }
 
-ncclResult_t ncclAllReduceDdaFabricLLTwoShot(const void* sendbuff, void* recvbuff, size_t count,
-                                             ncclDataType_t datatype, ncclRedOp_t op, ncclComm* comm,
-                                             cudaStream_t stream) {
-  (void)op;
-  switch (datatype) {
-  case ncclFloat32:
-    return ncclAllReduceDdaFabricLLTwoShotTyped<float>(sendbuff, recvbuff, count, comm, stream);
-  case ncclFloat16:
-    return ncclAllReduceDdaFabricLLTwoShotTyped<half>(sendbuff, recvbuff, count, comm, stream);
-  case ncclBfloat16:
-    return ncclAllReduceDdaFabricLLTwoShotTyped<bf16>(sendbuff, recvbuff, count, comm, stream);
-  default:
-    return ncclInvalidArgument;
+// Tier selection: enabled, within this tier's threshold, and shape-eligible.
+// One-shot is tested first, so a message that qualifies for both takes it; a run
+// hands sizes over to two-shot by lowering DDA_LL_THRESHOLD and raising
+// DDA_LL_TWOSHOT_THRESHOLD.
+static bool ddaLLArOneShotSelected(ncclComm* comm, const void* sendbuff, void* recvbuff, size_t count,
+                                   ncclDataType_t datatype, ncclRedOp_t op) {
+  return rcclParamDdaLL() != 0 && (count * ncclTypeSize(datatype)) <= (size_t)rcclParamDdaLLThreshold() &&
+         ddaLLArOneShotEligible(comm, sendbuff, recvbuff, count, datatype, op);
+}
+
+static bool ddaLLArTwoShotSelected(ncclComm* comm, const void* sendbuff, void* recvbuff, size_t count,
+                                   ncclDataType_t datatype, ncclRedOp_t op) {
+  return rcclParamDdaLLTwoShot() != 0 && (count * ncclTypeSize(datatype)) <= (size_t)rcclParamDdaLLTwoShotThreshold() &&
+         ddaLLArTwoShotEligible(comm, sendbuff, recvbuff, count, datatype, op);
+}
+
+} // namespace
+
+bool ncclAllReduceDdaFabricLLEligible(ncclComm* comm, const void* sendbuff, void* recvbuff, size_t count,
+                                      ncclDataType_t datatype, ncclRedOp_t op) {
+  return ddaLLArOneShotSelected(comm, sendbuff, recvbuff, count, datatype, op) ||
+         ddaLLArTwoShotSelected(comm, sendbuff, recvbuff, count, datatype, op);
+}
+
+ncclResult_t ncclAllReduceDdaFabricLL(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
+                                      ncclRedOp_t op, ncclComm* comm, cudaStream_t stream) {
+  const size_t bytes = count * ncclTypeSize(datatype);
+
+  if (ddaLLArOneShotSelected(comm, sendbuff, recvbuff, count, datatype, op)) {
+    INFO(NCCL_COLL, "AllReduce: taking DDA fabric LL one-shot path: nRanks=%d nNodes=%d count=%zu datatype=%d bytes=%zu",
+         comm->nRanks, comm->nNodes, count, (int)datatype, bytes);
+    (void)op;
+    switch (datatype) {
+    case ncclFloat32:
+      return ncclAllReduceDdaFabricLLTyped<float>(sendbuff, recvbuff, count, comm, stream);
+    case ncclFloat16:
+      return ncclAllReduceDdaFabricLLTyped<half>(sendbuff, recvbuff, count, comm, stream);
+    case ncclBfloat16:
+      return ncclAllReduceDdaFabricLLTyped<bf16>(sendbuff, recvbuff, count, comm, stream);
+    default:
+      return ncclInvalidArgument;
+    }
   }
+
+  if (ddaLLArTwoShotSelected(comm, sendbuff, recvbuff, count, datatype, op)) {
+    INFO(NCCL_COLL, "AllReduce: taking DDA fabric LL two-shot path: nRanks=%d nNodes=%d count=%zu datatype=%d bytes=%zu",
+         comm->nRanks, comm->nNodes, count, (int)datatype, bytes);
+    switch (datatype) {
+    case ncclFloat32:
+      return ncclAllReduceDdaFabricLLTwoShotTyped<float>(sendbuff, recvbuff, count, comm, stream);
+    case ncclFloat16:
+      return ncclAllReduceDdaFabricLLTwoShotTyped<half>(sendbuff, recvbuff, count, comm, stream);
+    case ncclBfloat16:
+      return ncclAllReduceDdaFabricLLTwoShotTyped<bf16>(sendbuff, recvbuff, count, comm, stream);
+    default:
+      return ncclInvalidArgument;
+    }
+  }
+
+  // Callers gate on ncclAllReduceDdaFabricLLEligible, which is the disjunction of
+  // the two selectors above, so neither matching means the caller skipped it.
+  WARN("ncclAllReduceDdaFabricLL called for a message no LL tier claims: count=%zu datatype=%d bytes=%zu", count,
+       (int)datatype, bytes);
+  return ncclInternalError;
 }
 
 uint32_t ncclAllReduceDdaFabricLLBlocks(ncclComm* comm, size_t count, ncclDataType_t datatype) {

--- a/projects/rccl/src/dda_all_reduce_fabric_ll.cu
+++ b/projects/rccl/src/dda_all_reduce_fabric_ll.cu
@@ -63,7 +63,7 @@ static_assert(kDdaLLArTwoShotSlotStridePkts == kDdaLLArSlotStridePkts / 2,
 static inline std::pair<dim3, dim3> ddaAllReduceFabricLLGeom(ncclComm* comm, size_t count, int typeSize) {
   const size_t nPk = ((size_t)count * (size_t)typeSize) >> 3; // 8 payload bytes per packet
   const unsigned threads = 256;
-  int nBlocksMax = std::min(comm->ddaFabricMaxBlocks, nccl_dda_detail::kDdaFabricLLArMaxBlocks);
+  int nBlocksMax = comm->ddaFabricMaxBlocks;
   if (nBlocksMax < 1) {
     nBlocksMax = 1;
   }

--- a/projects/rccl/src/dda_all_reduce_fabric_ll.cu
+++ b/projects/rccl/src/dda_all_reduce_fabric_ll.cu
@@ -19,7 +19,6 @@
 #include "algorithms/all_reduce/all_reduce_dda_ll_twoshot.h"
 #include "checks.h"
 #include "comm.h"
-#include "dda_init_detail.h" // nccl_dda_detail::kDdaFabricLLArMaxBlocks
 #include "debug.h"
 #include "fabric_gpu_barrier.h" // meta::comms::kDdaMaxNranks
 #include "param.h"
@@ -97,7 +96,7 @@ static ncclResult_t ncclAllReduceDdaFabricLLTyped(const void* sendbuff, void* re
   const size_t nPk = bytes >> 3; // 8 payload bytes per packet (for logging)
 
   const unsigned threads = 256;
-  int nBlocksMax = std::min(comm->ddaFabricMaxBlocks, nccl_dda_detail::kDdaFabricLLArMaxBlocks);
+  int nBlocksMax = comm->ddaFabricMaxBlocks;
   if (nBlocksMax < 1) {
     nBlocksMax = 1;
   }
@@ -151,7 +150,7 @@ static ncclResult_t ncclAllReduceDdaFabricLLTwoShotTyped(const void* sendbuff, v
   const size_t nPk = (bytes >> 3 ) / (size_t)nRanks; // 8 payload bytes per packet
 
   const unsigned threads = 256;
-  int nBlocksMax = std::min(comm->ddaFabricMaxBlocks, nccl_dda_detail::kDdaFabricLLArMaxBlocks);
+  int nBlocksMax = comm->ddaFabricMaxBlocks;
   if (nBlocksMax < 1) {
     nBlocksMax = 1;
   }

--- a/projects/rccl/src/dda_all_reduce_fabric_ll.cu
+++ b/projects/rccl/src/dda_all_reduce_fabric_ll.cu
@@ -5,10 +5,11 @@
  * All-reduce analogue of dda_all_gather_fabric_ll.cu; reuses the codepath-
  * agnostic ddaAllReduceFlatLL kernel from all_reduce_dda_ll.h.
  *
- * Carries both LL tiers. The two-shot tier's kernel is still a verbatim copy of
- * the one-shot's, so hosting the two launchers in one translation unit keeps
- * them on identical compile flags and leaves the dispatch tier as the only
- * difference between them.
+ * Carries both LL all-reduce tiers: the one-shot kernel above and the two-shot
+ * kernel from all_reduce_dda_ll_twoshot.h, which transports one shard per rank
+ * instead of the whole message. They share a scratch layout and epoch counter, so
+ * keeping both launchers in one translation unit also keeps the invariant that
+ * ties them (the static_assert below) next to the code it constrains.
  * See LICENSE.txt for license information.
  ************************************************************************/
 
@@ -42,8 +43,8 @@ static inline size_t ddaLLArScratchSize(int nRanks) {
   return (size_t)2 * (size_t)nRanks * kDdaLLArSlotStridePkts * sizeof(LLPacket16);
 }
 
-// Same shape, off the two-shot tier's own constant, so a tier that later grows
-// its slot is sized against the scratch it actually uses.
+// Two-shot footprint, sized off that tier's own slot constant so it tracks the
+// tier it guards rather than the one-shot's.
 static inline size_t ddaLLArTwoShotScratchSize(int nRanks) {
   return (size_t)2 * (size_t)nRanks * kDdaLLArTwoShotSlotStridePkts * sizeof(LLPacket16);
 }
@@ -120,10 +121,10 @@ static ncclResult_t ncclAllReduceDdaFabricLLTyped(const void* sendbuff, void* re
   return ncclSuccess;
 }
 
-// Mirrors ncclAllReduceDdaFabricLLTyped: the kernel it launches is a copy, so the
-// grid sizing and arguments are deliberately the same. Keep them that way while
-// the kernels match, so a measured difference between the tiers can only come
-// from the dispatch.
+// Every phase of the two-shot kernel loops over one shard, with the peer fan-out
+// inside it, so the grid covers count/nRanks packets rather than the whole
+// message; sizing it on the message would only add blocks whose gtid starts past
+// the loop bound.
 template <typename T>
 static ncclResult_t ncclAllReduceDdaFabricLLTwoShotTyped(const void* sendbuff, void* recvbuff, size_t count,
                                                          ncclComm* comm, cudaStream_t stream) {

--- a/projects/rccl/src/dda_all_reduce_fabric_ll.cu
+++ b/projects/rccl/src/dda_all_reduce_fabric_ll.cu
@@ -178,10 +178,12 @@ static ncclResult_t ncclAllReduceDdaFabricLLTwoShotTyped(const void* sendbuff, v
   return ncclSuccess;
 }
 
+} // namespace
+
 // Shape/resource eligibility for the one-shot variant, independent of whether
 // the tier is switched on for this size.
-static bool ddaLLArOneShotEligible(ncclComm* comm, const void* sendbuff, void* recvbuff, size_t count,
-                                   ncclDataType_t datatype, ncclRedOp_t op) {
+bool ddaLLArOneShotEligible(ncclComm* comm, const void* sendbuff, void* recvbuff, size_t count,
+                            ncclDataType_t datatype, ncclRedOp_t op) {
   (void)sendbuff;
   (void)recvbuff;
   if (rcclParamDdaLL() == 0) {
@@ -229,8 +231,8 @@ static bool ddaLLArOneShotEligible(ncclComm* comm, const void* sendbuff, void* r
 }
 
 // Shape/resource eligibility for the two-shot variant.
-static bool ddaLLArTwoShotEligible(ncclComm* comm, const void* sendbuff, void* recvbuff, size_t count,
-                                   ncclDataType_t datatype, ncclRedOp_t op) {
+bool ddaLLArTwoShotEligible(ncclComm* comm, const void* sendbuff, void* recvbuff, size_t count,
+                            ncclDataType_t datatype, ncclRedOp_t op) {
   (void)sendbuff;
   (void)recvbuff;
   if (rcclParamDdaLL() == 0) {
@@ -284,8 +286,6 @@ static bool ddaLLArTwoShotEligible(ncclComm* comm, const void* sendbuff, void* r
 
   return true;
 }
-
-} // namespace
 
 // Tier selection: enabled, within this tier's threshold, and shape-eligible.
 // One-shot is tested first, so a message that qualifies for both takes it; a run

--- a/projects/rccl/src/dda_all_reduce_fabric_ll.cu
+++ b/projects/rccl/src/dda_all_reduce_fabric_ll.cu
@@ -4,12 +4,18 @@
  * Host launcher + eligibility for the LL-protocol DDA fabric all-reduce.
  * All-reduce analogue of dda_all_gather_fabric_ll.cu; reuses the codepath-
  * agnostic ddaAllReduceFlatLL kernel from all_reduce_dda_ll.h.
+ *
+ * Carries both LL tiers. The two-shot tier's kernel is still a verbatim copy of
+ * the one-shot's, so hosting the two launchers in one translation unit keeps
+ * them on identical compile flags and leaves the dispatch tier as the only
+ * difference between them.
  * See LICENSE.txt for license information.
  ************************************************************************/
 
 #include "dda_all_reduce.h"
 
 #include "algorithms/all_reduce/all_reduce_dda_ll.h"
+#include "algorithms/all_reduce/all_reduce_dda_ll_twoshot.h"
 #include "checks.h"
 #include "comm.h"
 #include "dda_init_detail.h" // nccl_dda_detail::kDdaFabricLLArMaxBlocks
@@ -27,12 +33,26 @@ namespace {
 
 using meta::comms::kDdaLLArMaxBytes;
 using meta::comms::kDdaLLArSlotStridePkts;
+using meta::comms::kDdaLLArTwoShotMaxBytes;
+using meta::comms::kDdaLLArTwoShotSlotStridePkts;
 using meta::comms::LLPacket16;
 
 // LL scratch footprint: 2 banks * nRanks slots * slotStride packets * 16B.
 static inline size_t ddaLLArScratchSize(int nRanks) {
   return (size_t)2 * (size_t)nRanks * kDdaLLArSlotStridePkts * sizeof(LLPacket16);
 }
+
+// Same shape, off the two-shot tier's own constant, so a tier that later grows
+// its slot is sized against the scratch it actually uses.
+static inline size_t ddaLLArTwoShotScratchSize(int nRanks) {
+  return (size_t)2 * (size_t)nRanks * kDdaLLArTwoShotSlotStridePkts * sizeof(LLPacket16);
+}
+
+// The two tiers stage through one scratch under one epoch, so bank 1 has to
+// start at the same offset for both; otherwise a launch of one could write over
+// lines the other is still polling an epoch later.
+static_assert(kDdaLLArTwoShotSlotStridePkts == kDdaLLArSlotStridePkts,
+              "LL all-reduce tiers share one scratch and epoch; keep their slot strides equal");
 
 // Single source of the launch geometry: 1-D grid over 8-byte LL packets, capped
 // low (LL serves tiny messages where latency, not occupancy, dominates).
@@ -57,9 +77,17 @@ static ncclResult_t ncclAllReduceDdaFabricLLTyped(const void* sendbuff, void* re
   const size_t bytes = count * sizeof(T);
   const size_t nPk = bytes >> 3; // 8 payload bytes per packet (for logging)
 
-  auto gridBlock = ddaAllReduceFabricLLGeom(comm, count, sizeof(T));
-  const dim3 grid = gridBlock.first;
-  const dim3 block = gridBlock.second;
+  const unsigned threads = 256;
+  int nBlocksMax = std::min(comm->ddaFabricMaxBlocks, nccl_dda_detail::kDdaFabricLLArMaxBlocks);
+  if (nBlocksMax < 1) {
+    nBlocksMax = 1;
+  }
+  unsigned blocks = (unsigned)std::min<size_t>((nPk + threads - 1) / threads, (size_t)nBlocksMax);
+  if (blocks == 0) {
+    blocks = 1;
+  }
+  dim3 block(threads);
+  dim3 grid(blocks);
 
   T** peers = reinterpret_cast<T**>(comm->ddaPeerPtrsDev);
   // Shared epoch counter (same as AG/RS) so bank = flag & 1 is consistent
@@ -83,6 +111,60 @@ static ncclResult_t ncclAllReduceDdaFabricLLTyped(const void* sendbuff, void* re
     break;
   default:
     meta::comms::ddaAllReduceFlatLL<T, 0><<<grid, block, 0, stream>>>(
+      peers, static_cast<T*>(recvbuff), static_cast<const T*>(sendbuff), count, comm->rank, nRanks, epochDev, epochLen);
+    break;
+  }
+
+  CUDACHECK(cudaGetLastError());
+
+  return ncclSuccess;
+}
+
+// Mirrors ncclAllReduceDdaFabricLLTyped: the kernel it launches is a copy, so the
+// grid sizing and arguments are deliberately the same. Keep them that way while
+// the kernels match, so a measured difference between the tiers can only come
+// from the dispatch.
+template <typename T>
+static ncclResult_t ncclAllReduceDdaFabricLLTwoShotTyped(const void* sendbuff, void* recvbuff, size_t count,
+                                                         ncclComm* comm, cudaStream_t stream) {
+  const int nRanks = comm->nRanks;
+  const size_t bytes = count * sizeof(T);
+  const size_t nPk = bytes >> 3; // 8 payload bytes per packet
+
+  const unsigned threads = 256;
+  int nBlocksMax = std::min(comm->ddaFabricMaxBlocks, nccl_dda_detail::kDdaFabricLLArMaxBlocks);
+  if (nBlocksMax < 1) {
+    nBlocksMax = 1;
+  }
+  unsigned blocks = (unsigned)std::min<size_t>((nPk + threads - 1) / threads, (size_t)nBlocksMax);
+  if (blocks == 0) {
+    blocks = 1;
+  }
+  dim3 block(threads);
+  dim3 grid(blocks);
+
+  T** peers = reinterpret_cast<T**>(comm->ddaPeerPtrsDev);
+  // Same epoch counter the one-shot tier uses: the two share a scratch layout, so
+  // one monotonic flag is what keeps either from accepting a line the other left.
+  uint32_t* epochDev = comm->ddaLLEpochDev;
+  const int epochLen = comm->ddaLLEpochLen;
+
+  INFO(NCCL_COLL, "DDA fabric AllReduce LL two-shot: nRanks=%d bytes=%zu nPk=%zu grid=%u block=%u", nRanks, bytes, nPk,
+       grid.x, block.x);
+
+  // NRANKS_CT 4/8: unrolled reduce loop; 0: runtime fallback (up to
+  // kDdaMaxNranks).
+  switch (nRanks) {
+  case 4:
+    meta::comms::ddaAllReduceTwoShotLL<T, 4><<<grid, block, 0, stream>>>(
+      peers, static_cast<T*>(recvbuff), static_cast<const T*>(sendbuff), count, comm->rank, nRanks, epochDev, epochLen);
+    break;
+  case 8:
+    meta::comms::ddaAllReduceTwoShotLL<T, 8><<<grid, block, 0, stream>>>(
+      peers, static_cast<T*>(recvbuff), static_cast<const T*>(sendbuff), count, comm->rank, nRanks, epochDev, epochLen);
+    break;
+  default:
+    meta::comms::ddaAllReduceTwoShotLL<T, 0><<<grid, block, 0, stream>>>(
       peers, static_cast<T*>(recvbuff), static_cast<const T*>(sendbuff), count, comm->rank, nRanks, epochDev, epochLen);
     break;
   }
@@ -134,11 +216,6 @@ bool ncclAllReduceDdaFabricLLEligible(ncclComm* comm, const void* sendbuff, void
   return true;
 }
 
-uint32_t ncclAllReduceDdaFabricLLBlocks(ncclComm* comm, size_t count, ncclDataType_t datatype) {
-  const auto grid = ddaAllReduceFabricLLGeom(comm, count, ncclTypeSize(datatype)).first;
-  return grid.x * grid.y;
-}
-
 ncclResult_t ncclAllReduceDdaFabricLL(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
                                       ncclRedOp_t op, ncclComm* comm, cudaStream_t stream) {
   (void)op;
@@ -152,4 +229,65 @@ ncclResult_t ncclAllReduceDdaFabricLL(const void* sendbuff, void* recvbuff, size
   default:
     return ncclInvalidArgument;
   }
+}
+
+bool ncclAllReduceDdaFabricLLTwoShotEligible(ncclComm* comm, const void* sendbuff, void* recvbuff, size_t count,
+                                             ncclDataType_t datatype, ncclRedOp_t op) {
+  (void)sendbuff;
+  (void)recvbuff;
+  if (comm == nullptr || comm->bootstrap == nullptr) {
+    return false;
+  }
+  // Fabric path: requires the fabric handler + scratch + peer table.
+  if (comm->ddaFabricMemHandler == nullptr || comm->ddaScratch == nullptr || comm->ddaPeerPtrsDev == nullptr) {
+    return false;
+  }
+  if (comm->nRanks < 2 || comm->nRanks > meta::comms::kDdaMaxNranks) {
+    return false;
+  }
+  if (count == 0) {
+    return false;
+  }
+  if (op != ncclSum) {
+    return false;
+  }
+  if (datatype != ncclFloat32 && datatype != ncclFloat16 && datatype != ncclBfloat16) {
+    return false;
+  }
+
+  const size_t bytes = count * ncclTypeSize(datatype);
+  // Payload is staged as 8-byte LL packets, so it must be a whole number of
+  // packets.
+  if (bytes % 8 != 0) {
+    return false;
+  }
+  if (bytes > kDdaLLArTwoShotMaxBytes) {
+    return false;
+  }
+  if (ddaLLArTwoShotScratchSize(comm->nRanks) > comm->ddaScratchBytes) {
+    return false;
+  }
+
+  return true;
+}
+
+ncclResult_t ncclAllReduceDdaFabricLLTwoShot(const void* sendbuff, void* recvbuff, size_t count,
+                                             ncclDataType_t datatype, ncclRedOp_t op, ncclComm* comm,
+                                             cudaStream_t stream) {
+  (void)op;
+  switch (datatype) {
+  case ncclFloat32:
+    return ncclAllReduceDdaFabricLLTwoShotTyped<float>(sendbuff, recvbuff, count, comm, stream);
+  case ncclFloat16:
+    return ncclAllReduceDdaFabricLLTwoShotTyped<half>(sendbuff, recvbuff, count, comm, stream);
+  case ncclBfloat16:
+    return ncclAllReduceDdaFabricLLTwoShotTyped<bf16>(sendbuff, recvbuff, count, comm, stream);
+  default:
+    return ncclInvalidArgument;
+  }
+}
+
+uint32_t ncclAllReduceDdaFabricLLBlocks(ncclComm* comm, size_t count, ncclDataType_t datatype) {
+  const auto grid = ddaAllReduceFabricLLGeom(comm, count, ncclTypeSize(datatype)).first;
+  return grid.x * grid.y;
 }

--- a/projects/rccl/src/dda_all_reduce_fabric_ll.cu
+++ b/projects/rccl/src/dda_all_reduce_fabric_ll.cu
@@ -31,12 +31,8 @@
 #include <utility>
 
 RCCL_PARAM_DECLARE(DdaLL);
-
-// Total message size gates each LL tier, both also under DDA_LL. One-shot is tried
-// first, so <= 1 MiB takes one-shot and up to 16 MiB takes two-shot; past that the
-// message falls through to LL128/Simple. A threshold of 0 disables that tier.
-RCCL_PARAM(DdaLLOneShotThreshold, "DDA_LL_ONESHOT_THRESHOLD", (size_t)(1) * 1024 * 1024);
-RCCL_PARAM(DdaLLTwoShotThreshold, "DDA_LL_TWOSHOT_THRESHOLD", (size_t)(16) * 1024 * 1024);
+RCCL_PARAM_DECLARE(DdaLLOneShotThreshold);
+RCCL_PARAM_DECLARE(DdaLLTwoShotThreshold);
 
 namespace {
 

--- a/projects/rccl/src/dda_all_reduce_fabric_ll.cu
+++ b/projects/rccl/src/dda_all_reduce_fabric_ll.cu
@@ -81,7 +81,7 @@ static ncclResult_t ncclAllReduceDdaFabricLLTyped(const void* sendbuff, void* re
   const size_t bytes = count * sizeof(T);
   const size_t nPk = bytes >> 3; // 8 payload bytes per packet (for logging)
 
-  const unsigned threads = 256;
+  const unsigned threads = 512;
   int nBlocksMax = comm->ddaFabricMaxBlocks;
   if (nBlocksMax < 1) {
     nBlocksMax = 1;
@@ -135,7 +135,7 @@ static ncclResult_t ncclAllReduceDdaFabricLLTwoShotTyped(const void* sendbuff, v
   const size_t bytes = count * sizeof(T);
   const size_t nPk = (bytes >> 3 ) / (size_t)nRanks; // 8 payload bytes per packet
 
-  const unsigned threads = 256;
+  const unsigned threads = 1024;
   int nBlocksMax = comm->ddaFabricMaxBlocks;
   if (nBlocksMax < 1) {
     nBlocksMax = 1;

--- a/projects/rccl/src/dda_all_reduce_fabric_ll.cu
+++ b/projects/rccl/src/dda_all_reduce_fabric_ll.cu
@@ -51,10 +51,9 @@ RCCL_PARAM(DdaLLTwoShotThreshold, "DDA_LL_TWOSHOT_THRESHOLD", (size_t)(0));
 
 namespace {
 
-using meta::comms::kDdaLLArMaxBytes;
 using meta::comms::kDdaLLArSlotStridePkts;
-using meta::comms::kDdaLLArTwoShotMaxBytes;
 using meta::comms::kDdaLLArTwoShotSlotStridePkts;
+using meta::comms::kDdaLLMaxBytes;
 using meta::comms::LLPacket16;
 
 // LL scratch footprint: 2 banks * nRanks slots * slotStride packets * 16B.
@@ -225,7 +224,7 @@ static bool ddaLLArOneShotEligible(ncclComm* comm, const void* sendbuff, void* r
   if (bytes % 16 != 0) {
     return false;
   }
-  if (bytes > kDdaLLArMaxBytes) {
+  if (bytes > kDdaLLMaxBytes) {
     return false;
   }
   if (ddaLLArScratchSize(comm->nRanks) > comm->ddaScratchBytes) {
@@ -272,7 +271,7 @@ static bool ddaLLArTwoShotEligible(ncclComm* comm, const void* sendbuff, void* r
     return false;
   }
 
-  if (bytesPerRank > kDdaLLArTwoShotMaxBytes) {
+  if (bytesPerRank > kDdaLLMaxBytes) {
     return false;
   }
 

--- a/projects/rccl/src/dda_all_reduce_fabric_ll.cu
+++ b/projects/rccl/src/dda_all_reduce_fabric_ll.cu
@@ -217,7 +217,8 @@ static bool ddaLLArOneShotEligible(ncclComm* comm, const void* sendbuff, void* r
   if (bytes % 16 != 0) {
     return false;
   }
-  if (bytes > kDdaLLMaxBytes) {
+  // expand from 8B to 16B
+  if (bytes * 2 > kDdaLLMaxBytes) {
     return false;
   }
   if (ddaLLArScratchSize(comm->nRanks) > comm->ddaScratchBytes) {
@@ -272,8 +273,8 @@ static bool ddaLLArTwoShotEligible(ncclComm* comm, const void* sendbuff, void* r
     return false;
   }
 
-  // two copy phases
-  if (bytesPerRank * 2 > kDdaLLMaxBytes) {
+  // expand from 8B to 16B and two copy phases
+  if (bytesPerRank * 2 * 2 > kDdaLLMaxBytes) {
     return false;
   }
 

--- a/projects/rccl/src/dda_all_reduce_fabric_ll.cu
+++ b/projects/rccl/src/dda_all_reduce_fabric_ll.cu
@@ -184,6 +184,14 @@ static bool ddaLLArOneShotEligible(ncclComm* comm, const void* sendbuff, void* r
                                    ncclDataType_t datatype, ncclRedOp_t op) {
   (void)sendbuff;
   (void)recvbuff;
+  if (rcclParamDdaLL() == 0) {
+      return false;
+  }
+
+  if (count * ncclTypeSize(datatype) > (size_t)rcclParamDdaLLOneShotThreshold()) {
+      return false;
+  }
+
   if (comm == nullptr || comm->bootstrap == nullptr) {
     return false;
   }
@@ -224,6 +232,14 @@ static bool ddaLLArTwoShotEligible(ncclComm* comm, const void* sendbuff, void* r
                                    ncclDataType_t datatype, ncclRedOp_t op) {
   (void)sendbuff;
   (void)recvbuff;
+  if (rcclParamDdaLL() == 0) {
+      return false;
+  }
+
+  if (count * ncclTypeSize(datatype) > (size_t)rcclParamDdaLLTwoShotThreshold()) {
+      return false;
+  }
+
   if (comm == nullptr || comm->bootstrap == nullptr) {
     return false;
   }
@@ -268,35 +284,23 @@ static bool ddaLLArTwoShotEligible(ncclComm* comm, const void* sendbuff, void* r
   return true;
 }
 
+} // namespace
+
 // Tier selection: enabled, within this tier's threshold, and shape-eligible.
 // One-shot is tested first, so a message that qualifies for both takes it; a run
 // hands sizes over to two-shot by lowering DDA_LL_THRESHOLD and raising
 // DDA_LL_TWOSHOT_THRESHOLD.
-static bool ddaLLArOneShotSelected(ncclComm* comm, const void* sendbuff, void* recvbuff, size_t count,
-                                   ncclDataType_t datatype, ncclRedOp_t op) {
-  return rcclParamDdaLL() != 0 && (count * ncclTypeSize(datatype)) <= (size_t)rcclParamDdaLLOneShotThreshold() &&
-         ddaLLArOneShotEligible(comm, sendbuff, recvbuff, count, datatype, op);
-}
-
-static bool ddaLLArTwoShotSelected(ncclComm* comm, const void* sendbuff, void* recvbuff, size_t count,
-                                   ncclDataType_t datatype, ncclRedOp_t op) {
-  return rcclParamDdaLL() != 0 && (count * ncclTypeSize(datatype)) <= (size_t)rcclParamDdaLLTwoShotThreshold() &&
-         ddaLLArTwoShotEligible(comm, sendbuff, recvbuff, count, datatype, op);
-}
-
-} // namespace
-
 bool ncclAllReduceDdaFabricLLEligible(ncclComm* comm, const void* sendbuff, void* recvbuff, size_t count,
                                       ncclDataType_t datatype, ncclRedOp_t op) {
-  return ddaLLArOneShotSelected(comm, sendbuff, recvbuff, count, datatype, op) ||
-         ddaLLArTwoShotSelected(comm, sendbuff, recvbuff, count, datatype, op);
+  return ddaLLArOneShotEligible(comm, sendbuff, recvbuff, count, datatype, op) ||
+         ddaLLArTwoShotEligible(comm, sendbuff, recvbuff, count, datatype, op);
 }
 
 ncclResult_t ncclAllReduceDdaFabricLL(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
                                       ncclRedOp_t op, ncclComm* comm, cudaStream_t stream) {
   const size_t bytes = count * ncclTypeSize(datatype);
 
-  if (ddaLLArOneShotSelected(comm, sendbuff, recvbuff, count, datatype, op)) {
+  if (ddaLLArOneShotEligible(comm, sendbuff, recvbuff, count, datatype, op)) {
     INFO(NCCL_COLL, "AllReduce: taking DDA fabric LL one-shot path: nRanks=%d nNodes=%d count=%zu datatype=%d bytes=%zu",
          comm->nRanks, comm->nNodes, count, (int)datatype, bytes);
     (void)op;
@@ -312,7 +316,7 @@ ncclResult_t ncclAllReduceDdaFabricLL(const void* sendbuff, void* recvbuff, size
     }
   }
 
-  if (ddaLLArTwoShotSelected(comm, sendbuff, recvbuff, count, datatype, op)) {
+  if (ddaLLArTwoShotEligible(comm, sendbuff, recvbuff, count, datatype, op)) {
     INFO(NCCL_COLL, "AllReduce: taking DDA fabric LL two-shot path: nRanks=%d nNodes=%d count=%zu datatype=%d bytes=%zu",
          comm->nRanks, comm->nNodes, count, (int)datatype, bytes);
     switch (datatype) {

--- a/projects/rccl/src/dda_all_reduce_fabric_ll.cu
+++ b/projects/rccl/src/dda_all_reduce_fabric_ll.cu
@@ -30,23 +30,13 @@
 #include <cstdint>
 #include <utility>
 
-// Tier selection for the LL AllReduce lives here rather than in collectives.cc,
-// so that file has a single call site (ncclAllReduceDdaFabricLL) and does not
-// need to know that the tier has two variants.
-//
-// DDA_LL / DDA_LL_THRESHOLD are shared with the AllGather, AllToAll and
-// ReduceScatter LL tiers, so they stay defined in collectives.cc and are only
-// declared here. The two-shot knobs are AllReduce-only and are defined here.
 RCCL_PARAM_DECLARE(DdaLL);
-RCCL_PARAM_DECLARE(DdaLLThreshold);
 
-// Two-shot LL tier: transports one shard per rank instead of the whole message.
-// Left inert by default (threshold 0 matches no message) until its range is
-// tuned. Raising DDA_LL_TWOSHOT_THRESHOLD is what opts a run into it; setting
-// DDA_LL_THRESHOLD=0 alongside is what hands the same sizes over from the
-// one-shot tier.
-RCCL_PARAM(DdaLLTwoShot, "DDA_LL_TWOSHOT", 1);
-RCCL_PARAM(DdaLLTwoShotThreshold, "DDA_LL_TWOSHOT_THRESHOLD", (size_t)(0));
+// Total message size gates each LL tier, both also under DDA_LL. One-shot is tried
+// first, so <= 1 MiB takes one-shot and up to 16 MiB takes two-shot; past that the
+// message falls through to LL128/Simple. A threshold of 0 disables that tier.
+RCCL_PARAM(DdaLLOneShotThreshold, "DDA_LL_ONESHOT_THRESHOLD", (size_t)(1) * 1024 * 1024);
+RCCL_PARAM(DdaLLTwoShotThreshold, "DDA_LL_TWOSHOT_THRESHOLD", (size_t)(16) * 1024 * 1024);
 
 namespace {
 
@@ -70,7 +60,7 @@ static inline size_t ddaLLArTwoShotScratchSize(int nRanks) {
 // lines the other is still polling an epoch later.
 static_assert(kDdaLLArTwoShotSlotStridePkts == kDdaLLArSlotStridePkts / 2,
               "LL all-reduce tiers share one scratch and epoch; \
-              keep LL-ts slot half of LL becuase the scratch is used in two phases");
+              keep LL-ts slot half of LL because the scratch is used in two phases");
 
 // Single source of the launch geometry: 1-D grid over 8-byte LL packets, capped
 // low (LL serves tiny messages where latency, not occupancy, dominates).
@@ -270,7 +260,8 @@ static bool ddaLLArTwoShotEligible(ncclComm* comm, const void* sendbuff, void* r
     return false;
   }
 
-  if (bytesPerRank > kDdaLLMaxBytes) {
+  // two copy phases
+  if (bytesPerRank * 2 > kDdaLLMaxBytes) {
     return false;
   }
 
@@ -287,13 +278,13 @@ static bool ddaLLArTwoShotEligible(ncclComm* comm, const void* sendbuff, void* r
 // DDA_LL_TWOSHOT_THRESHOLD.
 static bool ddaLLArOneShotSelected(ncclComm* comm, const void* sendbuff, void* recvbuff, size_t count,
                                    ncclDataType_t datatype, ncclRedOp_t op) {
-  return rcclParamDdaLL() != 0 && (count * ncclTypeSize(datatype)) <= (size_t)rcclParamDdaLLThreshold() &&
+  return rcclParamDdaLL() != 0 && (count * ncclTypeSize(datatype)) <= (size_t)rcclParamDdaLLOneShotThreshold() &&
          ddaLLArOneShotEligible(comm, sendbuff, recvbuff, count, datatype, op);
 }
 
 static bool ddaLLArTwoShotSelected(ncclComm* comm, const void* sendbuff, void* recvbuff, size_t count,
                                    ncclDataType_t datatype, ncclRedOp_t op) {
-  return rcclParamDdaLLTwoShot() != 0 && (count * ncclTypeSize(datatype)) <= (size_t)rcclParamDdaLLTwoShotThreshold() &&
+  return rcclParamDdaLL() != 0 && (count * ncclTypeSize(datatype)) <= (size_t)rcclParamDdaLLTwoShotThreshold() &&
          ddaLLArTwoShotEligible(comm, sendbuff, recvbuff, count, datatype, op);
 }
 

--- a/projects/rccl/src/dda_alltoall_fabric_ll.cu
+++ b/projects/rccl/src/dda_alltoall_fabric_ll.cu
@@ -120,7 +120,8 @@ bool ncclAllToAllDdaFabricLLEligible(ncclComm* comm, const void* sendbuff, void*
   if (perChunkBytes % 16 != 0) {
     return false;
   }
-  if (perChunkBytes > kDdaLLMaxBytes) {
+  // expand from 8B to 16B
+  if (perChunkBytes * 2 > kDdaLLMaxBytes) {
     return false;
   }
   if (ddaLLA2AScratchSize(comm->nRanks) > comm->ddaScratchBytes) {

--- a/projects/rccl/src/dda_alltoall_fabric_ll.cu
+++ b/projects/rccl/src/dda_alltoall_fabric_ll.cu
@@ -23,8 +23,8 @@
 
 namespace {
 
-using meta::comms::kDdaLLA2AMaxPerChunkBytes;
 using meta::comms::kDdaLLA2ASlotStridePkts;
+using meta::comms::kDdaLLMaxBytes;
 using meta::comms::LLPacket16;
 using nccl_dda_detail::kDdaLLAgMaxBlocksPerPeer;
 
@@ -120,7 +120,7 @@ bool ncclAllToAllDdaFabricLLEligible(ncclComm* comm, const void* sendbuff, void*
   if (perChunkBytes % 16 != 0) {
     return false;
   }
-  if (perChunkBytes > kDdaLLA2AMaxPerChunkBytes) {
+  if (perChunkBytes > kDdaLLMaxBytes) {
     return false;
   }
   if (ddaLLA2AScratchSize(comm->nRanks) > comm->ddaScratchBytes) {

--- a/projects/rccl/src/dda_reduce_scatter_fabric_ll.cu
+++ b/projects/rccl/src/dda_reduce_scatter_fabric_ll.cu
@@ -23,7 +23,7 @@
 
 namespace {
 
-using meta::comms::kDdaLLRsMaxBytes;
+using meta::comms::kDdaLLMaxBytes;
 using meta::comms::kDdaLLRsSlotStridePkts;
 using meta::comms::LLPacket16;
 
@@ -118,7 +118,7 @@ bool ncclReduceScatterDdaFabricLLEligible(ncclComm* comm, const void* sendbuff, 
   if (bytes % 8 != 0) {
     return false;
   }
-  if (bytes > kDdaLLRsMaxBytes) {
+  if (bytes > kDdaLLMaxBytes) {
     return false;
   }
   if (ddaLLRsScratchSize(comm->nRanks) > comm->ddaScratchBytes) {

--- a/projects/rccl/src/dda_reduce_scatter_fabric_ll.cu
+++ b/projects/rccl/src/dda_reduce_scatter_fabric_ll.cu
@@ -113,12 +113,12 @@ bool ncclReduceScatterDdaFabricLLEligible(ncclComm* comm, const void* sendbuff, 
   }
 
   const size_t bytes = recvcount * ncclTypeSize(datatype); // per-rank shard
-  // Payload is staged as 8-byte LL packets, so the shard must be a whole
-  // number of packets.
-  if (bytes % 8 != 0) {
+
+  if (bytes % 16 != 0) {
     return false;
   }
-  if (bytes > kDdaLLMaxBytes) {
+  // expand from 8B to 16B
+  if (bytes * 2 > kDdaLLMaxBytes) {
     return false;
   }
   if (ddaLLRsScratchSize(comm->nRanks) > comm->ddaScratchBytes) {

--- a/projects/rccl/src/fabric_init.cu
+++ b/projects/rccl/src/fabric_init.cu
@@ -27,7 +27,6 @@ using nccl_dda_detail::ddaFabricMaxNBlocksForScratch;
 using nccl_dda_detail::ddaFabricScratchSizing;
 using nccl_dda_detail::ddaLLEpochCount;
 using nccl_dda_detail::DdaFabricBarrierState;
-using nccl_dda_detail::kDdaFabricLLArMaxBlocks;
 
 RCCL_PARAM(DdaFabricBufferSizeForScratch, "DDA_FABRIC_BUFFER_SIZE", -1);
 

--- a/projects/rccl/src/include/algorithms/CollCommon.h
+++ b/projects/rccl/src/include/algorithms/CollCommon.h
@@ -218,8 +218,7 @@ inline std::pair<dim3, dim3> getGridAndBlockDims(size_t count, int typeSize, siz
 // Per-rank scratch slot capacity and hard per-rank cap (enforced in the
 // eligibility check); fixes the slot stride at compile time so the double-buffered
 // layout is identical on every rank and call. The effective size gate is the total
-// collected size (DDA_*_LL_THRESHOLD, see collectives.cc), so the actual
-// per-rank payload is <= total / nRanks and usually well under this cap.
+// collected size, so the actual per-rank payload is under the cap.
 // Footprint = 2 banks * nRanks * (kDdaLLMaxBytes * 2) for the 8B->16B
 // expansion; 256 MiB at 16 MiB for 4 ranks
 // TODO: instead of making it fixed, use the size based on scratch size

--- a/projects/rccl/src/include/algorithms/CollCommon.h
+++ b/projects/rccl/src/include/algorithms/CollCommon.h
@@ -215,6 +215,16 @@ inline std::pair<dim3, dim3> getGridAndBlockDims(size_t count, int typeSize, siz
   return std::make_pair(blocks, threads);
 }
 
+// Per-rank scratch slot capacity and hard per-rank cap (enforced in the
+// eligibility check); fixes the slot stride at compile time so the double-buffered
+// layout is identical on every rank and call. The effective size gate is the total
+// collected size (DDA_*_LL_THRESHOLD, see collectives.cc), so the actual
+// per-rank payload is <= total / nRanks and usually well under this cap.
+// Footprint = 2 banks * nRanks * (kDdaLLMaxBytes * 2) for the 8B->16B
+// expansion; 256 MiB at 16 MiB for 4 ranks
+// TODO: instead of making it fixed, use the size based on scratch size
+constexpr size_t kDdaLLMaxBytes = 16777216;                     // 16M
+
 // 16-byte LL line: two (4B data, 4B flag) pairs carrying 8B of payload.
 union LLPacket16 {
   struct {

--- a/projects/rccl/src/include/algorithms/CollCommon.h
+++ b/projects/rccl/src/include/algorithms/CollCommon.h
@@ -278,4 +278,24 @@ __device__ __forceinline__ void ddaLLLoadLineB128(const uint32_t* src, uint32_t&
 #endif
 }
 
+__device__ __forceinline__ uint32_t ddaGetLLEpochInc(const uint32_t* __restrict__ epochDev, int flatBlockId, uint32_t inc) {
+  uint32_t flag = epochDev[flatBlockId] + inc;
+  if (flag == 0u) flag = 2u; // skip 0 sentinel; keep bank parity
+  __syncthreads();
+  return flag;
+}
+
+__device__ __forceinline__ void ddaSetLLEpoch(uint32_t* __restrict__ epochDev, int epochLen,
+                                              int flatBlockId, int total, uint32_t flag) {
+  // Bump every cell this block owns (cell e belongs to block e % total), split
+  // across the block's threads. The barrier is what makes the flag read above
+  // safe: thread 0 rewrites cell flatBlockId here, so every thread must have
+  // read it first. Cells at or above `total` are never read this launch.
+  for (int e = flatBlockId + (int)threadIdx.x * total;
+       e < epochLen;
+       e += total * (int)blockDim.x) {
+    epochDev[e] = flag;
+  }
+}
+
 } // namespace meta::comms

--- a/projects/rccl/src/include/algorithms/CollCommon.h
+++ b/projects/rccl/src/include/algorithms/CollCommon.h
@@ -220,9 +220,9 @@ inline std::pair<dim3, dim3> getGridAndBlockDims(size_t count, int typeSize, siz
 // layout is identical on every rank and call. The effective size gate is the total
 // collected size, so the actual per-rank payload is under the cap.
 // Footprint = 2 banks * nRanks * (kDdaLLMaxBytes * 2) for the 8B->16B
-// expansion; 256 MiB at 16 MiB for 4 ranks
+// expansion; 128 MiB at 8 MiB for 4 ranks
 // TODO: instead of making it fixed, use the size based on scratch size
-constexpr size_t kDdaLLMaxBytes = 16777216;                     // 16M
+constexpr size_t kDdaLLMaxBytes = (size_t)(8) * 1024 * 1024;      // 8M
 
 // 16-byte LL line: two (4B data, 4B flag) pairs carrying 8B of payload.
 union LLPacket16 {

--- a/projects/rccl/src/include/algorithms/CollCommon.h
+++ b/projects/rccl/src/include/algorithms/CollCommon.h
@@ -215,14 +215,12 @@ inline std::pair<dim3, dim3> getGridAndBlockDims(size_t count, int typeSize, siz
   return std::make_pair(blocks, threads);
 }
 
-// Per-rank scratch slot capacity and hard per-rank cap (enforced in the
-// eligibility check); fixes the slot stride at compile time so the double-buffered
-// layout is identical on every rank and call. The effective size gate is the total
-// collected size, so the actual per-rank payload is under the cap.
-// Footprint = 2 banks * nRanks * (kDdaLLMaxBytes * 2) for the 8B->16B
-// expansion; 128 MiB at 8 MiB for 4 ranks
-// TODO: instead of making it fixed, use the size based on scratch size
-constexpr size_t kDdaLLMaxBytes = (size_t)(8) * 1024 * 1024;      // 8M
+// Per-rank staging slot size in scratch bytes, fixed at compile time so the
+// double-buffered layout is identical on every rank and call. The eligibility
+// checks derive their per-message caps from it.
+// Footprint = 2 banks * nRanks * (kDdaLLMaxBytes)
+// example: 128 MiB at 16 MiB for 4 ranks
+constexpr size_t kDdaLLMaxBytes = (size_t)(16) * 1024 * 1024;      // 16M
 
 // 16-byte LL line: two (4B data, 4B flag) pairs carrying 8B of payload.
 union LLPacket16 {

--- a/projects/rccl/src/include/algorithms/all_gather/all_gather_dda_fabric_ll.h
+++ b/projects/rccl/src/include/algorithms/all_gather/all_gather_dda_fabric_ll.h
@@ -24,15 +24,8 @@
 
 namespace meta::comms {
 
-// Per-rank scratch slot capacity and hard per-rank cap (enforced in the
-// eligibility check); fixes the slot stride at compile time so the double-buffered
-// layout is identical on every rank and call. The effective size gate is the total
-// gathered size (DDA_ALLGATHER_LL_THRESHOLD, see collectives.cc), so the actual
-// per-rank payload is <= total / nRanks and usually well under this cap.
-// Footprint = 2 banks * nRanks * (kDdaLLAgMaxPerRankBytes * 2) for the 8B->16B
-// expansion; 36 MiB at 128 KiB / 72 ranks, within the 64 MiB DDA scratch.
-constexpr size_t kDdaLLAgMaxPerRankBytes = 131072;                     // 128 KiB
-constexpr size_t kDdaLLAgSlotStridePkts = kDdaLLAgMaxPerRankBytes / 8; // 16384
+// LL is for small-message, so the full payload is well under the staging cap.
+constexpr size_t kDdaLLAgSlotStridePkts = kDdaLLMaxBytes / 8;
 
 // LL all-gather kernel. 2D grid: grid.x == nRanks selects the peer (column b
 // owns peer b); grid.y == blocksPerPeer splits that peer's packets into gridDim.y

--- a/projects/rccl/src/include/algorithms/all_gather/all_gather_dda_fabric_ll.h
+++ b/projects/rccl/src/include/algorithms/all_gather/all_gather_dda_fabric_ll.h
@@ -25,7 +25,7 @@
 namespace meta::comms {
 
 // LL is for small-message, so the full payload is well under the staging cap.
-constexpr size_t kDdaLLAgSlotStridePkts = kDdaLLMaxBytes / 8;
+constexpr size_t kDdaLLAgSlotStridePkts = kDdaLLMaxBytes / sizeof(LLPacket16);
 
 // LL all-gather kernel. 2D grid: grid.x == nRanks selects the peer (column b
 // owns peer b); grid.y == blocksPerPeer splits that peer's packets into gridDim.y

--- a/projects/rccl/src/include/algorithms/all_gather/all_gather_dda_fabric_ll.h
+++ b/projects/rccl/src/include/algorithms/all_gather/all_gather_dda_fabric_ll.h
@@ -61,14 +61,7 @@ __launch_bounds__(512)
   // nothing is baked into a HIP graph capture. bank = flag & 1.
   const int flatBlockId = blockIdx.x * gridDim.y + blockIdx.y;
   const int total = gridDim.x * gridDim.y;
-  __shared__ uint32_t s_flag;
-  if (tid == 0) {
-    uint32_t f = epochDev[flatBlockId] + 1u;
-    if (f == 0u) f = 2u;                   // skip 0 sentinel; keep bank parity
-    s_flag = f;
-  }
-  __syncthreads();
-  const uint32_t flag = s_flag;
+  const uint32_t flag = ddaGetLLEpochInc(epochDev, flatBlockId, 1);
   const size_t bankOffsetPkts = (size_t)(flag & 1u) * (size_t)nRanks * slot;
 
   // This block's packet range [pkBegin, pkEnd); [0, nPk) when nChunks == 1.
@@ -122,11 +115,7 @@ __launch_bounds__(512)
     }
   }
 
-  if (tid == 0) {
-    for (int e = flatBlockId; e < epochLen; e += total) {
-      epochDev[e] = flag;
-    }
-  }
+  ddaSetLLEpoch(epochDev, epochLen, flatBlockId, total, flag);
 }
 
 } // namespace meta::comms

--- a/projects/rccl/src/include/algorithms/all_reduce/all_reduce_dda_ll.h
+++ b/projects/rccl/src/include/algorithms/all_reduce/all_reduce_dda_ll.h
@@ -30,7 +30,8 @@
 namespace meta::comms {
 
 // LL is for small-message, so the full payload is well under the staging cap.
-constexpr size_t kDdaLLArSlotStridePkts = kDdaLLMaxBytes / 8;
+// each packet takes 16 bytes.
+constexpr size_t kDdaLLArSlotStridePkts = kDdaLLMaxBytes / sizeof(LLPacket16);
 
 // LL flat all-reduce kernel. 1D grid over packets (8B payload each).
 //

--- a/projects/rccl/src/include/algorithms/all_reduce/all_reduce_dda_ll.h
+++ b/projects/rccl/src/include/algorithms/all_reduce/all_reduce_dda_ll.h
@@ -29,14 +29,8 @@
 
 namespace meta::comms {
 
-// Per-rank staging slot capacity and hard per-message cap (enforced in the
-// eligibility check). Fixes the slot stride at compile time so the
-// double-buffered layout is identical on every rank and call. LL is a
-// small-message fast lane, so the full-message payload is well under this cap.
-// Footprint = 2 banks * nRanks * (kDdaLLArMaxBytes * 2) for the 8B->16B
-// expansion; 128 MiB at 4 MiB for 8 ranks
-constexpr size_t kDdaLLArMaxBytes = 4194304;                      // 4 MiB
-constexpr size_t kDdaLLArSlotStridePkts = kDdaLLArMaxBytes / 8;   // 524288
+// LL is for small-message, so the full payload is well under the staging cap.
+constexpr size_t kDdaLLArSlotStridePkts = kDdaLLMaxBytes / 8;
 
 // LL flat all-reduce kernel. 1D grid over packets (8B payload each).
 //

--- a/projects/rccl/src/include/algorithms/all_reduce/all_reduce_dda_ll.h
+++ b/projects/rccl/src/include/algorithms/all_reduce/all_reduce_dda_ll.h
@@ -31,12 +31,12 @@ namespace meta::comms {
 
 // Per-rank staging slot capacity and hard per-message cap (enforced in the
 // eligibility check). Fixes the slot stride at compile time so the
-// double-buffered layout is identical on every rank and call. A slot has to hold
-// a whole message here, since this tier stages the full payload per peer.
-// Footprint = 2 banks * nRanks * kDdaLLArSlotStridePkts * 16B, i.e. nRanks * 16
-// MiB: 128 MiB at 8 ranks and 1.125 GiB at 72, within the 10 GiB DDA scratch.
+// double-buffered layout is identical on every rank and call. LL is a
+// small-message fast lane, so the full-message payload is well under this cap.
+// Footprint = 2 banks * nRanks * (kDdaLLArMaxBytes * 2) for the 8B->16B
+// expansion; 128 MiB at 4 MiB for 8 ranks
 constexpr size_t kDdaLLArMaxBytes = 4194304;                      // 4 MiB
-constexpr size_t kDdaLLArSlotStridePkts = kDdaLLArMaxBytes / 8;   // 524288 packets
+constexpr size_t kDdaLLArSlotStridePkts = kDdaLLArMaxBytes / 8;   // 524288
 
 // LL flat all-reduce kernel. 1D grid over packets (8B payload each).
 //

--- a/projects/rccl/src/include/algorithms/all_reduce/all_reduce_dda_ll.h
+++ b/projects/rccl/src/include/algorithms/all_reduce/all_reduce_dda_ll.h
@@ -61,19 +61,7 @@ __launch_bounds__(512)
   const size_t nPk = bytes >> 3;           // 8 payload bytes per packet
   const size_t slot = kDdaLLArSlotStridePkts;
 
-  // Flat block id + total launched blocks. tid 0 reads our own epoch cell (all
-  // cells hold the same value) and derives this launch's flag on the device, so
-  // nothing is baked into a HIP graph capture. bank = flag & 1.
-  const int flatBlockId = blockIdx.x;
-  const int total = gridDim.x;
-  __shared__ uint32_t s_flag;
-  if (threadIdx.x == 0) {
-    uint32_t f = epochDev[flatBlockId] + 1u;
-    if (f == 0u) f = 2u;                   // skip 0 sentinel; keep bank parity
-    s_flag = f;
-  }
-  __syncthreads();
-  const uint32_t flag = s_flag;
+  const uint32_t flag = ddaGetLLEpochInc(epochDev, blockIdx.x, 1);
   const size_t bankOffsetPkts = (size_t)(flag & 1u) * (size_t)nRanks * slot;
 
   const size_t gtid = (size_t)blockIdx.x * blockDim.x + threadIdx.x;
@@ -114,11 +102,7 @@ __launch_bounds__(512)
     out[2 * pk + 1] = acc1;
   }
 
-  if (threadIdx.x == 0) {
-    for (int e = flatBlockId; e < epochLen; e += total) {
-      epochDev[e] = flag;
-    }
-  }
+  ddaSetLLEpoch(epochDev, epochLen, blockIdx.x, gridDim.x, flag);
 }
 
 } // namespace meta::comms

--- a/projects/rccl/src/include/algorithms/all_reduce/all_reduce_dda_ll.h
+++ b/projects/rccl/src/include/algorithms/all_reduce/all_reduce_dda_ll.h
@@ -31,12 +31,12 @@ namespace meta::comms {
 
 // Per-rank staging slot capacity and hard per-message cap (enforced in the
 // eligibility check). Fixes the slot stride at compile time so the
-// double-buffered layout is identical on every rank and call. LL is a
-// small-message fast lane, so the full-message payload is well under this cap.
-// Footprint = 2 banks * nRanks * (kDdaLLArMaxBytes * 2) for the 8B->16B
-// expansion; 4 MiB at 128 KiB / 8 ranks, within the 64 MiB DDA scratch.
-constexpr size_t kDdaLLArMaxBytes = 4194304;                 // 4MB KiB
-constexpr size_t kDdaLLArSlotStridePkts = kDdaLLArMaxBytes / 8;   // 512KB
+// double-buffered layout is identical on every rank and call. A slot has to hold
+// a whole message here, since this tier stages the full payload per peer.
+// Footprint = 2 banks * nRanks * kDdaLLArSlotStridePkts * 16B, i.e. nRanks * 16
+// MiB: 128 MiB at 8 ranks and 1.125 GiB at 72, within the 10 GiB DDA scratch.
+constexpr size_t kDdaLLArMaxBytes = 4194304;                      // 4 MiB
+constexpr size_t kDdaLLArSlotStridePkts = kDdaLLArMaxBytes / 8;   // 524288 packets
 
 // LL flat all-reduce kernel. 1D grid over packets (8B payload each).
 //

--- a/projects/rccl/src/include/algorithms/all_reduce/all_reduce_dda_ll_twoshot.h
+++ b/projects/rccl/src/include/algorithms/all_reduce/all_reduce_dda_ll_twoshot.h
@@ -39,7 +39,6 @@ namespace meta::comms {
 // Both tiers share one scratch and epoch, so bank 1 has to start at the same
 // offset for both: a slot here holds only a shard, and the bank spans two of them
 // (publish + write-back). dda_all_reduce_fabric_ll.cu static_asserts the halving.
-constexpr size_t kDdaLLArTwoShotMaxBytes = kDdaLLArMaxBytes;
 constexpr size_t kDdaLLArTwoShotSlotStridePkts = kDdaLLArSlotStridePkts / 2;
 
 // Fixed-width peer staging for phase 1: a runtime-sized array, or a runtime index

--- a/projects/rccl/src/include/algorithms/all_reduce/all_reduce_dda_ll_twoshot.h
+++ b/projects/rccl/src/include/algorithms/all_reduce/all_reduce_dda_ll_twoshot.h
@@ -86,7 +86,8 @@ __launch_bounds__(512)
   }
   __syncthreads();
   const uint32_t flag = s_flag;
-  const size_t bankOffsetPkts = (size_t)(flag & 1u) * (size_t)nRanks * slot;
+  const size_t bankOffsetPkts = (size_t)(flag & 1u) * (size_t)nRanks * slot * 2;
+  const size_t bankOffsetPkts_next = bankOffsetPkts + (size_t)nRanks * slot;
 
   const size_t gtid = (size_t)blockIdx.x * blockDim.x + threadIdx.x;
   const size_t stride = (size_t)gridDim.x * blockDim.x;
@@ -107,10 +108,6 @@ __launch_bounds__(512)
 #pragma unroll
     for (int r = 1; r < nRanks; ++r) {
       const int peer = (selfRank + r) % nRanks;
-      //const uint32_t* peer_in = reinterpret_cast<const uint32_t*>(sendbuff) + peer * nPk_rank * 2;
-      //const uint32_t d0 = peer_in[2 * pk];
-      //const uint32_t d1 = peer_in[2 * pk + 1];
-
       LLPacket16* dst = reinterpret_cast<LLPacket16*>(peerScratch[peer]) + bankOffsetPkts + (size_t)selfRank * slot;
       ddaLLStoreLineB128(reinterpret_cast<uint32_t*>(&dst[pk]), d0[r], flag, d1[r], flag);
     }
@@ -133,6 +130,13 @@ __launch_bounds__(512)
     }
     out[2 * pk] = acc0;
     out[2 * pk + 1] = acc1;
+
+    #pragma unroll
+    for (int r = 1; r < nRanks; ++r) {
+      const int peer = (selfRank + r) % nRanks;
+      LLPacket16* dst = reinterpret_cast<LLPacket16*>(peerScratch[peer]) + bankOffsetPkts_next + (size_t)selfRank * slot;
+      ddaLLStoreLineB128(reinterpret_cast<uint32_t*>(&dst[pk]), acc0, flag, acc1, flag);
+    }
   }
 
   if (threadIdx.x == 0) {

--- a/projects/rccl/src/include/algorithms/all_reduce/all_reduce_dda_ll_twoshot.h
+++ b/projects/rccl/src/include/algorithms/all_reduce/all_reduce_dda_ll_twoshot.h
@@ -96,14 +96,23 @@ __launch_bounds__(512)
 
   // Phase 1: publish my payload into every peer's slot[selfRank].
   for (size_t pk = gtid; pk < nPk_rank; pk += stride) {
-    const uint32_t d0 = in[2 * pk];
-    const uint32_t d1 = in[2 * pk + 1];
-
+    uint32_t d0[nRanks], d1[nRanks];
 #pragma unroll
     for (int r = 1; r < nRanks; ++r) {
       const int peer = (selfRank + r) % nRanks;
+      const uint32_t* peer_in = reinterpret_cast<const uint32_t*>(sendbuff) + peer * nPk_rank * 2;
+      d0[r] = peer_in[2 * pk];
+      d1[r] = peer_in[2 * pk + 1];
+    }
+#pragma unroll
+    for (int r = 1; r < nRanks; ++r) {
+      const int peer = (selfRank + r) % nRanks;
+      //const uint32_t* peer_in = reinterpret_cast<const uint32_t*>(sendbuff) + peer * nPk_rank * 2;
+      //const uint32_t d0 = peer_in[2 * pk];
+      //const uint32_t d1 = peer_in[2 * pk + 1];
+
       LLPacket16* dst = reinterpret_cast<LLPacket16*>(peerScratch[peer]) + bankOffsetPkts + (size_t)selfRank * slot;
-      ddaLLStoreLineB128(reinterpret_cast<uint32_t*>(&dst[pk]), d0, flag, d1, flag);
+      ddaLLStoreLineB128(reinterpret_cast<uint32_t*>(&dst[pk]), d0[r], flag, d1[r], flag);
     }
   }
 

--- a/projects/rccl/src/include/algorithms/all_reduce/all_reduce_dda_ll_twoshot.h
+++ b/projects/rccl/src/include/algorithms/all_reduce/all_reduce_dda_ll_twoshot.h
@@ -41,7 +41,7 @@ namespace meta::comms {
 // tier that needs its own capacity has to also give the pair a bank stride that
 // still agrees.
 constexpr size_t kDdaLLArTwoShotMaxBytes = kDdaLLArMaxBytes;
-constexpr size_t kDdaLLArTwoShotSlotStridePkts = kDdaLLArSlotStridePkts;
+constexpr size_t kDdaLLArTwoShotSlotStridePkts = kDdaLLArSlotStridePkts / 2;
 
 // LL two-shot all-reduce kernel. 1D grid over packets (8B payload each).
 //
@@ -70,6 +70,7 @@ __launch_bounds__(512)
   const int nRanks = NRANKS_CT ? NRANKS_CT : nRanksRt;
   const size_t bytes = count * sizeof(T);
   const size_t nPk = bytes >> 3;           // 8 payload bytes per packet
+  const size_t nPk_rank = nPk / nRanks;
   const size_t slot = kDdaLLArTwoShotSlotStridePkts;
 
   // Flat block id + total launched blocks. tid 0 reads our own epoch cell (all
@@ -90,11 +91,11 @@ __launch_bounds__(512)
   const size_t gtid = (size_t)blockIdx.x * blockDim.x + threadIdx.x;
   const size_t stride = (size_t)gridDim.x * blockDim.x;
 
-  const uint32_t* in = reinterpret_cast<const uint32_t*>(sendbuff);
-  uint32_t* out = reinterpret_cast<uint32_t*>(recvbuff);
+  const uint32_t* in = reinterpret_cast<const uint32_t*>(sendbuff) + selfRank * nPk_rank * 2;
+  uint32_t* out = reinterpret_cast<uint32_t*>(recvbuff) + selfRank * nPk_rank * 2;
 
   // Phase 1: publish my payload into every peer's slot[selfRank].
-  for (size_t pk = gtid; pk < nPk; pk += stride) {
+  for (size_t pk = gtid; pk < nPk_rank; pk += stride) {
     const uint32_t d0 = in[2 * pk];
     const uint32_t d1 = in[2 * pk + 1];
 
@@ -108,7 +109,7 @@ __launch_bounds__(512)
 
   // Phase 2: poll my slots for the other ranks, reduce with my own data.
   LLPacket16* myBase = reinterpret_cast<LLPacket16*>(peerScratch[selfRank]) + bankOffsetPkts;
-  for (size_t pk = gtid; pk < nPk; pk += stride) {
+  for (size_t pk = gtid; pk < nPk_rank; pk += stride) {
     uint32_t acc0 = in[2 * pk];
     uint32_t acc1 = in[2 * pk + 1];
     for (int r = 1; r < nRanks; ++r) {

--- a/projects/rccl/src/include/algorithms/all_reduce/all_reduce_dda_ll_twoshot.h
+++ b/projects/rccl/src/include/algorithms/all_reduce/all_reduce_dda_ll_twoshot.h
@@ -3,17 +3,18 @@
  *
  * Two-shot tier of the LL-protocol all-reduce for the DDA path.
  *
- * The kernel below is currently a verbatim copy of ddaAllReduceFlatLL from
- * all_reduce_dda_ll.h -- same phases, same staging layout, same epoch. Only the
- * name and the dispatch tier differ, so any measured gap between the two tiers
- * comes from the launcher or the dispatch, never from the device code. The
- * reduce-scatter/all-gather decomposition that gives this tier its name is meant
- * to replace the body later; keeping the copy exact is what makes that a
- * one-variable change.
+ * Each rank owns one shard of count/nRanks elements and only ever transports
+ * that shard, so every rank moves nRanks-1 shards instead of nRanks-1 whole
+ * messages the way the one-shot tier does. Three phases, all flag-ordered like
+ * the one-shot, so still no GPU barrier:
  *
- * Because it is a copy, it shares the one-shot tier's scratch layout and epoch
- * counter (see the constants below), so the two tiers are interchangeable on the
- * same comm and neither can strand the other's scratch.
+ *   1. publish: send each peer the shard that peer owns,
+ *   2. reduce:  sum the copies of my own shard that arrived, write it to my part
+ *               of recvbuff, and publish the reduced shard back to every peer,
+ *   3. writeback: collect the peers' reduced shards into the rest of recvbuff.
+ *
+ * It shares comm->ddaScratch and the LL epoch counter with the one-shot tier
+ * (see the constants below), so the two stay interchangeable on the same comm.
  *
  * See LICENSE.txt for license information.
  ************************************************************************/
@@ -36,25 +37,39 @@
 namespace meta::comms {
 
 // Both tiers stage through comm->ddaScratch under one epoch counter, so bank =
-// flag & 1 only lands where the other tier expects it while the cap and the slot
-// stride stay identical. Aliased rather than copied so the two cannot drift: a
-// tier that needs its own capacity has to also give the pair a bank stride that
-// still agrees.
+// flag & 1 has to land where the other tier expects it. A slot here only holds a
+// shard, so it is half the one-shot slot; the bank then spans two of them (the
+// publish stage and the write-back stage), which puts bank 1 at the same offset
+// the one-shot tier uses. Derived from the one-shot constants rather than spelled
+// out so that pairing cannot drift silently -- dda_all_reduce_fabric_ll.cu
+// static_asserts the halving.
 constexpr size_t kDdaLLArTwoShotMaxBytes = kDdaLLArMaxBytes;
 constexpr size_t kDdaLLArTwoShotSlotStridePkts = kDdaLLArSlotStridePkts / 2;
 
-// LL two-shot all-reduce kernel. 1D grid over packets (8B payload each).
+// LL two-shot all-reduce kernel. 1D grid over one shard's packets (8B payload
+// each), so the launcher sizes the grid on count/nRanks, not on count.
 //
-// Phase 1 (publish): rank selfRank writes its full sendbuff into every peer's
-// scratch at slot selfRank, as LL lines carrying the epoch flag.
+// Phase 1 (publish): rank selfRank sends peer p the part of sendbuff that p
+// owns, into p's scratch at slot selfRank, as LL lines carrying the epoch flag.
+// The shard reads are hoisted out of the store loop on purpose: leaving them
+// interleaved makes each store wait on the next load and the per-peer streams
+// stop overlapping, which costs about 2x.
 // Phase 2 (reduce): rank selfRank polls its own scratch slot for each other
-// rank (waiting on the flag), and sums those with its own sendbuff into
-// recvbuff. The flag polling provides the cross-rank ordering, so no GPU
-// barrier is used.
+// rank (waiting on the flag), sums those with its own shard of sendbuff into
+// recvbuff, then publishes that reduced shard back to every peer at the
+// write-back stage of the bank.
+// Phase 3 (write-back): poll each peer's reduced shard and drop it into that
+// peer's part of recvbuff. Flag polling provides all the cross-rank ordering, so
+// no GPU barrier is used.
 //
-// Scratch is double-buffered: bank = epoch & 1, selected via bankOffsetPkts.
-// Self does not round-trip through scratch; its contribution is read directly
-// from sendbuff in the reduce.
+// Scratch is double-buffered: bank = epoch & 1, selected via bankOffsetPkts,
+// with bankOffsetPkts_next naming the write-back stage inside that bank. Self
+// does not round-trip through scratch; its contribution is read directly from
+// sendbuff in the reduce.
+//
+// Threads own disjoint packet indices in every phase, so an in-place call (where
+// sendbuff aliases recvbuff) never has one thread's phase-3 store land on a
+// packet another thread still has to read in phase 1.
 template <typename T, int NRANKS_CT>
 #if defined(USE_ROCM)
 __launch_bounds__(512)

--- a/projects/rccl/src/include/algorithms/all_reduce/all_reduce_dda_ll_twoshot.h
+++ b/projects/rccl/src/include/algorithms/all_reduce/all_reduce_dda_ll_twoshot.h
@@ -139,6 +139,23 @@ __launch_bounds__(512)
     }
   }
 
+  // Phase 3: poll my slots for the other ranks, read data and write to output.
+  myBase = reinterpret_cast<LLPacket16*>(peerScratch[selfRank]) + bankOffsetPkts_next;
+  for (size_t pk = gtid; pk < nPk_rank; pk += stride) {
+    #pragma unroll
+    for (int r = 1; r < nRanks; ++r) {
+      const int peer = (selfRank + r) % nRanks;
+      uint32_t *peer_out = reinterpret_cast<uint32_t*>(recvbuff) + peer * nPk_rank * 2;
+      volatile LLPacket16* src = myBase + (size_t)peer * slot;
+      uint32_t d0, f0, d1, f1;
+      do {
+        ddaLLLoadLineB128(reinterpret_cast<const uint32_t*>(const_cast<LLPacket16*>(&src[pk])), d0, f0, d1, f1);
+      } while (f0 != flag || f1 != flag);
+      peer_out[2 * pk] = d0;
+      peer_out[2 * pk + 1] = d1;
+    }
+  }
+
   if (threadIdx.x == 0) {
     for (int e = flatBlockId; e < epochLen; e += total) {
       epochDev[e] = flag;

--- a/projects/rccl/src/include/algorithms/all_reduce/all_reduce_dda_ll_twoshot.h
+++ b/projects/rccl/src/include/algorithms/all_reduce/all_reduce_dda_ll_twoshot.h
@@ -83,19 +83,7 @@ __launch_bounds__(512)
   const size_t nPk_rank = nPk / nRanks;
   const size_t slot = kDdaLLArTwoShotSlotStridePkts;
 
-  // Flat block id + total launched blocks. tid 0 reads our own epoch cell (all
-  // cells hold the same value) and derives this launch's flag on the device, so
-  // nothing is baked into a HIP graph capture. bank = flag & 1.
-  const int flatBlockId = blockIdx.x;
-  const int total = gridDim.x;
-  __shared__ uint32_t s_flag;
-  if (threadIdx.x == 0) {
-    uint32_t f = epochDev[flatBlockId] + 1u;
-    if (f == 0u) f = 2u;                   // skip 0 sentinel; keep bank parity
-    s_flag = f;
-  }
-  __syncthreads();
-  const uint32_t flag = s_flag;
+  const uint32_t flag = ddaGetLLEpochInc(epochDev, blockIdx.x, 1);
   const size_t bankOffsetPkts = (size_t)(flag & 1u) * (size_t)nRanks * slot * 2;
   const size_t bankOffsetPkts_next = bankOffsetPkts + (size_t)nRanks * slot;
 
@@ -179,11 +167,7 @@ __launch_bounds__(512)
     }
   }
 
-  if (threadIdx.x == 0) {
-    for (int e = flatBlockId; e < epochLen; e += total) {
-      epochDev[e] = flag;
-    }
-  }
+  ddaSetLLEpoch(epochDev, epochLen, blockIdx.x, gridDim.x, flag);
 }
 
 } // namespace meta::comms

--- a/projects/rccl/src/include/algorithms/all_reduce/all_reduce_dda_ll_twoshot.h
+++ b/projects/rccl/src/include/algorithms/all_reduce/all_reduce_dda_ll_twoshot.h
@@ -1,15 +1,19 @@
 /*************************************************************************
  * Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
  *
- * LL-protocol all-reduce device kernel for the DDA path. Each 16-byte line
- * holds 8 bytes of payload and two 4-byte flags; the flags carry cross-rank
- * sync, so no GPU barrier is needed. Staging uses the DDA scratch
- * (comm->ddaScratch, reachable via comm->ddaPeerPtrsDev).
+ * Two-shot tier of the LL-protocol all-reduce for the DDA path.
  *
- * This is the all-reduce analogue of all_gather_dda_fabric_ll.h. The kernel is
- * codepath-agnostic (it only needs the peer scratch table), so the same kernel
- * backs the fabric launcher (dda_all_reduce_fabric_ll.cu) and can equally back
- * an IPC launcher.
+ * The kernel below is currently a verbatim copy of ddaAllReduceFlatLL from
+ * all_reduce_dda_ll.h -- same phases, same staging layout, same epoch. Only the
+ * name and the dispatch tier differ, so any measured gap between the two tiers
+ * comes from the launcher or the dispatch, never from the device code. The
+ * reduce-scatter/all-gather decomposition that gives this tier its name is meant
+ * to replace the body later; keeping the copy exact is what makes that a
+ * one-variable change.
+ *
+ * Because it is a copy, it shares the one-shot tier's scratch layout and epoch
+ * counter (see the constants below), so the two tiers are interchangeable on the
+ * same comm and neither can strand the other's scratch.
  *
  * See LICENSE.txt for license information.
  ************************************************************************/
@@ -26,19 +30,20 @@
 #endif
 
 #include "algorithms/CollCommon.h"
+// Staging layout is shared with the one-shot tier, not redefined here.
+#include "algorithms/all_reduce/all_reduce_dda_ll.h"
 
 namespace meta::comms {
 
-// Per-rank staging slot capacity and hard per-message cap (enforced in the
-// eligibility check). Fixes the slot stride at compile time so the
-// double-buffered layout is identical on every rank and call. LL is a
-// small-message fast lane, so the full-message payload is well under this cap.
-// Footprint = 2 banks * nRanks * (kDdaLLArMaxBytes * 2) for the 8B->16B
-// expansion; 4 MiB at 128 KiB / 8 ranks, within the 64 MiB DDA scratch.
-constexpr size_t kDdaLLArMaxBytes = 4194304;                 // 4MB KiB
-constexpr size_t kDdaLLArSlotStridePkts = kDdaLLArMaxBytes / 8;   // 512KB
+// Both tiers stage through comm->ddaScratch under one epoch counter, so bank =
+// flag & 1 only lands where the other tier expects it while the cap and the slot
+// stride stay identical. Aliased rather than copied so the two cannot drift: a
+// tier that needs its own capacity has to also give the pair a bank stride that
+// still agrees.
+constexpr size_t kDdaLLArTwoShotMaxBytes = kDdaLLArMaxBytes;
+constexpr size_t kDdaLLArTwoShotSlotStridePkts = kDdaLLArSlotStridePkts;
 
-// LL flat all-reduce kernel. 1D grid over packets (8B payload each).
+// LL two-shot all-reduce kernel. 1D grid over packets (8B payload each).
 //
 // Phase 1 (publish): rank selfRank writes its full sendbuff into every peer's
 // scratch at slot selfRank, as LL lines carrying the epoch flag.
@@ -54,18 +59,18 @@ template <typename T, int NRANKS_CT>
 #if defined(USE_ROCM)
 __launch_bounds__(512)
 #endif
-  __global__ void ddaAllReduceFlatLL(T* const* __restrict__ peerScratch,    // ddaPeerPtrsDev: nRanks scratch bases
-                                     T* __restrict__ recvbuff,              // local user output
-                                     const T* __restrict__ sendbuff,        // local user input
-                                     size_t count,                          // full-message element count
-                                     int selfRank, int nRanksRt,
-                                     uint32_t* __restrict__ epochDev,       // per-block LL epoch cells (shared AG+AR)
-                                     int epochLen) {                        // number of cells in epochDev
+  __global__ void ddaAllReduceTwoShotLL(T* const* __restrict__ peerScratch, // ddaPeerPtrsDev: nRanks scratch bases
+                                        T* __restrict__ recvbuff,           // local user output
+                                        const T* __restrict__ sendbuff,     // local user input
+                                        size_t count,                       // full-message element count
+                                        int selfRank, int nRanksRt,
+                                        uint32_t* __restrict__ epochDev,    // per-block LL epoch cells (shared AG+AR)
+                                        int epochLen) {                     // number of cells in epochDev
 
   const int nRanks = NRANKS_CT ? NRANKS_CT : nRanksRt;
   const size_t bytes = count * sizeof(T);
   const size_t nPk = bytes >> 3;           // 8 payload bytes per packet
-  const size_t slot = kDdaLLArSlotStridePkts;
+  const size_t slot = kDdaLLArTwoShotSlotStridePkts;
 
   // Flat block id + total launched blocks. tid 0 reads our own epoch cell (all
   // cells hold the same value) and derives this launch's flag on the device, so

--- a/projects/rccl/src/include/algorithms/all_reduce/all_reduce_dda_ll_twoshot.h
+++ b/projects/rccl/src/include/algorithms/all_reduce/all_reduce_dda_ll_twoshot.h
@@ -36,36 +36,32 @@
 
 namespace meta::comms {
 
-// Both tiers stage through comm->ddaScratch under one epoch counter, so bank =
-// flag & 1 has to land where the other tier expects it. A slot here only holds a
-// shard, so it is half the one-shot slot; the bank then spans two of them (the
-// publish stage and the write-back stage), which puts bank 1 at the same offset
-// the one-shot tier uses. Derived from the one-shot constants rather than spelled
-// out so that pairing cannot drift silently -- dda_all_reduce_fabric_ll.cu
-// static_asserts the halving.
+// Both tiers share one scratch and epoch, so bank 1 has to start at the same
+// offset for both: a slot here holds only a shard, and the bank spans two of them
+// (publish + write-back). dda_all_reduce_fabric_ll.cu static_asserts the halving.
 constexpr size_t kDdaLLArTwoShotMaxBytes = kDdaLLArMaxBytes;
 constexpr size_t kDdaLLArTwoShotSlotStridePkts = kDdaLLArSlotStridePkts / 2;
+
+// Fixed-width peer staging for phase 1: a runtime-sized array, or a runtime index
+// into one, is placed in scratch. 8 covers rank counts 4 and 8 in a single pass.
+// TODO: should this be moved to common place so other kernels can do the same
+constexpr int kDdaLLArTwoShotPeerBatch = 8;
 
 // LL two-shot all-reduce kernel. 1D grid over one shard's packets (8B payload
 // each), so the launcher sizes the grid on count/nRanks, not on count.
 //
-// Phase 1 (publish): rank selfRank sends peer p the part of sendbuff that p
-// owns, into p's scratch at slot selfRank, as LL lines carrying the epoch flag.
-// The shard reads are hoisted out of the store loop on purpose: leaving them
-// interleaved makes each store wait on the next load and the per-peer streams
-// stop overlapping, which costs about 2x.
-// Phase 2 (reduce): rank selfRank polls its own scratch slot for each other
-// rank (waiting on the flag), sums those with its own shard of sendbuff into
-// recvbuff, then publishes that reduced shard back to every peer at the
-// write-back stage of the bank.
-// Phase 3 (write-back): poll each peer's reduced shard and drop it into that
-// peer's part of recvbuff. Flag polling provides all the cross-rank ordering, so
-// no GPU barrier is used.
+// Phase 1 (publish): send peer p the shard p owns, into p's scratch at slot
+// selfRank, as LL lines carrying the epoch flag.
+// Phase 2 (reduce and publish): poll my slot for each peer's copy of my shard,
+// sum with my own into my part of recvbuff, then publish the result to every peer.
+// Phase 3 (gather): poll for the reduced shards the peers published and write each
+// into that peer's part of recvbuff.
 //
-// Scratch is double-buffered: bank = epoch & 1, selected via bankOffsetPkts,
-// with bankOffsetPkts_next naming the write-back stage inside that bank. Self
-// does not round-trip through scratch; its contribution is read directly from
-// sendbuff in the reduce.
+// Flag polling provides all the cross-rank ordering, so no GPU barrier is used.
+// Scratch is double-buffered: bank = epoch & 1, selected via bankOffsetPkts, with
+// bankOffsetPkts_next naming the second stage inside that bank. Self does not
+// round-trip through scratch; its contribution is read directly from sendbuff in
+// the reduce.
 //
 // Threads own disjoint packet indices in every phase, so an in-place call (where
 // sendbuff aliases recvbuff) never has one thread's phase-3 store land on a
@@ -110,25 +106,38 @@ __launch_bounds__(512)
   const uint32_t* in = reinterpret_cast<const uint32_t*>(sendbuff) + selfRank * nPk_rank * 2;
   uint32_t* out = reinterpret_cast<uint32_t*>(recvbuff) + selfRank * nPk_rank * 2;
 
-  // Phase 1: publish my payload into every peer's slot[selfRank].
+  // Phase 1: publish my payload into every peer's slot[selfRank]. The gather is
+  // kept out of the store loop on purpose -- interleaved, each store waits on the
+  // next load and the per-peer streams stop overlapping, which costs about 2x. The
+  // fixed trip count with the rank test as a predicate is what unrolls both loops
+  // and keeps d0/d1 in registers rather than scratch.
   for (size_t pk = gtid; pk < nPk_rank; pk += stride) {
-    uint32_t d0[nRanks], d1[nRanks];
+    for (int base = 1; base < nRanks; base += kDdaLLArTwoShotPeerBatch) {
+      uint32_t d0[kDdaLLArTwoShotPeerBatch], d1[kDdaLLArTwoShotPeerBatch];
 #pragma unroll
-    for (int r = 1; r < nRanks; ++r) {
-      const int peer = (selfRank + r) % nRanks;
-      const uint32_t* peer_in = reinterpret_cast<const uint32_t*>(sendbuff) + peer * nPk_rank * 2;
-      d0[r] = peer_in[2 * pk];
-      d1[r] = peer_in[2 * pk + 1];
-    }
+      for (int i = 0; i < kDdaLLArTwoShotPeerBatch; ++i) {
+        const int r = base + i;
+        if (r < nRanks) {
+          const int peer = (selfRank + r) % nRanks;
+          const uint32_t* peer_in = reinterpret_cast<const uint32_t*>(sendbuff) + peer * nPk_rank * 2;
+          d0[i] = peer_in[2 * pk];
+          d1[i] = peer_in[2 * pk + 1];
+        }
+      }
 #pragma unroll
-    for (int r = 1; r < nRanks; ++r) {
-      const int peer = (selfRank + r) % nRanks;
-      LLPacket16* dst = reinterpret_cast<LLPacket16*>(peerScratch[peer]) + bankOffsetPkts + (size_t)selfRank * slot;
-      ddaLLStoreLineB128(reinterpret_cast<uint32_t*>(&dst[pk]), d0[r], flag, d1[r], flag);
+      for (int i = 0; i < kDdaLLArTwoShotPeerBatch; ++i) {
+        const int r = base + i;
+        if (r < nRanks) {
+          const int peer = (selfRank + r) % nRanks;
+          LLPacket16* dst = reinterpret_cast<LLPacket16*>(peerScratch[peer]) + bankOffsetPkts + (size_t)selfRank * slot;
+          ddaLLStoreLineB128(reinterpret_cast<uint32_t*>(&dst[pk]), d0[i], flag, d1[i], flag);
+        }
+      }
     }
   }
 
-  // Phase 2: poll my slots for the other ranks, reduce with my own data.
+  // Phase 2: poll my slots for the other ranks, reduce with my own data, then
+  // publish the reduced shard to every peer's second stage.
   LLPacket16* myBase = reinterpret_cast<LLPacket16*>(peerScratch[selfRank]) + bankOffsetPkts;
   for (size_t pk = gtid; pk < nPk_rank; pk += stride) {
     uint32_t acc0 = in[2 * pk];

--- a/projects/rccl/src/include/algorithms/all_reduce/all_reduce_dda_ll_twoshot.h
+++ b/projects/rccl/src/include/algorithms/all_reduce/all_reduce_dda_ll_twoshot.h
@@ -67,7 +67,7 @@ constexpr int kDdaLLArTwoShotPeerBatch = 8;
 // packet another thread still has to read in phase 1.
 template <typename T, int NRANKS_CT>
 #if defined(USE_ROCM)
-__launch_bounds__(512)
+__launch_bounds__(1024)
 #endif
   __global__ void ddaAllReduceTwoShotLL(T* const* __restrict__ peerScratch, // ddaPeerPtrsDev: nRanks scratch bases
                                         T* __restrict__ recvbuff,           // local user output

--- a/projects/rccl/src/include/algorithms/alltoall/alltoall_dda_fabric_ll.h
+++ b/projects/rccl/src/include/algorithms/alltoall/alltoall_dda_fabric_ll.h
@@ -31,7 +31,7 @@
 namespace meta::comms {
 
 // LL is for small-message, so the full payload is well under the staging cap.
-constexpr size_t kDdaLLA2ASlotStridePkts = kDdaLLMaxBytes / 8;
+constexpr size_t kDdaLLA2ASlotStridePkts = kDdaLLMaxBytes / sizeof(LLPacket16);
 
 // LL all-to-all kernel. 2D grid: grid.x == nRanks selects the peer (column b
 // owns peer b); grid.y == blocksPerPeer splits that peer's packets into gridDim.y

--- a/projects/rccl/src/include/algorithms/alltoall/alltoall_dda_fabric_ll.h
+++ b/projects/rccl/src/include/algorithms/alltoall/alltoall_dda_fabric_ll.h
@@ -30,12 +30,8 @@
 
 namespace meta::comms {
 
-// Per-peer chunk capacity and hard cap (enforced in the eligibility check);
-// fixes the slot stride at compile time so the double-buffered layout is
-// identical on every rank and call. The effective size gate is the runtime LL
-// threshold (see collectives.cc). Footprint = 2 banks * nRanks * slot * 16B.
-constexpr size_t kDdaLLA2AMaxPerChunkBytes = 131072;                    // 128 KiB
-constexpr size_t kDdaLLA2ASlotStridePkts = kDdaLLA2AMaxPerChunkBytes / 8; // 16384
+// LL is for small-message, so the full payload is well under the staging cap.
+constexpr size_t kDdaLLA2ASlotStridePkts = kDdaLLMaxBytes / 8;
 
 // LL all-to-all kernel. 2D grid: grid.x == nRanks selects the peer (column b
 // owns peer b); grid.y == blocksPerPeer splits that peer's packets into gridDim.y

--- a/projects/rccl/src/include/algorithms/alltoall/alltoall_dda_fabric_ll.h
+++ b/projects/rccl/src/include/algorithms/alltoall/alltoall_dda_fabric_ll.h
@@ -65,14 +65,7 @@ __launch_bounds__(512)
   // On-device, graph-safe flag/bank derivation. bank = flag & 1.
   const int flatBlockId = blockIdx.x * gridDim.y + blockIdx.y;
   const int total = gridDim.x * gridDim.y;
-  __shared__ uint32_t s_flag;
-  if (tid == 0) {
-    uint32_t f = epochDev[flatBlockId] + 1u;
-    if (f == 0u) f = 2u;                   // skip 0 sentinel; keep bank parity
-    s_flag = f;
-  }
-  __syncthreads();
-  const uint32_t flag = s_flag;
+  const uint32_t flag = ddaGetLLEpochInc(epochDev, flatBlockId, 1);
   const size_t bankOffsetPkts = (size_t)(flag & 1u) * (size_t)nRanks * slot;
 
   // This block's packet range [pkBegin, pkEnd); [0, nPk) when nChunks == 1.
@@ -127,11 +120,7 @@ __launch_bounds__(512)
     }
   }
 
-  if (tid == 0) {
-    for (int e = flatBlockId; e < epochLen; e += total) {
-      epochDev[e] = flag;
-    }
-  }
+  ddaSetLLEpoch(epochDev, epochLen, flatBlockId, total, flag);
 }
 
 } // namespace meta::comms

--- a/projects/rccl/src/include/algorithms/reduce_scatter/reduce_scatter_dda_fabric_ll.h
+++ b/projects/rccl/src/include/algorithms/reduce_scatter/reduce_scatter_dda_fabric_ll.h
@@ -61,17 +61,7 @@ __launch_bounds__(512)
   const size_t slot = kDdaLLRsSlotStridePkts;
   const size_t chunkWords = nPk * 2; // uint32 words per shard chunk
 
-  // On-device, graph-safe flag/bank derivation (1D grid: flatBlockId=blockIdx.x).
-  const int flatBlockId = blockIdx.x;
-  const int total = gridDim.x;
-  __shared__ uint32_t s_flag;
-  if (threadIdx.x == 0) {
-    uint32_t f = epochDev[flatBlockId] + 1u;
-    if (f == 0u) f = 2u; // skip 0 sentinel; keep bank parity
-    s_flag = f;
-  }
-  __syncthreads();
-  const uint32_t flag = s_flag;
+  const uint32_t flag = ddaGetLLEpochInc(epochDev, blockIdx.x, 1);
   const size_t bankOffsetPkts = (size_t)(flag & 1u) * (size_t)nRanks * slot;
 
   const size_t gtid = (size_t)blockIdx.x * blockDim.x + threadIdx.x;
@@ -113,11 +103,7 @@ __launch_bounds__(512)
     out[2 * pk + 1] = acc1;
   }
 
-  if (threadIdx.x == 0) {
-    for (int e = flatBlockId; e < epochLen; e += total) {
-      epochDev[e] = flag;
-    }
-  }
+  ddaSetLLEpoch(epochDev, epochLen, blockIdx.x, gridDim.x, flag);
 }
 
 } // namespace meta::comms

--- a/projects/rccl/src/include/algorithms/reduce_scatter/reduce_scatter_dda_fabric_ll.h
+++ b/projects/rccl/src/include/algorithms/reduce_scatter/reduce_scatter_dda_fabric_ll.h
@@ -31,13 +31,8 @@
 
 namespace meta::comms {
 
-// Per-shard staging slot capacity and hard per-shard cap (enforced in the
-// eligibility check). Fixes the slot stride at compile time so the
-// double-buffered layout is identical on every rank and call.
-// Footprint = 2 banks * nRanks * (kDdaLLRsMaxBytes * 2) for the 8B->16B
-// expansion; 4 MiB at 128 KiB / 8 ranks, within the 64 MiB DDA scratch.
-constexpr size_t kDdaLLRsMaxBytes = 131072;                 // 128 KiB
-constexpr size_t kDdaLLRsSlotStridePkts = kDdaLLRsMaxBytes / 8;   // 16384
+// LL is for small-message, so the full payload is well under the staging cap.
+constexpr size_t kDdaLLRsSlotStridePkts = kDdaLLMaxBytes / 8;
 
 // LL reduce-scatter kernel. 1D grid over packets (8B payload each) of the
 // per-rank shard (recvcount elements).

--- a/projects/rccl/src/include/algorithms/reduce_scatter/reduce_scatter_dda_fabric_ll.h
+++ b/projects/rccl/src/include/algorithms/reduce_scatter/reduce_scatter_dda_fabric_ll.h
@@ -32,7 +32,7 @@
 namespace meta::comms {
 
 // LL is for small-message, so the full payload is well under the staging cap.
-constexpr size_t kDdaLLRsSlotStridePkts = kDdaLLMaxBytes / 8;
+constexpr size_t kDdaLLRsSlotStridePkts = kDdaLLMaxBytes / sizeof(LLPacket16);
 
 // LL reduce-scatter kernel. 1D grid over packets (8B payload each) of the
 // per-rank shard (recvcount elements).

--- a/projects/rccl/src/include/dda_all_reduce.h
+++ b/projects/rccl/src/include/dda_all_reduce.h
@@ -29,20 +29,17 @@ ncclResult_t ncclAllReduceDdaFabric(const void* sendbuff, void* recvbuff, size_t
                                     ncclRedOp_t op, ncclComm* comm, cudaStream_t stream);
 
 // LL-protocol fabric path (small-message fast lane, flag-based sync, no barrier).
+//
+// The tier has two variants -- one-shot, and a two-shot that transports only the
+// shard each rank owns (count/nRanks per peer instead of count). Picking between
+// them, including the DDA_LL / DDA_LL_TWOSHOT enables and thresholds, is internal
+// to dda_all_reduce_fabric_ll.cu: Eligible reports whether either variant claims
+// the message, and the entry point launches whichever one did.
 bool ncclAllReduceDdaFabricLLEligible(ncclComm* comm, const void* sendbuff, void* recvbuff, size_t count,
                                       ncclDataType_t datatype, ncclRedOp_t op);
 
 ncclResult_t ncclAllReduceDdaFabricLL(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
                                       ncclRedOp_t op, ncclComm* comm, cudaStream_t stream);
-
-// Two-shot tier of the LL fabric path: each rank transports only the shard it
-// owns, so it moves count/nRanks per peer where the one-shot moves count.
-bool ncclAllReduceDdaFabricLLTwoShotEligible(ncclComm* comm, const void* sendbuff, void* recvbuff, size_t count,
-                                             ncclDataType_t datatype, ncclRedOp_t op);
-
-ncclResult_t ncclAllReduceDdaFabricLLTwoShot(const void* sendbuff, void* recvbuff, size_t count,
-                                             ncclDataType_t datatype, ncclRedOp_t op, ncclComm* comm,
-                                             cudaStream_t stream);
 
 // LL128-protocol fabric path (mid-message fast lane, 128B lines, no barrier).
 bool ncclAllReduceDdaFabricLL128Eligible(ncclComm* comm, const void* sendbuff, void* recvbuff, size_t count,

--- a/projects/rccl/src/include/dda_all_reduce.h
+++ b/projects/rccl/src/include/dda_all_reduce.h
@@ -38,6 +38,15 @@ ncclResult_t ncclAllReduceDdaFabric(const void* sendbuff, void* recvbuff, size_t
 bool ncclAllReduceDdaFabricLLEligible(ncclComm* comm, const void* sendbuff, void* recvbuff, size_t count,
                                       ncclDataType_t datatype, ncclRedOp_t op);
 
+// The per-variant predicates the gate above is the disjunction of. Declared here
+// so unit tests can exercise one tier without the other masking it; hidden in
+// Release by -fvisibility=hidden, as the rest of the internal surface is.
+bool ddaLLArOneShotEligible(ncclComm* comm, const void* sendbuff, void* recvbuff, size_t count,
+                            ncclDataType_t datatype, ncclRedOp_t op);
+
+bool ddaLLArTwoShotEligible(ncclComm* comm, const void* sendbuff, void* recvbuff, size_t count,
+                            ncclDataType_t datatype, ncclRedOp_t op);
+
 ncclResult_t ncclAllReduceDdaFabricLL(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
                                       ncclRedOp_t op, ncclComm* comm, cudaStream_t stream);
 

--- a/projects/rccl/src/include/dda_all_reduce.h
+++ b/projects/rccl/src/include/dda_all_reduce.h
@@ -35,8 +35,8 @@ bool ncclAllReduceDdaFabricLLEligible(ncclComm* comm, const void* sendbuff, void
 ncclResult_t ncclAllReduceDdaFabricLL(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
                                       ncclRedOp_t op, ncclComm* comm, cudaStream_t stream);
 
-// Two-shot tier of the LL fabric path. Its kernel is still a verbatim copy of the
-// one-shot tier's, so the two differ only in which tier dispatch picks.
+// Two-shot tier of the LL fabric path: each rank transports only the shard it
+// owns, so it moves count/nRanks per peer where the one-shot moves count.
 bool ncclAllReduceDdaFabricLLTwoShotEligible(ncclComm* comm, const void* sendbuff, void* recvbuff, size_t count,
                                              ncclDataType_t datatype, ncclRedOp_t op);
 

--- a/projects/rccl/src/include/dda_all_reduce.h
+++ b/projects/rccl/src/include/dda_all_reduce.h
@@ -35,6 +35,15 @@ bool ncclAllReduceDdaFabricLLEligible(ncclComm* comm, const void* sendbuff, void
 ncclResult_t ncclAllReduceDdaFabricLL(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
                                       ncclRedOp_t op, ncclComm* comm, cudaStream_t stream);
 
+// Two-shot tier of the LL fabric path. Its kernel is still a verbatim copy of the
+// one-shot tier's, so the two differ only in which tier dispatch picks.
+bool ncclAllReduceDdaFabricLLTwoShotEligible(ncclComm* comm, const void* sendbuff, void* recvbuff, size_t count,
+                                             ncclDataType_t datatype, ncclRedOp_t op);
+
+ncclResult_t ncclAllReduceDdaFabricLLTwoShot(const void* sendbuff, void* recvbuff, size_t count,
+                                             ncclDataType_t datatype, ncclRedOp_t op, ncclComm* comm,
+                                             cudaStream_t stream);
+
 // LL128-protocol fabric path (mid-message fast lane, 128B lines, no barrier).
 bool ncclAllReduceDdaFabricLL128Eligible(ncclComm* comm, const void* sendbuff, void* recvbuff, size_t count,
                                          ncclDataType_t datatype, ncclRedOp_t op);

--- a/projects/rccl/src/include/dda_init_detail.h
+++ b/projects/rccl/src/include/dda_init_detail.h
@@ -23,19 +23,17 @@
 
 namespace nccl_dda_detail {
 
+using meta::comms::kDdaLLMaxBytes;
 constexpr int kDdaNranks = meta::comms::NRANKS;
 
 // LL/LL128 fixed slot layout constants. These define the per-rank slot stride
 // used by the kernels, which must be known at compile time so all ranks use
 // identical offsets. The values match the algorithm headers:
-//   LL:    128 KiB per rank (all_gather_dda_fabric_ll.h, etc.)
 //   LL128: 512 KiB per rank (all_gather_dda_fabric_ll128.h, etc.)
-constexpr size_t kDdaLLMaxPerRankBytes = 131072;      // 128 KiB
 constexpr size_t kDdaLL128MaxPerRankBytes = 524288;   // 512 KiB
 constexpr int kDdaLL128DataElems = 15;                // payload words per 128B line
 
 // Derive slot stride from max per-rank bytes.
-constexpr size_t kDdaLLSlotStridePkts = kDdaLLMaxPerRankBytes / 8;  // 16384 pkts (16B lines)
 constexpr size_t kDdaLL128SlotStrideLines =
     (kDdaLL128MaxPerRankBytes / 8 + kDdaLL128DataElems - 1) / kDdaLL128DataElems;  // 4370 lines
 
@@ -44,7 +42,7 @@ constexpr size_t kDdaLL128SlotStrideLines =
 //
 // The derived size is: max(simpleCap, llFloor, ll128Floor) where:
 // - simpleCap: DDA_THRESHOLD (default 128 MiB)
-// - llFloor:   2 banks * nRanks * kDdaLLSlotStridePkts * 16B (when LL enabled)
+// - llFloor:   2 banks * nRanks * kDdaLLMaxBytes (when LL enabled)
 // - ll128Floor: 2 banks * nRanks * kDdaLL128SlotStrideLines * 128B (when LL128 enabled)
 //
 // Collectives that need more scratch (e.g., LL128 AR with large messages) are
@@ -63,8 +61,8 @@ inline size_t ddaFabricScratchSizing(int nRanks, int64_t overrideBytes, int64_t 
 
   if (nRanks < 1) nRanks = 1;
 
-  // LL fixed slot arrays: 2 banks * nRanks * slotStridePkts * 16B.
-  const size_t llFloor = llEnabled ? (size_t)2 * nRanks * kDdaLLSlotStridePkts * 16 : 0;
+  // LL fixed slot arrays: 2 banks * nRanks * slotMaxBytes.
+  const size_t llFloor = llEnabled ? (size_t)2 * nRanks * kDdaLLMaxBytes : 0;
 
   // LL128 fixed slot arrays: 2 banks * nRanks * slotStrideLines * 128B.
   const size_t ll128Floor = ll128Enabled ? (size_t)2 * nRanks * kDdaLL128SlotStrideLines * 128 : 0;

--- a/projects/rccl/src/include/dda_init_detail.h
+++ b/projects/rccl/src/include/dda_init_detail.h
@@ -114,12 +114,6 @@ inline int ddaFabricMaxNBlocksForScratch() {
 
 constexpr int kDdaLLAgMaxBlocksPerPeer = 8;
 
-// The LL AllReduce tier is intentionally narrow (tiny messages, latency-bound),
-// so it caps its grid at kDdaFabricLLArMaxBlocks instead of the 256-wide limit
-// used by LL128/Simple. AR uses the shared ddaLLEpochDev counter (same as AG/RS)
-// so that bank = flag & 1 is consistent across all LL operation types.
-constexpr int kDdaFabricLLArMaxBlocks = 24;
-
 // Number of device epoch cells for the LL collectives. it is sized for the larger of the two
 // max(AG total blocks, AR total blocks).
 inline size_t ddaLLEpochCount(int nRanks, int arMaxBlocks) {

--- a/projects/rccl/src/rccl_wrap.cc
+++ b/projects/rccl/src/rccl_wrap.cc
@@ -68,6 +68,8 @@ RCCL_PARAM(DdaEnable, "DDA_ENABLE", 1);
 RCCL_PARAM(DdaThreshold, "DDA_THRESHOLD", (size_t)(134217728));           // 128 MiB
 RCCL_PARAM(DdaLL, "DDA_LL", 1);
 RCCL_PARAM(DdaLLThreshold, "DDA_LL_THRESHOLD", (size_t)(32768));          // 32 KiB
+RCCL_PARAM(DdaLLTwoShot, "DDA_LL_TWOSHOT", 1);
+RCCL_PARAM(DdaLLTwoShotThreshold, "DDA_LL_TWOSHOT_THRESHOLD", (size_t)(0)); // 0 KiB
 RCCL_PARAM(DdaLL128, "DDA_LL128", 0);
 RCCL_PARAM(DdaLL128Threshold, "DDA_LL128_THRESHOLD", (size_t)(33554432)); // 32 MiB
 #ifdef ENABLE_WARP_SPEED

--- a/projects/rccl/src/rccl_wrap.cc
+++ b/projects/rccl/src/rccl_wrap.cc
@@ -935,8 +935,7 @@ ncclResult_t rcclSelectAllReduce(struct ncclComm* comm, const void* sendbuff, vo
   if (rcclAllReduceShouldTakeDdaPath(comm, count, datatype, symEligible, ceAllReduceAllowed)) {
     if (ddaFabricArch1250) {
       // Small-message fast lane: LL protocol (no GPU barrier).
-      if (rcclParamDdaLL() && msgBytes <= (size_t)rcclParamDdaLLThreshold() &&
-          ncclAllReduceDdaFabricLLEligible(comm, sendbuff, recvbuff, count, datatype, op)) {
+      if (ncclAllReduceDdaFabricLLEligible(comm, sendbuff, recvbuff, count, datatype, op)) {
         decision->algo = RCCL_DDA_FABRIC_LL;
         decision->protocol = NCCL_PROTO_LL;
         decision->nMaxChannels = ncclAllReduceDdaFabricLLBlocks(comm, count, datatype);

--- a/projects/rccl/src/rccl_wrap.cc
+++ b/projects/rccl/src/rccl_wrap.cc
@@ -68,8 +68,8 @@ RCCL_PARAM(DdaEnable, "DDA_ENABLE", 1);
 RCCL_PARAM(DdaThreshold, "DDA_THRESHOLD", (size_t)(134217728));           // 128 MiB
 RCCL_PARAM(DdaLL, "DDA_LL", 1);
 RCCL_PARAM(DdaLLThreshold, "DDA_LL_THRESHOLD", (size_t)(32768));          // 32 KiB
-RCCL_PARAM(DdaLLTwoShot, "DDA_LL_TWOSHOT", 1);
-RCCL_PARAM(DdaLLTwoShotThreshold, "DDA_LL_TWOSHOT_THRESHOLD", (size_t)(0)); // 0 KiB
+RCCL_PARAM(DdaLLOneShotThreshold, "DDA_LL_ONESHOT_THRESHOLD", (size_t)(1) * 1024 * 1024); // 1 MiB
+RCCL_PARAM(DdaLLTwoShotThreshold, "DDA_LL_TWOSHOT_THRESHOLD", (size_t)(16) * 1024 * 1024); // 16 MiB
 RCCL_PARAM(DdaLL128, "DDA_LL128", 0);
 RCCL_PARAM(DdaLL128Threshold, "DDA_LL128_THRESHOLD", (size_t)(33554432)); // 32 MiB
 #ifdef ENABLE_WARP_SPEED

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -676,6 +676,7 @@ if(BUILD_TESTS)
       DeviceApiMPITests.cpp
       CommNetMismatchMPITests.cpp
       test_sparse_send_recv.cpp
+      DdaAllReduceMPITests.cpp
     )
 
     add_executable(rccl-UnitTestsMPI ${MPI_TEST_SOURCE_FILES})

--- a/projects/rccl/test/DdaAllReduceMPITests.cpp
+++ b/projects/rccl/test/DdaAllReduceMPITests.cpp
@@ -1,0 +1,194 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+/**
+ * @file DdaAllReduceMPITests.cpp
+ * @brief MPI end-to-end tests for DDA fabric AllReduce LL one-shot and two-shot tiers
+ *
+ * Mirrors test/DdaAllReduceTests.cpp but uses MPI + ncclCommInitRank instead of
+ * ncclCommInitAll. Correctness is checked against the analytic sum; the COLL log
+ * line confirms which LL tier actually ran (fallback paths also sum correctly).
+ *
+ * Run (example):
+ *   mpirun -np 8 ./rccl-UnitTestsMPI --gtest_filter=DdaMPI_AllReduce.*
+ */
+
+#ifdef MPI_TESTS_ENABLED
+
+#include "DeviceBufferHelpers.hpp"
+#include "MPIHelpers.hpp"
+#include "MPITestBase.hpp"
+#include "ResourceGuards.hpp"
+#include "TestChecks.hpp"
+
+#include <gtest/gtest.h>
+#include <hip/hip_runtime.h>
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace MPITestConstants;
+using namespace RCCLTestGuards;
+using namespace RCCLTestHelpers;
+
+namespace
+{
+constexpr size_t kOneShotCount = 65536; // 256 KiB f32; below default 1 MiB one-shot threshold
+
+// Default thresholds put two-shot above 1 MiB; 262176 floats is 1 MiB + 128 B and
+// satisfies the two-shot shard alignment rules at typical MPI rank counts (see
+// DdaFabricEligibilityTests.cpp AllReduceLL_TwoShotClaimsPastOneShotThreshold).
+constexpr size_t kTwoShotBaseCount = 262176;
+
+constexpr char kOneShotLogNeedle[] = "taking DDA fabric LL one-shot path";
+constexpr char kTwoShotLogNeedle[] = "taking DDA fabric LL two-shot path";
+
+bool isGfx1250Device()
+{
+    hipDeviceProp_t props{};
+    if(hipGetDeviceProperties(&props, 0) != hipSuccess)
+        return false;
+    return std::string(props.gcnArchName).find("gfx1250") != std::string::npos;
+}
+
+void fillRankScalar(void* buf, size_t nElem, int rank)
+{
+    std::vector<float> host(nElem, static_cast<float>(rank + 1));
+    HIP_CHECK(hipMemcpy(buf, host.data(), nElem * sizeof(float), hipMemcpyHostToDevice));
+}
+
+bool ddaLLTwoShotShapeOk(size_t count, int nRanks)
+{
+    const size_t bytes = count * sizeof(float);
+    if(bytes % static_cast<size_t>(nRanks) != 0)
+        return false;
+    return (bytes / static_cast<size_t>(nRanks)) % 16 == 0;
+}
+
+// Pick a count past the default one-shot threshold whose total bytes satisfy the
+// two-shot per-rank shard alignment for the active communicator width.
+size_t twoShotCountForRanks(int nRanks)
+{
+    size_t count = kTwoShotBaseCount;
+    if(!ddaLLTwoShotShapeOk(count, nRanks))
+    {
+        count = (count + 3) & ~size_t(3);
+        for(int i = 0; i < 1024; ++i, count += 4)
+        {
+            if(ddaLLTwoShotShapeOk(count, nRanks))
+                return count;
+        }
+        return 0;
+    }
+    return count;
+}
+
+bool logContainsNeedle(const MPIHelpers::TestLogAssertionContext& logCtx, const char* needle)
+{
+    const std::string merged = logCtx.readNcclDebugLog() + logCtx.readPerRankStderrLog();
+    return merged.find(needle) != std::string::npos;
+}
+} // namespace
+
+/**
+ * @class DdaAllReduceMPITest
+ * @brief Shared fixture: COLL log capture and gfx1250 gate for DDA fabric LL tiers.
+ */
+class DdaAllReduceMPITest : public MPITestBase
+{
+protected:
+    std::unique_ptr<MPIHelpers::MpiEnvGuard>             debugGuard_;
+    std::unique_ptr<MPIHelpers::MpiEnvGuard>             debugSubsysGuard_;
+    std::unique_ptr<MPIHelpers::TestLogAssertionContext> logCtx_;
+
+    void SetUp() override
+    {
+        MPITestBase::SetUp();
+        debugGuard_       = std::make_unique<MPIHelpers::MpiEnvGuard>("NCCL_DEBUG", "INFO");
+        debugSubsysGuard_ = std::make_unique<MPIHelpers::MpiEnvGuard>("NCCL_DEBUG_SUBSYS", "NET,INIT,COLL,TUNING");
+        logCtx_           = std::make_unique<MPIHelpers::TestLogAssertionContext>(
+            MPIHelpers::makeCombinedAssertionLogOptions(getTestMpiRank()));
+    }
+
+    void TearDown() override
+    {
+        MPITestBase::TearDown();
+        logCtx_.reset();
+        debugSubsysGuard_.reset();
+        debugGuard_.reset();
+    }
+
+    void runAllReduce(size_t count, const char* logNeedle, const char* testId)
+    {
+        if(!validateTestPrerequisites(kMinProcessesForMPI))
+            GTEST_SKIP() << "Need at least 2 MPI ranks";
+
+        //if(!isGfx1250Device())
+        //    GTEST_SKIP() << "DDA fabric LL requires gfx1250";
+
+        ASSERT_EQ(ncclSuccess, createTestCommunicator());
+
+        int rank{}, nRanks{};
+        ncclCommUserRank(getActiveCommunicator(), &rank);
+        ncclCommCount(getActiveCommunicator(), &nRanks);
+
+        const size_t bytes = count * sizeof(float);
+
+        void* sendBuf = nullptr;
+        ASSERT_EQ(hipSuccess, hipMalloc(&sendBuf, bytes));
+        DeviceBufferAutoGuard sendGuard(sendBuf);
+
+        void* recvBuf = nullptr;
+        ASSERT_EQ(hipSuccess, hipMalloc(&recvBuf, bytes));
+        DeviceBufferAutoGuard recvGuard(recvBuf);
+
+        fillRankScalar(sendBuf, count, rank);
+        ASSERT_EQ(hipSuccess, hipMemset(recvBuf, 0, bytes));
+
+        ASSERT_EQ(ncclSuccess,
+                  ncclAllReduce(sendBuf, recvBuf, count, ncclFloat32, ncclSum,
+                                getActiveCommunicator(), getActiveStream()));
+        ASSERT_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
+
+        const float expectedSum = static_cast<float>(nRanks * (nRanks + 1) / 2);
+        ASSERT_TRUE(verifyBufferData<float>(recvBuf, count,
+                                            [expectedSum](size_t) { return expectedSum; }))
+            << "Rank " << rank << ": DDA LL AllReduce verification failed";
+
+        const bool tookExpectedPath = logContainsNeedle(*logCtx_, logNeedle);
+        EXPECT_TRUE(tookExpectedPath)
+            << "Rank " << rank << ": " << testId
+            << " did not log the expected DDA LL tier (needle: \"" << logNeedle << "\")";
+
+        if(getTestMpiRank() == 0 && tookExpectedPath)
+            TEST_INFO("%s: DDA LL path confirmed via COLL log", testId);
+    }
+};
+
+class DdaMPI_AllReduce : public DdaAllReduceMPITest
+{};
+
+TEST_F(DdaMPI_AllReduce, LLOneShotMultiRank)
+{
+    runAllReduce(kOneShotCount, kOneShotLogNeedle, "DdaMPI_AllReduce/LLOneShotMultiRank");
+}
+
+TEST_F(DdaMPI_AllReduce, LLTwoShotMultiRank)
+{
+    if(!validateTestPrerequisites(kMinProcessesForMPI))
+        GTEST_SKIP() << "Need at least 2 MPI ranks";
+
+    int nRanks = MPIEnvironment::world_size;
+    const size_t count = twoShotCountForRanks(nRanks);
+    if(count == 0)
+        GTEST_SKIP() << "Could not find a two-shot-aligned element count for nRanks="
+                     << nRanks;
+
+    runAllReduce(count, kTwoShotLogNeedle, "DdaMPI_AllReduce/LLTwoShotMultiRank");
+}
+
+#endif // MPI_TESTS_ENABLED

--- a/projects/rccl/test/DdaFabricEligibilityTests.cpp
+++ b/projects/rccl/test/DdaFabricEligibilityTests.cpp
@@ -520,6 +520,46 @@ TEST_F(DdaFabricEligibilityTest, AllReduceLL_PastBothThresholds)
         mockComm_.get(), sendbuff_, recvbuff_, 4194336, ncclFloat32, ncclSum));
 }
 
+// The gate above only reports the disjunction of the two tiers. These call each
+// per-variant predicate directly, so a tier can be pinned without the other
+// masking it, and assert the complementary tier to show which one owns the size.
+
+// 16 bytes is inside the one-shot threshold and a whole line, so one-shot takes
+// it; a quarter of it is a 4-byte shard, which is not, so two-shot cannot.
+TEST_F(DdaFabricEligibilityTest, AllReduceLL_OneShotEligible)
+{
+    mockComm_.comm.nRanks = 4;
+    EXPECT_TRUE(ddaLLArOneShotEligible(
+        mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32, ncclSum));
+    EXPECT_FALSE(ddaLLArTwoShotEligible(
+        mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32, ncclSum));
+}
+
+// 262160 floats is 1 MiB + 64 bytes: past the one-shot threshold, so that tier
+// declines, while the 262160-byte shard is a whole number of lines and within the
+// slot's payload capacity, so two-shot takes it.
+TEST_F(DdaFabricEligibilityTest, AllReduceLL_TwoShotEligible)
+{
+    mockComm_.comm.nRanks = 4;
+    EXPECT_TRUE(ddaLLArTwoShotEligible(
+        mockComm_.get(), sendbuff_, recvbuff_, 262160, ncclFloat32, ncclSum));
+    EXPECT_FALSE(ddaLLArOneShotEligible(
+        mockComm_.get(), sendbuff_, recvbuff_, 262160, ncclFloat32, ncclSum));
+}
+
+// The shard is carved out of the byte count, so 32 halves (64 bytes) divide evenly
+// across 4 ranks but 33 (66 bytes) do not. The pair differs only in that, which is
+// what makes the rejection attributable to the divisibility guard rather than to
+// the 16-byte rule that follows it.
+TEST_F(DdaFabricEligibilityTest, AllReduceLL_TwoShotRejectsUnevenShard)
+{
+    mockComm_.comm.nRanks = 4;
+    EXPECT_TRUE(ddaLLArTwoShotEligible(
+        mockComm_.get(), sendbuff_, recvbuff_, 32, ncclFloat16, ncclSum));
+    EXPECT_FALSE(ddaLLArTwoShotEligible(
+        mockComm_.get(), sendbuff_, recvbuff_, 33, ncclFloat16, ncclSum));
+}
+
 // ---------------------------------------------------------------------------
 // AllToAll
 // ---------------------------------------------------------------------------

--- a/projects/rccl/test/DdaFabricEligibilityTests.cpp
+++ b/projects/rccl/test/DdaFabricEligibilityTests.cpp
@@ -349,6 +349,178 @@ TEST_F(DdaFabricEligibilityTest, AllReduce_InvalidDatatypeDispatch)
 }
 
 // ---------------------------------------------------------------------------
+// AllReduce LL
+//
+// One gate fronts both LL tiers: ncclAllReduceDdaFabricLLEligible reports
+// whether the one-shot or the two-shot variant claims the message. Both are
+// enabled by DDA_LL and each carries its own threshold on the total message
+// size, with one-shot tested first.
+//
+// These run under the default parameter values -- DDA_LL=1, a 1 MiB
+// DDA_LL_ONESHOT_THRESHOLD and a 16 MiB DDA_LL_TWOSHOT_THRESHOLD -- so sizes
+// above 1 MiB and up to 16 MiB are claimed by the two-shot tier, which is what
+// makes the tier split observable from here. They deliberately do not setenv:
+// RCCL_PARAM caches on first read, and the NCCL_NO_CACHE opt-out is resolved once
+// per process, so a test that changed a threshold would depend on being the first
+// in the binary to touch it. Two guards stay out of reach as a result:
+// kDdaLLMaxBytes sits above the one-shot threshold, and the two-shot half-slot
+// bound needs a shard past kDdaLLMaxBytes / 2, so both are masked by the
+// thresholds and belong to a multi-rank run.
+// ---------------------------------------------------------------------------
+
+TEST_F(DdaFabricEligibilityTest, AllReduceLL_NullComm)
+{
+    EXPECT_FALSE(ncclAllReduceDdaFabricLLEligible(
+        nullptr, sendbuff_, recvbuff_, 4, ncclFloat32, ncclSum));
+}
+
+TEST_F(DdaFabricEligibilityTest, AllReduceLL_MissingBootstrap)
+{
+    mockComm_.comm.bootstrap = nullptr;
+    EXPECT_FALSE(ncclAllReduceDdaFabricLLEligible(
+        mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32, ncclSum));
+}
+
+TEST_F(DdaFabricEligibilityTest, AllReduceLL_MissingFabricResources)
+{
+    mockComm_.setFabricResourcesPresent(false);
+    EXPECT_FALSE(ncclAllReduceDdaFabricLLEligible(
+        mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32, ncclSum));
+}
+
+TEST_F(DdaFabricEligibilityTest, AllReduceLL_MissingScratch)
+{
+    mockComm_.comm.ddaScratch = nullptr;
+    EXPECT_FALSE(ncclAllReduceDdaFabricLLEligible(
+        mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32, ncclSum));
+}
+
+TEST_F(DdaFabricEligibilityTest, AllReduceLL_ZeroCount)
+{
+    EXPECT_FALSE(ncclAllReduceDdaFabricLLEligible(
+        mockComm_.get(), sendbuff_, recvbuff_, 0, ncclFloat32, ncclSum));
+}
+
+TEST_F(DdaFabricEligibilityTest, AllReduceLL_UnsupportedOp)
+{
+    EXPECT_FALSE(ncclAllReduceDdaFabricLLEligible(
+        mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32, ncclProd));
+}
+
+TEST_F(DdaFabricEligibilityTest, AllReduceLL_UnsupportedDatatype)
+{
+    EXPECT_FALSE(ncclAllReduceDdaFabricLLEligible(
+        mockComm_.get(), sendbuff_, recvbuff_, 4, ncclInt32, ncclSum));
+}
+
+// Both tiers store a 16-byte LL line at a time, so one-shot requires the message
+// to be a multiple of 16 bytes and two-shot requires that of each shard. One float
+// is 4 bytes, so a single element satisfies neither.
+TEST_F(DdaFabricEligibilityTest, AllReduceLL_UnalignedBytes)
+{
+    EXPECT_FALSE(ncclAllReduceDdaFabricLLEligible(
+        mockComm_.get(), sendbuff_, recvbuff_, 1, ncclFloat32, ncclSum));
+}
+
+// 8 bytes is a whole number of 8-byte payload packets but not a whole number of
+// 16-byte lines, so it is the size that separates the line rule from the packet
+// rule: one-shot rejects it on bytes % 16, and two-shot on a 1-byte shard.
+TEST_F(DdaFabricEligibilityTest, AllReduceLL_PacketButNotLineMultiple)
+{
+    EXPECT_FALSE(ncclAllReduceDdaFabricLLEligible(
+        mockComm_.get(), sendbuff_, recvbuff_, 2, ncclFloat32, ncclSum));
+}
+
+TEST_F(DdaFabricEligibilityTest, AllReduceLL_TooFewRanks)
+{
+    mockComm_.comm.nRanks = 1;
+    EXPECT_FALSE(ncclAllReduceDdaFabricLLEligible(
+        mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32, ncclSum));
+}
+
+TEST_F(DdaFabricEligibilityTest, AllReduceLL_TooManyRanks)
+{
+    mockComm_.comm.nRanks = meta::comms::kDdaMaxNranks + 1;
+    EXPECT_FALSE(ncclAllReduceDdaFabricLLEligible(
+        mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32, ncclSum));
+}
+
+TEST_F(DdaFabricEligibilityTest, AllReduceLL_MinRanksEligible)
+{
+    mockComm_.comm.nRanks = 2;
+    EXPECT_TRUE(ncclAllReduceDdaFabricLLEligible(
+        mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32, ncclSum));
+}
+
+// The staging footprint scales with nRanks, so the widest comm is also the one
+// that has to still fit the scratch.
+TEST_F(DdaFabricEligibilityTest, AllReduceLL_MaxRanksEligible)
+{
+    mockComm_.comm.nRanks = meta::comms::kDdaMaxNranks;
+    EXPECT_TRUE(ncclAllReduceDdaFabricLLEligible(
+        mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32, ncclSum));
+}
+
+TEST_F(DdaFabricEligibilityTest, AllReduceLL_ScratchTooSmall)
+{
+    mockComm_.comm.ddaScratchBytes = 8;
+    EXPECT_FALSE(ncclAllReduceDdaFabricLLEligible(
+        mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32, ncclSum));
+}
+
+TEST_F(DdaFabricEligibilityTest, AllReduceLL_EligibleFloat32)
+{
+    EXPECT_TRUE(ncclAllReduceDdaFabricLLEligible(
+        mockComm_.get(), sendbuff_, recvbuff_, 4, ncclFloat32, ncclSum));
+}
+
+TEST_F(DdaFabricEligibilityTest, AllReduceLL_EligibleFloat16)
+{
+    EXPECT_TRUE(ncclAllReduceDdaFabricLLEligible(
+        mockComm_.get(), sendbuff_, recvbuff_, 8, ncclFloat16, ncclSum));
+}
+
+TEST_F(DdaFabricEligibilityTest, AllReduceLL_EligibleBfloat16)
+{
+    EXPECT_TRUE(ncclAllReduceDdaFabricLLEligible(
+        mockComm_.get(), sendbuff_, recvbuff_, 8, ncclBfloat16, ncclSum));
+}
+
+// 262144 floats is exactly the default 1 MiB DDA_LL_ONESHOT_THRESHOLD, which the
+// tier takes with <=.
+TEST_F(DdaFabricEligibilityTest, AllReduceLL_AtOneShotThresholdEligible)
+{
+    EXPECT_TRUE(ncclAllReduceDdaFabricLLEligible(
+        mockComm_.get(), sendbuff_, recvbuff_, 262144, ncclFloat32, ncclSum));
+}
+
+// 262176 floats is 1 MiB + 128 bytes: past the one-shot threshold, so one-shot
+// cannot be what accepts it, and a multiple of 16 * nRanks so the shard satisfies
+// the two-shot shape rules. Accepting it is the two-shot tier serving the range
+// above the one-shot threshold.
+TEST_F(DdaFabricEligibilityTest, AllReduceLL_TwoShotClaimsPastOneShotThreshold)
+{
+    EXPECT_TRUE(ncclAllReduceDdaFabricLLEligible(
+        mockComm_.get(), sendbuff_, recvbuff_, 262176, ncclFloat32, ncclSum));
+}
+
+// 4194304 floats is exactly the default 16 MiB DDA_LL_TWOSHOT_THRESHOLD, the top
+// of the LL range, which the tier takes with <=.
+TEST_F(DdaFabricEligibilityTest, AllReduceLL_AtTwoShotThresholdEligible)
+{
+    EXPECT_TRUE(ncclAllReduceDdaFabricLLEligible(
+        mockComm_.get(), sendbuff_, recvbuff_, 4194304, ncclFloat32, ncclSum));
+}
+
+// 128 bytes past the two-shot threshold: neither tier claims it and the message
+// falls through to LL128 / Simple.
+TEST_F(DdaFabricEligibilityTest, AllReduceLL_PastBothThresholds)
+{
+    EXPECT_FALSE(ncclAllReduceDdaFabricLLEligible(
+        mockComm_.get(), sendbuff_, recvbuff_, 4194336, ncclFloat32, ncclSum));
+}
+
+// ---------------------------------------------------------------------------
 // AllToAll
 // ---------------------------------------------------------------------------
 

--- a/projects/rccl/test/DdaFabricEligibilityTests.cpp
+++ b/projects/rccl/test/DdaFabricEligibilityTests.cpp
@@ -84,7 +84,7 @@ TEST(DdaFabricScratchSizingTest, LLFloorDominatesAtHighRankCount)
     constexpr int nRanks = 72;
     constexpr int64_t smallSimpleCap = 8 * 1024 * 1024;  // 8 MiB
     const size_t sizing = nccl_dda_detail::ddaFabricScratchSizing(nRanks, -1, 1, smallSimpleCap, 1, 0);
-    constexpr size_t llFloor = 2 * nRanks * nccl_dda_detail::kDdaLLSlotStridePkts * 16;
+    constexpr size_t llFloor = 2 * nRanks * meta::comms::kDdaLLMaxBytes;
     EXPECT_EQ(sizing, llFloor);
     EXPECT_GT(sizing, (size_t)smallSimpleCap);
 }


### PR DESCRIPTION
## Motivation

The existing LL all-reduce is one-shot: every rank stages the entire message into every peer's scratch, so fabric traffic scales as (nRanks-1) × count per rank and the no-barrier LL fast lane stops paying off well before the top of its size range. This adds a two-shot LL variant that transports only the count/nRanks shard each rank owns, reducing per-rank traffic by roughly a factor of nRanks and extending the LL tier to larger messages.

## Technical Details

Adds ddaAllReduceTwoShotLL in all_reduce_dda_ll_twoshot.h: each rank owns one count/nRanks shard and only ever transports that shard, so it moves nRanks-1 shards instead of nRanks-1 whole messages.

Phase 1 (publish): send each peer the shard that peer owns, written into that peer's scratch at slot selfRank as LL lines carrying the epoch flag.
Phase 2 (reduce): poll my own slot for each peer's copy of my shard, sum them with my contribution read directly from sendbuff, write my slice of recvbuff, and publish the reduced shard back to every peer.
Phase 3 (write-back): poll for the peers' reduced shards and write each into that peer's slice of recvbuff.

Tier selection, including both enables and thresholds, moves out of collectives.cc into dda_all_reduce_fabric_ll.cu: Eligible reports whether either variant claims the message and the entry point launches whichever did, leaving collectives.cc with a single call site that need not know the tier has two variants.
Adds  RCCL_DDA_LL_ONESHOT_THRESHOLD (default 1MB) and RCCL_DDA_LL_TWOSHOT_THRESHOLD (default 16MB)

## Issue Tracking

Jira ID : AICOMRCCL-1489

## Test Plan

Covers every guard behind Allreduce LL eligibility testing.
The new algorithms (one shot and two shot) are enabled by default and hence executed whenever allreduce is called.

## Test Result

[----------] Global test environment tear-down
[==========] 21 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 21 tests.

Allreduce runs without errors.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
