### PR TITLE
fix(rdc): prioritize explicit bootstrap library paths

### DIFF
--- a/projects/rdc/python_binding/rdc_bootstrap.py
+++ b/projects/rdc/python_binding/rdc_bootstrap.py
@@ -14,16 +14,16 @@ librdc = "librdc_bootstrap.so"
 # Search librdc_bootstrap.so paths
 current_folder = os.path.dirname(os.path.realpath(__file__))
 rdc_paths = [
-    "",  # without path
-    current_folder + "/../../../lib/",  # package installation
-    current_folder + "/../../../lib64/",  # package installation
-    current_folder + "/../build/rdc_libs/",  # build from source code
+    os.path.join(current_folder, "../../../lib"),  # package installation
+    os.path.join(current_folder, "../../../lib64"),  # package installation
+    os.path.join(current_folder, "../build/rdc_libs"),  # build from source code
+    "",  # last-resort dynamic-loader lookup
 ]
 
 rdc = None
 for r in rdc_paths:
     try:
-        rdc = CDLL(r + librdc)
+        rdc = CDLL(os.path.join(r, librdc))
         break
     except:
         pass


### PR DESCRIPTION
## Summary
- Prefer package-install and source-build paths before the bare `librdc_bootstrap.so` loader lookup.
- Preserve `LD_LIBRARY_PATH` lookup as a last-resort compatibility fallback.
- Use `os.path.join` for consistent path construction.

JIRA ID: SWSPLAT-24322

## Test plan
- Verified old and new candidate paths are equivalent.