### PR TITLE
[rocjitsu] Fix gfx1250 B0->A0 literal mistaken for FLAT_SCRATCH_BASE

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -1284,13 +1284,14 @@ bool BinaryTranslator::is_gfx1250_b0_to_a0() const {
          options_.output_revision == ProcessorRevision::Gfx1250A0;
 }
 
-const InstructionLegalization *BinaryTranslator::lookup_legalization(const Instruction &inst) {
+const InstructionLegalization *
+BinaryTranslator::lookup_legalization(const Instruction &inst) const {
   // gfx1250 B0 and A0 have the same structural ISA, so the generated cross-ISA
   // tables cannot express their revision-specific behavior. Instructions in
   // the B0-to-A0 profile use handwritten legalization; everything else follows
   // the raw same-ISA copy path.
   if (is_gfx1250_b0_to_a0())
-    return gfx1250_b0_to_a0_legalization(inst, &reported_deferred_families_);
+    return gfx1250_b0_to_a0_legalization(inst);
 
   return legalization_lookup_ ? legalization_lookup_(inst.encoding_id(), inst.opcode()) : nullptr;
 }
@@ -2798,6 +2799,22 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
         }
 
         const InstructionLegalization *leg = lookup_legalization(inst);
+
+        // A deferred gfx1250 family has no A0 handling yet and stays on the copy
+        // path, so the omission is reported rather than left silent. The report
+        // describes the mnemonic, not the site, so one per mnemonic per
+        // translation says everything a second copy would: an earlier RCCL
+        // all_reduce run emitted 104,831 identical lines, burying the
+        // diagnostics that do name a specific instruction. The record is
+        // per-translation, so each code object still reports its own gaps.
+        if (leg == nullptr && is_gfx1250_b0_to_a0() &&
+            gfx1250_b0_to_a0_is_deferred_family(inst.mnemonic()) &&
+            reported_deferred_families_.emplace(inst.mnemonic()).second) {
+          append_warning(result.diagnostics, DiagnosticKind::Legalization,
+                         "gfx1250 translation passes through '" + std::string(inst.mnemonic()) +
+                             "' unchanged; target-specific handling is not yet implemented",
+                         offset, std::string(inst.mnemonic()));
+        }
 
         const uint16_t dst_opcode = leg ? leg->target_opcode : inst.opcode();
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -1284,14 +1284,13 @@ bool BinaryTranslator::is_gfx1250_b0_to_a0() const {
          options_.output_revision == ProcessorRevision::Gfx1250A0;
 }
 
-const InstructionLegalization *
-BinaryTranslator::lookup_legalization(const Instruction &inst) const {
+const InstructionLegalization *BinaryTranslator::lookup_legalization(const Instruction &inst) {
   // gfx1250 B0 and A0 have the same structural ISA, so the generated cross-ISA
   // tables cannot express their revision-specific behavior. Instructions in
   // the B0-to-A0 profile use handwritten legalization; everything else follows
   // the raw same-ISA copy path.
   if (is_gfx1250_b0_to_a0())
-    return gfx1250_b0_to_a0_legalization(inst);
+    return gfx1250_b0_to_a0_legalization(inst, &reported_deferred_families_);
 
   return legalization_lookup_ ? legalization_lookup_(inst.encoding_id(), inst.opcode()) : nullptr;
 }
@@ -1303,6 +1302,10 @@ void BinaryTranslator::set_trace_callback(TranslationTraceCallback callback) {
 TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   TranslatedCodeObject result;
   result.host_arch = host_arch_;
+
+  // Deferred-family warnings are suppressed per translation, not per translator
+  // instance, so a reused translator still reports each code object's gaps.
+  reported_deferred_families_.clear();
 
   auto leave_unchanged = [&]() {
     const auto *image = reinterpret_cast<const uint8_t *>(obj.image_data());

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.h
@@ -28,6 +28,7 @@
 #include <optional>
 #include <span>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include "rocjitsu/code/dbt/encoding_translator.h"
@@ -196,7 +197,11 @@ private:
   [[nodiscard]] bool is_gfx1250_b0_to_a0() const;
 
   /// @brief Return the generated or revision-specific legalization for an instruction.
-  [[nodiscard]] const InstructionLegalization *lookup_legalization(const Instruction &inst) const;
+  ///
+  /// @details Not const: the gfx1250 B0-to-A0 classifier records which deferred
+  /// mnemonics it has already warned about, so each translation reports a gap
+  /// once rather than once per instruction.
+  [[nodiscard]] const InstructionLegalization *lookup_legalization(const Instruction &inst);
 
   /// @brief Translate a single instruction via the encoding translation pipeline.
   ///
@@ -224,6 +229,14 @@ private:
   EncodingTranslateFn encoding_translate_;                  ///< Per-pair encoding translator.
   LegalizationLookupFn legalization_lookup_;                ///< Per-pair legalization table.
   std::unique_ptr<SemanticTranslator> semantic_translator_; ///< Per-pair semantic rule engine.
+
+  /// @brief Deferred-family mnemonics already warned about in this translation.
+  ///
+  /// @details Cleared at the start of every translate() call. Scoping the
+  /// suppression to one code object keeps the warning informative without
+  /// letting the first object that uses a deferred mnemonic hide the same gap
+  /// in every object loaded after it.
+  std::unordered_set<std::string> reported_deferred_families_;
 };
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.h
@@ -197,11 +197,7 @@ private:
   [[nodiscard]] bool is_gfx1250_b0_to_a0() const;
 
   /// @brief Return the generated or revision-specific legalization for an instruction.
-  ///
-  /// @details Not const: the gfx1250 B0-to-A0 classifier records which deferred
-  /// mnemonics it has already warned about, so each translation reports a gap
-  /// once rather than once per instruction.
-  [[nodiscard]] const InstructionLegalization *lookup_legalization(const Instruction &inst);
+  [[nodiscard]] const InstructionLegalization *lookup_legalization(const Instruction &inst) const;
 
   /// @brief Translate a single instruction via the encoding translation pipeline.
   ///
@@ -230,10 +226,10 @@ private:
   LegalizationLookupFn legalization_lookup_;                ///< Per-pair legalization table.
   std::unique_ptr<SemanticTranslator> semantic_translator_; ///< Per-pair semantic rule engine.
 
-  /// @brief Deferred-family mnemonics already warned about in this translation.
+  /// @brief Deferred-family mnemonics already reported in this translation.
   ///
   /// @details Cleared at the start of every translate() call. Scoping the
-  /// suppression to one code object keeps the warning informative without
+  /// suppression to one code object keeps the report informative without
   /// letting the first object that uses a deferred mnemonic hide the same gap
   /// in every object loaded after it.
   std::unordered_set<std::string> reported_deferred_families_;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/gfx1250_b0_to_a0_library.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/gfx1250_b0_to_a0_library.cpp
@@ -165,6 +165,13 @@ rj_gfx1250_b0_to_a0_translate(const void *source_elf, size_t source_size, uint8_
         ++info->changed_instruction_count;
     });
     auto result = translator.translate(source);
+    // Diagnostics are reported for every outcome, not only failures. A
+    // translation can succeed and still have something to say -- a family passed
+    // through unchanged because its A0 handling is not implemented yet is
+    // exactly the kind of gap someone triaging a misbehaving kernel needs to
+    // see, and it never reaches the caller if reporting is conditional on the
+    // object being undispatchable.
+    rocjitsu::emit_gfx1250_b0_to_a0_diagnostics(diagnostic_callback, user_data, result.diagnostics);
     // A translation that ran to completion and produced nothing dispatchable is a
     // statement about the input, not about this run: repeating it reaches the same
     // conclusion. Reporting it as such is what lets a caller distinguish it from
@@ -172,8 +179,6 @@ rj_gfx1250_b0_to_a0_translate(const void *source_elf, size_t source_size, uint8_
     // rediscovering it. ROCJITSU_STATUS_ERROR is left to mean the translator threw,
     // which carries no such promise.
     if (result.elf_bytes.empty() || !result.dispatchable()) {
-      rocjitsu::emit_gfx1250_b0_to_a0_diagnostics(diagnostic_callback, user_data,
-                                                  result.diagnostics);
       if (result.diagnostics.empty())
         emit_diagnostic(diagnostic_callback, user_data, kSeverityError, kKindResultNotDispatchable,
                         "translation produced no dispatchable code object");

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.cpp
@@ -20,7 +20,6 @@
 
 #include <array>
 #include <cstring>
-#include <mutex>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -163,21 +162,25 @@ inline constexpr std::array<std::string_view, 17> kExactB0ToA0TranslationMnemoni
          mnemonic == "s_monitor_sleep";
 }
 
-/// @brief True the first time each deferred mnemonic is seen in this process.
+/// @brief True the first time @p mnemonic is seen in the current translation.
 ///
 /// @details The warning reports a gap in the translator, which is a property of
 /// the mnemonic and not of any one instruction. Emitting it per instruction says
 /// nothing extra and drowns the log: one RCCL all_reduce run produced 104,831
-/// copies, which is itself a usability problem and buries the diagnostics that
-/// do identify a specific site.
+/// copies, which buries the diagnostics that do identify a specific site.
 ///
-/// The set is process-wide and never pruned. It is bounded by the small list in
-/// is_deferred_gfx1250_family(), so it cannot grow with workload size.
-[[nodiscard]] bool first_report_of_deferred_family(std::string_view mnemonic) {
-  static std::mutex reported_mutex;
-  static std::unordered_set<std::string> reported;
-  const std::lock_guard<std::mutex> lock(reported_mutex);
-  return reported.emplace(mnemonic).second;
+/// The state is owned by the caller and scoped to one translation, so every
+/// code object reports its own gaps. Process-wide state would be wrong here:
+/// HotSwap translates many code objects in one process, and the first one to
+/// use a deferred mnemonic would silence the warning for all the rest.
+///
+/// A null set disables suppression rather than silencing the warning, so a
+/// caller that has nowhere to keep the state still sees every occurrence.
+[[nodiscard]] bool first_report_of_deferred_family(std::unordered_set<std::string> *reported,
+                                                   std::string_view mnemonic) {
+  if (reported == nullptr)
+    return true;
+  return reported->emplace(mnemonic).second;
 }
 
 [[nodiscard]] bool is_wmma_completion_wait(const Instruction &inst) {
@@ -265,7 +268,9 @@ void gfx1250_b0_to_a0_append_wmma_completion_wait_if_needed(
   words.push_back(gfx1250::build_sopp(gfx1250::kSWaitAluSopp, {.simm16 = kWaitVaVdstZero})[0]);
 }
 
-const InstructionLegalization *gfx1250_b0_to_a0_legalization(const Instruction &inst) {
+const InstructionLegalization *
+gfx1250_b0_to_a0_legalization(const Instruction &inst,
+                              std::unordered_set<std::string> *reported_deferred_families) {
   // CLAMP=0 is the common E4M3 operation on both steppings. CLAMP=1 selects
   // the B0-only E5M3 behavior and therefore requires a semantic expansion.
   const std::string_view mnemonic = inst.mnemonic();
@@ -279,9 +284,10 @@ const InstructionLegalization *gfx1250_b0_to_a0_legalization(const Instruction &
   if (!requires_b0_to_a0_expansion(inst.mnemonic()) &&
       !gfx1250_reads_flat_scratch_base_64bit(inst)) {
     // Deferred families pass through unchanged but warn, so the not-yet-handled
-    // case is visible rather than silent. Once per mnemonic: see
-    // is_deferred_gfx1250_family and first_report_of_deferred_family.
-    if (is_deferred_gfx1250_family(mnemonic) && first_report_of_deferred_family(mnemonic))
+    // case is visible rather than silent. Once per mnemonic per translation:
+    // see is_deferred_gfx1250_family and first_report_of_deferred_family.
+    if (is_deferred_gfx1250_family(mnemonic) &&
+        first_report_of_deferred_family(reported_deferred_families, mnemonic))
       util::Logger::warn("gfx1250 translation passes through '", mnemonic,
                          "' unchanged; target-specific handling is not yet implemented");
     return nullptr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.cpp
@@ -16,14 +16,10 @@
 #include "rocjitsu/isa/arch/amdgpu/gfx1250/opcodes.h"
 #include "rocjitsu/isa/instruction.h"
 
-#include "util/log.h"
-
 #include <array>
 #include <cstring>
-#include <string>
 #include <string_view>
 #include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 namespace rocjitsu {
@@ -37,8 +33,8 @@ namespace {
 ///
 /// Separately, a 64-bit source reading FLAT_SCRATCH_BASE is classified via
 /// operand inspection (see gfx1250_reads_flat_scratch_base_64bit), and the
-/// barrier-state and sleep/monitor families are DEFERRED with a pass-through
-/// warning rather than fail-closed (see is_deferred_gfx1250_family).
+/// barrier-state query and s_monitor_sleep are DEFERRED with a pass-through
+/// report rather than fail-closed (see gfx1250_b0_to_a0_is_deferred_family).
 inline constexpr std::array<std::string_view, 17> kExactB0ToA0TranslationMnemonics = {
     "ds_load_2addr_b32",
     "ds_load_2addr_b64",
@@ -148,41 +144,6 @@ inline constexpr std::array<std::string_view, 17> kExactB0ToA0TranslationMnemoni
   return encoding.clamp != 0;
 }
 
-/// @brief True for instruction families whose A0 handling is deferred pending
-/// confirmation of the exact translated set.
-/// @details The barrier-state query and the sleep/monitor families may need
-/// target-specific translation that is not yet implemented. Rather than fail closed
-/// (which would refuse otherwise-translatable kernels that use very common ops
-/// such as s_sleep), these are passed through unchanged for now and a warning is
-/// emitted so the omission is visible. Revisit once the precise set is
-/// confirmed; if translation is required, move the relevant members to
-/// requires_b0_to_a0_expansion() so they fail closed instead.
-[[nodiscard]] bool is_deferred_gfx1250_family(std::string_view mnemonic) {
-  return mnemonic == "s_get_barrier_state" || mnemonic == "s_sleep" || mnemonic == "s_sleep_var" ||
-         mnemonic == "s_monitor_sleep";
-}
-
-/// @brief True the first time @p mnemonic is seen in the current translation.
-///
-/// @details The warning reports a gap in the translator, which is a property of
-/// the mnemonic and not of any one instruction. Emitting it per instruction says
-/// nothing extra and drowns the log: one RCCL all_reduce run produced 104,831
-/// copies, which buries the diagnostics that do identify a specific site.
-///
-/// The state is owned by the caller and scoped to one translation, so every
-/// code object reports its own gaps. Process-wide state would be wrong here:
-/// HotSwap translates many code objects in one process, and the first one to
-/// use a deferred mnemonic would silence the warning for all the rest.
-///
-/// A null set disables suppression rather than silencing the warning, so a
-/// caller that has nowhere to keep the state still sees every occurrence.
-[[nodiscard]] bool first_report_of_deferred_family(std::unordered_set<std::string> *reported,
-                                                   std::string_view mnemonic) {
-  if (reported == nullptr)
-    return true;
-  return reported->emplace(mnemonic).second;
-}
-
 [[nodiscard]] bool is_wmma_completion_wait(const Instruction &inst) {
   if (inst.size() != static_cast<int>(sizeof(uint32_t)) || inst.raw_encoding() == nullptr ||
       inst.mnemonic() != "s_wait_alu")
@@ -268,9 +229,17 @@ void gfx1250_b0_to_a0_append_wmma_completion_wait_if_needed(
   words.push_back(gfx1250::build_sopp(gfx1250::kSWaitAluSopp, {.simm16 = kWaitVaVdstZero})[0]);
 }
 
-const InstructionLegalization *
-gfx1250_b0_to_a0_legalization(const Instruction &inst,
-                              std::unordered_set<std::string> *reported_deferred_families) {
+bool gfx1250_b0_to_a0_is_deferred_family(std::string_view mnemonic) {
+  // s_sleep and s_sleep_var are deliberately absent. They behave identically on
+  // A0 and B0: the only sleep-family A0 erratum is DEGFXMI400-12268, which is
+  // specific to s_monitor_sleep('forever') with MWAIT=0. Copying a plain sleep
+  // through is the correct translation, not an unimplemented one, so reporting
+  // it said nothing and buried the reports that do name a real gap -- one RCCL
+  // all_reduce run emitted 104,831 of them.
+  return mnemonic == "s_get_barrier_state" || mnemonic == "s_monitor_sleep";
+}
+
+const InstructionLegalization *gfx1250_b0_to_a0_legalization(const Instruction &inst) {
   // CLAMP=0 is the common E4M3 operation on both steppings. CLAMP=1 selects
   // the B0-only E5M3 behavior and therefore requires a semantic expansion.
   const std::string_view mnemonic = inst.mnemonic();
@@ -281,15 +250,11 @@ gfx1250_b0_to_a0_legalization(const Instruction &inst,
 
   // Reading FLAT_SCRATCH_BASE through a 64-bit source position is a property of
   // the operand rather than the mnemonic, so it is classified separately.
+  // Deferred families reach here and stay on the copy path. Reporting that
+  // omission is the translation loop's job: see
+  // gfx1250_b0_to_a0_is_deferred_family.
   if (!requires_b0_to_a0_expansion(inst.mnemonic()) &&
       !gfx1250_reads_flat_scratch_base_64bit(inst)) {
-    // Deferred families pass through unchanged but warn, so the not-yet-handled
-    // case is visible rather than silent. Once per mnemonic per translation:
-    // see is_deferred_gfx1250_family and first_report_of_deferred_family.
-    if (is_deferred_gfx1250_family(mnemonic) &&
-        first_report_of_deferred_family(reported_deferred_families, mnemonic))
-      util::Logger::warn("gfx1250 translation passes through '", mnemonic,
-                         "' unchanged; target-specific handling is not yet implemented");
     return nullptr;
   }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.cpp
@@ -20,8 +20,11 @@
 
 #include <array>
 #include <cstring>
+#include <mutex>
+#include <string>
 #include <string_view>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace rocjitsu {
@@ -160,6 +163,23 @@ inline constexpr std::array<std::string_view, 17> kExactB0ToA0TranslationMnemoni
          mnemonic == "s_monitor_sleep";
 }
 
+/// @brief True the first time each deferred mnemonic is seen in this process.
+///
+/// @details The warning reports a gap in the translator, which is a property of
+/// the mnemonic and not of any one instruction. Emitting it per instruction says
+/// nothing extra and drowns the log: one RCCL all_reduce run produced 104,831
+/// copies, which is itself a usability problem and buries the diagnostics that
+/// do identify a specific site.
+///
+/// The set is process-wide and never pruned. It is bounded by the small list in
+/// is_deferred_gfx1250_family(), so it cannot grow with workload size.
+[[nodiscard]] bool first_report_of_deferred_family(std::string_view mnemonic) {
+  static std::mutex reported_mutex;
+  static std::unordered_set<std::string> reported;
+  const std::lock_guard<std::mutex> lock(reported_mutex);
+  return reported.emplace(mnemonic).second;
+}
+
 [[nodiscard]] bool is_wmma_completion_wait(const Instruction &inst) {
   if (inst.size() != static_cast<int>(sizeof(uint32_t)) || inst.raw_encoding() == nullptr ||
       inst.mnemonic() != "s_wait_alu")
@@ -259,8 +279,9 @@ const InstructionLegalization *gfx1250_b0_to_a0_legalization(const Instruction &
   if (!requires_b0_to_a0_expansion(inst.mnemonic()) &&
       !gfx1250_reads_flat_scratch_base_64bit(inst)) {
     // Deferred families pass through unchanged but warn, so the not-yet-handled
-    // case is visible rather than silent. See is_deferred_gfx1250_family.
-    if (is_deferred_gfx1250_family(mnemonic))
+    // case is visible rather than silent. Once per mnemonic: see
+    // is_deferred_gfx1250_family and first_report_of_deferred_family.
+    if (is_deferred_gfx1250_family(mnemonic) && first_report_of_deferred_family(mnemonic))
       util::Logger::warn("gfx1250 translation passes through '", mnemonic,
                          "' unchanged; target-specific handling is not yet implemented");
     return nullptr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.h
@@ -8,7 +8,9 @@
 #define ROCJITSU_CODE_DBT_LEGALIZATION_GFX1250_B0_TO_A0_H_
 
 #include <cstdint>
+#include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace rocjitsu {
@@ -30,7 +32,16 @@ struct InstructionLegalization;
 /// classifier may therefore recognize a complete mnemonic family while the
 /// corresponding semantic rule inspects the precise operand predicate before
 /// changing code.
-[[nodiscard]] const InstructionLegalization *gfx1250_b0_to_a0_legalization(const Instruction &inst);
+///
+/// @param inst The decoded instruction to classify.
+/// @param reported_deferred_families Mnemonics whose deferred-family
+///        pass-through warning has already been emitted for the translation in
+///        progress, updated in place. Each translation should pass its own set
+///        so a code object reports the gap independently of any earlier one.
+///        Passing nullptr emits the warning for every classified instruction.
+[[nodiscard]] const InstructionLegalization *
+gfx1250_b0_to_a0_legalization(const Instruction &inst,
+                              std::unordered_set<std::string> *reported_deferred_families);
 
 /// @brief True when a low-precision B0 WMMA needs an A0 completion wait.
 ///

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.h
@@ -8,9 +8,8 @@
 #define ROCJITSU_CODE_DBT_LEGALIZATION_GFX1250_B0_TO_A0_H_
 
 #include <cstdint>
-#include <string>
+#include <string_view>
 #include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 namespace rocjitsu {
@@ -32,16 +31,27 @@ struct InstructionLegalization;
 /// classifier may therefore recognize a complete mnemonic family while the
 /// corresponding semantic rule inspects the precise operand predicate before
 /// changing code.
+[[nodiscard]] const InstructionLegalization *gfx1250_b0_to_a0_legalization(const Instruction &inst);
+
+/// @brief True for instruction families whose A0 handling is deferred pending
+/// confirmation of the exact translated set.
 ///
-/// @param inst The decoded instruction to classify.
-/// @param reported_deferred_families Mnemonics whose deferred-family
-///        pass-through warning has already been emitted for the translation in
-///        progress, updated in place. Each translation should pass its own set
-///        so a code object reports the gap independently of any earlier one.
-///        Passing nullptr emits the warning for every classified instruction.
-[[nodiscard]] const InstructionLegalization *
-gfx1250_b0_to_a0_legalization(const Instruction &inst,
-                              std::unordered_set<std::string> *reported_deferred_families);
+/// @details The barrier-state query and s_monitor_sleep may need
+/// target-specific translation that is not yet implemented -- the latter
+/// because of DEGFXMI400-12268, where s_monitor_sleep('forever') with MWAIT=0
+/// can hang the wave. Rather than fail closed, they are passed through
+/// unchanged and the caller reports the omission so it is visible rather than
+/// silent. Revisit once the precise set is confirmed; if translation is
+/// required, move the relevant members into the fail-closed classification.
+///
+/// Plain s_sleep and s_sleep_var are NOT members: they behave identically on A0
+/// and B0, so copying them through is the correct translation rather than a
+/// missing one.
+///
+/// The classification is a pure query. Reporting belongs to the translation
+/// loop, which owns both the diagnostic list and the per-translation record of
+/// what it has already reported.
+[[nodiscard]] bool gfx1250_b0_to_a0_is_deferred_family(std::string_view mnemonic);
 
 /// @brief True when a low-precision B0 WMMA needs an A0 completion wait.
 ///

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_flat_scratch_base.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_flat_scratch_base.cpp
@@ -14,8 +14,10 @@
 
 #include <algorithm>
 #include <array>
+#include <cstdint>
 #include <cstring>
 #include <optional>
+#include <span>
 #include <vector>
 
 namespace rocjitsu {
@@ -25,9 +27,14 @@ namespace {
 /// @details Both deliver the whole 64-bit base in a 64-bit source position; the
 /// low selector is the spelling the A0 profile reads. See gfx1250
 /// operand_types.h (OPR_SSRC_SRC_FLAT_SCRATCH_BASE_LO / _HI).
-constexpr int kFlatScratchBaseLo = 230;
-constexpr int kFlatScratchBaseHi = 231;
+constexpr uint32_t kFlatScratchBaseLo = 230;
+constexpr uint32_t kFlatScratchBaseHi = 231;
 constexpr int k64BitOperand = 64;
+
+/// @brief True when an encoding field value names the flat-scratch base.
+[[nodiscard]] bool names_flat_scratch_base(uint32_t value) {
+  return value == kFlatScratchBaseLo || value == kFlatScratchBaseHi;
+}
 
 /// @brief Highest scalar selector usable as an ordinary SGPR source operand.
 /// @details Selectors above this range name architectural values rather than
@@ -98,26 +105,71 @@ void set_word_field(uint32_t &word, uint32_t value, uint32_t shift, uint32_t wid
   word = (word & ~mask) | ((value << shift) & mask);
 }
 
+/// @brief Read one source-operand field out of the instruction words.
+/// @returns The field's value, or nullopt when it lies outside @p words.
+[[nodiscard]] std::optional<uint32_t> read_word_field(std::span<const uint32_t> words,
+                                                      const SourceField &field) {
+  if (field.word >= words.size())
+    return std::nullopt;
+  const uint32_t mask = (uint32_t{1} << field.width) - 1;
+  return (words[field.word] >> field.shift) & mask;
+}
+
+/// @brief Words of the base encoding that a layout's source fields reach into.
+/// @details Derived from the layout rather than tabulated separately so the two
+/// cannot drift apart as encodings are added.
+[[nodiscard]] size_t modelled_word_count(const EncodingSourceFields &layout) {
+  size_t words = 0;
+  for (uint8_t i = 0; i < layout.count; ++i)
+    words = std::max<size_t>(words, static_cast<size_t>(layout.fields[i].word) + 1);
+  return words;
+}
+
 /// @brief True when source operand @p index names the base in a 64-bit position.
 ///
-/// @details The value alone is not decisive. A vector field that indexes the
-/// register file directly can hold the selector's number while meaning an
-/// ordinary register, so the field has to be one that reaches the scalar
-/// encodings before the value is compared.
+/// @details The selector is read from the encoding field, never from the
+/// decoded operand. A literal source reports the literal's *value* through
+/// Operand::encoding_value(), so an ordinary constant of 230 or 231 is
+/// indistinguishable there from the selector; the field itself still reads 255
+/// (literal) or 254 (literal64) and names no register at all. Trusting the
+/// operand rewrites the very field that marks the literal as present, which
+/// leaves its dword behind as a standalone illegal instruction.
+///
+/// The field must also be one that can reach the scalar encodings before its
+/// value means anything. A vector field that indexes the register file directly
+/// can hold the selector's number while naming an ordinary register.
 ///
 /// Operand::is_vgpr() cannot make that distinction: it is a construction-time
 /// capability of the operand *type*, and the ordinary vector source type is
 /// also the one that accepts scalar values, so it reports true for both.
 [[nodiscard]] bool is_flat_scratch_base_64bit_source(const Instruction &inst, int index,
-                                                     const EncodingSourceFields &layout) {
+                                                     const EncodingSourceFields &layout,
+                                                     std::span<const uint32_t> words) {
   const Operand *op = inst.src_operand(index);
   if (op == nullptr || op->size_bits() != k64BitOperand)
     return false;
   const SourceField &field = layout.fields[static_cast<size_t>(index)];
   if (layout.vector && field.width != kSelectorCapableVectorFieldWidth)
     return false;
-  const int value = op->encoding_value();
-  return value == kFlatScratchBaseLo || value == kFlatScratchBaseHi;
+  const std::optional<uint32_t> encoded = read_word_field(words, field);
+  return encoded.has_value() && names_flat_scratch_base(*encoded);
+}
+
+/// @brief True when @p op is a decoded literal rather than a named operand.
+///
+/// @details Used only by the conservative scans below, which have no field
+/// layout to read and so must fall back to the operand. It recognizes the
+/// 64-bit literal form, the only one the shared Operand interface exposes; a
+/// 32-bit literal widened into a 64-bit source position is indistinguishable
+/// from a selector by value alone. That residual gap is why the modelled
+/// encodings above read the encoding field instead of asking here, and it can
+/// only cause a refusal, never a miscompile.
+///
+/// TODO: close the gap with a generic immediate predicate on Operand, set from
+/// the per-arch is_immediate_type() the way is_vgpr_ already is. That is a
+/// change to the amdisa codegen templates and every generated arch.
+[[nodiscard]] bool is_decoded_literal(const Operand &op) {
+  return op.literal64_value().has_value();
 }
 
 /// @brief Copy the instruction's words from the authoritative source image.
@@ -152,8 +204,10 @@ instruction_words(const Instruction &inst, uint64_t offset, std::span<const uint
     const Operand *op = inst.src_operand(i);
     if (op == nullptr || op->is_vgpr() || op->size_bits() != k64BitOperand)
       continue;
+    if (is_decoded_literal(*op))
+      continue;
     const int value = op->encoding_value();
-    if (value == kFlatScratchBaseLo || value == kFlatScratchBaseHi)
+    if (value >= 0 && names_flat_scratch_base(static_cast<uint32_t>(value)))
       return true;
   }
   return false;
@@ -175,8 +229,10 @@ instruction_words(const Instruction &inst, uint64_t offset, std::span<const uint
     const Operand *op = inst.src_operand(i);
     if (op == nullptr || op->is_vgpr() || op->size_bits() != k64BitOperand)
       continue;
+    if (is_decoded_literal(*op))
+      continue;
     const int value = op->encoding_value();
-    if (value == kFlatScratchBaseLo || value == kFlatScratchBaseHi)
+    if (value >= 0 && names_flat_scratch_base(static_cast<uint32_t>(value)))
       return true;
   }
   return false;
@@ -193,9 +249,15 @@ bool gfx1250_reads_flat_scratch_base_64bit(const Instruction &inst) {
   // than let it reach the copy path unexamined.
   if (!layout)
     return instruction_names_selector_in_any_64bit_source(inst);
+  // Only the base encoding is read here. Every modelled source field lies
+  // inside it, so the decoded size bounds the span without depending on
+  // whether raw_encoding() also addresses trailing literal or modifier words.
+  const size_t available =
+      inst.size() > 0 ? static_cast<size_t>(inst.size()) / sizeof(uint32_t) : 0;
+  const std::span<const uint32_t> words(raw, std::min(modelled_word_count(*layout), available));
   const int sources = std::min(inst.num_src_operands(), static_cast<int>(layout->count));
   for (int i = 0; i < sources; ++i) {
-    if (is_flat_scratch_base_64bit_source(inst, i, *layout))
+    if (is_flat_scratch_base_64bit_source(inst, i, *layout, words))
       return true;
   }
   return false;
@@ -229,7 +291,7 @@ ExpandResult gfx1250_lower_flat_scratch_base_source(const Instruction &inst, uin
   std::vector<uint32_t> prologue;
   std::optional<uint16_t> borrowed_pair;
   for (int i = 0; i < rewritable; ++i) {
-    if (!is_flat_scratch_base_64bit_source(inst, i, *layout))
+    if (!is_flat_scratch_base_64bit_source(inst, i, *layout, *words))
       continue;
 
     const SourceField &field = layout->fields[static_cast<size_t>(i)];

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_flat_scratch_base.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_flat_scratch_base.h
@@ -27,7 +27,10 @@ class LivenessAnalysis;
 /// for vector reads, so both cases need an operand rewrite.
 ///
 /// Detection is operand-driven rather than opcode-driven: any instruction with
-/// a 64-bit source position can name these selectors.
+/// a 64-bit source position can name these selectors. The selector is matched
+/// against the encoding field, not the decoded operand value: a literal source
+/// reports its own value there, so the constants 230 and 231 would otherwise be
+/// mistaken for the selectors they collide with.
 [[nodiscard]] bool gfx1250_reads_flat_scratch_base_64bit(const Instruction &inst);
 
 /// @brief Rewrite a 64-bit FLAT_SCRATCH_BASE source for the A0 profile.

--- a/emulation/rocjitsu/tests/dbt/gfx1250_b0_to_a0_library_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/gfx1250_b0_to_a0_library_test.cpp
@@ -112,9 +112,10 @@ TEST(Gfx1250B0ToA0Library, ReportsInvalidCodeObjectDiagnostic) {
 // BinaryTranslatorE2E.ExpandLegalizationWithoutSemanticRuleFails (cdna4-to-cdna3,
 // tests/dbt/translate_test.cpp), where an Expand legalization without a rule is
 // reachable, and the reported kind and its required-work field by
-// HsaHotswapHookTest.RendersRequiredWorkDiagnostic, which feeds a synthetic
-// diagnostic straight through the rendering seam. Add a fixture here if a
-// gfx1250 mnemonic is ever classified fail-closed ahead of its rule.
+// FansOutRequiredWorkAsCallbackViews below and
+// HsaHotswapHookTest.RendersRequiredWorkDiagnostic, both of which feed a
+// synthetic diagnostic straight through the reporting seam. Add a fixture here
+// if a gfx1250 mnemonic is ever classified fail-closed ahead of its rule.
 TEST(Gfx1250B0ToA0Library, ReportsTranslatorDiagnostics) {
   rocjitsu::gfx1250::Vop3VopDpp16MachineInst dpp{};
   dpp.vdst = 30;
@@ -222,6 +223,44 @@ TEST(Gfx1250B0ToA0Library, FansOutRequiredWorkAsCallbackViews) {
   }
   EXPECT_EQ(captured[1].message, "first required step");
   EXPECT_EQ(captured[2].message, "second required step");
+}
+
+// Diagnostics are not only a failure channel. A translation can succeed and
+// still have something to report -- here a family passed through unchanged
+// because its A0 handling is not implemented yet -- and reporting only on the
+// undispatchable path would drop it. That gap is what someone triaging a
+// misbehaving kernel reads these diagnostics for, so it has to reach the
+// callback on the success path too.
+TEST(Gfx1250B0ToA0Library, ReportsDeferredFamilyDiagnosticOnSuccessfulTranslation) {
+  constexpr auto deferred =
+      rocjitsu::gfx1250::build_sopp(rocjitsu::gfx1250::kSMonitorSleepSopp, {.simm16 = 1});
+  constexpr uint32_t kEndpgm = 0xBFB00000u;
+  const std::array<uint32_t, 3> text = {deferred[0], deferred[0], kEndpgm};
+  const auto source = rocjitsu::test_support::make_gfx1250_code_object(text);
+  uint8_t *output = nullptr;
+  size_t output_size = 0;
+  rj_gfx1250_b0_to_a0_translation_info_t info{};
+  std::vector<CapturedDiagnostic> diagnostics;
+
+  ASSERT_EQ(rj_gfx1250_b0_to_a0_translate(source.data(), source.size(), &output, &output_size,
+                                          &info, capture_diagnostic, &diagnostics),
+            ROCJITSU_STATUS_SUCCESS);
+  EXPECT_NE(output, nullptr);
+  rj_gfx1250_b0_to_a0_free(output);
+
+  const auto reported = std::find_if(diagnostics.begin(), diagnostics.end(), [](const auto &item) {
+    return item.severity == "warning" && item.kind == "translator-legalization" &&
+           item.mnemonic == "s_monitor_sleep";
+  });
+  ASSERT_NE(reported, diagnostics.end())
+      << "a successful translation must still report the pass-through gap";
+  EXPECT_NE(reported->message.find("not yet implemented"), std::string::npos);
+
+  // Two instructions, one report: the gap is a property of the mnemonic.
+  const auto count = std::count_if(diagnostics.begin(), diagnostics.end(), [](const auto &item) {
+    return item.mnemonic == "s_monitor_sleep";
+  });
+  EXPECT_EQ(count, 1);
 }
 
 #ifdef GFX1250_B0_TO_A0_FIXTURE

--- a/emulation/rocjitsu/tests/dbt/gfx1250_b0_to_a0_library_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/gfx1250_b0_to_a0_library_test.cpp
@@ -98,6 +98,23 @@ TEST(Gfx1250B0ToA0Library, ReportsInvalidCodeObjectDiagnostic) {
   EXPECT_NE(matching, diagnostics.end());
 }
 
+// This fixture covers the rule-refused path (`translator-expand-failed`): a
+// rule exists for v_cvt_pk_fp8_f32 but declines the DPP operand form.
+//
+// The sibling `translator-expand-missing` kind -- classified as needing an
+// expansion with no rule registered at all -- has no end-to-end gfx1250 fixture
+// because no gfx1250 mnemonic can currently reach it. Every branch of
+// requires_b0_to_a0_expansion() has a matching entry in
+// semantic_expand_rules_gfx1250_b0_to_a0(), and the operand-driven
+// flat-scratch-base path answers Success or Failed but never NotHandled.
+//
+// It is still covered on both sides of that gap: the translator behavior by
+// BinaryTranslatorE2E.ExpandLegalizationWithoutSemanticRuleFails (cdna4-to-cdna3,
+// tests/dbt/translate_test.cpp), where an Expand legalization without a rule is
+// reachable, and the reported kind and its required-work field by
+// HsaHotswapHookTest.RendersRequiredWorkDiagnostic, which feeds a synthetic
+// diagnostic straight through the rendering seam. Add a fixture here if a
+// gfx1250 mnemonic is ever classified fail-closed ahead of its rule.
 TEST(Gfx1250B0ToA0Library, ReportsTranslatorDiagnostics) {
   rocjitsu::gfx1250::Vop3VopDpp16MachineInst dpp{};
   dpp.vdst = 30;

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -16263,6 +16263,143 @@ TEST(BinaryTranslatorE2E, Gfx1250LeavesLiteralMatchingSelectorNumberUnchangedFor
   }
 }
 
+// The cases above all put their source fields in word 0. VOP3 puts them in word
+// 1 and its literal in word 2, so it is the only layout where the field being
+// rewritten and the literal that must survive live in different words.
+//
+// Both sources here read 231: src0 genuinely names the selector, while src1 is
+// an ordinary literal that merely collides with its number. The two must be
+// treated differently in a single instruction -- src0 repointed at the borrowed
+// pair, src1 and its trailing dword untouched.
+TEST(BinaryTranslatorE2E, Gfx1250RewritesVop3SelectorButKeepsCollidingLiteralForA0) {
+  constexpr uint32_t kLiteralSelector = 255;
+  const auto source = gfx1250::build_vop3(
+      gfx1250::kVMulU64Vop3,
+      {.vdst = 10, .src0 = kFlatScratchBaseHiSelector, .src1 = kLiteralSelector});
+  const auto out =
+      translate_gfx1250_b0_to_a0_words({source[0], source[1], kFlatScratchBaseHiSelector});
+  ASSERT_GE(out.size(), 5u) << "the rewrite prepends one scalar move and keeps four words";
+
+  ASSERT_EQ((out[0] >> 23) & 0x1ffu, 381u) << "prologue must be a SOP1 instruction";
+  EXPECT_EQ(out[0] & 0xffu, kFlatScratchBaseLoSelector);
+  const uint32_t pair_base = (out[0] >> 16) & 0x7fu;
+  EXPECT_EQ(pair_base % 2u, 0u) << "a 64-bit scalar operand must be even-aligned";
+
+  EXPECT_EQ(out[1], source[0]) << "vdst, opcode, and modifiers are unchanged";
+  EXPECT_EQ(out[2] & 0x1ffu, pair_base) << "the real selector must name the borrowed pair";
+  EXPECT_EQ((out[2] >> 9) & 0x1ffu, kLiteralSelector)
+      << "the literal marker must survive, or its dword becomes an instruction";
+  EXPECT_EQ(out[3], kFlatScratchBaseHiSelector) << "the literal dword itself is unchanged";
+  EXPECT_EQ(out.size(), 5u) << "only the prologue is added";
+}
+
+namespace {
+
+/// @brief Run one gfx1250 B0-to-A0 translation and return what it wrote to
+/// stderr. The deferred-family warning goes through util::Logger, which emits
+/// to std::cerr with no redirection hook, so the buffer is swapped instead.
+[[nodiscard]] std::string translate_gfx1250_b0_to_a0_capturing_stderr(std::vector<uint32_t> words) {
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  words.push_back(kGfx1250SEndpgm);
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+
+  std::ostringstream captured;
+  std::streambuf *previous = std::cerr.rdbuf(captured.rdbuf());
+  const auto result = translator.translate(source);
+  std::cerr.rdbuf(previous);
+  EXPECT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+  return captured.str();
+}
+
+/// @brief Count non-overlapping occurrences of @p needle in @p haystack.
+[[nodiscard]] size_t count_occurrences(std::string_view haystack, std::string_view needle) {
+  size_t count = 0;
+  for (size_t pos = haystack.find(needle); pos != std::string_view::npos;
+       pos = haystack.find(needle, pos + needle.size())) {
+    ++count;
+  }
+  return count;
+}
+
+} // namespace
+
+// A deferred family passes through unchanged and warns so the gap stays
+// visible. The warning describes the mnemonic, not the site, so repeating it
+// per instruction adds nothing: one RCCL all_reduce run emitted 104,831 copies.
+TEST(BinaryTranslatorE2E, Gfx1250WarnsOncePerDeferredMnemonicWithinOneTranslation) {
+  const uint32_t sleep = gfx1250::build_sopp(gfx1250::kSSleepSopp, {.simm16 = 1})[0];
+  const std::string log =
+      translate_gfx1250_b0_to_a0_capturing_stderr({sleep, sleep, sleep, sleep, sleep});
+
+  EXPECT_EQ(count_occurrences(log, "'s_sleep'"), 1u)
+      << "five s_sleep instructions must produce one warning, not five:\n"
+      << log;
+}
+
+// Distinct deferred mnemonics are distinct gaps, so suppressing one must not
+// suppress another.
+TEST(BinaryTranslatorE2E, Gfx1250WarnsSeparatelyForEachDeferredMnemonic) {
+  const uint32_t sleep = gfx1250::build_sopp(gfx1250::kSSleepSopp, {.simm16 = 1})[0];
+  const uint32_t monitor_sleep = gfx1250::build_sopp(gfx1250::kSMonitorSleepSopp, {.simm16 = 1})[0];
+  const std::string log =
+      translate_gfx1250_b0_to_a0_capturing_stderr({sleep, monitor_sleep, sleep, monitor_sleep});
+
+  EXPECT_EQ(count_occurrences(log, "'s_sleep'"), 1u) << log;
+  EXPECT_EQ(count_occurrences(log, "'s_monitor_sleep'"), 1u) << log;
+}
+
+// The suppression is scoped to one translation. Process-wide state would let
+// the first code object that uses a deferred mnemonic hide the same gap in
+// every object loaded afterwards, which is exactly how HotSwap runs: many code
+// objects translated in one process.
+TEST(BinaryTranslatorE2E, Gfx1250WarnsAgainForEachSeparateTranslation) {
+  const uint32_t sleep = gfx1250::build_sopp(gfx1250::kSSleepSopp, {.simm16 = 1})[0];
+  const std::string first = translate_gfx1250_b0_to_a0_capturing_stderr({sleep, sleep});
+  const std::string second = translate_gfx1250_b0_to_a0_capturing_stderr({sleep, sleep});
+
+  EXPECT_EQ(count_occurrences(first, "'s_sleep'"), 1u) << first;
+  EXPECT_EQ(count_occurrences(second, "'s_sleep'"), 1u)
+      << "a second code object must report the gap independently:\n"
+      << second;
+}
+
+// A translator instance reused across code objects must behave the same way,
+// since the state lives on the translator rather than in a local.
+TEST(BinaryTranslatorE2E, Gfx1250WarnsAgainWhenOneTranslatorIsReused) {
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  const uint32_t sleep = gfx1250::build_sopp(gfx1250::kSSleepSopp, {.simm16 = 1})[0];
+  auto image =
+      rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text({sleep, sleep, kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+
+  std::array<std::string, 2> logs;
+  for (std::string &log : logs) {
+    std::ostringstream captured;
+    std::streambuf *previous = std::cerr.rdbuf(captured.rdbuf());
+    const auto result = translator.translate(source);
+    std::cerr.rdbuf(previous);
+    EXPECT_TRUE(result.ok());
+    log = captured.str();
+  }
+
+  EXPECT_EQ(count_occurrences(logs[0], "'s_sleep'"), 1u) << logs[0];
+  EXPECT_EQ(count_occurrences(logs[1], "'s_sleep'"), 1u)
+      << "translate() must reset the per-translation suppression state:\n"
+      << logs[1];
+}
+
 // A vector 64-bit read cannot name the selector on A0, so the base is moved
 // into a dead SGPR pair and the source position is repointed at that pair.
 TEST(BinaryTranslatorE2E, Gfx1250MovesVectorFlatScratchBase64BitSourceToSgprPairForA0) {

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -16295,109 +16295,147 @@ TEST(BinaryTranslatorE2E, Gfx1250RewritesVop3SelectorButKeepsCollidingLiteralFor
 
 namespace {
 
-/// @brief Run one gfx1250 B0-to-A0 translation and return what it wrote to
-/// stderr. The deferred-family warning goes through util::Logger, which emits
-/// to std::cerr with no redirection hook, so the buffer is swapped instead.
-[[nodiscard]] std::string translate_gfx1250_b0_to_a0_capturing_stderr(std::vector<uint32_t> words) {
+/// @brief Mnemonics reported once per translation for a deferred family, in the
+/// order the translation reported them.
+///
+/// The report is an ordinary translation diagnostic, so it reaches the library
+/// callback and the hotswap renderer alongside every other one. Reading it back
+/// off the result needs no stream redirection.
+[[nodiscard]] std::vector<std::string>
+deferred_family_reports(const rocjitsu::TranslatedCodeObject &result) {
+  std::vector<std::string> reported;
+  for (const auto &diagnostic : result.diagnostics) {
+    if (diagnostic.severity == rocjitsu::DiagnosticSeverity::Warning &&
+        diagnostic.kind == rocjitsu::DiagnosticKind::Legalization &&
+        diagnostic.message.find("target-specific handling is not yet implemented") !=
+            std::string::npos) {
+      reported.push_back(diagnostic.mnemonic);
+    }
+  }
+  return reported;
+}
+
+/// @brief Translate a single-kernel gfx1250 object with the B0-to-A0 profile.
+[[nodiscard]] rocjitsu::TranslatedCodeObject
+translate_gfx1250_b0_to_a0_result(rocjitsu::BinaryTranslator &translator,
+                                  std::vector<uint32_t> words) {
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
   words.push_back(kGfx1250SEndpgm);
   auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
   rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  auto result = translator.translate(source);
+  EXPECT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+  return result;
+}
 
-  rocjitsu::BinaryTranslator translator(
+[[nodiscard]] rocjitsu::BinaryTranslator make_gfx1250_b0_to_a0_translator() {
+  return rocjitsu::BinaryTranslator(
       ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
       gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
                                rocjitsu::ProcessorRevision::Gfx1250A0));
-
-  std::ostringstream captured;
-  std::streambuf *previous = std::cerr.rdbuf(captured.rdbuf());
-  const auto result = translator.translate(source);
-  std::cerr.rdbuf(previous);
-  EXPECT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
-                                                          : result.diagnostics.front().message);
-  return captured.str();
 }
 
-/// @brief Count non-overlapping occurrences of @p needle in @p haystack.
-[[nodiscard]] size_t count_occurrences(std::string_view haystack, std::string_view needle) {
-  size_t count = 0;
-  for (size_t pos = haystack.find(needle); pos != std::string_view::npos;
-       pos = haystack.find(needle, pos + needle.size())) {
-    ++count;
-  }
-  return count;
+/// @brief An s_monitor_sleep, whose A0 handling is deferred (DEGFXMI400-12268).
+[[nodiscard]] uint32_t gfx1250_deferred_word() {
+  return gfx1250::build_sopp(gfx1250::kSMonitorSleepSopp, {.simm16 = 1})[0];
 }
 
 } // namespace
 
-// A deferred family passes through unchanged and warns so the gap stays
-// visible. The warning describes the mnemonic, not the site, so repeating it
-// per instruction adds nothing: one RCCL all_reduce run emitted 104,831 copies.
-TEST(BinaryTranslatorE2E, Gfx1250WarnsOncePerDeferredMnemonicWithinOneTranslation) {
-  const uint32_t sleep = gfx1250::build_sopp(gfx1250::kSSleepSopp, {.simm16 = 1})[0];
-  const std::string log =
-      translate_gfx1250_b0_to_a0_capturing_stderr({sleep, sleep, sleep, sleep, sleep});
+// A deferred family passes through unchanged and is reported so the gap stays
+// visible. The report describes the mnemonic, not the site, so repeating it per
+// instruction adds nothing: one RCCL all_reduce run emitted 104,831 copies.
+TEST(BinaryTranslatorE2E, Gfx1250ReportsOncePerDeferredMnemonicWithinOneTranslation) {
+  const uint32_t deferred = gfx1250_deferred_word();
+  auto translator = make_gfx1250_b0_to_a0_translator();
+  const auto result = translate_gfx1250_b0_to_a0_result(
+      translator, {deferred, deferred, deferred, deferred, deferred});
 
-  EXPECT_EQ(count_occurrences(log, "'s_sleep'"), 1u)
-      << "five s_sleep instructions must produce one warning, not five:\n"
-      << log;
+  EXPECT_EQ(deferred_family_reports(result), (std::vector<std::string>{"s_monitor_sleep"}))
+      << "five deferred instructions must produce one diagnostic, not five";
 }
 
 // Distinct deferred mnemonics are distinct gaps, so suppressing one must not
 // suppress another.
-TEST(BinaryTranslatorE2E, Gfx1250WarnsSeparatelyForEachDeferredMnemonic) {
-  const uint32_t sleep = gfx1250::build_sopp(gfx1250::kSSleepSopp, {.simm16 = 1})[0];
-  const uint32_t monitor_sleep = gfx1250::build_sopp(gfx1250::kSMonitorSleepSopp, {.simm16 = 1})[0];
-  const std::string log =
-      translate_gfx1250_b0_to_a0_capturing_stderr({sleep, monitor_sleep, sleep, monitor_sleep});
+TEST(BinaryTranslatorE2E, Gfx1250ReportsSeparatelyForEachDeferredMnemonic) {
+  const uint32_t deferred = gfx1250_deferred_word();
+  const uint32_t barrier_state =
+      gfx1250::build_sop1(gfx1250::kSGetBarrierStateSop1, {.ssrc0 = 0, .sdst = 0})[0];
+  auto translator = make_gfx1250_b0_to_a0_translator();
+  const auto result = translate_gfx1250_b0_to_a0_result(
+      translator, {deferred, barrier_state, deferred, barrier_state});
 
-  EXPECT_EQ(count_occurrences(log, "'s_sleep'"), 1u) << log;
-  EXPECT_EQ(count_occurrences(log, "'s_monitor_sleep'"), 1u) << log;
+  auto reported = deferred_family_reports(result);
+  std::ranges::sort(reported);
+  EXPECT_EQ(reported, (std::vector<std::string>{"s_get_barrier_state", "s_monitor_sleep"}));
 }
 
 // The suppression is scoped to one translation. Process-wide state would let
 // the first code object that uses a deferred mnemonic hide the same gap in
 // every object loaded afterwards, which is exactly how HotSwap runs: many code
 // objects translated in one process.
-TEST(BinaryTranslatorE2E, Gfx1250WarnsAgainForEachSeparateTranslation) {
-  const uint32_t sleep = gfx1250::build_sopp(gfx1250::kSSleepSopp, {.simm16 = 1})[0];
-  const std::string first = translate_gfx1250_b0_to_a0_capturing_stderr({sleep, sleep});
-  const std::string second = translate_gfx1250_b0_to_a0_capturing_stderr({sleep, sleep});
+TEST(BinaryTranslatorE2E, Gfx1250ReportsAgainForEachSeparateTranslation) {
+  const uint32_t deferred = gfx1250_deferred_word();
+  auto first_translator = make_gfx1250_b0_to_a0_translator();
+  auto second_translator = make_gfx1250_b0_to_a0_translator();
+  const auto first = translate_gfx1250_b0_to_a0_result(first_translator, {deferred, deferred});
+  const auto second = translate_gfx1250_b0_to_a0_result(second_translator, {deferred, deferred});
 
-  EXPECT_EQ(count_occurrences(first, "'s_sleep'"), 1u) << first;
-  EXPECT_EQ(count_occurrences(second, "'s_sleep'"), 1u)
-      << "a second code object must report the gap independently:\n"
-      << second;
+  EXPECT_EQ(deferred_family_reports(first), (std::vector<std::string>{"s_monitor_sleep"}));
+  EXPECT_EQ(deferred_family_reports(second), (std::vector<std::string>{"s_monitor_sleep"}))
+      << "a second code object must report the gap independently";
 }
 
 // A translator instance reused across code objects must behave the same way,
 // since the state lives on the translator rather than in a local.
-TEST(BinaryTranslatorE2E, Gfx1250WarnsAgainWhenOneTranslatorIsReused) {
-  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
-  const uint32_t sleep = gfx1250::build_sopp(gfx1250::kSSleepSopp, {.simm16 = 1})[0];
-  auto image =
-      rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text({sleep, sleep, kGfx1250SEndpgm});
-  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+TEST(BinaryTranslatorE2E, Gfx1250ReportsAgainWhenOneTranslatorIsReused) {
+  const uint32_t deferred = gfx1250_deferred_word();
+  auto translator = make_gfx1250_b0_to_a0_translator();
+  const auto first = translate_gfx1250_b0_to_a0_result(translator, {deferred, deferred});
+  const auto second = translate_gfx1250_b0_to_a0_result(translator, {deferred, deferred});
 
-  rocjitsu::BinaryTranslator translator(
-      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
-      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
-                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  EXPECT_EQ(deferred_family_reports(first), (std::vector<std::string>{"s_monitor_sleep"}));
+  EXPECT_EQ(deferred_family_reports(second), (std::vector<std::string>{"s_monitor_sleep"}))
+      << "translate() must reset the per-translation suppression state";
+}
 
-  std::array<std::string, 2> logs;
-  for (std::string &log : logs) {
-    std::ostringstream captured;
-    std::streambuf *previous = std::cerr.rdbuf(captured.rdbuf());
-    const auto result = translator.translate(source);
-    std::cerr.rdbuf(previous);
-    EXPECT_TRUE(result.ok());
-    log = captured.str();
+// The report points at the first instruction of the family so a reader can find
+// one, and carries the mnemonic so callback consumers can group by gap.
+TEST(BinaryTranslatorE2E, Gfx1250DeferredFamilyReportCarriesOffsetAndMnemonic) {
+  constexpr uint32_t kGfx1250SNop = 0xBF800000u;
+  const uint32_t deferred = gfx1250_deferred_word();
+  auto translator = make_gfx1250_b0_to_a0_translator();
+  const auto result =
+      translate_gfx1250_b0_to_a0_result(translator, {kGfx1250SNop, deferred, deferred});
+
+  const auto reported = std::ranges::find_if(result.diagnostics, [](const auto &diagnostic) {
+    return diagnostic.mnemonic == "s_monitor_sleep";
+  });
+  ASSERT_NE(reported, result.diagnostics.end());
+  EXPECT_EQ(reported->severity, rocjitsu::DiagnosticSeverity::Warning);
+  EXPECT_EQ(reported->guest_offset, std::optional<uint64_t>(sizeof(uint32_t)))
+      << "the offset must name the first deferred instruction, not the s_nop before it";
+}
+
+// s_sleep and s_sleep_var behave identically on A0 and B0. The only sleep-family
+// A0 erratum, DEGFXMI400-12268, is specific to s_monitor_sleep('forever') with
+// MWAIT=0. Copying a plain sleep through is therefore the correct translation,
+// not an unimplemented one, and reporting it drowned the reports that do name a
+// real gap: one RCCL all_reduce run emitted 104,831 of them.
+TEST(BinaryTranslatorE2E, Gfx1250CopiesPlainSleepWithoutReportingAGap) {
+  const std::vector<uint32_t> sleeps = {
+      gfx1250::build_sopp(gfx1250::kSSleepSopp, {.simm16 = 1})[0],
+      gfx1250::build_sop1(gfx1250::kSSleepVarSop1, {.ssrc0 = 0})[0],
+  };
+  auto translator = make_gfx1250_b0_to_a0_translator();
+  const auto result = translate_gfx1250_b0_to_a0_result(translator, sleeps);
+
+  EXPECT_TRUE(deferred_family_reports(result).empty())
+      << "a plain sleep translates correctly and must not be reported as a gap";
+  for (const auto &diagnostic : result.diagnostics) {
+    EXPECT_EQ(diagnostic.severity, rocjitsu::DiagnosticSeverity::Warning) << diagnostic.message;
   }
-
-  EXPECT_EQ(count_occurrences(logs[0], "'s_sleep'"), 1u) << logs[0];
-  EXPECT_EQ(count_occurrences(logs[1], "'s_sleep'"), 1u)
-      << "translate() must reset the per-translation suppression state:\n"
-      << logs[1];
 }
 
 // A vector 64-bit read cannot name the selector on A0, so the base is moved

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -16210,6 +16210,59 @@ TEST(BinaryTranslatorE2E, Gfx1250LeavesCompactVgprMatchingSelectorNumberUnchange
   }
 }
 
+// A literal source reports the literal's own value as its encoding value, so
+// the constants 230 and 231 collide numerically with the two selectors. Reading
+// the operand instead of the encoding field mistakes such a constant for the
+// base, and rewriting the field then erases the marker that says a literal
+// follows -- stranding its dword as a standalone illegal instruction.
+//
+// The first VOP2 case is the RCCL all_reduce_perf kernel that first exposed
+// this: `v_mul_u64_e32 v[10:11], 0xe7, v[0:1]`, words 0x541400ff 0x000000e7.
+TEST(BinaryTranslatorE2E, Gfx1250LeavesLiteralMatchingSelectorNumberUnchangedForA0) {
+  struct LiteralCase {
+    const char *name;
+    std::vector<uint32_t> words;
+  };
+  constexpr uint32_t kLiteralSelector = 255;
+  constexpr uint32_t kLiteral64Selector = 254;
+  const std::vector<LiteralCase> cases = {
+      // The reported reproducer, and its twin on the other colliding constant.
+      {"vop2 literal 0xe7",
+       {gfx1250::build_vop2(gfx1250::kVMulU64Vop2,
+                            {.src0 = kLiteralSelector, .vsrc1 = 0, .vdst = 10})[0],
+        kFlatScratchBaseHiSelector}},
+      {"vop2 literal 0xe6",
+       {gfx1250::build_vop2(gfx1250::kVMulU64Vop2,
+                            {.src0 = kLiteralSelector, .vsrc1 = 0, .vdst = 10})[0],
+        kFlatScratchBaseLoSelector}},
+      // The scalar path rewrites the selector in place, so a stale literal there
+      // keeps the instruction's size and changes only what it reads: a silent
+      // wrong answer alongside the orphaned dword.
+      {"sop1 literal 0xe7",
+       {gfx1250::build_sop1(gfx1250::kSMovB64Sop1,
+                            {.ssrc0 = static_cast<uint8_t>(kLiteralSelector), .sdst = 0})[0],
+        kFlatScratchBaseHiSelector}},
+      // A 64-bit literal reports only its low dword as the encoding value, so it
+      // collides the same way while stranding two dwords rather than one.
+      {"vop2 literal64 low dword 0xe7",
+       {gfx1250::build_vop2(gfx1250::kVMulU64Vop2,
+                            {.src0 = kLiteral64Selector, .vsrc1 = 0, .vdst = 10})[0],
+        kFlatScratchBaseHiSelector, 1u}},
+  };
+  for (const LiteralCase &test_case : cases) {
+    SCOPED_TRACE(test_case.name);
+    const auto out = translate_gfx1250_b0_to_a0_words(test_case.words);
+    ASSERT_GE(out.size(), test_case.words.size() + 1u);
+
+    for (size_t i = 0; i < test_case.words.size(); ++i) {
+      EXPECT_EQ(out[i], test_case.words[i])
+          << "word " << i << " of a literal-source instruction must be copied verbatim";
+    }
+    EXPECT_EQ(out.size(), test_case.words.size() + 1u)
+        << "no prologue may be prepended for a literal that is not the selector";
+  }
+}
+
 // A vector 64-bit read cannot name the selector on A0, so the base is moved
 // into a dead SGPR pair and the source position is repointed at that pair.
 TEST(BinaryTranslatorE2E, Gfx1250MovesVectorFlatScratchBase64BitSourceToSgprPairForA0) {


### PR DESCRIPTION
The B0-to-A0 flat-scratch-base rewrite detected its selector by asking the decoded operand for its encoding value. For a literal source the gfx1250 decoder stores the literal's *value* there, so the ordinary constants 230 and 231 were indistinguishable from SRC_FLAT_SCRATCH_BASE_LO / _HI.

Rewriting the source field of such an instruction overwrites the 255 (or 254) that marks a trailing literal as present. The literal dword is then no longer consumed as an operand and the wave executes it. On gfx1250 the constant 0xe7 is not a valid encoding, so this raises HSA_STATUS_ERROR_ILLEGAL_INSTRUCTION.

The RCCL test kernel prepareInput2<float, ReduceSum> hits this eight times with v_mul_u64_e32 v[10:11], 0xe7, v[0:1] (words 541400ff 000000e7), which crashed every RCCL collective on gfx1250 A0 unless HSA_HOTSWAP_DISABLE=1 was set.

Match the selector against the encoding field instead. A literal field reads 255 or 254 and no longer matches, while a genuine selector still does. The two conservative scans for encodings with no modelled field layout keep using the operand, since they have nothing else to read; they now skip 64-bit literals, and a residual gap there can only cause a refusal rather than a miscompile.

Note the scalar path was affected more quietly than the vector one: it rewrites the selector in place, so a case such as s_mov_b64 s[0:1], 0xe7 kept its size and changed only what it read.

Separately, emit the deferred-family pass-through warning once per mnemonic rather than once per instruction. One RCCL all_reduce run produced 104,831 copies of the s_sleep warning, which buried the diagnostics that do name a specific site.

Verified on gfx1250 A0 with the all_reduce_perf binary and rccl_test_gfx1250.kpack from the matching test package: all_reduce_perf failed 10/10 runs with ILLEGAL_INSTRUCTION before, and passes 10/10 with zero wrong values after. A full 8 B to 128 MB sweep also passes. llvm-objdump reports zero invalid encodings in the translated object, and the eight v_mul_u64_e32 sites keep their original literal form.

The new regression test fails without the rewrite change.

Also fixes the stale diagnostic test to make ci pass.

Fixes [ROCM-29198]

[ROCM-29198]: https://amd-hub.atlassian.net/browse/ROCM-29198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ