### PR TITLE
fix(rccl-tests): use RTLD_DEFAULT to prevent double-loading librccl

### DIFF
--- a/projects/rccl-tests/src/all_reduce_bias.cu
+++ b/projects/rccl-tests/src/all_reduce_bias.cu
@@ -16,12 +16,9 @@ DECLARE_RCCL_PFN(ncclAllReduceWithBias);
 static pthread_once_t initOnceControl = PTHREAD_ONCE_INIT;
 
 static void initOnceFunc() {
-  void *librccl = dlopen("librccl.so", RTLD_LAZY | RTLD_LOCAL);
-  if (!librccl) {
-    fprintf(stderr, "dlopen failed: %s\n", dlerror());
-    return;
-  }
-  pfn_ncclAllReduceWithBias = (PFN_ncclAllReduceWithBias) dlsym(librccl, "ncclAllReduceWithBias");
+  // Resolve optional RCCL symbol from the already-loaded librccl.so.1 (via DT_NEEDED).
+  // Avoid dlopen("librccl.so") which can double-load in build trees with non-symlinked libs.
+  pfn_ncclAllReduceWithBias = (PFN_ncclAllReduceWithBias) dlsym(RTLD_DEFAULT, "ncclAllReduceWithBias");
 }
 
 void AllReduceGetCollByteCount(size_t *sendcount, size_t *recvcount, size_t *paramcount, size_t *sendInplaceOffset, size_t *recvInplaceOffset, size_t count, size_t eltSize, int nranks) {

--- a/projects/rccl-tests/src/common.cu
+++ b/projects/rccl-tests/src/common.cu
@@ -54,19 +54,12 @@ rcclTestsGetAlgoName_t rcclTestsGetAlgoName= NULL;
 rcclTestsGetSymkInfo_t rcclTestsGetSymkInfo = NULL;
 
 static void loadRcclSyms() {
-  static void* handle = NULL;
-  const char* libname = "librccl.so";
-  if (!handle) {
-    handle = dlopen(libname, RTLD_LAZY | RTLD_LOCAL);
-      if (!handle) {
-        fprintf(stderr, "dlopen failed: %s\n", dlerror());
-        return;
-      }
-  }
-  rcclTestsGetAlgoInfo      = (rcclTestsGetAlgoInfo_t)     dlsym(handle, "rcclGetAlgoInfo");
-  rcclTestsGetAlgoName      = (rcclTestsGetAlgoName_t)     dlsym(handle, "rcclGetAlgoName");
-  rcclTestsGetProtocolName  = (rcclTestsGetProtocolName_t) dlsym(handle, "rcclGetProtocolName");
-  rcclTestsGetSymkInfo      = (rcclTestsGetSymkInfo_t)     dlsym(handle, "rcclSymKGetInfo");
+  // Resolve optional RCCL symbols from the already-loaded librccl.so.1 (via DT_NEEDED).
+  // Avoid dlopen("librccl.so") which can double-load in build trees with non-symlinked libs.
+  rcclTestsGetAlgoInfo      = (rcclTestsGetAlgoInfo_t)     dlsym(RTLD_DEFAULT, "rcclGetAlgoInfo");
+  rcclTestsGetAlgoName      = (rcclTestsGetAlgoName_t)     dlsym(RTLD_DEFAULT, "rcclGetAlgoName");
+  rcclTestsGetProtocolName  = (rcclTestsGetProtocolName_t) dlsym(RTLD_DEFAULT, "rcclGetProtocolName");
+  rcclTestsGetSymkInfo      = (rcclTestsGetSymkInfo_t)     dlsym(RTLD_DEFAULT, "rcclSymKGetInfo");
 }
 
 // RCCL_FLOAT8 support


### PR DESCRIPTION
## Motivation

Fixes a double-free crash at exit when running rccl-tests against a build-tree librccl where `librccl.so`, `librccl.so.1`, and `librccl.so.1.0` are separate regular files rather than the usual symlink chain.

## Technical Details

The test binaries link against `roc::rccl`, giving them a DT_NEEDED dependency on `librccl.so.1`. At runtime, `loadRcclSyms()` and `initOnceFunc()` called `dlopen("librccl.so", ...)` to resolve optional symbols (`rcclGetAlgoInfo`, `rcclGetAlgoName`, `rcclGetProtocolName`, `rcclSymKGetInfo`, `ncclAllReduceWithBias`).

The dynamic loader only reuses an already-loaded library when:
1. The requested name exactly matches, OR
2. The file inode matches

In a build tree with three distinct files (no symlinks), neither condition holds. A second copy of RCCL gets mapped, both copies run their static initializers, and shared globals (e.g., `ncclParamDumpAllFlag`) get constructed twice at the same address. At exit, `__cxa_atexit` runs both destructors, double-freeing internal allocations.

**Fix:** Replace `dlopen` + `dlsym(handle, ...)` with `dlsym(RTLD_DEFAULT, ...)`. Since `librccl.so.1` is already loaded via DT_NEEDED, `RTLD_DEFAULT` finds the symbols in the existing library without loading a second copy. All call sites already NULL-check the function pointers, so missing symbols (older librccl versions) continue to work.

## Issue Tracking

JIRA ID: AICOMRCCL-1795

## Test Plan

- Build rccl-tests against a build-tree librccl (non-symlinked `.so` files)
- Run all collectives
- Verify clean exit with no double-free or heap corruption

## Test Result

- Exit completes without `corrupted size vs. prev_size in fastbins` abort
- Optional symbol resolution still works (algo/proto reporting functional)

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
