### PR TITLE
[rocjitsu] Avoid GuestKfd sysfs re-entry on reopen

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.cpp
@@ -163,16 +163,27 @@ void append_unique_gpu_id(std::vector<uint32_t> *ids, uint32_t gpu_id) {
 
 uint32_t max_numeric_dir(const fs::path &dir) {
   uint32_t max_id = 0;
-  std::error_code ec;
-  for (const auto &entry : fs::directory_iterator(dir, ec)) {
-    if (!entry.is_directory(ec))
+  const std::string dir_str = dir.string();
+  auto &real = libc_passthrough();
+  // Host validation can run with GuestKfd::mutex_ held. Going through the
+  // interposed directory functions for real sysfs would re-enter
+  // redirect_sysfs_path(), which takes the same mutex.
+  DIR *stream = real.opendir(dir_str.c_str());
+  if (!stream)
+    return max_id;
+
+  while (struct dirent *entry = real.readdir(stream)) {
+    std::string_view name(entry->d_name);
+    const std::string child = (dir / name).string();
+    struct stat st {};
+    if (real.stat(child.c_str(), &st) != 0 || !S_ISDIR(st.st_mode))
       continue;
-    auto name = entry.path().filename().string();
     uint32_t id = 0;
     auto [ptr, err] = std::from_chars(name.data(), name.data() + name.size(), id);
     if (err == std::errc{} && ptr == name.data() + name.size())
       max_id = std::max(max_id, id);
   }
+  real.closedir(stream);
   return max_id;
 }
 

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -1063,6 +1063,15 @@ if(RJ_HAS_GFX1201_GPU)
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
     add_test(
+        NAME "GuestKfdLifecycleTest.ReopensAfterLastClose"
+        COMMAND
+            ${RJ_CLI} --config
+            ${CMAKE_SOURCE_DIR}/configs/guest_gfx950_on_gfx1201.json --
+            $<TARGET_FILE:guest_kfd_test>
+            --gtest_filter=GuestKfdLifecycleTest.ReopensAfterLastClose
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    )
+    add_test(
         NAME "GuestKfdMemoryTest.GuestAllocationMmapOffsetIsRejected"
         COMMAND
             ${RJ_CLI} --config
@@ -1084,6 +1093,7 @@ if(RJ_HAS_GFX1201_GPU)
         "GuestKfdMultiprocessTest.ForkedChildrenDoNotRemoveParentOverlay"
         "GuestKfdMultiprocessTest.ForkedChildDropsInheritedGuestDriverBeforeReopen"
         "GuestKfdConcurrencyTest.ConcurrentOpenIoctlAndSysfsRedirect"
+        "GuestKfdLifecycleTest.ReopensAfterLastClose"
         "GuestKfdMemoryTest.GuestAllocationMmapOffsetIsRejected"
         "GuestKfdFdReuseTest.OverwritingHiddenRealFdKeepsRoutingCorrect"
         PROPERTIES TIMEOUT 60 SKIP_REGULAR_EXPRESSION "\\[  SKIPPED \\]"
@@ -1095,6 +1105,7 @@ if(RJ_HAS_GFX1201_GPU)
             "GuestKfdMultiprocessTest.ForkedChildrenDoNotRemoveParentOverlay"
             "GuestKfdMultiprocessTest.ForkedChildDropsInheritedGuestDriverBeforeReopen"
             "GuestKfdConcurrencyTest.ConcurrentOpenIoctlAndSysfsRedirect"
+            "GuestKfdLifecycleTest.ReopensAfterLastClose"
             "GuestKfdMemoryTest.GuestAllocationMmapOffsetIsRejected"
             "GuestKfdFdReuseTest.OverwritingHiddenRealFdKeepsRoutingCorrect"
     )

--- a/emulation/rocjitsu/tests/guest_kfd_test.cpp
+++ b/emulation/rocjitsu/tests/guest_kfd_test.cpp
@@ -386,6 +386,21 @@ TEST(GuestKfdConcurrencyTest, ConcurrentOpenIoctlAndSysfsRedirect) {
   EXPECT_EQ(sysfs_failures.load(std::memory_order_relaxed), 0);
 }
 
+TEST(GuestKfdLifecycleTest, ReopensAfterLastClose) {
+  if (access(kKfdPath, R_OK | W_OK) != 0)
+    GTEST_SKIP() << kKfdPath << " is not available: " << std::strerror(errno);
+
+  for (int attempt = 0; attempt < 2; ++attempt) {
+    int fd = open(kKfdPath, O_RDWR | O_CLOEXEC);
+    ASSERT_GE(fd, 0) << "open attempt " << attempt << " failed: " << std::strerror(errno);
+
+    kfd_ioctl_get_version_args version{};
+    EXPECT_EQ(ioctl(fd, AMDKFD_IOC_GET_VERSION, &version), 0);
+    EXPECT_TRUE(guest_gpu_is_visible());
+    EXPECT_EQ(close(fd), 0);
+  }
+}
+
 TEST(GuestKfdMemoryTest, GuestAllocationMmapOffsetIsRejected) {
   if (access(kKfdPath, R_OK | W_OK) != 0)
     GTEST_SKIP() << kKfdPath << " is not available: " << std::strerror(errno);


### PR DESCRIPTION
PR #9213 added physical topology validation while GuestKfd::mutex_ is held. Enumerating the real topology through std::filesystem re-enters the sysfs interposer, which attempts to acquire the same mutex and blocks subsequent /dev/kfd opens.

Enumerate and inspect topology nodes through libc_passthrough so host validation reaches the real sysfs directly. Add a focused lifecycle test covering close followed by reopen.

Tests:
- GuestKfd timeout cluster: 9/9 passed
- GuestKfd tests: 12/12 passed
- Full CTest: 2720 passed, 3 skipped, 2 unrelated failures