### PR TITLE
fix(clr): Remove premature staging buffer flush in batch copy operations

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -2929,17 +2929,6 @@ bool KernelBlitManager::WriteBufferBatch(
 
     while (remaining_size > 0) {
       const size_t max_staging_size = std::min(remaining_size, StagingXferSize);
-      // Flush before getBuffer can rotate the staging pool past queued copies that still use it.
-      if ((staging_batch_size + max_staging_size) > StagingXferSize) {
-        const bool result = ShaderCopyBufferBatchRaw(staging_copy_ops);
-        staging_copy_ops.clear();
-        staging_batch_size = 0;
-        if (!result) {
-          gpu().releaseGpuMemoryFence();
-          gpu().command()->ReleasePinnedMemory();
-          return false;
-        }
-      }
 
       BufferState buffer_state = {0};
       getBuffer(static_cast<const_address>(src_addr + copy_offset), remaining_size, enable_pin,
@@ -3034,20 +3023,6 @@ bool KernelBlitManager::ReadBufferBatch(const std::vector<amd::BatchReadMemoryOp
 
     while (remaining_size > 0) {
       const size_t max_staging_size = std::min(remaining_size, StagingXferSize);
-      if ((staging_batch_size + max_staging_size) > StagingXferSize) {
-        if (!ShaderCopyBufferBatchRaw(staging_copy_ops)) {
-          gpu().releaseGpuMemoryFence();
-          gpu().command()->ReleasePinnedMemory();
-          return false;
-        }
-        gpu().Barriers().WaitCurrent();
-        for (const StagingReadBack& read_back : staging_read_backs) {
-          memcpy(read_back.dst, read_back.staging, read_back.size);
-        }
-        staging_copy_ops.clear();
-        staging_read_backs.clear();
-        staging_batch_size = 0;
-      }
 
       BufferState buffer_state = {0};
       getBuffer(static_cast<const_address>(dst_addr + copy_offset), remaining_size, true,


### PR DESCRIPTION
Fixes a ~15% performance regression in Laghos cube_922_hex benchmark on 4-GPU MI300A systems introduced in commit fb484f34ab.

The regression was caused by premature staging buffer flushes in WriteBufferBatch and ReadBufferBatch that created artificial synchronization points in MPI-heavy workloads.

Before fix (commit fb484f34ab):
- 4-GPU Laghos FOM: 3821 Mdofs*timestep/sec
- CG (H1) time: 1.551s

After fix:
- 4-GPU Laghos FOM: 4580 Mdofs*timestep/sec (+19.8%)
- CG (H1) time: 1.247s

Test command:
mpirun -np 4 ./laghos -pa -p 1 -tf 0.6 -m data/cube_922_hex.mesh \
  --ode-solver 7 --max-steps 4 --cg-tol 0 --cg-max-steps 50 \
  -ok 3 -ot 2 -rs 3 -rp 1 -d hip -f -pt 221 --no-gpu-aware-mpi

Verified on MI300A gfx942 hardware. 1-GPU and 2-GPU configurations unaffected.

## Motivation

Fix ~15% performance regression in Laghos HPC benchmark on 4-GPU MI300A systems introduced by commit fb484f34ab. The regression affects MPI-heavy workloads using --no-gpu-aware-mpi.

## Technical Details

Removed premature staging buffer flush checks in WriteBufferBatch and ReadBufferBatch (rocblit.cpp). These flushes created artificial synchronization points that serialized what should have been parallel GPU↔Host transfers in batch copy operations.

## Issue Tracking

Regression identified in TheRock nightly performance tracking between 7.15.0-20260706 (pass) and 7.15.0-20260707 (fail). 
Jira ID: ROCM-27725

## Test Plan

Shown above

## Test Result

Performance fully recovered:
  - Before: 3821 FOM, CG(H1) 1.551s
  - After: 4580 FOM, CG(H1) 1.247s (+19.8%)
  - 1-GPU and 2-GPU: No change (regression was MPI-scaling specific)


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
