### PR TITLE
fix(rocprofiler-sdk): rocshmem-trace test timeout

### DIFF
--- a/projects/rocprofiler-sdk/tests/bin/rocshmem/rocshmem.cpp
+++ b/projects/rocprofiler-sdk/tests/bin/rocshmem/rocshmem.cpp
@@ -106,8 +106,7 @@ main(int /*argc*/, char** /*argv*/)
     // hipErrorNoDevice; treat both as unavailable so the outcome does not depend on which.
     if(device_err == hipErrorNoDevice || (device_err == hipSuccess && device_count <= 0))
     {
-        std::fprintf(
-            stderr, "[rocshmem-demo] %s: no HIP devices visible\n", kUnavailableMarker);
+        std::fprintf(stderr, "[rocshmem-demo] %s: no HIP devices visible\n", kUnavailableMarker);
         return 0;
     }
     CHECK_HIP(device_err);

--- a/projects/rocprofiler-sdk/tests/bin/rocshmem/rocshmem.cpp
+++ b/projects/rocprofiler-sdk/tests/bin/rocshmem/rocshmem.cpp
@@ -32,10 +32,12 @@ THE SOFTWARE.
 //
 // The demo must be launched by an MPI/PMI launcher (mpirun / mpiexec / srun) that exposes
 // the node-local rank via an environment variable; it uses that to pin each process to a
-// GPU before rocshmem_init(). If launched without one, exit cleanly with status 0 so the
-// validator interprets the trace as "unavailable" and skips rather than reporting a hard
-// failure. rocSHMEM itself is not tied to Open MPI -- it bootstraps against whatever MPI it
-// was built with (OpenMPI, MPICH, MVAPICH); the lookup below just covers common launchers.
+// GPU before rocshmem_init(). When it cannot run at all -- no launcher, or no visible GPU --
+// it prints kUnavailableMarker and exits 0. The integration tests match that marker with
+// ctest's SKIP_REGULAR_EXPRESSION so such a run is reported as skipped instead of passing
+// while exercising nothing. rocSHMEM itself is not tied to Open MPI -- it bootstraps against
+// whatever MPI it was built with (OpenMPI, MPICH, MVAPICH); the lookup below just covers
+// common launchers.
 
 #include <hip/hip_runtime.h>
 #include <rocshmem/rocshmem.hpp>
@@ -64,6 +66,11 @@ THE SOFTWARE.
 
 using namespace rocshmem;
 
+// Printed on every path that returns without exercising rocSHMEM. Both rocshmem-trace
+// integration tests match this via SKIP_REGULAR_EXPRESSION, so keep it in sync with
+// tests/rocshmem-trace/CMakeLists.txt and tests/rocprofv3/rocshmem-trace/CMakeLists.txt.
+constexpr auto kUnavailableMarker = "rocSHMEM demo unavailable";
+
 int
 main(int /*argc*/, char** /*argv*/)
 {
@@ -81,11 +88,11 @@ main(int /*argc*/, char** /*argv*/)
     if(local_rank == nullptr)
     {
         std::fprintf(stderr,
-                     "[rocshmem-demo] no node-local rank env var set (checked "
+                     "[rocshmem-demo] %s: no node-local rank env var set (checked "
                      "OMPI_COMM_WORLD_LOCAL_RANK, MV2_COMM_WORLD_LOCAL_RANK, MPI_LOCALRANKID, "
                      "SLURM_LOCALID); this demo must be launched via an MPI/PMI launcher "
-                     "(mpirun/mpiexec/srun). Exiting without exercising the rocSHMEM API so the "
-                     "integration test reports tracing as unavailable.\n");
+                     "(mpirun/mpiexec/srun).\n",
+                     kUnavailableMarker);
         return 0;
     }
 
@@ -93,14 +100,17 @@ main(int /*argc*/, char** /*argv*/)
     // is the identity (rank 0 -> device 0, rank 1 -> device 1, ...). On CI runners
     // where HIP_VISIBLE_DEVICES limits visibility to a single device, the modulo
     // makes ranks share the GPU instead of failing with "invalid device ordinal".
-    int device_count = 0;
-    CHECK_HIP(hipGetDeviceCount(&device_count));
-    if(device_count <= 0)
+    int  device_count = 0;
+    auto device_err   = hipGetDeviceCount(&device_count);
+    // Depending on driver state, "no GPU" surfaces either as a zero count or as an explicit
+    // hipErrorNoDevice; treat both as unavailable so the outcome does not depend on which.
+    if(device_err == hipErrorNoDevice || (device_err == hipSuccess && device_count <= 0))
     {
-        std::fprintf(stderr,
-                     "[rocshmem-demo] no HIP devices visible; skipping rocSHMEM exercise.\n");
+        std::fprintf(
+            stderr, "[rocshmem-demo] %s: no HIP devices visible\n", kUnavailableMarker);
         return 0;
     }
+    CHECK_HIP(device_err);
     CHECK_HIP(hipSetDevice(std::atoi(local_rank) % device_count));
 
     rocshmem_init();

--- a/projects/rocprofiler-sdk/tests/rocprofv3/rocshmem-trace/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/rocshmem-trace/CMakeLists.txt
@@ -61,10 +61,10 @@ if(NOT MPIRUN_EXECUTABLE)
 endif()
 
 # Both ranks are node-local, so confine Open MPI to the self/shared-memory transports and
-# keep it off the ob1 network components. CI runners expose RoCE devices whose kernel driver
-# ABI does not match the installed libibverbs; probing them floods the log with libibverbs
-# warnings and has been observed to wedge the ranks during teardown. This matches the
-# MPI_ENV_VARS used by the sibling tests/rocshmem-trace test.
+# keep it off the ob1 network components. CI runners expose RoCE devices whose kernel
+# driver ABI does not match the installed libibverbs; probing them floods the log with
+# libibverbs warnings and has been observed to wedge the ranks during teardown. This
+# matches the MPI_ENV_VARS used by the sibling tests/rocshmem-trace test.
 set(MPI_ENV_VARS OMPI_ALLOW_RUN_AS_ROOT=1 OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
                  OMPI_MCA_btl=self,vader OMPI_MCA_pml=ob1 PSM3_DEVICES=self,shm)
 

--- a/projects/rocprofiler-sdk/tests/rocprofv3/rocshmem-trace/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/rocshmem-trace/CMakeLists.txt
@@ -60,7 +60,13 @@ if(NOT MPIRUN_EXECUTABLE)
     set(IS_DISABLED ON)
 endif()
 
-set(MPI_ENV_VARS OMPI_ALLOW_RUN_AS_ROOT=1 OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1)
+# Both ranks are node-local, so confine Open MPI to the self/shared-memory transports and
+# keep it off the ob1 network components. CI runners expose RoCE devices whose kernel driver
+# ABI does not match the installed libibverbs; probing them floods the log with libibverbs
+# warnings and has been observed to wedge the ranks during teardown. This matches the
+# MPI_ENV_VARS used by the sibling tests/rocshmem-trace test.
+set(MPI_ENV_VARS OMPI_ALLOW_RUN_AS_ROOT=1 OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+                 OMPI_MCA_btl=self,vader OMPI_MCA_pml=ob1 PSM3_DEVICES=self,shm)
 
 # rocSHMEM cannot bootstrap with a single PE (MPI_Win_create fails) so the demo is
 # launched with -np 2. Each rank gets its own per-rank output directory keyed by
@@ -85,7 +91,7 @@ if(TARGET rocshmem-demo)
         DEPENDS rocshmem-demo
         TIMEOUT 60
         LABELS "integration-tests"
-        PRELOAD "${PRELOAD_ENV}"
+        ENVIRONMENT "${PRELOAD_ENV}"
         FIXTURES_SETUP rocprofv3-test-rocshmem-tracing
         DISABLED "${IS_DISABLED}")
 

--- a/projects/rocprofiler-sdk/tests/rocprofv3/rocshmem-trace/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/rocshmem-trace/CMakeLists.txt
@@ -92,6 +92,10 @@ if(TARGET rocshmem-demo)
         TIMEOUT 60
         LABELS "integration-tests"
         ENVIRONMENT "${PRELOAD_ENV}"
+        # rocshmem-demo prints this and exits 0 when it cannot run (no launcher-provided
+        # local rank, or no visible GPU). Without it such a run would be reported as a pass
+        # despite tracing nothing at all.
+        SKIP_REGULAR_EXPRESSION "rocSHMEM demo unavailable"
         FIXTURES_SETUP rocprofv3-test-rocshmem-tracing
         DISABLED "${IS_DISABLED}")
 
@@ -107,5 +111,9 @@ if(TARGET rocshmem-demo)
         TIMEOUT 45
         LABELS "integration-tests"
         FIXTURES_REQUIRED rocprofv3-test-rocshmem-tracing
+        # conftest.py skips when the trace files are absent, which happens whenever the
+        # execute test above was skipped. Surface that as a ctest skip so validating nothing
+        # is not reported as a pass.
+        SKIP_REGULAR_EXPRESSION "SKIPPED"
         DISABLED "${IS_DISABLED}")
 endif()

--- a/projects/rocprofiler-sdk/tests/rocprofv3/rocshmem-trace/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/rocshmem-trace/CMakeLists.txt
@@ -92,9 +92,6 @@ if(TARGET rocshmem-demo)
         TIMEOUT 60
         LABELS "integration-tests"
         ENVIRONMENT "${PRELOAD_ENV}"
-        # rocshmem-demo prints this and exits 0 when it cannot run (no launcher-provided
-        # local rank, or no visible GPU). Without it such a run would be reported as a pass
-        # despite tracing nothing at all.
         SKIP_REGULAR_EXPRESSION "rocSHMEM demo unavailable"
         FIXTURES_SETUP rocprofv3-test-rocshmem-tracing
         DISABLED "${IS_DISABLED}")
@@ -111,9 +108,6 @@ if(TARGET rocshmem-demo)
         TIMEOUT 45
         LABELS "integration-tests"
         FIXTURES_REQUIRED rocprofv3-test-rocshmem-tracing
-        # conftest.py skips when the trace files are absent, which happens whenever the
-        # execute test above was skipped. Surface that as a ctest skip so validating nothing
-        # is not reported as a pass.
         SKIP_REGULAR_EXPRESSION "SKIPPED"
         DISABLED "${IS_DISABLED}")
 endif()

--- a/projects/rocprofiler-sdk/tests/rocshmem-trace/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocshmem-trace/CMakeLists.txt
@@ -84,10 +84,6 @@ if(TARGET rocshmem-demo)
         ENVIRONMENT ${MPI_ENV_VARS}
         PRELOAD "${PRELOAD_ENV}"
         PASS_REGULAR_EXPRESSION "Finalization complete"
-        # rocshmem-demo prints this and exits 0 when it cannot run (no launcher-provided
-        # local rank, or no visible GPU). The tool still reports "Finalization complete" in
-        # that case, so without this the run would satisfy PASS_REGULAR_EXPRESSION despite
-        # tracing nothing at all.
         SKIP_REGULAR_EXPRESSION "rocSHMEM demo unavailable"
         FIXTURES_SETUP rocshmem-tracing
         DISABLED "${IS_DISABLED}")
@@ -101,9 +97,6 @@ if(TARGET rocshmem-demo)
         TIMEOUT 45
         ARGS --input ${CMAKE_CURRENT_BINARY_DIR}/rocshmem-tracing-test.rank-0.json
         FIXTURES_REQUIRED rocshmem-tracing
-        # conftest.py skips when the trace file is absent, which happens whenever the
-        # execute test above was skipped. Surface that as a ctest skip so validating nothing
-        # is not reported as a pass.
         SKIP_REGULAR_EXPRESSION "SKIPPED"
         DISABLED "${IS_DISABLED}")
 endif()

--- a/projects/rocprofiler-sdk/tests/rocshmem-trace/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocshmem-trace/CMakeLists.txt
@@ -84,6 +84,11 @@ if(TARGET rocshmem-demo)
         ENVIRONMENT ${MPI_ENV_VARS}
         PRELOAD "${PRELOAD_ENV}"
         PASS_REGULAR_EXPRESSION "Finalization complete"
+        # rocshmem-demo prints this and exits 0 when it cannot run (no launcher-provided
+        # local rank, or no visible GPU). The tool still reports "Finalization complete" in
+        # that case, so without this the run would satisfy PASS_REGULAR_EXPRESSION despite
+        # tracing nothing at all.
+        SKIP_REGULAR_EXPRESSION "rocSHMEM demo unavailable"
         FIXTURES_SETUP rocshmem-tracing
         DISABLED "${IS_DISABLED}")
 
@@ -96,5 +101,9 @@ if(TARGET rocshmem-demo)
         TIMEOUT 45
         ARGS --input ${CMAKE_CURRENT_BINARY_DIR}/rocshmem-tracing-test.rank-0.json
         FIXTURES_REQUIRED rocshmem-tracing
+        # conftest.py skips when the trace file is absent, which happens whenever the
+        # execute test above was skipped. Surface that as a ctest skip so validating nothing
+        # is not reported as a pass.
+        SKIP_REGULAR_EXPRESSION "SKIPPED"
         DISABLED "${IS_DISABLED}")
 endif()


### PR DESCRIPTION
## Motivation

`tests.integration.execute.rocprofv3-test-rocshmem-tracing` intermittently times out on
gfx94x CI. Every rank finishes tool finalization and writes its output, then the process
goes silent until ctest kills it at 60s.

## Technical Details

Root cause is Open MPI transport selection. This test never restricted the transports, so
Open MPI probes the runners' RoCE devices, whose `bnxt_re` kernel driver ABI does not match
the installed libibverbs (`does not support the kernel ABI of 8 (supports 1 to 1)`, repeated
for `bnxt_re0`–`bnxt_re7`) and the ranks wedge during teardown. The sibling
`tests/rocshmem-trace` test already guards against this; the fix applies the same
`OMPI_MCA_btl=self,vader`, `OMPI_MCA_pml=ob1`, `PSM3_DEVICES=self,shm`. Both ranks are
node-local, so nothing needs the network.

Two related fixes:

- **`PRELOAD` → `ENVIRONMENT`.** `PRELOAD_ENV` holds a `ROCPROF_PRELOAD=<lib>` assignment,
  but the `PRELOAD` argument expects bare paths and prepends its value to `LD_PRELOAD`,
  producing `LD_PRELOAD=<sanitizer>:ROCPROF_PRELOAD=<lib>` and the sanitizer-build error
  `ld.so: object 'ROCPROF_PRELOAD=...' cannot be preloaded`.
- **Silent skips.** `rocshmem-demo` exits 0 when no launcher rank or no GPU is visible, so a
  run that traced nothing was reported as a pass. Both paths now print a common marker
  matched by `SKIP_REGULAR_EXPRESSION`, and `hipErrorNoDevice` is treated the same as a zero
  device count instead of hard-failing. The validators get the same treatment, since
  `conftest.py` skips on a missing trace file and pytest exits 0.

## Issue Tracking

<!-- TODO: add GitHub issue / JIRA ID -->

## Test Plan

- `ctest -R rocshmem` and 12 repeats of the execute test.
- Skip path forced with `HIP_VISIBLE_DEVICES=""`.
- `PRELOAD` fix checked against the TSan configure, since a non-sanitizer build leaves
  `PRELOAD_ENV` empty and cannot exercise it.

## Test Result

All 18 rocSHMEM tests pass; 12/12 repeats clean. With no visible GPU, the execute and
validate tests now report `***Skipped` rather than passing. The TSan configure resolves to
two separate entries, `LD_PRELOAD=.../libtsan.so.0` and `ROCPROF_PRELOAD=.../libtsan.so.0`,
instead of the concatenated form. 

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.