### PR TITLE
test(rocjitsu): structure and validate HIP race expectations

### DIFF
--- a/emulation/rocjitsu/docs/race-detector.md
+++ b/emulation/rocjitsu/docs/race-detector.md
@@ -83,7 +83,7 @@ $BUILD_DIR/tools/rocjitsu/rocjitsu --config my_config.json -- /tmp/race_example
 You should see output:
 
 ```
-RACE kernel=transpose_lds symbol=_Z13transpose_ldsPKiPi dispatch=1 type=LDS reg=508 wave=0 lane=0 wg=0,0,0 conflict=unknown
+RACE kernel=transpose_lds symbol=_Z13transpose_ldsPKiPi dispatch=1 type=LDS access=read reg=508 wave=0 lane=0 wg=0,0,0 conflict=unknown
 Race on LDS byte 508 [workgroup (0, 0, 0), wave 0, lane 0]
   ==>  ds_write_b32 v0, v1  ; <-- wave 1
        v_sub_u32_e32 v1, 0, v0

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -542,6 +542,7 @@ add_executable(
     race-detector/race_detector_event_registry_test.cpp
     race-detector/race_detector_tests.cpp
     race-detector/interval_set_tests.cpp
+    race-detector/race_log_expectation_test.cpp
     data_types_test.cpp
     drm_info_layout_test.cpp
 )
@@ -2449,7 +2450,13 @@ if(RJ_ENABLE_HIP_TESTS)
 
     # Helper: build a HIP test binary with amdclang++ + gtest.
     function(rj_add_hip_test TEST_NAME)
-        cmake_parse_arguments(ARG "" "ARCH;SOURCE" "EXTRA_LIBS" ${ARGN})
+        cmake_parse_arguments(
+            ARG
+            ""
+            "ARCH;SOURCE"
+            "DEPENDENCIES;EXTRA_LIBS"
+            ${ARGN}
+        )
         if(NOT ARG_ARCH)
             set(ARG_ARCH ${RJ_HIP_TEST_ARCH})
         endif()
@@ -2473,7 +2480,11 @@ if(RJ_ENABLE_HIP_TESTS)
                 ${HIP_EXTRA_LIBS} -L${GTEST_LIB_DIR} -lgtest -lpthread
                 -Wl,-rpath,${GTEST_LIB_DIR} -Wl,-rpath,${RJ_HSA_LIBRARY_DIR}
                 ${RJ_HIP_SANITIZER_LINK_FLAGS}
-            DEPENDS ${HIP_TEST_SRC} GTest::gtest GTest::gtest_main
+            DEPENDS
+                ${HIP_TEST_SRC}
+                ${ARG_DEPENDENCIES}
+                GTest::gtest
+                GTest::gtest_main
             COMMENT "Building ${TEST_NAME} with amdclang++ -x hip (${ARG_ARCH})"
             VERBATIM
         )

--- a/emulation/rocjitsu/tests/race-detector/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/race-detector/CMakeLists.txt
@@ -11,8 +11,22 @@
 # The gfx950 race detector cases include CDNA-specific inline assembly
 # sequences for LDS and waitcnt coverage. Keep that binary on gfx950 even when
 # generic HIP smoke tests are overridden for local validation on another ISA.
-rj_add_hip_test(hip_race_tests_gfx950 ARCH gfx950 SOURCE hip_race_gfx950_test.hip)
-rj_add_hip_test(hip_race_tests_gfx1151 ARCH gfx1151 SOURCE hip_race_gfx1151_test.hip)
+set(RJ_RACE_TEST_SUPPORT_HEADERS
+    ${CMAKE_CURRENT_SOURCE_DIR}/race_log_expectation.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/race_test_support.hpp
+)
+rj_add_hip_test(
+    hip_race_tests_gfx950
+    ARCH gfx950
+    SOURCE hip_race_gfx950_test.hip
+    DEPENDENCIES ${RJ_RACE_TEST_SUPPORT_HEADERS}
+)
+rj_add_hip_test(
+    hip_race_tests_gfx1151
+    ARCH gfx1151
+    SOURCE hip_race_gfx1151_test.hip
+    DEPENDENCIES ${RJ_RACE_TEST_SUPPORT_HEADERS}
+)
 set(RJ_RACE_GFX950_CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/race_test_config.json)
 if(RJ_INSTALL_TESTS)
     install(

--- a/emulation/rocjitsu/tests/race-detector/hip_race_gfx1151_test.hip
+++ b/emulation/rocjitsu/tests/race-detector/hip_race_gfx1151_test.hip
@@ -7,10 +7,9 @@
 #include <gtest/gtest.h>
 #include <hip/hip_runtime.h>
 
-#include <cstdlib>
+#include "race_test_support.hpp"
+
 #include <cstdint>
-#include <fstream>
-#include <string>
 #include <vector>
 
 int main(int argc, char **argv) {
@@ -22,82 +21,10 @@ int main(int argc, char **argv) {
 
 namespace {
 
-struct RaceRecord {
-  std::string type;
-  std::string access;
-  std::string message;
-};
+using rocjitsu::test::FindingCount;
+using rocjitsu::test::RaceExpectation;
 
-std::vector<RaceRecord> parse_race_log() {
-  const char *dir = std::getenv("RJ_SINK_DIR");
-  if (!dir)
-    return {};
-
-  std::ifstream f(std::string(dir) + "/race.log");
-  std::vector<RaceRecord> records;
-  std::string line;
-  while (std::getline(f, line)) {
-    if (!line.starts_with("RACE "))
-      continue;
-
-    RaceRecord record;
-    auto type_pos = line.find("type=");
-    if (type_pos != std::string::npos) {
-      auto value_begin = type_pos + 5;
-      auto value_end = line.find(' ', value_begin);
-      record.type = line.substr(value_begin, value_end - value_begin);
-    }
-    auto access_pos = line.find("access=");
-    if (access_pos != std::string::npos) {
-      auto value_begin = access_pos + 7;
-      auto value_end = line.find(' ', value_begin);
-      record.access = line.substr(value_begin, value_end - value_begin);
-    }
-
-    while (std::getline(f, line)) {
-      if (line == "END_RACE")
-        break;
-      if (!record.message.empty())
-        record.message += '\n';
-      record.message += line;
-    }
-    records.push_back(std::move(record));
-  }
-  return records;
-}
-
-class Gfx1151RaceTest : public ::testing::Test {
-protected:
-  template <typename T>
-  T *alloc(int n) {
-    T *p = nullptr;
-    (void)hipMalloc(&p, n * sizeof(T));
-    return p;
-  }
-
-  template <typename T>
-  T *allocWithData(int n) {
-    T *p = alloc<T>(n);
-    std::vector<T> h(n);
-    for (int i = 0; i < n; ++i)
-      h[i] = static_cast<T>(i);
-    (void)hipMemcpy(p, h.data(), n * sizeof(T), hipMemcpyHostToDevice);
-    return p;
-  }
-
-  void sync() { (void)hipDeviceSynchronize(); }
-
-  void ExpectNoRace() {
-    auto records = parse_race_log();
-    EXPECT_TRUE(records.empty()) << "Expected no races, got " << records.size();
-  }
-
-  std::vector<RaceRecord> ExpectRace() {
-    auto records = parse_race_log();
-    EXPECT_FALSE(records.empty()) << "Expected at least one race, got none";
-    return records;
-  }
-};
+using Gfx1151RaceTest = rocjitsu::test::RaceTestBase;
 
 __global__ void vgpr_no_race_kernel(const float *src, float *dst) {
   int tid = threadIdx.x;
@@ -108,6 +35,11 @@ __global__ void vgpr_no_race_kernel(const float *src, float *dst) {
                : "v"(&src[tid]));
   dst[tid] = val;
 }
+
+static constexpr RaceExpectation kVgprWaitcntRaceExpectation{
+    .findings = FindingCount::OneOrMore,
+    .type = "VGPR",
+};
 
 __global__ void vgpr_race_kernel(const float *src, float *dst) {
   int tid = threadIdx.x;
@@ -152,6 +84,12 @@ __global__ void d16_global_load_hi_merge_kernel(const uint8_t *src, uint32_t *ds
 // omits s_waitcnt before storing the VGPR. The store consumes the load
 // destination while the low-half load is still outstanding, so the race detector
 // should report a real VGPR race after the memory-completion self-race is fixed.
+static constexpr RaceExpectation kD16GlobalLoadMissingWaitcntRaceExpectation{
+    .findings = FindingCount::OneOrMore,
+    .type = "VGPR",
+    .producer = "global_load_d16_u8",
+};
+
 __global__ void d16_global_load_missing_waitcnt_kernel(const uint8_t *src, uint32_t *dst) {
   int tid = threadIdx.x;
   uint32_t val = 0xABCD0000u;
@@ -162,6 +100,14 @@ __global__ void d16_global_load_missing_waitcnt_kernel(const uint8_t *src, uint3
                : "memory");
   dst[tid] = val;
 }
+
+static constexpr RaceExpectation kWawGlobalLoadThenWmmaExpectation{
+    .findings = FindingCount::OneOrMore,
+    .type = "VGPR",
+    .access = "write",
+    .producer = "global_load",
+    .consumer = "v_wmma",
+};
 
 __global__ void waw_global_load_then_wmma_kernel(const int *src, int *out) {
   int tid = threadIdx.x + blockIdx.x * blockDim.x;
@@ -186,6 +132,11 @@ lds_wave32_cross_wave_safe_kernel(int *out) {
   out[tid] = lds[(tid + 32) & 63];
 }
 
+static constexpr RaceExpectation kLdsWave32CrossWaveRaceExpectation{
+    .findings = FindingCount::OneOrMore,
+    .type = "LDS",
+};
+
 __attribute__((amdgpu_flat_work_group_size(64, 64))) __global__ void
 lds_wave32_cross_wave_race_kernel(int *out) {
   __shared__ int lds[64];
@@ -208,9 +159,7 @@ TEST_F(Gfx1151RaceTest, vgpr_waitcnt_race) {
   auto *dst = alloc<float>(32);
   vgpr_race_kernel<<<1, 32>>>(src, dst);
   sync();
-  auto records = ExpectRace();
-  ASSERT_FALSE(records.empty());
-  EXPECT_EQ(records[0].type, "VGPR");
+  ExpectRace(kVgprWaitcntRaceExpectation);
 }
 
 TEST_F(Gfx1151RaceTest, d16_global_load_merge_no_race) {
@@ -245,10 +194,7 @@ TEST_F(Gfx1151RaceTest, d16_global_load_missing_waitcnt_race) {
   d16_global_load_missing_waitcnt_kernel<<<1, 32>>>(src, dst);
   sync();
 
-  auto records = ExpectRace();
-  ASSERT_FALSE(records.empty());
-  EXPECT_EQ(records[0].type, "VGPR");
-  EXPECT_NE(records[0].message.find("global_load_d16_u8"), std::string::npos);
+  ExpectRace(kD16GlobalLoadMissingWaitcntRaceExpectation);
 }
 
 TEST_F(Gfx1151RaceTest, lds_wave32_cross_wave) {
@@ -260,9 +206,7 @@ TEST_F(Gfx1151RaceTest, lds_wave32_cross_wave) {
 TEST_F(Gfx1151RaceTest, lds_wave32_cross_wave_race) {
   lds_wave32_cross_wave_race_kernel<<<1, 64>>>(alloc<int>(64));
   sync();
-  auto records = ExpectRace();
-  ASSERT_FALSE(records.empty());
-  EXPECT_EQ(records[0].type, "LDS");
+  ExpectRace(kLdsWave32CrossWaveRaceExpectation);
 }
 
 TEST_F(Gfx1151RaceTest, waw_global_load_then_wmma) {
@@ -270,12 +214,7 @@ TEST_F(Gfx1151RaceTest, waw_global_load_then_wmma) {
   auto *out = alloc<int>(32);
   waw_global_load_then_wmma_kernel<<<1, 32>>>(src, out);
   sync();
-  auto records = ExpectRace();
-  ASSERT_FALSE(records.empty());
-  EXPECT_EQ(records[0].type, "VGPR");
-  EXPECT_EQ(records[0].access, "write");
-  EXPECT_NE(records[0].message.find("global_load"), std::string::npos);
-  EXPECT_NE(records[0].message.find("v_wmma"), std::string::npos);
+  ExpectRace(kWawGlobalLoadThenWmmaExpectation);
 }
 
 } // namespace

--- a/emulation/rocjitsu/tests/race-detector/hip_race_gfx950_test.hip
+++ b/emulation/rocjitsu/tests/race-detector/hip_race_gfx950_test.hip
@@ -1093,7 +1093,7 @@ TEST_F(Gfx950RaceTest, waw_global_load_then_mfma) {
 
 static constexpr RaceExpectation kF64VgprRaceExpectation{
     .findings = FindingCount::OneOrMore,
-    .type_substring = "VGPR",
+    .type = "VGPR",
 };
 
 __global__ void f64_vgpr_race_kernel(const double *src, double *dst) {

--- a/emulation/rocjitsu/tests/race-detector/hip_race_gfx950_test.hip
+++ b/emulation/rocjitsu/tests/race-detector/hip_race_gfx950_test.hip
@@ -19,222 +19,16 @@
 #include <gtest/gtest.h>
 #include <hip/hip_runtime.h>
 
-#include <algorithm>
-#include <cstdlib>
+#include "race_test_support.hpp"
+
+#include <cstdint>
 #include <cstdio>
-#include <fstream>
-#include <sstream>
-#include <string>
-#include <unistd.h>
 #include <vector>
 
-// ============================================================
-// Race log parser
-// ============================================================
+using rocjitsu::test::FindingCount;
+using rocjitsu::test::RaceExpectation;
 
-struct RaceRecord {
-  std::string kernel;   // compact readable kernel name, or "?" if unresolved
-  std::string symbol;   // exact ELF symbol name, or "?" if unresolved
-  int dispatch = -1;    // rocjitsu dispatch id
-  std::string type;     // "VGPR", "SGPR", "LDS"
-  std::string access;   // "read" or "write"
-  int reg = -1;         // register index (VGPR/SGPR) or byte address (LDS)
-  int wave = -1;
-  int lane = -1;
-  std::string wg;       // "x,y,z"
-  std::string conflict; // mnemonic of the instruction that initiated the
-                        // unresolved memory operation (e.g. global_load_dword)
-  std::string message;  // full diagnostic text between RACE header and END_RACE
-};
-
-/// Parse structured RACE blocks from the file at RJ_SINK_DIR/race.log.
-///
-/// Example log file content:
-///
-///   RACE kernel=vgpr_race_kernel symbol=_Z16vgpr_race_kernelPKfPf dispatch=1
-///       type=VGPR access=read reg=2 wave=0 lane=0 wg=0,0,0 conflict=global_load_dword
-///   Race on VGPR v2 [workgroup (0, 0, 0), wave 0, lane 0]
-///    ==>  0x5400021940  global_load_dword v2, v[2:3], off
-///         0x5400021948  s_nop 0
-///    ==>  0x540002194c  v_mov_b32_e32 v4, v2
-///   END_RACE
-///
-/// The first line ("RACE ...") is a machine-parseable header with key=value
-/// pairs. Lines between the header and "END_RACE" are the human-readable
-/// diagnostic message. Each such block becomes one RaceRecord.
-static std::vector<RaceRecord> parse_race_log() {
-  const char *dir = std::getenv("RJ_SINK_DIR");
-  if (!dir) return {};
-  std::string path = std::string(dir) + "/race.log";
-
-  std::ifstream f(path);
-  std::vector<RaceRecord> records;
-  std::string line;
-  while (std::getline(f, line)) {
-    if (line.substr(0, 5) != "RACE ") continue;
-
-    RaceRecord r;
-
-    // Parse key=value pairs from the RACE header line.
-    std::string rest = line.substr(5);
-    size_t pos = 0;
-    while (pos < rest.size()) {
-      size_t eq = rest.find('=', pos);
-      if (eq == std::string::npos) break;
-      size_t sp = rest.find(' ', eq);
-      if (sp == std::string::npos) sp = rest.size();
-      std::string key = rest.substr(pos, eq - pos);
-      std::string val = rest.substr(eq + 1, sp - eq - 1);
-      if (key == "kernel")        r.kernel = val;
-      else if (key == "symbol")   r.symbol = val;
-      else if (key == "dispatch") r.dispatch = std::stoi(val);
-      else if (key == "type")     r.type = val;
-      else if (key == "access")   r.access = val;
-      else if (key == "reg")      r.reg = std::stoi(val);
-      else if (key == "wave")     r.wave = val.empty() ? -1 : std::stoi(val);
-      else if (key == "lane")     r.lane = val.empty() ? -1 : std::stoi(val);
-      else if (key == "wg")       r.wg = val;
-      else if (key == "conflict") r.conflict = val;
-      pos = sp + 1;
-    }
-
-    // Collect message body until END_RACE.
-    while (std::getline(f, line)) {
-      if (line == "END_RACE") break;
-      if (!r.message.empty()) r.message += '\n';
-      r.message += line;
-    }
-
-    records.push_back(std::move(r));
-  }
-  return records;
-}
-
-// ============================================================
-// Trace section parser
-// ============================================================
-
-struct TraceSections {
-  std::string header;
-  std::vector<std::string> before;
-  std::string mark0;
-  std::vector<std::string> between;
-  std::string mark1;
-};
-
-static std::string stripMarkPrefix(const std::string &line) {
-  auto pos = line.find("==>");
-  if (pos == std::string::npos) return line;
-  std::string rest = line.substr(pos + 3);
-  auto hex = rest.find("0x");
-  if (hex != std::string::npos) {
-    auto sp = rest.find(' ', hex);
-    if (sp != std::string::npos)
-      sp = rest.find_first_not_of(' ', sp);
-    if (sp != std::string::npos)
-      return rest.substr(sp);
-  }
-  return rest;
-}
-
-static TraceSections parseTrace(const RaceRecord &r) {
-  TraceSections t;
-  std::istringstream ss(r.message);
-  std::string line;
-  int marks_seen = 0;
-  while (std::getline(ss, line)) {
-    if (t.header.empty()) { t.header = line; continue; }
-    bool is_mark = line.find("==>") != std::string::npos;
-    if (is_mark) {
-      if (marks_seen == 0) t.mark0 = stripMarkPrefix(line);
-      else                 t.mark1 = stripMarkPrefix(line);
-      ++marks_seen;
-    } else {
-      if (marks_seen == 0)      t.before.push_back(line);
-      else if (marks_seen == 1) t.between.push_back(line);
-    }
-  }
-  return t;
-}
-
-static bool anyContains(const std::vector<std::string> &lines,
-                        const std::string &s) {
-  return std::any_of(lines.begin(), lines.end(),
-      [&](const std::string &l) { return l.find(s) != std::string::npos; });
-}
-
-static constexpr auto npos = std::string::npos;
-
-// ============================================================
-// Test fixture
-// ============================================================
-
-class Gfx950RaceTest : public ::testing::Test {
-protected:
-  // Returned pointers are device pointers. Not freed (process exits).
-
-  template <typename T>
-  T *alloc(int n) {
-    T *p;
-    (void)hipMalloc(&p, n * sizeof(T));
-    return p;
-  }
-
-  template <typename T>
-  T *allocWithData(int n) {
-    T *p = alloc<T>(n);
-    std::vector<T> h(n);
-    for (int i = 0; i < n; ++i) h[i] = static_cast<T>(i);
-    (void)hipMemcpy(p, h.data(), n * sizeof(T), hipMemcpyHostToDevice);
-    return p;
-  }
-
-  void sync() { (void)hipDeviceSynchronize(); }
-
-  std::vector<RaceRecord> records() { return parse_race_log(); }
-
-  void ExpectNoRace() {
-    auto r = records();
-    if (!r.empty()) {
-      for (auto &rec : r)
-        fprintf(stderr, "  [%s symbol=%s dispatch=%d %s reg=%d wg=%s] %s\n",
-                rec.kernel.c_str(), rec.symbol.c_str(), rec.dispatch, rec.type.c_str(),
-                rec.reg, rec.wg.c_str(), rec.message.c_str());
-    }
-    EXPECT_TRUE(r.empty()) << "Expected no races, got " << r.size();
-  }
-
-  void ExpectRace() {
-    auto r = records();
-    EXPECT_FALSE(r.empty()) << "Expected at least one race, got none";
-  }
-
-  void ExpectNRaces(int n) {
-    auto r = records();
-    EXPECT_EQ(static_cast<int>(r.size()), n)
-        << "Expected " << n << " race(s), got " << r.size();
-  }
-
-  void ExpectDispatchContext(const RaceRecord &r, const std::string &kernel_name_substring) {
-    // Race reports should carry resolved dispatch context, not just the
-    // instruction trace. "?" would mean kernel-symbol resolution failed.
-    EXPECT_FALSE(r.kernel.empty());
-    EXPECT_NE(r.kernel, "?");
-    EXPECT_FALSE(r.symbol.empty());
-    EXPECT_NE(r.symbol, "?");
-
-    // The dispatch id ties the race back to the AQL dispatch that produced it.
-    // This catches regressions where the plugin logs a default-constructed
-    // context instead of the dispatch packet metadata.
-    EXPECT_GE(r.dispatch, 1);
-
-    // Match on the source kernel name rather than the whole demangled spelling:
-    // the exact symbol can include ABI/compiler-specific type detail, while the
-    // kernel name substring is the user-facing identity the report must preserve.
-    EXPECT_NE(r.kernel.find(kernel_name_substring), npos) << "kernel: " << r.kernel;
-    EXPECT_NE(r.symbol.find(kernel_name_substring), npos) << "symbol: " << r.symbol;
-  }
-};
+using Gfx950RaceTest = rocjitsu::test::RaceTestBase;
 
 // ============================================================
 // Tests
@@ -252,6 +46,16 @@ __global__ void vgpr_no_race_kernel(const float *src, float *dst) {
   );
   dst[tid] = val;
 }
+
+static constexpr RaceExpectation kVgprWaitcntRaceExpectation{
+    .kernel = "vgpr_race_kernel",
+    .type = "VGPR",
+    .access = "read",
+    .wave = 0,
+    .lane = 0,
+    .producer = "global_load_dword",
+    .consumer = "global_store_dword",
+};
 
 __global__ void vgpr_race_kernel(const float *src, float *dst) {
   int tid = threadIdx.x + blockIdx.x * blockDim.x;
@@ -276,15 +80,7 @@ TEST_F(Gfx950RaceTest, vgpr_waitcnt_race) {
   auto *src = allocWithData<float>(64), *dst = alloc<float>(64);
   vgpr_race_kernel<<<1, 64>>>(src, dst);
   sync();
-  auto r = records();
-  ASSERT_EQ(r.size(), 1u);
-  ExpectDispatchContext(r[0], "vgpr_race_kernel");
-  auto t = parseTrace(r[0]);
-  EXPECT_NE(t.header.find("VGPR"), npos);
-  EXPECT_NE(t.header.find("wave 0"), npos);
-  EXPECT_NE(t.header.find("lane 0"), npos);
-  EXPECT_NE(t.mark0.find("global_load_dword"), npos) << "mark0: " << t.mark0;
-  EXPECT_NE(t.mark1.find("global_store_dword"), npos) << "mark1: " << t.mark1;
+  ExpectRace(kVgprWaitcntRaceExpectation);
 }
 
 // --- SGPR waitcnt ---
@@ -299,6 +95,13 @@ __global__ void sgpr_no_race_kernel(const int *src, int *dst) {
   );
   dst[threadIdx.x] = val;
 }
+
+static constexpr RaceExpectation kSgprWaitcntRaceExpectation{
+    .type = "SGPR",
+    .wave = 0,
+    .producer = "s_load_dword",
+    .consumer = "s_add_u32",
+};
 
 __global__ void sgpr_race_kernel(const int *src, int *dst) {
   int val;
@@ -322,13 +125,7 @@ TEST_F(Gfx950RaceTest, sgpr_waitcnt_race) {
   auto *src = allocWithData<int>(64), *dst = alloc<int>(64);
   sgpr_race_kernel<<<1, 64>>>(src, dst);
   sync();
-  auto r = records();
-  ASSERT_EQ(r.size(), 1u);
-  auto t = parseTrace(r[0]);
-  EXPECT_NE(t.header.find("SGPR"), npos);
-  EXPECT_NE(t.header.find("wave 0"), npos);
-  EXPECT_NE(t.mark0.find("s_load_dword"), npos) << "mark0: " << t.mark0;
-  EXPECT_NE(t.mark1.find("s_add_u32"), npos) << "mark1: " << t.mark1;
+  ExpectRace(kSgprWaitcntRaceExpectation);
 }
 
 // --- LDS cross-wave ---
@@ -341,6 +138,14 @@ __global__ void lds_cross_wave_safe_kernel(int *out) {
   __syncthreads();
   out[tid] = lds[(tid + 64) % 128];
 }
+
+static constexpr RaceExpectation kLdsCrossWaveRaceExpectation{
+    .findings = FindingCount::OneOrMore,
+    .type = "LDS",
+    .wave = 0,
+    .producer = "ds_write_b32",
+    .consumer = "ds_read_b32",
+};
 
 __attribute__((amdgpu_flat_work_group_size(128, 128)))
 __global__ void lds_cross_wave_race_kernel(int *out) {
@@ -364,13 +169,7 @@ TEST_F(Gfx950RaceTest, lds_cross_wave) {
 TEST_F(Gfx950RaceTest, lds_cross_wave_race) {
   lds_cross_wave_race_kernel<<<5, 128>>>(alloc<int>(5 * 128));
   sync();
-  auto r = records();
-  ASSERT_GE(r.size(), 1u);
-  auto t = parseTrace(r[0]);
-  EXPECT_NE(t.header.find("LDS"), npos);
-  EXPECT_NE(t.header.find("wave 0"), npos);
-  EXPECT_NE(t.mark0.find("ds_write_b32"), npos) << "mark0: " << t.mark0;
-  EXPECT_NE(t.mark1.find("ds_read_b32"), npos) << "mark1: " << t.mark1;
+  ExpectRace(kLdsCrossWaveRaceExpectation);
 }
 
 // --- LDS same-wave instruction ordering ---
@@ -498,6 +297,16 @@ __global__ void buffer_load_lds_kernel(const int *src, int *out) {
   out[gid] = lds[tid];
 }
 
+static constexpr RaceExpectation kGlobalToLdsBufferRaceExpectation{
+    .findings = FindingCount::OneOrMore,
+    .type = "LDS",
+    .wave = 0,
+    .lane = 0,
+    .producer = "buffer_load_dword",
+    .between = "s_waitcnt",
+    .consumer = "ds_read_b32",
+};
+
 __attribute__((amdgpu_flat_work_group_size(128, 128)))
 __global__ void buffer_load_lds_race_kernel(const int *src, int *out) {
   __shared__ int lds[128];
@@ -561,18 +370,20 @@ TEST_F(Gfx950RaceTest, global_to_lds_buffer) {
 TEST_F(Gfx950RaceTest, global_to_lds_buffer_race) {
   buffer_load_lds_race_kernel<<<3, 128>>>(alloc<int>(384), alloc<int>(384));
   sync();
-  auto r = records();
-  ASSERT_GE(r.size(), 1u);
-  auto t = parseTrace(r[0]);
-  EXPECT_NE(t.header.find("LDS"), npos);
-  EXPECT_NE(t.header.find("wave 0"), npos);
-  EXPECT_NE(t.header.find("lane 0"), npos);
-  EXPECT_NE(t.mark0.find("buffer_load_dword"), npos) << "mark0: " << t.mark0;
-  EXPECT_TRUE(anyContains(t.between, "s_waitcnt"));
-  EXPECT_NE(t.mark1.find("ds_read_b32"), npos) << "mark1: " << t.mark1;
+  ExpectRace(kGlobalToLdsBufferRaceExpectation);
 }
 
 // --- Partial vmcnt ---
+
+static constexpr RaceExpectation kPartialVmcntRaceExpectation{
+    .kernel = "partial_vmcnt_kernel",
+    .type = "VGPR",
+    .wave = 0,
+    .lane = 0,
+    .producer = "global_load_dword",
+    .between = "s_waitcnt",
+    .consumer = "v_add_f32",
+};
 
 __global__ void partial_vmcnt_kernel(const float *src_a, const float *src_b,
                                      float *dst) {
@@ -593,19 +404,17 @@ TEST_F(Gfx950RaceTest, partial_vmcnt_race) {
   partial_vmcnt_kernel<<<1, 64>>>(alloc<float>(64), alloc<float>(64),
                                    alloc<float>(64));
   sync();
-  auto r = records();
-  ASSERT_EQ(r.size(), 1u);
-  ExpectDispatchContext(r[0], "partial_vmcnt_kernel");
-  auto t = parseTrace(r[0]);
-  EXPECT_NE(t.header.find("VGPR"), npos);
-  EXPECT_NE(t.header.find("wave 0"), npos);
-  EXPECT_NE(t.header.find("lane 0"), npos);
-  EXPECT_NE(t.mark0.find("global_load_dword"), npos) << "mark0: " << t.mark0;
-  EXPECT_TRUE(anyContains(t.between, "s_waitcnt"));
-  EXPECT_NE(t.mark1.find("v_add_f32"), npos) << "mark1: " << t.mark1;
+  ExpectRace(kPartialVmcntRaceExpectation);
 }
 
 // --- Multiple race ---
+
+static constexpr RaceExpectation kMultipleRaceExpectation{
+    .findings = FindingCount::OneOrMore,
+    .type = "VGPR",
+    .producer = "global_load_dword",
+    .consumer = "v_add_f32",
+};
 
 __global__ void two_races_kernel(const float *src_a, const float *src_b,
                                  float *dst) {
@@ -625,13 +434,8 @@ TEST_F(Gfx950RaceTest, multiple_race) {
   two_races_kernel<<<1, 64>>>(alloc<float>(64), alloc<float>(64),
                                alloc<float>(64));
   sync();
-  auto r = records();
   // Both loads race against v_add_f32, but dedup by PC collapses them to 1.
-  ASSERT_GE(r.size(), 1u);
-  auto t = parseTrace(r[0]);
-  EXPECT_NE(t.header.find("VGPR"), npos);
-  EXPECT_NE(t.mark0.find("global_load_dword"), npos) << "mark0: " << t.mark0;
-  EXPECT_NE(t.mark1.find("v_add_f32"), npos) << "mark1: " << t.mark1;
+  ExpectRace(kMultipleRaceExpectation);
 }
 
 // --- Multi-kernel ---
@@ -644,6 +448,15 @@ __global__ void clean_kernel_b(const float *src, float *dst) {
   int tid = threadIdx.x + blockIdx.x * blockDim.x;
   dst[tid] = src[tid] + 1.0f;
 }
+
+static constexpr RaceExpectation kMultiKernelRaceExpectation{
+    .kernel = "racy_kernel",
+    .type = "VGPR",
+    .wave = 0,
+    .lane = 0,
+    .producer = "global_load_dword",
+    .consumer = "global_store_dword",
+};
 
 __global__ void racy_kernel(const float *src, float *dst) {
   int tid = threadIdx.x;
@@ -673,15 +486,7 @@ TEST_F(Gfx950RaceTest, multi_kernel_race) {
   racy_kernel<<<1, 64>>>(s, d);
   clean_kernel_a<<<5, 64>>>(s, d);
   sync();
-  auto r = records();
-  ASSERT_EQ(r.size(), 1u);
-  ExpectDispatchContext(r[0], "racy_kernel");
-  auto t = parseTrace(r[0]);
-  EXPECT_NE(t.header.find("VGPR"), npos);
-  EXPECT_NE(t.header.find("wave 0"), npos);
-  EXPECT_NE(t.header.find("lane 0"), npos);
-  EXPECT_NE(t.mark0.find("global_load_dword"), npos) << "mark0: " << t.mark0;
-  EXPECT_NE(t.mark1.find("global_store_dword"), npos) << "mark1: " << t.mark1;
+  ExpectRace(kMultiKernelRaceExpectation);
 }
 
 // --- Multi-workgroup ---
@@ -696,6 +501,15 @@ __global__ void multi_wg_clean_kernel(const float *src, float *dst) {
   );
   dst[tid] = val;
 }
+
+static constexpr RaceExpectation kMultiWorkgroupRaceExpectation{
+    .findings = FindingCount::OneOrMore,
+    .type = "VGPR",
+    .wave = 0,
+    .lane = 0,
+    .producer = "global_load_dword",
+    .consumer = "global_store_dword",
+};
 
 __global__ void multi_wg_race_kernel(const float *src, float *dst) {
   int tid = threadIdx.x + blockIdx.x * blockDim.x;
@@ -719,17 +533,19 @@ TEST_F(Gfx950RaceTest, multi_workgroup_race) {
   auto *s = alloc<float>(401 * 64), *d = alloc<float>(401 * 64);
   multi_wg_race_kernel<<<401, 64>>>(s, d);
   sync();
-  auto r = records();
-  ASSERT_GE(r.size(), 1u);
-  auto t = parseTrace(r[0]);
-  EXPECT_NE(t.header.find("VGPR"), npos);
-  EXPECT_NE(t.header.find("wave 0"), npos);
-  EXPECT_NE(t.header.find("lane 0"), npos);
-  EXPECT_NE(t.mark0.find("global_load_dword"), npos) << "mark0: " << t.mark0;
-  EXPECT_NE(t.mark1.find("global_store_dword"), npos) << "mark1: " << t.mark1;
+  ExpectRace(kMultiWorkgroupRaceExpectation);
 }
 
 // --- Mixed counters ---
+
+static constexpr RaceExpectation kMixedCountersRaceExpectation{
+    .findings = FindingCount::OneOrMore,
+    .type = "SGPR",
+    .wave = 0,
+    .producer = "s_load_dword",
+    .between = "s_waitcnt",
+    .consumer = "v_cvt_f32_i32",
+};
 
 __global__ void mixed_counters_kernel(const float *vsrc, const int *ssrc,
                                       float *dst) {
@@ -751,14 +567,7 @@ TEST_F(Gfx950RaceTest, mixed_counters_race) {
   mixed_counters_kernel<<<1, 64>>>(alloc<float>(64), alloc<int>(64),
                                     alloc<float>(64));
   sync();
-  auto r = records();
-  ASSERT_GE(r.size(), 1u);
-  auto t = parseTrace(r[0]);
-  EXPECT_NE(t.header.find("SGPR"), npos);
-  EXPECT_NE(t.header.find("wave 0"), npos);
-  EXPECT_NE(t.mark0.find("s_load_dword"), npos) << "mark0: " << t.mark0;
-  EXPECT_TRUE(anyContains(t.between, "s_waitcnt"));
-  EXPECT_NE(t.mark1.find("v_cvt_f32_i32"), npos) << "mark1: " << t.mark1;
+  ExpectRace(kMixedCountersRaceExpectation);
 }
 
 // --- Stress: wavefront reuse ---
@@ -772,6 +581,15 @@ __global__ void stress_clean_b(const float *src, float *dst) {
   int tid = threadIdx.x + blockIdx.x * blockDim.x;
   dst[tid] = src[tid] + 1.0f;
 }
+
+static constexpr RaceExpectation kStressWavefrontReuseRaceExpectation{
+    .findings = FindingCount::OneOrMore,
+    .type = "VGPR",
+    .wave = 0,
+    .lane = 0,
+    .producer = "global_load_dword",
+    .consumer = "global_store_dword",
+};
 
 __global__ void stress_racy(const float *src, float *dst) {
   int tid = threadIdx.x + blockIdx.x * blockDim.x;
@@ -797,14 +615,7 @@ TEST_F(Gfx950RaceTest, stress_wavefront_reuse_race) {
   stress_clean_a<<<1000, 64>>>(s, d);
   stress_racy<<<1000, 64>>>(s, d);
   sync();
-  auto r = records();
-  ASSERT_GE(r.size(), 1u);
-  auto t = parseTrace(r[0]);
-  EXPECT_NE(t.header.find("VGPR"), npos);
-  EXPECT_NE(t.header.find("wave 0"), npos);
-  EXPECT_NE(t.header.find("lane 0"), npos);
-  EXPECT_NE(t.mark0.find("global_load_dword"), npos) << "mark0: " << t.mark0;
-  EXPECT_NE(t.mark1.find("global_store_dword"), npos) << "mark1: " << t.mark1;
+  ExpectRace(kStressWavefrontReuseRaceExpectation);
 }
 
 // --- EXEC mask ---
@@ -821,6 +632,15 @@ __global__ void exec_mask_safe_kernel(int *out) {
   if (tid >= 64)
     out[tid] = lds[tid - 64];
 }
+
+static constexpr RaceExpectation kExecMaskRaceExpectation{
+    .findings = FindingCount::OneOrMore,
+    .type = "LDS",
+    .wave = 1,
+    .lane = 0,
+    .producer = "ds_write_b32",
+    .consumer = "ds_read_b32",
+};
 
 __attribute__((amdgpu_flat_work_group_size(128, 128)))
 __global__ void exec_mask_race_kernel(int *out) {
@@ -842,14 +662,7 @@ TEST_F(Gfx950RaceTest, exec_mask) {
 TEST_F(Gfx950RaceTest, exec_mask_race) {
   exec_mask_race_kernel<<<1, 128>>>(alloc<int>(128));
   sync();
-  auto r = records();
-  ASSERT_GE(r.size(), 1u);
-  auto t = parseTrace(r[0]);
-  EXPECT_NE(t.header.find("LDS"), npos);
-  EXPECT_NE(t.header.find("wave 1"), npos);
-  EXPECT_NE(t.header.find("lane 0"), npos);
-  EXPECT_NE(t.mark0.find("ds_write_b32"), npos) << "mark0: " << t.mark0;
-  EXPECT_NE(t.mark1.find("ds_read_b32"), npos) << "mark1: " << t.mark1;
+  ExpectRace(kExecMaskRaceExpectation);
 }
 
 // --- EXEC mask: same-wave vs cross-wave boundary ---
@@ -888,6 +701,16 @@ __global__ void exec_mask_same_wave_kernel(int *out) {
   asm volatile("s_waitcnt lgkmcnt(0)\n" ::: "memory");
   out[tid] = lds[tid];
 }
+
+static constexpr RaceExpectation kExecMaskCrossWaveRaceExpectation{
+    .findings = FindingCount::OneOrMore,
+    .type = "LDS",
+    .wave = 1,
+    .lane = 0,
+    .producer = "ds_write_b32",
+    .between = "s_waitcnt",
+    .consumer = "ds_read_b32",
+};
 
 __attribute__((amdgpu_flat_work_group_size(256, 256)))
 __global__ void exec_mask_cross_wave_race_kernel(int *out) {
@@ -949,15 +772,7 @@ TEST_F(Gfx950RaceTest, exec_mask_same_wave) {
 TEST_F(Gfx950RaceTest, exec_mask_cross_wave_race) {
   exec_mask_cross_wave_race_kernel<<<1, 256>>>(alloc<int>(256));
   sync();
-  auto r = records();
-  ASSERT_GE(r.size(), 1u);
-  auto t = parseTrace(r[0]);
-  EXPECT_NE(t.header.find("LDS"), npos);
-  EXPECT_NE(t.header.find("wave 1"), npos);
-  EXPECT_NE(t.header.find("lane 0"), npos);
-  EXPECT_NE(t.mark0.find("ds_write_b32"), npos) << "mark0: " << t.mark0;
-  EXPECT_TRUE(anyContains(t.between, "s_waitcnt"));
-  EXPECT_NE(t.mark1.find("ds_read_b32"), npos) << "mark1: " << t.mark1;
+  ExpectRace(kExecMaskCrossWaveRaceExpectation);
 }
 
 TEST_F(Gfx950RaceTest, exec_mask_cross_wave) {
@@ -1011,6 +826,13 @@ __global__ void lds_transpose_safe_kernel(int *out) {
   out[tid] = val;
 }
 
+static constexpr RaceExpectation kLdsTransposeRaceExpectation{
+    .findings = FindingCount::OneOrMore,
+    .type = "LDS",
+    .producer = "ds_write_b32",
+    .consumer = "ds_read_b32",
+};
+
 __attribute__((amdgpu_flat_work_group_size(128, 128)))
 __global__ void lds_transpose_race_kernel(int *out) {
   __shared__ int lds[128];
@@ -1050,12 +872,7 @@ TEST_F(Gfx950RaceTest, lds_transpose) {
 TEST_F(Gfx950RaceTest, lds_transpose_race) {
   lds_transpose_race_kernel<<<1, 128>>>(alloc<int>(128));
   sync();
-  auto r = records();
-  ASSERT_GE(r.size(), 1u);
-  auto t = parseTrace(r[0]);
-  EXPECT_NE(t.header.find("LDS"), npos);
-  EXPECT_NE(t.mark0.find("ds_write_b32"), npos) << "mark0: " << t.mark0;
-  EXPECT_NE(t.mark1.find("ds_read_b32"), npos) << "mark1: " << t.mark1;
+  ExpectRace(kLdsTransposeRaceExpectation);
 }
 
 // --- Dual-offset LDS ---
@@ -1082,6 +899,16 @@ __global__ void dual_offset_lds_safe_kernel(int *out) {
     out[tid] = val;
   }
 }
+
+static constexpr RaceExpectation kDualOffsetLdsRaceExpectation{
+    .findings = FindingCount::OneOrMore,
+    .type = "LDS",
+    .wave = 1,
+    .lane = 0,
+    .producer = "ds_write2_b32",
+    .between = "s_waitcnt",
+    .consumer = "ds_read_b32",
+};
 
 __attribute__((amdgpu_flat_work_group_size(128, 128)))
 __global__ void dual_offset_lds_race_kernel(int *out) {
@@ -1113,15 +940,7 @@ TEST_F(Gfx950RaceTest, dual_offset_lds) {
 TEST_F(Gfx950RaceTest, dual_offset_lds_race) {
   dual_offset_lds_race_kernel<<<1, 128>>>(alloc<int>(128));
   sync();
-  auto r = records();
-  ASSERT_GE(r.size(), 1u);
-  auto t = parseTrace(r[0]);
-  EXPECT_NE(t.header.find("LDS"), npos);
-  EXPECT_NE(t.header.find("wave 1"), npos);
-  EXPECT_NE(t.header.find("lane 0"), npos);
-  EXPECT_NE(t.mark0.find("ds_write2_b32"), npos) << "mark0: " << t.mark0;
-  EXPECT_TRUE(anyContains(t.between, "s_waitcnt"));
-  EXPECT_NE(t.mark1.find("ds_read_b32"), npos) << "mark1: " << t.mark1;
+  ExpectRace(kDualOffsetLdsRaceExpectation);
 }
 
 // --- Scratch store vmcnt accounting ---
@@ -1143,6 +962,12 @@ __global__ void scratch_vmcnt_safe_kernel(const float *src, float *dst) {
   );
   dst[tid] = val;
 }
+
+static constexpr RaceExpectation kScratchVmcntRaceExpectation{
+    .findings = FindingCount::OneOrMore,
+    .type = "VGPR",
+    .producer = "global_load_dword",
+};
 
 __global__ void scratch_vmcnt_race_kernel(const float *src, float *dst) {
   int tid = threadIdx.x + blockIdx.x * blockDim.x;
@@ -1169,11 +994,7 @@ TEST_F(Gfx950RaceTest, scratch_vmcnt_race) {
   auto *src = allocWithData<float>(64), *dst = alloc<float>(64);
   scratch_vmcnt_race_kernel<<<1, 64>>>(src, dst);
   sync();
-  auto r = records();
-  ASSERT_GE(r.size(), 1u);
-  auto t = parseTrace(r[0]);
-  EXPECT_NE(t.header.find("VGPR"), npos);
-  EXPECT_NE(t.mark0.find("global_load_dword"), npos) << "mark0: " << t.mark0;
+  ExpectRace(kScratchVmcntRaceExpectation);
 }
 
 // gfx950 enables SRAM ECC, so D16 loads write the full 32-bit VGPR and the
@@ -1182,6 +1003,14 @@ TEST_F(Gfx950RaceTest, scratch_vmcnt_race) {
 // covered by the architecture-parameterized C++ plugin tests.
 
 // --- VGPR WAW: pending load then instruction write ---
+
+static constexpr RaceExpectation kWawGlobalLoadThenAluExpectation{
+    .findings = FindingCount::OneOrMore,
+    .type = "VGPR",
+    .access = "write",
+    .producer = "global_load_dword",
+    .consumer = "v_add_f32",
+};
 
 __global__ void waw_global_load_then_alu_kernel(const float *src, float *dst) {
   int tid = threadIdx.x + blockIdx.x * blockDim.x;
@@ -1213,6 +1042,14 @@ __global__ void waw_global_load_then_alu_safe_kernel(const float *src, float *ds
   dst[tid] = val;
 }
 
+static constexpr RaceExpectation kWawGlobalLoadThenMfmaExpectation{
+    .findings = FindingCount::OneOrMore,
+    .type = "VGPR",
+    .access = "write",
+    .producer = "global_load_dwordx4",
+    .consumer = "v_mfma",
+};
+
 __global__ void waw_global_load_then_mfma_kernel(const int *src, int *out) {
   int tid = threadIdx.x + blockIdx.x * blockDim.x;
   asm volatile(
@@ -1231,13 +1068,7 @@ TEST_F(Gfx950RaceTest, waw_global_load_then_alu) {
   auto *src = allocWithData<float>(64), *dst = alloc<float>(64);
   waw_global_load_then_alu_kernel<<<1, 64>>>(src, dst);
   sync();
-  auto r = records();
-  ASSERT_GE(r.size(), 1u);
-  EXPECT_EQ(r[0].type, "VGPR");
-  EXPECT_EQ(r[0].access, "write");
-  auto t = parseTrace(r[0]);
-  EXPECT_NE(t.mark0.find("global_load_dword"), npos) << "mark0: " << t.mark0;
-  EXPECT_NE(t.mark1.find("v_add_f32"), npos) << "mark1: " << t.mark1;
+  ExpectRace(kWawGlobalLoadThenAluExpectation);
 }
 
 TEST_F(Gfx950RaceTest, waw_global_load_then_alu_safe) {
@@ -1251,13 +1082,7 @@ TEST_F(Gfx950RaceTest, waw_global_load_then_mfma) {
   auto *src = allocWithData<int>(256), *out = alloc<int>(64);
   waw_global_load_then_mfma_kernel<<<1, 64>>>(src, out);
   sync();
-  auto r = records();
-  ASSERT_GE(r.size(), 1u);
-  EXPECT_EQ(r[0].type, "VGPR");
-  EXPECT_EQ(r[0].access, "write");
-  auto t = parseTrace(r[0]);
-  EXPECT_NE(t.mark0.find("global_load_dwordx4"), npos) << "mark0: " << t.mark0;
-  EXPECT_NE(t.mark1.find("v_mfma"), npos) << "mark1: " << t.mark1;
+  ExpectRace(kWawGlobalLoadThenMfmaExpectation);
 }
 
 // --- f64 VGPR race (64-bit global load + use without waitcnt) ---
@@ -1265,6 +1090,11 @@ TEST_F(Gfx950RaceTest, waw_global_load_then_mfma) {
 // consumes it with v_fma_f64 without an intervening s_waitcnt.
 // Exercises 64-bit VGPR race detection through the scalar read_lane64
 // path (v_fma_f64 does not currently have a SIMD fast-path probe).
+
+static constexpr RaceExpectation kF64VgprRaceExpectation{
+    .findings = FindingCount::OneOrMore,
+    .type_substring = "VGPR",
+};
 
 __global__ void f64_vgpr_race_kernel(const double *src, double *dst) {
   int tid = threadIdx.x + blockIdx.x * blockDim.x;
@@ -1278,6 +1108,14 @@ __global__ void f64_vgpr_race_kernel(const double *src, double *dst) {
   dst[tid] = result;
 }
 
+TEST_F(Gfx950RaceTest, f64_vgpr_race) {
+  double *src = allocWithData<double>(64);
+  double *dst = alloc<double>(64);
+  f64_vgpr_race_kernel<<<1, 64>>>(src, dst);
+  sync();
+  ExpectRace(kF64VgprRaceExpectation);
+}
+
 __global__ void f64_vgpr_safe_kernel(const double *src, double *dst) {
   int tid = threadIdx.x + blockIdx.x * blockDim.x;
   double val, result;
@@ -1289,6 +1127,22 @@ __global__ void f64_vgpr_safe_kernel(const double *src, double *dst) {
   );
   dst[tid] = result;
 }
+
+TEST_F(Gfx950RaceTest, f64_vgpr_safe) {
+  double *src = allocWithData<double>(64);
+  double *dst = alloc<double>(64);
+  f64_vgpr_safe_kernel<<<1, 64>>>(src, dst);
+  sync();
+  ExpectNoRace();
+}
+
+static constexpr RaceExpectation kF64VgprWawExpectation{
+    .findings = FindingCount::OneOrMore,
+    .type = "VGPR",
+    .access = "write",
+    .producer = "global_load_dwordx2",
+    .consumer = "v_fma_f64",
+};
 
 __global__ void f64_vgpr_waw_kernel(const double *src, double *dst) {
   int tid = threadIdx.x + blockIdx.x * blockDim.x;
@@ -1304,36 +1158,12 @@ __global__ void f64_vgpr_waw_kernel(const double *src, double *dst) {
   dst[tid] = val;
 }
 
-TEST_F(Gfx950RaceTest, f64_vgpr_race) {
-  double *src = allocWithData<double>(64);
-  double *dst = alloc<double>(64);
-  f64_vgpr_race_kernel<<<1, 64>>>(src, dst);
-  sync();
-  auto r = records();
-  ASSERT_GE(r.size(), 1u);
-  EXPECT_NE(r[0].type.find("VGPR"), npos);
-}
-
-TEST_F(Gfx950RaceTest, f64_vgpr_safe) {
-  double *src = allocWithData<double>(64);
-  double *dst = alloc<double>(64);
-  f64_vgpr_safe_kernel<<<1, 64>>>(src, dst);
-  sync();
-  ExpectNoRace();
-}
-
 TEST_F(Gfx950RaceTest, f64_vgpr_waw) {
   double *src = allocWithData<double>(64);
   double *dst = alloc<double>(64);
   f64_vgpr_waw_kernel<<<1, 64>>>(src, dst);
   sync();
-  auto r = records();
-  ASSERT_GE(r.size(), 1u);
-  EXPECT_EQ(r[0].type, "VGPR");
-  EXPECT_EQ(r[0].access, "write");
-  auto t = parseTrace(r[0]);
-  EXPECT_NE(t.mark0.find("global_load_dwordx2"), npos) << "mark0: " << t.mark0;
-  EXPECT_NE(t.mark1.find("v_fma_f64"), npos) << "mark1: " << t.mark1;
+  ExpectRace(kF64VgprWawExpectation);
 }
 
 int main(int argc, char **argv) {

--- a/emulation/rocjitsu/tests/race-detector/race_log_expectation.hpp
+++ b/emulation/rocjitsu/tests/race-detector/race_log_expectation.hpp
@@ -1,0 +1,431 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <algorithm>
+#include <charconv>
+#include <cstddef>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <istream>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+namespace rocjitsu::test {
+
+/// Controls whether a race test expects one or one-or-more findings.
+enum class FindingCount {
+  One,
+  OneOrMore,
+};
+
+/// Describes the observable race report expected from a test kernel.
+///
+/// Tests set only the fields relevant to the behavior they protect. The
+/// matcher compares those fields with the first race record after validating
+/// the requested finding count. Instruction fields refer to the two marked
+/// instructions and, optionally, an instruction between those markers in the
+/// human-readable race trace.
+struct RaceExpectation {
+  FindingCount findings = FindingCount::One;
+
+  // Normalized report fields. Type and access use exact matches. Kernel is a
+  // substring expected in both the resolved display name and ELF symbol;
+  // type_substring is a substring match for reports with a composite type.
+  const char *kernel = nullptr;
+  const char *type = nullptr;
+  const char *type_substring = nullptr;
+  const char *access = nullptr;
+
+  // Negative context values mean that the field is not checked.
+  int wave = -1;
+  int lane = -1;
+
+  // Substrings expected in the marked producer, intervening instructions, and
+  // marked consumer sections of the human-readable trace.
+  const char *producer = nullptr;
+  const char *between = nullptr;
+  const char *consumer = nullptr;
+};
+
+struct RaceRecord {
+  std::string kernel;
+  std::string symbol;
+  int dispatch = -1;
+  std::string type;
+  std::string access;
+  int reg = -1;
+  int wave = -1;
+  int lane = -1;
+  std::string workgroup;
+  std::string conflict;
+  std::string message;
+};
+
+struct RaceLogParseResult {
+  std::vector<RaceRecord> records;
+  std::string error;
+
+  [[nodiscard]] bool ok() const { return error.empty(); }
+};
+
+struct TraceSections {
+  std::string header;
+  std::string producer;
+  std::vector<std::string> between;
+  std::string consumer;
+  std::size_t marker_count = 0;
+};
+
+struct RaceExpectationMatchResult {
+  std::vector<std::string> errors;
+
+  [[nodiscard]] bool ok() const { return errors.empty(); }
+
+  [[nodiscard]] std::string message() const {
+    std::ostringstream output;
+    for (std::size_t index = 0; index < errors.size(); ++index) {
+      if (index != 0)
+        output << '\n';
+      output << errors[index];
+    }
+    return output.str();
+  }
+};
+
+namespace detail {
+
+inline RaceLogParseResult parseFailure(std::string error) {
+  return RaceLogParseResult{.records = {}, .error = std::move(error)};
+}
+
+inline bool parseInteger(std::string_view text, int &value) {
+  if (text.empty())
+    return false;
+  const char *begin = text.data();
+  const char *end = begin + text.size();
+  const auto [parsed_end, error] = std::from_chars(begin, end, value);
+  return error == std::errc{} && parsed_end == end;
+}
+
+inline std::string lineError(std::size_t line_number, const std::string &message) {
+  return "race log line " + std::to_string(line_number) + ": " + message;
+}
+
+inline void appendMismatch(std::vector<std::string> &errors, const std::string &field,
+                           const std::string &actual, const std::string &expected) {
+  errors.push_back(field + " mismatch: expected '" + expected + "', got '" + actual + "'");
+}
+
+inline void appendMissing(std::vector<std::string> &errors, const std::string &field) {
+  errors.push_back("missing " + field);
+}
+
+inline bool contains(const std::string &value, const std::string &substring) {
+  return value.find(substring) != std::string::npos;
+}
+
+} // namespace detail
+
+/// Parse structured RACE blocks from an already-open stream.
+///
+/// Non-RACE lines (such as plugin summaries and dispatch diagnostics) are
+/// ignored. Once a RACE header is observed, its complete required field set and
+/// END_RACE terminator are mandatory. A valid zero-finding log must still
+/// contain recognizable race-plugin output, such as a kernel dispatch line.
+inline RaceLogParseResult parseRaceLog(std::istream &input) {
+  std::vector<RaceRecord> records;
+  std::string line;
+  std::size_t line_number = 0;
+  bool saw_plugin_output = false;
+  while (std::getline(input, line)) {
+    ++line_number;
+    if (line == "END_RACE")
+      return detail::parseFailure(detail::lineError(line_number, "unexpected END_RACE"));
+    if (!line.starts_with("RACE ")) {
+      saw_plugin_output = saw_plugin_output || line.starts_with("[rocjitsu] Kernel dispatch:") ||
+                          line.find("ROCJITSU RACE DETECTION SUMMARY") != std::string::npos;
+      continue;
+    }
+    saw_plugin_output = true;
+
+    RaceRecord record;
+    bool saw_kernel = false;
+    bool saw_symbol = false;
+    bool saw_dispatch = false;
+    bool saw_type = false;
+    bool saw_access = false;
+    bool saw_reg = false;
+    bool saw_wave = false;
+    bool saw_lane = false;
+    bool saw_workgroup = false;
+    bool saw_conflict = false;
+
+    std::istringstream header(line.substr(5));
+    std::string field;
+    while (header >> field) {
+      const std::size_t equals = field.find('=');
+      if (equals == std::string::npos || equals == 0 || equals + 1 == field.size()) {
+        return detail::parseFailure(
+            detail::lineError(line_number, "malformed header field '" + field + "'"));
+      }
+
+      const std::string key = field.substr(0, equals);
+      const std::string value = field.substr(equals + 1);
+      auto reject_duplicate = [&](bool seen) -> RaceLogParseResult {
+        return seen ? detail::parseFailure(
+                          detail::lineError(line_number, "duplicate header field '" + key + "'"))
+                    : RaceLogParseResult{};
+      };
+
+      if (key == "kernel") {
+        if (auto duplicate = reject_duplicate(saw_kernel); !duplicate.ok())
+          return duplicate;
+        saw_kernel = true;
+        record.kernel = value;
+      } else if (key == "symbol") {
+        if (auto duplicate = reject_duplicate(saw_symbol); !duplicate.ok())
+          return duplicate;
+        saw_symbol = true;
+        record.symbol = value;
+      } else if (key == "dispatch") {
+        if (auto duplicate = reject_duplicate(saw_dispatch); !duplicate.ok())
+          return duplicate;
+        saw_dispatch = true;
+        if (!detail::parseInteger(value, record.dispatch)) {
+          return detail::parseFailure(
+              detail::lineError(line_number, "invalid dispatch value '" + value + "'"));
+        }
+      } else if (key == "type") {
+        if (auto duplicate = reject_duplicate(saw_type); !duplicate.ok())
+          return duplicate;
+        saw_type = true;
+        record.type = value;
+      } else if (key == "access") {
+        if (auto duplicate = reject_duplicate(saw_access); !duplicate.ok())
+          return duplicate;
+        saw_access = true;
+        record.access = value;
+      } else if (key == "reg") {
+        if (auto duplicate = reject_duplicate(saw_reg); !duplicate.ok())
+          return duplicate;
+        saw_reg = true;
+        if (!detail::parseInteger(value, record.reg)) {
+          return detail::parseFailure(
+              detail::lineError(line_number, "invalid reg value '" + value + "'"));
+        }
+      } else if (key == "wave") {
+        if (auto duplicate = reject_duplicate(saw_wave); !duplicate.ok())
+          return duplicate;
+        saw_wave = true;
+        if (!detail::parseInteger(value, record.wave)) {
+          return detail::parseFailure(
+              detail::lineError(line_number, "invalid wave value '" + value + "'"));
+        }
+      } else if (key == "lane") {
+        if (auto duplicate = reject_duplicate(saw_lane); !duplicate.ok())
+          return duplicate;
+        saw_lane = true;
+        if (!detail::parseInteger(value, record.lane)) {
+          return detail::parseFailure(
+              detail::lineError(line_number, "invalid lane value '" + value + "'"));
+        }
+      } else if (key == "wg") {
+        if (auto duplicate = reject_duplicate(saw_workgroup); !duplicate.ok())
+          return duplicate;
+        saw_workgroup = true;
+        record.workgroup = value;
+      } else if (key == "conflict") {
+        if (auto duplicate = reject_duplicate(saw_conflict); !duplicate.ok())
+          return duplicate;
+        saw_conflict = true;
+        record.conflict = value;
+      }
+    }
+
+    if (!(saw_kernel && saw_symbol && saw_dispatch && saw_type && saw_access && saw_reg &&
+          saw_wave && saw_lane && saw_workgroup && saw_conflict)) {
+      return detail::parseFailure(
+          detail::lineError(line_number, "RACE header is missing one or more required fields"));
+    }
+
+    bool terminated = false;
+    while (std::getline(input, line)) {
+      ++line_number;
+      if (line == "END_RACE") {
+        terminated = true;
+        break;
+      }
+      if (line.starts_with("RACE ")) {
+        return detail::parseFailure(
+            detail::lineError(line_number, "nested RACE header before END_RACE"));
+      }
+      if (!record.message.empty())
+        record.message += '\n';
+      record.message += line;
+    }
+    if (!terminated) {
+      return detail::parseFailure(
+          detail::lineError(line_number, "RACE block reached EOF before END_RACE"));
+    }
+    records.push_back(std::move(record));
+  }
+
+  if (input.bad())
+    return detail::parseFailure("failed while reading race log");
+  if (!saw_plugin_output)
+    return detail::parseFailure("race log contains no recognizable race-plugin output");
+  return RaceLogParseResult{.records = std::move(records), .error = {}};
+}
+
+inline RaceLogParseResult parseRaceLogFile(const std::filesystem::path &path) {
+  std::ifstream file(path);
+  if (!file.is_open())
+    return detail::parseFailure("could not open race log '" + path.string() + "'");
+  return parseRaceLog(file);
+}
+
+inline RaceLogParseResult parseRaceLogFromEnvironment() {
+  const char *directory = std::getenv("RJ_SINK_DIR");
+  if (directory == nullptr || directory[0] == '\0')
+    return detail::parseFailure("RJ_SINK_DIR is not set");
+  return parseRaceLogFile(std::filesystem::path(directory) / "race.log");
+}
+
+inline std::string stripTraceMarkPrefix(const std::string &line) {
+  const std::size_t mark = line.find("==>");
+  if (mark == std::string::npos)
+    return line;
+
+  const std::string rest = line.substr(mark + 3);
+  const std::size_t address = rest.find("0x");
+  if (address == std::string::npos)
+    return rest;
+
+  std::size_t instruction = rest.find(' ', address);
+  if (instruction != std::string::npos)
+    instruction = rest.find_first_not_of(' ', instruction);
+  if (instruction == std::string::npos)
+    return rest;
+  return rest.substr(instruction);
+}
+
+inline TraceSections parseTrace(const RaceRecord &record) {
+  TraceSections trace;
+  std::istringstream stream(record.message);
+  std::string line;
+  while (std::getline(stream, line)) {
+    if (trace.header.empty()) {
+      trace.header = line;
+      continue;
+    }
+
+    if (line.find("==>") != std::string::npos) {
+      if (trace.marker_count == 0)
+        trace.producer = stripTraceMarkPrefix(line);
+      else
+        trace.consumer = stripTraceMarkPrefix(line);
+      ++trace.marker_count;
+    } else if (trace.marker_count == 1) {
+      trace.between.push_back(line);
+    }
+  }
+  return trace;
+}
+
+inline bool anyContains(const std::vector<std::string> &lines, const std::string &substring) {
+  return std::any_of(lines.begin(), lines.end(),
+                     [&](const std::string &line) { return detail::contains(line, substring); });
+}
+
+inline RaceExpectationMatchResult matchRaceExpectation(const std::vector<RaceRecord> &records,
+                                                       const RaceExpectation &expected) {
+  RaceExpectationMatchResult result;
+  if (expected.findings == FindingCount::One && records.size() != 1) {
+    result.errors.push_back("expected exactly one race, got " + std::to_string(records.size()));
+    return result;
+  }
+  if (expected.findings == FindingCount::OneOrMore && records.empty()) {
+    result.errors.push_back("expected at least one race, got none");
+    return result;
+  }
+
+  const RaceRecord &record = records.front();
+  if (expected.kernel != nullptr) {
+    if (record.kernel.empty())
+      detail::appendMissing(result.errors, "kernel name");
+    else if (record.kernel == "?")
+      result.errors.push_back("kernel name is unresolved");
+    if (record.symbol.empty())
+      detail::appendMissing(result.errors, "kernel symbol");
+    else if (record.symbol == "?")
+      result.errors.push_back("kernel symbol is unresolved");
+    if (record.dispatch < 1)
+      result.errors.push_back("dispatch id must be positive");
+    if (!detail::contains(record.kernel, expected.kernel)) {
+      result.errors.push_back("kernel name '" + record.kernel + "' does not contain '" +
+                              expected.kernel + "'");
+    }
+    if (!detail::contains(record.symbol, expected.kernel)) {
+      result.errors.push_back("kernel symbol '" + record.symbol + "' does not contain '" +
+                              expected.kernel + "'");
+    }
+  }
+  if (expected.type != nullptr && record.type != expected.type)
+    detail::appendMismatch(result.errors, "race type", record.type, expected.type);
+  if (expected.type_substring != nullptr &&
+      !detail::contains(record.type, expected.type_substring)) {
+    result.errors.push_back("race type '" + record.type + "' does not contain '" +
+                            expected.type_substring + "'");
+  }
+  if (expected.access != nullptr && record.access != expected.access)
+    detail::appendMismatch(result.errors, "race access", record.access, expected.access);
+  if (expected.wave >= 0 && record.wave != expected.wave) {
+    detail::appendMismatch(result.errors, "wave", std::to_string(record.wave),
+                           std::to_string(expected.wave));
+  }
+  if (expected.lane >= 0 && record.lane != expected.lane) {
+    detail::appendMismatch(result.errors, "lane", std::to_string(record.lane),
+                           std::to_string(expected.lane));
+  }
+
+  const TraceSections trace = parseTrace(record);
+  if (expected.type != nullptr && !detail::contains(trace.header, expected.type)) {
+    result.errors.push_back("trace header does not contain race type '" +
+                            std::string(expected.type) + "'");
+  }
+  if (expected.type_substring != nullptr &&
+      !detail::contains(trace.header, expected.type_substring)) {
+    result.errors.push_back("trace header does not contain race type fragment '" +
+                            std::string(expected.type_substring) + "'");
+  }
+  if (expected.wave >= 0 &&
+      !detail::contains(trace.header, "wave " + std::to_string(expected.wave))) {
+    result.errors.push_back("trace header does not contain expected wave");
+  }
+  if (expected.lane >= 0 &&
+      !detail::contains(trace.header, "lane " + std::to_string(expected.lane))) {
+    result.errors.push_back("trace header does not contain expected lane");
+  }
+  if (expected.producer != nullptr && !detail::contains(trace.producer, expected.producer)) {
+    result.errors.push_back("producer trace '" + trace.producer + "' does not contain '" +
+                            expected.producer + "'");
+  }
+  if (expected.between != nullptr && !anyContains(trace.between, expected.between)) {
+    result.errors.push_back("intervening trace does not contain '" + std::string(expected.between) +
+                            "'");
+  }
+  if (expected.consumer != nullptr && !detail::contains(trace.consumer, expected.consumer)) {
+    result.errors.push_back("consumer trace '" + trace.consumer + "' does not contain '" +
+                            expected.consumer + "'");
+  }
+  return result;
+}
+
+} // namespace rocjitsu::test

--- a/emulation/rocjitsu/tests/race-detector/race_log_expectation.hpp
+++ b/emulation/rocjitsu/tests/race-detector/race_log_expectation.hpp
@@ -4,12 +4,14 @@
 #pragma once
 
 #include <algorithm>
+#include <array>
 #include <charconv>
 #include <cstddef>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <istream>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -131,6 +133,80 @@ inline bool contains(const std::string &value, const std::string &substring) {
   return value.find(substring) != std::string::npos;
 }
 
+class RaceHeaderParser {
+public:
+  explicit RaceHeaderParser(std::size_t line_number) : line_number_(line_number) {}
+
+  [[nodiscard]] std::optional<std::string> parse(std::string_view header_text) {
+    std::istringstream header{std::string(header_text)};
+    std::string field;
+    while (header >> field) {
+      const std::size_t equals = field.find('=');
+      if (equals == std::string::npos || equals == 0 || equals + 1 == field.size()) {
+        return lineError(line_number_, "malformed header field '" + field + "'");
+      }
+
+      const std::string_view key(field.data(), equals);
+      const std::string_view value(field.data() + equals + 1, field.size() - equals - 1);
+      if (auto error = parseField(key, value))
+        return error;
+    }
+
+    if (!std::all_of(seen_.begin(), seen_.end(), [](bool seen) { return seen; }))
+      return lineError(line_number_, "RACE header is missing one or more required fields");
+    return std::nullopt;
+  }
+
+  [[nodiscard]] RaceRecord takeRecord() && { return std::move(record_); }
+
+private:
+  struct FieldDescriptor {
+    std::string_view key;
+    std::string RaceRecord::*string_member;
+    int RaceRecord::*integer_member;
+  };
+
+  inline static constexpr std::array<FieldDescriptor, 10> fields_{{
+      {"kernel", &RaceRecord::kernel, nullptr},
+      {"symbol", &RaceRecord::symbol, nullptr},
+      {"dispatch", nullptr, &RaceRecord::dispatch},
+      {"type", &RaceRecord::type, nullptr},
+      {"access", &RaceRecord::access, nullptr},
+      {"reg", nullptr, &RaceRecord::reg},
+      {"wave", nullptr, &RaceRecord::wave},
+      {"lane", nullptr, &RaceRecord::lane},
+      {"wg", &RaceRecord::workgroup, nullptr},
+      {"conflict", &RaceRecord::conflict, nullptr},
+  }};
+
+  [[nodiscard]] std::optional<std::string> parseField(std::string_view key,
+                                                      std::string_view value) {
+    for (std::size_t index = 0; index < fields_.size(); ++index) {
+      const FieldDescriptor &descriptor = fields_[index];
+      if (descriptor.key != key)
+        continue;
+      if (seen_[index])
+        return lineError(line_number_, "duplicate header field '" + std::string(key) + "'");
+      seen_[index] = true;
+
+      if (descriptor.string_member != nullptr) {
+        record_.*descriptor.string_member = value;
+      } else if (!parseInteger(value, record_.*descriptor.integer_member)) {
+        return lineError(line_number_,
+                         "invalid " + std::string(key) + " value '" + std::string(value) + "'");
+      }
+      return std::nullopt;
+    }
+
+    // Ignore well-formed unknown fields so the producer can extend the format.
+    return std::nullopt;
+  }
+
+  std::size_t line_number_;
+  RaceRecord record_;
+  std::array<bool, fields_.size()> seen_{};
+};
+
 } // namespace detail
 
 /// Parse structured RACE blocks from an already-open stream.
@@ -155,105 +231,10 @@ inline RaceLogParseResult parseRaceLog(std::istream &input) {
     }
     saw_plugin_output = true;
 
-    RaceRecord record;
-    bool saw_kernel = false;
-    bool saw_symbol = false;
-    bool saw_dispatch = false;
-    bool saw_type = false;
-    bool saw_access = false;
-    bool saw_reg = false;
-    bool saw_wave = false;
-    bool saw_lane = false;
-    bool saw_workgroup = false;
-    bool saw_conflict = false;
-
-    std::istringstream header(line.substr(5));
-    std::string field;
-    while (header >> field) {
-      const std::size_t equals = field.find('=');
-      if (equals == std::string::npos || equals == 0 || equals + 1 == field.size()) {
-        return detail::parseFailure(
-            detail::lineError(line_number, "malformed header field '" + field + "'"));
-      }
-
-      const std::string key = field.substr(0, equals);
-      const std::string value = field.substr(equals + 1);
-      auto reject_duplicate = [&](bool seen) -> RaceLogParseResult {
-        return seen ? detail::parseFailure(
-                          detail::lineError(line_number, "duplicate header field '" + key + "'"))
-                    : RaceLogParseResult{};
-      };
-
-      if (key == "kernel") {
-        if (auto duplicate = reject_duplicate(saw_kernel); !duplicate.ok())
-          return duplicate;
-        saw_kernel = true;
-        record.kernel = value;
-      } else if (key == "symbol") {
-        if (auto duplicate = reject_duplicate(saw_symbol); !duplicate.ok())
-          return duplicate;
-        saw_symbol = true;
-        record.symbol = value;
-      } else if (key == "dispatch") {
-        if (auto duplicate = reject_duplicate(saw_dispatch); !duplicate.ok())
-          return duplicate;
-        saw_dispatch = true;
-        if (!detail::parseInteger(value, record.dispatch)) {
-          return detail::parseFailure(
-              detail::lineError(line_number, "invalid dispatch value '" + value + "'"));
-        }
-      } else if (key == "type") {
-        if (auto duplicate = reject_duplicate(saw_type); !duplicate.ok())
-          return duplicate;
-        saw_type = true;
-        record.type = value;
-      } else if (key == "access") {
-        if (auto duplicate = reject_duplicate(saw_access); !duplicate.ok())
-          return duplicate;
-        saw_access = true;
-        record.access = value;
-      } else if (key == "reg") {
-        if (auto duplicate = reject_duplicate(saw_reg); !duplicate.ok())
-          return duplicate;
-        saw_reg = true;
-        if (!detail::parseInteger(value, record.reg)) {
-          return detail::parseFailure(
-              detail::lineError(line_number, "invalid reg value '" + value + "'"));
-        }
-      } else if (key == "wave") {
-        if (auto duplicate = reject_duplicate(saw_wave); !duplicate.ok())
-          return duplicate;
-        saw_wave = true;
-        if (!detail::parseInteger(value, record.wave)) {
-          return detail::parseFailure(
-              detail::lineError(line_number, "invalid wave value '" + value + "'"));
-        }
-      } else if (key == "lane") {
-        if (auto duplicate = reject_duplicate(saw_lane); !duplicate.ok())
-          return duplicate;
-        saw_lane = true;
-        if (!detail::parseInteger(value, record.lane)) {
-          return detail::parseFailure(
-              detail::lineError(line_number, "invalid lane value '" + value + "'"));
-        }
-      } else if (key == "wg") {
-        if (auto duplicate = reject_duplicate(saw_workgroup); !duplicate.ok())
-          return duplicate;
-        saw_workgroup = true;
-        record.workgroup = value;
-      } else if (key == "conflict") {
-        if (auto duplicate = reject_duplicate(saw_conflict); !duplicate.ok())
-          return duplicate;
-        saw_conflict = true;
-        record.conflict = value;
-      }
-    }
-
-    if (!(saw_kernel && saw_symbol && saw_dispatch && saw_type && saw_access && saw_reg &&
-          saw_wave && saw_lane && saw_workgroup && saw_conflict)) {
-      return detail::parseFailure(
-          detail::lineError(line_number, "RACE header is missing one or more required fields"));
-    }
+    detail::RaceHeaderParser header_parser(line_number);
+    if (auto error = header_parser.parse(std::string_view(line).substr(5)))
+      return detail::parseFailure(std::move(*error));
+    RaceRecord record = std::move(header_parser).takeRecord();
 
     bool terminated = false;
     while (std::getline(input, line)) {

--- a/emulation/rocjitsu/tests/race-detector/race_log_expectation.hpp
+++ b/emulation/rocjitsu/tests/race-detector/race_log_expectation.hpp
@@ -30,19 +30,17 @@ enum class FindingCount {
 /// Describes the observable race report expected from a test kernel.
 ///
 /// Tests set only the fields relevant to the behavior they protect. The
-/// matcher compares those fields with the first race record after validating
-/// the requested finding count. Instruction fields refer to the two marked
+/// matcher compares those fields with a race record after validating the
+/// requested finding count. Instruction fields refer to the two marked
 /// instructions and, optionally, an instruction between those markers in the
 /// human-readable race trace.
 struct RaceExpectation {
   FindingCount findings = FindingCount::One;
 
   // Normalized report fields. Type and access use exact matches. Kernel is a
-  // substring expected in both the resolved display name and ELF symbol;
-  // type_substring is a substring match for reports with a composite type.
+  // substring expected in both the resolved display name and ELF symbol.
   const char *kernel = nullptr;
   const char *type = nullptr;
-  const char *type_substring = nullptr;
   const char *access = nullptr;
 
   // Negative context values mean that the field is not checked.
@@ -325,19 +323,9 @@ inline bool anyContains(const std::vector<std::string> &lines, const std::string
                      [&](const std::string &line) { return detail::contains(line, substring); });
 }
 
-inline RaceExpectationMatchResult matchRaceExpectation(const std::vector<RaceRecord> &records,
-                                                       const RaceExpectation &expected) {
+inline RaceExpectationMatchResult matchRaceRecord(const RaceRecord &record,
+                                                  const RaceExpectation &expected) {
   RaceExpectationMatchResult result;
-  if (expected.findings == FindingCount::One && records.size() != 1) {
-    result.errors.push_back("expected exactly one race, got " + std::to_string(records.size()));
-    return result;
-  }
-  if (expected.findings == FindingCount::OneOrMore && records.empty()) {
-    result.errors.push_back("expected at least one race, got none");
-    return result;
-  }
-
-  const RaceRecord &record = records.front();
   if (expected.kernel != nullptr) {
     if (record.kernel.empty())
       detail::appendMissing(result.errors, "kernel name");
@@ -360,11 +348,6 @@ inline RaceExpectationMatchResult matchRaceExpectation(const std::vector<RaceRec
   }
   if (expected.type != nullptr && record.type != expected.type)
     detail::appendMismatch(result.errors, "race type", record.type, expected.type);
-  if (expected.type_substring != nullptr &&
-      !detail::contains(record.type, expected.type_substring)) {
-    result.errors.push_back("race type '" + record.type + "' does not contain '" +
-                            expected.type_substring + "'");
-  }
   if (expected.access != nullptr && record.access != expected.access)
     detail::appendMismatch(result.errors, "race access", record.access, expected.access);
   if (expected.wave >= 0 && record.wave != expected.wave) {
@@ -380,11 +363,6 @@ inline RaceExpectationMatchResult matchRaceExpectation(const std::vector<RaceRec
   if (expected.type != nullptr && !detail::contains(trace.header, expected.type)) {
     result.errors.push_back("trace header does not contain race type '" +
                             std::string(expected.type) + "'");
-  }
-  if (expected.type_substring != nullptr &&
-      !detail::contains(trace.header, expected.type_substring)) {
-    result.errors.push_back("trace header does not contain race type fragment '" +
-                            std::string(expected.type_substring) + "'");
   }
   if (expected.wave >= 0 &&
       !detail::contains(trace.header, "wave " + std::to_string(expected.wave))) {
@@ -407,6 +385,36 @@ inline RaceExpectationMatchResult matchRaceExpectation(const std::vector<RaceRec
                             expected.consumer + "'");
   }
   return result;
+}
+
+inline RaceExpectationMatchResult matchRaceExpectation(const std::vector<RaceRecord> &records,
+                                                       const RaceExpectation &expected) {
+  if (expected.findings == FindingCount::One) {
+    if (records.size() != 1) {
+      return RaceExpectationMatchResult{
+          .errors = {"expected exactly one race, got " + std::to_string(records.size())}};
+    }
+    return matchRaceRecord(records.front(), expected);
+  }
+
+  if (records.empty())
+    return RaceExpectationMatchResult{.errors = {"expected at least one race, got none"}};
+
+  RaceExpectationMatchResult closest = matchRaceRecord(records.front(), expected);
+  if (closest.ok())
+    return closest;
+  for (std::size_t index = 1; index < records.size(); ++index) {
+    RaceExpectationMatchResult candidate = matchRaceRecord(records[index], expected);
+    if (candidate.ok())
+      return candidate;
+    if (candidate.errors.size() < closest.errors.size())
+      closest = std::move(candidate);
+  }
+
+  closest.errors.insert(closest.errors.begin(),
+                        "none of " + std::to_string(records.size()) +
+                            " races matched the expectation; closest record:");
+  return closest;
 }
 
 } // namespace rocjitsu::test

--- a/emulation/rocjitsu/tests/race-detector/race_log_expectation_test.cpp
+++ b/emulation/rocjitsu/tests/race-detector/race_log_expectation_test.cpp
@@ -1,0 +1,215 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "race_log_expectation.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <filesystem>
+#include <sstream>
+#include <string>
+
+namespace rocjitsu::test {
+namespace {
+
+constexpr std::string_view kValidRaceLog =
+    "[rocjitsu] Kernel dispatch: \"racy_kernel\" symbol=\"racy_kernel\"\n"
+    "RACE kernel=racy_kernel symbol=_Z11racy_kernelPKfPf dispatch=3 "
+    "type=VGPR access=read reg=2 wave=0 lane=1 wg=2,3,4 conflict=unknown\n"
+    "Race on VGPR v2 [workgroup (2, 3, 4), wave 0, lane 1]\n"
+    "  ==>  0x100  global_load_dword v2, v[0:1], off\n"
+    "       0x104  s_waitcnt vmcnt(1)\n"
+    "  ==>  0x108  global_store_dword v[0:1], v2, off\n"
+    "END_RACE\n"
+    "\n"
+    "========================================\n"
+    " ROCJITSU RACE DETECTION SUMMARY\n"
+    "========================================\n"
+    "  1 race(s) detected\n"
+    "========================================\n";
+
+RaceLogParseResult parse(std::string_view log) {
+  std::istringstream input{std::string(log)};
+  return parseRaceLog(input);
+}
+
+class EnvironmentGuard {
+public:
+  explicit EnvironmentGuard(const char *name) : name_(name) {
+    if (const char *value = std::getenv(name); value != nullptr) {
+      was_set_ = true;
+      value_ = value;
+    }
+  }
+
+  ~EnvironmentGuard() {
+    if (was_set_)
+      set(value_);
+    else
+      unset();
+  }
+
+  void set(const std::string &value) {
+#ifdef _WIN32
+    (void)_putenv_s(name_.c_str(), value.c_str());
+#else
+    (void)setenv(name_.c_str(), value.c_str(), 1);
+#endif
+  }
+
+  void unset() {
+#ifdef _WIN32
+    (void)_putenv_s(name_.c_str(), "");
+#else
+    (void)unsetenv(name_.c_str());
+#endif
+  }
+
+private:
+  std::string name_;
+  std::string value_;
+  bool was_set_ = false;
+};
+
+TEST(RaceLogExpectationTest, ParsesValidEmptyLog) {
+  const RaceLogParseResult parsed =
+      parse("[rocjitsu] Kernel dispatch: \"clean_kernel\" symbol=\"clean_kernel\"\n"
+            " ROCJITSU RACE DETECTION SUMMARY\n"
+            " No races detected.\n");
+
+  ASSERT_TRUE(parsed.ok()) << parsed.error;
+  EXPECT_TRUE(parsed.records.empty());
+}
+
+TEST(RaceLogExpectationTest, RejectsEmptyLog) {
+  const RaceLogParseResult parsed = parse("");
+
+  EXPECT_FALSE(parsed.ok());
+  EXPECT_NE(parsed.error.find("no recognizable race-plugin output"), std::string::npos);
+}
+
+TEST(RaceLogExpectationTest, RejectsUnrecognizedLog) {
+  const RaceLogParseResult parsed = parse("unrelated output\nwithout any race plugin evidence\n");
+
+  EXPECT_FALSE(parsed.ok());
+  EXPECT_NE(parsed.error.find("no recognizable race-plugin output"), std::string::npos);
+}
+
+TEST(RaceLogExpectationTest, ParsesValidRaceAndTrace) {
+  const RaceLogParseResult parsed = parse(kValidRaceLog);
+
+  ASSERT_TRUE(parsed.ok()) << parsed.error;
+  ASSERT_EQ(parsed.records.size(), 1u);
+  const RaceRecord &record = parsed.records.front();
+  EXPECT_EQ(record.kernel, "racy_kernel");
+  EXPECT_EQ(record.symbol, "_Z11racy_kernelPKfPf");
+  EXPECT_EQ(record.dispatch, 3);
+  EXPECT_EQ(record.type, "VGPR");
+  EXPECT_EQ(record.access, "read");
+  EXPECT_EQ(record.reg, 2);
+  EXPECT_EQ(record.wave, 0);
+  EXPECT_EQ(record.lane, 1);
+  EXPECT_EQ(record.workgroup, "2,3,4");
+  EXPECT_EQ(record.conflict, "unknown");
+
+  const TraceSections trace = parseTrace(record);
+  EXPECT_EQ(trace.marker_count, 2u);
+  EXPECT_NE(trace.header.find("VGPR"), std::string::npos);
+  EXPECT_NE(trace.producer.find("global_load_dword"), std::string::npos);
+  ASSERT_EQ(trace.between.size(), 1u);
+  EXPECT_NE(trace.between.front().find("s_waitcnt"), std::string::npos);
+  EXPECT_NE(trace.consumer.find("global_store_dword"), std::string::npos);
+}
+
+TEST(RaceLogExpectationTest, RejectsUnterminatedRaceBlock) {
+  const std::string truncated =
+      std::string(kValidRaceLog.substr(0, kValidRaceLog.find("END_RACE")));
+  const RaceLogParseResult parsed = parse(truncated);
+
+  EXPECT_FALSE(parsed.ok());
+  EXPECT_NE(parsed.error.find("before END_RACE"), std::string::npos);
+}
+
+TEST(RaceLogExpectationTest, RejectsMalformedInteger) {
+  std::string malformed(kValidRaceLog);
+  malformed.replace(malformed.find("dispatch=3"), std::string("dispatch=3").size(),
+                    "dispatch=three");
+  const RaceLogParseResult parsed = parse(malformed);
+
+  EXPECT_FALSE(parsed.ok());
+  EXPECT_NE(parsed.error.find("invalid dispatch"), std::string::npos);
+}
+
+TEST(RaceLogExpectationTest, RejectsMissingRequiredField) {
+  std::string malformed(kValidRaceLog);
+  malformed.erase(malformed.find(" access=read"), std::string(" access=read").size());
+  const RaceLogParseResult parsed = parse(malformed);
+
+  EXPECT_FALSE(parsed.ok());
+  EXPECT_NE(parsed.error.find("missing one or more required fields"), std::string::npos);
+}
+
+TEST(RaceLogExpectationTest, RejectsDuplicateField) {
+  std::string malformed(kValidRaceLog);
+  malformed.insert(malformed.find(" type=VGPR"), " dispatch=4");
+  const RaceLogParseResult parsed = parse(malformed);
+
+  EXPECT_FALSE(parsed.ok());
+  EXPECT_NE(parsed.error.find("duplicate header field 'dispatch'"), std::string::npos);
+}
+
+TEST(RaceLogExpectationTest, MissingEnvironmentFails) {
+  EnvironmentGuard environment("RJ_SINK_DIR");
+  environment.unset();
+
+  const RaceLogParseResult parsed = parseRaceLogFromEnvironment();
+
+  EXPECT_FALSE(parsed.ok());
+  EXPECT_EQ(parsed.error, "RJ_SINK_DIR is not set");
+}
+
+TEST(RaceLogExpectationTest, MissingFileFails) {
+  const std::filesystem::path missing =
+      std::filesystem::temp_directory_path() / "rocjitsu-race-log-expectation-missing" / "race.log";
+  const RaceLogParseResult parsed = parseRaceLogFile(missing);
+
+  EXPECT_FALSE(parsed.ok());
+  EXPECT_NE(parsed.error.find("could not open race log"), std::string::npos);
+}
+
+TEST(RaceLogExpectationTest, MatchesStructuredExpectation) {
+  const RaceLogParseResult parsed = parse(kValidRaceLog);
+  ASSERT_TRUE(parsed.ok()) << parsed.error;
+  const RaceExpectation expected{
+      .kernel = "racy_kernel",
+      .type = "VGPR",
+      .access = "read",
+      .wave = 0,
+      .lane = 1,
+      .producer = "global_load_dword",
+      .between = "s_waitcnt",
+      .consumer = "global_store_dword",
+  };
+
+  const RaceExpectationMatchResult matched = matchRaceExpectation(parsed.records, expected);
+
+  EXPECT_TRUE(matched.ok()) << matched.message();
+}
+
+TEST(RaceLogExpectationTest, MissingExpectedTraceMarkerFails) {
+  const RaceLogParseResult parsed = parse(kValidRaceLog);
+  ASSERT_TRUE(parsed.ok()) << parsed.error;
+  const RaceExpectation expected{
+      .type = "VGPR",
+      .consumer = "v_add_f32",
+  };
+
+  const RaceExpectationMatchResult matched = matchRaceExpectation(parsed.records, expected);
+
+  EXPECT_FALSE(matched.ok());
+  EXPECT_NE(matched.message().find("consumer trace"), std::string::npos);
+}
+
+} // namespace
+} // namespace rocjitsu::test

--- a/emulation/rocjitsu/tests/race-detector/race_log_expectation_test.cpp
+++ b/emulation/rocjitsu/tests/race-detector/race_log_expectation_test.cpp
@@ -34,6 +34,17 @@ RaceLogParseResult parse(std::string_view log) {
   return parseRaceLog(input);
 }
 
+std::vector<RaceRecord> validRaceRecords() {
+  RaceLogParseResult parsed = parse(kValidRaceLog);
+  EXPECT_TRUE(parsed.ok()) << parsed.error;
+  return std::move(parsed.records);
+}
+
+void expectMatchError(const RaceExpectationMatchResult &matched, std::string_view error) {
+  EXPECT_FALSE(matched.ok());
+  EXPECT_NE(matched.message().find(error), std::string::npos) << matched.message();
+}
+
 class EnvironmentGuard {
 public:
   explicit EnvironmentGuard(const char *name) : name_(name) {
@@ -195,6 +206,75 @@ TEST(RaceLogExpectationTest, MatchesStructuredExpectation) {
   const RaceExpectationMatchResult matched = matchRaceExpectation(parsed.records, expected);
 
   EXPECT_TRUE(matched.ok()) << matched.message();
+}
+
+TEST(RaceLogExpectationTest, RejectsFindingCountMismatches) {
+  const RaceExpectation exactly_one;
+  expectMatchError(matchRaceExpectation({}, exactly_one), "expected exactly one race, got 0");
+
+  std::vector<RaceRecord> two_records = validRaceRecords();
+  ASSERT_EQ(two_records.size(), 1u);
+  two_records.push_back(two_records.front());
+  expectMatchError(matchRaceExpectation(two_records, exactly_one),
+                   "expected exactly one race, got 2");
+
+  const RaceExpectation one_or_more{
+      .findings = FindingCount::OneOrMore,
+  };
+  expectMatchError(matchRaceExpectation({}, one_or_more), "expected at least one race, got none");
+}
+
+TEST(RaceLogExpectationTest, RejectsInvalidDispatchIdentity) {
+  std::vector<RaceRecord> records = validRaceRecords();
+  ASSERT_EQ(records.size(), 1u);
+  records.front().kernel = "?";
+  records.front().symbol.clear();
+  records.front().dispatch = 0;
+
+  const RaceExpectation expected{
+      .kernel = "racy_kernel",
+  };
+  const RaceExpectationMatchResult matched = matchRaceExpectation(records, expected);
+
+  expectMatchError(matched, "kernel name is unresolved");
+  expectMatchError(matched, "missing kernel symbol");
+  expectMatchError(matched, "dispatch id must be positive");
+}
+
+TEST(RaceLogExpectationTest, ReportsAllNormalizedFieldMismatches) {
+  const std::vector<RaceRecord> records = validRaceRecords();
+  ASSERT_EQ(records.size(), 1u);
+  const RaceExpectation expected{
+      .type = "SGPR",
+      .type_substring = "LDS",
+      .access = "write",
+      .wave = 2,
+      .lane = 3,
+  };
+
+  const RaceExpectationMatchResult matched = matchRaceExpectation(records, expected);
+
+  expectMatchError(matched, "race type mismatch");
+  expectMatchError(matched, "race type 'VGPR' does not contain 'LDS'");
+  expectMatchError(matched, "race access mismatch");
+  expectMatchError(matched, "wave mismatch");
+  expectMatchError(matched, "lane mismatch");
+}
+
+TEST(RaceLogExpectationTest, ReportsAllTraceSectionMismatches) {
+  const std::vector<RaceRecord> records = validRaceRecords();
+  ASSERT_EQ(records.size(), 1u);
+  const RaceExpectation expected{
+      .producer = "buffer_load_dword",
+      .between = "s_barrier",
+      .consumer = "v_add_f32",
+  };
+
+  const RaceExpectationMatchResult matched = matchRaceExpectation(records, expected);
+
+  expectMatchError(matched, "producer trace");
+  expectMatchError(matched, "intervening trace");
+  expectMatchError(matched, "consumer trace");
 }
 
 TEST(RaceLogExpectationTest, MissingExpectedTraceMarkerFails) {

--- a/emulation/rocjitsu/tests/race-detector/race_log_expectation_test.cpp
+++ b/emulation/rocjitsu/tests/race-detector/race_log_expectation_test.cpp
@@ -170,6 +170,16 @@ TEST(RaceLogExpectationTest, RejectsDuplicateField) {
   EXPECT_NE(parsed.error.find("duplicate header field 'dispatch'"), std::string::npos);
 }
 
+TEST(RaceLogExpectationTest, IgnoresUnknownHeaderField) {
+  std::string extended(kValidRaceLog);
+  extended.insert(extended.find(" conflict=unknown"), " future=value");
+  const RaceLogParseResult parsed = parse(extended);
+
+  ASSERT_TRUE(parsed.ok()) << parsed.error;
+  ASSERT_EQ(parsed.records.size(), 1u);
+  EXPECT_EQ(parsed.records.front().conflict, "unknown");
+}
+
 TEST(RaceLogExpectationTest, MissingEnvironmentFails) {
   EnvironmentGuard environment("RJ_SINK_DIR");
   environment.unset();

--- a/emulation/rocjitsu/tests/race-detector/race_log_expectation_test.cpp
+++ b/emulation/rocjitsu/tests/race-detector/race_log_expectation_test.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "race_log_expectation.hpp"
+#include "scoped_temp.h"
 
 #include <gtest/gtest.h>
 
@@ -88,6 +89,14 @@ TEST(RaceLogExpectationTest, ParsesValidEmptyLog) {
       parse("[rocjitsu] Kernel dispatch: \"clean_kernel\" symbol=\"clean_kernel\"\n"
             " ROCJITSU RACE DETECTION SUMMARY\n"
             " No races detected.\n");
+
+  ASSERT_TRUE(parsed.ok()) << parsed.error;
+  EXPECT_TRUE(parsed.records.empty());
+}
+
+TEST(RaceLogExpectationTest, ParsesDispatchOnlyEmptyLog) {
+  const RaceLogParseResult parsed =
+      parse("[rocjitsu] Kernel dispatch: \"clean_kernel\" symbol=\"clean_kernel\"\n");
 
   ASSERT_TRUE(parsed.ok()) << parsed.error;
   EXPECT_TRUE(parsed.records.empty());
@@ -191,8 +200,9 @@ TEST(RaceLogExpectationTest, MissingEnvironmentFails) {
 }
 
 TEST(RaceLogExpectationTest, MissingFileFails) {
+  const ScopedTempDirectory directory("rocjitsu-race-log-expectation-");
   const std::filesystem::path missing =
-      std::filesystem::temp_directory_path() / "rocjitsu-race-log-expectation-missing" / "race.log";
+      std::filesystem::path(directory.path()) / "missing" / "race.log";
   const RaceLogParseResult parsed = parseRaceLogFile(missing);
 
   EXPECT_FALSE(parsed.ok());
@@ -234,6 +244,27 @@ TEST(RaceLogExpectationTest, RejectsFindingCountMismatches) {
   expectMatchError(matchRaceExpectation({}, one_or_more), "expected at least one race, got none");
 }
 
+TEST(RaceLogExpectationTest, OneOrMoreFindsMatchingRecordAfterMismatch) {
+  std::vector<RaceRecord> records = validRaceRecords();
+  ASSERT_EQ(records.size(), 1u);
+  RaceRecord mismatch = records.front();
+  mismatch.type = "SGPR";
+  records.insert(records.begin(), std::move(mismatch));
+
+  const RaceExpectation one_or_more{
+      .findings = FindingCount::OneOrMore,
+      .type = "VGPR",
+  };
+  const RaceExpectation exactly_one{
+      .type = "VGPR",
+  };
+
+  const RaceExpectationMatchResult matched = matchRaceExpectation(records, one_or_more);
+
+  EXPECT_TRUE(matched.ok()) << matched.message();
+  expectMatchError(matchRaceExpectation(records, exactly_one), "expected exactly one race, got 2");
+}
+
 TEST(RaceLogExpectationTest, RejectsInvalidDispatchIdentity) {
   std::vector<RaceRecord> records = validRaceRecords();
   ASSERT_EQ(records.size(), 1u);
@@ -256,7 +287,6 @@ TEST(RaceLogExpectationTest, ReportsAllNormalizedFieldMismatches) {
   ASSERT_EQ(records.size(), 1u);
   const RaceExpectation expected{
       .type = "SGPR",
-      .type_substring = "LDS",
       .access = "write",
       .wave = 2,
       .lane = 3,
@@ -265,7 +295,6 @@ TEST(RaceLogExpectationTest, ReportsAllNormalizedFieldMismatches) {
   const RaceExpectationMatchResult matched = matchRaceExpectation(records, expected);
 
   expectMatchError(matched, "race type mismatch");
-  expectMatchError(matched, "race type 'VGPR' does not contain 'LDS'");
   expectMatchError(matched, "race access mismatch");
   expectMatchError(matched, "wave mismatch");
   expectMatchError(matched, "lane mismatch");

--- a/emulation/rocjitsu/tests/race-detector/race_test_support.hpp
+++ b/emulation/rocjitsu/tests/race-detector/race_test_support.hpp
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include <hip/hip_runtime.h>
+
+#include "race_log_expectation.hpp"
+
+#include <cstdio>
+#include <vector>
+
+namespace rocjitsu::test {
+
+class RaceTestBase : public ::testing::Test {
+protected:
+  template <typename T> T *alloc(int count) {
+    T *pointer = nullptr;
+    (void)hipMalloc(&pointer, count * sizeof(T));
+    return pointer;
+  }
+
+  template <typename T> T *allocWithData(int count) {
+    T *pointer = alloc<T>(count);
+    std::vector<T> host(count);
+    for (int index = 0; index < count; ++index)
+      host[index] = static_cast<T>(index);
+    (void)hipMemcpy(pointer, host.data(), count * sizeof(T), hipMemcpyHostToDevice);
+    return pointer;
+  }
+
+  void sync() { (void)hipDeviceSynchronize(); }
+
+  void ExpectNoRace() {
+    const RaceLogParseResult parsed = parseRaceLogFromEnvironment();
+    ASSERT_TRUE(parsed.ok()) << parsed.error;
+    if (!parsed.records.empty()) {
+      for (const auto &record : parsed.records) {
+        std::fprintf(stderr, "  [%s symbol=%s dispatch=%d %s reg=%d wg=%s] %s\n",
+                     record.kernel.c_str(), record.symbol.c_str(), record.dispatch,
+                     record.type.c_str(), record.reg, record.workgroup.c_str(),
+                     record.message.c_str());
+      }
+    }
+    EXPECT_TRUE(parsed.records.empty()) << "Expected no races, got " << parsed.records.size();
+  }
+
+  void ExpectRace(const RaceExpectation &expected) {
+    const RaceLogParseResult parsed = parseRaceLogFromEnvironment();
+    ASSERT_TRUE(parsed.ok()) << parsed.error;
+    const RaceExpectationMatchResult matched = matchRaceExpectation(parsed.records, expected);
+    EXPECT_TRUE(matched.ok()) << matched.message();
+  }
+};
+
+} // namespace rocjitsu::test


### PR DESCRIPTION
This is just a restructuring of the race detection plugin tests. Longer term goal here is to make these tests accessible to other plugins that do race detection, and other tools like waitcheck and consan. 

The PR centralizes the gfx950 and gfx1151 HIP race-test expectations so finding counts, normalized fields, dispatch context, wave/lane identity, and marked trace instructions live beside the kernels they protect. Splits the shared support into:

- a pure C++ race-log parser and expectation matcher; and
- a small HIP/GoogleTest fixture for allocation, synchronization, and assertion reporting.

Make the parser fail closed when the sink directory or log is missing, when the log contains no recognizable race-plugin output, or when a `RACE` block has malformed, missing, duplicate, or unterminated fields. This prevents missing or truncated diagnostic evidence from being interpreted as a passing no-race test. Existing HIP race scenarios and their exact-one versus one-or-more semantics are preserved.
