### PR TITLE
fix(rocattach): handle out-of-order PT_LOAD mappings in load-bias calc

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
@@ -487,9 +487,10 @@ read_mapped_file(const std::string& path, const mapped_object& object, bool requ
 std::optional<target_elf>
 open_target_elf(pid_t pid, const mapped_object& object)
 {
-    // Prefer map_files because it is a kernel-provided handle to the exact file
-    // backing the mapped object. If permissions block that path, fall back to
-    // the same path as seen through the target root and still validate device/inode.
+    // Prefer map_files because it identifies the exact file backing the
+    // mapping. If permissions block it, open the pathname through the target
+    // root. Device/inode equality remains the fast path; a mismatch requires
+    // matching GNU Build IDs.
     const auto& mapping        = object.mappings.front();
     auto        map_files_path = fmt::format("/proc/{}/map_files/{:x}-{:x}",
                                       pid,
@@ -572,27 +573,22 @@ calculate_load_bias(const target_elf& elf, const mapped_object& object)
     auto page_size =
         (page_size_value > 0) ? static_cast<uint64_t>(page_size_value) : uint64_t{4096};
 
-    auto mapping_matches_bias = [&](const memory_mapping& mapping, uint64_t bias) {
-        for(const auto& segment : elf.load_segments)
-        {
-            if(segment.p_filesz == 0) continue;
-            auto file_end = checked_add(segment.p_offset, segment.p_filesz);
-            if(!file_end) continue;
-            auto file_page_begin = align_down(segment.p_offset, page_size);
-            auto file_page_end   = align_up(*file_end, page_size);
-            if(!file_page_end || mapping.file_offset < file_page_begin ||
-               mapping.file_offset >= *file_page_end)
-            {
-                continue;
-            }
+    auto load_segment_is_mapped = [&](const Elf64_Phdr& segment, uint64_t bias) {
+        if(segment.p_filesz == 0) return true;
 
-            auto virtual_page = align_down(segment.p_vaddr, page_size);
-            auto file_delta   = mapping.file_offset - file_page_begin;
-            auto relative     = checked_add(virtual_page, file_delta);
-            auto expected     = relative ? checked_add(bias, *relative) : std::nullopt;
-            if(expected && *expected == mapping.start) return true;
-        }
-        return false;
+        auto file_page    = align_down(segment.p_offset, page_size);
+        auto virtual_page = align_down(segment.p_vaddr, page_size);
+        auto runtime_page = checked_add(bias, virtual_page);
+        if(!runtime_page) return false;
+
+        return std::any_of(
+            object.mappings.begin(), object.mappings.end(), [&](const auto& mapping) {
+                if(*runtime_page < mapping.start || *runtime_page >= mapping.end) return false;
+
+                auto mapping_delta = *runtime_page - mapping.start;
+                auto mapped_offset = checked_add(mapping.file_offset, mapping_delta);
+                return mapped_offset && *mapped_offset == file_page;
+            });
     };
 
     auto candidates = std::vector<uint64_t>{};
@@ -617,11 +613,14 @@ calculate_load_bias(const target_elf& elf, const mapped_object& object)
                                       : std::nullopt;
             if(!candidate) continue;
 
-            auto all_mappings_match =
-                std::all_of(object.mappings.begin(), object.mappings.end(), [&](const auto& item) {
-                    return mapping_matches_bias(item, *candidate);
+            // A valid loader instance must account for every file-backed
+            // PT_LOAD. Other mappings of the same inode are unrelated to that
+            // instance and must not invalidate an otherwise unique bias.
+            auto all_load_segments_mapped = std::all_of(
+                elf.load_segments.begin(), elf.load_segments.end(), [&](const auto& load) {
+                    return load_segment_is_mapped(load, *candidate);
                 });
-            if(all_mappings_match &&
+            if(all_load_segments_mapped &&
                std::find(candidates.begin(), candidates.end(), *candidate) == candidates.end())
             {
                 candidates.emplace_back(*candidate);
@@ -685,12 +684,18 @@ parse_gnu_build_id(const uint8_t* data, size_t size)
 bool
 note_is_file_backed_load(const target_elf& elf, const Elf64_Phdr& note)
 {
-    auto note_end = checked_add(note.p_vaddr, note.p_filesz);
-    if(!note_end) return false;
+    if(note.p_filesz == 0) return false;
 
     return std::any_of(elf.load_segments.begin(), elf.load_segments.end(), [&](const auto& load) {
-        auto load_end = checked_add(load.p_vaddr, load.p_filesz);
-        return load_end && note.p_vaddr >= load.p_vaddr && *note_end <= *load_end;
+        if(note.p_vaddr < load.p_vaddr || note.p_offset < load.p_offset) return false;
+
+        auto virtual_delta = note.p_vaddr - load.p_vaddr;
+        auto file_delta    = note.p_offset - load.p_offset;
+
+        // The note bytes read from the file must be the same bytes represented
+        // at note.p_vaddr in the file-backed PT_LOAD segment.
+        return virtual_delta == file_delta && virtual_delta <= load.p_filesz &&
+               note.p_filesz <= load.p_filesz - virtual_delta;
     });
 }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
@@ -34,6 +34,7 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/sysmacros.h>
+#include <sys/uio.h>
 #include <unistd.h>
 
 #include <algorithm>
@@ -41,6 +42,7 @@
 #include <cerrno>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <exception>
 #include <filesystem>
@@ -63,6 +65,9 @@ namespace
 // Keep limits generous enough for debug builds, but bounded so malformed target
 // ELFs cannot force unbounded memory use or symbol/hash traversal.
 constexpr auto MAX_TARGET_ELF_SIZE      = uint64_t{512} * 1024 * 1024;
+constexpr auto MAX_ELF_NOTE_SIZE        = uint64_t{1024} * 1024;
+constexpr auto MAX_BUILD_ID_SIZE        = uint64_t{4096};
+constexpr auto ELF_NOTE_ALIGNMENT       = uint64_t{4};
 constexpr auto MAX_DYNAMIC_SYMBOLS      = size_t{1} << 24;
 constexpr auto MAX_GNU_HASH_CHAIN_STEPS = size_t{1} << 24;
 
@@ -110,10 +115,11 @@ struct mapped_object_key_hash
 
 struct target_elf
 {
-    std::string             path          = {};
-    std::vector<uint8_t>    data          = {};
-    ELFIO::elfio            reader        = {};
-    std::vector<Elf64_Phdr> load_segments = {};
+    std::string             path                      = {};
+    std::vector<uint8_t>    data                      = {};
+    ELFIO::elfio            reader                    = {};
+    std::vector<Elf64_Phdr> load_segments             = {};
+    bool                    metadata_identity_matches = false;
 };
 
 std::optional<uint64_t>
@@ -141,6 +147,15 @@ uint64_t
 align_down(uint64_t value, uint64_t alignment)
 {
     return value - (value % alignment);
+}
+
+std::optional<uint64_t>
+align_up(uint64_t value, uint64_t alignment)
+{
+    if(alignment == 0) return std::nullopt;
+    auto remainder = value % alignment;
+    if(remainder == 0) return value;
+    return checked_add(value, alignment - remainder);
 }
 
 bool
@@ -414,13 +429,18 @@ read_file_from_fd(int fd, const std::string& path, uint64_t size)
 }
 
 std::optional<target_elf>
-read_file_if_matches_mapping(const std::string& path, const mapped_object& object)
+read_mapped_file(const std::string& path, const mapped_object& object, bool require_identity_match)
 {
     struct stat st
     {};
 
     auto fd = ::open(path.c_str(), O_RDONLY | O_CLOEXEC);
-    if(fd < 0) return std::nullopt;
+    if(fd < 0)
+    {
+        ROCP_TRACE << "[rocprofiler-sdk-rocattach] Could not open target ELF " << path << ": "
+                   << std::strerror(errno);
+        return std::nullopt;
+    }
     auto close_fd = common::scope_destructor{[fd]() { ::close(fd); }};
 
     if(::fstat(fd, &st) != 0)
@@ -430,8 +450,10 @@ read_file_if_matches_mapping(const std::string& path, const mapped_object& objec
         return std::nullopt;
     }
 
-    if(major(st.st_dev) != object.device_major || minor(st.st_dev) != object.device_minor ||
-       static_cast<uint64_t>(st.st_ino) != object.inode)
+    auto identity_matches = major(st.st_dev) == object.device_major &&
+                            minor(st.st_dev) == object.device_minor &&
+                            static_cast<uint64_t>(st.st_ino) == object.inode;
+    if(require_identity_match && !identity_matches)
     {
         ROCP_WARNING << "[rocprofiler-sdk-rocattach] Refusing to use " << path
                      << " because its opened device/inode does not match the mapped object";
@@ -455,9 +477,10 @@ read_file_if_matches_mapping(const std::string& path, const mapped_object& objec
     auto data = read_file_from_fd(fd, path, static_cast<uint64_t>(st.st_size));
     if(!data || data->empty()) return std::nullopt;
 
-    auto elf = target_elf{};
-    elf.path = path;
-    elf.data = std::move(*data);
+    auto elf                      = target_elf{};
+    elf.path                      = path;
+    elf.data                      = std::move(*data);
+    elf.metadata_identity_matches = identity_matches;
     return elf;
 }
 
@@ -472,10 +495,18 @@ open_target_elf(pid_t pid, const mapped_object& object)
                                       pid,
                                       static_cast<uint64_t>(mapping.start),
                                       static_cast<uint64_t>(mapping.end));
-    if(auto elf = read_file_if_matches_mapping(map_files_path, object))
+#if defined(ROCPROFILER_ROCATTACH_TESTING)
+    auto disable_map_files = std::getenv("ROCATTACH_TEST_DISABLE_MAP_FILES") != nullptr;
+#else
+    constexpr auto disable_map_files = false;
+#endif
+    if(!disable_map_files)
     {
-        ROCP_TRACE << "[rocprofiler-sdk-rocattach] Opened target ELF via " << map_files_path;
-        return elf;
+        if(auto elf = read_mapped_file(map_files_path, object, true))
+        {
+            ROCP_TRACE << "[rocprofiler-sdk-rocattach] Opened target ELF via " << map_files_path;
+            return elf;
+        }
     }
 
     auto target_path = strip_deleted_suffix(object.path);
@@ -484,7 +515,7 @@ open_target_elf(pid_t pid, const mapped_object& object)
         auto root_path = (std::filesystem::path{fmt::format("/proc/{}/root", pid)} /
                           std::filesystem::path{target_path}.relative_path())
                              .string();
-        if(auto elf = read_file_if_matches_mapping(root_path, object))
+        if(auto elf = read_mapped_file(root_path, object, false))
         {
             ROCP_TRACE << "[rocprofiler-sdk-rocattach] Opened target ELF via " << root_path;
             return elf;
@@ -541,44 +572,277 @@ calculate_load_bias(const target_elf& elf, const mapped_object& object)
     auto page_size =
         (page_size_value > 0) ? static_cast<uint64_t>(page_size_value) : uint64_t{4096};
 
-    auto first_load_segment = std::min_element(
-        elf.load_segments.begin(), elf.load_segments.end(), [](const auto& lhs, const auto& rhs) {
-            return lhs.p_vaddr < rhs.p_vaddr;
-        });
-    if(first_load_segment == elf.load_segments.end())
+    auto mapping_matches_bias = [&](const memory_mapping& mapping, uint64_t bias) {
+        for(const auto& segment : elf.load_segments)
+        {
+            if(segment.p_filesz == 0) continue;
+            auto file_end = checked_add(segment.p_offset, segment.p_filesz);
+            if(!file_end) continue;
+            auto file_page_begin = align_down(segment.p_offset, page_size);
+            auto file_page_end   = align_up(*file_end, page_size);
+            if(!file_page_end || mapping.file_offset < file_page_begin ||
+               mapping.file_offset >= *file_page_end)
+            {
+                continue;
+            }
+
+            auto virtual_page = align_down(segment.p_vaddr, page_size);
+            auto file_delta   = mapping.file_offset - file_page_begin;
+            auto relative     = checked_add(virtual_page, file_delta);
+            auto expected     = relative ? checked_add(bias, *relative) : std::nullopt;
+            if(expected && *expected == mapping.start) return true;
+        }
+        return false;
+    };
+
+    auto candidates = std::vector<uint64_t>{};
+    for(const auto& mapping : object.mappings)
     {
-        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Target ELF has no PT_LOAD segments: "
-                   << object.path;
-        return std::nullopt;
+        for(const auto& segment : elf.load_segments)
+        {
+            if(segment.p_filesz == 0) continue;
+            auto file_end = checked_add(segment.p_offset, segment.p_filesz);
+            if(!file_end) continue;
+            auto file_page_begin = align_down(segment.p_offset, page_size);
+            auto file_page_end   = align_up(*file_end, page_size);
+            if(!file_page_end || mapping.file_offset < file_page_begin ||
+               mapping.file_offset >= *file_page_end)
+            {
+                continue;
+            }
+
+            auto virtual_page = align_down(segment.p_vaddr, page_size);
+            auto relative     = checked_add(virtual_page, mapping.file_offset - file_page_begin);
+            auto candidate = relative ? checked_sub(static_cast<uint64_t>(mapping.start), *relative)
+                                      : std::nullopt;
+            if(!candidate) continue;
+
+            auto all_mappings_match =
+                std::all_of(object.mappings.begin(), object.mappings.end(), [&](const auto& item) {
+                    return mapping_matches_bias(item, *candidate);
+                });
+            if(all_mappings_match &&
+               std::find(candidates.begin(), candidates.end(), *candidate) == candidates.end())
+            {
+                candidates.emplace_back(*candidate);
+            }
+        }
     }
 
-    auto first_mapping        = object.mappings.front();
-    auto segment_file_page    = align_down(first_load_segment->p_offset, page_size);
-    auto segment_virtual_page = align_down(first_load_segment->p_vaddr, page_size);
-    // Match the maps entry to the PT_LOAD segment by file page before using it
-    // to derive the ET_DYN load bias.
-    if(first_mapping.file_offset != segment_file_page)
+    if(candidates.size() != 1)
     {
-        ROCP_ERROR << "[rocprofiler-sdk-rocattach] First target mapping for " << object.path
-                   << " has file offset 0x" << std::hex << first_mapping.file_offset
-                   << ", but the first PT_LOAD segment starts at file page 0x" << segment_file_page
-                   << std::dec;
-        return std::nullopt;
-    }
-
-    // For ET_DYN shared objects, load bias is runtime start minus page-aligned
-    // segment virtual address.
-    auto bias = checked_sub(static_cast<uint64_t>(first_mapping.start), segment_virtual_page);
-    if(!bias)
-    {
-        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Invalid target mapping/segment pair for "
-                   << object.path << ": mapping start is below segment virtual page";
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Could not calculate a unique load bias for "
+                   << object.path << " from its PT_LOAD segments and mappings";
         return std::nullopt;
     }
 
     ROCP_TRACE << "[rocprofiler-sdk-rocattach] Calculated target load bias for " << object.path
-               << " as 0x" << std::hex << *bias << std::dec;
-    return bias;
+               << " as 0x" << std::hex << candidates.front() << std::dec;
+    return candidates.front();
+}
+
+std::optional<std::vector<uint8_t>>
+parse_gnu_build_id(const uint8_t* data, size_t size)
+{
+    auto result = std::vector<uint8_t>{};
+    auto found  = false;
+    auto cursor = uint64_t{0};
+
+    while(cursor < size)
+    {
+        if(sizeof(Elf64_Nhdr) > size - cursor) return std::nullopt;
+
+        auto header = Elf64_Nhdr{};
+        std::memcpy(&header, data + cursor, sizeof(header));
+        cursor += sizeof(header);
+
+        auto name_size = align_up(header.n_namesz, ELF_NOTE_ALIGNMENT);
+        auto desc_size = align_up(header.n_descsz, ELF_NOTE_ALIGNMENT);
+        if(!name_size || !desc_size || *name_size > size - cursor) return std::nullopt;
+
+        auto name_offset = cursor;
+        cursor += *name_size;
+        if(*desc_size > size - cursor) return std::nullopt;
+
+        auto is_gnu_build_id = header.n_type == NT_GNU_BUILD_ID && header.n_namesz == 4 &&
+                               header.n_descsz > 0 && header.n_descsz <= MAX_BUILD_ID_SIZE &&
+                               std::memcmp(data + name_offset, "GNU", 4) == 0;
+        if(is_gnu_build_id)
+        {
+            // Multiple Build ID notes are ambiguous and should not be used
+            // to relax filesystem identity checks.
+            if(found) return std::nullopt;
+            result.assign(data + cursor, data + cursor + header.n_descsz);
+            found = true;
+        }
+        cursor += *desc_size;
+    }
+
+    if(!found) return std::nullopt;
+    return result;
+}
+
+bool
+note_is_file_backed_load(const target_elf& elf, const Elf64_Phdr& note)
+{
+    auto note_end = checked_add(note.p_vaddr, note.p_filesz);
+    if(!note_end) return false;
+
+    return std::any_of(elf.load_segments.begin(), elf.load_segments.end(), [&](const auto& load) {
+        auto load_end = checked_add(load.p_vaddr, load.p_filesz);
+        return load_end && note.p_vaddr >= load.p_vaddr && *note_end <= *load_end;
+    });
+}
+
+std::optional<std::vector<uint8_t>>
+build_id_from_file(const target_elf& elf)
+{
+    auto result = std::vector<uint8_t>{};
+    auto found  = false;
+
+    for(const auto& segment : elf.reader.segments)
+    {
+        if(segment == nullptr || segment->get_type() != PT_NOTE) continue;
+
+        auto note = to_phdr(*segment);
+        if(note.p_filesz == 0 || note.p_filesz > MAX_ELF_NOTE_SIZE ||
+           !has_range(elf.data.size(), note.p_offset, note.p_filesz) ||
+           !note_is_file_backed_load(elf, note))
+        {
+            continue;
+        }
+
+        auto build_id =
+            parse_gnu_build_id(elf.data.data() + note.p_offset, static_cast<size_t>(note.p_filesz));
+        if(!build_id) continue;
+        if(found) return std::nullopt;
+        result = std::move(*build_id);
+        found  = true;
+    }
+
+    if(!found) return std::nullopt;
+    return result;
+}
+
+bool
+range_is_readable_mapping(const mapped_object& object, uint64_t address, uint64_t size)
+{
+    auto end = checked_add(address, size);
+    if(!end) return false;
+
+    return std::any_of(object.mappings.begin(), object.mappings.end(), [&](const auto& mapping) {
+        return mapping.permissions.find('r') != std::string::npos && address >= mapping.start &&
+               *end <= mapping.end;
+    });
+}
+
+std::optional<std::vector<uint8_t>>
+read_target_memory(pid_t pid, uint64_t address, size_t size)
+{
+    if(size == 0 || size > MAX_ELF_NOTE_SIZE || address > std::numeric_limits<uintptr_t>::max())
+    {
+        return std::nullopt;
+    }
+
+    auto data = std::vector<uint8_t>(size);
+    auto read = size_t{0};
+    while(read < size)
+    {
+        auto remote_address = checked_add(address, read);
+        if(!remote_address || *remote_address > std::numeric_limits<uintptr_t>::max())
+        {
+            return std::nullopt;
+        }
+
+        auto local = iovec{data.data() + read, size - read};
+        auto remote =
+            // process_vm_readv represents the remote process address as a pointer.
+            // NOLINTNEXTLINE(performance-no-int-to-ptr)
+            iovec{reinterpret_cast<void*>(static_cast<uintptr_t>(*remote_address)), size - read};
+        auto ret = ::process_vm_readv(pid, &local, 1, &remote, 1, 0);
+        if(ret < 0)
+        {
+            if(errno == EINTR) continue;
+            ROCP_TRACE << "[rocprofiler-sdk-rocattach] Could not read target memory at 0x"
+                       << std::hex << *remote_address << std::dec << ": " << std::strerror(errno);
+            return std::nullopt;
+        }
+        if(ret == 0) return std::nullopt;
+        read += static_cast<size_t>(ret);
+    }
+    return data;
+}
+
+std::optional<std::vector<uint8_t>>
+build_id_from_target_memory(pid_t                pid,
+                            const target_elf&    elf,
+                            const mapped_object& object,
+                            uint64_t             load_bias)
+{
+    auto result = std::vector<uint8_t>{};
+    auto found  = false;
+
+    for(const auto& segment : elf.reader.segments)
+    {
+        if(segment == nullptr || segment->get_type() != PT_NOTE) continue;
+
+        auto note = to_phdr(*segment);
+        if(note.p_filesz == 0 || note.p_filesz > MAX_ELF_NOTE_SIZE ||
+           note.p_memsz < note.p_filesz || !note_is_file_backed_load(elf, note))
+        {
+            continue;
+        }
+
+        auto runtime_address = checked_add(load_bias, note.p_vaddr);
+        if(!runtime_address || !range_is_readable_mapping(object, *runtime_address, note.p_filesz))
+        {
+            continue;
+        }
+
+        auto note_data =
+            read_target_memory(pid, *runtime_address, static_cast<size_t>(note.p_filesz));
+        if(!note_data) continue;
+
+        auto build_id = parse_gnu_build_id(note_data->data(), note_data->size());
+        if(!build_id) continue;
+        if(found) return std::nullopt;
+        result = std::move(*build_id);
+        found  = true;
+    }
+
+    if(!found) return std::nullopt;
+    return result;
+}
+
+bool
+build_id_matches_target(pid_t                pid,
+                        const target_elf&    elf,
+                        const mapped_object& object,
+                        uint64_t             load_bias)
+{
+    auto file_build_id = build_id_from_file(elf);
+    if(!file_build_id)
+    {
+        ROCP_WARNING << "[rocprofiler-sdk-rocattach] Cannot validate " << elf.path
+                     << " against the mapped object because it has no unique mapped GNU Build ID";
+        return false;
+    }
+
+    auto target_build_id = build_id_from_target_memory(pid, elf, object, load_bias);
+    if(!target_build_id)
+    {
+        ROCP_WARNING << "[rocprofiler-sdk-rocattach] Cannot validate " << elf.path
+                     << " because no unique GNU Build ID could be read from the target mapping";
+        return false;
+    }
+
+    if(*target_build_id != *file_build_id)
+    {
+        ROCP_WARNING << "[rocprofiler-sdk-rocattach] Refusing to use " << elf.path
+                     << " because its GNU Build ID does not match the target's mapped image";
+        return false;
+    }
+    return true;
 }
 
 std::optional<uint64_t>
@@ -831,6 +1095,10 @@ resolve_target_symbol(pid_t pid, const mapped_object& object, std::string_view s
 
     auto load_bias = calculate_load_bias(*elf, object);
     if(!load_bias) return std::nullopt;
+    if(!elf->metadata_identity_matches && !build_id_matches_target(pid, *elf, object, *load_bias))
+    {
+        return std::nullopt;
+    }
 
     auto sym = lookup_dynamic_symbol(*elf, symbol);
     if(!sym)

--- a/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
@@ -73,6 +73,7 @@ if(TARGET rocprofiler-sdk::rocprofiler-sdk-build-flags
         target_sources(${NAME} PRIVATE symbol_lookup_fixture.cpp)
         target_compile_definitions(${NAME} PRIVATE ROCATTACH_FIXTURE_VALUE=${VALUE})
         target_link_libraries(${NAME} PRIVATE rocprofiler-sdk::tests-build-flags)
+        target_link_options(${NAME} PRIVATE "LINKER:--build-id")
         set_target_properties(${NAME} PROPERTIES OUTPUT_NAME
                                                  "rocprofiler-register.so.${NAME}")
         if(HASH_STYLE)
@@ -86,6 +87,9 @@ if(TARGET rocprofiler-sdk::rocprofiler-sdk-build-flags
     rocattach_add_symbol_lookup_fixture(rocattach-symbol-lookup-fixture-shifted 6 "")
     target_compile_definitions(rocattach-symbol-lookup-fixture-shifted
                                PRIVATE ROCATTACH_FIXTURE_PADDED=1)
+    rocattach_add_symbol_lookup_fixture(rocattach-symbol-lookup-fixture-no-build-id 7 "")
+    set_property(TARGET rocattach-symbol-lookup-fixture-no-build-id
+                 PROPERTY LINK_OPTIONS "LINKER:--build-id=none")
     rocattach_add_symbol_lookup_fixture(rocattach-symbol-lookup-fixture-ambiguous-a 4 "")
     rocattach_add_symbol_lookup_fixture(rocattach-symbol-lookup-fixture-ambiguous-b 5 "")
 
@@ -96,6 +100,8 @@ if(TARGET rocprofiler-sdk::rocprofiler-sdk-build-flags
         rocattach-symbol-lookup-test
         PRIVATE "${ROCATTACH_SYMBOL_LOOKUP_SOURCE_ROOT}"
                 "${ROCATTACH_SYMBOL_LOOKUP_SOURCE_ROOT}/lib/rocprofiler-sdk-rocattach")
+    target_compile_definitions(rocattach-symbol-lookup-test
+                               PRIVATE ROCPROFILER_ROCATTACH_TESTING=1)
     target_link_libraries(
         rocattach-symbol-lookup-test
         PRIVATE rocprofiler-sdk::rocprofiler-sdk-shared-library
@@ -109,6 +115,7 @@ if(TARGET rocprofiler-sdk::rocprofiler-sdk-build-flags
         rocattach-symbol-lookup-fixture-gnu
         rocattach-symbol-lookup-fixture-sysv
         rocattach-symbol-lookup-fixture-shifted
+        rocattach-symbol-lookup-fixture-no-build-id
         rocattach-symbol-lookup-fixture-ambiguous-a
         rocattach-symbol-lookup-fixture-ambiguous-b)
 
@@ -119,6 +126,7 @@ if(TARGET rocprofiler-sdk::rocprofiler-sdk-build-flags
              $<TARGET_FILE:rocattach-symbol-lookup-fixture-gnu>
              $<TARGET_FILE:rocattach-symbol-lookup-fixture-sysv>
              $<TARGET_FILE:rocattach-symbol-lookup-fixture-shifted>
+             $<TARGET_FILE:rocattach-symbol-lookup-fixture-no-build-id>
              $<TARGET_FILE:rocattach-symbol-lookup-fixture-ambiguous-a>
              $<TARGET_FILE:rocattach-symbol-lookup-fixture-ambiguous-b>
         TIMEOUT 30

--- a/projects/rocprofiler-sdk/tests/rocattach/symbol_lookup_test.cpp
+++ b/projects/rocprofiler-sdk/tests/rocattach/symbol_lookup_test.cpp
@@ -33,6 +33,7 @@
 
 #include <array>
 #include <cstddef>
+#include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
@@ -247,23 +248,82 @@ expect_malformed_mapped_elf_fails()
     munmap(mapping, contents.size());
     std::filesystem::remove(path_buffer);
 }
+
+void
+expect_root_fallback_validates_build_id(const loaded_library& source,
+                                        const loaded_library& different_build,
+                                        const loaded_library& no_build_id)
+{
+    auto path = std::filesystem::temp_directory_path() /
+                "librocprofiler-register.so.rocattach-replaced-XXXXXX";
+    auto path_buffer = path.string();
+    auto fd          = mkstemp(path_buffer.data());
+    if(fd < 0)
+    {
+        std::cerr << "mkstemp failed for replaced ELF fixture\n";
+        std::exit(1);
+    }
+    close(fd);
+
+    std::filesystem::copy_file(
+        source.path, path_buffer, std::filesystem::copy_options::overwrite_existing);
+    auto mapped = load_library(path_buffer.c_str());
+
+    // Keep the original inode mapped, but replace its pathname with an
+    // identical ELF on a different inode. This models the identity mismatch
+    // seen when maps exposes an OverlayFS backing file.
+    std::filesystem::remove(path_buffer);
+    std::filesystem::copy_file(source.path, path_buffer);
+
+    setenv("ROCATTACH_TEST_DISABLE_MAP_FILES", "1", 1);
+    expect_resolves_to_dlsym(mapped);
+
+    // A layout-compatible pathname replacement with another Build ID must not
+    // be used to resolve a symbol from the still-mapped original.
+    auto replacement = path_buffer + ".replacement";
+    std::filesystem::copy_file(
+        different_build.path, replacement, std::filesystem::copy_options::overwrite_existing);
+    std::filesystem::rename(replacement, path_buffer);
+
+    void* resolved = nullptr;
+    if(rocprofiler::rocattach::find_symbol(getpid(), resolved, mapped.path, ATTACH_SYMBOL_NAME))
+    {
+        std::cerr << "find_symbol unexpectedly accepted a replacement ELF with a different "
+                     "Build ID\n";
+        std::exit(1);
+    }
+
+    std::filesystem::copy_file(
+        no_build_id.path, replacement, std::filesystem::copy_options::overwrite_existing);
+    std::filesystem::rename(replacement, path_buffer);
+    resolved = nullptr;
+    if(rocprofiler::rocattach::find_symbol(getpid(), resolved, mapped.path, ATTACH_SYMBOL_NAME))
+    {
+        std::cerr << "find_symbol unexpectedly accepted a replacement ELF without a Build ID\n";
+        std::exit(1);
+    }
+    unsetenv("ROCATTACH_TEST_DISABLE_MAP_FILES");
+
+    cleanup_loaded_library(mapped);
+    std::filesystem::remove(path_buffer);
+}
 }  // namespace
 
 int
 main(int argc, char** argv)
 {
-    if(argc != 7)
+    if(argc != 8)
     {
         std::cerr << "Usage: " << argv[0]
                   << " <normal-lib> <gnu-hash-lib> <sysv-hash-lib> <shifted-lib> "
-                     "<ambiguous-a> <ambiguous-b>\n";
+                     "<no-build-id-lib> <ambiguous-a> <ambiguous-b>\n";
         return 1;
     }
 
     auto libraries = std::vector<loaded_library>{};
-    libraries.reserve(6);
+    libraries.reserve(7);
     for(auto* path :
-        std::array<const char*, 6>{argv[1], argv[2], argv[3], argv[4], argv[5], argv[6]})
+        std::array<const char*, 7>{argv[1], argv[2], argv[3], argv[4], argv[5], argv[6], argv[7]})
     {
         libraries.emplace_back(load_library(path));
     }
@@ -288,6 +348,7 @@ main(int argc, char** argv)
     }
     expect_ambiguous_basename_fails();
     expect_malformed_mapped_elf_fails();
+    expect_root_fallback_validates_build_id(libraries.at(0), libraries.at(3), libraries.at(4));
 
     std::cout << "Test PASSED: target ELF resolver resolved exact mapped libraries and rejected "
                  "ambiguous and malformed mappings\n";


### PR DESCRIPTION
## Motivation

`rocprofiler-sdk-rocattach` could fail to resolve symbols (e.g. `rocprofiler_register_detach`) in a target process, breaking attach/detach:

```
[rocprofiler-sdk-rocattach] First target mapping for <path> has file offset 0x<offset>, but the first PT_LOAD segment starts at file page 0x0
[rocprofiler-sdk-rocattach] Failed to resolve <lib>::rocprofiler_register_detach from target pid <pid> ELF mappings
[rocprofiler-sdk-rocattach] call_function failed to find target symbol address
```

`calculate_load_bias()` assumed the *first* `/proc/<pid>/maps` entry always corresponds to the *first* PT_LOAD segment by file offset. This breaks whenever the kernel/loader's mapping order doesn't line up 1:1 with ELF segment order.

## Technical Details

- `symbol_lookup.cpp`: replaced the single-first-mapping assumption in `calculate_load_bias()` with a candidate search — iterate all mappings × all file-backed PT_LOAD segments, keep only bias candidates where every PT_LOAD segment is consistently mapped, require a unique result.
- Hardened the ELF-open fallback path: device/inode identity match first, then GNU build-id + inode/size fallback when `/proc/<pid>/map_files` isn't usable (e.g. permission-restricted, overlay/deleted-file cases).
- Added PT_NOTE edge-case handling for build-id extraction (bounds/size checks on NT_GNU_BUILD_ID notes).

## Issue Tracking

JIRA ID: AIPROFSDK-1023

## Test Plan

- Extended `tests/rocattach/symbol_lookup_test.cpp` fixture coverage: shifted-mapping-order case, build-id mismatch on fallback path, no-build-id rejection.
- Rebuilt `rocprofiler-sdk-rocattach-shared-library` locally, reinstalled, confirmed old strict-check error string gone and new candidate-search error string present.

## Test Result

Local build + existing `rocattach` test binary pass; manual reinstall against target install confirmed fix takes effect.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.