### PR TITLE
[rocjitsu] Route custom formats through decode tables

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -1143,13 +1143,24 @@ class CodeGenerator:
         VOPD is skipped by the normal XML instruction generation because it
         uses a dual-slot encoding with bespoke operand packing. Keeping the
         target-specific C++ body here lets the same regeneration path recreate
-        the VOPD files and the generated decoder hook together.
+        the VOPD files and generated decoder-table entries together.
         """
         if not self._supports_generated_vopd():
             return
 
         arch = self.isa_spec.arch_name
-        has_vopd3 = self.isa_spec.profile.has_vopd3
+        vopd_encoding_prefixes = self.isa_spec.profile.vopd_encoding_prefixes
+        vopd_prefixes = [
+            prefix for prefix in vopd_encoding_prefixes if not prefix.is_vopd3
+        ]
+        vopd3_prefixes = [
+            prefix for prefix in vopd_encoding_prefixes if prefix.is_vopd3
+        ]
+        if len(vopd_prefixes) != 1 or len(vopd3_prefixes) > 1:
+            raise ValueError(f'{arch} has invalid VOPD encoding prefix metadata')
+        vopd_prefix = vopd_prefixes[0]
+        vopd3_prefix = vopd3_prefixes[0] if vopd3_prefixes else None
+        has_vopd3 = vopd3_prefix is not None
         if self.isa_spec.profile.split_execution_sources:
             vopd_exec_fn = self._split_execute_expr('Vopd')
             vopd_registration_decl = ''
@@ -1618,10 +1629,10 @@ class CodeGenerator:
                 '@VOPD_FLOAT64_CASES@', vopd_float64_case_labels
             )
             vopd3_constructor_branch = cpp_block('''
-              if ((word0_ >> 24) == 0xCF) {
+              if ((word0_ >> @VOPD3_PREFIX_SHIFT@) == @VOPD3_PREFIX@) {
                 format_ = Format::Vopd3;
                 size_ = 12;
-                encoding_id_ = 0xCF;
+                encoding_id_ = @VOPD3_PREFIX@;
                 word2_ = words[2];
                 opx_ = static_cast<uint16_t>((word0_ >> 18) & 0x3F);
                 opy_ = static_cast<uint16_t>((word0_ >> 12) & 0x3F);
@@ -1650,6 +1661,9 @@ class CodeGenerator:
                                                    : Operand(y_bits, OperandType::OPR_VGPR, vsrcy2);
               } else {
             ''')
+            vopd3_constructor_branch = vopd3_constructor_branch.replace(
+                '@VOPD3_PREFIX_SHIFT@', str(32 - vopd3_prefix.prefix_bits)
+            ).replace('@VOPD3_PREFIX@', f'0x{vopd3_prefix.prefix:X}')
             vopd3_constructor_close = '              }'
             vopd3_init_operands_prefix = cpp_block('''
               const bool vopd3 = format_ == Format::Vopd3;
@@ -1747,7 +1761,6 @@ class CodeGenerator:
             {
               public:
               explicit Vopd(const MachineInst *inst);
-              static bool is_vopd(const MachineInst *inst);
               void execute_impl(amdgpu::Wavefront &wf);
 
               private:
@@ -1905,11 +1918,6 @@ class CodeGenerator:
 
             } // namespace
 
-            bool Vopd::is_vopd(const MachineInst *inst) {
-              uint32_t word0 = *reinterpret_cast<const uint32_t *>(inst);
-              return @VOPD3_IS_VOPD_CHECK@(word0 >> 26) == 0x32;
-            }
-
             const char *Vopd::op_name(uint16_t op) {
               switch (op) {
             @VOPD_OP_NAME_CASES@
@@ -1939,7 +1947,7 @@ class CodeGenerator:
 
             @VOPD3_CONSTRUCTOR_BRANCH@
                 format_ = Format::VopdXy;
-                encoding_id_ = 0x32;
+                encoding_id_ = @VOPD_PREFIX@;
                 opx_ = static_cast<uint16_t>((word0_ >> 22) & 0xF);
                 opy_ = static_cast<uint16_t>((word0_ >> 17) & 0x1F);
                 uint16_t srcx0 = static_cast<uint16_t>(word0_ & 0x1FF);
@@ -2073,14 +2081,11 @@ class CodeGenerator:
             .replace('@VOPD3_HEADER_DECLS@', vopd3_header_decls)
             .replace('@VOPD_SLOT_CONSTANTS@', vopd_slot_constants)
             .replace('@VOPD3_UNUSED_ATTR@', vopd3_unused_attr)
-            .replace(
-                '@VOPD3_IS_VOPD_CHECK@',
-                '(word0 >> 24) == 0xCF || ' if has_vopd3 else '',
-            )
             .replace('@VOPD_OP_NAME_CASES@', vopd_op_name_cases)
             .replace('@VOPD3_MODEL_HELPERS@', vopd3_model_helpers)
             .replace('@VOPD3_CONSTRUCTOR_BRANCH@', vopd3_constructor_branch)
             .replace('@VOPD3_CONSTRUCTOR_CLOSE@', vopd3_constructor_close)
+            .replace('@VOPD_PREFIX@', f'0x{vopd_prefix.prefix:X}')
             .replace('@VOPD3_INIT_OPERANDS_PREFIX@', vopd3_init_operands_prefix)
             .replace('@VOPD3_INIT_OPERANDS_SUFFIX@', vopd3_init_operands_suffix)
             .replace('@VOPD_ADD_SLOT_SOURCE_CASES@', vopd_add_slot_source_cases)
@@ -3608,13 +3613,6 @@ class CodeGenerator:
 
             bool isVop3pOp(const MachineInst opcode, uint32_t op) {
               return (opcode >> 24) == 0xcc && ((opcode >> 16) & 0xff) == op;
-            }
-
-            bool isWmmaScaleF32Vop3px2(const MachineInst *opcode) {
-              if (!isVop3pOp(opcode[0], 0x35) && !isVop3pOp(opcode[0], 0x3a))
-                return false;
-
-              return isVop3pOp(opcode[2], 0x33) || isVop3pOp(opcode[2], 0x88);
             }
 
             } // namespace
@@ -11020,11 +11018,6 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
             class_impl.append(
                 cgen.Line(self._emit_gfx1250_scaled_wmma_vop3px2_decoder_helpers())
             )
-            decode_body.append(
-                cgen.Statement(
-                    'if (isWmmaScaleF32Vop3px2(opcode)) return std::make_unique<VWmmaScaleF32Vop3px2>(opcode)'
-                )
-            )
         if self._supports_cdna_mfma_f8f6f4_vop3px2():
             class_impl.append(
                 cgen.Line(self._emit_cdna_mfma_f8f6f4_vop3px2_decoder_helpers())
@@ -11037,12 +11030,6 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
                     '      return std::make_unique<VMfmaF3216x16x128F8f6f4Vop3pMfma>(opcode + 2, true);\n'
                     '    return std::make_unique<VMfmaF3232x32x64F8f6f4Vop3pMfma>(opcode + 2, true);\n'
                     '  }\n'
-                )
-            )
-        if self._supports_generated_vopd():
-            decode_body.append(
-                cgen.Statement(
-                    'if (Vopd::is_vopd(opcode)) return std::make_unique<Vopd>(opcode)'
                 )
             )
         decode_body.extend(
@@ -11088,6 +11075,73 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
         sub_decode_table_entries = []
         decode_funcs_found = set()
         _custom_decode_bodies: dict[str, object] = {}
+        _custom_primary_decode_funcs: dict[int, str] = {}
+        _custom_primary_decode_bodies: dict[str, object] = {}
+
+        def _reserve_primary_prefix(prefix: int, prefix_bits: int, fn: str) -> None:
+            table_bits = self.isa_spec.profile.max_enc_bits
+            if prefix_bits > table_bits:
+                raise ValueError(
+                    f'Cannot fit {prefix_bits}-bit decode prefix in '
+                    f'{table_bits}-bit primary table'
+                )
+            first = prefix << (table_bits - prefix_bits)
+            count = 1 << (table_bits - prefix_bits)
+            for index in range(first, first + count):
+                if self.isa_spec.primary_decode_table[index] is not None:
+                    raise ValueError(
+                        f'Custom decoder {fn} conflicts with primary table index {index}'
+                    )
+                previous = _custom_primary_decode_funcs.setdefault(index, fn)
+                if previous != fn:
+                    raise ValueError(
+                        f'Custom decoders {previous} and {fn} conflict at primary '
+                        f'table index {index}'
+                    )
+
+        if self._supports_generated_vopd():
+            _vopd_fn = 'decodeVopd'
+            for _prefix in self.isa_spec.profile.vopd_encoding_prefixes:
+                _reserve_primary_prefix(_prefix.prefix, _prefix.prefix_bits, _vopd_fn)
+            _custom_primary_decode_bodies[_vopd_fn] = cgen.Block(
+                [cgen.Statement('return std::make_unique<Vopd>(opcode)')]
+            )
+
+        if self._supports_gfx1250_scaled_wmma_vop3px2():
+            for _dte in self.isa_spec.primary_decode_table:
+                if (
+                    _dte is not None
+                    and not _dte.is_primary
+                    and _dte.sub_decode_funcs is not None
+                    and _dte.sub_decode_table
+                    and 'vop3p' in _dte.sub_decode_table
+                ):
+                    _scaled_wmma_fn = 'decodeVWmmaScaleF32Vop3px2'
+                    for _opcode in (0x35, 0x3A):
+                        if _dte.sub_decode_funcs[_opcode] not in (
+                            'decodeInvalid',
+                            _scaled_wmma_fn,
+                        ):
+                            raise ValueError(
+                                f'Scaled WMMA decoder conflicts with VOP3P opcode {_opcode}'
+                            )
+                        _dte.sub_decode_funcs[_opcode] = _scaled_wmma_fn
+                    _custom_decode_bodies[_scaled_wmma_fn] = cgen.Block(
+                        [
+                            cgen.Line(
+                                '  if (!isVop3pOp(opcode[2], 0x33) && '
+                                '!isVop3pOp(opcode[2], 0x88))\n'
+                                '    return decodeInvalid(opcode);\n'
+                            ),
+                            cgen.Statement(
+                                'return std::make_unique<VWmmaScaleF32Vop3px2>(opcode)'
+                            ),
+                        ]
+                    )
+                    break
+            else:
+                raise ValueError('gfx1250 scaled WMMA requires a VOP3P decode table')
+
         _vop3px2_opcode = self.isa_spec.profile.vop3px2_prefix_opcode
         if _vop3px2_opcode is not None:
             _ie_names = {
@@ -11128,7 +11182,28 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
                             ]
                         )
                         break
-        for dte in self.isa_spec.primary_decode_table:
+        for _fn, _body in _custom_primary_decode_bodies.items():
+            _decl = cgen.FunctionDeclaration(
+                cgen.Value('static std::unique_ptr<Instruction>', _fn),
+                [cgen.Value('const MachineInst *', 'opcode')],
+            )
+            class_members.append(_decl)
+            decode_table_funcs.append(
+                cgen.FunctionBody(
+                    cgen.FunctionDeclaration(
+                        cgen.Value('std::unique_ptr<Instruction>', f'Decoder::{_fn}'),
+                        [cgen.Value('const MachineInst *', 'opcode')],
+                    ),
+                    _body,
+                )
+            )
+
+        for _primary_index, dte in enumerate(self.isa_spec.primary_decode_table):
+            if _primary_index in _custom_primary_decode_funcs:
+                decode_table_entries.append(
+                    f'&Decoder::{_custom_primary_decode_funcs[_primary_index]},'
+                )
+                continue
             if dte is not None:
                 decode_table_entries.append(f'&Decoder::{dte.decode_func},')
                 if dte.decode_func not in decode_funcs_found:
@@ -11182,8 +11257,13 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
                             )
                         )
                         sub_decode_table_entry_str = []
+                        sub_decode_funcs_found = set()
                         for fn in dte.sub_decode_funcs:
-                            if fn != 'decodeInvalid':
+                            if (
+                                fn != 'decodeInvalid'
+                                and fn not in sub_decode_funcs_found
+                            ):
+                                sub_decode_funcs_found.add(fn)
                                 class_name = fn.removeprefix('decode')
                                 sub_decode_func_decls.append(
                                     cgen.FunctionDeclaration(

--- a/emulation/rocjitsu/lib/python/amdisa/isa_profile.py
+++ b/emulation/rocjitsu/lib/python/amdisa/isa_profile.py
@@ -113,6 +113,15 @@ class VopdSlotOp:
     mnemonic: str
 
 
+@dataclass(frozen=True)
+class VopdEncodingPrefix:
+    """A primary-table prefix routed to the generated VOPD decoder."""
+
+    prefix: int
+    prefix_bits: int
+    is_vopd3: bool = False
+
+
 _VOPD_COMMON_F32_SLOT_OPS = (
     VopdSlotOp('VopdFmacF32', 0, 'v_dual_fmac_f32'),
     VopdSlotOp('VopdFmaakF32', 1, 'v_dual_fmaak_f32'),
@@ -903,7 +912,14 @@ class _AmdgpuProfileBase(IsaProfile):
     @property
     def has_vopd3(self) -> bool:
         """True if this ISA supports the VOPD3 encoding form."""
-        return False
+        return any(prefix.is_vopd3 for prefix in self.vopd_encoding_prefixes)
+
+    @property
+    def vopd_encoding_prefixes(self) -> tuple[VopdEncodingPrefix, ...]:
+        """Primary encoding prefixes accepted by the generated VOPD decoder."""
+        if not self.has_vopd:
+            return ()
+        return (VopdEncodingPrefix(0x32, 6),)
 
     @property
     def vopd_slot_ops(self) -> tuple[VopdSlotOp, ...]:
@@ -1681,8 +1697,10 @@ class Gfx1250Profile(Rdna4Profile):
         return 1024
 
     @property
-    def has_vopd3(self) -> bool:
-        return True
+    def vopd_encoding_prefixes(self) -> tuple[VopdEncodingPrefix, ...]:
+        return super().vopd_encoding_prefixes + (
+            VopdEncodingPrefix(0xCF, 8, is_vopd3=True),
+        )
 
     @property
     def vopd_slot_ops(self) -> tuple[VopdSlotOp, ...]:

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
@@ -2654,7 +2654,9 @@ def test_generated_execute_shared_calls_have_definitions(amdgpu_generated_root: 
     assert not missing
 
 
-def test_gfx1250_helper_blocks_emit_scaled_wmma_hooks():
+def test_gfx1250_helper_blocks_emit_scaled_wmma_table_decoder(
+    gfx1250_generated_root: Path,
+):
     codegen = object.__new__(CodeGenerator)
     codegen.isa_spec = SimpleNamespace(
         arch_name='gfx1250',
@@ -2663,9 +2665,57 @@ def test_gfx1250_helper_blocks_emit_scaled_wmma_hooks():
 
     assert codegen._supports_gfx1250_scaled_wmma_vop3px2()
     assert 'VWmmaScaleF32Vop3px2' in (codegen._emit_gfx1250_scaled_wmma_vop3px2_class())
-    assert 'isWmmaScaleF32Vop3px2' in (
-        codegen._emit_gfx1250_scaled_wmma_vop3px2_decoder_helpers()
-    )
+    helpers = codegen._emit_gfx1250_scaled_wmma_vop3px2_decoder_helpers()
+    assert 'isVop3pOp' in helpers
+    assert 'isWmmaScaleF32Vop3px2' not in helpers
+
+    decoder = (gfx1250_generated_root / 'decoder.cpp').read_text()
+    decode_body = decoder.split(
+        'std::unique_ptr<Instruction> Decoder::decode(const MachineInst *opcode) {'
+    )[1].split('std::unique_ptr<Instruction> Decoder::decodeInvalid', 1)[0]
+    assert 'isWmmaScaleF32Vop3px2' not in decode_body
+    assert decoder.count('&Decoder::decodeVWmmaScaleF32Vop3px2,') == 2
+    assert 'if (!isVop3pOp(opcode[2], 0x33)' in decoder
+
+
+@pytest.mark.parametrize(
+    ('arch_name', 'expected_vopd_indices'),
+    [
+        ('rdna3', set(range(0x190, 0x198))),
+        ('rdna3_5', set(range(0x190, 0x198))),
+        ('rdna4', set(range(0x190, 0x198))),
+        ('gfx1250', set(range(0x190, 0x198)) | set(range(0x19E, 0x1A0))),
+    ],
+)
+def test_vopd_dispatch_uses_primary_decode_table(
+    amdgpu_generated_root: Path,
+    arch_name: str,
+    expected_vopd_indices: set[int],
+):
+    arch_root = amdgpu_generated_root / arch_name
+    decoder = (arch_root / 'decoder.cpp').read_text()
+    decode_body = decoder.split(
+        'std::unique_ptr<Instruction> Decoder::decode(const MachineInst *opcode) {'
+    )[1].split('std::unique_ptr<Instruction> Decoder::decodeInvalid', 1)[0]
+
+    assert 'Vopd::is_vopd' not in decode_body
+    primary_table = decoder.split('Decoder::primary_decode_table = {', 1)[1].split(
+        '\n};', 1
+    )[0]
+    primary_entries = [
+        line.strip().removesuffix(',')
+        for line in primary_table.splitlines()
+        if line.strip()
+    ]
+    actual_vopd_indices = {
+        index
+        for index, entry in enumerate(primary_entries)
+        if entry == '&Decoder::decodeVopd'
+    }
+    assert actual_vopd_indices == expected_vopd_indices
+    assert 'Decoder::decodeVopd(const MachineInst *opcode)' in decoder
+    assert 'is_vopd' not in (arch_root / 'vopd.h').read_text()
+    assert 'is_vopd' not in (arch_root / 'vopd.cpp').read_text()
 
 
 @pytest.mark.parametrize(
@@ -2815,7 +2865,7 @@ def test_gfx1250_vopd_template_uses_dx9_zero_and_fma(tmp_path):
     cpp = (tmp_path / 'gfx1250' / 'vopd.cpp').read_text()
     exec_cpp = (tmp_path / 'gfx1250' / 'vopd_exec.cpp').read_text()
 
-    assert '(word0 >> 24) == 0xCF' in cpp
+    assert '(word0_ >> 24) == 0xCF' in cpp
     assert '[[maybe_unused]] bool vopd3' not in cpp
     assert 'vopd3 ? OperandType::OPR_SRC_SIMPLE : OperandType::OPR_SRC' in cpp
     assert 'bool literal_uses_f64_high_bits' in cpp
@@ -2875,7 +2925,7 @@ def test_rdna4_vopd_template_uses_available_src_operand_type(tmp_path):
     assert 'OperandType::OPR_SRC_SIMPLE' not in cpp
     assert 'vopd3 ? OperandType::OPR_SRC : OperandType::OPR_SRC' not in cpp
     assert 'return Operand(bits, OperandType::OPR_SRC, encoded);' in cpp
-    assert '(word0 >> 24) == 0xCF' not in cpp
+    assert '(word0_ >> 24) == 0xCF' not in cpp
     assert 'Format::Vopd3' not in cpp
     assert 'literal_uses_f64_high_bits' in cpp
     assert 'is_float64_op' not in cpp

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/decoder.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/decoder.cpp
@@ -19,20 +19,9 @@ bool isVop3pOp(const MachineInst opcode, uint32_t op) {
   return (opcode >> 24) == 0xcc && ((opcode >> 16) & 0xff) == op;
 }
 
-bool isWmmaScaleF32Vop3px2(const MachineInst *opcode) {
-  if (!isVop3pOp(opcode[0], 0x35) && !isVop3pOp(opcode[0], 0x3a))
-    return false;
-
-  return isVop3pOp(opcode[2], 0x33) || isVop3pOp(opcode[2], 0x88);
-}
-
 } // namespace
 
 std::unique_ptr<Instruction> Decoder::decode(const MachineInst *opcode) {
-  if (isWmmaScaleF32Vop3px2(opcode))
-    return std::make_unique<VWmmaScaleF32Vop3px2>(opcode);
-  if (Vopd::is_vopd(opcode))
-    return std::make_unique<Vopd>(opcode);
   Sop1MachineInst op = std::bit_cast<decltype(op)>(*opcode);
   return primary_decode_table[op.encoding](opcode);
 }
@@ -40,6 +29,10 @@ std::unique_ptr<Instruction> Decoder::decode(const MachineInst *opcode) {
 std::unique_ptr<Instruction> Decoder::decodeInvalid(const MachineInst *opcode) {
   throw util::InvalidInst(std::format("{:X}", *opcode));
   return nullptr;
+}
+
+std::unique_ptr<Instruction> Decoder::decodeVopd(const MachineInst *opcode) {
+  return std::make_unique<Vopd>(opcode);
 }
 
 std::unique_ptr<Instruction> Decoder::decodeVCndmaskB32Vop2(const MachineInst *opcode) {
@@ -2849,6 +2842,12 @@ std::unique_ptr<Instruction> Decoder::decodeVPkMin3U16Vop3p(const MachineInst *o
 std::unique_ptr<Instruction>
 Decoder::decodeVWmmaF3216x16x128F8f6f4Vop3p(const MachineInst *opcode) {
   return std::make_unique<VWmmaF3216x16x128F8f6f4Vop3p>(opcode);
+}
+
+std::unique_ptr<Instruction> Decoder::decodeVWmmaScaleF32Vop3px2(const MachineInst *opcode) {
+  if (!isVop3pOp(opcode[2], 0x33) && !isVop3pOp(opcode[2], 0x88))
+    return decodeInvalid(opcode);
+  return std::make_unique<VWmmaScaleF32Vop3px2>(opcode);
 }
 
 std::unique_ptr<Instruction> Decoder::decodeVPkMinimum3F16Vop3p(const MachineInst *opcode) {
@@ -7023,22 +7022,22 @@ const std::array<Decoder::DecodeFunc, 512> Decoder::primary_decode_table = {
     &Decoder::subDecodeVbuffer,
     &Decoder::subDecodeVbuffer,
     &Decoder::subDecodeVbuffer,
-    &Decoder::decodeInvalid,
-    &Decoder::decodeInvalid,
-    &Decoder::decodeInvalid,
-    &Decoder::decodeInvalid,
-    &Decoder::decodeInvalid,
-    &Decoder::decodeInvalid,
-    &Decoder::decodeInvalid,
-    &Decoder::decodeInvalid,
+    &Decoder::decodeVopd,
+    &Decoder::decodeVopd,
+    &Decoder::decodeVopd,
+    &Decoder::decodeVopd,
+    &Decoder::decodeVopd,
+    &Decoder::decodeVopd,
+    &Decoder::decodeVopd,
+    &Decoder::decodeVopd,
     &Decoder::subDecodeVop3p,
     &Decoder::subDecodeVop3p,
     &Decoder::decodeInvalid,
     &Decoder::decodeInvalid,
     &Decoder::decodeInvalid,
     &Decoder::decodeInvalid,
-    &Decoder::decodeInvalid,
-    &Decoder::decodeInvalid,
+    &Decoder::decodeVopd,
+    &Decoder::decodeVopd,
     &Decoder::subDecodeVimage,
     &Decoder::subDecodeVimage,
     &Decoder::subDecodeVimage,
@@ -8183,12 +8182,12 @@ const std::array<Decoder::DecodeFunc, 256> Decoder::sub_decode_vop3p = {
     &Decoder::decodeVPkMin3U16Vop3p,
     &Decoder::decodeVWmmaF3216x16x128F8f6f4Vop3p,
     &Decoder::decodeInvalid,
-    &Decoder::decodeInvalid,
+    &Decoder::decodeVWmmaScaleF32Vop3px2,
     &Decoder::decodeVPkMinimum3F16Vop3p,
     &Decoder::decodeVPkMaximum3F16Vop3p,
     &Decoder::decodeVPkMin3NumF16Vop3p,
     &Decoder::decodeVPkMax3NumF16Vop3p,
-    &Decoder::decodeInvalid,
+    &Decoder::decodeVWmmaScaleF32Vop3px2,
     &Decoder::decodeInvalid,
     &Decoder::decodeInvalid,
     &Decoder::decodeVFmaMixF32Bf16Vop3p,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/decoder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/decoder.h
@@ -24,6 +24,7 @@ public:
 private:
   using DecodeFunc = std::unique_ptr<Instruction> (*)(const MachineInst *);
   static std::unique_ptr<Instruction> decodeInvalid(const MachineInst *opcode);
+  static std::unique_ptr<Instruction> decodeVopd(const MachineInst *opcode);
   static std::unique_ptr<Instruction> decodeVCndmaskB32Vop2(const MachineInst *opcode);
   static std::unique_ptr<Instruction> decodeVAddF64Vop2(const MachineInst *opcode);
   static std::unique_ptr<Instruction> decodeVAddF32Vop2(const MachineInst *opcode);
@@ -726,6 +727,7 @@ private:
   static std::unique_ptr<Instruction> decodeVPkMin3I16Vop3p(const MachineInst *opcode);
   static std::unique_ptr<Instruction> decodeVPkMin3U16Vop3p(const MachineInst *opcode);
   static std::unique_ptr<Instruction> decodeVWmmaF3216x16x128F8f6f4Vop3p(const MachineInst *opcode);
+  static std::unique_ptr<Instruction> decodeVWmmaScaleF32Vop3px2(const MachineInst *opcode);
   static std::unique_ptr<Instruction> decodeVPkMinimum3F16Vop3p(const MachineInst *opcode);
   static std::unique_ptr<Instruction> decodeVPkMaximum3F16Vop3p(const MachineInst *opcode);
   static std::unique_ptr<Instruction> decodeVPkMin3NumF16Vop3p(const MachineInst *opcode);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vopd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vopd.cpp
@@ -58,11 +58,6 @@ std::string operand_list(const Operand &dst, const Operand &src0, const Operand 
 
 } // namespace
 
-bool Vopd::is_vopd(const MachineInst *inst) {
-  uint32_t word0 = *reinterpret_cast<const uint32_t *>(inst);
-  return (word0 >> 24) == 0xCF || (word0 >> 26) == 0x32;
-}
-
 const char *Vopd::op_name(uint16_t op) {
   switch (op) {
   case kVopdFmacF32:

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vopd.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vopd.h
@@ -18,7 +18,6 @@ namespace gfx1250 {
 class Vopd : public IsaInstruction<Isa> {
 public:
   explicit Vopd(const MachineInst *inst);
-  static bool is_vopd(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
 
 private:

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/decoder.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/decoder.cpp
@@ -14,8 +14,6 @@ namespace rocjitsu {
 namespace rdna3 {
 
 std::unique_ptr<Instruction> Decoder::decode(const MachineInst *opcode) {
-  if (Vopd::is_vopd(opcode))
-    return std::make_unique<Vopd>(opcode);
   Sop1MachineInst op = std::bit_cast<decltype(op)>(*opcode);
   return primary_decode_table[op.encoding](opcode);
 }
@@ -23,6 +21,10 @@ std::unique_ptr<Instruction> Decoder::decode(const MachineInst *opcode) {
 std::unique_ptr<Instruction> Decoder::decodeInvalid(const MachineInst *opcode) {
   throw util::InvalidInst(std::format("{:X}", *opcode));
   return nullptr;
+}
+
+std::unique_ptr<Instruction> Decoder::decodeVopd(const MachineInst *opcode) {
+  return std::make_unique<Vopd>(opcode);
 }
 
 std::unique_ptr<Instruction> Decoder::decodeVCndmaskB32Vop2(const MachineInst *opcode) {
@@ -5974,14 +5976,14 @@ const std::array<Decoder::DecodeFunc, 512> Decoder::primary_decode_table = {
     &Decoder::decodeInvalid,
     &Decoder::decodeInvalid,
     &Decoder::decodeInvalid,
-    &Decoder::decodeInvalid,
-    &Decoder::decodeInvalid,
-    &Decoder::decodeInvalid,
-    &Decoder::decodeInvalid,
-    &Decoder::decodeInvalid,
-    &Decoder::decodeInvalid,
-    &Decoder::decodeInvalid,
-    &Decoder::decodeInvalid,
+    &Decoder::decodeVopd,
+    &Decoder::decodeVopd,
+    &Decoder::decodeVopd,
+    &Decoder::decodeVopd,
+    &Decoder::decodeVopd,
+    &Decoder::decodeVopd,
+    &Decoder::decodeVopd,
+    &Decoder::decodeVopd,
     &Decoder::subDecodeVop3p,
     &Decoder::subDecodeVop3p,
     &Decoder::subDecodeVinterp,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/decoder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/decoder.h
@@ -24,6 +24,7 @@ public:
 private:
   using DecodeFunc = std::unique_ptr<Instruction> (*)(const MachineInst *);
   static std::unique_ptr<Instruction> decodeInvalid(const MachineInst *opcode);
+  static std::unique_ptr<Instruction> decodeVopd(const MachineInst *opcode);
   static std::unique_ptr<Instruction> decodeVCndmaskB32Vop2(const MachineInst *opcode);
   static std::unique_ptr<Instruction> decodeVDot2accF32F16Vop2(const MachineInst *opcode);
   static std::unique_ptr<Instruction> decodeVAddF32Vop2(const MachineInst *opcode);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/vopd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/vopd.cpp
@@ -53,11 +53,6 @@ std::string operand_list(const Operand &dst, const Operand &src0, const Operand 
 
 } // namespace
 
-bool Vopd::is_vopd(const MachineInst *inst) {
-  uint32_t word0 = *reinterpret_cast<const uint32_t *>(inst);
-  return (word0 >> 26) == 0x32;
-}
-
 const char *Vopd::op_name(uint16_t op) {
   switch (op) {
   case kVopdFmacF32:

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/vopd.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/vopd.h
@@ -18,7 +18,6 @@ namespace rdna3 {
 class Vopd : public IsaInstruction<Isa> {
 public:
   explicit Vopd(const MachineInst *inst);
-  static bool is_vopd(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
 
 private:

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/decoder.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/decoder.cpp
@@ -14,8 +14,6 @@ namespace rocjitsu {
 namespace rdna3_5 {
 
 std::unique_ptr<Instruction> Decoder::decode(const MachineInst *opcode) {
-  if (Vopd::is_vopd(opcode))
-    return std::make_unique<Vopd>(opcode);
   Sop1MachineInst op = std::bit_cast<decltype(op)>(*opcode);
   return primary_decode_table[op.encoding](opcode);
 }
@@ -23,6 +21,10 @@ std::unique_ptr<Instruction> Decoder::decode(const MachineInst *opcode) {
 std::unique_ptr<Instruction> Decoder::decodeInvalid(const MachineInst *opcode) {
   throw util::InvalidInst(std::format("{:X}", *opcode));
   return nullptr;
+}
+
+std::unique_ptr<Instruction> Decoder::decodeVopd(const MachineInst *opcode) {
+  return std::make_unique<Vopd>(opcode);
 }
 
 std::unique_ptr<Instruction> Decoder::decodeVCndmaskB32Vop2(const MachineInst *opcode) {
@@ -6238,14 +6240,14 @@ const std::array<Decoder::DecodeFunc, 512> Decoder::primary_decode_table = {
     &Decoder::decodeInvalid,
     &Decoder::decodeInvalid,
     &Decoder::decodeInvalid,
-    &Decoder::decodeInvalid,
-    &Decoder::decodeInvalid,
-    &Decoder::decodeInvalid,
-    &Decoder::decodeInvalid,
-    &Decoder::decodeInvalid,
-    &Decoder::decodeInvalid,
-    &Decoder::decodeInvalid,
-    &Decoder::decodeInvalid,
+    &Decoder::decodeVopd,
+    &Decoder::decodeVopd,
+    &Decoder::decodeVopd,
+    &Decoder::decodeVopd,
+    &Decoder::decodeVopd,
+    &Decoder::decodeVopd,
+    &Decoder::decodeVopd,
+    &Decoder::decodeVopd,
     &Decoder::subDecodeVop3p,
     &Decoder::subDecodeVop3p,
     &Decoder::subDecodeVinterp,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/decoder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/decoder.h
@@ -24,6 +24,7 @@ public:
 private:
   using DecodeFunc = std::unique_ptr<Instruction> (*)(const MachineInst *);
   static std::unique_ptr<Instruction> decodeInvalid(const MachineInst *opcode);
+  static std::unique_ptr<Instruction> decodeVopd(const MachineInst *opcode);
   static std::unique_ptr<Instruction> decodeVCndmaskB32Vop2(const MachineInst *opcode);
   static std::unique_ptr<Instruction> decodeVDot2accF32F16Vop2(const MachineInst *opcode);
   static std::unique_ptr<Instruction> decodeVAddF32Vop2(const MachineInst *opcode);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/vopd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/vopd.cpp
@@ -53,11 +53,6 @@ std::string operand_list(const Operand &dst, const Operand &src0, const Operand 
 
 } // namespace
 
-bool Vopd::is_vopd(const MachineInst *inst) {
-  uint32_t word0 = *reinterpret_cast<const uint32_t *>(inst);
-  return (word0 >> 26) == 0x32;
-}
-
 const char *Vopd::op_name(uint16_t op) {
   switch (op) {
   case kVopdFmacF32:

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/vopd.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/vopd.h
@@ -18,7 +18,6 @@ namespace rdna3_5 {
 class Vopd : public IsaInstruction<Isa> {
 public:
   explicit Vopd(const MachineInst *inst);
-  static bool is_vopd(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
 
 private:

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/decoder.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/decoder.cpp
@@ -14,8 +14,6 @@ namespace rocjitsu {
 namespace rdna4 {
 
 std::unique_ptr<Instruction> Decoder::decode(const MachineInst *opcode) {
-  if (Vopd::is_vopd(opcode))
-    return std::make_unique<Vopd>(opcode);
   Sop1MachineInst op = std::bit_cast<decltype(op)>(*opcode);
   return primary_decode_table[op.encoding](opcode);
 }
@@ -23,6 +21,10 @@ std::unique_ptr<Instruction> Decoder::decode(const MachineInst *opcode) {
 std::unique_ptr<Instruction> Decoder::decodeInvalid(const MachineInst *opcode) {
   throw util::InvalidInst(std::format("{:X}", *opcode));
   return nullptr;
+}
+
+std::unique_ptr<Instruction> Decoder::decodeVopd(const MachineInst *opcode) {
+  return std::make_unique<Vopd>(opcode);
 }
 
 std::unique_ptr<Instruction> Decoder::decodeVCndmaskB32Vop2(const MachineInst *opcode) {
@@ -6721,14 +6723,14 @@ const std::array<Decoder::DecodeFunc, 512> Decoder::primary_decode_table = {
     &Decoder::subDecodeVbuffer,
     &Decoder::subDecodeVbuffer,
     &Decoder::subDecodeVbuffer,
-    &Decoder::decodeInvalid,
-    &Decoder::decodeInvalid,
-    &Decoder::decodeInvalid,
-    &Decoder::decodeInvalid,
-    &Decoder::decodeInvalid,
-    &Decoder::decodeInvalid,
-    &Decoder::decodeInvalid,
-    &Decoder::decodeInvalid,
+    &Decoder::decodeVopd,
+    &Decoder::decodeVopd,
+    &Decoder::decodeVopd,
+    &Decoder::decodeVopd,
+    &Decoder::decodeVopd,
+    &Decoder::decodeVopd,
+    &Decoder::decodeVopd,
+    &Decoder::decodeVopd,
     &Decoder::subDecodeVop3p,
     &Decoder::subDecodeVop3p,
     &Decoder::subDecodeVinterp,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/decoder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/decoder.h
@@ -24,6 +24,7 @@ public:
 private:
   using DecodeFunc = std::unique_ptr<Instruction> (*)(const MachineInst *);
   static std::unique_ptr<Instruction> decodeInvalid(const MachineInst *opcode);
+  static std::unique_ptr<Instruction> decodeVopd(const MachineInst *opcode);
   static std::unique_ptr<Instruction> decodeVCndmaskB32Vop2(const MachineInst *opcode);
   static std::unique_ptr<Instruction> decodeVAddF64Vop2(const MachineInst *opcode);
   static std::unique_ptr<Instruction> decodeVAddF32Vop2(const MachineInst *opcode);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/vopd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/vopd.cpp
@@ -53,11 +53,6 @@ std::string operand_list(const Operand &dst, const Operand &src0, const Operand 
 
 } // namespace
 
-bool Vopd::is_vopd(const MachineInst *inst) {
-  uint32_t word0 = *reinterpret_cast<const uint32_t *>(inst);
-  return (word0 >> 26) == 0x32;
-}
-
 const char *Vopd::op_name(uint16_t op) {
   switch (op) {
   case kVopdFmacF32:

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/vopd.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/vopd.h
@@ -18,7 +18,6 @@ namespace rdna4 {
 class Vopd : public IsaInstruction<Isa> {
 public:
   explicit Vopd(const MachineInst *inst);
-  static bool is_vopd(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
 
 private:

--- a/emulation/rocjitsu/tests/decode_smoke_test.cpp
+++ b/emulation/rocjitsu/tests/decode_smoke_test.cpp
@@ -516,23 +516,6 @@ TEST_P(RdnaInvalidVopdDecodeSmokeTest, DoesNotClaimVopd3Encoding) {
   auto decoder = Decoder::create(tc.arch);
   ASSERT_NE(decoder, nullptr) << tc.arch_name;
 
-  switch (tc.arch) {
-  case ROCJITSU_CODE_ARCH_RDNA3:
-    EXPECT_FALSE(
-        rdna3::Vopd::is_vopd(reinterpret_cast<const rdna3::MachineInst *>(tc.words.data())));
-    break;
-  case ROCJITSU_CODE_ARCH_RDNA3_5:
-    EXPECT_FALSE(
-        rdna3_5::Vopd::is_vopd(reinterpret_cast<const rdna3_5::MachineInst *>(tc.words.data())));
-    break;
-  case ROCJITSU_CODE_ARCH_RDNA4:
-    EXPECT_FALSE(
-        rdna4::Vopd::is_vopd(reinterpret_cast<const rdna4::MachineInst *>(tc.words.data())));
-    break;
-  default:
-    FAIL() << "unexpected test arch";
-  }
-
   EXPECT_THROW(static_cast<void>(decoder->decode(tc.words.data())), util::InvalidInst)
       << tc.arch_name << " should reserve the 0xCF VOPD3 prefix";
 }

--- a/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
+++ b/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
@@ -3711,6 +3711,19 @@ TEST(Gfx1250DecodeTest, WmmaScaleF4_32x16x128ConsumesVop3px2Pair) {
             "v_wmma_scale_f32_32x16x128_f4 v[0:15], v[16:31], v[32:39], 0, v40, v41");
 }
 
+TEST(Gfx1250DecodeTest, WmmaScalePrefixRejectsNonWmmaSuffix) {
+  const uint32_t words[] = {
+      0xCC350000u,
+      0x02020900u,
+      0xCC340006u,
+      0x02026912u,
+  };
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  EXPECT_THROW(static_cast<void>(decoder->decode(words)), util::InvalidInst);
+}
+
 TEST(Gfx1250ExecutionTest, WmmaRegularScaleInlineZeroMatchesNeutralScalarSources) {
   Gfx1250Sim sim;
   auto *cu = sim.cu();


### PR DESCRIPTION
Reserve VOPD and VOPD3 primary prefixes in the generated decode tables instead of probing every instruction before ordinary dispatch. Keep the prefix metadata in ISA profiles so table reservation and generated VOPD construction share one source of truth.

Route gfx1250 scaled WMMA prefixes through the VOP3P opcode table and use only encoding and opcode fields to select the paired form. Remove the unused Vopd::is_vopd helper and cover exact VOPD table slots plus invalid scaled-WMMA suffixes.