### PR TITLE
fix(rocr/trap_handler): to not advance the PC for abort traps

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/trap_handler/trap_handler.s
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/trap_handler/trap_handler.s
@@ -344,9 +344,13 @@ trap_entry:
 .endif
 
 .not_host_trap:
-  // It's an s_trap; advance the PC
+  // We have an s_trap.  We should advance the PC past the trap instruction
+  // except for s_trap 2 (TRAP_ID_ABORT).
+  s_cmp_eq_u32                          ttmp2, TRAP_ID_ABORT
+  s_cbranch_scc1                        .skip_advance_pc
   s_add_u32                             ttmp0, ttmp0, 0x4
   s_addc_u32                            ttmp1, ttmp1, 0x0
+.skip_advance_pc:
 
   // If llvm.debugtrap and debugger is not attached.
   s_cmp_eq_u32                          ttmp2, TRAP_ID_DEBUGTRAP

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/trap_handler/trap_handler_gfx12.s
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/trap_handler/trap_handler_gfx12.s
@@ -307,10 +307,26 @@
   s_bfe_u32         ttmp2, ttmp1, SQ_WAVE_PC_HI_TRAP_ID_BFE // ttmp2 = TrapID
   s_cbranch_scc0    .check_exceptions			    // If TrapID is 0, it's an exception, so branch.
 
-  // If caused by s_trap then advance PC, then figure out the trap ID:
-  // - if trapID is DEBUGTRAP and debugger is attach, report WAVE_TRAP,
-  // - if trapID is ABORTTRAP, report WAVE_ABORT,
-  // - report WAVE_TRAP for any other trap ID.
+  // We have executed an s_trap instruction.
+  //
+  // +---------------------------------------------+--------------------------+
+  // | Trap ID                                     | Action                   |
+  // +---------------------------------------------+--------------------------+
+  // | TRAP_ID_ABORT                               | raise WAVE_ABORT         |
+  // | TRAP_ID_DEBUGTRAP and debugger not attached | incr PC, ignore          |
+  // | other traps                                 | incr PC, raise WAVE_TRAP |
+  // +---------------------------------------------+--------------------------+
+  //
+  // Handle the TRAP_ID_ABORT first as for abort, we want to keep the PC at the
+  // trap instruction.
+  s_cmp_eq_u32      ttmp2, TRAP_ID_ABORT
+  s_cbranch_scc0    .not_abort_trap
+  s_or_b32          ttmp3, ttmp3, EC_QUEUE_WAVE_ABORT_M0
+  s_branch          .check_exceptions
+
+.not_abort_trap:
+  // For s_trap with an ID other than TRAP_ID_ABORT, advance the PC past the
+  // s_trap instruction.
   s_add_u32         ttmp0, ttmp0, 0x4                       // PC_LO += 4
   s_addc_u32        ttmp1, ttmp1, 0x0                       // PC_HI += carry.
 
@@ -323,12 +339,6 @@
   s_or_b32          ttmp3, ttmp3, EC_QUEUE_WAVE_TRAP_M0
 
 .not_debug_trap:
-  s_cmp_eq_u32      ttmp2, TRAP_ID_ABORT
-  s_cbranch_scc0    .not_abort_trap
-  s_or_b32          ttmp3, ttmp3, EC_QUEUE_WAVE_ABORT_M0
-  s_branch          .check_exceptions
-
-.not_abort_trap:
   s_or_b32          ttmp3, ttmp3, EC_QUEUE_WAVE_TRAP_M0
 
   s_bitcmp1_b32     ttmp8, TTMP8_DEBUG_FLAG_SHIFT


### PR DESCRIPTION
## Motivation

AIROCGDB-646

## Technical Details

When executing an s_trap instruction (used to implement breakpoints, abort, debugtrap), the trap handler bumps the PC of the wave.  This means that when we return from the trap handler, the PC points to the instruction just after the s_trap.

For most of the cases, this is what we want, but for abort this causes issues.  Namely, when a wave calls abort, we can have the wave's PC point past the abort instruction (s_trap 2), which ends-up past the end of the end of the abort function.  As a consequence, the debugger ends up being confused and not being able to do a proper backtrace.

To address this issue, this patch changes the behavior of s_trap 2, which would leave the PC at the address of the s_trap, not past it. This is safe to do as execution is never intended to resume after this anyway.  There are other trap IDs where the debugger it needs to rewind (like for breakpoints, implemented as s_trap).  Considering both of those arguments, it is deemed safe to do this behavior change.

Also, this change matches what is currently described in the ABI document[1]:

```
  +-----------+-------------+-----------------------------------------+
  | llvm.trap | s_trap 0x02 | Causes wave to be halted with the PC at |
  |           |             | the trap instruction. The associated    |
  |           |             | queue is signalled to put it into the   |
  |           |             | error state. When the queue is put in   |
  |           |             | the error state, the waves executing    |
  |           |             | dispatches on the queue will be         |
  |           |             | terminated.                             |
  +-----------+-------------+-----------------------------------------+
```

Note that the s_trap 1 and s_trap 3 cases also have similar wording about realving the PC at the trap instruction, but the debugger currently relies on this behaviour.  Changing this for s_trap 1 and s_trap 3 would break backwards compatibility.

[1] https://llvm.org/docs/AMDGPUUsage.html

## Issue Tracking

JIRA ID:  AIROCGDB-646

## Test Plan

Debugger testsuite.

## Test Result

OK

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
