### PR TITLE
[rocjitsu] Add packed-f16 f8/bf8 wmma lowering

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.cpp
@@ -33,20 +33,10 @@ namespace {
 /// rules. Prefix-classified WMMA/SWMMAC and cluster-load instructions are
 /// handled separately by family-level translation rules.
 ///
-/// NOT-YET-SUPPORTED (classified as needing an expansion but with no semantic
-/// expander, so translating a kernel that uses them fails closed rather than
-/// passing the instruction through unchanged):
-///   * v_cvt_pk_fp8_f32, v_cvt_sr_fp8_f32 (only when CLAMP selects the B0-only
-///     mode; the ordinary form stays on the copy path),
-///   * v_wmma_scale / v_wmma_scale16 forms without an implemented rule,
-///   * integer IU4 and IU8 WMMA/SWMMAC forms without an implemented spacing
-///     rule.
 /// Separately, a 64-bit source reading FLAT_SCRATCH_BASE is classified via
 /// operand inspection (see gfx1250_reads_flat_scratch_base_64bit), and the
 /// barrier-state and sleep/monitor families are DEFERRED with a pass-through
 /// warning rather than fail-closed (see is_deferred_gfx1250_family).
-/// Classifying the fail-closed cases keeps the failure explicit and located; add
-/// the semantic rule (and update this note) once each expansion is implemented.
 inline constexpr std::array<std::string_view, 17> kExactB0ToA0TranslationMnemonics = {
     "ds_load_2addr_b32",
     "ds_load_2addr_b64",
@@ -96,8 +86,8 @@ inline constexpr std::array<std::string_view, 17> kExactB0ToA0TranslationMnemoni
   // but not A0, so they require semantic expansion. The common f32 K=128 forms
   // use one neutral regular-Scale mixed-format operation. Source fields with no
   // meaning for these opcodes are discarded while constructing the target.
-  // The standalone 32x16 FP4 form splits into two scaled M=16 halves; the f16
-  // K=128 forms still fail closed in their semantic rule.
+  // The standalone 32x16 FP4 form splits into two scaled M=16 halves. Packed-f16
+  // K=128 forms lower through an f32 accumulator and pack the final result.
   const bool is_k128_fp8_bf8 = (mnemonic.starts_with("v_wmma_f16_16x16x128_") ||
                                 mnemonic.starts_with("v_wmma_f32_16x16x128_")) &&
                                (mnemonic.ends_with("_fp8_fp8") || mnemonic.ends_with("_fp8_bf8") ||

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
@@ -2121,6 +2121,16 @@ ExpandResult expand_gfx1250_k128_wmma(const Instruction &inst, uint32_t, uint64_
   if (source.src0 < kVgprEncoding || source.src1 < kVgprEncoding) {
     return ExpandResult::failed("gfx1250 K=128 WMMA matrix operands are not ordinary VGPR ranges");
   }
+  if ((source.src0 & 1u) != 0 || (source.src1 & 1u) != 0 || (source.vdst & 1u) != 0) {
+    return ExpandResult::failed(
+        "gfx1250 K=128 WMMA matrix operands and destination are not even VGPR ranges");
+  }
+  if (source.src2 < kVgprEncoding && source.src2 != kGfx1250InlineZero) {
+    return ExpandResult::failed(
+        "gfx1250 K=128 WMMA accumulator is not a VGPR range or inline zero");
+  }
+  if (source.src2 >= kVgprEncoding && (source.src2 & 1u) != 0)
+    return ExpandResult::failed("gfx1250 K=128 WMMA accumulator is not an even VGPR range");
 
   const bool packed_f16 = gfx1250_is_f16_k128_wmma(inst.opcode());
   if (!gfx1250_k128_wmma_formats(inst.opcode(), matrix_a_fmt, matrix_b_fmt)) {
@@ -2145,11 +2155,6 @@ ExpandResult expand_gfx1250_k128_wmma(const Instruction &inst, uint32_t, uint64_
   }
 
   if (packed_f16) {
-    if (static_cast<uint16_t>(source.vdst) + 4u > 256u)
-      return ExpandResult::failed("gfx1250 f16 K=128 WMMA destination crosses a VGPR bank");
-    if (source.src2 >= kVgprEncoding && source.src2 + 4u > 512u)
-      return ExpandResult::failed("gfx1250 f16 K=128 WMMA accumulator crosses a VGPR bank");
-
     SemanticScratchAllocator allocator(
         inst, liveness, context,
         SemanticScratchPolicy{.max_vgprs = 256,
@@ -2168,7 +2173,9 @@ ExpandResult expand_gfx1250_k128_wmma(const Instruction &inst, uint32_t, uint64_
     mode_request.count = 1;
     mode_request.forbidden = request.forbidden;
     mode_request.forbidden.expand(scratch.lease->registers());
-    const auto mode_scratch = acquire_gfx1250_sgprs(inst, liveness, context, nullptr, mode_request);
+    mode_request.carrier_mode = Gfx1250SgprCarrierMode::ExecMasked;
+    const auto mode_scratch =
+        acquire_gfx1250_sgprs(inst, liveness, context, &allocator, mode_request);
     if (!mode_scratch)
       return ExpandResult::failed("gfx1250 f16 K=128 WMMA could not read FP16 overflow mode");
 
@@ -2178,33 +2185,49 @@ ExpandResult expand_gfx1250_k128_wmma(const Instruction &inst, uint32_t, uint64_
     const auto dst_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Dst);
     if (!src0_bank || !src1_bank || !src2_bank || !dst_bank)
       return ExpandResult::failed("gfx1250 f16 K=128 WMMA cannot prove the VGPR-MSB mode");
+    const uint16_t physical_dst = static_cast<uint16_t>(*dst_bank * 256u + source.vdst);
+    if (physical_dst + 4u > 1024u)
+      return ExpandResult::failed("gfx1250 f16 K=128 WMMA destination exceeds the VGPR file");
+    uint16_t physical_accumulator = 0;
+    if (source.src2 >= kVgprEncoding) {
+      physical_accumulator =
+          static_cast<uint16_t>(*src2_bank * 256u + (source.src2 - kVgprEncoding));
+      if (physical_accumulator + 4u > 1024u)
+        return ExpandResult::failed("gfx1250 f16 K=128 WMMA accumulator exceeds the VGPR file");
+    }
     const uint8_t original_mode =
         static_cast<uint8_t>(*src0_bank | (*src1_bank << 2) | (*src2_bank << 4) | (*dst_bank << 6));
 
     std::vector<uint32_t> words;
-    words.reserve(40);
+    words.reserve(96);
     append_gfx1250_scratch_dependency_barrier(words);
     uint8_t current_mode = original_mode;
-    if (scratch.lease->spilled) {
+    if (scratch.lease->spilled || mode_scratch->has_carrier()) {
       append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
-      if (!append_gfx1250_scratch_preservation(words, *scratch.lease, false))
-        return ExpandResult::failed("gfx1250 f16 K=128 WMMA could not preserve scratch VGPRs");
+      if (!append_gfx1250_scratch_preservation(words, *scratch.lease, false) ||
+          !append_gfx1250_sgpr_preservation(words, *mode_scratch, false)) {
+        return ExpandResult::failed("gfx1250 f16 K=128 WMMA could not preserve scratch registers");
+      }
     }
     append_words(words, gfx1250::build_sopk(gfx1250::kSGetregB32Sopk,
                                             {.simm16 = kGfx1250ModeFp16OvflHwreg,
                                              .sdst = static_cast<uint8_t>(mode_scratch->base)}));
-
     const uint16_t scratch_src = gfx1250_vgpr_src(scratch.lease->base);
     uint16_t f32_accumulator = source.src2;
     if (source.src2 >= kVgprEncoding) {
-      const uint8_t unpack_mode = static_cast<uint8_t>(*src2_bank << 2);
-      append_gfx1250_vgpr_msb_transition(words, current_mode, unpack_mode);
       for (uint16_t element = 0; element < 8; ++element) {
-        append_words(words, gfx1250::build_vop3(
-                                gfx1250::kVCvtF32F16Vop3,
-                                {.vdst = static_cast<uint8_t>(scratch.lease->base + element),
-                                 .opsel = static_cast<uint8_t>(element & 1u),
-                                 .src0 = static_cast<uint16_t>(source.src2 + element / 2u)}));
+        // The generated conversion consumes the source accumulator as SRC0.
+        // Select SRC0's bank per dword because a legal sequential tuple can
+        // cross the v255/v256 boundary.
+        const uint16_t source_register = static_cast<uint16_t>(physical_accumulator + element / 2u);
+        const uint8_t unpack_mode = static_cast<uint8_t>(source_register / 256u);
+        append_gfx1250_vgpr_msb_transition(words, current_mode, unpack_mode);
+        append_words(words,
+                     gfx1250::build_vop3(
+                         gfx1250::kVCvtF32F16Vop3,
+                         {.vdst = static_cast<uint8_t>(scratch.lease->base + element),
+                          .opsel = static_cast<uint8_t>(element & 1u),
+                          .src0 = static_cast<uint16_t>(kVgprEncoding + source_register % 256u)}));
       }
       f32_accumulator = scratch_src;
       append_words(words, gfx1250::build_sopp(gfx1250::kSWaitAluSopp,
@@ -2229,8 +2252,10 @@ ExpandResult expand_gfx1250_k128_wmma(const Instruction &inst, uint32_t, uint64_
                                             {.simm16 = kGfx1250WmmaCompletionWaitImmediate}));
     for (uint16_t slot = 0; slot < 16; ++slot)
       append_words(words, gfx1250::build_vop1(gfx1250::kVNopVop1));
-    const uint8_t pack_mode = static_cast<uint8_t>(*dst_bank << 6);
-    append_gfx1250_vgpr_msb_transition(words, current_mode, pack_mode);
+    // Ordinary FP16 conversions preserve infinities, while packed-f16 WMMA
+    // saturates them when MODE.FP16_OVFL is set. Apply that WMMA-specific
+    // behavior in the low scratch bank before selecting each destination bank.
+    append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
     const uint16_t limit = static_cast<uint16_t>(scratch.lease->base + 8u);
     append_words(words, gfx1250::build_vop3(gfx1250::kVMulLoU32Vop3,
                                             {.vdst = static_cast<uint8_t>(limit),
@@ -2255,18 +2280,26 @@ ExpandResult expand_gfx1250_k128_wmma(const Instruction &inst, uint32_t, uint64_
                                                .src1 = gfx1250_vgpr_src(limit)}));
     }
     for (uint16_t pair = 0; pair < 4; ++pair) {
+      const uint16_t destination_register = static_cast<uint16_t>(physical_dst + pair);
+      const uint8_t pack_mode = static_cast<uint8_t>((destination_register / 256u) << 6);
+      append_gfx1250_vgpr_msb_transition(words, current_mode, pack_mode);
       append_words(words, gfx1250::build_vop3(
                               gfx1250::kVCvtPkF16F32Vop3,
-                              {.vdst = static_cast<uint8_t>(source.vdst + pair),
+                              {.vdst = static_cast<uint8_t>(destination_register % 256u),
                                .src0 = static_cast<uint16_t>(scratch_src + pair * 2u),
                                .src1 = static_cast<uint16_t>(scratch_src + pair * 2u + 1u)}));
     }
-    if (scratch.lease->spilled) {
+    if (scratch.lease->spilled || mode_scratch->has_carrier()) {
       append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
-      if (!append_gfx1250_scratch_preservation(words, *scratch.lease, true))
-        return ExpandResult::failed("gfx1250 f16 K=128 WMMA could not restore scratch VGPRs");
+      if (!append_gfx1250_sgpr_preservation(words, *mode_scratch, true) ||
+          !append_gfx1250_scratch_preservation(words, *scratch.lease, true)) {
+        return ExpandResult::failed("gfx1250 f16 K=128 WMMA could not restore scratch registers");
+      }
     }
     append_gfx1250_vgpr_msb_transition(words, current_mode, original_mode);
+    if (!prepend_gfx1250_execz_guard_for_masked_replacement(words, mode_scratch->has_carrier())) {
+      return ExpandResult::failed("gfx1250 f16 K=128 WMMA SGPR-carrier guard is too large");
+    }
     return ExpandResult::success(std::move(words));
   }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
@@ -2121,17 +2121,6 @@ ExpandResult expand_gfx1250_k128_wmma(const Instruction &inst, uint32_t, uint64_
   if (source.src0 < kVgprEncoding || source.src1 < kVgprEncoding) {
     return ExpandResult::failed("gfx1250 K=128 WMMA matrix operands are not ordinary VGPR ranges");
   }
-  if ((source.src0 & 1u) != 0 || (source.src1 & 1u) != 0 || (source.vdst & 1u) != 0) {
-    return ExpandResult::failed(
-        "gfx1250 K=128 WMMA matrix operands and destination are not even VGPR ranges");
-  }
-  if (source.src2 < kVgprEncoding && source.src2 != kGfx1250InlineZero) {
-    return ExpandResult::failed(
-        "gfx1250 K=128 WMMA accumulator is not a VGPR range or inline zero");
-  }
-  if (source.src2 >= kVgprEncoding && (source.src2 & 1u) != 0)
-    return ExpandResult::failed("gfx1250 K=128 WMMA accumulator is not an even VGPR range");
-
   const bool packed_f16 = gfx1250_is_f16_k128_wmma(inst.opcode());
   if (!gfx1250_k128_wmma_formats(inst.opcode(), matrix_a_fmt, matrix_b_fmt)) {
     if (packed_f16) {
@@ -2155,6 +2144,22 @@ ExpandResult expand_gfx1250_k128_wmma(const Instruction &inst, uint32_t, uint64_
   }
 
   if (packed_f16) {
+    // These operand restrictions belong to the packed-f16 lowering alone: it
+    // addresses the accumulator and destination one dword at a time and needs
+    // an f32 source it can materialize. The f32 path re-encodes VDST, SRC0,
+    // SRC1, and SRC2 unchanged, so it must keep accepting whatever the source
+    // instruction already encoded.
+    if ((source.src0 & 1u) != 0 || (source.src1 & 1u) != 0 || (source.vdst & 1u) != 0) {
+      return ExpandResult::failed(
+          "gfx1250 f16 K=128 WMMA matrix operands and destination are not even VGPR ranges");
+    }
+    if (source.src2 < kVgprEncoding && source.src2 != kGfx1250InlineZero) {
+      return ExpandResult::failed(
+          "gfx1250 f16 K=128 WMMA accumulator is not a VGPR range or inline zero");
+    }
+    if (source.src2 >= kVgprEncoding && (source.src2 & 1u) != 0)
+      return ExpandResult::failed("gfx1250 f16 K=128 WMMA accumulator is not an even VGPR range");
+
     SemanticScratchAllocator allocator(
         inst, liveness, context,
         SemanticScratchPolicy{.max_vgprs = 256,
@@ -2252,9 +2257,20 @@ ExpandResult expand_gfx1250_k128_wmma(const Instruction &inst, uint32_t, uint64_
                                             {.simm16 = kGfx1250WmmaCompletionWaitImmediate}));
     for (uint16_t slot = 0; slot < 16; ++slot)
       append_words(words, gfx1250::build_vop1(gfx1250::kVNopVop1));
-    // Ordinary FP16 conversions preserve infinities, while packed-f16 WMMA
-    // saturates them when MODE.FP16_OVFL is set. Apply that WMMA-specific
-    // behavior in the low scratch bank before selecting each destination bank.
+    // MI400 Shader Programming 4.6.12: a WMMA or SWMMAC result of 16 bits or
+    // fewer becomes +/-MAX rather than +/-infinity when MODE.FP16_OVFL is set,
+    // and the MODE table adds that WMMA saturates INF on this generation while
+    // every other opcode preserves it. V_CVT_PK_F16_F32 is one of those other
+    // opcodes, so the pack below reproduces only the finite-overflow half of
+    // the contract; clamp the infinities here. The clamp bound is
+    // MODE.FP16_OVFL scaled to 0x38002000 and subtracted from f32 +infinity,
+    // giving +infinity when the mode is clear and 65504.0 when it is set.
+    // Do this in the low scratch bank before selecting each destination bank.
+    //
+    // V_MAXIMUM_F32 and V_MINIMUM_F32 return the canonical quiet NaN, so a NaN
+    // result keeps its NaN class but loses the sign and payload the source
+    // instruction would have produced. IEEE 754 leaves both uninterpreted and
+    // the ISA promises only that a NaN input yields a NaN output.
     append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
     const uint16_t limit = static_cast<uint16_t>(scratch.lease->base + 8u);
     append_words(words, gfx1250::build_vop3(gfx1250::kVMulLoU32Vop3,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
@@ -51,6 +51,7 @@ constexpr uint16_t kWmmaScale16PrefixOp = 0x3a;
 constexpr uint16_t kGfx1250InlineZero = 128;
 constexpr uint32_t kGfx1250ScratchMaxDwordOffset = 0x7ffffcu;
 constexpr uint16_t kGfx1250ModeFp16OvflHwreg = 1u | (23u << 6);
+constexpr uint16_t kGfx1250WmmaCompletionWaitImmediate = 0x0f9f;
 
 /// @brief Diagnose control fields that are invalid for floating-point WMMA.
 ///
@@ -1380,9 +1381,8 @@ void append_gfx1250_f32_to_e5m3(std::vector<uint32_t> &words, uint16_t source, u
   };
   const uint8_t source_mode = source >= 256u ? static_cast<uint8_t>(source_bank << 2) : 0;
 
-  // E5M3 is an unsigned scale format. Taking the magnitude also makes the
-  // unsupported source ABS/NEG encodings immaterial, matching the execution
-  // model's conversion helper.
+  // E5M3 ignores the source sign bit, so convert the magnitude. Classify NaNs
+  // after clearing the sign so both NaN signs use the terminal encoding.
   append_gfx1250_vgpr_msb_transition(words, current_mode, source_mode);
   append_literal(gfx1250::kVAndB32Vop3,
                  {.vdst = static_cast<uint8_t>(out), .src0 = 255, .src1 = source}, 0x7fffffffu);
@@ -1464,6 +1464,8 @@ ExpandResult expand_gfx1250_cvt_pk_fp8_f32_e5m3(const Instruction &inst, uint32_
   std::memcpy(&source, inst.raw_encoding(), sizeof(source));
   if (source.clamp == 0)
     return ExpandResult::not_handled();
+  // ABS, NEG, and OMOD are unsupported for this conversion and do not affect
+  // its result, so their encoded values are intentionally ignored.
   if (source.src0 == 233u || source.src0 == 234u || source.src0 == 250u)
     return ExpandResult::failed("gfx1250 E5M3 pack does not support DPP");
   // SRC_LITERAL64 carries a two-word payload, and the expansion has no free
@@ -1613,6 +1615,8 @@ ExpandResult expand_gfx1250_cvt_sr_fp8_f32_e5m3(const Instruction &inst, uint32_
   std::memcpy(&source, inst.raw_encoding(), sizeof(source));
   if (source.clamp == 0)
     return ExpandResult::not_handled();
+  // ABS, NEG, and OMOD are unsupported for this conversion and do not affect
+  // its result, so their encoded values are intentionally ignored.
   if (source.src0 == 233u || source.src0 == 234u || source.src0 == 250u)
     return ExpandResult::failed("gfx1250 stochastic E5M3 does not support DPP");
   if (source.src0 == 254u || source.src1 == 254u)
@@ -1869,6 +1873,8 @@ ExpandResult expand_gfx1250_cvt_f32_fp8_e5m3(const Instruction &inst, uint32_t, 
   constexpr uint16_t kVgprEncoding = 256;
   if (source.clamp == 0)
     return ExpandResult::not_handled();
+  // ABS, NEG, and OMOD are unsupported for this conversion and do not affect
+  // its result, so their encoded values are intentionally ignored.
   if (source.src0 < kVgprEncoding) {
     return ExpandResult::failed("gfx1250 E5M3 unpack source is not a VGPR");
   }
@@ -2068,9 +2074,24 @@ ExpandResult expand_gfx1250_bare_f8f6f4_wmma(const Instruction &inst, uint32_t, 
   }
 }
 
-/// @brief Lower a B0 K=128 FP8/BF8 WMMA to an A0 K=128 mixed-format WMMA.
+/// @brief Return whether an opcode is a B0 packed-f16 K=128 WMMA.
+[[nodiscard]] bool gfx1250_is_f16_k128_wmma(uint16_t opcode) {
+  switch (opcode) {
+  case gfx1250::kVWmmaF1616x16x128Fp8Fp8Vop3p:
+  case gfx1250::kVWmmaF1616x16x128Fp8Bf8Vop3p:
+  case gfx1250::kVWmmaF1616x16x128Bf8Fp8Vop3p:
+  case gfx1250::kVWmmaF1616x16x128Bf8Bf8Vop3p:
+    return true;
+  default:
+    return false;
+  }
+}
+
+/// @brief Lower B0 K=128 FP8/BF8 WMMAs to A0-supported forms.
 ///
-/// @details The preferred path emits one regular-Scale F8F6F4 operation with
+/// @details Packed-f16 results use the f32 K=128 mixed-format operation in
+/// scratch registers and round once when packing the final result. F32 results
+/// emit one regular-Scale F8F6F4 operation with
 /// FP8/BF8 matrix-format selectors and neutral inline E8M0 scales. It retains
 /// the K=128 accumulation topology and requires no partial destination. Source
 /// reuse hints are cleared: the target instruction family differs, and a
@@ -2082,30 +2103,15 @@ ExpandResult expand_gfx1250_bare_f8f6f4_wmma(const Instruction &inst, uint32_t, 
 /// target belongs to a different instruction family. Only the defined C
 /// absolute and negate bits are transferred.
 ExpandResult expand_gfx1250_k128_wmma(const Instruction &inst, uint32_t, uint64_t,
-                                      std::span<const uint8_t>, const LivenessAnalysis &,
-                                      TranslationContext &, const LaneLayout *,
+                                      std::span<const uint8_t>, const LivenessAnalysis &liveness,
+                                      TranslationContext &context, const LaneLayout *,
                                       const LaneLayout *) {
-  switch (inst.opcode()) {
-  case gfx1250::kVWmmaF1616x16x128Fp8Fp8Vop3p:
-  case gfx1250::kVWmmaF1616x16x128Fp8Bf8Vop3p:
-  case gfx1250::kVWmmaF1616x16x128Bf8Fp8Vop3p:
-  case gfx1250::kVWmmaF1616x16x128Bf8Bf8Vop3p:
-    return ExpandResult::failed(
-        "gfx1250 f16 K=128 WMMA A0 lowering is not yet implemented",
-        {"Provide an exact packed-f16 accumulator and single-rounding lowering."});
-  default:
-    break;
-  }
-
   uint8_t matrix_a_fmt = 0;
   uint8_t matrix_b_fmt = 0;
   if (inst.size() != static_cast<int>(sizeof(gfx1250::Vop3pMachineInst)) ||
       inst.raw_encoding() == nullptr) {
     return ExpandResult::failed("gfx1250 K=128 WMMA has no complete source encoding");
   }
-  if (!gfx1250_k128_wmma_formats(inst.opcode(), matrix_a_fmt, matrix_b_fmt))
-    return ExpandResult::failed("gfx1250 K=128 WMMA rule received an unsupported opcode");
-
   gfx1250::Vop3pMachineInst source{};
   std::memcpy(&source, inst.raw_encoding(), sizeof(source));
   if (const char *error = gfx1250_floating_wmma_control_error(source))
@@ -2115,6 +2121,157 @@ ExpandResult expand_gfx1250_k128_wmma(const Instruction &inst, uint32_t, uint64_
   if (source.src0 < kVgprEncoding || source.src1 < kVgprEncoding) {
     return ExpandResult::failed("gfx1250 K=128 WMMA matrix operands are not ordinary VGPR ranges");
   }
+
+  const bool packed_f16 = gfx1250_is_f16_k128_wmma(inst.opcode());
+  if (!gfx1250_k128_wmma_formats(inst.opcode(), matrix_a_fmt, matrix_b_fmt)) {
+    if (packed_f16) {
+      switch (inst.opcode()) {
+      case gfx1250::kVWmmaF1616x16x128Fp8Bf8Vop3p:
+        matrix_b_fmt = 1;
+        break;
+      case gfx1250::kVWmmaF1616x16x128Bf8Fp8Vop3p:
+        matrix_a_fmt = 1;
+        break;
+      case gfx1250::kVWmmaF1616x16x128Bf8Bf8Vop3p:
+        matrix_a_fmt = 1;
+        matrix_b_fmt = 1;
+        break;
+      default:
+        break;
+      }
+    } else {
+      return ExpandResult::failed("gfx1250 K=128 WMMA rule received an unsupported opcode");
+    }
+  }
+
+  if (packed_f16) {
+    if (static_cast<uint16_t>(source.vdst) + 4u > 256u)
+      return ExpandResult::failed("gfx1250 f16 K=128 WMMA destination crosses a VGPR bank");
+    if (source.src2 >= kVgprEncoding && source.src2 + 4u > 512u)
+      return ExpandResult::failed("gfx1250 f16 K=128 WMMA accumulator crosses a VGPR bank");
+
+    SemanticScratchAllocator allocator(
+        inst, liveness, context,
+        SemanticScratchPolicy{.max_vgprs = 256,
+                              .max_spill_dword_offset = kGfx1250ScratchMaxDwordOffset});
+    SemanticScratchRequest request;
+    request.count = 9;
+    request.alignment = 2;
+    request.forbidden = gfx1250_instruction_registers(inst);
+    request.allow_spill = true;
+    const SemanticScratchResult scratch = allocator.acquire_vgprs(request);
+    if (!scratch)
+      return ExpandResult::failed(
+          "gfx1250 f16 K=128 WMMA could not allocate f32 accumulator scratch");
+
+    Gfx1250SgprScratchRequest mode_request;
+    mode_request.count = 1;
+    mode_request.forbidden = request.forbidden;
+    mode_request.forbidden.expand(scratch.lease->registers());
+    const auto mode_scratch = acquire_gfx1250_sgprs(inst, liveness, context, nullptr, mode_request);
+    if (!mode_scratch)
+      return ExpandResult::failed("gfx1250 f16 K=128 WMMA could not read FP16 overflow mode");
+
+    const auto src0_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Src0);
+    const auto src1_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Src1);
+    const auto src2_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Src2);
+    const auto dst_bank = liveness.vgpr_msb_bank_before(inst, amdgpu::VgprMsbRole::Dst);
+    if (!src0_bank || !src1_bank || !src2_bank || !dst_bank)
+      return ExpandResult::failed("gfx1250 f16 K=128 WMMA cannot prove the VGPR-MSB mode");
+    const uint8_t original_mode =
+        static_cast<uint8_t>(*src0_bank | (*src1_bank << 2) | (*src2_bank << 4) | (*dst_bank << 6));
+
+    std::vector<uint32_t> words;
+    words.reserve(40);
+    append_gfx1250_scratch_dependency_barrier(words);
+    uint8_t current_mode = original_mode;
+    if (scratch.lease->spilled) {
+      append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
+      if (!append_gfx1250_scratch_preservation(words, *scratch.lease, false))
+        return ExpandResult::failed("gfx1250 f16 K=128 WMMA could not preserve scratch VGPRs");
+    }
+    append_words(words, gfx1250::build_sopk(gfx1250::kSGetregB32Sopk,
+                                            {.simm16 = kGfx1250ModeFp16OvflHwreg,
+                                             .sdst = static_cast<uint8_t>(mode_scratch->base)}));
+
+    const uint16_t scratch_src = gfx1250_vgpr_src(scratch.lease->base);
+    uint16_t f32_accumulator = source.src2;
+    if (source.src2 >= kVgprEncoding) {
+      const uint8_t unpack_mode = static_cast<uint8_t>(*src2_bank << 2);
+      append_gfx1250_vgpr_msb_transition(words, current_mode, unpack_mode);
+      for (uint16_t element = 0; element < 8; ++element) {
+        append_words(words, gfx1250::build_vop3(
+                                gfx1250::kVCvtF32F16Vop3,
+                                {.vdst = static_cast<uint8_t>(scratch.lease->base + element),
+                                 .opsel = static_cast<uint8_t>(element & 1u),
+                                 .src0 = static_cast<uint16_t>(source.src2 + element / 2u)}));
+      }
+      f32_accumulator = scratch_src;
+      append_words(words, gfx1250::build_sopp(gfx1250::kSWaitAluSopp,
+                                              {.simm16 = kGfx1250WmmaCompletionWaitImmediate}));
+    }
+
+    const uint8_t matrix_mode = static_cast<uint8_t>(*src0_bank | (*src1_bank << 2));
+    append_gfx1250_vgpr_msb_transition(words, current_mode, matrix_mode);
+    append_words(words, gfx1250::build_vop3p(kWmmaScaleSrc2PrefixOp, {.src0 = kGfx1250InlineZero,
+                                                                      .src1 = kGfx1250InlineZero,
+                                                                      .src2 = kVgprEncoding}));
+    append_words(words, gfx1250::build_vop3p(gfx1250::kVWmmaF3216x16x128F8f6f4Vop3p,
+                                             {.vdst = static_cast<uint8_t>(scratch.lease->base),
+                                              .neg_hi = static_cast<uint8_t>(source.neg_hi & 0x4u),
+                                              .opsel = matrix_a_fmt,
+                                              .src0 = static_cast<uint16_t>(source.src0),
+                                              .src1 = static_cast<uint16_t>(source.src1),
+                                              .src2 = f32_accumulator,
+                                              .opsel_hi = matrix_b_fmt,
+                                              .neg = static_cast<uint8_t>(source.neg & 0x4u)}));
+    append_words(words, gfx1250::build_sopp(gfx1250::kSWaitAluSopp,
+                                            {.simm16 = kGfx1250WmmaCompletionWaitImmediate}));
+    for (uint16_t slot = 0; slot < 16; ++slot)
+      append_words(words, gfx1250::build_vop1(gfx1250::kVNopVop1));
+    const uint8_t pack_mode = static_cast<uint8_t>(*dst_bank << 6);
+    append_gfx1250_vgpr_msb_transition(words, current_mode, pack_mode);
+    const uint16_t limit = static_cast<uint16_t>(scratch.lease->base + 8u);
+    append_words(words, gfx1250::build_vop3(gfx1250::kVMulLoU32Vop3,
+                                            {.vdst = static_cast<uint8_t>(limit),
+                                             .src0 = 255,
+                                             .src1 = static_cast<uint16_t>(mode_scratch->base)}));
+    words.push_back(0x38002000u);
+    append_words(words,
+                 gfx1250::build_vop3(gfx1250::kVSubNcU32Vop3, {.vdst = static_cast<uint8_t>(limit),
+                                                               .src0 = 255,
+                                                               .src1 = gfx1250_vgpr_src(limit)}));
+    words.push_back(0x7f800000u);
+    for (uint16_t element = 0; element < 8; ++element) {
+      const uint16_t value = static_cast<uint16_t>(scratch.lease->base + element);
+      append_words(words, gfx1250::build_vop3(gfx1250::kVMaximumF32Vop3,
+                                              {.vdst = static_cast<uint8_t>(value),
+                                               .src0 = gfx1250_vgpr_src(value),
+                                               .src1 = gfx1250_vgpr_src(limit),
+                                               .neg = 2}));
+      append_words(words, gfx1250::build_vop3(gfx1250::kVMinimumF32Vop3,
+                                              {.vdst = static_cast<uint8_t>(value),
+                                               .src0 = gfx1250_vgpr_src(value),
+                                               .src1 = gfx1250_vgpr_src(limit)}));
+    }
+    for (uint16_t pair = 0; pair < 4; ++pair) {
+      append_words(words, gfx1250::build_vop3(
+                              gfx1250::kVCvtPkF16F32Vop3,
+                              {.vdst = static_cast<uint8_t>(source.vdst + pair),
+                               .src0 = static_cast<uint16_t>(scratch_src + pair * 2u),
+                               .src1 = static_cast<uint16_t>(scratch_src + pair * 2u + 1u)}));
+    }
+    if (scratch.lease->spilled) {
+      append_gfx1250_vgpr_msb_transition(words, current_mode, 0);
+      if (!append_gfx1250_scratch_preservation(words, *scratch.lease, true))
+        return ExpandResult::failed("gfx1250 f16 K=128 WMMA could not restore scratch VGPRs");
+    }
+    append_gfx1250_vgpr_msb_transition(words, current_mode, original_mode);
+    return ExpandResult::success(std::move(words));
+  }
+
+  if (!gfx1250_k128_wmma_formats(inst.opcode(), matrix_a_fmt, matrix_b_fmt))
+    return ExpandResult::failed("gfx1250 K=128 WMMA rule received an unsupported opcode");
 
   std::vector<uint32_t> words;
   words.reserve(4);
@@ -2160,13 +2317,13 @@ inline constexpr std::array<TranslationRule, 41> kGfx1250B0ToA0ExpandRules = {{
     {gfx1250::encoding::kVop3pOpHi1, gfx1250::kVWmmaF3216x16x128Bf8Bf8Vop3p, RuleAction::Expand, 0,
      0, nullptr, expand_gfx1250_k128_wmma, nullptr, nullptr, false},
     {gfx1250::encoding::kVop3pOpHi1, gfx1250::kVWmmaF1616x16x128Fp8Fp8Vop3p, RuleAction::Expand, 0,
-     0, nullptr, expand_gfx1250_k128_wmma, nullptr, nullptr, false},
+     0, nullptr, expand_gfx1250_k128_wmma, nullptr, nullptr},
     {gfx1250::encoding::kVop3pOpHi1, gfx1250::kVWmmaF1616x16x128Fp8Bf8Vop3p, RuleAction::Expand, 0,
-     0, nullptr, expand_gfx1250_k128_wmma, nullptr, nullptr, false},
+     0, nullptr, expand_gfx1250_k128_wmma, nullptr, nullptr},
     {gfx1250::encoding::kVop3pOpHi1, gfx1250::kVWmmaF1616x16x128Bf8Fp8Vop3p, RuleAction::Expand, 0,
-     0, nullptr, expand_gfx1250_k128_wmma, nullptr, nullptr, false},
+     0, nullptr, expand_gfx1250_k128_wmma, nullptr, nullptr},
     {gfx1250::encoding::kVop3pOpHi1, gfx1250::kVWmmaF1616x16x128Bf8Bf8Vop3p, RuleAction::Expand, 0,
-     0, nullptr, expand_gfx1250_k128_wmma, nullptr, nullptr, false},
+     0, nullptr, expand_gfx1250_k128_wmma, nullptr, nullptr},
     {gfx1250::encoding::kVop3pOpHi1, gfx1250::kVWmmaF3232x16x128F4Vop3p, RuleAction::Expand, 0, 0,
      nullptr, expand_gfx1250_wmma_32x16_f4, nullptr, nullptr},
     {gfx1250::encoding::kVimage, gfx1250::kTensorLoadToLdsVimage, RuleAction::Expand, 0, 0, nullptr,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3p_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3p_exec.cpp
@@ -1998,7 +1998,7 @@ void VWmmaF1616x16x64Fp8Fp8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
     const_acc = amdgpu::RegisterAccess(wf).read_scalar(src2);
   }
   amdgpu::exec_wmma_f16_f8_spec<16, 16, 64, true, true>(cu, dst, src0_base, src1_base, s2,
-                                                        const_acc);
+                                                        const_acc, wf.fp16_ovfl());
 }
 
 void VWmmaF1616x16x64Fp8Bf8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
@@ -2021,7 +2021,7 @@ void VWmmaF1616x16x64Fp8Bf8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
     const_acc = amdgpu::RegisterAccess(wf).read_scalar(src2);
   }
   amdgpu::exec_wmma_f16_f8_spec<16, 16, 64, true, false>(cu, dst, src0_base, src1_base, s2,
-                                                         const_acc);
+                                                         const_acc, wf.fp16_ovfl());
 }
 
 void VWmmaF1616x16x64Bf8Fp8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
@@ -2044,7 +2044,7 @@ void VWmmaF1616x16x64Bf8Fp8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
     const_acc = amdgpu::RegisterAccess(wf).read_scalar(src2);
   }
   amdgpu::exec_wmma_f16_f8_spec<16, 16, 64, false, true>(cu, dst, src0_base, src1_base, s2,
-                                                         const_acc);
+                                                         const_acc, wf.fp16_ovfl());
 }
 
 void VWmmaF1616x16x64Bf8Bf8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
@@ -2067,7 +2067,7 @@ void VWmmaF1616x16x64Bf8Bf8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
     const_acc = amdgpu::RegisterAccess(wf).read_scalar(src2);
   }
   amdgpu::exec_wmma_f16_f8_spec<16, 16, 64, false, false>(cu, dst, src0_base, src1_base, s2,
-                                                          const_acc);
+                                                          const_acc, wf.fp16_ovfl());
 }
 
 void VWmmaI3216x16x64Iu8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
@@ -2407,7 +2407,7 @@ void VWmmaF1616x16x128Fp8Fp8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
     const_acc = amdgpu::RegisterAccess(wf).read_scalar(src2);
   }
   amdgpu::exec_wmma_f16_f8_spec<16, 16, 128, true, true>(cu, dst, src0_base, src1_base, s2,
-                                                         const_acc);
+                                                         const_acc, wf.fp16_ovfl());
 }
 
 void VWmmaF1616x16x128Fp8Bf8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
@@ -2430,7 +2430,7 @@ void VWmmaF1616x16x128Fp8Bf8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
     const_acc = amdgpu::RegisterAccess(wf).read_scalar(src2);
   }
   amdgpu::exec_wmma_f16_f8_spec<16, 16, 128, true, false>(cu, dst, src0_base, src1_base, s2,
-                                                          const_acc);
+                                                          const_acc, wf.fp16_ovfl());
 }
 
 void VWmmaF1616x16x128Bf8Fp8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
@@ -2453,7 +2453,7 @@ void VWmmaF1616x16x128Bf8Fp8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
     const_acc = amdgpu::RegisterAccess(wf).read_scalar(src2);
   }
   amdgpu::exec_wmma_f16_f8_spec<16, 16, 128, false, true>(cu, dst, src0_base, src1_base, s2,
-                                                          const_acc);
+                                                          const_acc, wf.fp16_ovfl());
 }
 
 void VWmmaF1616x16x128Bf8Bf8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
@@ -2476,7 +2476,7 @@ void VWmmaF1616x16x128Bf8Bf8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
     const_acc = amdgpu::RegisterAccess(wf).read_scalar(src2);
   }
   amdgpu::exec_wmma_f16_f8_spec<16, 16, 128, false, false>(cu, dst, src0_base, src1_base, s2,
-                                                           const_acc);
+                                                           const_acc, wf.fp16_ovfl());
 }
 
 void VWmmaF3232x16x128F4Vop3p::execute_impl(amdgpu::Wavefront &wf) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
@@ -2515,17 +2515,32 @@ void exec_swmmac_packed16(auto &cu, uint32_t M, uint32_t N, uint32_t K, uint32_t
   }
 }
 
+/// @brief Round a WMMA f32 accumulator to f16 under MODE.FP16_OVFL.
+///
+/// @details MI400 Shader Programming 4.6.12 gives WMMA and SWMMAC results of 16
+/// bits or fewer +/-MAX instead of +/-infinity when the mode bit is set, and the
+/// MODE table records that WMMA saturates INF on this generation while every
+/// other opcode preserves it. Ordinary conversions therefore keep using
+/// util::f32_to_f16_mode, which clamps finite overflow only. Architectures whose
+/// WMMA has no FP16_OVFL support pass false and keep the plain rounding.
+inline uint16_t wmma_round_f16(float val, bool fp16_ovfl) {
+  if (fp16_ovfl && std::isinf(val))
+    return std::signbit(val) ? uint16_t{0xFBFF} : uint16_t{0x7BFF};
+  return util::f32_to_f16_mode(val, fp16_ovfl);
+}
+
 template <typename ExtractA, typename ExtractB>
 void exec_wmma_f16(auto &cu, uint32_t M, uint32_t N, uint32_t K, uint32_t in_bits, uint32_t dst,
                    uint32_t s0, uint32_t s1, uint32_t s2, ExtractA ea, ExtractB eb,
-                   uint32_t const_acc = ACC_FROM_VGPR, uint32_t wave_size = WMMA_WAVE32) {
+                   uint32_t const_acc = ACC_FROM_VGPR, uint32_t wave_size = WMMA_WAVE32,
+                   bool fp16_ovfl = false) {
   exec_wmma_packed16(
       cu, M, N, K, in_bits, dst, s0, s1, s2, ea, eb,
       [](auto &cu, uint32_t reg, uint32_t lane, uint32_t sub) {
         uint32_t raw = RegisterAccess(cu).read_vgpr(reg, lane);
         return util::f16_to_f32(static_cast<uint16_t>((raw >> (sub * 16)) & 0xFFFF));
       },
-      [](float val) { return util::f32_to_f16(val); }, const_acc, wave_size);
+      [fp16_ovfl](float val) { return wmma_round_f16(val, fp16_ovfl); }, const_acc, wave_size);
 }
 
 /// Fast path for the f16-output WMMA shapes (v_wmma_f16_*_f16). Like the f32-out
@@ -2761,13 +2776,13 @@ void exec_wmma_bf16_spec(auto &cu, uint32_t dst, uint32_t s0, uint32_t s1, uint3
 /// force-scalar.
 template <uint32_t M, uint32_t N, uint32_t K, bool A_FP8, bool B_FP8, bool FNUZ = false>
 void exec_wmma_f16_f8_spec(auto &cu, uint32_t dst, uint32_t s0, uint32_t s1, uint32_t s2,
-                           uint32_t const_acc = ACC_FROM_VGPR) {
+                           uint32_t const_acc = ACC_FROM_VGPR, bool fp16_ovfl = false) {
   constexpr uint32_t in_bits = 8;
   static_assert(N % 16 == 0, "specialized f8 WMMA assumes N is a multiple of the zmm width");
   constexpr auto ea = f8_extract_fn<A_FP8, FNUZ>();
   constexpr auto eb = f8_extract_fn<B_FP8, FNUZ>();
   auto fallback = [&]() {
-    exec_wmma_f16(cu, M, N, K, in_bits, dst, s0, s1, s2, ea, eb, const_acc);
+    exec_wmma_f16(cu, M, N, K, in_bits, dst, s0, s1, s2, ea, eb, const_acc, WMMA_WAVE32, fp16_ovfl);
   };
   if constexpr (!util::has_stdx_simd) {
     fallback();
@@ -2835,7 +2850,7 @@ void exec_wmma_f16_f8_spec(auto &cu, uint32_t dst, uint32_t s0, uint32_t s1, uin
         auto out = wmma_output_loc_16(M, N, row, col);
         uint32_t idx = out.reg * WMMA_WAVE32 + out.lane;
         uint32_t shift = out.sub_element * 16;
-        uint16_t v = util::f32_to_f16(C_buf[row * N + col]);
+        uint16_t v = wmma_round_f16(C_buf[row * N + col], fp16_ovfl);
         words[idx] = (words[idx] & ~(0xFFFFu << shift)) | (static_cast<uint32_t>(v) << shift);
         masks[idx] |= 1u << out.sub_element;
       }

--- a/emulation/rocjitsu/tests/dbt/gfx1250_b0_to_a0_library_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/gfx1250_b0_to_a0_library_test.cpp
@@ -138,6 +138,46 @@ TEST(Gfx1250B0ToA0Library, ReportsTranslatorDiagnostics) {
   EXPECT_NE(primary->message.find("does not support DPP"), std::string::npos);
 }
 
+// The diagnostic above carries no required work. This one does, so it covers
+// the fan-out through the public C entry point rather than the emit helper
+// exercised by FansOutRequiredWorkAsCallbackViews.
+TEST(Gfx1250B0ToA0Library, ReportsTranslatorDiagnosticsAndRequiredWork) {
+  constexpr auto conversion =
+      rocjitsu::gfx1250::build_sop1(rocjitsu::gfx1250::kSBarrierSignalIsfirstSop1, {.ssrc0 = 195});
+  constexpr uint32_t kEndpgm = 0xBFB00000u;
+  const std::array<uint32_t, 2> text = {conversion[0], kEndpgm};
+  const auto source = rocjitsu::test_support::make_gfx1250_code_object(text);
+  uint8_t *output = nullptr;
+  size_t output_size = 0;
+  rj_gfx1250_b0_to_a0_translation_info_t info{};
+  std::vector<CapturedDiagnostic> diagnostics;
+
+  EXPECT_EQ(rj_gfx1250_b0_to_a0_translate(source.data(), source.size(), &output, &output_size,
+                                          &info, capture_diagnostic, &diagnostics),
+            ROCJITSU_STATUS_INVALID_CODE_OBJECT);
+  EXPECT_EQ(output, nullptr);
+  EXPECT_EQ(output_size, 0u);
+  ASSERT_FALSE(diagnostics.empty());
+
+  const auto primary = std::find_if(diagnostics.begin(), diagnostics.end(), [](const auto &item) {
+    return !item.required_work && item.severity == "error" &&
+           item.kind == "translator-expand-failed";
+  });
+  ASSERT_NE(primary, diagnostics.end());
+  EXPECT_TRUE(primary->has_guest_offset);
+  EXPECT_EQ(primary->guest_offset, 0u);
+  EXPECT_EQ(primary->mnemonic, "s_barrier_signal_isfirst");
+
+  const auto required = std::find_if(diagnostics.begin(), diagnostics.end(), [](const auto &item) {
+    return item.required_work && item.kind == "translator-expand-failed";
+  });
+  ASSERT_NE(required, diagnostics.end());
+  EXPECT_TRUE(required->has_guest_offset);
+  EXPECT_EQ(required->guest_offset, 0u);
+  EXPECT_EQ(required->mnemonic, "s_barrier_signal_isfirst");
+  EXPECT_NE(required->message.find("different barrier id"), std::string::npos);
+}
+
 TEST(Gfx1250B0ToA0Library, FansOutRequiredWorkAsCallbackViews) {
   const std::vector<rocjitsu::TranslationDiagnostic> source = {{
       .severity = rocjitsu::DiagnosticSeverity::Error,

--- a/emulation/rocjitsu/tests/dbt/gfx1250_b0_to_a0_library_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/gfx1250_b0_to_a0_library_test.cpp
@@ -141,7 +141,7 @@ TEST(Gfx1250B0ToA0Library, ReportsTranslatorDiagnostics) {
 // The diagnostic above carries no required work. This one does, so it covers
 // the fan-out through the public C entry point rather than the emit helper
 // exercised by FansOutRequiredWorkAsCallbackViews.
-TEST(Gfx1250B0ToA0Library, ReportsTranslatorDiagnosticsAndRequiredWork) {
+TEST(Gfx1250B0ToA0Library, ReportsTranslatorExpandFailedAndRequiredWork) {
   constexpr auto conversion =
       rocjitsu::gfx1250::build_sop1(rocjitsu::gfx1250::kSBarrierSignalIsfirstSop1, {.ssrc0 = 195});
   constexpr uint32_t kEndpgm = 0xBFB00000u;

--- a/emulation/rocjitsu/tests/dbt/hsa_hotswap_rocjitsu_unit_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/hsa_hotswap_rocjitsu_unit_test.cpp
@@ -569,21 +569,10 @@ TEST_F(HsaHotswapHookTest, TranslationFailureDoesNotLoadOrRetain) {
 
 TEST_F(HsaHotswapHookTest, RendersTranslatorDiagnosticsAndDumpsFailedSource) {
   ASSERT_TRUE(OnLoad(&api.table, 0, 0, nullptr));
-  rocjitsu::gfx1250::Vop3VopDpp16MachineInst dpp{};
-  dpp.vdst = 30;
-  dpp.clamp = 1;
-  dpp.op = rocjitsu::gfx1250::kVCvtPkFp8F32Vop3;
-  dpp.encoding = 0x35;
-  dpp.src0 = 250;
-  dpp.src1 = 256 + 2;
-  dpp.vsrc0 = 22;
-  dpp.fi = 1;
-  dpp.bank_mask = 0xf;
-  dpp.row_mask = 0xf;
-  std::array<uint32_t, 3> conversion{};
-  std::memcpy(conversion.data(), &dpp, sizeof(dpp));
+  constexpr auto conversion =
+      rocjitsu::gfx1250::build_sop1(rocjitsu::gfx1250::kSBarrierSignalIsfirstSop1, {.ssrc0 = 195});
   constexpr uint32_t kEndpgm = 0xBFB00000u;
-  const std::array<uint32_t, 4> text = {conversion[0], conversion[1], conversion[2], kEndpgm};
+  const std::array<uint32_t, 2> text = {conversion[0], kEndpgm};
   const auto source = rocjitsu::test_support::make_gfx1250_code_object(text);
   hsa_code_object_reader_t reader{};
   ASSERT_EQ(
@@ -604,9 +593,14 @@ TEST_F(HsaHotswapHookTest, RendersTranslatorDiagnosticsAndDumpsFailedSource) {
       << log_text;
   EXPECT_NE(log_text.find(" severity=error kind=translator-expand-failed "), std::string::npos)
       << log_text;
-  EXPECT_NE(log_text.find(" guest_offset=.text+0x0 mnemonic=v_cvt_pk_fp8_f32 "), std::string::npos)
+  EXPECT_NE(log_text.find(" guest_offset=.text+0x0 mnemonic=s_barrier_signal_isfirst "),
+            std::string::npos)
       << log_text;
   EXPECT_NE(log_text.find(" message="), std::string::npos) << log_text;
+  EXPECT_NE(log_text.find(" required=Use a different barrier id, or signal it without the first-"
+                          "signal form."),
+            std::string::npos)
+      << log_text;
   expect_failure_dump(log_text, source);
 }
 

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -11140,6 +11140,52 @@ TEST(BinaryTranslatorE2E, Gfx1250F32K128WmmaRejectsClamp) {
       "floating-point results"));
 }
 
+// The f32 lowering re-encodes VDST, SRC0, SRC1, and SRC2 unchanged, so the
+// operand shapes that the packed-f16 lowering cannot address must still
+// translate here. Narrowing this path would reject code objects that the
+// hardware accepts.
+TEST(BinaryTranslatorE2E, Gfx1250F32K128WmmaAcceptsOperandsThePackedF16PathRejects) {
+  struct OperandCase {
+    const char *name;
+    gfx1250::Vop3pBuilderFields fields;
+  };
+  const std::array cases = {
+      OperandCase{"odd_matrix_and_destination",
+                  {.vdst = 55, .src0 = 256 + 17, .src1 = 256 + 33, .src2 = 256 + 49}},
+      OperandCase{"sgpr_accumulator", {.vdst = 54, .src0 = 256 + 16, .src1 = 256 + 32, .src2 = 8}},
+      OperandCase{"nonzero_inline_accumulator",
+                  {.vdst = 54, .src0 = 256 + 16, .src1 = 256 + 32, .src2 = 129}},
+  };
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+
+  for (const OperandCase &test_case : cases) {
+    SCOPED_TRACE(test_case.name);
+    const auto source_wmma =
+        gfx1250::build_vop3p(gfx1250::kVWmmaF3216x16x128Fp8Fp8Vop3p, test_case.fields);
+    auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+        {source_wmma[0], source_wmma[1], kGfx1250SEndpgm});
+    rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+    rocjitsu::BinaryTranslator translator(
+        ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+        gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                                 rocjitsu::ProcessorRevision::Gfx1250A0));
+    const auto result = translator.translate(source);
+    ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                            : result.diagnostics.front().message);
+
+    rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+    ASSERT_FALSE(translated.text_sections().empty());
+    const auto *words = reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+    gfx1250::Vop3pMachineInst matrix{};
+    std::memcpy(&matrix, words + 2, sizeof(matrix));
+    EXPECT_EQ(matrix.op, gfx1250::kVWmmaF3216x16x128F8f6f4Vop3p);
+    EXPECT_EQ(matrix.vdst, test_case.fields.vdst);
+    EXPECT_EQ(matrix.src0, test_case.fields.src0);
+    EXPECT_EQ(matrix.src1, test_case.fields.src1);
+    EXPECT_EQ(matrix.src2, test_case.fields.src2);
+  }
+}
+
 TEST(BinaryTranslatorE2E, Gfx1250LowersF16K128Fp8Bf8WmmaThroughF32Scratch) {
   constexpr std::array source_opcodes = {
       gfx1250::kVWmmaF1616x16x128Fp8Fp8Vop3p,
@@ -11365,7 +11411,7 @@ TEST(BinaryTranslatorE2E, Gfx1250F16K128WmmaAllowsSequentialTuplesToCrossVgprBan
       << "the high destination dwords must select DST bank 1";
 }
 
-TEST(BinaryTranslatorE2E, Gfx1250K128WmmaRejectsOddVgprTuples) {
+TEST(BinaryTranslatorE2E, Gfx1250F16K128WmmaRejectsOddVgprTuples) {
   constexpr auto source_wmma =
       gfx1250::build_vop3p(gfx1250::kVWmmaF1616x16x128Fp8Fp8Vop3p,
                            {.vdst = 54, .src0 = 256 + 17, .src1 = 256 + 32, .src2 = 256 + 48});
@@ -11454,6 +11500,248 @@ TEST(BinaryTranslatorE2E, Gfx1250F16K128WmmaUsesSpillBackedScratchWhenVgprsAreFu
                                     return inst->mnemonic() == "v_wmma_scale_f32_16x16x128_f8f6f4";
                                   }),
             1);
+}
+
+// Numerical evidence that the packed-f16 lowering preserves values, including
+// the FP16 overflow contract. MI400 Shader Programming 4.6.12 makes a WMMA
+// result of 16 bits or fewer saturate to +/-MAX when MODE.FP16_OVFL is set,
+// infinities included, while V_CVT_PK_F16_F32 preserves infinities in the same
+// mode. The lowering compensates with an explicit clamp, so both mode settings
+// have to be exercised, and the accumulator has to carry both infinity signs
+// plus values that overflow FP16 only after the matrix product.
+TEST(BinaryTranslatorE2E, Gfx1250F16K128WmmaLoweringMatchesUnloweredExecution) {
+  constexpr uint16_t kMatrixA = 16; // A occupies 16 dwords of packed FP8.
+  constexpr uint16_t kMatrixB = 32; // B occupies 16 dwords of packed FP8.
+  constexpr uint16_t kMatrixC = 48; // C occupies 4 dwords of packed FP16.
+  constexpr uint8_t kDestination = 52;
+  constexpr uint32_t kMatrixARegs = 16;
+  constexpr uint32_t kMatrixBRegs = 16;
+  constexpr uint32_t kMatrixCRegs = 4;
+  constexpr uint32_t kDestinationRegs = 4;
+
+  constexpr auto matrix =
+      gfx1250::build_vop3p(gfx1250::kVWmmaF1616x16x128Fp8Fp8Vop3p, {.vdst = kDestination,
+                                                                    .src0 = 256 + kMatrixA,
+                                                                    .src1 = 256 + kMatrixB,
+                                                                    .src2 = 256 + kMatrixC});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {matrix[0], matrix[1], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_FALSE(translated.text_sections().empty());
+  const auto *text_words =
+      reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+  const size_t text_word_count = translated.text_sections()[0]->size() / sizeof(uint32_t);
+
+  auto decoder = rocjitsu::Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+
+  std::vector<uint32_t> body_words;
+  for (size_t offset = 0; offset < text_word_count;) {
+    std::unique_ptr<rocjitsu::Instruction> inst(decoder->decode(text_words + offset));
+    ASSERT_NE(inst, nullptr) << "translated word " << offset << " failed to decode";
+    const std::string_view mnemonic(inst->mnemonic());
+    if (mnemonic == "s_endpgm")
+      break;
+    EXPECT_NE(mnemonic, "s_set_vgpr_msb") << "bank-0 operands must not need a mode transition";
+    EXPECT_NE(mnemonic, "scratch_store_b32") << "the scratch lease must not spill here";
+    const size_t words = static_cast<size_t>(inst->size()) / sizeof(uint32_t);
+    ASSERT_GT(words, 0u);
+    body_words.insert(body_words.end(), text_words + offset, text_words + offset + words);
+    offset += words;
+  }
+
+  rocjitsu::amdgpu::GpuMemory gpu_mem("gfx1250_f16_k128_diff_mem");
+  rocjitsu::amdgpu::L2Cache l2("gfx1250_f16_k128_diff_l2");
+  rocjitsu::amdgpu::ComputeUnitCore::Config cfg{};
+  cfg.arch = ROCJITSU_CODE_ARCH_GFX1250;
+  cfg.num_wf_slots = 1;
+  cfg.sgprs_per_wf = 106;
+  cfg.vgprs_per_wf = 256;
+  cfg.lds_size_kb = 64;
+
+  auto cu = rocjitsu::amdgpu::ComputeUnitCore::create("gfx1250", cfg, &gpu_mem, &l2);
+  ASSERT_NE(cu, nullptr);
+  auto *wf = cu->dispatch_wf(0, 0, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
+  ASSERT_NE(wf, nullptr);
+  ASSERT_EQ(wf->wf_size(), 32u);
+  wf->set_exec((1ULL << wf->wf_size()) - 1ULL);
+  const uint32_t vb = wf->vgpr_alloc().base;
+  const uint32_t lanes = wf->wf_size();
+
+  // FP8 E4M3 magnitudes reach 448, and K=128 terms accumulate, so ordinary
+  // pseudo-random matrices already overflow FP16 in most output elements. The
+  // accumulator adds both infinities, which only the clamp handles. NaN is
+  // excluded here and covered separately below.
+  auto fill_inputs = [&](uint32_t accumulator_override) {
+    uint32_t state = 0x0f16ac21u;
+    auto next = [&state] {
+      state = state * 1664525u + 1013904223u;
+      return state;
+    };
+    auto without_fp8_nan = [](uint32_t word) {
+      uint32_t out = 0;
+      for (uint32_t byte = 0; byte < 4; ++byte) {
+        uint32_t value = (word >> (byte * 8)) & 0xffu;
+        if ((value & 0x7fu) == 0x7fu)
+          value ^= 1u;
+        out |= value << (byte * 8);
+      }
+      return out;
+    };
+    auto without_f16_nan = [](uint32_t word) {
+      uint32_t out = 0;
+      for (uint32_t half = 0; half < 2; ++half) {
+        uint32_t value = (word >> (half * 16)) & 0xffffu;
+        if ((value & 0x7c00u) == 0x7c00u && (value & 0x03ffu) != 0)
+          value &= 0xfbffu;
+        out |= value << (half * 16);
+      }
+      return out;
+    };
+    for (uint32_t reg = 0; reg < kMatrixARegs; ++reg)
+      for (uint32_t lane = 0; lane < lanes; ++lane)
+        cu->write_vgpr(vb + kMatrixA + reg, lane, without_fp8_nan(next()));
+    for (uint32_t reg = 0; reg < kMatrixBRegs; ++reg)
+      for (uint32_t lane = 0; lane < lanes; ++lane)
+        cu->write_vgpr(vb + kMatrixB + reg, lane, without_fp8_nan(next()));
+    for (uint32_t reg = 0; reg < kMatrixCRegs; ++reg)
+      for (uint32_t lane = 0; lane < lanes; ++lane)
+        cu->write_vgpr(vb + kMatrixC + reg, lane,
+                       accumulator_override != 0 ? accumulator_override : without_f16_nan(next()));
+    if (accumulator_override != 0)
+      return;
+    // Packed FP16 pairs: +Inf/-Inf, +MAX/-MAX, +0/-0, denormal/one.
+    static constexpr std::array<uint32_t, 4> kSpecials = {0xFC007C00u, 0xFBFF7BFFu, 0x80000000u,
+                                                          0x3C000001u};
+    for (uint32_t reg = 0; reg < kMatrixCRegs; ++reg)
+      for (uint32_t i = 0; i < kSpecials.size(); ++i)
+        cu->write_vgpr(vb + kMatrixC + reg, i * 7u, kSpecials[i]);
+  };
+
+  auto zero_destination = [&] {
+    for (uint32_t reg = 0; reg < kDestinationRegs; ++reg)
+      for (uint32_t lane = 0; lane < lanes; ++lane)
+        cu->write_vgpr(vb + kDestination + reg, lane, 0u);
+  };
+
+  auto snapshot_destination = [&] {
+    std::vector<uint32_t> out;
+    out.reserve(kDestinationRegs * lanes);
+    for (uint32_t reg = 0; reg < kDestinationRegs; ++reg)
+      for (uint32_t lane = 0; lane < lanes; ++lane)
+        out.push_back(cu->read_vgpr(vb + kDestination + reg, lane));
+    return out;
+  };
+
+  auto run_source = [&] {
+    const std::array<uint32_t, 2> words = {matrix[0], matrix[1]};
+    std::unique_ptr<rocjitsu::Instruction> inst(decoder->decode(words.data()));
+    EXPECT_NE(inst, nullptr);
+    EXPECT_EQ(std::string_view(inst->mnemonic()), "v_wmma_f16_16x16x128_fp8_fp8");
+    cu->execute_instruction(inst.get(), *wf);
+  };
+
+  auto run_lowered = [&] {
+    for (size_t offset = 0; offset < body_words.size();) {
+      std::unique_ptr<rocjitsu::Instruction> inst(decoder->decode(body_words.data() + offset));
+      ASSERT_NE(inst, nullptr);
+      cu->execute_instruction(inst.get(), *wf);
+      offset += static_cast<size_t>(inst->size()) / sizeof(uint32_t);
+    }
+  };
+
+  std::array<std::vector<uint32_t>, 2> source_by_mode;
+  for (const bool fp16_ovfl : {false, true}) {
+    SCOPED_TRACE(fp16_ovfl ? "FP16_OVFL=1" : "FP16_OVFL=0");
+    wf->set_mode_raw(fp16_ovfl ? rocjitsu::amdgpu::Wavefront::FP16_OVFL_BIT : 0u);
+
+    fill_inputs(0);
+    zero_destination();
+    run_source();
+    const std::vector<uint32_t> run_a = snapshot_destination();
+
+    fill_inputs(0);
+    zero_destination();
+    run_lowered();
+    const std::vector<uint32_t> run_b = snapshot_destination();
+
+    EXPECT_EQ(run_a, run_b);
+    for (size_t i = 0; i < run_a.size() && run_a != run_b; ++i) {
+      if (run_a[i] == run_b[i])
+        continue;
+      ADD_FAILURE() << "first divergence at D reg " << (i / lanes) << " lane " << (i % lanes)
+                    << ": source=0x" << std::hex << run_a[i] << " lowered=0x" << run_b[i]
+                    << std::dec;
+      break;
+    }
+    source_by_mode[fp16_ovfl ? 1 : 0] = run_a;
+  }
+
+  // The comparison above only proves the two paths agree. This proves they
+  // agree on something: every element that reaches infinity with the mode clear
+  // must saturate to the same-signed MAX with it set, and nothing else moves.
+  ASSERT_EQ(source_by_mode[0].size(), source_by_mode[1].size());
+  size_t saturated_positive = 0;
+  size_t saturated_negative = 0;
+  for (size_t i = 0; i < source_by_mode[0].size(); ++i) {
+    for (uint32_t half = 0; half < 2; ++half) {
+      const auto clear = static_cast<uint16_t>(source_by_mode[0][i] >> (half * 16));
+      const auto set = static_cast<uint16_t>(source_by_mode[1][i] >> (half * 16));
+      if (clear == 0x7C00u) {
+        EXPECT_EQ(set, 0x7BFFu) << "+infinity must saturate to +MAX";
+        ++saturated_positive;
+      } else if (clear == 0xFC00u) {
+        EXPECT_EQ(set, 0xFBFFu) << "-infinity must saturate to -MAX";
+        ++saturated_negative;
+      } else {
+        EXPECT_EQ(set, clear) << "FP16_OVFL must not disturb representable results";
+      }
+    }
+  }
+  EXPECT_GT(saturated_positive, 0u) << "no output element reached +infinity";
+  EXPECT_GT(saturated_negative, 0u) << "no output element reached -infinity";
+
+  // A NaN accumulator produces a NaN result on both paths, but not the same
+  // encoding: V_MAXIMUM_F32 and V_MINIMUM_F32 return the canonical quiet NaN,
+  // so the clamp drops the sign and payload the source instruction carries
+  // through. IEEE 754 leaves both uninterpreted and the ISA promises only that
+  // a NaN input yields a NaN output, so compare NaN-ness instead of bits.
+  wf->set_mode_raw(0u);
+  fill_inputs(0xFE00FE00u);
+  zero_destination();
+  run_source();
+  const std::vector<uint32_t> nan_source = snapshot_destination();
+  fill_inputs(0xFE00FE00u);
+  zero_destination();
+  run_lowered();
+  const std::vector<uint32_t> nan_lowered = snapshot_destination();
+
+  auto all_halves_are_nan = [](const std::vector<uint32_t> &values) {
+    return std::ranges::all_of(values, [](uint32_t word) {
+      for (uint32_t half = 0; half < 2; ++half) {
+        const auto value = static_cast<uint16_t>(word >> (half * 16));
+        if ((value & 0x7C00u) != 0x7C00u || (value & 0x03FFu) == 0)
+          return false;
+      }
+      return true;
+    });
+  };
+  EXPECT_TRUE(all_halves_are_nan(nan_source));
+  EXPECT_TRUE(all_halves_are_nan(nan_lowered));
+
+  if (!wf->is_halted())
+    wf->halt();
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250MasksM0AroundOffFormClusterLoadForA0) {

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -10952,17 +10952,9 @@ TEST(SemanticTranslator, Gfx1250ClassifiesLivenessFreeExpandRules) {
           gfx1250::kVWmmaF3216x16x128Bf8Fp8Vop3p,
       (static_cast<uint32_t>(gfx1250::encoding::kVop3pOpHi1) << 16) |
           gfx1250::kVWmmaF3216x16x128Bf8Bf8Vop3p,
-      (static_cast<uint32_t>(gfx1250::encoding::kVop3pOpHi1) << 16) |
-          gfx1250::kVWmmaF1616x16x128Fp8Fp8Vop3p,
-      (static_cast<uint32_t>(gfx1250::encoding::kVop3pOpHi1) << 16) |
-          gfx1250::kVWmmaF1616x16x128Fp8Bf8Vop3p,
-      (static_cast<uint32_t>(gfx1250::encoding::kVop3pOpHi1) << 16) |
-          gfx1250::kVWmmaF1616x16x128Bf8Fp8Vop3p,
-      (static_cast<uint32_t>(gfx1250::encoding::kVop3pOpHi1) << 16) |
-          gfx1250::kVWmmaF1616x16x128Bf8Bf8Vop3p,
   };
-  // The standalone 32x16 FP4 rule is deliberately absent: its split borrows the
-  // VGPR-MSB banks of the source operands, so it queries liveness.
+  // The standalone 32x16 FP4 and packed-f16 K=128 rules are deliberately
+  // absent because they query operand-bank liveness.
   EXPECT_EQ(liveness_free_rules, expected);
 
   rocjitsu::SemanticTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250,
@@ -11148,11 +11140,7 @@ TEST(BinaryTranslatorE2E, Gfx1250F32K128WmmaRejectsClamp) {
       "floating-point results"));
 }
 
-TEST(BinaryTranslatorE2E, Gfx1250F16K128Fp8Bf8WmmaStillFailsClosedForA0) {
-  // A two-K=64 lowering would materialize the first result as packed f16 before
-  // feeding it back as C, adding an intermediate rounding that the K=128 form
-  // does not perform. Keep every f16 form fail-closed until an exact lowering
-  // preserves the single final f16 round.
+TEST(BinaryTranslatorE2E, Gfx1250LowersF16K128Fp8Bf8WmmaThroughF32Scratch) {
   constexpr std::array source_opcodes = {
       gfx1250::kVWmmaF1616x16x128Fp8Fp8Vop3p,
       gfx1250::kVWmmaF1616x16x128Fp8Bf8Vop3p,
@@ -11160,7 +11148,13 @@ TEST(BinaryTranslatorE2E, Gfx1250F16K128Fp8Bf8WmmaStillFailsClosedForA0) {
       gfx1250::kVWmmaF1616x16x128Bf8Bf8Vop3p,
   };
   constexpr gfx1250::Vop3pBuilderFields fields{
-      .vdst = 54, .src0 = 256 + 16, .src1 = 256 + 32, .src2 = 256 + 48};
+      .vdst = 54,
+      .neg_hi = 4,
+      .src0 = 256 + 16,
+      .src1 = 256 + 32,
+      .src2 = 256 + 48,
+      .neg = 4,
+  };
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
 
   for (const uint16_t source_opcode : source_opcodes) {
@@ -11173,11 +11167,51 @@ TEST(BinaryTranslatorE2E, Gfx1250F16K128Fp8Bf8WmmaStillFailsClosedForA0) {
         gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
                                  rocjitsu::ProcessorRevision::Gfx1250A0));
     const auto result = translator.translate(source);
-    EXPECT_FALSE(result.ok());
-    EXPECT_EQ(result.elf_bytes, image) << "fail-closed must leave the object unchanged";
-    EXPECT_TRUE(
-        rocjitsu::has_error_containing(result, rocjitsu::DiagnosticKind::ExpandFailed,
-                                       "f16 K=128 WMMA A0 lowering is not yet implemented"));
+    ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                            : result.diagnostics.front().message);
+
+    rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+    ASSERT_FALSE(translated.text_sections().empty());
+    const auto decoded =
+        decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+    const auto matrix = std::ranges::find_if(decoded, [](const auto &candidate) {
+      return candidate->mnemonic() == "v_wmma_scale_f32_16x16x128_f8f6f4";
+    });
+    ASSERT_NE(matrix, decoded.end());
+    ASSERT_NE(matrix, decoded.begin());
+    EXPECT_EQ((*std::prev(matrix))->mnemonic(), "s_wait_alu");
+    ASSERT_NE(std::next(matrix), decoded.end());
+    EXPECT_EQ((*std::next(matrix))->mnemonic(), "s_wait_alu");
+    ASSERT_NE((*matrix)->raw_encoding(), nullptr);
+    gfx1250::Vop3pMachineInst lowered_matrix{};
+    std::memcpy(&lowered_matrix, (*matrix)->raw_encoding() + 2, sizeof(lowered_matrix));
+    EXPECT_EQ(lowered_matrix.vdst % 2u, 0u) << "WMMA scratch tuples must start at an even VGPR";
+    auto after_wait = std::next(matrix, 2);
+    ASSERT_LE(std::distance(decoded.begin(), after_wait) + 16,
+              std::distance(decoded.begin(), decoded.end()));
+    for (uint16_t slot = 0; slot < 16; ++slot, ++after_wait)
+      EXPECT_EQ((*after_wait)->mnemonic(), "v_nop_e32");
+    EXPECT_EQ(std::ranges::count_if(decoded,
+                                    [](const auto &candidate) {
+                                      return candidate->mnemonic() ==
+                                             "v_wmma_scale_f32_16x16x128_f8f6f4";
+                                    }),
+              1);
+    EXPECT_EQ(std::ranges::count_if(
+                  decoded,
+                  [](const auto &candidate) { return candidate->mnemonic() == "v_cvt_f32_f16"; }),
+              8);
+    EXPECT_EQ(std::ranges::count_if(decoded,
+                                    [](const auto &candidate) {
+                                      return candidate->mnemonic() == "v_cvt_pk_f16_f32";
+                                    }),
+              4);
+    EXPECT_EQ(std::ranges::count_if(decoded,
+                                    [](const auto &candidate) {
+                                      return candidate->mnemonic().find("16x16x64") !=
+                                             std::string_view::npos;
+                                    }),
+              0);
   }
 }
 

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -11186,6 +11186,17 @@ TEST(BinaryTranslatorE2E, Gfx1250LowersF16K128Fp8Bf8WmmaThroughF32Scratch) {
     gfx1250::Vop3pMachineInst lowered_matrix{};
     std::memcpy(&lowered_matrix, (*matrix)->raw_encoding() + 2, sizeof(lowered_matrix));
     EXPECT_EQ(lowered_matrix.vdst % 2u, 0u) << "WMMA scratch tuples must start at an even VGPR";
+    EXPECT_EQ(lowered_matrix.opsel, source_opcode == gfx1250::kVWmmaF1616x16x128Bf8Fp8Vop3p ||
+                                            source_opcode == gfx1250::kVWmmaF1616x16x128Bf8Bf8Vop3p
+                                        ? 1u
+                                        : 0u);
+    EXPECT_EQ(lowered_matrix.opsel_hi,
+              source_opcode == gfx1250::kVWmmaF1616x16x128Fp8Bf8Vop3p ||
+                      source_opcode == gfx1250::kVWmmaF1616x16x128Bf8Bf8Vop3p
+                  ? 1u
+                  : 0u);
+    EXPECT_EQ(lowered_matrix.neg_hi, 4u);
+    EXPECT_EQ(lowered_matrix.neg, 4u);
     auto after_wait = std::next(matrix, 2);
     ASSERT_LE(std::distance(decoded.begin(), after_wait) + 16,
               std::distance(decoded.begin(), decoded.end()));
@@ -11206,6 +11217,18 @@ TEST(BinaryTranslatorE2E, Gfx1250LowersF16K128Fp8Bf8WmmaThroughF32Scratch) {
                                       return candidate->mnemonic() == "v_cvt_pk_f16_f32";
                                     }),
               4);
+    EXPECT_EQ(
+        std::ranges::count_if(
+            decoded, [](const auto &candidate) { return candidate->mnemonic() == "s_getreg_b32"; }),
+        1);
+    EXPECT_EQ(std::ranges::count_if(
+                  decoded,
+                  [](const auto &candidate) { return candidate->mnemonic() == "v_maximum_f32"; }),
+              8);
+    EXPECT_EQ(std::ranges::count_if(
+                  decoded,
+                  [](const auto &candidate) { return candidate->mnemonic() == "v_minimum_f32"; }),
+              8);
     EXPECT_EQ(std::ranges::count_if(decoded,
                                     [](const auto &candidate) {
                                       return candidate->mnemonic().find("16x16x64") !=
@@ -11213,6 +11236,224 @@ TEST(BinaryTranslatorE2E, Gfx1250LowersF16K128Fp8Bf8WmmaThroughF32Scratch) {
                                     }),
               0);
   }
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250F16K128WmmaAcceptsInlineZeroAccumulator) {
+  constexpr auto source_wmma =
+      gfx1250::build_vop3p(gfx1250::kVWmmaF1616x16x128Fp8Fp8Vop3p,
+                           {.vdst = 54, .src0 = 256 + 16, .src1 = 256 + 32, .src2 = 128});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {source_wmma[0], source_wmma[1], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  EXPECT_EQ(
+      std::ranges::count_if(
+          decoded, [](const auto &candidate) { return candidate->mnemonic() == "v_cvt_f32_f16"; }),
+      0);
+  const auto matrix = std::ranges::find_if(decoded, [](const auto &candidate) {
+    return candidate->mnemonic() == "v_wmma_scale_f32_16x16x128_f8f6f4";
+  });
+  ASSERT_NE(matrix, decoded.end());
+  gfx1250::Vop3pMachineInst lowered_matrix{};
+  std::memcpy(&lowered_matrix, (*matrix)->raw_encoding() + 2, sizeof(lowered_matrix));
+  EXPECT_EQ(lowered_matrix.src2, 128u);
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250F16K128WmmaRejectsNonVgprNonzeroAccumulator) {
+  for (const uint16_t accumulator : {uint16_t{0}, uint16_t{129}}) {
+    const auto source_wmma =
+        gfx1250::build_vop3p(gfx1250::kVWmmaF1616x16x128Fp8Fp8Vop3p,
+                             {.vdst = 54, .src0 = 256 + 16, .src1 = 256 + 32, .src2 = accumulator});
+    constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+    auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+        {source_wmma[0], source_wmma[1], kGfx1250SEndpgm});
+    rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+    rocjitsu::BinaryTranslator translator(
+        ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+        gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                                 rocjitsu::ProcessorRevision::Gfx1250A0));
+    const auto result = translator.translate(source);
+    EXPECT_FALSE(result.ok());
+    EXPECT_EQ(result.elf_bytes, image);
+    EXPECT_TRUE(rocjitsu::has_error_containing(
+        result, rocjitsu::DiagnosticKind::ExpandFailed,
+        "K=128 WMMA accumulator is not a VGPR range or inline zero"));
+  }
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250F16K128WmmaUsesAccumulatorBankAsGeneratedSrc0) {
+  constexpr auto set_vgpr_msb = gfx1250::build_sopp(gfx1250::kSSetVgprMsbSopp, {.simm16 = 0x10});
+  constexpr auto source_wmma =
+      gfx1250::build_vop3p(gfx1250::kVWmmaF1616x16x128Fp8Fp8Vop3p,
+                           {.vdst = 54, .src0 = 256 + 16, .src1 = 256 + 32, .src2 = 256 + 48});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {set_vgpr_msb[0], source_wmma[0], source_wmma[1], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  std::vector<uint8_t> modes;
+  for (const auto &candidate : decoded) {
+    if (candidate->mnemonic() == "s_set_vgpr_msb")
+      modes.push_back(static_cast<uint8_t>(candidate->raw_encoding()[0] & 0xffu));
+  }
+  ASSERT_GE(modes.size(), 2u);
+  EXPECT_EQ(modes[0], 0x10u);
+  EXPECT_EQ(modes[1], 0x01u) << "the generated conversion reads the accumulator through SRC0";
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250F16K128WmmaAllowsSequentialTuplesToCrossVgprBanks) {
+  constexpr auto source_wmma =
+      gfx1250::build_vop3p(gfx1250::kVWmmaF1616x16x128Fp8Fp8Vop3p,
+                           {.vdst = 254, .src0 = 256 + 16, .src1 = 256 + 32, .src2 = 256 + 254});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {source_wmma[0], source_wmma[1], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  std::vector<uint16_t> unpack_sources;
+  std::vector<uint8_t> packed_destinations;
+  std::vector<uint8_t> modes;
+  for (const auto &candidate : decoded) {
+    if (candidate->mnemonic() == "s_set_vgpr_msb") {
+      modes.push_back(static_cast<uint8_t>(candidate->raw_encoding()[0] & 0xffu));
+    } else if (candidate->mnemonic() == "v_cvt_f32_f16") {
+      gfx1250::Vop3MachineInst conversion{};
+      std::memcpy(&conversion, candidate->raw_encoding(), sizeof(conversion));
+      unpack_sources.push_back(conversion.src0);
+    } else if (candidate->mnemonic() == "v_cvt_pk_f16_f32") {
+      gfx1250::Vop3MachineInst conversion{};
+      std::memcpy(&conversion, candidate->raw_encoding(), sizeof(conversion));
+      packed_destinations.push_back(conversion.vdst);
+    }
+  }
+  EXPECT_EQ(unpack_sources, (std::vector<uint16_t>{510, 510, 511, 511, 256, 256, 257, 257}));
+  EXPECT_EQ(packed_destinations, (std::vector<uint8_t>{254, 255, 0, 1}));
+  EXPECT_NE(std::ranges::find(modes, 0x01u), modes.end())
+      << "the high accumulator dwords must select SRC0 bank 1";
+  EXPECT_NE(std::ranges::find(modes, 0x40u), modes.end())
+      << "the high destination dwords must select DST bank 1";
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250K128WmmaRejectsOddVgprTuples) {
+  constexpr auto source_wmma =
+      gfx1250::build_vop3p(gfx1250::kVWmmaF1616x16x128Fp8Fp8Vop3p,
+                           {.vdst = 54, .src0 = 256 + 17, .src1 = 256 + 32, .src2 = 256 + 48});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {source_wmma[0], source_wmma[1], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(rocjitsu::has_error_containing(
+      result, rocjitsu::DiagnosticKind::ExpandFailed,
+      "K=128 WMMA matrix operands and destination are not even VGPR ranges"));
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250F16K128WmmaUsesCarrierUnderSgprPressure) {
+  constexpr auto source_wmma =
+      gfx1250::build_vop3p(gfx1250::kVWmmaF1616x16x128Fp8Fp8Vop3p,
+                           {.vdst = 54, .src0 = 256 + 16, .src1 = 256 + 32, .src2 = 256 + 48});
+  auto image =
+      rocjitsu::make_gfx1250_image_with_live_sgprs(source_wmma, rocjitsu::REGISTER_SET_MAX_SGPRS);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  EXPECT_EQ(
+      std::ranges::count_if(
+          decoded, [](const auto &inst) { return inst->mnemonic() == "v_readfirstlane_b32_e32"; }),
+      1);
+  EXPECT_EQ(std::ranges::count_if(
+                decoded, [](const auto &inst) { return inst->mnemonic() == "s_cbranch_execz"; }),
+            1);
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250F16K128WmmaUsesSpillBackedScratchWhenVgprsAreFull) {
+  using namespace rocr::llvm::amdhsa;
+
+  constexpr auto source_wmma =
+      gfx1250::build_vop3p(gfx1250::kVWmmaF1616x16x128Fp8Fp8Vop3p,
+                           {.vdst = 54, .src0 = 256 + 16, .src1 = 256 + 32, .src2 = 256 + 48});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {source_wmma[0], source_wmma[1], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject layout(image.data(), image.size());
+  ASSERT_TRUE(layout.is_valid());
+  const auto *rodata = rocjitsu::find_section(layout, ".rodata");
+  ASSERT_NE(rodata, nullptr);
+  auto descriptor = rocjitsu::read_kernel_descriptor_for_test(rodata->data());
+  AMDHSA_BITS_SET(descriptor.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT,
+                  63);
+  rocjitsu::write_kernel_descriptor_for_test(image.data() + rodata->sectionOffset(), descriptor);
+
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  auto options = gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                                          rocjitsu::ProcessorRevision::Gfx1250A0);
+  options.debug_min_free_vgpr = 256;
+  rocjitsu::BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+                                        options);
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+  EXPECT_EQ(std::ranges::count_if(
+                decoded, [](const auto &inst) { return inst->mnemonic() == "scratch_store_b32"; }),
+            9);
+  EXPECT_EQ(std::ranges::count_if(
+                decoded, [](const auto &inst) { return inst->mnemonic() == "scratch_load_b32"; }),
+            9);
+  EXPECT_EQ(std::ranges::count_if(decoded,
+                                  [](const auto &inst) {
+                                    return inst->mnemonic() == "v_wmma_scale_f32_16x16x128_f8f6f4";
+                                  }),
+            1);
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250MasksM0AroundOffFormClusterLoadForA0) {

--- a/emulation/rocjitsu/tests/simd_correctness/wmma_simd_exact_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/wmma_simd_exact_test.cpp
@@ -28,8 +28,11 @@ constexpr uint32_t SCALE_A = 100, SCALE_B = 104;
 
 using WmmaF32SpecFn = void (*)(amdgpu::ComputeUnitCore &, uint32_t, uint32_t, uint32_t, uint32_t,
                                uint32_t, uint32_t);
+// The trailing bool is MODE.FP16_OVFL. These cases compare the SIMD fast path
+// against the scalar reference, which the mode does not distinguish, so every
+// call below leaves it clear.
 using WmmaF16SpecFn = void (*)(amdgpu::ComputeUnitCore &, uint32_t, uint32_t, uint32_t, uint32_t,
-                               uint32_t);
+                               uint32_t, bool);
 
 struct WmmaFixture : ExactFixture {
   WmmaFixture() : ExactFixture(ROCJITSU_CODE_ARCH_GFX1250, WF) {}
@@ -177,7 +180,7 @@ TEST(WmmaSimdExact, F8SpecDense) {
   };
   auto spec_f16 = [](WmmaF16SpecFn fn, Fmt fmt, const char *label) {
     run_case(label, fmt, Fmt::F16, [fn](WmmaFixture &fx, uint32_t ca) {
-      fn(*fx.cu, fx.vbase + ACC, fx.vbase + S0, fx.vbase + S1, fx.vbase + ACC, ca);
+      fn(*fx.cu, fx.vbase + ACC, fx.vbase + S0, fx.vbase + S1, fx.vbase + ACC, ca, false);
     });
   };
   spec_f32(amdgpu::exec_wmma_f32_f8_spec<16, 16, 64, true, true>, Fmt::FP8, "spec_f32_fp8_fp8_k64");


### PR DESCRIPTION
Lower packed-f16 K=128 FP8/BF8 WMMA forms through an F32 scratch accumulator, preserve VGPR-bank state, and enforce the required dependency spacing before packing the final result.

Also add a few comments to f32_to_e5m3 lowering.