### PR TITLE
fix(rocprofiler-systems): Stop dumping LastTest.log on test failure in CI

### DIFF
--- a/projects/rocprofiler-systems/scripts/run-ci.py
+++ b/projects/rocprofiler-systems/scripts/run-ci.py
@@ -64,9 +64,19 @@ def log(msg, level="info"):
             print(f"[INFO] {msg}", flush=True)
 
 
+def _escape_workflow_data(text):
+    """Percent-encode the characters that would end a "::command::" line.
+
+    GitHub Actions parses workflow commands one line at a time, so a CR or LF
+    inside a title truncates the command and lets the remainder be read as a
+    new one; "%" has to go first so the escapes below are not re-escaped.
+    """
+    return text.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
 def log_group_start(title):
     if IS_GITHUB_ACTIONS:
-        print(f"::group::{title}", flush=True)
+        print(f"::group::{_escape_workflow_data(title)}", flush=True)
     else:
         bar = "=" * 60
         print(_color(f"\n{bar}\n{title}\n{bar}", "cyan", "bold"), flush=True)
@@ -581,8 +591,10 @@ def set_python_hints_from_cmake_args(cmake_args):
 # lives only inline in Testing/<TAG>/Build.xml, where CTest's XML writer has
 # already replaced every non-XML-safe control byte (including the ESC byte
 # that starts each compiler color code) with the literal text
-# "[NON-XML-CHAR-0xNN]". Build failures therefore need XML recovery instead
-# of a raw-log read; configure does not.
+# "[NON-XML-CHAR-0xNN]". Build failures therefore need XML recovery to get
+# those bytes back; configure does not. Test failures read Test.xml for an
+# unrelated reason: LastTest.log concatenates every test's output, so only
+# the XML keeps it attributed per test and lets the passing ones be dropped.
 # ---------------------------------------------------------------------------
 
 _ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")

--- a/projects/rocprofiler-systems/scripts/run-ci.py
+++ b/projects/rocprofiler-systems/scripts/run-ci.py
@@ -582,7 +582,7 @@ def set_python_hints_from_cmake_args(cmake_args):
 # already replaced every non-XML-safe control byte (including the ESC byte
 # that starts each compiler color code) with the literal text
 # "[NON-XML-CHAR-0xNN]". Build failures therefore need XML recovery instead
-# of a raw-log read; configure/test do not.
+# of a raw-log read; configure does not.
 # ---------------------------------------------------------------------------
 
 _ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
@@ -671,6 +671,39 @@ def _read_build_xml_failures(args):
     return blocks
 
 
+def _read_test_xml_failures(args):
+    """Recover the captured output of each failed test from CTest's test
+    report (Testing/<TAG>/Test.xml). Returns a list of (name, output) pairs,
+    empty if Test.xml doesn't exist or recorded no failures.
+
+    LastTest.log holds every test's output, passing ones included, so printing
+    it raw buries the failures in the whole suite. Test.xml keeps the output
+    attributed per test, which is what makes filtering possible.
+    """
+    tag_dir = _current_run_tag_dir(args)
+    if tag_dir is None:
+        return []
+    path = os.path.join(tag_dir, "Test.xml")
+    if not os.path.isfile(path):
+        return []
+    try:
+        root = ET.parse(path).getroot()
+    except ET.ParseError:
+        return []
+
+    failures = []
+    for test in root.iter("Test"):
+        if test.get("Status") != "failed":
+            continue
+        output = "\n".join(
+            _restore_non_xml_chars(_decode_ctest_value(value))
+            for measurement in test.iter("Measurement")
+            for value in measurement.findall("Value")
+        )
+        failures.append((test.findtext("Name") or "<unknown>", output))
+    return failures
+
+
 def _print_log_group(title: str, content: str) -> None:
     if os.environ.get("NO_COLOR") or os.environ.get("TERM") == "dumb":
         content = _strip_ansi(content)
@@ -688,6 +721,13 @@ def print_failure_log(args, stage_label: str) -> None:
             return
         _print_log_group("build log: Build.xml (recovered)", "\n".join(blocks))
         return
+
+    if stage_label == "test":
+        failures = _read_test_xml_failures(args)
+        if failures:
+            for name, output in failures:
+                _print_log_group(f"test log: {name} (failed)", output)
+            return
 
     content = _read_raw_stage_log(args, stage_label)
     if content is None:

--- a/projects/rocprofiler-systems/scripts/run-ci.py
+++ b/projects/rocprofiler-systems/scripts/run-ci.py
@@ -64,7 +64,7 @@ def log(msg, level="info"):
             print(f"[INFO] {msg}", flush=True)
 
 
-def _escape_workflow_data(text):
+def _escape_workflow_data(text: str) -> str:
     """Percent-encode the characters that would end a "::command::" line.
 
     GitHub Actions parses workflow commands one line at a time, so a CR or LF
@@ -74,7 +74,7 @@ def _escape_workflow_data(text):
     return text.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
 
 
-def log_group_start(title):
+def log_group_start(title: str) -> None:
     if IS_GITHUB_ACTIONS:
         print(f"::group::{_escape_workflow_data(title)}", flush=True)
     else:

--- a/projects/rocprofiler-systems/scripts/test_ci_workflow_contracts.py
+++ b/projects/rocprofiler-systems/scripts/test_ci_workflow_contracts.py
@@ -1090,12 +1090,12 @@ def write_fake_build_success_log(bin_dir: Path, binary_dir: Path) -> None:
 
 
 def _ctest_measurement(text: str) -> str:
-    """Encode *text* as gzip+base64, the container real CTest uses for a test's
-    captured output once it holds the ESC bytes of colored output."""
-    payload = base64.b64encode(gzip.compress(text.encode("utf-8"))).decode("ascii")
+    """Wrap *text* as a CTest <Measurement>, gzip+base64-encoded the way real
+    CTest stores a test's captured output once it holds the ESC bytes of
+    colored output."""
     return (
         '<Measurement><Value encoding="base64" compression="gzip">'
-        f"{payload}</Value></Measurement>"
+        f"{_gzip_base64_value(text)}</Value></Measurement>"
     )
 
 

--- a/projects/rocprofiler-systems/scripts/test_ci_workflow_contracts.py
+++ b/projects/rocprofiler-systems/scripts/test_ci_workflow_contracts.py
@@ -595,7 +595,7 @@ def check_sanitizer_workflow(
     ok("sanitizer workflow is reusable and reports through artifacts")
 
 
-def write_fake_tool(bin_dir: Path, name: str, log_path: Path) -> None:
+def write_fake_tool(bin_dir: Path, name: str, log_path: Path, exit_code: int = 0) -> None:
     tool_path = bin_dir / name
     tool_path.write_text(
         "#!/usr/bin/env bash\n"
@@ -603,7 +603,7 @@ def write_fake_tool(bin_dir: Path, name: str, log_path: Path) -> None:
         f"{str(log_path)!r}\n"
         "printf '\\n' >> "
         f"{str(log_path)!r}\n"
-        "exit 0\n",
+        f"exit {exit_code}\n",
         encoding="utf-8",
     )
     tool_path.chmod(tool_path.stat().st_mode | stat.S_IXUSR)
@@ -1026,6 +1026,12 @@ def check_run_ci_split_stage_contract(verbose: bool) -> None:
 _FAILURE_SENTINEL = "SENTINEL_BUILD_FAILURE"
 _WARNING_SENTINEL = "SENTINEL_BUILD_WARNING"
 _NON_XML_ESC = "[NON-XML-CHAR-0x1B]"
+_TEST_PASS_SENTINEL = "SENTINEL_PASSING_TEST_OUTPUT"
+_TEST_FAIL_SENTINEL = "SENTINEL_FAILING_TEST_OUTPUT"
+# A test name carrying every character that terminates a workflow command, so
+# the check can prove the "::group::" title is escaped instead of being split
+# into a second, forged command.
+_HOSTILE_TEST_NAME = "bad%name\n::error::forged"
 
 
 def write_fake_build_xml_failure(bin_dir: Path, binary_dir: Path) -> None:
@@ -1081,6 +1087,43 @@ def write_fake_build_success_log(bin_dir: Path, binary_dir: Path) -> None:
         encoding="utf-8",
     )
     tool_path.chmod(tool_path.stat().st_mode | stat.S_IXUSR)
+
+
+def _ctest_measurement(text: str) -> str:
+    """Encode *text* as gzip+base64, the container real CTest uses for a test's
+    captured output once it holds the ESC bytes of colored output."""
+    payload = base64.b64encode(gzip.compress(text.encode("utf-8"))).decode("ascii")
+    return (
+        '<Measurement><Value encoding="base64" compression="gzip">'
+        f"{payload}</Value></Measurement>"
+    )
+
+
+def write_fake_test_results(binary_dir: Path) -> None:
+    """Write what real ctest leaves behind after a failing test run: Test.xml,
+    which attributes the captured output per test, and LastTest*.log, which
+    concatenates the whole suite's output into one unattributed file.
+    """
+    testing_dir = binary_dir / "Testing"
+    tag_dir = testing_dir / "20260101-0000"
+    log_dir = testing_dir / "Temporary"
+    for directory in (tag_dir, log_dir):
+        directory.mkdir(parents=True, exist_ok=True)
+
+    (testing_dir / "TAG").write_text("20260101-0000\n", encoding="utf-8")
+    (log_dir / "LastTest_20260101-0000.log").write_text(
+        f"{_TEST_PASS_SENTINEL}\n{_TEST_FAIL_SENTINEL}\n", encoding="utf-8"
+    )
+    xml_name = _HOSTILE_TEST_NAME.replace("\n", "&#10;")
+    (tag_dir / "Test.xml").write_text(
+        "<Site><Testing>"
+        '<Test Status="passed"><Name>passing-test</Name>'
+        f"<Results>{_ctest_measurement(_TEST_PASS_SENTINEL)}</Results></Test>"
+        f'<Test Status="failed"><Name>{xml_name}</Name>'
+        f"<Results>{_ctest_measurement(_TEST_FAIL_SENTINEL)}</Results></Test>"
+        "</Testing></Site>\n",
+        encoding="utf-8",
+    )
 
 
 def check_run_ci_failure_colored_log(verbose: bool) -> None:
@@ -1190,6 +1233,73 @@ def check_run_ci_build_success_annotation(verbose: bool) -> None:
     ok("run-ci.py annotates build warnings correctly on a successful build")
 
 
+def check_run_ci_test_failure_filtering(verbose: bool) -> None:
+    """A failed test stage must print only the failing tests' output, recovered
+    per test from Test.xml, instead of dumping LastTest*.log with the whole
+    suite in it. The test name reaches the "::group::" title from that XML, so
+    it must be escaped or a malformed name could end the workflow command and
+    start one of its own (see run-ci.py print_failure_log())."""
+    with tempfile.TemporaryDirectory(prefix="rocprofsys-ci-test-fail-") as temp_dir:
+        temp_path = Path(temp_dir)
+        binary_dir = temp_path / "build"
+        fake_bin_dir = temp_path / "bin"
+        fake_bin_dir.mkdir()
+        fake_tool_log = temp_path / "fake-tools.log"
+
+        for tool in ("cmake", "git", "gcov"):
+            write_fake_tool(fake_bin_dir, tool, fake_tool_log)
+        write_fake_tool(fake_bin_dir, "ctest", fake_tool_log, exit_code=1)
+
+        common_args = [
+            "--name",
+            "local-ci-test-fail-check",
+            "--site",
+            "Local",
+            "-B",
+            str(binary_dir),
+        ]
+        env = {"TERM": "dumb", "GITHUB_ACTIONS": "true"}
+        run_ci_command(
+            ["--stage", "generate", *common_args], binary_dir, fake_bin_dir, env
+        )
+        write_fake_test_results(binary_dir)
+
+        test = run_ci_command(
+            ["--stage", "test", *common_args],
+            binary_dir,
+            fake_bin_dir,
+            env,
+            check=False,
+        )
+        require(
+            test.returncode != 0,
+            "fake failing ctest did not cause the run-ci.py test stage to fail",
+        )
+        require(
+            _TEST_FAIL_SENTINEL in test.stdout,
+            "run-ci.py must print the failing test's output recovered from Test.xml",
+        )
+        require(
+            _TEST_PASS_SENTINEL not in test.stdout,
+            "run-ci.py must not print passing tests' output when a test fails",
+        )
+        require(
+            "::group::test log: bad%25name%0A::error::forged (failed)" in test.stdout,
+            "run-ci.py must escape %, CR and LF in a test name used as a "
+            "::group:: title",
+        )
+        require(
+            not any(
+                line.strip() == "::error::forged" for line in test.stdout.splitlines()
+            ),
+            "an unescaped test name must not be able to emit its own workflow command",
+        )
+
+        if verbose:
+            print(test.stdout)
+    ok("run-ci.py prints only failing tests and escapes their names")
+
+
 def run_checks(args: argparse.Namespace) -> None:
     for path in TARGET_WORKFLOWS + [RUN_CI, SUMMARY_SCRIPT, MATRIX_HELPER, MATRIX_FILE]:
         require(path.exists(), f"required file is missing: {path.relative_to(REPO_ROOT)}")
@@ -1212,6 +1322,7 @@ def run_checks(args: argparse.Namespace) -> None:
     check_run_ci_split_stage_contract(args.verbose)
     check_run_ci_failure_colored_log(args.verbose)
     check_run_ci_build_success_annotation(args.verbose)
+    check_run_ci_test_failure_filtering(args.verbose)
     check_summarize_skipped_tests_unit(args.verbose)
     check_run_ci_skipped_tests_summary(args.verbose)
     check_summarize_junit_results_unit(args.verbose)


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Closes: https://github.com/ROCm/rocm-systems/issues/9837

When the test stage failed (e.g. see https://github.com/ROCm/rocm-systems/actions/runs/31180925864/job/92873980367?pr=9814), `run-ci.py` printed all of `Testing/Temporary/LastTest.log`... and `CTest` writes every test's output into that single file, passing ones included, so one failing test dumped the whole suite's logs into the Actions output. The build stage already extracted just the failing blocks from Build.xml; the test stage had no equivalent filtering, so the fix reads `Test.xml` (which keeps output attributed per test) and prints only the tests marked failed.

It seems the problem was accidentally introduced in https://github.com/ROCm/rocm-systems/pull/7744

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

 - Added _read_test_xml_failures() to scripts/run-ci.py, mirroring the existing _read_build_xml_failures(): parses Testing/<TAG>/Test.xml, keeps only <Test Status="failed">, and decodes each <Measurement><Value> with the existing _decode_ctest_value() helper.
 - `print_failure_log()` now prints one collapsible group per failing test for the test stage, falling back to the raw LastTest.log when no test is credited with the failure.
 - ANSI colour still renders, since `CTest's base64/gzip` Measurements preserve the ESC bytes that the raw-log read originally existed to protect.
 - `log_group_start()` now percent-encodes `%`, CR and LF in group titles: a test name read from Test.xml reaches the `::group::` header, and GitHub Actions parses workflow commands one line at a time, so a malformed name could otherwise truncate the command or forge another one. This covers every group title, not just the new per-test ones.
- Added a check to `scripts/test_ci_workflow_contracts.py` that fakes a failed run — a Test.xml with one passing and one failing test, plus a LastTest.log holding both — and asserts only the failing test's output is printed and its name arrives escaped.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

I will force a test to fail, and view logs.

## Test Result

<!-- Briefly summarize test outcomes. -->

See https://github.com/ROCm/rocm-systems/actions/runs/31192449326/job/92912871265?pr=9838, we are back to expected behavior.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
