### PR TITLE
[HACK] Add HSA_DISABLE_INST_PREFETCH environment variable

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -51,7 +51,6 @@
 #include <cinttypes>
 #include <cstring>
 #include <fstream>
-#include <iostream>
 #include <iomanip>
 #include <memory>
 #include <sstream>
@@ -637,6 +636,10 @@ bool Device::create() {
   info_.hdpRegFlushCntl = hdpInfo.HDP_REG_FLUSH_CNTL;
   bool hasValidHDPFlush = (info_.hdpMemFlushCntl != nullptr) && (info_.hdpRegFlushCntl != nullptr);
 
+  uint32_t ucodeVersion = 0;
+  const hsa_status_t ucodeStatus = Hsa::agent_get_info(
+      bkendDevice_, static_cast<hsa_agent_info_t>(HSA_AMD_AGENT_INFO_UCODE_VERSION), &ucodeVersion);
+
   // Create HSA settings
   assert(!settings_);
   roc::Settings* hsaSettings = new roc::Settings();
@@ -648,6 +651,10 @@ bool Device::create() {
                    pciDeviceId_);
     return false;
   }
+
+  static constexpr uint32_t kMinUcodeForFormat4 = 255;
+  hsaSettings->launch_desc_supported_ =
+      (ucodeStatus == HSA_STATUS_SUCCESS) && (ucodeVersion >= kMinUcodeForFormat4);
 
   if (!ValidateComgr()) {
     LogPrintfError("Code object manager initialization failed for HSA device %s (PCI ID %x)",
@@ -4042,7 +4049,8 @@ void Device::ApplyHwEventPatches(const std::vector<HwEventPatch>& patches,
       ps->flags_.isPacketDispatch_ =
           (pktType == HSA_PACKET_TYPE_KERNEL_DISPATCH) ||
           (pktType == HSA_PACKET_TYPE_VENDOR_SPECIFIC &&
-           amdFormat == HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH);
+           (amdFormat == HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH ||
+            amdFormat == HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH_LD));
     } else {
       // dep_slot >= 0: patch a barrier's dependency signal slot (cross-segment wait)
       auto* pkt = reinterpret_cast<hsa_barrier_and_packet_t*>(raw);

--- a/projects/clr/rocclr/device/rocm/rocsettings.cpp
+++ b/projects/clr/rocclr/device/rocm/rocsettings.cpp
@@ -72,6 +72,7 @@ Settings::Settings() {
   fgs_kernel_arg_ = false;
   barrier_value_packet_ = false;
   ext_dispatch_packet_ = false;
+  launch_desc_supported_ = false;
   kernel_arg_impl_ = KernelArgImpl::HostKernelArgs;
   gwsInitSupported_ = true;
   limit_blit_wg_ = 16;

--- a/projects/clr/rocclr/device/rocm/rocsettings.hpp
+++ b/projects/clr/rocclr/device/rocm/rocsettings.hpp
@@ -38,7 +38,8 @@ class Settings : public device::Settings {
       uint blocking_blit_ : 1;         //!< Blit ops can be blocking on CPU
       uint queue_pipe_dist_ : 1;       //!< gfx94x queue pipe distribution
       uint ext_dispatch_packet_ : 1;   //!< Uses new ext dispatch packet for all launches
-      uint reserved_ : 18;
+      uint launch_desc_supported_ : 1; //!< Launch descriptor (Format 4 / DISPATCH_LD) supported by CP ucode
+      uint reserved_ : 17;
     };
     uint value_;
   };

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -5318,7 +5318,7 @@ static void convertDynDataPrefetchToHsa(const amd::DynDataPrefetchRegion* region
     hw[i].cooperative = 1;
     hw[i].temporal = hints & 0x3u;
     hw[i].scope = 2; // DEVICE
-    hw[i].mode = 1; // ABSOLUTE_VA
+    hw[i].mode = HIP_DISABLE_DYN_PREFETCH ? 0 : 1; // 0=disabled, 1=ABSOLUTE_VA
   }
 }
 

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1346,7 +1346,8 @@ std::string VirtualGPU::AnalyzeAqlQueue() const {
   fprintf(stderr, "VGPU(%p) hang analysis:\n", this);
   if (pkt_type == HSA_PACKET_TYPE_VENDOR_SPECIFIC) {
     auto* vendor_hdr = reinterpret_cast<const hsa_amd_vendor_packet_header_t*>(aql_loc);
-    if (vendor_hdr->AmdFormat == HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH) {
+    if (vendor_hdr->AmdFormat == HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH ||
+        vendor_hdr->AmdFormat == HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH_LD) {
       auto* ext = reinterpret_cast<const hsa_amd_ext_kernel_dispatch_packet_t*>(aql_loc);
       lookupKernelName(ext->kernel_object);
       logAqlDispatchPacketExtended(dev(), gpu_queue_, header, ext, index, priority_, meta,
@@ -1419,7 +1420,8 @@ bool VirtualGPU::dispatchGenericAqlPacket(AqlPacket* packet, uint16_t header, ui
   AqlPacket* aql_loc = &((AqlPacket*)(gpu_queue_->base_address))[index & queueMask];
   *aql_loc = *packet;
 
-  metadata_preloader_.Set(packet, header, index & queueMask);
+  metadata_preloader_.Set(packet, header, index & queueMask, rest, aql_loc);
+
   if (header != 0) {
     packet_store_release(reinterpret_cast<uint32_t*>(aql_loc), header, rest);
   }
@@ -1442,6 +1444,11 @@ bool VirtualGPU::dispatchGenericAqlPacket(AqlPacket* packet, uint16_t header, ui
   bool ring_doorbell = IS_LINUX || dev().IsPm4Emulation() || blocking ||
                        (skippedDispatches_ >= skip_limit) || ring_for_non_profiler_signal;
   if (ring_doorbell) {
+    if constexpr (std::is_same_v<AqlPacket, hsa_amd_ext_kernel_dispatch_packet_t>) {
+      auto* ext_aql = reinterpret_cast<hsa_amd_ext_kernel_dispatch_packet_t*>(aql_loc);
+      ClPrint(amd::LOG_DEBUG, amd::LOG_AQL, "LD_DEBUG: amd_format=%d, rest=0x%x, rest_low_byte=0x%x",
+              static_cast<int>(ext_aql->amd_format), rest, (rest & 0xFF));
+    }
     Hsa::signal_store_screlease(gpu_queue_->doorbell_signal, index);
     skippedDispatches_ = 0;
   } else {
@@ -1494,14 +1501,20 @@ void VirtualGPU::adjustHeader(uint16_t& header) {
 }
 
 // ================================================================================================
-void VirtualGPU::dispatchBlockingWait(hsa_kernel_dispatch_packet_t* packet) {
+void VirtualGPU::dispatchBlockingWait(hsa_kernel_dispatch_packet_t* packet,
+                                      hsa_amd_packet_type8_t amd_format) {
   auto wait_signals = Barriers().WaitingSignal();
-  if (dev().settings().ext_dispatch_packet_ && wait_signals.size() == 1 && packet != nullptr) {
-      // The Ext Dispatch Packet supports only one dependent signal
-      auto ext_packet = reinterpret_cast<hsa_amd_ext_kernel_dispatch_packet_t*>(packet);
-      ext_packet->dep_signal = wait_signals[0];
+
+  // Format 3 (DISPATCH) supports one dep_signal when there's exactly one wait signal
+  if (amd_format == HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH &&
+      wait_signals.size() == 1 && packet != nullptr) {
+    auto ext_packet = reinterpret_cast<hsa_amd_ext_kernel_dispatch_packet_t*>(packet);
+    ext_packet->dep_signal = wait_signals[0];
   } else {
-    // AQL dispatch doesn't support dependent signals and extra barrier packet must be generated
+    // All other cases: use barrier packets for dependencies
+    // - Format 4 (DISPATCH1): dep_signal field is launch_descriptor, must use barriers
+    // - Format 3 with multiple signals or null packet: use barriers
+    // - Standard dispatch packets: use barriers
     for (uint32_t i = 0; i < wait_signals.size(); ++i) {
       uint32_t j = i % 5;
       barrier_packet_.dep_signal[j] = wait_signals[i];
@@ -1539,7 +1552,12 @@ bool VirtualGPU::dispatchAqlPacket(AqlPacket* packet, uint16_t header,
     }
     return true;
   } else {
-    dispatchBlockingWait(reinterpret_cast<hsa_kernel_dispatch_packet_t*>(packet));
+    // rest is setup (dimensions) for regular dispatch; amd_format lives in rest only for ext packets.
+    hsa_amd_packet_type8_t amd_format = 0;
+    if constexpr (std::is_same_v<AqlPacket, hsa_amd_ext_kernel_dispatch_packet_t>) {
+      amd_format = static_cast<hsa_amd_packet_type8_t>(rest & 0xFF);
+    }
+    dispatchBlockingWait(reinterpret_cast<hsa_kernel_dispatch_packet_t*>(packet), amd_format);
     return dispatchGenericAqlPacket(packet, header, rest, blocking, attach_signal);
   }
 }
@@ -1713,7 +1731,8 @@ bool VirtualGPU::dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPack
         const bool isKernelDispatch =
             isBaseKernelDispatch ||
             (pktType == HSA_PACKET_TYPE_VENDOR_SPECIFIC &&
-             amdFormat == HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH);
+             (amdFormat == HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH ||
+              amdFormat == HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH_LD));
         if (timestamp_ != nullptr) {
           // When pre_patched, skip any slot whose completion_signal was already
           // written by ApplyHwEventPatches (non-zero means pre-patched).
@@ -2224,7 +2243,7 @@ bool VirtualGPU::create() {
   SetGpuQueue(queue, md_rb);
   if (!gpu_queue_) return false;
 
-  if (dev().isa().versionMajor() == 12 && dev().isa().versionMinor() >= 5) {
+  if (dev().settings().launch_desc_supported_) {
     metadata_preloader_.SetLaunchDescriptorVersion(AMD_LAUNCH_DESCRIPTOR_VERSION_GFX1250);
   }
 
@@ -4784,6 +4803,12 @@ bool VirtualGPU::submitKernelInternal(const amd::NDRangeContainer& sizes, const 
     }
   }
 
+  // Use Format 4 (DISPATCH_LD) only if forced via env var and device supports it
+  hsa_amd_packet_type8_t amd_format = HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH;
+  if (extDispatchPacket && AMD_FORCE_LD_DISPATCH_PACKET && dev().settings().launch_desc_supported_) {
+    amd_format = HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH_LD;
+  }
+
   // Copy scheduler's AQL packet for possible relaunch from the scheduler itself
     if (aql_packet != nullptr) {
       *aql_packet = dispatchPacket;
@@ -4793,8 +4818,8 @@ bool VirtualGPU::submitKernelInternal(const amd::NDRangeContainer& sizes, const 
                               (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_ACQUIRE_FENCE_SCOPE) |
                               (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_RELEASE_FENCE_SCOPE);
         // For an ext-dispatch vendor packet byte+2 is amd_format, not setup; set
-        // amd_format=EXT_KERNEL_DISPATCH and shift setup (dimensions) into byte+3.
-        aql_packet->setup = static_cast<uint16_t>(HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH
+        // amd_format and shift setup (dimensions) into byte+3.
+        aql_packet->setup = static_cast<uint16_t>(amd_format
                               | ((sizes.dimensions()
                                   << HSA_KERNEL_DISPATCH_PACKET_SETUP_DIMENSIONS) << 8));
       } else {
@@ -4814,8 +4839,7 @@ bool VirtualGPU::submitKernelInternal(const amd::NDRangeContainer& sizes, const 
       // on normal dispatch packet, first 32 bits are header & setup. In ext dispatch packet,
       // the first 32 bits are header, amd_format, setup. Update the "rest" of the 32 bits, so we
       // can commit it atomically in packet_store_release.
-      rest = (HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH
-              | ((sizes.dimensions() << HSA_KERNEL_DISPATCH_PACKET_SETUP_DIMENSIONS) << 8));
+      rest = (amd_format | ((sizes.dimensions() << HSA_KERNEL_DISPATCH_PACKET_SETUP_DIMENSIONS) << 8));
     } else {
       rest = (sizes.dimensions() << HSA_KERNEL_DISPATCH_PACKET_SETUP_DIMENSIONS);
     }

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -347,12 +347,28 @@ class VirtualGPU : public device::VirtualDevice {
 
       //! Set metadata prefetching packet associated with regular aql packet
       template <class AqlPacket>
-      inline void Set(AqlPacket* packet, uint16_t header, uint64_t index) {
+      inline void Set(AqlPacket* packet, uint16_t header, uint64_t index, uint32_t rest = 0,
+                      AqlPacket* aql_loc = nullptr) {
         if (!IsAttached()) {
           return;
         }
         FillMetadata(packet, header,
                      static_cast<uint8_t*>(queue_base_) + index * kMetadataPacketSize);
+
+        // For Format 4 (DISPATCH_LD), set the launch_descriptor pointer in the AQL packet
+        // to point to the launch_descriptor structure in the metadata packet
+        if constexpr (std::is_same_v<AqlPacket, hsa_amd_ext_kernel_dispatch_packet_t>) {
+          hsa_amd_packet_type8_t amd_format = static_cast<hsa_amd_packet_type8_t>(rest & 0xFF);
+          if (amd_format == HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH_LD) {
+            auto* metadata = GetMetadataPacket(index);
+            if (metadata != nullptr && aql_loc != nullptr) {
+              // Set the pointer in both the local packet copy and the queue location
+              auto* launch_desc = const_cast<amd_launch_descriptor_t*>(&metadata->launch_descriptor);
+              packet->launch_descriptor = launch_desc;
+              aql_loc->launch_descriptor = launch_desc;
+            }
+          }
+        }
       }
 
       //! Set the launch descriptor version (called once from VirtualGPU::create)
@@ -668,7 +684,8 @@ class VirtualGPU : public device::VirtualDevice {
   void adjustHeader(uint16_t& header);
 
   //! Dispatches a barrier with blocking HSA signals
-  void dispatchBlockingWait(hsa_kernel_dispatch_packet_t* packet);
+  void dispatchBlockingWait(hsa_kernel_dispatch_packet_t* packet,
+                            hsa_amd_packet_type8_t amd_format = 0);
 
   //! Dispatch (or capture, when graph-capturing) a kernel dispatch packet.
   //! Handles both hsa_kernel_dispatch_packet_t and hsa_amd_ext_kernel_dispatch_packet_t.

--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -287,7 +287,9 @@ release(bool, HIP_HRR_DEBUG_ARGS, false,                                      \
 release(uint, DEBUG_CLR_DOORBELL_SKIP, 16,                                    \
         "Number of consecutive dispatches that may skip the doorbell flush.") \
 release(bool, DEBUG_CLR_DISABLE_FALLBACK, false,                              \
-        "Disables certain fallback paths")
+        "Disables certain fallback paths")                                    \
+release(bool, AMD_FORCE_LD_DISPATCH_PACKET, false,                            \
+        "Force use of launch descriptor dispatch packet (Format 4)")
 
 
 namespace amd {

--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -279,6 +279,8 @@ release(bool, DEBUG_CLR_DISABLE_IMAGE, false,                                 \
         "1 = Disable Image support for ROC path")                             \
 release(bool, DEBUG_CLR_ENABLE_PREFETCH_METADATA, true,                       \
         "Enable metadata prefetch for some Aql packets")                      \
+release(bool, HIP_DISABLE_DYN_PREFETCH, false,                                \
+        "Disable dynamic data prefetch by setting mode=0 in launch descriptor") \
 release(cstring, HIP_HRR_CAPTURE_OUTPUT, "",                                  \
         "Set to a directory path to enable HRR capture; archive written there") \
 release(bool, HIP_HRR_DEBUG_ARGS, false,                                      \

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
@@ -133,6 +133,12 @@ typedef enum {
    */
   HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH = 3,
 
+  /**
+   * Extended kernel dispatch packet with spatial locality computing support.
+   * Supports clusters, launch descriptor for advanced scheduling, and L2 prefetch.
+   */
+  HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH_LD = 4,
+
   /* Reserved for a packet that is not yet released */
   HSA_AMD_PACKET_TYPE_RESERVED200 = 200,
 } hsa_amd_packet_type_t;
@@ -293,6 +299,10 @@ typedef union {
 
 /**
  * @brief AMD extended kernel dispatch packet.
+ *
+ * Supports both Format 3 (HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH) and
+ * Format 4 (HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH_LD).
+ * The amd_format field determines which interpretation to use.
  */
 typedef struct hsa_amd_ext_kernel_dispatch_packet_s {
   /**
@@ -306,15 +316,18 @@ typedef struct hsa_amd_ext_kernel_dispatch_packet_s {
 
   /**
    * AMD vendor-specific packet type. Used to configure which vendor packet this
-   * is. The parameters are described by hsa_amd_packet_type_t. This packet is
-   * of type HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH.​
+   * is. The parameters are described by hsa_amd_packet_type_t.
+   * This packet supports:
+   * - HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH (Format 3)
+   * - HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH_LD (Format 4)
    */
   hsa_amd_packet_type8_t amd_format;
 
   /**
-   * Dispatch setup parameters. Used to configure kernel dispatch parameters
-   * such as the number of dimensions in the grid. The parameters are described
-   * by hsa_kernel_dispatch_packet_setup_t.​
+   * Dispatch setup parameters.
+   * Used to configure kernel dispatch parameters such as the number of
+   * dimensions in the grid. The parameters are described by
+   * hsa_kernel_dispatch_packet_setup_t.
    */
   uint8_t setup;
 
@@ -410,16 +423,25 @@ typedef struct hsa_amd_ext_kernel_dispatch_packet_s {
   void* kernarg_address;
 
   /**
-   * Dependent signal object. This signal is read in the launch phase.​
+   * Format-dependent field (DW 14:13).
+   * Interpretation depends on amd_format:
    *
-   * The packet processor does not exit the launch phase for this packet, and
-   * thus does not perform the requested acquire fence scope’s actions, until
-   * the signal has been observed with the value 0.​
+   * Format 3 (HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH):
+   *   - dep_signal: Dependent signal object read in the launch phase.
+   *     The packet processor waits until the signal value is 0 before
+   *     exiting the launch phase. A signal handle value of 0 is allowed
+   *     and is interpreted as a satisfied dependency.
    *
-   * A signal handle value of 0 is allowed and is interpreted by the packet
-   * processor as a satisfied dependency.​
+   * Format 4 (HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH_LD):
+   *   - launch_descriptor: Pointer to amd_launch_descriptor_t structure
+   *     providing advanced scheduling control (CU enable, wave limiter,
+   *     L2 prefetch, etc.). A NULL pointer indicates no launch descriptor
+   *     is used. Dependencies must be handled via barrier packets.
    */
-  hsa_signal_t dep_signal;
+  union {
+    hsa_signal_t dep_signal;                      // Format 3: signal-based dependency
+    amd_launch_descriptor_t* launch_descriptor;   // Format 4: pointer to descriptor
+  };
 
   /**
    * Signal used to indicate completion of the job. The application can use the

--- a/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
@@ -1621,13 +1621,29 @@ hsa_status_t ExecutableImpl::LoadDefinitionSymbol(hsa_agent_t agent,
     llvm::amdhsa::kernel_descriptor_t kd;
     sym->GetSection()->getData(sym->SectionOffset(), &kd, sizeof(kd));
 
+    // Extract original INST_PREF_SIZE
+    uint32_t inst_pref_original = AMDHSA_BITS_GET(
+        kd.compute_pgm_rsrc3, rocr::llvm::amdhsa::COMPUTE_PGM_RSRC3_GFX12_PLUS_INST_PREF_SIZE);
+
+    // Check environment variable to disable instruction prefetch
+    static const char* disable_inst_pref = getenv("HSA_DISABLE_INST_PREFETCH");
+    uint32_t inst_pref = inst_pref_original;
+
+    if (disable_inst_pref && atoi(disable_inst_pref) != 0) {
+      kd.compute_pgm_rsrc3 = AMDHSA_BITS_SET(
+          kd.compute_pgm_rsrc3,
+          rocr::llvm::amdhsa::COMPUTE_PGM_RSRC3_GFX12_PLUS_INST_PREF_SIZE,
+          0);
+      inst_pref = 0;
+      std::cout << "[ROCR] InstPrefetch size requested: " << inst_pref_original
+                << " - zeroed out (HSA_DISABLE_INST_PREFETCH=1)" << std::endl;
+    }
+
     if (trampoline_enabled_gfx125x_) {
       // Record this descriptor; the trampoline is installed after relocations.
       // sym->VAddr() is the descriptor's ELF vaddr (matches SymbolAddress below).
       // INST_PREF_SIZE = number of 128B I$ lines the CP prefetches ahead of the
       // entry; captured here to size the trampoline's prefetch guard.
-      uint32_t inst_pref = AMDHSA_BITS_GET(
-          kd.compute_pgm_rsrc3, rocr::llvm::amdhsa::COMPUTE_PGM_RSRC3_GFX12_PLUS_INST_PREF_SIZE);
       kd_fixups_.push_back(
           {SymbolSegment(agent, sym), sym->VAddr(), kd.kernel_code_entry_byte_offset, inst_pref});
     }


### PR DESCRIPTION
This is a debugging/workaround hack to disable instruction prefetch on GFX12+ architectures by zeroing out COMPUTE_PGM_RSRC3.INST_PREF_SIZE in kernel descriptors.

Usage:
  export HSA_DISABLE_INST_PREFETCH=1
  ./your_application

When enabled, prints diagnostic message:
  [ROCR] InstPrefetch size requested: <N> - zeroed out (HSA_DISABLE_INST_PREFETCH=1)

This allows testing whether instruction prefetch is contributing to performance issues without requiring kernel recompilation.

Location: runtime/hsa-runtime/loader/executable.cpp

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
