### PR TITLE
rocrtst: Fix Memory_Async_Copy failure on multi-NUMA CPU systems

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/performance/memory_async_copy.cc
+++ b/projects/rocr-runtime/rocrtst/suites/performance/memory_async_copy.cc
@@ -810,7 +810,7 @@ static hsa_status_t GetAgentInfo(hsa_agent_t agent, void* data) {
   int ret;
 
   if (ptr->cpu_agent().handle != 0) {
-    return HSA_STATUS_ERROR;
+    return HSA_STATUS_SUCCESS;  // Already found CPU agent, skip remaining agents
   }
 
 


### PR DESCRIPTION
Fix test failure on systems with multiple CPU HSA agents. Return HSA_STATUS_SUCCESS to skip additional CPU agents instead of HSA_STATUS_ERROR which aborts agent iteration.

## Motivation
Fix rocrtstPerf.Memory_Async_Copy and rocrtstPerf.Memory_Async_Copy_On_Engine test failures on multi-NUMA systems with multiple CPU HSA agents.
The test aborted agent iteration prematurely when encountering a second CPU agent, preventing GPU agents from being enumerated and causing assertion failures.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking
JIRA ID: ROCM-29094

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.