### PR TITLE
[rocjitsu] Rename EXEC analysis helper to avoid symbol-boundary collision

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/exec_state.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/exec_state.cpp
@@ -28,7 +28,7 @@ enum class ExecWrite : uint8_t {
   Narrowing, ///< Writes EXEC some other way -> Unknown.
 };
 
-[[nodiscard]] bool writes_exec(const Instruction &inst) {
+[[nodiscard]] bool writes_execution_mask(const Instruction &inst) {
   // Two complementary signals: the WRITES_EXEC flag covers instructions whose
   // semantics always write EXEC (s_*_saveexec, s_wrexec, v_cmpx), while an EXEC
   // destination operand covers the generic move case (`s_mov_b64 exec, ...`),
@@ -145,7 +145,7 @@ enum class Combinator { Other, Copy, Or };
 /// AND-style writes (incl. `s_and_saveexec exec, -1`, where `exec & -1 == exec`)
 /// and writes of any other value fall through to `Narrowing`.
 [[nodiscard]] ExecWrite classify(const Instruction &inst, uint32_t wave_size) {
-  if (!writes_exec(inst))
+  if (!writes_execution_mask(inst))
     return ExecWrite::None;
   const ExecWriteExtent ext = exec_write_extent(inst, wave_size);
   if (ext.disjoint)

--- a/emulation/rocjitsu/tests/check_model_only_symbols.cmake
+++ b/emulation/rocjitsu/tests/check_model_only_symbols.cmake
@@ -17,7 +17,6 @@ endif()
 
 set(_forbidden_symbols
     "::execute_impl("
-    "_exec("
     "rocjitsu::amdgpu::ComputeUnitCore"
     "ds_calculate_addresses("
     "flat_calculate_addresses("
@@ -32,6 +31,17 @@ foreach(_forbidden IN LISTS _forbidden_symbols)
         )
     endif()
 endforeach()
+
+# Generated gfx1250 execution helpers use an `_exec` suffix. Qualify the
+# namespace so unrelated analysis helpers such as writes_exec remain valid.
+set(_forbidden_symbol_pattern "rocjitsu::gfx1250::[A-Za-z0-9_:]+_exec\\(")
+string(REGEX MATCH "${_forbidden_symbol_pattern}" _match "${_symbols}")
+if(_match)
+    message(
+        FATAL_ERROR
+        "model-only binary contains forbidden symbol matching: ${_forbidden_symbol_pattern}"
+    )
+endif()
 
 # Keep the denylist from passing vacuously if the model objects disappear from
 # the final link.

--- a/emulation/rocjitsu/tests/check_model_only_symbols.cmake
+++ b/emulation/rocjitsu/tests/check_model_only_symbols.cmake
@@ -17,6 +17,7 @@ endif()
 
 set(_forbidden_symbols
     "::execute_impl("
+    "_exec("
     "rocjitsu::amdgpu::ComputeUnitCore"
     "ds_calculate_addresses("
     "flat_calculate_addresses("
@@ -31,17 +32,6 @@ foreach(_forbidden IN LISTS _forbidden_symbols)
         )
     endif()
 endforeach()
-
-# Generated gfx1250 execution helpers use an `_exec` suffix. Qualify the
-# namespace so unrelated analysis helpers such as writes_exec remain valid.
-set(_forbidden_symbol_pattern "rocjitsu::gfx1250::[A-Za-z0-9_:]+_exec\\(")
-string(REGEX MATCH "${_forbidden_symbol_pattern}" _match "${_symbols}")
-if(_match)
-    message(
-        FATAL_ERROR
-        "model-only binary contains forbidden symbol matching: ${_forbidden_symbol_pattern}"
-    )
-endif()
 
 # Keep the denylist from passing vacuously if the model objects disappear from
 # the final link.


### PR DESCRIPTION
## Motivation

Fix the model-only symbol boundary test under GCC sanitizer builds. GCC retains the internal writes_exec analysis helper, whose name collides with the _exec( denylist intended for execution-semantic helpers.

## Technical Details

Rename writes_exec to writes_execution_mask.

This preserves the existing _exec( boundary check while clarifying that the helper analyzes writes to the GPU EXEC mask rather than implementing instruction execution semantics.

## Issue Tracking

N/A

## Test Plan

Build RocJITsu with GCC and sanitizers enabled, then run:

ctest --test-dir build -R Gfx1250B0ToA0Library.SymbolBoundary --output-on-failure
rocjitsu::gfx1250::*_exec(...)

This continues to detect execution symbols in model-only binaries while allowing unrelated analysis helpers such as rocjitsu::(anonymous namespace)::writes_exec(...).

## Test Result

The targeted symbol boundary test passes with the GCC sanitizer build. No lint or formatting errors were reported.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
