### PR TITLE
[rocjitsu][CI] Warn after unrelated corpus matrix failures

### DIFF
--- a/.github/scripts/rocjitsu_corpus_translation_comment.py
+++ b/.github/scripts/rocjitsu_corpus_translation_comment.py
@@ -169,8 +169,9 @@ def resolve_plan(event: dict[str, Any], api: Any, repository: str) -> Comparison
     run = event.get("workflow_run")
     if not isinstance(run, dict) or run.get("event") != "pull_request":
         return ComparisonPlan(False, "Source workflow was not a pull-request run.")
-    if run.get("conclusion") != "success":
-        return ComparisonPlan(False, "Source pull-request workflow did not succeed.")
+    # The candidate artifact is uploaded only after the release manifest is
+    # finalized. Other matrix lanes may fail independently, so the aggregate
+    # workflow conclusion is not a prerequisite for comparison.
     if run.get("path") != TRUSTED_WORKFLOW_PATH:
         return ComparisonPlan(
             False,

--- a/.github/scripts/test-rocjitsu-corpus-translation-comment.py
+++ b/.github/scripts/test-rocjitsu-corpus-translation-comment.py
@@ -103,13 +103,22 @@ class PlanTest(unittest.TestCase):
         self.assertTrue(plan.ready)
         self.assertIsNone(plan.baseline_run_id)
 
-    def test_skips_unsuccessful_source_run(self) -> None:
+    def test_accepts_failed_source_run_with_valid_candidate(self) -> None:
         self.event["workflow_run"]["conclusion"] = "failure"
 
         plan = HELPER.resolve_plan(self.event, self.api, REPOSITORY)
 
+        self.assertTrue(plan.ready)
+        self.assertEqual(plan.candidate_run_id, 100)
+
+    def test_skips_source_run_without_candidate(self) -> None:
+        self.event["workflow_run"]["conclusion"] = "failure"
+        self.api.artifacts[100] = []
+
+        plan = HELPER.resolve_plan(self.event, self.api, REPOSITORY)
+
         self.assertFalse(plan.ready)
-        self.assertIn("did not succeed", plan.reason)
+        self.assertIn("found 0", plan.reason)
 
     def test_skips_untrusted_source_workflow_path(self) -> None:
         self.event["workflow_run"]["path"] = ".github/workflows/untrusted.yml"


### PR DESCRIPTION
Compare a pull-request translation manifest whenever the release lane successfully uploads it, even if another corpus matrix lane fails. The candidate artifact remains gated on successful manifest finalization, and the trusted workflow continues to validate workflow provenance, repository identity, the current PR head, artifact uniqueness, and artifact size.

Cover both failed-matrix cases: a valid candidate proceeds, while a missing candidate remains ineligible. Validated the 20 helper tests, 15 manifest-tool tests, Python compilation, and pre-commit hooks.