### PR TITLE
[rocSHMEM] Reduce IPC RMA latency in symmetric address translation

### DIFF
--- a/projects/rocshmem/src/constmem.cpp
+++ b/projects/rocshmem/src/constmem.cpp
@@ -32,6 +32,9 @@ void init_constant_memory(void) {
   // Non-zero when IPC is available, regardless of stride pattern.
   constmem_values.ipc_shm_size = (backend->ipcImpl.pes_with_ipc_avail != nullptr)
                                  ? backend->ipcImpl.shm_size : 0;
+  constmem_values.heap_base =
+      reinterpret_cast<uintptr_t>(backend->heap.get_local_heap_base());
+  constmem_values.heap_size = backend->heap.get_size();
 
   constmem_values.backend_type = backend->get_type();
 #if defined(USE_GDA)

--- a/projects/rocshmem/src/constmem.hpp
+++ b/projects/rocshmem/src/constmem.hpp
@@ -26,6 +26,8 @@
 #define LIBRARY_SRC_CONSTMEM_HPP_
 
 #include <array>
+#include <cstddef>
+#include <cstdint>
 
 #include "gda/gda_enums.hpp"
 #include "rocshmem/rocshmem_common.hpp"

--- a/projects/rocshmem/src/constmem.hpp
+++ b/projects/rocshmem/src/constmem.hpp
@@ -42,6 +42,8 @@ struct constmem_t {
   int ipc_first_pe;
   int ipc_stride;    // 0 = pattern invalid (use fallback linear scan)
   int ipc_shm_size;
+  uintptr_t heap_base;  // Local symmetric heap base
+  size_t heap_size;     // Local symmetric heap size in bytes
 } __attribute__ ((aligned (16)));
 
 extern __constant__ constmem_t constmem;

--- a/projects/rocshmem/src/gda/context_gda_device.cpp
+++ b/projects/rocshmem/src/gda/context_gda_device.cpp
@@ -84,7 +84,7 @@ __device__ void GDAContext::putmem(void *dest, const void *source, size_t nelems
   int local_pe{-1};
   char *remote{nullptr};
   if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe) &&
-      (remote = ipc_peer_ptr(dest, local_pe)) != nullptr) {
+      (remote = ipcImpl_.ipcPeerPtr(dest, local_pe)) != nullptr) {
     ipcImpl_.ipcCopy<MemcpyKind::PutBlocking>(remote, const_cast<void *>(source), nelems, local_pe);
     return;
   }
@@ -99,7 +99,7 @@ __device__ void GDAContext::getmem(void *dest, const void *source, size_t nelems
   int local_pe{-1};
   char *remote{nullptr};
   if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe) &&
-      (remote = ipc_peer_ptr(source, local_pe)) != nullptr) {
+      (remote = ipcImpl_.ipcPeerPtr(source, local_pe)) != nullptr) {
     ipcImpl_.ipcCopy<MemcpyKind::GetBlocking>(dest, remote, nelems, local_pe);
     return;
   }
@@ -114,7 +114,7 @@ __device__ void GDAContext::putmem_nbi(void *dest, const void *source,
   int local_pe{-1};
   char *remote{nullptr};
   if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe) &&
-      (remote = ipc_peer_ptr(dest, local_pe)) != nullptr) {
+      (remote = ipcImpl_.ipcPeerPtr(dest, local_pe)) != nullptr) {
     ipcImpl_.ipcCopy<MemcpyKind::Put>(remote, const_cast<void *>(source), nelems, local_pe);
     return;
   }
@@ -128,7 +128,7 @@ __device__ void GDAContext::getmem_nbi(void *dest, const void *source,
   int local_pe{-1};
   char *remote{nullptr};
   if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe) &&
-      (remote = ipc_peer_ptr(source, local_pe)) != nullptr) {
+      (remote = ipcImpl_.ipcPeerPtr(source, local_pe)) != nullptr) {
     ipcImpl_.ipcCopy<MemcpyKind::Get>(dest, remote, nelems, local_pe);
     return;
   }
@@ -223,7 +223,7 @@ __device__ void *GDAContext::shmem_ptr(const void *dest, int pe) {
    * IPC). NIC-only registered buffers and non-node-local peers return nullptr.
    */
   if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
-    return ipc_peer_ptr(dest, local_pe);
+    return ipcImpl_.ipcPeerPtr(dest, local_pe);
   }
   return nullptr;
 }
@@ -233,7 +233,7 @@ __device__ void GDAContext::putmem_wg(void *dest, const void *source,
   int local_pe{-1};
   char *remote{nullptr};
   if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe) &&
-      (remote = ipc_peer_ptr(dest, local_pe)) != nullptr) {
+      (remote = ipcImpl_.ipcPeerPtr(dest, local_pe)) != nullptr) {
     ipcImpl_.ipcCopy_wg<MemcpyKind::PutBlocking>(remote, const_cast<void *>(source), nelems, local_pe);
     return;
   }
@@ -250,7 +250,7 @@ __device__ void GDAContext::getmem_wg(void *dest, const void *source,
   int local_pe{-1};
   char *remote{nullptr};
   if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe) &&
-      (remote = ipc_peer_ptr(source, local_pe)) != nullptr) {
+      (remote = ipcImpl_.ipcPeerPtr(source, local_pe)) != nullptr) {
     ipcImpl_.ipcCopy_wg<MemcpyKind::GetBlocking>(dest, remote, nelems, local_pe);
     return;
   }
@@ -267,7 +267,7 @@ __device__ void GDAContext::putmem_nbi_wg(void *dest, const void *source,
   int local_pe{-1};
   char *remote{nullptr};
   if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe) &&
-      (remote = ipc_peer_ptr(dest, local_pe)) != nullptr) {
+      (remote = ipcImpl_.ipcPeerPtr(dest, local_pe)) != nullptr) {
     ipcImpl_.ipcCopy_wg<MemcpyKind::Put>(remote, const_cast<void *>(source), nelems, local_pe);
     return;
   }
@@ -283,7 +283,7 @@ __device__ void GDAContext::getmem_nbi_wg(void *dest, const void *source,
   int local_pe{-1};
   char *remote{nullptr};
   if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe) &&
-      (remote = ipc_peer_ptr(source, local_pe)) != nullptr) {
+      (remote = ipcImpl_.ipcPeerPtr(source, local_pe)) != nullptr) {
     ipcImpl_.ipcCopy_wg<MemcpyKind::Get>(dest, remote, nelems, local_pe);
     return;
   }
@@ -299,7 +299,7 @@ __device__ void GDAContext::putmem_wave(void *dest, const void *source,
   int local_pe{-1};
   char *remote{nullptr};
   if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe) &&
-      (remote = ipc_peer_ptr(dest, local_pe)) != nullptr) {
+      (remote = ipcImpl_.ipcPeerPtr(dest, local_pe)) != nullptr) {
     ipcImpl_.ipcCopy_wave<MemcpyKind::PutBlocking>(remote, const_cast<void *>(source), nelems, local_pe);
     return;
   }
@@ -316,7 +316,7 @@ __device__ void GDAContext::getmem_wave(void *dest, const void *source,
   int local_pe{-1};
   char *remote{nullptr};
   if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe) &&
-      (remote = ipc_peer_ptr(source, local_pe)) != nullptr) {
+      (remote = ipcImpl_.ipcPeerPtr(source, local_pe)) != nullptr) {
     ipcImpl_.ipcCopy_wave<MemcpyKind::GetBlocking>(dest, remote, nelems, local_pe);
     return;
   }
@@ -333,7 +333,7 @@ __device__ void GDAContext::putmem_nbi_wave(void *dest, const void *source,
   int local_pe{-1};
   char *remote{nullptr};
   if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe) &&
-      (remote = ipc_peer_ptr(dest, local_pe)) != nullptr) {
+      (remote = ipcImpl_.ipcPeerPtr(dest, local_pe)) != nullptr) {
     ipcImpl_.ipcCopy_wave<MemcpyKind::Put>(remote, const_cast<void *>(source), nelems, local_pe);
     return;
   }
@@ -349,7 +349,7 @@ __device__ void GDAContext::getmem_nbi_wave(void *dest, const void *source,
   int local_pe{-1};
   char *remote{nullptr};
   if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe) &&
-      (remote = ipc_peer_ptr(source, local_pe)) != nullptr) {
+      (remote = ipcImpl_.ipcPeerPtr(source, local_pe)) != nullptr) {
     ipcImpl_.ipcCopy_wave<MemcpyKind::Get>(dest, remote, nelems, local_pe);
     return;
   }

--- a/projects/rocshmem/src/gda/context_gda_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_device.hpp
@@ -454,7 +454,7 @@ class GDAContext : public Context {
    */
   __device__ __forceinline__ char *ipc_peer_ptr(const void *sym_addr,
                                                  int local_pe) {
-    return ipcImpl_.ipcPeerPtr(sym_addr, ipcImpl_.shm_rank, local_pe);
+    return ipcImpl_.ipcPeerPtr(sym_addr, local_pe);
   }
 
   //Temporary scratchpad memory used by internal barrier algorithms.

--- a/projects/rocshmem/src/gda/context_gda_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_device.hpp
@@ -443,20 +443,6 @@ class GDAContext : public Context {
    */
   __device__ __forceinline__ uint32_t get_qp_index(int pe, ActiveWFInfo wf_info);
 
-  /**
-   * @brief Resolve the node-local peer pointer for a symmetric address.
-   *
-   * Delegates to the shared IpcImpl::ipcPeerPtr resolver, indexed by this PE's
-   * shm rank and the node-local peer index (as returned by isIpcAvailable).
-   * Handles both heap objects and IPC-registered user buffers; returns nullptr
-   * when the address is not reachable over IPC (e.g. an NIC-only registered
-   * buffer or IPC disabled), so callers fall back to the NIC path.
-   */
-  __device__ __forceinline__ char *ipc_peer_ptr(const void *sym_addr,
-                                                 int local_pe) {
-    return ipcImpl_.ipcPeerPtr(sym_addr, local_pe);
-  }
-
   //Temporary scratchpad memory used by internal barrier algorithms.
   int64_t *barrier_sync{nullptr};
 

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -48,7 +48,7 @@ __device__ void GDAContext::p(T *dest, T value, int pe) {
   int local_pe{-1};
   char *remote{nullptr};
   if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe) &&
-      (remote = ipc_peer_ptr(dest, local_pe)) != nullptr) {
+      (remote = ipcImpl_.ipcPeerPtr(dest, local_pe)) != nullptr) {
     ipcImpl_.ipcCopy<MemcpyKind::Put>(remote, reinterpret_cast<void *>(&value), sizeof(T), local_pe);
     return;
   }
@@ -71,7 +71,7 @@ __device__ T GDAContext::g(const T *source, int pe) {
   int local_pe{-1};
   char *remote{nullptr};
   if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe) &&
-      (remote = ipc_peer_ptr(source, local_pe)) != nullptr) {
+      (remote = ipcImpl_.ipcPeerPtr(source, local_pe)) != nullptr) {
     ipcImpl_.ipcCopy<MemcpyKind::Get>(&ret, remote, sizeof(T), local_pe);
     return ret;
   }

--- a/projects/rocshmem/src/ipc/context_ipc_device.cpp
+++ b/projects/rocshmem/src/ipc/context_ipc_device.cpp
@@ -51,26 +51,26 @@ __host__ IPCContext::IPCContext(Backend *b, unsigned int ctx_id)
 
 __device__ void IPCContext::putmem(void *dest, const void *source, size_t nelems,
                                   int pe) {
-  char *remote = ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe);
+  char *remote = ipcImpl_.ipcPeerPtr(dest, pe);
   ipcImpl_.ipcCopy<MemcpyKind::PutBlocking>(
       remote, const_cast<void *>(source), nelems, pe);
 }
 
 __device__ void IPCContext::getmem(void *dest, const void *source, size_t nelems,
                                   int pe) {
-  char *remote = ipcImpl_.ipcPeerPtr(source, constmem.my_pe, pe);
+  char *remote = ipcImpl_.ipcPeerPtr(source, pe);
   ipcImpl_.ipcCopy<MemcpyKind::GetBlocking>(dest, remote, nelems, pe);
 }
 
 __device__ void IPCContext::putmem_nbi(void *dest, const void *source,
                                       size_t nelems, int pe) {
-  char *remote = ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe);
+  char *remote = ipcImpl_.ipcPeerPtr(dest, pe);
   ipcImpl_.ipcCopy<MemcpyKind::Put>(remote, const_cast<void *>(source), nelems, pe);
 }
 
 __device__ void IPCContext::getmem_nbi(void *dest, const void *source,
                                       size_t nelems, int pe) {
-  char *remote = ipcImpl_.ipcPeerPtr(source, constmem.my_pe, pe);
+  char *remote = ipcImpl_.ipcPeerPtr(source, pe);
   ipcImpl_.ipcCopy<MemcpyKind::Get>(dest, remote, nelems, pe);
 }
 
@@ -92,12 +92,12 @@ __device__ void IPCContext::pe_quiet(size_t pe) {
 }
 
 __device__ void *IPCContext::shmem_ptr(const void *dest, int pe) {
-  return ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe);
+  return ipcImpl_.ipcPeerPtr(dest, pe);
 }
 
 __device__ void IPCContext::putmem_wg(void *dest, const void *source,
                                      size_t nelems, int pe) {
-  char *remote = ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe);
+  char *remote = ipcImpl_.ipcPeerPtr(dest, pe);
   ipcImpl_.ipcCopy_wg<MemcpyKind::PutBlocking>(
       remote, const_cast<void *>(source), nelems, pe);
   __builtin_amdgcn_s_barrier();
@@ -105,45 +105,45 @@ __device__ void IPCContext::putmem_wg(void *dest, const void *source,
 
 __device__ void IPCContext::getmem_wg(void *dest, const void *source,
                                      size_t nelems, int pe) {
-  char *remote = ipcImpl_.ipcPeerPtr(source, constmem.my_pe, pe);
+  char *remote = ipcImpl_.ipcPeerPtr(source, pe);
   ipcImpl_.ipcCopy_wg<MemcpyKind::GetBlocking>(dest, remote, nelems, pe);
   __builtin_amdgcn_s_barrier();
 }
 
 __device__ void IPCContext::putmem_nbi_wg(void *dest, const void *source,
                                          size_t nelems, int pe) {
-  char *remote = ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe);
+  char *remote = ipcImpl_.ipcPeerPtr(dest, pe);
   ipcImpl_.ipcCopy_wg<MemcpyKind::Put>(remote, const_cast<void *>(source), nelems, pe);
 }
 
 __device__ void IPCContext::getmem_nbi_wg(void *dest, const void *source,
                                          size_t nelems, int pe) {
-  char *remote = ipcImpl_.ipcPeerPtr(source, constmem.my_pe, pe);
+  char *remote = ipcImpl_.ipcPeerPtr(source, pe);
   ipcImpl_.ipcCopy_wg<MemcpyKind::Get>(dest, remote, nelems, pe);
 }
 
 __device__ void IPCContext::putmem_wave(void *dest, const void *source,
                                        size_t nelems, int pe) {
-  char *remote = ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe);
+  char *remote = ipcImpl_.ipcPeerPtr(dest, pe);
   ipcImpl_.ipcCopy_wave<MemcpyKind::PutBlocking>(
       remote, const_cast<void *>(source), nelems, pe);
 }
 
 __device__ void IPCContext::getmem_wave(void *dest, const void *source,
                                        size_t nelems, int pe) {
-  char *remote = ipcImpl_.ipcPeerPtr(source, constmem.my_pe, pe);
+  char *remote = ipcImpl_.ipcPeerPtr(source, pe);
   ipcImpl_.ipcCopy_wave<MemcpyKind::GetBlocking>(dest, remote, nelems, pe);
 }
 
 __device__ void IPCContext::putmem_nbi_wave(void *dest, const void *source,
                                            size_t nelems, int pe) {
-  char *remote = ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe);
+  char *remote = ipcImpl_.ipcPeerPtr(dest, pe);
   ipcImpl_.ipcCopy_wave<MemcpyKind::Put>(remote, const_cast<void *>(source), nelems, pe);
 }
 
 __device__ void IPCContext::getmem_nbi_wave(void *dest, const void *source,
                                            size_t nelems, int pe) {
-  char *remote = ipcImpl_.ipcPeerPtr(source, constmem.my_pe, pe);
+  char *remote = ipcImpl_.ipcPeerPtr(source, pe);
   ipcImpl_.ipcCopy_wave<MemcpyKind::Get>(dest, remote, nelems, pe);
 }
 

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -76,69 +76,71 @@ __device__ void IPCContext::get_nbi(T *dest, const T *source, size_t nelems, int
 // Atomics
 template <typename T>
 __device__ void IPCContext::amo_add(void *dest, T value, int pe) {
-  ipcImpl_.ipcAMOAdd(reinterpret_cast<T *>(ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe)), value);
+  ipcImpl_.ipcAMOAdd(reinterpret_cast<T *>(ipcImpl_.ipcPeerPtr(dest, pe)), value);
 }
 
 template <typename T>
 __device__ void IPCContext::amo_set(void *dest, T value, int pe) {
-  ipcImpl_.ipcAMOSet(reinterpret_cast<T *>(ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe)), value);
+  ipcImpl_.ipcAMOSet(reinterpret_cast<T *>(ipcImpl_.ipcPeerPtr(dest, pe)), value);
 }
 
 template <typename T>
 __device__ T IPCContext::amo_swap(void *dest, T value, int pe) {
   return ipcImpl_.ipcAMOSwap(
-      reinterpret_cast<T *>(ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe)), value);
+      reinterpret_cast<T *>(ipcImpl_.ipcPeerPtr(dest, pe)), value);
 }
 
 template <typename T>
 __device__ T IPCContext::amo_fetch_and(void *dest, T value, int pe) {
   return ipcImpl_.ipcAMOFetchAnd(
-      reinterpret_cast<T *>(ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe)), value);
+      reinterpret_cast<T *>(ipcImpl_.ipcPeerPtr(dest, pe)), value);
 }
 
 template <typename T>
 __device__ void IPCContext::amo_and(void *dest, T value, int pe) {
   ipcImpl_.ipcAMOAnd(
-      reinterpret_cast<T *>(ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe)), value);
+      reinterpret_cast<T *>(ipcImpl_.ipcPeerPtr(dest, pe)), value);
 }
 
 template <typename T>
 __device__ T IPCContext::amo_fetch_or(void *dest, T value, int pe) {
   return ipcImpl_.ipcAMOFetchOr(
-      reinterpret_cast<T *>(ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe)), value);
+      reinterpret_cast<T *>(ipcImpl_.ipcPeerPtr(dest, pe)), value);
 }
 
 template <typename T>
 __device__ void IPCContext::amo_or(void *dest, T value, int pe) {
   ipcImpl_.ipcAMOOr(
-      reinterpret_cast<T *>(ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe)), value);
+      reinterpret_cast<T *>(ipcImpl_.ipcPeerPtr(dest, pe)), value);
 }
 
 template <typename T>
 __device__ T IPCContext::amo_fetch_xor(void *dest, T value, int pe) {
   return ipcImpl_.ipcAMOFetchXor(
-      reinterpret_cast<T *>(ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe)), value);
+      reinterpret_cast<T *>(ipcImpl_.ipcPeerPtr(dest, pe)), value);
 }
 
 template <typename T>
 __device__ void IPCContext::amo_xor(void *dest, T value, int pe) {
   ipcImpl_.ipcAMOXor(
-      reinterpret_cast<T *>(ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe)), value);
+      reinterpret_cast<T *>(ipcImpl_.ipcPeerPtr(dest, pe)), value);
 }
 
 template <typename T>
 __device__ void IPCContext::amo_cas(void *dest, T value, T cond, int pe) {
-  ipcImpl_.ipcAMOCas(reinterpret_cast<T *>(ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe)), cond, value);
+  ipcImpl_.ipcAMOCas(reinterpret_cast<T *>(ipcImpl_.ipcPeerPtr(dest, pe)), cond, value);
 }
 
 template <typename T>
 __device__ T IPCContext::amo_fetch_add(void *dest, T value, int pe) {
-  return ipcImpl_.ipcAMOFetchAdd(reinterpret_cast<T *>(ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe)), value);
+  return ipcImpl_.ipcAMOFetchAdd(
+      reinterpret_cast<T *>(ipcImpl_.ipcPeerPtr(dest, pe)), value);
 }
 
 template <typename T>
 __device__ T IPCContext::amo_fetch_cas(void *dest, T value, T cond, int pe) {
-  return ipcImpl_.ipcAMOFetchCas(reinterpret_cast<T *>(ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe)), cond, value);
+  return ipcImpl_.ipcAMOFetchCas(
+      reinterpret_cast<T *>(ipcImpl_.ipcPeerPtr(dest, pe)), cond, value);
 }
 
 // Collectives

--- a/projects/rocshmem/src/ipc_policy.hpp
+++ b/projects/rocshmem/src/ipc_policy.hpp
@@ -178,17 +178,17 @@ class IpcOnImpl {
    * @param[in] pe       Target PE id
    * @return Address of the corresponding data in PE 'pe'
    */
-  __device__ __forceinline__ char *ipcPeerPtr(const void *sym_addr, int my_pe,
-                                               int pe) {
+  __device__ __forceinline__ char *ipcPeerPtr(
+      const void *sym_addr, [[maybe_unused]] int my_pe, int pe) {
     uintptr_t addr = reinterpret_cast<uintptr_t>(sym_addr);
-    uintptr_t heap_base = reinterpret_cast<uintptr_t>(ipc_bases[my_pe]);
+    uintptr_t heap_base = constmem.heap_base;
 
     /*
      * Common case: the address lives in the symmetric heap. Translate it
      * directly and skip the registered-buffer search. The single unsigned
      * compare also rejects addresses below the heap base (they wrap large).
      */
-    if (addr - heap_base < heap_size) {
+    if (addr - heap_base < constmem.heap_size) {
       return ipc_bases[pe] + (addr - heap_base);
     }
 

--- a/projects/rocshmem/src/ipc_policy.hpp
+++ b/projects/rocshmem/src/ipc_policy.hpp
@@ -174,12 +174,10 @@ class IpcOnImpl {
    * matched against the symmetrically-registered user buffers.
    *
    * @param[in] sym_addr Symmetric address (valid in the local address space)
-   * @param[in] my_pe    Local PE id (index into ipc_bases for the local base)
    * @param[in] pe       Target PE id
    * @return Address of the corresponding data in PE 'pe'
    */
-  __device__ __forceinline__ char *ipcPeerPtr(
-      const void *sym_addr, [[maybe_unused]] int my_pe, int pe) {
+  __device__ __forceinline__ char *ipcPeerPtr(const void *sym_addr, int pe) {
     uintptr_t addr = reinterpret_cast<uintptr_t>(sym_addr);
     uintptr_t heap_base = constmem.heap_base;
 
@@ -505,9 +503,8 @@ class IpcOffImpl {
   int ipc_first_pe{0};
   int ipc_stride{0};
 
-  __device__ __forceinline__ char *ipcPeerPtr([[maybe_unused]] const void *sym_addr,
-                                               [[maybe_unused]] int my_pe,
-                                               [[maybe_unused]] int pe) {
+  __device__ __forceinline__ char *ipcPeerPtr(
+      [[maybe_unused]] const void *sym_addr, [[maybe_unused]] int pe) {
     return nullptr;
   }
 


### PR DESCRIPTION
## Motivation
Symmetric user-buffer registration routed IPC get/put operations through `ipcPeerPtr()` to distinguish symmetric-heap addresses from registered buffers. This added heap metadata loads and a range check to the common RMA hot path, increasing short-message latency.

This PR removes the avoidable memory indirection while preserving registered-buffer support and the existing address-translation behavior.

## Technical Details

- Cache the local symmetric-heap base and size in device constant memory.
- Use the cached values in the `ipcPeerPtr()` heap fast path.
- Preserve registered symmetric-buffer lookup for addresses outside the heap.
- Remove the unused local PE argument and update IPC/GDA call sites.

## Issue Tracking

- JIRA ID : AIROCSHMEM-487

## Test Plan

- Build IPC and GDA configurations.
- Run the IPC heatmap against pre-feature, develop, and fix revisions.

## Test Result

- IPC builds and heatmap tests passed.
- Median RMA latency improved by 10.3% versus develop.
- Wave RMA latency improved by 12.1%.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.