### PR TITLE
feat(cuid): Adjustments for theRock build integration

### DIFF
--- a/projects/cuid/lib/CMakeLists.txt
+++ b/projects/cuid/lib/CMakeLists.txt
@@ -83,17 +83,11 @@ set(CUID_HEADERS
 )
 
 add_library(amdcuid_static STATIC ${CUID_SOURCES} ${CUID_HEADERS})
-add_library(amdcuid_shared SHARED ${CUID_SOURCES} ${CUID_HEADERS})
 
 set_property(TARGET amdcuid_static PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 target_include_directories(
     amdcuid_static
-    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
-    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src
-)
-target_include_directories(
-    amdcuid_shared
     PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
@@ -105,33 +99,12 @@ target_compile_definitions(
     amdcuid_static
     PRIVATE AMDCUID_CONFIG_DIR="${AMDCUID_SHARED_CONFIG_DIR}"
 )
-target_compile_definitions(
-    amdcuid_shared
-    PRIVATE AMDCUID_CONFIG_DIR="${AMDCUID_SHARED_CONFIG_DIR}"
-)
 
 if(WIN32)
-    target_link_libraries(amdcuid_shared PRIVATE bcrypt)
     target_link_libraries(amdcuid_static PUBLIC bcrypt)
 else()
-    target_link_libraries(amdcuid_shared PRIVATE OpenSSL::Crypto)
     target_link_libraries(amdcuid_static PUBLIC OpenSSL::Crypto)
 endif()
-
-# Shared library
-install(
-    TARGETS amdcuid_shared
-    RUNTIME
-        DESTINATION
-            ${CMAKE_INSTALL_BINDIR} # Windows DLLs go here
-    LIBRARY
-        DESTINATION
-            ${CMAKE_INSTALL_LIBDIR} # Linux .so
-    ARCHIVE
-        DESTINATION
-            ${CMAKE_INSTALL_LIBDIR} # Static libs & Windows import libs
-        COMPONENT ${LIB_COMPONENT}
-)
 
 # Static library
 install(

--- a/projects/cuid/lib/src/hmac.cc
+++ b/projects/cuid/lib/src/hmac.cc
@@ -27,6 +27,8 @@
 
 #include "hmac.h"
 
+#include <stdlib.h>
+
 #include <cerrno>
 #include <cstdio>
 #include <cstring>
@@ -65,8 +67,8 @@ struct cuid_hmac::Impl {
 };
 
 cuid_hmac::cuid_hmac() : impl_(nullptr), key(nullptr), key_len(key_length), valid(false) {
-  const char* env_path = getenv("AMDCUID_HMAC_KEY_PATH");
-  key_file_path = env_path ? env_path : AMDCUID_CONFIG_DIR "/hmac_key.bin";
+  const char* env_path = std::getenv("AMDCUID_HMAC_KEY_PATH");
+  key_file_path = (env_path && env_path[0]) ? env_path : AMDCUID_CONFIG_DIR "/hmac_key.bin";
   impl_ = new Impl();
   impl_->digest_name = "SHA256";
   impl_->hAlg = nullptr;
@@ -86,6 +88,11 @@ cuid_hmac::cuid_hmac() : impl_(nullptr), key(nullptr), key_len(key_length), vali
   }
   key_file_stream.seekg(0, std::ios::end);
   key_len = static_cast<size_t>(key_file_stream.tellg());
+  if (key_len == 0 || key_len != key_length) {  // sanity check on key length
+    std::cerr << "Invalid key length in key file" << std::endl;
+    key_file_stream.close();
+    return;
+  }
   key_file_stream.seekg(0, std::ios::beg);
   key = new uint8_t[key_len];
   key_file_stream.read(reinterpret_cast<char*>(key), key_len);
@@ -265,8 +272,8 @@ struct cuid_hmac::Impl {
 };
 
 cuid_hmac::cuid_hmac() : impl_(nullptr), key(nullptr), key_len(key_length), valid(false) {
-  const char* env_path = getenv("AMDCUID_HMAC_KEY_PATH");
-  key_file_path = env_path ? env_path : AMDCUID_CONFIG_DIR "/hmac_key.bin";
+  const char* env_path = std::getenv("AMDCUID_HMAC_KEY_PATH");
+  key_file_path = (env_path && env_path[0]) ? env_path : AMDCUID_CONFIG_DIR "/hmac_key.bin";
   impl_ = new Impl();
   impl_->digest_name = "SHA256";
   impl_->mac = nullptr;
@@ -404,8 +411,8 @@ struct cuid_hmac::Impl {
 };
 
 cuid_hmac::cuid_hmac() : impl_(nullptr), key(nullptr), key_len(0), valid(false) {
-  const char* env_path = getenv("AMDCUID_HMAC_KEY_PATH");
-  key_file_path = env_path ? env_path : AMDCUID_CONFIG_DIR "/hmac_key.bin";
+  const char* env_path = std::getenv("AMDCUID_HMAC_KEY_PATH");
+  key_file_path = (env_path && env_path[0]) ? env_path : AMDCUID_CONFIG_DIR "/hmac_key.bin";
   impl_ = new Impl();
   impl_->digest_name = "SHA256";
   impl_->ctx = HMAC_CTX_new();

--- a/projects/cuid/lib/src/hmac.cc
+++ b/projects/cuid/lib/src/hmac.cc
@@ -65,7 +65,8 @@ struct cuid_hmac::Impl {
 };
 
 cuid_hmac::cuid_hmac() : impl_(nullptr), key(nullptr), key_len(key_length), valid(false) {
-  key_file_path = AMDCUID_CONFIG_DIR "/hmac_key.bin";
+  const char* env_path = getenv("AMDCUID_HMAC_KEY_PATH");
+  key_file_path = env_path ? env_path : AMDCUID_CONFIG_DIR "/hmac_key.bin";
   impl_ = new Impl();
   impl_->digest_name = "SHA256";
   impl_->hAlg = nullptr;
@@ -264,7 +265,8 @@ struct cuid_hmac::Impl {
 };
 
 cuid_hmac::cuid_hmac() : impl_(nullptr), key(nullptr), key_len(key_length), valid(false) {
-  key_file_path = AMDCUID_CONFIG_DIR "/hmac_key.bin";
+  const char* env_path = getenv("AMDCUID_HMAC_KEY_PATH");
+  key_file_path = env_path ? env_path : AMDCUID_CONFIG_DIR "/hmac_key.bin";
   impl_ = new Impl();
   impl_->digest_name = "SHA256";
   impl_->mac = nullptr;
@@ -402,7 +404,8 @@ struct cuid_hmac::Impl {
 };
 
 cuid_hmac::cuid_hmac() : impl_(nullptr), key(nullptr), key_len(0), valid(false) {
-  key_file_path = AMDCUID_CONFIG_DIR "/hmac_key.bin";
+  const char* env_path = getenv("AMDCUID_HMAC_KEY_PATH");
+  key_file_path = env_path ? env_path : AMDCUID_CONFIG_DIR "/hmac_key.bin";
   impl_ = new Impl();
   impl_->digest_name = "SHA256";
   impl_->ctx = HMAC_CTX_new();


### PR DESCRIPTION
## Motivation
CI testing when CUID would be added to theRock would fail since the HMAC key would not be provisioned in the CI container environment. Additionally, CUID is expected to only be distributed as a static library so changes to remove the building of the shared object file are necessary.

## Technical Details
Allows CI to set the location of the HMAC Key file to a custom location to so that it works within CI container environments. Removes amdcuid_shared from library CMakeLists.

## Issue Tracking
JIRA ID : ROCM-28698
