### PR TITLE
docs(rocprofiler-sdk): Add rocprofv3 output format warnings and ROCpd guidance 

### DIFF
--- a/.github/actions/rocprofiler-sdk-util/action.yml
+++ b/.github/actions/rocprofiler-sdk-util/action.yml
@@ -79,7 +79,7 @@ runs:
       run: |
         echo "PKG_CONFIG_PATH=/opt/amdgpu/lib64/pkgconfig:/opt/amdgpu/lib/pkgconfig:/opt/amdgpu/lib/$(uname -p)-linux-gnu/pkgconfig:${PKG_CONFIG_PATH}" >> $GITHUB_ENV
         echo "LD_LIBRARY_PATH=${{ inputs.rocm-path }}/lib64:${{ inputs.rocm-path }}/lib:${{ inputs.rocm-path }}/llvm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
-        echo "PATH=${{ inputs.rocm-path }}/bin:${{ inputs.rocm-path }}/llvm/bin:$HOME/.local/bin:${PATH}" >> $GITHUB_ENV
+        echo "PATH=$HOME/.local/bin:${{ inputs.rocm-path }}/bin:${{ inputs.rocm-path }}/llvm/bin:${PATH}" >> $GITHUB_ENV
 
     - name: Setup ccache
       if: ${{ inputs.enable-ccache == 'true' }}

--- a/.github/actions/rocprofiler-sdk-util/action.yml
+++ b/.github/actions/rocprofiler-sdk-util/action.yml
@@ -79,7 +79,7 @@ runs:
       run: |
         echo "PKG_CONFIG_PATH=/opt/amdgpu/lib64/pkgconfig:/opt/amdgpu/lib/pkgconfig:/opt/amdgpu/lib/$(uname -p)-linux-gnu/pkgconfig:${PKG_CONFIG_PATH}" >> $GITHUB_ENV
         echo "LD_LIBRARY_PATH=${{ inputs.rocm-path }}/lib64:${{ inputs.rocm-path }}/lib:${{ inputs.rocm-path }}/llvm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
-        echo "PATH=$HOME/.local/bin:${{ inputs.rocm-path }}/bin:${{ inputs.rocm-path }}/llvm/bin:${PATH}" >> $GITHUB_ENV
+        echo "PATH=${{ inputs.rocm-path }}/bin:${{ inputs.rocm-path }}/llvm/bin:$HOME/.local/bin:${PATH}" >> $GITHUB_ENV
 
     - name: Setup ccache
       if: ${{ inputs.enable-ccache == 'true' }}

--- a/.github/workflows/rocprofiler-sdk-code_coverage.yml
+++ b/.github/workflows/rocprofiler-sdk-code_coverage.yml
@@ -213,8 +213,8 @@ jobs:
         git config --global --add safe.directory '*'
         apt-get update
         apt-get install -y build-essential ccache python3-pip gcovr wkhtmltopdf xvfb xfonts-base xfonts-75dpi xfonts-100dpi xfonts-utils xfonts-encodings libfontconfig libdw-dev libsqlite3-dev libdrm-dev file autoconf pkg-config rpm libzstd-dev
-        python3 -m pip install -U --user cmake==3.25.0
         python3 -m pip install -U --user -r requirements.txt
+        python3 -m pip install -U --user cmake==3.25.0
 
     - name: Sync gcov with compilers
       timeout-minutes: 10

--- a/.github/workflows/rocprofiler-sdk-code_coverage.yml
+++ b/.github/workflows/rocprofiler-sdk-code_coverage.yml
@@ -199,12 +199,6 @@ jobs:
       run: |
         if [ -d .codecov ]; then cp -r .codecov .codecov.ref; fi
 
-    - name: Configure Env
-      shell: bash
-      run: |
-        echo "${PATH}:/usr/local/bin:${HOME}/.local/bin" >> $GITHUB_PATH
-        echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib:${HOME}/.local/lib" >> $GITHUB_ENV
-
     - name: Install requirements
       timeout-minutes: 10
       shell: bash
@@ -212,7 +206,7 @@ jobs:
       run: |
         git config --global --add safe.directory '*'
         apt-get update
-        apt-get install -y build-essential ccache python3-pip gcovr wkhtmltopdf xvfb xfonts-base xfonts-75dpi xfonts-100dpi xfonts-utils xfonts-encodings libfontconfig libdw-dev libsqlite3-dev libdrm-dev file autoconf pkg-config rpm libzstd-dev
+        apt-get install -y build-essential ccache cmake python3-pip gcovr wkhtmltopdf xvfb xfonts-base xfonts-75dpi xfonts-100dpi xfonts-utils xfonts-encodings libfontconfig libdw-dev libsqlite3-dev libdrm-dev file autoconf pkg-config rpm libzstd-dev
         python3 -m pip install -U --user -r requirements.txt
         python3 -m pip install -U --user cmake==3.25.0
 

--- a/.github/workflows/rocprofiler-sdk-docs.yml
+++ b/.github/workflows/rocprofiler-sdk-docs.yml
@@ -179,6 +179,7 @@ jobs:
           apt-get update
           apt-get install -y cmake gcc g++ libdw-dev libsqlite3-dev rpm
           python3 -m pip install -r requirements.txt
+          python3 -m pip install -U --user cmake==3.25.0
 
       - name: Build ROCProfiler SDK Dependencies
         uses: ./.github/actions/rocprofiler-sdk-util

--- a/projects/rocprofiler-sdk/source/bin/rocprofv3.py
+++ b/projects/rocprofiler-sdk/source/bin/rocprofv3.py
@@ -51,6 +51,7 @@ CONST_VERSION_INFO = {
 # source/lib/output/output_config.hpp) so both validation paths agree.
 PERFETTO_BUFFER_SIZE_KB_MIN = 1
 PERFETTO_BUFFER_SIZE_KB_MAX = ((1 << 32) - 1) // 1024
+DEPRECATED_DIRECT_OUTPUT_FORMATS = ("csv", "pftrace", "otf2")
 
 
 class dotdict(dict):
@@ -98,6 +99,30 @@ def warning(msg, *args):
     msg = patch_message(msg, *args)
     sys.stderr.write(f"[rocprofv3] Warning: {msg}\n")
     sys.stderr.flush()
+
+
+def warn_deprecated_output_formats(output_formats):
+    requested_formats = {
+        str(itr).strip().lower() for itr in (output_formats or []) if str(itr).strip()
+    }
+    deprecated_formats = [
+        itr for itr in DEPRECATED_DIRECT_OUTPUT_FORMATS if itr in requested_formats
+    ]
+
+    if deprecated_formats:
+        display_names = {
+            "csv": "CSV",
+            "pftrace": "PFTrace (Perfetto)",
+            "otf2": "OTF2",
+        }
+        warning(
+            "The following direct rocprofv3 output format(s) are deprecated: "
+            f"{', '.join(display_names[itr] for itr in deprecated_formats)}. "
+            "Some tracing features, including hipFILE and rocSHMEM tracing, might not "
+            "produce output in these formats. Use `--output-format rocpd` (the default), "
+            "then run `rocpd convert -i <database>.db --output-format csv` when CSV "
+            "output is needed."
+        )
 
 
 def format_help(formatter, w=120, h=40):
@@ -515,7 +540,7 @@ For attachment profiling of running processes:
     io_options.add_argument(
         "-f",
         "--output-format",
-        help="For adding output format (supported formats: csv, json, pftrace, otf2, rocpd)",
+        help="For adding output format (supported formats: csv, json, pftrace, otf2, rocpd). Direct csv, pftrace, and otf2 output is deprecated; use rocpd and rocpd convert",
         nargs="+",
         default=None,
         choices=("csv", "json", "pftrace", "otf2", "rocpd"),
@@ -1699,6 +1724,12 @@ def run(app_args, args, **kwargs):
 
     if not args.output_format:
         args.output_format = ["rocpd"]
+
+    effective_output_formats = list(args.output_format)
+    effective_output_formats.extend(
+        re.split(r"[\s,;:]+", app_env.get("ROCPROF_OUTPUT_FORMAT", ""))
+    )
+    warn_deprecated_output_formats(effective_output_formats)
 
     if args.kokkos_trace:
         update_env("KOKKOS_TOOLS_LIBS", ROCPROF_KOKKOSP_LIBRARY, append=True)

--- a/projects/rocprofiler-sdk/source/bin/rocprofv3.py
+++ b/projects/rocprofiler-sdk/source/bin/rocprofv3.py
@@ -1729,7 +1729,8 @@ def run(app_args, args, **kwargs):
     effective_output_formats.extend(
         re.split(r"[\s,;:]+", app_env.get("ROCPROF_OUTPUT_FORMAT", ""))
     )
-    warn_deprecated_output_formats(effective_output_formats)
+    if args.hipfile_trace or args.rocshmem_trace:
+        warn_deprecated_output_formats(effective_output_formats)
 
     if args.kokkos_trace:
         update_env("KOKKOS_TOOLS_LIBS", ROCPROF_KOKKOSP_LIBRARY, append=True)

--- a/projects/rocprofiler-sdk/source/docs/conceptual/comparing-with-legacy-tools.rst
+++ b/projects/rocprofiler-sdk/source/docs/conceptual/comparing-with-legacy-tools.rst
@@ -450,4 +450,4 @@ Timing information: rocprofv3 versus rocprof and rocprofv2
 Default behavior: rocprofv3 versus rocprof and rocprofv2
 =========================================================
 
-When run without an option, ``rocprofv3`` behaves differently than ``rocprof`` and ``rocprofv2``. The default behavior of ``rocprofv3`` is to collect all available agents on the system and output them in ``CSV`` format, while ``rocprof`` and ``rocprofv2`` output the kernel traces in ``CSV`` format by default. On ``rocprofv3``, kernel traces are generated using ``--kernel-trace`` option.
+When run without an option, ``rocprofv3`` behaves differently than ``rocprof`` and ``rocprofv2``. The default behavior of ``rocprofv3`` is to collect all available agents on the system and output them in the ``rocpd`` SQLite3 database format, while ``rocprof`` and ``rocprofv2`` output kernel traces in CSV format by default. On ``rocprofv3``, kernel traces are generated using the ``--kernel-trace`` option. To obtain CSV from ``rocprofv3``, collect in the default rocpd format and run ``rocpd convert -i <output-file>_results.db --output-format csv``.

--- a/projects/rocprofiler-sdk/source/docs/conf.py
+++ b/projects/rocprofiler-sdk/source/docs/conf.py
@@ -75,6 +75,7 @@ breathe_default_project = "rocprofiler-sdk"
 doxyfile = "rocprofiler-sdk.dox"
 
 external_projects_current_project = "rocprofiler-sdk"
+external_projects_remote_repository = ""
 external_projects = []
 
 master_doc = "index"

--- a/projects/rocprofiler-sdk/source/docs/how-to/rocprofv3-io-options.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/rocprofv3-io-options.rst
@@ -11,6 +11,12 @@ rocprofv3 I/O control options
 
 ``rocprofv3`` provides the following options to control the output.
 
+.. warning::
+
+   Direct CSV, PFTrace, and OTF2 output from ``rocprofv3`` is deprecated and might omit data for some tracing features, including hipFILE and rocSHMEM tracing.
+   The examples below use direct CSV to illustrate output naming.
+   For data collection, use the default rocpd format and run ``rocpd convert -i <output-file>_results.db --output-format csv`` when CSV is needed.
+
 .. _output-prefix-keys:
 
 Output prefix keys

--- a/projects/rocprofiler-sdk/source/docs/how-to/using-rocpd-output-format.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/using-rocpd-output-format.rst
@@ -16,6 +16,11 @@ To accommodate diverse analysis workflows, ``rocprofv3`` provides comprehensive 
 - **PFTrace** (Perfetto protocol buffers) - Binary trace format for high-performance visualization using Perfetto.
 - **OTF2** (Open Trace Format 2) - Standardized trace format for interoperability with third-party analysis tools.
 
+.. warning::
+
+   Direct CSV, PFTrace, and OTF2 output from ``rocprofv3`` is deprecated and might omit data for some tracing features, including hipFILE and rocSHMEM tracing.
+   Collect in the default rocpd format, then use ``rocpd convert`` to create CSV, PFTrace, or OTF2 output.
+
 The ``rocpd`` output format serves as the primary data repository for ``rocprofv3`` profiling sessions. This format leverages SQLite3's ACID-compliant database engine to provide robust, structured storage of comprehensive profiling datasets. The relational schema enables efficient querying and manipulation of profiling data through standard SQL interfaces, facilitating complex analytical operations and custom reporting workflows.
 
 Features

--- a/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3.rst
@@ -131,12 +131,19 @@ To use ``rocprofv3`` for application tracing, run:
     rocprofv3 <tracing_option> -- <application_path>
 
 
-.. note::
+.. warning::
 
-  All the tracing examples below use the ``--output-format csv`` option to generate output in CSV format.
-  However, the default output format is ``rocpd`` (SQLite3 database). You can simply omit the ``--output-format`` option to generate output in the default format.
-  ``rocpd`` format can be converted to other formats such as CSV, OTF2, and PFTrace using the ``rocpd`` module.
-  To understand how to convert ``rocpd`` output to other formats, see :ref:`using-rocpd-output-format`.
+  The tracing examples below use ``--output-format csv`` to demonstrate the CSV data layout.
+  Direct CSV, PFTrace (Perfetto), and OTF2 output from ``rocprofv3`` is deprecated and might omit data for some tracing features, including hipFILE and rocSHMEM tracing.
+  Use the default ``rocpd`` format for data collection, then use ``rocpd convert`` when CSV output is needed:
+
+  .. code-block:: bash
+
+     rocprofv3 <tracing_option> --output-format rocpd -- <application_path>
+     rocpd convert -i <output-file>_results.db --output-format csv
+
+  You can omit ``--output-format rocpd`` because ``rocpd`` is the default.
+  For more conversion options, see :ref:`using-rocpd-output-format`.
 
 HIP trace
 +++++++++++
@@ -612,9 +619,11 @@ hipFILE trace
 
 .. code-block:: shell
 
-    rocprofv3 --hipfile-trace --output-format json rocpd -- <application_path>
+    rocprofv3 --hipfile-trace -- <application_path>
+    rocpd convert -i <output-file>_results.db --output-format csv
 
-The above command stores hipFILE API records in the JSON results file and the rocpd database file.
+The first command stores hipFILE API records in the default rocpd database.
+hipFILE is emitted directly only to the JSON and ``rocpd`` formats; use ``rocpd convert`` to produce CSV, Perfetto, or OTF2 output from the database.
 
 The hipFILE records include API arguments. Pointers are not dereferenced unless argument
 iteration is configured to do so.
@@ -1491,27 +1500,38 @@ Output formats
 ----------------
 
 - rocpd (SQLite3 Database (Default))
-- CSV
+- CSV (direct output is deprecated)
 - JSON (Custom format for programmatic analysis only)
-- PFTrace (Perfetto trace for visualization with Perfetto)
-- OTF2 (Open Trace Format for visualization with compatible third-party tools)
+- PFTrace (Perfetto trace; direct output is deprecated)
+- OTF2 (Open Trace Format; direct output is deprecated)
 
 
-The default output format is ``rocpd``. To know more about the rocpd format, see :ref:`using-rocpd-output-format`.
+The default and recommended output format is ``rocpd``. To know more about the rocpd format, see :ref:`using-rocpd-output-format`.
 To specify the particular output format, use the ``--output-format`` option followed by the desired format.
 
-.. code-block::
+.. warning::
+
+   Direct CSV, PFTrace, and OTF2 generation by ``rocprofv3`` is deprecated.
+   These direct generators might not produce output for every tracing feature, including hipFILE and rocSHMEM tracing.
+   Collect to rocpd and convert the database instead:
+
+   .. code-block:: bash
+
+      rocprofv3 <tracing_option> --output-format rocpd -- <application_path>
+      rocpd convert -i <output-file>_results.db --output-format csv
+
+.. code-block:: bash
 
    rocprofv3 -i input.txt --output-format json -- <application_path>
 
-Format selection is case-insensitive and multiple output formats are supported. While ``--output-format json`` exclusively enables JSON output, ``--output-format csv json pftrace otf2, rocpd`` enables all four output formats for the run.
+Format selection is case-insensitive and multiple output formats are supported. For example, ``--output-format json rocpd`` enables both JSON and rocpd output for the run.
 
-For PFTrace trace visualization, use the PFTrace format and open the trace in `ui.perfetto.dev <https://ui.perfetto.dev/>`_.
+For PFTrace trace visualization, convert the rocpd database using ``rocpd convert -i <output-file>_results.db --output-format pftrace`` and open the trace in `ui.perfetto.dev <https://ui.perfetto.dev/>`_.
 
-For OTF2 trace visualization, open the trace in `vampir.eu <https://vampir.eu/>`_ or any supported visualizer.
+For OTF2 trace visualization, convert the rocpd database using ``rocpd convert -i <output-file>_results.db --output-format otf2`` and open the trace in `vampir.eu <https://vampir.eu/>`_ or any supported visualizer.
 
 .. note::
-  For large trace files (> 10GB), it's recommended to use OTF2 format.
+  For large converted trace files (> 10GB), it's recommended to use OTF2 format.
 
 JSON output schema
 ++++++++++++++++++++

--- a/projects/rocprofiler-sdk/source/docs/quick-reference/quick_guide.rst
+++ b/projects/rocprofiler-sdk/source/docs/quick-reference/quick_guide.rst
@@ -148,13 +148,15 @@ Working with rocpd database format
 
 **Documentation:** :ref:`using-rocpd-output-format`
 
-Collection in various formats
-------------------------------
+Conversion to other formats
+---------------------------
 
 .. code-block:: bash
 
-   # Multiple output formats in one run
-   rocprofv3 --runtime-trace --output-format csv json pftrace otf2 -- ./your_app
+   # Direct CSV, PFTrace, and OTF2 collection is deprecated.
+   # Collect in the default rocpd format, then convert the database.
+   rocprofv3 --runtime-trace -- ./your_app
+   rocpd convert -i hostname/12345_results.db -f csv pftrace otf2
 
 **Documentation:** :ref:`using-rocpd-output-format`
 

--- a/projects/rocprofiler-sdk/source/docs/quick-reference/rocprofv3-cli-options.rst
+++ b/projects/rocprofiler-sdk/source/docs/quick-reference/rocprofv3-cli-options.rst
@@ -41,7 +41,7 @@ The following table lists the commonly used ``rocprofv3`` command-line options c
                 </tr>
                 <tr>
                     <td>-f {csv,json,pftrace,otf2,rocpd} [{csv,json,pftrace,otf2,rocpd} ...] | --output-format {csv,json,pftrace,otf2,rocpd} [{csv,json,pftrace,otf2,rocpd} ...]</td>
-                    <td>Specifies output format. Supported formats: CSV, JSON, PFTrace, OTF2 and rocpd. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#output-formats">Read more...</a></td>
+                    <td>Specifies output format. Supported formats: CSV, JSON, PFTrace, OTF2 and rocpd. Direct CSV, PFTrace, and OTF2 output is deprecated; collect in the default rocpd format and use <code>rocpd convert</code> instead. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#output-formats">Read more...</a></td>
                 </tr>
                 <tr>
                     <td>--output-config [BOOL]</td>

--- a/projects/rocprofiler-sdk/source/docs/rocprofv3_input_schema.json
+++ b/projects/rocprofiler-sdk/source/docs/rocprofv3_input_schema.json
@@ -157,7 +157,7 @@
 
                      "output_format":{
                       "type": "array",
-                      "description": "For adding output format (supported formats: csv, json, pftrace)"
+                      "description": "For adding output format (supported formats: csv, json, pftrace, otf2, rocpd). Direct csv, pftrace, and otf2 output is deprecated; use rocpd and rocpd convert"
                      },
 
                      "list_metrics" : {

--- a/projects/rocprofiler-sdk/tests/rocprofv3/negate-aggregate-tracing-options/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/negate-aggregate-tracing-options/CMakeLists.txt
@@ -86,7 +86,7 @@ rocprofiler_add_integration_execute_test(
 rocprofiler_add_integration_execute_test(
     rocprofv3-test-deprecated-direct-output-formats-warning
     COMMAND $<TARGET_FILE:rocprofiler-sdk::rocprofv3> --output-format csv pftrace otf2
-            --echo -- ${CMAKE_COMMAND}
+            --hipfile-trace --rocshmem-trace --echo -- ${CMAKE_COMMAND}
     DEPENDS rocprofiler-sdk::rocprofv3
     TIMEOUT 45
     LABELS "integration-tests"
@@ -98,7 +98,8 @@ rocprofiler_add_integration_execute_test(
 rocprofiler_add_integration_execute_test(
     rocprofv3-test-deprecated-direct-output-format-env-warning
     COMMAND ${CMAKE_COMMAND} -E env ROCPROF_OUTPUT_FORMAT=csv
-            $<TARGET_FILE:rocprofiler-sdk::rocprofv3> --echo -- ${CMAKE_COMMAND}
+            $<TARGET_FILE:rocprofiler-sdk::rocprofv3> --hipfile-trace --echo --
+            ${CMAKE_COMMAND}
     DEPENDS rocprofiler-sdk::rocprofv3
     TIMEOUT 45
     LABELS "integration-tests"

--- a/projects/rocprofiler-sdk/tests/rocprofv3/negate-aggregate-tracing-options/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/negate-aggregate-tracing-options/CMakeLists.txt
@@ -82,3 +82,26 @@ rocprofiler_add_integration_execute_test(
     LABELS "integration-tests"
     PRELOAD "${PRELOAD_ENV}"
     WILL_FAIL)
+
+rocprofiler_add_integration_execute_test(
+    rocprofv3-test-deprecated-direct-output-formats-warning
+    COMMAND $<TARGET_FILE:rocprofiler-sdk::rocprofv3> --output-format csv pftrace otf2
+            --echo -- ${CMAKE_COMMAND}
+    DEPENDS rocprofiler-sdk::rocprofv3
+    TIMEOUT 45
+    LABELS "integration-tests"
+    PRELOAD "${PRELOAD_ENV}"
+    PASS_REGULAR_EXPRESSION
+        "direct rocprofv3 output format.*deprecated: CSV, PFTrace \\(Perfetto\\), OTF2.*hipFILE and rocSHMEM"
+    )
+
+rocprofiler_add_integration_execute_test(
+    rocprofv3-test-deprecated-direct-output-format-env-warning
+    COMMAND ${CMAKE_COMMAND} -E env ROCPROF_OUTPUT_FORMAT=csv
+            $<TARGET_FILE:rocprofiler-sdk::rocprofv3> --echo -- ${CMAKE_COMMAND}
+    DEPENDS rocprofiler-sdk::rocprofv3
+    TIMEOUT 45
+    LABELS "integration-tests"
+    PRELOAD "${PRELOAD_ENV}"
+    PASS_REGULAR_EXPRESSION
+        "direct rocprofv3 output format.*deprecated: CSV.*hipFILE and rocSHMEM")

--- a/projects/rocprofiler-sdk/tests/rocprofv3/negate-aggregate-tracing-options/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/negate-aggregate-tracing-options/CMakeLists.txt
@@ -97,9 +97,10 @@ rocprofiler_add_integration_execute_test(
 
 rocprofiler_add_integration_execute_test(
     rocprofv3-test-deprecated-direct-output-format-env-warning
-    COMMAND ${CMAKE_COMMAND} -E env ROCPROF_OUTPUT_FORMAT=csv
-            $<TARGET_FILE:rocprofiler-sdk::rocprofv3> --hipfile-trace --echo --
-            ${CMAKE_COMMAND}
+    COMMAND
+        ${CMAKE_COMMAND} -E env ROCPROF_OUTPUT_FORMAT=csv
+        $<TARGET_FILE:rocprofiler-sdk::rocprofv3> --hipfile-trace --echo --
+        ${CMAKE_COMMAND}
     DEPENDS rocprofiler-sdk::rocprofv3
     TIMEOUT 45
     LABELS "integration-tests"


### PR DESCRIPTION
## Motivation

- Clear documentation about rocprofv3 output-format 

## Technical Details

- Added runtime deprecation warning for direct CSV, PFTrace/Perfetto, and OTF2 output.
- Warning recommends ROCpd and rocpd convert, noting hipFILE/rocSHMEM limitations.
- Updated CLI help, ROCpd/rocprofv3 docs, quick references, and input schema.

## Issue Tracking

JIRA ID: AIPROFSDK-1010
JIRA ID: ROCM-28947
JIRA ID: ROCM-27452

## Test Plan

Added and passed an integration test for the warning.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
