### PR TITLE
fix(clr): Ensure agent metadata is destroyed after runtime teardown

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -81,8 +81,8 @@ extern const char* HipExtraSourceCodeNoGWS;
 namespace amd::roc {
 bool roc::Device::isHsaInitialized_ = false;
 bool roc::Device::hostVmemSupported_ = false;
-std::vector<hsa_agent_t> roc::Device::gpu_agents_;
-std::vector<AgentInfo> roc::Device::cpu_agents_;
+std::vector<hsa_agent_t> roc::Device::gpu_agents_ ROCCLR_INIT_PRIORITY(101);
+std::vector<AgentInfo> roc::Device::cpu_agents_ ROCCLR_INIT_PRIORITY(101);
 
 address Device::mg_sync_ = nullptr;
 


### PR DESCRIPTION
## Motivation

Fix asan heap-use-after-free during process teardown in Graph tests. The static cpu_agents_ vector was destroyed before RuntimeTearDown, leaving cpu_agent_info_ pointing to freed AgentInfo storage. The goal is to keep agent metadata valid until runtime has drained asynchronous callbacks and completed teardown.


## Technical Details

Apply ROCCLR_INIT_PRIORITY(101) to roc::Device::gpu_agents_ and roc::Device::cpu_agents_ which constructs the vectors early. Since static objects are destroyed in reverse construction order, the agent metadata remains valid until the rest of the runtime teardown is complete. 

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->
JIRA ID : ROCM-29029

## Test Plan

Build TheRock with asan enabled and run:

Unit_hipGraphMemFreeNodeGetParams_ValidArgs
Unit_hipGraphMem_Alloc_Free_NodeGetParams_Functional
Unit_hipGraphMem_Alloc_Free_NodeGetParams_Functional_MultiDevice
Unit_hipGraphAddMemAllocNode_Negative_Instanciate_Graph_Again
Unit_hipGraphAddNodeTypeMemAlloc_Positive_Basic

## Test Result

Test passed without use-after-free issue.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
