### PR TITLE
ci: perm test commits/pulls API scopes (do not merge)

### DIFF
--- a/.github/workflows/perm_test_commits_pulls.yml
+++ b/.github/workflows/perm_test_commits_pulls.yml
@@ -15,6 +15,9 @@ on:
 
 permissions: {}
 
+env:
+  TEST_COMMIT_SHA: ${{ inputs.commit_sha || '62aebd434513280321db9129c741970a129ebcb9' }}
+
 jobs:
   contents-read-only:
     runs-on: ubuntu-24.04
@@ -27,7 +30,7 @@ jobs:
         run: |
           set -x
           set +e
-          resp=$(gh api -i "repos/${{ github.repository }}/commits/${{ inputs.commit_sha }}/pulls" 2>&1)
+          resp=$(gh api -i "repos/${{ github.repository }}/commits/${{ env.TEST_COMMIT_SHA }}/pulls" 2>&1)
           rc=$?
           echo "--- raw response (headers + body) ---"
           echo "$resp"
@@ -52,7 +55,7 @@ jobs:
         run: |
           set -x
           set +e
-          resp=$(gh api -i "repos/${{ github.repository }}/commits/${{ inputs.commit_sha }}/pulls" 2>&1)
+          resp=$(gh api -i "repos/${{ github.repository }}/commits/${{ env.TEST_COMMIT_SHA }}/pulls" 2>&1)
           rc=$?
           echo "--- raw response (headers + body) ---"
           echo "$resp"
@@ -61,7 +64,7 @@ jobs:
           if echo "$resp" | rg -q "403|Resource not accessible"; then
             echo "verdict=FAIL_403"
           elif [ "$rc" -eq 0 ] && echo "$resp" | rg -q '"number"'; then
-            pr=$(gh api "repos/${{ github.repository }}/commits/${{ inputs.commit_sha }}/pulls" --jq '.[0].number')
+            pr=$(gh api "repos/${{ github.repository }}/commits/${{ env.TEST_COMMIT_SHA }}/pulls" --jq '.[0].number')
             echo "verdict=OK pr=${pr}"
           else
             echo "verdict=OTHER_FAIL"
@@ -79,7 +82,7 @@ jobs:
         run: |
           set -x
           set +e
-          resp=$(gh api -i "repos/${{ github.repository }}/commits/${{ inputs.commit_sha }}/pulls" 2>&1)
+          resp=$(gh api -i "repos/${{ github.repository }}/commits/${{ env.TEST_COMMIT_SHA }}/pulls" 2>&1)
           rc=$?
           echo "--- raw response (headers + body) ---"
           echo "$resp"
@@ -88,7 +91,7 @@ jobs:
           if echo "$resp" | rg -q "403|Resource not accessible"; then
             echo "verdict=FAIL_403"
           elif [ "$rc" -eq 0 ] && echo "$resp" | rg -q '"number"'; then
-            pr=$(gh api "repos/${{ github.repository }}/commits/${{ inputs.commit_sha }}/pulls" --jq '.[0].number')
+            pr=$(gh api "repos/${{ github.repository }}/commits/${{ env.TEST_COMMIT_SHA }}/pulls" --jq '.[0].number')
             echo "verdict=OK pr=${pr}"
           else
             echo "verdict=OTHER_FAIL"

--- a/.github/workflows/perm_test_commits_pulls.yml
+++ b/.github/workflows/perm_test_commits_pulls.yml
@@ -12,6 +12,9 @@ on:
   pull_request:
     paths:
       - .github/workflows/perm_test_commits_pulls.yml
+  push:
+    branches:
+      - users/jechrist/gha-perm-test
 
 permissions: {}
 

--- a/.github/workflows/perm_test_commits_pulls.yml
+++ b/.github/workflows/perm_test_commits_pulls.yml
@@ -99,3 +99,26 @@ jobs:
           else
             echo "verdict=OTHER_FAIL"
           fi
+
+  no-permissions:
+    runs-on: ubuntu-24.04
+    permissions: {}
+    steps:
+      - name: gh api commits/pulls with no GITHUB_TOKEN scopes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -x
+          set +e
+          resp=$(gh api -i "repos/${{ github.repository }}/commits/${{ env.TEST_COMMIT_SHA }}/pulls" 2>&1)
+          rc=$?
+          echo "--- summary ---"
+          echo "exit_code=${rc}"
+          echo "$resp" | rg "HTTP/|403|Resource not accessible|X-Accepted-Github-Permissions" || true
+          if echo "$resp" | rg -q "403|Resource not accessible"; then
+            echo "verdict=FAIL_403"
+          elif [ "$rc" -eq 0 ]; then
+            echo "verdict=OK_UNEXPECTED"
+          else
+            echo "verdict=OTHER_FAIL"
+          fi

--- a/.github/workflows/perm_test_commits_pulls.yml
+++ b/.github/workflows/perm_test_commits_pulls.yml
@@ -1,0 +1,92 @@
+# Temporary workflow_dispatch experiment: which GITHUB_TOKEN scopes are required for
+# GET /repos/{owner}/{repo}/commits/{sha}/pulls (pr-merge-sync-patches step 1).
+name: Perm test commits pulls API
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: Commit SHA known to be from a merged PR on develop
+        required: true
+        default: "62aebd434513280321db9129c741970a129ebcb9"
+
+permissions: {}
+
+jobs:
+  contents-read-only:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: gh api commits/pulls with contents read only
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -x
+          set +e
+          resp=$(gh api -i "repos/${{ github.repository }}/commits/${{ inputs.commit_sha }}/pulls" 2>&1)
+          rc=$?
+          echo "--- raw response (headers + body) ---"
+          echo "$resp"
+          echo "--- summary ---"
+          echo "exit_code=${rc}"
+          if echo "$resp" | rg -q "403|Resource not accessible"; then
+            echo "verdict=FAIL_403"
+          elif [ "$rc" -eq 0 ] && echo "$resp" | rg -q '"number"'; then
+            echo "verdict=OK"
+          else
+            echo "verdict=OTHER_FAIL"
+          fi
+
+  pull-requests-read-only:
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: read
+    steps:
+      - name: gh api commits/pulls with pull-requests read only
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -x
+          set +e
+          resp=$(gh api -i "repos/${{ github.repository }}/commits/${{ inputs.commit_sha }}/pulls" 2>&1)
+          rc=$?
+          echo "--- raw response (headers + body) ---"
+          echo "$resp"
+          echo "--- summary ---"
+          echo "exit_code=${rc}"
+          if echo "$resp" | rg -q "403|Resource not accessible"; then
+            echo "verdict=FAIL_403"
+          elif [ "$rc" -eq 0 ] && echo "$resp" | rg -q '"number"'; then
+            pr=$(gh api "repos/${{ github.repository }}/commits/${{ inputs.commit_sha }}/pulls" --jq '.[0].number')
+            echo "verdict=OK pr=${pr}"
+          else
+            echo "verdict=OTHER_FAIL"
+          fi
+
+  both-read:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: gh api commits/pulls with contents + pull-requests read
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -x
+          set +e
+          resp=$(gh api -i "repos/${{ github.repository }}/commits/${{ inputs.commit_sha }}/pulls" 2>&1)
+          rc=$?
+          echo "--- raw response (headers + body) ---"
+          echo "$resp"
+          echo "--- summary ---"
+          echo "exit_code=${rc}"
+          if echo "$resp" | rg -q "403|Resource not accessible"; then
+            echo "verdict=FAIL_403"
+          elif [ "$rc" -eq 0 ] && echo "$resp" | rg -q '"number"'; then
+            pr=$(gh api "repos/${{ github.repository }}/commits/${{ inputs.commit_sha }}/pulls" --jq '.[0].number')
+            echo "verdict=OK pr=${pr}"
+          else
+            echo "verdict=OTHER_FAIL"
+          fi

--- a/.github/workflows/perm_test_commits_pulls.yml
+++ b/.github/workflows/perm_test_commits_pulls.yml
@@ -9,6 +9,9 @@ on:
         description: Commit SHA known to be from a merged PR on develop
         required: true
         default: "62aebd434513280321db9129c741970a129ebcb9"
+  pull_request:
+    paths:
+      - .github/workflows/perm_test_commits_pulls.yml
 
 permissions: {}
 


### PR DESCRIPTION
Temporary experiment branch to test GITHUB_TOKEN scopes for commits/{sha}/pulls. Do not merge.

Made with [Cursor](https://cursor.com)