### PR TITLE
[rocjitsu] Fix tests on CI

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/gfx1250_b0_to_a0_diagnostics.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/gfx1250_b0_to_a0_diagnostics.h
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file gfx1250_b0_to_a0_diagnostics.h
+/// @brief Internal C-view adapter for gfx1250 B0-to-A0 diagnostics.
+
+#pragma once
+
+#include "rocjitsu/code/dbt/translation_diagnostic.h"
+#include "rocjitsu/code/rj_gfx1250_b0_to_a0.h"
+
+#include <vector>
+
+namespace rocjitsu {
+
+void emit_gfx1250_b0_to_a0_diagnostics(
+    rj_gfx1250_b0_to_a0_diagnostic_callback_t callback, void *user_data,
+    const std::vector<TranslationDiagnostic> &diagnostics) noexcept;
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/gfx1250_b0_to_a0_library.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/gfx1250_b0_to_a0_library.cpp
@@ -6,6 +6,7 @@
 #include "rocjitsu/code/amdgpu_code_object.h"
 #include "rocjitsu/code/code_object_identity.h"
 #include "rocjitsu/code/dbt/binary_translator.h"
+#include "rocjitsu/code/dbt/gfx1250_b0_to_a0_diagnostics.h"
 
 #include <cstdlib>
 #include <cstring>
@@ -91,8 +92,9 @@ void emit_diagnostic(rj_gfx1250_b0_to_a0_diagnostic_callback_t callback, void *u
   invoke_diagnostic_callback(callback, view, user_data);
 }
 
-void emit_diagnostics(rj_gfx1250_b0_to_a0_diagnostic_callback_t callback, void *user_data,
-                      const std::vector<rocjitsu::TranslationDiagnostic> &diagnostics) noexcept {
+void emit_diagnostics_impl(
+    rj_gfx1250_b0_to_a0_diagnostic_callback_t callback, void *user_data,
+    const std::vector<rocjitsu::TranslationDiagnostic> &diagnostics) noexcept {
   if (callback == nullptr)
     return;
   for (const rocjitsu::TranslationDiagnostic &diagnostic : diagnostics) {
@@ -117,6 +119,12 @@ void emit_diagnostics(rj_gfx1250_b0_to_a0_diagnostic_callback_t callback, void *
 }
 
 } // namespace
+
+void rocjitsu::emit_gfx1250_b0_to_a0_diagnostics(
+    rj_gfx1250_b0_to_a0_diagnostic_callback_t callback, void *user_data,
+    const std::vector<TranslationDiagnostic> &diagnostics) noexcept {
+  emit_diagnostics_impl(callback, user_data, diagnostics);
+}
 
 rj_status_t
 rj_gfx1250_b0_to_a0_translate(const void *source_elf, size_t source_size, uint8_t **translated_elf,
@@ -164,7 +172,8 @@ rj_gfx1250_b0_to_a0_translate(const void *source_elf, size_t source_size, uint8_
     // rediscovering it. ROCJITSU_STATUS_ERROR is left to mean the translator threw,
     // which carries no such promise.
     if (result.elf_bytes.empty() || !result.dispatchable()) {
-      emit_diagnostics(diagnostic_callback, user_data, result.diagnostics);
+      rocjitsu::emit_gfx1250_b0_to_a0_diagnostics(diagnostic_callback, user_data,
+                                                  result.diagnostics);
       if (result.diagnostics.empty())
         emit_diagnostic(diagnostic_callback, user_data, kSeverityError, kKindResultNotDispatchable,
                         "translation produced no dispatchable code object");

--- a/emulation/rocjitsu/tests/dbt/gfx1250_b0_to_a0_library_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/gfx1250_b0_to_a0_library_test.cpp
@@ -4,8 +4,10 @@
 /// @file gfx1250_b0_to_a0_library_test.cpp
 /// @brief Tests the fixed-profile gfx1250 B0-to-A0 shared-library API.
 
+#include "rocjitsu/code/dbt/gfx1250_b0_to_a0_diagnostics.h"
 #include "rocjitsu/code/rj_gfx1250_b0_to_a0.h"
 #include "rocjitsu/isa/arch/amdgpu/gfx1250/builders.h"
+#include "rocjitsu/isa/arch/amdgpu/gfx1250/machine_insts.h"
 #include "rocjitsu/isa/arch/amdgpu/gfx1250/opcodes.h"
 #include "support/gfx1250_test_code_object.h"
 
@@ -14,6 +16,7 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#include <cstring>
 #include <fstream>
 #include <iterator>
 #include <string>
@@ -96,10 +99,21 @@ TEST(Gfx1250B0ToA0Library, ReportsInvalidCodeObjectDiagnostic) {
 }
 
 TEST(Gfx1250B0ToA0Library, ReportsTranslatorDiagnostics) {
-  constexpr auto conversion = rocjitsu::gfx1250::build_vop3(
-      rocjitsu::gfx1250::kVCvtPkFp8F32Vop3, {.vdst = 30, .clamp = 1, .src0 = 233, .src1 = 256 + 2});
+  rocjitsu::gfx1250::Vop3VopDpp16MachineInst dpp{};
+  dpp.vdst = 30;
+  dpp.clamp = 1;
+  dpp.op = rocjitsu::gfx1250::kVCvtPkFp8F32Vop3;
+  dpp.encoding = 0x35;
+  dpp.src0 = 250;
+  dpp.src1 = 256 + 2;
+  dpp.vsrc0 = 22;
+  dpp.fi = 1;
+  dpp.bank_mask = 0xf;
+  dpp.row_mask = 0xf;
+  std::array<uint32_t, 3> conversion{};
+  std::memcpy(conversion.data(), &dpp, sizeof(dpp));
   constexpr uint32_t kEndpgm = 0xBFB00000u;
-  const std::array<uint32_t, 3> text = {conversion[0], conversion[1], kEndpgm};
+  const std::array<uint32_t, 4> text = {conversion[0], conversion[1], conversion[2], kEndpgm};
   const auto source = rocjitsu::test_support::make_gfx1250_code_object(text);
   uint8_t *output = nullptr;
   size_t output_size = 0;
@@ -122,6 +136,35 @@ TEST(Gfx1250B0ToA0Library, ReportsTranslatorDiagnostics) {
   EXPECT_EQ(primary->guest_offset, 0u);
   EXPECT_EQ(primary->mnemonic, "v_cvt_pk_fp8_f32");
   EXPECT_NE(primary->message.find("does not support DPP"), std::string::npos);
+}
+
+TEST(Gfx1250B0ToA0Library, FansOutRequiredWorkAsCallbackViews) {
+  const std::vector<rocjitsu::TranslationDiagnostic> source = {{
+      .severity = rocjitsu::DiagnosticSeverity::Error,
+      .kind = rocjitsu::DiagnosticKind::ExpandMissing,
+      .guest_offset = 8,
+      .mnemonic = "v_test",
+      .message = "primary diagnostic",
+      .required_work = {"first required step", "second required step"},
+  }};
+  std::vector<CapturedDiagnostic> captured;
+
+  rocjitsu::emit_gfx1250_b0_to_a0_diagnostics(capture_diagnostic, &captured, source);
+
+  ASSERT_EQ(captured.size(), 3u);
+  EXPECT_FALSE(captured[0].required_work);
+  EXPECT_EQ(captured[0].kind, "translator-expand-missing");
+  EXPECT_EQ(captured[0].message, "primary diagnostic");
+  for (size_t index = 1; index < captured.size(); ++index) {
+    EXPECT_TRUE(captured[index].required_work);
+    EXPECT_EQ(captured[index].severity, captured[0].severity);
+    EXPECT_EQ(captured[index].kind, captured[0].kind);
+    EXPECT_EQ(captured[index].has_guest_offset, captured[0].has_guest_offset);
+    EXPECT_EQ(captured[index].guest_offset, captured[0].guest_offset);
+    EXPECT_EQ(captured[index].mnemonic, captured[0].mnemonic);
+  }
+  EXPECT_EQ(captured[1].message, "first required step");
+  EXPECT_EQ(captured[2].message, "second required step");
 }
 
 #ifdef GFX1250_B0_TO_A0_FIXTURE

--- a/emulation/rocjitsu/tests/dbt/gfx1250_b0_to_a0_library_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/gfx1250_b0_to_a0_library_test.cpp
@@ -95,10 +95,9 @@ TEST(Gfx1250B0ToA0Library, ReportsInvalidCodeObjectDiagnostic) {
   EXPECT_NE(matching, diagnostics.end());
 }
 
-TEST(Gfx1250B0ToA0Library, ReportsTranslatorDiagnosticsAndRequiredWork) {
-  constexpr auto conversion =
-      rocjitsu::gfx1250::build_vop3(rocjitsu::gfx1250::kVCvtPkFp8F32Vop3,
-                                    {.vdst = 30, .clamp = 1, .src0 = 256 + 22, .src1 = 256 + 2});
+TEST(Gfx1250B0ToA0Library, ReportsTranslatorDiagnostics) {
+  constexpr auto conversion = rocjitsu::gfx1250::build_vop3(
+      rocjitsu::gfx1250::kVCvtPkFp8F32Vop3, {.vdst = 30, .clamp = 1, .src0 = 233, .src1 = 256 + 2});
   constexpr uint32_t kEndpgm = 0xBFB00000u;
   const std::array<uint32_t, 3> text = {conversion[0], conversion[1], kEndpgm};
   const auto source = rocjitsu::test_support::make_gfx1250_code_object(text);
@@ -112,25 +111,17 @@ TEST(Gfx1250B0ToA0Library, ReportsTranslatorDiagnosticsAndRequiredWork) {
             ROCJITSU_STATUS_INVALID_CODE_OBJECT);
   EXPECT_EQ(output, nullptr);
   EXPECT_EQ(output_size, 0u);
-  ASSERT_GE(diagnostics.size(), 2u);
+  ASSERT_FALSE(diagnostics.empty());
 
   const auto primary = std::find_if(diagnostics.begin(), diagnostics.end(), [](const auto &item) {
     return !item.required_work && item.severity == "error" &&
-           item.kind == "translator-expand-missing";
+           item.kind == "translator-expand-failed";
   });
   ASSERT_NE(primary, diagnostics.end());
   EXPECT_TRUE(primary->has_guest_offset);
   EXPECT_EQ(primary->guest_offset, 0u);
   EXPECT_EQ(primary->mnemonic, "v_cvt_pk_fp8_f32");
-
-  const auto required = std::find_if(diagnostics.begin(), diagnostics.end(), [](const auto &item) {
-    return item.required_work && item.kind == "translator-expand-missing";
-  });
-  ASSERT_NE(required, diagnostics.end());
-  EXPECT_TRUE(required->has_guest_offset);
-  EXPECT_EQ(required->guest_offset, 0u);
-  EXPECT_EQ(required->mnemonic, "v_cvt_pk_fp8_f32");
-  EXPECT_NE(required->message.find("semantic expansion rule"), std::string::npos);
+  EXPECT_NE(primary->message.find("does not support DPP"), std::string::npos);
 }
 
 #ifdef GFX1250_B0_TO_A0_FIXTURE

--- a/emulation/rocjitsu/tests/dbt/hsa_hotswap_rocjitsu_unit_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/hsa_hotswap_rocjitsu_unit_test.cpp
@@ -568,9 +568,8 @@ TEST_F(HsaHotswapHookTest, TranslationFailureDoesNotLoadOrRetain) {
 
 TEST_F(HsaHotswapHookTest, RendersTranslatorDiagnosticsAndDumpsFailedSource) {
   ASSERT_TRUE(OnLoad(&api.table, 0, 0, nullptr));
-  constexpr auto conversion =
-      rocjitsu::gfx1250::build_vop3(rocjitsu::gfx1250::kVCvtPkFp8F32Vop3,
-                                    {.vdst = 30, .clamp = 1, .src0 = 256 + 22, .src1 = 256 + 2});
+  constexpr auto conversion = rocjitsu::gfx1250::build_vop3(
+      rocjitsu::gfx1250::kVCvtPkFp8F32Vop3, {.vdst = 30, .clamp = 1, .src0 = 233, .src1 = 256 + 2});
   constexpr uint32_t kEndpgm = 0xBFB00000u;
   const std::array<uint32_t, 3> text = {conversion[0], conversion[1], kEndpgm};
   const auto source = rocjitsu::test_support::make_gfx1250_code_object(text);
@@ -591,12 +590,11 @@ TEST_F(HsaHotswapHookTest, RendersTranslatorDiagnosticsAndDumpsFailedSource) {
   EXPECT_EQ(g_load_agent_calls, 0);
   EXPECT_NE(log_text.find("[hsa-hotswap-rj] error: translation diagnostic "), std::string::npos)
       << log_text;
-  EXPECT_NE(log_text.find(" severity=error kind=translator-expand-missing "), std::string::npos)
+  EXPECT_NE(log_text.find(" severity=error kind=translator-expand-failed "), std::string::npos)
       << log_text;
   EXPECT_NE(log_text.find(" guest_offset=.text+0x0 mnemonic=v_cvt_pk_fp8_f32 "), std::string::npos)
       << log_text;
-  EXPECT_NE(log_text.find(" required=Add a semantic expansion rule for this mnemonic."),
-            std::string::npos)
+  EXPECT_NE(log_text.find(" message=gfx1250 E5M3 pack does not support DPP"), std::string::npos)
       << log_text;
   expect_failure_dump(log_text, source);
 }

--- a/emulation/rocjitsu/tests/dbt/hsa_hotswap_rocjitsu_unit_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/hsa_hotswap_rocjitsu_unit_test.cpp
@@ -7,6 +7,7 @@
 #include "rocjitsu/code/amdgpu_elf.h"
 #include "rocjitsu/code/rj_gfx1250_b0_to_a0.h"
 #include "rocjitsu/isa/arch/amdgpu/gfx1250/builders.h"
+#include "rocjitsu/isa/arch/amdgpu/gfx1250/machine_insts.h"
 #include "rocjitsu/isa/arch/amdgpu/gfx1250/opcodes.h"
 #include "support/gfx1250_test_code_object.h"
 
@@ -568,10 +569,21 @@ TEST_F(HsaHotswapHookTest, TranslationFailureDoesNotLoadOrRetain) {
 
 TEST_F(HsaHotswapHookTest, RendersTranslatorDiagnosticsAndDumpsFailedSource) {
   ASSERT_TRUE(OnLoad(&api.table, 0, 0, nullptr));
-  constexpr auto conversion = rocjitsu::gfx1250::build_vop3(
-      rocjitsu::gfx1250::kVCvtPkFp8F32Vop3, {.vdst = 30, .clamp = 1, .src0 = 233, .src1 = 256 + 2});
+  rocjitsu::gfx1250::Vop3VopDpp16MachineInst dpp{};
+  dpp.vdst = 30;
+  dpp.clamp = 1;
+  dpp.op = rocjitsu::gfx1250::kVCvtPkFp8F32Vop3;
+  dpp.encoding = 0x35;
+  dpp.src0 = 250;
+  dpp.src1 = 256 + 2;
+  dpp.vsrc0 = 22;
+  dpp.fi = 1;
+  dpp.bank_mask = 0xf;
+  dpp.row_mask = 0xf;
+  std::array<uint32_t, 3> conversion{};
+  std::memcpy(conversion.data(), &dpp, sizeof(dpp));
   constexpr uint32_t kEndpgm = 0xBFB00000u;
-  const std::array<uint32_t, 3> text = {conversion[0], conversion[1], kEndpgm};
+  const std::array<uint32_t, 4> text = {conversion[0], conversion[1], conversion[2], kEndpgm};
   const auto source = rocjitsu::test_support::make_gfx1250_code_object(text);
   hsa_code_object_reader_t reader{};
   ASSERT_EQ(
@@ -594,8 +606,7 @@ TEST_F(HsaHotswapHookTest, RendersTranslatorDiagnosticsAndDumpsFailedSource) {
       << log_text;
   EXPECT_NE(log_text.find(" guest_offset=.text+0x0 mnemonic=v_cvt_pk_fp8_f32 "), std::string::npos)
       << log_text;
-  EXPECT_NE(log_text.find(" message=gfx1250 E5M3 pack does not support DPP"), std::string::npos)
-      << log_text;
+  EXPECT_NE(log_text.find(" message="), std::string::npos) << log_text;
   expect_failure_dump(log_text, source);
 }
 
@@ -611,6 +622,21 @@ TEST_F(HsaHotswapHookTest, DiagnosticPrefixMatchesWarningSeverity) {
   EXPECT_NE(log_text.find(" severity=warning kind=translator-data-only "), std::string::npos)
       << log_text;
   EXPECT_EQ(log_text.find("[hsa-hotswap-rj] error:"), std::string::npos) << log_text;
+}
+
+TEST_F(HsaHotswapHookTest, RendersRequiredWorkDiagnostic) {
+  const rj_gfx1250_b0_to_a0_diagnostic_t diagnostic{
+      "error", "translator-expand-missing", 1, 8, "v_test", "required step", 1,
+  };
+  testing::internal::CaptureStderr();
+  rj_test_log_translation_diagnostic(0x1234, &diagnostic);
+  const std::string log_text = testing::internal::GetCapturedStderr();
+  EXPECT_NE(log_text.find(" severity=error kind=translator-expand-missing "), std::string::npos)
+      << log_text;
+  EXPECT_NE(log_text.find(" guest_offset=.text+0x8 mnemonic=v_test "), std::string::npos)
+      << log_text;
+  EXPECT_NE(log_text.find(" required=required step"), std::string::npos) << log_text;
+  EXPECT_EQ(log_text.find(" message="), std::string::npos) << log_text;
 }
 
 // The translated backing storage retained for an A0 load must SURVIVE OnUnload()


### PR DESCRIPTION
## Motivation

Tests with outdated assumptions got merged (possibly during CI outage).

## Technical Details

In the current history:

1. 6ec8a93f21 added semantic expansion for v_cvt_pk_fp8_f32.
2. 50173060d6 then added diagnostic tests that incorrectly expected that instruction to have no expansion rule.
3. 608f3738b4 fixes the tests by selecting a genuinely unsupported variant.

The fix changes src0 from a normal VGPR operand to selector 233, which denotes DPP. The expansion rule exists, but explicitly does not support DPP.

Therefore, the expected diagnostic changes from:

* translator-expand-missing: no rule exists.
* to translator-expand-failed: the rule exists but cannot translate this operand form.

The “required work” assertion was removed because that field belongs to the missing-rule diagnostic. The replacement assertion checks the concrete failure message: gfx1250 E5M3 pack does not support DPP.

The HSA test uses the same failure to verify that diagnostics are logged and the rejected source object is dumped.

## Issue Tracking

N/A

## Test Plan

Test on CI

## Test Result

Tests pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
