### PR TITLE
feat(rccl): unify mixed-TU device images into one device.elf

### DIFF
--- a/projects/rccl/cmake/DeviceLinker.cmake
+++ b/projects/rccl/cmake/DeviceLinker.cmake
@@ -7,6 +7,13 @@
 # Per-arch linking (objects -> aggregate -> patch -> link -> elf) uses the driver
 # in --link mode via a custom command.
 #
+# Every device image (the specialized dispatcher kernels below, AND the
+# kernels living in mixed host+device TUs like onerank/collectives/dda_*/
+# sym_*/ce_reduce) is unified into ONE device.elf per arch, bundled into ONE
+# device.hipfb, and embedded exactly ONCE in the final librccl.so by a small
+# "glue" object. See the "Shared CUID" and "Mixed host+device TU" sections
+# below for how that dedup works.
+#
 # Required variables (set by src/CMakeLists.txt before including this file):
 #   HIPIFY_DIR, GEN_DIR, GPU_TARGETS, PROJECT_BINARY_DIR, PROJECT_SOURCE_DIR,
 #   Python3_EXECUTABLE
@@ -24,6 +31,12 @@ get_filename_component(_dl_compiler_dir "${CMAKE_CXX_COMPILER}" DIRECTORY)
 find_program(DL_CLANG NAMES amdclang++ clang++
   HINTS "${_dl_compiler_dir}" "${ROCM_PATH}/bin" REQUIRED)
 find_program(DL_BUNDLER NAMES clang-offload-bundler
+  HINTS "${_dl_compiler_dir}" "${_dl_compiler_dir}/../lib/llvm/bin"
+        "${ROCM_PATH}/llvm/bin" REQUIRED)
+find_program(DL_READELF NAMES llvm-readelf
+  HINTS "${_dl_compiler_dir}" "${_dl_compiler_dir}/../lib/llvm/bin"
+        "${ROCM_PATH}/llvm/bin" REQUIRED)
+find_program(DL_OBJCOPY NAMES llvm-objcopy
   HINTS "${_dl_compiler_dir}" "${_dl_compiler_dir}/../lib/llvm/bin"
         "${ROCM_PATH}/llvm/bin" REQUIRED)
 
@@ -45,6 +58,7 @@ endif()
 
 set(DEVICE_BUILD_DIR "${PROJECT_BINARY_DIR}/device_build")
 set(SPECIALIZED_DIR  "${GEN_DIR}/specialized")
+file(MAKE_DIRECTORY "${DEVICE_BUILD_DIR}")
 
 # ---------------------------------------------------------------------------
 # Compile options inherited from the rccl target
@@ -169,6 +183,38 @@ elseif(TARGET fmt::fmt-header-only)
 endif()
 
 # ---------------------------------------------------------------------------
+# Definitions and include flags shared by every out-of-line amdclang++
+# invocation below (mixed-TU host/device compiles, dispatcher --link,
+# IR emission). Computed once here since none of it varies per arch.
+# ---------------------------------------------------------------------------
+set(_link_def_flags "")
+get_target_property(_iface_defs rccl_device_defs INTERFACE_COMPILE_DEFINITIONS)
+if(_iface_defs)
+  foreach(_d ${_iface_defs})
+    list(APPEND _link_def_flags "-D${_d}")
+  endforeach()
+endif()
+list(REMOVE_DUPLICATES _link_def_flags)
+
+get_target_property(_dev_includes rccl_device_defs INTERFACE_INCLUDE_DIRECTORIES)
+set(_link_inc_flags "")
+if(_dev_includes)
+  foreach(_inc ${_dev_includes})
+    list(APPEND _link_inc_flags "-I${_inc}")
+  endforeach()
+endif()
+get_target_property(_dev_sys_includes rccl_device_defs INTERFACE_SYSTEM_INCLUDE_DIRECTORIES)
+if(_dev_sys_includes)
+  foreach(_inc ${_dev_sys_includes})
+    if(NOT _inc IN_LIST CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES)
+      list(APPEND _link_inc_flags "-isystem${_inc}")
+    endif()
+  endforeach()
+endif()
+# Mixed-TU host/device compiles use the same include set as the dispatcher link.
+set(_host_inc_flags ${_link_inc_flags})
+
+# ---------------------------------------------------------------------------
 # Read specialized file list
 # ---------------------------------------------------------------------------
 set(SPECIALIZED_FILES_TXT "${GEN_DIR}/specialized_files.txt")
@@ -215,6 +261,181 @@ if(NOT _dl_sys_name)
   set(_dl_sys_name "linux")
 endif()
 set(_dl_host_triple "${CMAKE_SYSTEM_PROCESSOR}-unknown-${_dl_sys_name}-gnu")
+
+# ===========================================================================
+# Shared CUID: fatbin deduplication for mixed host+device TUs
+#
+# Fully embedding every mixed TU's own device kernels (the historical
+# approach: plain `-x hip` full compilation) makes each TU generate and
+# embed its OWN self-contained fatbin -- one copy of the runtime's fatbin
+# format PER TU. `.hip_fatbin` is a plain PROGBITS section (no COMDAT), so
+# the final linker just concatenates all these copies with padding instead
+# of deduping them: a build with N mixed TUs pays for N copies of (that TU's
+# kernels), which is the actual size blowup this file exists to fix.
+#
+# Fix: force every mixed TU's HOST compile to use the same fixed `-cuid`
+# string (`DL_SHARED_CUID`). HIP's frontend derives the `__hip_fatbin_<hash>`
+# symbol name (and a `__hip_cuid_<hash>` "duplicate CUID misuse" marker
+# symbol) purely from the `-cuid` string -- independent of the source
+# filename or --offload-arch list (verified via probe below) -- so every
+# mixed TU ends up referencing the exact same external symbol instead of
+# defining its own. Combined with `--offload-host-only` (so the host compile
+# emits no fatbin of its own at all, just an undefined reference) and one
+# "glue" object that defines that symbol exactly once with the real combined
+# fatbin bytes (see the glue.o custom command after DEVICE_HIPFB below), the
+# unified image ends up embedded exactly once in librccl.so.
+#
+# `--offload-host-only` compiles never define `__hip_cuid_<hash>` themselves
+# only to complain -- HIP still emits that marker as a GLOBAL symbol on every
+# TU that references the fatbin, so linking N mixed TUs together still hits
+# a duplicate-symbol error on `__hip_cuid_<hash>` even though they're
+# deliberately sharing the same image. `llvm-objcopy --localize-symbol` on
+# every mixed TU's raw host object (see the per-TU loop after glue.o) strips
+# that marker down to local, since we don't need the misuse detector once
+# the sharing is intentional.
+# ===========================================================================
+set(DL_SHARED_CUID "RCCL_SHARED_DEVICE_IMAGE")
+
+set(_cuid_probe_src "${DEVICE_BUILD_DIR}/cuid_probe.hip")
+set(_cuid_probe_obj "${DEVICE_BUILD_DIR}/cuid_probe.o")
+file(WRITE "${_cuid_probe_src}"
+"#include <hip/hip_runtime.h>
+__global__ void dl_cuid_probe_kernel(int* p) { *p = 1; }
+extern \"C\" void dl_cuid_probe_launch(int* p) { dl_cuid_probe_kernel<<<1,1>>>(p); }
+")
+
+execute_process(
+  COMMAND ${DL_CLANG} -x hip --offload-host-only ${DL_OFFLOAD_ARCH_FLAGS}
+          ${DL_HIP_COMPILER_FLAGS} -cuid=${DL_SHARED_CUID} -std=c++17
+          -c -o "${_cuid_probe_obj}" "${_cuid_probe_src}"
+  RESULT_VARIABLE _cuid_probe_result
+  OUTPUT_VARIABLE _cuid_probe_stdout
+  ERROR_VARIABLE _cuid_probe_stderr
+)
+if(NOT _cuid_probe_result EQUAL 0)
+  message(FATAL_ERROR "Device Linker: CUID probe compile failed:\n${_cuid_probe_stdout}\n${_cuid_probe_stderr}")
+endif()
+
+execute_process(
+  COMMAND ${DL_READELF} -sW "${_cuid_probe_obj}"
+  OUTPUT_VARIABLE _cuid_probe_syms
+)
+string(REGEX MATCH "__hip_fatbin_([0-9a-f]+)" _fatbin_match "${_cuid_probe_syms}")
+if(NOT CMAKE_MATCH_1)
+  message(FATAL_ERROR "Device Linker: could not discover __hip_fatbin_<hash> symbol from CUID probe. readelf output:\n${_cuid_probe_syms}")
+endif()
+set(DL_FATBIN_HASH "${CMAKE_MATCH_1}")
+set(DL_FATBIN_SYMBOL "__hip_fatbin_${DL_FATBIN_HASH}")
+set(DL_CUID_SYMBOL "__hip_cuid_${DL_FATBIN_HASH}")
+message(STATUS "Device Linker: shared CUID '${DL_SHARED_CUID}' -> ${DL_FATBIN_SYMBOL}")
+
+# ===========================================================================
+# Mixed host+device TU registration
+#
+# Each registered TU gets, further below:
+#   - (if HAS_DEVICE) a per-arch device-only object via the driver's
+#     --emit-device-obj mode, containing ALL of its __global__ kernels
+#     (no extraction -- these are standalone entries with their own .kd, not
+#     participants in the specialized-kernel dispatcher's resource
+#     aggregation), merged into that arch's device.elf alongside the
+#     specialized kernels (see the per-arch loop below).
+#   - A host-only object (--offload-host-only -cuid=<shared>), referencing
+#     rather than embedding the fatbin, then localized (see the "Mixed-TU
+#     host compiles" loop after glue.o) and added to DEVICE_LINKER_OBJECTS.
+#
+# `common` (common.cu.cpp) is HAS_DEVICE FALSE: it has no __global__ kernels
+# of its own -- the driver's --link mode already compiles+patches+links its
+# generic dispatcher kernel directly into every arch's device.elf as part of
+# the existing resource-aggregation pipeline (see --dispatcher= below). It
+# only needs the host-side registration change here: previously the one TU
+# that explicitly embedded DEVICE_HIPFB via -fcuda-include-gpubinary, now
+# just another shared-cuid reference like the rest (glue.o is the sole
+# embedder).
+# ===========================================================================
+set(DL_MIXED_TU_NAMES "")
+
+macro(dl_register_mixed_tu NAME SRC)
+  cmake_parse_arguments(MTU "HAS_DEVICE;SUPPRESS_WARNINGS;INHERIT_FLAGS;DEPFILE_TRACKING" "" "" ${ARGN})
+  list(APPEND DL_MIXED_TU_NAMES "${NAME}")
+  set(DL_MTU_SRC_${NAME} "${SRC}")
+  set(DL_MTU_HAS_DEVICE_${NAME} ${MTU_HAS_DEVICE})
+  set(DL_MTU_SUPPRESS_WARNINGS_${NAME} ${MTU_SUPPRESS_WARNINGS})
+  set(DL_MTU_INHERIT_FLAGS_${NAME} ${MTU_INHERIT_FLAGS})
+  set(DL_MTU_DEPFILE_TRACKING_${NAME} ${MTU_DEPFILE_TRACKING})
+endmacro()
+
+dl_register_mixed_tu(common "${HIPIFY_DIR}/src/device/common.cu.cpp"
+  INHERIT_FLAGS)
+dl_register_mixed_tu(onerank "${HIPIFY_DIR}/src/device/onerank.cu.cpp"
+  HAS_DEVICE INHERIT_FLAGS)
+# Dependency tracking note (CMake >= 3.20 vs < 3.20): add_custom_command only
+# rebuilds when files listed in DEPENDS change. It does NOT automatically
+# track transitive headers (e.g. ce_coll.h), so a struct layout change in a
+# header would not invalidate collectives.o. CMake 3.20 DEPFILE support fixes
+# this by reading the compiler-generated .d file; on older CMake the
+# workaround is: touch hipify/src/collectives.cc.
+dl_register_mixed_tu(collectives "${HIPIFY_DIR}/src/collectives.cc"
+  HAS_DEVICE INHERIT_FLAGS DEPFILE_TRACKING)
+# ce_reduce.cc itself is now pure host code (a dispatcher calling into
+# per-instantiation launchers; see src/device/ce_reduce/generate.py) and is
+# compiled normally as part of the main rccl target -- NOT registered here.
+# Its 40 (type, redop) __global__ kernel instantiations live in
+# gensrc/ce_reduce/*.cpp instead (one per instantiation, so ninja
+# parallelizes them like every other device TU -- two of the 40,
+# int8_t/uint8_t Min/Max, individually generate ~56K instructions and used
+# to dominate the whole build's wall-clock time when they all lived in one
+# TU). Globbed dynamically, mirroring the sym_* pattern below.
+file(GLOB _ce_reduce_srcs CONFIGURE_DEPENDS "${HIPIFY_DIR}/gensrc/ce_reduce/*.cpp")
+foreach(_ce_reduce_src IN LISTS _ce_reduce_srcs)
+  get_filename_component(_ce_reduce_name "${_ce_reduce_src}" NAME_WE)
+  string(MAKE_C_IDENTIFIER "${_ce_reduce_name}" _ce_reduce_name_id)
+  dl_register_mixed_tu(ce_reduce_${_ce_reduce_name_id} "${_ce_reduce_src}" HAS_DEVICE SUPPRESS_WARNINGS)
+endforeach()
+dl_register_mixed_tu(dda_all_reduce_ipc "${HIPIFY_DIR}/src/dda_all_reduce_ipc.cu.cpp"
+  HAS_DEVICE INHERIT_FLAGS)
+dl_register_mixed_tu(dda_reduce_scatter_ipc "${HIPIFY_DIR}/src/dda_reduce_scatter_ipc.cu.cpp"
+  HAS_DEVICE INHERIT_FLAGS)
+dl_register_mixed_tu(dda_all_gather_ipc "${HIPIFY_DIR}/src/dda_all_gather_ipc.cu.cpp"
+  HAS_DEVICE INHERIT_FLAGS)
+dl_register_mixed_tu(dda_alltoall_ipc "${HIPIFY_DIR}/src/dda_alltoall_ipc.cu.cpp"
+  HAS_DEVICE INHERIT_FLAGS)
+dl_register_mixed_tu(dda_all_reduce_fabric "${HIPIFY_DIR}/src/dda_all_reduce_fabric.cu.cpp"
+  HAS_DEVICE INHERIT_FLAGS SUPPRESS_WARNINGS)
+dl_register_mixed_tu(dda_all_reduce_fabric_ll "${HIPIFY_DIR}/src/dda_all_reduce_fabric_ll.cu.cpp"
+  HAS_DEVICE SUPPRESS_WARNINGS)
+dl_register_mixed_tu(dda_all_reduce_fabric_ll128 "${HIPIFY_DIR}/src/dda_all_reduce_fabric_ll128.cu.cpp"
+  HAS_DEVICE SUPPRESS_WARNINGS)
+dl_register_mixed_tu(dda_reduce_scatter_fabric "${HIPIFY_DIR}/src/dda_reduce_scatter_fabric.cu.cpp"
+  HAS_DEVICE INHERIT_FLAGS SUPPRESS_WARNINGS)
+dl_register_mixed_tu(dda_all_gather_fabric "${HIPIFY_DIR}/src/dda_all_gather_fabric.cu.cpp"
+  HAS_DEVICE INHERIT_FLAGS SUPPRESS_WARNINGS)
+dl_register_mixed_tu(dda_all_gather_fabric_ll "${HIPIFY_DIR}/src/dda_all_gather_fabric_ll.cu.cpp"
+  HAS_DEVICE SUPPRESS_WARNINGS)
+dl_register_mixed_tu(dda_all_gather_fabric_ll128 "${HIPIFY_DIR}/src/dda_all_gather_fabric_ll128.cu.cpp"
+  HAS_DEVICE SUPPRESS_WARNINGS)
+dl_register_mixed_tu(dda_alltoall_fabric "${HIPIFY_DIR}/src/dda_alltoall_fabric.cu.cpp"
+  HAS_DEVICE INHERIT_FLAGS SUPPRESS_WARNINGS)
+dl_register_mixed_tu(dda_alltoall_fabric_ll "${HIPIFY_DIR}/src/dda_alltoall_fabric_ll.cu.cpp"
+  HAS_DEVICE SUPPRESS_WARNINGS)
+dl_register_mixed_tu(dda_alltoall_fabric_ll128 "${HIPIFY_DIR}/src/dda_alltoall_fabric_ll128.cu.cpp"
+  HAS_DEVICE SUPPRESS_WARNINGS)
+dl_register_mixed_tu(dda_reduce_scatter_fabric_ll "${HIPIFY_DIR}/src/dda_reduce_scatter_fabric_ll.cu.cpp"
+  HAS_DEVICE SUPPRESS_WARNINGS)
+dl_register_mixed_tu(dda_reduce_scatter_fabric_ll128 "${HIPIFY_DIR}/src/dda_reduce_scatter_fabric_ll128.cu.cpp"
+  HAS_DEVICE SUPPRESS_WARNINGS)
+
+# Symmetric kernels: per-instantiation device TUs from gensrc/symmetric/.
+# Each instantiation file defines a handful of __global__ ncclSymkDevKernel_*
+# entries. SYM names are globbed dynamically (vs the fixed names above)
+# because the symmetric generator emits one TU per instantiation.
+if(GENERATE_SYM_KERNELS)
+  file(GLOB _sym_srcs CONFIGURE_DEPENDS "${HIPIFY_DIR}/gensrc/symmetric/*.cpp")
+  foreach(_sym_src IN LISTS _sym_srcs)
+    get_filename_component(_sym_name "${_sym_src}" NAME_WE)
+    string(MAKE_C_IDENTIFIER "${_sym_name}" _sym_name_id)
+    dl_register_mixed_tu(sym_${_sym_name_id} "${_sym_src}" HAS_DEVICE INHERIT_FLAGS)
+  endforeach()
+endif()
 
 # ===========================================================================
 # Per-GPU-target: OBJECT library (compile) + link custom command
@@ -298,47 +519,46 @@ foreach(DL_GPU_TARGET ${DL_GPU_TARGETS})
   endif()
 
   # =========================================================================
+  # Mixed-TU per-arch device objects: merged into this arch's device.elf
+  # alongside the specialized kernels above (see dl_register_mixed_tu doc).
+  # =========================================================================
+  set(_mixed_dev_objs "")
+  foreach(_mtu_name IN LISTS DL_MIXED_TU_NAMES)
+    if(NOT DL_MTU_HAS_DEVICE_${_mtu_name})
+      continue()
+    endif()
+    set(_mtu_dev_obj "${DL_ARCH_DIR}/${_mtu_name}.o")
+    add_custom_command(
+      OUTPUT  ${_mtu_dev_obj}
+      COMMAND ${CMAKE_RCCLDEV_COMPILER}
+        --emit-device-obj
+        --arch=${DL_GPU_TARGET}
+        --clang=${DL_CLANG}
+        ${DL_HIP_COMPILER_FLAGS}
+        -DRCCL_DEVICE_LINKER
+        ${_link_def_flags}
+        ${_host_inc_flags}
+        ${DL_OPT_FLAGS}
+        -std=c++17
+        -o ${_mtu_dev_obj}
+        ${DL_MTU_SRC_${_mtu_name}}
+      DEPENDS ${DL_MTU_SRC_${_mtu_name}}
+      COMMENT "DL [${DL_GPU_TARGET}] device-obj: ${_mtu_name}"
+      VERBATIM
+      COMMAND_EXPAND_LISTS
+    )
+    list(APPEND _mixed_dev_objs "${_mtu_dev_obj}")
+  endforeach()
+
+  # =========================================================================
   # Link step: driver --link mode produces device.elf
   # =========================================================================
   set(ARCH_DEVICE_ELF "${DL_ARCH_DIR}/device.elf")
 
-  # Gather definitions and includes for the dispatcher compilation inside --link.
-  # The driver forwards these to amdclang++ when compiling common.cu.cpp.
-  get_target_property(_dev_defs ${_dev_target} COMPILE_DEFINITIONS)
-  set(_link_def_flags "")
-  if(_dev_defs)
-    foreach(_d ${_dev_defs})
-      list(APPEND _link_def_flags "-D${_d}")
-    endforeach()
-  endif()
-  # Also add interface definitions from rccl_device_defs
-  get_target_property(_iface_defs rccl_device_defs INTERFACE_COMPILE_DEFINITIONS)
-  if(_iface_defs)
-    foreach(_d ${_iface_defs})
-      list(APPEND _link_def_flags "-D${_d}")
-    endforeach()
-  endif()
-  list(REMOVE_DUPLICATES _link_def_flags)
-
-  get_target_property(_dev_includes rccl_device_defs INTERFACE_INCLUDE_DIRECTORIES)
-  set(_link_inc_flags "")
-  if(_dev_includes)
-    foreach(_inc ${_dev_includes})
-      list(APPEND _link_inc_flags "-I${_inc}")
-    endforeach()
-  endif()
-  get_target_property(_dev_sys_includes rccl_device_defs INTERFACE_SYSTEM_INCLUDE_DIRECTORIES)
-  if(_dev_sys_includes)
-    foreach(_inc ${_dev_sys_includes})
-      if(NOT _inc IN_LIST CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES)
-        list(APPEND _link_inc_flags "-isystem${_inc}")
-      endif()
-    endforeach()
-  endif()
-
   set(_link_rsp "${DL_ARCH_DIR}/link_objects.rsp")
+  list(JOIN _mixed_dev_objs "\n" _mixed_dev_objs_joined)
   file(GENERATE OUTPUT "${_link_rsp}"
-    CONTENT "$<JOIN:$<TARGET_OBJECTS:${_dev_target}>,\n>\n")
+    CONTENT "$<JOIN:$<TARGET_OBJECTS:${_dev_target}>,\n>\n${_mixed_dev_objs_joined}\n")
 
   # When rocSHMEM is enabled, pass the per-arch device bitcode to the driver.
   # rocSHMEM device API symbols have hidden visibility and must be statically
@@ -372,7 +592,7 @@ foreach(DL_GPU_TARGET ${DL_GPU_TARGETS})
       -std=c++17
       -o ${ARCH_DEVICE_ELF}
       @${_link_rsp}
-    DEPENDS ${_dev_target} ${HIPIFY_DIR}/src/device/common.cu.cpp ${_rocshmem_link_depends}
+    DEPENDS ${_dev_target} ${_mixed_dev_objs} ${HIPIFY_DIR}/src/device/common.cu.cpp ${_rocshmem_link_depends}
     COMMENT "DL [${DL_GPU_TARGET}] link: device.elf"
     VERBATIM
     COMMAND_EXPAND_LISTS
@@ -428,6 +648,8 @@ endforeach()  # end per-GPU-target loop
 
 # ===========================================================================
 # Bundle all per-arch device.elf files into a single .hipfb fat binary
+# (now the ONE unified image: specialized dispatcher kernels + every mixed
+# TU's kernels, for every arch)
 # ===========================================================================
 set(DEVICE_HIPFB "${DEVICE_BUILD_DIR}/device.hipfb")
 
@@ -452,574 +674,105 @@ add_custom_command(
 )
 
 # ===========================================================================
-# Host compile common.cu.cpp with embedded device binary
+# Glue object: the ONE place that embeds DEVICE_HIPFB's bytes, defining
+# DL_FATBIN_SYMBOL globally via .incbin. Every mixed TU (including common)
+# only references this symbol (undefined in their own objects); the final
+# librccl.so link resolves all of them against this single definition. glue.s
+# itself is static (the symbol name and DEVICE_HIPFB's path are both already
+# known at configure time); glue.o still depends on DEVICE_HIPFB so it's
+# reassembled -- re-running .incbin -- whenever the bundled image's bytes
+# change.
 # ===========================================================================
-set(COMMON_FAT_OBJ "${DEVICE_BUILD_DIR}/common.o")
-
-set(DL_HOST_COMPRESS "")
-if(ENABLE_COMPRESS)
-  set(DL_HOST_COMPRESS "--offload-compress")
-endif()
-
-# Gather include flags for host compile (same paths as device)
-set(_host_inc_flags "")
-if(_dev_includes)
-  foreach(_inc ${_dev_includes})
-    list(APPEND _host_inc_flags "-I${_inc}")
-  endforeach()
-endif()
-if(_dev_sys_includes)
-  foreach(_inc ${_dev_sys_includes})
-    if(NOT _inc IN_LIST CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES)
-      list(APPEND _host_inc_flags "-isystem${_inc}")
-    endif()
-  endforeach()
-endif()
-
+set(DL_GLUE_S "${DEVICE_BUILD_DIR}/glue.s")
+file(WRITE "${DL_GLUE_S}"
+"\t.section .hip_fatbin, \"a\", @progbits
+\t.globl ${DL_FATBIN_SYMBOL}
+\t.p2align 12
+${DL_FATBIN_SYMBOL}:
+\t.incbin \"${DEVICE_HIPFB}\"
+")
+set(DL_GLUE_OBJ "${DEVICE_BUILD_DIR}/glue.o")
 add_custom_command(
-  OUTPUT  ${COMMON_FAT_OBJ}
-  COMMAND ${DL_CLANG}
-    -x hip --offload-host-only ${DL_OFFLOAD_ARCH_FLAGS}
-    ${DL_HIP_COMPILER_FLAGS}
-    -Xclang -fcuda-include-gpubinary -Xclang ${DEVICE_HIPFB}
-    -DRCCL_DEVICE_LINKER
-    ${_link_def_flags}
-    ${_host_inc_flags}
-    ${DL_OPT_FLAGS}
-    ${DL_INHERITED_FLAGS}
-    -std=c++17
-    -fPIC
-    ${DL_HOST_COMPRESS}
-    -c -o ${COMMON_FAT_OBJ}
-    ${HIPIFY_DIR}/src/device/common.cu.cpp
-  DEPENDS ${DEVICE_HIPFB} ${HIPIFY_DIR}/src/device/common.cu.cpp
-  COMMENT "DL host compile: common.cu.cpp with embedded device binary"
+  OUTPUT  ${DL_GLUE_OBJ}
+  COMMAND ${DL_CLANG} -c -o ${DL_GLUE_OBJ} ${DL_GLUE_S}
+  DEPENDS ${DEVICE_HIPFB} ${DL_GLUE_S}
+  COMMENT "DL glue: single embed of ${DL_FATBIN_SYMBOL}"
   VERBATIM
 )
 
 # ===========================================================================
-# Onerank: normal HIP compilation (host+device, no RDC)
+# Mixed-TU host compiles: --offload-host-only -cuid=<shared>, referencing
+# (not embedding) the fatbin, then llvm-objcopy --localize-symbol strips the
+# per-TU __hip_cuid_<hash> duplicate-CUID marker so linking them all
+# together doesn't hit a duplicate-symbol error (see the "Shared CUID"
+# section above for why that marker exists and why we deliberately want to
+# suppress its complaint here).
 # ===========================================================================
-set(ONERANK_FAT_OBJ "${DEVICE_BUILD_DIR}/onerank.o")
+set(DEVICE_LINKER_OBJECTS "${DL_GLUE_OBJ}")
 
-add_custom_command(
-  OUTPUT  ${ONERANK_FAT_OBJ}
-  COMMAND ${DL_CLANG}
-    -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-    ${DL_HIP_COMPILER_FLAGS}
-    -DRCCL_DEVICE_LINKER
-    ${_link_def_flags}
-    ${_host_inc_flags}
-    ${DL_OPT_FLAGS}
-    ${DL_INHERITED_FLAGS}
-    -std=c++17
-    -fPIC
-    -c -o ${ONERANK_FAT_OBJ}
-    ${HIPIFY_DIR}/src/device/onerank.cu.cpp
-  DEPENDS ${HIPIFY_DIR}/src/device/onerank.cu.cpp
-  COMMENT "DL compile: onerank.cu.cpp (normal fat object)"
-  VERBATIM
-)
+foreach(_mtu_name IN LISTS DL_MIXED_TU_NAMES)
+  set(_mtu_raw_obj   "${DEVICE_BUILD_DIR}/${_mtu_name}_raw.o")
+  set(_mtu_final_obj "${DEVICE_BUILD_DIR}/${_mtu_name}.o")
 
-# ===========================================================================
-# collectives.cc: contains a __global__ kernel launch (hierarchicalShuffle)
-# so it needs full HIP compilation, not --offload-host-only.
-# ===========================================================================
-# Dependency tracking note (CMake >= 3.20 vs < 3.20):
-# add_custom_command only rebuilds when files listed in DEPENDS change.  It
-# does NOT automatically track transitive headers (e.g. ce_coll.h), so a
-# struct layout change in a header would not invalidate collectives.o.
-# CMake 3.20 DEPFILE support fixes this by reading the compiler-generated .d
-# file; on older CMake the workaround is: touch hipify/src/collectives.cc.
-# ===========================================================================
-set(COLLECTIVES_FAT_OBJ "${DEVICE_BUILD_DIR}/collectives.o")
+  set(_mtu_w_flag "")
+  if(DL_MTU_SUPPRESS_WARNINGS_${_mtu_name})
+    set(_mtu_w_flag -w)
+  endif()
+  set(_mtu_inherit_flags "")
+  if(DL_MTU_INHERIT_FLAGS_${_mtu_name})
+    set(_mtu_inherit_flags ${DL_INHERITED_FLAGS})
+  endif()
 
-if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.20")
-  set(COLLECTIVES_DEPFILE "${DEVICE_BUILD_DIR}/collectives.d")
+  set(_mtu_mdmf_flags "")
+  set(_mtu_depfile_kw "")
+  if(DL_MTU_DEPFILE_TRACKING_${_mtu_name} AND CMAKE_VERSION VERSION_GREATER_EQUAL "3.20")
+    set(_mtu_depfile "${DEVICE_BUILD_DIR}/${_mtu_name}.d")
+    set(_mtu_mdmf_flags -MD -MF ${_mtu_depfile})
+    set(_mtu_depfile_kw DEPFILE ${_mtu_depfile})
+  endif()
+
   add_custom_command(
-    OUTPUT  ${COLLECTIVES_FAT_OBJ}
+    OUTPUT  ${_mtu_raw_obj}
     COMMAND ${DL_CLANG}
-      -x hip ${DL_OFFLOAD_ARCH_FLAGS}
+      -x hip --offload-host-only ${DL_OFFLOAD_ARCH_FLAGS}
+      -cuid=${DL_SHARED_CUID}
       ${DL_HIP_COMPILER_FLAGS}
       -DRCCL_DEVICE_LINKER
       ${_link_def_flags}
       ${_host_inc_flags}
       ${DL_OPT_FLAGS}
-      ${DL_INHERITED_FLAGS}
+      ${_mtu_inherit_flags}
       -std=c++17
       -fPIC
-      -MD -MF ${COLLECTIVES_DEPFILE}
-      -c -o ${COLLECTIVES_FAT_OBJ}
-      ${HIPIFY_DIR}/src/collectives.cc
-    DEPENDS ${HIPIFY_DIR}/src/collectives.cc
-    DEPFILE ${COLLECTIVES_DEPFILE}
-    COMMENT "DL compile: collectives.cc (has __global__ kernel, header-tracking via DEPFILE)"
+      ${_mtu_w_flag}
+      ${_mtu_mdmf_flags}
+      -c -o ${_mtu_raw_obj}
+      ${DL_MTU_SRC_${_mtu_name}}
+    DEPENDS ${DL_MTU_SRC_${_mtu_name}}
+    ${_mtu_depfile_kw}
+    COMMENT "DL compile (host, shared cuid): ${_mtu_name}"
     VERBATIM
+    COMMAND_EXPAND_LISTS
   )
-else()
+
   add_custom_command(
-    OUTPUT  ${COLLECTIVES_FAT_OBJ}
-    COMMAND ${DL_CLANG}
-      -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-      ${DL_HIP_COMPILER_FLAGS}
-      -DRCCL_DEVICE_LINKER
-      ${_link_def_flags}
-      ${_host_inc_flags}
-      ${DL_OPT_FLAGS}
-      ${DL_INHERITED_FLAGS}
-      -std=c++17
-      -fPIC
-      -c -o ${COLLECTIVES_FAT_OBJ}
-      ${HIPIFY_DIR}/src/collectives.cc
-    DEPENDS ${HIPIFY_DIR}/src/collectives.cc
-    COMMENT "DL compile: collectives.cc (has __global__ kernel)"
+    OUTPUT  ${_mtu_final_obj}
+    COMMAND ${DL_OBJCOPY} --localize-symbol=${DL_CUID_SYMBOL} ${_mtu_raw_obj} ${_mtu_final_obj}
+    DEPENDS ${_mtu_raw_obj}
+    COMMENT "DL localize CUID marker: ${_mtu_name}"
     VERBATIM
   )
-endif()
 
-# ===========================================================================
-# dda_all_reduce_ipc.cu.cpp: contains device kernels and kernel launches.
-# Like collectives.cc, it cannot be built with --offload-host-only on the
-# main rccl target or __hip_fatbin_* stays undefined in librccl.so.
-# ===========================================================================
-set(DDA_ALL_REDUCE_IPC_FAT_OBJ "${DEVICE_BUILD_DIR}/dda_all_reduce_ipc.o")
-set(DDA_REDUCE_SCATTER_IPC_FAT_OBJ "${DEVICE_BUILD_DIR}/dda_reduce_scatter_ipc.o")
-set(DDA_ALL_GATHER_IPC_FAT_OBJ "${DEVICE_BUILD_DIR}/dda_all_gather_ipc.o")
-set(DDA_ALLTOALL_IPC_FAT_OBJ "${DEVICE_BUILD_DIR}/dda_alltoall_ipc.o")
-
-add_custom_command(
-  OUTPUT  ${DDA_ALL_REDUCE_IPC_FAT_OBJ}
-  COMMAND ${DL_CLANG}
-    -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-    ${DL_HIP_COMPILER_FLAGS}
-    -DRCCL_DEVICE_LINKER
-    ${_link_def_flags}
-    ${_host_inc_flags}
-    ${DL_OPT_FLAGS}
-    ${DL_INHERITED_FLAGS}
-    -std=c++17
-    -fPIC
-    -c -o ${DDA_ALL_REDUCE_IPC_FAT_OBJ}
-    ${HIPIFY_DIR}/src/dda_all_reduce_ipc.cu.cpp
-  DEPENDS ${HIPIFY_DIR}/src/dda_all_reduce_ipc.cu.cpp
-  COMMENT "DL compile: dda_all_reduce_ipc.cu.cpp (has device kernels)"
-  VERBATIM
-)
-
-add_custom_command(
-  OUTPUT  ${DDA_REDUCE_SCATTER_IPC_FAT_OBJ}
-  COMMAND ${DL_CLANG}
-    -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-    ${DL_HIP_COMPILER_FLAGS}
-    -DRCCL_DEVICE_LINKER
-    ${_link_def_flags}
-    ${_host_inc_flags}
-    ${DL_OPT_FLAGS}
-    ${DL_INHERITED_FLAGS}
-    -std=c++17
-    -fPIC
-    -c -o ${DDA_REDUCE_SCATTER_IPC_FAT_OBJ}
-    ${HIPIFY_DIR}/src/dda_reduce_scatter_ipc.cu.cpp
-  DEPENDS ${HIPIFY_DIR}/src/dda_reduce_scatter_ipc.cu.cpp
-  COMMENT "DL compile: dda_reduce_scatter_ipc.cu.cpp (has device kernels)"
-  VERBATIM
-)
-
-add_custom_command(
-  OUTPUT  ${DDA_ALL_GATHER_IPC_FAT_OBJ}
-  COMMAND ${DL_CLANG}
-    -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-    ${DL_HIP_COMPILER_FLAGS}
-    -DRCCL_DEVICE_LINKER
-    ${_link_def_flags}
-    ${_host_inc_flags}
-    ${DL_OPT_FLAGS}
-    ${DL_INHERITED_FLAGS}
-    -std=c++17
-    -fPIC
-    -c -o ${DDA_ALL_GATHER_IPC_FAT_OBJ}
-    ${HIPIFY_DIR}/src/dda_all_gather_ipc.cu.cpp
-  DEPENDS ${HIPIFY_DIR}/src/dda_all_gather_ipc.cu.cpp
-  COMMENT "DL compile: dda_all_gather_ipc.cu.cpp (has device kernels)"
-  VERBATIM
-)
-
-add_custom_command(
-  OUTPUT  ${DDA_ALLTOALL_IPC_FAT_OBJ}
-  COMMAND ${DL_CLANG}
-    -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-    ${DL_HIP_COMPILER_FLAGS}
-    -DRCCL_DEVICE_LINKER
-    ${_link_def_flags}
-    ${_host_inc_flags}
-    ${DL_OPT_FLAGS}
-    ${DL_INHERITED_FLAGS}
-    -std=c++17
-    -fPIC
-    -c -o ${DDA_ALLTOALL_IPC_FAT_OBJ}
-    ${HIPIFY_DIR}/src/dda_alltoall_ipc.cu.cpp
-  DEPENDS ${HIPIFY_DIR}/src/dda_alltoall_ipc.cu.cpp
-  COMMENT "DL compile: dda_alltoall_ipc.cu.cpp (has device kernels)"
-  VERBATIM
-)
-
-# ===========================================================================
-# dda_all_reduce_fabric.cu.cpp: fabric/VMM counterpart of the IPC file above.
-# ===========================================================================
-set(DDA_ALL_REDUCE_FABRIC_FAT_OBJ "${DEVICE_BUILD_DIR}/dda_all_reduce_fabric.o")
-
-add_custom_command(
-  OUTPUT  ${DDA_ALL_REDUCE_FABRIC_FAT_OBJ}
-  COMMAND ${DL_CLANG}
-    -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-    ${DL_HIP_COMPILER_FLAGS}
-    -DRCCL_DEVICE_LINKER
-    ${_link_def_flags}
-    ${_host_inc_flags}
-    ${DL_OPT_FLAGS}
-    ${DL_INHERITED_FLAGS}
-    -std=c++17
-    -fPIC
-    -w
-    -c -o ${DDA_ALL_REDUCE_FABRIC_FAT_OBJ}
-    ${HIPIFY_DIR}/src/dda_all_reduce_fabric.cu.cpp
-  DEPENDS ${HIPIFY_DIR}/src/dda_all_reduce_fabric.cu.cpp
-  COMMENT "DL compile: dda_all_reduce_fabric.cu.cpp (has device kernels)"
-  VERBATIM
-)
-
-set(DDA_ALL_REDUCE_FABRIC_LL_FAT_OBJ "${DEVICE_BUILD_DIR}/dda_all_reduce_fabric_ll.o")
-set(DDA_ALL_REDUCE_FABRIC_LL128_FAT_OBJ "${DEVICE_BUILD_DIR}/dda_all_reduce_fabric_ll128.o")
-
-add_custom_command(
-  OUTPUT  ${DDA_ALL_REDUCE_FABRIC_LL_FAT_OBJ}
-  COMMAND ${DL_CLANG}
-    -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-    ${DL_HIP_COMPILER_FLAGS}
-    -DRCCL_DEVICE_LINKER
-    ${_link_def_flags}
-    ${_host_inc_flags}
-    ${DL_OPT_FLAGS}
-    -std=c++17
-    -fPIC
-    -w
-    -c -o ${DDA_ALL_REDUCE_FABRIC_LL_FAT_OBJ}
-    ${HIPIFY_DIR}/src/dda_all_reduce_fabric_ll.cu.cpp
-  DEPENDS ${HIPIFY_DIR}/src/dda_all_reduce_fabric_ll.cu.cpp
-  COMMENT "DL compile: dda_all_reduce_fabric_ll.cu.cpp (has device kernels)"
-  VERBATIM
-)
-
-add_custom_command(
-  OUTPUT  ${DDA_ALL_REDUCE_FABRIC_LL128_FAT_OBJ}
-  COMMAND ${DL_CLANG}
-    -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-    ${DL_HIP_COMPILER_FLAGS}
-    -DRCCL_DEVICE_LINKER
-    ${_link_def_flags}
-    ${_host_inc_flags}
-    ${DL_OPT_FLAGS}
-    -std=c++17
-    -fPIC
-    -w
-    -c -o ${DDA_ALL_REDUCE_FABRIC_LL128_FAT_OBJ}
-    ${HIPIFY_DIR}/src/dda_all_reduce_fabric_ll128.cu.cpp
-  DEPENDS ${HIPIFY_DIR}/src/dda_all_reduce_fabric_ll128.cu.cpp
-  COMMENT "DL compile: dda_all_reduce_fabric_ll128.cu.cpp (has device kernels)"
-  VERBATIM
-)
-
-set(DDA_REDUCE_SCATTER_FABRIC_FAT_OBJ "${DEVICE_BUILD_DIR}/dda_reduce_scatter_fabric.o")
-set(DDA_ALL_GATHER_FABRIC_FAT_OBJ "${DEVICE_BUILD_DIR}/dda_all_gather_fabric.o")
-set(DDA_ALL_GATHER_FABRIC_LL_FAT_OBJ "${DEVICE_BUILD_DIR}/dda_all_gather_fabric_ll.o")
-set(DDA_ALL_GATHER_FABRIC_LL128_FAT_OBJ "${DEVICE_BUILD_DIR}/dda_all_gather_fabric_ll128.o")
-set(DDA_ALLTOALL_FABRIC_FAT_OBJ "${DEVICE_BUILD_DIR}/dda_alltoall_fabric.o")
-set(DDA_ALLTOALL_FABRIC_LL_FAT_OBJ "${DEVICE_BUILD_DIR}/dda_alltoall_fabric_ll.o")
-set(DDA_ALLTOALL_FABRIC_LL128_FAT_OBJ "${DEVICE_BUILD_DIR}/dda_alltoall_fabric_ll128.o")
-set(DDA_REDUCE_SCATTER_FABRIC_LL_FAT_OBJ "${DEVICE_BUILD_DIR}/dda_reduce_scatter_fabric_ll.o")
-set(DDA_REDUCE_SCATTER_FABRIC_LL128_FAT_OBJ "${DEVICE_BUILD_DIR}/dda_reduce_scatter_fabric_ll128.o")
-
-add_custom_command(
-  OUTPUT  ${DDA_REDUCE_SCATTER_FABRIC_FAT_OBJ}
-  COMMAND ${DL_CLANG}
-    -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-    ${DL_HIP_COMPILER_FLAGS}
-    -DRCCL_DEVICE_LINKER
-    ${_link_def_flags}
-    ${_host_inc_flags}
-    ${DL_OPT_FLAGS}
-    ${DL_INHERITED_FLAGS}
-    -std=c++17
-    -fPIC
-    -w
-    -c -o ${DDA_REDUCE_SCATTER_FABRIC_FAT_OBJ}
-    ${HIPIFY_DIR}/src/dda_reduce_scatter_fabric.cu.cpp
-  DEPENDS ${HIPIFY_DIR}/src/dda_reduce_scatter_fabric.cu.cpp
-  COMMENT "DL compile: dda_reduce_scatter_fabric.cu.cpp (has device kernels)"
-  VERBATIM
-)
-
-add_custom_command(
-  OUTPUT  ${DDA_ALL_GATHER_FABRIC_FAT_OBJ}
-  COMMAND ${DL_CLANG}
-    -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-    ${DL_HIP_COMPILER_FLAGS}
-    -DRCCL_DEVICE_LINKER
-    ${_link_def_flags}
-    ${_host_inc_flags}
-    ${DL_OPT_FLAGS}
-    ${DL_INHERITED_FLAGS}
-    -std=c++17
-    -fPIC
-    -w
-    -c -o ${DDA_ALL_GATHER_FABRIC_FAT_OBJ}
-    ${HIPIFY_DIR}/src/dda_all_gather_fabric.cu.cpp
-  DEPENDS ${HIPIFY_DIR}/src/dda_all_gather_fabric.cu.cpp
-  COMMENT "DL compile: dda_all_gather_fabric.cu.cpp (has device kernels)"
-  VERBATIM
-)
-
-add_custom_command(
-  OUTPUT  ${DDA_ALL_GATHER_FABRIC_LL_FAT_OBJ}
-  COMMAND ${DL_CLANG}
-    -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-    ${DL_HIP_COMPILER_FLAGS}
-    -DRCCL_DEVICE_LINKER
-    ${_link_def_flags}
-    ${_host_inc_flags}
-    ${DL_OPT_FLAGS}
-    -std=c++17
-    -fPIC
-    -w
-    -c -o ${DDA_ALL_GATHER_FABRIC_LL_FAT_OBJ}
-    ${HIPIFY_DIR}/src/dda_all_gather_fabric_ll.cu.cpp
-  DEPENDS ${HIPIFY_DIR}/src/dda_all_gather_fabric_ll.cu.cpp
-  COMMENT "DL compile: dda_all_gather_fabric_ll.cu.cpp (has device kernels)"
-  VERBATIM
-)
-
-add_custom_command(
-  OUTPUT  ${DDA_ALL_GATHER_FABRIC_LL128_FAT_OBJ}
-  COMMAND ${DL_CLANG}
-    -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-    ${DL_HIP_COMPILER_FLAGS}
-    -DRCCL_DEVICE_LINKER
-    ${_link_def_flags}
-    ${_host_inc_flags}
-    ${DL_OPT_FLAGS}
-    -std=c++17
-    -fPIC
-    -w
-    -c -o ${DDA_ALL_GATHER_FABRIC_LL128_FAT_OBJ}
-    ${HIPIFY_DIR}/src/dda_all_gather_fabric_ll128.cu.cpp
-  DEPENDS ${HIPIFY_DIR}/src/dda_all_gather_fabric_ll128.cu.cpp
-  COMMENT "DL compile: dda_all_gather_fabric_ll128.cu.cpp (has device kernels)"
-  VERBATIM
-)
-
-add_custom_command(
-  OUTPUT  ${DDA_ALLTOALL_FABRIC_FAT_OBJ}
-  COMMAND ${DL_CLANG}
-    -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-    ${DL_HIP_COMPILER_FLAGS}
-    -DRCCL_DEVICE_LINKER
-    ${_link_def_flags}
-    ${_host_inc_flags}
-    ${DL_OPT_FLAGS}
-    ${DL_INHERITED_FLAGS}
-    -std=c++17
-    -fPIC
-    -w
-    -c -o ${DDA_ALLTOALL_FABRIC_FAT_OBJ}
-    ${HIPIFY_DIR}/src/dda_alltoall_fabric.cu.cpp
-  DEPENDS ${HIPIFY_DIR}/src/dda_alltoall_fabric.cu.cpp
-  COMMENT "DL compile: dda_alltoall_fabric.cu.cpp (has device kernels)"
-  VERBATIM
-)
-
-add_custom_command(
-  OUTPUT  ${DDA_ALLTOALL_FABRIC_LL_FAT_OBJ}
-  COMMAND ${DL_CLANG}
-    -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-    ${DL_HIP_COMPILER_FLAGS}
-    -DRCCL_DEVICE_LINKER
-    ${_link_def_flags}
-    ${_host_inc_flags}
-    ${DL_OPT_FLAGS}
-    -std=c++17
-    -fPIC
-    -w
-    -c -o ${DDA_ALLTOALL_FABRIC_LL_FAT_OBJ}
-    ${HIPIFY_DIR}/src/dda_alltoall_fabric_ll.cu.cpp
-  DEPENDS ${HIPIFY_DIR}/src/dda_alltoall_fabric_ll.cu.cpp
-  COMMENT "DL compile: dda_alltoall_fabric_ll.cu.cpp (has device kernels)"
-  VERBATIM
-)
-
-add_custom_command(
-  OUTPUT  ${DDA_ALLTOALL_FABRIC_LL128_FAT_OBJ}
-  COMMAND ${DL_CLANG}
-    -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-    ${DL_HIP_COMPILER_FLAGS}
-    -DRCCL_DEVICE_LINKER
-    ${_link_def_flags}
-    ${_host_inc_flags}
-    ${DL_OPT_FLAGS}
-    -std=c++17
-    -fPIC
-    -w
-    -c -o ${DDA_ALLTOALL_FABRIC_LL128_FAT_OBJ}
-    ${HIPIFY_DIR}/src/dda_alltoall_fabric_ll128.cu.cpp
-  DEPENDS ${HIPIFY_DIR}/src/dda_alltoall_fabric_ll128.cu.cpp
-  COMMENT "DL compile: dda_alltoall_fabric_ll128.cu.cpp (has device kernels)"
-  VERBATIM
-)
-
-add_custom_command(
-  OUTPUT  ${DDA_REDUCE_SCATTER_FABRIC_LL_FAT_OBJ}
-  COMMAND ${DL_CLANG}
-    -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-    ${DL_HIP_COMPILER_FLAGS}
-    -DRCCL_DEVICE_LINKER
-    ${_link_def_flags}
-    ${_host_inc_flags}
-    ${DL_OPT_FLAGS}
-    -std=c++17
-    -fPIC
-    -w
-    -c -o ${DDA_REDUCE_SCATTER_FABRIC_LL_FAT_OBJ}
-    ${HIPIFY_DIR}/src/dda_reduce_scatter_fabric_ll.cu.cpp
-  DEPENDS ${HIPIFY_DIR}/src/dda_reduce_scatter_fabric_ll.cu.cpp
-  COMMENT "DL compile: dda_reduce_scatter_fabric_ll.cu.cpp (has device kernels)"
-  VERBATIM
-)
-
-add_custom_command(
-  OUTPUT  ${DDA_REDUCE_SCATTER_FABRIC_LL128_FAT_OBJ}
-  COMMAND ${DL_CLANG}
-    -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-    ${DL_HIP_COMPILER_FLAGS}
-    -DRCCL_DEVICE_LINKER
-    ${_link_def_flags}
-    ${_host_inc_flags}
-    ${DL_OPT_FLAGS}
-    -std=c++17
-    -fPIC
-    -w
-    -c -o ${DDA_REDUCE_SCATTER_FABRIC_LL128_FAT_OBJ}
-    ${HIPIFY_DIR}/src/dda_reduce_scatter_fabric_ll128.cu.cpp
-  DEPENDS ${HIPIFY_DIR}/src/dda_reduce_scatter_fabric_ll128.cu.cpp
-  COMMENT "DL compile: dda_reduce_scatter_fabric_ll128.cu.cpp (has device kernels)"
-  VERBATIM
-)
-
-# ===========================================================================
-# CE-reduce kernels: per-instantiation device TUs from gensrc/ce_reduce/.
-# Each instantiation file defines one ncclCeLocalReduceKernelVec<T,RedOp,U>
-# (__global__) and its host-callable launcher. Compiled with full HIP here so
-# each fat binary is self-contained (ce_coll.cc, the main target, has no
-# __global__ call sites and stays --offload-host-only).
-#
-# CE_REDUCE_FAT_OBJS is plural (mirroring SYM_FAT_OBJS below) because
-# src/device/ce_reduce/generate.py emits one TU per (type, redop)
-# instantiation instead of one aggregate ce_reduce.cc -- see that script for
-# why: two of the 40 instantiations (int8_t/uint8_t Min/Max) individually
-# generate ~56K instructions each and used to dominate the whole build's
-# wall-clock time by serializing all 40 kernels' codegen into one TU.
-# ===========================================================================
-set(CE_REDUCE_FAT_OBJS "")
-file(GLOB _ce_reduce_srcs CONFIGURE_DEPENDS "${HIPIFY_DIR}/gensrc/ce_reduce/*.cpp")
-foreach(_ce_reduce_src IN LISTS _ce_reduce_srcs)
-  get_filename_component(_ce_reduce_name "${_ce_reduce_src}" NAME_WE)
-  set(_ce_reduce_obj "${DEVICE_BUILD_DIR}/${_ce_reduce_name}.o")
-  add_custom_command(
-    OUTPUT  ${_ce_reduce_obj}
-    COMMAND ${DL_CLANG}
-      -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-      ${DL_HIP_COMPILER_FLAGS}
-      -DRCCL_DEVICE_LINKER
-      ${_link_def_flags}
-      ${_host_inc_flags}
-      ${DL_OPT_FLAGS}
-      -std=c++17
-      -fPIC
-      -w
-      -c -o ${_ce_reduce_obj}
-      ${_ce_reduce_src}
-    DEPENDS ${_ce_reduce_src}
-    COMMENT "DL compile: ${_ce_reduce_name} (CE AllReduce reduce kernel)"
-    VERBATIM
-  )
-  list(APPEND CE_REDUCE_FAT_OBJS ${_ce_reduce_obj})
+  list(APPEND DEVICE_LINKER_OBJECTS "${_mtu_final_obj}")
 endforeach()
-
-# ===========================================================================
-# Symmetric kernels: per-instantiation device TUs from gensrc/symmetric/.
-# Each instantiation file defines a handful of __global__ ncclSymkDevKernel_*
-# entries. Compiled standalone as multi-arch fat objects, mirroring onerank.o.
-#
-# SYM_FAT_OBJS is plural (vs the singular COMMON/ONERANK/COLLECTIVES_FAT_OBJ
-# siblings) because the symmetric generator emits one TU per instantiation.
-# ===========================================================================
-set(SYM_FAT_OBJS "")
-if(GENERATE_SYM_KERNELS)
-  file(GLOB _sym_srcs CONFIGURE_DEPENDS "${HIPIFY_DIR}/gensrc/symmetric/*.cpp")
-  foreach(_sym_src IN LISTS _sym_srcs)
-    get_filename_component(_sym_name "${_sym_src}" NAME_WE)
-    set(_sym_obj "${DEVICE_BUILD_DIR}/sym_${_sym_name}.o")
-    add_custom_command(
-      OUTPUT  ${_sym_obj}
-      COMMAND ${DL_CLANG}
-        -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-        ${DL_HIP_COMPILER_FLAGS}
-        -DRCCL_DEVICE_LINKER
-        ${_link_def_flags}
-        ${_host_inc_flags}
-        ${DL_OPT_FLAGS}
-        ${DL_INHERITED_FLAGS}
-        -std=c++17
-        -fPIC
-        -c -o ${_sym_obj}
-        ${_sym_src}
-      DEPENDS ${_sym_src}
-      COMMENT "DL compile: sym ${_sym_name} (multi-arch fat object)"
-      VERBATIM
-    )
-    list(APPEND SYM_FAT_OBJS ${_sym_obj})
-  endforeach()
-endif()
 
 # ===========================================================================
 # Top-level target
 # ===========================================================================
 add_custom_target(device_linker_build ALL
-  DEPENDS ${COMMON_FAT_OBJ} ${ONERANK_FAT_OBJ} ${COLLECTIVES_FAT_OBJ} ${DDA_ALL_REDUCE_IPC_FAT_OBJ} ${DDA_REDUCE_SCATTER_IPC_FAT_OBJ} ${DDA_ALL_GATHER_IPC_FAT_OBJ} ${DDA_ALLTOALL_IPC_FAT_OBJ} ${DDA_ALL_REDUCE_FABRIC_FAT_OBJ} ${DDA_ALL_REDUCE_FABRIC_LL_FAT_OBJ} ${DDA_ALL_REDUCE_FABRIC_LL128_FAT_OBJ} ${DDA_REDUCE_SCATTER_FABRIC_FAT_OBJ} ${DDA_ALL_GATHER_FABRIC_FAT_OBJ} ${DDA_ALL_GATHER_FABRIC_LL_FAT_OBJ} ${DDA_ALL_GATHER_FABRIC_LL128_FAT_OBJ} ${DDA_ALLTOALL_FABRIC_FAT_OBJ} ${DDA_ALLTOALL_FABRIC_LL_FAT_OBJ} ${DDA_ALLTOALL_FABRIC_LL128_FAT_OBJ} ${DDA_REDUCE_SCATTER_FABRIC_LL_FAT_OBJ} ${DDA_REDUCE_SCATTER_FABRIC_LL128_FAT_OBJ} ${CE_REDUCE_FAT_OBJS} ${SYM_FAT_OBJS}
+  DEPENDS ${DEVICE_LINKER_OBJECTS}
 )
 add_dependencies(device_linker_build hipify_all copy_nccl_device_headers)
-
-set(DEVICE_LINKER_OBJECTS
-  ${COMMON_FAT_OBJ}
-  ${ONERANK_FAT_OBJ}
-  ${COLLECTIVES_FAT_OBJ}
-  ${CE_REDUCE_FAT_OBJS}
-  ${DDA_ALL_REDUCE_IPC_FAT_OBJ}
-  ${DDA_REDUCE_SCATTER_IPC_FAT_OBJ}
-  ${DDA_ALL_GATHER_IPC_FAT_OBJ}
-  ${DDA_ALLTOALL_IPC_FAT_OBJ}
-  ${DDA_ALL_REDUCE_FABRIC_FAT_OBJ}
-  ${DDA_ALL_REDUCE_FABRIC_LL_FAT_OBJ}
-  ${DDA_ALL_REDUCE_FABRIC_LL128_FAT_OBJ}
-  ${DDA_REDUCE_SCATTER_FABRIC_FAT_OBJ}
-  ${DDA_ALL_GATHER_FABRIC_FAT_OBJ}
-  ${DDA_ALL_GATHER_FABRIC_LL_FAT_OBJ}
-  ${DDA_ALL_GATHER_FABRIC_LL128_FAT_OBJ}
-  ${DDA_ALLTOALL_FABRIC_FAT_OBJ}
-  ${DDA_ALLTOALL_FABRIC_LL_FAT_OBJ}
-  ${DDA_ALLTOALL_FABRIC_LL128_FAT_OBJ}
-  ${DDA_REDUCE_SCATTER_FABRIC_LL_FAT_OBJ}
-  ${DDA_REDUCE_SCATTER_FABRIC_LL128_FAT_OBJ}
-  ${SYM_FAT_OBJS}
-)
 
 # ===========================================================================
 # Optional: emit LLVM IR (ninja device_ir)

--- a/projects/rccl/cmake/DeviceLinker.cmake
+++ b/projects/rccl/cmake/DeviceLinker.cmake
@@ -707,7 +707,27 @@ add_custom_command(
 # together doesn't hit a duplicate-symbol error (see the "Shared CUID"
 # section above for why that marker exists and why we deliberately want to
 # suppress its complaint here).
+#
+# Shared fatbin REGISTRATION handle: sharing -cuid makes every mixed TU
+# reference the same __hip_fatbin_<hash> bytes, but clang still emits a
+# per-TU-*local* __hip_gpubin_handle_<hash> variable, and each TU's static
+# constructor calls __hipRegisterFatBinary() independently the first time
+# its own local copy of that handle is zero. With ~85 mixed TUs, that means
+# ~85 independent module registrations of the identical (multi-hundred-MB)
+# device.elf at process startup -- harmless on an idle GPU with headroom,
+# but enough to exhaust GPU memory under concurrent/resource-constrained CI
+# runs ("device kernel image is invalid" at kernel launch; see PR #9763).
+#
+# Fix: the driver's --emit-host-obj mode patches the handle's storage class
+# so all mixed TUs share ONE instance instead of one each -- `common` is
+# designated the sole --fatbin-role=owner (it's always registered, and was
+# the historical embedder of the combined fatbin before this refactor; see
+# dl_register_mixed_tu doc above), every other mixed TU uses
+# --fatbin-role=shared. See rccl-device-compile's
+# patch_fatbin_handle_sharing() docstring for why this doesn't depend on
+# which TU is "owner" or on static-initializer order across TUs.
 # ===========================================================================
+set(DL_FATBIN_OWNER "common")
 set(DEVICE_LINKER_OBJECTS "${DL_GLUE_OBJ}")
 
 foreach(_mtu_name IN LISTS DL_MIXED_TU_NAMES)
@@ -731,10 +751,19 @@ foreach(_mtu_name IN LISTS DL_MIXED_TU_NAMES)
     set(_mtu_depfile_kw DEPFILE ${_mtu_depfile})
   endif()
 
+  if(_mtu_name STREQUAL DL_FATBIN_OWNER)
+    set(_mtu_fatbin_role "owner")
+  else()
+    set(_mtu_fatbin_role "shared")
+  endif()
+
   add_custom_command(
     OUTPUT  ${_mtu_raw_obj}
-    COMMAND ${DL_CLANG}
-      -x hip --offload-host-only ${DL_OFFLOAD_ARCH_FLAGS}
+    COMMAND ${CMAKE_RCCLDEV_COMPILER}
+      --emit-host-obj
+      --clang=${DL_CLANG}
+      --fatbin-role=${_mtu_fatbin_role}
+      ${DL_OFFLOAD_ARCH_FLAGS}
       -cuid=${DL_SHARED_CUID}
       ${DL_HIP_COMPILER_FLAGS}
       -DRCCL_DEVICE_LINKER
@@ -746,11 +775,11 @@ foreach(_mtu_name IN LISTS DL_MIXED_TU_NAMES)
       -fPIC
       ${_mtu_w_flag}
       ${_mtu_mdmf_flags}
-      -c -o ${_mtu_raw_obj}
+      -o ${_mtu_raw_obj}
       ${DL_MTU_SRC_${_mtu_name}}
     DEPENDS ${DL_MTU_SRC_${_mtu_name}}
     ${_mtu_depfile_kw}
-    COMMENT "DL compile (host, shared cuid): ${_mtu_name}"
+    COMMENT "DL compile (host, shared cuid, fatbin-role=${_mtu_fatbin_role}): ${_mtu_name}"
     VERBATIM
     COMMAND_EXPAND_LISTS
   )

--- a/projects/rccl/cmake/DeviceLinker.cmake
+++ b/projects/rccl/cmake/DeviceLinker.cmake
@@ -826,7 +826,27 @@ add_custom_command(
 # together doesn't hit a duplicate-symbol error (see the "Shared CUID"
 # section above for why that marker exists and why we deliberately want to
 # suppress its complaint here).
+#
+# Shared fatbin REGISTRATION handle: sharing -cuid makes every mixed TU
+# reference the same __hip_fatbin_<hash> bytes, but clang still emits a
+# per-TU-*local* __hip_gpubin_handle_<hash> variable, and each TU's static
+# constructor calls __hipRegisterFatBinary() independently the first time
+# its own local copy of that handle is zero. With ~85 mixed TUs, that means
+# ~85 independent module registrations of the identical (multi-hundred-MB)
+# device.elf at process startup -- harmless on an idle GPU with headroom,
+# but enough to exhaust GPU memory under concurrent/resource-constrained CI
+# runs ("device kernel image is invalid" at kernel launch; see PR #9763).
+#
+# Fix: the driver's --emit-host-obj mode patches the handle's storage class
+# so all mixed TUs share ONE instance instead of one each -- `common` is
+# designated the sole --fatbin-role=owner (it's always registered, and was
+# the historical embedder of the combined fatbin before this refactor; see
+# dl_register_mixed_tu doc above), every other mixed TU uses
+# --fatbin-role=shared. See rccl-device-compile's
+# patch_fatbin_handle_sharing() docstring for why this doesn't depend on
+# which TU is "owner" or on static-initializer order across TUs.
 # ===========================================================================
+set(DL_FATBIN_OWNER "common")
 set(DEVICE_LINKER_OBJECTS "${DL_GLUE_OBJ}")
 
 foreach(_mtu_name IN LISTS DL_MIXED_TU_NAMES)
@@ -850,10 +870,19 @@ foreach(_mtu_name IN LISTS DL_MIXED_TU_NAMES)
     set(_mtu_depfile_kw DEPFILE ${_mtu_depfile})
   endif()
 
+  if(_mtu_name STREQUAL DL_FATBIN_OWNER)
+    set(_mtu_fatbin_role "owner")
+  else()
+    set(_mtu_fatbin_role "shared")
+  endif()
+
   add_custom_command(
     OUTPUT  ${_mtu_raw_obj}
-    COMMAND ${DL_CLANG}
-      -x hip --offload-host-only ${DL_OFFLOAD_ARCH_FLAGS}
+    COMMAND ${CMAKE_RCCLDEV_COMPILER}
+      --emit-host-obj
+      --clang=${DL_CLANG}
+      --fatbin-role=${_mtu_fatbin_role}
+      ${DL_OFFLOAD_ARCH_FLAGS}
       -cuid=${DL_SHARED_CUID}
       ${DL_HIP_COMPILER_FLAGS}
       -DRCCL_DEVICE_LINKER
@@ -866,11 +895,11 @@ foreach(_mtu_name IN LISTS DL_MIXED_TU_NAMES)
       -fPIC
       ${_mtu_w_flag}
       ${_mtu_mdmf_flags}
-      -c -o ${_mtu_raw_obj}
+      -o ${_mtu_raw_obj}
       ${DL_MTU_SRC_${_mtu_name}}
     DEPENDS ${DL_MTU_SRC_${_mtu_name}}
     ${_mtu_depfile_kw}
-    COMMENT "DL compile (host, shared cuid): ${_mtu_name}"
+    COMMENT "DL compile (host, shared cuid, fatbin-role=${_mtu_fatbin_role}): ${_mtu_name}"
     VERBATIM
     COMMAND_EXPAND_LISTS
   )

--- a/projects/rccl/cmake/DeviceLinker.cmake
+++ b/projects/rccl/cmake/DeviceLinker.cmake
@@ -7,6 +7,13 @@
 # Per-arch linking (objects -> aggregate -> patch -> link -> elf) uses the driver
 # in --link mode via a custom command.
 #
+# Every device image (the specialized dispatcher kernels below, AND the
+# kernels living in mixed host+device TUs like onerank/collectives/dda_*/
+# sym_*/ce_reduce) is unified into ONE device.elf per arch, bundled into ONE
+# device.hipfb, and embedded exactly ONCE in the final librccl.so by a small
+# "glue" object. See the "Shared CUID" and "Mixed host+device TU" sections
+# below for how that dedup works.
+#
 # Required variables (set by src/CMakeLists.txt before including this file):
 #   HIPIFY_DIR, GEN_DIR, GPU_TARGETS, PROJECT_BINARY_DIR, PROJECT_SOURCE_DIR,
 #   Python3_EXECUTABLE
@@ -24,6 +31,12 @@ get_filename_component(_dl_compiler_dir "${CMAKE_CXX_COMPILER}" DIRECTORY)
 find_program(DL_CLANG NAMES amdclang++ clang++
   HINTS "${_dl_compiler_dir}" "${ROCM_PATH}/bin" REQUIRED)
 find_program(DL_BUNDLER NAMES clang-offload-bundler
+  HINTS "${_dl_compiler_dir}" "${_dl_compiler_dir}/../lib/llvm/bin"
+        "${ROCM_PATH}/llvm/bin" REQUIRED)
+find_program(DL_READELF NAMES llvm-readelf
+  HINTS "${_dl_compiler_dir}" "${_dl_compiler_dir}/../lib/llvm/bin"
+        "${ROCM_PATH}/llvm/bin" REQUIRED)
+find_program(DL_OBJCOPY NAMES llvm-objcopy
   HINTS "${_dl_compiler_dir}" "${_dl_compiler_dir}/../lib/llvm/bin"
         "${ROCM_PATH}/llvm/bin" REQUIRED)
 
@@ -45,6 +58,7 @@ endif()
 
 set(DEVICE_BUILD_DIR "${PROJECT_BINARY_DIR}/device_build")
 set(SPECIALIZED_DIR  "${GEN_DIR}/specialized")
+file(MAKE_DIRECTORY "${DEVICE_BUILD_DIR}")
 
 # ---------------------------------------------------------------------------
 # Compile options inherited from the rccl target
@@ -169,6 +183,38 @@ elseif(TARGET fmt::fmt-header-only)
 endif()
 
 # ---------------------------------------------------------------------------
+# Definitions and include flags shared by every out-of-line amdclang++
+# invocation below (mixed-TU host/device compiles, dispatcher --link,
+# IR emission). Computed once here since none of it varies per arch.
+# ---------------------------------------------------------------------------
+set(_link_def_flags "")
+get_target_property(_iface_defs rccl_device_defs INTERFACE_COMPILE_DEFINITIONS)
+if(_iface_defs)
+  foreach(_d ${_iface_defs})
+    list(APPEND _link_def_flags "-D${_d}")
+  endforeach()
+endif()
+list(REMOVE_DUPLICATES _link_def_flags)
+
+get_target_property(_dev_includes rccl_device_defs INTERFACE_INCLUDE_DIRECTORIES)
+set(_link_inc_flags "")
+if(_dev_includes)
+  foreach(_inc ${_dev_includes})
+    list(APPEND _link_inc_flags "-I${_inc}")
+  endforeach()
+endif()
+get_target_property(_dev_sys_includes rccl_device_defs INTERFACE_SYSTEM_INCLUDE_DIRECTORIES)
+if(_dev_sys_includes)
+  foreach(_inc ${_dev_sys_includes})
+    if(NOT _inc IN_LIST CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES)
+      list(APPEND _link_inc_flags "-isystem${_inc}")
+    endif()
+  endforeach()
+endif()
+# Mixed-TU host/device compiles use the same include set as the dispatcher link.
+set(_host_inc_flags ${_link_inc_flags})
+
+# ---------------------------------------------------------------------------
 # Read specialized file list
 # ---------------------------------------------------------------------------
 set(SPECIALIZED_FILES_TXT "${GEN_DIR}/specialized_files.txt")
@@ -215,6 +261,281 @@ if(NOT _dl_sys_name)
   set(_dl_sys_name "linux")
 endif()
 set(_dl_host_triple "${CMAKE_SYSTEM_PROCESSOR}-unknown-${_dl_sys_name}-gnu")
+
+# ===========================================================================
+# Shared CUID: fatbin deduplication for mixed host+device TUs
+#
+# Fully embedding every mixed TU's own device kernels (the historical
+# approach: plain `-x hip` full compilation) makes each TU generate and
+# embed its OWN self-contained fatbin -- one copy of the runtime's fatbin
+# format PER TU. `.hip_fatbin` is a plain PROGBITS section (no COMDAT), so
+# the final linker just concatenates all these copies with padding instead
+# of deduping them: a build with N mixed TUs pays for N copies of (that TU's
+# kernels), which is the actual size blowup this file exists to fix.
+#
+# Fix: force every mixed TU's HOST compile to use the same fixed `-cuid`
+# string (`DL_SHARED_CUID`). HIP's frontend derives the `__hip_fatbin_<hash>`
+# symbol name (and a `__hip_cuid_<hash>` "duplicate CUID misuse" marker
+# symbol) purely from the `-cuid` string -- independent of the source
+# filename or --offload-arch list (verified via probe below) -- so every
+# mixed TU ends up referencing the exact same external symbol instead of
+# defining its own. Combined with `--offload-host-only` (so the host compile
+# emits no fatbin of its own at all, just an undefined reference) and one
+# "glue" object that defines that symbol exactly once with the real combined
+# fatbin bytes (see the glue.o custom command after DEVICE_HIPFB below), the
+# unified image ends up embedded exactly once in librccl.so.
+#
+# `--offload-host-only` compiles never define `__hip_cuid_<hash>` themselves
+# only to complain -- HIP still emits that marker as a GLOBAL symbol on every
+# TU that references the fatbin, so linking N mixed TUs together still hits
+# a duplicate-symbol error on `__hip_cuid_<hash>` even though they're
+# deliberately sharing the same image. `llvm-objcopy --localize-symbol` on
+# every mixed TU's raw host object (see the per-TU loop after glue.o) strips
+# that marker down to local, since we don't need the misuse detector once
+# the sharing is intentional.
+# ===========================================================================
+set(DL_SHARED_CUID "RCCL_SHARED_DEVICE_IMAGE")
+
+set(_cuid_probe_src "${DEVICE_BUILD_DIR}/cuid_probe.hip")
+set(_cuid_probe_obj "${DEVICE_BUILD_DIR}/cuid_probe.o")
+file(WRITE "${_cuid_probe_src}"
+"#include <hip/hip_runtime.h>
+__global__ void dl_cuid_probe_kernel(int* p) { *p = 1; }
+extern \"C\" void dl_cuid_probe_launch(int* p) { dl_cuid_probe_kernel<<<1,1>>>(p); }
+")
+
+execute_process(
+  COMMAND ${DL_CLANG} -x hip --offload-host-only ${DL_OFFLOAD_ARCH_FLAGS}
+          ${DL_HIP_COMPILER_FLAGS} -cuid=${DL_SHARED_CUID} -std=c++17
+          -c -o "${_cuid_probe_obj}" "${_cuid_probe_src}"
+  RESULT_VARIABLE _cuid_probe_result
+  OUTPUT_VARIABLE _cuid_probe_stdout
+  ERROR_VARIABLE _cuid_probe_stderr
+)
+if(NOT _cuid_probe_result EQUAL 0)
+  message(FATAL_ERROR "Device Linker: CUID probe compile failed:\n${_cuid_probe_stdout}\n${_cuid_probe_stderr}")
+endif()
+
+execute_process(
+  COMMAND ${DL_READELF} -sW "${_cuid_probe_obj}"
+  OUTPUT_VARIABLE _cuid_probe_syms
+)
+string(REGEX MATCH "__hip_fatbin_([0-9a-f]+)" _fatbin_match "${_cuid_probe_syms}")
+if(NOT CMAKE_MATCH_1)
+  message(FATAL_ERROR "Device Linker: could not discover __hip_fatbin_<hash> symbol from CUID probe. readelf output:\n${_cuid_probe_syms}")
+endif()
+set(DL_FATBIN_HASH "${CMAKE_MATCH_1}")
+set(DL_FATBIN_SYMBOL "__hip_fatbin_${DL_FATBIN_HASH}")
+set(DL_CUID_SYMBOL "__hip_cuid_${DL_FATBIN_HASH}")
+message(STATUS "Device Linker: shared CUID '${DL_SHARED_CUID}' -> ${DL_FATBIN_SYMBOL}")
+
+# ===========================================================================
+# Mixed host+device TU registration
+#
+# Each registered TU gets, further below:
+#   - (if HAS_DEVICE) a per-arch device-only object via the driver's
+#     --emit-device-obj mode, containing ALL of its __global__ kernels
+#     (no extraction -- these are standalone entries with their own .kd, not
+#     participants in the specialized-kernel dispatcher's resource
+#     aggregation), merged into that arch's device.elf alongside the
+#     specialized kernels (see the per-arch loop below).
+#   - A host-only object (--offload-host-only -cuid=<shared>), referencing
+#     rather than embedding the fatbin, then localized (see the "Mixed-TU
+#     host compiles" loop after glue.o) and added to DEVICE_LINKER_OBJECTS.
+#
+# `common` (common.cu.cpp) is HAS_DEVICE FALSE: it has no __global__ kernels
+# of its own -- the driver's --link mode already compiles+patches+links its
+# generic dispatcher kernel directly into every arch's device.elf as part of
+# the existing resource-aggregation pipeline (see --dispatcher= below). It
+# only needs the host-side registration change here: previously the one TU
+# that explicitly embedded DEVICE_HIPFB via -fcuda-include-gpubinary, now
+# just another shared-cuid reference like the rest (glue.o is the sole
+# embedder).
+# ===========================================================================
+set(DL_MIXED_TU_NAMES "")
+
+macro(dl_register_mixed_tu NAME SRC)
+  cmake_parse_arguments(MTU "HAS_DEVICE;SUPPRESS_WARNINGS;INHERIT_FLAGS;DEPFILE_TRACKING"
+    "" "EXTRA_DEFS;EXTRA_DEVICE_FLAGS;EXTRA_DEVICE_DEPS" ${ARGN})
+  list(APPEND DL_MIXED_TU_NAMES "${NAME}")
+  set(DL_MTU_SRC_${NAME} "${SRC}")
+  set(DL_MTU_HAS_DEVICE_${NAME} ${MTU_HAS_DEVICE})
+  set(DL_MTU_SUPPRESS_WARNINGS_${NAME} ${MTU_SUPPRESS_WARNINGS})
+  set(DL_MTU_INHERIT_FLAGS_${NAME} ${MTU_INHERIT_FLAGS})
+  set(DL_MTU_DEPFILE_TRACKING_${NAME} ${MTU_DEPFILE_TRACKING})
+  # EXTRA_DEFS go to both halves (the -D must agree between the host stub and
+  # the device kernel it launches); EXTRA_DEVICE_FLAGS/DEPS only to the
+  # --emit-device-obj compile.
+  set(DL_MTU_EXTRA_DEFS_${NAME} "${MTU_EXTRA_DEFS}")
+  set(DL_MTU_EXTRA_DEVICE_FLAGS_${NAME} "${MTU_EXTRA_DEVICE_FLAGS}")
+  set(DL_MTU_EXTRA_DEVICE_DEPS_${NAME} "${MTU_EXTRA_DEVICE_DEPS}")
+endmacro()
+
+dl_register_mixed_tu(common "${HIPIFY_DIR}/src/device/common.cu.cpp"
+  INHERIT_FLAGS)
+dl_register_mixed_tu(onerank "${HIPIFY_DIR}/src/device/onerank.cu.cpp"
+  HAS_DEVICE INHERIT_FLAGS)
+# Dependency tracking note (CMake >= 3.20 vs < 3.20): add_custom_command only
+# rebuilds when files listed in DEPENDS change. It does NOT automatically
+# track transitive headers (e.g. ce_coll.h), so a struct layout change in a
+# header would not invalidate collectives.o. CMake 3.20 DEPFILE support fixes
+# this by reading the compiler-generated .d file; on older CMake the
+# workaround is: touch hipify/src/collectives.cc.
+dl_register_mixed_tu(collectives "${HIPIFY_DIR}/src/collectives.cc"
+  HAS_DEVICE INHERIT_FLAGS DEPFILE_TRACKING)
+# ce_reduce.cc itself is now pure host code (a dispatcher calling into
+# per-instantiation launchers; see src/device/ce_reduce/generate.py) and is
+# compiled normally as part of the main rccl target -- NOT registered here.
+# Its 40 (type, redop) __global__ kernel instantiations live in
+# gensrc/ce_reduce/*.cpp instead (one per instantiation, so ninja
+# parallelizes them like every other device TU -- two of the 40,
+# int8_t/uint8_t Min/Max, individually generate ~56K instructions and used
+# to dominate the whole build's wall-clock time when they all lived in one
+# TU). Globbed dynamically, mirroring the sym_* pattern below.
+file(GLOB _ce_reduce_srcs CONFIGURE_DEPENDS "${HIPIFY_DIR}/gensrc/ce_reduce/*.cpp")
+foreach(_ce_reduce_src IN LISTS _ce_reduce_srcs)
+  get_filename_component(_ce_reduce_name "${_ce_reduce_src}" NAME_WE)
+  string(MAKE_C_IDENTIFIER "${_ce_reduce_name}" _ce_reduce_name_id)
+  dl_register_mixed_tu(ce_reduce_${_ce_reduce_name_id} "${_ce_reduce_src}"
+    HAS_DEVICE INHERIT_FLAGS SUPPRESS_WARNINGS)
+endforeach()
+set(_dda_dir "${HIPIFY_DIR}/src/algorithms/dda")
+dl_register_mixed_tu(dda_all_reduce_ipc "${_dda_dir}/all_reduce/dda_all_reduce_ipc.cu.cpp"
+  HAS_DEVICE INHERIT_FLAGS)
+dl_register_mixed_tu(dda_reduce_scatter_ipc "${_dda_dir}/reduce_scatter/dda_reduce_scatter_ipc.cu.cpp"
+  HAS_DEVICE INHERIT_FLAGS)
+dl_register_mixed_tu(dda_all_gather_ipc "${_dda_dir}/all_gather/dda_all_gather_ipc.cu.cpp"
+  HAS_DEVICE INHERIT_FLAGS)
+dl_register_mixed_tu(dda_alltoall_ipc "${_dda_dir}/alltoall/dda_alltoall_ipc.cu.cpp"
+  HAS_DEVICE INHERIT_FLAGS)
+dl_register_mixed_tu(dda_all_reduce_fabric "${_dda_dir}/all_reduce/dda_all_reduce_fabric.cu.cpp"
+  HAS_DEVICE INHERIT_FLAGS SUPPRESS_WARNINGS)
+dl_register_mixed_tu(dda_all_reduce_fabric_ll "${_dda_dir}/all_reduce/dda_all_reduce_fabric_ll.cu.cpp"
+  HAS_DEVICE INHERIT_FLAGS SUPPRESS_WARNINGS)
+dl_register_mixed_tu(dda_all_reduce_fabric_ll128 "${_dda_dir}/all_reduce/dda_all_reduce_fabric_ll128.cu.cpp"
+  HAS_DEVICE INHERIT_FLAGS SUPPRESS_WARNINGS)
+dl_register_mixed_tu(dda_reduce_scatter_fabric "${_dda_dir}/reduce_scatter/dda_reduce_scatter_fabric.cu.cpp"
+  HAS_DEVICE INHERIT_FLAGS SUPPRESS_WARNINGS)
+dl_register_mixed_tu(dda_all_gather_fabric "${_dda_dir}/all_gather/dda_all_gather_fabric.cu.cpp"
+  HAS_DEVICE INHERIT_FLAGS SUPPRESS_WARNINGS)
+dl_register_mixed_tu(dda_all_gather_fabric_ll "${_dda_dir}/all_gather/dda_all_gather_fabric_ll.cu.cpp"
+  HAS_DEVICE INHERIT_FLAGS SUPPRESS_WARNINGS)
+dl_register_mixed_tu(dda_all_gather_fabric_ll128 "${_dda_dir}/all_gather/dda_all_gather_fabric_ll128.cu.cpp"
+  HAS_DEVICE INHERIT_FLAGS SUPPRESS_WARNINGS)
+dl_register_mixed_tu(dda_alltoall_fabric "${_dda_dir}/alltoall/dda_alltoall_fabric.cu.cpp"
+  HAS_DEVICE INHERIT_FLAGS SUPPRESS_WARNINGS)
+dl_register_mixed_tu(dda_alltoall_fabric_ll "${_dda_dir}/alltoall/dda_alltoall_fabric_ll.cu.cpp"
+  HAS_DEVICE INHERIT_FLAGS SUPPRESS_WARNINGS)
+dl_register_mixed_tu(dda_alltoall_fabric_ll128 "${_dda_dir}/alltoall/dda_alltoall_fabric_ll128.cu.cpp"
+  HAS_DEVICE INHERIT_FLAGS SUPPRESS_WARNINGS)
+dl_register_mixed_tu(dda_reduce_scatter_fabric_ll "${_dda_dir}/reduce_scatter/dda_reduce_scatter_fabric_ll.cu.cpp"
+  HAS_DEVICE INHERIT_FLAGS SUPPRESS_WARNINGS)
+dl_register_mixed_tu(dda_reduce_scatter_fabric_ll128 "${_dda_dir}/reduce_scatter/dda_reduce_scatter_fabric_ll128.cu.cpp"
+  HAS_DEVICE INHERIT_FLAGS SUPPRESS_WARNINGS)
+
+# GIN-SDMA kernels. The -D flags live here rather than as per-source properties
+# because these files are filtered out of the rccl target. Leaving only SDMA on
+# keeps ncclGinCallImpl on its single backend branch; GDA must stay off, as
+# these TUs get no QueuePair bitcode.
+if(ENABLE_ROCSHMEM_GIN)
+  dl_register_mixed_tu(gin_alltoall_sdma "${HIPIFY_DIR}/src/algorithms/gin/sdma/gin_alltoall_sdma.cu.cpp"
+    HAS_DEVICE INHERIT_FLAGS
+    EXTRA_DEFS -DNCCL_GIN_ANVIL_SDMA_ENABLE=1 -DNCCL_GIN_PROXY_ENABLE=0
+               -DNCCL_GIN_ROCSHMEM_GDA_ENABLE=0)
+  dl_register_mixed_tu(gin_all_reduce_sdma "${HIPIFY_DIR}/src/algorithms/gin/sdma/gin_all_reduce_sdma.cu.cpp"
+    HAS_DEVICE INHERIT_FLAGS
+    EXTRA_DEFS -DNCCL_GIN_ANVIL_SDMA_ENABLE=1 -DNCCL_GIN_PROXY_ENABLE=0
+               -DNCCL_GIN_ROCSHMEM_GDA_ENABLE=0)
+endif()
+
+# Symmetric kernels: per-instantiation device TUs from gensrc/symmetric/.
+# Each instantiation file defines a handful of __global__ ncclSymkDevKernel_*
+# entries. SYM names are globbed dynamically (vs the fixed names above)
+# because the symmetric generator emits one TU per instantiation.
+if(GENERATE_SYM_KERNELS)
+  # When ENABLE_ROCSHMEM_GIN is set, GIN device templates reference rocshmem
+  # device symbols (QueuePair::put_nbi, atomic_add, etc.). The installed per-arch
+  # .bc files are arch-optimized (opt -mcpu=) and can't be used with
+  # -mlink-builtin-bitcode across archs. Instead, llvm-link the pre-opt
+  # individual source .bc files (arch-agnostic) into a minimal QP-only bitcode.
+  set(_sym_rocshmem_bc_flag "")
+  set(_sym_rocshmem_deps "")
+  if(ENABLE_ROCSHMEM_GIN AND ROCSHMEM_SOURCE_DIR)
+    # Pick the first arch's pre-opt bitcode dir (all archs produce identical
+    # unoptimized IR since -Xclang -disable-llvm-passes is used).
+    list(GET DL_GPU_TARGETS 0 _bc_arch)
+    set(_bc_dir "${ROCSHMEM_SOURCE_DIR}/build/bitcode/${_bc_arch}")
+    set(_qp_bc "${DEVICE_BUILD_DIR}/rocshmem_qp_device.bc")
+    find_program(_llvm_link llvm-link HINTS ${ROCM_PATH}/llvm/bin REQUIRED)
+    find_program(_llvm_dis  llvm-dis  HINTS ${ROCM_PATH}/llvm/bin REQUIRED)
+    find_program(_llvm_as   llvm-as   HINTS ${ROCM_PATH}/llvm/bin REQUIRED)
+
+    # Pipeline:
+    #  1. Compile gin_rocshmem_constmem.hip → device-only .bc (provides
+    #     rocshmem::constmem and rocshmem::logd_constants definitions that
+    #     queue_pair.bc references as external)
+    #  2. llvm-link QP .bc files + constmem .bc into one module
+    #  3. Strip @llvm.compiler.used and @__hip_cuid_ via text round-trip
+    #     (these AMDGCN addrspace(1) appending globals clash with the
+    #     host-side addrspace(0) equivalents in fat-object compilation)
+    set(_cm_src "${CMAKE_SOURCE_DIR}/src/gin/gin_rocshmem_constmem.hip")
+    set(_cm_bc  "${DEVICE_BUILD_DIR}/gin_rocshmem_constmem.bc")
+    set(_qp_raw "${DEVICE_BUILD_DIR}/rocshmem_qp_raw.bc")
+
+    add_custom_command(
+      OUTPUT ${_cm_bc}
+      COMMAND ${DL_CLANG}
+        -x hip --cuda-device-only --offload-arch=${_bc_arch}
+        -emit-llvm -Xclang -disable-llvm-passes
+        -std=c++17 -fPIC
+        -I${ROCSHMEM_SOURCE_DIR}/src
+        -I${ROCSHMEM_SOURCE_DIR}/include
+        -c -o ${_cm_bc} ${_cm_src}
+      DEPENDS ${_cm_src}
+      COMMENT "DL: compiling rocshmem constmem stubs to device bitcode"
+      VERBATIM)
+
+    add_custom_command(
+      OUTPUT ${_qp_bc}
+      COMMAND ${_llvm_link}
+        ${_bc_dir}/queue_pair.bc
+        ${_bc_dir}/queue_pair_mlx5.bc
+        ${_bc_dir}/queue_pair_bnxt.bc
+        ${_bc_dir}/queue_pair_ionic.bc
+        ${_cm_bc}
+        -o ${_qp_raw}
+      COMMAND ${_llvm_dis} -o ${_qp_raw}.ll ${_qp_raw}
+      COMMAND grep -v -E "@llvm[.]compiler[.]used|@__hip_cuid_"
+        ${_qp_raw}.ll > ${_qp_raw}.clean.ll
+      COMMAND ${_llvm_as} ${_qp_raw}.clean.ll -o ${_qp_bc}
+      DEPENDS ${_cm_bc}
+      COMMENT "DL: linking rocshmem QP device bitcode (with constmem, stripped)"
+      VERBATIM)
+    add_custom_target(dl_rocshmem_qp_bc DEPENDS ${_qp_bc})
+    if(TARGET rocshmem_static)
+      add_dependencies(dl_rocshmem_qp_bc rocshmem_static)
+    endif()
+    set(_sym_rocshmem_bc_flag -Xclang -mlink-builtin-bitcode -Xclang ${_qp_bc})
+    set(_sym_rocshmem_deps dl_rocshmem_qp_bc)
+  endif()
+  file(GLOB _sym_srcs CONFIGURE_DEPENDS "${HIPIFY_DIR}/gensrc/symmetric/*.cpp")
+  foreach(_sym_src IN LISTS _sym_srcs)
+    get_filename_component(_sym_name "${_sym_src}" NAME_WE)
+    string(MAKE_C_IDENTIFIER "${_sym_name}" _sym_name_id)
+    # Only GIN symmetric kernels need the QP bitcode; non-GIN ones would
+    # just ingest and DCE it, wasting compile time. It is a device-side flag,
+    # so it goes only on the --emit-device-obj half.
+    set(_this_bc_flag "")
+    set(_this_bc_deps "")
+    if(_sym_name MATCHES "_gin_")
+      set(_this_bc_flag "${_sym_rocshmem_bc_flag}")
+      set(_this_bc_deps "${_sym_rocshmem_deps}")
+    endif()
+    dl_register_mixed_tu(sym_${_sym_name_id} "${_sym_src}" HAS_DEVICE INHERIT_FLAGS
+      EXTRA_DEVICE_FLAGS ${_this_bc_flag}
+      EXTRA_DEVICE_DEPS ${_this_bc_deps})
+  endforeach()
+endif()
 
 # ===========================================================================
 # Per-GPU-target: OBJECT library (compile) + link custom command
@@ -305,47 +626,60 @@ foreach(DL_GPU_TARGET ${DL_GPU_TARGETS})
   endif()
 
   # =========================================================================
+  # Mixed-TU per-arch device objects: merged into this arch's device.elf
+  # alongside the specialized kernels above (see dl_register_mixed_tu doc).
+  # =========================================================================
+  set(_mixed_dev_objs "")
+  foreach(_mtu_name IN LISTS DL_MIXED_TU_NAMES)
+    if(NOT DL_MTU_HAS_DEVICE_${_mtu_name})
+      continue()
+    endif()
+    set(_mtu_dev_obj "${DL_ARCH_DIR}/${_mtu_name}.o")
+
+    set(_mtu_dev_w_flag "")
+    if(DL_MTU_SUPPRESS_WARNINGS_${_mtu_name})
+      set(_mtu_dev_w_flag -w)
+    endif()
+    set(_mtu_dev_inherit_flags "")
+    if(DL_MTU_INHERIT_FLAGS_${_mtu_name})
+      set(_mtu_dev_inherit_flags ${DL_INHERITED_FLAGS})
+    endif()
+
+    add_custom_command(
+      OUTPUT  ${_mtu_dev_obj}
+      COMMAND ${CMAKE_RCCLDEV_COMPILER}
+        --emit-device-obj
+        --arch=${DL_GPU_TARGET}
+        --clang=${DL_CLANG}
+        ${DL_HIP_COMPILER_FLAGS}
+        -DRCCL_DEVICE_LINKER
+        ${DL_MTU_EXTRA_DEFS_${_mtu_name}}
+        ${_link_def_flags}
+        ${_host_inc_flags}
+        ${DL_OPT_FLAGS}
+        ${_mtu_dev_inherit_flags}
+        -std=c++17
+        ${_mtu_dev_w_flag}
+        ${DL_MTU_EXTRA_DEVICE_FLAGS_${_mtu_name}}
+        -o ${_mtu_dev_obj}
+        ${DL_MTU_SRC_${_mtu_name}}
+      DEPENDS ${DL_MTU_SRC_${_mtu_name}} ${DL_MTU_EXTRA_DEVICE_DEPS_${_mtu_name}}
+      COMMENT "DL [${DL_GPU_TARGET}] device-obj: ${_mtu_name}"
+      VERBATIM
+      COMMAND_EXPAND_LISTS
+    )
+    list(APPEND _mixed_dev_objs "${_mtu_dev_obj}")
+  endforeach()
+
+  # =========================================================================
   # Link step: driver --link mode produces device.elf
   # =========================================================================
   set(ARCH_DEVICE_ELF "${DL_ARCH_DIR}/device.elf")
 
-  # Gather definitions and includes for the dispatcher compilation inside --link.
-  # The driver forwards these to amdclang++ when compiling common.cu.cpp.
-  get_target_property(_dev_defs ${_dev_target} COMPILE_DEFINITIONS)
-  set(_link_def_flags "")
-  if(_dev_defs)
-    foreach(_d ${_dev_defs})
-      list(APPEND _link_def_flags "-D${_d}")
-    endforeach()
-  endif()
-  # Also add interface definitions from rccl_device_defs
-  get_target_property(_iface_defs rccl_device_defs INTERFACE_COMPILE_DEFINITIONS)
-  if(_iface_defs)
-    foreach(_d ${_iface_defs})
-      list(APPEND _link_def_flags "-D${_d}")
-    endforeach()
-  endif()
-  list(REMOVE_DUPLICATES _link_def_flags)
-
-  get_target_property(_dev_includes rccl_device_defs INTERFACE_INCLUDE_DIRECTORIES)
-  set(_link_inc_flags "")
-  if(_dev_includes)
-    foreach(_inc ${_dev_includes})
-      list(APPEND _link_inc_flags "-I${_inc}")
-    endforeach()
-  endif()
-  get_target_property(_dev_sys_includes rccl_device_defs INTERFACE_SYSTEM_INCLUDE_DIRECTORIES)
-  if(_dev_sys_includes)
-    foreach(_inc ${_dev_sys_includes})
-      if(NOT _inc IN_LIST CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES)
-        list(APPEND _link_inc_flags "-isystem${_inc}")
-      endif()
-    endforeach()
-  endif()
-
   set(_link_rsp "${DL_ARCH_DIR}/link_objects.rsp")
+  list(JOIN _mixed_dev_objs "\n" _mixed_dev_objs_joined)
   file(GENERATE OUTPUT "${_link_rsp}"
-    CONTENT "$<JOIN:$<TARGET_OBJECTS:${_dev_target}>,\n>\n")
+    CONTENT "$<JOIN:$<TARGET_OBJECTS:${_dev_target}>,\n>\n${_mixed_dev_objs_joined}\n")
 
   # When rocSHMEM is enabled, pass the per-arch device bitcode to the driver.
   # rocSHMEM device API symbols have hidden visibility and must be statically
@@ -377,7 +711,7 @@ foreach(DL_GPU_TARGET ${DL_GPU_TARGETS})
       -std=c++17
       -o ${ARCH_DEVICE_ELF}
       @${_link_rsp}
-    DEPENDS ${_dev_target} ${HIPIFY_DIR}/src/device/common.cu.cpp ${_rocshmem_link_depends}
+    DEPENDS ${_dev_target} ${_mixed_dev_objs} ${HIPIFY_DIR}/src/device/common.cu.cpp ${_rocshmem_link_depends}
     COMMENT "DL [${DL_GPU_TARGET}] link: device.elf"
     VERBATIM
     COMMAND_EXPAND_LISTS
@@ -433,6 +767,8 @@ endforeach()  # end per-GPU-target loop
 
 # ===========================================================================
 # Bundle all per-arch device.elf files into a single .hipfb fat binary
+# (now the ONE unified image: specialized dispatcher kernels + every mixed
+# TU's kernels, for every arch)
 # ===========================================================================
 set(DEVICE_HIPFB "${DEVICE_BUILD_DIR}/device.hipfb")
 
@@ -457,696 +793,104 @@ add_custom_command(
 )
 
 # ===========================================================================
-# Host compile common.cu.cpp with embedded device binary
+# Glue object: the ONE place that embeds DEVICE_HIPFB's bytes, defining
+# DL_FATBIN_SYMBOL globally via .incbin. Every mixed TU (including common)
+# only references this symbol (undefined in their own objects); the final
+# librccl.so link resolves all of them against this single definition. glue.s
+# itself is static (the symbol name and DEVICE_HIPFB's path are both already
+# known at configure time); glue.o still depends on DEVICE_HIPFB so it's
+# reassembled -- re-running .incbin -- whenever the bundled image's bytes
+# change.
 # ===========================================================================
-set(COMMON_FAT_OBJ "${DEVICE_BUILD_DIR}/common.o")
-
-set(DL_HOST_COMPRESS "")
-if(ENABLE_COMPRESS)
-  set(DL_HOST_COMPRESS "--offload-compress")
-endif()
-
-# Gather include flags for host compile (same paths as device)
-set(_host_inc_flags "")
-if(_dev_includes)
-  foreach(_inc ${_dev_includes})
-    list(APPEND _host_inc_flags "-I${_inc}")
-  endforeach()
-endif()
-if(_dev_sys_includes)
-  foreach(_inc ${_dev_sys_includes})
-    if(NOT _inc IN_LIST CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES)
-      list(APPEND _host_inc_flags "-isystem${_inc}")
-    endif()
-  endforeach()
-endif()
-
+set(DL_GLUE_S "${DEVICE_BUILD_DIR}/glue.s")
+file(WRITE "${DL_GLUE_S}"
+"\t.section .hip_fatbin, \"a\", @progbits
+\t.globl ${DL_FATBIN_SYMBOL}
+\t.p2align 12
+${DL_FATBIN_SYMBOL}:
+\t.incbin \"${DEVICE_HIPFB}\"
+")
+set(DL_GLUE_OBJ "${DEVICE_BUILD_DIR}/glue.o")
 add_custom_command(
-  OUTPUT  ${COMMON_FAT_OBJ}
-  COMMAND ${DL_CLANG}
-    -x hip --offload-host-only ${DL_OFFLOAD_ARCH_FLAGS}
-    ${DL_HIP_COMPILER_FLAGS}
-    -Xclang -fcuda-include-gpubinary -Xclang ${DEVICE_HIPFB}
-    -DRCCL_DEVICE_LINKER
-    ${_link_def_flags}
-    ${_host_inc_flags}
-    ${DL_OPT_FLAGS}
-    ${DL_INHERITED_FLAGS}
-    -std=c++17
-    -fPIC
-    ${DL_HOST_COMPRESS}
-    -c -o ${COMMON_FAT_OBJ}
-    ${HIPIFY_DIR}/src/device/common.cu.cpp
-  DEPENDS ${DEVICE_HIPFB} ${HIPIFY_DIR}/src/device/common.cu.cpp
-  COMMENT "DL host compile: common.cu.cpp with embedded device binary"
+  OUTPUT  ${DL_GLUE_OBJ}
+  COMMAND ${DL_CLANG} -c -o ${DL_GLUE_OBJ} ${DL_GLUE_S}
+  DEPENDS ${DEVICE_HIPFB} ${DL_GLUE_S}
+  COMMENT "DL glue: single embed of ${DL_FATBIN_SYMBOL}"
   VERBATIM
 )
 
 # ===========================================================================
-# Onerank: normal HIP compilation (host+device, no RDC)
+# Mixed-TU host compiles: --offload-host-only -cuid=<shared>, referencing
+# (not embedding) the fatbin, then llvm-objcopy --localize-symbol strips the
+# per-TU __hip_cuid_<hash> duplicate-CUID marker so linking them all
+# together doesn't hit a duplicate-symbol error (see the "Shared CUID"
+# section above for why that marker exists and why we deliberately want to
+# suppress its complaint here).
 # ===========================================================================
-set(ONERANK_FAT_OBJ "${DEVICE_BUILD_DIR}/onerank.o")
+set(DEVICE_LINKER_OBJECTS "${DL_GLUE_OBJ}")
 
-add_custom_command(
-  OUTPUT  ${ONERANK_FAT_OBJ}
-  COMMAND ${DL_CLANG}
-    -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-    ${DL_HIP_COMPILER_FLAGS}
-    -DRCCL_DEVICE_LINKER
-    ${_link_def_flags}
-    ${_host_inc_flags}
-    ${DL_OPT_FLAGS}
-    ${DL_INHERITED_FLAGS}
-    -std=c++17
-    -fPIC
-    -c -o ${ONERANK_FAT_OBJ}
-    ${HIPIFY_DIR}/src/device/onerank.cu.cpp
-  DEPENDS ${HIPIFY_DIR}/src/device/onerank.cu.cpp
-  COMMENT "DL compile: onerank.cu.cpp (normal fat object)"
-  VERBATIM
-)
+foreach(_mtu_name IN LISTS DL_MIXED_TU_NAMES)
+  set(_mtu_raw_obj   "${DEVICE_BUILD_DIR}/${_mtu_name}_raw.o")
+  set(_mtu_final_obj "${DEVICE_BUILD_DIR}/${_mtu_name}.o")
 
-# ===========================================================================
-# collectives.cc: contains a __global__ kernel launch (hierarchicalShuffle)
-# so it needs full HIP compilation, not --offload-host-only.
-# ===========================================================================
-# Dependency tracking note (CMake >= 3.20 vs < 3.20):
-# add_custom_command only rebuilds when files listed in DEPENDS change.  It
-# does NOT automatically track transitive headers (e.g. ce_coll.h), so a
-# struct layout change in a header would not invalidate collectives.o.
-# CMake 3.20 DEPFILE support fixes this by reading the compiler-generated .d
-# file; on older CMake the workaround is: touch hipify/src/collectives.cc.
-# ===========================================================================
-set(COLLECTIVES_FAT_OBJ "${DEVICE_BUILD_DIR}/collectives.o")
-
-if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.20")
-  set(COLLECTIVES_DEPFILE "${DEVICE_BUILD_DIR}/collectives.d")
-  add_custom_command(
-    OUTPUT  ${COLLECTIVES_FAT_OBJ}
-    COMMAND ${DL_CLANG}
-      -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-      ${DL_HIP_COMPILER_FLAGS}
-      -DRCCL_DEVICE_LINKER
-      ${_link_def_flags}
-      ${_host_inc_flags}
-      ${DL_OPT_FLAGS}
-      ${DL_INHERITED_FLAGS}
-      -std=c++17
-      -fPIC
-      -MD -MF ${COLLECTIVES_DEPFILE}
-      -c -o ${COLLECTIVES_FAT_OBJ}
-      ${HIPIFY_DIR}/src/collectives.cc
-    DEPENDS ${HIPIFY_DIR}/src/collectives.cc
-    DEPFILE ${COLLECTIVES_DEPFILE}
-    COMMENT "DL compile: collectives.cc (has __global__ kernel, header-tracking via DEPFILE)"
-    VERBATIM
-  )
-else()
-  add_custom_command(
-    OUTPUT  ${COLLECTIVES_FAT_OBJ}
-    COMMAND ${DL_CLANG}
-      -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-      ${DL_HIP_COMPILER_FLAGS}
-      -DRCCL_DEVICE_LINKER
-      ${_link_def_flags}
-      ${_host_inc_flags}
-      ${DL_OPT_FLAGS}
-      ${DL_INHERITED_FLAGS}
-      -std=c++17
-      -fPIC
-      -c -o ${COLLECTIVES_FAT_OBJ}
-      ${HIPIFY_DIR}/src/collectives.cc
-    DEPENDS ${HIPIFY_DIR}/src/collectives.cc
-    COMMENT "DL compile: collectives.cc (has __global__ kernel)"
-    VERBATIM
-  )
-endif()
-
-# ===========================================================================
-# dda_all_reduce_ipc.cu.cpp: contains device kernels and kernel launches.
-# Like collectives.cc, it cannot be built with --offload-host-only on the
-# main rccl target or __hip_fatbin_* stays undefined in librccl.so.
-# ===========================================================================
-set(DDA_ALL_REDUCE_IPC_FAT_OBJ "${DEVICE_BUILD_DIR}/dda_all_reduce_ipc.o")
-set(DDA_REDUCE_SCATTER_IPC_FAT_OBJ "${DEVICE_BUILD_DIR}/dda_reduce_scatter_ipc.o")
-set(DDA_ALL_GATHER_IPC_FAT_OBJ "${DEVICE_BUILD_DIR}/dda_all_gather_ipc.o")
-set(DDA_ALLTOALL_IPC_FAT_OBJ "${DEVICE_BUILD_DIR}/dda_alltoall_ipc.o")
-
-add_custom_command(
-  OUTPUT  ${DDA_ALL_REDUCE_IPC_FAT_OBJ}
-  COMMAND ${DL_CLANG}
-    -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-    ${DL_HIP_COMPILER_FLAGS}
-    -DRCCL_DEVICE_LINKER
-    ${_link_def_flags}
-    ${_host_inc_flags}
-    ${DL_OPT_FLAGS}
-    ${DL_INHERITED_FLAGS}
-    -std=c++17
-    -fPIC
-    -c -o ${DDA_ALL_REDUCE_IPC_FAT_OBJ}
-    ${HIPIFY_DIR}/src/algorithms/dda/all_reduce/dda_all_reduce_ipc.cu.cpp
-  DEPENDS ${HIPIFY_DIR}/src/algorithms/dda/all_reduce/dda_all_reduce_ipc.cu.cpp
-  COMMENT "DL compile: dda_all_reduce_ipc.cu.cpp (has device kernels)"
-  VERBATIM
-)
-
-add_custom_command(
-  OUTPUT  ${DDA_REDUCE_SCATTER_IPC_FAT_OBJ}
-  COMMAND ${DL_CLANG}
-    -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-    ${DL_HIP_COMPILER_FLAGS}
-    -DRCCL_DEVICE_LINKER
-    ${_link_def_flags}
-    ${_host_inc_flags}
-    ${DL_OPT_FLAGS}
-    ${DL_INHERITED_FLAGS}
-    -std=c++17
-    -fPIC
-    -c -o ${DDA_REDUCE_SCATTER_IPC_FAT_OBJ}
-    ${HIPIFY_DIR}/src/algorithms/dda/reduce_scatter/dda_reduce_scatter_ipc.cu.cpp
-  DEPENDS ${HIPIFY_DIR}/src/algorithms/dda/reduce_scatter/dda_reduce_scatter_ipc.cu.cpp
-  COMMENT "DL compile: dda_reduce_scatter_ipc.cu.cpp (has device kernels)"
-  VERBATIM
-)
-
-add_custom_command(
-  OUTPUT  ${DDA_ALL_GATHER_IPC_FAT_OBJ}
-  COMMAND ${DL_CLANG}
-    -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-    ${DL_HIP_COMPILER_FLAGS}
-    -DRCCL_DEVICE_LINKER
-    ${_link_def_flags}
-    ${_host_inc_flags}
-    ${DL_OPT_FLAGS}
-    ${DL_INHERITED_FLAGS}
-    -std=c++17
-    -fPIC
-    -c -o ${DDA_ALL_GATHER_IPC_FAT_OBJ}
-    ${HIPIFY_DIR}/src/algorithms/dda/all_gather/dda_all_gather_ipc.cu.cpp
-  DEPENDS ${HIPIFY_DIR}/src/algorithms/dda/all_gather/dda_all_gather_ipc.cu.cpp
-  COMMENT "DL compile: dda_all_gather_ipc.cu.cpp (has device kernels)"
-  VERBATIM
-)
-
-add_custom_command(
-  OUTPUT  ${DDA_ALLTOALL_IPC_FAT_OBJ}
-  COMMAND ${DL_CLANG}
-    -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-    ${DL_HIP_COMPILER_FLAGS}
-    -DRCCL_DEVICE_LINKER
-    ${_link_def_flags}
-    ${_host_inc_flags}
-    ${DL_OPT_FLAGS}
-    ${DL_INHERITED_FLAGS}
-    -std=c++17
-    -fPIC
-    -c -o ${DDA_ALLTOALL_IPC_FAT_OBJ}
-    ${HIPIFY_DIR}/src/algorithms/dda/alltoall/dda_alltoall_ipc.cu.cpp
-  DEPENDS ${HIPIFY_DIR}/src/algorithms/dda/alltoall/dda_alltoall_ipc.cu.cpp
-  COMMENT "DL compile: dda_alltoall_ipc.cu.cpp (has device kernels)"
-  VERBATIM
-)
-
-# ===========================================================================
-# gin_alltoall_sdma.cu.cpp: GIN-SDMA alltoall kernel.
-#
-# The defines go here because this file is filtered out of the rccl target, so
-# per-source properties never apply. Leaving only SDMA on keeps ncclGinCallImpl
-# on its single backend branch. GDA must stay off, as this object gets no QP bitcode.
-# ===========================================================================
-set(GIN_ALLTOALL_SDMA_FAT_OBJ "")
-if(ENABLE_ROCSHMEM_GIN)
-  set(GIN_ALLTOALL_SDMA_FAT_OBJ "${DEVICE_BUILD_DIR}/gin_alltoall_sdma.o")
-  add_custom_command(
-    OUTPUT  ${GIN_ALLTOALL_SDMA_FAT_OBJ}
-    COMMAND ${DL_CLANG}
-      -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-      ${DL_HIP_COMPILER_FLAGS}
-      -DRCCL_DEVICE_LINKER
-      -DNCCL_GIN_ANVIL_SDMA_ENABLE=1
-      -DNCCL_GIN_PROXY_ENABLE=0
-      -DNCCL_GIN_ROCSHMEM_GDA_ENABLE=0
-      ${_link_def_flags}
-      ${_host_inc_flags}
-      ${DL_OPT_FLAGS}
-      ${DL_INHERITED_FLAGS}
-      -std=c++17
-      -fPIC
-      -c -o ${GIN_ALLTOALL_SDMA_FAT_OBJ}
-      ${HIPIFY_DIR}/src/algorithms/gin/sdma/gin_alltoall_sdma.cu.cpp
-    DEPENDS ${HIPIFY_DIR}/src/algorithms/gin/sdma/gin_alltoall_sdma.cu.cpp
-    COMMENT "DL compile: gin_alltoall_sdma.cu.cpp (GIN-SDMA alltoall kernel)"
-    VERBATIM
-  )
-endif()
-
-# ===========================================================================
-# gin_all_reduce_sdma.cu.cpp: GIN-SDMA allreduce kernel.
-#
-# The defines go here because this file is filtered out of the rccl target, so
-# per-source properties never apply. Leaving only SDMA on keeps ncclGinCallImpl
-# on its single backend branch. GDA must stay off, as this object gets no QP bitcode.
-# ===========================================================================
-set(GIN_ALLREDUCE_SDMA_FAT_OBJ "")
-if(ENABLE_ROCSHMEM_GIN)
-  set(GIN_ALLREDUCE_SDMA_FAT_OBJ "${DEVICE_BUILD_DIR}/gin_all_reduce_sdma.o")
-  add_custom_command(
-    OUTPUT  ${GIN_ALLREDUCE_SDMA_FAT_OBJ}
-    COMMAND ${DL_CLANG}
-      -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-      ${DL_HIP_COMPILER_FLAGS}
-      -DRCCL_DEVICE_LINKER
-      -DNCCL_GIN_ANVIL_SDMA_ENABLE=1
-      -DNCCL_GIN_PROXY_ENABLE=0
-      -DNCCL_GIN_ROCSHMEM_GDA_ENABLE=0
-      ${_link_def_flags}
-      ${_host_inc_flags}
-      ${DL_OPT_FLAGS}
-      ${DL_INHERITED_FLAGS}
-      -std=c++17
-      -fPIC
-      -c -o ${GIN_ALLREDUCE_SDMA_FAT_OBJ}
-      ${HIPIFY_DIR}/src/algorithms/gin/sdma/gin_all_reduce_sdma.cu.cpp
-    DEPENDS ${HIPIFY_DIR}/src/algorithms/gin/sdma/gin_all_reduce_sdma.cu.cpp
-    COMMENT "DL compile: gin_all_reduce_sdma.cu.cpp (GIN-SDMA allreduce kernel)"
-    VERBATIM
-  )
-endif()
-# ===========================================================================
-# dda_all_reduce_fabric.cu.cpp: fabric/VMM counterpart of the IPC file above.
-# ===========================================================================
-set(DDA_ALL_REDUCE_FABRIC_FAT_OBJ "${DEVICE_BUILD_DIR}/dda_all_reduce_fabric.o")
-
-add_custom_command(
-  OUTPUT  ${DDA_ALL_REDUCE_FABRIC_FAT_OBJ}
-  COMMAND ${DL_CLANG}
-    -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-    ${DL_HIP_COMPILER_FLAGS}
-    -DRCCL_DEVICE_LINKER
-    ${_link_def_flags}
-    ${_host_inc_flags}
-    ${DL_OPT_FLAGS}
-    ${DL_INHERITED_FLAGS}
-    -std=c++17
-    -fPIC
-    -w
-    -c -o ${DDA_ALL_REDUCE_FABRIC_FAT_OBJ}
-    ${HIPIFY_DIR}/src/algorithms/dda/all_reduce/dda_all_reduce_fabric.cu.cpp
-  DEPENDS ${HIPIFY_DIR}/src/algorithms/dda/all_reduce/dda_all_reduce_fabric.cu.cpp
-  COMMENT "DL compile: dda_all_reduce_fabric.cu.cpp (has device kernels)"
-  VERBATIM
-)
-
-set(DDA_ALL_REDUCE_FABRIC_LL_FAT_OBJ "${DEVICE_BUILD_DIR}/dda_all_reduce_fabric_ll.o")
-set(DDA_ALL_REDUCE_FABRIC_LL128_FAT_OBJ "${DEVICE_BUILD_DIR}/dda_all_reduce_fabric_ll128.o")
-
-add_custom_command(
-  OUTPUT  ${DDA_ALL_REDUCE_FABRIC_LL_FAT_OBJ}
-  COMMAND ${DL_CLANG}
-    -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-    ${DL_HIP_COMPILER_FLAGS}
-    -DRCCL_DEVICE_LINKER
-    ${_link_def_flags}
-    ${_host_inc_flags}
-    ${DL_OPT_FLAGS}
-    -std=c++17
-    -fPIC
-    ${DL_INHERITED_FLAGS}
-    -w
-    -c -o ${DDA_ALL_REDUCE_FABRIC_LL_FAT_OBJ}
-    ${HIPIFY_DIR}/src/algorithms/dda/all_reduce/dda_all_reduce_fabric_ll.cu.cpp
-  DEPENDS ${HIPIFY_DIR}/src/algorithms/dda/all_reduce/dda_all_reduce_fabric_ll.cu.cpp
-  COMMENT "DL compile: dda_all_reduce_fabric_ll.cu.cpp (has device kernels)"
-  VERBATIM
-)
-
-add_custom_command(
-  OUTPUT  ${DDA_ALL_REDUCE_FABRIC_LL128_FAT_OBJ}
-  COMMAND ${DL_CLANG}
-    -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-    ${DL_HIP_COMPILER_FLAGS}
-    -DRCCL_DEVICE_LINKER
-    ${_link_def_flags}
-    ${_host_inc_flags}
-    ${DL_OPT_FLAGS}
-    -std=c++17
-    -fPIC
-    ${DL_INHERITED_FLAGS}
-    -w
-    -c -o ${DDA_ALL_REDUCE_FABRIC_LL128_FAT_OBJ}
-    ${HIPIFY_DIR}/src/algorithms/dda/all_reduce/dda_all_reduce_fabric_ll128.cu.cpp
-  DEPENDS ${HIPIFY_DIR}/src/algorithms/dda/all_reduce/dda_all_reduce_fabric_ll128.cu.cpp
-  COMMENT "DL compile: dda_all_reduce_fabric_ll128.cu.cpp (has device kernels)"
-  VERBATIM
-)
-
-set(DDA_REDUCE_SCATTER_FABRIC_FAT_OBJ "${DEVICE_BUILD_DIR}/dda_reduce_scatter_fabric.o")
-set(DDA_ALL_GATHER_FABRIC_FAT_OBJ "${DEVICE_BUILD_DIR}/dda_all_gather_fabric.o")
-set(DDA_ALL_GATHER_FABRIC_LL_FAT_OBJ "${DEVICE_BUILD_DIR}/dda_all_gather_fabric_ll.o")
-set(DDA_ALL_GATHER_FABRIC_LL128_FAT_OBJ "${DEVICE_BUILD_DIR}/dda_all_gather_fabric_ll128.o")
-set(DDA_ALLTOALL_FABRIC_FAT_OBJ "${DEVICE_BUILD_DIR}/dda_alltoall_fabric.o")
-set(DDA_ALLTOALL_FABRIC_LL_FAT_OBJ "${DEVICE_BUILD_DIR}/dda_alltoall_fabric_ll.o")
-set(DDA_ALLTOALL_FABRIC_LL128_FAT_OBJ "${DEVICE_BUILD_DIR}/dda_alltoall_fabric_ll128.o")
-set(DDA_REDUCE_SCATTER_FABRIC_LL_FAT_OBJ "${DEVICE_BUILD_DIR}/dda_reduce_scatter_fabric_ll.o")
-set(DDA_REDUCE_SCATTER_FABRIC_LL128_FAT_OBJ "${DEVICE_BUILD_DIR}/dda_reduce_scatter_fabric_ll128.o")
-
-add_custom_command(
-  OUTPUT  ${DDA_REDUCE_SCATTER_FABRIC_FAT_OBJ}
-  COMMAND ${DL_CLANG}
-    -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-    ${DL_HIP_COMPILER_FLAGS}
-    -DRCCL_DEVICE_LINKER
-    ${_link_def_flags}
-    ${_host_inc_flags}
-    ${DL_OPT_FLAGS}
-    ${DL_INHERITED_FLAGS}
-    -std=c++17
-    -fPIC
-    -w
-    -c -o ${DDA_REDUCE_SCATTER_FABRIC_FAT_OBJ}
-    ${HIPIFY_DIR}/src/algorithms/dda/reduce_scatter/dda_reduce_scatter_fabric.cu.cpp
-  DEPENDS ${HIPIFY_DIR}/src/algorithms/dda/reduce_scatter/dda_reduce_scatter_fabric.cu.cpp
-  COMMENT "DL compile: dda_reduce_scatter_fabric.cu.cpp (has device kernels)"
-  VERBATIM
-)
-
-add_custom_command(
-  OUTPUT  ${DDA_ALL_GATHER_FABRIC_FAT_OBJ}
-  COMMAND ${DL_CLANG}
-    -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-    ${DL_HIP_COMPILER_FLAGS}
-    -DRCCL_DEVICE_LINKER
-    ${_link_def_flags}
-    ${_host_inc_flags}
-    ${DL_OPT_FLAGS}
-    ${DL_INHERITED_FLAGS}
-    -std=c++17
-    -fPIC
-    -w
-    -c -o ${DDA_ALL_GATHER_FABRIC_FAT_OBJ}
-    ${HIPIFY_DIR}/src/algorithms/dda/all_gather/dda_all_gather_fabric.cu.cpp
-  DEPENDS ${HIPIFY_DIR}/src/algorithms/dda/all_gather/dda_all_gather_fabric.cu.cpp
-  COMMENT "DL compile: dda_all_gather_fabric.cu.cpp (has device kernels)"
-  VERBATIM
-)
-
-add_custom_command(
-  OUTPUT  ${DDA_ALL_GATHER_FABRIC_LL_FAT_OBJ}
-  COMMAND ${DL_CLANG}
-    -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-    ${DL_HIP_COMPILER_FLAGS}
-    -DRCCL_DEVICE_LINKER
-    ${_link_def_flags}
-    ${_host_inc_flags}
-    ${DL_OPT_FLAGS}
-    -std=c++17
-    -fPIC
-    ${DL_INHERITED_FLAGS}
-    -w
-    -c -o ${DDA_ALL_GATHER_FABRIC_LL_FAT_OBJ}
-    ${HIPIFY_DIR}/src/algorithms/dda/all_gather/dda_all_gather_fabric_ll.cu.cpp
-  DEPENDS ${HIPIFY_DIR}/src/algorithms/dda/all_gather/dda_all_gather_fabric_ll.cu.cpp
-  COMMENT "DL compile: dda_all_gather_fabric_ll.cu.cpp (has device kernels)"
-  VERBATIM
-)
-
-add_custom_command(
-  OUTPUT  ${DDA_ALL_GATHER_FABRIC_LL128_FAT_OBJ}
-  COMMAND ${DL_CLANG}
-    -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-    ${DL_HIP_COMPILER_FLAGS}
-    -DRCCL_DEVICE_LINKER
-    ${_link_def_flags}
-    ${_host_inc_flags}
-    ${DL_OPT_FLAGS}
-    -std=c++17
-    -fPIC
-    ${DL_INHERITED_FLAGS}
-    -w
-    -c -o ${DDA_ALL_GATHER_FABRIC_LL128_FAT_OBJ}
-    ${HIPIFY_DIR}/src/algorithms/dda/all_gather/dda_all_gather_fabric_ll128.cu.cpp
-  DEPENDS ${HIPIFY_DIR}/src/algorithms/dda/all_gather/dda_all_gather_fabric_ll128.cu.cpp
-  COMMENT "DL compile: dda_all_gather_fabric_ll128.cu.cpp (has device kernels)"
-  VERBATIM
-)
-
-add_custom_command(
-  OUTPUT  ${DDA_ALLTOALL_FABRIC_FAT_OBJ}
-  COMMAND ${DL_CLANG}
-    -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-    ${DL_HIP_COMPILER_FLAGS}
-    -DRCCL_DEVICE_LINKER
-    ${_link_def_flags}
-    ${_host_inc_flags}
-    ${DL_OPT_FLAGS}
-    ${DL_INHERITED_FLAGS}
-    -std=c++17
-    -fPIC
-    -w
-    -c -o ${DDA_ALLTOALL_FABRIC_FAT_OBJ}
-    ${HIPIFY_DIR}/src/algorithms/dda/alltoall/dda_alltoall_fabric.cu.cpp
-  DEPENDS ${HIPIFY_DIR}/src/algorithms/dda/alltoall/dda_alltoall_fabric.cu.cpp
-  COMMENT "DL compile: dda_alltoall_fabric.cu.cpp (has device kernels)"
-  VERBATIM
-)
-
-add_custom_command(
-  OUTPUT  ${DDA_ALLTOALL_FABRIC_LL_FAT_OBJ}
-  COMMAND ${DL_CLANG}
-    -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-    ${DL_HIP_COMPILER_FLAGS}
-    -DRCCL_DEVICE_LINKER
-    ${_link_def_flags}
-    ${_host_inc_flags}
-    ${DL_OPT_FLAGS}
-    -std=c++17
-    -fPIC
-    ${DL_INHERITED_FLAGS}
-    -w
-    -c -o ${DDA_ALLTOALL_FABRIC_LL_FAT_OBJ}
-    ${HIPIFY_DIR}/src/algorithms/dda/alltoall/dda_alltoall_fabric_ll.cu.cpp
-  DEPENDS ${HIPIFY_DIR}/src/algorithms/dda/alltoall/dda_alltoall_fabric_ll.cu.cpp
-  COMMENT "DL compile: dda_alltoall_fabric_ll.cu.cpp (has device kernels)"
-  VERBATIM
-)
-
-add_custom_command(
-  OUTPUT  ${DDA_ALLTOALL_FABRIC_LL128_FAT_OBJ}
-  COMMAND ${DL_CLANG}
-    -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-    ${DL_HIP_COMPILER_FLAGS}
-    -DRCCL_DEVICE_LINKER
-    ${_link_def_flags}
-    ${_host_inc_flags}
-    ${DL_OPT_FLAGS}
-    -std=c++17
-    -fPIC
-    ${DL_INHERITED_FLAGS}
-    -w
-    -c -o ${DDA_ALLTOALL_FABRIC_LL128_FAT_OBJ}
-    ${HIPIFY_DIR}/src/algorithms/dda/alltoall/dda_alltoall_fabric_ll128.cu.cpp
-  DEPENDS ${HIPIFY_DIR}/src/algorithms/dda/alltoall/dda_alltoall_fabric_ll128.cu.cpp
-  COMMENT "DL compile: dda_alltoall_fabric_ll128.cu.cpp (has device kernels)"
-  VERBATIM
-)
-
-add_custom_command(
-  OUTPUT  ${DDA_REDUCE_SCATTER_FABRIC_LL_FAT_OBJ}
-  COMMAND ${DL_CLANG}
-    -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-    ${DL_HIP_COMPILER_FLAGS}
-    -DRCCL_DEVICE_LINKER
-    ${_link_def_flags}
-    ${_host_inc_flags}
-    ${DL_OPT_FLAGS}
-    -std=c++17
-    -fPIC
-    ${DL_INHERITED_FLAGS}
-    -w
-    -c -o ${DDA_REDUCE_SCATTER_FABRIC_LL_FAT_OBJ}
-    ${HIPIFY_DIR}/src/algorithms/dda/reduce_scatter/dda_reduce_scatter_fabric_ll.cu.cpp
-  DEPENDS ${HIPIFY_DIR}/src/algorithms/dda/reduce_scatter/dda_reduce_scatter_fabric_ll.cu.cpp
-  COMMENT "DL compile: dda_reduce_scatter_fabric_ll.cu.cpp (has device kernels)"
-  VERBATIM
-)
-
-add_custom_command(
-  OUTPUT  ${DDA_REDUCE_SCATTER_FABRIC_LL128_FAT_OBJ}
-  COMMAND ${DL_CLANG}
-    -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-    ${DL_HIP_COMPILER_FLAGS}
-    -DRCCL_DEVICE_LINKER
-    ${_link_def_flags}
-    ${_host_inc_flags}
-    ${DL_OPT_FLAGS}
-    -std=c++17
-    -fPIC
-    ${DL_INHERITED_FLAGS}
-    -w
-    -c -o ${DDA_REDUCE_SCATTER_FABRIC_LL128_FAT_OBJ}
-    ${HIPIFY_DIR}/src/algorithms/dda/reduce_scatter/dda_reduce_scatter_fabric_ll128.cu.cpp
-  DEPENDS ${HIPIFY_DIR}/src/algorithms/dda/reduce_scatter/dda_reduce_scatter_fabric_ll128.cu.cpp
-  COMMENT "DL compile: dda_reduce_scatter_fabric_ll128.cu.cpp (has device kernels)"
-  VERBATIM
-)
-
-# ===========================================================================
-# CE-reduce kernels: per-instantiation device TUs from gensrc/ce_reduce/.
-# Each instantiation file defines one ncclCeLocalReduceKernelVec<T,RedOp,U>
-# (__global__) and its host-callable launcher. Compiled with full HIP here so
-# each fat binary is self-contained (ce_coll.cc, the main target, has no
-# __global__ call sites and stays --offload-host-only).
-#
-# CE_REDUCE_FAT_OBJS is plural (mirroring SYM_FAT_OBJS below) because
-# src/device/ce_reduce/generate.py emits one TU per (type, redop)
-# instantiation instead of one aggregate ce_reduce.cc -- see that script for
-# why: two of the 40 instantiations (int8_t/uint8_t Min/Max) individually
-# generate ~56K instructions each and used to dominate the whole build's
-# wall-clock time by serializing all 40 kernels' codegen into one TU.
-# ===========================================================================
-set(CE_REDUCE_FAT_OBJS "")
-file(GLOB _ce_reduce_srcs CONFIGURE_DEPENDS "${HIPIFY_DIR}/gensrc/ce_reduce/*.cpp")
-foreach(_ce_reduce_src IN LISTS _ce_reduce_srcs)
-  get_filename_component(_ce_reduce_name "${_ce_reduce_src}" NAME_WE)
-  set(_ce_reduce_obj "${DEVICE_BUILD_DIR}/${_ce_reduce_name}.o")
-  add_custom_command(
-    OUTPUT  ${_ce_reduce_obj}
-    COMMAND ${DL_CLANG}
-      -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-      ${DL_HIP_COMPILER_FLAGS}
-      -DRCCL_DEVICE_LINKER
-      ${_link_def_flags}
-      ${_host_inc_flags}
-      ${DL_OPT_FLAGS}
-      -std=c++17
-      -fPIC
-      ${DL_INHERITED_FLAGS}
-      -w
-      -c -o ${_ce_reduce_obj}
-      ${_ce_reduce_src}
-    DEPENDS ${_ce_reduce_src}
-    COMMENT "DL compile: ${_ce_reduce_name} (CE AllReduce reduce kernel)"
-    VERBATIM
-  )
-  list(APPEND CE_REDUCE_FAT_OBJS ${_ce_reduce_obj})
-endforeach()
-
-# ===========================================================================
-# Symmetric kernels: per-instantiation device TUs from gensrc/symmetric/.
-# Each instantiation file defines a handful of __global__ ncclSymkDevKernel_*
-# entries. Compiled standalone as multi-arch fat objects, mirroring onerank.o.
-#
-# SYM_FAT_OBJS is plural (vs the singular COMMON/ONERANK/COLLECTIVES_FAT_OBJ
-# siblings) because the symmetric generator emits one TU per instantiation.
-# ===========================================================================
-set(SYM_FAT_OBJS "")
-if(GENERATE_SYM_KERNELS)
-  # When ENABLE_ROCSHMEM_GIN is set, GIN device templates reference rocshmem
-  # device symbols (QueuePair::put_nbi, atomic_add, etc.). The installed per-arch
-  # .bc files are arch-optimized (opt -mcpu=) and can't be used with
-  # -mlink-builtin-bitcode across archs. Instead, llvm-link the pre-opt
-  # individual source .bc files (arch-agnostic) into a minimal QP-only bitcode.
-  set(_sym_rocshmem_bc_flag "")
-  set(_sym_rocshmem_deps "")
-  if(ENABLE_ROCSHMEM_GIN AND ROCSHMEM_SOURCE_DIR)
-    # Pick the first arch's pre-opt bitcode dir (all archs produce identical
-    # unoptimized IR since -Xclang -disable-llvm-passes is used).
-    list(GET DL_GPU_TARGETS 0 _bc_arch)
-    set(_bc_dir "${ROCSHMEM_SOURCE_DIR}/build/bitcode/${_bc_arch}")
-    set(_qp_bc "${DEVICE_BUILD_DIR}/rocshmem_qp_device.bc")
-    find_program(_llvm_link llvm-link HINTS ${ROCM_PATH}/llvm/bin REQUIRED)
-    find_program(_llvm_dis  llvm-dis  HINTS ${ROCM_PATH}/llvm/bin REQUIRED)
-    find_program(_llvm_as   llvm-as   HINTS ${ROCM_PATH}/llvm/bin REQUIRED)
-
-    # Pipeline:
-    #  1. Compile gin_rocshmem_constmem.hip → device-only .bc (provides
-    #     rocshmem::constmem and rocshmem::logd_constants definitions that
-    #     queue_pair.bc references as external)
-    #  2. llvm-link QP .bc files + constmem .bc into one module
-    #  3. Strip @llvm.compiler.used and @__hip_cuid_ via text round-trip
-    #     (these AMDGCN addrspace(1) appending globals clash with the
-    #     host-side addrspace(0) equivalents in fat-object compilation)
-    set(_cm_src "${CMAKE_SOURCE_DIR}/src/gin/gin_rocshmem_constmem.hip")
-    set(_cm_bc  "${DEVICE_BUILD_DIR}/gin_rocshmem_constmem.bc")
-    set(_qp_raw "${DEVICE_BUILD_DIR}/rocshmem_qp_raw.bc")
-
-    add_custom_command(
-      OUTPUT ${_cm_bc}
-      COMMAND ${DL_CLANG}
-        -x hip --cuda-device-only --offload-arch=${_bc_arch}
-        -emit-llvm -Xclang -disable-llvm-passes
-        -std=c++17 -fPIC
-        -I${ROCSHMEM_SOURCE_DIR}/src
-        -I${ROCSHMEM_SOURCE_DIR}/include
-        -c -o ${_cm_bc} ${_cm_src}
-      DEPENDS ${_cm_src}
-      COMMENT "DL: compiling rocshmem constmem stubs to device bitcode"
-      VERBATIM)
-
-    add_custom_command(
-      OUTPUT ${_qp_bc}
-      COMMAND ${_llvm_link}
-        ${_bc_dir}/queue_pair.bc
-        ${_bc_dir}/queue_pair_mlx5.bc
-        ${_bc_dir}/queue_pair_bnxt.bc
-        ${_bc_dir}/queue_pair_ionic.bc
-        ${_cm_bc}
-        -o ${_qp_raw}
-      COMMAND ${_llvm_dis} -o ${_qp_raw}.ll ${_qp_raw}
-      COMMAND grep -v -E "@llvm[.]compiler[.]used|@__hip_cuid_"
-        ${_qp_raw}.ll > ${_qp_raw}.clean.ll
-      COMMAND ${_llvm_as} ${_qp_raw}.clean.ll -o ${_qp_bc}
-      DEPENDS ${_cm_bc}
-      COMMENT "DL: linking rocshmem QP device bitcode (with constmem, stripped)"
-      VERBATIM)
-    add_custom_target(dl_rocshmem_qp_bc DEPENDS ${_qp_bc})
-    if(TARGET rocshmem_static)
-      add_dependencies(dl_rocshmem_qp_bc rocshmem_static)
-    endif()
-    set(_sym_rocshmem_bc_flag -Xclang -mlink-builtin-bitcode -Xclang ${_qp_bc})
-    set(_sym_rocshmem_deps dl_rocshmem_qp_bc)
+  set(_mtu_w_flag "")
+  if(DL_MTU_SUPPRESS_WARNINGS_${_mtu_name})
+    set(_mtu_w_flag -w)
   endif()
-  file(GLOB _sym_srcs CONFIGURE_DEPENDS "${HIPIFY_DIR}/gensrc/symmetric/*.cpp")
-  foreach(_sym_src IN LISTS _sym_srcs)
-    get_filename_component(_sym_name "${_sym_src}" NAME_WE)
-    set(_sym_obj "${DEVICE_BUILD_DIR}/sym_${_sym_name}.o")
-    # Only GIN symmetric kernels need the QP bitcode; non-GIN ones would
-    # just ingest and DCE it, wasting compile time.
-    set(_this_bc_flag "")
-    set(_this_bc_deps "")
-    if(_sym_name MATCHES "_gin_")
-      set(_this_bc_flag "${_sym_rocshmem_bc_flag}")
-      set(_this_bc_deps "${_sym_rocshmem_deps}")
-    endif()
-    add_custom_command(
-      OUTPUT  ${_sym_obj}
-      COMMAND ${DL_CLANG}
-        -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-        ${DL_HIP_COMPILER_FLAGS}
-        -DRCCL_DEVICE_LINKER
-        ${_link_def_flags}
-        ${_host_inc_flags}
-        ${DL_OPT_FLAGS}
-        ${DL_INHERITED_FLAGS}
-        -std=c++17
-        -fPIC
-        ${_this_bc_flag}
-        -c -o ${_sym_obj}
-        ${_sym_src}
-      DEPENDS ${_sym_src} ${_this_bc_deps}
-      COMMENT "DL compile: sym ${_sym_name} (multi-arch fat object)"
-      VERBATIM
-    )
-    list(APPEND SYM_FAT_OBJS ${_sym_obj})
-  endforeach()
-endif()
+  set(_mtu_inherit_flags "")
+  if(DL_MTU_INHERIT_FLAGS_${_mtu_name})
+    set(_mtu_inherit_flags ${DL_INHERITED_FLAGS})
+  endif()
+
+  set(_mtu_mdmf_flags "")
+  set(_mtu_depfile_kw "")
+  if(DL_MTU_DEPFILE_TRACKING_${_mtu_name} AND CMAKE_VERSION VERSION_GREATER_EQUAL "3.20")
+    set(_mtu_depfile "${DEVICE_BUILD_DIR}/${_mtu_name}.d")
+    set(_mtu_mdmf_flags -MD -MF ${_mtu_depfile})
+    set(_mtu_depfile_kw DEPFILE ${_mtu_depfile})
+  endif()
+
+  add_custom_command(
+    OUTPUT  ${_mtu_raw_obj}
+    COMMAND ${DL_CLANG}
+      -x hip --offload-host-only ${DL_OFFLOAD_ARCH_FLAGS}
+      -cuid=${DL_SHARED_CUID}
+      ${DL_HIP_COMPILER_FLAGS}
+      -DRCCL_DEVICE_LINKER
+      ${DL_MTU_EXTRA_DEFS_${_mtu_name}}
+      ${_link_def_flags}
+      ${_host_inc_flags}
+      ${DL_OPT_FLAGS}
+      ${_mtu_inherit_flags}
+      -std=c++17
+      -fPIC
+      ${_mtu_w_flag}
+      ${_mtu_mdmf_flags}
+      -c -o ${_mtu_raw_obj}
+      ${DL_MTU_SRC_${_mtu_name}}
+    DEPENDS ${DL_MTU_SRC_${_mtu_name}}
+    ${_mtu_depfile_kw}
+    COMMENT "DL compile (host, shared cuid): ${_mtu_name}"
+    VERBATIM
+    COMMAND_EXPAND_LISTS
+  )
+
+  add_custom_command(
+    OUTPUT  ${_mtu_final_obj}
+    COMMAND ${DL_OBJCOPY} --localize-symbol=${DL_CUID_SYMBOL} ${_mtu_raw_obj} ${_mtu_final_obj}
+    DEPENDS ${_mtu_raw_obj}
+    COMMENT "DL localize CUID marker: ${_mtu_name}"
+    VERBATIM
+  )
+
+  list(APPEND DEVICE_LINKER_OBJECTS "${_mtu_final_obj}")
+endforeach()
 
 # ===========================================================================
 # Top-level target
 # ===========================================================================
 add_custom_target(device_linker_build ALL
-	DEPENDS ${COMMON_FAT_OBJ} ${ONERANK_FAT_OBJ} ${COLLECTIVES_FAT_OBJ} ${DDA_ALL_REDUCE_IPC_FAT_OBJ} ${DDA_REDUCE_SCATTER_IPC_FAT_OBJ} ${DDA_ALL_GATHER_IPC_FAT_OBJ} ${DDA_ALLTOALL_IPC_FAT_OBJ} ${DDA_ALL_REDUCE_FABRIC_FAT_OBJ} ${DDA_ALL_REDUCE_FABRIC_LL_FAT_OBJ} ${DDA_ALL_REDUCE_FABRIC_LL128_FAT_OBJ} ${DDA_REDUCE_SCATTER_FABRIC_FAT_OBJ} ${DDA_ALL_GATHER_FABRIC_FAT_OBJ} ${DDA_ALL_GATHER_FABRIC_LL_FAT_OBJ} ${DDA_ALL_GATHER_FABRIC_LL128_FAT_OBJ} ${DDA_ALLTOALL_FABRIC_FAT_OBJ} ${DDA_ALLTOALL_FABRIC_LL_FAT_OBJ} ${DDA_ALLTOALL_FABRIC_LL128_FAT_OBJ} ${DDA_REDUCE_SCATTER_FABRIC_LL_FAT_OBJ} ${DDA_REDUCE_SCATTER_FABRIC_LL128_FAT_OBJ} ${CE_REDUCE_FAT_OBJS} ${SYM_FAT_OBJS} ${GIN_ALLTOALL_SDMA_FAT_OBJ} ${GIN_ALLREDUCE_SDMA_FAT_OBJ}
+  DEPENDS ${DEVICE_LINKER_OBJECTS}
 )
 add_dependencies(device_linker_build hipify_all copy_nccl_device_headers)
 if((ENABLE_ROCSHMEM OR ENABLE_ROCSHMEM_GIN) AND TARGET rocshmem_static)
@@ -1154,32 +898,6 @@ if((ENABLE_ROCSHMEM OR ENABLE_ROCSHMEM_GIN) AND TARGET rocshmem_static)
   # headers installed to ext/rocshmem/include by the ExternalProject.
   add_dependencies(device_linker_build rocshmem_static)
 endif()
-
-set(DEVICE_LINKER_OBJECTS
-  ${COMMON_FAT_OBJ}
-  ${ONERANK_FAT_OBJ}
-  ${COLLECTIVES_FAT_OBJ}
-  ${CE_REDUCE_FAT_OBJS}
-  ${DDA_ALL_REDUCE_IPC_FAT_OBJ}
-  ${DDA_REDUCE_SCATTER_IPC_FAT_OBJ}
-  ${DDA_ALL_GATHER_IPC_FAT_OBJ}
-  ${DDA_ALLTOALL_IPC_FAT_OBJ}
-  ${DDA_ALL_REDUCE_FABRIC_FAT_OBJ}
-  ${DDA_ALL_REDUCE_FABRIC_LL_FAT_OBJ}
-  ${DDA_ALL_REDUCE_FABRIC_LL128_FAT_OBJ}
-  ${DDA_REDUCE_SCATTER_FABRIC_FAT_OBJ}
-  ${DDA_ALL_GATHER_FABRIC_FAT_OBJ}
-  ${DDA_ALL_GATHER_FABRIC_LL_FAT_OBJ}
-  ${DDA_ALL_GATHER_FABRIC_LL128_FAT_OBJ}
-  ${DDA_ALLTOALL_FABRIC_FAT_OBJ}
-  ${DDA_ALLTOALL_FABRIC_LL_FAT_OBJ}
-  ${DDA_ALLTOALL_FABRIC_LL128_FAT_OBJ}
-  ${DDA_REDUCE_SCATTER_FABRIC_LL_FAT_OBJ}
-  ${DDA_REDUCE_SCATTER_FABRIC_LL128_FAT_OBJ}
-  ${SYM_FAT_OBJS}
-  ${GIN_ALLTOALL_SDMA_FAT_OBJ}
-  ${GIN_ALLREDUCE_SDMA_FAT_OBJ}
-)
 
 # ===========================================================================
 # Optional: emit LLVM IR (ninja device_ir)

--- a/projects/rccl/cmake/DeviceLinker.cmake
+++ b/projects/rccl/cmake/DeviceLinker.cmake
@@ -477,7 +477,15 @@ if(GENERATE_SYM_KERNELS)
     #  2. llvm-link QP .bc files + constmem .bc into one module
     #  3. Strip @llvm.compiler.used and @__hip_cuid_ via text round-trip
     #     (these AMDGCN addrspace(1) appending globals clash with the
-    #     host-side addrspace(0) equivalents in fat-object compilation)
+    #     host-side addrspace(0) equivalents in fat-object compilation),
+    #     and weaken this module's externally_initialized __constant__
+    #     definitions (rocshmem::constmem, rocshmem::logd_constants) to
+    #     weak_odr. -mlink-builtin-bitcode copies them into every GIN
+    #     symmetric TU; those TUs used to land in separate fat binaries, but
+    #     now share one device.elf, so N strong definitions collide at the
+    #     ld.lld -shared step. Every copy comes from this same module and is
+    #     a zeroinitializer, so folding them to one is what the unified image
+    #     wants: a single symbol for the host to write at init.
     set(_cm_src "${CMAKE_SOURCE_DIR}/src/gin/gin_rocshmem_constmem.hip")
     set(_cm_bc  "${DEVICE_BUILD_DIR}/gin_rocshmem_constmem.bc")
     set(_qp_raw "${DEVICE_BUILD_DIR}/rocshmem_qp_raw.bc")
@@ -505,7 +513,9 @@ if(GENERATE_SYM_KERNELS)
         ${_cm_bc}
         -o ${_qp_raw}
       COMMAND ${_llvm_dis} -o ${_qp_raw}.ll ${_qp_raw}
-      COMMAND grep -v -E "@llvm[.]compiler[.]used|@__hip_cuid_"
+      COMMAND sed -E
+        -e "/@llvm[.]compiler[.]used|@__hip_cuid_/d"
+        -e "s/^(@[^ ]+ = )(protected |hidden )?addrspace\\(4\\) externally_initialized/\\1weak_odr \\2addrspace(4) externally_initialized/"
         ${_qp_raw}.ll > ${_qp_raw}.clean.ll
       COMMAND ${_llvm_as} ${_qp_raw}.clean.ll -o ${_qp_bc}
       DEPENDS ${_cm_bc}

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -35,6 +35,16 @@ if(BUILD_TESTS)
             "${PROJECT_SOURCE_DIR}/src/device/ce_reduce/test_generate_ce_reduce.py"
   )
 
+  # CPU-only unit test: guards the pure-Python assembly-extraction, resource-
+  # aggregation, dispatcher-patching, and flag-parsing logic in
+  # tools/rccl-device-compile (the device-image-unification driver). Needs no
+  # GPU, no built library, and no amdclang++/ld.lld.
+  add_test(
+    NAME rccl-device-compile-unittest
+    COMMAND "${Python3_EXECUTABLE}"
+            "${PROJECT_SOURCE_DIR}/tools/test_rccl_device_compile.py"
+  )
+
   if (ENABLE_CODE_COVERAGE)
     add_compile_options("SHELL:-Xarch_host -fprofile-instr-generate" "SHELL:-Xarch_host -fcoverage-mapping")
     add_link_options("SHELL:-Xarch_host -fprofile-instr-generate" "SHELL:-Xarch_host -fcoverage-mapping")

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -35,6 +35,16 @@ if(BUILD_TESTS)
             "${PROJECT_SOURCE_DIR}/src/device/ce_reduce/test_generate_ce_reduce.py"
   )
 
+  # CPU-only unit test: guards the pure-Python assembly-extraction, resource-
+  # aggregation, dispatcher-patching, and flag-parsing logic in
+  # tools/rccl-device-compile (the device-image-unification driver). Needs no
+  # GPU, no built library, and no amdclang++/ld.lld.
+  add_test(
+    NAME rccl-device-compile-unittest
+    COMMAND "${Python3_EXECUTABLE}"
+            "${PROJECT_SOURCE_DIR}/tools/test_rccl_device_compile.py"
+  )
+
   # The kernel-count leak guards (src/device/test_generate_kernel_counts.py and
   # src/device/symmetric/test_generate_symmetric.py) are intentionally NOT
   # registered as ctest cases here: nothing in RCCL CI runs `ctest`, so an

--- a/projects/rccl/tools/rccl-device-compile
+++ b/projects/rccl/tools/rccl-device-compile
@@ -31,12 +31,19 @@ Host-object mode (--emit-host-obj):
     rccl-device-compile --emit-host-obj --clang=... --fatbin-role=owner|shared
         -cuid=<shared> -DFOO -Ipath -o out.o in.cu.cpp
     Compiles a mixed host+device TU's HOST half (--offload-host-only), then
-    patches the per-TU __hip_gpubin_handle_<hash> fatbin-registration handle
-    so that ALL mixed TUs built with the same -cuid share ONE handle
-    instance at link time instead of one copy per TU (which otherwise makes
-    the HIP runtime load one separate module of the identical multi-hundred-
-    MB device.elf per TU -- see patch_fatbin_handle_sharing() for the full
-    story). Exactly one mixed TU must be compiled with --fatbin-role=owner;
+    patches two per-TU HIP-registration objects so that ALL mixed TUs built
+    with the same -cuid share ONE instance of each at link time instead of
+    one copy per TU:
+      - __hip_gpubin_handle_<hash>, the fatbin-registration handle (see
+        patch_fatbin_handle_sharing()) -- otherwise the HIP runtime loads
+        one separate module of the identical multi-hundred-MB device.elf
+        per TU.
+      - __hip_fatbin_wrapper, the __CudaFatBinaryWrapper struct itself (see
+        patch_fatbin_wrapper_sharing()) -- otherwise TheRock CI's kpack
+        packaging pipeline mis-indexes device code per wrapper position,
+        which is the actual cause of the CI-only "device kernel image is
+        invalid" failures (e.g. AllReduce.OneRankAvgTailElements).
+    Exactly one mixed TU must be compiled with --fatbin-role=owner;
     every other one uses --fatbin-role=shared.
 
 Link mode (--link):
@@ -612,6 +619,119 @@ def do_emit_device_obj(args, forwarded_flags):
 # ---------------------------------------------------------------------------
 
 _GPUBIN_HANDLE_RE = re.compile(r'__hip_gpubin_handle_[0-9a-f]+')
+_FATBIN_WRAPPER_TYPE_RE = re.compile(r'\s*\.type\s+__hip_fatbin_wrapper,\s*@object\b')
+_FATBIN_WRAPPER_SIZE_RE = re.compile(r'\s*\.size\s+__hip_fatbin_wrapper,\s*24\b')
+_FATBIN_WRAPPER_SECTION_RE = re.compile(r'\s*\.section\s+\.hipFatBinSegment\b')
+
+
+def patch_fatbin_wrapper_sharing(asm_lines, role, source):
+    """Rewrite the per-TU __hip_fatbin_wrapper object (the 24-byte
+    __CudaFatBinaryWrapper struct clang emits into .hipFatBinSegment for
+    every HIP TU) so that all mixed TUs sharing the same -cuid end up with
+    exactly ONE wrapper instance at link time, instead of one copy per TU.
+
+    Background: patch_fatbin_handle_sharing() (below) already collapses the
+    *handle* (the pointer __hipRegisterFatBinary() returns) down to one
+    shared instance, and the "Shared CUID" mechanism in DeviceLinker.cmake
+    already collapses the actual fatbin *bytes* (__hip_fatbin_<hash>) down
+    to one glue-provided definition. But clang still independently emits,
+    in EVERY mixed TU's own host object, its own byte-for-byte-identical
+    __hip_fatbin_wrapper struct (magic/version/pointer-to-the-shared-
+    fatbin/reserved) as a `.local` object in .hipFatBinSegment -- this
+    struct has no per-TU content at all once the fatbin is shared, but its
+    *presence* is what TheRock's CI packaging pipeline (kpack, see
+    rocm-systems/shared/kpack) counts to decide how many device-code
+    "bundles" a binary has.
+
+    kpack's extractor scans .hip_fatbin for concatenated
+    __CLANG_OFFLOAD_BUNDLE__ blocks and (correctly, post-unification) finds
+    exactly ONE, so it writes exactly one code-object entry ("...#0") into
+    the .kpack archive. But kpack's ELF-rewriter walks .hipFatBinSegment
+    and, unaware that multiple wrapper structs can point at the same
+    bundle, assigns each of the N wrapper structs it finds a distinct
+    sequential co_index (0..N-1) purely by position. Since N (wrapper
+    count, still one per TU) no longer matches 1 (actual bundle count post-
+    unification), N-1 of those co_index values have no corresponding kpack
+    archive entry. At runtime kpack_load_code_object() does a strict
+    "name#co_index" lookup with no fallback, so any kernel registered
+    through one of the mismatched TUs fails to load its device code and
+    hipLaunchKernel returns hipErrorInvalidImage -- this is the actual
+    cause of the CI-only, unreproducible-locally "device kernel image is
+    invalid" failure (e.g. AllReduce.OneRankAvgTailElements), since a
+    plain (non-kpack) local build never exercises this path at all.
+
+    Fix: make the wrapper struct itself shared instead of per-TU, so there
+    is truly only one wrapper in .hipFatBinSegment for kpack to see --
+    eliminating the N-vs-1 mismatch at the source instead of teaching
+    either side of kpack about it.
+      - role == 'owner': keep this TU's __hip_fatbin_wrapper definition
+        (the .hipFatBinSegment data block) but promote it from implicitly
+        `.local` to `.globl .hidden` so other TUs can bind to it. As with
+        the handle, '.hidden' is required alongside '.globl': librccl.so
+        is a shared object, and __hip_module_ctor's existing
+        `leaq __hip_fatbin_wrapper(%rip), %rdi` was emitted as a direct
+        RIP-relative access (clang believed, at compile time, that this
+        was an internal-linkage local object), which ld.lld only permits
+        against a non-preemptible (hidden) symbol.
+      - role == 'shared': delete this TU's own __hip_fatbin_wrapper data
+        block entirely (there is nothing per-TU left in it once the fatbin
+        bytes and handle are shared), leaving only the existing
+        `leaq __hip_fatbin_wrapper(%rip), %rdi` reference in
+        __hip_module_ctor -- which becomes an ordinary undefined external
+        reference that the final librccl.so link resolves against the
+        owner's single definition, and a `.hidden` declaration is added so
+        that reference is legal for the same preemptibility reason as
+        above.
+
+    Validated end-to-end on real gfx942 hardware with a standalone 2-TU
+    repro (reversed link order too) before wiring this in.
+    """
+    start_idx = None
+    end_idx = None
+    for i, line in enumerate(asm_lines):
+        if start_idx is None and _FATBIN_WRAPPER_TYPE_RE.match(line):
+            start_idx = i
+            continue
+        if start_idx is not None and _FATBIN_WRAPPER_SIZE_RE.match(line):
+            end_idx = i
+            break
+
+    if start_idx is None:
+        # Some registered mixed TUs (e.g. a generated dispatcher .cpp that
+        # only #includes headers, with the real __global__ kernels living
+        # in sibling per-instantiation TUs) compile to host assembly with
+        # no HIP device-registration boilerplate at all. Nothing to patch.
+        return asm_lines
+    if end_idx is None:
+        raise RuntimeError(
+            f"{source}: found __hip_fatbin_wrapper .type but no matching "
+            f".size __hip_fatbin_wrapper, 24 -- unexpected assembly shape")
+
+    if role == 'owner':
+        out = list(asm_lines)
+        # Insert .globl/.hidden right after the .section switch (mirrors
+        # clang's own placement of .globl for other objects in this file),
+        # so the label below is defined as a global, hidden symbol.
+        for j in range(start_idx, end_idx + 1):
+            if _FATBIN_WRAPPER_SECTION_RE.match(out[j]):
+                out[j:j + 1] = [
+                    out[j],
+                    '\t.globl\t__hip_fatbin_wrapper\n',
+                    '\t.hidden\t__hip_fatbin_wrapper\n',
+                ]
+                break
+        else:
+            raise RuntimeError(
+                f"{source}: __hip_fatbin_wrapper block has no "
+                f".section .hipFatBinSegment switch -- unexpected assembly shape")
+        return out
+    elif role == 'shared':
+        out = list(asm_lines[:start_idx])
+        out.append('\t.hidden\t__hip_fatbin_wrapper\n')
+        out.extend(asm_lines[end_idx + 1:])
+        return out
+    else:
+        raise RuntimeError(f"unknown --fatbin-role={role!r}, expected 'owner' or 'shared'")
 
 
 def patch_fatbin_handle_sharing(asm_lines, role, source):
@@ -709,10 +829,11 @@ def patch_fatbin_handle_sharing(asm_lines, role, source):
 
 def do_emit_host_obj(args, forwarded_flags):
     """Compile a mixed host+device TU's HOST half (--offload-host-only),
-    then patch its fatbin registration handle per --fatbin-role so that all
-    mixed TUs sharing a -cuid end up with ONE shared handle at link time
-    instead of one per TU. See patch_fatbin_handle_sharing() docstring for
-    the full rationale.
+    then patch its fatbin registration handle AND its fatbin wrapper struct
+    per --fatbin-role so that all mixed TUs sharing a -cuid end up with ONE
+    shared handle and ONE shared wrapper at link time instead of one of
+    each per TU. See patch_fatbin_handle_sharing() and
+    patch_fatbin_wrapper_sharing() docstrings for the full rationale.
     """
     clang, _ = discover_tools(args.clang)
     source = args.source
@@ -748,6 +869,7 @@ def do_emit_host_obj(args, forwarded_flags):
             asm_lines = f.readlines()
 
         patched_lines = patch_fatbin_handle_sharing(asm_lines, role, source)
+        patched_lines = patch_fatbin_wrapper_sharing(patched_lines, role, source)
 
         with open(patched_file, 'w') as f:
             f.writelines(patched_lines)

--- a/projects/rccl/tools/rccl-device-compile
+++ b/projects/rccl/tools/rccl-device-compile
@@ -11,6 +11,22 @@ Compile mode (--compile):
     3. Assembles extracted .s to .o via amdclang++
     Side effect: writes out.resources.json alongside out.o
 
+Device-object mode (--emit-device-obj):
+    rccl-device-compile --emit-device-obj --arch=gfx942 -DFOO -Ipath -o out.o in.cu.cpp
+    Compiles the whole TU's device half straight to a real per-arch
+    relocatable ELF object via amdclang++ (--offload-device-only
+    -fhip-emit-relocatable), keeping every __global__ kernel in the file
+    (unlike --compile, no ncclDevFunc extraction, no resources.json, no
+    intermediate assembly text). -fhip-emit-relocatable makes the driver
+    stop after cc1's -emit-obj and skip its usual internal "link to a
+    self-contained device shared object" step, which is what would
+    otherwise make the output un-mergeable with other TUs' device code.
+    For mixed host+device TUs (onerank, collectives, dda_*, sym_*) whose
+    kernels are standalone entries with their own .kd, not participants in
+    the leaf-kernel dispatcher's resource-aggregation patch. The resulting
+    .o is meant to be listed alongside --compile's leaf-kernel outputs in a
+    --link invocation, so its device code lands in the same device.elf.
+
 Link mode (--link):
     rccl-device-compile --link --arch=gfx942 --dispatcher=common.cu.cpp -o device.elf obj1.o obj2.o
     1. Aggregates resource JSON files from all input objects
@@ -535,6 +551,49 @@ def do_compile(args, forwarded_flags):
 
 
 # ---------------------------------------------------------------------------
+# Device-object mode: whole mixed TU's device half -> real per-arch .o
+# ---------------------------------------------------------------------------
+
+
+def do_emit_device_obj(args, forwarded_flags):
+    """Compile a mixed host+device TU's device half to a real per-arch object.
+
+    Unlike do_compile (leaf kernels), this keeps the WHOLE translation unit's
+    device code as-is -- no ncclDevFunc extraction, no .resources.json (these
+    kernels are standalone __global__ entries with their own .kd, not
+    participants in the leaf-kernel dispatcher's resource-aggregation patch).
+
+    A single amdclang++ invocation with -fhip-emit-relocatable is enough: it
+    makes the driver stop right after cc1's own -emit-obj and skip the
+    internal "lld -shared" + offload-bundle steps it would otherwise run to
+    turn the compile into a self-contained device shared object (verified via
+    `-###`: without this flag, --offload-device-only -c chains cc1 -> an
+    internal `lld -shared` -> clang-offload-bundler, and that internal
+    lld -shared step is exactly what makes the output un-mergeable with other
+    TUs' device code -- ld.lld can fold multiple relocatable objects into one
+    device.elf, but not multiple already-linked shared objects). No bitcode,
+    no LTO, no manual assembly text step needed either.
+    """
+    clang, _ = discover_tools(args.clang)
+    arch = args.arch
+    source = args.source
+    output = args.output
+
+    compile_cmd = [
+        clang,
+        '-x', 'hip',
+        '--offload-device-only',
+        f'--offload-arch={arch}',
+        '-fhip-emit-relocatable',
+        '-gline-tables-only',
+        '-w',
+    ] + forwarded_flags + [
+        '-c', '-o', output, source,
+    ]
+    run(compile_cmd, f"compile (device-obj) {os.path.basename(source)}")
+
+
+# ---------------------------------------------------------------------------
 # Link mode: objects -> device.elf
 # ---------------------------------------------------------------------------
 
@@ -683,7 +742,7 @@ def parse_compiler_flags(argv):
     while i < len(argv):
         arg = argv[i]
         # Our flags
-        if arg in ('--compile', '--link', '--keep-temps', '--version'):
+        if arg in ('--compile', '--link', '--emit-device-obj', '--keep-temps', '--version'):
             our_args.append(arg)
         elif arg.startswith('--arch='):
             our_args.append(arg)
@@ -747,6 +806,7 @@ def main():
     parser = argparse.ArgumentParser(prog='rccl-device-compile', add_help=False)
     parser.add_argument('--compile', action='store_true')
     parser.add_argument('--link', action='store_true')
+    parser.add_argument('--emit-device-obj', action='store_true', dest='emit_device_obj')
     parser.add_argument('--arch', required=False)
     parser.add_argument('--clang', default=None)
     parser.add_argument('--dispatcher', default=None)
@@ -771,6 +831,16 @@ def main():
         args.source = positional[0]
         do_compile(args, forwarded_flags)
 
+    elif args.emit_device_obj:
+        if not positional:
+            raise SystemExit("ERROR: --emit-device-obj requires a source file")
+        if not args.arch:
+            raise SystemExit("ERROR: --emit-device-obj requires --arch=<target>")
+        if not args.output:
+            raise SystemExit("ERROR: --emit-device-obj requires -o <output>")
+        args.source = positional[0]
+        do_emit_device_obj(args, forwarded_flags)
+
     elif args.link:
         if not positional:
             raise SystemExit("ERROR: --link requires object files")
@@ -782,7 +852,7 @@ def main():
         do_link(args, forwarded_flags)
 
     else:
-        raise SystemExit("ERROR: specify --compile or --link mode")
+        raise SystemExit("ERROR: specify --compile, --emit-device-obj, or --link mode")
 
 
 if __name__ == '__main__':

--- a/projects/rccl/tools/rccl-device-compile
+++ b/projects/rccl/tools/rccl-device-compile
@@ -27,6 +27,18 @@ Device-object mode (--emit-device-obj):
     .o is meant to be listed alongside --compile's leaf-kernel outputs in a
     --link invocation, so its device code lands in the same device.elf.
 
+Host-object mode (--emit-host-obj):
+    rccl-device-compile --emit-host-obj --clang=... --fatbin-role=owner|shared
+        -cuid=<shared> -DFOO -Ipath -o out.o in.cu.cpp
+    Compiles a mixed host+device TU's HOST half (--offload-host-only), then
+    patches the per-TU __hip_gpubin_handle_<hash> fatbin-registration handle
+    so that ALL mixed TUs built with the same -cuid share ONE handle
+    instance at link time instead of one copy per TU (which otherwise makes
+    the HIP runtime load one separate module of the identical multi-hundred-
+    MB device.elf per TU -- see patch_fatbin_handle_sharing() for the full
+    story). Exactly one mixed TU must be compiled with --fatbin-role=owner;
+    every other one uses --fatbin-role=shared.
+
 Link mode (--link):
     rccl-device-compile --link --arch=gfx942 --dispatcher=common.cu.cpp -o device.elf obj1.o obj2.o
     1. Aggregates resource JSON files from all input objects
@@ -595,6 +607,171 @@ def do_emit_device_obj(args, forwarded_flags):
 
 
 # ---------------------------------------------------------------------------
+# Host-object mode: mixed TU's host half -> .o, with a SHARED fatbin
+# registration handle across all mixed TUs (see do_emit_host_obj docstring).
+# ---------------------------------------------------------------------------
+
+_GPUBIN_HANDLE_RE = re.compile(r'__hip_gpubin_handle_[0-9a-f]+')
+
+
+def patch_fatbin_handle_sharing(asm_lines, role, source):
+    """Rewrite the per-TU __hip_gpubin_handle_<hash> storage class so that
+    all mixed TUs sharing the same -cuid end up with exactly ONE handle
+    instance at link time, instead of one copy per TU.
+
+    Background: forcing every mixed TU to compile with the same -cuid makes
+    them all reference the same __hip_fatbin_<hash> bytes (see "Shared CUID"
+    in DeviceLinker.cmake), but clang still emits a *per-TU-local*
+    __hip_gpubin_handle_<hash> variable and a static constructor
+    (__hip_module_ctor) that calls __hipRegisterFatBinary() whenever THAT
+    TU's own copy of the handle is still zero. Because the handle is
+    TU-local, every mixed TU takes that branch independently at process
+    startup, so the HIP runtime ends up loading one separate module instance
+    of the identical (multi-hundred-MB) device.elf PER TU -- harmless on an
+    idle GPU with plenty of headroom, but enough to exhaust GPU memory under
+    concurrent/resource-constrained CI runs ("device kernel image is
+    invalid" at kernel launch).
+
+    Fix: make the handle *storage* shared instead of per-TU.
+      - role == 'owner':  keep __hip_gpubin_handle_<hash> as a COMMON symbol
+        but promote it from '.local' to '.globl .hidden' so other TUs can
+        bind to it. '.hidden' matters as much as '.globl' here: librccl.so
+        is a shared object, and without it the symbol would have default
+        (exported/preemptible) visibility, which ld.lld refuses to allow
+        direct PC-relative access to ("relocation R_X86_64_PC32 cannot be
+        used against symbol ...; recompile with -fPIC") -- the existing
+        movq/cmpq instructions addressing the handle were already emitted as
+        direct RIP-relative accesses (clang's normal codegen for what it
+        believed, at compile time, was an internal-linkage local variable),
+        so the symbol must stay non-preemptible for those to remain legal.
+      - role == 'shared': drop this TU's own .type/.local/.comm declarations
+        for the handle entirely (replacing them with a matching .hidden
+        declaration on the now-undefined reference, for the same
+        preemptibility reason as above), leaving only the existing
+        movq/cmpq references to it -- those become an ordinary undefined
+        external reference that the final librccl.so link resolves against
+        the owner's single definition.
+
+    This does not depend on which TU is the "owner" or on static-initializer
+    order across TUs: these are ordinary sequential static initializers
+    running in one thread before main(), so whichever TU's constructor
+    happens to run first performs the one real __hipRegisterFatBinary() call
+    (on the content-identical fatbin wrapper); every other TU's constructor
+    then sees the shared handle already set, skips re-registering, and just
+    calls its own __hip_register_globals() against that shared module handle
+    to register its own kernels. Validated end-to-end -- including reversed
+    link/init order -- against real gfx942 hardware with a standalone 2-TU
+    repro before wiring this in.
+    """
+    handles = sorted({m.group(0) for line in asm_lines
+                       for m in [_GPUBIN_HANDLE_RE.search(line)] if m})
+    if not handles:
+        # Some registered mixed TUs (e.g. a generated dispatcher .cpp that
+        # only #includes headers, with the real __global__ kernels living in
+        # sibling per-instantiation TUs) compile to host assembly with no
+        # HIP device-registration boilerplate at all -- nothing references
+        # any device symbol, so clang emits no fatbin wrapper/ctor/handle.
+        # Nothing to patch in that case; pass the assembly through as-is.
+        return asm_lines
+    if len(handles) > 1:
+        raise RuntimeError(
+            f"{source}: multiple distinct gpubin handle symbols found "
+            f"({handles}); expected exactly one shared -cuid hash")
+    handle_name = handles[0]
+    handle = re.escape(handle_name)
+
+    out = []
+    if role == 'owner':
+        for line in asm_lines:
+            if re.match(rf'\s*\.local\s+{handle}\b', line):
+                out.append(line.replace('.local', '.globl', 1))
+                out.append(f'\t.hidden\t{handle_name}\n')
+            else:
+                out.append(line)
+    elif role == 'shared':
+        inserted_hidden = False
+        for line in asm_lines:
+            stripped = line.strip()
+            if re.match(rf'\.type\s+{handle},\s*@object', stripped):
+                if not inserted_hidden:
+                    out.append(f'\t.hidden\t{handle_name}\n')
+                    inserted_hidden = True
+                continue
+            if re.match(rf'\.local\s+{handle}\b', stripped):
+                continue
+            if re.match(rf'\.comm\s+{handle}\b', stripped):
+                continue
+            out.append(line)
+    else:
+        raise RuntimeError(f"unknown --fatbin-role={role!r}, expected 'owner' or 'shared'")
+    return out
+
+
+def do_emit_host_obj(args, forwarded_flags):
+    """Compile a mixed host+device TU's HOST half (--offload-host-only),
+    then patch its fatbin registration handle per --fatbin-role so that all
+    mixed TUs sharing a -cuid end up with ONE shared handle at link time
+    instead of one per TU. See patch_fatbin_handle_sharing() docstring for
+    the full rationale.
+    """
+    clang, _ = discover_tools(args.clang)
+    source = args.source
+    output = args.output
+    role = args.fatbin_role
+    keep_temps = args.keep_temps
+
+    if not role:
+        raise SystemExit("ERROR: --emit-host-obj requires --fatbin-role=owner|shared")
+
+    base = os.path.splitext(output)[0]
+    if keep_temps:
+        asm_file = base + '.full.s'
+        patched_file = base + '.patched.s'
+        cleanup = []
+    else:
+        tmpdir = tempfile.mkdtemp(prefix='rccl-dc-host-')
+        asm_file = os.path.join(tmpdir, 'full.s')
+        patched_file = os.path.join(tmpdir, 'patched.s')
+        cleanup = [asm_file, patched_file, tmpdir]
+
+    try:
+        compile_cmd = [
+            clang,
+            '-x', 'hip',
+            '--offload-host-only',
+        ] + forwarded_flags + [
+            '-S', '-o', asm_file, source,
+        ]
+        run(compile_cmd, f"compile (host, shared cuid) {os.path.basename(source)}")
+
+        with open(asm_file) as f:
+            asm_lines = f.readlines()
+
+        patched_lines = patch_fatbin_handle_sharing(asm_lines, role, source)
+
+        with open(patched_file, 'w') as f:
+            f.writelines(patched_lines)
+
+        assemble_cmd = [
+            clang,
+            '-x', 'assembler',
+            '-c', '-o', output, patched_file,
+        ]
+        run(assemble_cmd, f"assemble (host) {os.path.basename(source)}")
+
+    finally:
+        if not keep_temps:
+            for f in cleanup:
+                try:
+                    if os.path.isfile(f):
+                        os.unlink(f)
+                    elif os.path.isdir(f):
+                        os.rmdir(f)
+                except OSError:
+                    pass
+
+
+# ---------------------------------------------------------------------------
 # Link mode: objects -> device.elf
 # ---------------------------------------------------------------------------
 
@@ -743,11 +920,16 @@ def parse_compiler_flags(argv):
     while i < len(argv):
         arg = argv[i]
         # Our flags
-        if arg in ('--compile', '--link', '--emit-device-obj', '--keep-temps', '--version'):
+        if arg in ('--compile', '--link', '--emit-device-obj', '--emit-host-obj', '--keep-temps', '--version'):
             our_args.append(arg)
         elif arg.startswith('--arch='):
             our_args.append(arg)
         elif arg == '--arch' and i + 1 < len(argv):
+            our_args.extend([arg, argv[i + 1]])
+            i += 1
+        elif arg.startswith('--fatbin-role='):
+            our_args.append(arg)
+        elif arg == '--fatbin-role' and i + 1 < len(argv):
             our_args.extend([arg, argv[i + 1]])
             i += 1
         elif arg.startswith('--clang='):
@@ -779,6 +961,12 @@ def parse_compiler_flags(argv):
         elif arg == '-I' and i + 1 < len(argv):
             forwarded.extend(['-I', argv[i + 1]])
             i += 1
+        elif arg in ('-MF', '-MT', '-MQ') and i + 1 < len(argv):
+            # These take a following value (path/target name) that doesn't
+            # start with '-' and would otherwise be misparsed as a
+            # positional source/object file.
+            forwarded.extend([arg, argv[i + 1]])
+            i += 1
         elif arg.startswith('-'):
             forwarded.append(arg)
         else:
@@ -808,6 +996,9 @@ def main():
     parser.add_argument('--compile', action='store_true')
     parser.add_argument('--link', action='store_true')
     parser.add_argument('--emit-device-obj', action='store_true', dest='emit_device_obj')
+    parser.add_argument('--emit-host-obj', action='store_true', dest='emit_host_obj')
+    parser.add_argument('--fatbin-role', default=None, dest='fatbin_role',
+                         choices=['owner', 'shared'])
     parser.add_argument('--arch', required=False)
     parser.add_argument('--clang', default=None)
     parser.add_argument('--dispatcher', default=None)
@@ -842,6 +1033,14 @@ def main():
         args.source = positional[0]
         do_emit_device_obj(args, forwarded_flags)
 
+    elif args.emit_host_obj:
+        if not positional:
+            raise SystemExit("ERROR: --emit-host-obj requires a source file")
+        if not args.output:
+            raise SystemExit("ERROR: --emit-host-obj requires -o <output>")
+        args.source = positional[0]
+        do_emit_host_obj(args, forwarded_flags)
+
     elif args.link:
         if not positional:
             raise SystemExit("ERROR: --link requires object files")
@@ -853,7 +1052,7 @@ def main():
         do_link(args, forwarded_flags)
 
     else:
-        raise SystemExit("ERROR: specify --compile, --emit-device-obj, or --link mode")
+        raise SystemExit("ERROR: specify --compile, --emit-device-obj, --emit-host-obj, or --link mode")
 
 
 if __name__ == '__main__':

--- a/projects/rccl/tools/rccl-device-compile
+++ b/projects/rccl/tools/rccl-device-compile
@@ -585,6 +585,7 @@ def do_emit_device_obj(args, forwarded_flags):
         '--offload-device-only',
         f'--offload-arch={arch}',
         '-fhip-emit-relocatable',
+        '-fPIC',
         '-gline-tables-only',
         '-w',
     ] + forwarded_flags + [

--- a/projects/rccl/tools/rccl-device-compile
+++ b/projects/rccl/tools/rccl-device-compile
@@ -1083,10 +1083,12 @@ def parse_compiler_flags(argv):
         elif arg == '-I' and i + 1 < len(argv):
             forwarded.extend(['-I', argv[i + 1]])
             i += 1
-        elif arg in ('-MF', '-MT', '-MQ') and i + 1 < len(argv):
+        elif arg in ('-MF', '-MT', '-MQ', '-Xclang', '-mllvm', '-include') and i + 1 < len(argv):
             # These take a following value (path/target name) that doesn't
             # start with '-' and would otherwise be misparsed as a
-            # positional source/object file.
+            # positional source/object file. -Xclang in particular is how
+            # DeviceLinker.cmake passes -mlink-builtin-bitcode <file.bc> for
+            # the GIN symmetric kernels.
             forwarded.extend([arg, argv[i + 1]])
             i += 1
         elif arg.startswith('-'):

--- a/projects/rccl/tools/test_rccl_device_compile.py
+++ b/projects/rccl/tools/test_rccl_device_compile.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Unit tests for the --emit-device-obj mode added to tools/rccl-device-compile.
+
+Only covers what this change actually touches: --emit-device-obj recognition
+in parse_compiler_flags() and the mode-dispatch wiring in main(). The rest of
+rccl-device-compile (assembly extraction, resource aggregation, dispatcher
+patching) predates this change and is untouched by it. do_emit_device_obj
+itself is a thin amdclang++ subprocess wrapper like do_compile/do_link, so
+(like those) it's exercised by the required clean build rather than mocked
+here.
+
+rccl-device-compile has no .py suffix (it's installed as a CMake custom-
+language driver), so it's loaded here via importlib rather than a normal
+import.
+"""
+
+import importlib.machinery
+import importlib.util
+import os
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+MODULE_PATH = os.path.join(HERE, "rccl-device-compile")
+
+# No .py suffix means importlib can't pick a loader for it by extension alone
+# -- hand it the source-file loader explicitly.
+_loader = importlib.machinery.SourceFileLoader("rccl_device_compile", MODULE_PATH)
+_spec = importlib.util.spec_from_loader("rccl_device_compile", _loader)
+rdc = importlib.util.module_from_spec(_spec)
+_loader.exec_module(rdc)
+
+
+class EmitDeviceObjFlagParsingTest(unittest.TestCase):
+    def test_emit_device_obj_flag_is_recognized_as_our_flag(self):
+        our_args, forwarded, sources = rdc.parse_compiler_flags([
+            "--emit-device-obj", "--arch=gfx950", "-DFOO", "-Ipath",
+            "-o", "out.o", "in.cu.cpp",
+        ])
+        self.assertIn("--emit-device-obj", our_args)
+        self.assertEqual(forwarded, ["-DFOO", "-Ipath"])
+        self.assertEqual(sources, ["in.cu.cpp"])
+
+    def test_emit_device_obj_coexists_with_other_our_flags(self):
+        our_args, _, _ = rdc.parse_compiler_flags([
+            "--emit-device-obj", "--arch=gfx942", "--clang", "/opt/rocm/bin/amdclang++",
+            "--keep-temps", "-o", "out.o", "in.cu.cpp",
+        ])
+        self.assertEqual(
+            our_args,
+            ["--emit-device-obj", "--arch=gfx942", "--clang", "/opt/rocm/bin/amdclang++",
+             "--keep-temps", "-o", "out.o"],
+        )
+
+
+class EmitDeviceObjModeDispatchTest(unittest.TestCase):
+    """main() requires --arch/-o/a source for --emit-device-obj, same as --compile."""
+
+    def _run_main_with(self, argv):
+        old_argv = rdc.sys.argv
+        rdc.sys.argv = ["rccl-device-compile"] + argv
+        try:
+            rdc.main()
+        finally:
+            rdc.sys.argv = old_argv
+
+    def test_missing_arch_is_rejected(self):
+        with self.assertRaises(SystemExit) as cm:
+            self._run_main_with(["--emit-device-obj", "-o", "out.o", "in.cu.cpp"])
+        self.assertIn("--arch", str(cm.exception))
+
+    def test_missing_output_is_rejected(self):
+        with self.assertRaises(SystemExit) as cm:
+            self._run_main_with(["--emit-device-obj", "--arch=gfx950", "in.cu.cpp"])
+        self.assertIn("-o", str(cm.exception))
+
+    def test_missing_source_is_rejected(self):
+        with self.assertRaises(SystemExit) as cm:
+            self._run_main_with(["--emit-device-obj", "--arch=gfx950", "-o", "out.o"])
+        self.assertIn("source file", str(cm.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/projects/rccl/tools/test_rccl_device_compile.py
+++ b/projects/rccl/tools/test_rccl_device_compile.py
@@ -51,6 +51,22 @@ class EmitDeviceObjFlagParsingTest(unittest.TestCase):
              "--keep-temps", "-o", "out.o"],
         )
 
+    def test_xclang_value_is_not_mistaken_for_the_source(self):
+        """-Xclang -mlink-builtin-bitcode -Xclang <file.bc> (how the GIN
+        symmetric kernels get the rocSHMEM QueuePair bitcode) must forward
+        whole; the .bc path does not start with '-' and would otherwise be
+        collected as a positional source."""
+        our_args, forwarded, sources = rdc.parse_compiler_flags([
+            "--emit-device-obj", "--arch=gfx950",
+            "-Xclang", "-mlink-builtin-bitcode", "-Xclang", "qp.bc",
+            "-o", "out.o", "in.cu.cpp",
+        ])
+        self.assertEqual(
+            forwarded,
+            ["-Xclang", "-mlink-builtin-bitcode", "-Xclang", "qp.bc"],
+        )
+        self.assertEqual(sources, ["in.cu.cpp"])
+
 
 class EmitDeviceObjModeDispatchTest(unittest.TestCase):
     """main() requires --arch/-o/a source for --emit-device-obj, same as --compile."""


### PR DESCRIPTION
## Summary

- #9756 fixed the ~48min build time (#9757) by splitting `ce_reduce.cc`'s 40 kernel instantiations into 40 separate TUs — but every mixed host+device TU (onerank, collectives, the new per-kernel ce_reduce TUs, dda_*, sym_*) embeds its own full copy of the device fatbin, so more TUs means more duplicated device images. The number of device images was getting too large as a direct consequence of #9756's fix.
- This PR unifies every mixed TU's device kernels into a single `device.elf`/`device.hipfb`, embedded exactly once in `librccl.so` via a shared-CUID + glue-object mechanism, instead of once per TU.

**Depends on #9756 — this branch is stacked on top of it and must not be merged until #9756 lands in `develop` first.**

ISSUE ID: #9757

## Test plan

- [x] Full clean build on gfx950 (srock toolchain)
- [x] Single `.hip_fatbin` section confirmed in `librccl.so` (previously duplicated per mixed TU)
- [x] All 142 `rccl-UnitTests` pass on 4x MI350X (bacon)

Made with [Cursor](https://cursor.com)