### PR TITLE
fix(amdsmi): Fix json output for list with multiple devices

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -108,6 +108,9 @@ GPU: 0
 
 ### Fixed
 
+- **Fixed `amd-smi list --json` emitting multiple concatenated JSON documents on systems with more than one device type**.
+  - When GPUs coexisted with Broadcom NICs, AI-NICs, or switches, each device group printed its own separate JSON document, so the combined stdout was not valid JSON and `json.loads` failed. The command now aggregates every active device type into a single JSON document when more than one type is present. Systems with a single device type are unchanged.
+
 - **Fixed `amd-smi ras --cper --json` emitting nothing when there are no CPER entries**.
   - The common no-entries case printed empty output, so consumers feeding stdout to `json.loads` failed with `Expecting value: line 1 column 1 (char 0)`. The command now always emits exactly one valid JSON document: `[]` when there are no entries, or a single aggregated array across all GPUs when there are. `--follow` mode stays silent until entries appear. The human-readable primary-partition warning is also suppressed in JSON mode so it no longer corrupts the output.
 

--- a/projects/amdsmi/amdsmi_cli/subcommands/list_devices.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/list_devices.py
@@ -384,20 +384,20 @@ class ListDevicesCommands:
         if switch:
             args.switch = switch
 
-        gpuCount = 0
+        gpu_count = 0
 
         # Handle No GPU passed
         if args.gpu == None:
             args.gpu = self.device_handles_gpus
             if isinstance(args.gpu, list):
-                gpuCount = len(args.gpu)
+                gpu_count = len(args.gpu)
         else:
             if isinstance(args.gpu, list):
-                gpuCount = len(args.gpu)
+                gpu_count = len(args.gpu)
                 self.logger.output = {}
                 self.logger.clear_multiple_devices_output()
 
-                if gpuCount > 0:
+                if gpu_count > 0:
                     self.list_gpu(args, False, gpu=args.gpu)
                     return
 
@@ -406,27 +406,56 @@ class ListDevicesCommands:
         if self.list_switchs(args):
             return
 
-        self.logger.output = {}
-        self.logger.clear_multiple_devices_output()
+        nic_count = 0
+        ainic_count = 0
+        switch_count = 0
 
-        if gpuCount > 0:
-            self.list_gpu(args, False, gpu=args.gpu)
-
-        self.logger.output = {}
-        self.logger.clear_multiple_devices_output()
-
+        # Find which devices are active
         if self.helpers.is_ainic_initialized() or self.helpers.is_brcm_nic_initialized():
             nics, ainics = self._get_nics_from_args(args)
-            if len(nics) > 0:
-                self.list_brcm_nic(args, False, nic=nics)
-            if len(ainics) > 0:
-                self.list_ainic(args, False, nic=ainics)
+            nic_count = len(nics)
+            ainic_count = len(ainics)
+
+        if self.helpers.is_brcm_switch_initialized() and args.switch:
+            switch_count = 1
+
+        # Determine if more than 1 device is active
+        device_count = 0
+        if gpu_count > 0:
+            device_count += 1
+        if nic_count > 0:
+            device_count += 1
+        if ainic_count > 0:
+            device_count += 1
+        if switch_count > 0:
+            device_count += 1
+        if device_count > 1:
+            multiple_devices = True
 
         self.logger.output = {}
         self.logger.clear_multiple_devices_output()
 
-        if self.helpers.is_brcm_switch_initialized() and args.switch:
-            self.list_switch(args, False, switch=args.switch)
+        if gpu_count > 0:
+            self.list_gpu(args, multiple_devices, gpu=args.gpu)
+
+        if not multiple_devices:
+            self.logger.output = {}
+            self.logger.clear_multiple_devices_output()
+
+        if nic_count > 0:
+            self.list_brcm_nic(args, multiple_devices, nic=nics)
+        if ainic_count > 0:
+            self.list_ainic(args, multiple_devices, nic=ainics)
+
+        if not multiple_devices:
+            self.logger.output = {}
+            self.logger.clear_multiple_devices_output()
+
+        if switch_count > 0 and args.switch:
+            self.list_switch(args, multiple_devices, switch=args.switch)
+
+        if multiple_devices:
+            self.logger.print_output(multiple_device_enabled=multiple_devices)
 
         self.logger.output = {}
         self.logger.clear_multiple_devices_output()


### PR DESCRIPTION
## Motivation
amd-smi list --json is meant to produce machine-readable output that downstream tooling parses with json.loads. On systems that expose more than one device type at once — GPUs together with Broadcom NICs, AI-NICs, or switches — the command printed a separate JSON document for each device group. The concatenation of several top-level JSON documents is not valid JSON, so any consumer piping the output into a JSON parser failed. GPU-only systems (the common case) were unaffected, which made the bug easy to miss. This fix makes list --json emit a single, valid JSON document regardless of how many device types are present.

## Technical Details
ListDevicesCommands.list_devices() previously called list_gpu(), list_brcm_nic(), list_ainic(), and list_switch() in sequence, each ending in its own print_output(), producing one JSON document per group.

The command now first counts how many device types are active (gpu_count, nic_count, ainic_count, switch_count) and derives device_count. When device_count > 1, multiple_devices is set and each list_* call is invoked with that flag, causing them to accumulate into the shared buffer via store_multiple_device_output() and return without printing. A single terminal print_output(multiple_device_enabled=True) then emits the combined document. This mirrors the existing multi-device pattern already used in partition.py, process.py, and metric.py.

Behavior is preserved for single-type systems: when device_count <= 1, multiple_devices stays False and the active group prints exactly as before, with the buffer cleared between groups. Local counters were also renamed to snake_case (gpuCount → gpu_count) for consistency.

Note: the file-editing tools couldn't resolve the nested worktree path, so the CHANGELOG insertion was applied via a scripted, verified edit; the result is shown above.

Added the CHANGELOG ### Fixed entry (verified in place) and provided the Motivation and Technical statements above in markdown, ready to paste into the PR description.

## Issue Tracking
JIRA ID : ROCM-28926

## Test Plan
Run amd-smi on several systems with different gpu and nic configurations

## Test Result
amd-smi results showed json output properly for all device combinations
