### PR TITLE
fix(gin): set isRMA after listen() to enable flush QP creation

### DIFF
--- a/projects/rccl/src/transport/net_ib_cast/gin.cc
+++ b/projects/rccl/src/transport/net_ib_cast/gin.cc
@@ -429,10 +429,12 @@ ncclResult_t IbCastGinIbProxyCreateContext(void* collComm, ncclGinConfig_v13_t* 
   NCCLCHECKGOTO(ncclIbMalloc((void**)&handles, NCCL_NET_HANDLE_MAXSIZE * cComm->nranks), ret, end);
   handle = handles + NCCL_NET_HANDLE_MAXSIZE * cComm->rank;
 
+  NCCLCHECKGOTO(netIbCast.listen(cComm->ctx, cComm->dev, handle, &lComm), ret, end);
+
   // Mark communicator as RMA communicator: 1QP, Flush enabled, no CTS offload.
+  // Must be set after listen() which memsets the handle, but before allGather().
   ((struct ncclIbHandle*)handle)->isRMA = true;
 
-  NCCLCHECKGOTO(netIbCast.listen(cComm->ctx, cComm->dev, handle, &lComm), ret, end);
   NCCLCHECKGOTO(cComm->allGather(cComm, handle, handles, NCCL_NET_HANDLE_MAXSIZE), ret, end);
 
   for (int c = 0; c < config->nContexts; c++) {


### PR DESCRIPTION
## Summary

- Fix SIGSEGV in `IbCastGinIbProxyIFlush` caused by gpuFlush loopback QP never being created
- Root cause: `IbCastListen()` memsets the handle to zero (`connect.cc:592`), clearing the `isRMA=true` flag set just before the call. The zeroed flag propagates via allGather so the accept side sees `isRMA=false` → `flushEnabled=0` → no flush QP
- Move `isRMA` assignment to after `listen()` but before `allGather()`

JIRA ID: AICOMRCCL-1201

## Test plan

- [ ] Rebuild librccl.so and rccl-UnitTestsMPI (only `gin.cc` changed)
- [ ] Run `IFlushAfterIGet` — should PASS instead of SIGSEGV
- [ ] Run all GIN MPI tests (`*IGet*:*IFlush*:*IPut*`) — no regressions
- [ ] Verify NCCL_DEBUG=TRACE shows `isRMA=1` in IbCastConnect messages