### PR TITLE
[release/therock-10.0][rocjitsu] Backport gfx1250 literal/FLAT_SCRATCH_BASE fix

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.cpp
@@ -20,8 +20,11 @@
 
 #include <array>
 #include <cstring>
+#include <mutex>
+#include <string>
 #include <string_view>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace rocjitsu {
@@ -170,6 +173,23 @@ inline constexpr std::array<std::string_view, 17> kExactB0ToA0TranslationMnemoni
          mnemonic == "s_monitor_sleep";
 }
 
+/// @brief True the first time each deferred mnemonic is seen in this process.
+///
+/// @details The warning reports a gap in the translator, which is a property of
+/// the mnemonic and not of any one instruction. Emitting it per instruction says
+/// nothing extra and drowns the log: one RCCL all_reduce run produced 104,831
+/// copies, which is itself a usability problem and buries the diagnostics that
+/// do identify a specific site.
+///
+/// The set is process-wide and never pruned. It is bounded by the small list in
+/// is_deferred_gfx1250_family(), so it cannot grow with workload size.
+[[nodiscard]] bool first_report_of_deferred_family(std::string_view mnemonic) {
+  static std::mutex reported_mutex;
+  static std::unordered_set<std::string> reported;
+  const std::lock_guard<std::mutex> lock(reported_mutex);
+  return reported.emplace(mnemonic).second;
+}
+
 [[nodiscard]] bool is_wmma_completion_wait(const Instruction &inst) {
   if (inst.size() != static_cast<int>(sizeof(uint32_t)) || inst.raw_encoding() == nullptr ||
       inst.mnemonic() != "s_wait_alu")
@@ -269,8 +289,9 @@ const InstructionLegalization *gfx1250_b0_to_a0_legalization(const Instruction &
   if (!requires_b0_to_a0_expansion(inst.mnemonic()) &&
       !gfx1250_reads_flat_scratch_base_64bit(inst)) {
     // Deferred families pass through unchanged but warn, so the not-yet-handled
-    // case is visible rather than silent. See is_deferred_gfx1250_family.
-    if (is_deferred_gfx1250_family(mnemonic))
+    // case is visible rather than silent. Once per mnemonic: see
+    // is_deferred_gfx1250_family and first_report_of_deferred_family.
+    if (is_deferred_gfx1250_family(mnemonic) && first_report_of_deferred_family(mnemonic))
       util::Logger::warn("gfx1250 translation passes through '", mnemonic,
                          "' unchanged; target-specific handling is not yet implemented");
     return nullptr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_flat_scratch_base.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_flat_scratch_base.cpp
@@ -14,8 +14,10 @@
 
 #include <algorithm>
 #include <array>
+#include <cstdint>
 #include <cstring>
 #include <optional>
+#include <span>
 #include <vector>
 
 namespace rocjitsu {
@@ -25,9 +27,14 @@ namespace {
 /// @details Both deliver the whole 64-bit base in a 64-bit source position; the
 /// low selector is the spelling the A0 profile reads. See gfx1250
 /// operand_types.h (OPR_SSRC_SRC_FLAT_SCRATCH_BASE_LO / _HI).
-constexpr int kFlatScratchBaseLo = 230;
-constexpr int kFlatScratchBaseHi = 231;
+constexpr uint32_t kFlatScratchBaseLo = 230;
+constexpr uint32_t kFlatScratchBaseHi = 231;
 constexpr int k64BitOperand = 64;
+
+/// @brief True when an encoding field value names the flat-scratch base.
+[[nodiscard]] bool names_flat_scratch_base(uint32_t value) {
+  return value == kFlatScratchBaseLo || value == kFlatScratchBaseHi;
+}
 
 /// @brief Highest scalar selector usable as an ordinary SGPR source operand.
 /// @details Selectors above this range name architectural values rather than
@@ -98,26 +105,71 @@ void set_word_field(uint32_t &word, uint32_t value, uint32_t shift, uint32_t wid
   word = (word & ~mask) | ((value << shift) & mask);
 }
 
+/// @brief Read one source-operand field out of the instruction words.
+/// @returns The field's value, or nullopt when it lies outside @p words.
+[[nodiscard]] std::optional<uint32_t> read_word_field(std::span<const uint32_t> words,
+                                                      const SourceField &field) {
+  if (field.word >= words.size())
+    return std::nullopt;
+  const uint32_t mask = (uint32_t{1} << field.width) - 1;
+  return (words[field.word] >> field.shift) & mask;
+}
+
+/// @brief Words of the base encoding that a layout's source fields reach into.
+/// @details Derived from the layout rather than tabulated separately so the two
+/// cannot drift apart as encodings are added.
+[[nodiscard]] size_t modelled_word_count(const EncodingSourceFields &layout) {
+  size_t words = 0;
+  for (uint8_t i = 0; i < layout.count; ++i)
+    words = std::max<size_t>(words, static_cast<size_t>(layout.fields[i].word) + 1);
+  return words;
+}
+
 /// @brief True when source operand @p index names the base in a 64-bit position.
 ///
-/// @details The value alone is not decisive. A vector field that indexes the
-/// register file directly can hold the selector's number while meaning an
-/// ordinary register, so the field has to be one that reaches the scalar
-/// encodings before the value is compared.
+/// @details The selector is read from the encoding field, never from the
+/// decoded operand. A literal source reports the literal's *value* through
+/// Operand::encoding_value(), so an ordinary constant of 230 or 231 is
+/// indistinguishable there from the selector; the field itself still reads 255
+/// (literal) or 254 (literal64) and names no register at all. Trusting the
+/// operand rewrites the very field that marks the literal as present, which
+/// leaves its dword behind as a standalone illegal instruction.
+///
+/// The field must also be one that can reach the scalar encodings before its
+/// value means anything. A vector field that indexes the register file directly
+/// can hold the selector's number while naming an ordinary register.
 ///
 /// Operand::is_vgpr() cannot make that distinction: it is a construction-time
 /// capability of the operand *type*, and the ordinary vector source type is
 /// also the one that accepts scalar values, so it reports true for both.
 [[nodiscard]] bool is_flat_scratch_base_64bit_source(const Instruction &inst, int index,
-                                                     const EncodingSourceFields &layout) {
+                                                     const EncodingSourceFields &layout,
+                                                     std::span<const uint32_t> words) {
   const Operand *op = inst.src_operand(index);
   if (op == nullptr || op->size_bits() != k64BitOperand)
     return false;
   const SourceField &field = layout.fields[static_cast<size_t>(index)];
   if (layout.vector && field.width != kSelectorCapableVectorFieldWidth)
     return false;
-  const int value = op->encoding_value();
-  return value == kFlatScratchBaseLo || value == kFlatScratchBaseHi;
+  const std::optional<uint32_t> encoded = read_word_field(words, field);
+  return encoded.has_value() && names_flat_scratch_base(*encoded);
+}
+
+/// @brief True when @p op is a decoded literal rather than a named operand.
+///
+/// @details Used only by the conservative scans below, which have no field
+/// layout to read and so must fall back to the operand. It recognizes the
+/// 64-bit literal form, the only one the shared Operand interface exposes; a
+/// 32-bit literal widened into a 64-bit source position is indistinguishable
+/// from a selector by value alone. That residual gap is why the modelled
+/// encodings above read the encoding field instead of asking here, and it can
+/// only cause a refusal, never a miscompile.
+///
+/// TODO: close the gap with a generic immediate predicate on Operand, set from
+/// the per-arch is_immediate_type() the way is_vgpr_ already is. That is a
+/// change to the amdisa codegen templates and every generated arch.
+[[nodiscard]] bool is_decoded_literal(const Operand &op) {
+  return op.literal64_value().has_value();
 }
 
 /// @brief Copy the instruction's words from the authoritative source image.
@@ -152,8 +204,10 @@ instruction_words(const Instruction &inst, uint64_t offset, std::span<const uint
     const Operand *op = inst.src_operand(i);
     if (op == nullptr || op->is_vgpr() || op->size_bits() != k64BitOperand)
       continue;
+    if (is_decoded_literal(*op))
+      continue;
     const int value = op->encoding_value();
-    if (value == kFlatScratchBaseLo || value == kFlatScratchBaseHi)
+    if (value >= 0 && names_flat_scratch_base(static_cast<uint32_t>(value)))
       return true;
   }
   return false;
@@ -175,8 +229,10 @@ instruction_words(const Instruction &inst, uint64_t offset, std::span<const uint
     const Operand *op = inst.src_operand(i);
     if (op == nullptr || op->is_vgpr() || op->size_bits() != k64BitOperand)
       continue;
+    if (is_decoded_literal(*op))
+      continue;
     const int value = op->encoding_value();
-    if (value == kFlatScratchBaseLo || value == kFlatScratchBaseHi)
+    if (value >= 0 && names_flat_scratch_base(static_cast<uint32_t>(value)))
       return true;
   }
   return false;
@@ -193,9 +249,15 @@ bool gfx1250_reads_flat_scratch_base_64bit(const Instruction &inst) {
   // than let it reach the copy path unexamined.
   if (!layout)
     return instruction_names_selector_in_any_64bit_source(inst);
+  // Only the base encoding is read here. Every modelled source field lies
+  // inside it, so the decoded size bounds the span without depending on
+  // whether raw_encoding() also addresses trailing literal or modifier words.
+  const size_t available =
+      inst.size() > 0 ? static_cast<size_t>(inst.size()) / sizeof(uint32_t) : 0;
+  const std::span<const uint32_t> words(raw, std::min(modelled_word_count(*layout), available));
   const int sources = std::min(inst.num_src_operands(), static_cast<int>(layout->count));
   for (int i = 0; i < sources; ++i) {
-    if (is_flat_scratch_base_64bit_source(inst, i, *layout))
+    if (is_flat_scratch_base_64bit_source(inst, i, *layout, words))
       return true;
   }
   return false;
@@ -229,7 +291,7 @@ ExpandResult gfx1250_lower_flat_scratch_base_source(const Instruction &inst, uin
   std::vector<uint32_t> prologue;
   std::optional<uint16_t> borrowed_pair;
   for (int i = 0; i < rewritable; ++i) {
-    if (!is_flat_scratch_base_64bit_source(inst, i, *layout))
+    if (!is_flat_scratch_base_64bit_source(inst, i, *layout, *words))
       continue;
 
     const SourceField &field = layout->fields[static_cast<size_t>(i)];

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_flat_scratch_base.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_flat_scratch_base.h
@@ -27,7 +27,10 @@ class LivenessAnalysis;
 /// for vector reads, so both cases need an operand rewrite.
 ///
 /// Detection is operand-driven rather than opcode-driven: any instruction with
-/// a 64-bit source position can name these selectors.
+/// a 64-bit source position can name these selectors. The selector is matched
+/// against the encoding field, not the decoded operand value: a literal source
+/// reports its own value there, so the constants 230 and 231 would otherwise be
+/// mistaken for the selectors they collide with.
 [[nodiscard]] bool gfx1250_reads_flat_scratch_base_64bit(const Instruction &inst);
 
 /// @brief Rewrite a 64-bit FLAT_SCRATCH_BASE source for the A0 profile.

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -15574,6 +15574,59 @@ TEST(BinaryTranslatorE2E, Gfx1250LeavesCompactVgprMatchingSelectorNumberUnchange
   }
 }
 
+// A literal source reports the literal's own value as its encoding value, so
+// the constants 230 and 231 collide numerically with the two selectors. Reading
+// the operand instead of the encoding field mistakes such a constant for the
+// base, and rewriting the field then erases the marker that says a literal
+// follows -- stranding its dword as a standalone illegal instruction.
+//
+// The first VOP2 case is the RCCL all_reduce_perf kernel that first exposed
+// this: `v_mul_u64_e32 v[10:11], 0xe7, v[0:1]`, words 0x541400ff 0x000000e7.
+TEST(BinaryTranslatorE2E, Gfx1250LeavesLiteralMatchingSelectorNumberUnchangedForA0) {
+  struct LiteralCase {
+    const char *name;
+    std::vector<uint32_t> words;
+  };
+  constexpr uint32_t kLiteralSelector = 255;
+  constexpr uint32_t kLiteral64Selector = 254;
+  const std::vector<LiteralCase> cases = {
+      // The reported reproducer, and its twin on the other colliding constant.
+      {"vop2 literal 0xe7",
+       {gfx1250::build_vop2(gfx1250::kVMulU64Vop2,
+                            {.src0 = kLiteralSelector, .vsrc1 = 0, .vdst = 10})[0],
+        kFlatScratchBaseHiSelector}},
+      {"vop2 literal 0xe6",
+       {gfx1250::build_vop2(gfx1250::kVMulU64Vop2,
+                            {.src0 = kLiteralSelector, .vsrc1 = 0, .vdst = 10})[0],
+        kFlatScratchBaseLoSelector}},
+      // The scalar path rewrites the selector in place, so a stale literal there
+      // keeps the instruction's size and changes only what it reads: a silent
+      // wrong answer alongside the orphaned dword.
+      {"sop1 literal 0xe7",
+       {gfx1250::build_sop1(gfx1250::kSMovB64Sop1,
+                            {.ssrc0 = static_cast<uint8_t>(kLiteralSelector), .sdst = 0})[0],
+        kFlatScratchBaseHiSelector}},
+      // A 64-bit literal reports only its low dword as the encoding value, so it
+      // collides the same way while stranding two dwords rather than one.
+      {"vop2 literal64 low dword 0xe7",
+       {gfx1250::build_vop2(gfx1250::kVMulU64Vop2,
+                            {.src0 = kLiteral64Selector, .vsrc1 = 0, .vdst = 10})[0],
+        kFlatScratchBaseHiSelector, 1u}},
+  };
+  for (const LiteralCase &test_case : cases) {
+    SCOPED_TRACE(test_case.name);
+    const auto out = translate_gfx1250_b0_to_a0_words(test_case.words);
+    ASSERT_GE(out.size(), test_case.words.size() + 1u);
+
+    for (size_t i = 0; i < test_case.words.size(); ++i) {
+      EXPECT_EQ(out[i], test_case.words[i])
+          << "word " << i << " of a literal-source instruction must be copied verbatim";
+    }
+    EXPECT_EQ(out.size(), test_case.words.size() + 1u)
+        << "no prologue may be prepended for a literal that is not the selector";
+  }
+}
+
 // A vector 64-bit read cannot name the selector on A0, so the base is moved
 // into a dead SGPR pair and the source position is repointed at that pair.
 TEST(BinaryTranslatorE2E, Gfx1250MovesVectorFlatScratchBase64BitSourceToSgprPairForA0) {


### PR DESCRIPTION
## Summary

- Cherry-picks the gfx1250 B0-to-A0 literal/FLAT_SCRATCH_BASE fix from ROCm/rocm-systems#9819 onto `release/therock-10.0`.
- Preserves literal selectors `255/254` by matching FLAT_SCRATCH_BASE against the encoded source field instead of the decoded literal value.
- Includes the upstream regression coverage for the RCCL `v_mul_u64_e32 ... 0xe7` reproducer, scalar literals, and 64-bit literals.
- Deduplicates deferred-family pass-through warnings to once per mnemonic.

JIRA ID: ROCM-29198

Upstream commit: d5e201c085e876149ed808ff2b0c1f824757384b
Release cherry-pick: e72c59e533e1324620f10da92acaf37c60a00a6f

## Validation

- Release cherry-pick patch ID exactly matches upstream PR #9819.
- `git diff --check` passed.
- Repository pre-commit hooks passed for all four changed files, including clang-format.
- Validated on gfx1250 A0 J19-2 using the original matching test-tarball `all_reduce_perf` binary: return code 0, no SIGILL markers, zero wrong values, and one deduplicated `s_sleep` warning.

## Scope

This is a focused release backport of the four upstream files; no unrelated release changes are included.