### PR TITLE
fix(rocprofiler-compute): correct gfx9 VGPR label

### DIFF
--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -36,6 +36,8 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 ### Resolved issues
 
+* Corrected the VGPR allocation label from `RVGPRseq` to `VGPRs` in gfx9 memory charts
+
 ### Upcoming changes
 
 ### Known issues

--- a/projects/rocprofiler-compute/src/utils/gui_components/memchart.py
+++ b/projects/rocprofiler-compute/src/utils/gui_components/memchart.py
@@ -137,7 +137,9 @@ def insert_chart_data(mem_data: list[dict[str, Any]], base_data: schema.Workload
                 fill="#FFFF33",
                 fontSize="20px",
                 fontWeight="bold",
-                children=format_value_for_display(memchart_values.get("Active CUs")),
+                children=format_value_for_display(
+                    memchart_values.get("Active CUs (deprecated)")
+                ),
             ),  # x=454
             Text(
                 x="580",

--- a/projects/rocprofiler-compute/src/utils/gui_components/memchart.py
+++ b/projects/rocprofiler-compute/src/utils/gui_components/memchart.py
@@ -137,9 +137,7 @@ def insert_chart_data(mem_data: list[dict[str, Any]], base_data: schema.Workload
                 fill="#FFFF33",
                 fontSize="20px",
                 fontWeight="bold",
-                children=format_value_for_display(
-                    memchart_values.get("Active CUs (deprecated)")
-                ),
+                children=format_value_for_display(memchart_values.get("Active CUs")),
             ),  # x=454
             Text(
                 x="580",

--- a/projects/rocprofiler-compute/src/utils/mem_chart_gfx9.py
+++ b/projects/rocprofiler-compute/src/utils/mem_chart_gfx9.py
@@ -248,7 +248,7 @@ class Exec(RectFrame):
             self.x_min + 4.0,
             self.y_max - 6.0,
             format_text(
-                key="RVGPRseq",
+                key="VGPRs",
                 value=self.vgprs,
                 key_step_prec_leftalign=6,
                 value_step_prec_rightalign=5,
@@ -1033,7 +1033,7 @@ class MemChart:
         block_exec.y_min = block_instr_disp.y_min - 6
         block_exec.y_max = block_instr_disp.y_max
 
-        block_exec.active_cus = metric_dict.get("Active CUs", "n/a")
+        block_exec.active_cus = metric_dict.get("Active CUs (deprecated)", "n/a")
         block_exec.num_cus = metric_dict.get("Num CUs", "n/a")
         block_exec.vgprs = metric_dict.get("VGPR", "n/a")
         block_exec.sgprs = metric_dict.get("SGPR", "n/a")

--- a/projects/rocprofiler-compute/src/utils/mem_chart_gfx9.py
+++ b/projects/rocprofiler-compute/src/utils/mem_chart_gfx9.py
@@ -1033,7 +1033,7 @@ class MemChart:
         block_exec.y_min = block_instr_disp.y_min - 6
         block_exec.y_max = block_instr_disp.y_max
 
-        block_exec.active_cus = metric_dict.get("Active CUs (deprecated)", "n/a")
+        block_exec.active_cus = metric_dict.get("Active CUs", "n/a")
         block_exec.num_cus = metric_dict.get("Num CUs", "n/a")
         block_exec.vgprs = metric_dict.get("VGPR", "n/a")
         block_exec.sgprs = metric_dict.get("SGPR", "n/a")


### PR DESCRIPTION
## Motivation

The gfx9 memory chart labels VGPR allocation as `RVGPRseq`, misidentifying the displayed value in CLI/TUI.

## Technical Details

- Restore the `VGPRs` allocation label in the CLI/TUI memory chart

## JIRA ID

JIRA ID: AIPROFCOMP-795

## Test Plan

- [X] Run pytest tests/test_mem_chart.py

## Test Result

- [X] pytest tests/test_mem_chart.py passes

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.