### PR TITLE
fix(rocjitsu): route tensor DMA through wave VMID

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/tensor_dma.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/tensor_dma.h
@@ -14,6 +14,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <span>
 
 namespace rocjitsu {
 namespace amdgpu {
@@ -220,8 +221,7 @@ inline void validate_supported_descriptor(const TensorDmaDescriptor &desc, bool 
 
 inline void copy_bytes(const TensorDmaDescriptor &desc, Wavefront &wf, uint64_t global_element,
                        uint64_t lds_element, bool in_bounds, bool store_from_lds) {
-  auto *memory = wf.cu().memory();
-  if (!memory)
+  if (!wf.has_gpu_memory())
     throw util::UnimplementedInst("tensor DMA without GPU memory");
 
   const uint64_t global_addr = desc.global_base + global_element * desc.elem_size;
@@ -233,15 +233,21 @@ inline void copy_bytes(const TensorDmaDescriptor &desc, Wavefront &wf, uint64_t 
   }
 
   const uint32_t lds_addr = wf.lds_base() + desc.lds_base + static_cast<uint32_t>(lds_byte);
-  for (uint32_t byte = 0; byte < desc.elem_size; ++byte) {
-    if (store_from_lds) {
-      if (in_bounds)
-        memory->write8(global_addr + byte, wf.lds().read8(lds_addr + byte));
-    } else {
-      const uint8_t value = in_bounds ? memory->read8(global_addr + byte) : 0;
-      wf.lds().write8(lds_addr + byte, value);
-    }
+  std::array<uint8_t, 8> bytes{};
+  auto element_bytes = std::span<uint8_t>(bytes).first(desc.elem_size);
+  if (store_from_lds) {
+    if (!in_bounds)
+      return;
+    for (uint32_t byte = 0; byte < desc.elem_size; ++byte)
+      element_bytes[byte] = wf.lds().read8(lds_addr + byte);
+    wf.write_gpu_memory(global_addr, element_bytes);
+    return;
   }
+
+  if (in_bounds)
+    wf.read_gpu_memory(global_addr, element_bytes);
+  for (uint32_t byte = 0; byte < desc.elem_size; ++byte)
+    wf.lds().write8(lds_addr + byte, element_bytes[byte]);
 }
 
 inline void copy_gather_tensor(const TensorDmaDescriptor &desc, Wavefront &wf,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -638,7 +638,6 @@ protected:
   bool functional_yield_requested_ = false;
 };
 
-inline GpuMemory *InstructionComputeUnitView::memory() const { return raw_cu().memory(); }
 inline L1ScalarCache &InstructionComputeUnitView::l1_scalar() { return raw_cu().l1_scalar(); }
 inline L1VectorCache &InstructionComputeUnitView::l1_vector() { return raw_cu().l1_vector(); }
 inline L2Cache *InstructionComputeUnitView::l2() const { return raw_cu().l2(); }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
@@ -54,10 +54,12 @@ static_assert(KfdProcess::kPageSize == simdojo::SparseMemory::PAGE_SIZE,
 /// @brief AMDGPU VRAM memory with VMID-based per-process page table resolution.
 ///
 /// @details Mirrors the GFXHUB's VMID register file. Each process registers its
-/// page table via register_process(). Every memory access carries an explicit
-/// vmid parameter that selects the page table for VA-to-host translation,
-/// matching real hardware where the VMID travels with each request from the
-/// issuing wave through the memory hierarchy.
+/// page table via register_process(). A memory access's vmid parameter selects
+/// the page table for VA-to-host translation. VMID zero remains the intentional
+/// default for host, driver, and test callers. Wave-issued accesses must instead
+/// bind the issuing wave's process ID through a wave-scoped memory API, matching
+/// real hardware where the VMID travels with each request through the memory
+/// hierarchy.
 class GpuMemory : public simdojo::SparseMemory {
 public:
   explicit GpuMemory(std::string name)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/instruction_compute_unit_view.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/instruction_compute_unit_view.h
@@ -22,7 +22,6 @@ template <typename Isa> class AmdgpuIsaOperand;
 
 namespace amdgpu {
 class ComputeUnitCore;
-class GpuMemory;
 class L1ScalarCache;
 class L1VectorCache;
 class L2Cache;
@@ -39,7 +38,6 @@ class InstructionComputeUnitView {
 public:
   explicit InstructionComputeUnitView(ComputeUnitCore &cu) : cu_(&cu) {}
 
-  GpuMemory *memory() const;
   L1ScalarCache &l1_scalar();
   L1VectorCache &l1_vector();
   L2Cache *l2() const;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/wavefront.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/wavefront.cpp
@@ -12,6 +12,18 @@ Lds &Wavefront::lds() { return lds_ ? *lds_ : cu_.lds(); }
 
 const Lds &Wavefront::lds() const { return lds_ ? *lds_ : cu_.lds(); }
 
+bool Wavefront::has_gpu_memory() const { return cu_.memory() != nullptr; }
+
+void Wavefront::read_gpu_memory(uint64_t addr, std::span<uint8_t> dst) const {
+  assert(has_gpu_memory());
+  cu_.memory()->read_block(addr, dst, process_id_);
+}
+
+void Wavefront::write_gpu_memory(uint64_t addr, std::span<const uint8_t> src) {
+  assert(has_gpu_memory());
+  cu_.memory()->write_block(addr, src, process_id_);
+}
+
 void Wavefront::halt() {
   // s_endpgm terminates the wave, frees its resources, and notifies the CP as one
   // action, mirroring hardware. Order matters:

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/wavefront.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/wavefront.h
@@ -18,6 +18,7 @@
 #include <cassert>
 #include <cstdint>
 #include <memory>
+#include <span>
 #include <string_view>
 #include <vector>
 
@@ -186,6 +187,15 @@ public:
   /// @brief Override the LDS backing for this workgroup placement.
   /// Passing nullptr restores the owning CU's LDS.
   void set_lds(Lds *lds) { lds_ = lds; }
+
+  /// @brief Return whether this wave's compute unit has GPU memory backing.
+  bool has_gpu_memory() const;
+
+  /// @brief Read GPU memory in this wave's process address space.
+  void read_gpu_memory(uint64_t addr, std::span<uint8_t> dst) const;
+
+  /// @brief Write GPU memory in this wave's process address space.
+  void write_gpu_memory(uint64_t addr, std::span<const uint8_t> src);
 
   /// @brief Return this workgroup's rank within its cluster.
   uint32_t cluster_rank() const { return cluster_rank_; }

--- a/emulation/rocjitsu/tests/cdna5_tensor_dma_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_tensor_dma_test.cpp
@@ -17,6 +17,74 @@ void write_tensor_dma_d0(amdgpu::ComputeUnitCore &cu, amdgpu::Wavefront &wf, uin
                   static_cast<uint32_t>((global_addr >> 32) & 0x01ffffffu) | 0x80000000u);
 }
 
+TEST(Gfx1250ExecutionTest, TensorDmaUsesWaveProcessPageTable) {
+  constexpr uint32_t kProcessId = 1250;
+  constexpr uint32_t kElements = 4;
+  constexpr uint64_t kLoadGlobal = 0x20000000;
+  constexpr uint64_t kStoreGlobal = kLoadGlobal + KfdProcess::kPageSize;
+  constexpr std::array<uint32_t, kElements> kLoadValues = {
+      0x11000000u,
+      0x22000000u,
+      0x33000000u,
+      0x44000000u,
+  };
+  constexpr std::array<uint32_t, kElements> kStoreValues = {
+      0x55000000u,
+      0x66000000u,
+      0x77000000u,
+      0x88000000u,
+  };
+
+  KfdProcess process(kProcessId);
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf, nullptr);
+  wf->set_process_id(kProcessId);
+  wf->set_lds_base(cu->allocate_lds(256));
+
+  std::array<uint32_t, kElements> load_storage = kLoadValues;
+  std::array<uint32_t, kElements> store_storage{};
+  process.map_pages(kLoadGlobal, load_storage.data(), sizeof(load_storage));
+  process.map_pages(kStoreGlobal, store_storage.data(), sizeof(store_storage));
+  sim.memory->register_process(kProcessId, &process.page_table_, &process.page_table_mutex_,
+                               process.page_table_generation());
+
+  // The same GPU VA intentionally resolves to different storage for VMID zero
+  // and for the dispatched process. Tensor DMA must use the wave's process ID.
+  EXPECT_EQ(sim.memory->read32(kLoadGlobal), 0u);
+  EXPECT_EQ(sim.memory->read32(kLoadGlobal, kProcessId), kLoadValues[0]);
+
+  write_tensor_dma_d0(*cu, *wf, 0, kLoadGlobal);
+  write_wave_sgpr(*cu, *wf, 12, 2u << 16);        // i32 elements.
+  write_wave_sgpr(*cu, *wf, 13, kElements << 16); // Tensor dim0.
+  write_wave_sgpr(*cu, *wf, 14, 0);
+  write_wave_sgpr(*cu, *wf, 15, kElements << 16); // Tile dim0.
+  write_wave_sgpr(*cu, *wf, 16, 0);
+  write_wave_sgpr(*cu, *wf, 17, 0);
+  write_wave_sgpr(*cu, *wf, 18, 0);
+  write_wave_sgpr(*cu, *wf, 19, 0);
+
+  const std::array<uint32_t, 3> load_words = {0xd0710001u, 0x7c000000u, 0x7c7c0c00u};
+  auto load = decode_gfx1250(load_words, "tensor_load_to_lds");
+  ASSERT_NE(load, nullptr);
+  load->execute(*load, wf);
+  for (uint32_t i = 0; i < kElements; ++i)
+    EXPECT_EQ(cu->lds().read32(wf->lds_base() + i * sizeof(uint32_t)), kLoadValues[i]);
+
+  for (uint32_t i = 0; i < kElements; ++i)
+    cu->lds().write32(wf->lds_base() + i * sizeof(uint32_t), kStoreValues[i]);
+
+  write_tensor_dma_d0(*cu, *wf, 0, kStoreGlobal);
+  const std::array<uint32_t, 3> store_words = {0xd0714001u, 0x7c000000u, 0x7c7c0c00u};
+  auto store = decode_gfx1250(store_words, "tensor_store_from_lds");
+  ASSERT_NE(store, nullptr);
+  store->execute(*store, wf);
+  EXPECT_EQ(store_storage, kStoreValues);
+
+  sim.memory->unregister_process(kProcessId);
+}
+
 TEST(Gfx1250ExecutionTest, TensorDmaD2CopiesGlobalAndLds) {
   Gfx1250Sim sim;
   auto *cu = sim.cu();


### PR DESCRIPTION
## Summary

This change fixes the first rocJITsu tensor-DMA memory-translation failure reached by a gfx1250 TensileLite BF16 TDM GEMM.

The workload comes from:

```text
Tensile/Tests/common/gemm/gfx12/tdm_gfx1250.yaml
problem identifier: Contraction_l_Alik_Bljk_Cijk_Dijk
generated group: Cijk_Alik_Bljk_BBS_BH_UserArgs_00
representative problem: (64, 64, 1, 512)
```

## Failure before this fix

`tensilelite-client` segfaulted while executing a gfx1250 tensor load-to-LDS operation:

```text
tensor_dma_detail::copy_bytes
  -> tensor_dma_detail::copy_dense_tensor
  -> execute_tensor_load_to_lds<TensorLoadToLdsVimage>
```

The fault was a direct host dereference of a GPU virtual address such as `0x7fff2cc00000`.

## Root cause

Tensor DMA accessed `GpuMemory` without binding the issuing wavefront's process ID. The access therefore used VMID zero. In local functional mode, VMID-zero passthrough treated the user-space-looking GPU VA as a host pointer instead of resolving it through the dispatched process page table.

## Fix

- Add wave-scoped block read and write methods that always bind `Wavefront::process_id()`.
- Route tensor-DMA global-memory accesses through those methods.
- Remove the raw `InstructionComputeUnitView::memory()` accessor so instruction code cannot accidentally omit the wave VMID.
- Use one `GpuMemory::read_block` or `write_block` operation per 1-, 2-, 4-, or 8-byte tensor element instead of acquiring translation locks once per byte.
- Keep VMID zero as the intentional default for host, driver, and test callers.

An equivalent VMID propagation exists in the broader unmerged [`users/kuhar/dbt-sim`](https://github.com/ROCm/rocm-systems/tree/users/kuhar/dbt-sim) work at commit [`08a5c461a5`](https://github.com/ROCm/rocm-systems/commit/08a5c461a58d4ce21d911740f66652206f828afc); this PR isolates the tensor-DMA correction, strengthens the instruction-facing memory contract, and adds direct regression coverage.

## Test coverage

The new unit test:

- registers a nonzero process page table;
- maps load and store GPU VAs to separate host arrays;
- proves VMID zero resolves to different storage;
- verifies tensor load-to-LDS uses the wave process page table; and
- verifies tensor store-from-LDS uses the same page table.

Local validation includes the complete `Gfx1250ExecutionTest.TensorDma*` test set and changed-file pre-commit checks.

## Workload status

With this fix, the generated TensileLite client advances past the original VMID-zero direct-VA fault. The complete stock workload still has separate tensor-DMA tail and descriptor-contract questions tracked by #9935. This PR removes the narrow translation failure and does not claim to resolve the full workload.

## Issue Tracking

Closes #9774

This is the first independently reviewable rocJITsu correction tracked by #9935.
