### PR TITLE
[RCCL] fix: AINIC CTS inline data path correctness and memory optimization

### DIFF
--- a/projects/rccl/ext-src/rocm_netib.patch
+++ b/projects/rccl/ext-src/rocm_netib.patch
@@ -1,5 +1,3 @@
-diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
-index 9bfd8dcf..4d3f0a08 100644
 --- a/src/transport/net_ib.cc
 +++ b/src/transport/net_ib.cc
 @@ -29,6 +29,7 @@
@@ -10,7 +8,7 @@ index 9bfd8dcf..4d3f0a08 100644
  #include "graph/xml.h"
  
  #define MAXSUFFIXSIZE 16
-@@ -110,16 +111,38 @@ struct ncclIbMergedDev ncclIbMergedDevs[MAX_IB_VDEVS];
+@@ -110,6 +111,26 @@
  struct ncclIbDev ncclIbDevs[MAX_IB_DEVS];
  static std::mutex ncclIbMutex;
  static int ncclIbRelaxedOrderingEnabled = 0;
@@ -37,10 +35,7 @@ index 9bfd8dcf..4d3f0a08 100644
  
  // With ncclNet_v11_t the NCCL core initializes the network plugin per-communicator
  // rather than once for all communicators. However, the internal plugin implementation
- // still assumes the plugin is initialized only once across all communicators. The ref
- // counter makes sure the plugin internally initializes only once. When per communicator
- // context support is added to the plugin the ref counter can be removed.
- static int netRefCount;
+@@ -120,6 +141,8 @@
  
  #define NCCL_IB_LLSTR(ll) (((ll) == IBV_LINK_LAYER_INFINIBAND) ? "IB" : (((ll) == IBV_LINK_LAYER_ETHERNET) ? "RoCE" : "UNSPECIFIED"))
  
@@ -49,21 +44,20 @@ index 9bfd8dcf..4d3f0a08 100644
  #define NCCL_IB_SL_DEFAULT 0
  #define NCCL_IB_TC_DEFAULT 0
  
-@@ -141,6 +164,13 @@ NCCL_PARAM(IbEceEnable,"IB_ECE_ENABLE",1);
+@@ -141,6 +164,12 @@
  NCCL_PARAM(IbDataDirect,"IB_DATA_DIRECT",1);
  NCCL_PARAM(IbQpsPerConn, "IB_QPS_PER_CONNECTION", 1);
  RCCL_PARAM(IbQpsPerP2p, "IB_QPS_PER_P2P", 0);
-+NCCL_PARAM(IbGdrFlushDisable, "GDR_FLUSH_DISABLE", 0);
++NCCL_PARAM(IbGdrFlushDisable, "GDR_FLUSH_DISABLE", 1);
 +
 +// AMD AINIC
-+RCCL_PARAM(CtsInlineData, "CTS_INLINE_DATA", -1);
 +RCCL_PARAM(CtsOffloadEnabled, "CTS_OFFLOAD_ENABLED", -1);
 +
 +extern int64_t rcclParamAinicRoce();
  
  static ncclResult_t ncclIbStatsInit(struct ncclIbStats* stat) {
    __atomic_store_n(&stat->fatalErrorCount, 0, __ATOMIC_RELAXED);
-@@ -779,6 +809,10 @@ ncclResult_t ncclIbInit(void** ctx, uint64_t commId, ncclNetCommConfig_t* config
+@@ -779,6 +808,10 @@
    static int shownIbHcaEnv = 0;
    if(wrap_ibv_symbols() != ncclSuccess) { return ncclInternalError; }
    if(wrap_mlx5dv_symbols() != ncclSuccess) { INFO(NCCL_NET, "NET/IB : Failed to open mlx5dv symbols. Advance features like CX-8 Direct-NIC will be disabled."); }
@@ -74,7 +68,7 @@ index 9bfd8dcf..4d3f0a08 100644
  
    // Detect IB cards
    int nIbDevs = 0;
-@@ -944,6 +978,23 @@ ncclResult_t ncclIbInit(void** ctx, uint64_t commId, ncclNetCommConfig_t* config
+@@ -944,6 +977,24 @@
      INFO(NCCL_INIT|NCCL_NET, "NET/IB : Using%s %s; OOB %s:%s", line, ncclIbRelaxedOrderingEnabled ? "[RO]" : "",
            ncclIbIfName, ncclSocketToString(&ncclIbIfAddr, addrline));
  
@@ -83,22 +77,36 @@ index 9bfd8dcf..4d3f0a08 100644
 +
 +    rcclAinicRoce = ((rcclParamAinicRoce() == 1) ? true : false);
 +    if (rcclAinicRoce) {
-+      // for AINIC, these params are defaulted to enabled unless user forces it to disable(0).
-+      rcclCtsInlineData = ((rcclParamCtsInlineData() == 0) ? false : true);
 +      rcclCtsOffloadEnabled = ((rcclParamCtsOffloadEnabled() == 0) ? false : true);
-+      // for AINIC IbUseInline is enabled by default always
-+      ncclIbUseInline = true;
 +      // for AINIC GDR flush is disabled by default
-+      ncclIbGdrFlushDisable = 1;
-+
++      // ncclIbGdrFlushDisable = 1;
++      if (rcclCtsOffloadEnabled && !ncclIbUseInline) {
++        INFO(NCCL_INIT|NCCL_NET, "NET/IB : IB Use Inline is disabled and CTS Offload is enabled - enabling IB Use Inline Data");
++        ncclIbUseInline = true;
++      }
++      rcclCtsInlineData = ncclIbUseInline;
 +      INFO(NCCL_INIT|NCCL_NET, "NET/IB : AINIC RoCEv2 optimizations enabled: CTS Inline Data: %s; CTS Offload: %s; "
-+           "IB Use Inline: enabled; GDR Flush: disabled", rcclCtsInlineData ? "Enabled": "Disabled",
-+           rcclCtsOffloadEnabled ? "Enabled": "Disabled");
++           "GDR Flush: %s", rcclCtsInlineData ? "Enabled": "Disabled",
++           rcclCtsOffloadEnabled ? "Enabled": "Disabled",
++           ncclIbGdrFlushDisable ? "Disabled" : "Enabled");
 +    }
    }
  exit:
    ibContext.trafficClass = config->trafficClass;
-@@ -1271,6 +1322,8 @@ struct ncclIbListenComm {
+@@ -1115,7 +1166,11 @@
+   props->latency = 0; // Not set
+   props->port = ibDev->portNum + ibDev->realPort;
+   props->maxComms = ibDev->maxQp;
+-  props->maxRecvs = NCCL_NET_IB_MAX_RECVS;
++  if (rcclCtsInlineData) {
++    props->maxRecvs = 1;
++  } else {
++    props->maxRecvs = NCCL_NET_IB_MAX_RECVS;
++  }
+   props->netDeviceType    = NCCL_NET_DEVICE_HOST;
+   props->netDeviceVersion = NCCL_NET_DEVICE_INVALID_VERSION;
+   props->maxP2pBytes = NCCL_MAX_NET_SIZE_BYTES;
+@@ -1271,6 +1326,8 @@
    struct ncclIbCommStage stage;
  };
  
@@ -107,7 +115,7 @@ index 9bfd8dcf..4d3f0a08 100644
  struct alignas(64) ncclIbSendFifo {
    uint64_t addr;
    uint64_t size;
-@@ -1281,10 +1334,21 @@ struct alignas(64) ncclIbSendFifo {
+@@ -1281,10 +1338,21 @@
    char padding[16];
  };
  
@@ -129,31 +137,43 @@ index 9bfd8dcf..4d3f0a08 100644
  };
  
  struct ncclIbRemSizesFifo {
-@@ -1331,6 +1395,7 @@ struct ncclIbSendComm {
+@@ -1330,7 +1398,10 @@
+ struct ncclIbSendComm {
    struct ncclIbNetCommBase base;
    // Start with fifo and ibv structs as they have alignment restrictions
-   struct ncclIbSendFifo fifo[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
-+  struct ncclIbSendFifoCtsInline fifo_inline[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
+-  struct ncclIbSendFifo fifo[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
++  union {
++    struct ncclIbSendFifo fifo[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
++    struct ncclIbSendFifoCtsInline fifo_inline[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
++  } u;
    struct ibv_sge sges[NCCL_NET_IB_MAX_RECVS];
    struct ibv_send_wr wrs[NCCL_NET_IB_MAX_RECVS + 1];
    // Each dev correlates to a mergedIbDev
-@@ -1346,6 +1411,7 @@ struct ncclIbSendComm {
+@@ -1344,8 +1415,10 @@
+ // to be a 32-byte multiple, so that an entry does not get split and
+ // written out of order when IB Relaxed Ordering is enabled
  static_assert((sizeof(struct ncclIbNetCommBase) % 32) == 0, "ncclIbNetCommBase size must be 32-byte multiple to ensure fifo is at proper offset");
- static_assert((offsetof(struct ncclIbSendComm, fifo) % 32) == 0, "ncclIbSendComm fifo must be 32-byte aligned");
+-static_assert((offsetof(struct ncclIbSendComm, fifo) % 32) == 0, "ncclIbSendComm fifo must be 32-byte aligned");
++static_assert((offsetof(struct ncclIbSendComm, u.fifo) % 32) == 0, "ncclIbSendComm fifo must be 32-byte aligned");
  static_assert((sizeof(struct ncclIbSendFifo) % 32) == 0, "ncclIbSendFifo element size must be 32-byte multiples");
-+static_assert((sizeof(struct ncclIbSendFifoCtsInline) % 32) == 0, "ncclIbSendFifoCtsInline element size must be 32-byte multiples");
++static_assert((sizeof(struct ncclIbSendFifoCtsInline) % 32) == 0, "ncclIbSendFifoCtsInline element size must be 32-byte aligned");
++static_assert((sizeof(struct ncclIbSendFifoCtsInline) <=32), "struct ncclIbSendFifoCtsInline should fit within 32-bytes");
  static_assert((offsetof(struct ncclIbSendComm, sges) % 32) == 0, "sges must be 32-byte aligned");
  static_assert((offsetof(struct ncclIbSendComm, wrs) % 32) == 0, "wrs must be 32-byte aligned");
  
-@@ -1360,6 +1426,7 @@ struct ncclIbGpuFlush {
+@@ -1359,7 +1432,10 @@
+ };
  
  struct ncclIbRemFifo {
-   struct ncclIbSendFifo elems[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
-+  struct ncclIbSendFifoCtsInline elems_cts_inline[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
+-  struct ncclIbSendFifo elems[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
++  union {
++    struct ncclIbSendFifo elems[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
++    struct ncclIbSendFifoCtsInline elems_cts_inline[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
++  } u;
    uint64_t fifoTail;
    uint64_t addr;
    uint32_t flags;
-@@ -1415,20 +1482,59 @@ ncclResult_t ncclIbDestroyBase(struct ncclIbNetCommDevBase* base) {
+@@ -1415,20 +1491,59 @@
    return ncclSuccess;
  }
  
@@ -215,7 +235,7 @@ index 9bfd8dcf..4d3f0a08 100644
    struct ibv_qp_attr qpAttr;
    memset(&qpAttr, 0, sizeof(struct ibv_qp_attr));
    qpAttr.qp_state = IBV_QPS_INIT;
-@@ -1438,6 +1544,9 @@ ncclResult_t ncclIbCreateQp(uint8_t ib_port, struct ncclIbNetCommDevBase* base,
+@@ -1438,6 +1553,9 @@
    NCCLCHECK(wrap_ibv_modify_qp(qp->qp, &qpAttr, IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_ACCESS_FLAGS));
    TRACE(NCCL_NET, "NET/IB : ncclIbCreateQp port=%d dev=%d devName=%s ndevs=%d nmdevs=%d qpn=%u pkey=%u pd=%p",
      ib_port, base->ibDevN, ncclIbDevs[base->ibDevN].devName, ncclNIbDevs, ncclNMergedIbDevs, qp->qp->qp_num, qpAttr.pkey_index, base->pd);
@@ -225,7 +245,7 @@ index 9bfd8dcf..4d3f0a08 100644
    return ncclSuccess;
  }
  
-@@ -1521,7 +1630,7 @@ fail:
+@@ -1521,7 +1639,7 @@
    goto exit;
  }
  
@@ -234,7 +254,7 @@ index 9bfd8dcf..4d3f0a08 100644
    ncclResult_t ret = ncclSuccess;
    struct ncclIbHandle* handle = (struct ncclIbHandle*) opaqueHandle;
    struct ncclIbCommStage* stage = &handle->stage;
-@@ -1529,8 +1638,13 @@ ncclResult_t ncclIbConnect(void* ctx, int dev, void* opaqueHandle, void** sendCo
+@@ -1529,8 +1647,13 @@
    int ready;
    uint8_t link_layer = IBV_LINK_LAYER_UNSPECIFIED;
    int isP2p = 0; 
@@ -248,7 +268,7 @@ index 9bfd8dcf..4d3f0a08 100644
    if (stage->state == ncclIbCommStateConnect)      goto ib_connect_check;
    if (stage->state == ncclIbCommStateSendDevList)  goto ib_send_dev_list;
    if (stage->state == ncclIbCommStateRecvDevList)  goto ib_recv_dev_list;
-@@ -1612,7 +1726,7 @@ ib_recv_dev_list:
+@@ -1612,7 +1735,7 @@
    for (int q = 0; q < comm->base.nqps; q++) {
      ncclIbSendCommDev* commDev = comm->devs + devIndex;
      ncclIbDev* ibDev = ncclIbDevs + commDev->base.ibDevN;
@@ -257,33 +277,29 @@ index 9bfd8dcf..4d3f0a08 100644
      comm->base.qps[q].devIndex = devIndex;
      meta.qpInfo[q].qpn      = comm->base.qps[q].qp->qp_num;
      meta.qpInfo[q].devIndex = comm->base.qps[q].devIndex;
-@@ -1637,7 +1751,11 @@ ib_recv_dev_list:
+@@ -1637,7 +1760,7 @@
      devInfo->lid           = ibDev->portAttr.lid;
      devInfo->ibv_dev_index = commDev->base.ibDevN;
      // Prepare my fifo
 -    NCCLCHECKGOTO(wrap_ibv_reg_mr(&commDev->fifoMr, commDev->base.pd, comm->fifo, sizeof(struct ncclIbSendFifo)*MAX_REQUESTS*NCCL_NET_IB_MAX_RECVS, IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
-+    if (rcclCtsInlineData) {
-+      NCCLCHECKGOTO(wrap_ibv_reg_mr(&commDev->fifoMr, commDev->base.pd, comm->fifo_inline, sizeof(struct ncclIbSendFifoCtsInline)*MAX_REQUESTS*NCCL_NET_IB_MAX_RECVS, IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
-+    } else {
-+      NCCLCHECKGOTO(wrap_ibv_reg_mr(&commDev->fifoMr, commDev->base.pd, comm->fifo, sizeof(struct ncclIbSendFifo)*MAX_REQUESTS*NCCL_NET_IB_MAX_RECVS, IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
-+    }
++    NCCLCHECKGOTO(wrap_ibv_reg_mr(&commDev->fifoMr, commDev->base.pd, comm->u.fifo, sizeof(struct ncclIbSendFifo)*MAX_REQUESTS*NCCL_NET_IB_MAX_RECVS, IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
      devInfo->fifoRkey = commDev->fifoMr->rkey;
  
      // Pack local GID info
-@@ -1680,7 +1798,11 @@ ib_recv_dev_list:
+@@ -1680,7 +1803,11 @@
      }
    }
    config = (ncclNetCommConfig_t*)ctx;
 -  meta.fifoAddr = (uint64_t)comm->fifo;
 +  if (rcclCtsInlineData) {
-+    meta.fifoAddr = (uint64_t)comm->fifo_inline;
++    meta.fifoAddr = (uint64_t)comm->u.fifo_inline;
 +  } else {
-+    meta.fifoAddr = (uint64_t)comm->fifo;
++    meta.fifoAddr = (uint64_t)comm->u.fifo;
 +  }
    meta.sl = (ncclParamIbSl() != -1) ? ncclParamIbSl() : (config && config->trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? config->trafficClass : NCCL_IB_SL_DEFAULT;
    meta.tc = (ncclParamIbTc() != -1) ? ncclParamIbTc() : (config && config->trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? config->trafficClass : NCCL_IB_TC_DEFAULT;
    strncpy(meta.devName, mergedDev->devName, MAX_MERGED_DEV_NAME);
-@@ -1825,18 +1947,22 @@ ncclResult_t ncclIbCheckVProps(ncclNetVDeviceProps_t* vProps1, ncclNetVDevicePro
+@@ -1825,18 +1952,22 @@
    return ncclSuccess;
  }
  
@@ -308,7 +324,7 @@ index 9bfd8dcf..4d3f0a08 100644
    if (stage->state == ncclIbCommStateAccept)   goto ib_accept_check;
    if (stage->state == ncclIbCommStateRecvDevList) goto ib_recv_dev_list;
    if (stage->state == ncclIbCommStateSendDevList) goto ib_send_dev_list;
-@@ -1966,7 +2092,7 @@ ib_recv:
+@@ -1966,7 +2097,7 @@
      // Local ibDevN
      ibDevN = rComm->devs[devIndex].base.ibDevN;
      ibDev = ncclIbDevs + ibDevN;
@@ -317,9 +333,9 @@ index 9bfd8dcf..4d3f0a08 100644
      qp->devIndex = devIndex;
      devIndex = (devIndex + 1) % rComm->base.vProps.ndevs;
  
-@@ -1992,16 +2118,22 @@ ib_recv:
+@@ -1992,16 +2123,16 @@
  
-   useDmaBuf  = (ncclIbDmaBufSupport(lComm->dev) == ncclSuccess);
+   useDmaBuf  = (ncclIbDmaBufSupport(lComm->dev) == ncclSuccess && ncclParamDmaBufEnable());
    rComm->flushEnabled = ((ncclIbGdrSupport() == ncclSuccess || useDmaBuf)
 -                            && (ncclParamIbGdrFlushDisable() == 0)) ? 1 : 0;              
 +                            && (ncclIbGdrFlushDisable == 0)) ? 1 : 0;
@@ -330,20 +346,14 @@ index 9bfd8dcf..4d3f0a08 100644
      // Retain remote fifo info and prepare my RDMA ops
      rComm->remFifo.addr = remMeta.fifoAddr;
 -    NCCLCHECKGOTO(wrap_ibv_reg_mr(&rCommDev->fifoMr, rCommDev->base.pd, &rComm->remFifo.elems, sizeof(struct ncclIbSendFifo)*MAX_REQUESTS*NCCL_NET_IB_MAX_RECVS, IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
-+    if (rcclCtsInlineData) {
-+      NCCLCHECKGOTO(wrap_ibv_reg_mr(&rCommDev->fifoMr, rCommDev->base.pd, &rComm->remFifo.elems_cts_inline,
-+                                    sizeof(struct ncclIbSendFifoCtsInline)*MAX_REQUESTS*NCCL_NET_IB_MAX_RECVS,
-+                                    IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
-+    } else {
-+      NCCLCHECKGOTO(wrap_ibv_reg_mr(&rCommDev->fifoMr, rCommDev->base.pd, &rComm->remFifo.elems, sizeof(struct ncclIbSendFifo)*MAX_REQUESTS*NCCL_NET_IB_MAX_RECVS, IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
-+    }
++    NCCLCHECKGOTO(wrap_ibv_reg_mr(&rCommDev->fifoMr, rCommDev->base.pd, &rComm->remFifo.u.elems, sizeof(struct ncclIbSendFifo)*MAX_REQUESTS*NCCL_NET_IB_MAX_RECVS, IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
      rCommDev->fifoSge.lkey = rCommDev->fifoMr->lkey;
 -    if (ncclParamIbUseInline()) rComm->remFifo.flags = IBV_SEND_INLINE;
 +    if (ncclIbUseInline) rComm->remFifo.flags = IBV_SEND_INLINE;
  
      // Allocate Flush dummy buffer for GPU Direct RDMA
      if (rComm->flushEnabled) {
-@@ -2039,7 +2171,7 @@ ib_recv:
+@@ -2039,7 +2170,7 @@
        rCommDev->gpuFlush.sge.addr = (uint64_t)&rComm->gpuFlushHostMem;
        rCommDev->gpuFlush.sge.length = 1;
        rCommDev->gpuFlush.sge.lkey = rCommDev->gpuFlush.hostMr->lkey;
@@ -352,25 +362,27 @@ index 9bfd8dcf..4d3f0a08 100644
        struct ncclIbDevInfo devInfo;
        devInfo.lid         = ibDev->portAttr.lid;
        devInfo.link_layer  = ibDev->portAttr.link_layer;
-@@ -2257,10 +2389,15 @@ ncclResult_t ncclIbDeregMr(void* comm, void* mhandle) {
+@@ -2261,10 +2392,16 @@
  
  NCCL_PARAM(IbSplitDataOnQps, "IB_SPLIT_DATA_ON_QPS", 0);
  
 -ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
 +ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot, bool use_write_op) {
    struct ncclIbRequest** reqs = comm->fifoReqs[slot];
-   volatile struct ncclIbSendFifo* slots = comm->fifo[slot];
+-  volatile struct ncclIbSendFifo* slots = comm->fifo[slot];
 -  int nreqs = slots[0].nreqs;
++  volatile struct ncclIbSendFifo* slots = comm->u.fifo[slot];
++  volatile struct ncclIbSendFifoCtsInline* slots_inline = comm->u.fifo_inline[slot];
 +  int nreqs;
 +  if (rcclCtsOffloadEnabled) {
 +    nreqs = 1;
 +  } else {
-+    nreqs = slots[0].nreqs;
++    nreqs = (rcclCtsInlineData) ? slots_inline[0].nreqs : slots[0].nreqs;
 +  }
    if (nreqs > NCCL_NET_IB_MAX_RECVS) return ncclInternalError;
  
    uint64_t wr_id = 0ULL;
-@@ -2272,7 +2409,11 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
+@@ -2276,7 +2413,11 @@
      sge->addr=(uintptr_t)reqs[r]->send.data;
      wr->opcode = IBV_WR_RDMA_WRITE;
      wr->send_flags = 0;
@@ -378,12 +390,12 @@ index 9bfd8dcf..4d3f0a08 100644
 +    if (rcclCtsOffloadEnabled) {
 +      wr->wr.rdma.remote_addr = 0xdeadbeef;
 +    } else {
-+      wr->wr.rdma.remote_addr = slots[r].addr;
++      wr->wr.rdma.remote_addr = (rcclCtsInlineData) ? slots_inline[r].addr : slots[r].addr;
 +    }
      wr->next = wr + 1;
      wr_id += (reqs[r] - comm->base.reqs) << (r*8);
  #ifdef NCCL_ENABLE_NET_PROFILING
-@@ -2283,7 +2424,7 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
+@@ -2287,7 +2428,7 @@
    // Write size as immediate data. In the case of multi-send, only write
    // 0 or 1 as size to indicate whether there was data sent or received.
    uint32_t immData = 0;
@@ -392,7 +404,7 @@ index 9bfd8dcf..4d3f0a08 100644
      immData = reqs[0]->send.size;
    } else {
      int* sizes = comm->remSizesFifo.elems[slot];
-@@ -2293,22 +2434,24 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
+@@ -2297,22 +2438,24 @@
    }
  
    struct ibv_send_wr* lastWr = comm->wrs+nreqs-1;
@@ -430,7 +442,7 @@ index 9bfd8dcf..4d3f0a08 100644
    lastWr->next = NULL;
    lastWr->send_flags = IBV_SEND_SIGNALED;
  
-@@ -2324,7 +2467,11 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
+@@ -2328,7 +2471,11 @@
        //ncclIbAddEvent(reqs[r], devIndex, &comm->devs[devIndex].base);
  
        // Select proper rkey (needed even for 0-size send)
@@ -438,12 +450,12 @@ index 9bfd8dcf..4d3f0a08 100644
 +      if (rcclCtsOffloadEnabled) {
 +        comm->wrs[r].wr.rdma.rkey = 0xbade;
 +      } else {
-+        comm->wrs[r].wr.rdma.rkey = slots[r].rkeys[qp->remDevIdx];
++        comm->wrs[r].wr.rdma.rkey = (rcclCtsInlineData) ? slots_inline[r].rkeys[0] : slots[r].rkeys[qp->remDevIdx];
 +      }
  
        int chunkSize = DIVUP(DIVUP(reqs[r]->send.size, nqps), align) * align;
        int length = std::min(reqs[r]->send.size-reqs[r]->send.offset, chunkSize);
-@@ -2340,7 +2487,7 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
+@@ -2344,7 +2491,7 @@
        }
      }
  
@@ -452,7 +464,7 @@ index 9bfd8dcf..4d3f0a08 100644
        // Also make sure lastWr writes remote sizes using the right lkey
        comm->remSizesFifo.sge.lkey = comm->remSizesFifo.mrs[devIndex]->lkey;
        lastWr->wr.rdma.rkey = comm->remSizesFifo.rkeys[devIndex];
-@@ -2398,32 +2545,46 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
+@@ -2402,32 +2549,59 @@
    NCCLCHECK(ncclIbStatsCheckFatalCount(&comm->base.stats,__func__));
  
    struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*) mhandle;
@@ -464,11 +476,12 @@ index 9bfd8dcf..4d3f0a08 100644
    // Wait for the receiver to have posted the corresponding receive
    int nreqs = 0;
    volatile struct ncclIbSendFifo* slots;
- 
++  volatile struct ncclIbSendFifoCtsInline* slots_inline;
++
 +  if (rcclCtsOffloadEnabled) {
 +      nreqs = 1;
 +  }
-+
+ 
    int slot = (comm->fifoHead) % MAX_REQUESTS;
    struct ncclIbRequest** reqs = comm->fifoReqs[slot];
 -  slots = comm->fifo[slot];
@@ -479,12 +492,20 @@ index 9bfd8dcf..4d3f0a08 100644
 -  for (int r=1; r<nreqs; r++) while(slots[r].idx != idx);
 -  __sync_synchronize(); // order the nreqsPtr load against tag/rkey/addr loads below
 +  if (!rcclCtsOffloadEnabled) {
-+    slots = comm->fifo[slot];
++    slots = comm->u.fifo[slot];
++    slots_inline = comm->u.fifo_inline[slot];
 +    uint64_t idx = comm->fifoHead+1;
-+    if (slots[0].idx != idx) { *request = NULL; return ncclSuccess; }
-+    nreqs = slots[0].nreqs;
-+    // Wait until all data has arrived
-+    for (int r=1; r<nreqs; r++) while(slots[r].idx != idx);
++    if (rcclCtsInlineData) {
++      if (slots_inline[0].idx != (uint32_t)idx) { *request = NULL; return ncclSuccess; }
++      nreqs = slots_inline[0].nreqs;
++      // Wait until all data has arrived
++      for (int r=1; r<nreqs; r++) while(slots_inline[r].idx != (uint32_t)idx);
++    } else {
++      if (slots[0].idx != idx) { *request = NULL; return ncclSuccess; }
++      nreqs = slots[0].nreqs;
++      // Wait until all data has arrived
++      for (int r=1; r<nreqs; r++) while(slots[r].idx != idx);
++    }
 +    __sync_synchronize(); // order the nreqsPtr load against tag/rkey/addr loads below
 +  }
    for (int r=0; r<nreqs; r++) {
@@ -500,16 +521,20 @@ index 9bfd8dcf..4d3f0a08 100644
 -        r, nreqs, tag, ncclSocketToString(&addr, line), slots[r].size, slots[r].addr, slots[r].rkeys[0]);
 -      return ncclInternalError;
 +    if (!rcclCtsOffloadEnabled) {
-+      if (reqs[r] != NULL || slots[r].tag != tag) continue;
++      uint64_t slot_addr = (rcclCtsInlineData) ? slots_inline[r].addr : slots[r].addr;
++      uint64_t slot_size = (rcclCtsInlineData) ? slots_inline[r].size : slots[r].size;
++      uint32_t slot_rkey = (rcclCtsInlineData) ? slots_inline[r].rkeys[0] : slots[r].rkeys[0];
++      uint32_t slot_tag = (rcclCtsInlineData) ? slots_inline[r].tag : slots[r].tag;
++      if (reqs[r] != NULL || slot_tag != tag) continue;
 +
-+      if (size > slots[r].size) size = slots[r].size;
++      if (size > slot_size) size = slot_size;
 +      // Sanity checks
-+      if (slots[r].size < 0 || slots[r].addr == 0 || slots[r].rkeys[0] == 0) {
++      if (slot_size < 0 || slot_addr == 0 || slot_rkey == 0) {
 +        char line[SOCKET_NAME_MAXLEN + 1];
 +        union ncclSocketAddress addr;
 +        ncclSocketGetAddr(&comm->base.sock, &addr);
 +        WARN("NET/IB : req %d/%d tag %x peer %s posted incorrect receive info: size %ld addr %lx rkeys[0]=%x",
-+             r, nreqs, tag, ncclSocketToString(&addr, line), slots[r].size, slots[r].addr, slots[r].rkeys[0]);
++             r, nreqs, tag, ncclSocketToString(&addr, line), slot_size, slot_addr, slot_rkey);
 +        return ncclInternalError;
 +      }
 +    } else{
@@ -517,7 +542,7 @@ index 9bfd8dcf..4d3f0a08 100644
      }
  
      struct ncclIbRequest* req;
-@@ -2467,10 +2628,12 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
+@@ -2471,10 +2645,16 @@
      }
  
      TIME_START(0);
@@ -527,12 +552,16 @@ index 9bfd8dcf..4d3f0a08 100644
      // Clear slots[0]->nreqs, as well as other fields to help debugging and sanity checks
 -    memset((void*)slots, 0, sizeof(struct ncclIbSendFifo));
 +    if (!rcclCtsOffloadEnabled) {
-+      memset((void*)slots, 0, sizeof(struct ncclIbSendFifo));
++      if (rcclCtsInlineData) {
++        memset((void*)slots_inline, 0, sizeof(struct ncclIbSendFifoCtsInline));
++      } else {
++        memset((void*)slots, 0, sizeof(struct ncclIbSendFifo));
++      }
 +    }
      memset(reqs, 0, NCCL_NET_IB_MAX_RECVS*sizeof(struct ncclIbRequest*));
      comm->fifoHead++;
      TIME_STOP(0);
-@@ -2483,30 +2646,60 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
+@@ -2487,39 +2667,74 @@
  
  ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, size_t* sizes, int* tags, void** mhandles, struct ncclIbRequest* req) {
    struct ibv_send_wr wr;
@@ -548,9 +577,9 @@ index 9bfd8dcf..4d3f0a08 100644
    for (int i=0; i<n; i++) req->recv.sizes[i] = 0;
 -  struct ncclIbSendFifo* localElem = comm->remFifo.elems[slot];
 +  if (rcclCtsInlineData) {
-+    localElemCtsInline = comm->remFifo.elems_cts_inline[slot];
++    localElemCtsInline = comm->remFifo.u.elems_cts_inline[slot];
 +  } else {
-+    localElem = comm->remFifo.elems[slot];
++    localElem = comm->remFifo.u.elems[slot];
 +  }
  
 -  // Select the next devIndex (local) and QP to use for posting this CTS message
@@ -572,11 +601,8 @@ index 9bfd8dcf..4d3f0a08 100644
      struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*) mhandles[i];
 +    if (rcclCtsInlineData) {
 +      localElemCtsInline[i].addr = (uint64_t)data[i];
-+
-+      // Send all applicable rkeys
-+      for (int j = 0; j < comm->base.vProps.ndevs; j++)
-+        localElemCtsInline[i].rkeys[j] = mhandleWrapper->mrs[j]->rkey;
-+
++      // for Inline only one rkey is valid
++      localElemCtsInline[i].rkeys[0] = mhandleWrapper->mrs[0]->rkey;
 +      localElemCtsInline[i].nreqs = n;
 +      localElemCtsInline[i].size = sizes[i]; // Sanity/Debugging
 +      localElemCtsInline[i].tag = tags[i];
@@ -585,14 +611,15 @@ index 9bfd8dcf..4d3f0a08 100644
 +
 +    } else {
 +      localElem[i].addr = (uint64_t)data[i];
- 
--    // Send all applicable rkeys
--    for (int j = 0; j < comm->base.vProps.ndevs; j++)
--      localElem[i].rkeys[j] = mhandleWrapper->mrs[j]->rkey;
++
 +      // Send all applicable rkeys
 +      for (int j = 0; j < comm->base.vProps.ndevs; j++)
 +        localElem[i].rkeys[j] = mhandleWrapper->mrs[j]->rkey;
  
+-    // Send all applicable rkeys
+-    for (int j = 0; j < comm->base.vProps.ndevs; j++)
+-      localElem[i].rkeys[j] = mhandleWrapper->mrs[j]->rkey;
+-
 -    localElem[i].nreqs = n;
 -    localElem[i].size = sizes[i]; // Sanity/Debugging
 -    localElem[i].tag = tags[i];
@@ -603,10 +630,15 @@ index 9bfd8dcf..4d3f0a08 100644
 +      localElem[i].idx = comm->remFifo.fifoTail+1;
 +      localElemRef = (uint64_t)localElem;
 +    }
++  }
++  if (rcclCtsInlineData) {
++    wr.wr.rdma.remote_addr = comm->remFifo.addr + slot*NCCL_NET_IB_MAX_RECVS*sizeof(struct ncclIbSendFifoCtsInline);
++  } else {
++    wr.wr.rdma.remote_addr = comm->remFifo.addr + slot*NCCL_NET_IB_MAX_RECVS*sizeof(struct ncclIbSendFifo);
    }
-   wr.wr.rdma.remote_addr = comm->remFifo.addr + slot*NCCL_NET_IB_MAX_RECVS*sizeof(struct ncclIbSendFifo);
+-  wr.wr.rdma.remote_addr = comm->remFifo.addr + slot*NCCL_NET_IB_MAX_RECVS*sizeof(struct ncclIbSendFifo);
  
-@@ -2514,8 +2707,12 @@ ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, siz
+   // Lookup the correct fifoRkey
    wr.wr.rdma.rkey = comm->base.remDevs[ctsQp->remDevIdx].fifoRkey;
  
    // Set the correct sge properties
@@ -621,7 +653,7 @@ index 9bfd8dcf..4d3f0a08 100644
    wr.sg_list = &comm->devs[ctsQp->devIndex].fifoSge;
    wr.num_sge = 1;
  
-@@ -2545,7 +2742,13 @@ ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, siz
+@@ -2549,7 +2764,13 @@
    //
    // slot == devIndex - When writing to fifo slot N, and this QP lives on device index N, it should send signalled.
    // This works out that each fifo posting QP gets drained
@@ -636,7 +668,7 @@ index 9bfd8dcf..4d3f0a08 100644
      wr.send_flags |= IBV_SEND_SIGNALED;
      wr.wr_id = req - comm->base.reqs;
      ncclIbAddEvent(req, ctsQp->devIndex, &comm->devs[ctsQp->devIndex].base);
-@@ -2560,10 +2763,16 @@ ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, siz
+@@ -2564,10 +2785,16 @@
  
    comm->remFifo.fifoTail++;
  
@@ -653,7 +685,7 @@ index 9bfd8dcf..4d3f0a08 100644
    struct ncclIbRecvComm* comm = (struct ncclIbRecvComm*)recvComm;
    if (comm->base.ready == 0) {
      WARN("NET/IB: ncclIbIrecv() called when comm->base.ready == 0");
-@@ -2573,6 +2782,11 @@ ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
+@@ -2577,6 +2804,11 @@
    if (n > NCCL_NET_IB_MAX_RECVS) return ncclInternalError;
    NCCLCHECK(ncclIbStatsCheckFatalCount(&comm->base.stats,__func__));
  
@@ -665,7 +697,7 @@ index 9bfd8dcf..4d3f0a08 100644
    struct ncclIbRequest* req;
    NCCLCHECK(ncclIbGetRequest(&comm->base, &req));
    req->type = NCCL_NET_IB_REQ_RECV;
-@@ -2586,50 +2800,64 @@ ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
+@@ -2590,50 +2822,64 @@
      req->devBases[i] = &comm->devs[i].base;
    }
  
@@ -674,6 +706,10 @@ index 9bfd8dcf..4d3f0a08 100644
 -  wr.wr_id = req - comm->base.reqs;
 -  wr.sg_list = NULL;
 -  wr.num_sge = 0;
+-
+-  TIME_START(1);
+-  // Select either all QPs, or one qp per-device
+-  const int nqps = ncclParamIbSplitDataOnQps() ? comm->base.nqps : comm->base.nDataQps;
 +  if (!netOptRecvCompletionEnabled) {
 +    struct ibv_recv_wr wr;
 +    memset(&wr, 0, sizeof(wr));
@@ -681,18 +717,15 @@ index 9bfd8dcf..4d3f0a08 100644
 +    wr.sg_list = NULL;
 +    wr.num_sge = 0;
  
--  TIME_START(1);
--  // Select either all QPs, or one qp per-device
--  const int nqps = ncclParamIbSplitDataOnQps() ? comm->base.nqps : comm->base.nDataQps;
-+    TIME_START(1);
-+    // Select either all QPs, or one qp per-device
-+    const int nqps = ncclParamIbSplitDataOnQps() ? comm->base.nqps : comm->base.nDataQps;
- 
 -  // Post recvs
 -  struct ibv_recv_wr* bad_wr;
 -  for (int i = 0; i < nqps; i++) {
 -    struct ncclIbQp* qp = comm->base.qps + comm->base.qpIndex;
 -    ncclIbAddEvent(req, qp->devIndex, &comm->devs[qp->devIndex].base);
++    TIME_START(1);
++    // Select either all QPs, or one qp per-device
++    const int nqps = ncclParamIbSplitDataOnQps() ? comm->base.nqps : comm->base.nDataQps;
++
 +    // Post recvs
 +    struct ibv_recv_wr* bad_wr;
 +    int qpIndex = comm->base.qpIndex;
@@ -762,7 +795,7 @@ index 9bfd8dcf..4d3f0a08 100644
  }
  
  ncclResult_t ncclIbIflush(void* recvComm, int n, void** data, int* sizes, void** mhandles, void** request) {
-@@ -2698,6 +2926,8 @@ static int getReqQpIndex(struct ncclIbRequest* req, int request, int qpNumber) {
+@@ -2702,6 +2948,8 @@
  }
  #endif
  
@@ -771,7 +804,7 @@ index 9bfd8dcf..4d3f0a08 100644
  ncclResult_t ncclIbTest(void* request, int* done, int* sizes) {
    struct ncclIbRequest *r = (struct ncclIbRequest*)request;
    *done = 0;
-@@ -2731,13 +2961,18 @@ ncclResult_t ncclIbTest(void* request, int* done, int* sizes) {
+@@ -2735,13 +2983,18 @@
  
      int totalWrDone = 0;
      int wrDone = 0;
@@ -792,7 +825,7 @@ index 9bfd8dcf..4d3f0a08 100644
          totalWrDone += wrDone;
          if (wrDone == 0) { TIME_CANCEL(3); } else { TIME_STOP(3); }
          if (wrDone == 0) continue;
-@@ -2889,7 +3124,7 @@ ncclResult_t rcclNetP2pPolicy(void* handle, int isP2p) {
+@@ -2893,7 +3146,7 @@
  }
  
  ncclNet_t ncclNetIb = {

--- a/projects/rccl/src/transport/net_ib_rocm.cc
+++ b/projects/rccl/src/transport/net_ib_rocm.cc
@@ -164,10 +164,9 @@ NCCL_PARAM(RocmIbEceEnable,"IB_ECE_ENABLE",1);
 NCCL_PARAM(RocmIbDataDirect,"IB_DATA_DIRECT",1);
 NCCL_PARAM(RocmIbQpsPerConn, "IB_QPS_PER_CONNECTION", 1);
 RCCL_PARAM(RocmIbQpsPerP2p, "IB_QPS_PER_P2P", 0);
-NCCL_PARAM(RocmIbGdrFlushDisable, "GDR_FLUSH_DISABLE", 0);
+NCCL_PARAM(RocmIbGdrFlushDisable, "GDR_FLUSH_DISABLE", 1);
 
 // AMD AINIC
-RCCL_PARAM(CtsInlineData, "CTS_INLINE_DATA", -1);
 RCCL_PARAM(CtsOffloadEnabled, "CTS_OFFLOAD_ENABLED", -1);
 
 extern int64_t rcclParamAinicRoce();
@@ -983,17 +982,18 @@ ncclResult_t rocmIbInit(void** ctx, uint64_t commId, ncclNetCommConfig_t* config
 
     rcclAinicRoce = ((rcclParamAinicRoce() == 1) ? true : false);
     if (rcclAinicRoce) {
-      // for AINIC, these params are defaulted to enabled unless user forces it to disable(0).
-      rcclCtsInlineData = ((rcclParamCtsInlineData() == 0) ? false : true);
       rcclCtsOffloadEnabled = ((rcclParamCtsOffloadEnabled() == 0) ? false : true);
-      // for AINIC IbUseInline is enabled by default always
-      ncclIbUseInline = true;
       // for AINIC GDR flush is disabled by default
-      ncclIbGdrFlushDisable = 1;
-
+      // ncclIbGdrFlushDisable = 1;
+      if (rcclCtsOffloadEnabled && !ncclIbUseInline) {
+        INFO(NCCL_INIT|NCCL_NET, "NET/IB : IB Use Inline is disabled and CTS Offload is enabled - enabling IB Use Inline Data");
+        ncclIbUseInline = true;
+      }
+      rcclCtsInlineData = ncclIbUseInline;
       INFO(NCCL_INIT|NCCL_NET, "NET/IB : AINIC RoCEv2 optimizations enabled: CTS Inline Data: %s; CTS Offload: %s; "
-           "IB Use Inline: enabled; GDR Flush: disabled", rcclCtsInlineData ? "Enabled": "Disabled",
-           rcclCtsOffloadEnabled ? "Enabled": "Disabled");
+           "GDR Flush: %s", rcclCtsInlineData ? "Enabled": "Disabled",
+           rcclCtsOffloadEnabled ? "Enabled": "Disabled",
+           ncclIbGdrFlushDisable ? "Disabled" : "Enabled");
     }
   }
 exit:
@@ -1166,7 +1166,11 @@ ncclResult_t rocmIbGetPhysProperties(int dev, ncclNetProperties_t* props) {
   props->latency = 0; // Not set
   props->port = ibDev->portNum + ibDev->realPort;
   props->maxComms = ibDev->maxQp;
-  props->maxRecvs = NCCL_NET_IB_MAX_RECVS;
+  if (rcclCtsInlineData) {
+    props->maxRecvs = 1;
+  } else {
+    props->maxRecvs = NCCL_NET_IB_MAX_RECVS;
+  }
   props->netDeviceType    = NCCL_NET_DEVICE_HOST;
   props->netDeviceVersion = NCCL_NET_DEVICE_INVALID_VERSION;
   props->maxP2pBytes = NCCL_MAX_NET_SIZE_BYTES;
@@ -1394,8 +1398,10 @@ struct alignas(32) ncclIbNetCommBase {
 struct ncclIbSendComm {
   struct ncclIbNetCommBase base;
   // Start with fifo and ibv structs as they have alignment restrictions
-  struct ncclIbSendFifo fifo[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
-  struct ncclIbSendFifoCtsInline fifo_inline[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
+  union {
+    struct ncclIbSendFifo fifo[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
+    struct ncclIbSendFifoCtsInline fifo_inline[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
+  } u;
   struct ibv_sge sges[NCCL_NET_IB_MAX_RECVS];
   struct ibv_send_wr wrs[NCCL_NET_IB_MAX_RECVS + 1];
   // Each dev correlates to a mergedIbDev
@@ -1409,9 +1415,10 @@ struct ncclIbSendComm {
 // to be a 32-byte multiple, so that an entry does not get split and
 // written out of order when IB Relaxed Ordering is enabled
 static_assert((sizeof(struct ncclIbNetCommBase) % 32) == 0, "ncclIbNetCommBase size must be 32-byte multiple to ensure fifo is at proper offset");
-static_assert((offsetof(struct ncclIbSendComm, fifo) % 32) == 0, "ncclIbSendComm fifo must be 32-byte aligned");
+static_assert((offsetof(struct ncclIbSendComm, u.fifo) % 32) == 0, "ncclIbSendComm fifo must be 32-byte aligned");
 static_assert((sizeof(struct ncclIbSendFifo) % 32) == 0, "ncclIbSendFifo element size must be 32-byte multiples");
-static_assert((sizeof(struct ncclIbSendFifoCtsInline) % 32) == 0, "ncclIbSendFifoCtsInline element size must be 32-byte multiples");
+static_assert((sizeof(struct ncclIbSendFifoCtsInline) % 32) == 0, "ncclIbSendFifoCtsInline element size must be 32-byte aligned");
+static_assert((sizeof(struct ncclIbSendFifoCtsInline) <=32), "struct ncclIbSendFifoCtsInline should fit within 32-bytes");
 static_assert((offsetof(struct ncclIbSendComm, sges) % 32) == 0, "sges must be 32-byte aligned");
 static_assert((offsetof(struct ncclIbSendComm, wrs) % 32) == 0, "wrs must be 32-byte aligned");
 
@@ -1425,8 +1432,10 @@ struct ncclIbGpuFlush {
 };
 
 struct ncclIbRemFifo {
-  struct ncclIbSendFifo elems[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
-  struct ncclIbSendFifoCtsInline elems_cts_inline[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
+  union {
+    struct ncclIbSendFifo elems[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
+    struct ncclIbSendFifoCtsInline elems_cts_inline[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
+  } u;
   uint64_t fifoTail;
   uint64_t addr;
   uint32_t flags;
@@ -1751,11 +1760,7 @@ ib_recv_dev_list:
     devInfo->lid           = ibDev->portAttr.lid;
     devInfo->ibv_dev_index = commDev->base.ibDevN;
     // Prepare my fifo
-    if (rcclCtsInlineData) {
-      NCCLCHECKGOTO(wrap_ibv_reg_mr(&commDev->fifoMr, commDev->base.pd, comm->fifo_inline, sizeof(struct ncclIbSendFifoCtsInline)*MAX_REQUESTS*NCCL_NET_IB_MAX_RECVS, IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
-    } else {
-      NCCLCHECKGOTO(wrap_ibv_reg_mr(&commDev->fifoMr, commDev->base.pd, comm->fifo, sizeof(struct ncclIbSendFifo)*MAX_REQUESTS*NCCL_NET_IB_MAX_RECVS, IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
-    }
+    NCCLCHECKGOTO(wrap_ibv_reg_mr(&commDev->fifoMr, commDev->base.pd, comm->u.fifo, sizeof(struct ncclIbSendFifo)*MAX_REQUESTS*NCCL_NET_IB_MAX_RECVS, IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
     devInfo->fifoRkey = commDev->fifoMr->rkey;
 
     // Pack local GID info
@@ -1799,9 +1804,9 @@ ib_recv_dev_list:
   }
   config = (ncclNetCommConfig_t*)ctx;
   if (rcclCtsInlineData) {
-    meta.fifoAddr = (uint64_t)comm->fifo_inline;
+    meta.fifoAddr = (uint64_t)comm->u.fifo_inline;
   } else {
-    meta.fifoAddr = (uint64_t)comm->fifo;
+    meta.fifoAddr = (uint64_t)comm->u.fifo;
   }
   meta.sl = (ncclParamRocmIbSl() != -1) ? ncclParamRocmIbSl() : (config && config->trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? config->trafficClass : NCCL_IB_SL_DEFAULT;
   meta.tc = (ncclParamRocmIbTc() != -1) ? ncclParamRocmIbTc() : (config && config->trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? config->trafficClass : NCCL_IB_TC_DEFAULT;
@@ -2125,13 +2130,7 @@ ib_recv:
 
     // Retain remote fifo info and prepare my RDMA ops
     rComm->remFifo.addr = remMeta.fifoAddr;
-    if (rcclCtsInlineData) {
-      NCCLCHECKGOTO(wrap_ibv_reg_mr(&rCommDev->fifoMr, rCommDev->base.pd, &rComm->remFifo.elems_cts_inline,
-                                    sizeof(struct ncclIbSendFifoCtsInline)*MAX_REQUESTS*NCCL_NET_IB_MAX_RECVS,
-                                    IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
-    } else {
-      NCCLCHECKGOTO(wrap_ibv_reg_mr(&rCommDev->fifoMr, rCommDev->base.pd, &rComm->remFifo.elems, sizeof(struct ncclIbSendFifo)*MAX_REQUESTS*NCCL_NET_IB_MAX_RECVS, IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
-    }
+    NCCLCHECKGOTO(wrap_ibv_reg_mr(&rCommDev->fifoMr, rCommDev->base.pd, &rComm->remFifo.u.elems, sizeof(struct ncclIbSendFifo)*MAX_REQUESTS*NCCL_NET_IB_MAX_RECVS, IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
     rCommDev->fifoSge.lkey = rCommDev->fifoMr->lkey;
     if (ncclIbUseInline) rComm->remFifo.flags = IBV_SEND_INLINE;
 
@@ -2395,12 +2394,13 @@ NCCL_PARAM(RocmIbSplitDataOnQps, "IB_SPLIT_DATA_ON_QPS", 0);
 
 ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot, bool use_write_op) {
   struct ncclIbRequest** reqs = comm->fifoReqs[slot];
-  volatile struct ncclIbSendFifo* slots = comm->fifo[slot];
+  volatile struct ncclIbSendFifo* slots = comm->u.fifo[slot];
+  volatile struct ncclIbSendFifoCtsInline* slots_inline = comm->u.fifo_inline[slot];
   int nreqs;
   if (rcclCtsOffloadEnabled) {
     nreqs = 1;
   } else {
-    nreqs = slots[0].nreqs;
+    nreqs = (rcclCtsInlineData) ? slots_inline[0].nreqs : slots[0].nreqs;
   }
   if (nreqs > NCCL_NET_IB_MAX_RECVS) return ncclInternalError;
 
@@ -2416,7 +2416,7 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot, bool use_wri
     if (rcclCtsOffloadEnabled) {
       wr->wr.rdma.remote_addr = 0xdeadbeef;
     } else {
-      wr->wr.rdma.remote_addr = slots[r].addr;
+      wr->wr.rdma.remote_addr = (rcclCtsInlineData) ? slots_inline[r].addr : slots[r].addr;
     }
     wr->next = wr + 1;
     wr_id += (reqs[r] - comm->base.reqs) << (r*8);
@@ -2474,7 +2474,7 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot, bool use_wri
       if (rcclCtsOffloadEnabled) {
         comm->wrs[r].wr.rdma.rkey = 0xbade;
       } else {
-        comm->wrs[r].wr.rdma.rkey = slots[r].rkeys[qp->remDevIdx];
+        comm->wrs[r].wr.rdma.rkey = (rcclCtsInlineData) ? slots_inline[r].rkeys[0] : slots[r].rkeys[qp->remDevIdx];
       }
 
       int chunkSize = DIVUP(DIVUP(reqs[r]->send.size, nqps), align) * align;
@@ -2557,6 +2557,7 @@ ncclResult_t rocmIbIsend(void* sendComm, void* data, size_t size, int tag, void*
   // Wait for the receiver to have posted the corresponding receive
   int nreqs = 0;
   volatile struct ncclIbSendFifo* slots;
+  volatile struct ncclIbSendFifoCtsInline* slots_inline;
 
   if (rcclCtsOffloadEnabled) {
       nreqs = 1;
@@ -2565,26 +2566,38 @@ ncclResult_t rocmIbIsend(void* sendComm, void* data, size_t size, int tag, void*
   int slot = (comm->fifoHead) % MAX_REQUESTS;
   struct ncclIbRequest** reqs = comm->fifoReqs[slot];
   if (!rcclCtsOffloadEnabled) {
-    slots = comm->fifo[slot];
+    slots = comm->u.fifo[slot];
+    slots_inline = comm->u.fifo_inline[slot];
     uint64_t idx = comm->fifoHead+1;
-    if (slots[0].idx != idx) { *request = NULL; return ncclSuccess; }
-    nreqs = slots[0].nreqs;
-    // Wait until all data has arrived
-    for (int r=1; r<nreqs; r++) while(slots[r].idx != idx);
+    if (rcclCtsInlineData) {
+      if (slots_inline[0].idx != (uint32_t)idx) { *request = NULL; return ncclSuccess; }
+      nreqs = slots_inline[0].nreqs;
+      // Wait until all data has arrived
+      for (int r=1; r<nreqs; r++) while(slots_inline[r].idx != (uint32_t)idx);
+    } else {
+      if (slots[0].idx != idx) { *request = NULL; return ncclSuccess; }
+      nreqs = slots[0].nreqs;
+      // Wait until all data has arrived
+      for (int r=1; r<nreqs; r++) while(slots[r].idx != idx);
+    }
     __sync_synchronize(); // order the nreqsPtr load against tag/rkey/addr loads below
   }
   for (int r=0; r<nreqs; r++) {
     if (!rcclCtsOffloadEnabled) {
-      if (reqs[r] != NULL || slots[r].tag != tag) continue;
+      uint64_t slot_addr = (rcclCtsInlineData) ? slots_inline[r].addr : slots[r].addr;
+      uint64_t slot_size = (rcclCtsInlineData) ? slots_inline[r].size : slots[r].size;
+      uint32_t slot_rkey = (rcclCtsInlineData) ? slots_inline[r].rkeys[0] : slots[r].rkeys[0];
+      uint32_t slot_tag = (rcclCtsInlineData) ? slots_inline[r].tag : slots[r].tag;
+      if (reqs[r] != NULL || slot_tag != tag) continue;
 
-      if (size > slots[r].size) size = slots[r].size;
+      if (size > slot_size) size = slot_size;
       // Sanity checks
-      if (slots[r].size < 0 || slots[r].addr == 0 || slots[r].rkeys[0] == 0) {
+      if (slot_size < 0 || slot_addr == 0 || slot_rkey == 0) {
         char line[SOCKET_NAME_MAXLEN + 1];
         union ncclSocketAddress addr;
         ncclSocketGetAddr(&comm->base.sock, &addr);
         WARN("NET/IB : req %d/%d tag %x peer %s posted incorrect receive info: size %ld addr %lx rkeys[0]=%x",
-             r, nreqs, tag, ncclSocketToString(&addr, line), slots[r].size, slots[r].addr, slots[r].rkeys[0]);
+             r, nreqs, tag, ncclSocketToString(&addr, line), slot_size, slot_addr, slot_rkey);
         return ncclInternalError;
       }
     } else{
@@ -2636,7 +2649,11 @@ ncclResult_t rocmIbIsend(void* sendComm, void* data, size_t size, int tag, void*
 
     // Clear slots[0]->nreqs, as well as other fields to help debugging and sanity checks
     if (!rcclCtsOffloadEnabled) {
-      memset((void*)slots, 0, sizeof(struct ncclIbSendFifo));
+      if (rcclCtsInlineData) {
+        memset((void*)slots_inline, 0, sizeof(struct ncclIbSendFifoCtsInline));
+      } else {
+        memset((void*)slots, 0, sizeof(struct ncclIbSendFifo));
+      }
     }
     memset(reqs, 0, NCCL_NET_IB_MAX_RECVS*sizeof(struct ncclIbRequest*));
     comm->fifoHead++;
@@ -2661,9 +2678,9 @@ ncclResult_t rocmIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, siz
   req->recv.sizes = comm->sizesFifo[slot];
   for (int i=0; i<n; i++) req->recv.sizes[i] = 0;
   if (rcclCtsInlineData) {
-    localElemCtsInline = comm->remFifo.elems_cts_inline[slot];
+    localElemCtsInline = comm->remFifo.u.elems_cts_inline[slot];
   } else {
-    localElem = comm->remFifo.elems[slot];
+    localElem = comm->remFifo.u.elems[slot];
   }
 
   if (rcclAinicRoce) {
@@ -2680,11 +2697,8 @@ ncclResult_t rocmIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, siz
     struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*) mhandles[i];
     if (rcclCtsInlineData) {
       localElemCtsInline[i].addr = (uint64_t)data[i];
-
-      // Send all applicable rkeys
-      for (int j = 0; j < comm->base.vProps.ndevs; j++)
-        localElemCtsInline[i].rkeys[j] = mhandleWrapper->mrs[j]->rkey;
-
+      // for Inline only one rkey is valid
+      localElemCtsInline[i].rkeys[0] = mhandleWrapper->mrs[0]->rkey;
       localElemCtsInline[i].nreqs = n;
       localElemCtsInline[i].size = sizes[i]; // Sanity/Debugging
       localElemCtsInline[i].tag = tags[i];
@@ -2705,7 +2719,11 @@ ncclResult_t rocmIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, siz
       localElemRef = (uint64_t)localElem;
     }
   }
-  wr.wr.rdma.remote_addr = comm->remFifo.addr + slot*NCCL_NET_IB_MAX_RECVS*sizeof(struct ncclIbSendFifo);
+  if (rcclCtsInlineData) {
+    wr.wr.rdma.remote_addr = comm->remFifo.addr + slot*NCCL_NET_IB_MAX_RECVS*sizeof(struct ncclIbSendFifoCtsInline);
+  } else {
+    wr.wr.rdma.remote_addr = comm->remFifo.addr + slot*NCCL_NET_IB_MAX_RECVS*sizeof(struct ncclIbSendFifo);
+  }
 
   // Lookup the correct fifoRkey
   wr.wr.rdma.rkey = comm->base.remDevs[ctsQp->remDevIdx].fifoRkey;


### PR DESCRIPTION
## Motivation

fix(rccl/net_ib_rocm): The AINIC CTS (Clear-to-Send) inline data path in RCCL's IB transport had multiple correctness and memory efficiency issues:

### Problem

For AINIC (IbCastAinicRoce), the CTS FIFO supports two data layouts:
A 64-byte ncclIbSendFifo (standard) and a 32-byte ncclIbSendFifoCtsInline (compact, for inline data). 
When IbCastAinicCtsInlineData is true, each slot's buffer is reinterpreted as a contiguous array of 32-byte elements
rather than 64-byte elements. The code had several issues preventing correct operation in the 32-byte layout:
    
1. Memory bloat: ncclIbSendComm and ncclIbRemFifo allocated both fifo (64B entries) and fifo_inline (32B entries) arrays as separate members, doubling FIFO memory even though only one format is ever active at runtime.

2. FIFO remote address miscalculation: rocmIbPostFifo() always computed the RDMA remote target offset using sizeof(ncclIbSendFifo) (64B stride), even when CTS inline mode was active and entries are 32B. This caused FIFO writes to land at wrong offsets, leading to data corruption or silent mismatches on the sender side.

3. Wrong FIFO struct accessed on send path: ncclIbMultiSend() and rocmIbIsend() unconditionally read metadata (nreqs, addr, rkeys, tag, size, idx) from the 64B ncclIbSendFifo layout, even when the receiver had written 32B ncclIbSendFifoCtsInline entries - reading garbage from the wrong memory layout.

4. Redundant rkey population: rocmIbPostFifo() looped over all devices (ndevs) to fill rkeys in the CTS inline struct, but the inline path only uses a single rkey (rkeys[0]).

5. Confusing / conflicting env knobs: rcclCtsInlineData had its own independent RCCL_CTS_INLINE_DATA env param, while ncclIbUseInline was also unconditionally forced to true for all AINIC - two knobs controlling overlapping behavior with no clear precedence.

6. GDR flush default mismatch: GDR_FLUSH_DISABLE defaulted to 0 (flush enabled), but AINIC always overrode it to 1 at runtime - the default didn't match the intended AINIC behavior.

## Technical Details

### Fix

- Memory layout (structs): fifo/fifo_inline in ncclIbSendComm and elems/elems_cts_inline in ncclIbRemFifo are now wrapped in a named union u, so they overlay the same memory - halving the FIFO footprint.

- FIFO remote address math: rocmIbPostFifo() now branches on rcclCtsInlineData to compute remote_addr using sizeof(ncclIbSendFifoCtsInline) (32B) vs sizeof(ncclIbSendFifo) (64B), so the RDMA write targets the correct offset.

- Send-path struct dispatch: ncclIbMultiSend() and rocmIbIsend() now maintain a separate slots_inline pointer alongside slots, and branch on rcclCtsInlineData to read nreqs, addr, rkeys, tag, size, idx from the correct struct type.

- maxRecvs clamped: rocmIbGetPhysProperties() now returns maxRecvs=1 when CTS inline is active, matching the hardware/protocol constraint.

- rkey simplification: rocmIbPostFifo() inline path now writes only rkeys[0] directly instead of looping over all devices.

- Env var consolidation: Removed the standalone RCCL_CTS_INLINE_DATA env param. rcclCtsInlineData is now derived from ncclIbUseInline. When CTS offload is enabled and IB inline is not already on, it is auto-enabled with a log message.

- GDR flush default: GDR_FLUSH_DISABLE default changed from 0 to 1, matching AINIC intent.

- Alignment assertions: Added static_assert for ncclIbSendFifoCtsInline <= 32B. Updated offsetof assert to use u.fifo.

- Simplify FIFO MR registration and fix memset for inline mode. Simplify send-side and recv-side ibv_reg_mr to a single unconditional call using the union's larger member (ncclIbSendFifo, 64B). Since fifo and fifo_inline share the same base address in the union, registering the larger size covers both layouts.

- Fix memset after send completion to clear the correct struct size: ncclIbSendFifoCtsInline (32B) for inline mode vs ncclIbSendFifo (64B) for standard mode, preventing a 64B zeroing of a 32B-entry region.

- CTS inline idx comparison truncation and rkeys out-of-bounds read. Fix uint32_t vs uint64_t idx comparison in rocmIbIsend() inline path: cast idx to uint32_t to match ncclIbSendFifoCtsInline::idx field width, preventing sender stall/spin after fifoHead exceeds 2^32-1.

- Fix out-of-bounds rkeys read in ncclIbMultiSend() inline path: use rkeys[0] instead of rkeys[qp->remDevIdx] since the CTS inline struct only has rkeys[1] (single element).

## Issue Tracking

`JIRA ID: AICOMRCCL-1558`
This also fixes JIRA ROCM-29123

## Test Plan

    Test matrix (RCCL test combinations to exercise the changed paths):
    -------------------------------------------------------------------
    All AINIC tests target Pollara nodes with NCCL_IB_AINIC_ROCE=1.
    
    For AINIC + Inline enabled (default AINIC path):
       RCCL_AINIC_ROCE=1 NCCL_IB_USE_INLINE=1
       Run RCCL benchmarking tests for all collectives and compare perf before the change and with the changes.


## Test Result
PASS.
Attached report: 
* Run-A--> RCCL branch rccl/drop_2026-02 tot (commit hash fa361248fce)
* Run-B--> RCCL branch rccl/drop_2026-02 tot (same as above) + fix
[RCCL_comparison_tot_vs_inline-change_8N_20260807.html](https://github.com/user-attachments/files/30847458/RCCL_comparison_tot_vs_inline-change_8N_20260807.html)
Note: In the report attached, for some collectives/msg sizes (like gather 256M or 2G/all_gather 64M) it would seem like perf reduced with the change; but that's an anomaly. Seeing run to run variation with those collectives and thus showed up as perf drop during the runs with the fix. Upon rerunning those collectives/msg sizes separately, I could see the same run to run variation even for tot (without the change). 
