### PR TITLE
fix(rocr): Fix rocrtst Memory_Async_Copy failure on multi-NUMA CPU systems

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/performance/memory_async_copy.cc
+++ b/projects/rocr-runtime/rocrtst/suites/performance/memory_async_copy.cc
@@ -810,7 +810,7 @@ static hsa_status_t GetAgentInfo(hsa_agent_t agent, void* data) {
   int ret;
 
   if (ptr->cpu_agent().handle != 0) {
-    return HSA_STATUS_ERROR;
+    return HSA_STATUS_SUCCESS;  // Already found CPU agent, skip remaining agents
   }
 
 


### PR DESCRIPTION
## Summary

Cherry-pick of f52a60fcba139a788279aae2f6db604e91a00650 from https://github.com/ROCm/rocm-systems/pull/9781.

`GetAgentInfo()` in the rocrtst performance suite returned `HSA_STATUS_ERROR` once a CPU agent had already been selected. On multi-NUMA systems that expose more than one CPU HSA agent, this aborted `hsa_iterate_agents()` before any GPU agent was visited, so `rocrtstPerf.Memory_Async_Copy` and `rocrtstPerf.Memory_Async_Copy_On_Engine` failed their agent assertions.

Returning `HSA_STATUS_SUCCESS` instead simply skips the extra CPU agents and lets iteration continue to the GPU agents.

## JIRA ID

JIRA ID : ROCM-29094

## Test plan

- [ ] Run `rocrtstPerf.Memory_Async_Copy` and `rocrtstPerf.Memory_Async_Copy_On_Engine` on a multi-NUMA system with multiple CPU HSA agents.
- [ ] Confirm no regression on a single CPU agent system.

Made with [Cursor](https://cursor.com)