### PR TITLE
test(rccl): cover AllReduce DDA-vs-CE dispatch decision (follow-up to #9777)

### DIFF
--- a/projects/rccl/src/collectives.cc
+++ b/projects/rccl/src/collectives.cc
@@ -214,6 +214,25 @@ static bool rcclDdaEnabled(const ncclComm* comm, size_t totalBytes, size_t gfx94
   return threshold > 0 && totalBytes <= threshold;
 }
 
+// Decides whether ncclAllReduce_impl takes the DDA path for this call. Kept as a small named helper
+// (rather than an inline expression) so the dispatch decision is reachable from host unit tests; the
+// logic is identical to the guard at the AllReduce call site below.
+bool rcclAllReduceShouldTakeDdaPath(const ncclComm* comm, size_t count, ncclDataType_t datatype,
+                                    ncclRedOp_t op, bool symEligible, bool ceArGraphAllowed) {
+  const size_t msgBytes = count * ncclTypeSize(datatype);
+  // gfx1250 DDA fabric AR is bounded by rcclDdaEnabled (RCCL_DDA_THRESHOLD) and the per-tier
+  // thresholds, so it may claim the full range. On the other arches CE AllReduce owns
+  // [NCCL_CE_AR_MIN_MSG_BYTES, NCCL_CE_AR_MAX_MSG_BYTES], but only yield to it when it can actually
+  // service this call: it additionally requires single-node symmetric-memory support, a count
+  // divisible by nRanks and a supported op/datatype. Yielding on message size alone left comms
+  // without those prerequisites (e.g. gfx950 with symmetricSupport off) with no DDA and no CE,
+  // falling back to the generic ring/tree kernel across the whole 4 MiB+ range that DDA still wins.
+  const bool ddaFabricArch1250 = IsArchMatch(comm->archName, "gfx1250");
+  const bool ceAllReduceHandlesCall =
+    !ddaFabricArch1250 && ceArGraphAllowed && rcclUseCeAllReduce(const_cast<ncclComm*>(comm), count, datatype, op);
+  return !symEligible && !ceAllReduceHandlesCall && rcclDdaEnabled(comm, msgBytes, 8388608);
+}
+
 // Check if symmteric kernels is requested for this collective
 static bool isSymmetricKernelRequested(ncclComm* comm, ncclFunc_t coll, int symkOp, ncclDataType_t datatype,
                                        size_t nElts, const void* sendbuff, void* recvbuff) {
@@ -628,20 +647,7 @@ ncclResult_t ncclAllReduce_impl(const void* sendbuff, void* recvbuff, size_t cou
   info.ceCapturing = ceCapturing;
   info.ceArGraphAllowed = ceArGraphAllowed;
   info.ceGraphDecisionValid = true;
-  size_t msgBytes = count * ncclTypeSize(datatype);
-  // gfx1250 DDA fabric AR is bounded by rcclDdaEnabled (RCCL_DDA_THRESHOLD) and
-  // the per-tier thresholds, so it may claim the full range. On the other arches
-  // CE AllReduce owns [NCCL_CE_AR_MIN_MSG_BYTES, NCCL_CE_AR_MAX_MSG_BYTES], but
-  // only yield to it when it can actually service this call: it additionally
-  // requires single-node symmetric-memory support, a count divisible by nRanks
-  // and a supported op/datatype. Yielding on message size alone left comms
-  // without those prerequisites (e.g. gfx950 with symmetricSupport off) with no
-  // DDA and no CE, falling back to the generic RING kernel across the whole
-  // 4 MiB+ range that DDA still wins.
-  const bool ddaFabricArch1250 = IsArchMatch(comm->archName, "gfx1250");
-  const bool ceAllReduceHandlesCall =
-    !ddaFabricArch1250 && ceArGraphAllowed && rcclUseCeAllReduce(comm, count, datatype, op);
-  if (!symEligible && !ceAllReduceHandlesCall && rcclDdaEnabled(comm, msgBytes, 8388608)) {
+  if (rcclAllReduceShouldTakeDdaPath(comm, count, datatype, op, symEligible, ceArGraphAllowed)) {
     if (IsArchMatch(comm->archName, "gfx1250")) {
       // Small-message fast lane: LL protocol (no GPU barrier).
       if (rcclParamDdaLL() && (count * ncclTypeSize(datatype)) <= (size_t)rcclParamDdaLLThreshold() &&

--- a/projects/rccl/src/include/rccl_common.h
+++ b/projects/rccl/src/include/rccl_common.h
@@ -139,6 +139,12 @@ bool rcclUseCeAllReduce(struct ncclComm* comm, size_t count, ncclDataType_t data
 void rcclCeAllReduceGraphLatchTick(struct ncclComm* comm, bool ceCapturing);
 // Pure query: is CE AllReduce currently allowed on this comm?
 bool rcclCeAllReduceAllowed(struct ncclComm* comm);
+// Decides whether ncclAllReduce_impl takes the DDA path for this call. Mirrors the guard in
+// collectives.cc exactly: DDA runs when the buffers are not symmetric-kernel eligible, CE AllReduce
+// will not service the call (non-gfx1250 only; gfx1250 always keeps the DDA fabric path), and DDA is
+// enabled for this arch/size. Host-side and GPU-free so the dispatch decision can be unit tested.
+bool rcclAllReduceShouldTakeDdaPath(const struct ncclComm* comm, size_t count, ncclDataType_t datatype,
+                                    ncclRedOp_t op, bool symEligible, bool ceArGraphAllowed);
 void rcclSetPxn(struct ncclComm* comm, int& rcclPxnDisable);
 void rcclSetP2pNetChunkSize(struct ncclComm* comm, int& rcclP2pNetChunkSize);
 ncclResult_t rcclFuncMaxSendRecvCount(ncclFunc_t func, int nRanks, size_t count, size_t& maxCount);

--- a/projects/rccl/test/RcclWrapTests.cpp
+++ b/projects/rccl/test/RcclWrapTests.cpp
@@ -2002,4 +2002,181 @@ TEST(Rcclwrap, AdjustChannels_Gfx950SingleNode8Ranks_MainColl_NoDouble)
 
 #endif // ENABLE_WARP_SPEED
 
+// ---------------------------------------------------------------------------
+// rcclAllReduceShouldTakeDdaPath: the AllReduce DDA-vs-CE dispatch decision.
+//
+// The helper returns true when ncclAllReduce_impl should take the DDA path, and
+// false when it should yield (to CE AllReduce, the symmetric kernel, or the
+// generic ring/tree fallback). DDA is taken when the buffers are not
+// symmetric-kernel eligible, CE AllReduce will not service the call, and DDA is
+// enabled for this arch and size. CE is only allowed to claim the call when it
+// can actually run it: symmetricSupport, single node, count divisible by nRanks,
+// a supported op and datatype, and an in-range size. Otherwise DDA keeps it.
+//
+// These tests drive the real decision (no GPU): RCCL_DDA_ENABLE defaults to 1,
+// LAUNCH_ORDER_IMPLICIT to 0 and ncclGroupDepth to 0, so rcclDdaEnabled() runs
+// its real arch/threshold logic. RCCL_CE_ALLREDUCE defaults to 1, so CE is
+// gated only by symmetricSupport / nNodes / count / op / dtype / size.
+namespace
+{
+// Fill a zero-initialized comm with just the fields the decision reads. Filled by
+// reference because ncclComm is not copyable.
+void InitDdaDecisionComm(ncclComm& comm, const char* arch, int nRanks, int nNodes, bool symmetricSupport)
+{
+    comm.archName         = const_cast<char*>(arch);
+    comm.nRanks           = nRanks;
+    comm.nNodes           = nNodes;
+    comm.symmetricSupport = symmetricSupport ? 1 : 0;
+}
+
+// count for a target byte size and datatype.
+size_t CountForBytes(size_t bytes, ncclDataType_t dt)
+{
+    return bytes / ncclTypeSize(dt);
+}
+} // namespace
+
+// gfx950 with symmetricSupport off: CE cannot run, so an 8 MiB call (at/above the
+// 4 MiB CE minimum) must still take DDA rather than fall to the generic kernel.
+TEST(RcclAllReduceDdaDecision, Gfx950_SymOff_LargeMsg_TakesDda)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx950", 8, 1, /*symmetricSupport=*/false);
+    size_t   count = CountForBytes(8ull * 1024 * 1024, ncclFloat32);
+    EXPECT_TRUE(rcclAllReduceShouldTakeDdaPath(&comm, count, ncclFloat32, ncclSum,
+                                               /*symEligible=*/false, /*ceArGraphAllowed=*/true));
+}
+
+// gfx950, small message with CE unavailable: squarely in DDA's range, takes DDA.
+TEST(RcclAllReduceDdaDecision, Gfx950_SymOff_SmallMsg_TakesDda)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx950", 8, 1, /*symmetricSupport=*/false);
+    size_t   count = CountForBytes(2ull * 1024 * 1024, ncclFloat32);
+    EXPECT_TRUE(rcclAllReduceShouldTakeDdaPath(&comm, count, ncclFloat32, ncclSum,
+                                               /*symEligible=*/false, /*ceArGraphAllowed=*/true));
+}
+
+// gfx950 with symmetricSupport on and every CE prerequisite met: CE will service
+// the call, so the DDA guard must yield (returns false).
+TEST(RcclAllReduceDdaDecision, Gfx950_SymOn_CeEligible_YieldsToCe)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx950", 8, 1, /*symmetricSupport=*/true);
+    size_t   count = CountForBytes(8ull * 1024 * 1024, ncclFloat32); // divisible by 8 ranks
+    EXPECT_FALSE(rcclAllReduceShouldTakeDdaPath(&comm, count, ncclFloat32, ncclSum,
+                                                /*symEligible=*/false, /*ceArGraphAllowed=*/true));
+}
+
+// CE eligible by size/op/dtype but disabled by the graph latch (ceArGraphAllowed
+// false): CE will not run, so DDA must reclaim the call.
+TEST(RcclAllReduceDdaDecision, Gfx950_SymOn_GraphLatched_TakesDda)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx950", 8, 1, /*symmetricSupport=*/true);
+    size_t   count = CountForBytes(8ull * 1024 * 1024, ncclFloat32);
+    EXPECT_TRUE(rcclAllReduceShouldTakeDdaPath(&comm, count, ncclFloat32, ncclSum,
+                                               /*symEligible=*/false, /*ceArGraphAllowed=*/false));
+}
+
+// CE declines on an unsupported op (ncclAvg) even with symmetricSupport on, so
+// DDA reclaims the call.
+TEST(RcclAllReduceDdaDecision, Gfx950_SymOn_UnsupportedOp_TakesDda)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx950", 8, 1, /*symmetricSupport=*/true);
+    size_t   count = CountForBytes(8ull * 1024 * 1024, ncclFloat32);
+    EXPECT_TRUE(rcclAllReduceShouldTakeDdaPath(&comm, count, ncclFloat32, ncclAvg,
+                                               /*symEligible=*/false, /*ceArGraphAllowed=*/true));
+}
+
+// gfx942 with symmetricSupport off: a 6 MiB call is within the 8 MiB gfx942 DDA
+// cap and, with CE unavailable, takes DDA.
+TEST(RcclAllReduceDdaDecision, Gfx942_SymOff_MidMsg_TakesDda)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx942", 8, 1, /*symmetricSupport=*/false);
+    size_t   count = CountForBytes(6ull * 1024 * 1024, ncclFloat32);
+    EXPECT_TRUE(rcclAllReduceShouldTakeDdaPath(&comm, count, ncclFloat32, ncclSum,
+                                               /*symEligible=*/false, /*ceArGraphAllowed=*/true));
+}
+
+// gfx942 above its 8 MiB DDA cap: rcclDdaEnabled returns false, so no DDA.
+TEST(RcclAllReduceDdaDecision, Gfx942_SymOff_AboveCap_NoDda)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx942", 8, 1, /*symmetricSupport=*/false);
+    size_t   count = CountForBytes(9ull * 1024 * 1024, ncclFloat32);
+    EXPECT_FALSE(rcclAllReduceShouldTakeDdaPath(&comm, count, ncclFloat32, ncclSum,
+                                                /*symEligible=*/false, /*ceArGraphAllowed=*/true));
+}
+
+// gfx942 with symmetricSupport on and every CE prerequisite met: CE claims the call
+// and the DDA guard yields, even though 6 MiB is within the 8 MiB gfx942 DDA cap.
+// Mirror of Gfx942_SymOff_MidMsg_TakesDda: symmetricSupport flips the decision.
+TEST(RcclAllReduceDdaDecision, Gfx942_SymOn_CeEligible_YieldsToCe)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx942", 8, 1, /*symmetricSupport=*/true);
+    size_t   count = CountForBytes(6ull * 1024 * 1024, ncclFloat32); // divisible by 8 ranks
+    EXPECT_FALSE(rcclAllReduceShouldTakeDdaPath(&comm, count, ncclFloat32, ncclSum,
+                                                /*symEligible=*/false, /*ceArGraphAllowed=*/true));
+}
+
+// gfx942 with symmetricSupport on but CE declines on an unsupported op (ncclAvg):
+// DDA reclaims the call since 6 MiB is within the 8 MiB gfx942 cap.
+TEST(RcclAllReduceDdaDecision, Gfx942_SymOn_UnsupportedOp_TakesDda)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx942", 8, 1, /*symmetricSupport=*/true);
+    size_t   count = CountForBytes(6ull * 1024 * 1024, ncclFloat32);
+    EXPECT_TRUE(rcclAllReduceShouldTakeDdaPath(&comm, count, ncclFloat32, ncclAvg,
+                                               /*symEligible=*/false, /*ceArGraphAllowed=*/true));
+}
+
+// gfx1250 forces the DDA fabric path regardless of CE eligibility: the
+// ddaFabricArch1250 short-circuit means CE never claims the call on this arch.
+// symmetricSupport is on (the gfx1250 default) and the call is otherwise fully
+// CE-eligible (64 MiB, sum, divisible), so the short-circuit is the only reason
+// DDA is chosen here.
+TEST(RcclAllReduceDdaDecision, Gfx1250_CeEligible_StillTakesDda)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx1250", 8, 1, /*symmetricSupport=*/true);
+    size_t   count = CountForBytes(64ull * 1024 * 1024, ncclFloat32); // CE-eligible size, divisible by 8
+    EXPECT_TRUE(rcclAllReduceShouldTakeDdaPath(&comm, count, ncclFloat32, ncclSum,
+                                               /*symEligible=*/false, /*ceArGraphAllowed=*/true));
+}
+
+// An arch DDA never runs on: rcclDdaEnabled returns false, so no DDA on any size.
+TEST(RcclAllReduceDdaDecision, UnsupportedArch_NoDda)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx90a", 8, 1, /*symmetricSupport=*/false);
+    size_t   count = CountForBytes(2ull * 1024 * 1024, ncclFloat32);
+    EXPECT_FALSE(rcclAllReduceShouldTakeDdaPath(&comm, count, ncclFloat32, ncclSum,
+                                                /*symEligible=*/false, /*ceArGraphAllowed=*/true));
+}
+
+// gfx942/gfx950 DDA requires the full 8-GPU node; fewer ranks disables it.
+TEST(RcclAllReduceDdaDecision, Gfx950_TooFewRanks_NoDda)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx950", 4, 1, /*symmetricSupport=*/false);
+    size_t   count = CountForBytes(2ull * 1024 * 1024, ncclFloat32);
+    EXPECT_FALSE(rcclAllReduceShouldTakeDdaPath(&comm, count, ncclFloat32, ncclSum,
+                                                /*symEligible=*/false, /*ceArGraphAllowed=*/true));
+}
+
+// Symmetric-kernel eligible buffers win outright: the DDA guard yields (returns false)
+// regardless of arch/size.
+TEST(RcclAllReduceDdaDecision, SymEligible_YieldsToSymmetricKernel)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx950", 8, 1, /*symmetricSupport=*/false);
+    size_t   count = CountForBytes(2ull * 1024 * 1024, ncclFloat32);
+    EXPECT_FALSE(rcclAllReduceShouldTakeDdaPath(&comm, count, ncclFloat32, ncclSum,
+                                                /*symEligible=*/true, /*ceArGraphAllowed=*/true));
+}
+
 } // namespace RcclUnitTesting


### PR DESCRIPTION
## Motivation

#9777 changes the AllReduce DDA-vs-CE dispatch guard in ncclAllReduce_impl, but
the decision is inlined and calls the file-static rcclDdaEnabled(), so it cannot
be exercised by a host unit test. This adds that coverage on top of that branch.

## Change

- Extract the guard into a non-static, GPU-free helper rcclAllReduceShouldTakeDdaPath()
  (declared in rccl_common.h). Behavior is identical to the current call site, which
  now just calls the helper; this also drops the duplicate rcclUseCeAllReduce() call.
- Add the RcclAllReduceDdaDecision gtest suite (13 cases) in RcclWrapTests.cpp
  (compiled into rccl-UnitTestsFixturesDebug):
  - gfx950 CE-ineligible (symmetricSupport off), at/above 4 MiB -> DDA
  - gfx950 CE-eligible -> yields to CE; graph-latched / unsupported op -> DDA
  - gfx942 CE-ineligible mid-size -> DDA; above the 8 MiB gfx942 cap -> no DDA
  - gfx942 CE-eligible -> yields; unsupported op -> DDA
  - gfx1250 CE-eligible -> still DDA (ddaFabricArch1250 short-circuit)
  - unsupported arch / <8 ranks -> no DDA; symmetric-kernel eligible -> yields

## Test Result

Built and ran on gfx942 / ROCm 7.0.2 (rccl-UnitTestsFixturesDebug):
[  PASSED  ] 20 tests. (13 RcclAllReduceDdaDecision + 7 RcclCeGraphLatch)

## Note

Offered as a follow-up to #9777; base is that PR's branch so it can be merged in
directly if useful.

JIRA ID: AICOMRCCL-1714
