### PR TITLE
test(rccl): gate build time against the PR's base commit

### DIFF
--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -35,6 +35,28 @@ if(BUILD_TESTS)
             "${PROJECT_SOURCE_DIR}/src/device/ce_reduce/test_generate_ce_reduce.py"
   )
 
+  # Clean-builds RCCL once per GPU target and fails if any exceeds the time
+  # threshold. Opt-in: it drives its own nested from-scratch builds, so it costs
+  # minutes per target and would dominate an ordinary test run. The script is
+  # also runnable directly (test/test_build_time.py --help) without configuring.
+  option(ENABLE_BUILD_TIME_TEST "Register the per-target build-time regression test" OFF)
+  if(ENABLE_BUILD_TIME_TEST)
+    # DEFAULT_GPUS, not the rocm_check_target_ids-filtered GPU_TARGETS: archs
+    # this toolchain cannot build should be reported as skipped, not dropped.
+    add_test(
+      NAME rccl-build-time
+      COMMAND "${Python3_EXECUTABLE}"
+              "${CMAKE_CURRENT_SOURCE_DIR}/test_build_time.py"
+              --targets ${DEFAULT_GPUS}
+    )
+    set_tests_properties(rccl-build-time PROPERTIES
+      LABELS "build-time"
+      RUN_SERIAL TRUE
+      TIMEOUT 7200
+      ENVIRONMENT "ROCM_PATH=${ROCM_PATH}"
+    )
+  endif()
+
   if (ENABLE_CODE_COVERAGE)
     add_compile_options("SHELL:-Xarch_host -fprofile-instr-generate" "SHELL:-Xarch_host -fcoverage-mapping")
     add_link_options("SHELL:-Xarch_host -fprofile-instr-generate" "SHELL:-Xarch_host -fcoverage-mapping")

--- a/projects/rccl/test/test_build_time.py
+++ b/projects/rccl/test/test_build_time.py
@@ -52,6 +52,7 @@ import sys
 import tempfile
 import time
 from dataclasses import dataclass
+from typing import Any, IO
 
 HERE: str = os.path.dirname(os.path.abspath(__file__))
 RCCL_ROOT: str = os.path.dirname(HERE)
@@ -60,6 +61,43 @@ CMAKELISTS: str = os.path.join(RCCL_ROOT, "CMakeLists.txt")
 DEFAULT_THRESHOLD_SEC: int = 300
 
 PASS, FAIL, SKIP = "PASS", "FAIL", "SKIP"
+
+
+class CommandError(RuntimeError):
+    """A subprocess exited non-zero."""
+
+    def __init__(self, cmd: list[str], returncode: int, output: str = "") -> None:
+        self.cmd = cmd
+        self.returncode = returncode
+        self.output = output
+        msg = "%s failed (rc=%d)" % (" ".join(cmd), returncode)
+        if output:
+            msg += ": %s" % output
+        super().__init__(msg)
+
+
+def run_checked(
+    cmd: list[str],
+    *,
+    cwd: str | None = None,
+    env: dict[str, str] | None = None,
+    capture_output: bool = True,
+    stdout: int | IO[Any] | None = None,
+    stderr: int | IO[Any] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run a subprocess and raise CommandError if it exits non-zero."""
+    if stdout is not None or stderr is not None:
+        capture_output = False
+    proc = subprocess.run(
+        cmd, cwd=cwd, env=env, capture_output=capture_output,
+        text=True, stdout=stdout, stderr=stderr, check=False,
+    )
+    if proc.returncode != 0:
+        detail = ""
+        if capture_output:
+            detail = (proc.stderr or proc.stdout or "").strip()
+        raise CommandError(cmd, proc.returncode, detail)
+    return proc
 
 # Ordered most- to least-specific; plain CI is last so it only acts as a
 # fallback for runners that set nothing else.
@@ -142,11 +180,11 @@ def local_gpu_targets() -> list[str]:
     if not enumerator:
         raise RuntimeError("rocm_agent_enumerator not found; pass --targets explicitly")
 
-    proc = subprocess.run([enumerator], capture_output=True, text=True)
-    if proc.returncode != 0:
-        msg = (proc.stderr or proc.stdout).strip()
+    try:
+        proc = run_checked([enumerator], capture_output=True)
+    except CommandError as exc:
         raise RuntimeError("rocm_agent_enumerator failed (rc=%d): %s"
-                           % (proc.returncode, msg))
+                           % (exc.returncode, exc.output)) from exc
     out = proc.stdout
     # Deduplicate but keep discovery order; gfx000 is the CPU agent.
     targets: list[str] = []
@@ -171,11 +209,16 @@ def _hipcc_accepts(hipcc: str, extra_args: list[str]) -> bool:
     with tempfile.TemporaryDirectory() as tmp:
         empty = os.path.join(tmp, "empty.hip")
         open(empty, "w").close()
-        return subprocess.run(
-            [hipcc, "-x", "hip"] + extra_args + ["-fsyntax-only", empty],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        ).returncode == 0
+        try:
+            run_checked(
+                [hipcc, "-x", "hip"] + extra_args + ["-fsyntax-only", empty],
+                capture_output=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            return True
+        except CommandError:
+            return False
 
 
 def compiler_works(hipcc: str) -> bool:
@@ -241,9 +284,12 @@ def build_target(
             log.write("\n$ " + " ".join(cmd) + "\n")
             log.flush()
             start = time.monotonic()
-            rc = subprocess.call(cmd, cwd=build_dir, stdout=log, stderr=subprocess.STDOUT,
-                                 env=env)
-            return time.monotonic() - start, rc
+            try:
+                run_checked(cmd, cwd=build_dir, env=env, capture_output=False,
+                            stdout=log, stderr=subprocess.STDOUT)
+                return time.monotonic() - start, 0
+            except CommandError:
+                return time.monotonic() - start, 1
 
         configure_s, rc = run(configure)
         if rc != 0:
@@ -264,21 +310,23 @@ def rccl_dir_within(worktree: str) -> str:
     root is not itself a configurable source directory. Resolves to the
     worktree root when RCCL is checked out standalone.
     """
-    top, err = git_err("rev-parse", "--show-toplevel")
-    if err or not top:
-        raise RuntimeError("cannot locate git toplevel: %s" % (err or "unknown error"))
+    top = git_run("rev-parse", "--show-toplevel")
     rel = os.path.relpath(RCCL_ROOT, top)
     return os.path.normpath(os.path.join(worktree, rel))
 
 
+def git_run(*args: str) -> str:
+    """Run git in the RCCL source tree; raise CommandError on failure."""
+    proc = run_checked(["git", "-C", RCCL_ROOT, *args], capture_output=True)
+    return proc.stdout.strip()
+
+
 def git_err(*args: str) -> tuple[str | None, str | None]:
     """Run git; return (stdout, None) on success or (None, error) on failure."""
-    proc = subprocess.run(["git", "-C", RCCL_ROOT, *args],
-                          capture_output=True, text=True, check=False)
-    if proc.returncode == 0:
-        return proc.stdout.strip(), None
-    msg = (proc.stderr or proc.stdout or "").strip()
-    return None, msg or ("git %s exited %d" % (" ".join(args), proc.returncode))
+    try:
+        return git_run(*args), None
+    except CommandError as exc:
+        return None, exc.output or str(exc)
 
 
 def ensure_upstream_fetched(upstream: str) -> None:
@@ -286,8 +334,11 @@ def ensure_upstream_fetched(upstream: str) -> None:
     if "/" not in upstream:
         return
     remote, ref = upstream.split("/", 1)
-    subprocess.run(["git", "-C", RCCL_ROOT, "fetch", "--depth=1", remote, ref],
-                   capture_output=True, text=True, check=False)
+    try:
+        run_checked(["git", "-C", RCCL_ROOT, "fetch", "--depth=1", remote, ref],
+                    capture_output=True)
+    except CommandError:
+        pass
 
 
 def resolve_base_sha(explicit_rev: str | None) -> tuple[str | None, str, str | None]:
@@ -326,21 +377,28 @@ class Comparison:
 def time_best_of(
     target: str, source_dir: str, build_root: str, tag: str, jobs: int,
     round_index: int, keep: bool,
-) -> tuple[float, bool]:
-    """Build one revision once and return (total_s, ok) for this round."""
+) -> tuple[float, bool, str]:
+    """Build one revision once and return (total_s, ok, log_path) for this round."""
     build_dir = os.path.join(build_root, "%s-%s-%d" % (target, tag, round_index))
     log_path = os.path.join(build_root, "%s-%s-%d.log" % (target, tag, round_index))
-    configure_s, build_s, ok = build_target(target, build_dir, jobs, log_path, source_dir)
+    for attempt in range(2):
+        configure_s, build_s, ok = build_target(target, build_dir, jobs, log_path, source_dir)
+        if ok:
+            if not keep:
+                shutil.rmtree(build_dir, ignore_errors=True)
+            return configure_s + build_s, True, log_path
+        if attempt == 0:
+            print("    build failed (attempt 1/2), retrying ... see %s" % log_path, flush=True)
     if not keep:
         shutil.rmtree(build_dir, ignore_errors=True)
-    return configure_s + build_s, ok
+    return 0.0, False, log_path
 
 
 def compare_target(
     target: str, head_dir: str, base_dir: str, build_root: str, jobs: int, repeat: int,
     keep: bool,
-) -> tuple[float, float, bool]:
-    """Time base and head alternately; return (base_best, head_best, ok).
+) -> tuple[float, float, bool, str | None]:
+    """Time base and head alternately; return (base_best, head_best, ok, fail_log).
 
     Alternating rather than running all of one revision then the other keeps
     slow drift (thermal, noisy neighbours) from landing on just one side. The
@@ -350,20 +408,20 @@ def compare_target(
     base_times: list[float] = []
     head_times: list[float] = []
     for i in range(repeat):
-        base_s, ok = time_best_of(target, base_dir, build_root, "base", jobs, i, keep)
+        base_s, ok, log_path = time_best_of(target, base_dir, build_root, "base", jobs, i, keep)
         if not ok:
-            return 0.0, 0.0, False
+            return 0.0, 0.0, False, log_path
         base_times.append(base_s)
 
-        head_s, ok = time_best_of(target, head_dir, build_root, "head", jobs, i, keep)
+        head_s, ok, log_path = time_best_of(target, head_dir, build_root, "head", jobs, i, keep)
         if not ok:
-            return 0.0, 0.0, False
+            return 0.0, 0.0, False, log_path
         head_times.append(head_s)
 
         print("    round %d/%d: base %s  head %s" %
               (i + 1, repeat, fmt(base_s), fmt(head_s)), flush=True)
 
-    return min(base_times), min(head_times), True
+    return min(base_times), min(head_times), True, None
 
 
 def resolve_targets(args: argparse.Namespace) -> tuple[list[str], str]:
@@ -372,8 +430,8 @@ def resolve_targets(args: argparse.Namespace) -> tuple[list[str], str]:
         return args.targets, "--targets"
     if args.local_gpu:
         return local_gpu_targets(), "local GPUs (rocm_agent_enumerator)"
-    if os.environ.get("RCCL_BUILD_TIME_TARGETS", "").split():
-        return os.environ["RCCL_BUILD_TIME_TARGETS"].split(), "RCCL_BUILD_TIME_TARGETS"
+    if (env_targets := os.environ.get("RCCL_BUILD_TIME_TARGETS", "").split()):
+        return env_targets, "RCCL_BUILD_TIME_TARGETS"
     return targets_from_cmake(), "DEFAULT_GPUS in CMakeLists.txt"
 
 
@@ -444,8 +502,8 @@ def run_comparison(
     if err:
         print("SKIP: cannot check out base commit %s (%s)" % (base_sha[:10], err))
         return 0
-    base_dir = rccl_dir_within(worktree)
     try:
+        base_dir = rccl_dir_within(worktree)
         results: list[Comparison] = []
         for target in targets:
             if not compiler_supports(target, hipcc):
@@ -456,11 +514,11 @@ def run_comparison(
                 continue
 
             print("[%s] timing base and head ..." % target, flush=True)
-            base_s, head_s, ok = compare_target(
+            base_s, head_s, ok, fail_log = compare_target(
                 target, RCCL_ROOT, base_dir, build_root, args.jobs, args.repeat, args.keep)
             if not ok:
-                print("[%s] FAIL - build failed, see %s" % (target, build_root))
-                results.append(Comparison(target, FAIL, "build failed"))
+                print("[%s] FAIL - build failed, see %s" % (target, fail_log))
+                results.append(Comparison(target, FAIL, "build failed, see %s" % fail_log))
                 continue
 
             result = Comparison(target, PASS, "", base_s, head_s)

--- a/projects/rccl/test/test_build_time.py
+++ b/projects/rccl/test/test_build_time.py
@@ -59,6 +59,7 @@ RCCL_ROOT: str = os.path.dirname(HERE)
 CMAKELISTS: str = os.path.join(RCCL_ROOT, "CMakeLists.txt")
 
 DEFAULT_THRESHOLD_SEC: int = 300
+BUILD_ATTEMPTS: int = 2
 
 PASS, FAIL, SKIP = "PASS", "FAIL", "SKIP"
 
@@ -81,21 +82,22 @@ def run_checked(
     *,
     cwd: str | None = None,
     env: dict[str, str] | None = None,
-    capture_output: bool = True,
     stdout: int | IO[Any] | None = None,
     stderr: int | IO[Any] | None = None,
 ) -> subprocess.CompletedProcess[str]:
-    """Run a subprocess and raise CommandError if it exits non-zero."""
-    if stdout is not None or stderr is not None:
-        capture_output = False
+    """Run a subprocess and raise CommandError if it exits non-zero.
+
+    Output is captured and attached to the exception unless the caller
+    redirects it, which the build steps do to stream straight into their log.
+    """
+    redirected = stdout is not None or stderr is not None
     proc = subprocess.run(
-        cmd, cwd=cwd, env=env, capture_output=capture_output,
-        text=True, stdout=stdout, stderr=stderr, check=False,
+        cmd, cwd=cwd, env=env, text=True, check=False,
+        stdout=stdout if redirected else subprocess.PIPE,
+        stderr=stderr if redirected else subprocess.PIPE,
     )
     if proc.returncode != 0:
-        detail = ""
-        if capture_output:
-            detail = (proc.stderr or proc.stdout or "").strip()
+        detail = "" if redirected else (proc.stderr or proc.stdout or "").strip()
         raise CommandError(cmd, proc.returncode, detail)
     return proc
 
@@ -181,7 +183,7 @@ def local_gpu_targets() -> list[str]:
         raise RuntimeError("rocm_agent_enumerator not found; pass --targets explicitly")
 
     try:
-        proc = run_checked([enumerator], capture_output=True)
+        proc = run_checked([enumerator])
     except CommandError as exc:
         raise RuntimeError("rocm_agent_enumerator failed (rc=%d): %s"
                            % (exc.returncode, exc.output)) from exc
@@ -210,15 +212,10 @@ def _hipcc_accepts(hipcc: str, extra_args: list[str]) -> bool:
         empty = os.path.join(tmp, "empty.hip")
         open(empty, "w").close()
         try:
-            run_checked(
-                [hipcc, "-x", "hip"] + extra_args + ["-fsyntax-only", empty],
-                capture_output=True,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-            )
-            return True
+            run_checked([hipcc, "-x", "hip"] + extra_args + ["-fsyntax-only", empty])
         except CommandError:
             return False
+        return True
 
 
 def compiler_works(hipcc: str) -> bool:
@@ -285,11 +282,11 @@ def build_target(
             log.flush()
             start = time.monotonic()
             try:
-                run_checked(cmd, cwd=build_dir, env=env, capture_output=False,
+                run_checked(cmd, cwd=build_dir, env=env,
                             stdout=log, stderr=subprocess.STDOUT)
                 return time.monotonic() - start, 0
-            except CommandError:
-                return time.monotonic() - start, 1
+            except CommandError as exc:
+                return time.monotonic() - start, exc.returncode
 
         configure_s, rc = run(configure)
         if rc != 0:
@@ -317,8 +314,7 @@ def rccl_dir_within(worktree: str) -> str:
 
 def git_run(*args: str) -> str:
     """Run git in the RCCL source tree; raise CommandError on failure."""
-    proc = run_checked(["git", "-C", RCCL_ROOT, *args], capture_output=True)
-    return proc.stdout.strip()
+    return run_checked(["git", "-C", RCCL_ROOT, *args]).stdout.strip()
 
 
 def git_err(*args: str) -> tuple[str | None, str | None]:
@@ -335,26 +331,32 @@ def ensure_upstream_fetched(upstream: str) -> None:
         return
     remote, ref = upstream.split("/", 1)
     try:
-        run_checked(["git", "-C", RCCL_ROOT, "fetch", "--depth=1", remote, ref],
-                    capture_output=True)
+        run_checked(["git", "-C", RCCL_ROOT, "fetch", "--depth=1", remote, ref])
     except CommandError:
+        # Deliberately best-effort: the caller reports a usable error if the
+        # merge-base is still unreachable afterwards.
         pass
 
 
 def resolve_base_sha(explicit_rev: str | None) -> tuple[str | None, str, str | None]:
-    """Return (base_sha, label, error). label is printed in the report header."""
+    """Return (base_sha, label, error). label is printed in the report header.
+
+    A --compare-base REV the caller named explicitly and that does not resolve
+    is their mistake, so it raises. Only the automatic merge-base path degrades
+    to an error string, which lets a shallow CI checkout skip rather than
+    report the missing history as a build-time regression.
+    """
     if explicit_rev:
-        sha, err = git_err("rev-parse", explicit_rev)
-        return sha, explicit_rev, err
+        return git_run("rev-parse", explicit_rev), explicit_rev, None
 
     upstream = os.environ.get("RCCL_BUILD_TIME_UPSTREAM", "origin/develop")
     ensure_upstream_fetched(upstream)
+    # merge-base already reports a full SHA, so no rev-parse is needed here.
     merge_base, err = git_err("merge-base", upstream, "HEAD")
     if err or not merge_base:
-        return None, upstream, "cannot resolve merge-base with %s: %s" % (upstream, err or "unknown error")
-    sha, err = git_err("rev-parse", merge_base)
-    label = "%s (merge-base with %s)" % (merge_base[:10], upstream)
-    return sha, label, err
+        return None, upstream, "cannot resolve merge-base with %s: %s" % (
+            upstream, err or "unknown error")
+    return merge_base, "merge-base with %s" % upstream, None
 
 
 @dataclass
@@ -378,19 +380,29 @@ def time_best_of(
     target: str, source_dir: str, build_root: str, tag: str, jobs: int,
     round_index: int, keep: bool,
 ) -> tuple[float, bool, str]:
-    """Build one revision once and return (total_s, ok, log_path) for this round."""
-    build_dir = os.path.join(build_root, "%s-%s-%d" % (target, tag, round_index))
-    log_path = os.path.join(build_root, "%s-%s-%d.log" % (target, tag, round_index))
-    for attempt in range(2):
+    """Build one revision once and return (total_s, ok, log_path) for this round.
+
+    A failed build is retried once. With --repeat 2 a comparison is four builds
+    per target, so a single flake (an OOM under a high -j, a transient ninja
+    error) would otherwise sink the run as if it were a real failure. Each
+    attempt gets its own log so the retry does not overwrite the evidence.
+    """
+    stem = "%s-%s-%d" % (target, tag, round_index)
+    log_path = ""
+    for attempt in range(BUILD_ATTEMPTS):
+        name = stem if attempt == 0 else "%s-retry%d" % (stem, attempt)
+        build_dir = os.path.join(build_root, name)
+        log_path = os.path.join(build_root, "%s.log" % name)
+
         configure_s, build_s, ok = build_target(target, build_dir, jobs, log_path, source_dir)
+        if not keep:
+            shutil.rmtree(build_dir, ignore_errors=True)
         if ok:
-            if not keep:
-                shutil.rmtree(build_dir, ignore_errors=True)
             return configure_s + build_s, True, log_path
-        if attempt == 0:
-            print("    build failed (attempt 1/2), retrying ... see %s" % log_path, flush=True)
-    if not keep:
-        shutil.rmtree(build_dir, ignore_errors=True)
+
+        if attempt + 1 < BUILD_ATTEMPTS:
+            print("    build failed (attempt %d of %d), see %s; retrying"
+                  % (attempt + 1, BUILD_ATTEMPTS, log_path), flush=True)
     return 0.0, False, log_path
 
 
@@ -444,7 +456,9 @@ def parse_args() -> argparse.Namespace:
     which.add_argument("--local-gpu", action="store_true",
                        help="time only the arch(es) of the GPUs in this machine")
     parser.add_argument("--threshold-sec", type=float,
-                        default=float(os.environ.get("RCCL_BUILD_TIME_THRESHOLD_SEC", DEFAULT_THRESHOLD_SEC)))
+                        default=float(os.environ.get("RCCL_BUILD_TIME_THRESHOLD_SEC", DEFAULT_THRESHOLD_SEC)),
+                        help="per-target wall-clock budget; ignored under --compare-base, "
+                             "which gates on the ratio instead (default: %d)" % DEFAULT_THRESHOLD_SEC)
     parser.add_argument("--jobs", type=int,
                         default=int(os.environ.get("RCCL_BUILD_TIME_JOBS", 0)) or cpu_count())
     parser.add_argument("--build-root", default=os.environ.get("RCCL_BUILD_TIME_ROOT"),
@@ -502,9 +516,9 @@ def run_comparison(
     if err:
         print("SKIP: cannot check out base commit %s (%s)" % (base_sha[:10], err))
         return 0
+    results: list[Comparison] = []
     try:
         base_dir = rccl_dir_within(worktree)
-        results: list[Comparison] = []
         for target in targets:
             if not compiler_supports(target, hipcc):
                 reason = "compiler does not support --offload-arch=%s" % target
@@ -522,7 +536,15 @@ def run_comparison(
                 continue
 
             result = Comparison(target, PASS, "", base_s, head_s)
-            pct = result.delta_pct or 0.0
+            pct = result.delta_pct
+            if pct is None:
+                # A zero-second base build means the timing, not the code, is
+                # broken; passing it as a 0% delta would hide that.
+                result.status = FAIL
+                result.note = "base build measured %s, so the ratio is meaningless" % fmt(base_s)
+                print("[%s] FAIL - %s" % (target, result.note))
+                results.append(result)
+                continue
 
             if pct > args.max_regression_pct:
                 result.status = FAIL
@@ -534,16 +556,19 @@ def run_comparison(
                    "  " + result.note if result.note else ""))
             results.append(result)
     finally:
-        git_err("worktree", "remove", "--force", worktree)
+        _, cleanup_err = git_err("worktree", "remove", "--force", worktree)
+        if cleanup_err:
+            print("WARNING: could not remove base worktree %s (%s); "
+                  "run 'git worktree prune' to clean up" % (worktree, cleanup_err))
 
     print()
     print("%-10s %10s %10s %9s  %s" % ("TARGET", "BASE", "HEAD", "DELTA", "RESULT"))
     for r in results:
-        if r.base_s is None or r.head_s is None:
+        if r.base_s is None or r.head_s is None or r.delta_pct is None:
             print("%-10s %10s %10s %9s  %s (%s)" % (r.target, "-", "-", "-", r.status, r.note))
         else:
             print("%-10s %10s %10s %8.1f%%  %s" %
-                  (r.target, fmt(r.base_s), fmt(r.head_s), r.delta_pct or 0.0, r.status))
+                  (r.target, fmt(r.base_s), fmt(r.head_s), r.delta_pct, r.status))
 
     failed = [r.target for r in results if r.status == FAIL]
     if failed:

--- a/projects/rccl/test/test_build_time.py
+++ b/projects/rccl/test/test_build_time.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+"""Build-time regression test: clean-build RCCL once per GPU target and fail if
+any target takes longer than a threshold (default 5 minutes).
+
+Each target is configured and built from scratch in its own throwaway build
+directory, mirroring the Release configuration that ``install.sh`` produces:
+
+    cmake --toolchain=toolchain-linux.cmake -DCMAKE_BUILD_TYPE=Release \\
+          -DGPU_TARGETS=<target> -DROCM_PATH=$ROCM_PATH -GNinja
+
+The reported time is configure + build wall clock, since that is what a
+developer waits through after ``rm -rf build``.
+
+The target list comes from DEFAULT_GPUS in the top-level CMakeLists.txt, so
+archs stay in sync as RCCL adds or drops them. The CTest registration passes
+that CMake list on the command line; a standalone run parses it out of the file.
+
+Targets the installed compiler cannot build are SKIPPED rather than failed --
+the RCCL default arch list runs ahead of released ROCm, so e.g. gfx1250 is not
+buildable on ROCm 7.0.x. Pass --strict (or set RCCL_BUILD_TIME_STRICT=1) on a
+runner whose toolchain is expected to cover every target.
+
+The threshold is wall clock, so it is only meaningful relative to the machine:
+a clean single-arch build is ~50s on a 256-core host but will exceed 5 minutes
+on a small runner. Parallelism defaults to the CPU count and is recorded in the
+report; use --jobs to pin it when comparing results across machines.
+
+Usage:
+    ./test_build_time.py                      # every arch in DEFAULT_GPUS
+    ./test_build_time.py --local-gpu          # only this machine's arch (CI gate)
+    ./test_build_time.py --targets gfx942     # one target
+    ./test_build_time.py --threshold-sec 600 --jobs 32
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from typing import TextIO
+
+HERE: str = os.path.dirname(os.path.abspath(__file__))
+RCCL_ROOT: str = os.path.dirname(HERE)
+TOOLCHAIN: str = os.path.join(RCCL_ROOT, "toolchain-linux.cmake")
+CMAKELISTS: str = os.path.join(RCCL_ROOT, "CMakeLists.txt")
+
+DEFAULT_THRESHOLD_SEC: int = 300
+
+PASS, FAIL, SKIP = "PASS", "FAIL", "SKIP"
+
+# Ordered most- to least-specific; plain CI is last so it only acts as a
+# fallback for runners that set nothing else.
+CI_MARKERS: tuple[tuple[str, str, str | None], ...] = (
+    ("GITHUB_ACTIONS", "GitHub Actions", "GITHUB_RUN_ID"),
+    ("SLURM_JOB_ID", "SLURM", "SLURM_JOB_ID"),
+    ("JENKINS_URL", "Jenkins", "BUILD_NUMBER"),
+    ("TF_BUILD", "Azure Pipelines", "BUILD_BUILDID"),
+    ("GITLAB_CI", "GitLab CI", "CI_JOB_ID"),
+    ("CI", "CI (unidentified)", None),
+)
+
+
+@dataclass
+class TargetResult:
+    """Outcome for one GPU target.
+
+    The timings are None when no build ran at all (skipped, or failed in
+    --strict), which is what the report distinguishes with "-" columns.
+    """
+
+    target: str
+    status: str
+    note: str
+    configure_s: float | None = None
+    build_s: float | None = None
+
+
+def ci_context() -> str | None:
+    """Name the CI system if one is detectable, else None.
+
+    Recorded in the report because the threshold is wall clock: a number is
+    only comparable against others from the same runner class.
+    """
+    for var, name, id_var in CI_MARKERS:
+        if os.environ.get(var):
+            job_id = os.environ.get(id_var or "")
+            return "%s %s" % (name, job_id) if job_id else name
+    return None
+
+
+def cpu_count() -> int:
+    """CPU count, treating the unknowable case as a single CPU.
+
+    os.cpu_count() is Optional, and both -j and the report need a real number.
+    """
+    return os.cpu_count() or 1
+
+
+def targets_from_cmake(path: str = CMAKELISTS) -> list[str]:
+    """Read the DEFAULT_GPUS arch list out of the top-level CMakeLists.txt.
+
+    This keeps a standalone run covering exactly the archs RCCL ships for,
+    without a second copy of the list to update. The CTest registration passes
+    the same CMake list explicitly, so both entry points agree.
+
+    Deliberately reads DEFAULT_GPUS rather than the post-rocm_check_target_ids
+    GPU_TARGETS: archs the local compiler cannot build should show up as an
+    explicit SKIP here, not silently vanish from the report.
+    """
+    with open(path) as f:
+        match = re.search(r"set\s*\(\s*DEFAULT_GPUS\s+([^)]*)\)", f.read())
+    if not match:
+        raise RuntimeError("could not find DEFAULT_GPUS in %s" % path)
+    targets = re.findall(r"gfx[0-9a-fA-F]+", match.group(1))
+    if not targets:
+        raise RuntimeError("DEFAULT_GPUS in %s contained no gfx targets" % path)
+    return targets
+
+
+def local_gpu_targets() -> list[str]:
+    """Resolve the archs of the GPUs installed in this machine.
+
+    Mirrors what BUILD_LOCAL_GPU_TARGET_ONLY does via rocm_local_targets, so a
+    CI gate can time only the arch its runner actually ships rather than the
+    whole DEFAULT_GPUS list.
+    """
+    bundled = os.path.join(rocm_path(), "bin", "rocm_agent_enumerator")
+    enumerator = bundled if os.path.exists(bundled) else shutil.which("rocm_agent_enumerator")
+    if not enumerator:
+        raise RuntimeError("rocm_agent_enumerator not found; pass --targets explicitly")
+
+    out = subprocess.run([enumerator], capture_output=True, text=True).stdout
+    # Deduplicate but keep discovery order; gfx000 is the CPU agent.
+    targets: list[str] = []
+    for arch in re.findall(r"gfx[0-9a-fA-F]+", out):
+        if arch != "gfx000" and arch not in targets:
+            targets.append(arch)
+    if not targets:
+        raise RuntimeError("no local AMD GPUs found; pass --targets explicitly")
+    return targets
+
+
+def rocm_path() -> str:
+    return os.environ.get("ROCM_PATH", "/opt/rocm")
+
+
+def _hipcc_accepts(hipcc: str, extra_args: list[str]) -> bool:
+    """Run a syntax-only compile of an empty HIP file; True if it succeeds.
+
+    Empty input keeps this well under a second, and invalid target IDs are
+    rejected during argument handling rather than compilation.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        empty = os.path.join(tmp, "empty.hip")
+        open(empty, "w").close()
+        return subprocess.run(
+            [hipcc, "-x", "hip"] + extra_args + ["-fsyntax-only", empty],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        ).returncode == 0
+
+
+def compiler_works(hipcc: str) -> bool:
+    """True if the compiler can compile HIP at all, before any arch selection.
+
+    hipcc dispatches to $ROCM_PATH/lib/llvm/bin/clang++, so a wrong ROCM_PATH
+    makes every --offload-arch probe fail. Without this check that misreports
+    as "no arch is supported" rather than as the configuration error it is.
+    """
+    return _hipcc_accepts(hipcc, [])
+
+
+def compiler_supports(target: str, hipcc: str) -> bool:
+    """True if the installed compiler accepts --offload-arch=<target>."""
+    return _hipcc_accepts(hipcc, ["--offload-arch=" + target])
+
+
+def pick_generator() -> tuple[str, list[str]]:
+    """Prefer Ninja: it parallelizes the per-arch device pipeline far better."""
+    if shutil.which("ninja"):
+        return "Ninja", ["ninja"]
+    return "Unix Makefiles", ["make"]
+
+
+def build_target(
+    target: str, build_dir: str, jobs: int, log_path: str
+) -> tuple[float, float, bool]:
+    """Clean-configure and build one target. Returns (configure_s, build_s, ok)."""
+    shutil.rmtree(build_dir, ignore_errors=True)
+    os.makedirs(build_dir)
+
+    generator, build_cmd = pick_generator()
+    configure = [
+        "cmake",
+        "--toolchain=" + TOOLCHAIN,
+        "-G", generator,
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DGPU_TARGETS=" + target,
+        "-DROCM_PATH=" + rocm_path(),
+        RCCL_ROOT,
+    ]
+
+    log: TextIO
+    with open(log_path, "w") as log:
+        def run(cmd: list[str]) -> tuple[float, int]:
+            log.write("\n$ " + " ".join(cmd) + "\n")
+            log.flush()
+            start = time.monotonic()
+            rc = subprocess.call(cmd, cwd=build_dir, stdout=log, stderr=subprocess.STDOUT)
+            return time.monotonic() - start, rc
+
+        configure_s, rc = run(configure)
+        if rc != 0:
+            return configure_s, 0.0, False
+
+        build_s, rc = run(build_cmd + ["-j", str(jobs)])
+        return configure_s, build_s, rc == 0
+
+
+def fmt(seconds: float) -> str:
+    return "%d:%05.2f" % (int(seconds // 60), seconds % 60)
+
+
+def resolve_targets(args: argparse.Namespace) -> tuple[list[str], str]:
+    """Pick the target list and report where it came from."""
+    if args.targets:
+        return args.targets, "--targets"
+    if args.local_gpu:
+        return local_gpu_targets(), "local GPUs (rocm_agent_enumerator)"
+    if os.environ.get("RCCL_BUILD_TIME_TARGETS", "").split():
+        return os.environ["RCCL_BUILD_TIME_TARGETS"].split(), "RCCL_BUILD_TIME_TARGETS"
+    return targets_from_cmake(), "DEFAULT_GPUS in CMakeLists.txt"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    which = parser.add_mutually_exclusive_group()
+    which.add_argument("--targets", nargs="+",
+                       help="GPU targets to time (default: DEFAULT_GPUS from CMakeLists.txt)")
+    which.add_argument("--local-gpu", action="store_true",
+                       help="time only the arch(es) of the GPUs in this machine")
+    parser.add_argument("--threshold-sec", type=float,
+                        default=float(os.environ.get("RCCL_BUILD_TIME_THRESHOLD_SEC", DEFAULT_THRESHOLD_SEC)))
+    parser.add_argument("--jobs", type=int,
+                        default=int(os.environ.get("RCCL_BUILD_TIME_JOBS", 0)) or cpu_count())
+    parser.add_argument("--build-root", default=os.environ.get("RCCL_BUILD_TIME_ROOT"),
+                        help="where to put scratch build dirs (default: a temp dir)")
+    parser.add_argument("--keep", action="store_true", help="keep build dirs for inspection")
+    parser.add_argument("--strict", action="store_true",
+                        default=os.environ.get("RCCL_BUILD_TIME_STRICT") == "1",
+                        help="fail, rather than skip, targets the compiler cannot build")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    targets, targets_from = resolve_targets(args)
+
+    bundled = os.path.join(rocm_path(), "bin", "hipcc")
+    hipcc = bundled if os.path.exists(bundled) else shutil.which("hipcc")
+    if not hipcc:
+        print("ERROR: hipcc not found; set ROCM_PATH or put hipcc on PATH", file=sys.stderr)
+        return 1
+    if not compiler_works(hipcc):
+        print("ERROR: %s cannot compile a trivial HIP file, so no target can be "
+              "measured.\n       Check ROCM_PATH (currently %r) and the toolchain "
+              "install." % (hipcc, rocm_path()), file=sys.stderr)
+        return 1
+
+    build_root: str = args.build_root or tempfile.mkdtemp(prefix="rccl-build-time-")
+    os.makedirs(build_root, exist_ok=True)
+    generator, _ = pick_generator()
+
+    ci = ci_context()
+    print("RCCL build-time regression test")
+    print("  context    : %s" % (ci if ci else "local (no CI environment detected)"))
+    print("  source     : %s" % RCCL_ROOT)
+    print("  ROCM_PATH  : %s" % rocm_path())
+    print("  generator  : %s" % generator)
+    print("  jobs       : %d (of %d CPUs)" % (args.jobs, cpu_count()))
+    print("  threshold  : %s (%.0fs) per target, configure + build" %
+          (fmt(args.threshold_sec), args.threshold_sec))
+    print("  build root : %s" % build_root)
+    print("  targets    : %s (from %s)" % (" ".join(targets), targets_from))
+    print()
+
+    results: list[TargetResult] = []
+    for target in targets:
+        if not compiler_supports(target, hipcc):
+            reason = "compiler does not support --offload-arch=%s" % target
+            status = FAIL if args.strict else SKIP
+            print("[%s] %s - %s%s" % (target, status, reason,
+                                      " (--strict)" if args.strict else ""))
+            results.append(TargetResult(target, status, reason))
+            continue
+
+        build_dir = os.path.join(build_root, target)
+        log_path = os.path.join(build_root, "%s.log" % target)
+        print("[%s] building ..." % target, flush=True)
+
+        configure_s, build_s, ok = build_target(target, build_dir, args.jobs, log_path)
+        total_s = configure_s + build_s
+
+        if not ok:
+            status, note = FAIL, "build failed, see %s" % log_path
+        elif total_s > args.threshold_sec:
+            status, note = FAIL, "exceeded threshold by %s" % fmt(total_s - args.threshold_sec)
+        else:
+            status, note = PASS, "%s under threshold" % fmt(args.threshold_sec - total_s)
+
+        print("[%s] %s - %s (configure %s + build %s) - %s" %
+              (target, status, fmt(total_s), fmt(configure_s), fmt(build_s), note))
+        results.append(TargetResult(target, status, note, configure_s, build_s))
+
+        if not args.keep:
+            shutil.rmtree(build_dir, ignore_errors=True)
+
+    print()
+    print("%-10s %10s %10s %10s  %s" % ("TARGET", "CONFIGURE", "BUILD", "TOTAL", "RESULT"))
+    for r in results:
+        if r.configure_s is None or r.build_s is None:
+            print("%-10s %10s %10s %10s  %s (%s)" % (r.target, "-", "-", "-", r.status, r.note))
+        else:
+            print("%-10s %10s %10s %10s  %s" %
+                  (r.target, fmt(r.configure_s), fmt(r.build_s),
+                   fmt(r.configure_s + r.build_s), r.status))
+
+    failed = [r.target for r in results if r.status == FAIL]
+    if failed:
+        print("\nFAILED: %s" % ", ".join(failed))
+        return 1
+
+    built = [r.target for r in results if r.status == PASS]
+    if not built:
+        print("\nNo targets were buildable with this toolchain; nothing was measured.")
+        return 1
+
+    print("\nPASSED: %s" % ", ".join(built))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/projects/rccl/test/test_build_time.py
+++ b/projects/rccl/test/test_build_time.py
@@ -140,7 +140,11 @@ def local_gpu_targets() -> list[str]:
     if not enumerator:
         raise RuntimeError("rocm_agent_enumerator not found; pass --targets explicitly")
 
-    out = subprocess.run([enumerator], capture_output=True, text=True).stdout
+    proc = subprocess.run([enumerator], capture_output=True, text=True)
+    if proc.returncode != 0:
+        msg = (proc.stderr or proc.stdout).strip()
+        raise RuntimeError(f"rocm_agent_enumerator failed (rc={proc.returncode}): {msg}")
+    out = proc.stdout
     # Deduplicate but keep discovery order; gfx000 is the CPU agent.
     targets: list[str] = []
     for arch in re.findall(r"gfx[0-9a-fA-F]+", out):

--- a/projects/rccl/test/test_build_time.py
+++ b/projects/rccl/test/test_build_time.py
@@ -26,8 +26,12 @@ on a small runner. Parallelism defaults to the CPU count and is recorded in the
 report; use --jobs to pin it when comparing results across machines.
 
 --compare-base sidesteps that: it builds the PR's base commit and its head on
-this same runner and gates on the relative change, and a ratio cancels out
-machine speed. It costs 2*--repeat builds per target instead of one.
+this same runner and gates only on the relative change; a ratio cancels out
+machine speed and needs no per-machine threshold. It costs 2*--repeat builds
+per target instead of one. On shallow CI checkouts the script attempts a
+shallow fetch of the upstream ref before resolving the merge-base; if git
+history is still unavailable it skips with a clear message rather than failing
+the run as a false regression.
 
 Usage:
     ./test_build_time.py                      # every arch in DEFAULT_GPUS
@@ -143,7 +147,8 @@ def local_gpu_targets() -> list[str]:
     proc = subprocess.run([enumerator], capture_output=True, text=True)
     if proc.returncode != 0:
         msg = (proc.stderr or proc.stdout).strip()
-        raise RuntimeError(f"rocm_agent_enumerator failed (rc={proc.returncode}): {msg}")
+        raise RuntimeError("rocm_agent_enumerator failed (rc=%d): %s"
+                           % (proc.returncode, msg))
     out = proc.stdout
     # Deduplicate but keep discovery order; gfx000 is the CPU agent.
     targets: list[str] = []
@@ -261,10 +266,39 @@ def git(*args: str) -> str:
                           capture_output=True, text=True, check=True).stdout.strip()
 
 
-def default_base_rev() -> str:
-    """The commit a PR branched from: the merge base with the upstream branch."""
+def git_err(*args: str) -> tuple[str | None, str | None]:
+    """Run git; return (stdout, None) on success or (None, error) on failure."""
+    proc = subprocess.run(["git", "-C", RCCL_ROOT, *args],
+                          capture_output=True, text=True, check=False)
+    if proc.returncode == 0:
+        return proc.stdout.strip(), None
+    msg = (proc.stderr or proc.stdout or "").strip()
+    return None, msg or ("git %s exited %d" % (" ".join(args), proc.returncode))
+
+
+def ensure_upstream_fetched(upstream: str) -> None:
+    """Best-effort shallow fetch of the remote branch used for merge-base."""
+    if "/" not in upstream:
+        return
+    remote, ref = upstream.split("/", 1)
+    subprocess.run(["git", "-C", RCCL_ROOT, "fetch", "--depth=1", remote, ref],
+                   capture_output=True, text=True, check=False)
+
+
+def resolve_base_sha(explicit_rev: str | None) -> tuple[str | None, str, str | None]:
+    """Return (base_sha, label, error). label is printed in the report header."""
+    if explicit_rev:
+        sha, err = git_err("rev-parse", explicit_rev)
+        return sha, explicit_rev, err
+
     upstream = os.environ.get("RCCL_BUILD_TIME_UPSTREAM", "origin/develop")
-    return git("merge-base", upstream, "HEAD")
+    ensure_upstream_fetched(upstream)
+    merge_base, err = git_err("merge-base", upstream, "HEAD")
+    if err:
+        return None, upstream, "cannot resolve merge-base with %s: %s" % (upstream, err)
+    sha, err = git_err("rev-parse", merge_base)
+    label = "%s (merge-base with %s)" % (merge_base[:10], upstream)
+    return sha, label, err
 
 
 def rccl_dir_within(worktree: str) -> str:
@@ -296,19 +330,21 @@ class Comparison:
 
 
 def time_best_of(
-    target: str, source_dir: str, build_root: str, tag: str, jobs: int, repeat: int,
-    round_index: int,
+    target: str, source_dir: str, build_root: str, tag: str, jobs: int,
+    round_index: int, keep: bool,
 ) -> tuple[float, bool]:
     """Build one revision once and return (total_s, ok) for this round."""
     build_dir = os.path.join(build_root, "%s-%s-%d" % (target, tag, round_index))
     log_path = os.path.join(build_root, "%s-%s-%d.log" % (target, tag, round_index))
     configure_s, build_s, ok = build_target(target, build_dir, jobs, log_path, source_dir)
-    shutil.rmtree(build_dir, ignore_errors=True)
+    if not keep:
+        shutil.rmtree(build_dir, ignore_errors=True)
     return configure_s + build_s, ok
 
 
 def compare_target(
     target: str, head_dir: str, base_dir: str, build_root: str, jobs: int, repeat: int,
+    keep: bool,
 ) -> tuple[float, float, bool]:
     """Time base and head alternately; return (base_best, head_best, ok).
 
@@ -320,12 +356,12 @@ def compare_target(
     base_times: list[float] = []
     head_times: list[float] = []
     for i in range(repeat):
-        base_s, ok = time_best_of(target, base_dir, build_root, "base", jobs, repeat, i)
+        base_s, ok = time_best_of(target, base_dir, build_root, "base", jobs, i, keep)
         if not ok:
             return 0.0, 0.0, False
         base_times.append(base_s)
 
-        head_s, ok = time_best_of(target, head_dir, build_root, "head", jobs, repeat, i)
+        head_s, ok = time_best_of(target, head_dir, build_root, "head", jobs, i, keep)
         if not ok:
             return 0.0, 0.0, False
         head_times.append(head_s)
@@ -386,15 +422,22 @@ def run_comparison(
     args: argparse.Namespace, targets: list[str], hipcc: str, build_root: str,
 ) -> int:
     """Time base vs head for each target and gate on the relative change."""
-    base_rev = args.compare_base or default_base_rev()
-    base_sha = git("rev-parse", base_rev)
-    head_sha = git("rev-parse", "HEAD")
+    explicit_rev = args.compare_base if args.compare_base else None
+    base_sha, base_label, err = resolve_base_sha(explicit_rev)
+    if err or not base_sha:
+        print("SKIP: cannot resolve base commit (%s)" % (err or "unknown error"))
+        return 0
+
+    head_sha, err = git_err("rev-parse", "HEAD")
+    if err or not head_sha:
+        print("SKIP: cannot resolve HEAD (%s)" % (err or "unknown error"))
+        return 0
 
     print("  mode       : base-vs-head comparison")
-    print("  base       : %s (%s)" % (base_sha[:10], base_rev))
+    print("  base       : %s (%s)" % (base_sha[:10], base_label))
     print("  head       : %s" % head_sha[:10])
-    print("  tolerance  : head may be at most %.1f%% slower than base, and must "
-          "still finish within %s" % (args.max_regression_pct, fmt(args.threshold_sec)))
+    print("  tolerance  : head may be at most %.1f%% slower than base"
+          % args.max_regression_pct)
     print("  rounds     : %d (alternating; minimum of each wins)" % args.repeat)
     print()
 
@@ -403,7 +446,10 @@ def run_comparison(
         return 0
 
     worktree = os.path.join(build_root, "base-tree")
-    git("worktree", "add", "--detach", "--quiet", worktree, base_sha)
+    _, err = git_err("worktree", "add", "--detach", "--quiet", worktree, base_sha)
+    if err:
+        print("SKIP: cannot check out base commit %s (%s)" % (base_sha[:10], err))
+        return 0
     base_dir = rccl_dir_within(worktree)
     try:
         results: list[Comparison] = []
@@ -417,7 +463,7 @@ def run_comparison(
 
             print("[%s] timing base and head ..." % target, flush=True)
             base_s, head_s, ok = compare_target(
-                target, RCCL_ROOT, base_dir, build_root, args.jobs, args.repeat)
+                target, RCCL_ROOT, base_dir, build_root, args.jobs, args.repeat, args.keep)
             if not ok:
                 print("[%s] FAIL - build failed, see %s" % (target, build_root))
                 results.append(Comparison(target, FAIL, "build failed"))
@@ -426,25 +472,17 @@ def run_comparison(
             result = Comparison(target, PASS, "", base_s, head_s)
             pct = result.delta_pct or 0.0
 
-            # The head build is timed here anyway, so this run enforces the
-            # absolute budget too and there is no need for a second CI entry.
-            problems: list[str] = []
             if pct > args.max_regression_pct:
-                problems.append("%.1f%% slower than base (limit %.1f%%)"
-                                % (pct, args.max_regression_pct))
-            if head_s > args.threshold_sec:
-                problems.append("took %s, over the %s budget"
-                                % (fmt(head_s), fmt(args.threshold_sec)))
-            if problems:
                 result.status = FAIL
-                result.note = "; ".join(problems)
+                result.note = "%.1f%% slower than base (limit %.1f%%)" % (
+                    pct, args.max_regression_pct)
 
             print("[%s] %s - base %s -> head %s (%+.1f%%)%s" %
                   (target, result.status, fmt(base_s), fmt(head_s), pct,
-                   "  " + result.note if problems else ""))
+                   "  " + result.note if result.note else ""))
             results.append(result)
     finally:
-        git("worktree", "remove", "--force", worktree)
+        git_err("worktree", "remove", "--force", worktree)
 
     print()
     print("%-10s %10s %10s %9s  %s" % ("TARGET", "BASE", "HEAD", "DELTA", "RESULT"))

--- a/projects/rccl/test/test_build_time.py
+++ b/projects/rccl/test/test_build_time.py
@@ -52,11 +52,9 @@ import sys
 import tempfile
 import time
 from dataclasses import dataclass
-from typing import TextIO
 
 HERE: str = os.path.dirname(os.path.abspath(__file__))
 RCCL_ROOT: str = os.path.dirname(HERE)
-TOOLCHAIN: str = os.path.join(RCCL_ROOT, "toolchain-linux.cmake")
 CMAKELISTS: str = os.path.join(RCCL_ROOT, "CMakeLists.txt")
 
 DEFAULT_THRESHOLD_SEC: int = 300
@@ -238,7 +236,6 @@ def build_target(
     ]
 
     env = build_env()
-    log: TextIO
     with open(log_path, "w") as log:
         def run(cmd: list[str]) -> tuple[float, int]:
             log.write("\n$ " + " ".join(cmd) + "\n")
@@ -260,10 +257,18 @@ def fmt(seconds: float) -> str:
     return "%d:%05.2f" % (int(seconds // 60), seconds % 60)
 
 
-def git(*args: str) -> str:
-    """Run git in the RCCL source tree and return stripped stdout."""
-    return subprocess.run(["git", "-C", RCCL_ROOT, *args],
-                          capture_output=True, text=True, check=True).stdout.strip()
+def rccl_dir_within(worktree: str) -> str:
+    """Locate the RCCL project inside a checkout of the enclosing repository.
+
+    RCCL lives at projects/rccl in the rocm-systems monorepo, so a worktree
+    root is not itself a configurable source directory. Resolves to the
+    worktree root when RCCL is checked out standalone.
+    """
+    top, err = git_err("rev-parse", "--show-toplevel")
+    if err or not top:
+        raise RuntimeError("cannot locate git toplevel: %s" % (err or "unknown error"))
+    rel = os.path.relpath(RCCL_ROOT, top)
+    return os.path.normpath(os.path.join(worktree, rel))
 
 
 def git_err(*args: str) -> tuple[str | None, str | None]:
@@ -294,22 +299,11 @@ def resolve_base_sha(explicit_rev: str | None) -> tuple[str | None, str, str | N
     upstream = os.environ.get("RCCL_BUILD_TIME_UPSTREAM", "origin/develop")
     ensure_upstream_fetched(upstream)
     merge_base, err = git_err("merge-base", upstream, "HEAD")
-    if err:
-        return None, upstream, "cannot resolve merge-base with %s: %s" % (upstream, err)
+    if err or not merge_base:
+        return None, upstream, "cannot resolve merge-base with %s: %s" % (upstream, err or "unknown error")
     sha, err = git_err("rev-parse", merge_base)
     label = "%s (merge-base with %s)" % (merge_base[:10], upstream)
     return sha, label, err
-
-
-def rccl_dir_within(worktree: str) -> str:
-    """Locate the RCCL project inside a checkout of the enclosing repository.
-
-    RCCL lives at projects/rccl in the rocm-systems monorepo, so a worktree
-    root is not itself a configurable source directory. Resolves to the
-    worktree root when RCCL is checked out standalone.
-    """
-    rel = os.path.relpath(RCCL_ROOT, git("rev-parse", "--show-toplevel"))
-    return os.path.normpath(os.path.join(worktree, rel))
 
 
 @dataclass

--- a/projects/rccl/test/test_build_time.py
+++ b/projects/rccl/test/test_build_time.py
@@ -25,11 +25,16 @@ a clean single-arch build is ~50s on a 256-core host but will exceed 5 minutes
 on a small runner. Parallelism defaults to the CPU count and is recorded in the
 report; use --jobs to pin it when comparing results across machines.
 
+--compare-base sidesteps that: it builds the PR's base commit and its head on
+this same runner and gates on the relative change, and a ratio cancels out
+machine speed. It costs 2*--repeat builds per target instead of one.
+
 Usage:
     ./test_build_time.py                      # every arch in DEFAULT_GPUS
     ./test_build_time.py --local-gpu          # only this machine's arch (CI gate)
     ./test_build_time.py --targets gfx942     # one target
     ./test_build_time.py --threshold-sec 600 --jobs 32
+    ./test_build_time.py --local-gpu --compare-base --max-regression-pct 10
 """
 
 from __future__ import annotations
@@ -188,31 +193,50 @@ def pick_generator() -> tuple[str, list[str]]:
     return "Unix Makefiles", ["make"]
 
 
+def build_env() -> dict[str, str]:
+    """Environment for build subprocesses, with compiler caching disabled.
+
+    A warm ccache would make the second half of an A/B comparison finish
+    almost instantly and silently invalidate the result. RCCL's own build does
+    not enable ccache, but TheRock CI does, so force it off rather than trust
+    the surrounding configuration.
+    """
+    env = dict(os.environ)
+    env["CCACHE_DISABLE"] = "1"
+    return env
+
+
 def build_target(
-    target: str, build_dir: str, jobs: int, log_path: str
+    target: str, build_dir: str, jobs: int, log_path: str, source_dir: str = RCCL_ROOT
 ) -> tuple[float, float, bool]:
-    """Clean-configure and build one target. Returns (configure_s, build_s, ok)."""
+    """Clean-configure and build one target. Returns (configure_s, build_s, ok).
+
+    source_dir selects which checkout to build, so a single copy of this script
+    can time two revisions; each tree supplies its own toolchain file.
+    """
     shutil.rmtree(build_dir, ignore_errors=True)
     os.makedirs(build_dir)
 
     generator, build_cmd = pick_generator()
     configure = [
         "cmake",
-        "--toolchain=" + TOOLCHAIN,
+        "--toolchain=" + os.path.join(source_dir, "toolchain-linux.cmake"),
         "-G", generator,
         "-DCMAKE_BUILD_TYPE=Release",
         "-DGPU_TARGETS=" + target,
         "-DROCM_PATH=" + rocm_path(),
-        RCCL_ROOT,
+        source_dir,
     ]
 
+    env = build_env()
     log: TextIO
     with open(log_path, "w") as log:
         def run(cmd: list[str]) -> tuple[float, int]:
             log.write("\n$ " + " ".join(cmd) + "\n")
             log.flush()
             start = time.monotonic()
-            rc = subprocess.call(cmd, cwd=build_dir, stdout=log, stderr=subprocess.STDOUT)
+            rc = subprocess.call(cmd, cwd=build_dir, stdout=log, stderr=subprocess.STDOUT,
+                                 env=env)
             return time.monotonic() - start, rc
 
         configure_s, rc = run(configure)
@@ -225,6 +249,87 @@ def build_target(
 
 def fmt(seconds: float) -> str:
     return "%d:%05.2f" % (int(seconds // 60), seconds % 60)
+
+
+def git(*args: str) -> str:
+    """Run git in the RCCL source tree and return stripped stdout."""
+    return subprocess.run(["git", "-C", RCCL_ROOT, *args],
+                          capture_output=True, text=True, check=True).stdout.strip()
+
+
+def default_base_rev() -> str:
+    """The commit a PR branched from: the merge base with the upstream branch."""
+    upstream = os.environ.get("RCCL_BUILD_TIME_UPSTREAM", "origin/develop")
+    return git("merge-base", upstream, "HEAD")
+
+
+def rccl_dir_within(worktree: str) -> str:
+    """Locate the RCCL project inside a checkout of the enclosing repository.
+
+    RCCL lives at projects/rccl in the rocm-systems monorepo, so a worktree
+    root is not itself a configurable source directory. Resolves to the
+    worktree root when RCCL is checked out standalone.
+    """
+    rel = os.path.relpath(RCCL_ROOT, git("rev-parse", "--show-toplevel"))
+    return os.path.normpath(os.path.join(worktree, rel))
+
+
+@dataclass
+class Comparison:
+    """Base-vs-head timings for one target, in seconds (min across repeats)."""
+
+    target: str
+    status: str
+    note: str
+    base_s: float | None = None
+    head_s: float | None = None
+
+    @property
+    def delta_pct(self) -> float | None:
+        if self.base_s is None or self.head_s is None or self.base_s == 0:
+            return None
+        return (self.head_s - self.base_s) / self.base_s * 100.0
+
+
+def time_best_of(
+    target: str, source_dir: str, build_root: str, tag: str, jobs: int, repeat: int,
+    round_index: int,
+) -> tuple[float, bool]:
+    """Build one revision once and return (total_s, ok) for this round."""
+    build_dir = os.path.join(build_root, "%s-%s-%d" % (target, tag, round_index))
+    log_path = os.path.join(build_root, "%s-%s-%d.log" % (target, tag, round_index))
+    configure_s, build_s, ok = build_target(target, build_dir, jobs, log_path, source_dir)
+    shutil.rmtree(build_dir, ignore_errors=True)
+    return configure_s + build_s, ok
+
+
+def compare_target(
+    target: str, head_dir: str, base_dir: str, build_root: str, jobs: int, repeat: int,
+) -> tuple[float, float, bool]:
+    """Time base and head alternately; return (base_best, head_best, ok).
+
+    Alternating rather than running all of one revision then the other keeps
+    slow drift (thermal, noisy neighbours) from landing on just one side. The
+    minimum across repeats is the estimator because build-time noise is
+    one-sided: interference can only ever make a build slower.
+    """
+    base_times: list[float] = []
+    head_times: list[float] = []
+    for i in range(repeat):
+        base_s, ok = time_best_of(target, base_dir, build_root, "base", jobs, repeat, i)
+        if not ok:
+            return 0.0, 0.0, False
+        base_times.append(base_s)
+
+        head_s, ok = time_best_of(target, head_dir, build_root, "head", jobs, repeat, i)
+        if not ok:
+            return 0.0, 0.0, False
+        head_times.append(head_s)
+
+        print("    round %d/%d: base %s  head %s" %
+              (i + 1, repeat, fmt(base_s), fmt(head_s)), flush=True)
+
+    return min(base_times), min(head_times), True
 
 
 def resolve_targets(args: argparse.Namespace) -> tuple[list[str], str]:
@@ -256,7 +361,105 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--strict", action="store_true",
                         default=os.environ.get("RCCL_BUILD_TIME_STRICT") == "1",
                         help="fail, rather than skip, targets the compiler cannot build")
+
+    compare = parser.add_argument_group(
+        "base comparison",
+        "Time the PR's base commit and its head on this same runner and gate on the "
+        "relative change. A ratio cancels out runner speed, so unlike --threshold-sec "
+        "it needs no per-machine tuning.")
+    compare.add_argument("--compare-base", nargs="?", const="", metavar="REV",
+                         help="compare against REV (default: merge-base with origin/develop)")
+    compare.add_argument("--max-regression-pct", type=float,
+                         default=float(os.environ.get("RCCL_BUILD_TIME_MAX_REGRESSION_PCT", 10.0)),
+                         help="fail if head is more than this %% slower than base (default: 10)")
+    compare.add_argument("--repeat", type=int,
+                         default=int(os.environ.get("RCCL_BUILD_TIME_REPEAT", 2)),
+                         help="alternating base/head rounds; the minimum of each wins (default: 2)")
     return parser.parse_args()
+
+
+def run_comparison(
+    args: argparse.Namespace, targets: list[str], hipcc: str, build_root: str,
+) -> int:
+    """Time base vs head for each target and gate on the relative change."""
+    base_rev = args.compare_base or default_base_rev()
+    base_sha = git("rev-parse", base_rev)
+    head_sha = git("rev-parse", "HEAD")
+
+    print("  mode       : base-vs-head comparison")
+    print("  base       : %s (%s)" % (base_sha[:10], base_rev))
+    print("  head       : %s" % head_sha[:10])
+    print("  tolerance  : head may be at most %.1f%% slower than base, and must "
+          "still finish within %s" % (args.max_regression_pct, fmt(args.threshold_sec)))
+    print("  rounds     : %d (alternating; minimum of each wins)" % args.repeat)
+    print()
+
+    if base_sha == head_sha:
+        print("Base and head are the same commit; nothing to compare.")
+        return 0
+
+    worktree = os.path.join(build_root, "base-tree")
+    git("worktree", "add", "--detach", "--quiet", worktree, base_sha)
+    base_dir = rccl_dir_within(worktree)
+    try:
+        results: list[Comparison] = []
+        for target in targets:
+            if not compiler_supports(target, hipcc):
+                reason = "compiler does not support --offload-arch=%s" % target
+                status = FAIL if args.strict else SKIP
+                print("[%s] %s - %s" % (target, status, reason))
+                results.append(Comparison(target, status, reason))
+                continue
+
+            print("[%s] timing base and head ..." % target, flush=True)
+            base_s, head_s, ok = compare_target(
+                target, RCCL_ROOT, base_dir, build_root, args.jobs, args.repeat)
+            if not ok:
+                print("[%s] FAIL - build failed, see %s" % (target, build_root))
+                results.append(Comparison(target, FAIL, "build failed"))
+                continue
+
+            result = Comparison(target, PASS, "", base_s, head_s)
+            pct = result.delta_pct or 0.0
+
+            # The head build is timed here anyway, so this run enforces the
+            # absolute budget too and there is no need for a second CI entry.
+            problems: list[str] = []
+            if pct > args.max_regression_pct:
+                problems.append("%.1f%% slower than base (limit %.1f%%)"
+                                % (pct, args.max_regression_pct))
+            if head_s > args.threshold_sec:
+                problems.append("took %s, over the %s budget"
+                                % (fmt(head_s), fmt(args.threshold_sec)))
+            if problems:
+                result.status = FAIL
+                result.note = "; ".join(problems)
+
+            print("[%s] %s - base %s -> head %s (%+.1f%%)%s" %
+                  (target, result.status, fmt(base_s), fmt(head_s), pct,
+                   "  " + result.note if problems else ""))
+            results.append(result)
+    finally:
+        git("worktree", "remove", "--force", worktree)
+
+    print()
+    print("%-10s %10s %10s %9s  %s" % ("TARGET", "BASE", "HEAD", "DELTA", "RESULT"))
+    for r in results:
+        if r.base_s is None or r.head_s is None:
+            print("%-10s %10s %10s %9s  %s (%s)" % (r.target, "-", "-", "-", r.status, r.note))
+        else:
+            print("%-10s %10s %10s %8.1f%%  %s" %
+                  (r.target, fmt(r.base_s), fmt(r.head_s), r.delta_pct or 0.0, r.status))
+
+    failed = [r.target for r in results if r.status == FAIL]
+    if failed:
+        print("\nFAILED: %s" % ", ".join(failed))
+        return 1
+    if not any(r.status == PASS for r in results):
+        print("\nNo targets were buildable with this toolchain; nothing was measured.")
+        return 1
+    print("\nPASSED: %s" % ", ".join(r.target for r in results if r.status == PASS))
+    return 0
 
 
 def main() -> int:
@@ -285,10 +488,29 @@ def main() -> int:
     print("  ROCM_PATH  : %s" % rocm_path())
     print("  generator  : %s" % generator)
     print("  jobs       : %d (of %d CPUs)" % (args.jobs, cpu_count()))
-    print("  threshold  : %s (%.0fs) per target, configure + build" %
-          (fmt(args.threshold_sec), args.threshold_sec))
     print("  build root : %s" % build_root)
     print("  targets    : %s (from %s)" % (" ".join(targets), targets_from))
+
+    if args.compare_base is not None:
+        rc = run_comparison(args, targets, hipcc, build_root)
+    else:
+        rc = run_absolute(args, targets, hipcc, build_root)
+
+    # Each run leaves a few MB of build logs; they are only interesting when
+    # something failed, and this runs on every PR.
+    if rc == 0 and not args.keep and not args.build_root:
+        shutil.rmtree(build_root, ignore_errors=True)
+    elif rc != 0:
+        print("\nBuild logs kept at %s" % build_root)
+    return rc
+
+
+def run_absolute(
+    args: argparse.Namespace, targets: list[str], hipcc: str, build_root: str,
+) -> int:
+    """Time each target once and gate on the absolute threshold."""
+    print("  threshold  : %s (%.0fs) per target, configure + build" %
+          (fmt(args.threshold_sec), args.threshold_sec))
     print()
 
     results: list[TargetResult] = []

--- a/projects/rccl/tools/scripts/test_runner/configs/ci-precheckin.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/ci-precheckin.json
@@ -204,7 +204,7 @@
       "timeout": 2400,
       "command_args": "--local-gpu --compare-base --max-regression-pct 10 --repeat 2 --jobs 64",
       "tests": [
-        {"name": "BuildTime.LocalGpuArch", "description": "Clean build of the runner's GPU arch is no more than 10% slower than the PR's base commit, and stays under 5 minutes"}
+        {"name": "BuildTime.LocalGpuArch", "description": "Clean build of the runner's GPU arch is no more than 10% slower than the PR's base commit"}
       ]
     }
   },
@@ -229,7 +229,7 @@
     },
     {
       "name": "RCCL Build Time",
-      "description": "Times the PR's base commit and its head on this runner and gates on both the relative change and the absolute budget. Drives its own cmake build, separate from the install.sh build the other suites use.",
+      "description": "Times the PR's base commit and its head on this runner and gates on the relative change. Drives its own cmake build, separate from the install.sh build the other suites use.",
       "config": "build_time",
       "enabled": true
     }

--- a/projects/rccl/tools/scripts/test_runner/configs/ci-precheckin.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/ci-precheckin.json
@@ -201,10 +201,10 @@
       "num_ranks": 1,
       "num_nodes": 1,
       "num_gpus": 1,
-      "timeout": 900,
-      "command_args": "--local-gpu --jobs 64",
+      "timeout": 2400,
+      "command_args": "--local-gpu --compare-base --max-regression-pct 10 --repeat 2 --jobs 64",
       "tests": [
-        {"name": "BuildTime.LocalGpuArch", "description": "Clean build of the runner's GPU arch stays under 5 minutes"}
+        {"name": "BuildTime.LocalGpuArch", "description": "Clean build of the runner's GPU arch is no more than 10% slower than the PR's base commit, and stays under 5 minutes"}
       ]
     }
   },
@@ -229,7 +229,7 @@
     },
     {
       "name": "RCCL Build Time",
-      "description": "Clean-build wall-clock regression for the runner's GPU arch. Drives its own cmake build, separate from the install.sh build the other suites use.",
+      "description": "Times the PR's base commit and its head on this runner and gates on both the relative change and the absolute budget. Drives its own cmake build, separate from the install.sh build the other suites use.",
       "config": "build_time",
       "enabled": true
     }

--- a/projects/rccl/tools/scripts/test_runner/configs/ci-precheckin.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/ci-precheckin.json
@@ -194,6 +194,18 @@
       "tests": [
         {"name": "GdrPeerMem", "description": "net_ib peer-memory client sysfs detection (mock memory_peers tree)", "test_filter": "GdrPeerMem.*"}
       ]
+    },
+    "build_time": {
+      "is_gtest": false,
+      "binary": "${WORKDIR:-$PWD}/test/test_build_time.py",
+      "num_ranks": 1,
+      "num_nodes": 1,
+      "num_gpus": 1,
+      "timeout": 900,
+      "command_args": "--local-gpu --jobs 64",
+      "tests": [
+        {"name": "BuildTime.LocalGpuArch", "description": "Clean build of the runner's GPU arch stays under 5 minutes"}
+      ]
     }
   },
   "test_suites": [
@@ -213,6 +225,12 @@
       "name": "RCCL Unit Tests - GDR Peer-Memory Detection",
       "description": "rccl-UnitTestsGdr (net_ib memory_peers sysfs scan, CPU-only)",
       "config": "unit_tests_gdr",
+      "enabled": true
+    },
+    {
+      "name": "RCCL Build Time",
+      "description": "Clean-build wall-clock regression for the runner's GPU arch. Drives its own cmake build, separate from the install.sh build the other suites use.",
+      "config": "build_time",
       "enabled": true
     }
   ]


### PR DESCRIPTION
Adds a test that runs as part of Math CI that fails if build time regresses more than x%. Currently, it's set to 10%.

## Why

The absolute 5-minute threshold added in #9889 only means something on hardware close to what it was tuned on (hence I abandoned it). A clean single-arch build is about 50s on a 256-core host but would blow the same budget on a small runner, so the number needs re-tuning per machine class.

A ratio does not have that problem. `--compare-base` builds the PR's merge-base and its head on the same runner and fails when the head is more than `--max-regression-pct` slower.

## Keeping it honest

Three things stop this from being a flaky test:

- **Alternating rounds.** Base and head builds interleave rather than running all of one then the other, so thermal drift or a noisy neighbour cannot land on just one side.
- **Minimum across rounds, not the mean.** Build-time noise is one-sided — interference only ever makes a build slower — so the minimum is the better estimator. This mattered: a single round read −1.5% on a change that touches no source, while min-of-2 tightened the same comparison to −0.1%.
- **ccache forced off.** A warm cache would let the second build finish almost instantly and silently invalidate the comparison. RCCL's own build path does not enable ccache, but TheRock CI does, so the script sets `CCACHE_DISABLE=1` rather than trusting the surrounding configuration.

## Compare mode is ratio-only

Precheckin runs `--compare-base`, which gates only on the relative change. The absolute `--threshold-sec` budget remains available for standalone/CTest use in absolute mode, but compare mode no longer applies it — that avoids reintroducing per-runner tuning on slower CI hosts.

## Review feedback addressed

- **Shallow CI checkout:** attempt a shallow fetch of the upstream ref before `merge-base`; on unrecoverable git errors, skip with a clear message instead of a traceback that looks like a regression failure.
- **Ratio-only gate in compare mode:** drop the absolute 300s head budget from `--compare-base`; update precheckin descriptions accordingly.
- **`rocm_agent_enumerator` errors:** surface nonzero exit codes and stderr instead of misreporting as "no local GPUs".
- **`--keep` in compare mode:** honour the flag when cleaning per-round build dirs.
- **Dead API:** remove the unused `repeat` parameter from `time_best_of()`.

## Measurements

All on gfx950 at `-j 64`, through the precheckin harness:

| scenario | result |
| --- | --- |
| Change touching only test files | −0.1%, PASS |
| Eight days of `develop` (1:19 → 1:30) | +13.8%, FAIL |
| PR branch vs merge-base (`repeat=2`, 10% limit) | −3.4%, PASS |
| Tight threshold sanity check (3% limit) | +10.8%, FAIL |

The four raw readings in the last passing run spanned 0.1s on 90s, and two separate harness runs both landed on −0.1%. A 10% limit therefore sits well clear of the noise on this class of runner; it could go lower later if the data holds on the real CI hardware.

## Cost

Four builds instead of one, 365s measured. Because it replaces the previous 92s entry, the net addition to precheckin is roughly 4.5 minutes.

## Test plan

- [x] `mypy --strict` clean
- [x] Config validates against the harness JSON schema
- [x] Passing case through `test_runner.py` (365s, exit 0)
- [x] Failing case on a real regression (+13.8%, exit 1)
- [x] End-to-end PASS on PR branch (`repeat=2`, 10% limit, exit 0)
- [x] End-to-end FAIL when delta exceeds threshold (exit 1)
- [x] Temporary git worktree removed on both success and failure
- [x] Build logs cleaned up on success, retained on failure
- [ ] Confirm timings and pick a final threshold on the actual CI runner, which will be noisier than the dev host used here

## Coverage is scoped to the toolchain it runs under

Worth stating plainly, since it bounds what this gate can promise: it only catches regressions that reproduce under the compiler the runner uses. Precheckin builds against the local `/opt/rocm` install, so a regression that only manifests on another toolchain will pass here.

This is not hypothetical. #9756 fixed a `ce_reduce.cc` translation unit that took ~48 minutes to compile on the srock toolchain, caused by LLVM's runtime loop-unroller auto-unrolling a rank loop by up to 64x. Measured against `/opt/rocm` 7.0.2.1 on gfx950, the same pre-fix file compiles in **2.63s** (confirmed from ninja's per-edge log on a full clean build), and this gate scores the fix at **-0.0%** — 90.38s before, 90.37s after. The pathological unroll simply does not happen with that clang, so there was never anything here to catch.

Two consequences for reviewers:

- A green result means "no regression on this runner's toolchain", not "no regression". Covering the srock toolchain would need the gate wired into TheRock CI, where the ccache interaction described above has to be solved first.
- Wall-clock totals can hide large shifts in compile work. On `/opt/rocm`, #9756 takes `ce_reduce` from one 2.63s job to 42 jobs totaling 30.64s of CPU — roughly 12x the aggregate work — while wall clock is unchanged (83.80s vs 83.77s) because `-j 64` has slack to absorb it. That is the right trade against a 48-minute serialized job, but on a core-starved runner the same split could cost wall clock instead of saving it.