### PR TITLE
kfdtest: blacklist KFDEvictTest.BasicTest on gfx1250

### DIFF
--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/scripts/kfdtest.exclude
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/scripts/kfdtest.exclude
@@ -363,6 +363,7 @@ FILTER[gfx1250]=\
 "KFDQMTest.MultipleCpQueuesStressDispatch:"\
 "KFDCWSRTest.InternalRegTest:"\
 "KFDEvictTest.QueueTest:"\
+"KFDEvictTest.BasicTest:"\
 "KFDRASTest.*:"\
 "KFDExceptionTest.AddressFault:"\
 "KFDQMTest.GpuMemCopyTest:"\


### PR DESCRIPTION
Test fails on gfx1250 due to intended driver behavior, not a defect.

## Motivation

Blacklisting KFDEvictTest.BasicTest on gfx1250 since user submissions for kernel queues are not supported.

## Technical Details


## Issue Tracking

JIRA ID: 

ROCM-29028

## Test Plan

Verified on A0

## Test Result

Test wont be executed.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
