### PR TITLE
fix(rccl): restore DDA IPC AllReduce fallback on gfx950 for CE-ineligible calls

### DIFF
--- a/projects/rccl/src/collectives.cc
+++ b/projects/rccl/src/collectives.cc
@@ -630,11 +630,18 @@ ncclResult_t ncclAllReduce_impl(const void* sendbuff, void* recvbuff, size_t cou
   info.ceGraphDecisionValid = true;
   size_t msgBytes = count * ncclTypeSize(datatype);
   // gfx1250 DDA fabric AR is bounded by rcclDdaEnabled (RCCL_DDA_THRESHOLD) and
-  // the per-tier thresholds, so it may claim the full range; the CE min-size cap
-  // only applies to the other arches' DDA paths.
+  // the per-tier thresholds, so it may claim the full range. On the other arches
+  // CE AllReduce owns [NCCL_CE_AR_MIN_MSG_BYTES, NCCL_CE_AR_MAX_MSG_BYTES], but
+  // only yield to it when it can actually service this call: it additionally
+  // requires single-node symmetric-memory support, a count divisible by nRanks
+  // and a supported op/datatype. Yielding on message size alone left comms
+  // without those prerequisites (e.g. gfx950 with symmetricSupport off) with no
+  // DDA and no CE, falling back to the generic RING kernel across the whole
+  // 4 MiB+ range that DDA still wins.
   const bool ddaFabricArch1250 = IsArchMatch(comm->archName, "gfx1250");
-  if (!symEligible && rcclDdaEnabled(comm, count * ncclTypeSize(datatype), 8388608) &&
-      (ddaFabricArch1250 || msgBytes < NCCL_CE_AR_MIN_MSG_BYTES)) {
+  const bool ceAllReduceHandlesCall =
+    !ddaFabricArch1250 && ceArGraphAllowed && rcclUseCeAllReduce(comm, count, datatype, op);
+  if (!symEligible && !ceAllReduceHandlesCall && rcclDdaEnabled(comm, msgBytes, 8388608)) {
     if (IsArchMatch(comm->archName, "gfx1250")) {
       // Small-message fast lane: LL protocol (no GPU barrier).
       if (rcclParamDdaLL() && (count * ncclTypeSize(datatype)) <= (size_t)rcclParamDdaLLThreshold() &&

--- a/projects/rccl/src/collectives.cc
+++ b/projects/rccl/src/collectives.cc
@@ -214,6 +214,25 @@ static bool rcclDdaEnabled(const ncclComm* comm, size_t totalBytes, size_t gfx94
   return threshold > 0 && totalBytes <= threshold;
 }
 
+// Decides whether ncclAllReduce_impl takes the DDA path for this call. Kept as a small named helper
+// (rather than an inline expression) so the dispatch decision is reachable from host unit tests; the
+// logic is identical to the guard at the AllReduce call site below.
+bool rcclAllReduceShouldTakeDdaPath(const ncclComm* comm, size_t count, ncclDataType_t datatype,
+                                    ncclRedOp_t op, bool symEligible, bool ceArGraphAllowed) {
+  const size_t msgBytes = count * ncclTypeSize(datatype);
+  // gfx1250 DDA fabric AR is bounded by rcclDdaEnabled (RCCL_DDA_THRESHOLD) and the per-tier
+  // thresholds, so it may claim the full range. On the other arches CE AllReduce owns
+  // [NCCL_CE_AR_MIN_MSG_BYTES, NCCL_CE_AR_MAX_MSG_BYTES], but only yield to it when it can actually
+  // service this call: it additionally requires single-node symmetric-memory support, a count
+  // divisible by nRanks and a supported op/datatype. Yielding on message size alone left comms
+  // without those prerequisites (e.g. gfx950 with symmetricSupport off) with no DDA and no CE,
+  // falling back to the generic ring/tree kernel across the whole 4 MiB+ range that DDA still wins.
+  const bool ddaFabricArch1250 = IsArchMatch(comm->archName, "gfx1250");
+  const bool ceAllReduceHandlesCall =
+    !ddaFabricArch1250 && ceArGraphAllowed && rcclUseCeAllReduce(const_cast<ncclComm*>(comm), count, datatype, op);
+  return !symEligible && !ceAllReduceHandlesCall && rcclDdaEnabled(comm, msgBytes, 8388608);
+}
+
 // Check if symmteric kernels is requested for this collective
 static bool isSymmetricKernelRequested(ncclComm* comm, ncclFunc_t coll, int symkOp, ncclDataType_t datatype,
                                        size_t nElts, const void* sendbuff, void* recvbuff) {
@@ -628,20 +647,7 @@ ncclResult_t ncclAllReduce_impl(const void* sendbuff, void* recvbuff, size_t cou
   info.ceCapturing = ceCapturing;
   info.ceArGraphAllowed = ceArGraphAllowed;
   info.ceGraphDecisionValid = true;
-  size_t msgBytes = count * ncclTypeSize(datatype);
-  // gfx1250 DDA fabric AR is bounded by rcclDdaEnabled (RCCL_DDA_THRESHOLD) and
-  // the per-tier thresholds, so it may claim the full range. On the other arches
-  // CE AllReduce owns [NCCL_CE_AR_MIN_MSG_BYTES, NCCL_CE_AR_MAX_MSG_BYTES], but
-  // only yield to it when it can actually service this call: it additionally
-  // requires single-node symmetric-memory support, a count divisible by nRanks
-  // and a supported op/datatype. Yielding on message size alone left comms
-  // without those prerequisites (e.g. gfx950 with symmetricSupport off) with no
-  // DDA and no CE, falling back to the generic RING kernel across the whole
-  // 4 MiB+ range that DDA still wins.
-  const bool ddaFabricArch1250 = IsArchMatch(comm->archName, "gfx1250");
-  const bool ceAllReduceHandlesCall =
-    !ddaFabricArch1250 && ceArGraphAllowed && rcclUseCeAllReduce(comm, count, datatype, op);
-  if (!symEligible && !ceAllReduceHandlesCall && rcclDdaEnabled(comm, msgBytes, 8388608)) {
+  if (rcclAllReduceShouldTakeDdaPath(comm, count, datatype, op, symEligible, ceArGraphAllowed)) {
     if (IsArchMatch(comm->archName, "gfx1250")) {
       // Small-message fast lane: LL protocol (no GPU barrier).
       if (rcclParamDdaLL() && (count * ncclTypeSize(datatype)) <= (size_t)rcclParamDdaLLThreshold() &&

--- a/projects/rccl/src/include/rccl_common.h
+++ b/projects/rccl/src/include/rccl_common.h
@@ -139,6 +139,12 @@ bool rcclUseCeAllReduce(struct ncclComm* comm, size_t count, ncclDataType_t data
 void rcclCeAllReduceGraphLatchTick(struct ncclComm* comm, bool ceCapturing);
 // Pure query: is CE AllReduce currently allowed on this comm?
 bool rcclCeAllReduceAllowed(struct ncclComm* comm);
+// Decides whether ncclAllReduce_impl takes the DDA path for this call. Mirrors the guard in
+// collectives.cc exactly: DDA runs when the buffers are not symmetric-kernel eligible, CE AllReduce
+// will not service the call (non-gfx1250 only; gfx1250 always keeps the DDA fabric path), and DDA is
+// enabled for this arch/size. Host-side and GPU-free so the dispatch decision can be unit tested.
+bool rcclAllReduceShouldTakeDdaPath(const struct ncclComm* comm, size_t count, ncclDataType_t datatype,
+                                    ncclRedOp_t op, bool symEligible, bool ceArGraphAllowed);
 void rcclSetPxn(struct ncclComm* comm, int& rcclPxnDisable);
 void rcclSetP2pNetChunkSize(struct ncclComm* comm, int& rcclP2pNetChunkSize);
 ncclResult_t rcclFuncMaxSendRecvCount(ncclFunc_t func, int nRanks, size_t count, size_t& maxCount);

--- a/projects/rccl/test/RcclWrapTests.cpp
+++ b/projects/rccl/test/RcclWrapTests.cpp
@@ -2002,4 +2002,181 @@ TEST(Rcclwrap, AdjustChannels_Gfx950SingleNode8Ranks_MainColl_NoDouble)
 
 #endif // ENABLE_WARP_SPEED
 
+// ---------------------------------------------------------------------------
+// rcclAllReduceShouldTakeDdaPath: the AllReduce DDA-vs-CE dispatch decision.
+//
+// The helper returns true when ncclAllReduce_impl should take the DDA path, and
+// false when it should yield (to CE AllReduce, the symmetric kernel, or the
+// generic ring/tree fallback). DDA is taken when the buffers are not
+// symmetric-kernel eligible, CE AllReduce will not service the call, and DDA is
+// enabled for this arch and size. CE is only allowed to claim the call when it
+// can actually run it: symmetricSupport, single node, count divisible by nRanks,
+// a supported op and datatype, and an in-range size. Otherwise DDA keeps it.
+//
+// These tests drive the real decision (no GPU): RCCL_DDA_ENABLE defaults to 1,
+// LAUNCH_ORDER_IMPLICIT to 0 and ncclGroupDepth to 0, so rcclDdaEnabled() runs
+// its real arch/threshold logic. RCCL_CE_ALLREDUCE defaults to 1, so CE is
+// gated only by symmetricSupport / nNodes / count / op / dtype / size.
+namespace
+{
+// Fill a zero-initialized comm with just the fields the decision reads. Filled by
+// reference because ncclComm is not copyable.
+void InitDdaDecisionComm(ncclComm& comm, const char* arch, int nRanks, int nNodes, bool symmetricSupport)
+{
+    comm.archName         = const_cast<char*>(arch);
+    comm.nRanks           = nRanks;
+    comm.nNodes           = nNodes;
+    comm.symmetricSupport = symmetricSupport ? 1 : 0;
+}
+
+// count for a target byte size and datatype.
+size_t CountForBytes(size_t bytes, ncclDataType_t dt)
+{
+    return bytes / ncclTypeSize(dt);
+}
+} // namespace
+
+// gfx950 with symmetricSupport off: CE cannot run, so an 8 MiB call (at/above the
+// 4 MiB CE minimum) must still take DDA rather than fall to the generic kernel.
+TEST(RcclAllReduceDdaDecision, Gfx950_SymOff_LargeMsg_TakesDda)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx950", 8, 1, /*symmetricSupport=*/false);
+    size_t   count = CountForBytes(8ull * 1024 * 1024, ncclFloat32);
+    EXPECT_TRUE(rcclAllReduceShouldTakeDdaPath(&comm, count, ncclFloat32, ncclSum,
+                                               /*symEligible=*/false, /*ceArGraphAllowed=*/true));
+}
+
+// gfx950, small message with CE unavailable: squarely in DDA's range, takes DDA.
+TEST(RcclAllReduceDdaDecision, Gfx950_SymOff_SmallMsg_TakesDda)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx950", 8, 1, /*symmetricSupport=*/false);
+    size_t   count = CountForBytes(2ull * 1024 * 1024, ncclFloat32);
+    EXPECT_TRUE(rcclAllReduceShouldTakeDdaPath(&comm, count, ncclFloat32, ncclSum,
+                                               /*symEligible=*/false, /*ceArGraphAllowed=*/true));
+}
+
+// gfx950 with symmetricSupport on and every CE prerequisite met: CE will service
+// the call, so the DDA guard must yield (returns false).
+TEST(RcclAllReduceDdaDecision, Gfx950_SymOn_CeEligible_YieldsToCe)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx950", 8, 1, /*symmetricSupport=*/true);
+    size_t   count = CountForBytes(8ull * 1024 * 1024, ncclFloat32); // divisible by 8 ranks
+    EXPECT_FALSE(rcclAllReduceShouldTakeDdaPath(&comm, count, ncclFloat32, ncclSum,
+                                                /*symEligible=*/false, /*ceArGraphAllowed=*/true));
+}
+
+// CE eligible by size/op/dtype but disabled by the graph latch (ceArGraphAllowed
+// false): CE will not run, so DDA must reclaim the call.
+TEST(RcclAllReduceDdaDecision, Gfx950_SymOn_GraphLatched_TakesDda)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx950", 8, 1, /*symmetricSupport=*/true);
+    size_t   count = CountForBytes(8ull * 1024 * 1024, ncclFloat32);
+    EXPECT_TRUE(rcclAllReduceShouldTakeDdaPath(&comm, count, ncclFloat32, ncclSum,
+                                               /*symEligible=*/false, /*ceArGraphAllowed=*/false));
+}
+
+// CE declines on an unsupported op (ncclAvg) even with symmetricSupport on, so
+// DDA reclaims the call.
+TEST(RcclAllReduceDdaDecision, Gfx950_SymOn_UnsupportedOp_TakesDda)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx950", 8, 1, /*symmetricSupport=*/true);
+    size_t   count = CountForBytes(8ull * 1024 * 1024, ncclFloat32);
+    EXPECT_TRUE(rcclAllReduceShouldTakeDdaPath(&comm, count, ncclFloat32, ncclAvg,
+                                               /*symEligible=*/false, /*ceArGraphAllowed=*/true));
+}
+
+// gfx942 with symmetricSupport off: a 6 MiB call is within the 8 MiB gfx942 DDA
+// cap and, with CE unavailable, takes DDA.
+TEST(RcclAllReduceDdaDecision, Gfx942_SymOff_MidMsg_TakesDda)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx942", 8, 1, /*symmetricSupport=*/false);
+    size_t   count = CountForBytes(6ull * 1024 * 1024, ncclFloat32);
+    EXPECT_TRUE(rcclAllReduceShouldTakeDdaPath(&comm, count, ncclFloat32, ncclSum,
+                                               /*symEligible=*/false, /*ceArGraphAllowed=*/true));
+}
+
+// gfx942 above its 8 MiB DDA cap: rcclDdaEnabled returns false, so no DDA.
+TEST(RcclAllReduceDdaDecision, Gfx942_SymOff_AboveCap_NoDda)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx942", 8, 1, /*symmetricSupport=*/false);
+    size_t   count = CountForBytes(9ull * 1024 * 1024, ncclFloat32);
+    EXPECT_FALSE(rcclAllReduceShouldTakeDdaPath(&comm, count, ncclFloat32, ncclSum,
+                                                /*symEligible=*/false, /*ceArGraphAllowed=*/true));
+}
+
+// gfx942 with symmetricSupport on and every CE prerequisite met: CE claims the call
+// and the DDA guard yields, even though 6 MiB is within the 8 MiB gfx942 DDA cap.
+// Mirror of Gfx942_SymOff_MidMsg_TakesDda: symmetricSupport flips the decision.
+TEST(RcclAllReduceDdaDecision, Gfx942_SymOn_CeEligible_YieldsToCe)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx942", 8, 1, /*symmetricSupport=*/true);
+    size_t   count = CountForBytes(6ull * 1024 * 1024, ncclFloat32); // divisible by 8 ranks
+    EXPECT_FALSE(rcclAllReduceShouldTakeDdaPath(&comm, count, ncclFloat32, ncclSum,
+                                                /*symEligible=*/false, /*ceArGraphAllowed=*/true));
+}
+
+// gfx942 with symmetricSupport on but CE declines on an unsupported op (ncclAvg):
+// DDA reclaims the call since 6 MiB is within the 8 MiB gfx942 cap.
+TEST(RcclAllReduceDdaDecision, Gfx942_SymOn_UnsupportedOp_TakesDda)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx942", 8, 1, /*symmetricSupport=*/true);
+    size_t   count = CountForBytes(6ull * 1024 * 1024, ncclFloat32);
+    EXPECT_TRUE(rcclAllReduceShouldTakeDdaPath(&comm, count, ncclFloat32, ncclAvg,
+                                               /*symEligible=*/false, /*ceArGraphAllowed=*/true));
+}
+
+// gfx1250 forces the DDA fabric path regardless of CE eligibility: the
+// ddaFabricArch1250 short-circuit means CE never claims the call on this arch.
+// symmetricSupport is on (the gfx1250 default) and the call is otherwise fully
+// CE-eligible (64 MiB, sum, divisible), so the short-circuit is the only reason
+// DDA is chosen here.
+TEST(RcclAllReduceDdaDecision, Gfx1250_CeEligible_StillTakesDda)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx1250", 8, 1, /*symmetricSupport=*/true);
+    size_t   count = CountForBytes(64ull * 1024 * 1024, ncclFloat32); // CE-eligible size, divisible by 8
+    EXPECT_TRUE(rcclAllReduceShouldTakeDdaPath(&comm, count, ncclFloat32, ncclSum,
+                                               /*symEligible=*/false, /*ceArGraphAllowed=*/true));
+}
+
+// An arch DDA never runs on: rcclDdaEnabled returns false, so no DDA on any size.
+TEST(RcclAllReduceDdaDecision, UnsupportedArch_NoDda)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx90a", 8, 1, /*symmetricSupport=*/false);
+    size_t   count = CountForBytes(2ull * 1024 * 1024, ncclFloat32);
+    EXPECT_FALSE(rcclAllReduceShouldTakeDdaPath(&comm, count, ncclFloat32, ncclSum,
+                                                /*symEligible=*/false, /*ceArGraphAllowed=*/true));
+}
+
+// gfx942/gfx950 DDA requires the full 8-GPU node; fewer ranks disables it.
+TEST(RcclAllReduceDdaDecision, Gfx950_TooFewRanks_NoDda)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx950", 4, 1, /*symmetricSupport=*/false);
+    size_t   count = CountForBytes(2ull * 1024 * 1024, ncclFloat32);
+    EXPECT_FALSE(rcclAllReduceShouldTakeDdaPath(&comm, count, ncclFloat32, ncclSum,
+                                                /*symEligible=*/false, /*ceArGraphAllowed=*/true));
+}
+
+// Symmetric-kernel eligible buffers win outright: the DDA guard yields (returns false)
+// regardless of arch/size.
+TEST(RcclAllReduceDdaDecision, SymEligible_YieldsToSymmetricKernel)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx950", 8, 1, /*symmetricSupport=*/false);
+    size_t   count = CountForBytes(2ull * 1024 * 1024, ncclFloat32);
+    EXPECT_FALSE(rcclAllReduceShouldTakeDdaPath(&comm, count, ncclFloat32, ncclSum,
+                                                /*symEligible=*/true, /*ceArGraphAllowed=*/true));
+}
+
 } // namespace RcclUnitTesting


### PR DESCRIPTION
## Motivation

Commit 91347a4f5a ("upstream gfx1250 features", #8945) gated DDA IPC
AllReduce to messages < NCCL_CE_AR_MIN_MSG_BYTES (4MB) on non-gfx1250
architectures, assuming CE AllReduce would catch the >=4MB range as a
fallback. CE AllReduce requires comm->symmetricSupport, which is only
auto-enabled on gfx1250 (see ncclIsCuMemSupported()); gfx950 never has
it by default. With no CE fallback and DDA now excluded, 4MB-32MB
AllReduce falls back to the slow generic ring/tree kernel, causing up
to a 55% busbw regression on gfx950 (MI355X) in that range.

## Technical Details

Replace the `(ddaFabricArch1250 || msgBytes < NCCL_CE_AR_MIN_MSG_BYTES)`
guard in ncclAllReduce_impl (src/collectives.cc) with a direct check of
whether CE AllReduce will actually handle the call:
    const bool ceAllReduceHandlesCall =
      !ddaFabricArch1250 && ceArGraphAllowed && rcclUseCeAllReduce(comm, count, datatype, op);
    if (!symEligible && !ceAllReduceHandlesCall && rcclDdaEnabled(comm, msgBytes, 8388608)) {
This reuses rcclUseCeAllReduce() -- the same predicate the earlier CE
early-return check already relies on -- instead of approximating CE
eligibility with a single symmetricSupport check. DDA now falls back
correctly whenever CE won't take the call for any reason (missing
symmetricSupport, RCCL_CE_ALLREDUCE=0, non-sum/prod/min/max op,
multi-node, non-divisible count, fp8 dtype, or graph-capture latch),
not just when symmetricSupport is false. gfx1250 is unaffected:
ddaFabricArch1250 continues to force the DDA fabric path unconditionally.

## Issue Tracking

JIRA ID: AICOMRCCL-1714
JIRA ID: AICOMRCCL-1875

## Test Plan

Single-node AllReduce (8x MI355X/gfx950, float, mpirun, 1KB-4GB) before
and after the fix, plus a rocprofv3 kernel-level check confirming
ddaAllReduceTreeIpc dispatches again at 4MB-32MB instead of
ncclDevKernel_Generic_2.

## Test Result

Restores 4MB-32MB busbw to match the pre-regression baseline (parent
commit a497330a) within run-to-run noise (<2%), e.g. 4MB: 264.99 GB/s
vs. 261.80 GB/s baseline (was 117.76 GB/s regressed).

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
