### PR TITLE
fix(clr): do not rely on amd::Elf for validation since it makes copies

### DIFF
--- a/projects/clr/rocclr/device/devprogram.cpp
+++ b/projects/clr/rocclr/device/devprogram.cpp
@@ -1563,6 +1563,8 @@ bool Program::setBinary(const char* binaryIn, size_t size, const device::Program
     ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_KERN, "Invalid size to validate \n");
     return false;
   }
+
+  // So we do the validation by explicitly getting the ELF headers
   const amd::Elf64_Ehdr* ehdr = reinterpret_cast<const amd::Elf64_Ehdr*>(binary);
   uint16_t type = ehdr->e_type;
 

--- a/projects/clr/rocclr/device/devprogram.cpp
+++ b/projects/clr/rocclr/device/devprogram.cpp
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <atomic>
 #include <cstdio>
+#include <cstring>
 #include <fstream>
 #include <iostream>
 #include <iomanip>
@@ -1560,13 +1561,16 @@ bool Program::setBinary(const char* binaryIn, size_t size, const device::Program
   // and depending on the binary size, that might be costly.
   auto [binary, binSize] = clBinary()->data();
   if (binSize < sizeof(amd::Elf64_Ehdr)) {
-    ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_KERN, "Invalid size to validate \n");
+    ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_KERN,
+            "The elf size is way too small to validate: %d \n", binSize);
     return false;
   }
 
-  // So we do the validation by explicitly getting the ELF headers
-  const amd::Elf64_Ehdr* ehdr = reinterpret_cast<const amd::Elf64_Ehdr*>(binary);
-  uint16_t type = ehdr->e_type;
+  // So we do the validation by explicitly getting the ELF header. Copy it into an
+  // aligned local, since the binary buffer has no alignment guarantee.
+  amd::Elf64_Ehdr ehdr;
+  std::memcpy(&ehdr, binary, sizeof(ehdr));
+  uint16_t type = ehdr.e_type;
 
   switch (type) {
     case ET_NONE: {
@@ -1582,7 +1586,7 @@ bool Program::setBinary(const char* binaryIn, size_t size, const device::Program
       break;
     }
     case ET_DYN: {
-      if (ehdr->e_machine == EM_AMDGPU) {
+      if (ehdr.e_machine == EM_AMDGPU) {
         setType(TYPE_EXECUTABLE);
       } else {
         setType(TYPE_LIBRARY);

--- a/projects/clr/rocclr/device/devprogram.cpp
+++ b/projects/clr/rocclr/device/devprogram.cpp
@@ -1556,15 +1556,16 @@ bool Program::setBinary(const char* binaryIn, size_t size, const device::Program
     return false;
   }
 
-  if (!clBinary()->setElfIn()) {
-    LogError("Setting input OCL binary failed");
+  // Do not rely on amd::Elf to do validations here since it makes copies
+  // and depending on the binary size, that might be costly.
+  auto [binary, binSize] = clBinary()->data();
+  if (binSize < sizeof(amd::Elf64_Ehdr)) {
+    ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_KERN, "Invalid size to validate \n");
     return false;
   }
-  uint16_t type;
-  if (!clBinary()->elfIn()->getType(type)) {
-    LogError("Bad OCL Binary: error loading ELF type!");
-    return false;
-  }
+  const amd::Elf64_Ehdr* ehdr = reinterpret_cast<const amd::Elf64_Ehdr*>(binary);
+  uint16_t type = ehdr->e_type;
+
   switch (type) {
     case ET_NONE: {
       setType(TYPE_NONE);
@@ -1579,9 +1580,7 @@ bool Program::setBinary(const char* binaryIn, size_t size, const device::Program
       break;
     }
     case ET_DYN: {
-      char* sect = nullptr;
-      size_t sz = 0;
-      if (clBinary()->elfIn()->isHsaCo()) {
+      if (ehdr->e_machine == EM_AMDGPU) {
         setType(TYPE_EXECUTABLE);
       } else {
         setType(TYPE_LIBRARY);
@@ -1605,7 +1604,6 @@ bool Program::setBinary(const char* binaryIn, size_t size, const device::Program
     linkOptions_.clear();
   }
 
-  clBinary()->resetElfIn();
   return true;
 }
 


### PR DESCRIPTION
## Motivation

Do not make copies of code object to validate its values.

## Technical Details

`amd::Elf` makes copies of the code object, which leads to increased loading time. This scales linearly with the number of GPUs on a system. So we use the elf header directly, without changing its core logic.

## Issue Tracking

https://github.com/ROCm/rocm-systems/issues/5767

## Test Plan

Load time reported by python script should reduce.

Test script:
```python
import ctypes
import subprocess
import sys
import time

if sys.argv[1:] == ["slow"]:
    h = ctypes.CDLL("libamdhip64.so")
    t1 = time.monotonic()
    h.hipInit(0)
    t2 = time.monotonic()
    ctypes.CDLL("librccl.so")
    t3 = time.monotonic()
    print(f"slow (hipInit before librccl) : {(t2 - t1) * 1e3:7.1f} ms", flush=True)
    print(f"slow (librccl time)           : {(t3 - t2) * 1e3:7.1f} ms", flush=True)
elif sys.argv[1:] == ["fast"]:
    h = ctypes.CDLL("libamdhip64.so")
    t1 = time.monotonic()
    ctypes.CDLL("librccl.so")
    t2 = time.monotonic()
    h.hipInit(0)
    t3 = time.monotonic()
    print(f"fast (librccl before hipInit) : {(t2 - t1) * 1e3:7.1f} ms", flush=True)
    print(f"fast (hipInit time)           : {(t3 - t2) * 1e3:7.1f} ms", flush=True)
else:
    # Run in a fresh subprocess so process state is clean.
    subprocess.run([sys.executable, sys.argv[0], "slow"], check=True)
    subprocess.run([sys.executable, sys.argv[0], "fast"], check=True)
```

## Test Result

Pre this patch:
```bash
slow (hipInit before librccl) :    61.5 ms
slow (librccl time)           :  1726.5 ms
fast (librccl before hipInit) :     3.1 ms
fast (hipInit time)           :    62.1 ms
```

Post:
```bash
slow (hipInit before librccl) :    62.8 ms
slow (librccl time)           :   182.8 ms
fast (librccl before hipInit) :     2.8 ms
fast (hipInit time)           :    62.3 ms
```

We will still see increased librccl time after hipInit, due to it loading the code objects.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
