### PR TITLE
ci(docs): add rocprofiler-compute-develop branch

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -19,6 +19,7 @@ on:
     branches:
       - 'develop'
       - 'docs/**'
+      - 'rocprofiler-compute-develop'
     paths:
      - 'projects/**'
      - 'shared/**'


### PR DESCRIPTION
## Motivation

Documentation for the `rocprofiler-compute-develop` branch is never built on Read the Docs. That branch carries rocprofiler-compute work for the whole sprint, so doc changes are invisible until they land on `develop`.

## Technical Details

`on.push.branches` in `.github/workflows/update-docs.yml` matches only `develop` and `docs/**`, so pushes to `rocprofiler-compute-develop` never start the workflow. This adds the branch to the filter.

The job derives the RTD version slug from the branch name, so it will POST to the `rocprofiler-compute-develop` version of `advanced-micro-devices-rocprofiler-compute`.

For `push` events GitHub reads the workflow file from the pushed ref, so this takes effect on `rocprofiler-compute-develop` once `develop` is synced into it.

## Issue Tracking

JIRA ID: N/A

## Test Plan

Confirmed against the workflow run history that the workflow has never run on `rocprofiler-compute-develop`, and that a `develop` push touching `projects/rocprofiler-compute` does trigger an RTD build for version `develop`. Verified the edited YAML parses.

## Test Result

Works locally: YAML parses and the diff is a single branch-filter entry. Behavior can only be confirmed by a push to the branch after this merges and syncs.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.