### PR TITLE
[rocprofiler-compute] Update test_categories.yaml with latest test_profile_roofline_*

### DIFF
--- a/projects/rocprofiler-compute/tests/test_categories.yaml
+++ b/projects/rocprofiler-compute/tests/test_categories.yaml
@@ -60,8 +60,10 @@ test_categories:
       - test_profile_misc
       - test_profile_path
       - test_pc_sampling
-      - test_profile_roofline_1
-      - test_profile_roofline_2
+      - test_profile_roofline_dir
+      - test_profile_roofline_bench
+      - test_profile_roofline_plot
+      - test_profile_roofline_validation
       - test_profile_section
       - test_profile_sets_func
       - test_profile_sort
@@ -125,8 +127,11 @@ test_categories:
       - test_profile_misc
       - test_profile_path
       - test_pc_sampling
-      - test_profile_roofline_1
-      - test_profile_roofline_2
+      - test_profile_roofline_dir
+      - test_profile_roofline_extra_options
+      - test_profile_roofline_bench
+      - test_profile_roofline_plot
+      - test_profile_roofline_validation
       - test_profile_section
       - test_profile_sets_func
       - test_profile_sort
@@ -190,8 +195,11 @@ test_categories:
       - test_profile_misc
       - test_profile_path
       - test_pc_sampling
-      - test_profile_roofline_1
-      - test_profile_roofline_2
+      - test_profile_roofline_dir
+      - test_profile_roofline_extra_options
+      - test_profile_roofline_bench
+      - test_profile_roofline_plot
+      - test_profile_roofline_validation
       - test_profile_section
       - test_profile_sets_func
       - test_profile_sort


### PR DESCRIPTION
## Motivation

Updating test categories yaml with latest roofline testing changes to the splitting and renaming of the tests to fit the time constraints.

## Technical Details

Tied to the changes made in this commit: https://github.com/ROCm/rocm-systems/commit/9d29a1da312470ebfb1cc3d862e607d9a1960559

Replaced test_profile_roofline_# with:
      - test_profile_roofline_dir
      - test_profile_roofline_extra_options
      - test_profile_roofline_bench
      - test_profile_roofline_plot
      - test_profile_roofline_validation

Note- leaving test_profile_roofline_extra_options out of 'standard' test list because it is ~20 minutes for the one subcategory and would exceed the recommended time frame to complete a 'standard' run. Roofline basic functionality covered in the other test cases.

## Issue Tracking

JIRA ID : AIPROFCOMP-163

## Test Plan

Local manual ctest passing with these new test cases. This PR is just to force CI to pick up and run the new test cases as well.
 
## Test Result

Local passing, expect no issues when CI runs the exact same tests.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
