### PR TITLE
contrib/nccl_m2n: add ROCm build (Makefile.rocm, build-time hipify)

### DIFF
--- a/projects/rccl/contrib/nccl_m2n/GNUmakefile
+++ b/projects/rccl/contrib/nccl_m2n/GNUmakefile
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# See LICENSE.txt for more license information.
+
+# ============================================================================
+# Front-end that picks the build backend automatically (GNU make reads
+# GNUmakefile before Makefile), so `make [target]` works unchanged on ROCm:
+#   * hipcc present -> Makefile.rocm  (ROCm build)
+#   * otherwise     -> Makefile       (upstream build)
+#
+# Options:
+#   make M2N_BACKEND=Makefile.rocm   # force ROCm backend
+#   make M2N_BACKEND=Makefile        # force upstream backend
+# ============================================================================
+
+ROCM_PATH ?= /opt/rocm
+
+ifeq ($(origin M2N_BACKEND),undefined)
+  ifneq ($(wildcard $(ROCM_PATH)/bin/hipcc),)
+    M2N_BACKEND := Makefile.rocm
+  else ifneq ($(shell command -v hipcc 2>/dev/null),)
+    M2N_BACKEND := Makefile.rocm
+  else
+    M2N_BACKEND := Makefile
+  endif
+endif
+
+# Forward every requested goal (and the bare `make` default) to the selected
+# backend in a SINGLE sub-make. The goals depend on one shared forwarding rule
+# so multiple goals (`make tests bench`) still run exactly one sub-make, and
+# the goals themselves become no-ops.
+GOALS := $(or $(MAKECMDGOALS),all)
+
+.PHONY: $(GOALS) __m2n_dispatch
+$(GOALS): __m2n_dispatch ; @:
+
+__m2n_dispatch:
+	@$(MAKE) --no-print-directory -f $(M2N_BACKEND) $(MAKECMDGOALS)

--- a/projects/rccl/contrib/nccl_m2n/Makefile.rocm
+++ b/projects/rccl/contrib/nccl_m2n/Makefile.rocm
@@ -1,0 +1,356 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# See LICENSE.txt for more license information.
+
+# ============================================================================
+# ROCm build for the NCCL M2N library (reshard release).
+# ============================================================================
+#
+# This is the AMD/ROCm counterpart of the upstream Makefile. It keeps
+# the exact same project structure, source lists and target names as the
+# upstream build, but swaps the toolchain:
+#
+#   * Source -> HIP conversion is done at BUILD TIME with hipify-perl, exactly
+#     like the main RCCL build (cmake/src/CMakeLists.txt) and RCCL's own
+#     standalone tools (tools/topo_expl/Makefile). The upstream sources
+#     under src/, tests/ and benchmarks/ are NEVER edited in place -- they are
+#     copied into $(HIPIFY_DIR) and hipified there. No hand-hipified .cu/.cc
+#     files are committed to the repository.
+#   * upstream compiler -> hipcc
+#   * -lnccl (NCCL)   -> -lrccl (RCCL, built from source)
+#   * nccl_device.h   comes from the RCCL build tree (RCCL_HOME/NCCL_HOME).
+#
+# Usage:
+#   make -f Makefile.rocm              - Build the shared library (default)
+#   make -f Makefile.rocm lib          - Build libnccl_m2n.so
+#   make -f Makefile.rocm tests        - Build basic_api_test_{mpi,local}
+#   make -f Makefile.rocm bench        - Build all benchmarks
+#   make -f Makefile.rocm hipify       - Stage + hipify sources only
+#   make -f Makefile.rocm install      - Install lib + header to PREFIX
+#   make -f Makefile.rocm clean        - Remove all build artifacts
+#   make -f Makefile.rocm help         - Show this help
+#
+# Required environment variables:
+#   RCCL_HOME (or legacy NCCL_HOME) - Path to the RCCL build directory. Must
+#                              contain include/nccl_device.h and librccl.so.
+#
+# Optional environment variables:
+#   ROCM_PATH     - ROCm install (default: /opt/rocm)
+#   RCCL_LIBDIR   - Directory holding librccl.so (default: $(RCCL_HOME))
+#   OFFLOAD_ARCH  - GPU arch (default: gfx950)
+#   GTEST_DIR     - googletest tree with include/ and lib/ (for tests)
+#   MPI_HOME      - MPI install (benchmarks + MPI test); auto-detected via mpicc
+#   PREFIX        - Install prefix (default: /usr/local)
+#   DEBUG         - 1=-g, full=-g -O0
+#   BUILDDIR      - Override build/ output directory
+
+# ── Project root = directory containing this Makefile ──────────────────────
+NCCL_M2N_ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
+# ── Toolchain ──────────────────────────────────────────────────────────────
+ROCM_PATH   ?= /opt/rocm
+HIPCC       := $(ROCM_PATH)/bin/hipcc
+HIPIFY      := $(ROCM_PATH)/bin/hipify-perl
+HIPIFY_FLAGS := -quiet-warnings
+OFFLOAD_ARCH ?= gfx950
+
+# ── ROCm version ───────────────────────────────────────────────────────────
+# RCCL's device headers gate behaviour on ROCM_VERSION, which hipcc does NOT
+# predefine: RCCL's own CMake computes it from $(ROCM_PATH)/.info/version and
+# passes -DROCM_VERSION.  Consumers of those headers must do the same, or the
+# headers silently take their pre-7.0 fallbacks -- for warp-level coop syncs
+# that fallback is a whole-CTA __syncthreads(), which deadlocks any kernel that
+# calls ncclGin::waitSignal() from a subset of its waves.  Same arithmetic as
+# rccl/CMakeLists.txt: 10000*major + 100*minor + patch.
+ROCM_INFO_VERSION_FILE := $(firstword $(wildcard $(ROCM_PATH)/.info/version $(ROCM_PATH)/core/.info/version))
+ifneq ($(ROCM_INFO_VERSION_FILE),)
+    ROCM_VERSION_STRING := $(shell head -n1 $(ROCM_INFO_VERSION_FILE) | tr -d '[:space:]')
+    ROCM_MAJOR_VERSION := $(word 1,$(subst ., ,$(ROCM_VERSION_STRING)))
+    ROCM_MINOR_VERSION := $(word 2,$(subst ., ,$(ROCM_VERSION_STRING)))
+    ROCM_PATCH_VERSION := $(word 3,$(subst ., ,$(ROCM_VERSION_STRING)))
+    ROCM_VERSION ?= $(shell expr 10000 \* $(ROCM_MAJOR_VERSION) + 100 \* $(ROCM_MINOR_VERSION) + $(ROCM_PATCH_VERSION) 2>/dev/null)
+endif
+
+# ── RCCL dependency (device API headers + librccl) ─────────────────────────
+# RCCL_HOME is the canonical variable: point it at the RCCL build tree. The
+# upstream name NCCL_HOME is still accepted as a legacy alias so existing
+# tooling/docs keep working; RCCL_HOME wins when both are set.
+RCCL_HOME ?= $(NCCL_HOME)
+RCCL_LIBDIR ?= $(RCCL_HOME)
+
+# ── Required dependency checks (skipped for clean/help/hipify) ─────────────
+NO_DEPS_GOALS := clean help
+SKIP_DEP_CHECK := $(if $(MAKECMDGOALS),$(if $(filter-out $(NO_DEPS_GOALS),$(MAKECMDGOALS)),,1))
+ifeq ($(SKIP_DEP_CHECK),)
+ifeq ($(RCCL_HOME),)
+$(error RCCL_HOME is not set (legacy NCCL_HOME also accepted). Point it at your RCCL build dir, e.g. /path/to/rccl/build/debug)
+endif
+ifeq ($(wildcard $(RCCL_HOME)/include/nccl_device.h),)
+$(error $(RCCL_HOME)/include/nccl_device.h not found. RCCL must be built from source (device API enabled).)
+endif
+ifeq ($(wildcard $(HIPCC)),)
+$(error hipcc not found at $(HIPCC). Set ROCM_PATH correctly.)
+endif
+ifeq ($(ROCM_VERSION),)
+$(error Could not determine ROCM_VERSION: no $(ROCM_PATH)/.info/version or $(ROCM_PATH)/core/.info/version. Pass ROCM_VERSION=<10000*major+100*minor+patch> explicitly.)
+endif
+endif
+
+# ── MPI (benchmarks + MPI test only; the library itself does not link MPI) ──
+MPICC ?= mpicc
+ifdef MPI_HOME
+MPI_CFLAGS  := -I$(MPI_HOME)/include
+MPI_LDFLAGS := -L$(MPI_HOME)/lib -lmpi
+else
+MPI_CFLAGS  := $(shell $(MPICC) --showme:compile 2>/dev/null)
+MPI_LDFLAGS := $(shell $(MPICC) --showme:link 2>/dev/null)
+ifeq ($(strip $(MPI_LDFLAGS)),)
+MPI_LDFLAGS := -lmpi
+endif
+endif
+
+# ── Output layout (single shared build/ at the project root) ───────────────
+BUILDDIR   ?= $(NCCL_M2N_ROOT)/build
+LIBDIR     := $(BUILDDIR)/lib
+BINDIR     := $(BUILDDIR)/bin
+INCDIR     := $(BUILDDIR)/include
+HIPIFY_DIR := $(BUILDDIR)/hipify
+
+M2N_LIBNAME       := libnccl_m2n.so
+M2N_LIBTARGET     := $(LIBDIR)/$(M2N_LIBNAME)
+M2N_HEADER_TARGET := $(INCDIR)/nccl_m2n.h
+
+# ── Pristine (upstream) source trees - never modified in place ─────────────
+SRCDIR   := $(NCCL_M2N_ROOT)/src
+TESTSDIR := $(NCCL_M2N_ROOT)/tests
+BENCHDIR := $(NCCL_M2N_ROOT)/benchmarks
+
+# ── Hipified (generated) source trees ──────────────────────────────────────
+HSRC   := $(HIPIFY_DIR)/src
+HTESTS := $(HIPIFY_DIR)/tests
+HBENCH := $(HIPIFY_DIR)/benchmarks
+
+# ── Compiler flags ─────────────────────────────────────────────────────────
+CXXSTD   := -std=c++17
+INCLUDES := -isystem $(RCCL_HOME)/include \
+            -isystem $(RCCL_HOME)/include/nccl_device \
+            -I$(HSRC) \
+            -isystem $(NCCL_M2N_ROOT)/third_party
+
+HIPFLAGS := $(CXXSTD) \
+            --offload-arch=$(OFFLOAD_ARCH) \
+            -D__HIP_PLATFORM_AMD__ \
+            -DNCCL_OS_LINUX \
+            -DROCM_VERSION=$(ROCM_VERSION) \
+            -fPIC -Wall -Wno-unused-result -O3 \
+            $(INCLUDES)
+
+ifeq ($(DEBUG),full)
+    HIPFLAGS += -g -O0
+    $(info [DEBUG] Full debug enabled (-g -O0))
+else ifeq ($(DEBUG),1)
+    HIPFLAGS += -g
+    $(info [DEBUG] Debug symbols enabled (-g))
+endif
+
+# Host-only flags (no --offload-arch): used for host-only TUs that contain no
+# device code (e.g. reshard_model_bench.cu is a pure host JSON-config driver).
+# The upstream compiler discards such host-only code from its device pass
+# automatically; clang-HIP
+# would otherwise try to compile the host-only templates (nlohmann/json) for
+# the device and fail, so we force -x c++ for those TUs.
+HOSTFLAGS := $(CXXSTD) \
+             -D__HIP_PLATFORM_AMD__ \
+             -DNCCL_OS_LINUX \
+             -DROCM_VERSION=$(ROCM_VERSION) \
+             -fPIC -Wall -Wno-unused-result -O3 \
+             -isystem $(ROCM_PATH)/include \
+             $(INCLUDES)
+
+# ── Linker flags ───────────────────────────────────────────────────────────
+LIB_LDFLAGS      := -L$(RCCL_LIBDIR) -lrccl -Wl,-rpath,$(RCCL_LIBDIR)
+M2N_LIB_LDFLAGS  := $(LIB_LDFLAGS) -Wl,-rpath,'$$ORIGIN'
+M2N_CLIENT_LDFLAGS := -L$(LIBDIR) -lnccl_m2n -Wl,-rpath,'$$ORIGIN/../lib'
+BENCH_LDFLAGS    := $(LIB_LDFLAGS) $(MPI_LDFLAGS)
+
+# ── googletest (optional; prebuilt tree with include/ + lib/) ──────────────
+GTEST_DIR ?=
+ifneq ($(GTEST_DIR),)
+GTEST_INC   := $(GTEST_DIR)/include
+GTEST_LIB   := $(GTEST_DIR)/lib
+# Prebuilt libgtest.a is usually non-PIC -> link the test binaries -no-pie.
+GTEST_LDFLAGS := -L$(GTEST_LIB) -lgtest -no-pie
+GTEST_AVAILABLE := $(if $(wildcard $(GTEST_INC)/gtest/gtest.h),1,0)
+else
+GTEST_AVAILABLE := 0
+endif
+
+# ── Source lists (identical to the upstream Makefiles) ─────────────────────
+LIB_CC_NAMES := m2n_config.cc reshard_cache.cc reshard_mesh.cc \
+                reshard_loadbalance.cc reshard_prepare.cc reshard_transpose.cc \
+                m2n_init.cc
+LIB_CU_NAMES := reshard_user_window.cu
+LIB_SRC_NAMES := $(LIB_CC_NAMES) $(LIB_CU_NAMES)
+LIB_HDR_NAMES := nccl_m2n.h reshard_types.h reshard_limits.h m2n_checks.h \
+                 m2n_log.h reshard_internal.h reshard_kernels.cuh
+
+TEST_HELPERS_NAME := test_helpers.cu
+TEST_HDR_NAMES    := test_helpers.h basic_api_test_core.h
+TEST_MPI_NAMES    := basic_api_test_mpi.cc   $(TEST_HELPERS_NAME)
+TEST_LOCAL_NAMES  := basic_api_test_local.cc $(TEST_HELPERS_NAME)
+
+BENCH_KERNELS_NAME := bench_common_kernels.cu
+BENCH_NAMES        := reshard_bench.cc $(BENCH_KERNELS_NAME)
+BATCH_BENCH_NAMES  := reshard_batch_bench_user_window.cu
+MODEL_BENCH_NAMES  := reshard_model_bench.cu $(BENCH_KERNELS_NAME)
+
+# Staged (hipified) full paths.
+LIB_SRCS   := $(addprefix $(HSRC)/,$(LIB_SRC_NAMES))
+TEST_MPI_SRCS   := $(addprefix $(HTESTS)/,basic_api_test_mpi.cc) $(HTESTS)/$(TEST_HELPERS_NAME)
+TEST_LOCAL_SRCS := $(addprefix $(HTESTS)/,basic_api_test_local.cc) $(HTESTS)/$(TEST_HELPERS_NAME)
+BENCH_SRCS       := $(HBENCH)/reshard_bench.cc $(HBENCH)/$(BENCH_KERNELS_NAME)
+BATCH_BENCH_SRCS := $(HBENCH)/reshard_batch_bench_user_window.cu
+MODEL_BENCH_SRCS := $(HBENCH)/reshard_model_bench.cu $(HBENCH)/$(BENCH_KERNELS_NAME)
+
+# Sentinel that marks a completed hipify pass (all trees staged + converted).
+HIPIFY_STAMP := $(HIPIFY_DIR)/.hipify.stamp
+
+.PHONY: all lib tests bench basic_api_test_mpi basic_api_test_local \
+        reshard reshard_batch_user_window reshard_model \
+        hipify install clean help
+
+all: lib
+
+# ============================================================================
+# Build-time hipify (RCCL style): copy pristine upstream sources into $(HIPIFY_DIR)
+# and convert them there with hipify-perl. Upstream sources stay untouched.
+# ============================================================================
+hipify: $(HIPIFY_STAMP)
+
+$(HIPIFY_STAMP): $(addprefix $(SRCDIR)/,$(LIB_SRC_NAMES) $(LIB_HDR_NAMES))
+	@printf ">>> Staging + hipifying sources into $(HIPIFY_DIR) ...\n"
+	@rm -rf $(HIPIFY_DIR)
+	@mkdir -p $(HSRC) $(HTESTS) $(HBENCH)
+	@cp -a $(SRCDIR)/. $(HSRC)/
+	@if [ -d $(TESTSDIR) ]; then cp -a $(TESTSDIR)/. $(HTESTS)/ ; fi
+	@if [ -d $(BENCHDIR) ]; then cp -a $(BENCHDIR)/. $(HBENCH)/ ; fi
+	@# Convert every source TU/header in the staged trees. -inplace rewrites the
+	@# staged copy (leaving a .prehip backup); the originals are never touched.
+	@find $(HSRC) $(HTESTS) $(HBENCH) -type f \
+	    \( -name '*.cu' -o -name '*.cuh' -o -name '*.cc' -o -name '*.h' \) \
+	    -exec $(HIPIFY) -inplace $(HIPIFY_FLAGS) {} + >/dev/null 2>&1 || true
+	@# Drop the .prehip backups so the staged tree only holds HIP sources.
+	@find $(HIPIFY_DIR) -name '*.prehip' -delete
+	@touch $@
+	@printf ">>> Hipify complete.\n"
+
+# ============================================================================
+# Library
+# ============================================================================
+lib: $(M2N_LIBTARGET) $(M2N_HEADER_TARGET)
+
+$(M2N_LIBTARGET): $(HIPIFY_STAMP)
+	@printf "Building $(M2N_LIBNAME) (hipcc, arch=$(OFFLOAD_ARCH)) ...\n"
+	@mkdir -p $(LIBDIR)
+	$(HIPCC) -shared -o $@ $(HIPFLAGS) $(LIB_SRCS) $(M2N_LIB_LDFLAGS)
+	@printf "Done! Library at: $@\n"
+
+$(M2N_HEADER_TARGET): $(HIPIFY_STAMP)
+	@mkdir -p $(INCDIR)
+	cp $(HSRC)/nccl_m2n.h $@
+
+# ============================================================================
+# Tests (gtest)
+# ============================================================================
+ifeq ($(GTEST_AVAILABLE),1)
+tests: basic_api_test_mpi basic_api_test_local
+
+basic_api_test_mpi:   $(BINDIR)/basic_api_test_mpi   ; @:
+basic_api_test_local: $(BINDIR)/basic_api_test_local ; @:
+
+$(BINDIR)/basic_api_test_mpi: $(M2N_LIBTARGET)
+	@printf "Building basic_api_test_mpi (hipcc, gtest, MPI) ...\n"
+	@mkdir -p $(BINDIR)
+	$(HIPCC) -o $@ $(HIPFLAGS) $(MPI_CFLAGS) -I$(HTESTS) -isystem $(GTEST_INC) \
+	    $(TEST_MPI_SRCS) $(M2N_CLIENT_LDFLAGS) $(BENCH_LDFLAGS) $(GTEST_LDFLAGS) -lpthread
+	@printf "Done! Test binary at: $@\n"
+
+$(BINDIR)/basic_api_test_local: $(M2N_LIBTARGET)
+	@printf "Building basic_api_test_local (hipcc, gtest, no MPI) ...\n"
+	@mkdir -p $(BINDIR)
+	$(HIPCC) -o $@ $(HIPFLAGS) -I$(HTESTS) -isystem $(GTEST_INC) \
+	    $(TEST_LOCAL_SRCS) $(M2N_CLIENT_LDFLAGS) $(LIB_LDFLAGS) $(GTEST_LDFLAGS) -lpthread
+	@printf "Done! Test binary at: $@\n"
+else
+tests basic_api_test_mpi basic_api_test_local:
+	@echo "tests: googletest not found -- set GTEST_DIR=/path/to/googletest (with include/ + lib/)."
+endif
+
+# ============================================================================
+# Benchmarks
+# ============================================================================
+bench: reshard reshard_batch_user_window reshard_model
+
+reshard:                   $(BINDIR)/reshard_bench                   ; @:
+reshard_batch_user_window: $(BINDIR)/reshard_batch_bench_user_window ; @:
+reshard_model:             $(BINDIR)/reshard_model_bench             ; @:
+
+$(BINDIR)/reshard_bench: $(M2N_LIBTARGET)
+	@printf "Building reshard_bench ...\n"
+	@mkdir -p $(BINDIR)
+	$(HIPCC) -o $@ $(HIPFLAGS) $(MPI_CFLAGS) -I$(HBENCH) \
+	    $(BENCH_SRCS) $(M2N_CLIENT_LDFLAGS) $(BENCH_LDFLAGS)
+	@printf "Done! Benchmark binary at: $@\n"
+
+$(BINDIR)/reshard_batch_bench_user_window: $(M2N_LIBTARGET)
+	@printf "Building reshard_batch_bench_user_window ...\n"
+	@mkdir -p $(BINDIR)
+	$(HIPCC) -o $@ $(HIPFLAGS) $(MPI_CFLAGS) -I$(HBENCH) \
+	    $(BATCH_BENCH_SRCS) $(M2N_CLIENT_LDFLAGS) $(BENCH_LDFLAGS)
+	@printf "Done! Benchmark binary at: $@\n"
+
+# reshard_model_bench.cu is a host-only driver (JSON model/system configs, no
+# device code) -> compile it -x c++ so clang-HIP does not run a device pass on
+# the vendored nlohmann/json templates. The kernels live in the companion
+# bench_common_kernels.cu, which is compiled as HIP.
+$(BINDIR)/reshard_model_bench: $(M2N_LIBTARGET)
+	@printf "Building reshard_model_bench ...\n"
+	@mkdir -p $(BINDIR) $(BUILDDIR)/obj
+	$(HIPCC) -x c++ $(HOSTFLAGS) $(MPI_CFLAGS) -I$(HBENCH) \
+	    -c $(HBENCH)/reshard_model_bench.cu -o $(BUILDDIR)/obj/reshard_model_bench.o
+	$(HIPCC) $(HIPFLAGS) $(MPI_CFLAGS) -I$(HBENCH) \
+	    -c $(HBENCH)/$(BENCH_KERNELS_NAME) -o $(BUILDDIR)/obj/bench_common_kernels.model.o
+	$(HIPCC) -o $@ $(HIPFLAGS) \
+	    $(BUILDDIR)/obj/reshard_model_bench.o $(BUILDDIR)/obj/bench_common_kernels.model.o \
+	    $(M2N_CLIENT_LDFLAGS) $(BENCH_LDFLAGS)
+	@printf "Done! Benchmark binary at: $@\n"
+
+# ============================================================================
+# Install / clean / help
+# ============================================================================
+PREFIX ?= /usr/local
+install: lib
+	@printf "Installing to $(PREFIX) ...\n"
+	@mkdir -p $(PREFIX)/lib $(PREFIX)/include
+	cp $(M2N_LIBTARGET) $(PREFIX)/lib/
+	cp $(M2N_HEADER_TARGET) $(PREFIX)/include/
+	@printf "Done!\n"
+
+clean:
+	rm -rf $(BUILDDIR)
+
+help:
+	@echo "NCCL M2N library - ROCm build (build-time hipify + hipcc, links librccl)"
+	@echo ""
+	@echo "Targets:"
+	@echo "  all (default)        - Build shared library"
+	@echo "  lib                  - Build libnccl_m2n.so"
+	@echo "  hipify               - Stage + hipify sources into build/hipify only"
+	@echo "  tests                - Build basic_api_test_{mpi,local} (needs GTEST_DIR)"
+	@echo "  bench                - Build all benchmarks"
+	@echo "  install              - Install lib + header to PREFIX"
+	@echo "  clean                - Remove all build artifacts"
+	@echo ""
+	@echo "Required: RCCL_HOME (or legacy NCCL_HOME) -> RCCL build dir with include/nccl_device.h + librccl.so"
+	@echo "Optional: ROCM_PATH, RCCL_LIBDIR, OFFLOAD_ARCH (default gfx950),"
+	@echo "          GTEST_DIR, MPI_HOME, PREFIX, DEBUG, BUILDDIR"


### PR DESCRIPTION
## Motivation

`contrib/nccl_m2n` (M2N reshard) currently ships only an upstream build that uses the upstream toolchain and links the upstream NCCL library, so it cannot be built on AMD/ROCm. This PR adds a ROCm build path so the library can be built with `hipcc` and linked against RCCL, using the same build-time hipify approach as the main RCCL build: the upstream sources are never edited in place and no hand-hipified files are committed.

## Technical Details

- **`Makefile.rocm`** - ROCm counterpart of the upstream Makefile: identical project structure, source lists and target names, but
  - converts the sources to HIP at build time with `hipify-perl` (copied into `build/hipify/`, originals untouched),
  - compiles with `hipcc` (`--offload-arch`, default `gfx950`) and links `librccl`,
  - derives `ROCM_VERSION` from `$(ROCM_PATH)/.info/version` (required so the RCCL device headers do not fall back to pre-7.0 behaviour),
  - produces `libnccl_m2n.so` plus `basic_api_test_{local,mpi}`, `reshard_bench`, `reshard_batch_bench_user_window`, `reshard_model_bench`.
- **`GNUmakefile`** - a small front-end so the usual commands (`make`, `make tests`, `make bench`, `make install`) work unchanged on ROCm. GNU make reads `GNUmakefile` before `Makefile`, so it dispatches to `Makefile.rocm` when `hipcc` is present and to the pristine upstream `Makefile` otherwise, without editing the upstream Makefile. Override with `make M2N_BACKEND=Makefile.rocm` / `M2N_BACKEND=Makefile`.
- `RCCL_HOME` is the canonical dependency variable (legacy `NCCL_HOME` still accepted). It must point at a from-source RCCL build tree containing `include/nccl_device.h` and `librccl.so`.
- CI wiring (build + functional matrix) is intentionally out of scope here and lands in a follow-up.

### How to build

```bash
git clone https://github.com/ROCm/rocm-systems.git
cd rocm-systems/projects/rccl

# 1) Build RCCL from source (provides include/nccl_device.h + librccl.so)
./install.sh --amdgpu_targets gfx950          # output in build/release

# 2) Build nccl_m2n against that RCCL build
cd contrib/nccl_m2n
export RCCL_HOME=$(pwd)/../../build/release    # projects/rccl/build/release
make                                           # -> build/lib/libnccl_m2n.so

# optional: tests and benchmarks
make tests GTEST_DIR=/path/to/googletest       # basic_api_test_{local,mpi}
make bench MPI_HOME=/path/to/ompi              # reshard_bench, ...
```

`make` auto-selects the ROCm backend when `hipcc` is on the machine; on a non-ROCm host it falls back to the upstream build.

## Issue Tracking

<!-- GitHub issue: n/a -->
<!-- JIRA ID: AICOMNET-332 (HL3 M2N / reshard enablement) -->

## Test Plan

- **Hipify validation:** ran `hipify-perl` over every source file in `src/`, `tests/`, `benchmarks/` (26 files) with per-file status capture - all convert with no failures, and no unconverted runtime constructs remain (only comments, kernel-launch `<<<>>>`, and public RCCL API field names).
- **Build:** clean `make lib tests bench` on ROCm (gfx950), linking a from-source RCCL - builds the library and all five binaries with no errors. Verified both directly (`-f Makefile.rocm`) and through the `GNUmakefile` dispatcher.
- **Dispatcher:** confirmed plain `make` → `Makefile.rocm` when `hipcc` is present, `M2N_BACKEND=Makefile` → upstream backend, and multi-goal (`make tests bench`) forwards in a single sub-make.

## Test Result

- Hipify: **26/26 files OK, 0 failures.**
- Build: **green** - produced `libnccl_m2n.so`, `basic_api_test_local`, `basic_api_test_mpi`, `reshard_bench`, `reshard_batch_bench_user_window`, `reshard_model_bench`.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
