### PR TITLE
[rocjitsu][decoder] Validate VOPD encodings

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -1316,6 +1316,40 @@ class CodeGenerator:
             f'  case k{op.enum_name}:\n    return "{op.mnemonic}";'
             for op in vopd_slot_ops
         )
+
+        def opcode_mask(name: str, opcodes: frozenset[int]) -> str:
+            unknown_opcodes = opcodes.difference(op.opcode for op in vopd_slot_ops)
+            if unknown_opcodes:
+                raise ValueError(
+                    f'{arch} {name} references unknown VOPD opcodes: '
+                    f'{sorted(unknown_opcodes)}'
+                )
+            mask = sum(1 << opcode for opcode in opcodes)
+            return f'constexpr uint64_t {name} = 0x{mask:016X}ULL;'
+
+        opcode_masks = [
+            opcode_mask('kVopdXOpcodeMask', self.isa_spec.profile.vopd_x_slot_opcodes),
+            opcode_mask('kVopdYOpcodeMask', self.isa_spec.profile.vopd_y_slot_opcodes),
+        ]
+        if has_vopd3:
+            opcode_masks.extend(
+                (
+                    opcode_mask(
+                        'kVopd3XOpcodeMask',
+                        self.isa_spec.profile.vopd3_x_slot_opcodes,
+                    ),
+                    opcode_mask(
+                        'kVopd3YOpcodeMask',
+                        self.isa_spec.profile.vopd3_y_slot_opcodes,
+                    ),
+                )
+            )
+        vopd_opcode_validation_helpers = '\n'.join(opcode_masks) + textwrap.dedent('''
+
+            bool is_valid_opcode(uint16_t opcode, uint64_t mask) {
+              return opcode < 64 && (mask & (1ULL << opcode));
+            }
+        ''')
         vopd_src_neg_case_labels = case_labels(
             (
                 'VopdFmacF32',
@@ -1746,6 +1780,10 @@ class CodeGenerator:
                 word2_ = words[2];
                 opx_ = static_cast<uint16_t>((word0_ >> 18) & 0x3F);
                 opy_ = static_cast<uint16_t>((word0_ >> 12) & 0x3F);
+                if (!is_valid_opcode(opx_, kVopd3XOpcodeMask))
+                  throw util::InvalidInst("invalid VOPD3 X opcode", "");
+                if (!is_valid_opcode(opy_, kVopd3YOpcodeMask))
+                  throw util::InvalidInst("invalid VOPD3 Y opcode", "");
                 uint16_t srcx0 = static_cast<uint16_t>(word0_ & 0x1FF);
                 uint16_t srcy0 = static_cast<uint16_t>(word1_ & 0x1FF);
                 negx_ = static_cast<uint8_t>((word1_ >> 9) & 0x7);
@@ -1759,6 +1797,10 @@ class CodeGenerator:
 
                 uint32_t x_bits = is_float64_op(opx_) ? 64 : 32;
                 uint32_t y_bits = is_float64_op(opy_) ? 64 : 32;
+                const uint32_t x_end = vdstx + x_bits / 32;
+                const uint32_t y_end = vdsty + y_bits / 32;
+                if (vdstx < y_end && vdsty < x_end)
+                  throw util::InvalidInst("VOPD3 destination ranges overlap", "");
                 dstx_ = Operand(x_bits, OperandType::OPR_VGPR, vdstx);
                 dsty_ = Operand(y_bits, OperandType::OPR_VGPR, vdsty);
                 srcx0_ = make_src0(x_bits, true, false, 0, srcx0);
@@ -2010,6 +2052,8 @@ class CodeGenerator:
             // VOPD slot opcode values are the MRISA <Opcode> values for V_DUAL_* encodings.
             @VOPD_SLOT_CONSTANTS@
 
+            @VOPD_OPCODE_VALIDATION_HELPERS@
+
             Operand make_src0(uint32_t bits, @VOPD3_UNUSED_ATTR@bool vopd3, bool use_literal,
                               uint32_t literal, uint16_t encoded) {
               if (use_literal && encoded == 255)
@@ -2056,6 +2100,10 @@ class CodeGenerator:
                 encoding_id_ = @VOPD_PREFIX@;
                 opx_ = static_cast<uint16_t>((word0_ >> 22) & 0xF);
                 opy_ = static_cast<uint16_t>((word0_ >> 17) & 0x1F);
+                if (!is_valid_opcode(opx_, kVopdXOpcodeMask))
+                  throw util::InvalidInst("invalid VOPD X opcode", "");
+                if (!is_valid_opcode(opy_, kVopdYOpcodeMask))
+                  throw util::InvalidInst("invalid VOPD Y opcode", "");
                 uint16_t srcx0 = static_cast<uint16_t>(word0_ & 0x1FF);
                 uint16_t vsrcx1 = static_cast<uint16_t>((word0_ >> 9) & 0xFF);
                 uint16_t srcy0 = static_cast<uint16_t>(word1_ & 0x1FF);
@@ -2184,6 +2232,7 @@ class CodeGenerator:
             .replace('@VOPD3_FORMAT_ENUM@', ', Vopd3' if has_vopd3 else '')
             .replace('@VOPD3_HEADER_DECLS@', vopd3_header_decls)
             .replace('@VOPD_SLOT_CONSTANTS@', vopd_slot_constants)
+            .replace('@VOPD_OPCODE_VALIDATION_HELPERS@', vopd_opcode_validation_helpers)
             .replace('@VOPD3_UNUSED_ATTR@', vopd3_unused_attr)
             .replace('@VOPD_OP_NAME_CASES@', vopd_op_name_cases)
             .replace('@VOPD3_MODEL_HELPERS@', vopd3_model_helpers)

--- a/emulation/rocjitsu/lib/python/amdisa/isa_profile.py
+++ b/emulation/rocjitsu/lib/python/amdisa/isa_profile.py
@@ -937,6 +937,26 @@ class _AmdgpuProfileBase(IsaProfile):
         return ()
 
     @property
+    def vopd_x_slot_opcodes(self) -> frozenset[int]:
+        """Opcode values accepted in the VOPD X slot."""
+        return frozenset(op.opcode for op in self.vopd_slot_ops)
+
+    @property
+    def vopd_y_slot_opcodes(self) -> frozenset[int]:
+        """Opcode values accepted in the VOPD Y slot."""
+        return frozenset(op.opcode for op in self.vopd_slot_ops)
+
+    @property
+    def vopd3_x_slot_opcodes(self) -> frozenset[int]:
+        """Opcode values accepted in the VOPD3 X slot."""
+        return frozenset()
+
+    @property
+    def vopd3_y_slot_opcodes(self) -> frozenset[int]:
+        """Opcode values accepted in the VOPD3 Y slot."""
+        return frozenset()
+
+    @property
     def coherency_model(self) -> MemoryCoherencyModel:
         """Memory coherency encoding model for this ISA family."""
         return MemoryCoherencyModel.GFX9_GLC
@@ -1442,6 +1462,10 @@ class Rdna3Profile(_AmdgpuProfileBase):
         return _RDNA3_VOPD_SLOT_OPS
 
     @property
+    def vopd_x_slot_opcodes(self) -> frozenset[int]:
+        return frozenset(range(14))
+
+    @property
     def coherency_model(self) -> MemoryCoherencyModel:
         return MemoryCoherencyModel.GFX11_SC0_SC1_TH
 
@@ -1593,6 +1617,10 @@ class Rdna4Profile(_AmdgpuProfileBase):
     @property
     def vopd_slot_ops(self) -> tuple[VopdSlotOp, ...]:
         return _RDNA4_VOPD_SLOT_OPS
+
+    @property
+    def vopd_x_slot_opcodes(self) -> frozenset[int]:
+        return frozenset(range(14))
 
     @property
     def coherency_model(self) -> MemoryCoherencyModel:
@@ -1770,6 +1798,22 @@ class Gfx1250Profile(Rdna4Profile):
     @property
     def vopd_slot_ops(self) -> tuple[VopdSlotOp, ...]:
         return _GFX1250_VOPD_SLOT_OPS
+
+    @property
+    def vopd_x_slot_opcodes(self) -> frozenset[int]:
+        return frozenset(range(12))
+
+    @property
+    def vopd_y_slot_opcodes(self) -> frozenset[int]:
+        return frozenset((*range(12), 16, 17, *range(20, 25)))
+
+    @property
+    def vopd3_x_slot_opcodes(self) -> frozenset[int]:
+        return frozenset((0, *range(3, 12), 16, 17, *range(19, 23), *range(32, 37)))
+
+    @property
+    def vopd3_y_slot_opcodes(self) -> frozenset[int]:
+        return frozenset((0, *range(3, 12), *range(16, 25)))
 
     @property
     def uses_vgpr_msb_indexing(self) -> bool:

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
@@ -3206,6 +3206,11 @@ def test_gfx1250_vopd_template_uses_dx9_zero_and_fma(tmp_path):
     assert 'make_src0(y_bits, true, false, 0, srcy0)' in cpp
     assert 'make_src0(x_bits, false, has_literal_, literal_, srcx0)' in cpp
     assert 'make_src0(y_bits, false, has_literal_, literal_, srcy0)' in cpp
+    assert 'if (!is_valid_opcode(opx_, kVopdXOpcodeMask))' in cpp
+    assert 'if (!is_valid_opcode(opy_, kVopdYOpcodeMask))' in cpp
+    assert 'if (!is_valid_opcode(opx_, kVopd3XOpcodeMask))' in cpp
+    assert 'if (!is_valid_opcode(opy_, kVopd3YOpcodeMask))' in cpp
+    assert 'if (vdstx < y_end && vdsty < x_end)' in cpp
     assert 'case 3:\n              case 7:' not in cpp
     assert 'if (lhs == 0.0f || rhs == 0.0f)' in exec_cpp
     src_neg_start = exec_cpp.index('bool Vopd::uses_src_neg_modifier')

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_profile_properties.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_profile_properties.py
@@ -458,6 +458,10 @@ class TestRdna3Profile:
     def test_has_vopd3_false(self):
         assert self.p.has_vopd3 is False
 
+    def test_vopd_slot_opcodes(self):
+        assert self.p.vopd_x_slot_opcodes == frozenset(range(14))
+        assert self.p.vopd_y_slot_opcodes == frozenset((*range(14), 16, 17, 18))
+
     def test_operand_read64_zero_extends_simm32_literal(self, tmp_path):
         generator = CodeGenerator(
             SimpleNamespace(
@@ -515,6 +519,18 @@ class TestGfx1250Profile:
 
     def test_has_vopd3(self):
         assert self.p.has_vopd3 is True
+
+    def test_vopd_slot_opcodes(self):
+        assert self.p.vopd_x_slot_opcodes == frozenset(range(12))
+        assert self.p.vopd_y_slot_opcodes == frozenset(
+            (*range(12), 16, 17, *range(20, 25))
+        )
+        assert self.p.vopd3_x_slot_opcodes == frozenset(
+            (0, *range(3, 12), 16, 17, *range(19, 23), *range(32, 37))
+        )
+        assert self.p.vopd3_y_slot_opcodes == frozenset(
+            (0, *range(3, 12), *range(16, 25))
+        )
 
     def test_generated_arch_name(self):
         assert self.p.generated_arch_name == 'gfx1250'

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/gfx1250/vopd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/gfx1250/vopd.cpp
@@ -42,6 +42,15 @@ constexpr uint16_t kVopdMulF64 = 34;
 constexpr uint16_t kVopdMaxNumF64 = 35;
 constexpr uint16_t kVopdMinNumF64 = 36;
 
+constexpr uint64_t kVopdXOpcodeMask = 0x0000000000000FFFULL;
+constexpr uint64_t kVopdYOpcodeMask = 0x0000000001F30FFFULL;
+constexpr uint64_t kVopd3XOpcodeMask = 0x0000001F007B0FF9ULL;
+constexpr uint64_t kVopd3YOpcodeMask = 0x0000000001FF0FF9ULL;
+
+bool is_valid_opcode(uint16_t opcode, uint64_t mask) {
+  return opcode < 64 && (mask & (1ULL << opcode));
+}
+
 Operand make_src0(uint32_t bits, bool vopd3, bool use_literal, uint32_t literal, uint16_t encoded) {
   if (use_literal && encoded == 255)
     return Operand(bits, OperandType::OPR_SIMM32, static_cast<int>(literal));
@@ -144,6 +153,10 @@ Vopd::Vopd(const MachineInst *inst)
     word2_ = words[2];
     opx_ = static_cast<uint16_t>((word0_ >> 18) & 0x3F);
     opy_ = static_cast<uint16_t>((word0_ >> 12) & 0x3F);
+    if (!is_valid_opcode(opx_, kVopd3XOpcodeMask))
+      throw util::InvalidInst("invalid VOPD3 X opcode", "");
+    if (!is_valid_opcode(opy_, kVopd3YOpcodeMask))
+      throw util::InvalidInst("invalid VOPD3 Y opcode", "");
     uint16_t srcx0 = static_cast<uint16_t>(word0_ & 0x1FF);
     uint16_t srcy0 = static_cast<uint16_t>(word1_ & 0x1FF);
     negx_ = static_cast<uint8_t>((word1_ >> 9) & 0x7);
@@ -157,6 +170,10 @@ Vopd::Vopd(const MachineInst *inst)
 
     uint32_t x_bits = is_float64_op(opx_) ? 64 : 32;
     uint32_t y_bits = is_float64_op(opy_) ? 64 : 32;
+    const uint32_t x_end = vdstx + x_bits / 32;
+    const uint32_t y_end = vdsty + y_bits / 32;
+    if (vdstx < y_end && vdsty < x_end)
+      throw util::InvalidInst("VOPD3 destination ranges overlap", "");
     dstx_ = Operand(x_bits, OperandType::OPR_VGPR, vdstx);
     dsty_ = Operand(y_bits, OperandType::OPR_VGPR, vdsty);
     srcx0_ = make_src0(x_bits, true, false, 0, srcx0);
@@ -172,6 +189,10 @@ Vopd::Vopd(const MachineInst *inst)
     encoding_id_ = 0x32;
     opx_ = static_cast<uint16_t>((word0_ >> 22) & 0xF);
     opy_ = static_cast<uint16_t>((word0_ >> 17) & 0x1F);
+    if (!is_valid_opcode(opx_, kVopdXOpcodeMask))
+      throw util::InvalidInst("invalid VOPD X opcode", "");
+    if (!is_valid_opcode(opy_, kVopdYOpcodeMask))
+      throw util::InvalidInst("invalid VOPD Y opcode", "");
     uint16_t srcx0 = static_cast<uint16_t>(word0_ & 0x1FF);
     uint16_t vsrcx1 = static_cast<uint16_t>((word0_ >> 9) & 0xFF);
     uint16_t srcy0 = static_cast<uint16_t>(word1_ & 0x1FF);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/vopd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/vopd.cpp
@@ -37,6 +37,13 @@ constexpr uint16_t kVopdAddNcU32 = 16;
 constexpr uint16_t kVopdLshlrevB32 = 17;
 constexpr uint16_t kVopdAndB32 = 18;
 
+constexpr uint64_t kVopdXOpcodeMask = 0x0000000000003FFFULL;
+constexpr uint64_t kVopdYOpcodeMask = 0x0000000000073FFFULL;
+
+bool is_valid_opcode(uint16_t opcode, uint64_t mask) {
+  return opcode < 64 && (mask & (1ULL << opcode));
+}
+
 Operand make_src0(uint32_t bits, [[maybe_unused]] bool vopd3, bool use_literal, uint32_t literal,
                   uint16_t encoded) {
   if (use_literal && encoded == 255)
@@ -215,6 +222,10 @@ Vopd::Vopd(const MachineInst *inst)
   encoding_id_ = 0x32;
   opx_ = static_cast<uint16_t>((word0_ >> 22) & 0xF);
   opy_ = static_cast<uint16_t>((word0_ >> 17) & 0x1F);
+  if (!is_valid_opcode(opx_, kVopdXOpcodeMask))
+    throw util::InvalidInst("invalid VOPD X opcode", "");
+  if (!is_valid_opcode(opy_, kVopdYOpcodeMask))
+    throw util::InvalidInst("invalid VOPD Y opcode", "");
   uint16_t srcx0 = static_cast<uint16_t>(word0_ & 0x1FF);
   uint16_t vsrcx1 = static_cast<uint16_t>((word0_ >> 9) & 0xFF);
   uint16_t srcy0 = static_cast<uint16_t>(word1_ & 0x1FF);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vopd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vopd.cpp
@@ -37,6 +37,13 @@ constexpr uint16_t kVopdAddNcU32 = 16;
 constexpr uint16_t kVopdLshlrevB32 = 17;
 constexpr uint16_t kVopdAndB32 = 18;
 
+constexpr uint64_t kVopdXOpcodeMask = 0x0000000000003FFFULL;
+constexpr uint64_t kVopdYOpcodeMask = 0x0000000000073FFFULL;
+
+bool is_valid_opcode(uint16_t opcode, uint64_t mask) {
+  return opcode < 64 && (mask & (1ULL << opcode));
+}
+
 Operand make_src0(uint32_t bits, [[maybe_unused]] bool vopd3, bool use_literal, uint32_t literal,
                   uint16_t encoded) {
   if (use_literal && encoded == 255)
@@ -215,6 +222,10 @@ Vopd::Vopd(const MachineInst *inst)
   encoding_id_ = 0x32;
   opx_ = static_cast<uint16_t>((word0_ >> 22) & 0xF);
   opy_ = static_cast<uint16_t>((word0_ >> 17) & 0x1F);
+  if (!is_valid_opcode(opx_, kVopdXOpcodeMask))
+    throw util::InvalidInst("invalid VOPD X opcode", "");
+  if (!is_valid_opcode(opy_, kVopdYOpcodeMask))
+    throw util::InvalidInst("invalid VOPD Y opcode", "");
   uint16_t srcx0 = static_cast<uint16_t>(word0_ & 0x1FF);
   uint16_t vsrcx1 = static_cast<uint16_t>((word0_ >> 9) & 0xFF);
   uint16_t srcy0 = static_cast<uint16_t>(word1_ & 0x1FF);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vopd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vopd.cpp
@@ -37,6 +37,13 @@ constexpr uint16_t kVopdAddNcU32 = 16;
 constexpr uint16_t kVopdLshlrevB32 = 17;
 constexpr uint16_t kVopdAndB32 = 18;
 
+constexpr uint64_t kVopdXOpcodeMask = 0x0000000000003FFFULL;
+constexpr uint64_t kVopdYOpcodeMask = 0x0000000000073FFFULL;
+
+bool is_valid_opcode(uint16_t opcode, uint64_t mask) {
+  return opcode < 64 && (mask & (1ULL << opcode));
+}
+
 Operand make_src0(uint32_t bits, [[maybe_unused]] bool vopd3, bool use_literal, uint32_t literal,
                   uint16_t encoded) {
   if (use_literal && encoded == 255)
@@ -215,6 +222,10 @@ Vopd::Vopd(const MachineInst *inst)
   encoding_id_ = 0x32;
   opx_ = static_cast<uint16_t>((word0_ >> 22) & 0xF);
   opy_ = static_cast<uint16_t>((word0_ >> 17) & 0x1F);
+  if (!is_valid_opcode(opx_, kVopdXOpcodeMask))
+    throw util::InvalidInst("invalid VOPD X opcode", "");
+  if (!is_valid_opcode(opy_, kVopdYOpcodeMask))
+    throw util::InvalidInst("invalid VOPD Y opcode", "");
   uint16_t srcx0 = static_cast<uint16_t>(word0_ & 0x1FF);
   uint16_t vsrcx1 = static_cast<uint16_t>((word0_ >> 9) & 0xFF);
   uint16_t srcy0 = static_cast<uint16_t>(word1_ & 0x1FF);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/rj_decode.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/rj_decode.cpp
@@ -69,6 +69,7 @@ rj_status_t rj_code_decoder_decode(rj_code_decoder_t *decoder,
   if (!decoder || !decoder->decoder || !binary_inst || !inst)
     return ROCJITSU_STATUS_INVALID_ARGUMENT;
 
+  *inst = nullptr;
   Instruction *decoded = nullptr;
   try {
     decoded = decoder->decoder->decode(binary_inst);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/rj_decode.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/rj_decode.cpp
@@ -7,6 +7,7 @@
 #include "rocjitsu/isa/instruction.h"
 #include "rocjitsu/isa/target_registry.h"
 #include "rocjitsu/refcount.h"
+#include "util/except.h"
 
 #include <memory>
 
@@ -68,7 +69,12 @@ rj_status_t rj_code_decoder_decode(rj_code_decoder_t *decoder,
   if (!decoder || !decoder->decoder || !binary_inst || !inst)
     return ROCJITSU_STATUS_INVALID_ARGUMENT;
 
-  auto decoded = decoder->decoder->decode(binary_inst);
+  Instruction *decoded = nullptr;
+  try {
+    decoded = decoder->decoder->decode(binary_inst);
+  } catch (const util::InvalidInst &) {
+    return ROCJITSU_STATUS_ERROR;
+  }
   if (!decoded)
     return ROCJITSU_STATUS_ERROR;
 

--- a/emulation/rocjitsu/tests/decode_smoke_test.cpp
+++ b/emulation/rocjitsu/tests/decode_smoke_test.cpp
@@ -629,6 +629,49 @@ INSTANTIATE_TEST_SUITE_P(
       return name;
     });
 
+struct InvalidVopdSlotCase {
+  rj_code_arch_t arch;
+  const char *arch_name;
+  const char *case_name;
+  std::array<uint32_t, 3> words;
+};
+
+class InvalidVopdSlotDecodeTest : public ::testing::TestWithParam<InvalidVopdSlotCase> {};
+
+TEST_P(InvalidVopdSlotDecodeTest, RejectsOpcodeOutsideProfileSlot) {
+  const auto &tc = GetParam();
+  auto decoder = Decoder::create(tc.arch);
+  ASSERT_NE(decoder, nullptr) << tc.arch_name;
+
+  EXPECT_THROW(static_cast<void>(decoder->decode(tc.words.data())), util::InvalidInst)
+      << tc.arch_name << " " << tc.case_name;
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    VopdSlotValidation, InvalidVopdSlotDecodeTest,
+    ::testing::Values(InvalidVopdSlotCase{ROCJITSU_CODE_ARCH_RDNA3, "rdna3", "invalid_x",
+                                          make_vopdxy_pair(14, 8)},
+                      InvalidVopdSlotCase{ROCJITSU_CODE_ARCH_RDNA3, "rdna3", "invalid_y",
+                                          make_vopdxy_pair(8, 14)},
+                      InvalidVopdSlotCase{ROCJITSU_CODE_ARCH_RDNA3_5, "rdna3_5", "invalid_x",
+                                          make_vopdxy_pair(14, 8)},
+                      InvalidVopdSlotCase{ROCJITSU_CODE_ARCH_RDNA3_5, "rdna3_5", "invalid_y",
+                                          make_vopdxy_pair(8, 14)},
+                      InvalidVopdSlotCase{ROCJITSU_CODE_ARCH_RDNA4, "rdna4", "invalid_x",
+                                          make_vopdxy_pair(14, 8)},
+                      InvalidVopdSlotCase{ROCJITSU_CODE_ARCH_RDNA4, "rdna4", "invalid_y",
+                                          make_vopdxy_pair(8, 14)},
+                      InvalidVopdSlotCase{ROCJITSU_CODE_ARCH_GFX1250, "gfx1250", "invalid_x",
+                                          make_vopdxy_pair(12, 8)},
+                      InvalidVopdSlotCase{ROCJITSU_CODE_ARCH_GFX1250, "gfx1250",
+                                          "invalid_y_defined_opcode", make_vopdxy_pair(8, 18)}),
+    [](const ::testing::TestParamInfo<InvalidVopdSlotCase> &info) {
+      std::string name = info.param.arch_name;
+      name += "_";
+      name += info.param.case_name;
+      return name;
+    });
+
 struct InvalidVopdDecodeCase {
   rj_code_arch_t arch;
   const char *arch_name;

--- a/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
+++ b/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
@@ -4595,7 +4595,7 @@ TEST(Gfx1250DecodeTest, PublicDecoderReportsInvalidVopdEncoding) {
   ASSERT_EQ(rj_code_decoder_create(ROCJITSU_CODE_ARCH_GFX1250, &decoder), ROCJITSU_STATUS_SUCCESS);
   ASSERT_NE(decoder, nullptr);
 
-  rj_code_inst_t *inst = nullptr;
+  auto *inst = reinterpret_cast<rj_code_inst_t *>(static_cast<uintptr_t>(1));
   EXPECT_EQ(rj_code_decoder_decode(decoder, words, &inst), ROCJITSU_STATUS_ERROR);
   EXPECT_EQ(inst, nullptr);
   rj_code_decoder_destroy(decoder);

--- a/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
+++ b/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
@@ -502,6 +502,7 @@ enum class VopdOp : uint16_t {
   MovB32 = 8,
   CndmaskB32 = 9,
   FmaF32 = 19,
+  FmaF64 = 32,
 };
 
 struct VopdSlot {
@@ -4568,6 +4569,50 @@ TEST(Gfx1250DecodeTest, VopdSourceOperandsFollowPrintedSlots) {
   EXPECT_EQ(inst->src_operand(2)->name(), "s11");
   ASSERT_TRUE(inst->src_operand(2)->to_register_ref().has_value());
   EXPECT_EQ(*inst->src_operand(2)->to_register_ref(), (RegisterRef{RegClass::SGPR, 11, 1}));
+}
+
+TEST(Gfx1250DecodeTest, VopdRejectsInvalidOpcodes) {
+  const std::array<std::array<uint32_t, 3>, 2> words = {{
+      // Opcode 18 is valid in the Y slot, but not the X slot.
+      {0xCF000000u | (18u << 18) | (3u << 12), 0, 0},
+      // Opcode 32 is valid in the X slot, but not the Y slot.
+      {0xCF000000u | (3u << 18) | (32u << 12), 0, 0},
+  }};
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  for (const auto &encoding : words)
+    EXPECT_THROW(static_cast<void>(decoder->decode(encoding.data())), util::InvalidInst);
+}
+
+TEST(Gfx1250DecodeTest, PublicDecoderReportsInvalidVopdEncoding) {
+  const uint32_t words[] = {
+      (0x32u << 26) | (12u << 22) | (8u << 17), // Opcode 12 is not an X op.
+      0,
+  };
+
+  rj_code_decoder_t *decoder = nullptr;
+  ASSERT_EQ(rj_code_decoder_create(ROCJITSU_CODE_ARCH_GFX1250, &decoder), ROCJITSU_STATUS_SUCCESS);
+  ASSERT_NE(decoder, nullptr);
+
+  rj_code_inst_t *inst = nullptr;
+  EXPECT_EQ(rj_code_decoder_decode(decoder, words, &inst), ROCJITSU_STATUS_ERROR);
+  EXPECT_EQ(inst, nullptr);
+  rj_code_decoder_destroy(decoder);
+}
+
+TEST(Gfx1250DecodeTest, Vopd3RejectsOverlappingDestinations) {
+  const std::array<std::array<uint32_t, 3>, 2> words = {{
+      make_vopd3_pair({.op = VopdOp::CndmaskB32, .src0 = 0, .src1 = 1, .src2 = 2, .dst = 10},
+                      {.op = VopdOp::MulF32, .src0 = 0, .src1 = 1, .src2 = 2, .dst = 10}),
+      make_vopd3_pair({.op = VopdOp::FmaF64, .src0 = 0, .src1 = 1, .src2 = 2, .dst = 10},
+                      {.op = VopdOp::MulF32, .src0 = 0, .src1 = 1, .src2 = 2, .dst = 11}),
+  }};
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  for (const auto &encoding : words)
+    EXPECT_THROW(static_cast<void>(decoder->decode(encoding.data())), util::InvalidInst);
 }
 
 TEST(Gfx1250SimulationTest, DispatchesEndpgmThroughConfig) {


### PR DESCRIPTION
Use the exact per-profile X and Y opcode tables for VOPD and VOPD3, rejecting undefined or slot-incompatible opcodes before operand construction. Also reject overlapping VOPD3 destination ranges, including partial overlap with 64-bit results.

Regenerate the affected decoders and add gfx1250 coverage for invalid slot opcodes and destination overlap.