### PR TITLE
[rocjitsu][decoder] Render DPP8 decode attributes

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -2472,6 +2472,13 @@ class CodeGenerator:
                     )
                 else:
                     modifier_lines += f'if ({field_ref}) modifiers_ += "{mod.display}";'
+            dpp8_modifier_line = ''
+            if dpp8_struct is not None:
+                dpp8_modifier_line = (
+                    'if (amdgpu::dpp::is_src_dpp8(inst_.src0)) '
+                    'amdgpu::dpp::append_dpp8_disassembly('
+                    'out, dpp8_lane_sel_, dpp_fi_);'
+                )
 
             has_op = any(f.name == 'op' for f in inst_enc.ucode_fields)
             size_line = (
@@ -2613,19 +2620,24 @@ class CodeGenerator:
             # that have modifier flags (memory instructions). This is
             # called lazily by disassemble() instead of eagerly in the
             # constructor, avoiding string allocation on the hot path.
-            if modifier_lines:
+            if modifier_lines or dpp8_modifier_line:
                 public_members.append(
                     cgen.Line('void build_modifiers(std::string &out) const override;'),
                 )
                 # The modifier_lines were written for the constructor where
                 # they appended to modifiers_ and accessed inst->field.
                 # Rewrite to append to 'out' and access via local pointer.
-                mod_impl = modifier_lines.replace('modifiers_', 'out')
+                mod_impl = (
+                    modifier_lines.replace('modifiers_', 'out') + dpp8_modifier_line
+                )
+                mod_prologue = (
+                    ' auto *inst = &inst_;(void)inst;' if modifier_lines else ''
+                )
                 class_func_impls.append(
                     cgen.Line(
                         f'void {inst_enc.fmt_enc_name}::build_modifiers'
                         f'(std::string &out) const '
-                        f'{{ auto *inst = &inst_;(void)inst;'
+                        f'{{{mod_prologue}'
                         f'{mod_impl}}}'
                     )
                 )
@@ -7458,6 +7470,27 @@ class CodeGenerator:
                     # so the encoding base gets a string_view to static storage.
                     rule = self.isa_spec.profile.mnemonic_rule(enc.enc_name)
                     full_mnemonic = inst.mnemonic + (rule.suffix or '')
+                    mnemonic_expr = f'"{full_mnemonic}"'
+                    _, dpp8_struct = self._vop_dpp_struct_names(enc.enc_name)
+                    if dpp8_struct is not None:
+                        compact_encoding = enc.enc_name.upper() in (
+                            'ENC_VOP1',
+                            'ENC_VOP2',
+                            'ENC_VOPC',
+                        )
+                        if compact_encoding:
+                            assert full_mnemonic.endswith('_e32'), (
+                                f'{inst.name}: compact DPP8 mnemonic does not end in _e32: '
+                                f'{full_mnemonic}'
+                            )
+                            dpp8_mnemonic = full_mnemonic[:-4] + '_dpp'
+                        else:
+                            dpp8_mnemonic = full_mnemonic + '_e64_dpp'
+                        mnemonic_expr = (
+                            'amdgpu::dpp::is_src_dpp8('
+                            'reinterpret_cast<const OpEncoding*>(inst)->src0) ? '
+                            f'"{dpp8_mnemonic}" : "{full_mnemonic}"'
+                        )
                     exec_fn_expr = f'make_exec_fn<{inst.fmt_name}>()'
                     if profile.split_execution_sources:
                         exec_fn_expr = self._split_execute_expr(inst.fmt_name)
@@ -7490,7 +7523,7 @@ class CodeGenerator:
                                 f', {len(active_selector_fields)}'
                             )
                     init_list_parts = [
-                        f'{inst.fmt_true_enc_name}("{full_mnemonic}", '
+                        f'{inst.fmt_true_enc_name}({mnemonic_expr}, '
                         f'reinterpret_cast<const OpEncoding*>(inst), '
                         f'{exec_fn_expr}{encoded_source_count_arg})'
                     ] + opnd_ctor_init

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
@@ -2153,6 +2153,35 @@ def test_gfx1250_generated_vop3_add_f16_applies_dpp(
     assert 'src0.clear_delegate();' not in body
 
 
+def test_generated_dpp8_disassembly_uses_encoding_state(
+    amdgpu_generated_root: Path,
+) -> None:
+    for arch in ('rdna1', 'rdna2', 'rdna3', 'rdna3_5', 'rdna4', 'gfx1250'):
+        encodings_cpp = (amdgpu_generated_root / arch / 'encodings.cpp').read_text()
+        encodings_h = (amdgpu_generated_root / arch / 'encodings.h').read_text()
+        generated_cpp = '\n'.join(
+            path.read_text() for path in (amdgpu_generated_root / arch).glob('*.cpp')
+        )
+
+        vop1_modifiers = encodings_cpp[
+            encodings_cpp.index('void Vop1::build_modifiers') :
+        ]
+        vop1_modifiers = vop1_modifiers[: vop1_modifiers.index('\n\n')]
+
+        assert 'append_dpp8_disassembly' in encodings_cpp
+        assert 'auto *inst = &inst_;' not in vop1_modifiers
+        for class_name in ('Vop1', 'Vop2', 'Vopc', 'Vop3', 'Vop3p', 'Vop3SdstEnc'):
+            class_match = re.search(
+                rf'class {class_name}\b.*?\n}};', encodings_h, flags=re.DOTALL
+            )
+            assert class_match is not None
+            assert 'owned_mnemonic_' not in class_match.group()
+        assert 'dpp8_mnemonic' not in generated_cpp
+        assert re.search(r'\? "v_add_f16_dpp"\s*: "v_add_f16_e32"', generated_cpp)
+        if arch not in ('rdna1', 'rdna2'):
+            assert re.search(r'"v_rcp_f16_e64_dpp"\s*: "v_rcp_f16"', generated_cpp)
+
+
 def test_generated_sdwa_uses_shared_source_staging(
     amdgpu_generated_root: Path,
 ) -> None:

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/gfx1250/encodings.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/gfx1250/encodings.cpp
@@ -183,6 +183,11 @@ Vop1::Vop1(std::string_view mnemonic, const Vop1MachineInst *inst, ExecuteFn exe
   raw_encoding_ = raw_words_.data();
 }
 
+void Vop1::build_modifiers(std::string &out) const {
+  if (amdgpu::dpp::is_src_dpp8(inst_.src0))
+    amdgpu::dpp::append_dpp8_disassembly(out, dpp8_lane_sel_, dpp_fi_);
+}
+
 void Vop1::implicit_uses(RegisterSet &uses) const {
   bool sdwa_preserve =
       sdwa_dst_sel_ != amdgpu::sdwa::DWORD && sdwa_dst_unused_ == amdgpu::sdwa::UNUSED_PRESERVE;
@@ -238,6 +243,11 @@ Vopc::Vopc(std::string_view mnemonic, const VopcMachineInst *inst, ExecuteFn exe
   raw_encoding_ = raw_words_.data();
 }
 
+void Vopc::build_modifiers(std::string &out) const {
+  if (amdgpu::dpp::is_src_dpp8(inst_.src0))
+    amdgpu::dpp::append_dpp8_disassembly(out, dpp8_lane_sel_, dpp_fi_);
+}
+
 bool Vopc::default_encoding() {
   return (inst_.src0 != 250 && inst_.src0 != 233 && inst_.src0 != 234 && inst_.src0 != 255 &&
           inst_.src0 != 254);
@@ -267,6 +277,11 @@ Vop2::Vop2(std::string_view mnemonic, const Vop2MachineInst *inst, ExecuteFn exe
     literal_ = reinterpret_cast<const uint32_t *>(inst)[1];
   std::memcpy(raw_words_.data(), inst, size_);
   raw_encoding_ = raw_words_.data();
+}
+
+void Vop2::build_modifiers(std::string &out) const {
+  if (amdgpu::dpp::is_src_dpp8(inst_.src0))
+    amdgpu::dpp::append_dpp8_disassembly(out, dpp8_lane_sel_, dpp_fi_);
 }
 
 void Vop2::implicit_uses(RegisterSet &uses) const {
@@ -341,6 +356,11 @@ Vop3::Vop3(std::string_view mnemonic, const Vop3MachineInst *inst, ExecuteFn exe
     size_ += sizeof(MachineInst);
   std::memcpy(raw_words_.data(), inst, size_);
   raw_encoding_ = raw_words_.data();
+}
+
+void Vop3::build_modifiers(std::string &out) const {
+  if (amdgpu::dpp::is_src_dpp8(inst_.src0))
+    amdgpu::dpp::append_dpp8_disassembly(out, dpp8_lane_sel_, dpp_fi_);
 }
 
 void Vop3::implicit_uses(RegisterSet &uses) const {
@@ -430,6 +450,11 @@ Vop3p::Vop3p(std::string_view mnemonic, const Vop3pMachineInst *inst, ExecuteFn 
     std::memcpy(raw_words_.data(), inst, size_);
     raw_encoding_ = raw_words_.data();
   }
+}
+
+void Vop3p::build_modifiers(std::string &out) const {
+  if (amdgpu::dpp::is_src_dpp8(inst_.src0))
+    amdgpu::dpp::append_dpp8_disassembly(out, dpp8_lane_sel_, dpp_fi_);
 }
 
 void Vop3p::implicit_uses(RegisterSet &uses) const {
@@ -595,6 +620,11 @@ Vop3SdstEnc::Vop3SdstEnc(std::string_view mnemonic, const Vop3SdstEncMachineInst
     size_ += sizeof(MachineInst);
   std::memcpy(raw_words_.data(), inst, size_);
   raw_encoding_ = raw_words_.data();
+}
+
+void Vop3SdstEnc::build_modifiers(std::string &out) const {
+  if (amdgpu::dpp::is_src_dpp8(inst_.src0))
+    amdgpu::dpp::append_dpp8_disassembly(out, dpp8_lane_sel_, dpp_fi_);
 }
 
 void Vop3SdstEnc::implicit_uses(RegisterSet &uses) const {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/gfx1250/encodings.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/gfx1250/encodings.h
@@ -438,6 +438,7 @@ public:
 class Vop1 : public IsaInstruction<Isa> {
 public:
   Vop1(std::string_view mnemonic, const Vop1MachineInst *inst, ExecuteFn exec_fn);
+  void build_modifiers(std::string &out) const override;
   void implicit_uses(RegisterSet &uses) const override;
   void implicit_use_operands(std::vector<const ::rocjitsu::Operand *> &operands) const override;
   bool default_encoding();
@@ -472,6 +473,7 @@ public:
 class Vopc : public IsaInstruction<Isa> {
 public:
   Vopc(std::string_view mnemonic, const VopcMachineInst *inst, ExecuteFn exec_fn);
+  void build_modifiers(std::string &out) const override;
   bool default_encoding();
   bool has_lit();
   bool has_lit64();
@@ -503,6 +505,7 @@ public:
 class Vop2 : public IsaInstruction<Isa> {
 public:
   Vop2(std::string_view mnemonic, const Vop2MachineInst *inst, ExecuteFn exec_fn);
+  void build_modifiers(std::string &out) const override;
   void implicit_uses(RegisterSet &uses) const override;
   void implicit_use_operands(std::vector<const ::rocjitsu::Operand *> &operands) const override;
   bool default_encoding();
@@ -541,6 +544,7 @@ public:
 class Vop3 : public IsaInstruction<Isa> {
 public:
   Vop3(std::string_view mnemonic, const Vop3MachineInst *inst, ExecuteFn exec_fn);
+  void build_modifiers(std::string &out) const override;
   void implicit_uses(RegisterSet &uses) const override;
   void implicit_use_operands(std::vector<const ::rocjitsu::Operand *> &operands) const override;
   bool has_lit_0();
@@ -571,6 +575,7 @@ public:
   Vop3p(std::string_view mnemonic, const Vop3pMachineInst *inst, ExecuteFn exec_fn,
         int num_encoded_sources = 3,
         ExtensionDecodePolicy extension_policy = ExtensionDecodePolicy::Decode);
+  void build_modifiers(std::string &out) const override;
   void implicit_uses(RegisterSet &uses) const override;
   void implicit_use_operands(std::vector<const ::rocjitsu::Operand *> &operands) const override;
   bool has_lit_0();
@@ -644,6 +649,7 @@ public:
 class Vop3SdstEnc : public IsaInstruction<Isa> {
 public:
   Vop3SdstEnc(std::string_view mnemonic, const Vop3SdstEncMachineInst *inst, ExecuteFn exec_fn);
+  void build_modifiers(std::string &out) const override;
   void implicit_uses(RegisterSet &uses) const override;
   void implicit_use_operands(std::vector<const ::rocjitsu::Operand *> &operands) const override;
   bool has_lit_0();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/gfx1250/vop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/gfx1250/vop1.cpp
@@ -12,13 +12,18 @@ namespace rocjitsu {
 namespace gfx1250 {
 
 VNopVop1::VNopVop1(const MachineInst *inst)
-    : Vop1("v_nop_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(291)) {
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0) ? "v_nop_dpp"
+                                                                                      : "v_nop_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(291)) {
   num_src_ = 0;
   num_dst_ = 0;
 }
 
 VMovB32Vop1::VMovB32Vop1(const MachineInst *inst)
-    : Vop1("v_mov_b32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(292)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mov_b32_dpp"
+               : "v_mov_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(292)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -58,8 +63,10 @@ VMovB32Vop1::VMovB32Vop1(const MachineInst *inst)
 }
 
 VReadfirstlaneB32Vop1::VReadfirstlaneB32Vop1(const MachineInst *inst)
-    : Vop1("v_readfirstlane_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(293)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_readfirstlane_b32_dpp"
+               : "v_readfirstlane_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(293)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -84,7 +91,10 @@ VReadfirstlaneB32Vop1::VReadfirstlaneB32Vop1(const MachineInst *inst)
 }
 
 VCvtI32F64Vop1::VCvtI32F64Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_i32_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(294)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_i32_f64_dpp"
+               : "v_cvt_i32_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(294)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -119,7 +129,10 @@ VCvtI32F64Vop1::VCvtI32F64Vop1(const MachineInst *inst)
 }
 
 VCvtF64I32Vop1::VCvtF64I32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f64_i32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(295)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f64_i32_dpp"
+               : "v_cvt_f64_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(295)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -153,7 +166,10 @@ VCvtF64I32Vop1::VCvtF64I32Vop1(const MachineInst *inst)
 }
 
 VCvtF32I32Vop1::VCvtF32I32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_i32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(296)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_i32_dpp"
+               : "v_cvt_f32_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(296)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -193,7 +209,10 @@ VCvtF32I32Vop1::VCvtF32I32Vop1(const MachineInst *inst)
 }
 
 VCvtF32U32Vop1::VCvtF32U32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_u32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(297)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_u32_dpp"
+               : "v_cvt_f32_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(297)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -233,7 +252,10 @@ VCvtF32U32Vop1::VCvtF32U32Vop1(const MachineInst *inst)
 }
 
 VCvtU32F32Vop1::VCvtU32F32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_u32_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(298)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_u32_f32_dpp"
+               : "v_cvt_u32_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(298)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -273,7 +295,10 @@ VCvtU32F32Vop1::VCvtU32F32Vop1(const MachineInst *inst)
 }
 
 VCvtI32F32Vop1::VCvtI32F32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_i32_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(299)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_i32_f32_dpp"
+               : "v_cvt_i32_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(299)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -313,7 +338,10 @@ VCvtI32F32Vop1::VCvtI32F32Vop1(const MachineInst *inst)
 }
 
 VCvtF16F32Vop1::VCvtF16F32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f16_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(300)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f16_f32_dpp"
+               : "v_cvt_f16_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(300)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -368,7 +396,10 @@ void VCvtF16F32Vop1::implicit_use_operands(
 }
 
 VCvtF32F16Vop1::VCvtF32F16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(301)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_f16_dpp"
+               : "v_cvt_f32_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(301)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true) {
@@ -410,8 +441,10 @@ VCvtF32F16Vop1::VCvtF32F16Vop1(const MachineInst *inst)
 }
 
 VCvtNearestI32F32Vop1::VCvtNearestI32F32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_nearest_i32_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(302)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_nearest_i32_f32_dpp"
+               : "v_cvt_nearest_i32_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(302)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -451,8 +484,10 @@ VCvtNearestI32F32Vop1::VCvtNearestI32F32Vop1(const MachineInst *inst)
 }
 
 VCvtFloorI32F32Vop1::VCvtFloorI32F32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_floor_i32_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(303)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_floor_i32_f32_dpp"
+               : "v_cvt_floor_i32_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(303)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -492,8 +527,10 @@ VCvtFloorI32F32Vop1::VCvtFloorI32F32Vop1(const MachineInst *inst)
 }
 
 VCvtOffF32I4Vop1::VCvtOffF32I4Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_off_f32_i4_e32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(304)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_off_f32_i4_dpp"
+               : "v_cvt_off_f32_i4_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(304)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -533,7 +570,10 @@ VCvtOffF32I4Vop1::VCvtOffF32I4Vop1(const MachineInst *inst)
 }
 
 VCvtF32F64Vop1::VCvtF32F64Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(305)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_f64_dpp"
+               : "v_cvt_f32_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(305)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -568,7 +608,10 @@ VCvtF32F64Vop1::VCvtF32F64Vop1(const MachineInst *inst)
 }
 
 VCvtF64F32Vop1::VCvtF64F32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f64_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(306)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f64_f32_dpp"
+               : "v_cvt_f64_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(306)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -602,8 +645,10 @@ VCvtF64F32Vop1::VCvtF64F32Vop1(const MachineInst *inst)
 }
 
 VCvtF32Ubyte0Vop1::VCvtF32Ubyte0Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_ubyte0_e32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(307)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_ubyte0_dpp"
+               : "v_cvt_f32_ubyte0_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(307)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -643,8 +688,10 @@ VCvtF32Ubyte0Vop1::VCvtF32Ubyte0Vop1(const MachineInst *inst)
 }
 
 VCvtF32Ubyte1Vop1::VCvtF32Ubyte1Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_ubyte1_e32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(308)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_ubyte1_dpp"
+               : "v_cvt_f32_ubyte1_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(308)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -684,8 +731,10 @@ VCvtF32Ubyte1Vop1::VCvtF32Ubyte1Vop1(const MachineInst *inst)
 }
 
 VCvtF32Ubyte2Vop1::VCvtF32Ubyte2Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_ubyte2_e32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(309)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_ubyte2_dpp"
+               : "v_cvt_f32_ubyte2_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(309)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -725,8 +774,10 @@ VCvtF32Ubyte2Vop1::VCvtF32Ubyte2Vop1(const MachineInst *inst)
 }
 
 VCvtF32Ubyte3Vop1::VCvtF32Ubyte3Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_ubyte3_e32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(310)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_ubyte3_dpp"
+               : "v_cvt_f32_ubyte3_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(310)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -766,7 +817,10 @@ VCvtF32Ubyte3Vop1::VCvtF32Ubyte3Vop1(const MachineInst *inst)
 }
 
 VCvtU32F64Vop1::VCvtU32F64Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_u32_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(311)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_u32_f64_dpp"
+               : "v_cvt_u32_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(311)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -801,7 +855,10 @@ VCvtU32F64Vop1::VCvtU32F64Vop1(const MachineInst *inst)
 }
 
 VCvtF64U32Vop1::VCvtF64U32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f64_u32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(312)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f64_u32_dpp"
+               : "v_cvt_f64_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(312)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -835,7 +892,10 @@ VCvtF64U32Vop1::VCvtF64U32Vop1(const MachineInst *inst)
 }
 
 VTruncF64Vop1::VTruncF64Vop1(const MachineInst *inst)
-    : Vop1("v_trunc_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(313)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_trunc_f64_dpp"
+               : "v_trunc_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(313)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -870,7 +930,10 @@ VTruncF64Vop1::VTruncF64Vop1(const MachineInst *inst)
 }
 
 VCeilF64Vop1::VCeilF64Vop1(const MachineInst *inst)
-    : Vop1("v_ceil_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(314)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ceil_f64_dpp"
+               : "v_ceil_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(314)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -905,7 +968,10 @@ VCeilF64Vop1::VCeilF64Vop1(const MachineInst *inst)
 }
 
 VRndneF64Vop1::VRndneF64Vop1(const MachineInst *inst)
-    : Vop1("v_rndne_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(315)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rndne_f64_dpp"
+               : "v_rndne_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(315)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -940,7 +1006,10 @@ VRndneF64Vop1::VRndneF64Vop1(const MachineInst *inst)
 }
 
 VFloorF64Vop1::VFloorF64Vop1(const MachineInst *inst)
-    : Vop1("v_floor_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(316)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_floor_f64_dpp"
+               : "v_floor_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(316)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -975,13 +1044,19 @@ VFloorF64Vop1::VFloorF64Vop1(const MachineInst *inst)
 }
 
 VPipeflushVop1::VPipeflushVop1(const MachineInst *inst)
-    : Vop1("v_pipeflush_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(317)) {
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_pipeflush_dpp"
+               : "v_pipeflush_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(317)) {
   num_src_ = 0;
   num_dst_ = 0;
 }
 
 VMovB16Vop1::VMovB16Vop1(const MachineInst *inst)
-    : Vop1("v_mov_b16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(318)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mov_b16_dpp"
+               : "v_mov_b16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(318)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -1037,7 +1112,10 @@ void VMovB16Vop1::implicit_use_operands(std::vector<const ::rocjitsu::Operand *>
 }
 
 VMovB64Vop1::VMovB64Vop1(const MachineInst *inst)
-    : Vop1("v_mov_b64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(319)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mov_b64_dpp"
+               : "v_mov_b64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(319)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1072,7 +1150,10 @@ VMovB64Vop1::VMovB64Vop1(const MachineInst *inst)
 }
 
 VTanhF32Vop1::VTanhF32Vop1(const MachineInst *inst)
-    : Vop1("v_tanh_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(320)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_tanh_f32_dpp"
+               : "v_tanh_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(320)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1112,7 +1193,10 @@ VTanhF32Vop1::VTanhF32Vop1(const MachineInst *inst)
 }
 
 VTanhF16Vop1::VTanhF16Vop1(const MachineInst *inst)
-    : Vop1("v_tanh_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(321)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_tanh_f16_dpp"
+               : "v_tanh_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(321)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -1168,7 +1252,10 @@ void VTanhF16Vop1::implicit_use_operands(std::vector<const ::rocjitsu::Operand *
 }
 
 VFractF32Vop1::VFractF32Vop1(const MachineInst *inst)
-    : Vop1("v_fract_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(322)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fract_f32_dpp"
+               : "v_fract_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(322)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1208,7 +1295,10 @@ VFractF32Vop1::VFractF32Vop1(const MachineInst *inst)
 }
 
 VTruncF32Vop1::VTruncF32Vop1(const MachineInst *inst)
-    : Vop1("v_trunc_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(323)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_trunc_f32_dpp"
+               : "v_trunc_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(323)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1248,7 +1338,10 @@ VTruncF32Vop1::VTruncF32Vop1(const MachineInst *inst)
 }
 
 VCeilF32Vop1::VCeilF32Vop1(const MachineInst *inst)
-    : Vop1("v_ceil_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(324)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ceil_f32_dpp"
+               : "v_ceil_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(324)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1288,7 +1381,10 @@ VCeilF32Vop1::VCeilF32Vop1(const MachineInst *inst)
 }
 
 VRndneF32Vop1::VRndneF32Vop1(const MachineInst *inst)
-    : Vop1("v_rndne_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(325)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rndne_f32_dpp"
+               : "v_rndne_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(325)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1328,7 +1424,10 @@ VRndneF32Vop1::VRndneF32Vop1(const MachineInst *inst)
 }
 
 VFloorF32Vop1::VFloorF32Vop1(const MachineInst *inst)
-    : Vop1("v_floor_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(326)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_floor_f32_dpp"
+               : "v_floor_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(326)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1368,7 +1467,10 @@ VFloorF32Vop1::VFloorF32Vop1(const MachineInst *inst)
 }
 
 VExpF32Vop1::VExpF32Vop1(const MachineInst *inst)
-    : Vop1("v_exp_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(327)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_exp_f32_dpp"
+               : "v_exp_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(327)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1408,7 +1510,10 @@ VExpF32Vop1::VExpF32Vop1(const MachineInst *inst)
 }
 
 VLogF32Vop1::VLogF32Vop1(const MachineInst *inst)
-    : Vop1("v_log_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(328)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_log_f32_dpp"
+               : "v_log_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(328)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1448,7 +1553,10 @@ VLogF32Vop1::VLogF32Vop1(const MachineInst *inst)
 }
 
 VRcpF32Vop1::VRcpF32Vop1(const MachineInst *inst)
-    : Vop1("v_rcp_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(329)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_f32_dpp"
+               : "v_rcp_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(329)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1488,8 +1596,10 @@ VRcpF32Vop1::VRcpF32Vop1(const MachineInst *inst)
 }
 
 VRcpIflagF32Vop1::VRcpIflagF32Vop1(const MachineInst *inst)
-    : Vop1("v_rcp_iflag_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(330)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_iflag_f32_dpp"
+               : "v_rcp_iflag_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(330)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1529,7 +1639,10 @@ VRcpIflagF32Vop1::VRcpIflagF32Vop1(const MachineInst *inst)
 }
 
 VRsqF32Vop1::VRsqF32Vop1(const MachineInst *inst)
-    : Vop1("v_rsq_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(331)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rsq_f32_dpp"
+               : "v_rsq_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(331)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1569,7 +1682,10 @@ VRsqF32Vop1::VRsqF32Vop1(const MachineInst *inst)
 }
 
 VRcpF64Vop1::VRcpF64Vop1(const MachineInst *inst)
-    : Vop1("v_rcp_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(332)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_f64_dpp"
+               : "v_rcp_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(332)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1596,7 +1712,10 @@ VRcpF64Vop1::VRcpF64Vop1(const MachineInst *inst)
 }
 
 VRsqF64Vop1::VRsqF64Vop1(const MachineInst *inst)
-    : Vop1("v_rsq_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(333)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rsq_f64_dpp"
+               : "v_rsq_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(333)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1623,7 +1742,10 @@ VRsqF64Vop1::VRsqF64Vop1(const MachineInst *inst)
 }
 
 VSqrtF32Vop1::VSqrtF32Vop1(const MachineInst *inst)
-    : Vop1("v_sqrt_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(334)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sqrt_f32_dpp"
+               : "v_sqrt_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(334)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1663,7 +1785,10 @@ VSqrtF32Vop1::VSqrtF32Vop1(const MachineInst *inst)
 }
 
 VSqrtF64Vop1::VSqrtF64Vop1(const MachineInst *inst)
-    : Vop1("v_sqrt_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(335)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sqrt_f64_dpp"
+               : "v_sqrt_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(335)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1690,7 +1815,10 @@ VSqrtF64Vop1::VSqrtF64Vop1(const MachineInst *inst)
 }
 
 VSinF32Vop1::VSinF32Vop1(const MachineInst *inst)
-    : Vop1("v_sin_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(336)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sin_f32_dpp"
+               : "v_sin_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(336)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1730,7 +1858,10 @@ VSinF32Vop1::VSinF32Vop1(const MachineInst *inst)
 }
 
 VCosF32Vop1::VCosF32Vop1(const MachineInst *inst)
-    : Vop1("v_cos_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(337)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cos_f32_dpp"
+               : "v_cos_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(337)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1770,7 +1901,10 @@ VCosF32Vop1::VCosF32Vop1(const MachineInst *inst)
 }
 
 VNotB32Vop1::VNotB32Vop1(const MachineInst *inst)
-    : Vop1("v_not_b32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(338)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_not_b32_dpp"
+               : "v_not_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(338)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1810,7 +1944,10 @@ VNotB32Vop1::VNotB32Vop1(const MachineInst *inst)
 }
 
 VBfrevB32Vop1::VBfrevB32Vop1(const MachineInst *inst)
-    : Vop1("v_bfrev_b32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(339)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_bfrev_b32_dpp"
+               : "v_bfrev_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(339)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1850,7 +1987,10 @@ VBfrevB32Vop1::VBfrevB32Vop1(const MachineInst *inst)
 }
 
 VClzI32U32Vop1::VClzI32U32Vop1(const MachineInst *inst)
-    : Vop1("v_clz_i32_u32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(340)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_clz_i32_u32_dpp"
+               : "v_clz_i32_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(340)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1890,7 +2030,10 @@ VClzI32U32Vop1::VClzI32U32Vop1(const MachineInst *inst)
 }
 
 VCtzI32B32Vop1::VCtzI32B32Vop1(const MachineInst *inst)
-    : Vop1("v_ctz_i32_b32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(341)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ctz_i32_b32_dpp"
+               : "v_ctz_i32_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(341)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1930,7 +2073,10 @@ VCtzI32B32Vop1::VCtzI32B32Vop1(const MachineInst *inst)
 }
 
 VClsI32Vop1::VClsI32Vop1(const MachineInst *inst)
-    : Vop1("v_cls_i32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(342)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cls_i32_dpp"
+               : "v_cls_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(342)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1970,8 +2116,10 @@ VClsI32Vop1::VClsI32Vop1(const MachineInst *inst)
 }
 
 VFrexpExpI32F64Vop1::VFrexpExpI32F64Vop1(const MachineInst *inst)
-    : Vop1("v_frexp_exp_i32_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(343)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_exp_i32_f64_dpp"
+               : "v_frexp_exp_i32_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(343)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2006,8 +2154,10 @@ VFrexpExpI32F64Vop1::VFrexpExpI32F64Vop1(const MachineInst *inst)
 }
 
 VFrexpMantF64Vop1::VFrexpMantF64Vop1(const MachineInst *inst)
-    : Vop1("v_frexp_mant_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(344)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_mant_f64_dpp"
+               : "v_frexp_mant_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(344)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2042,7 +2192,10 @@ VFrexpMantF64Vop1::VFrexpMantF64Vop1(const MachineInst *inst)
 }
 
 VFractF64Vop1::VFractF64Vop1(const MachineInst *inst)
-    : Vop1("v_fract_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(345)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fract_f64_dpp"
+               : "v_fract_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(345)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2077,8 +2230,10 @@ VFractF64Vop1::VFractF64Vop1(const MachineInst *inst)
 }
 
 VFrexpExpI32F32Vop1::VFrexpExpI32F32Vop1(const MachineInst *inst)
-    : Vop1("v_frexp_exp_i32_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(346)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_exp_i32_f32_dpp"
+               : "v_frexp_exp_i32_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(346)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2118,8 +2273,10 @@ VFrexpExpI32F32Vop1::VFrexpExpI32F32Vop1(const MachineInst *inst)
 }
 
 VFrexpMantF32Vop1::VFrexpMantF32Vop1(const MachineInst *inst)
-    : Vop1("v_frexp_mant_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(347)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_mant_f32_dpp"
+               : "v_frexp_mant_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(347)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2159,7 +2316,10 @@ VFrexpMantF32Vop1::VFrexpMantF32Vop1(const MachineInst *inst)
 }
 
 VMovreldB32Vop1::VMovreldB32Vop1(const MachineInst *inst)
-    : Vop1("v_movreld_b32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(348)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_movreld_b32_dpp"
+               : "v_movreld_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(348)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -2202,7 +2362,10 @@ VMovreldB32Vop1::VMovreldB32Vop1(const MachineInst *inst)
 }
 
 VMovrelsB32Vop1::VMovrelsB32Vop1(const MachineInst *inst)
-    : Vop1("v_movrels_b32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(349)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_movrels_b32_dpp"
+               : "v_movrels_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(349)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -2245,7 +2408,10 @@ VMovrelsB32Vop1::VMovrelsB32Vop1(const MachineInst *inst)
 }
 
 VMovrelsdB32Vop1::VMovrelsdB32Vop1(const MachineInst *inst)
-    : Vop1("v_movrelsd_b32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(350)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_movrelsd_b32_dpp"
+               : "v_movrelsd_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(350)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -2288,8 +2454,10 @@ VMovrelsdB32Vop1::VMovrelsdB32Vop1(const MachineInst *inst)
 }
 
 VMovrelsd2B32Vop1::VMovrelsd2B32Vop1(const MachineInst *inst)
-    : Vop1("v_movrelsd_2_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(351)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_movrelsd_2_b32_dpp"
+               : "v_movrelsd_2_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(351)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -2332,8 +2500,10 @@ VMovrelsd2B32Vop1::VMovrelsd2B32Vop1(const MachineInst *inst)
 }
 
 VPermlane16SwapB32Vop1::VPermlane16SwapB32Vop1(const MachineInst *inst)
-    : Vop1("v_permlane16_swap_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(352)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_permlane16_swap_b32_dpp"
+               : "v_permlane16_swap_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(352)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2361,7 +2531,10 @@ VPermlane16SwapB32Vop1::VPermlane16SwapB32Vop1(const MachineInst *inst)
 }
 
 VTanhBf16Vop1::VTanhBf16Vop1(const MachineInst *inst)
-    : Vop1("v_tanh_bf16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(353)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_tanh_bf16_dpp"
+               : "v_tanh_bf16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(353)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2418,7 +2591,10 @@ void VTanhBf16Vop1::implicit_use_operands(
 }
 
 VPrngB32Vop1::VPrngB32Vop1(const MachineInst *inst)
-    : Vop1("v_prng_b32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(354)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_prng_b32_dpp"
+               : "v_prng_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(354)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2458,7 +2634,10 @@ VPrngB32Vop1::VPrngB32Vop1(const MachineInst *inst)
 }
 
 VCvtF16U16Vop1::VCvtF16U16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f16_u16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(355)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f16_u16_dpp"
+               : "v_cvt_f16_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(355)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2515,7 +2694,10 @@ void VCvtF16U16Vop1::implicit_use_operands(
 }
 
 VCvtF16I16Vop1::VCvtF16I16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f16_i16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(356)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f16_i16_dpp"
+               : "v_cvt_f16_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(356)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2572,7 +2754,10 @@ void VCvtF16I16Vop1::implicit_use_operands(
 }
 
 VCvtU16F16Vop1::VCvtU16F16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_u16_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(357)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_u16_f16_dpp"
+               : "v_cvt_u16_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(357)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2629,7 +2814,10 @@ void VCvtU16F16Vop1::implicit_use_operands(
 }
 
 VCvtI16F16Vop1::VCvtI16F16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_i16_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(358)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_i16_f16_dpp"
+               : "v_cvt_i16_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(358)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2686,7 +2874,10 @@ void VCvtI16F16Vop1::implicit_use_operands(
 }
 
 VRcpF16Vop1::VRcpF16Vop1(const MachineInst *inst)
-    : Vop1("v_rcp_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(359)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_f16_dpp"
+               : "v_rcp_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(359)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2742,7 +2933,10 @@ void VRcpF16Vop1::implicit_use_operands(std::vector<const ::rocjitsu::Operand *>
 }
 
 VSqrtF16Vop1::VSqrtF16Vop1(const MachineInst *inst)
-    : Vop1("v_sqrt_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(360)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sqrt_f16_dpp"
+               : "v_sqrt_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(360)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2798,7 +2992,10 @@ void VSqrtF16Vop1::implicit_use_operands(std::vector<const ::rocjitsu::Operand *
 }
 
 VRsqF16Vop1::VRsqF16Vop1(const MachineInst *inst)
-    : Vop1("v_rsq_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(361)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rsq_f16_dpp"
+               : "v_rsq_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(361)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2854,7 +3051,10 @@ void VRsqF16Vop1::implicit_use_operands(std::vector<const ::rocjitsu::Operand *>
 }
 
 VLogF16Vop1::VLogF16Vop1(const MachineInst *inst)
-    : Vop1("v_log_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(362)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_log_f16_dpp"
+               : "v_log_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(362)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2910,7 +3110,10 @@ void VLogF16Vop1::implicit_use_operands(std::vector<const ::rocjitsu::Operand *>
 }
 
 VExpF16Vop1::VExpF16Vop1(const MachineInst *inst)
-    : Vop1("v_exp_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(363)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_exp_f16_dpp"
+               : "v_exp_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(363)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2966,8 +3169,10 @@ void VExpF16Vop1::implicit_use_operands(std::vector<const ::rocjitsu::Operand *>
 }
 
 VFrexpMantF16Vop1::VFrexpMantF16Vop1(const MachineInst *inst)
-    : Vop1("v_frexp_mant_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(364)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_mant_f16_dpp"
+               : "v_frexp_mant_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(364)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -3024,8 +3229,10 @@ void VFrexpMantF16Vop1::implicit_use_operands(
 }
 
 VFrexpExpI16F16Vop1::VFrexpExpI16F16Vop1(const MachineInst *inst)
-    : Vop1("v_frexp_exp_i16_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(365)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_exp_i16_f16_dpp"
+               : "v_frexp_exp_i16_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(365)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -3082,7 +3289,10 @@ void VFrexpExpI16F16Vop1::implicit_use_operands(
 }
 
 VFloorF16Vop1::VFloorF16Vop1(const MachineInst *inst)
-    : Vop1("v_floor_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(366)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_floor_f16_dpp"
+               : "v_floor_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(366)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -3139,7 +3349,10 @@ void VFloorF16Vop1::implicit_use_operands(
 }
 
 VCeilF16Vop1::VCeilF16Vop1(const MachineInst *inst)
-    : Vop1("v_ceil_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(367)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ceil_f16_dpp"
+               : "v_ceil_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(367)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -3195,7 +3408,10 @@ void VCeilF16Vop1::implicit_use_operands(std::vector<const ::rocjitsu::Operand *
 }
 
 VTruncF16Vop1::VTruncF16Vop1(const MachineInst *inst)
-    : Vop1("v_trunc_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(368)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_trunc_f16_dpp"
+               : "v_trunc_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(368)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -3252,7 +3468,10 @@ void VTruncF16Vop1::implicit_use_operands(
 }
 
 VRndneF16Vop1::VRndneF16Vop1(const MachineInst *inst)
-    : Vop1("v_rndne_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(369)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rndne_f16_dpp"
+               : "v_rndne_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(369)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -3309,7 +3528,10 @@ void VRndneF16Vop1::implicit_use_operands(
 }
 
 VFractF16Vop1::VFractF16Vop1(const MachineInst *inst)
-    : Vop1("v_fract_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(370)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fract_f16_dpp"
+               : "v_fract_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(370)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -3366,7 +3588,10 @@ void VFractF16Vop1::implicit_use_operands(
 }
 
 VSinF16Vop1::VSinF16Vop1(const MachineInst *inst)
-    : Vop1("v_sin_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(371)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sin_f16_dpp"
+               : "v_sin_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(371)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -3422,7 +3647,10 @@ void VSinF16Vop1::implicit_use_operands(std::vector<const ::rocjitsu::Operand *>
 }
 
 VCosF16Vop1::VCosF16Vop1(const MachineInst *inst)
-    : Vop1("v_cos_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(372)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cos_f16_dpp"
+               : "v_cos_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(372)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -3478,8 +3706,10 @@ void VCosF16Vop1::implicit_use_operands(std::vector<const ::rocjitsu::Operand *>
 }
 
 VSatPkU8I16Vop1::VSatPkU8I16Vop1(const MachineInst *inst)
-    : Vop1("v_sat_pk_u8_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(373)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sat_pk_u8_i16_dpp"
+               : "v_sat_pk_u8_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(373)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -3534,8 +3764,10 @@ void VSatPkU8I16Vop1::implicit_use_operands(
 }
 
 VCvtNormI16F16Vop1::VCvtNormI16F16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_norm_i16_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(374)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_norm_i16_f16_dpp"
+               : "v_cvt_norm_i16_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(374)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -3592,8 +3824,10 @@ void VCvtNormI16F16Vop1::implicit_use_operands(
 }
 
 VCvtNormU16F16Vop1::VCvtNormU16F16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_norm_u16_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(375)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_norm_u16_f16_dpp"
+               : "v_cvt_norm_u16_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(375)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -3650,7 +3884,10 @@ void VCvtNormU16F16Vop1::implicit_use_operands(
 }
 
 VSwapB32Vop1::VSwapB32Vop1(const MachineInst *inst)
-    : Vop1("v_swap_b32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(376)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_swap_b32_dpp"
+               : "v_swap_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(376)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3678,7 +3915,10 @@ VSwapB32Vop1::VSwapB32Vop1(const MachineInst *inst)
 }
 
 VSwapB16Vop1::VSwapB16Vop1(const MachineInst *inst)
-    : Vop1("v_swap_b16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(377)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_swap_b16_dpp"
+               : "v_swap_b16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(377)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), true,
            true),
@@ -3725,7 +3965,10 @@ void VSwapB16Vop1::implicit_use_operands(std::vector<const ::rocjitsu::Operand *
 }
 
 VSwaprelB32Vop1::VSwaprelB32Vop1(const MachineInst *inst)
-    : Vop1("v_swaprel_b32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(378)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_swaprel_b32_dpp"
+               : "v_swaprel_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(378)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -3754,7 +3997,10 @@ VSwaprelB32Vop1::VSwaprelB32Vop1(const MachineInst *inst)
 }
 
 VNotB16Vop1::VNotB16Vop1(const MachineInst *inst)
-    : Vop1("v_not_b16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(379)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_not_b16_dpp"
+               : "v_not_b16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(379)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -3810,7 +4056,10 @@ void VNotB16Vop1::implicit_use_operands(std::vector<const ::rocjitsu::Operand *>
 }
 
 VCvtI32I16Vop1::VCvtI32I16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_i32_i16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(380)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_i32_i16_dpp"
+               : "v_cvt_i32_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(380)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true) {
@@ -3852,7 +4101,10 @@ VCvtI32I16Vop1::VCvtI32I16Vop1(const MachineInst *inst)
 }
 
 VCvtU32U16Vop1::VCvtU32U16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_u32_u16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(381)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_u32_u16_dpp"
+               : "v_cvt_u32_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(381)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true) {
@@ -3894,7 +4146,10 @@ VCvtU32U16Vop1::VCvtU32U16Vop1(const MachineInst *inst)
 }
 
 VCvtF32Fp8Vop1::VCvtF32Fp8Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_fp8_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(382)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_fp8_dpp"
+               : "v_cvt_f32_fp8_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(382)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(8, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3934,7 +4189,10 @@ VCvtF32Fp8Vop1::VCvtF32Fp8Vop1(const MachineInst *inst)
 }
 
 VCvtF32Bf8Vop1::VCvtF32Bf8Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_bf8_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(383)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_bf8_dpp"
+               : "v_cvt_f32_bf8_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(383)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(8, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3974,8 +4232,10 @@ VCvtF32Bf8Vop1::VCvtF32Bf8Vop1(const MachineInst *inst)
 }
 
 VCvtPkF32Fp8Vop1::VCvtPkF32Fp8Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_pk_f32_fp8_e32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(384)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_f32_fp8_dpp"
+               : "v_cvt_pk_f32_fp8_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(384)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true) {
@@ -4003,8 +4263,10 @@ VCvtPkF32Fp8Vop1::VCvtPkF32Fp8Vop1(const MachineInst *inst)
 }
 
 VCvtPkF32Bf8Vop1::VCvtPkF32Bf8Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_pk_f32_bf8_e32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(385)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_f32_bf8_dpp"
+               : "v_cvt_pk_f32_bf8_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(385)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true) {
@@ -4032,7 +4294,10 @@ VCvtPkF32Bf8Vop1::VCvtPkF32Bf8Vop1(const MachineInst *inst)
 }
 
 VCvtF32Bf16Vop1::VCvtF32Bf16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_bf16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(386)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_bf16_dpp"
+               : "v_cvt_f32_bf16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(386)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true) {
@@ -4074,8 +4339,10 @@ VCvtF32Bf16Vop1::VCvtF32Bf16Vop1(const MachineInst *inst)
 }
 
 VSatPk4I4I8Vop1::VSatPk4I4I8Vop1(const MachineInst *inst)
-    : Vop1("v_sat_pk4_i4_i8_e32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(387)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sat_pk4_i4_i8_dpp"
+               : "v_sat_pk4_i4_i8_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(387)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -4130,8 +4397,10 @@ void VSatPk4I4I8Vop1::implicit_use_operands(
 }
 
 VSatPk4U4U8Vop1::VSatPk4U4U8Vop1(const MachineInst *inst)
-    : Vop1("v_sat_pk4_u4_u8_e32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(388)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sat_pk4_u4_u8_dpp"
+               : "v_sat_pk4_u4_u8_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(388)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -4186,8 +4455,10 @@ void VSatPk4U4U8Vop1::implicit_use_operands(
 }
 
 VCvtPkF16Fp8Vop1::VCvtPkF16Fp8Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_pk_f16_fp8_e32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(389)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_f16_fp8_dpp"
+               : "v_cvt_pk_f16_fp8_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(389)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true) {
@@ -4229,8 +4500,10 @@ VCvtPkF16Fp8Vop1::VCvtPkF16Fp8Vop1(const MachineInst *inst)
 }
 
 VCvtPkF16Bf8Vop1::VCvtPkF16Bf8Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_pk_f16_bf8_e32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(390)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_f16_bf8_dpp"
+               : "v_cvt_pk_f16_bf8_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(390)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true) {
@@ -4272,7 +4545,10 @@ VCvtPkF16Bf8Vop1::VCvtPkF16Bf8Vop1(const MachineInst *inst)
 }
 
 VCvtF16Fp8Vop1::VCvtF16Fp8Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f16_fp8_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(391)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f16_fp8_dpp"
+               : "v_cvt_f16_fp8_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(391)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -4327,7 +4603,10 @@ void VCvtF16Fp8Vop1::implicit_use_operands(
 }
 
 VCvtF16Bf8Vop1::VCvtF16Bf8Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f16_bf8_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(392)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f16_bf8_dpp"
+               : "v_cvt_f16_bf8_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(392)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -4382,7 +4661,10 @@ void VCvtF16Bf8Vop1::implicit_use_operands(
 }
 
 VRcpBf16Vop1::VRcpBf16Vop1(const MachineInst *inst)
-    : Vop1("v_rcp_bf16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(393)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_bf16_dpp"
+               : "v_rcp_bf16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(393)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -4438,7 +4720,10 @@ void VRcpBf16Vop1::implicit_use_operands(std::vector<const ::rocjitsu::Operand *
 }
 
 VSqrtBf16Vop1::VSqrtBf16Vop1(const MachineInst *inst)
-    : Vop1("v_sqrt_bf16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(394)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sqrt_bf16_dpp"
+               : "v_sqrt_bf16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(394)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -4495,7 +4780,10 @@ void VSqrtBf16Vop1::implicit_use_operands(
 }
 
 VRsqBf16Vop1::VRsqBf16Vop1(const MachineInst *inst)
-    : Vop1("v_rsq_bf16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(395)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rsq_bf16_dpp"
+               : "v_rsq_bf16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(395)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -4551,7 +4839,10 @@ void VRsqBf16Vop1::implicit_use_operands(std::vector<const ::rocjitsu::Operand *
 }
 
 VLogBf16Vop1::VLogBf16Vop1(const MachineInst *inst)
-    : Vop1("v_log_bf16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(396)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_log_bf16_dpp"
+               : "v_log_bf16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(396)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -4607,7 +4898,10 @@ void VLogBf16Vop1::implicit_use_operands(std::vector<const ::rocjitsu::Operand *
 }
 
 VExpBf16Vop1::VExpBf16Vop1(const MachineInst *inst)
-    : Vop1("v_exp_bf16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(397)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_exp_bf16_dpp"
+               : "v_exp_bf16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(397)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -4663,7 +4957,10 @@ void VExpBf16Vop1::implicit_use_operands(std::vector<const ::rocjitsu::Operand *
 }
 
 VSinBf16Vop1::VSinBf16Vop1(const MachineInst *inst)
-    : Vop1("v_sin_bf16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(398)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sin_bf16_dpp"
+               : "v_sin_bf16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(398)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -4719,7 +5016,10 @@ void VSinBf16Vop1::implicit_use_operands(std::vector<const ::rocjitsu::Operand *
 }
 
 VCosBf16Vop1::VCosBf16Vop1(const MachineInst *inst)
-    : Vop1("v_cos_bf16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(399)),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cos_bf16_dpp"
+               : "v_cos_bf16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(399)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/gfx1250/vop2.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/gfx1250/vop2.cpp
@@ -12,7 +12,10 @@ namespace rocjitsu {
 namespace gfx1250 {
 
 VCndmaskB32Vop2::VCndmaskB32Vop2(const MachineInst *inst)
-    : Vop2("v_cndmask_b32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(562)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cndmask_b32_dpp"
+               : "v_cndmask_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(562)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -58,7 +61,10 @@ VCndmaskB32Vop2::VCndmaskB32Vop2(const MachineInst *inst)
 }
 
 VAddF64Vop2::VAddF64Vop2(const MachineInst *inst)
-    : Vop2("v_add_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(563)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_f64_dpp"
+               : "v_add_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(563)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -96,7 +102,10 @@ VAddF64Vop2::VAddF64Vop2(const MachineInst *inst)
 }
 
 VAddF32Vop2::VAddF32Vop2(const MachineInst *inst)
-    : Vop2("v_add_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(564)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_f32_dpp"
+               : "v_add_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(564)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -139,7 +148,10 @@ VAddF32Vop2::VAddF32Vop2(const MachineInst *inst)
 }
 
 VSubF32Vop2::VSubF32Vop2(const MachineInst *inst)
-    : Vop2("v_sub_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(565)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_f32_dpp"
+               : "v_sub_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(565)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -182,7 +194,10 @@ VSubF32Vop2::VSubF32Vop2(const MachineInst *inst)
 }
 
 VSubrevF32Vop2::VSubrevF32Vop2(const MachineInst *inst)
-    : Vop2("v_subrev_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(566)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_subrev_f32_dpp"
+               : "v_subrev_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(566)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -225,7 +240,10 @@ VSubrevF32Vop2::VSubrevF32Vop2(const MachineInst *inst)
 }
 
 VMulF64Vop2::VMulF64Vop2(const MachineInst *inst)
-    : Vop2("v_mul_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(567)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_f64_dpp"
+               : "v_mul_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(567)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -263,8 +281,10 @@ VMulF64Vop2::VMulF64Vop2(const MachineInst *inst)
 }
 
 VMulDx9ZeroF32Vop2::VMulDx9ZeroF32Vop2(const MachineInst *inst)
-    : Vop2("v_mul_dx9_zero_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(568)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_dx9_zero_f32_dpp"
+               : "v_mul_dx9_zero_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(568)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -307,7 +327,10 @@ VMulDx9ZeroF32Vop2::VMulDx9ZeroF32Vop2(const MachineInst *inst)
 }
 
 VMulF32Vop2::VMulF32Vop2(const MachineInst *inst)
-    : Vop2("v_mul_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(569)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_f32_dpp"
+               : "v_mul_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(569)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -350,7 +373,10 @@ VMulF32Vop2::VMulF32Vop2(const MachineInst *inst)
 }
 
 VMulI32I24Vop2::VMulI32I24Vop2(const MachineInst *inst)
-    : Vop2("v_mul_i32_i24_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(570)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_i32_i24_dpp"
+               : "v_mul_i32_i24_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(570)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -393,8 +419,10 @@ VMulI32I24Vop2::VMulI32I24Vop2(const MachineInst *inst)
 }
 
 VMulHiI32I24Vop2::VMulHiI32I24Vop2(const MachineInst *inst)
-    : Vop2("v_mul_hi_i32_i24_e32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(571)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_hi_i32_i24_dpp"
+               : "v_mul_hi_i32_i24_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(571)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -437,7 +465,10 @@ VMulHiI32I24Vop2::VMulHiI32I24Vop2(const MachineInst *inst)
 }
 
 VMulU32U24Vop2::VMulU32U24Vop2(const MachineInst *inst)
-    : Vop2("v_mul_u32_u24_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(572)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_u32_u24_dpp"
+               : "v_mul_u32_u24_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(572)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -480,8 +511,10 @@ VMulU32U24Vop2::VMulU32U24Vop2(const MachineInst *inst)
 }
 
 VMulHiU32U24Vop2::VMulHiU32U24Vop2(const MachineInst *inst)
-    : Vop2("v_mul_hi_u32_u24_e32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(573)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_hi_u32_u24_dpp"
+               : "v_mul_hi_u32_u24_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(573)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -524,7 +557,10 @@ VMulHiU32U24Vop2::VMulHiU32U24Vop2(const MachineInst *inst)
 }
 
 VMinNumF64Vop2::VMinNumF64Vop2(const MachineInst *inst)
-    : Vop2("v_min_num_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(574)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_num_f64_dpp"
+               : "v_min_num_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(574)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -562,7 +598,10 @@ VMinNumF64Vop2::VMinNumF64Vop2(const MachineInst *inst)
 }
 
 VMaxNumF64Vop2::VMaxNumF64Vop2(const MachineInst *inst)
-    : Vop2("v_max_num_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(575)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_num_f64_dpp"
+               : "v_max_num_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(575)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -600,7 +639,10 @@ VMaxNumF64Vop2::VMaxNumF64Vop2(const MachineInst *inst)
 }
 
 VMinI32Vop2::VMinI32Vop2(const MachineInst *inst)
-    : Vop2("v_min_i32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(576)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_i32_dpp"
+               : "v_min_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(576)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -643,7 +685,10 @@ VMinI32Vop2::VMinI32Vop2(const MachineInst *inst)
 }
 
 VMaxI32Vop2::VMaxI32Vop2(const MachineInst *inst)
-    : Vop2("v_max_i32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(577)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_i32_dpp"
+               : "v_max_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(577)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -686,7 +731,10 @@ VMaxI32Vop2::VMaxI32Vop2(const MachineInst *inst)
 }
 
 VMinU32Vop2::VMinU32Vop2(const MachineInst *inst)
-    : Vop2("v_min_u32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(578)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_u32_dpp"
+               : "v_min_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(578)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -729,7 +777,10 @@ VMinU32Vop2::VMinU32Vop2(const MachineInst *inst)
 }
 
 VMaxU32Vop2::VMaxU32Vop2(const MachineInst *inst)
-    : Vop2("v_max_u32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(579)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_u32_dpp"
+               : "v_max_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(579)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -772,7 +823,10 @@ VMaxU32Vop2::VMaxU32Vop2(const MachineInst *inst)
 }
 
 VMinNumF32Vop2::VMinNumF32Vop2(const MachineInst *inst)
-    : Vop2("v_min_num_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(580)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_num_f32_dpp"
+               : "v_min_num_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(580)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -815,7 +869,10 @@ VMinNumF32Vop2::VMinNumF32Vop2(const MachineInst *inst)
 }
 
 VMaxNumF32Vop2::VMaxNumF32Vop2(const MachineInst *inst)
-    : Vop2("v_max_num_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(581)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_num_f32_dpp"
+               : "v_max_num_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(581)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -858,7 +915,10 @@ VMaxNumF32Vop2::VMaxNumF32Vop2(const MachineInst *inst)
 }
 
 VFmacF64Vop2::VFmacF64Vop2(const MachineInst *inst)
-    : Vop2("v_fmac_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(582)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmac_f64_dpp"
+               : "v_fmac_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(582)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -897,7 +957,10 @@ VFmacF64Vop2::VFmacF64Vop2(const MachineInst *inst)
 }
 
 VLshlrevB32Vop2::VLshlrevB32Vop2(const MachineInst *inst)
-    : Vop2("v_lshlrev_b32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(583)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshlrev_b32_dpp"
+               : "v_lshlrev_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(583)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -940,7 +1003,10 @@ VLshlrevB32Vop2::VLshlrevB32Vop2(const MachineInst *inst)
 }
 
 VLshrrevB32Vop2::VLshrrevB32Vop2(const MachineInst *inst)
-    : Vop2("v_lshrrev_b32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(584)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshrrev_b32_dpp"
+               : "v_lshrrev_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(584)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -983,7 +1049,10 @@ VLshrrevB32Vop2::VLshrrevB32Vop2(const MachineInst *inst)
 }
 
 VAshrrevI32Vop2::VAshrrevI32Vop2(const MachineInst *inst)
-    : Vop2("v_ashrrev_i32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(585)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ashrrev_i32_dpp"
+               : "v_ashrrev_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(585)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1026,7 +1095,10 @@ VAshrrevI32Vop2::VAshrrevI32Vop2(const MachineInst *inst)
 }
 
 VAndB32Vop2::VAndB32Vop2(const MachineInst *inst)
-    : Vop2("v_and_b32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(586)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_and_b32_dpp"
+               : "v_and_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(586)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1069,7 +1141,10 @@ VAndB32Vop2::VAndB32Vop2(const MachineInst *inst)
 }
 
 VOrB32Vop2::VOrB32Vop2(const MachineInst *inst)
-    : Vop2("v_or_b32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(587)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_or_b32_dpp"
+               : "v_or_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(587)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1112,7 +1187,10 @@ VOrB32Vop2::VOrB32Vop2(const MachineInst *inst)
 }
 
 VXorB32Vop2::VXorB32Vop2(const MachineInst *inst)
-    : Vop2("v_xor_b32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(588)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_xor_b32_dpp"
+               : "v_xor_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(588)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1155,7 +1233,10 @@ VXorB32Vop2::VXorB32Vop2(const MachineInst *inst)
 }
 
 VXnorB32Vop2::VXnorB32Vop2(const MachineInst *inst)
-    : Vop2("v_xnor_b32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(589)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_xnor_b32_dpp"
+               : "v_xnor_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(589)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1198,7 +1279,10 @@ VXnorB32Vop2::VXnorB32Vop2(const MachineInst *inst)
 }
 
 VLshlrevB64Vop2::VLshlrevB64Vop2(const MachineInst *inst)
-    : Vop2("v_lshlrev_b64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(590)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshlrev_b64_dpp"
+               : "v_lshlrev_b64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(590)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1235,8 +1319,10 @@ VLshlrevB64Vop2::VLshlrevB64Vop2(const MachineInst *inst)
 }
 
 VAddCoCiU32Vop2::VAddCoCiU32Vop2(const MachineInst *inst)
-    : Vop2("v_add_co_ci_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(591)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_co_ci_u32_dpp"
+               : "v_add_co_ci_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(591)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -1285,8 +1371,10 @@ VAddCoCiU32Vop2::VAddCoCiU32Vop2(const MachineInst *inst)
 }
 
 VSubCoCiU32Vop2::VSubCoCiU32Vop2(const MachineInst *inst)
-    : Vop2("v_sub_co_ci_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(592)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_co_ci_u32_dpp"
+               : "v_sub_co_ci_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(592)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -1335,8 +1423,10 @@ VSubCoCiU32Vop2::VSubCoCiU32Vop2(const MachineInst *inst)
 }
 
 VSubrevCoCiU32Vop2::VSubrevCoCiU32Vop2(const MachineInst *inst)
-    : Vop2("v_subrev_co_ci_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(593)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_subrev_co_ci_u32_dpp"
+               : "v_subrev_co_ci_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(593)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -1385,7 +1475,10 @@ VSubrevCoCiU32Vop2::VSubrevCoCiU32Vop2(const MachineInst *inst)
 }
 
 VFmamkF64Vop2::VFmamkF64Vop2(const MachineInst *inst)
-    : Vop2("v_fmamk_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(594)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmamk_f64_dpp"
+               : "v_fmamk_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(594)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       literal64(64, OperandType::OPR_SIMM64, 0),
@@ -1421,7 +1514,10 @@ VFmamkF64Vop2::VFmamkF64Vop2(const MachineInst *inst)
 }
 
 VFmaakF64Vop2::VFmaakF64Vop2(const MachineInst *inst)
-    : Vop2("v_fmaak_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(595)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmaak_f64_dpp"
+               : "v_fmaak_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(595)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -1457,7 +1553,10 @@ VFmaakF64Vop2::VFmaakF64Vop2(const MachineInst *inst)
 }
 
 VAddNcU32Vop2::VAddNcU32Vop2(const MachineInst *inst)
-    : Vop2("v_add_nc_u32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(596)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_nc_u32_dpp"
+               : "v_add_nc_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(596)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1500,7 +1599,10 @@ VAddNcU32Vop2::VAddNcU32Vop2(const MachineInst *inst)
 }
 
 VSubNcU32Vop2::VSubNcU32Vop2(const MachineInst *inst)
-    : Vop2("v_sub_nc_u32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(597)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_nc_u32_dpp"
+               : "v_sub_nc_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(597)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1543,8 +1645,10 @@ VSubNcU32Vop2::VSubNcU32Vop2(const MachineInst *inst)
 }
 
 VSubrevNcU32Vop2::VSubrevNcU32Vop2(const MachineInst *inst)
-    : Vop2("v_subrev_nc_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(598)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_subrev_nc_u32_dpp"
+               : "v_subrev_nc_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(598)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1587,7 +1691,10 @@ VSubrevNcU32Vop2::VSubrevNcU32Vop2(const MachineInst *inst)
 }
 
 VAddNcU64Vop2::VAddNcU64Vop2(const MachineInst *inst)
-    : Vop2("v_add_nc_u64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(599)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_nc_u64_dpp"
+               : "v_add_nc_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(599)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1625,7 +1732,10 @@ VAddNcU64Vop2::VAddNcU64Vop2(const MachineInst *inst)
 }
 
 VSubNcU64Vop2::VSubNcU64Vop2(const MachineInst *inst)
-    : Vop2("v_sub_nc_u64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(600)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_nc_u64_dpp"
+               : "v_sub_nc_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(600)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1663,7 +1773,10 @@ VSubNcU64Vop2::VSubNcU64Vop2(const MachineInst *inst)
 }
 
 VMulU64Vop2::VMulU64Vop2(const MachineInst *inst)
-    : Vop2("v_mul_u64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(601)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_u64_dpp"
+               : "v_mul_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(601)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1693,7 +1806,10 @@ VMulU64Vop2::VMulU64Vop2(const MachineInst *inst)
 }
 
 VFmacF32Vop2::VFmacF32Vop2(const MachineInst *inst)
-    : Vop2("v_fmac_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(602)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmac_f32_dpp"
+               : "v_fmac_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(602)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1737,7 +1853,10 @@ VFmacF32Vop2::VFmacF32Vop2(const MachineInst *inst)
 }
 
 VFmamkF32Vop2::VFmamkF32Vop2(const MachineInst *inst)
-    : Vop2("v_fmamk_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(603)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmamk_f32_dpp"
+               : "v_fmamk_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(603)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       literal(32, OperandType::OPR_SIMM32, 0),
@@ -1771,7 +1890,10 @@ VFmamkF32Vop2::VFmamkF32Vop2(const MachineInst *inst)
 }
 
 VFmaakF32Vop2::VFmaakF32Vop2(const MachineInst *inst)
-    : Vop2("v_fmaak_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(604)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmaak_f32_dpp"
+               : "v_fmaak_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(604)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -1805,8 +1927,10 @@ VFmaakF32Vop2::VFmaakF32Vop2(const MachineInst *inst)
 }
 
 VCvtPkRtzF16F32Vop2::VCvtPkRtzF16F32Vop2(const MachineInst *inst)
-    : Vop2("v_cvt_pk_rtz_f16_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(605)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_rtz_f16_f32_dpp"
+               : "v_cvt_pk_rtz_f16_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(605)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1849,7 +1973,10 @@ VCvtPkRtzF16F32Vop2::VCvtPkRtzF16F32Vop2(const MachineInst *inst)
 }
 
 VMinNumF16Vop2::VMinNumF16Vop2(const MachineInst *inst)
-    : Vop2("v_min_num_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(606)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_num_f16_dpp"
+               : "v_min_num_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(606)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -1910,7 +2037,10 @@ void VMinNumF16Vop2::implicit_use_operands(
 }
 
 VMaxNumF16Vop2::VMaxNumF16Vop2(const MachineInst *inst)
-    : Vop2("v_max_num_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(607)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_num_f16_dpp"
+               : "v_max_num_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(607)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -1971,7 +2101,10 @@ void VMaxNumF16Vop2::implicit_use_operands(
 }
 
 VAddF16Vop2::VAddF16Vop2(const MachineInst *inst)
-    : Vop2("v_add_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(608)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_f16_dpp"
+               : "v_add_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(608)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2031,7 +2164,10 @@ void VAddF16Vop2::implicit_use_operands(std::vector<const ::rocjitsu::Operand *>
 }
 
 VSubF16Vop2::VSubF16Vop2(const MachineInst *inst)
-    : Vop2("v_sub_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(609)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_f16_dpp"
+               : "v_sub_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(609)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2091,7 +2227,10 @@ void VSubF16Vop2::implicit_use_operands(std::vector<const ::rocjitsu::Operand *>
 }
 
 VSubrevF16Vop2::VSubrevF16Vop2(const MachineInst *inst)
-    : Vop2("v_subrev_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(610)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_subrev_f16_dpp"
+               : "v_subrev_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(610)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2152,7 +2291,10 @@ void VSubrevF16Vop2::implicit_use_operands(
 }
 
 VMulF16Vop2::VMulF16Vop2(const MachineInst *inst)
-    : Vop2("v_mul_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(611)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_f16_dpp"
+               : "v_mul_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(611)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2212,7 +2354,10 @@ void VMulF16Vop2::implicit_use_operands(std::vector<const ::rocjitsu::Operand *>
 }
 
 VFmacF16Vop2::VFmacF16Vop2(const MachineInst *inst)
-    : Vop2("v_fmac_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(612)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmac_f16_dpp"
+               : "v_fmac_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(612)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), true,
            true),
@@ -2273,7 +2418,10 @@ void VFmacF16Vop2::implicit_use_operands(std::vector<const ::rocjitsu::Operand *
 }
 
 VFmamkF16Vop2::VFmamkF16Vop2(const MachineInst *inst)
-    : Vop2("v_fmamk_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(613)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmamk_f16_dpp"
+               : "v_fmamk_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(613)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2326,7 +2474,10 @@ void VFmamkF16Vop2::implicit_use_operands(
 }
 
 VFmaakF16Vop2::VFmaakF16Vop2(const MachineInst *inst)
-    : Vop2("v_fmaak_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(614)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmaak_f16_dpp"
+               : "v_fmaak_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(614)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2379,7 +2530,10 @@ void VFmaakF16Vop2::implicit_use_operands(
 }
 
 VLdexpF16Vop2::VLdexpF16Vop2(const MachineInst *inst)
-    : Vop2("v_ldexp_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(615)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ldexp_f16_dpp"
+               : "v_ldexp_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(615)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2440,7 +2594,10 @@ void VLdexpF16Vop2::implicit_use_operands(
 }
 
 VPkFmacF16Vop2::VPkFmacF16Vop2(const MachineInst *inst)
-    : Vop2("v_pk_fmac_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(616)),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_pk_fmac_f16_dpp"
+               : "v_pk_fmac_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(616)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/gfx1250/vop3_alu.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/gfx1250/vop3_alu.cpp
@@ -12,7 +12,10 @@ namespace rocjitsu {
 namespace gfx1250 {
 
 VTruncF64Vop3::VTruncF64Vop3(const MachineInst *inst)
-    : Vop3("v_trunc_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(639)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_trunc_f64_e64_dpp"
+               : "v_trunc_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(639)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -47,7 +50,10 @@ VTruncF64Vop3::VTruncF64Vop3(const MachineInst *inst)
 }
 
 VCeilF64Vop3::VCeilF64Vop3(const MachineInst *inst)
-    : Vop3("v_ceil_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(640)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ceil_f64_e64_dpp"
+               : "v_ceil_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(640)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -82,7 +88,10 @@ VCeilF64Vop3::VCeilF64Vop3(const MachineInst *inst)
 }
 
 VRndneF64Vop3::VRndneF64Vop3(const MachineInst *inst)
-    : Vop3("v_rndne_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(641)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rndne_f64_e64_dpp"
+               : "v_rndne_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(641)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -117,7 +126,10 @@ VRndneF64Vop3::VRndneF64Vop3(const MachineInst *inst)
 }
 
 VFloorF64Vop3::VFloorF64Vop3(const MachineInst *inst)
-    : Vop3("v_floor_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(642)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_floor_f64_e64_dpp"
+               : "v_floor_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(642)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -152,7 +164,10 @@ VFloorF64Vop3::VFloorF64Vop3(const MachineInst *inst)
 }
 
 VTanhF32Vop3::VTanhF32Vop3(const MachineInst *inst)
-    : Vop3("v_tanh_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(646)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_tanh_f32_e64_dpp"
+               : "v_tanh_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(646)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -192,7 +207,10 @@ VTanhF32Vop3::VTanhF32Vop3(const MachineInst *inst)
 }
 
 VTanhF16Vop3::VTanhF16Vop3(const MachineInst *inst)
-    : Vop3("v_tanh_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(647)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_tanh_f16_e64_dpp"
+               : "v_tanh_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(647)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -248,7 +266,10 @@ void VTanhF16Vop3::implicit_use_operands(std::vector<const ::rocjitsu::Operand *
 }
 
 VFractF32Vop3::VFractF32Vop3(const MachineInst *inst)
-    : Vop3("v_fract_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(648)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fract_f32_e64_dpp"
+               : "v_fract_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(648)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -288,7 +309,10 @@ VFractF32Vop3::VFractF32Vop3(const MachineInst *inst)
 }
 
 VTruncF32Vop3::VTruncF32Vop3(const MachineInst *inst)
-    : Vop3("v_trunc_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(649)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_trunc_f32_e64_dpp"
+               : "v_trunc_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(649)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -328,7 +352,10 @@ VTruncF32Vop3::VTruncF32Vop3(const MachineInst *inst)
 }
 
 VCeilF32Vop3::VCeilF32Vop3(const MachineInst *inst)
-    : Vop3("v_ceil_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(650)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ceil_f32_e64_dpp"
+               : "v_ceil_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(650)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -368,7 +395,10 @@ VCeilF32Vop3::VCeilF32Vop3(const MachineInst *inst)
 }
 
 VRndneF32Vop3::VRndneF32Vop3(const MachineInst *inst)
-    : Vop3("v_rndne_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(651)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rndne_f32_e64_dpp"
+               : "v_rndne_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(651)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -408,7 +438,10 @@ VRndneF32Vop3::VRndneF32Vop3(const MachineInst *inst)
 }
 
 VFloorF32Vop3::VFloorF32Vop3(const MachineInst *inst)
-    : Vop3("v_floor_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(652)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_floor_f32_e64_dpp"
+               : "v_floor_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(652)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -448,7 +481,10 @@ VFloorF32Vop3::VFloorF32Vop3(const MachineInst *inst)
 }
 
 VExpF32Vop3::VExpF32Vop3(const MachineInst *inst)
-    : Vop3("v_exp_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(653)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_exp_f32_e64_dpp"
+               : "v_exp_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(653)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -488,7 +524,10 @@ VExpF32Vop3::VExpF32Vop3(const MachineInst *inst)
 }
 
 VLogF32Vop3::VLogF32Vop3(const MachineInst *inst)
-    : Vop3("v_log_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(654)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_log_f32_e64_dpp"
+               : "v_log_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(654)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -528,7 +567,10 @@ VLogF32Vop3::VLogF32Vop3(const MachineInst *inst)
 }
 
 VRcpF32Vop3::VRcpF32Vop3(const MachineInst *inst)
-    : Vop3("v_rcp_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(655)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_f32_e64_dpp"
+               : "v_rcp_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(655)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -568,7 +610,10 @@ VRcpF32Vop3::VRcpF32Vop3(const MachineInst *inst)
 }
 
 VRcpIflagF32Vop3::VRcpIflagF32Vop3(const MachineInst *inst)
-    : Vop3("v_rcp_iflag_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(656)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_iflag_f32_e64_dpp"
+               : "v_rcp_iflag_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(656)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -608,7 +653,10 @@ VRcpIflagF32Vop3::VRcpIflagF32Vop3(const MachineInst *inst)
 }
 
 VRsqF32Vop3::VRsqF32Vop3(const MachineInst *inst)
-    : Vop3("v_rsq_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(657)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rsq_f32_e64_dpp"
+               : "v_rsq_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(657)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -648,7 +696,10 @@ VRsqF32Vop3::VRsqF32Vop3(const MachineInst *inst)
 }
 
 VRcpF64Vop3::VRcpF64Vop3(const MachineInst *inst)
-    : Vop3("v_rcp_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(658)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_f64_e64_dpp"
+               : "v_rcp_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(658)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -675,7 +726,10 @@ VRcpF64Vop3::VRcpF64Vop3(const MachineInst *inst)
 }
 
 VRsqF64Vop3::VRsqF64Vop3(const MachineInst *inst)
-    : Vop3("v_rsq_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(659)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rsq_f64_e64_dpp"
+               : "v_rsq_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(659)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -702,7 +756,10 @@ VRsqF64Vop3::VRsqF64Vop3(const MachineInst *inst)
 }
 
 VSqrtF32Vop3::VSqrtF32Vop3(const MachineInst *inst)
-    : Vop3("v_sqrt_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(660)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sqrt_f32_e64_dpp"
+               : "v_sqrt_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(660)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -742,7 +799,10 @@ VSqrtF32Vop3::VSqrtF32Vop3(const MachineInst *inst)
 }
 
 VSqrtF64Vop3::VSqrtF64Vop3(const MachineInst *inst)
-    : Vop3("v_sqrt_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(661)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sqrt_f64_e64_dpp"
+               : "v_sqrt_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(661)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -769,7 +829,10 @@ VSqrtF64Vop3::VSqrtF64Vop3(const MachineInst *inst)
 }
 
 VSinF32Vop3::VSinF32Vop3(const MachineInst *inst)
-    : Vop3("v_sin_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(662)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sin_f32_e64_dpp"
+               : "v_sin_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(662)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -809,7 +872,10 @@ VSinF32Vop3::VSinF32Vop3(const MachineInst *inst)
 }
 
 VCosF32Vop3::VCosF32Vop3(const MachineInst *inst)
-    : Vop3("v_cos_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(663)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cos_f32_e64_dpp"
+               : "v_cos_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(663)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -849,7 +915,10 @@ VCosF32Vop3::VCosF32Vop3(const MachineInst *inst)
 }
 
 VNotB32Vop3::VNotB32Vop3(const MachineInst *inst)
-    : Vop3("v_not_b32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(664)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_not_b32_e64_dpp"
+               : "v_not_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(664)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -889,7 +958,10 @@ VNotB32Vop3::VNotB32Vop3(const MachineInst *inst)
 }
 
 VBfrevB32Vop3::VBfrevB32Vop3(const MachineInst *inst)
-    : Vop3("v_bfrev_b32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(665)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_bfrev_b32_e64_dpp"
+               : "v_bfrev_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(665)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -929,7 +1001,10 @@ VBfrevB32Vop3::VBfrevB32Vop3(const MachineInst *inst)
 }
 
 VClzI32U32Vop3::VClzI32U32Vop3(const MachineInst *inst)
-    : Vop3("v_clz_i32_u32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(666)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_clz_i32_u32_e64_dpp"
+               : "v_clz_i32_u32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(666)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -969,7 +1044,10 @@ VClzI32U32Vop3::VClzI32U32Vop3(const MachineInst *inst)
 }
 
 VCtzI32B32Vop3::VCtzI32B32Vop3(const MachineInst *inst)
-    : Vop3("v_ctz_i32_b32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(667)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ctz_i32_b32_e64_dpp"
+               : "v_ctz_i32_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(667)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1009,7 +1087,10 @@ VCtzI32B32Vop3::VCtzI32B32Vop3(const MachineInst *inst)
 }
 
 VClsI32Vop3::VClsI32Vop3(const MachineInst *inst)
-    : Vop3("v_cls_i32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(668)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cls_i32_e64_dpp"
+               : "v_cls_i32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(668)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1049,7 +1130,10 @@ VClsI32Vop3::VClsI32Vop3(const MachineInst *inst)
 }
 
 VFractF64Vop3::VFractF64Vop3(const MachineInst *inst)
-    : Vop3("v_fract_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(671)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fract_f64_e64_dpp"
+               : "v_fract_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(671)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1084,7 +1168,10 @@ VFractF64Vop3::VFractF64Vop3(const MachineInst *inst)
 }
 
 VTanhBf16Vop3::VTanhBf16Vop3(const MachineInst *inst)
-    : Vop3("v_tanh_bf16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(679)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_tanh_bf16_e64_dpp"
+               : "v_tanh_bf16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(679)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1141,7 +1228,10 @@ void VTanhBf16Vop3::implicit_use_operands(
 }
 
 VRcpF16Vop3::VRcpF16Vop3(const MachineInst *inst)
-    : Vop3("v_rcp_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(685)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_f16_e64_dpp"
+               : "v_rcp_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(685)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1197,7 +1287,10 @@ void VRcpF16Vop3::implicit_use_operands(std::vector<const ::rocjitsu::Operand *>
 }
 
 VSqrtF16Vop3::VSqrtF16Vop3(const MachineInst *inst)
-    : Vop3("v_sqrt_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(686)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sqrt_f16_e64_dpp"
+               : "v_sqrt_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(686)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1253,7 +1346,10 @@ void VSqrtF16Vop3::implicit_use_operands(std::vector<const ::rocjitsu::Operand *
 }
 
 VRsqF16Vop3::VRsqF16Vop3(const MachineInst *inst)
-    : Vop3("v_rsq_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(687)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rsq_f16_e64_dpp"
+               : "v_rsq_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(687)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1309,7 +1405,10 @@ void VRsqF16Vop3::implicit_use_operands(std::vector<const ::rocjitsu::Operand *>
 }
 
 VLogF16Vop3::VLogF16Vop3(const MachineInst *inst)
-    : Vop3("v_log_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(688)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_log_f16_e64_dpp"
+               : "v_log_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(688)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1365,7 +1464,10 @@ void VLogF16Vop3::implicit_use_operands(std::vector<const ::rocjitsu::Operand *>
 }
 
 VExpF16Vop3::VExpF16Vop3(const MachineInst *inst)
-    : Vop3("v_exp_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(689)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_exp_f16_e64_dpp"
+               : "v_exp_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(689)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1421,7 +1523,10 @@ void VExpF16Vop3::implicit_use_operands(std::vector<const ::rocjitsu::Operand *>
 }
 
 VFloorF16Vop3::VFloorF16Vop3(const MachineInst *inst)
-    : Vop3("v_floor_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(692)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_floor_f16_e64_dpp"
+               : "v_floor_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(692)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1478,7 +1583,10 @@ void VFloorF16Vop3::implicit_use_operands(
 }
 
 VCeilF16Vop3::VCeilF16Vop3(const MachineInst *inst)
-    : Vop3("v_ceil_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(693)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ceil_f16_e64_dpp"
+               : "v_ceil_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(693)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1534,7 +1642,10 @@ void VCeilF16Vop3::implicit_use_operands(std::vector<const ::rocjitsu::Operand *
 }
 
 VTruncF16Vop3::VTruncF16Vop3(const MachineInst *inst)
-    : Vop3("v_trunc_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(694)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_trunc_f16_e64_dpp"
+               : "v_trunc_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(694)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1591,7 +1702,10 @@ void VTruncF16Vop3::implicit_use_operands(
 }
 
 VRndneF16Vop3::VRndneF16Vop3(const MachineInst *inst)
-    : Vop3("v_rndne_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(695)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rndne_f16_e64_dpp"
+               : "v_rndne_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(695)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1648,7 +1762,10 @@ void VRndneF16Vop3::implicit_use_operands(
 }
 
 VFractF16Vop3::VFractF16Vop3(const MachineInst *inst)
-    : Vop3("v_fract_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(696)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fract_f16_e64_dpp"
+               : "v_fract_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(696)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1705,7 +1822,10 @@ void VFractF16Vop3::implicit_use_operands(
 }
 
 VSinF16Vop3::VSinF16Vop3(const MachineInst *inst)
-    : Vop3("v_sin_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(697)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sin_f16_e64_dpp"
+               : "v_sin_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(697)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1761,7 +1881,10 @@ void VSinF16Vop3::implicit_use_operands(std::vector<const ::rocjitsu::Operand *>
 }
 
 VCosF16Vop3::VCosF16Vop3(const MachineInst *inst)
-    : Vop3("v_cos_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(698)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cos_f16_e64_dpp"
+               : "v_cos_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(698)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1817,7 +1940,10 @@ void VCosF16Vop3::implicit_use_operands(std::vector<const ::rocjitsu::Operand *>
 }
 
 VNotB16Vop3::VNotB16Vop3(const MachineInst *inst)
-    : Vop3("v_not_b16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(702)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_not_b16_e64_dpp"
+               : "v_not_b16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(702)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1873,7 +1999,10 @@ void VNotB16Vop3::implicit_use_operands(std::vector<const ::rocjitsu::Operand *>
 }
 
 VRcpBf16Vop3::VRcpBf16Vop3(const MachineInst *inst)
-    : Vop3("v_rcp_bf16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(716)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_bf16_e64_dpp"
+               : "v_rcp_bf16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(716)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1929,7 +2058,10 @@ void VRcpBf16Vop3::implicit_use_operands(std::vector<const ::rocjitsu::Operand *
 }
 
 VSqrtBf16Vop3::VSqrtBf16Vop3(const MachineInst *inst)
-    : Vop3("v_sqrt_bf16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(717)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sqrt_bf16_e64_dpp"
+               : "v_sqrt_bf16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(717)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1986,7 +2118,10 @@ void VSqrtBf16Vop3::implicit_use_operands(
 }
 
 VRsqBf16Vop3::VRsqBf16Vop3(const MachineInst *inst)
-    : Vop3("v_rsq_bf16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(718)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rsq_bf16_e64_dpp"
+               : "v_rsq_bf16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(718)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2042,7 +2177,10 @@ void VRsqBf16Vop3::implicit_use_operands(std::vector<const ::rocjitsu::Operand *
 }
 
 VLogBf16Vop3::VLogBf16Vop3(const MachineInst *inst)
-    : Vop3("v_log_bf16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(719)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_log_bf16_e64_dpp"
+               : "v_log_bf16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(719)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2098,7 +2236,10 @@ void VLogBf16Vop3::implicit_use_operands(std::vector<const ::rocjitsu::Operand *
 }
 
 VExpBf16Vop3::VExpBf16Vop3(const MachineInst *inst)
-    : Vop3("v_exp_bf16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(720)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_exp_bf16_e64_dpp"
+               : "v_exp_bf16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(720)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2154,7 +2295,10 @@ void VExpBf16Vop3::implicit_use_operands(std::vector<const ::rocjitsu::Operand *
 }
 
 VSinBf16Vop3::VSinBf16Vop3(const MachineInst *inst)
-    : Vop3("v_sin_bf16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(721)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sin_bf16_e64_dpp"
+               : "v_sin_bf16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(721)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2210,7 +2354,10 @@ void VSinBf16Vop3::implicit_use_operands(std::vector<const ::rocjitsu::Operand *
 }
 
 VCosBf16Vop3::VCosBf16Vop3(const MachineInst *inst)
-    : Vop3("v_cos_bf16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(722)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cos_bf16_e64_dpp"
+               : "v_cos_bf16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(722)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2266,7 +2413,10 @@ void VCosBf16Vop3::implicit_use_operands(std::vector<const ::rocjitsu::Operand *
 }
 
 VAddF64Vop3::VAddF64Vop3(const MachineInst *inst)
-    : Vop3("v_add_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(724)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_f64_e64_dpp"
+               : "v_add_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(724)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2316,7 +2466,10 @@ VAddF64Vop3::VAddF64Vop3(const MachineInst *inst)
 }
 
 VAddF32Vop3::VAddF32Vop3(const MachineInst *inst)
-    : Vop3("v_add_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(725)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_f32_e64_dpp"
+               : "v_add_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(725)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2370,7 +2523,10 @@ VAddF32Vop3::VAddF32Vop3(const MachineInst *inst)
 }
 
 VSubF32Vop3::VSubF32Vop3(const MachineInst *inst)
-    : Vop3("v_sub_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(726)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_f32_e64_dpp"
+               : "v_sub_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(726)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2424,7 +2580,10 @@ VSubF32Vop3::VSubF32Vop3(const MachineInst *inst)
 }
 
 VSubrevF32Vop3::VSubrevF32Vop3(const MachineInst *inst)
-    : Vop3("v_subrev_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(727)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_subrev_f32_e64_dpp"
+               : "v_subrev_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(727)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2478,7 +2637,10 @@ VSubrevF32Vop3::VSubrevF32Vop3(const MachineInst *inst)
 }
 
 VMulF64Vop3::VMulF64Vop3(const MachineInst *inst)
-    : Vop3("v_mul_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(728)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_f64_e64_dpp"
+               : "v_mul_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(728)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2528,7 +2690,10 @@ VMulF64Vop3::VMulF64Vop3(const MachineInst *inst)
 }
 
 VMulDx9ZeroF32Vop3::VMulDx9ZeroF32Vop3(const MachineInst *inst)
-    : Vop3("v_mul_dx9_zero_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(729)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_dx9_zero_f32_e64_dpp"
+               : "v_mul_dx9_zero_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(729)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2582,7 +2747,10 @@ VMulDx9ZeroF32Vop3::VMulDx9ZeroF32Vop3(const MachineInst *inst)
 }
 
 VMulF32Vop3::VMulF32Vop3(const MachineInst *inst)
-    : Vop3("v_mul_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(730)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_f32_e64_dpp"
+               : "v_mul_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(730)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2636,7 +2804,10 @@ VMulF32Vop3::VMulF32Vop3(const MachineInst *inst)
 }
 
 VMulI32I24Vop3::VMulI32I24Vop3(const MachineInst *inst)
-    : Vop3("v_mul_i32_i24", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(731)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_i32_i24_e64_dpp"
+               : "v_mul_i32_i24",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(731)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2690,7 +2861,10 @@ VMulI32I24Vop3::VMulI32I24Vop3(const MachineInst *inst)
 }
 
 VMulHiI32I24Vop3::VMulHiI32I24Vop3(const MachineInst *inst)
-    : Vop3("v_mul_hi_i32_i24", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(732)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_hi_i32_i24_e64_dpp"
+               : "v_mul_hi_i32_i24",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(732)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2744,7 +2918,10 @@ VMulHiI32I24Vop3::VMulHiI32I24Vop3(const MachineInst *inst)
 }
 
 VMulU32U24Vop3::VMulU32U24Vop3(const MachineInst *inst)
-    : Vop3("v_mul_u32_u24", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(733)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_u32_u24_e64_dpp"
+               : "v_mul_u32_u24",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(733)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2798,7 +2975,10 @@ VMulU32U24Vop3::VMulU32U24Vop3(const MachineInst *inst)
 }
 
 VMulHiU32U24Vop3::VMulHiU32U24Vop3(const MachineInst *inst)
-    : Vop3("v_mul_hi_u32_u24", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(734)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_hi_u32_u24_e64_dpp"
+               : "v_mul_hi_u32_u24",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(734)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2852,7 +3032,10 @@ VMulHiU32U24Vop3::VMulHiU32U24Vop3(const MachineInst *inst)
 }
 
 VMinNumF64Vop3::VMinNumF64Vop3(const MachineInst *inst)
-    : Vop3("v_min_num_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(735)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_num_f64_e64_dpp"
+               : "v_min_num_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(735)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2902,7 +3085,10 @@ VMinNumF64Vop3::VMinNumF64Vop3(const MachineInst *inst)
 }
 
 VMaxNumF64Vop3::VMaxNumF64Vop3(const MachineInst *inst)
-    : Vop3("v_max_num_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(736)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_num_f64_e64_dpp"
+               : "v_max_num_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(736)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2952,7 +3138,10 @@ VMaxNumF64Vop3::VMaxNumF64Vop3(const MachineInst *inst)
 }
 
 VMinI32Vop3::VMinI32Vop3(const MachineInst *inst)
-    : Vop3("v_min_i32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(737)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_i32_e64_dpp"
+               : "v_min_i32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(737)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3006,7 +3195,10 @@ VMinI32Vop3::VMinI32Vop3(const MachineInst *inst)
 }
 
 VMaxI32Vop3::VMaxI32Vop3(const MachineInst *inst)
-    : Vop3("v_max_i32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(738)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_i32_e64_dpp"
+               : "v_max_i32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(738)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3060,7 +3252,10 @@ VMaxI32Vop3::VMaxI32Vop3(const MachineInst *inst)
 }
 
 VMinU32Vop3::VMinU32Vop3(const MachineInst *inst)
-    : Vop3("v_min_u32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(739)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_u32_e64_dpp"
+               : "v_min_u32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(739)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3114,7 +3309,10 @@ VMinU32Vop3::VMinU32Vop3(const MachineInst *inst)
 }
 
 VMaxU32Vop3::VMaxU32Vop3(const MachineInst *inst)
-    : Vop3("v_max_u32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(740)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_u32_e64_dpp"
+               : "v_max_u32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(740)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3168,7 +3366,10 @@ VMaxU32Vop3::VMaxU32Vop3(const MachineInst *inst)
 }
 
 VMinNumF32Vop3::VMinNumF32Vop3(const MachineInst *inst)
-    : Vop3("v_min_num_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(741)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_num_f32_e64_dpp"
+               : "v_min_num_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(741)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3222,7 +3423,10 @@ VMinNumF32Vop3::VMinNumF32Vop3(const MachineInst *inst)
 }
 
 VMaxNumF32Vop3::VMaxNumF32Vop3(const MachineInst *inst)
-    : Vop3("v_max_num_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(742)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_num_f32_e64_dpp"
+               : "v_max_num_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(742)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3276,7 +3480,10 @@ VMaxNumF32Vop3::VMaxNumF32Vop3(const MachineInst *inst)
 }
 
 VFmacF64Vop3::VFmacF64Vop3(const MachineInst *inst)
-    : Vop3("v_fmac_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(743)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmac_f64_e64_dpp"
+               : "v_fmac_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(743)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3327,7 +3534,10 @@ VFmacF64Vop3::VFmacF64Vop3(const MachineInst *inst)
 }
 
 VLshlrevB32Vop3::VLshlrevB32Vop3(const MachineInst *inst)
-    : Vop3("v_lshlrev_b32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(744)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshlrev_b32_e64_dpp"
+               : "v_lshlrev_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(744)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3381,7 +3591,10 @@ VLshlrevB32Vop3::VLshlrevB32Vop3(const MachineInst *inst)
 }
 
 VLshrrevB32Vop3::VLshrrevB32Vop3(const MachineInst *inst)
-    : Vop3("v_lshrrev_b32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(745)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshrrev_b32_e64_dpp"
+               : "v_lshrrev_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(745)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3435,7 +3648,10 @@ VLshrrevB32Vop3::VLshrrevB32Vop3(const MachineInst *inst)
 }
 
 VAshrrevI32Vop3::VAshrrevI32Vop3(const MachineInst *inst)
-    : Vop3("v_ashrrev_i32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(746)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ashrrev_i32_e64_dpp"
+               : "v_ashrrev_i32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(746)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3489,7 +3705,10 @@ VAshrrevI32Vop3::VAshrrevI32Vop3(const MachineInst *inst)
 }
 
 VAndB32Vop3::VAndB32Vop3(const MachineInst *inst)
-    : Vop3("v_and_b32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(747)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_and_b32_e64_dpp"
+               : "v_and_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(747)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3543,7 +3762,10 @@ VAndB32Vop3::VAndB32Vop3(const MachineInst *inst)
 }
 
 VOrB32Vop3::VOrB32Vop3(const MachineInst *inst)
-    : Vop3("v_or_b32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(748)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_or_b32_e64_dpp"
+               : "v_or_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(748)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3597,7 +3819,10 @@ VOrB32Vop3::VOrB32Vop3(const MachineInst *inst)
 }
 
 VXorB32Vop3::VXorB32Vop3(const MachineInst *inst)
-    : Vop3("v_xor_b32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(749)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_xor_b32_e64_dpp"
+               : "v_xor_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(749)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3651,7 +3876,10 @@ VXorB32Vop3::VXorB32Vop3(const MachineInst *inst)
 }
 
 VXnorB32Vop3::VXnorB32Vop3(const MachineInst *inst)
-    : Vop3("v_xnor_b32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(750)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_xnor_b32_e64_dpp"
+               : "v_xnor_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(750)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3705,7 +3933,10 @@ VXnorB32Vop3::VXnorB32Vop3(const MachineInst *inst)
 }
 
 VLshlrevB64Vop3::VLshlrevB64Vop3(const MachineInst *inst)
-    : Vop3("v_lshlrev_b64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(751)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshlrev_b64_e64_dpp"
+               : "v_lshlrev_b64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(751)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3754,7 +3985,10 @@ VLshlrevB64Vop3::VLshlrevB64Vop3(const MachineInst *inst)
 }
 
 VAddNcU32Vop3::VAddNcU32Vop3(const MachineInst *inst)
-    : Vop3("v_add_nc_u32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(752)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_nc_u32_e64_dpp"
+               : "v_add_nc_u32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(752)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3808,7 +4042,10 @@ VAddNcU32Vop3::VAddNcU32Vop3(const MachineInst *inst)
 }
 
 VSubNcU32Vop3::VSubNcU32Vop3(const MachineInst *inst)
-    : Vop3("v_sub_nc_u32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(753)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_nc_u32_e64_dpp"
+               : "v_sub_nc_u32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(753)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3862,7 +4099,10 @@ VSubNcU32Vop3::VSubNcU32Vop3(const MachineInst *inst)
 }
 
 VSubrevNcU32Vop3::VSubrevNcU32Vop3(const MachineInst *inst)
-    : Vop3("v_subrev_nc_u32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(754)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_subrev_nc_u32_e64_dpp"
+               : "v_subrev_nc_u32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(754)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3916,7 +4156,10 @@ VSubrevNcU32Vop3::VSubrevNcU32Vop3(const MachineInst *inst)
 }
 
 VAddNcU64Vop3::VAddNcU64Vop3(const MachineInst *inst)
-    : Vop3("v_add_nc_u64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(755)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_nc_u64_e64_dpp"
+               : "v_add_nc_u64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(755)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3966,7 +4209,10 @@ VAddNcU64Vop3::VAddNcU64Vop3(const MachineInst *inst)
 }
 
 VSubNcU64Vop3::VSubNcU64Vop3(const MachineInst *inst)
-    : Vop3("v_sub_nc_u64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(756)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_nc_u64_e64_dpp"
+               : "v_sub_nc_u64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(756)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4016,7 +4262,10 @@ VSubNcU64Vop3::VSubNcU64Vop3(const MachineInst *inst)
 }
 
 VMulU64Vop3::VMulU64Vop3(const MachineInst *inst)
-    : Vop3("v_mul_u64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(757)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_u64_e64_dpp"
+               : "v_mul_u64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(757)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4058,7 +4307,10 @@ VMulU64Vop3::VMulU64Vop3(const MachineInst *inst)
 }
 
 VFmacF32Vop3::VFmacF32Vop3(const MachineInst *inst)
-    : Vop3("v_fmac_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(758)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmac_f32_e64_dpp"
+               : "v_fmac_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(758)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4113,7 +4365,10 @@ VFmacF32Vop3::VFmacF32Vop3(const MachineInst *inst)
 }
 
 VMinNumF16Vop3::VMinNumF16Vop3(const MachineInst *inst)
-    : Vop3("v_min_num_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(760)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_num_f16_e64_dpp"
+               : "v_min_num_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(760)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4188,7 +4443,10 @@ void VMinNumF16Vop3::implicit_use_operands(
 }
 
 VMaxNumF16Vop3::VMaxNumF16Vop3(const MachineInst *inst)
-    : Vop3("v_max_num_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(761)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_num_f16_e64_dpp"
+               : "v_max_num_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(761)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4263,7 +4521,10 @@ void VMaxNumF16Vop3::implicit_use_operands(
 }
 
 VAddF16Vop3::VAddF16Vop3(const MachineInst *inst)
-    : Vop3("v_add_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(762)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_f16_e64_dpp"
+               : "v_add_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(762)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4337,7 +4598,10 @@ void VAddF16Vop3::implicit_use_operands(std::vector<const ::rocjitsu::Operand *>
 }
 
 VSubF16Vop3::VSubF16Vop3(const MachineInst *inst)
-    : Vop3("v_sub_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(763)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_f16_e64_dpp"
+               : "v_sub_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(763)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4411,7 +4675,10 @@ void VSubF16Vop3::implicit_use_operands(std::vector<const ::rocjitsu::Operand *>
 }
 
 VSubrevF16Vop3::VSubrevF16Vop3(const MachineInst *inst)
-    : Vop3("v_subrev_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(764)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_subrev_f16_e64_dpp"
+               : "v_subrev_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(764)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4486,7 +4753,10 @@ void VSubrevF16Vop3::implicit_use_operands(
 }
 
 VMulF16Vop3::VMulF16Vop3(const MachineInst *inst)
-    : Vop3("v_mul_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(765)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_f16_e64_dpp"
+               : "v_mul_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(765)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4560,7 +4830,10 @@ void VMulF16Vop3::implicit_use_operands(std::vector<const ::rocjitsu::Operand *>
 }
 
 VFmacF16Vop3::VFmacF16Vop3(const MachineInst *inst)
-    : Vop3("v_fmac_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(766)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmac_f16_e64_dpp"
+               : "v_fmac_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(766)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4635,7 +4908,10 @@ void VFmacF16Vop3::implicit_use_operands(std::vector<const ::rocjitsu::Operand *
 }
 
 VLdexpF16Vop3::VLdexpF16Vop3(const MachineInst *inst)
-    : Vop3("v_ldexp_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(767)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ldexp_f16_e64_dpp"
+               : "v_ldexp_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(767)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4710,7 +4986,10 @@ void VLdexpF16Vop3::implicit_use_operands(
 }
 
 VDivFixupF32Vop3::VDivFixupF32Vop3(const MachineInst *inst)
-    : Vop3("v_div_fixup_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(795)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_div_fixup_f32_e64_dpp"
+               : "v_div_fixup_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(795)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4764,7 +5043,10 @@ VDivFixupF32Vop3::VDivFixupF32Vop3(const MachineInst *inst)
 }
 
 VDivFixupF64Vop3::VDivFixupF64Vop3(const MachineInst *inst)
-    : Vop3("v_div_fixup_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(796)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_div_fixup_f64_e64_dpp"
+               : "v_div_fixup_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(796)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4829,7 +5111,10 @@ VDivFixupF64Vop3::VDivFixupF64Vop3(const MachineInst *inst)
 }
 
 VBitop3B16Vop3::VBitop3B16Vop3(const MachineInst *inst)
-    : Vop3("v_bitop3_b16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(807)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_bitop3_b16_e64_dpp"
+               : "v_bitop3_b16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(807)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4922,7 +5207,10 @@ void VBitop3B16Vop3::implicit_use_operands(
 }
 
 VBitop3B32Vop3::VBitop3B32Vop3(const MachineInst *inst)
-    : Vop3("v_bitop3_b32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(808)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_bitop3_b32_e64_dpp"
+               : "v_bitop3_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(808)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4990,7 +5278,10 @@ VBitop3B32Vop3::VBitop3B32Vop3(const MachineInst *inst)
 }
 
 VDivFmasF32Vop3::VDivFmasF32Vop3(const MachineInst *inst)
-    : Vop3("v_div_fmas_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(810)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_div_fmas_f32_e64_dpp"
+               : "v_div_fmas_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(810)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5047,7 +5338,10 @@ VDivFmasF32Vop3::VDivFmasF32Vop3(const MachineInst *inst)
 }
 
 VDivFmasF64Vop3::VDivFmasF64Vop3(const MachineInst *inst)
-    : Vop3("v_div_fmas_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(811)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_div_fmas_f64_e64_dpp"
+               : "v_div_fmas_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(811)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5115,7 +5409,10 @@ VDivFmasF64Vop3::VDivFmasF64Vop3(const MachineInst *inst)
 }
 
 VDivFixupF16Vop3::VDivFixupF16Vop3(const MachineInst *inst)
-    : Vop3("v_div_fixup_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(834)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_div_fixup_f16_e64_dpp"
+               : "v_div_fixup_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(834)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5208,7 +5505,10 @@ void VDivFixupF16Vop3::implicit_use_operands(
 }
 
 VSExpF32Vop3::VSExpF32Vop3(const MachineInst *inst)
-    : Vop3("v_s_exp_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(864)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_s_exp_f32_e64_dpp"
+               : "v_s_exp_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(864)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -5234,7 +5534,10 @@ VSExpF32Vop3::VSExpF32Vop3(const MachineInst *inst)
 }
 
 VSExpF16Vop3::VSExpF16Vop3(const MachineInst *inst)
-    : Vop3("v_s_exp_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(865)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_s_exp_f16_e64_dpp"
+               : "v_s_exp_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(865)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -5261,7 +5564,10 @@ VSExpF16Vop3::VSExpF16Vop3(const MachineInst *inst)
 }
 
 VSLogF32Vop3::VSLogF32Vop3(const MachineInst *inst)
-    : Vop3("v_s_log_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(866)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_s_log_f32_e64_dpp"
+               : "v_s_log_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(866)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -5287,7 +5593,10 @@ VSLogF32Vop3::VSLogF32Vop3(const MachineInst *inst)
 }
 
 VSLogF16Vop3::VSLogF16Vop3(const MachineInst *inst)
-    : Vop3("v_s_log_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(867)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_s_log_f16_e64_dpp"
+               : "v_s_log_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(867)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -5314,7 +5623,10 @@ VSLogF16Vop3::VSLogF16Vop3(const MachineInst *inst)
 }
 
 VSRcpF32Vop3::VSRcpF32Vop3(const MachineInst *inst)
-    : Vop3("v_s_rcp_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(868)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_s_rcp_f32_e64_dpp"
+               : "v_s_rcp_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(868)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -5340,7 +5652,10 @@ VSRcpF32Vop3::VSRcpF32Vop3(const MachineInst *inst)
 }
 
 VSRcpF16Vop3::VSRcpF16Vop3(const MachineInst *inst)
-    : Vop3("v_s_rcp_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(869)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_s_rcp_f16_e64_dpp"
+               : "v_s_rcp_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(869)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -5367,7 +5682,10 @@ VSRcpF16Vop3::VSRcpF16Vop3(const MachineInst *inst)
 }
 
 VSRsqF32Vop3::VSRsqF32Vop3(const MachineInst *inst)
-    : Vop3("v_s_rsq_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(870)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_s_rsq_f32_e64_dpp"
+               : "v_s_rsq_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(870)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -5393,7 +5711,10 @@ VSRsqF32Vop3::VSRsqF32Vop3(const MachineInst *inst)
 }
 
 VSRsqF16Vop3::VSRsqF16Vop3(const MachineInst *inst)
-    : Vop3("v_s_rsq_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(871)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_s_rsq_f16_e64_dpp"
+               : "v_s_rsq_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(871)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -5420,7 +5741,10 @@ VSRsqF16Vop3::VSRsqF16Vop3(const MachineInst *inst)
 }
 
 VSSqrtF32Vop3::VSSqrtF32Vop3(const MachineInst *inst)
-    : Vop3("v_s_sqrt_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(872)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_s_sqrt_f32_e64_dpp"
+               : "v_s_sqrt_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(872)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -5446,7 +5770,10 @@ VSSqrtF32Vop3::VSSqrtF32Vop3(const MachineInst *inst)
 }
 
 VSSqrtF16Vop3::VSSqrtF16Vop3(const MachineInst *inst)
-    : Vop3("v_s_sqrt_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(873)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_s_sqrt_f16_e64_dpp"
+               : "v_s_sqrt_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(873)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -5473,7 +5800,10 @@ VSSqrtF16Vop3::VSSqrtF16Vop3(const MachineInst *inst)
 }
 
 VAddNcU16Vop3::VAddNcU16Vop3(const MachineInst *inst)
-    : Vop3("v_add_nc_u16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(923)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_nc_u16_e64_dpp"
+               : "v_add_nc_u16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(923)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5548,7 +5878,10 @@ void VAddNcU16Vop3::implicit_use_operands(
 }
 
 VSubNcU16Vop3::VSubNcU16Vop3(const MachineInst *inst)
-    : Vop3("v_sub_nc_u16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(924)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_nc_u16_e64_dpp"
+               : "v_sub_nc_u16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(924)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5623,7 +5956,10 @@ void VSubNcU16Vop3::implicit_use_operands(
 }
 
 VMulLoU16Vop3::VMulLoU16Vop3(const MachineInst *inst)
-    : Vop3("v_mul_lo_u16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(925)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_lo_u16_e64_dpp"
+               : "v_mul_lo_u16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(925)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5698,7 +6034,10 @@ void VMulLoU16Vop3::implicit_use_operands(
 }
 
 VMaxU16Vop3::VMaxU16Vop3(const MachineInst *inst)
-    : Vop3("v_max_u16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(928)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_u16_e64_dpp"
+               : "v_max_u16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(928)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5772,7 +6111,10 @@ void VMaxU16Vop3::implicit_use_operands(std::vector<const ::rocjitsu::Operand *>
 }
 
 VMaxI16Vop3::VMaxI16Vop3(const MachineInst *inst)
-    : Vop3("v_max_i16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(929)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_i16_e64_dpp"
+               : "v_max_i16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(929)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5846,7 +6188,10 @@ void VMaxI16Vop3::implicit_use_operands(std::vector<const ::rocjitsu::Operand *>
 }
 
 VMinU16Vop3::VMinU16Vop3(const MachineInst *inst)
-    : Vop3("v_min_u16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(930)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_u16_e64_dpp"
+               : "v_min_u16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(930)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5920,7 +6265,10 @@ void VMinU16Vop3::implicit_use_operands(std::vector<const ::rocjitsu::Operand *>
 }
 
 VMinI16Vop3::VMinI16Vop3(const MachineInst *inst)
-    : Vop3("v_min_i16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(931)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_i16_e64_dpp"
+               : "v_min_i16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(931)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5994,7 +6342,10 @@ void VMinI16Vop3::implicit_use_operands(std::vector<const ::rocjitsu::Operand *>
 }
 
 VAddNcI16Vop3::VAddNcI16Vop3(const MachineInst *inst)
-    : Vop3("v_add_nc_i16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(932)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_nc_i16_e64_dpp"
+               : "v_add_nc_i16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(932)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6069,7 +6420,10 @@ void VAddNcI16Vop3::implicit_use_operands(
 }
 
 VSubNcI16Vop3::VSubNcI16Vop3(const MachineInst *inst)
-    : Vop3("v_sub_nc_i16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(933)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_nc_i16_e64_dpp"
+               : "v_sub_nc_i16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(933)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6144,7 +6498,10 @@ void VSubNcI16Vop3::implicit_use_operands(
 }
 
 VMinU64Vop3::VMinU64Vop3(const MachineInst *inst)
-    : Vop3("v_min_u64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(940)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_u64_e64_dpp"
+               : "v_min_u64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(940)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6194,7 +6551,10 @@ VMinU64Vop3::VMinU64Vop3(const MachineInst *inst)
 }
 
 VMaxU64Vop3::VMaxU64Vop3(const MachineInst *inst)
-    : Vop3("v_max_u64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(941)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_u64_e64_dpp"
+               : "v_max_u64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(941)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6244,7 +6604,10 @@ VMaxU64Vop3::VMaxU64Vop3(const MachineInst *inst)
 }
 
 VMinI64Vop3::VMinI64Vop3(const MachineInst *inst)
-    : Vop3("v_min_i64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(942)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_i64_e64_dpp"
+               : "v_min_i64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(942)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6294,7 +6657,10 @@ VMinI64Vop3::VMinI64Vop3(const MachineInst *inst)
 }
 
 VMaxI64Vop3::VMaxI64Vop3(const MachineInst *inst)
-    : Vop3("v_max_i64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(943)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_i64_e64_dpp"
+               : "v_max_i64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(943)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6344,7 +6710,10 @@ VMaxI64Vop3::VMaxI64Vop3(const MachineInst *inst)
 }
 
 VLdexpF32Vop3::VLdexpF32Vop3(const MachineInst *inst)
-    : Vop3("v_ldexp_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(944)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ldexp_f32_e64_dpp"
+               : "v_ldexp_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(944)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6398,7 +6767,10 @@ VLdexpF32Vop3::VLdexpF32Vop3(const MachineInst *inst)
 }
 
 VBfmB32Vop3::VBfmB32Vop3(const MachineInst *inst)
-    : Vop3("v_bfm_b32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(945)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_bfm_b32_e64_dpp"
+               : "v_bfm_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(945)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6452,7 +6824,10 @@ VBfmB32Vop3::VBfmB32Vop3(const MachineInst *inst)
 }
 
 VBcntU32B32Vop3::VBcntU32B32Vop3(const MachineInst *inst)
-    : Vop3("v_bcnt_u32_b32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(946)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_bcnt_u32_b32_e64_dpp"
+               : "v_bcnt_u32_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(946)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6506,7 +6881,10 @@ VBcntU32B32Vop3::VBcntU32B32Vop3(const MachineInst *inst)
 }
 
 VMbcntLoU32B32Vop3::VMbcntLoU32B32Vop3(const MachineInst *inst)
-    : Vop3("v_mbcnt_lo_u32_b32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(947)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mbcnt_lo_u32_b32_e64_dpp"
+               : "v_mbcnt_lo_u32_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(947)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6560,7 +6938,10 @@ VMbcntLoU32B32Vop3::VMbcntLoU32B32Vop3(const MachineInst *inst)
 }
 
 VMbcntHiU32B32Vop3::VMbcntHiU32B32Vop3(const MachineInst *inst)
-    : Vop3("v_mbcnt_hi_u32_b32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(948)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mbcnt_hi_u32_b32_e64_dpp"
+               : "v_mbcnt_hi_u32_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(948)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6614,7 +6995,10 @@ VMbcntHiU32B32Vop3::VMbcntHiU32B32Vop3(const MachineInst *inst)
 }
 
 VSubNcI32Vop3::VSubNcI32Vop3(const MachineInst *inst)
-    : Vop3("v_sub_nc_i32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(953)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_nc_i32_e64_dpp"
+               : "v_sub_nc_i32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(953)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6668,7 +7052,10 @@ VSubNcI32Vop3::VSubNcI32Vop3(const MachineInst *inst)
 }
 
 VAddNcI32Vop3::VAddNcI32Vop3(const MachineInst *inst)
-    : Vop3("v_add_nc_i32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(954)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_nc_i32_e64_dpp"
+               : "v_add_nc_i32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(954)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6722,7 +7109,10 @@ VAddNcI32Vop3::VAddNcI32Vop3(const MachineInst *inst)
 }
 
 VLdexpF64Vop3::VLdexpF64Vop3(const MachineInst *inst)
-    : Vop3("v_ldexp_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(955)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ldexp_f64_e64_dpp"
+               : "v_ldexp_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(955)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6771,7 +7161,10 @@ VLdexpF64Vop3::VLdexpF64Vop3(const MachineInst *inst)
 }
 
 VMulLoU32Vop3::VMulLoU32Vop3(const MachineInst *inst)
-    : Vop3("v_mul_lo_u32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(956)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_lo_u32_e64_dpp"
+               : "v_mul_lo_u32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(956)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6819,7 +7212,10 @@ VMulLoU32Vop3::VMulLoU32Vop3(const MachineInst *inst)
 }
 
 VMulHiU32Vop3::VMulHiU32Vop3(const MachineInst *inst)
-    : Vop3("v_mul_hi_u32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(957)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_hi_u32_e64_dpp"
+               : "v_mul_hi_u32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(957)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6867,7 +7263,10 @@ VMulHiU32Vop3::VMulHiU32Vop3(const MachineInst *inst)
 }
 
 VMulHiI32Vop3::VMulHiI32Vop3(const MachineInst *inst)
-    : Vop3("v_mul_hi_i32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(958)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_hi_i32_e64_dpp"
+               : "v_mul_hi_i32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(958)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6915,7 +7314,10 @@ VMulHiI32Vop3::VMulHiI32Vop3(const MachineInst *inst)
 }
 
 VLshlrevB16Vop3::VLshlrevB16Vop3(const MachineInst *inst)
-    : Vop3("v_lshlrev_b16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(960)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshlrev_b16_e64_dpp"
+               : "v_lshlrev_b16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(960)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6990,7 +7392,10 @@ void VLshlrevB16Vop3::implicit_use_operands(
 }
 
 VLshrrevB16Vop3::VLshrrevB16Vop3(const MachineInst *inst)
-    : Vop3("v_lshrrev_b16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(961)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshrrev_b16_e64_dpp"
+               : "v_lshrrev_b16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(961)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -7065,7 +7470,10 @@ void VLshrrevB16Vop3::implicit_use_operands(
 }
 
 VAshrrevI16Vop3::VAshrrevI16Vop3(const MachineInst *inst)
-    : Vop3("v_ashrrev_i16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(962)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ashrrev_i16_e64_dpp"
+               : "v_ashrrev_i16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(962)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -7140,7 +7548,10 @@ void VAshrrevI16Vop3::implicit_use_operands(
 }
 
 VLshrrevB64Vop3::VLshrrevB64Vop3(const MachineInst *inst)
-    : Vop3("v_lshrrev_b64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(963)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshrrev_b64_e64_dpp"
+               : "v_lshrrev_b64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(963)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -7189,7 +7600,10 @@ VLshrrevB64Vop3::VLshrrevB64Vop3(const MachineInst *inst)
 }
 
 VAshrrevI64Vop3::VAshrrevI64Vop3(const MachineInst *inst)
-    : Vop3("v_ashrrev_i64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(964)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ashrrev_i64_e64_dpp"
+               : "v_ashrrev_i64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(964)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -7238,7 +7652,10 @@ VAshrrevI64Vop3::VAshrrevI64Vop3(const MachineInst *inst)
 }
 
 VMinimumF64Vop3::VMinimumF64Vop3(const MachineInst *inst)
-    : Vop3("v_minimum_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(965)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_minimum_f64_e64_dpp"
+               : "v_minimum_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(965)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -7288,7 +7705,10 @@ VMinimumF64Vop3::VMinimumF64Vop3(const MachineInst *inst)
 }
 
 VMaximumF64Vop3::VMaximumF64Vop3(const MachineInst *inst)
-    : Vop3("v_maximum_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(966)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_maximum_f64_e64_dpp"
+               : "v_maximum_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(966)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -7338,7 +7758,10 @@ VMaximumF64Vop3::VMaximumF64Vop3(const MachineInst *inst)
 }
 
 VAndB16Vop3::VAndB16Vop3(const MachineInst *inst)
-    : Vop3("v_and_b16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(969)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_and_b16_e64_dpp"
+               : "v_and_b16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(969)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -7412,7 +7835,10 @@ void VAndB16Vop3::implicit_use_operands(std::vector<const ::rocjitsu::Operand *>
 }
 
 VOrB16Vop3::VOrB16Vop3(const MachineInst *inst)
-    : Vop3("v_or_b16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(970)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_or_b16_e64_dpp"
+               : "v_or_b16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(970)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -7486,7 +7912,10 @@ void VOrB16Vop3::implicit_use_operands(std::vector<const ::rocjitsu::Operand *> 
 }
 
 VXorB16Vop3::VXorB16Vop3(const MachineInst *inst)
-    : Vop3("v_xor_b16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(971)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_xor_b16_e64_dpp"
+               : "v_xor_b16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(971)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -7560,7 +7989,10 @@ void VXorB16Vop3::implicit_use_operands(std::vector<const ::rocjitsu::Operand *>
 }
 
 VMinimumF32Vop3::VMinimumF32Vop3(const MachineInst *inst)
-    : Vop3("v_minimum_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(972)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_minimum_f32_e64_dpp"
+               : "v_minimum_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(972)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -7614,7 +8046,10 @@ VMinimumF32Vop3::VMinimumF32Vop3(const MachineInst *inst)
 }
 
 VMaximumF32Vop3::VMaximumF32Vop3(const MachineInst *inst)
-    : Vop3("v_maximum_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(973)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_maximum_f32_e64_dpp"
+               : "v_maximum_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(973)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -7668,7 +8103,10 @@ VMaximumF32Vop3::VMaximumF32Vop3(const MachineInst *inst)
 }
 
 VMinimumF16Vop3::VMinimumF16Vop3(const MachineInst *inst)
-    : Vop3("v_minimum_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(974)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_minimum_f16_e64_dpp"
+               : "v_minimum_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(974)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -7743,7 +8181,10 @@ void VMinimumF16Vop3::implicit_use_operands(
 }
 
 VMaximumF16Vop3::VMaximumF16Vop3(const MachineInst *inst)
-    : Vop3("v_maximum_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(975)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_maximum_f16_e64_dpp"
+               : "v_maximum_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(975)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -7818,8 +8259,10 @@ void VMaximumF16Vop3::implicit_use_operands(
 }
 
 VAddCoCiU32Vop3SdstEnc::VAddCoCiU32Vop3SdstEnc(const MachineInst *inst)
-    : Vop3SdstEnc("v_add_co_ci_u32", reinterpret_cast<const OpEncoding *>(inst),
-                  selected_exec_fn(1150)),
+    : Vop3SdstEnc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                      ? "v_add_co_ci_u32_e64_dpp"
+                      : "v_add_co_ci_u32",
+                  reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1150)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -7890,8 +8333,10 @@ VAddCoCiU32Vop3SdstEnc::VAddCoCiU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 VSubCoCiU32Vop3SdstEnc::VSubCoCiU32Vop3SdstEnc(const MachineInst *inst)
-    : Vop3SdstEnc("v_sub_co_ci_u32", reinterpret_cast<const OpEncoding *>(inst),
-                  selected_exec_fn(1151)),
+    : Vop3SdstEnc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                      ? "v_sub_co_ci_u32_e64_dpp"
+                      : "v_sub_co_ci_u32",
+                  reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1151)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -7962,8 +8407,10 @@ VSubCoCiU32Vop3SdstEnc::VSubCoCiU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 VSubrevCoCiU32Vop3SdstEnc::VSubrevCoCiU32Vop3SdstEnc(const MachineInst *inst)
-    : Vop3SdstEnc("v_subrev_co_ci_u32", reinterpret_cast<const OpEncoding *>(inst),
-                  selected_exec_fn(1152)),
+    : Vop3SdstEnc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                      ? "v_subrev_co_ci_u32_e64_dpp"
+                      : "v_subrev_co_ci_u32",
+                  reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1152)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -8034,8 +8481,10 @@ VSubrevCoCiU32Vop3SdstEnc::VSubrevCoCiU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 VDivScaleF32Vop3SdstEnc::VDivScaleF32Vop3SdstEnc(const MachineInst *inst)
-    : Vop3SdstEnc("v_div_scale_f32", reinterpret_cast<const OpEncoding *>(inst),
-                  selected_exec_fn(1153)),
+    : Vop3SdstEnc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                      ? "v_div_scale_f32_e64_dpp"
+                      : "v_div_scale_f32",
+                  reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1153)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -8091,8 +8540,10 @@ VDivScaleF32Vop3SdstEnc::VDivScaleF32Vop3SdstEnc(const MachineInst *inst)
 }
 
 VDivScaleF64Vop3SdstEnc::VDivScaleF64Vop3SdstEnc(const MachineInst *inst)
-    : Vop3SdstEnc("v_div_scale_f64", reinterpret_cast<const OpEncoding *>(inst),
-                  selected_exec_fn(1154)),
+    : Vop3SdstEnc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                      ? "v_div_scale_f64_e64_dpp"
+                      : "v_div_scale_f64",
+                  reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1154)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -8162,8 +8613,10 @@ VDivScaleF64Vop3SdstEnc::VDivScaleF64Vop3SdstEnc(const MachineInst *inst)
 }
 
 VMadCoU64U32Vop3SdstEnc::VMadCoU64U32Vop3SdstEnc(const MachineInst *inst)
-    : Vop3SdstEnc("v_mad_co_u64_u32", reinterpret_cast<const OpEncoding *>(inst),
-                  selected_exec_fn(1155)),
+    : Vop3SdstEnc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                      ? "v_mad_co_u64_u32_e64_dpp"
+                      : "v_mad_co_u64_u32",
+                  reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1155)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -8229,8 +8682,10 @@ VMadCoU64U32Vop3SdstEnc::VMadCoU64U32Vop3SdstEnc(const MachineInst *inst)
 }
 
 VMadCoI64I32Vop3SdstEnc::VMadCoI64I32Vop3SdstEnc(const MachineInst *inst)
-    : Vop3SdstEnc("v_mad_co_i64_i32", reinterpret_cast<const OpEncoding *>(inst),
-                  selected_exec_fn(1156)),
+    : Vop3SdstEnc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                      ? "v_mad_co_i64_i32_e64_dpp"
+                      : "v_mad_co_i64_i32",
+                  reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1156)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -8296,8 +8751,10 @@ VMadCoI64I32Vop3SdstEnc::VMadCoI64I32Vop3SdstEnc(const MachineInst *inst)
 }
 
 VAddCoU32Vop3SdstEnc::VAddCoU32Vop3SdstEnc(const MachineInst *inst)
-    : Vop3SdstEnc("v_add_co_u32", reinterpret_cast<const OpEncoding *>(inst),
-                  selected_exec_fn(1157)),
+    : Vop3SdstEnc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                      ? "v_add_co_u32_e64_dpp"
+                      : "v_add_co_u32",
+                  reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1157)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -8353,8 +8810,10 @@ VAddCoU32Vop3SdstEnc::VAddCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 VSubCoU32Vop3SdstEnc::VSubCoU32Vop3SdstEnc(const MachineInst *inst)
-    : Vop3SdstEnc("v_sub_co_u32", reinterpret_cast<const OpEncoding *>(inst),
-                  selected_exec_fn(1158)),
+    : Vop3SdstEnc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                      ? "v_sub_co_u32_e64_dpp"
+                      : "v_sub_co_u32",
+                  reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1158)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -8410,8 +8869,10 @@ VSubCoU32Vop3SdstEnc::VSubCoU32Vop3SdstEnc(const MachineInst *inst)
 }
 
 VSubrevCoU32Vop3SdstEnc::VSubrevCoU32Vop3SdstEnc(const MachineInst *inst)
-    : Vop3SdstEnc("v_subrev_co_u32", reinterpret_cast<const OpEncoding *>(inst),
-                  selected_exec_fn(1159)),
+    : Vop3SdstEnc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                      ? "v_subrev_co_u32_e64_dpp"
+                      : "v_subrev_co_u32",
+                  reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1159)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/gfx1250/vop3_cmp.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/gfx1250/vop3_cmp.cpp
@@ -12,7 +12,10 @@ namespace rocjitsu {
 namespace gfx1250 {
 
 VCmpLtF16Vop3::VCmpLtF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lt_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(988)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_f16_e64_dpp"
+               : "v_cmp_lt_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(988)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -73,7 +76,10 @@ VCmpLtF16Vop3::VCmpLtF16Vop3(const MachineInst *inst)
 }
 
 VCmpEqF16Vop3::VCmpEqF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_eq_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(989)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_f16_e64_dpp"
+               : "v_cmp_eq_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(989)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -134,7 +140,10 @@ VCmpEqF16Vop3::VCmpEqF16Vop3(const MachineInst *inst)
 }
 
 VCmpLeF16Vop3::VCmpLeF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_le_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(990)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_f16_e64_dpp"
+               : "v_cmp_le_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(990)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -195,7 +204,10 @@ VCmpLeF16Vop3::VCmpLeF16Vop3(const MachineInst *inst)
 }
 
 VCmpGtF16Vop3::VCmpGtF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_gt_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(991)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_f16_e64_dpp"
+               : "v_cmp_gt_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(991)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -256,7 +268,10 @@ VCmpGtF16Vop3::VCmpGtF16Vop3(const MachineInst *inst)
 }
 
 VCmpLgF16Vop3::VCmpLgF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lg_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(992)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lg_f16_e64_dpp"
+               : "v_cmp_lg_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(992)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -317,7 +332,10 @@ VCmpLgF16Vop3::VCmpLgF16Vop3(const MachineInst *inst)
 }
 
 VCmpGeF16Vop3::VCmpGeF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ge_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(993)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_f16_e64_dpp"
+               : "v_cmp_ge_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(993)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -378,7 +396,10 @@ VCmpGeF16Vop3::VCmpGeF16Vop3(const MachineInst *inst)
 }
 
 VCmpOF16Vop3::VCmpOF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_o_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(994)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_o_f16_e64_dpp"
+               : "v_cmp_o_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(994)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -439,7 +460,10 @@ VCmpOF16Vop3::VCmpOF16Vop3(const MachineInst *inst)
 }
 
 VCmpUF16Vop3::VCmpUF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_u_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(995)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_u_f16_e64_dpp"
+               : "v_cmp_u_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(995)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -500,7 +524,10 @@ VCmpUF16Vop3::VCmpUF16Vop3(const MachineInst *inst)
 }
 
 VCmpNgeF16Vop3::VCmpNgeF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nge_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(996)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nge_f16_e64_dpp"
+               : "v_cmp_nge_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(996)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -561,7 +588,10 @@ VCmpNgeF16Vop3::VCmpNgeF16Vop3(const MachineInst *inst)
 }
 
 VCmpNlgF16Vop3::VCmpNlgF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nlg_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(997)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlg_f16_e64_dpp"
+               : "v_cmp_nlg_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(997)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -622,7 +652,10 @@ VCmpNlgF16Vop3::VCmpNlgF16Vop3(const MachineInst *inst)
 }
 
 VCmpNgtF16Vop3::VCmpNgtF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ngt_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(998)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ngt_f16_e64_dpp"
+               : "v_cmp_ngt_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(998)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -683,7 +716,10 @@ VCmpNgtF16Vop3::VCmpNgtF16Vop3(const MachineInst *inst)
 }
 
 VCmpNleF16Vop3::VCmpNleF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nle_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(999)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nle_f16_e64_dpp"
+               : "v_cmp_nle_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(999)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -744,7 +780,10 @@ VCmpNleF16Vop3::VCmpNleF16Vop3(const MachineInst *inst)
 }
 
 VCmpNeqF16Vop3::VCmpNeqF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_neq_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1000)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_neq_f16_e64_dpp"
+               : "v_cmp_neq_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1000)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -805,7 +844,10 @@ VCmpNeqF16Vop3::VCmpNeqF16Vop3(const MachineInst *inst)
 }
 
 VCmpNltF16Vop3::VCmpNltF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nlt_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1001)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlt_f16_e64_dpp"
+               : "v_cmp_nlt_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1001)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -866,7 +908,10 @@ VCmpNltF16Vop3::VCmpNltF16Vop3(const MachineInst *inst)
 }
 
 VCmpLtF32Vop3::VCmpLtF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lt_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1002)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_f32_e64_dpp"
+               : "v_cmp_lt_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1002)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -919,7 +964,10 @@ VCmpLtF32Vop3::VCmpLtF32Vop3(const MachineInst *inst)
 }
 
 VCmpEqF32Vop3::VCmpEqF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_eq_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1003)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_f32_e64_dpp"
+               : "v_cmp_eq_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1003)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -972,7 +1020,10 @@ VCmpEqF32Vop3::VCmpEqF32Vop3(const MachineInst *inst)
 }
 
 VCmpLeF32Vop3::VCmpLeF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_le_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1004)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_f32_e64_dpp"
+               : "v_cmp_le_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1004)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1025,7 +1076,10 @@ VCmpLeF32Vop3::VCmpLeF32Vop3(const MachineInst *inst)
 }
 
 VCmpGtF32Vop3::VCmpGtF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_gt_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1005)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_f32_e64_dpp"
+               : "v_cmp_gt_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1005)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1078,7 +1132,10 @@ VCmpGtF32Vop3::VCmpGtF32Vop3(const MachineInst *inst)
 }
 
 VCmpLgF32Vop3::VCmpLgF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lg_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1006)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lg_f32_e64_dpp"
+               : "v_cmp_lg_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1006)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1131,7 +1188,10 @@ VCmpLgF32Vop3::VCmpLgF32Vop3(const MachineInst *inst)
 }
 
 VCmpGeF32Vop3::VCmpGeF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ge_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1007)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_f32_e64_dpp"
+               : "v_cmp_ge_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1007)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1184,7 +1244,10 @@ VCmpGeF32Vop3::VCmpGeF32Vop3(const MachineInst *inst)
 }
 
 VCmpOF32Vop3::VCmpOF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_o_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1008)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_o_f32_e64_dpp"
+               : "v_cmp_o_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1008)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1237,7 +1300,10 @@ VCmpOF32Vop3::VCmpOF32Vop3(const MachineInst *inst)
 }
 
 VCmpUF32Vop3::VCmpUF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_u_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1009)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_u_f32_e64_dpp"
+               : "v_cmp_u_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1009)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1290,7 +1356,10 @@ VCmpUF32Vop3::VCmpUF32Vop3(const MachineInst *inst)
 }
 
 VCmpNgeF32Vop3::VCmpNgeF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nge_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1010)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nge_f32_e64_dpp"
+               : "v_cmp_nge_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1010)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1343,7 +1412,10 @@ VCmpNgeF32Vop3::VCmpNgeF32Vop3(const MachineInst *inst)
 }
 
 VCmpNlgF32Vop3::VCmpNlgF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nlg_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1011)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlg_f32_e64_dpp"
+               : "v_cmp_nlg_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1011)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1396,7 +1468,10 @@ VCmpNlgF32Vop3::VCmpNlgF32Vop3(const MachineInst *inst)
 }
 
 VCmpNgtF32Vop3::VCmpNgtF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ngt_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1012)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ngt_f32_e64_dpp"
+               : "v_cmp_ngt_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1012)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1449,7 +1524,10 @@ VCmpNgtF32Vop3::VCmpNgtF32Vop3(const MachineInst *inst)
 }
 
 VCmpNleF32Vop3::VCmpNleF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nle_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1013)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nle_f32_e64_dpp"
+               : "v_cmp_nle_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1013)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1502,7 +1580,10 @@ VCmpNleF32Vop3::VCmpNleF32Vop3(const MachineInst *inst)
 }
 
 VCmpNeqF32Vop3::VCmpNeqF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_neq_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1014)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_neq_f32_e64_dpp"
+               : "v_cmp_neq_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1014)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1555,7 +1636,10 @@ VCmpNeqF32Vop3::VCmpNeqF32Vop3(const MachineInst *inst)
 }
 
 VCmpNltF32Vop3::VCmpNltF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nlt_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1015)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlt_f32_e64_dpp"
+               : "v_cmp_nlt_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1015)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1608,7 +1692,10 @@ VCmpNltF32Vop3::VCmpNltF32Vop3(const MachineInst *inst)
 }
 
 VCmpLtF64Vop3::VCmpLtF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lt_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1016)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_f64_e64_dpp"
+               : "v_cmp_lt_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1016)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1649,7 +1736,10 @@ VCmpLtF64Vop3::VCmpLtF64Vop3(const MachineInst *inst)
 }
 
 VCmpEqF64Vop3::VCmpEqF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_eq_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1017)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_f64_e64_dpp"
+               : "v_cmp_eq_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1017)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1690,7 +1780,10 @@ VCmpEqF64Vop3::VCmpEqF64Vop3(const MachineInst *inst)
 }
 
 VCmpLeF64Vop3::VCmpLeF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_le_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1018)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_f64_e64_dpp"
+               : "v_cmp_le_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1018)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1731,7 +1824,10 @@ VCmpLeF64Vop3::VCmpLeF64Vop3(const MachineInst *inst)
 }
 
 VCmpGtF64Vop3::VCmpGtF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_gt_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1019)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_f64_e64_dpp"
+               : "v_cmp_gt_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1019)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1772,7 +1868,10 @@ VCmpGtF64Vop3::VCmpGtF64Vop3(const MachineInst *inst)
 }
 
 VCmpLgF64Vop3::VCmpLgF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lg_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1020)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lg_f64_e64_dpp"
+               : "v_cmp_lg_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1020)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1813,7 +1912,10 @@ VCmpLgF64Vop3::VCmpLgF64Vop3(const MachineInst *inst)
 }
 
 VCmpGeF64Vop3::VCmpGeF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ge_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1021)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_f64_e64_dpp"
+               : "v_cmp_ge_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1021)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1854,7 +1956,10 @@ VCmpGeF64Vop3::VCmpGeF64Vop3(const MachineInst *inst)
 }
 
 VCmpOF64Vop3::VCmpOF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_o_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1022)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_o_f64_e64_dpp"
+               : "v_cmp_o_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1022)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1895,7 +2000,10 @@ VCmpOF64Vop3::VCmpOF64Vop3(const MachineInst *inst)
 }
 
 VCmpUF64Vop3::VCmpUF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_u_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1023)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_u_f64_e64_dpp"
+               : "v_cmp_u_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1023)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1936,7 +2044,10 @@ VCmpUF64Vop3::VCmpUF64Vop3(const MachineInst *inst)
 }
 
 VCmpNgeF64Vop3::VCmpNgeF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nge_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1024)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nge_f64_e64_dpp"
+               : "v_cmp_nge_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1024)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1977,7 +2088,10 @@ VCmpNgeF64Vop3::VCmpNgeF64Vop3(const MachineInst *inst)
 }
 
 VCmpNlgF64Vop3::VCmpNlgF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nlg_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1025)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlg_f64_e64_dpp"
+               : "v_cmp_nlg_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1025)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2018,7 +2132,10 @@ VCmpNlgF64Vop3::VCmpNlgF64Vop3(const MachineInst *inst)
 }
 
 VCmpNgtF64Vop3::VCmpNgtF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ngt_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1026)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ngt_f64_e64_dpp"
+               : "v_cmp_ngt_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1026)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2059,7 +2176,10 @@ VCmpNgtF64Vop3::VCmpNgtF64Vop3(const MachineInst *inst)
 }
 
 VCmpNleF64Vop3::VCmpNleF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nle_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1027)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nle_f64_e64_dpp"
+               : "v_cmp_nle_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1027)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2100,7 +2220,10 @@ VCmpNleF64Vop3::VCmpNleF64Vop3(const MachineInst *inst)
 }
 
 VCmpNeqF64Vop3::VCmpNeqF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_neq_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1028)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_neq_f64_e64_dpp"
+               : "v_cmp_neq_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1028)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2141,7 +2264,10 @@ VCmpNeqF64Vop3::VCmpNeqF64Vop3(const MachineInst *inst)
 }
 
 VCmpNltF64Vop3::VCmpNltF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nlt_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1029)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlt_f64_e64_dpp"
+               : "v_cmp_nlt_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1029)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2182,7 +2308,10 @@ VCmpNltF64Vop3::VCmpNltF64Vop3(const MachineInst *inst)
 }
 
 VCmpLtI16Vop3::VCmpLtI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lt_i16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1030)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_i16_e64_dpp"
+               : "v_cmp_lt_i16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1030)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2243,7 +2372,10 @@ VCmpLtI16Vop3::VCmpLtI16Vop3(const MachineInst *inst)
 }
 
 VCmpEqI16Vop3::VCmpEqI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_eq_i16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1031)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_i16_e64_dpp"
+               : "v_cmp_eq_i16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1031)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2304,7 +2436,10 @@ VCmpEqI16Vop3::VCmpEqI16Vop3(const MachineInst *inst)
 }
 
 VCmpLeI16Vop3::VCmpLeI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_le_i16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1032)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_i16_e64_dpp"
+               : "v_cmp_le_i16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1032)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2365,7 +2500,10 @@ VCmpLeI16Vop3::VCmpLeI16Vop3(const MachineInst *inst)
 }
 
 VCmpGtI16Vop3::VCmpGtI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_gt_i16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1033)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_i16_e64_dpp"
+               : "v_cmp_gt_i16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1033)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2426,7 +2564,10 @@ VCmpGtI16Vop3::VCmpGtI16Vop3(const MachineInst *inst)
 }
 
 VCmpNeI16Vop3::VCmpNeI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ne_i16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1034)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_i16_e64_dpp"
+               : "v_cmp_ne_i16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1034)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2487,7 +2628,10 @@ VCmpNeI16Vop3::VCmpNeI16Vop3(const MachineInst *inst)
 }
 
 VCmpGeI16Vop3::VCmpGeI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ge_i16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1035)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_i16_e64_dpp"
+               : "v_cmp_ge_i16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1035)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2548,7 +2692,10 @@ VCmpGeI16Vop3::VCmpGeI16Vop3(const MachineInst *inst)
 }
 
 VCmpLtU16Vop3::VCmpLtU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lt_u16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1036)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_u16_e64_dpp"
+               : "v_cmp_lt_u16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1036)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2609,7 +2756,10 @@ VCmpLtU16Vop3::VCmpLtU16Vop3(const MachineInst *inst)
 }
 
 VCmpEqU16Vop3::VCmpEqU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_eq_u16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1037)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_u16_e64_dpp"
+               : "v_cmp_eq_u16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1037)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2670,7 +2820,10 @@ VCmpEqU16Vop3::VCmpEqU16Vop3(const MachineInst *inst)
 }
 
 VCmpLeU16Vop3::VCmpLeU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_le_u16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1038)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_u16_e64_dpp"
+               : "v_cmp_le_u16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1038)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2731,7 +2884,10 @@ VCmpLeU16Vop3::VCmpLeU16Vop3(const MachineInst *inst)
 }
 
 VCmpGtU16Vop3::VCmpGtU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_gt_u16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1039)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_u16_e64_dpp"
+               : "v_cmp_gt_u16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1039)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2792,7 +2948,10 @@ VCmpGtU16Vop3::VCmpGtU16Vop3(const MachineInst *inst)
 }
 
 VCmpNeU16Vop3::VCmpNeU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ne_u16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1040)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_u16_e64_dpp"
+               : "v_cmp_ne_u16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1040)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2853,7 +3012,10 @@ VCmpNeU16Vop3::VCmpNeU16Vop3(const MachineInst *inst)
 }
 
 VCmpGeU16Vop3::VCmpGeU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ge_u16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1041)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_u16_e64_dpp"
+               : "v_cmp_ge_u16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1041)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2914,7 +3076,10 @@ VCmpGeU16Vop3::VCmpGeU16Vop3(const MachineInst *inst)
 }
 
 VCmpLtI32Vop3::VCmpLtI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lt_i32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1042)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_i32_e64_dpp"
+               : "v_cmp_lt_i32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1042)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2967,7 +3132,10 @@ VCmpLtI32Vop3::VCmpLtI32Vop3(const MachineInst *inst)
 }
 
 VCmpEqI32Vop3::VCmpEqI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_eq_i32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1043)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_i32_e64_dpp"
+               : "v_cmp_eq_i32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1043)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3020,7 +3188,10 @@ VCmpEqI32Vop3::VCmpEqI32Vop3(const MachineInst *inst)
 }
 
 VCmpLeI32Vop3::VCmpLeI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_le_i32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1044)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_i32_e64_dpp"
+               : "v_cmp_le_i32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1044)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3073,7 +3244,10 @@ VCmpLeI32Vop3::VCmpLeI32Vop3(const MachineInst *inst)
 }
 
 VCmpGtI32Vop3::VCmpGtI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_gt_i32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1045)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_i32_e64_dpp"
+               : "v_cmp_gt_i32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1045)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3126,7 +3300,10 @@ VCmpGtI32Vop3::VCmpGtI32Vop3(const MachineInst *inst)
 }
 
 VCmpNeI32Vop3::VCmpNeI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ne_i32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1046)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_i32_e64_dpp"
+               : "v_cmp_ne_i32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1046)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3179,7 +3356,10 @@ VCmpNeI32Vop3::VCmpNeI32Vop3(const MachineInst *inst)
 }
 
 VCmpGeI32Vop3::VCmpGeI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ge_i32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1047)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_i32_e64_dpp"
+               : "v_cmp_ge_i32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1047)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3232,7 +3412,10 @@ VCmpGeI32Vop3::VCmpGeI32Vop3(const MachineInst *inst)
 }
 
 VCmpLtU32Vop3::VCmpLtU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lt_u32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1048)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_u32_e64_dpp"
+               : "v_cmp_lt_u32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1048)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3285,7 +3468,10 @@ VCmpLtU32Vop3::VCmpLtU32Vop3(const MachineInst *inst)
 }
 
 VCmpEqU32Vop3::VCmpEqU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_eq_u32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1049)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_u32_e64_dpp"
+               : "v_cmp_eq_u32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1049)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3338,7 +3524,10 @@ VCmpEqU32Vop3::VCmpEqU32Vop3(const MachineInst *inst)
 }
 
 VCmpLeU32Vop3::VCmpLeU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_le_u32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1050)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_u32_e64_dpp"
+               : "v_cmp_le_u32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1050)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3391,7 +3580,10 @@ VCmpLeU32Vop3::VCmpLeU32Vop3(const MachineInst *inst)
 }
 
 VCmpGtU32Vop3::VCmpGtU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_gt_u32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1051)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_u32_e64_dpp"
+               : "v_cmp_gt_u32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1051)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3444,7 +3636,10 @@ VCmpGtU32Vop3::VCmpGtU32Vop3(const MachineInst *inst)
 }
 
 VCmpNeU32Vop3::VCmpNeU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ne_u32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1052)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_u32_e64_dpp"
+               : "v_cmp_ne_u32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1052)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3497,7 +3692,10 @@ VCmpNeU32Vop3::VCmpNeU32Vop3(const MachineInst *inst)
 }
 
 VCmpGeU32Vop3::VCmpGeU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ge_u32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1053)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_u32_e64_dpp"
+               : "v_cmp_ge_u32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1053)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3550,7 +3748,10 @@ VCmpGeU32Vop3::VCmpGeU32Vop3(const MachineInst *inst)
 }
 
 VCmpLtI64Vop3::VCmpLtI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lt_i64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1054)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_i64_e64_dpp"
+               : "v_cmp_lt_i64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1054)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3591,7 +3792,10 @@ VCmpLtI64Vop3::VCmpLtI64Vop3(const MachineInst *inst)
 }
 
 VCmpEqI64Vop3::VCmpEqI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_eq_i64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1055)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_i64_e64_dpp"
+               : "v_cmp_eq_i64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1055)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3632,7 +3836,10 @@ VCmpEqI64Vop3::VCmpEqI64Vop3(const MachineInst *inst)
 }
 
 VCmpLeI64Vop3::VCmpLeI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_le_i64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1056)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_i64_e64_dpp"
+               : "v_cmp_le_i64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1056)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3673,7 +3880,10 @@ VCmpLeI64Vop3::VCmpLeI64Vop3(const MachineInst *inst)
 }
 
 VCmpGtI64Vop3::VCmpGtI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_gt_i64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1057)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_i64_e64_dpp"
+               : "v_cmp_gt_i64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1057)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3714,7 +3924,10 @@ VCmpGtI64Vop3::VCmpGtI64Vop3(const MachineInst *inst)
 }
 
 VCmpNeI64Vop3::VCmpNeI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ne_i64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1058)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_i64_e64_dpp"
+               : "v_cmp_ne_i64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1058)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3755,7 +3968,10 @@ VCmpNeI64Vop3::VCmpNeI64Vop3(const MachineInst *inst)
 }
 
 VCmpGeI64Vop3::VCmpGeI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ge_i64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1059)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_i64_e64_dpp"
+               : "v_cmp_ge_i64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1059)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3796,7 +4012,10 @@ VCmpGeI64Vop3::VCmpGeI64Vop3(const MachineInst *inst)
 }
 
 VCmpLtU64Vop3::VCmpLtU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lt_u64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1060)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_u64_e64_dpp"
+               : "v_cmp_lt_u64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1060)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3837,7 +4056,10 @@ VCmpLtU64Vop3::VCmpLtU64Vop3(const MachineInst *inst)
 }
 
 VCmpEqU64Vop3::VCmpEqU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_eq_u64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1061)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_u64_e64_dpp"
+               : "v_cmp_eq_u64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1061)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3878,7 +4100,10 @@ VCmpEqU64Vop3::VCmpEqU64Vop3(const MachineInst *inst)
 }
 
 VCmpLeU64Vop3::VCmpLeU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_le_u64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1062)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_u64_e64_dpp"
+               : "v_cmp_le_u64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1062)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3919,7 +4144,10 @@ VCmpLeU64Vop3::VCmpLeU64Vop3(const MachineInst *inst)
 }
 
 VCmpGtU64Vop3::VCmpGtU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_gt_u64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1063)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_u64_e64_dpp"
+               : "v_cmp_gt_u64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1063)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3960,7 +4188,10 @@ VCmpGtU64Vop3::VCmpGtU64Vop3(const MachineInst *inst)
 }
 
 VCmpNeU64Vop3::VCmpNeU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ne_u64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1064)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_u64_e64_dpp"
+               : "v_cmp_ne_u64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1064)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4001,7 +4232,10 @@ VCmpNeU64Vop3::VCmpNeU64Vop3(const MachineInst *inst)
 }
 
 VCmpGeU64Vop3::VCmpGeU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ge_u64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1065)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_u64_e64_dpp"
+               : "v_cmp_ge_u64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1065)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4042,7 +4276,10 @@ VCmpGeU64Vop3::VCmpGeU64Vop3(const MachineInst *inst)
 }
 
 VCmpClassF16Vop3::VCmpClassF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_class_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1066)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_class_f16_e64_dpp"
+               : "v_cmp_class_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1066)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4103,7 +4340,10 @@ VCmpClassF16Vop3::VCmpClassF16Vop3(const MachineInst *inst)
 }
 
 VCmpClassF32Vop3::VCmpClassF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_class_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1067)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_class_f32_e64_dpp"
+               : "v_cmp_class_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1067)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4156,7 +4396,10 @@ VCmpClassF32Vop3::VCmpClassF32Vop3(const MachineInst *inst)
 }
 
 VCmpClassF64Vop3::VCmpClassF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_class_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1068)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_class_f64_e64_dpp"
+               : "v_cmp_class_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1068)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4196,7 +4439,10 @@ VCmpClassF64Vop3::VCmpClassF64Vop3(const MachineInst *inst)
 }
 
 VCmpxLtF16Vop3::VCmpxLtF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lt_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1069)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_f16_e64_dpp"
+               : "v_cmpx_lt_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1069)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4261,7 +4507,10 @@ VCmpxLtF16Vop3::VCmpxLtF16Vop3(const MachineInst *inst)
 }
 
 VCmpxEqF16Vop3::VCmpxEqF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_eq_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1070)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_f16_e64_dpp"
+               : "v_cmpx_eq_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1070)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4326,7 +4575,10 @@ VCmpxEqF16Vop3::VCmpxEqF16Vop3(const MachineInst *inst)
 }
 
 VCmpxLeF16Vop3::VCmpxLeF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_le_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1071)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_f16_e64_dpp"
+               : "v_cmpx_le_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1071)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4391,7 +4643,10 @@ VCmpxLeF16Vop3::VCmpxLeF16Vop3(const MachineInst *inst)
 }
 
 VCmpxGtF16Vop3::VCmpxGtF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_gt_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1072)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_f16_e64_dpp"
+               : "v_cmpx_gt_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1072)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4456,7 +4711,10 @@ VCmpxGtF16Vop3::VCmpxGtF16Vop3(const MachineInst *inst)
 }
 
 VCmpxLgF16Vop3::VCmpxLgF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lg_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1073)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lg_f16_e64_dpp"
+               : "v_cmpx_lg_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1073)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4521,7 +4779,10 @@ VCmpxLgF16Vop3::VCmpxLgF16Vop3(const MachineInst *inst)
 }
 
 VCmpxGeF16Vop3::VCmpxGeF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ge_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1074)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_f16_e64_dpp"
+               : "v_cmpx_ge_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1074)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4586,7 +4847,10 @@ VCmpxGeF16Vop3::VCmpxGeF16Vop3(const MachineInst *inst)
 }
 
 VCmpxOF16Vop3::VCmpxOF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_o_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1075)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_o_f16_e64_dpp"
+               : "v_cmpx_o_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1075)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4651,7 +4915,10 @@ VCmpxOF16Vop3::VCmpxOF16Vop3(const MachineInst *inst)
 }
 
 VCmpxUF16Vop3::VCmpxUF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_u_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1076)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_u_f16_e64_dpp"
+               : "v_cmpx_u_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1076)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4716,7 +4983,10 @@ VCmpxUF16Vop3::VCmpxUF16Vop3(const MachineInst *inst)
 }
 
 VCmpxNgeF16Vop3::VCmpxNgeF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nge_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1077)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nge_f16_e64_dpp"
+               : "v_cmpx_nge_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1077)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4781,7 +5051,10 @@ VCmpxNgeF16Vop3::VCmpxNgeF16Vop3(const MachineInst *inst)
 }
 
 VCmpxNlgF16Vop3::VCmpxNlgF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nlg_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1078)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlg_f16_e64_dpp"
+               : "v_cmpx_nlg_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1078)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4846,7 +5119,10 @@ VCmpxNlgF16Vop3::VCmpxNlgF16Vop3(const MachineInst *inst)
 }
 
 VCmpxNgtF16Vop3::VCmpxNgtF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ngt_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1079)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ngt_f16_e64_dpp"
+               : "v_cmpx_ngt_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1079)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4911,7 +5187,10 @@ VCmpxNgtF16Vop3::VCmpxNgtF16Vop3(const MachineInst *inst)
 }
 
 VCmpxNleF16Vop3::VCmpxNleF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nle_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1080)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nle_f16_e64_dpp"
+               : "v_cmpx_nle_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1080)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4976,7 +5255,10 @@ VCmpxNleF16Vop3::VCmpxNleF16Vop3(const MachineInst *inst)
 }
 
 VCmpxNeqF16Vop3::VCmpxNeqF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_neq_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1081)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_neq_f16_e64_dpp"
+               : "v_cmpx_neq_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1081)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5041,7 +5323,10 @@ VCmpxNeqF16Vop3::VCmpxNeqF16Vop3(const MachineInst *inst)
 }
 
 VCmpxNltF16Vop3::VCmpxNltF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nlt_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1082)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlt_f16_e64_dpp"
+               : "v_cmpx_nlt_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1082)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5106,7 +5391,10 @@ VCmpxNltF16Vop3::VCmpxNltF16Vop3(const MachineInst *inst)
 }
 
 VCmpxLtF32Vop3::VCmpxLtF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lt_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1083)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_f32_e64_dpp"
+               : "v_cmpx_lt_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1083)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5163,7 +5451,10 @@ VCmpxLtF32Vop3::VCmpxLtF32Vop3(const MachineInst *inst)
 }
 
 VCmpxEqF32Vop3::VCmpxEqF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_eq_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1084)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_f32_e64_dpp"
+               : "v_cmpx_eq_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1084)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5220,7 +5511,10 @@ VCmpxEqF32Vop3::VCmpxEqF32Vop3(const MachineInst *inst)
 }
 
 VCmpxLeF32Vop3::VCmpxLeF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_le_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1085)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_f32_e64_dpp"
+               : "v_cmpx_le_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1085)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5277,7 +5571,10 @@ VCmpxLeF32Vop3::VCmpxLeF32Vop3(const MachineInst *inst)
 }
 
 VCmpxGtF32Vop3::VCmpxGtF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_gt_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1086)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_f32_e64_dpp"
+               : "v_cmpx_gt_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1086)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5334,7 +5631,10 @@ VCmpxGtF32Vop3::VCmpxGtF32Vop3(const MachineInst *inst)
 }
 
 VCmpxLgF32Vop3::VCmpxLgF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lg_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1087)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lg_f32_e64_dpp"
+               : "v_cmpx_lg_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1087)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5391,7 +5691,10 @@ VCmpxLgF32Vop3::VCmpxLgF32Vop3(const MachineInst *inst)
 }
 
 VCmpxGeF32Vop3::VCmpxGeF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ge_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1088)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_f32_e64_dpp"
+               : "v_cmpx_ge_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1088)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5448,7 +5751,10 @@ VCmpxGeF32Vop3::VCmpxGeF32Vop3(const MachineInst *inst)
 }
 
 VCmpxOF32Vop3::VCmpxOF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_o_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1089)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_o_f32_e64_dpp"
+               : "v_cmpx_o_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1089)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5505,7 +5811,10 @@ VCmpxOF32Vop3::VCmpxOF32Vop3(const MachineInst *inst)
 }
 
 VCmpxUF32Vop3::VCmpxUF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_u_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1090)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_u_f32_e64_dpp"
+               : "v_cmpx_u_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1090)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5562,7 +5871,10 @@ VCmpxUF32Vop3::VCmpxUF32Vop3(const MachineInst *inst)
 }
 
 VCmpxNgeF32Vop3::VCmpxNgeF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nge_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1091)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nge_f32_e64_dpp"
+               : "v_cmpx_nge_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1091)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5619,7 +5931,10 @@ VCmpxNgeF32Vop3::VCmpxNgeF32Vop3(const MachineInst *inst)
 }
 
 VCmpxNlgF32Vop3::VCmpxNlgF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nlg_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1092)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlg_f32_e64_dpp"
+               : "v_cmpx_nlg_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1092)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5676,7 +5991,10 @@ VCmpxNlgF32Vop3::VCmpxNlgF32Vop3(const MachineInst *inst)
 }
 
 VCmpxNgtF32Vop3::VCmpxNgtF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ngt_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1093)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ngt_f32_e64_dpp"
+               : "v_cmpx_ngt_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1093)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5733,7 +6051,10 @@ VCmpxNgtF32Vop3::VCmpxNgtF32Vop3(const MachineInst *inst)
 }
 
 VCmpxNleF32Vop3::VCmpxNleF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nle_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1094)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nle_f32_e64_dpp"
+               : "v_cmpx_nle_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1094)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5790,7 +6111,10 @@ VCmpxNleF32Vop3::VCmpxNleF32Vop3(const MachineInst *inst)
 }
 
 VCmpxNeqF32Vop3::VCmpxNeqF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_neq_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1095)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_neq_f32_e64_dpp"
+               : "v_cmpx_neq_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1095)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5847,7 +6171,10 @@ VCmpxNeqF32Vop3::VCmpxNeqF32Vop3(const MachineInst *inst)
 }
 
 VCmpxNltF32Vop3::VCmpxNltF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nlt_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1096)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlt_f32_e64_dpp"
+               : "v_cmpx_nlt_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1096)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5904,7 +6231,10 @@ VCmpxNltF32Vop3::VCmpxNltF32Vop3(const MachineInst *inst)
 }
 
 VCmpxLtF64Vop3::VCmpxLtF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lt_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1097)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_f64_e64_dpp"
+               : "v_cmpx_lt_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1097)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5949,7 +6279,10 @@ VCmpxLtF64Vop3::VCmpxLtF64Vop3(const MachineInst *inst)
 }
 
 VCmpxEqF64Vop3::VCmpxEqF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_eq_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1098)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_f64_e64_dpp"
+               : "v_cmpx_eq_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1098)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5994,7 +6327,10 @@ VCmpxEqF64Vop3::VCmpxEqF64Vop3(const MachineInst *inst)
 }
 
 VCmpxLeF64Vop3::VCmpxLeF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_le_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1099)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_f64_e64_dpp"
+               : "v_cmpx_le_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1099)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6039,7 +6375,10 @@ VCmpxLeF64Vop3::VCmpxLeF64Vop3(const MachineInst *inst)
 }
 
 VCmpxGtF64Vop3::VCmpxGtF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_gt_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1100)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_f64_e64_dpp"
+               : "v_cmpx_gt_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1100)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6084,7 +6423,10 @@ VCmpxGtF64Vop3::VCmpxGtF64Vop3(const MachineInst *inst)
 }
 
 VCmpxLgF64Vop3::VCmpxLgF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lg_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1101)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lg_f64_e64_dpp"
+               : "v_cmpx_lg_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1101)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6129,7 +6471,10 @@ VCmpxLgF64Vop3::VCmpxLgF64Vop3(const MachineInst *inst)
 }
 
 VCmpxGeF64Vop3::VCmpxGeF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ge_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1102)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_f64_e64_dpp"
+               : "v_cmpx_ge_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1102)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6174,7 +6519,10 @@ VCmpxGeF64Vop3::VCmpxGeF64Vop3(const MachineInst *inst)
 }
 
 VCmpxOF64Vop3::VCmpxOF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_o_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1103)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_o_f64_e64_dpp"
+               : "v_cmpx_o_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1103)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6219,7 +6567,10 @@ VCmpxOF64Vop3::VCmpxOF64Vop3(const MachineInst *inst)
 }
 
 VCmpxUF64Vop3::VCmpxUF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_u_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1104)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_u_f64_e64_dpp"
+               : "v_cmpx_u_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1104)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6264,7 +6615,10 @@ VCmpxUF64Vop3::VCmpxUF64Vop3(const MachineInst *inst)
 }
 
 VCmpxNgeF64Vop3::VCmpxNgeF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nge_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1105)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nge_f64_e64_dpp"
+               : "v_cmpx_nge_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1105)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6309,7 +6663,10 @@ VCmpxNgeF64Vop3::VCmpxNgeF64Vop3(const MachineInst *inst)
 }
 
 VCmpxNlgF64Vop3::VCmpxNlgF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nlg_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1106)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlg_f64_e64_dpp"
+               : "v_cmpx_nlg_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1106)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6354,7 +6711,10 @@ VCmpxNlgF64Vop3::VCmpxNlgF64Vop3(const MachineInst *inst)
 }
 
 VCmpxNgtF64Vop3::VCmpxNgtF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ngt_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1107)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ngt_f64_e64_dpp"
+               : "v_cmpx_ngt_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1107)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6399,7 +6759,10 @@ VCmpxNgtF64Vop3::VCmpxNgtF64Vop3(const MachineInst *inst)
 }
 
 VCmpxNleF64Vop3::VCmpxNleF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nle_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1108)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nle_f64_e64_dpp"
+               : "v_cmpx_nle_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1108)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6444,7 +6807,10 @@ VCmpxNleF64Vop3::VCmpxNleF64Vop3(const MachineInst *inst)
 }
 
 VCmpxNeqF64Vop3::VCmpxNeqF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_neq_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1109)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_neq_f64_e64_dpp"
+               : "v_cmpx_neq_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1109)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6489,7 +6855,10 @@ VCmpxNeqF64Vop3::VCmpxNeqF64Vop3(const MachineInst *inst)
 }
 
 VCmpxNltF64Vop3::VCmpxNltF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nlt_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1110)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlt_f64_e64_dpp"
+               : "v_cmpx_nlt_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1110)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6534,7 +6903,10 @@ VCmpxNltF64Vop3::VCmpxNltF64Vop3(const MachineInst *inst)
 }
 
 VCmpxLtI16Vop3::VCmpxLtI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lt_i16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1111)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_i16_e64_dpp"
+               : "v_cmpx_lt_i16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1111)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6599,7 +6971,10 @@ VCmpxLtI16Vop3::VCmpxLtI16Vop3(const MachineInst *inst)
 }
 
 VCmpxEqI16Vop3::VCmpxEqI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_eq_i16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1112)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_i16_e64_dpp"
+               : "v_cmpx_eq_i16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1112)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6664,7 +7039,10 @@ VCmpxEqI16Vop3::VCmpxEqI16Vop3(const MachineInst *inst)
 }
 
 VCmpxLeI16Vop3::VCmpxLeI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_le_i16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1113)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_i16_e64_dpp"
+               : "v_cmpx_le_i16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1113)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6729,7 +7107,10 @@ VCmpxLeI16Vop3::VCmpxLeI16Vop3(const MachineInst *inst)
 }
 
 VCmpxGtI16Vop3::VCmpxGtI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_gt_i16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1114)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_i16_e64_dpp"
+               : "v_cmpx_gt_i16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1114)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6794,7 +7175,10 @@ VCmpxGtI16Vop3::VCmpxGtI16Vop3(const MachineInst *inst)
 }
 
 VCmpxNeI16Vop3::VCmpxNeI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ne_i16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1115)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_i16_e64_dpp"
+               : "v_cmpx_ne_i16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1115)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6859,7 +7243,10 @@ VCmpxNeI16Vop3::VCmpxNeI16Vop3(const MachineInst *inst)
 }
 
 VCmpxGeI16Vop3::VCmpxGeI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ge_i16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1116)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_i16_e64_dpp"
+               : "v_cmpx_ge_i16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1116)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6924,7 +7311,10 @@ VCmpxGeI16Vop3::VCmpxGeI16Vop3(const MachineInst *inst)
 }
 
 VCmpxLtU16Vop3::VCmpxLtU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lt_u16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1117)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_u16_e64_dpp"
+               : "v_cmpx_lt_u16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1117)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6989,7 +7379,10 @@ VCmpxLtU16Vop3::VCmpxLtU16Vop3(const MachineInst *inst)
 }
 
 VCmpxEqU16Vop3::VCmpxEqU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_eq_u16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1118)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_u16_e64_dpp"
+               : "v_cmpx_eq_u16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1118)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7054,7 +7447,10 @@ VCmpxEqU16Vop3::VCmpxEqU16Vop3(const MachineInst *inst)
 }
 
 VCmpxLeU16Vop3::VCmpxLeU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_le_u16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1119)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_u16_e64_dpp"
+               : "v_cmpx_le_u16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1119)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7119,7 +7515,10 @@ VCmpxLeU16Vop3::VCmpxLeU16Vop3(const MachineInst *inst)
 }
 
 VCmpxGtU16Vop3::VCmpxGtU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_gt_u16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1120)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_u16_e64_dpp"
+               : "v_cmpx_gt_u16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1120)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7184,7 +7583,10 @@ VCmpxGtU16Vop3::VCmpxGtU16Vop3(const MachineInst *inst)
 }
 
 VCmpxNeU16Vop3::VCmpxNeU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ne_u16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1121)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_u16_e64_dpp"
+               : "v_cmpx_ne_u16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1121)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7249,7 +7651,10 @@ VCmpxNeU16Vop3::VCmpxNeU16Vop3(const MachineInst *inst)
 }
 
 VCmpxGeU16Vop3::VCmpxGeU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ge_u16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1122)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_u16_e64_dpp"
+               : "v_cmpx_ge_u16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1122)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7314,7 +7719,10 @@ VCmpxGeU16Vop3::VCmpxGeU16Vop3(const MachineInst *inst)
 }
 
 VCmpxLtI32Vop3::VCmpxLtI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lt_i32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1123)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_i32_e64_dpp"
+               : "v_cmpx_lt_i32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1123)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7371,7 +7779,10 @@ VCmpxLtI32Vop3::VCmpxLtI32Vop3(const MachineInst *inst)
 }
 
 VCmpxEqI32Vop3::VCmpxEqI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_eq_i32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1124)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_i32_e64_dpp"
+               : "v_cmpx_eq_i32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1124)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7428,7 +7839,10 @@ VCmpxEqI32Vop3::VCmpxEqI32Vop3(const MachineInst *inst)
 }
 
 VCmpxLeI32Vop3::VCmpxLeI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_le_i32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1125)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_i32_e64_dpp"
+               : "v_cmpx_le_i32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1125)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7485,7 +7899,10 @@ VCmpxLeI32Vop3::VCmpxLeI32Vop3(const MachineInst *inst)
 }
 
 VCmpxGtI32Vop3::VCmpxGtI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_gt_i32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1126)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_i32_e64_dpp"
+               : "v_cmpx_gt_i32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1126)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7542,7 +7959,10 @@ VCmpxGtI32Vop3::VCmpxGtI32Vop3(const MachineInst *inst)
 }
 
 VCmpxNeI32Vop3::VCmpxNeI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ne_i32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1127)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_i32_e64_dpp"
+               : "v_cmpx_ne_i32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1127)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7599,7 +8019,10 @@ VCmpxNeI32Vop3::VCmpxNeI32Vop3(const MachineInst *inst)
 }
 
 VCmpxGeI32Vop3::VCmpxGeI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ge_i32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1128)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_i32_e64_dpp"
+               : "v_cmpx_ge_i32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1128)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7656,7 +8079,10 @@ VCmpxGeI32Vop3::VCmpxGeI32Vop3(const MachineInst *inst)
 }
 
 VCmpxLtU32Vop3::VCmpxLtU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lt_u32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1129)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_u32_e64_dpp"
+               : "v_cmpx_lt_u32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1129)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7713,7 +8139,10 @@ VCmpxLtU32Vop3::VCmpxLtU32Vop3(const MachineInst *inst)
 }
 
 VCmpxEqU32Vop3::VCmpxEqU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_eq_u32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1130)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_u32_e64_dpp"
+               : "v_cmpx_eq_u32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1130)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7770,7 +8199,10 @@ VCmpxEqU32Vop3::VCmpxEqU32Vop3(const MachineInst *inst)
 }
 
 VCmpxLeU32Vop3::VCmpxLeU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_le_u32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1131)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_u32_e64_dpp"
+               : "v_cmpx_le_u32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1131)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7827,7 +8259,10 @@ VCmpxLeU32Vop3::VCmpxLeU32Vop3(const MachineInst *inst)
 }
 
 VCmpxGtU32Vop3::VCmpxGtU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_gt_u32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1132)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_u32_e64_dpp"
+               : "v_cmpx_gt_u32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1132)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7884,7 +8319,10 @@ VCmpxGtU32Vop3::VCmpxGtU32Vop3(const MachineInst *inst)
 }
 
 VCmpxNeU32Vop3::VCmpxNeU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ne_u32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1133)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_u32_e64_dpp"
+               : "v_cmpx_ne_u32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1133)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7941,7 +8379,10 @@ VCmpxNeU32Vop3::VCmpxNeU32Vop3(const MachineInst *inst)
 }
 
 VCmpxGeU32Vop3::VCmpxGeU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ge_u32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1134)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_u32_e64_dpp"
+               : "v_cmpx_ge_u32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1134)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7998,7 +8439,10 @@ VCmpxGeU32Vop3::VCmpxGeU32Vop3(const MachineInst *inst)
 }
 
 VCmpxLtI64Vop3::VCmpxLtI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lt_i64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1135)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_i64_e64_dpp"
+               : "v_cmpx_lt_i64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1135)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8043,7 +8487,10 @@ VCmpxLtI64Vop3::VCmpxLtI64Vop3(const MachineInst *inst)
 }
 
 VCmpxEqI64Vop3::VCmpxEqI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_eq_i64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1136)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_i64_e64_dpp"
+               : "v_cmpx_eq_i64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1136)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8088,7 +8535,10 @@ VCmpxEqI64Vop3::VCmpxEqI64Vop3(const MachineInst *inst)
 }
 
 VCmpxLeI64Vop3::VCmpxLeI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_le_i64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1137)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_i64_e64_dpp"
+               : "v_cmpx_le_i64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1137)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8133,7 +8583,10 @@ VCmpxLeI64Vop3::VCmpxLeI64Vop3(const MachineInst *inst)
 }
 
 VCmpxGtI64Vop3::VCmpxGtI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_gt_i64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1138)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_i64_e64_dpp"
+               : "v_cmpx_gt_i64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1138)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8178,7 +8631,10 @@ VCmpxGtI64Vop3::VCmpxGtI64Vop3(const MachineInst *inst)
 }
 
 VCmpxNeI64Vop3::VCmpxNeI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ne_i64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1139)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_i64_e64_dpp"
+               : "v_cmpx_ne_i64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1139)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8223,7 +8679,10 @@ VCmpxNeI64Vop3::VCmpxNeI64Vop3(const MachineInst *inst)
 }
 
 VCmpxGeI64Vop3::VCmpxGeI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ge_i64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1140)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_i64_e64_dpp"
+               : "v_cmpx_ge_i64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1140)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8268,7 +8727,10 @@ VCmpxGeI64Vop3::VCmpxGeI64Vop3(const MachineInst *inst)
 }
 
 VCmpxLtU64Vop3::VCmpxLtU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lt_u64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1141)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_u64_e64_dpp"
+               : "v_cmpx_lt_u64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1141)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8313,7 +8775,10 @@ VCmpxLtU64Vop3::VCmpxLtU64Vop3(const MachineInst *inst)
 }
 
 VCmpxEqU64Vop3::VCmpxEqU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_eq_u64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1142)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_u64_e64_dpp"
+               : "v_cmpx_eq_u64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1142)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8358,7 +8823,10 @@ VCmpxEqU64Vop3::VCmpxEqU64Vop3(const MachineInst *inst)
 }
 
 VCmpxLeU64Vop3::VCmpxLeU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_le_u64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1143)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_u64_e64_dpp"
+               : "v_cmpx_le_u64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1143)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8403,7 +8871,10 @@ VCmpxLeU64Vop3::VCmpxLeU64Vop3(const MachineInst *inst)
 }
 
 VCmpxGtU64Vop3::VCmpxGtU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_gt_u64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1144)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_u64_e64_dpp"
+               : "v_cmpx_gt_u64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1144)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8448,7 +8919,10 @@ VCmpxGtU64Vop3::VCmpxGtU64Vop3(const MachineInst *inst)
 }
 
 VCmpxNeU64Vop3::VCmpxNeU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ne_u64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1145)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_u64_e64_dpp"
+               : "v_cmpx_ne_u64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1145)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8493,7 +8967,10 @@ VCmpxNeU64Vop3::VCmpxNeU64Vop3(const MachineInst *inst)
 }
 
 VCmpxGeU64Vop3::VCmpxGeU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ge_u64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1146)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_u64_e64_dpp"
+               : "v_cmpx_ge_u64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1146)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8538,7 +9015,10 @@ VCmpxGeU64Vop3::VCmpxGeU64Vop3(const MachineInst *inst)
 }
 
 VCmpxClassF16Vop3::VCmpxClassF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_class_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1147)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_class_f16_e64_dpp"
+               : "v_cmpx_class_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1147)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8603,7 +9083,10 @@ VCmpxClassF16Vop3::VCmpxClassF16Vop3(const MachineInst *inst)
 }
 
 VCmpxClassF32Vop3::VCmpxClassF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_class_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1148)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_class_f32_e64_dpp"
+               : "v_cmpx_class_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1148)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8660,7 +9143,10 @@ VCmpxClassF32Vop3::VCmpxClassF32Vop3(const MachineInst *inst)
 }
 
 VCmpxClassF64Vop3::VCmpxClassF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_class_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1149)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_class_f64_e64_dpp"
+               : "v_cmpx_class_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1149)),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/gfx1250/vop3_cvt.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/gfx1250/vop3_cvt.cpp
@@ -12,7 +12,10 @@ namespace rocjitsu {
 namespace gfx1250 {
 
 VCvtI32F64Vop3::VCvtI32F64Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_i32_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(620)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_i32_f64_e64_dpp"
+               : "v_cvt_i32_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(620)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -47,7 +50,10 @@ VCvtI32F64Vop3::VCvtI32F64Vop3(const MachineInst *inst)
 }
 
 VCvtF64I32Vop3::VCvtF64I32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f64_i32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(621)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f64_i32_e64_dpp"
+               : "v_cvt_f64_i32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(621)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -81,7 +87,10 @@ VCvtF64I32Vop3::VCvtF64I32Vop3(const MachineInst *inst)
 }
 
 VCvtF32I32Vop3::VCvtF32I32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f32_i32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(622)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_i32_e64_dpp"
+               : "v_cvt_f32_i32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(622)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -121,7 +130,10 @@ VCvtF32I32Vop3::VCvtF32I32Vop3(const MachineInst *inst)
 }
 
 VCvtF32U32Vop3::VCvtF32U32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f32_u32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(623)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_u32_e64_dpp"
+               : "v_cvt_f32_u32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(623)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -161,7 +173,10 @@ VCvtF32U32Vop3::VCvtF32U32Vop3(const MachineInst *inst)
 }
 
 VCvtU32F32Vop3::VCvtU32F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_u32_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(624)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_u32_f32_e64_dpp"
+               : "v_cvt_u32_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(624)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -201,7 +216,10 @@ VCvtU32F32Vop3::VCvtU32F32Vop3(const MachineInst *inst)
 }
 
 VCvtI32F32Vop3::VCvtI32F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_i32_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(625)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_i32_f32_e64_dpp"
+               : "v_cvt_i32_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(625)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -241,7 +259,10 @@ VCvtI32F32Vop3::VCvtI32F32Vop3(const MachineInst *inst)
 }
 
 VCvtF16F32Vop3::VCvtF16F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f16_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(626)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f16_f32_e64_dpp"
+               : "v_cvt_f16_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(626)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -294,7 +315,10 @@ void VCvtF16F32Vop3::implicit_use_operands(
 }
 
 VCvtF32F16Vop3::VCvtF32F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f32_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(627)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_f16_e64_dpp"
+               : "v_cvt_f32_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(627)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -338,8 +362,10 @@ VCvtF32F16Vop3::VCvtF32F16Vop3(const MachineInst *inst)
 }
 
 VCvtNearestI32F32Vop3::VCvtNearestI32F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_nearest_i32_f32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(628)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_nearest_i32_f32_e64_dpp"
+               : "v_cvt_nearest_i32_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(628)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -379,8 +405,10 @@ VCvtNearestI32F32Vop3::VCvtNearestI32F32Vop3(const MachineInst *inst)
 }
 
 VCvtFloorI32F32Vop3::VCvtFloorI32F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_floor_i32_f32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(629)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_floor_i32_f32_e64_dpp"
+               : "v_cvt_floor_i32_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(629)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -420,7 +448,10 @@ VCvtFloorI32F32Vop3::VCvtFloorI32F32Vop3(const MachineInst *inst)
 }
 
 VCvtOffF32I4Vop3::VCvtOffF32I4Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_off_f32_i4", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(630)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_off_f32_i4_e64_dpp"
+               : "v_cvt_off_f32_i4",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(630)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -460,7 +491,10 @@ VCvtOffF32I4Vop3::VCvtOffF32I4Vop3(const MachineInst *inst)
 }
 
 VCvtF32F64Vop3::VCvtF32F64Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f32_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(631)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_f64_e64_dpp"
+               : "v_cvt_f32_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(631)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -495,7 +529,10 @@ VCvtF32F64Vop3::VCvtF32F64Vop3(const MachineInst *inst)
 }
 
 VCvtF64F32Vop3::VCvtF64F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f64_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(632)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f64_f32_e64_dpp"
+               : "v_cvt_f64_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(632)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -529,7 +566,10 @@ VCvtF64F32Vop3::VCvtF64F32Vop3(const MachineInst *inst)
 }
 
 VCvtF32Ubyte0Vop3::VCvtF32Ubyte0Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f32_ubyte0", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(633)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_ubyte0_e64_dpp"
+               : "v_cvt_f32_ubyte0",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(633)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -569,7 +609,10 @@ VCvtF32Ubyte0Vop3::VCvtF32Ubyte0Vop3(const MachineInst *inst)
 }
 
 VCvtF32Ubyte1Vop3::VCvtF32Ubyte1Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f32_ubyte1", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(634)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_ubyte1_e64_dpp"
+               : "v_cvt_f32_ubyte1",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(634)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -609,7 +652,10 @@ VCvtF32Ubyte1Vop3::VCvtF32Ubyte1Vop3(const MachineInst *inst)
 }
 
 VCvtF32Ubyte2Vop3::VCvtF32Ubyte2Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f32_ubyte2", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(635)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_ubyte2_e64_dpp"
+               : "v_cvt_f32_ubyte2",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(635)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -649,7 +695,10 @@ VCvtF32Ubyte2Vop3::VCvtF32Ubyte2Vop3(const MachineInst *inst)
 }
 
 VCvtF32Ubyte3Vop3::VCvtF32Ubyte3Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f32_ubyte3", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(636)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_ubyte3_e64_dpp"
+               : "v_cvt_f32_ubyte3",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(636)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -689,7 +738,10 @@ VCvtF32Ubyte3Vop3::VCvtF32Ubyte3Vop3(const MachineInst *inst)
 }
 
 VCvtU32F64Vop3::VCvtU32F64Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_u32_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(637)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_u32_f64_e64_dpp"
+               : "v_cvt_u32_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(637)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -724,7 +776,10 @@ VCvtU32F64Vop3::VCvtU32F64Vop3(const MachineInst *inst)
 }
 
 VCvtF64U32Vop3::VCvtF64U32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f64_u32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(638)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f64_u32_e64_dpp"
+               : "v_cvt_f64_u32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(638)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -758,8 +813,10 @@ VCvtF64U32Vop3::VCvtF64U32Vop3(const MachineInst *inst)
 }
 
 VFrexpExpI32F64Vop3::VFrexpExpI32F64Vop3(const MachineInst *inst)
-    : Vop3("v_frexp_exp_i32_f64", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(669)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_exp_i32_f64_e64_dpp"
+               : "v_frexp_exp_i32_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(669)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -794,7 +851,10 @@ VFrexpExpI32F64Vop3::VFrexpExpI32F64Vop3(const MachineInst *inst)
 }
 
 VFrexpMantF64Vop3::VFrexpMantF64Vop3(const MachineInst *inst)
-    : Vop3("v_frexp_mant_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(670)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_mant_f64_e64_dpp"
+               : "v_frexp_mant_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(670)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -829,8 +889,10 @@ VFrexpMantF64Vop3::VFrexpMantF64Vop3(const MachineInst *inst)
 }
 
 VFrexpExpI32F32Vop3::VFrexpExpI32F32Vop3(const MachineInst *inst)
-    : Vop3("v_frexp_exp_i32_f32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(672)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_exp_i32_f32_e64_dpp"
+               : "v_frexp_exp_i32_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(672)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -870,7 +932,10 @@ VFrexpExpI32F32Vop3::VFrexpExpI32F32Vop3(const MachineInst *inst)
 }
 
 VFrexpMantF32Vop3::VFrexpMantF32Vop3(const MachineInst *inst)
-    : Vop3("v_frexp_mant_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(673)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_mant_f32_e64_dpp"
+               : "v_frexp_mant_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(673)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -910,7 +975,10 @@ VFrexpMantF32Vop3::VFrexpMantF32Vop3(const MachineInst *inst)
 }
 
 VCvtF16U16Vop3::VCvtF16U16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f16_u16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(681)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f16_u16_e64_dpp"
+               : "v_cvt_f16_u16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(681)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -967,7 +1035,10 @@ void VCvtF16U16Vop3::implicit_use_operands(
 }
 
 VCvtF16I16Vop3::VCvtF16I16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f16_i16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(682)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f16_i16_e64_dpp"
+               : "v_cvt_f16_i16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(682)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1024,7 +1095,10 @@ void VCvtF16I16Vop3::implicit_use_operands(
 }
 
 VCvtU16F16Vop3::VCvtU16F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_u16_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(683)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_u16_f16_e64_dpp"
+               : "v_cvt_u16_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(683)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1081,7 +1155,10 @@ void VCvtU16F16Vop3::implicit_use_operands(
 }
 
 VCvtI16F16Vop3::VCvtI16F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_i16_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(684)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_i16_f16_e64_dpp"
+               : "v_cvt_i16_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(684)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1138,7 +1215,10 @@ void VCvtI16F16Vop3::implicit_use_operands(
 }
 
 VFrexpMantF16Vop3::VFrexpMantF16Vop3(const MachineInst *inst)
-    : Vop3("v_frexp_mant_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(690)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_mant_f16_e64_dpp"
+               : "v_frexp_mant_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(690)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1195,8 +1275,10 @@ void VFrexpMantF16Vop3::implicit_use_operands(
 }
 
 VFrexpExpI16F16Vop3::VFrexpExpI16F16Vop3(const MachineInst *inst)
-    : Vop3("v_frexp_exp_i16_f16", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(691)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_exp_i16_f16_e64_dpp"
+               : "v_frexp_exp_i16_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(691)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1253,7 +1335,10 @@ void VFrexpExpI16F16Vop3::implicit_use_operands(
 }
 
 VCvtNormI16F16Vop3::VCvtNormI16F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_norm_i16_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(700)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_norm_i16_f16_e64_dpp"
+               : "v_cvt_norm_i16_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(700)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1310,7 +1395,10 @@ void VCvtNormI16F16Vop3::implicit_use_operands(
 }
 
 VCvtNormU16F16Vop3::VCvtNormU16F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_norm_u16_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(701)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_norm_u16_f16_e64_dpp"
+               : "v_cvt_norm_u16_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(701)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1367,7 +1455,10 @@ void VCvtNormU16F16Vop3::implicit_use_operands(
 }
 
 VCvtI32I16Vop3::VCvtI32I16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_i32_i16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(703)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_i32_i16_e64_dpp"
+               : "v_cvt_i32_i16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(703)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1411,7 +1502,10 @@ VCvtI32I16Vop3::VCvtI32I16Vop3(const MachineInst *inst)
 }
 
 VCvtU32U16Vop3::VCvtU32U16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_u32_u16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(704)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_u32_u16_e64_dpp"
+               : "v_cvt_u32_u16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(704)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1455,7 +1549,10 @@ VCvtU32U16Vop3::VCvtU32U16Vop3(const MachineInst *inst)
 }
 
 VCvtF32Fp8Vop3::VCvtF32Fp8Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f32_fp8", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(705)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_fp8_e64_dpp"
+               : "v_cvt_f32_fp8",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(705)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(8, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1495,7 +1592,10 @@ VCvtF32Fp8Vop3::VCvtF32Fp8Vop3(const MachineInst *inst)
 }
 
 VCvtF32Bf8Vop3::VCvtF32Bf8Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f32_bf8", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(706)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_bf8_e64_dpp"
+               : "v_cvt_f32_bf8",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(706)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(8, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1535,7 +1635,10 @@ VCvtF32Bf8Vop3::VCvtF32Bf8Vop3(const MachineInst *inst)
 }
 
 VCvtPkF32Fp8Vop3::VCvtPkF32Fp8Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_f32_fp8", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(707)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_f32_fp8_e64_dpp"
+               : "v_cvt_pk_f32_fp8",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(707)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1565,7 +1668,10 @@ VCvtPkF32Fp8Vop3::VCvtPkF32Fp8Vop3(const MachineInst *inst)
 }
 
 VCvtPkF32Bf8Vop3::VCvtPkF32Bf8Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_f32_bf8", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(708)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_f32_bf8_e64_dpp"
+               : "v_cvt_pk_f32_bf8",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(708)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1595,7 +1701,10 @@ VCvtPkF32Bf8Vop3::VCvtPkF32Bf8Vop3(const MachineInst *inst)
 }
 
 VCvtF32Bf16Vop3::VCvtF32Bf16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f32_bf16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(709)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_bf16_e64_dpp"
+               : "v_cvt_f32_bf16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(709)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1639,7 +1748,10 @@ VCvtF32Bf16Vop3::VCvtF32Bf16Vop3(const MachineInst *inst)
 }
 
 VCvtPkF16Fp8Vop3::VCvtPkF16Fp8Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_f16_fp8", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(712)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_f16_fp8_e64_dpp"
+               : "v_cvt_pk_f16_fp8",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(712)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1683,7 +1795,10 @@ VCvtPkF16Fp8Vop3::VCvtPkF16Fp8Vop3(const MachineInst *inst)
 }
 
 VCvtPkF16Bf8Vop3::VCvtPkF16Bf8Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_f16_bf8", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(713)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_f16_bf8_e64_dpp"
+               : "v_cvt_pk_f16_bf8",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(713)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1727,7 +1842,10 @@ VCvtPkF16Bf8Vop3::VCvtPkF16Bf8Vop3(const MachineInst *inst)
 }
 
 VCvtF16Fp8Vop3::VCvtF16Fp8Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f16_fp8", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(714)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f16_fp8_e64_dpp"
+               : "v_cvt_f16_fp8",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(714)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(8, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1780,7 +1898,10 @@ void VCvtF16Fp8Vop3::implicit_use_operands(
 }
 
 VCvtF16Bf8Vop3::VCvtF16Bf8Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f16_bf8", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(715)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f16_bf8_e64_dpp"
+               : "v_cvt_f16_bf8",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(715)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(8, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1833,8 +1954,10 @@ void VCvtF16Bf8Vop3::implicit_use_operands(
 }
 
 VCvtPkRtzF16F32Vop3::VCvtPkRtzF16F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_rtz_f16_f32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(759)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_rtz_f16_f32_e64_dpp"
+               : "v_cvt_pk_rtz_f16_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(759)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1888,7 +2011,10 @@ VCvtPkRtzF16F32Vop3::VCvtPkRtzF16F32Vop3(const MachineInst *inst)
 }
 
 VCvtPkU8F32Vop3::VCvtPkU8F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_u8_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(794)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_u8_f32_e64_dpp"
+               : "v_cvt_pk_u8_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(794)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1956,8 +2082,10 @@ VCvtPkU8F32Vop3::VCvtPkU8F32Vop3(const MachineInst *inst)
 }
 
 VCvtScalef32SrPk8Fp4F32Vop3::VCvtScalef32SrPk8Fp4F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scalef32_sr_pk8_fp4_f32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(876)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scalef32_sr_pk8_fp4_f32_e64_dpp"
+               : "v_cvt_scalef32_sr_pk8_fp4_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(876)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2011,8 +2139,10 @@ VCvtScalef32SrPk8Fp4F32Vop3::VCvtScalef32SrPk8Fp4F32Vop3(const MachineInst *inst
 }
 
 VCvtScalef32SrPk8Fp8F32Vop3::VCvtScalef32SrPk8Fp8F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scalef32_sr_pk8_fp8_f32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(877)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scalef32_sr_pk8_fp8_f32_e64_dpp"
+               : "v_cvt_scalef32_sr_pk8_fp8_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(877)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2066,8 +2196,10 @@ VCvtScalef32SrPk8Fp8F32Vop3::VCvtScalef32SrPk8Fp8F32Vop3(const MachineInst *inst
 }
 
 VCvtScalef32SrPk8Bf8F32Vop3::VCvtScalef32SrPk8Bf8F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scalef32_sr_pk8_bf8_f32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(878)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scalef32_sr_pk8_bf8_f32_e64_dpp"
+               : "v_cvt_scalef32_sr_pk8_bf8_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(878)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2121,8 +2253,10 @@ VCvtScalef32SrPk8Bf8F32Vop3::VCvtScalef32SrPk8Bf8F32Vop3(const MachineInst *inst
 }
 
 VCvtScalePk8F16Fp4Vop3::VCvtScalePk8F16Fp4Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scale_pk8_f16_fp4", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(879)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scale_pk8_f16_fp4_e64_dpp"
+               : "v_cvt_scale_pk8_f16_fp4",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(879)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2162,8 +2296,10 @@ VCvtScalePk8F16Fp4Vop3::VCvtScalePk8F16Fp4Vop3(const MachineInst *inst)
 }
 
 VCvtScalePk8Bf16Fp4Vop3::VCvtScalePk8Bf16Fp4Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scale_pk8_bf16_fp4", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(880)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scale_pk8_bf16_fp4_e64_dpp"
+               : "v_cvt_scale_pk8_bf16_fp4",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(880)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2203,8 +2339,10 @@ VCvtScalePk8Bf16Fp4Vop3::VCvtScalePk8Bf16Fp4Vop3(const MachineInst *inst)
 }
 
 VCvtScalePk8F32Fp4Vop3::VCvtScalePk8F32Fp4Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scale_pk8_f32_fp4", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(881)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scale_pk8_f32_fp4_e64_dpp"
+               : "v_cvt_scale_pk8_f32_fp4",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(881)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2244,8 +2382,10 @@ VCvtScalePk8F32Fp4Vop3::VCvtScalePk8F32Fp4Vop3(const MachineInst *inst)
 }
 
 VCvtScalePk8F16Fp8Vop3::VCvtScalePk8F16Fp8Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scale_pk8_f16_fp8", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(882)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scale_pk8_f16_fp8_e64_dpp"
+               : "v_cvt_scale_pk8_f16_fp8",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(882)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2286,8 +2426,10 @@ VCvtScalePk8F16Fp8Vop3::VCvtScalePk8F16Fp8Vop3(const MachineInst *inst)
 }
 
 VCvtScalePk8Bf16Fp8Vop3::VCvtScalePk8Bf16Fp8Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scale_pk8_bf16_fp8", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(883)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scale_pk8_bf16_fp8_e64_dpp"
+               : "v_cvt_scale_pk8_bf16_fp8",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(883)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2328,8 +2470,10 @@ VCvtScalePk8Bf16Fp8Vop3::VCvtScalePk8Bf16Fp8Vop3(const MachineInst *inst)
 }
 
 VCvtScalePk8F32Fp8Vop3::VCvtScalePk8F32Fp8Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scale_pk8_f32_fp8", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(884)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scale_pk8_f32_fp8_e64_dpp"
+               : "v_cvt_scale_pk8_f32_fp8",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(884)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2370,8 +2514,10 @@ VCvtScalePk8F32Fp8Vop3::VCvtScalePk8F32Fp8Vop3(const MachineInst *inst)
 }
 
 VCvtScalePk8F16Bf8Vop3::VCvtScalePk8F16Bf8Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scale_pk8_f16_bf8", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(885)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scale_pk8_f16_bf8_e64_dpp"
+               : "v_cvt_scale_pk8_f16_bf8",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(885)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2412,8 +2558,10 @@ VCvtScalePk8F16Bf8Vop3::VCvtScalePk8F16Bf8Vop3(const MachineInst *inst)
 }
 
 VCvtScalePk8Bf16Bf8Vop3::VCvtScalePk8Bf16Bf8Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scale_pk8_bf16_bf8", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(886)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scale_pk8_bf16_bf8_e64_dpp"
+               : "v_cvt_scale_pk8_bf16_bf8",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(886)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2454,8 +2602,10 @@ VCvtScalePk8Bf16Bf8Vop3::VCvtScalePk8Bf16Bf8Vop3(const MachineInst *inst)
 }
 
 VCvtScalePk8F32Bf8Vop3::VCvtScalePk8F32Bf8Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scale_pk8_f32_bf8", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(887)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scale_pk8_f32_bf8_e64_dpp"
+               : "v_cvt_scale_pk8_f32_bf8",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(887)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2496,8 +2646,10 @@ VCvtScalePk8F32Bf8Vop3::VCvtScalePk8F32Bf8Vop3(const MachineInst *inst)
 }
 
 VCvtScalef32Pk8Fp4F32Vop3::VCvtScalef32Pk8Fp4F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scalef32_pk8_fp4_f32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(888)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scalef32_pk8_fp4_f32_e64_dpp"
+               : "v_cvt_scalef32_pk8_fp4_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(888)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2537,8 +2689,10 @@ VCvtScalef32Pk8Fp4F32Vop3::VCvtScalef32Pk8Fp4F32Vop3(const MachineInst *inst)
 }
 
 VCvtScalef32Pk8Fp4F16Vop3::VCvtScalef32Pk8Fp4F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scalef32_pk8_fp4_f16", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(889)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scalef32_pk8_fp4_f16_e64_dpp"
+               : "v_cvt_scalef32_pk8_fp4_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(889)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2578,8 +2732,10 @@ VCvtScalef32Pk8Fp4F16Vop3::VCvtScalef32Pk8Fp4F16Vop3(const MachineInst *inst)
 }
 
 VCvtScalef32Pk8Fp8Bf16Vop3::VCvtScalef32Pk8Fp8Bf16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scalef32_pk8_fp8_bf16", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(890)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scalef32_pk8_fp8_bf16_e64_dpp"
+               : "v_cvt_scalef32_pk8_fp8_bf16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(890)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2619,8 +2775,10 @@ VCvtScalef32Pk8Fp8Bf16Vop3::VCvtScalef32Pk8Fp8Bf16Vop3(const MachineInst *inst)
 }
 
 VCvtScalef32Pk8Bf8Bf16Vop3::VCvtScalef32Pk8Bf8Bf16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scalef32_pk8_bf8_bf16", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(891)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scalef32_pk8_bf8_bf16_e64_dpp"
+               : "v_cvt_scalef32_pk8_bf8_bf16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(891)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2660,8 +2818,10 @@ VCvtScalef32Pk8Bf8Bf16Vop3::VCvtScalef32Pk8Bf8Bf16Vop3(const MachineInst *inst)
 }
 
 VCvtScalef32Pk8Fp4Bf16Vop3::VCvtScalef32Pk8Fp4Bf16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scalef32_pk8_fp4_bf16", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(892)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scalef32_pk8_fp4_bf16_e64_dpp"
+               : "v_cvt_scalef32_pk8_fp4_bf16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(892)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -2701,8 +2861,10 @@ VCvtScalef32Pk8Fp4Bf16Vop3::VCvtScalef32Pk8Fp4Bf16Vop3(const MachineInst *inst)
 }
 
 VCvtScalef32SrPk8Fp4F16Vop3::VCvtScalef32SrPk8Fp4F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scalef32_sr_pk8_fp4_f16", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(893)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scalef32_sr_pk8_fp4_f16_e64_dpp"
+               : "v_cvt_scalef32_sr_pk8_fp4_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(893)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2756,8 +2918,10 @@ VCvtScalef32SrPk8Fp4F16Vop3::VCvtScalef32SrPk8Fp4F16Vop3(const MachineInst *inst
 }
 
 VCvtScalef32SrPk8Fp4Bf16Vop3::VCvtScalef32SrPk8Fp4Bf16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scalef32_sr_pk8_fp4_bf16", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(894)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scalef32_sr_pk8_fp4_bf16_e64_dpp"
+               : "v_cvt_scalef32_sr_pk8_fp4_bf16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(894)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2811,8 +2975,10 @@ VCvtScalef32SrPk8Fp4Bf16Vop3::VCvtScalef32SrPk8Fp4Bf16Vop3(const MachineInst *in
 }
 
 VCvtScalef32SrPk8Fp8F16Vop3::VCvtScalef32SrPk8Fp8F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scalef32_sr_pk8_fp8_f16", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(895)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scalef32_sr_pk8_fp8_f16_e64_dpp"
+               : "v_cvt_scalef32_sr_pk8_fp8_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(895)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2866,8 +3032,10 @@ VCvtScalef32SrPk8Fp8F16Vop3::VCvtScalef32SrPk8Fp8F16Vop3(const MachineInst *inst
 }
 
 VCvtScalef32SrPk8Fp8Bf16Vop3::VCvtScalef32SrPk8Fp8Bf16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scalef32_sr_pk8_fp8_bf16", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(896)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scalef32_sr_pk8_fp8_bf16_e64_dpp"
+               : "v_cvt_scalef32_sr_pk8_fp8_bf16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(896)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2921,8 +3089,10 @@ VCvtScalef32SrPk8Fp8Bf16Vop3::VCvtScalef32SrPk8Fp8Bf16Vop3(const MachineInst *in
 }
 
 VCvtScalef32SrPk8Bf8F16Vop3::VCvtScalef32SrPk8Bf8F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scalef32_sr_pk8_bf8_f16", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(897)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scalef32_sr_pk8_bf8_f16_e64_dpp"
+               : "v_cvt_scalef32_sr_pk8_bf8_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(897)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2976,8 +3146,10 @@ VCvtScalef32SrPk8Bf8F16Vop3::VCvtScalef32SrPk8Bf8F16Vop3(const MachineInst *inst
 }
 
 VCvtScalef32SrPk8Bf8Bf16Vop3::VCvtScalef32SrPk8Bf8Bf16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scalef32_sr_pk8_bf8_bf16", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(898)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scalef32_sr_pk8_bf8_bf16_e64_dpp"
+               : "v_cvt_scalef32_sr_pk8_bf8_bf16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(898)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3031,8 +3203,10 @@ VCvtScalef32SrPk8Bf8Bf16Vop3::VCvtScalef32SrPk8Bf8Bf16Vop3(const MachineInst *in
 }
 
 VCvtScalef32Pk8Fp8F32Vop3::VCvtScalef32Pk8Fp8F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scalef32_pk8_fp8_f32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(899)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scalef32_pk8_fp8_f32_e64_dpp"
+               : "v_cvt_scalef32_pk8_fp8_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(899)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3072,8 +3246,10 @@ VCvtScalef32Pk8Fp8F32Vop3::VCvtScalef32Pk8Fp8F32Vop3(const MachineInst *inst)
 }
 
 VCvtScalef32Pk8Fp8F16Vop3::VCvtScalef32Pk8Fp8F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scalef32_pk8_fp8_f16", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(900)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scalef32_pk8_fp8_f16_e64_dpp"
+               : "v_cvt_scalef32_pk8_fp8_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(900)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3113,8 +3289,10 @@ VCvtScalef32Pk8Fp8F16Vop3::VCvtScalef32Pk8Fp8F16Vop3(const MachineInst *inst)
 }
 
 VCvtScalef32Pk8Bf8F32Vop3::VCvtScalef32Pk8Bf8F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scalef32_pk8_bf8_f32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(901)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scalef32_pk8_bf8_f32_e64_dpp"
+               : "v_cvt_scalef32_pk8_bf8_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(901)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3154,8 +3332,10 @@ VCvtScalef32Pk8Bf8F32Vop3::VCvtScalef32Pk8Bf8F32Vop3(const MachineInst *inst)
 }
 
 VCvtScalef32Pk8Bf8F16Vop3::VCvtScalef32Pk8Bf8F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scalef32_pk8_bf8_f16", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(902)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scalef32_pk8_bf8_f16_e64_dpp"
+               : "v_cvt_scalef32_pk8_bf8_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(902)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3195,8 +3375,10 @@ VCvtScalef32Pk8Bf8F16Vop3::VCvtScalef32Pk8Bf8F16Vop3(const MachineInst *inst)
 }
 
 VCvtScalePk16F16Fp6Vop3::VCvtScalePk16F16Fp6Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scale_pk16_f16_fp6", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(903)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scale_pk16_f16_fp6_e64_dpp"
+               : "v_cvt_scale_pk16_f16_fp6",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(903)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(96, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3236,8 +3418,10 @@ VCvtScalePk16F16Fp6Vop3::VCvtScalePk16F16Fp6Vop3(const MachineInst *inst)
 }
 
 VCvtScalePk16Bf16Fp6Vop3::VCvtScalePk16Bf16Fp6Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scale_pk16_bf16_fp6", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(904)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scale_pk16_bf16_fp6_e64_dpp"
+               : "v_cvt_scale_pk16_bf16_fp6",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(904)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(96, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3277,8 +3461,10 @@ VCvtScalePk16Bf16Fp6Vop3::VCvtScalePk16Bf16Fp6Vop3(const MachineInst *inst)
 }
 
 VCvtScalePk16F32Fp6Vop3::VCvtScalePk16F32Fp6Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scale_pk16_f32_fp6", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(905)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scale_pk16_f32_fp6_e64_dpp"
+               : "v_cvt_scale_pk16_f32_fp6",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(905)),
       vdst(512, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(96, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3318,8 +3504,10 @@ VCvtScalePk16F32Fp6Vop3::VCvtScalePk16F32Fp6Vop3(const MachineInst *inst)
 }
 
 VCvtScalePk16F16Bf6Vop3::VCvtScalePk16F16Bf6Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scale_pk16_f16_bf6", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(906)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scale_pk16_f16_bf6_e64_dpp"
+               : "v_cvt_scale_pk16_f16_bf6",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(906)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(96, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3359,8 +3547,10 @@ VCvtScalePk16F16Bf6Vop3::VCvtScalePk16F16Bf6Vop3(const MachineInst *inst)
 }
 
 VCvtScalePk16Bf16Bf6Vop3::VCvtScalePk16Bf16Bf6Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scale_pk16_bf16_bf6", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(907)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scale_pk16_bf16_bf6_e64_dpp"
+               : "v_cvt_scale_pk16_bf16_bf6",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(907)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(96, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3400,8 +3590,10 @@ VCvtScalePk16Bf16Bf6Vop3::VCvtScalePk16Bf16Bf6Vop3(const MachineInst *inst)
 }
 
 VCvtScalePk16F32Bf6Vop3::VCvtScalePk16F32Bf6Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scale_pk16_f32_bf6", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(908)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scale_pk16_f32_bf6_e64_dpp"
+               : "v_cvt_scale_pk16_f32_bf6",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(908)),
       vdst(512, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(96, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3441,8 +3633,10 @@ VCvtScalePk16F32Bf6Vop3::VCvtScalePk16F32Bf6Vop3(const MachineInst *inst)
 }
 
 VCvtScalef32Pk16Fp6F32Vop3::VCvtScalef32Pk16Fp6F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scalef32_pk16_fp6_f32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(909)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scalef32_pk16_fp6_f32_e64_dpp"
+               : "v_cvt_scalef32_pk16_fp6_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(909)),
       vdst(96, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3482,8 +3676,10 @@ VCvtScalef32Pk16Fp6F32Vop3::VCvtScalef32Pk16Fp6F32Vop3(const MachineInst *inst)
 }
 
 VCvtScalef32Pk16Bf6F32Vop3::VCvtScalef32Pk16Bf6F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scalef32_pk16_bf6_f32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(910)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scalef32_pk16_bf6_f32_e64_dpp"
+               : "v_cvt_scalef32_pk16_bf6_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(910)),
       vdst(96, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3523,8 +3719,10 @@ VCvtScalef32Pk16Bf6F32Vop3::VCvtScalef32Pk16Bf6F32Vop3(const MachineInst *inst)
 }
 
 VCvtScalef32Pk16Fp6F16Vop3::VCvtScalef32Pk16Fp6F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scalef32_pk16_fp6_f16", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(911)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scalef32_pk16_fp6_f16_e64_dpp"
+               : "v_cvt_scalef32_pk16_fp6_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(911)),
       vdst(96, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3564,8 +3762,10 @@ VCvtScalef32Pk16Fp6F16Vop3::VCvtScalef32Pk16Fp6F16Vop3(const MachineInst *inst)
 }
 
 VCvtScalef32Pk16Bf6F16Vop3::VCvtScalef32Pk16Bf6F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scalef32_pk16_bf6_f16", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(912)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scalef32_pk16_bf6_f16_e64_dpp"
+               : "v_cvt_scalef32_pk16_bf6_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(912)),
       vdst(96, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3605,8 +3805,10 @@ VCvtScalef32Pk16Bf6F16Vop3::VCvtScalef32Pk16Bf6F16Vop3(const MachineInst *inst)
 }
 
 VCvtScalef32Pk16Fp6Bf16Vop3::VCvtScalef32Pk16Fp6Bf16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scalef32_pk16_fp6_bf16", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(913)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scalef32_pk16_fp6_bf16_e64_dpp"
+               : "v_cvt_scalef32_pk16_fp6_bf16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(913)),
       vdst(96, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3646,8 +3848,10 @@ VCvtScalef32Pk16Fp6Bf16Vop3::VCvtScalef32Pk16Fp6Bf16Vop3(const MachineInst *inst
 }
 
 VCvtScalef32Pk16Bf6Bf16Vop3::VCvtScalef32Pk16Bf6Bf16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scalef32_pk16_bf6_bf16", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(914)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scalef32_pk16_bf6_bf16_e64_dpp"
+               : "v_cvt_scalef32_pk16_bf6_bf16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(914)),
       vdst(96, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -3687,8 +3891,10 @@ VCvtScalef32Pk16Bf6Bf16Vop3::VCvtScalef32Pk16Bf6Bf16Vop3(const MachineInst *inst
 }
 
 VCvtScalef32SrPk16Fp6F32Vop3::VCvtScalef32SrPk16Fp6F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scalef32_sr_pk16_fp6_f32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(915)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scalef32_sr_pk16_fp6_f32_e64_dpp"
+               : "v_cvt_scalef32_sr_pk16_fp6_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(915)),
       vdst(96, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3742,8 +3948,10 @@ VCvtScalef32SrPk16Fp6F32Vop3::VCvtScalef32SrPk16Fp6F32Vop3(const MachineInst *in
 }
 
 VCvtScalef32SrPk16Bf6F32Vop3::VCvtScalef32SrPk16Bf6F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scalef32_sr_pk16_bf6_f32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(916)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scalef32_sr_pk16_bf6_f32_e64_dpp"
+               : "v_cvt_scalef32_sr_pk16_bf6_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(916)),
       vdst(96, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3797,8 +4005,10 @@ VCvtScalef32SrPk16Bf6F32Vop3::VCvtScalef32SrPk16Bf6F32Vop3(const MachineInst *in
 }
 
 VCvtScalef32SrPk16Fp6F16Vop3::VCvtScalef32SrPk16Fp6F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scalef32_sr_pk16_fp6_f16", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(917)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scalef32_sr_pk16_fp6_f16_e64_dpp"
+               : "v_cvt_scalef32_sr_pk16_fp6_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(917)),
       vdst(96, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3852,8 +4062,10 @@ VCvtScalef32SrPk16Fp6F16Vop3::VCvtScalef32SrPk16Fp6F16Vop3(const MachineInst *in
 }
 
 VCvtScalef32SrPk16Bf6F16Vop3::VCvtScalef32SrPk16Bf6F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scalef32_sr_pk16_bf6_f16", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(918)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scalef32_sr_pk16_bf6_f16_e64_dpp"
+               : "v_cvt_scalef32_sr_pk16_bf6_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(918)),
       vdst(96, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3907,8 +4119,10 @@ VCvtScalef32SrPk16Bf6F16Vop3::VCvtScalef32SrPk16Bf6F16Vop3(const MachineInst *in
 }
 
 VCvtScalef32SrPk16Fp6Bf16Vop3::VCvtScalef32SrPk16Fp6Bf16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scalef32_sr_pk16_fp6_bf16", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(919)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scalef32_sr_pk16_fp6_bf16_e64_dpp"
+               : "v_cvt_scalef32_sr_pk16_fp6_bf16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(919)),
       vdst(96, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3962,8 +4176,10 @@ VCvtScalef32SrPk16Fp6Bf16Vop3::VCvtScalef32SrPk16Fp6Bf16Vop3(const MachineInst *
 }
 
 VCvtScalef32SrPk16Bf6Bf16Vop3::VCvtScalef32SrPk16Bf6Bf16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_scalef32_sr_pk16_bf6_bf16", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(920)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_scalef32_sr_pk16_bf6_bf16_e64_dpp"
+               : "v_cvt_scalef32_sr_pk16_bf6_bf16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(920)),
       vdst(96, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4017,7 +4233,10 @@ VCvtScalef32SrPk16Bf6Bf16Vop3::VCvtScalef32SrPk16Bf6Bf16Vop3(const MachineInst *
 }
 
 VCvtPkI16F32Vop3::VCvtPkI16F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_i16_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(926)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_i16_f32_e64_dpp"
+               : "v_cvt_pk_i16_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(926)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4071,7 +4290,10 @@ VCvtPkI16F32Vop3::VCvtPkI16F32Vop3(const MachineInst *inst)
 }
 
 VCvtPkU16F32Vop3::VCvtPkU16F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_u16_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(927)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_u16_f32_e64_dpp"
+               : "v_cvt_pk_u16_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(927)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4125,7 +4347,10 @@ VCvtPkU16F32Vop3::VCvtPkU16F32Vop3(const MachineInst *inst)
 }
 
 VPackB32F16Vop3::VPackB32F16Vop3(const MachineInst *inst)
-    : Vop3("v_pack_b32_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(936)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_pack_b32_f16_e64_dpp"
+               : "v_pack_b32_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(936)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4187,8 +4412,10 @@ VPackB32F16Vop3::VPackB32F16Vop3(const MachineInst *inst)
 }
 
 VCvtPkNormI16F16Vop3::VCvtPkNormI16F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_norm_i16_f16", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(937)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_norm_i16_f16_e64_dpp"
+               : "v_cvt_pk_norm_i16_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(937)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4250,8 +4477,10 @@ VCvtPkNormI16F16Vop3::VCvtPkNormI16F16Vop3(const MachineInst *inst)
 }
 
 VCvtPkNormU16F16Vop3::VCvtPkNormU16F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_norm_u16_f16", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(938)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_norm_u16_f16_e64_dpp"
+               : "v_cvt_pk_norm_u16_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(938)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4313,8 +4542,10 @@ VCvtPkNormU16F16Vop3::VCvtPkNormU16F16Vop3(const MachineInst *inst)
 }
 
 VCvtPkNormI16F32Vop3::VCvtPkNormI16F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_norm_i16_f32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(949)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_norm_i16_f32_e64_dpp"
+               : "v_cvt_pk_norm_i16_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(949)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4368,8 +4599,10 @@ VCvtPkNormI16F32Vop3::VCvtPkNormI16F32Vop3(const MachineInst *inst)
 }
 
 VCvtPkNormU16F32Vop3::VCvtPkNormU16F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_norm_u16_f32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(950)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_norm_u16_f32_e64_dpp"
+               : "v_cvt_pk_norm_u16_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(950)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4423,7 +4656,10 @@ VCvtPkNormU16F32Vop3::VCvtPkNormU16F32Vop3(const MachineInst *inst)
 }
 
 VCvtPkU16U32Vop3::VCvtPkU16U32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_u16_u32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(951)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_u16_u32_e64_dpp"
+               : "v_cvt_pk_u16_u32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(951)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4477,7 +4713,10 @@ VCvtPkU16U32Vop3::VCvtPkU16U32Vop3(const MachineInst *inst)
 }
 
 VCvtPkI16I32Vop3::VCvtPkI16I32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_i16_i32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(952)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_i16_i32_e64_dpp"
+               : "v_cvt_pk_i16_i32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(952)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4531,7 +4770,10 @@ VCvtPkI16I32Vop3::VCvtPkI16I32Vop3(const MachineInst *inst)
 }
 
 VCvtPkFp8F32Vop3::VCvtPkFp8F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_fp8_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(976)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_fp8_f32_e64_dpp"
+               : "v_cvt_pk_fp8_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(976)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4598,7 +4840,10 @@ void VCvtPkFp8F32Vop3::implicit_use_operands(
 }
 
 VCvtPkBf8F32Vop3::VCvtPkBf8F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_bf8_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(977)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_bf8_f32_e64_dpp"
+               : "v_cvt_pk_bf8_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(977)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4665,7 +4910,10 @@ void VCvtPkBf8F32Vop3::implicit_use_operands(
 }
 
 VCvtSrFp8F32Vop3::VCvtSrFp8F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_sr_fp8_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(978)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_sr_fp8_f32_e64_dpp"
+               : "v_cvt_sr_fp8_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(978)),
       vdst(8, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4732,7 +4980,10 @@ void VCvtSrFp8F32Vop3::implicit_use_operands(
 }
 
 VCvtSrBf8F32Vop3::VCvtSrBf8F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_sr_bf8_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(979)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_sr_bf8_f32_e64_dpp"
+               : "v_cvt_sr_bf8_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(979)),
       vdst(8, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4799,7 +5050,10 @@ void VCvtSrBf8F32Vop3::implicit_use_operands(
 }
 
 VCvtPkBf16F32Vop3::VCvtPkBf16F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_bf16_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(980)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_bf16_f32_e64_dpp"
+               : "v_cvt_pk_bf16_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(980)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4853,8 +5107,10 @@ VCvtPkBf16F32Vop3::VCvtPkBf16F32Vop3(const MachineInst *inst)
 }
 
 VCvtSrPkBf16F32Vop3::VCvtSrPkBf16F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_sr_pk_bf16_f32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(981)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_sr_pk_bf16_f32_e64_dpp"
+               : "v_cvt_sr_pk_bf16_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(981)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4922,7 +5178,10 @@ VCvtSrPkBf16F32Vop3::VCvtSrPkBf16F32Vop3(const MachineInst *inst)
 }
 
 VCvtPkF16F32Vop3::VCvtPkF16F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_f16_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(982)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_f16_f32_e64_dpp"
+               : "v_cvt_pk_f16_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(982)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4976,8 +5235,10 @@ VCvtPkF16F32Vop3::VCvtPkF16F32Vop3(const MachineInst *inst)
 }
 
 VCvtSrPkF16F32Vop3::VCvtSrPkF16F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_sr_pk_f16_f32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(983)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_sr_pk_f16_f32_e64_dpp"
+               : "v_cvt_sr_pk_f16_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(983)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5045,7 +5306,10 @@ VCvtSrPkF16F32Vop3::VCvtSrPkF16F32Vop3(const MachineInst *inst)
 }
 
 VCvtPkFp8F16Vop3::VCvtPkFp8F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_fp8_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(984)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_fp8_f16_e64_dpp"
+               : "v_cvt_pk_fp8_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(984)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_NOINLINE, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -5098,7 +5362,10 @@ void VCvtPkFp8F16Vop3::implicit_use_operands(
 }
 
 VCvtPkBf8F16Vop3::VCvtPkBf8F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_bf8_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(985)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_bf8_f16_e64_dpp"
+               : "v_cvt_pk_bf8_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(985)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_NOINLINE, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -5151,7 +5418,10 @@ void VCvtPkBf8F16Vop3::implicit_use_operands(
 }
 
 VCvtSrFp8F16Vop3::VCvtSrFp8F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_sr_fp8_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(986)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_sr_fp8_f16_e64_dpp"
+               : "v_cvt_sr_fp8_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(986)),
       vdst(8, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5222,7 +5492,10 @@ void VCvtSrFp8F16Vop3::implicit_use_operands(
 }
 
 VCvtSrBf8F16Vop3::VCvtSrBf8F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_sr_bf8_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(987)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_sr_bf8_f16_e64_dpp"
+               : "v_cvt_sr_bf8_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(987)),
       vdst(8, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/gfx1250/vop3_data.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/gfx1250/vop3_data.cpp
@@ -12,7 +12,10 @@ namespace rocjitsu {
 namespace gfx1250 {
 
 VMovB32Vop3::VMovB32Vop3(const MachineInst *inst)
-    : Vop3("v_mov_b32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(618)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mov_b32_e64_dpp"
+               : "v_mov_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(618)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -52,8 +55,10 @@ VMovB32Vop3::VMovB32Vop3(const MachineInst *inst)
 }
 
 VReadfirstlaneB32Vop3::VReadfirstlaneB32Vop3(const MachineInst *inst)
-    : Vop3("v_readfirstlane_b32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(619)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_readfirstlane_b32_e64_dpp"
+               : "v_readfirstlane_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(619)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -78,7 +83,10 @@ VReadfirstlaneB32Vop3::VReadfirstlaneB32Vop3(const MachineInst *inst)
 }
 
 VMovB16Vop3::VMovB16Vop3(const MachineInst *inst)
-    : Vop3("v_mov_b16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(644)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mov_b16_e64_dpp"
+               : "v_mov_b16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(644)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -134,7 +142,10 @@ void VMovB16Vop3::implicit_use_operands(std::vector<const ::rocjitsu::Operand *>
 }
 
 VMovB64Vop3::VMovB64Vop3(const MachineInst *inst)
-    : Vop3("v_mov_b64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(645)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mov_b64_e64_dpp"
+               : "v_mov_b64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(645)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -169,7 +180,10 @@ VMovB64Vop3::VMovB64Vop3(const MachineInst *inst)
 }
 
 VMovreldB32Vop3::VMovreldB32Vop3(const MachineInst *inst)
-    : Vop3("v_movreld_b32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(674)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_movreld_b32_e64_dpp"
+               : "v_movreld_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(674)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -212,7 +226,10 @@ VMovreldB32Vop3::VMovreldB32Vop3(const MachineInst *inst)
 }
 
 VMovrelsB32Vop3::VMovrelsB32Vop3(const MachineInst *inst)
-    : Vop3("v_movrels_b32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(675)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_movrels_b32_e64_dpp"
+               : "v_movrels_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(675)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -255,8 +272,10 @@ VMovrelsB32Vop3::VMovrelsB32Vop3(const MachineInst *inst)
 }
 
 VPermlane16SwapB32Vop3::VPermlane16SwapB32Vop3(const MachineInst *inst)
-    : Vop3("v_permlane16_swap_b32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(678)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_permlane16_swap_b32_e64_dpp"
+               : "v_permlane16_swap_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(678)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -284,7 +303,10 @@ VPermlane16SwapB32Vop3::VPermlane16SwapB32Vop3(const MachineInst *inst)
 }
 
 VCndmaskB32Vop3::VCndmaskB32Vop3(const MachineInst *inst)
-    : Vop3("v_cndmask_b32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(723)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cndmask_b32_e64_dpp"
+               : "v_cndmask_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(723)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -352,7 +374,10 @@ VCndmaskB32Vop3::VCndmaskB32Vop3(const MachineInst *inst)
 }
 
 VCubeidF32Vop3::VCubeidF32Vop3(const MachineInst *inst)
-    : Vop3("v_cubeid_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(771)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cubeid_f32_e64_dpp"
+               : "v_cubeid_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(771)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -420,7 +445,10 @@ VCubeidF32Vop3::VCubeidF32Vop3(const MachineInst *inst)
 }
 
 VCubescF32Vop3::VCubescF32Vop3(const MachineInst *inst)
-    : Vop3("v_cubesc_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(772)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cubesc_f32_e64_dpp"
+               : "v_cubesc_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(772)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -488,7 +516,10 @@ VCubescF32Vop3::VCubescF32Vop3(const MachineInst *inst)
 }
 
 VCubetcF32Vop3::VCubetcF32Vop3(const MachineInst *inst)
-    : Vop3("v_cubetc_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(773)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cubetc_f32_e64_dpp"
+               : "v_cubetc_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(773)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -556,7 +587,10 @@ VCubetcF32Vop3::VCubetcF32Vop3(const MachineInst *inst)
 }
 
 VCubemaF32Vop3::VCubemaF32Vop3(const MachineInst *inst)
-    : Vop3("v_cubema_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(774)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cubema_f32_e64_dpp"
+               : "v_cubema_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(774)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -624,7 +658,10 @@ VCubemaF32Vop3::VCubemaF32Vop3(const MachineInst *inst)
 }
 
 VPermPk16B4U4Vop3::VPermPk16B4U4Vop3(const MachineInst *inst)
-    : Vop3("v_perm_pk16_b4_u4", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(816)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_perm_pk16_b4_u4_e64_dpp"
+               : "v_perm_pk16_b4_u4",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(816)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -679,7 +716,10 @@ VPermPk16B4U4Vop3::VPermPk16B4U4Vop3(const MachineInst *inst)
 }
 
 VPermPk16B6U4Vop3::VPermPk16B6U4Vop3(const MachineInst *inst)
-    : Vop3("v_perm_pk16_b6_u4", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(819)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_perm_pk16_b6_u4_e64_dpp"
+               : "v_perm_pk16_b6_u4",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(819)),
       vdst(96, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -735,7 +775,10 @@ VPermPk16B6U4Vop3::VPermPk16B6U4Vop3(const MachineInst *inst)
 }
 
 VPermPk16B8U4Vop3::VPermPk16B8U4Vop3(const MachineInst *inst)
-    : Vop3("v_perm_pk16_b8_u4", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(820)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_perm_pk16_b8_u4_e64_dpp"
+               : "v_perm_pk16_b8_u4",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(820)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -792,7 +835,10 @@ VPermPk16B8U4Vop3::VPermPk16B8U4Vop3(const MachineInst *inst)
 }
 
 VPermB32Vop3::VPermB32Vop3(const MachineInst *inst)
-    : Vop3("v_perm_b32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(821)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_perm_b32_e64_dpp"
+               : "v_perm_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(821)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -860,7 +906,10 @@ VPermB32Vop3::VPermB32Vop3(const MachineInst *inst)
 }
 
 VPermlane16B32Vop3::VPermlane16B32Vop3(const MachineInst *inst)
-    : Vop3("v_permlane16_b32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(841)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_permlane16_b32_e64_dpp"
+               : "v_permlane16_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(841)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -912,7 +961,10 @@ VPermlane16B32Vop3::VPermlane16B32Vop3(const MachineInst *inst)
 }
 
 VPermlanex16B32Vop3::VPermlanex16B32Vop3(const MachineInst *inst)
-    : Vop3("v_permlanex16_b32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(842)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_permlanex16_b32_e64_dpp"
+               : "v_permlanex16_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(842)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -964,7 +1016,10 @@ VPermlanex16B32Vop3::VPermlanex16B32Vop3(const MachineInst *inst)
 }
 
 VCndmaskB16Vop3::VCndmaskB16Vop3(const MachineInst *inst)
-    : Vop3("v_cndmask_b16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(843)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cndmask_b16_e64_dpp"
+               : "v_cndmask_b16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(843)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1053,8 +1108,10 @@ void VCndmaskB16Vop3::implicit_use_operands(
 }
 
 VPermlaneBcastB32Vop3::VPermlaneBcastB32Vop3(const MachineInst *inst)
-    : Vop3("v_permlane_bcast_b32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(860)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_permlane_bcast_b32_e64_dpp"
+               : "v_permlane_bcast_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(860)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1106,7 +1163,10 @@ VPermlaneBcastB32Vop3::VPermlaneBcastB32Vop3(const MachineInst *inst)
 }
 
 VPermlaneUpB32Vop3::VPermlaneUpB32Vop3(const MachineInst *inst)
-    : Vop3("v_permlane_up_b32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(861)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_permlane_up_b32_e64_dpp"
+               : "v_permlane_up_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(861)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1158,8 +1218,10 @@ VPermlaneUpB32Vop3::VPermlaneUpB32Vop3(const MachineInst *inst)
 }
 
 VPermlaneDownB32Vop3::VPermlaneDownB32Vop3(const MachineInst *inst)
-    : Vop3("v_permlane_down_b32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(862)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_permlane_down_b32_e64_dpp"
+               : "v_permlane_down_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(862)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1211,7 +1273,10 @@ VPermlaneDownB32Vop3::VPermlaneDownB32Vop3(const MachineInst *inst)
 }
 
 VPermlaneXorB32Vop3::VPermlaneXorB32Vop3(const MachineInst *inst)
-    : Vop3("v_permlane_xor_b32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(863)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_permlane_xor_b32_e64_dpp"
+               : "v_permlane_xor_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(863)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1263,8 +1328,10 @@ VPermlaneXorB32Vop3::VPermlaneXorB32Vop3(const MachineInst *inst)
 }
 
 VPermlane16VarB32Vop3::VPermlane16VarB32Vop3(const MachineInst *inst)
-    : Vop3("v_permlane16_var_b32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(934)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_permlane16_var_b32_e64_dpp"
+               : "v_permlane16_var_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(934)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1304,8 +1371,10 @@ VPermlane16VarB32Vop3::VPermlane16VarB32Vop3(const MachineInst *inst)
 }
 
 VPermlanex16VarB32Vop3::VPermlanex16VarB32Vop3(const MachineInst *inst)
-    : Vop3("v_permlanex16_var_b32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(935)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_permlanex16_var_b32_e64_dpp"
+               : "v_permlanex16_var_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(935)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1345,8 +1414,10 @@ VPermlanex16VarB32Vop3::VPermlanex16VarB32Vop3(const MachineInst *inst)
 }
 
 VPermlaneIdxGenB32Vop3::VPermlaneIdxGenB32Vop3(const MachineInst *inst)
-    : Vop3("v_permlane_idx_gen_b32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(939)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_permlane_idx_gen_b32_e64_dpp"
+               : "v_permlane_idx_gen_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(939)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1385,7 +1456,10 @@ VPermlaneIdxGenB32Vop3::VPermlaneIdxGenB32Vop3(const MachineInst *inst)
 }
 
 VReadlaneB32Vop3::VReadlaneB32Vop3(const MachineInst *inst)
-    : Vop3("v_readlane_b32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(967)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_readlane_b32_e64_dpp"
+               : "v_readlane_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(967)),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SSRC_LANESEL, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1423,7 +1497,10 @@ VReadlaneB32Vop3::VReadlaneB32Vop3(const MachineInst *inst)
 }
 
 VWritelaneB32Vop3::VWritelaneB32Vop3(const MachineInst *inst)
-    : Vop3("v_writelane_b32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(968)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_writelane_b32_e64_dpp"
+               : "v_writelane_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(968)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SSRC_LANESEL, reinterpret_cast<const OpEncoding *>(inst)->src1) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/gfx1250/vop3_misc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/gfx1250/vop3_misc.cpp
@@ -12,19 +12,28 @@ namespace rocjitsu {
 namespace gfx1250 {
 
 VNopVop3::VNopVop3(const MachineInst *inst)
-    : Vop3("v_nop", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(617)) {
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_nop_e64_dpp"
+               : "v_nop",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(617)) {
   num_src_ = 0;
   num_dst_ = 0;
 }
 
 VPipeflushVop3::VPipeflushVop3(const MachineInst *inst)
-    : Vop3("v_pipeflush", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(643)) {
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_pipeflush_e64_dpp"
+               : "v_pipeflush",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(643)) {
   num_src_ = 0;
   num_dst_ = 0;
 }
 
 VMovrelsdB32Vop3::VMovrelsdB32Vop3(const MachineInst *inst)
-    : Vop3("v_movrelsd_b32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(676)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_movrelsd_b32_e64_dpp"
+               : "v_movrelsd_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(676)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -67,7 +76,10 @@ VMovrelsdB32Vop3::VMovrelsdB32Vop3(const MachineInst *inst)
 }
 
 VMovrelsd2B32Vop3::VMovrelsd2B32Vop3(const MachineInst *inst)
-    : Vop3("v_movrelsd_2_b32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(677)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_movrelsd_2_b32_e64_dpp"
+               : "v_movrelsd_2_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(677)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -110,7 +122,10 @@ VMovrelsd2B32Vop3::VMovrelsd2B32Vop3(const MachineInst *inst)
 }
 
 VPrngB32Vop3::VPrngB32Vop3(const MachineInst *inst)
-    : Vop3("v_prng_b32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(680)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_prng_b32_e64_dpp"
+               : "v_prng_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(680)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -150,7 +165,10 @@ VPrngB32Vop3::VPrngB32Vop3(const MachineInst *inst)
 }
 
 VSatPkU8I16Vop3::VSatPkU8I16Vop3(const MachineInst *inst)
-    : Vop3("v_sat_pk_u8_i16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(699)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sat_pk_u8_i16_e64_dpp"
+               : "v_sat_pk_u8_i16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(699)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -203,7 +221,10 @@ void VSatPkU8I16Vop3::implicit_use_operands(
 }
 
 VSatPk4I4I8Vop3::VSatPk4I4I8Vop3(const MachineInst *inst)
-    : Vop3("v_sat_pk4_i4_i8", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(710)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sat_pk4_i4_i8_e64_dpp"
+               : "v_sat_pk4_i4_i8",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(710)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -256,7 +277,10 @@ void VSatPk4I4I8Vop3::implicit_use_operands(
 }
 
 VSatPk4U4U8Vop3::VSatPk4U4U8Vop3(const MachineInst *inst)
-    : Vop3("v_sat_pk4_u4_u8", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(711)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sat_pk4_u4_u8_e64_dpp"
+               : "v_sat_pk4_u4_u8",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(711)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -309,7 +333,10 @@ void VSatPk4U4U8Vop3::implicit_use_operands(
 }
 
 VMullitF32Vop3::VMullitF32Vop3(const MachineInst *inst)
-    : Vop3("v_mullit_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(783)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mullit_f32_e64_dpp"
+               : "v_mullit_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(783)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -377,7 +404,10 @@ VMullitF32Vop3::VMullitF32Vop3(const MachineInst *inst)
 }
 
 VQsadPkU16U8Vop3::VQsadPkU16U8Vop3(const MachineInst *inst)
-    : Vop3("v_qsad_pk_u16_u8", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(813)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_qsad_pk_u16_u8_e64_dpp"
+               : "v_qsad_pk_u16_u8",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(813)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -433,7 +463,10 @@ VQsadPkU16U8Vop3::VQsadPkU16U8Vop3(const MachineInst *inst)
 }
 
 VMqsadPkU16U8Vop3::VMqsadPkU16U8Vop3(const MachineInst *inst)
-    : Vop3("v_mqsad_pk_u16_u8", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(814)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mqsad_pk_u16_u8_e64_dpp"
+               : "v_mqsad_pk_u16_u8",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(814)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -489,7 +522,10 @@ VMqsadPkU16U8Vop3::VMqsadPkU16U8Vop3(const MachineInst *inst)
 }
 
 VMqsadU32U8Vop3::VMqsadU32U8Vop3(const MachineInst *inst)
-    : Vop3("v_mqsad_u32_u8", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(815)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mqsad_u32_u8_e64_dpp"
+               : "v_mqsad_u32_u8",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(815)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -544,7 +580,10 @@ VMqsadU32U8Vop3::VMqsadU32U8Vop3(const MachineInst *inst)
 }
 
 VTrigPreopF64Vop3::VTrigPreopF64Vop3(const MachineInst *inst)
-    : Vop3("v_trig_preop_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(959)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_trig_preop_f64_e64_dpp"
+               : "v_trig_preop_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(959)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/gfx1250/vop3_ternary.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/gfx1250/vop3_ternary.cpp
@@ -12,7 +12,10 @@ namespace rocjitsu {
 namespace gfx1250 {
 
 VFmaDx9ZeroF32Vop3::VFmaDx9ZeroF32Vop3(const MachineInst *inst)
-    : Vop3("v_fma_dx9_zero_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(768)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fma_dx9_zero_f32_e64_dpp"
+               : "v_fma_dx9_zero_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(768)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -80,7 +83,10 @@ VFmaDx9ZeroF32Vop3::VFmaDx9ZeroF32Vop3(const MachineInst *inst)
 }
 
 VMadI32I24Vop3::VMadI32I24Vop3(const MachineInst *inst)
-    : Vop3("v_mad_i32_i24", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(769)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mad_i32_i24_e64_dpp"
+               : "v_mad_i32_i24",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(769)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(24, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(24, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -148,7 +154,10 @@ VMadI32I24Vop3::VMadI32I24Vop3(const MachineInst *inst)
 }
 
 VMadU32U24Vop3::VMadU32U24Vop3(const MachineInst *inst)
-    : Vop3("v_mad_u32_u24", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(770)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mad_u32_u24_e64_dpp"
+               : "v_mad_u32_u24",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(770)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(24, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(24, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -216,7 +225,10 @@ VMadU32U24Vop3::VMadU32U24Vop3(const MachineInst *inst)
 }
 
 VBfeU32Vop3::VBfeU32Vop3(const MachineInst *inst)
-    : Vop3("v_bfe_u32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(775)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_bfe_u32_e64_dpp"
+               : "v_bfe_u32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(775)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -284,7 +296,10 @@ VBfeU32Vop3::VBfeU32Vop3(const MachineInst *inst)
 }
 
 VBfeI32Vop3::VBfeI32Vop3(const MachineInst *inst)
-    : Vop3("v_bfe_i32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(776)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_bfe_i32_e64_dpp"
+               : "v_bfe_i32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(776)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -352,7 +367,10 @@ VBfeI32Vop3::VBfeI32Vop3(const MachineInst *inst)
 }
 
 VBfiB32Vop3::VBfiB32Vop3(const MachineInst *inst)
-    : Vop3("v_bfi_b32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(777)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_bfi_b32_e64_dpp"
+               : "v_bfi_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(777)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -420,7 +438,10 @@ VBfiB32Vop3::VBfiB32Vop3(const MachineInst *inst)
 }
 
 VFmaF32Vop3::VFmaF32Vop3(const MachineInst *inst)
-    : Vop3("v_fma_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(778)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fma_f32_e64_dpp"
+               : "v_fma_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(778)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -488,7 +509,10 @@ VFmaF32Vop3::VFmaF32Vop3(const MachineInst *inst)
 }
 
 VFmaF64Vop3::VFmaF64Vop3(const MachineInst *inst)
-    : Vop3("v_fma_f64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(779)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fma_f64_e64_dpp"
+               : "v_fma_f64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(779)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -553,7 +577,10 @@ VFmaF64Vop3::VFmaF64Vop3(const MachineInst *inst)
 }
 
 VLerpU8Vop3::VLerpU8Vop3(const MachineInst *inst)
-    : Vop3("v_lerp_u8", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(780)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lerp_u8_e64_dpp"
+               : "v_lerp_u8",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(780)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -621,7 +648,10 @@ VLerpU8Vop3::VLerpU8Vop3(const MachineInst *inst)
 }
 
 VAlignbitB32Vop3::VAlignbitB32Vop3(const MachineInst *inst)
-    : Vop3("v_alignbit_b32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(781)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_alignbit_b32_e64_dpp"
+               : "v_alignbit_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(781)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -693,7 +723,10 @@ VAlignbitB32Vop3::VAlignbitB32Vop3(const MachineInst *inst)
 }
 
 VAlignbyteB32Vop3::VAlignbyteB32Vop3(const MachineInst *inst)
-    : Vop3("v_alignbyte_b32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(782)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_alignbyte_b32_e64_dpp"
+               : "v_alignbyte_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(782)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -765,7 +798,10 @@ VAlignbyteB32Vop3::VAlignbyteB32Vop3(const MachineInst *inst)
 }
 
 VMin3I32Vop3::VMin3I32Vop3(const MachineInst *inst)
-    : Vop3("v_min3_i32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(784)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min3_i32_e64_dpp"
+               : "v_min3_i32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(784)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -833,7 +869,10 @@ VMin3I32Vop3::VMin3I32Vop3(const MachineInst *inst)
 }
 
 VMin3U32Vop3::VMin3U32Vop3(const MachineInst *inst)
-    : Vop3("v_min3_u32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(785)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min3_u32_e64_dpp"
+               : "v_min3_u32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(785)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -901,7 +940,10 @@ VMin3U32Vop3::VMin3U32Vop3(const MachineInst *inst)
 }
 
 VMax3I32Vop3::VMax3I32Vop3(const MachineInst *inst)
-    : Vop3("v_max3_i32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(786)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max3_i32_e64_dpp"
+               : "v_max3_i32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(786)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -969,7 +1011,10 @@ VMax3I32Vop3::VMax3I32Vop3(const MachineInst *inst)
 }
 
 VMax3U32Vop3::VMax3U32Vop3(const MachineInst *inst)
-    : Vop3("v_max3_u32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(787)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max3_u32_e64_dpp"
+               : "v_max3_u32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(787)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1037,7 +1082,10 @@ VMax3U32Vop3::VMax3U32Vop3(const MachineInst *inst)
 }
 
 VMed3I32Vop3::VMed3I32Vop3(const MachineInst *inst)
-    : Vop3("v_med3_i32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(788)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_med3_i32_e64_dpp"
+               : "v_med3_i32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(788)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1105,7 +1153,10 @@ VMed3I32Vop3::VMed3I32Vop3(const MachineInst *inst)
 }
 
 VMed3U32Vop3::VMed3U32Vop3(const MachineInst *inst)
-    : Vop3("v_med3_u32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(789)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_med3_u32_e64_dpp"
+               : "v_med3_u32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(789)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1173,7 +1224,10 @@ VMed3U32Vop3::VMed3U32Vop3(const MachineInst *inst)
 }
 
 VSadU8Vop3::VSadU8Vop3(const MachineInst *inst)
-    : Vop3("v_sad_u8", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(790)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sad_u8_e64_dpp"
+               : "v_sad_u8",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(790)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1241,7 +1295,10 @@ VSadU8Vop3::VSadU8Vop3(const MachineInst *inst)
 }
 
 VSadHiU8Vop3::VSadHiU8Vop3(const MachineInst *inst)
-    : Vop3("v_sad_hi_u8", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(791)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sad_hi_u8_e64_dpp"
+               : "v_sad_hi_u8",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(791)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1309,7 +1366,10 @@ VSadHiU8Vop3::VSadHiU8Vop3(const MachineInst *inst)
 }
 
 VSadU16Vop3::VSadU16Vop3(const MachineInst *inst)
-    : Vop3("v_sad_u16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(792)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sad_u16_e64_dpp"
+               : "v_sad_u16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(792)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1377,7 +1437,10 @@ VSadU16Vop3::VSadU16Vop3(const MachineInst *inst)
 }
 
 VSadU32Vop3::VSadU32Vop3(const MachineInst *inst)
-    : Vop3("v_sad_u32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(793)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sad_u32_e64_dpp"
+               : "v_sad_u32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(793)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1445,7 +1508,10 @@ VSadU32Vop3::VSadU32Vop3(const MachineInst *inst)
 }
 
 VMin3NumF32Vop3::VMin3NumF32Vop3(const MachineInst *inst)
-    : Vop3("v_min3_num_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(797)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min3_num_f32_e64_dpp"
+               : "v_min3_num_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(797)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1513,7 +1579,10 @@ VMin3NumF32Vop3::VMin3NumF32Vop3(const MachineInst *inst)
 }
 
 VMax3NumF32Vop3::VMax3NumF32Vop3(const MachineInst *inst)
-    : Vop3("v_max3_num_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(798)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max3_num_f32_e64_dpp"
+               : "v_max3_num_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(798)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1581,7 +1650,10 @@ VMax3NumF32Vop3::VMax3NumF32Vop3(const MachineInst *inst)
 }
 
 VMin3NumF16Vop3::VMin3NumF16Vop3(const MachineInst *inst)
-    : Vop3("v_min3_num_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(799)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min3_num_f16_e64_dpp"
+               : "v_min3_num_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(799)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1674,7 +1746,10 @@ void VMin3NumF16Vop3::implicit_use_operands(
 }
 
 VMax3NumF16Vop3::VMax3NumF16Vop3(const MachineInst *inst)
-    : Vop3("v_max3_num_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(800)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max3_num_f16_e64_dpp"
+               : "v_max3_num_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(800)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1767,7 +1842,10 @@ void VMax3NumF16Vop3::implicit_use_operands(
 }
 
 VMinimum3F32Vop3::VMinimum3F32Vop3(const MachineInst *inst)
-    : Vop3("v_minimum3_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(801)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_minimum3_f32_e64_dpp"
+               : "v_minimum3_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(801)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1835,7 +1913,10 @@ VMinimum3F32Vop3::VMinimum3F32Vop3(const MachineInst *inst)
 }
 
 VMaximum3F32Vop3::VMaximum3F32Vop3(const MachineInst *inst)
-    : Vop3("v_maximum3_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(802)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_maximum3_f32_e64_dpp"
+               : "v_maximum3_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(802)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1903,7 +1984,10 @@ VMaximum3F32Vop3::VMaximum3F32Vop3(const MachineInst *inst)
 }
 
 VMinimum3F16Vop3::VMinimum3F16Vop3(const MachineInst *inst)
-    : Vop3("v_minimum3_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(803)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_minimum3_f16_e64_dpp"
+               : "v_minimum3_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(803)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1996,7 +2080,10 @@ void VMinimum3F16Vop3::implicit_use_operands(
 }
 
 VMaximum3F16Vop3::VMaximum3F16Vop3(const MachineInst *inst)
-    : Vop3("v_maximum3_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(804)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_maximum3_f16_e64_dpp"
+               : "v_maximum3_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(804)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2089,7 +2176,10 @@ void VMaximum3F16Vop3::implicit_use_operands(
 }
 
 VMed3NumF32Vop3::VMed3NumF32Vop3(const MachineInst *inst)
-    : Vop3("v_med3_num_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(805)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_med3_num_f32_e64_dpp"
+               : "v_med3_num_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(805)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2157,7 +2247,10 @@ VMed3NumF32Vop3::VMed3NumF32Vop3(const MachineInst *inst)
 }
 
 VMed3NumF16Vop3::VMed3NumF16Vop3(const MachineInst *inst)
-    : Vop3("v_med3_num_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(806)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_med3_num_f16_e64_dpp"
+               : "v_med3_num_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(806)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2250,7 +2343,10 @@ void VMed3NumF16Vop3::implicit_use_operands(
 }
 
 VMadU32Vop3::VMadU32Vop3(const MachineInst *inst)
-    : Vop3("v_mad_u32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(809)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mad_u32_e64_dpp"
+               : "v_mad_u32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(809)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2312,7 +2408,10 @@ VMadU32Vop3::VMadU32Vop3(const MachineInst *inst)
 }
 
 VMsadU8Vop3::VMsadU8Vop3(const MachineInst *inst)
-    : Vop3("v_msad_u8", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(812)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_msad_u8_e64_dpp"
+               : "v_msad_u8",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(812)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2380,7 +2479,10 @@ VMsadU8Vop3::VMsadU8Vop3(const MachineInst *inst)
 }
 
 VXor3B32Vop3::VXor3B32Vop3(const MachineInst *inst)
-    : Vop3("v_xor3_b32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(817)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_xor3_b32_e64_dpp"
+               : "v_xor3_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(817)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2448,7 +2550,10 @@ VXor3B32Vop3::VXor3B32Vop3(const MachineInst *inst)
 }
 
 VMadU16Vop3::VMadU16Vop3(const MachineInst *inst)
-    : Vop3("v_mad_u16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(818)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mad_u16_e64_dpp"
+               : "v_mad_u16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(818)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2540,7 +2645,10 @@ void VMadU16Vop3::implicit_use_operands(std::vector<const ::rocjitsu::Operand *>
 }
 
 VXadU32Vop3::VXadU32Vop3(const MachineInst *inst)
-    : Vop3("v_xad_u32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(822)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_xad_u32_e64_dpp"
+               : "v_xad_u32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(822)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2608,7 +2716,10 @@ VXadU32Vop3::VXadU32Vop3(const MachineInst *inst)
 }
 
 VLshlAddU32Vop3::VLshlAddU32Vop3(const MachineInst *inst)
-    : Vop3("v_lshl_add_u32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(823)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshl_add_u32_e64_dpp"
+               : "v_lshl_add_u32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(823)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2676,7 +2787,10 @@ VLshlAddU32Vop3::VLshlAddU32Vop3(const MachineInst *inst)
 }
 
 VAddLshlU32Vop3::VAddLshlU32Vop3(const MachineInst *inst)
-    : Vop3("v_add_lshl_u32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(824)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_lshl_u32_e64_dpp"
+               : "v_add_lshl_u32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(824)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2744,7 +2858,10 @@ VAddLshlU32Vop3::VAddLshlU32Vop3(const MachineInst *inst)
 }
 
 VFmaF16Vop3::VFmaF16Vop3(const MachineInst *inst)
-    : Vop3("v_fma_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(825)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fma_f16_e64_dpp"
+               : "v_fma_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(825)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2836,7 +2953,10 @@ void VFmaF16Vop3::implicit_use_operands(std::vector<const ::rocjitsu::Operand *>
 }
 
 VMin3I16Vop3::VMin3I16Vop3(const MachineInst *inst)
-    : Vop3("v_min3_i16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(826)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min3_i16_e64_dpp"
+               : "v_min3_i16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(826)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2928,7 +3048,10 @@ void VMin3I16Vop3::implicit_use_operands(std::vector<const ::rocjitsu::Operand *
 }
 
 VMin3U16Vop3::VMin3U16Vop3(const MachineInst *inst)
-    : Vop3("v_min3_u16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(827)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min3_u16_e64_dpp"
+               : "v_min3_u16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(827)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3020,7 +3143,10 @@ void VMin3U16Vop3::implicit_use_operands(std::vector<const ::rocjitsu::Operand *
 }
 
 VMax3I16Vop3::VMax3I16Vop3(const MachineInst *inst)
-    : Vop3("v_max3_i16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(828)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max3_i16_e64_dpp"
+               : "v_max3_i16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(828)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3112,7 +3238,10 @@ void VMax3I16Vop3::implicit_use_operands(std::vector<const ::rocjitsu::Operand *
 }
 
 VMax3U16Vop3::VMax3U16Vop3(const MachineInst *inst)
-    : Vop3("v_max3_u16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(829)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max3_u16_e64_dpp"
+               : "v_max3_u16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(829)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3204,7 +3333,10 @@ void VMax3U16Vop3::implicit_use_operands(std::vector<const ::rocjitsu::Operand *
 }
 
 VMed3I16Vop3::VMed3I16Vop3(const MachineInst *inst)
-    : Vop3("v_med3_i16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(830)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_med3_i16_e64_dpp"
+               : "v_med3_i16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(830)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3296,7 +3428,10 @@ void VMed3I16Vop3::implicit_use_operands(std::vector<const ::rocjitsu::Operand *
 }
 
 VMed3U16Vop3::VMed3U16Vop3(const MachineInst *inst)
-    : Vop3("v_med3_u16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(831)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_med3_u16_e64_dpp"
+               : "v_med3_u16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(831)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3388,7 +3523,10 @@ void VMed3U16Vop3::implicit_use_operands(std::vector<const ::rocjitsu::Operand *
 }
 
 VLshlAddU64Vop3::VLshlAddU64Vop3(const MachineInst *inst)
-    : Vop3("v_lshl_add_u64", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(832)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshl_add_u64_e64_dpp"
+               : "v_lshl_add_u64",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(832)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3452,7 +3590,10 @@ VLshlAddU64Vop3::VLshlAddU64Vop3(const MachineInst *inst)
 }
 
 VMadI16Vop3::VMadI16Vop3(const MachineInst *inst)
-    : Vop3("v_mad_i16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(833)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mad_i16_e64_dpp"
+               : "v_mad_i16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(833)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3544,7 +3685,10 @@ void VMadI16Vop3::implicit_use_operands(std::vector<const ::rocjitsu::Operand *>
 }
 
 VAdd3U32Vop3::VAdd3U32Vop3(const MachineInst *inst)
-    : Vop3("v_add3_u32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(835)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add3_u32_e64_dpp"
+               : "v_add3_u32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(835)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3612,7 +3756,10 @@ VAdd3U32Vop3::VAdd3U32Vop3(const MachineInst *inst)
 }
 
 VLshlOrB32Vop3::VLshlOrB32Vop3(const MachineInst *inst)
-    : Vop3("v_lshl_or_b32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(836)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshl_or_b32_e64_dpp"
+               : "v_lshl_or_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(836)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3680,7 +3827,10 @@ VLshlOrB32Vop3::VLshlOrB32Vop3(const MachineInst *inst)
 }
 
 VAndOrB32Vop3::VAndOrB32Vop3(const MachineInst *inst)
-    : Vop3("v_and_or_b32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(837)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_and_or_b32_e64_dpp"
+               : "v_and_or_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(837)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3748,7 +3898,10 @@ VAndOrB32Vop3::VAndOrB32Vop3(const MachineInst *inst)
 }
 
 VOr3B32Vop3::VOr3B32Vop3(const MachineInst *inst)
-    : Vop3("v_or3_b32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(838)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_or3_b32_e64_dpp"
+               : "v_or3_b32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(838)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3816,7 +3969,10 @@ VOr3B32Vop3::VOr3B32Vop3(const MachineInst *inst)
 }
 
 VMadU32U16Vop3::VMadU32U16Vop3(const MachineInst *inst)
-    : Vop3("v_mad_u32_u16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(839)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mad_u32_u16_e64_dpp"
+               : "v_mad_u32_u16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(839)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3892,7 +4048,10 @@ VMadU32U16Vop3::VMadU32U16Vop3(const MachineInst *inst)
 }
 
 VMadI32I16Vop3::VMadI32I16Vop3(const MachineInst *inst)
-    : Vop3("v_mad_i32_i16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(840)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mad_i32_i16_e64_dpp"
+               : "v_mad_i32_i16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(840)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3968,7 +4127,10 @@ VMadI32I16Vop3::VMadI32I16Vop3(const MachineInst *inst)
 }
 
 VAddMaxI32Vop3::VAddMaxI32Vop3(const MachineInst *inst)
-    : Vop3("v_add_max_i32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(844)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_max_i32_e64_dpp"
+               : "v_add_max_i32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(844)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4036,7 +4198,10 @@ VAddMaxI32Vop3::VAddMaxI32Vop3(const MachineInst *inst)
 }
 
 VAddMaxU32Vop3::VAddMaxU32Vop3(const MachineInst *inst)
-    : Vop3("v_add_max_u32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(845)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_max_u32_e64_dpp"
+               : "v_add_max_u32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(845)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4104,7 +4269,10 @@ VAddMaxU32Vop3::VAddMaxU32Vop3(const MachineInst *inst)
 }
 
 VAddMinI32Vop3::VAddMinI32Vop3(const MachineInst *inst)
-    : Vop3("v_add_min_i32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(846)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_min_i32_e64_dpp"
+               : "v_add_min_i32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(846)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4172,7 +4340,10 @@ VAddMinI32Vop3::VAddMinI32Vop3(const MachineInst *inst)
 }
 
 VAddMinU32Vop3::VAddMinU32Vop3(const MachineInst *inst)
-    : Vop3("v_add_min_u32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(847)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_min_u32_e64_dpp"
+               : "v_add_min_u32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(847)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4240,7 +4411,10 @@ VAddMinU32Vop3::VAddMinU32Vop3(const MachineInst *inst)
 }
 
 VMaxminU32Vop3::VMaxminU32Vop3(const MachineInst *inst)
-    : Vop3("v_maxmin_u32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(848)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_maxmin_u32_e64_dpp"
+               : "v_maxmin_u32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(848)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4308,7 +4482,10 @@ VMaxminU32Vop3::VMaxminU32Vop3(const MachineInst *inst)
 }
 
 VMinmaxU32Vop3::VMinmaxU32Vop3(const MachineInst *inst)
-    : Vop3("v_minmax_u32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(849)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_minmax_u32_e64_dpp"
+               : "v_minmax_u32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(849)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4376,7 +4553,10 @@ VMinmaxU32Vop3::VMinmaxU32Vop3(const MachineInst *inst)
 }
 
 VMaxminI32Vop3::VMaxminI32Vop3(const MachineInst *inst)
-    : Vop3("v_maxmin_i32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(850)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_maxmin_i32_e64_dpp"
+               : "v_maxmin_i32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(850)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4444,7 +4624,10 @@ VMaxminI32Vop3::VMaxminI32Vop3(const MachineInst *inst)
 }
 
 VMinmaxI32Vop3::VMinmaxI32Vop3(const MachineInst *inst)
-    : Vop3("v_minmax_i32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(851)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_minmax_i32_e64_dpp"
+               : "v_minmax_i32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(851)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4512,7 +4695,10 @@ VMinmaxI32Vop3::VMinmaxI32Vop3(const MachineInst *inst)
 }
 
 VMinmaxNumF32Vop3::VMinmaxNumF32Vop3(const MachineInst *inst)
-    : Vop3("v_minmax_num_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(852)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_minmax_num_f32_e64_dpp"
+               : "v_minmax_num_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(852)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4580,7 +4766,10 @@ VMinmaxNumF32Vop3::VMinmaxNumF32Vop3(const MachineInst *inst)
 }
 
 VMaxminNumF32Vop3::VMaxminNumF32Vop3(const MachineInst *inst)
-    : Vop3("v_maxmin_num_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(853)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_maxmin_num_f32_e64_dpp"
+               : "v_maxmin_num_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(853)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4648,7 +4837,10 @@ VMaxminNumF32Vop3::VMaxminNumF32Vop3(const MachineInst *inst)
 }
 
 VMinmaxNumF16Vop3::VMinmaxNumF16Vop3(const MachineInst *inst)
-    : Vop3("v_minmax_num_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(854)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_minmax_num_f16_e64_dpp"
+               : "v_minmax_num_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(854)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4741,7 +4933,10 @@ void VMinmaxNumF16Vop3::implicit_use_operands(
 }
 
 VMaxminNumF16Vop3::VMaxminNumF16Vop3(const MachineInst *inst)
-    : Vop3("v_maxmin_num_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(855)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_maxmin_num_f16_e64_dpp"
+               : "v_maxmin_num_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(855)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4834,8 +5029,10 @@ void VMaxminNumF16Vop3::implicit_use_operands(
 }
 
 VMinimummaximumF32Vop3::VMinimummaximumF32Vop3(const MachineInst *inst)
-    : Vop3("v_minimummaximum_f32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(856)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_minimummaximum_f32_e64_dpp"
+               : "v_minimummaximum_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(856)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4903,8 +5100,10 @@ VMinimummaximumF32Vop3::VMinimummaximumF32Vop3(const MachineInst *inst)
 }
 
 VMaximumminimumF32Vop3::VMaximumminimumF32Vop3(const MachineInst *inst)
-    : Vop3("v_maximumminimum_f32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(857)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_maximumminimum_f32_e64_dpp"
+               : "v_maximumminimum_f32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(857)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4972,8 +5171,10 @@ VMaximumminimumF32Vop3::VMaximumminimumF32Vop3(const MachineInst *inst)
 }
 
 VMinimummaximumF16Vop3::VMinimummaximumF16Vop3(const MachineInst *inst)
-    : Vop3("v_minimummaximum_f16", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(858)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_minimummaximum_f16_e64_dpp"
+               : "v_minimummaximum_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(858)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5066,8 +5267,10 @@ void VMinimummaximumF16Vop3::implicit_use_operands(
 }
 
 VMaximumminimumF16Vop3::VMaximumminimumF16Vop3(const MachineInst *inst)
-    : Vop3("v_maximumminimum_f16", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(859)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_maximumminimum_f16_e64_dpp"
+               : "v_maximumminimum_f16",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(859)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5160,7 +5363,10 @@ void VMaximumminimumF16Vop3::implicit_use_operands(
 }
 
 VAshrPkI8I32Vop3::VAshrPkI8I32Vop3(const MachineInst *inst)
-    : Vop3("v_ashr_pk_i8_i32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(874)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ashr_pk_i8_i32_e64_dpp"
+               : "v_ashr_pk_i8_i32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(874)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5241,7 +5447,10 @@ void VAshrPkI8I32Vop3::implicit_use_operands(
 }
 
 VAshrPkU8I32Vop3::VAshrPkU8I32Vop3(const MachineInst *inst)
-    : Vop3("v_ashr_pk_u8_i32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(875)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ashr_pk_u8_i32_e64_dpp"
+               : "v_ashr_pk_u8_i32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(875)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5322,7 +5531,10 @@ void VAshrPkU8I32Vop3::implicit_use_operands(
 }
 
 VMadNcU64U32Vop3::VMadNcU64U32Vop3(const MachineInst *inst)
-    : Vop3("v_mad_nc_u64_u32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(921)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mad_nc_u64_u32_e64_dpp"
+               : "v_mad_nc_u64_u32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(921)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -5385,7 +5597,10 @@ VMadNcU64U32Vop3::VMadNcU64U32Vop3(const MachineInst *inst)
 }
 
 VMadNcI64I32Vop3::VMadNcI64I32Vop3(const MachineInst *inst)
-    : Vop3("v_mad_nc_i64_i32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(922)),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mad_nc_i64_i32_e64_dpp"
+               : "v_mad_nc_i64_i32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(922)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/gfx1250/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/gfx1250/vop3p.cpp
@@ -100,7 +100,10 @@ int gfx1250_scaled_wmma_src1_size_bits(const MachineInst *inst) {
 } // namespace
 
 VPkMadI16Vop3p::VPkMadI16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_mad_i16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1160)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_mad_i16_e64_dpp"
+                : "v_pk_mad_i16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1160)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -133,8 +136,10 @@ VPkMadI16Vop3p::VPkMadI16Vop3p(const MachineInst *inst)
 }
 
 VPkMulLoU16Vop3p::VPkMulLoU16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_mul_lo_u16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1161),
-            2),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_mul_lo_u16_e64_dpp"
+                : "v_pk_mul_lo_u16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1161), 2),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -160,7 +165,10 @@ VPkMulLoU16Vop3p::VPkMulLoU16Vop3p(const MachineInst *inst)
 }
 
 VPkAddI16Vop3p::VPkAddI16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_add_i16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1162), 2),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_add_i16_e64_dpp"
+                : "v_pk_add_i16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1162), 2),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -186,7 +194,10 @@ VPkAddI16Vop3p::VPkAddI16Vop3p(const MachineInst *inst)
 }
 
 VPkSubI16Vop3p::VPkSubI16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_sub_i16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1163), 2),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_sub_i16_e64_dpp"
+                : "v_pk_sub_i16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1163), 2),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -212,8 +223,10 @@ VPkSubI16Vop3p::VPkSubI16Vop3p(const MachineInst *inst)
 }
 
 VPkLshlrevB16Vop3p::VPkLshlrevB16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_lshlrev_b16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1164),
-            2),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_lshlrev_b16_e64_dpp"
+                : "v_pk_lshlrev_b16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1164), 2),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -239,8 +252,10 @@ VPkLshlrevB16Vop3p::VPkLshlrevB16Vop3p(const MachineInst *inst)
 }
 
 VPkLshrrevB16Vop3p::VPkLshrrevB16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_lshrrev_b16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1165),
-            2),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_lshrrev_b16_e64_dpp"
+                : "v_pk_lshrrev_b16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1165), 2),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -266,8 +281,10 @@ VPkLshrrevB16Vop3p::VPkLshrrevB16Vop3p(const MachineInst *inst)
 }
 
 VPkAshrrevI16Vop3p::VPkAshrrevI16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_ashrrev_i16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1166),
-            2),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_ashrrev_i16_e64_dpp"
+                : "v_pk_ashrrev_i16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1166), 2),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -293,7 +310,10 @@ VPkAshrrevI16Vop3p::VPkAshrrevI16Vop3p(const MachineInst *inst)
 }
 
 VPkMaxI16Vop3p::VPkMaxI16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_max_i16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1167), 2),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_max_i16_e64_dpp"
+                : "v_pk_max_i16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1167), 2),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -319,7 +339,10 @@ VPkMaxI16Vop3p::VPkMaxI16Vop3p(const MachineInst *inst)
 }
 
 VPkMinI16Vop3p::VPkMinI16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_min_i16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1168), 2),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_min_i16_e64_dpp"
+                : "v_pk_min_i16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1168), 2),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -345,7 +368,10 @@ VPkMinI16Vop3p::VPkMinI16Vop3p(const MachineInst *inst)
 }
 
 VPkMadU16Vop3p::VPkMadU16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_mad_u16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1169)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_mad_u16_e64_dpp"
+                : "v_pk_mad_u16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1169)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -378,7 +404,10 @@ VPkMadU16Vop3p::VPkMadU16Vop3p(const MachineInst *inst)
 }
 
 VPkAddU16Vop3p::VPkAddU16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_add_u16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1170), 2),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_add_u16_e64_dpp"
+                : "v_pk_add_u16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1170), 2),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -404,7 +433,10 @@ VPkAddU16Vop3p::VPkAddU16Vop3p(const MachineInst *inst)
 }
 
 VPkSubU16Vop3p::VPkSubU16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_sub_u16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1171), 2),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_sub_u16_e64_dpp"
+                : "v_pk_sub_u16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1171), 2),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -430,7 +462,10 @@ VPkSubU16Vop3p::VPkSubU16Vop3p(const MachineInst *inst)
 }
 
 VPkMaxU16Vop3p::VPkMaxU16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_max_u16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1172), 2),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_max_u16_e64_dpp"
+                : "v_pk_max_u16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1172), 2),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -456,7 +491,10 @@ VPkMaxU16Vop3p::VPkMaxU16Vop3p(const MachineInst *inst)
 }
 
 VPkMinU16Vop3p::VPkMinU16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_min_u16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1173), 2),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_min_u16_e64_dpp"
+                : "v_pk_min_u16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1173), 2),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -482,7 +520,10 @@ VPkMinU16Vop3p::VPkMinU16Vop3p(const MachineInst *inst)
 }
 
 VPkFmaF16Vop3p::VPkFmaF16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_fma_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1174)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_fma_f16_e64_dpp"
+                : "v_pk_fma_f16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1174)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -515,7 +556,10 @@ VPkFmaF16Vop3p::VPkFmaF16Vop3p(const MachineInst *inst)
 }
 
 VPkAddF16Vop3p::VPkAddF16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_add_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1175), 2),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_add_f16_e64_dpp"
+                : "v_pk_add_f16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1175), 2),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -541,7 +585,10 @@ VPkAddF16Vop3p::VPkAddF16Vop3p(const MachineInst *inst)
 }
 
 VPkMulF16Vop3p::VPkMulF16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_mul_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1176), 2),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_mul_f16_e64_dpp"
+                : "v_pk_mul_f16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1176), 2),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -567,7 +614,10 @@ VPkMulF16Vop3p::VPkMulF16Vop3p(const MachineInst *inst)
 }
 
 VPkFmaBf16Vop3p::VPkFmaBf16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_fma_bf16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1177)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_fma_bf16_e64_dpp"
+                : "v_pk_fma_bf16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1177)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -600,7 +650,10 @@ VPkFmaBf16Vop3p::VPkFmaBf16Vop3p(const MachineInst *inst)
 }
 
 VPkAddMaxI16Vop3p::VPkAddMaxI16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_add_max_i16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1178)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_add_max_i16_e64_dpp"
+                : "v_pk_add_max_i16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1178)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -633,7 +686,10 @@ VPkAddMaxI16Vop3p::VPkAddMaxI16Vop3p(const MachineInst *inst)
 }
 
 VPkAddMaxU16Vop3p::VPkAddMaxU16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_add_max_u16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1179)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_add_max_u16_e64_dpp"
+                : "v_pk_add_max_u16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1179)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -666,7 +722,10 @@ VPkAddMaxU16Vop3p::VPkAddMaxU16Vop3p(const MachineInst *inst)
 }
 
 VDot4I32Iu8Vop3p::VDot4I32Iu8Vop3p(const MachineInst *inst)
-    : Vop3p("v_dot4_i32_iu8", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1180)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_dot4_i32_iu8_e64_dpp"
+                : "v_dot4_i32_iu8",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1180)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -699,7 +758,10 @@ VDot4I32Iu8Vop3p::VDot4I32Iu8Vop3p(const MachineInst *inst)
 }
 
 VDot4U32U8Vop3p::VDot4U32U8Vop3p(const MachineInst *inst)
-    : Vop3p("v_dot4_u32_u8", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1181)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_dot4_u32_u8_e64_dpp"
+                : "v_dot4_u32_u8",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1181)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -732,7 +794,10 @@ VDot4U32U8Vop3p::VDot4U32U8Vop3p(const MachineInst *inst)
 }
 
 VDot8I32Iu4Vop3p::VDot8I32Iu4Vop3p(const MachineInst *inst)
-    : Vop3p("v_dot8_i32_iu4", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1182)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_dot8_i32_iu4_e64_dpp"
+                : "v_dot8_i32_iu4",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1182)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -765,7 +830,10 @@ VDot8I32Iu4Vop3p::VDot8I32Iu4Vop3p(const MachineInst *inst)
 }
 
 VDot8U32U4Vop3p::VDot8U32U4Vop3p(const MachineInst *inst)
-    : Vop3p("v_dot8_u32_u4", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1183)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_dot8_u32_u4_e64_dpp"
+                : "v_dot8_u32_u4",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1183)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -798,8 +866,10 @@ VDot8U32U4Vop3p::VDot8U32U4Vop3p(const MachineInst *inst)
 }
 
 VPkMinNumF16Vop3p::VPkMinNumF16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_min_num_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1184),
-            2),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_min_num_f16_e64_dpp"
+                : "v_pk_min_num_f16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1184), 2),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -825,8 +895,10 @@ VPkMinNumF16Vop3p::VPkMinNumF16Vop3p(const MachineInst *inst)
 }
 
 VPkMaxNumF16Vop3p::VPkMaxNumF16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_max_num_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1185),
-            2),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_max_num_f16_e64_dpp"
+                : "v_pk_max_num_f16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1185), 2),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -852,8 +924,10 @@ VPkMaxNumF16Vop3p::VPkMaxNumF16Vop3p(const MachineInst *inst)
 }
 
 VPkMinimumF16Vop3p::VPkMinimumF16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_minimum_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1186),
-            2),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_minimum_f16_e64_dpp"
+                : "v_pk_minimum_f16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1186), 2),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -879,8 +953,10 @@ VPkMinimumF16Vop3p::VPkMinimumF16Vop3p(const MachineInst *inst)
 }
 
 VPkMaximumF16Vop3p::VPkMaximumF16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_maximum_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1187),
-            2),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_maximum_f16_e64_dpp"
+                : "v_pk_maximum_f16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1187), 2),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -906,7 +982,10 @@ VPkMaximumF16Vop3p::VPkMaximumF16Vop3p(const MachineInst *inst)
 }
 
 VPkFmaF32Vop3p::VPkFmaF32Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_fma_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1188)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_fma_f32_e64_dpp"
+                : "v_pk_fma_f32",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1188)),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -942,7 +1021,10 @@ VPkFmaF32Vop3p::VPkFmaF32Vop3p(const MachineInst *inst)
 }
 
 VFmaMixF32Vop3p::VFmaMixF32Vop3p(const MachineInst *inst)
-    : Vop3p("v_fma_mix_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1189)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_fma_mix_f32_e64_dpp"
+                : "v_fma_mix_f32",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1189)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -989,7 +1071,10 @@ VFmaMixF32Vop3p::VFmaMixF32Vop3p(const MachineInst *inst)
 }
 
 VFmaMixloF16Vop3p::VFmaMixloF16Vop3p(const MachineInst *inst)
-    : Vop3p("v_fma_mixlo_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1190)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_fma_mixlo_f16_e64_dpp"
+                : "v_fma_mixlo_f16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1190)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1050,7 +1135,10 @@ void VFmaMixloF16Vop3p::implicit_use_operands(
 }
 
 VFmaMixhiF16Vop3p::VFmaMixhiF16Vop3p(const MachineInst *inst)
-    : Vop3p("v_fma_mixhi_f16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1191)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_fma_mixhi_f16_e64_dpp"
+                : "v_fma_mixhi_f16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1191)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1111,7 +1199,10 @@ void VFmaMixhiF16Vop3p::implicit_use_operands(
 }
 
 VPkAddBf16Vop3p::VPkAddBf16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_add_bf16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1192), 2),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_add_bf16_e64_dpp"
+                : "v_pk_add_bf16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1192), 2),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1137,7 +1228,10 @@ VPkAddBf16Vop3p::VPkAddBf16Vop3p(const MachineInst *inst)
 }
 
 VPkMulF32Vop3p::VPkMulF32Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_mul_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1193), 2),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_mul_f32_e64_dpp"
+                : "v_pk_mul_f32",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1193), 2),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1165,7 +1259,10 @@ VPkMulF32Vop3p::VPkMulF32Vop3p(const MachineInst *inst)
 }
 
 VPkAddF32Vop3p::VPkAddF32Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_add_f32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1194), 2),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_add_f32_e64_dpp"
+                : "v_pk_add_f32",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1194), 2),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1193,7 +1290,10 @@ VPkAddF32Vop3p::VPkAddF32Vop3p(const MachineInst *inst)
 }
 
 VPkMulBf16Vop3p::VPkMulBf16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_mul_bf16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1195), 2),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_mul_bf16_e64_dpp"
+                : "v_pk_mul_bf16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1195), 2),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1219,8 +1319,10 @@ VPkMulBf16Vop3p::VPkMulBf16Vop3p(const MachineInst *inst)
 }
 
 VPkMinNumBf16Vop3p::VPkMinNumBf16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_min_num_bf16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1196),
-            2),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_min_num_bf16_e64_dpp"
+                : "v_pk_min_num_bf16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1196), 2),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1246,8 +1348,10 @@ VPkMinNumBf16Vop3p::VPkMinNumBf16Vop3p(const MachineInst *inst)
 }
 
 VPkMaxNumBf16Vop3p::VPkMaxNumBf16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_max_num_bf16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1197),
-            2),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_max_num_bf16_e64_dpp"
+                : "v_pk_max_num_bf16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1197), 2),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1273,7 +1377,10 @@ VPkMaxNumBf16Vop3p::VPkMaxNumBf16Vop3p(const MachineInst *inst)
 }
 
 VPkAddMinI16Vop3p::VPkAddMinI16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_add_min_i16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1198)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_add_min_i16_e64_dpp"
+                : "v_pk_add_min_i16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1198)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1306,7 +1413,10 @@ VPkAddMinI16Vop3p::VPkAddMinI16Vop3p(const MachineInst *inst)
 }
 
 VPkAddMinU16Vop3p::VPkAddMinU16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_add_min_u16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1199)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_add_min_u16_e64_dpp"
+                : "v_pk_add_min_u16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1199)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1339,7 +1449,10 @@ VPkAddMinU16Vop3p::VPkAddMinU16Vop3p(const MachineInst *inst)
 }
 
 VPkMax3I16Vop3p::VPkMax3I16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_max3_i16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1200)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_max3_i16_e64_dpp"
+                : "v_pk_max3_i16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1200)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1372,7 +1485,10 @@ VPkMax3I16Vop3p::VPkMax3I16Vop3p(const MachineInst *inst)
 }
 
 VPkMax3U16Vop3p::VPkMax3U16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_max3_u16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1201)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_max3_u16_e64_dpp"
+                : "v_pk_max3_u16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1201)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1405,7 +1521,10 @@ VPkMax3U16Vop3p::VPkMax3U16Vop3p(const MachineInst *inst)
 }
 
 VPkMin3I16Vop3p::VPkMin3I16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_min3_i16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1202)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_min3_i16_e64_dpp"
+                : "v_pk_min3_i16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1202)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1438,7 +1557,10 @@ VPkMin3I16Vop3p::VPkMin3I16Vop3p(const MachineInst *inst)
 }
 
 VPkMin3U16Vop3p::VPkMin3U16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_min3_u16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1203)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_min3_u16_e64_dpp"
+                : "v_pk_min3_u16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1203)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1471,8 +1593,10 @@ VPkMin3U16Vop3p::VPkMin3U16Vop3p(const MachineInst *inst)
 }
 
 VWmmaF3216x16x128F8f6f4Vop3p::VWmmaF3216x16x128F8f6f4Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_f32_16x16x128_f8f6f4", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1204)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_f32_16x16x128_f8f6f4_e64_dpp"
+                : "v_wmma_f32_16x16x128_f8f6f4",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1204)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(gfx1250_matrix_fmt_operand_size_bits(reinterpret_cast<const OpEncoding *>(inst)->opsel,
                                                 16, 128),
@@ -1525,8 +1649,10 @@ void VWmmaF3216x16x128F8f6f4Vop3p::build_modifiers(std::string &out) const {
 }
 
 VPkMinimum3F16Vop3p::VPkMinimum3F16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_minimum3_f16", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1205)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_minimum3_f16_e64_dpp"
+                : "v_pk_minimum3_f16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1205)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1559,8 +1685,10 @@ VPkMinimum3F16Vop3p::VPkMinimum3F16Vop3p(const MachineInst *inst)
 }
 
 VPkMaximum3F16Vop3p::VPkMaximum3F16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_maximum3_f16", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1206)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_maximum3_f16_e64_dpp"
+                : "v_pk_maximum3_f16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1206)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1593,8 +1721,10 @@ VPkMaximum3F16Vop3p::VPkMaximum3F16Vop3p(const MachineInst *inst)
 }
 
 VPkMin3NumF16Vop3p::VPkMin3NumF16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_min3_num_f16", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1207)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_min3_num_f16_e64_dpp"
+                : "v_pk_min3_num_f16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1207)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1627,8 +1757,10 @@ VPkMin3NumF16Vop3p::VPkMin3NumF16Vop3p(const MachineInst *inst)
 }
 
 VPkMax3NumF16Vop3p::VPkMax3NumF16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_max3_num_f16", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1208)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_max3_num_f16_e64_dpp"
+                : "v_pk_max3_num_f16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1208)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1661,8 +1793,10 @@ VPkMax3NumF16Vop3p::VPkMax3NumF16Vop3p(const MachineInst *inst)
 }
 
 VFmaMixF32Bf16Vop3p::VFmaMixF32Bf16Vop3p(const MachineInst *inst)
-    : Vop3p("v_fma_mix_f32_bf16", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1209)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_fma_mix_f32_bf16_e64_dpp"
+                : "v_fma_mix_f32_bf16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1209)),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1709,7 +1843,10 @@ VFmaMixF32Bf16Vop3p::VFmaMixF32Bf16Vop3p(const MachineInst *inst)
 }
 
 VFmaMixloBf16Vop3p::VFmaMixloBf16Vop3p(const MachineInst *inst)
-    : Vop3p("v_fma_mixlo_bf16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1210)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_fma_mixlo_bf16_e64_dpp"
+                : "v_fma_mixlo_bf16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1210)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1770,7 +1907,10 @@ void VFmaMixloBf16Vop3p::implicit_use_operands(
 }
 
 VFmaMixhiBf16Vop3p::VFmaMixhiBf16Vop3p(const MachineInst *inst)
-    : Vop3p("v_fma_mixhi_bf16", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1211)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_fma_mixhi_bf16_e64_dpp"
+                : "v_fma_mixhi_bf16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1211)),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1831,8 +1971,10 @@ void VFmaMixhiBf16Vop3p::implicit_use_operands(
 }
 
 VWmmaF3216x16x4F32Vop3p::VWmmaF3216x16x4F32Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_f32_16x16x4_f32", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1212)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_f32_16x16x4_f32_e64_dpp"
+                : "v_wmma_f32_16x16x4_f32",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1212)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1868,8 +2010,10 @@ VWmmaF3216x16x4F32Vop3p::VWmmaF3216x16x4F32Vop3p(const MachineInst *inst)
 }
 
 VWmmaF3216x16x32F16Vop3p::VWmmaF3216x16x32F16Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_f32_16x16x32_f16", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1213)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_f32_16x16x32_f16_e64_dpp"
+                : "v_wmma_f32_16x16x32_f16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1213)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1903,8 +2047,10 @@ VWmmaF3216x16x32F16Vop3p::VWmmaF3216x16x32F16Vop3p(const MachineInst *inst)
 }
 
 VWmmaF1616x16x32F16Vop3p::VWmmaF1616x16x32F16Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_f16_16x16x32_f16", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1214)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_f16_16x16x32_f16_e64_dpp"
+                : "v_wmma_f16_16x16x32_f16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1214)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1938,8 +2084,10 @@ VWmmaF1616x16x32F16Vop3p::VWmmaF1616x16x32F16Vop3p(const MachineInst *inst)
 }
 
 VWmmaF3216x16x32Bf16Vop3p::VWmmaF3216x16x32Bf16Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_f32_16x16x32_bf16", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1215)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_f32_16x16x32_bf16_e64_dpp"
+                : "v_wmma_f32_16x16x32_bf16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1215)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1973,8 +2121,10 @@ VWmmaF3216x16x32Bf16Vop3p::VWmmaF3216x16x32Bf16Vop3p(const MachineInst *inst)
 }
 
 VWmmaBf1616x16x32Bf16Vop3p::VWmmaBf1616x16x32Bf16Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_bf16_16x16x32_bf16", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1216)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_bf16_16x16x32_bf16_e64_dpp"
+                : "v_wmma_bf16_16x16x32_bf16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1216)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2008,8 +2158,10 @@ VWmmaBf1616x16x32Bf16Vop3p::VWmmaBf1616x16x32Bf16Vop3p(const MachineInst *inst)
 }
 
 VWmmaBf16f3216x16x32Bf16Vop3p::VWmmaBf16f3216x16x32Bf16Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_bf16f32_16x16x32_bf16", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1217)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_bf16f32_16x16x32_bf16_e64_dpp"
+                : "v_wmma_bf16f32_16x16x32_bf16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1217)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2043,8 +2195,10 @@ VWmmaBf16f3216x16x32Bf16Vop3p::VWmmaBf16f3216x16x32Bf16Vop3p(const MachineInst *
 }
 
 VSwmmacF3216x16x64F16Vop3p::VSwmmacF3216x16x64F16Vop3p(const MachineInst *inst)
-    : Vop3p("v_swmmac_f32_16x16x64_f16", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1218)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_swmmac_f32_16x16x64_f16_e64_dpp"
+                : "v_swmmac_f32_16x16x64_f16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1218)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2086,8 +2240,10 @@ void VSwmmacF3216x16x64F16Vop3p::build_modifiers(std::string &out) const {
 }
 
 VSwmmacF3216x16x64Bf16Vop3p::VSwmmacF3216x16x64Bf16Vop3p(const MachineInst *inst)
-    : Vop3p("v_swmmac_f32_16x16x64_bf16", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1219)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_swmmac_f32_16x16x64_bf16_e64_dpp"
+                : "v_swmmac_f32_16x16x64_bf16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1219)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2129,8 +2285,10 @@ void VSwmmacF3216x16x64Bf16Vop3p::build_modifiers(std::string &out) const {
 }
 
 VSwmmacF1616x16x64F16Vop3p::VSwmmacF1616x16x64F16Vop3p(const MachineInst *inst)
-    : Vop3p("v_swmmac_f16_16x16x64_f16", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1220)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_swmmac_f16_16x16x64_f16_e64_dpp"
+                : "v_swmmac_f16_16x16x64_f16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1220)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2172,8 +2330,10 @@ void VSwmmacF1616x16x64F16Vop3p::build_modifiers(std::string &out) const {
 }
 
 VSwmmacBf1616x16x64Bf16Vop3p::VSwmmacBf1616x16x64Bf16Vop3p(const MachineInst *inst)
-    : Vop3p("v_swmmac_bf16_16x16x64_bf16", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1221)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_swmmac_bf16_16x16x64_bf16_e64_dpp"
+                : "v_swmmac_bf16_16x16x64_bf16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1221)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2215,8 +2375,10 @@ void VSwmmacBf1616x16x64Bf16Vop3p::build_modifiers(std::string &out) const {
 }
 
 VSwmmacBf16f3216x16x64Bf16Vop3p::VSwmmacBf16f3216x16x64Bf16Vop3p(const MachineInst *inst)
-    : Vop3p("v_swmmac_bf16f32_16x16x64_bf16", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1222)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_swmmac_bf16f32_16x16x64_bf16_e64_dpp"
+                : "v_swmmac_bf16f32_16x16x64_bf16",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1222)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2258,8 +2420,10 @@ void VSwmmacBf16f3216x16x64Bf16Vop3p::build_modifiers(std::string &out) const {
 }
 
 VWmmaF3216x16x64Fp8Fp8Vop3p::VWmmaF3216x16x64Fp8Fp8Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_f32_16x16x64_fp8_fp8", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1223)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_f32_16x16x64_fp8_fp8_e64_dpp"
+                : "v_wmma_f32_16x16x64_fp8_fp8",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1223)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2293,8 +2457,10 @@ VWmmaF3216x16x64Fp8Fp8Vop3p::VWmmaF3216x16x64Fp8Fp8Vop3p(const MachineInst *inst
 }
 
 VWmmaF3216x16x64Fp8Bf8Vop3p::VWmmaF3216x16x64Fp8Bf8Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_f32_16x16x64_fp8_bf8", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1224)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_f32_16x16x64_fp8_bf8_e64_dpp"
+                : "v_wmma_f32_16x16x64_fp8_bf8",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1224)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2328,8 +2494,10 @@ VWmmaF3216x16x64Fp8Bf8Vop3p::VWmmaF3216x16x64Fp8Bf8Vop3p(const MachineInst *inst
 }
 
 VWmmaF3216x16x64Bf8Fp8Vop3p::VWmmaF3216x16x64Bf8Fp8Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_f32_16x16x64_bf8_fp8", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1225)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_f32_16x16x64_bf8_fp8_e64_dpp"
+                : "v_wmma_f32_16x16x64_bf8_fp8",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1225)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2363,8 +2531,10 @@ VWmmaF3216x16x64Bf8Fp8Vop3p::VWmmaF3216x16x64Bf8Fp8Vop3p(const MachineInst *inst
 }
 
 VWmmaF3216x16x64Bf8Bf8Vop3p::VWmmaF3216x16x64Bf8Bf8Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_f32_16x16x64_bf8_bf8", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1226)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_f32_16x16x64_bf8_bf8_e64_dpp"
+                : "v_wmma_f32_16x16x64_bf8_bf8",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1226)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2398,8 +2568,10 @@ VWmmaF3216x16x64Bf8Bf8Vop3p::VWmmaF3216x16x64Bf8Bf8Vop3p(const MachineInst *inst
 }
 
 VWmmaF1616x16x64Fp8Fp8Vop3p::VWmmaF1616x16x64Fp8Fp8Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_f16_16x16x64_fp8_fp8", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1227)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_f16_16x16x64_fp8_fp8_e64_dpp"
+                : "v_wmma_f16_16x16x64_fp8_fp8",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1227)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2433,8 +2605,10 @@ VWmmaF1616x16x64Fp8Fp8Vop3p::VWmmaF1616x16x64Fp8Fp8Vop3p(const MachineInst *inst
 }
 
 VWmmaF1616x16x64Fp8Bf8Vop3p::VWmmaF1616x16x64Fp8Bf8Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_f16_16x16x64_fp8_bf8", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1228)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_f16_16x16x64_fp8_bf8_e64_dpp"
+                : "v_wmma_f16_16x16x64_fp8_bf8",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1228)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2468,8 +2642,10 @@ VWmmaF1616x16x64Fp8Bf8Vop3p::VWmmaF1616x16x64Fp8Bf8Vop3p(const MachineInst *inst
 }
 
 VWmmaF1616x16x64Bf8Fp8Vop3p::VWmmaF1616x16x64Bf8Fp8Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_f16_16x16x64_bf8_fp8", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1229)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_f16_16x16x64_bf8_fp8_e64_dpp"
+                : "v_wmma_f16_16x16x64_bf8_fp8",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1229)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2503,8 +2679,10 @@ VWmmaF1616x16x64Bf8Fp8Vop3p::VWmmaF1616x16x64Bf8Fp8Vop3p(const MachineInst *inst
 }
 
 VWmmaF1616x16x64Bf8Bf8Vop3p::VWmmaF1616x16x64Bf8Bf8Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_f16_16x16x64_bf8_bf8", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1230)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_f16_16x16x64_bf8_bf8_e64_dpp"
+                : "v_wmma_f16_16x16x64_bf8_bf8",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1230)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2538,8 +2716,10 @@ VWmmaF1616x16x64Bf8Bf8Vop3p::VWmmaF1616x16x64Bf8Bf8Vop3p(const MachineInst *inst
 }
 
 VWmmaI3216x16x64Iu8Vop3p::VWmmaI3216x16x64Iu8Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_i32_16x16x64_iu8", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1231)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_i32_16x16x64_iu8_e64_dpp"
+                : "v_wmma_i32_16x16x64_iu8",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1231)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2573,8 +2753,10 @@ VWmmaI3216x16x64Iu8Vop3p::VWmmaI3216x16x64Iu8Vop3p(const MachineInst *inst)
 }
 
 VSwmmacF3216x16x128Fp8Fp8Vop3p::VSwmmacF3216x16x128Fp8Fp8Vop3p(const MachineInst *inst)
-    : Vop3p("v_swmmac_f32_16x16x128_fp8_fp8", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1232)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_swmmac_f32_16x16x128_fp8_fp8_e64_dpp"
+                : "v_swmmac_f32_16x16x128_fp8_fp8",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1232)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2617,8 +2799,10 @@ void VSwmmacF3216x16x128Fp8Fp8Vop3p::build_modifiers(std::string &out) const {
 }
 
 VSwmmacF3216x16x128Fp8Bf8Vop3p::VSwmmacF3216x16x128Fp8Bf8Vop3p(const MachineInst *inst)
-    : Vop3p("v_swmmac_f32_16x16x128_fp8_bf8", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1233)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_swmmac_f32_16x16x128_fp8_bf8_e64_dpp"
+                : "v_swmmac_f32_16x16x128_fp8_bf8",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1233)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2661,8 +2845,10 @@ void VSwmmacF3216x16x128Fp8Bf8Vop3p::build_modifiers(std::string &out) const {
 }
 
 VSwmmacF3216x16x128Bf8Fp8Vop3p::VSwmmacF3216x16x128Bf8Fp8Vop3p(const MachineInst *inst)
-    : Vop3p("v_swmmac_f32_16x16x128_bf8_fp8", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1234)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_swmmac_f32_16x16x128_bf8_fp8_e64_dpp"
+                : "v_swmmac_f32_16x16x128_bf8_fp8",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1234)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2705,8 +2891,10 @@ void VSwmmacF3216x16x128Bf8Fp8Vop3p::build_modifiers(std::string &out) const {
 }
 
 VSwmmacF3216x16x128Bf8Bf8Vop3p::VSwmmacF3216x16x128Bf8Bf8Vop3p(const MachineInst *inst)
-    : Vop3p("v_swmmac_f32_16x16x128_bf8_bf8", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1235)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_swmmac_f32_16x16x128_bf8_bf8_e64_dpp"
+                : "v_swmmac_f32_16x16x128_bf8_bf8",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1235)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2749,8 +2937,10 @@ void VSwmmacF3216x16x128Bf8Bf8Vop3p::build_modifiers(std::string &out) const {
 }
 
 VSwmmacF1616x16x128Fp8Fp8Vop3p::VSwmmacF1616x16x128Fp8Fp8Vop3p(const MachineInst *inst)
-    : Vop3p("v_swmmac_f16_16x16x128_fp8_fp8", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1236)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_swmmac_f16_16x16x128_fp8_fp8_e64_dpp"
+                : "v_swmmac_f16_16x16x128_fp8_fp8",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1236)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2793,8 +2983,10 @@ void VSwmmacF1616x16x128Fp8Fp8Vop3p::build_modifiers(std::string &out) const {
 }
 
 VSwmmacF1616x16x128Fp8Bf8Vop3p::VSwmmacF1616x16x128Fp8Bf8Vop3p(const MachineInst *inst)
-    : Vop3p("v_swmmac_f16_16x16x128_fp8_bf8", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1237)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_swmmac_f16_16x16x128_fp8_bf8_e64_dpp"
+                : "v_swmmac_f16_16x16x128_fp8_bf8",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1237)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2837,8 +3029,10 @@ void VSwmmacF1616x16x128Fp8Bf8Vop3p::build_modifiers(std::string &out) const {
 }
 
 VSwmmacF1616x16x128Bf8Fp8Vop3p::VSwmmacF1616x16x128Bf8Fp8Vop3p(const MachineInst *inst)
-    : Vop3p("v_swmmac_f16_16x16x128_bf8_fp8", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1238)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_swmmac_f16_16x16x128_bf8_fp8_e64_dpp"
+                : "v_swmmac_f16_16x16x128_bf8_fp8",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1238)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2881,8 +3075,10 @@ void VSwmmacF1616x16x128Bf8Fp8Vop3p::build_modifiers(std::string &out) const {
 }
 
 VSwmmacF1616x16x128Bf8Bf8Vop3p::VSwmmacF1616x16x128Bf8Bf8Vop3p(const MachineInst *inst)
-    : Vop3p("v_swmmac_f16_16x16x128_bf8_bf8", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1239)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_swmmac_f16_16x16x128_bf8_bf8_e64_dpp"
+                : "v_swmmac_f16_16x16x128_bf8_bf8",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1239)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2925,8 +3121,10 @@ void VSwmmacF1616x16x128Bf8Bf8Vop3p::build_modifiers(std::string &out) const {
 }
 
 VSwmmacI3216x16x128Iu8Vop3p::VSwmmacI3216x16x128Iu8Vop3p(const MachineInst *inst)
-    : Vop3p("v_swmmac_i32_16x16x128_iu8", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1240)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_swmmac_i32_16x16x128_iu8_e64_dpp"
+                : "v_swmmac_i32_16x16x128_iu8",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1240)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2969,8 +3167,10 @@ void VSwmmacI3216x16x128Iu8Vop3p::build_modifiers(std::string &out) const {
 }
 
 VWmmaF3216x16x128Fp8Fp8Vop3p::VWmmaF3216x16x128Fp8Fp8Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_f32_16x16x128_fp8_fp8", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1241)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_f32_16x16x128_fp8_fp8_e64_dpp"
+                : "v_wmma_f32_16x16x128_fp8_fp8",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1241)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3004,8 +3204,10 @@ VWmmaF3216x16x128Fp8Fp8Vop3p::VWmmaF3216x16x128Fp8Fp8Vop3p(const MachineInst *in
 }
 
 VWmmaF3216x16x128Fp8Bf8Vop3p::VWmmaF3216x16x128Fp8Bf8Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_f32_16x16x128_fp8_bf8", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1242)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_f32_16x16x128_fp8_bf8_e64_dpp"
+                : "v_wmma_f32_16x16x128_fp8_bf8",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1242)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3039,8 +3241,10 @@ VWmmaF3216x16x128Fp8Bf8Vop3p::VWmmaF3216x16x128Fp8Bf8Vop3p(const MachineInst *in
 }
 
 VWmmaF3216x16x128Bf8Fp8Vop3p::VWmmaF3216x16x128Bf8Fp8Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_f32_16x16x128_bf8_fp8", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1243)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_f32_16x16x128_bf8_fp8_e64_dpp"
+                : "v_wmma_f32_16x16x128_bf8_fp8",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1243)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3074,8 +3278,10 @@ VWmmaF3216x16x128Bf8Fp8Vop3p::VWmmaF3216x16x128Bf8Fp8Vop3p(const MachineInst *in
 }
 
 VWmmaF3216x16x128Bf8Bf8Vop3p::VWmmaF3216x16x128Bf8Bf8Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_f32_16x16x128_bf8_bf8", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1244)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_f32_16x16x128_bf8_bf8_e64_dpp"
+                : "v_wmma_f32_16x16x128_bf8_bf8",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1244)),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3109,8 +3315,10 @@ VWmmaF3216x16x128Bf8Bf8Vop3p::VWmmaF3216x16x128Bf8Bf8Vop3p(const MachineInst *in
 }
 
 VWmmaF1616x16x128Fp8Fp8Vop3p::VWmmaF1616x16x128Fp8Fp8Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_f16_16x16x128_fp8_fp8", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1245)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_f16_16x16x128_fp8_fp8_e64_dpp"
+                : "v_wmma_f16_16x16x128_fp8_fp8",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1245)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3144,8 +3352,10 @@ VWmmaF1616x16x128Fp8Fp8Vop3p::VWmmaF1616x16x128Fp8Fp8Vop3p(const MachineInst *in
 }
 
 VWmmaF1616x16x128Fp8Bf8Vop3p::VWmmaF1616x16x128Fp8Bf8Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_f16_16x16x128_fp8_bf8", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1246)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_f16_16x16x128_fp8_bf8_e64_dpp"
+                : "v_wmma_f16_16x16x128_fp8_bf8",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1246)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3179,8 +3389,10 @@ VWmmaF1616x16x128Fp8Bf8Vop3p::VWmmaF1616x16x128Fp8Bf8Vop3p(const MachineInst *in
 }
 
 VWmmaF1616x16x128Bf8Fp8Vop3p::VWmmaF1616x16x128Bf8Fp8Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_f16_16x16x128_bf8_fp8", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1247)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_f16_16x16x128_bf8_fp8_e64_dpp"
+                : "v_wmma_f16_16x16x128_bf8_fp8",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1247)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3214,8 +3426,10 @@ VWmmaF1616x16x128Bf8Fp8Vop3p::VWmmaF1616x16x128Bf8Fp8Vop3p(const MachineInst *in
 }
 
 VWmmaF1616x16x128Bf8Bf8Vop3p::VWmmaF1616x16x128Bf8Bf8Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_f16_16x16x128_bf8_bf8", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1248)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_f16_16x16x128_bf8_bf8_e64_dpp"
+                : "v_wmma_f16_16x16x128_bf8_bf8",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1248)),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -3249,8 +3463,10 @@ VWmmaF1616x16x128Bf8Bf8Vop3p::VWmmaF1616x16x128Bf8Bf8Vop3p(const MachineInst *in
 }
 
 VWmmaF3232x16x128F4Vop3p::VWmmaF3232x16x128F4Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_f32_32x16x128_f4", reinterpret_cast<const OpEncoding *>(inst),
-            selected_exec_fn(1249)),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_f32_32x16x128_f4_e64_dpp"
+                : "v_wmma_f32_32x16x128_f4",
+            reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(1249)),
       vdst(512, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(512, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/gfx1250/vopc_cmp.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/gfx1250/vopc_cmp.cpp
@@ -12,7 +12,10 @@ namespace rocjitsu {
 namespace gfx1250 {
 
 VCmpLtF16Vopc::VCmpLtF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lt_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(400)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_f16_dpp"
+               : "v_cmp_lt_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(400)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -58,7 +61,10 @@ VCmpLtF16Vopc::VCmpLtF16Vopc(const MachineInst *inst)
 }
 
 VCmpEqF16Vopc::VCmpEqF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_eq_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(401)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_f16_dpp"
+               : "v_cmp_eq_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(401)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -104,7 +110,10 @@ VCmpEqF16Vopc::VCmpEqF16Vopc(const MachineInst *inst)
 }
 
 VCmpLeF16Vopc::VCmpLeF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_le_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(402)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_f16_dpp"
+               : "v_cmp_le_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(402)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -150,7 +159,10 @@ VCmpLeF16Vopc::VCmpLeF16Vopc(const MachineInst *inst)
 }
 
 VCmpGtF16Vopc::VCmpGtF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_gt_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(403)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_f16_dpp"
+               : "v_cmp_gt_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(403)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -196,7 +208,10 @@ VCmpGtF16Vopc::VCmpGtF16Vopc(const MachineInst *inst)
 }
 
 VCmpLgF16Vopc::VCmpLgF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lg_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(404)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lg_f16_dpp"
+               : "v_cmp_lg_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(404)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -242,7 +257,10 @@ VCmpLgF16Vopc::VCmpLgF16Vopc(const MachineInst *inst)
 }
 
 VCmpGeF16Vopc::VCmpGeF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ge_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(405)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_f16_dpp"
+               : "v_cmp_ge_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(405)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -288,7 +306,10 @@ VCmpGeF16Vopc::VCmpGeF16Vopc(const MachineInst *inst)
 }
 
 VCmpOF16Vopc::VCmpOF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_o_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(406)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_o_f16_dpp"
+               : "v_cmp_o_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(406)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -334,7 +355,10 @@ VCmpOF16Vopc::VCmpOF16Vopc(const MachineInst *inst)
 }
 
 VCmpUF16Vopc::VCmpUF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_u_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(407)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_u_f16_dpp"
+               : "v_cmp_u_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(407)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -380,7 +404,10 @@ VCmpUF16Vopc::VCmpUF16Vopc(const MachineInst *inst)
 }
 
 VCmpNgeF16Vopc::VCmpNgeF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nge_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(408)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nge_f16_dpp"
+               : "v_cmp_nge_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(408)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -426,7 +453,10 @@ VCmpNgeF16Vopc::VCmpNgeF16Vopc(const MachineInst *inst)
 }
 
 VCmpNlgF16Vopc::VCmpNlgF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nlg_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(409)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlg_f16_dpp"
+               : "v_cmp_nlg_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(409)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -472,7 +502,10 @@ VCmpNlgF16Vopc::VCmpNlgF16Vopc(const MachineInst *inst)
 }
 
 VCmpNgtF16Vopc::VCmpNgtF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ngt_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(410)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ngt_f16_dpp"
+               : "v_cmp_ngt_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(410)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -518,7 +551,10 @@ VCmpNgtF16Vopc::VCmpNgtF16Vopc(const MachineInst *inst)
 }
 
 VCmpNleF16Vopc::VCmpNleF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nle_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(411)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nle_f16_dpp"
+               : "v_cmp_nle_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(411)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -564,7 +600,10 @@ VCmpNleF16Vopc::VCmpNleF16Vopc(const MachineInst *inst)
 }
 
 VCmpNeqF16Vopc::VCmpNeqF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_neq_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(412)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_neq_f16_dpp"
+               : "v_cmp_neq_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(412)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -610,7 +649,10 @@ VCmpNeqF16Vopc::VCmpNeqF16Vopc(const MachineInst *inst)
 }
 
 VCmpNltF16Vopc::VCmpNltF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nlt_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(413)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlt_f16_dpp"
+               : "v_cmp_nlt_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(413)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -656,7 +698,10 @@ VCmpNltF16Vopc::VCmpNltF16Vopc(const MachineInst *inst)
 }
 
 VCmpLtF32Vopc::VCmpLtF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lt_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(414)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_f32_dpp"
+               : "v_cmp_lt_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(414)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -699,7 +744,10 @@ VCmpLtF32Vopc::VCmpLtF32Vopc(const MachineInst *inst)
 }
 
 VCmpEqF32Vopc::VCmpEqF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_eq_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(415)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_f32_dpp"
+               : "v_cmp_eq_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(415)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -742,7 +790,10 @@ VCmpEqF32Vopc::VCmpEqF32Vopc(const MachineInst *inst)
 }
 
 VCmpLeF32Vopc::VCmpLeF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_le_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(416)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_f32_dpp"
+               : "v_cmp_le_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(416)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -785,7 +836,10 @@ VCmpLeF32Vopc::VCmpLeF32Vopc(const MachineInst *inst)
 }
 
 VCmpGtF32Vopc::VCmpGtF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_gt_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(417)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_f32_dpp"
+               : "v_cmp_gt_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(417)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -828,7 +882,10 @@ VCmpGtF32Vopc::VCmpGtF32Vopc(const MachineInst *inst)
 }
 
 VCmpLgF32Vopc::VCmpLgF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lg_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(418)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lg_f32_dpp"
+               : "v_cmp_lg_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(418)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -871,7 +928,10 @@ VCmpLgF32Vopc::VCmpLgF32Vopc(const MachineInst *inst)
 }
 
 VCmpGeF32Vopc::VCmpGeF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ge_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(419)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_f32_dpp"
+               : "v_cmp_ge_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(419)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -914,7 +974,10 @@ VCmpGeF32Vopc::VCmpGeF32Vopc(const MachineInst *inst)
 }
 
 VCmpOF32Vopc::VCmpOF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_o_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(420)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_o_f32_dpp"
+               : "v_cmp_o_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(420)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -957,7 +1020,10 @@ VCmpOF32Vopc::VCmpOF32Vopc(const MachineInst *inst)
 }
 
 VCmpUF32Vopc::VCmpUF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_u_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(421)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_u_f32_dpp"
+               : "v_cmp_u_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(421)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1000,7 +1066,10 @@ VCmpUF32Vopc::VCmpUF32Vopc(const MachineInst *inst)
 }
 
 VCmpNgeF32Vopc::VCmpNgeF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nge_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(422)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nge_f32_dpp"
+               : "v_cmp_nge_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(422)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1043,7 +1112,10 @@ VCmpNgeF32Vopc::VCmpNgeF32Vopc(const MachineInst *inst)
 }
 
 VCmpNlgF32Vopc::VCmpNlgF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nlg_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(423)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlg_f32_dpp"
+               : "v_cmp_nlg_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(423)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1086,7 +1158,10 @@ VCmpNlgF32Vopc::VCmpNlgF32Vopc(const MachineInst *inst)
 }
 
 VCmpNgtF32Vopc::VCmpNgtF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ngt_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(424)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ngt_f32_dpp"
+               : "v_cmp_ngt_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(424)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1129,7 +1204,10 @@ VCmpNgtF32Vopc::VCmpNgtF32Vopc(const MachineInst *inst)
 }
 
 VCmpNleF32Vopc::VCmpNleF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nle_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(425)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nle_f32_dpp"
+               : "v_cmp_nle_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(425)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1172,7 +1250,10 @@ VCmpNleF32Vopc::VCmpNleF32Vopc(const MachineInst *inst)
 }
 
 VCmpNeqF32Vopc::VCmpNeqF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_neq_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(426)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_neq_f32_dpp"
+               : "v_cmp_neq_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(426)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1215,7 +1296,10 @@ VCmpNeqF32Vopc::VCmpNeqF32Vopc(const MachineInst *inst)
 }
 
 VCmpNltF32Vopc::VCmpNltF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nlt_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(427)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlt_f32_dpp"
+               : "v_cmp_nlt_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(427)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1258,7 +1342,10 @@ VCmpNltF32Vopc::VCmpNltF32Vopc(const MachineInst *inst)
 }
 
 VCmpLtF64Vopc::VCmpLtF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lt_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(428)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_f64_dpp"
+               : "v_cmp_lt_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(428)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1288,7 +1375,10 @@ VCmpLtF64Vopc::VCmpLtF64Vopc(const MachineInst *inst)
 }
 
 VCmpEqF64Vopc::VCmpEqF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_eq_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(429)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_f64_dpp"
+               : "v_cmp_eq_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(429)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1318,7 +1408,10 @@ VCmpEqF64Vopc::VCmpEqF64Vopc(const MachineInst *inst)
 }
 
 VCmpLeF64Vopc::VCmpLeF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_le_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(430)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_f64_dpp"
+               : "v_cmp_le_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(430)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1348,7 +1441,10 @@ VCmpLeF64Vopc::VCmpLeF64Vopc(const MachineInst *inst)
 }
 
 VCmpGtF64Vopc::VCmpGtF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_gt_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(431)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_f64_dpp"
+               : "v_cmp_gt_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(431)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1378,7 +1474,10 @@ VCmpGtF64Vopc::VCmpGtF64Vopc(const MachineInst *inst)
 }
 
 VCmpLgF64Vopc::VCmpLgF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lg_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(432)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lg_f64_dpp"
+               : "v_cmp_lg_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(432)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1408,7 +1507,10 @@ VCmpLgF64Vopc::VCmpLgF64Vopc(const MachineInst *inst)
 }
 
 VCmpGeF64Vopc::VCmpGeF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ge_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(433)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_f64_dpp"
+               : "v_cmp_ge_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(433)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1438,7 +1540,10 @@ VCmpGeF64Vopc::VCmpGeF64Vopc(const MachineInst *inst)
 }
 
 VCmpOF64Vopc::VCmpOF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_o_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(434)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_o_f64_dpp"
+               : "v_cmp_o_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(434)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1468,7 +1573,10 @@ VCmpOF64Vopc::VCmpOF64Vopc(const MachineInst *inst)
 }
 
 VCmpUF64Vopc::VCmpUF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_u_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(435)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_u_f64_dpp"
+               : "v_cmp_u_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(435)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1498,7 +1606,10 @@ VCmpUF64Vopc::VCmpUF64Vopc(const MachineInst *inst)
 }
 
 VCmpNgeF64Vopc::VCmpNgeF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nge_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(436)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nge_f64_dpp"
+               : "v_cmp_nge_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(436)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1528,7 +1639,10 @@ VCmpNgeF64Vopc::VCmpNgeF64Vopc(const MachineInst *inst)
 }
 
 VCmpNlgF64Vopc::VCmpNlgF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nlg_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(437)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlg_f64_dpp"
+               : "v_cmp_nlg_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(437)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1558,7 +1672,10 @@ VCmpNlgF64Vopc::VCmpNlgF64Vopc(const MachineInst *inst)
 }
 
 VCmpNgtF64Vopc::VCmpNgtF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ngt_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(438)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ngt_f64_dpp"
+               : "v_cmp_ngt_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(438)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1588,7 +1705,10 @@ VCmpNgtF64Vopc::VCmpNgtF64Vopc(const MachineInst *inst)
 }
 
 VCmpNleF64Vopc::VCmpNleF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nle_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(439)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nle_f64_dpp"
+               : "v_cmp_nle_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(439)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1618,7 +1738,10 @@ VCmpNleF64Vopc::VCmpNleF64Vopc(const MachineInst *inst)
 }
 
 VCmpNeqF64Vopc::VCmpNeqF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_neq_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(440)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_neq_f64_dpp"
+               : "v_cmp_neq_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(440)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1648,7 +1771,10 @@ VCmpNeqF64Vopc::VCmpNeqF64Vopc(const MachineInst *inst)
 }
 
 VCmpNltF64Vopc::VCmpNltF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nlt_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(441)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlt_f64_dpp"
+               : "v_cmp_nlt_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(441)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1678,7 +1804,10 @@ VCmpNltF64Vopc::VCmpNltF64Vopc(const MachineInst *inst)
 }
 
 VCmpLtI16Vopc::VCmpLtI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lt_i16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(442)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_i16_dpp"
+               : "v_cmp_lt_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(442)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -1724,7 +1853,10 @@ VCmpLtI16Vopc::VCmpLtI16Vopc(const MachineInst *inst)
 }
 
 VCmpEqI16Vopc::VCmpEqI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_eq_i16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(443)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_i16_dpp"
+               : "v_cmp_eq_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(443)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -1770,7 +1902,10 @@ VCmpEqI16Vopc::VCmpEqI16Vopc(const MachineInst *inst)
 }
 
 VCmpLeI16Vopc::VCmpLeI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_le_i16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(444)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_i16_dpp"
+               : "v_cmp_le_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(444)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -1816,7 +1951,10 @@ VCmpLeI16Vopc::VCmpLeI16Vopc(const MachineInst *inst)
 }
 
 VCmpGtI16Vopc::VCmpGtI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_gt_i16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(445)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_i16_dpp"
+               : "v_cmp_gt_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(445)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -1862,7 +2000,10 @@ VCmpGtI16Vopc::VCmpGtI16Vopc(const MachineInst *inst)
 }
 
 VCmpNeI16Vopc::VCmpNeI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ne_i16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(446)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_i16_dpp"
+               : "v_cmp_ne_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(446)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -1908,7 +2049,10 @@ VCmpNeI16Vopc::VCmpNeI16Vopc(const MachineInst *inst)
 }
 
 VCmpGeI16Vopc::VCmpGeI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ge_i16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(447)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_i16_dpp"
+               : "v_cmp_ge_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(447)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -1954,7 +2098,10 @@ VCmpGeI16Vopc::VCmpGeI16Vopc(const MachineInst *inst)
 }
 
 VCmpLtU16Vopc::VCmpLtU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lt_u16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(448)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_u16_dpp"
+               : "v_cmp_lt_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(448)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2000,7 +2147,10 @@ VCmpLtU16Vopc::VCmpLtU16Vopc(const MachineInst *inst)
 }
 
 VCmpEqU16Vopc::VCmpEqU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_eq_u16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(449)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_u16_dpp"
+               : "v_cmp_eq_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(449)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2046,7 +2196,10 @@ VCmpEqU16Vopc::VCmpEqU16Vopc(const MachineInst *inst)
 }
 
 VCmpLeU16Vopc::VCmpLeU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_le_u16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(450)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_u16_dpp"
+               : "v_cmp_le_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(450)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2092,7 +2245,10 @@ VCmpLeU16Vopc::VCmpLeU16Vopc(const MachineInst *inst)
 }
 
 VCmpGtU16Vopc::VCmpGtU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_gt_u16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(451)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_u16_dpp"
+               : "v_cmp_gt_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(451)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2138,7 +2294,10 @@ VCmpGtU16Vopc::VCmpGtU16Vopc(const MachineInst *inst)
 }
 
 VCmpNeU16Vopc::VCmpNeU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ne_u16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(452)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_u16_dpp"
+               : "v_cmp_ne_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(452)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2184,7 +2343,10 @@ VCmpNeU16Vopc::VCmpNeU16Vopc(const MachineInst *inst)
 }
 
 VCmpGeU16Vopc::VCmpGeU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ge_u16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(453)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_u16_dpp"
+               : "v_cmp_ge_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(453)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2230,7 +2392,10 @@ VCmpGeU16Vopc::VCmpGeU16Vopc(const MachineInst *inst)
 }
 
 VCmpLtI32Vopc::VCmpLtI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lt_i32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(454)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_i32_dpp"
+               : "v_cmp_lt_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(454)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2273,7 +2438,10 @@ VCmpLtI32Vopc::VCmpLtI32Vopc(const MachineInst *inst)
 }
 
 VCmpEqI32Vopc::VCmpEqI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_eq_i32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(455)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_i32_dpp"
+               : "v_cmp_eq_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(455)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2316,7 +2484,10 @@ VCmpEqI32Vopc::VCmpEqI32Vopc(const MachineInst *inst)
 }
 
 VCmpLeI32Vopc::VCmpLeI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_le_i32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(456)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_i32_dpp"
+               : "v_cmp_le_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(456)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2359,7 +2530,10 @@ VCmpLeI32Vopc::VCmpLeI32Vopc(const MachineInst *inst)
 }
 
 VCmpGtI32Vopc::VCmpGtI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_gt_i32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(457)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_i32_dpp"
+               : "v_cmp_gt_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(457)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2402,7 +2576,10 @@ VCmpGtI32Vopc::VCmpGtI32Vopc(const MachineInst *inst)
 }
 
 VCmpNeI32Vopc::VCmpNeI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ne_i32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(458)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_i32_dpp"
+               : "v_cmp_ne_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(458)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2445,7 +2622,10 @@ VCmpNeI32Vopc::VCmpNeI32Vopc(const MachineInst *inst)
 }
 
 VCmpGeI32Vopc::VCmpGeI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ge_i32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(459)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_i32_dpp"
+               : "v_cmp_ge_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(459)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2488,7 +2668,10 @@ VCmpGeI32Vopc::VCmpGeI32Vopc(const MachineInst *inst)
 }
 
 VCmpLtU32Vopc::VCmpLtU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lt_u32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(460)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_u32_dpp"
+               : "v_cmp_lt_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(460)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2531,7 +2714,10 @@ VCmpLtU32Vopc::VCmpLtU32Vopc(const MachineInst *inst)
 }
 
 VCmpEqU32Vopc::VCmpEqU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_eq_u32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(461)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_u32_dpp"
+               : "v_cmp_eq_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(461)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2574,7 +2760,10 @@ VCmpEqU32Vopc::VCmpEqU32Vopc(const MachineInst *inst)
 }
 
 VCmpLeU32Vopc::VCmpLeU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_le_u32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(462)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_u32_dpp"
+               : "v_cmp_le_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(462)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2617,7 +2806,10 @@ VCmpLeU32Vopc::VCmpLeU32Vopc(const MachineInst *inst)
 }
 
 VCmpGtU32Vopc::VCmpGtU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_gt_u32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(463)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_u32_dpp"
+               : "v_cmp_gt_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(463)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2660,7 +2852,10 @@ VCmpGtU32Vopc::VCmpGtU32Vopc(const MachineInst *inst)
 }
 
 VCmpNeU32Vopc::VCmpNeU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ne_u32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(464)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_u32_dpp"
+               : "v_cmp_ne_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(464)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2703,7 +2898,10 @@ VCmpNeU32Vopc::VCmpNeU32Vopc(const MachineInst *inst)
 }
 
 VCmpGeU32Vopc::VCmpGeU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ge_u32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(465)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_u32_dpp"
+               : "v_cmp_ge_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(465)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2746,7 +2944,10 @@ VCmpGeU32Vopc::VCmpGeU32Vopc(const MachineInst *inst)
 }
 
 VCmpLtI64Vopc::VCmpLtI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lt_i64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(466)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_i64_dpp"
+               : "v_cmp_lt_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(466)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2776,7 +2977,10 @@ VCmpLtI64Vopc::VCmpLtI64Vopc(const MachineInst *inst)
 }
 
 VCmpEqI64Vopc::VCmpEqI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_eq_i64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(467)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_i64_dpp"
+               : "v_cmp_eq_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(467)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2806,7 +3010,10 @@ VCmpEqI64Vopc::VCmpEqI64Vopc(const MachineInst *inst)
 }
 
 VCmpLeI64Vopc::VCmpLeI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_le_i64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(468)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_i64_dpp"
+               : "v_cmp_le_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(468)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2836,7 +3043,10 @@ VCmpLeI64Vopc::VCmpLeI64Vopc(const MachineInst *inst)
 }
 
 VCmpGtI64Vopc::VCmpGtI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_gt_i64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(469)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_i64_dpp"
+               : "v_cmp_gt_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(469)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2866,7 +3076,10 @@ VCmpGtI64Vopc::VCmpGtI64Vopc(const MachineInst *inst)
 }
 
 VCmpNeI64Vopc::VCmpNeI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ne_i64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(470)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_i64_dpp"
+               : "v_cmp_ne_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(470)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2896,7 +3109,10 @@ VCmpNeI64Vopc::VCmpNeI64Vopc(const MachineInst *inst)
 }
 
 VCmpGeI64Vopc::VCmpGeI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ge_i64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(471)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_i64_dpp"
+               : "v_cmp_ge_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(471)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2926,7 +3142,10 @@ VCmpGeI64Vopc::VCmpGeI64Vopc(const MachineInst *inst)
 }
 
 VCmpLtU64Vopc::VCmpLtU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lt_u64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(472)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_u64_dpp"
+               : "v_cmp_lt_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(472)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2956,7 +3175,10 @@ VCmpLtU64Vopc::VCmpLtU64Vopc(const MachineInst *inst)
 }
 
 VCmpEqU64Vopc::VCmpEqU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_eq_u64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(473)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_u64_dpp"
+               : "v_cmp_eq_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(473)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2986,7 +3208,10 @@ VCmpEqU64Vopc::VCmpEqU64Vopc(const MachineInst *inst)
 }
 
 VCmpLeU64Vopc::VCmpLeU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_le_u64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(474)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_u64_dpp"
+               : "v_cmp_le_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(474)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3016,7 +3241,10 @@ VCmpLeU64Vopc::VCmpLeU64Vopc(const MachineInst *inst)
 }
 
 VCmpGtU64Vopc::VCmpGtU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_gt_u64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(475)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_u64_dpp"
+               : "v_cmp_gt_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(475)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3046,7 +3274,10 @@ VCmpGtU64Vopc::VCmpGtU64Vopc(const MachineInst *inst)
 }
 
 VCmpNeU64Vopc::VCmpNeU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ne_u64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(476)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_u64_dpp"
+               : "v_cmp_ne_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(476)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3076,7 +3307,10 @@ VCmpNeU64Vopc::VCmpNeU64Vopc(const MachineInst *inst)
 }
 
 VCmpGeU64Vopc::VCmpGeU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ge_u64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(477)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_u64_dpp"
+               : "v_cmp_ge_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(477)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3106,8 +3340,10 @@ VCmpGeU64Vopc::VCmpGeU64Vopc(const MachineInst *inst)
 }
 
 VCmpClassF16Vopc::VCmpClassF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_class_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(478)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_class_f16_dpp"
+               : "v_cmp_class_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(478)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -3153,8 +3389,10 @@ VCmpClassF16Vopc::VCmpClassF16Vopc(const MachineInst *inst)
 }
 
 VCmpClassF32Vopc::VCmpClassF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_class_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(479)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_class_f32_dpp"
+               : "v_cmp_class_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(479)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3197,8 +3435,10 @@ VCmpClassF32Vopc::VCmpClassF32Vopc(const MachineInst *inst)
 }
 
 VCmpClassF64Vopc::VCmpClassF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_class_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(480)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_class_f64_dpp"
+               : "v_cmp_class_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(480)),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/gfx1250/vopc_cmpx.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/gfx1250/vopc_cmpx.cpp
@@ -12,7 +12,10 @@ namespace rocjitsu {
 namespace gfx1250 {
 
 VCmpxLtF16Vopc::VCmpxLtF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lt_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(481)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_f16_dpp"
+               : "v_cmpx_lt_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(481)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -62,7 +65,10 @@ VCmpxLtF16Vopc::VCmpxLtF16Vopc(const MachineInst *inst)
 }
 
 VCmpxEqF16Vopc::VCmpxEqF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_eq_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(482)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_f16_dpp"
+               : "v_cmpx_eq_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(482)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -112,7 +118,10 @@ VCmpxEqF16Vopc::VCmpxEqF16Vopc(const MachineInst *inst)
 }
 
 VCmpxLeF16Vopc::VCmpxLeF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_le_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(483)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_f16_dpp"
+               : "v_cmpx_le_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(483)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -162,7 +171,10 @@ VCmpxLeF16Vopc::VCmpxLeF16Vopc(const MachineInst *inst)
 }
 
 VCmpxGtF16Vopc::VCmpxGtF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_gt_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(484)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_f16_dpp"
+               : "v_cmpx_gt_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(484)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -212,7 +224,10 @@ VCmpxGtF16Vopc::VCmpxGtF16Vopc(const MachineInst *inst)
 }
 
 VCmpxLgF16Vopc::VCmpxLgF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lg_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(485)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lg_f16_dpp"
+               : "v_cmpx_lg_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(485)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -262,7 +277,10 @@ VCmpxLgF16Vopc::VCmpxLgF16Vopc(const MachineInst *inst)
 }
 
 VCmpxGeF16Vopc::VCmpxGeF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ge_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(486)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_f16_dpp"
+               : "v_cmpx_ge_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(486)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -312,7 +330,10 @@ VCmpxGeF16Vopc::VCmpxGeF16Vopc(const MachineInst *inst)
 }
 
 VCmpxOF16Vopc::VCmpxOF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_o_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(487)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_o_f16_dpp"
+               : "v_cmpx_o_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(487)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -362,7 +383,10 @@ VCmpxOF16Vopc::VCmpxOF16Vopc(const MachineInst *inst)
 }
 
 VCmpxUF16Vopc::VCmpxUF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_u_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(488)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_u_f16_dpp"
+               : "v_cmpx_u_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(488)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -412,7 +436,10 @@ VCmpxUF16Vopc::VCmpxUF16Vopc(const MachineInst *inst)
 }
 
 VCmpxNgeF16Vopc::VCmpxNgeF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nge_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(489)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nge_f16_dpp"
+               : "v_cmpx_nge_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(489)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -462,7 +489,10 @@ VCmpxNgeF16Vopc::VCmpxNgeF16Vopc(const MachineInst *inst)
 }
 
 VCmpxNlgF16Vopc::VCmpxNlgF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nlg_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(490)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlg_f16_dpp"
+               : "v_cmpx_nlg_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(490)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -512,7 +542,10 @@ VCmpxNlgF16Vopc::VCmpxNlgF16Vopc(const MachineInst *inst)
 }
 
 VCmpxNgtF16Vopc::VCmpxNgtF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ngt_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(491)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ngt_f16_dpp"
+               : "v_cmpx_ngt_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(491)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -562,7 +595,10 @@ VCmpxNgtF16Vopc::VCmpxNgtF16Vopc(const MachineInst *inst)
 }
 
 VCmpxNleF16Vopc::VCmpxNleF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nle_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(492)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nle_f16_dpp"
+               : "v_cmpx_nle_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(492)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -612,7 +648,10 @@ VCmpxNleF16Vopc::VCmpxNleF16Vopc(const MachineInst *inst)
 }
 
 VCmpxNeqF16Vopc::VCmpxNeqF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_neq_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(493)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_neq_f16_dpp"
+               : "v_cmpx_neq_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(493)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -662,7 +701,10 @@ VCmpxNeqF16Vopc::VCmpxNeqF16Vopc(const MachineInst *inst)
 }
 
 VCmpxNltF16Vopc::VCmpxNltF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nlt_f16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(494)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlt_f16_dpp"
+               : "v_cmpx_nlt_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(494)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -712,7 +754,10 @@ VCmpxNltF16Vopc::VCmpxNltF16Vopc(const MachineInst *inst)
 }
 
 VCmpxLtF32Vopc::VCmpxLtF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lt_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(495)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_f32_dpp"
+               : "v_cmpx_lt_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(495)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -759,7 +804,10 @@ VCmpxLtF32Vopc::VCmpxLtF32Vopc(const MachineInst *inst)
 }
 
 VCmpxEqF32Vopc::VCmpxEqF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_eq_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(496)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_f32_dpp"
+               : "v_cmpx_eq_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(496)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -806,7 +854,10 @@ VCmpxEqF32Vopc::VCmpxEqF32Vopc(const MachineInst *inst)
 }
 
 VCmpxLeF32Vopc::VCmpxLeF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_le_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(497)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_f32_dpp"
+               : "v_cmpx_le_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(497)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -853,7 +904,10 @@ VCmpxLeF32Vopc::VCmpxLeF32Vopc(const MachineInst *inst)
 }
 
 VCmpxGtF32Vopc::VCmpxGtF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_gt_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(498)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_f32_dpp"
+               : "v_cmpx_gt_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(498)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -900,7 +954,10 @@ VCmpxGtF32Vopc::VCmpxGtF32Vopc(const MachineInst *inst)
 }
 
 VCmpxLgF32Vopc::VCmpxLgF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lg_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(499)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lg_f32_dpp"
+               : "v_cmpx_lg_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(499)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -947,7 +1004,10 @@ VCmpxLgF32Vopc::VCmpxLgF32Vopc(const MachineInst *inst)
 }
 
 VCmpxGeF32Vopc::VCmpxGeF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ge_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(500)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_f32_dpp"
+               : "v_cmpx_ge_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(500)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -994,7 +1054,10 @@ VCmpxGeF32Vopc::VCmpxGeF32Vopc(const MachineInst *inst)
 }
 
 VCmpxOF32Vopc::VCmpxOF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_o_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(501)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_o_f32_dpp"
+               : "v_cmpx_o_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(501)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -1041,7 +1104,10 @@ VCmpxOF32Vopc::VCmpxOF32Vopc(const MachineInst *inst)
 }
 
 VCmpxUF32Vopc::VCmpxUF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_u_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(502)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_u_f32_dpp"
+               : "v_cmpx_u_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(502)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -1088,7 +1154,10 @@ VCmpxUF32Vopc::VCmpxUF32Vopc(const MachineInst *inst)
 }
 
 VCmpxNgeF32Vopc::VCmpxNgeF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nge_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(503)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nge_f32_dpp"
+               : "v_cmpx_nge_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(503)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -1135,7 +1204,10 @@ VCmpxNgeF32Vopc::VCmpxNgeF32Vopc(const MachineInst *inst)
 }
 
 VCmpxNlgF32Vopc::VCmpxNlgF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nlg_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(504)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlg_f32_dpp"
+               : "v_cmpx_nlg_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(504)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -1182,7 +1254,10 @@ VCmpxNlgF32Vopc::VCmpxNlgF32Vopc(const MachineInst *inst)
 }
 
 VCmpxNgtF32Vopc::VCmpxNgtF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ngt_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(505)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ngt_f32_dpp"
+               : "v_cmpx_ngt_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(505)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -1229,7 +1304,10 @@ VCmpxNgtF32Vopc::VCmpxNgtF32Vopc(const MachineInst *inst)
 }
 
 VCmpxNleF32Vopc::VCmpxNleF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nle_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(506)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nle_f32_dpp"
+               : "v_cmpx_nle_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(506)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -1276,7 +1354,10 @@ VCmpxNleF32Vopc::VCmpxNleF32Vopc(const MachineInst *inst)
 }
 
 VCmpxNeqF32Vopc::VCmpxNeqF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_neq_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(507)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_neq_f32_dpp"
+               : "v_cmpx_neq_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(507)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -1323,7 +1404,10 @@ VCmpxNeqF32Vopc::VCmpxNeqF32Vopc(const MachineInst *inst)
 }
 
 VCmpxNltF32Vopc::VCmpxNltF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nlt_f32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(508)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlt_f32_dpp"
+               : "v_cmpx_nlt_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(508)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -1370,7 +1454,10 @@ VCmpxNltF32Vopc::VCmpxNltF32Vopc(const MachineInst *inst)
 }
 
 VCmpxLtF64Vopc::VCmpxLtF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lt_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(509)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_f64_dpp"
+               : "v_cmpx_lt_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(509)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -1404,7 +1491,10 @@ VCmpxLtF64Vopc::VCmpxLtF64Vopc(const MachineInst *inst)
 }
 
 VCmpxEqF64Vopc::VCmpxEqF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_eq_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(510)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_f64_dpp"
+               : "v_cmpx_eq_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(510)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -1438,7 +1528,10 @@ VCmpxEqF64Vopc::VCmpxEqF64Vopc(const MachineInst *inst)
 }
 
 VCmpxLeF64Vopc::VCmpxLeF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_le_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(511)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_f64_dpp"
+               : "v_cmpx_le_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(511)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -1472,7 +1565,10 @@ VCmpxLeF64Vopc::VCmpxLeF64Vopc(const MachineInst *inst)
 }
 
 VCmpxGtF64Vopc::VCmpxGtF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_gt_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(512)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_f64_dpp"
+               : "v_cmpx_gt_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(512)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -1506,7 +1602,10 @@ VCmpxGtF64Vopc::VCmpxGtF64Vopc(const MachineInst *inst)
 }
 
 VCmpxLgF64Vopc::VCmpxLgF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lg_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(513)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lg_f64_dpp"
+               : "v_cmpx_lg_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(513)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -1540,7 +1639,10 @@ VCmpxLgF64Vopc::VCmpxLgF64Vopc(const MachineInst *inst)
 }
 
 VCmpxGeF64Vopc::VCmpxGeF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ge_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(514)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_f64_dpp"
+               : "v_cmpx_ge_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(514)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -1574,7 +1676,10 @@ VCmpxGeF64Vopc::VCmpxGeF64Vopc(const MachineInst *inst)
 }
 
 VCmpxOF64Vopc::VCmpxOF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_o_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(515)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_o_f64_dpp"
+               : "v_cmpx_o_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(515)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -1608,7 +1713,10 @@ VCmpxOF64Vopc::VCmpxOF64Vopc(const MachineInst *inst)
 }
 
 VCmpxUF64Vopc::VCmpxUF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_u_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(516)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_u_f64_dpp"
+               : "v_cmpx_u_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(516)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -1642,7 +1750,10 @@ VCmpxUF64Vopc::VCmpxUF64Vopc(const MachineInst *inst)
 }
 
 VCmpxNgeF64Vopc::VCmpxNgeF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nge_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(517)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nge_f64_dpp"
+               : "v_cmpx_nge_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(517)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -1676,7 +1787,10 @@ VCmpxNgeF64Vopc::VCmpxNgeF64Vopc(const MachineInst *inst)
 }
 
 VCmpxNlgF64Vopc::VCmpxNlgF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nlg_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(518)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlg_f64_dpp"
+               : "v_cmpx_nlg_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(518)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -1710,7 +1824,10 @@ VCmpxNlgF64Vopc::VCmpxNlgF64Vopc(const MachineInst *inst)
 }
 
 VCmpxNgtF64Vopc::VCmpxNgtF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ngt_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(519)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ngt_f64_dpp"
+               : "v_cmpx_ngt_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(519)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -1744,7 +1861,10 @@ VCmpxNgtF64Vopc::VCmpxNgtF64Vopc(const MachineInst *inst)
 }
 
 VCmpxNleF64Vopc::VCmpxNleF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nle_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(520)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nle_f64_dpp"
+               : "v_cmpx_nle_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(520)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -1778,7 +1898,10 @@ VCmpxNleF64Vopc::VCmpxNleF64Vopc(const MachineInst *inst)
 }
 
 VCmpxNeqF64Vopc::VCmpxNeqF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_neq_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(521)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_neq_f64_dpp"
+               : "v_cmpx_neq_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(521)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -1812,7 +1935,10 @@ VCmpxNeqF64Vopc::VCmpxNeqF64Vopc(const MachineInst *inst)
 }
 
 VCmpxNltF64Vopc::VCmpxNltF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nlt_f64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(522)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlt_f64_dpp"
+               : "v_cmpx_nlt_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(522)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -1846,7 +1972,10 @@ VCmpxNltF64Vopc::VCmpxNltF64Vopc(const MachineInst *inst)
 }
 
 VCmpxLtI16Vopc::VCmpxLtI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lt_i16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(523)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_i16_dpp"
+               : "v_cmpx_lt_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(523)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -1896,7 +2025,10 @@ VCmpxLtI16Vopc::VCmpxLtI16Vopc(const MachineInst *inst)
 }
 
 VCmpxEqI16Vopc::VCmpxEqI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_eq_i16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(524)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_i16_dpp"
+               : "v_cmpx_eq_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(524)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -1946,7 +2078,10 @@ VCmpxEqI16Vopc::VCmpxEqI16Vopc(const MachineInst *inst)
 }
 
 VCmpxLeI16Vopc::VCmpxLeI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_le_i16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(525)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_i16_dpp"
+               : "v_cmpx_le_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(525)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -1996,7 +2131,10 @@ VCmpxLeI16Vopc::VCmpxLeI16Vopc(const MachineInst *inst)
 }
 
 VCmpxGtI16Vopc::VCmpxGtI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_gt_i16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(526)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_i16_dpp"
+               : "v_cmpx_gt_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(526)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2046,7 +2184,10 @@ VCmpxGtI16Vopc::VCmpxGtI16Vopc(const MachineInst *inst)
 }
 
 VCmpxNeI16Vopc::VCmpxNeI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ne_i16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(527)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_i16_dpp"
+               : "v_cmpx_ne_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(527)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2096,7 +2237,10 @@ VCmpxNeI16Vopc::VCmpxNeI16Vopc(const MachineInst *inst)
 }
 
 VCmpxGeI16Vopc::VCmpxGeI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ge_i16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(528)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_i16_dpp"
+               : "v_cmpx_ge_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(528)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2146,7 +2290,10 @@ VCmpxGeI16Vopc::VCmpxGeI16Vopc(const MachineInst *inst)
 }
 
 VCmpxLtU16Vopc::VCmpxLtU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lt_u16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(529)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_u16_dpp"
+               : "v_cmpx_lt_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(529)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2196,7 +2343,10 @@ VCmpxLtU16Vopc::VCmpxLtU16Vopc(const MachineInst *inst)
 }
 
 VCmpxEqU16Vopc::VCmpxEqU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_eq_u16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(530)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_u16_dpp"
+               : "v_cmpx_eq_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(530)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2246,7 +2396,10 @@ VCmpxEqU16Vopc::VCmpxEqU16Vopc(const MachineInst *inst)
 }
 
 VCmpxLeU16Vopc::VCmpxLeU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_le_u16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(531)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_u16_dpp"
+               : "v_cmpx_le_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(531)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2296,7 +2449,10 @@ VCmpxLeU16Vopc::VCmpxLeU16Vopc(const MachineInst *inst)
 }
 
 VCmpxGtU16Vopc::VCmpxGtU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_gt_u16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(532)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_u16_dpp"
+               : "v_cmpx_gt_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(532)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2346,7 +2502,10 @@ VCmpxGtU16Vopc::VCmpxGtU16Vopc(const MachineInst *inst)
 }
 
 VCmpxNeU16Vopc::VCmpxNeU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ne_u16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(533)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_u16_dpp"
+               : "v_cmpx_ne_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(533)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2396,7 +2555,10 @@ VCmpxNeU16Vopc::VCmpxNeU16Vopc(const MachineInst *inst)
 }
 
 VCmpxGeU16Vopc::VCmpxGeU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ge_u16_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(534)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_u16_dpp"
+               : "v_cmpx_ge_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(534)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2446,7 +2608,10 @@ VCmpxGeU16Vopc::VCmpxGeU16Vopc(const MachineInst *inst)
 }
 
 VCmpxLtI32Vopc::VCmpxLtI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lt_i32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(535)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_i32_dpp"
+               : "v_cmpx_lt_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(535)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -2493,7 +2658,10 @@ VCmpxLtI32Vopc::VCmpxLtI32Vopc(const MachineInst *inst)
 }
 
 VCmpxEqI32Vopc::VCmpxEqI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_eq_i32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(536)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_i32_dpp"
+               : "v_cmpx_eq_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(536)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -2540,7 +2708,10 @@ VCmpxEqI32Vopc::VCmpxEqI32Vopc(const MachineInst *inst)
 }
 
 VCmpxLeI32Vopc::VCmpxLeI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_le_i32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(537)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_i32_dpp"
+               : "v_cmpx_le_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(537)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -2587,7 +2758,10 @@ VCmpxLeI32Vopc::VCmpxLeI32Vopc(const MachineInst *inst)
 }
 
 VCmpxGtI32Vopc::VCmpxGtI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_gt_i32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(538)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_i32_dpp"
+               : "v_cmpx_gt_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(538)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -2634,7 +2808,10 @@ VCmpxGtI32Vopc::VCmpxGtI32Vopc(const MachineInst *inst)
 }
 
 VCmpxNeI32Vopc::VCmpxNeI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ne_i32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(539)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_i32_dpp"
+               : "v_cmpx_ne_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(539)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -2681,7 +2858,10 @@ VCmpxNeI32Vopc::VCmpxNeI32Vopc(const MachineInst *inst)
 }
 
 VCmpxGeI32Vopc::VCmpxGeI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ge_i32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(540)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_i32_dpp"
+               : "v_cmpx_ge_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(540)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -2728,7 +2908,10 @@ VCmpxGeI32Vopc::VCmpxGeI32Vopc(const MachineInst *inst)
 }
 
 VCmpxLtU32Vopc::VCmpxLtU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lt_u32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(541)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_u32_dpp"
+               : "v_cmpx_lt_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(541)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -2775,7 +2958,10 @@ VCmpxLtU32Vopc::VCmpxLtU32Vopc(const MachineInst *inst)
 }
 
 VCmpxEqU32Vopc::VCmpxEqU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_eq_u32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(542)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_u32_dpp"
+               : "v_cmpx_eq_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(542)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -2822,7 +3008,10 @@ VCmpxEqU32Vopc::VCmpxEqU32Vopc(const MachineInst *inst)
 }
 
 VCmpxLeU32Vopc::VCmpxLeU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_le_u32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(543)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_u32_dpp"
+               : "v_cmpx_le_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(543)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -2869,7 +3058,10 @@ VCmpxLeU32Vopc::VCmpxLeU32Vopc(const MachineInst *inst)
 }
 
 VCmpxGtU32Vopc::VCmpxGtU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_gt_u32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(544)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_u32_dpp"
+               : "v_cmpx_gt_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(544)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -2916,7 +3108,10 @@ VCmpxGtU32Vopc::VCmpxGtU32Vopc(const MachineInst *inst)
 }
 
 VCmpxNeU32Vopc::VCmpxNeU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ne_u32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(545)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_u32_dpp"
+               : "v_cmpx_ne_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(545)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -2963,7 +3158,10 @@ VCmpxNeU32Vopc::VCmpxNeU32Vopc(const MachineInst *inst)
 }
 
 VCmpxGeU32Vopc::VCmpxGeU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ge_u32_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(546)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_u32_dpp"
+               : "v_cmpx_ge_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(546)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -3010,7 +3208,10 @@ VCmpxGeU32Vopc::VCmpxGeU32Vopc(const MachineInst *inst)
 }
 
 VCmpxLtI64Vopc::VCmpxLtI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lt_i64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(547)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_i64_dpp"
+               : "v_cmpx_lt_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(547)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -3044,7 +3245,10 @@ VCmpxLtI64Vopc::VCmpxLtI64Vopc(const MachineInst *inst)
 }
 
 VCmpxEqI64Vopc::VCmpxEqI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_eq_i64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(548)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_i64_dpp"
+               : "v_cmpx_eq_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(548)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -3078,7 +3282,10 @@ VCmpxEqI64Vopc::VCmpxEqI64Vopc(const MachineInst *inst)
 }
 
 VCmpxLeI64Vopc::VCmpxLeI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_le_i64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(549)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_i64_dpp"
+               : "v_cmpx_le_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(549)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -3112,7 +3319,10 @@ VCmpxLeI64Vopc::VCmpxLeI64Vopc(const MachineInst *inst)
 }
 
 VCmpxGtI64Vopc::VCmpxGtI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_gt_i64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(550)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_i64_dpp"
+               : "v_cmpx_gt_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(550)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -3146,7 +3356,10 @@ VCmpxGtI64Vopc::VCmpxGtI64Vopc(const MachineInst *inst)
 }
 
 VCmpxNeI64Vopc::VCmpxNeI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ne_i64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(551)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_i64_dpp"
+               : "v_cmpx_ne_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(551)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -3180,7 +3393,10 @@ VCmpxNeI64Vopc::VCmpxNeI64Vopc(const MachineInst *inst)
 }
 
 VCmpxGeI64Vopc::VCmpxGeI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ge_i64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(552)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_i64_dpp"
+               : "v_cmpx_ge_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(552)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -3214,7 +3430,10 @@ VCmpxGeI64Vopc::VCmpxGeI64Vopc(const MachineInst *inst)
 }
 
 VCmpxLtU64Vopc::VCmpxLtU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lt_u64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(553)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_u64_dpp"
+               : "v_cmpx_lt_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(553)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -3248,7 +3467,10 @@ VCmpxLtU64Vopc::VCmpxLtU64Vopc(const MachineInst *inst)
 }
 
 VCmpxEqU64Vopc::VCmpxEqU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_eq_u64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(554)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_u64_dpp"
+               : "v_cmpx_eq_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(554)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -3282,7 +3504,10 @@ VCmpxEqU64Vopc::VCmpxEqU64Vopc(const MachineInst *inst)
 }
 
 VCmpxLeU64Vopc::VCmpxLeU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_le_u64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(555)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_u64_dpp"
+               : "v_cmpx_le_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(555)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -3316,7 +3541,10 @@ VCmpxLeU64Vopc::VCmpxLeU64Vopc(const MachineInst *inst)
 }
 
 VCmpxGtU64Vopc::VCmpxGtU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_gt_u64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(556)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_u64_dpp"
+               : "v_cmpx_gt_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(556)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -3350,7 +3578,10 @@ VCmpxGtU64Vopc::VCmpxGtU64Vopc(const MachineInst *inst)
 }
 
 VCmpxNeU64Vopc::VCmpxNeU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ne_u64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(557)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_u64_dpp"
+               : "v_cmpx_ne_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(557)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -3384,7 +3615,10 @@ VCmpxNeU64Vopc::VCmpxNeU64Vopc(const MachineInst *inst)
 }
 
 VCmpxGeU64Vopc::VCmpxGeU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ge_u64_e32", reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(558)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_u64_dpp"
+               : "v_cmpx_ge_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(558)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -3418,8 +3652,10 @@ VCmpxGeU64Vopc::VCmpxGeU64Vopc(const MachineInst *inst)
 }
 
 VCmpxClassF16Vopc::VCmpxClassF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_class_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(559)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_class_f16_dpp"
+               : "v_cmpx_class_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(559)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -3469,8 +3705,10 @@ VCmpxClassF16Vopc::VCmpxClassF16Vopc(const MachineInst *inst)
 }
 
 VCmpxClassF32Vopc::VCmpxClassF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_class_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(560)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_class_f32_dpp"
+               : "v_cmpx_class_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(560)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -3517,8 +3755,10 @@ VCmpxClassF32Vopc::VCmpxClassF32Vopc(const MachineInst *inst)
 }
 
 VCmpxClassF64Vopc::VCmpxClassF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_class_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           selected_exec_fn(561)),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_class_f64_dpp"
+               : "v_cmpx_class_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), selected_exec_fn(561)),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/encodings.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/encodings.cpp
@@ -137,6 +137,11 @@ Vop1::Vop1(std::string_view mnemonic, const Vop1MachineInst *inst, ExecuteFn exe
   raw_encoding_ = raw_words_.data();
 }
 
+void Vop1::build_modifiers(std::string &out) const {
+  if (amdgpu::dpp::is_src_dpp8(inst_.src0))
+    amdgpu::dpp::append_dpp8_disassembly(out, dpp8_lane_sel_, dpp_fi_);
+}
+
 void Vop1::implicit_uses(RegisterSet &uses) const {
   bool sdwa_preserve =
       sdwa_dst_sel_ != amdgpu::sdwa::DWORD && sdwa_dst_unused_ == amdgpu::sdwa::UNUSED_PRESERVE;
@@ -189,6 +194,11 @@ Vop2::Vop2(std::string_view mnemonic, const Vop2MachineInst *inst, ExecuteFn exe
     literal_ = reinterpret_cast<const uint32_t *>(inst)[1];
   std::memcpy(raw_words_.data(), inst, size_);
   raw_encoding_ = raw_words_.data();
+}
+
+void Vop2::build_modifiers(std::string &out) const {
+  if (amdgpu::dpp::is_src_dpp8(inst_.src0))
+    amdgpu::dpp::append_dpp8_disassembly(out, dpp8_lane_sel_, dpp_fi_);
 }
 
 void Vop2::implicit_uses(RegisterSet &uses) const {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/encodings.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/encodings.h
@@ -429,6 +429,7 @@ public:
 class Vop1 : public IsaInstruction<Isa> {
 public:
   Vop1(std::string_view mnemonic, const Vop1MachineInst *inst, ExecuteFn exec_fn);
+  void build_modifiers(std::string &out) const override;
   void implicit_uses(RegisterSet &uses) const override;
   bool default_encoding();
   bool has_lit();
@@ -486,6 +487,7 @@ public:
 class Vop2 : public IsaInstruction<Isa> {
 public:
   Vop2(std::string_view mnemonic, const Vop2MachineInst *inst, ExecuteFn exec_fn);
+  void build_modifiers(std::string &out) const override;
   void implicit_uses(RegisterSet &uses) const override;
   bool default_encoding();
   bool has_lit();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/vop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/vop1.cpp
@@ -22,7 +22,9 @@ namespace rocjitsu {
 namespace rdna1 {
 
 VNopVop1::VNopVop1(const MachineInst *inst)
-    : Vop1("v_nop_e32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VNopVop1>()) {
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0) ? "v_nop_dpp"
+                                                                                      : "v_nop_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VNopVop1>()) {
   num_src_ = 0;
   num_dst_ = 0;
 }
@@ -30,8 +32,10 @@ VNopVop1::VNopVop1(const MachineInst *inst)
 void VNopVop1::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_nop_vop1(*this, wf); }
 
 VMovB32Vop1::VMovB32Vop1(const MachineInst *inst)
-    : Vop1("v_mov_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMovB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mov_b32_dpp"
+               : "v_mov_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -92,8 +96,10 @@ void VMovB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VReadfirstlaneB32Vop1::VReadfirstlaneB32Vop1(const MachineInst *inst)
-    : Vop1("v_readfirstlane_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VReadfirstlaneB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_readfirstlane_b32_dpp"
+               : "v_readfirstlane_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VReadfirstlaneB32Vop1>()),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -124,8 +130,10 @@ void VReadfirstlaneB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtI32F64Vop1::VCvtI32F64Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_i32_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtI32F64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_i32_f64_dpp"
+               : "v_cvt_i32_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtI32F64Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_NOLDS, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -149,8 +157,10 @@ void VCvtI32F64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF64I32Vop1::VCvtF64I32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f64_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF64I32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f64_i32_dpp"
+               : "v_cvt_f64_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF64I32Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -173,8 +183,10 @@ void VCvtF64I32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32I32Vop1::VCvtF32I32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32I32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_i32_dpp"
+               : "v_cvt_f32_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32I32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -235,8 +247,10 @@ void VCvtF32I32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32U32Vop1::VCvtF32U32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32U32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_u32_dpp"
+               : "v_cvt_f32_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32U32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -297,8 +311,10 @@ void VCvtF32U32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtU32F32Vop1::VCvtU32F32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_u32_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtU32F32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_u32_f32_dpp"
+               : "v_cvt_u32_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtU32F32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -359,8 +375,10 @@ void VCvtU32F32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtI32F32Vop1::VCvtI32F32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_i32_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtI32F32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_i32_f32_dpp"
+               : "v_cvt_i32_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtI32F32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -421,8 +439,10 @@ void VCvtI32F32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF16F32Vop1::VCvtF16F32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f16_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF16F32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f16_f32_dpp"
+               : "v_cvt_f16_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF16F32Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -489,8 +509,10 @@ void VCvtF16F32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32F16Vop1::VCvtF32F16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32F16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_f16_dpp"
+               : "v_cvt_f32_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32F16Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -552,8 +574,10 @@ void VCvtF32F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtRpiI32F32Vop1::VCvtRpiI32F32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_rpi_i32_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtRpiI32F32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_rpi_i32_f32_dpp"
+               : "v_cvt_rpi_i32_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtRpiI32F32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -614,8 +638,10 @@ void VCvtRpiI32F32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtFlrI32F32Vop1::VCvtFlrI32F32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_flr_i32_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtFlrI32F32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_flr_i32_f32_dpp"
+               : "v_cvt_flr_i32_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtFlrI32F32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -676,8 +702,10 @@ void VCvtFlrI32F32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtOffF32I4Vop1::VCvtOffF32I4Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_off_f32_i4_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtOffF32I4Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_off_f32_i4_dpp"
+               : "v_cvt_off_f32_i4_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtOffF32I4Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -738,8 +766,10 @@ void VCvtOffF32I4Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32F64Vop1::VCvtF32F64Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32F64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_f64_dpp"
+               : "v_cvt_f32_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32F64Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_NOLDS, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -763,8 +793,10 @@ void VCvtF32F64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF64F32Vop1::VCvtF64F32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f64_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF64F32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f64_f32_dpp"
+               : "v_cvt_f64_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF64F32Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -787,8 +819,10 @@ void VCvtF64F32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32Ubyte0Vop1::VCvtF32Ubyte0Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_ubyte0_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32Ubyte0Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_ubyte0_dpp"
+               : "v_cvt_f32_ubyte0_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32Ubyte0Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -849,8 +883,10 @@ void VCvtF32Ubyte0Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32Ubyte1Vop1::VCvtF32Ubyte1Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_ubyte1_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32Ubyte1Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_ubyte1_dpp"
+               : "v_cvt_f32_ubyte1_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32Ubyte1Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -911,8 +947,10 @@ void VCvtF32Ubyte1Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32Ubyte2Vop1::VCvtF32Ubyte2Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_ubyte2_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32Ubyte2Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_ubyte2_dpp"
+               : "v_cvt_f32_ubyte2_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32Ubyte2Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -973,8 +1011,10 @@ void VCvtF32Ubyte2Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32Ubyte3Vop1::VCvtF32Ubyte3Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_ubyte3_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32Ubyte3Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_ubyte3_dpp"
+               : "v_cvt_f32_ubyte3_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32Ubyte3Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1035,8 +1075,10 @@ void VCvtF32Ubyte3Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtU32F64Vop1::VCvtU32F64Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_u32_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtU32F64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_u32_f64_dpp"
+               : "v_cvt_u32_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtU32F64Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_NOLDS, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1060,8 +1102,10 @@ void VCvtU32F64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF64U32Vop1::VCvtF64U32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f64_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF64U32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f64_u32_dpp"
+               : "v_cvt_f64_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF64U32Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1084,8 +1128,10 @@ void VCvtF64U32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VTruncF64Vop1::VTruncF64Vop1(const MachineInst *inst)
-    : Vop1("v_trunc_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VTruncF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_trunc_f64_dpp"
+               : "v_trunc_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VTruncF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_NOLDS, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1109,8 +1155,10 @@ void VTruncF64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCeilF64Vop1::VCeilF64Vop1(const MachineInst *inst)
-    : Vop1("v_ceil_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCeilF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ceil_f64_dpp"
+               : "v_ceil_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCeilF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_NOLDS, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1134,8 +1182,10 @@ void VCeilF64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRndneF64Vop1::VRndneF64Vop1(const MachineInst *inst)
-    : Vop1("v_rndne_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRndneF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rndne_f64_dpp"
+               : "v_rndne_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRndneF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_NOLDS, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1159,8 +1209,10 @@ void VRndneF64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFloorF64Vop1::VFloorF64Vop1(const MachineInst *inst)
-    : Vop1("v_floor_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFloorF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_floor_f64_dpp"
+               : "v_floor_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFloorF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_NOLDS, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1184,8 +1236,10 @@ void VFloorF64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPipeflushVop1::VPipeflushVop1(const MachineInst *inst)
-    : Vop1("v_pipeflush_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VPipeflushVop1>()) {
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_pipeflush_dpp"
+               : "v_pipeflush_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPipeflushVop1>()) {
   num_src_ = 0;
   num_dst_ = 0;
 }
@@ -1195,8 +1249,10 @@ void VPipeflushVop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFractF32Vop1::VFractF32Vop1(const MachineInst *inst)
-    : Vop1("v_fract_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFractF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fract_f32_dpp"
+               : "v_fract_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFractF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1257,8 +1313,10 @@ void VFractF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VTruncF32Vop1::VTruncF32Vop1(const MachineInst *inst)
-    : Vop1("v_trunc_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VTruncF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_trunc_f32_dpp"
+               : "v_trunc_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VTruncF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1319,8 +1377,10 @@ void VTruncF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCeilF32Vop1::VCeilF32Vop1(const MachineInst *inst)
-    : Vop1("v_ceil_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCeilF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ceil_f32_dpp"
+               : "v_ceil_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCeilF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1381,8 +1441,10 @@ void VCeilF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRndneF32Vop1::VRndneF32Vop1(const MachineInst *inst)
-    : Vop1("v_rndne_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRndneF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rndne_f32_dpp"
+               : "v_rndne_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRndneF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1443,8 +1505,10 @@ void VRndneF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFloorF32Vop1::VFloorF32Vop1(const MachineInst *inst)
-    : Vop1("v_floor_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFloorF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_floor_f32_dpp"
+               : "v_floor_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFloorF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1505,8 +1569,10 @@ void VFloorF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VExpF32Vop1::VExpF32Vop1(const MachineInst *inst)
-    : Vop1("v_exp_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VExpF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_exp_f32_dpp"
+               : "v_exp_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VExpF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1567,8 +1633,10 @@ void VExpF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLogF32Vop1::VLogF32Vop1(const MachineInst *inst)
-    : Vop1("v_log_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLogF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_log_f32_dpp"
+               : "v_log_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLogF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1629,8 +1697,10 @@ void VLogF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRcpF32Vop1::VRcpF32Vop1(const MachineInst *inst)
-    : Vop1("v_rcp_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRcpF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_f32_dpp"
+               : "v_rcp_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1691,8 +1761,10 @@ void VRcpF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRcpIflagF32Vop1::VRcpIflagF32Vop1(const MachineInst *inst)
-    : Vop1("v_rcp_iflag_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRcpIflagF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_iflag_f32_dpp"
+               : "v_rcp_iflag_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpIflagF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1753,8 +1825,10 @@ void VRcpIflagF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRsqF32Vop1::VRsqF32Vop1(const MachineInst *inst)
-    : Vop1("v_rsq_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRsqF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rsq_f32_dpp"
+               : "v_rsq_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRsqF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1815,8 +1889,10 @@ void VRsqF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRcpF64Vop1::VRcpF64Vop1(const MachineInst *inst)
-    : Vop1("v_rcp_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRcpF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_f64_dpp"
+               : "v_rcp_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_NOLDS, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1838,8 +1914,10 @@ VRcpF64Vop1::VRcpF64Vop1(const MachineInst *inst)
 void VRcpF64Vop1::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_rcp_f64_vop1(*this, wf); }
 
 VRsqF64Vop1::VRsqF64Vop1(const MachineInst *inst)
-    : Vop1("v_rsq_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRsqF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rsq_f64_dpp"
+               : "v_rsq_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRsqF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_NOLDS, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1861,8 +1939,10 @@ VRsqF64Vop1::VRsqF64Vop1(const MachineInst *inst)
 void VRsqF64Vop1::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_rsq_f64_vop1(*this, wf); }
 
 VSqrtF32Vop1::VSqrtF32Vop1(const MachineInst *inst)
-    : Vop1("v_sqrt_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSqrtF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sqrt_f32_dpp"
+               : "v_sqrt_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSqrtF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1923,8 +2003,10 @@ void VSqrtF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSqrtF64Vop1::VSqrtF64Vop1(const MachineInst *inst)
-    : Vop1("v_sqrt_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSqrtF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sqrt_f64_dpp"
+               : "v_sqrt_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSqrtF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_NOLDS, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1948,8 +2030,10 @@ void VSqrtF64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSinF32Vop1::VSinF32Vop1(const MachineInst *inst)
-    : Vop1("v_sin_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSinF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sin_f32_dpp"
+               : "v_sin_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSinF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2010,8 +2094,10 @@ void VSinF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCosF32Vop1::VCosF32Vop1(const MachineInst *inst)
-    : Vop1("v_cos_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCosF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cos_f32_dpp"
+               : "v_cos_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCosF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2072,8 +2158,10 @@ void VCosF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VNotB32Vop1::VNotB32Vop1(const MachineInst *inst)
-    : Vop1("v_not_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VNotB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_not_b32_dpp"
+               : "v_not_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VNotB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2134,8 +2222,10 @@ void VNotB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VBfrevB32Vop1::VBfrevB32Vop1(const MachineInst *inst)
-    : Vop1("v_bfrev_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VBfrevB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_bfrev_b32_dpp"
+               : "v_bfrev_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VBfrevB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2196,8 +2286,10 @@ void VBfrevB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFfbhU32Vop1::VFfbhU32Vop1(const MachineInst *inst)
-    : Vop1("v_ffbh_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFfbhU32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ffbh_u32_dpp"
+               : "v_ffbh_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFfbhU32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2258,8 +2350,10 @@ void VFfbhU32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFfblB32Vop1::VFfblB32Vop1(const MachineInst *inst)
-    : Vop1("v_ffbl_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFfblB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ffbl_b32_dpp"
+               : "v_ffbl_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFfblB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2320,8 +2414,10 @@ void VFfblB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFfbhI32Vop1::VFfbhI32Vop1(const MachineInst *inst)
-    : Vop1("v_ffbh_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFfbhI32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ffbh_i32_dpp"
+               : "v_ffbh_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFfbhI32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2382,8 +2478,10 @@ void VFfbhI32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpExpI32F64Vop1::VFrexpExpI32F64Vop1(const MachineInst *inst)
-    : Vop1("v_frexp_exp_i32_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpExpI32F64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_exp_i32_f64_dpp"
+               : "v_frexp_exp_i32_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpExpI32F64Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_NOLDS, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2407,8 +2505,10 @@ void VFrexpExpI32F64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpMantF64Vop1::VFrexpMantF64Vop1(const MachineInst *inst)
-    : Vop1("v_frexp_mant_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpMantF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_mant_f64_dpp"
+               : "v_frexp_mant_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpMantF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_NOLDS, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2432,8 +2532,10 @@ void VFrexpMantF64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFractF64Vop1::VFractF64Vop1(const MachineInst *inst)
-    : Vop1("v_fract_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFractF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fract_f64_dpp"
+               : "v_fract_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFractF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_NOLDS, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2457,8 +2559,10 @@ void VFractF64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpExpI32F32Vop1::VFrexpExpI32F32Vop1(const MachineInst *inst)
-    : Vop1("v_frexp_exp_i32_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpExpI32F32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_exp_i32_f32_dpp"
+               : "v_frexp_exp_i32_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpExpI32F32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2519,8 +2623,10 @@ void VFrexpExpI32F32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpMantF32Vop1::VFrexpMantF32Vop1(const MachineInst *inst)
-    : Vop1("v_frexp_mant_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpMantF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_mant_f32_dpp"
+               : "v_frexp_mant_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpMantF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2581,8 +2687,10 @@ void VFrexpMantF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VClrexcpVop1::VClrexcpVop1(const MachineInst *inst)
-    : Vop1("v_clrexcp_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VClrexcpVop1>()) {
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_clrexcp_dpp"
+               : "v_clrexcp_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VClrexcpVop1>()) {
   num_src_ = 0;
   num_dst_ = 0;
 }
@@ -2592,8 +2700,10 @@ void VClrexcpVop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMovreldB32Vop1::VMovreldB32Vop1(const MachineInst *inst)
-    : Vop1("v_movreld_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMovreldB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_movreld_b32_dpp"
+               : "v_movreld_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovreldB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 124) {
@@ -2670,8 +2780,10 @@ void VMovreldB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMovrelsB32Vop1::VMovrelsB32Vop1(const MachineInst *inst)
-    : Vop1("v_movrels_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMovrelsB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_movrels_b32_dpp"
+               : "v_movrels_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovrelsB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 124) {
@@ -2748,8 +2860,10 @@ void VMovrelsB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMovrelsdB32Vop1::VMovrelsdB32Vop1(const MachineInst *inst)
-    : Vop1("v_movrelsd_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMovrelsdB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_movrelsd_b32_dpp"
+               : "v_movrelsd_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovrelsdB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 124) {
@@ -2803,8 +2917,10 @@ void VMovrelsdB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMovrelsd2B32Vop1::VMovrelsd2B32Vop1(const MachineInst *inst)
-    : Vop1("v_movrelsd_2_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMovrelsd2B32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_movrelsd_2_b32_dpp"
+               : "v_movrelsd_2_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovrelsd2B32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 124) {
@@ -2858,8 +2974,10 @@ void VMovrelsd2B32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF16U16Vop1::VCvtF16U16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f16_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF16U16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f16_u16_dpp"
+               : "v_cvt_f16_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF16U16Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2927,8 +3045,10 @@ void VCvtF16U16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF16I16Vop1::VCvtF16I16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f16_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF16I16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f16_i16_dpp"
+               : "v_cvt_f16_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF16I16Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2996,8 +3116,10 @@ void VCvtF16I16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtU16F16Vop1::VCvtU16F16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_u16_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtU16F16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_u16_f16_dpp"
+               : "v_cvt_u16_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtU16F16Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3065,8 +3187,10 @@ void VCvtU16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtI16F16Vop1::VCvtI16F16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_i16_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtI16F16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_i16_f16_dpp"
+               : "v_cvt_i16_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtI16F16Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3134,8 +3258,10 @@ void VCvtI16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRcpF16Vop1::VRcpF16Vop1(const MachineInst *inst)
-    : Vop1("v_rcp_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRcpF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_f16_dpp"
+               : "v_rcp_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3203,8 +3329,10 @@ void VRcpF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSqrtF16Vop1::VSqrtF16Vop1(const MachineInst *inst)
-    : Vop1("v_sqrt_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSqrtF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sqrt_f16_dpp"
+               : "v_sqrt_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSqrtF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3272,8 +3400,10 @@ void VSqrtF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRsqF16Vop1::VRsqF16Vop1(const MachineInst *inst)
-    : Vop1("v_rsq_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRsqF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rsq_f16_dpp"
+               : "v_rsq_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRsqF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3341,8 +3471,10 @@ void VRsqF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLogF16Vop1::VLogF16Vop1(const MachineInst *inst)
-    : Vop1("v_log_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLogF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_log_f16_dpp"
+               : "v_log_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLogF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3410,8 +3542,10 @@ void VLogF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VExpF16Vop1::VExpF16Vop1(const MachineInst *inst)
-    : Vop1("v_exp_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VExpF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_exp_f16_dpp"
+               : "v_exp_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VExpF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3479,8 +3613,10 @@ void VExpF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpMantF16Vop1::VFrexpMantF16Vop1(const MachineInst *inst)
-    : Vop1("v_frexp_mant_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpMantF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_mant_f16_dpp"
+               : "v_frexp_mant_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpMantF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3548,8 +3684,10 @@ void VFrexpMantF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpExpI16F16Vop1::VFrexpExpI16F16Vop1(const MachineInst *inst)
-    : Vop1("v_frexp_exp_i16_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpExpI16F16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_exp_i16_f16_dpp"
+               : "v_frexp_exp_i16_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpExpI16F16Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3617,8 +3755,10 @@ void VFrexpExpI16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFloorF16Vop1::VFloorF16Vop1(const MachineInst *inst)
-    : Vop1("v_floor_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFloorF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_floor_f16_dpp"
+               : "v_floor_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFloorF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3686,8 +3826,10 @@ void VFloorF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCeilF16Vop1::VCeilF16Vop1(const MachineInst *inst)
-    : Vop1("v_ceil_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCeilF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ceil_f16_dpp"
+               : "v_ceil_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCeilF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3755,8 +3897,10 @@ void VCeilF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VTruncF16Vop1::VTruncF16Vop1(const MachineInst *inst)
-    : Vop1("v_trunc_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VTruncF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_trunc_f16_dpp"
+               : "v_trunc_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VTruncF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3824,8 +3968,10 @@ void VTruncF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRndneF16Vop1::VRndneF16Vop1(const MachineInst *inst)
-    : Vop1("v_rndne_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRndneF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rndne_f16_dpp"
+               : "v_rndne_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRndneF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3893,8 +4039,10 @@ void VRndneF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFractF16Vop1::VFractF16Vop1(const MachineInst *inst)
-    : Vop1("v_fract_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFractF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fract_f16_dpp"
+               : "v_fract_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFractF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3962,8 +4110,10 @@ void VFractF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSinF16Vop1::VSinF16Vop1(const MachineInst *inst)
-    : Vop1("v_sin_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSinF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sin_f16_dpp"
+               : "v_sin_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSinF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -4031,8 +4181,10 @@ void VSinF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCosF16Vop1::VCosF16Vop1(const MachineInst *inst)
-    : Vop1("v_cos_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCosF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cos_f16_dpp"
+               : "v_cos_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCosF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -4100,8 +4252,10 @@ void VCosF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSatPkU8I16Vop1::VSatPkU8I16Vop1(const MachineInst *inst)
-    : Vop1("v_sat_pk_u8_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSatPkU8I16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sat_pk_u8_i16_dpp"
+               : "v_sat_pk_u8_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSatPkU8I16Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -4152,8 +4306,10 @@ void VSatPkU8I16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtNormI16F16Vop1::VCvtNormI16F16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_norm_i16_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtNormI16F16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_norm_i16_f16_dpp"
+               : "v_cvt_norm_i16_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtNormI16F16Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -4221,8 +4377,10 @@ void VCvtNormI16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtNormU16F16Vop1::VCvtNormU16F16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_norm_u16_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtNormU16F16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_norm_u16_f16_dpp"
+               : "v_cvt_norm_u16_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtNormU16F16Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -4290,8 +4448,10 @@ void VCvtNormU16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSwapB32Vop1::VSwapB32Vop1(const MachineInst *inst)
-    : Vop1("v_swap_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSwapB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_swap_b32_dpp"
+               : "v_swap_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSwapB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   src_operands_[0] = &vdst;
@@ -4324,8 +4484,10 @@ void VSwapB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSwaprelB32Vop1::VSwaprelB32Vop1(const MachineInst *inst)
-    : Vop1("v_swaprel_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSwaprelB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_swaprel_b32_dpp"
+               : "v_swaprel_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSwaprelB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 124) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/vop2.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/vop2.cpp
@@ -22,8 +22,10 @@ namespace rocjitsu {
 namespace rdna1 {
 
 VCndmaskB32Vop2::VCndmaskB32Vop2(const MachineInst *inst)
-    : Vop2("v_cndmask_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCndmaskB32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cndmask_b32_dpp"
+               : "v_cndmask_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCndmaskB32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -96,8 +98,10 @@ void VCndmaskB32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDot2cF32F16Vop2::VDot2cF32F16Vop2(const MachineInst *inst)
-    : Vop2("v_dot2c_f32_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VDot2cF32F16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_dot2c_f32_f16_dpp"
+               : "v_dot2c_f32_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDot2cF32F16Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -144,8 +148,10 @@ void VDot2cF32F16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddF32Vop2::VAddF32Vop2(const MachineInst *inst)
-    : Vop2("v_add_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAddF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_f32_dpp"
+               : "v_add_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -215,8 +221,10 @@ void VAddF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubF32Vop2::VSubF32Vop2(const MachineInst *inst)
-    : Vop2("v_sub_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_f32_dpp"
+               : "v_sub_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -286,8 +294,10 @@ void VSubF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubrevF32Vop2::VSubrevF32Vop2(const MachineInst *inst)
-    : Vop2("v_subrev_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubrevF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_subrev_f32_dpp"
+               : "v_subrev_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubrevF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_NOLDS, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -357,8 +367,10 @@ void VSubrevF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMacLegacyF32Vop2::VMacLegacyF32Vop2(const MachineInst *inst)
-    : Vop2("v_mac_legacy_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMacLegacyF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mac_legacy_f32_dpp"
+               : "v_mac_legacy_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMacLegacyF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -394,8 +406,10 @@ void VMacLegacyF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulLegacyF32Vop2::VMulLegacyF32Vop2(const MachineInst *inst)
-    : Vop2("v_mul_legacy_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulLegacyF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_legacy_f32_dpp"
+               : "v_mul_legacy_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulLegacyF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -465,8 +479,10 @@ void VMulLegacyF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulF32Vop2::VMulF32Vop2(const MachineInst *inst)
-    : Vop2("v_mul_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_f32_dpp"
+               : "v_mul_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -536,8 +552,10 @@ void VMulF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulI32I24Vop2::VMulI32I24Vop2(const MachineInst *inst)
-    : Vop2("v_mul_i32_i24_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulI32I24Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_i32_i24_dpp"
+               : "v_mul_i32_i24_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulI32I24Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -607,8 +625,10 @@ void VMulI32I24Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulHiI32I24Vop2::VMulHiI32I24Vop2(const MachineInst *inst)
-    : Vop2("v_mul_hi_i32_i24_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulHiI32I24Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_hi_i32_i24_dpp"
+               : "v_mul_hi_i32_i24_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulHiI32I24Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -678,8 +698,10 @@ void VMulHiI32I24Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulU32U24Vop2::VMulU32U24Vop2(const MachineInst *inst)
-    : Vop2("v_mul_u32_u24_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulU32U24Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_u32_u24_dpp"
+               : "v_mul_u32_u24_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulU32U24Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -749,8 +771,10 @@ void VMulU32U24Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulHiU32U24Vop2::VMulHiU32U24Vop2(const MachineInst *inst)
-    : Vop2("v_mul_hi_u32_u24_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulHiU32U24Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_hi_u32_u24_dpp"
+               : "v_mul_hi_u32_u24_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulHiU32U24Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -820,8 +844,10 @@ void VMulHiU32U24Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDot4cI32I8Vop2::VDot4cI32I8Vop2(const MachineInst *inst)
-    : Vop2("v_dot4c_i32_i8_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VDot4cI32I8Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_dot4c_i32_i8_dpp"
+               : "v_dot4c_i32_i8_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDot4cI32I8Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -868,8 +894,10 @@ void VDot4cI32I8Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinF32Vop2::VMinF32Vop2(const MachineInst *inst)
-    : Vop2("v_min_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_f32_dpp"
+               : "v_min_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -939,8 +967,10 @@ void VMinF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxF32Vop2::VMaxF32Vop2(const MachineInst *inst)
-    : Vop2("v_max_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaxF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_f32_dpp"
+               : "v_max_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1010,8 +1040,10 @@ void VMaxF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinI32Vop2::VMinI32Vop2(const MachineInst *inst)
-    : Vop2("v_min_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinI32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_i32_dpp"
+               : "v_min_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinI32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1081,8 +1113,10 @@ void VMinI32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxI32Vop2::VMaxI32Vop2(const MachineInst *inst)
-    : Vop2("v_max_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaxI32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_i32_dpp"
+               : "v_max_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxI32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1152,8 +1186,10 @@ void VMaxI32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinU32Vop2::VMinU32Vop2(const MachineInst *inst)
-    : Vop2("v_min_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinU32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_u32_dpp"
+               : "v_min_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinU32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1223,8 +1259,10 @@ void VMinU32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxU32Vop2::VMaxU32Vop2(const MachineInst *inst)
-    : Vop2("v_max_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaxU32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_u32_dpp"
+               : "v_max_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxU32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1294,8 +1332,10 @@ void VMaxU32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLshrrevB32Vop2::VLshrrevB32Vop2(const MachineInst *inst)
-    : Vop2("v_lshrrev_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLshrrevB32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshrrev_b32_dpp"
+               : "v_lshrrev_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLshrrevB32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_NOLDS, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1365,8 +1405,10 @@ void VLshrrevB32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAshrrevI32Vop2::VAshrrevI32Vop2(const MachineInst *inst)
-    : Vop2("v_ashrrev_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAshrrevI32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ashrrev_i32_dpp"
+               : "v_ashrrev_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAshrrevI32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_NOLDS, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1436,8 +1478,10 @@ void VAshrrevI32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLshlrevB32Vop2::VLshlrevB32Vop2(const MachineInst *inst)
-    : Vop2("v_lshlrev_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLshlrevB32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshlrev_b32_dpp"
+               : "v_lshlrev_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLshlrevB32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_NOLDS, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1507,8 +1551,10 @@ void VLshlrevB32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAndB32Vop2::VAndB32Vop2(const MachineInst *inst)
-    : Vop2("v_and_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAndB32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_and_b32_dpp"
+               : "v_and_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAndB32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1578,7 +1624,10 @@ void VAndB32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VOrB32Vop2::VOrB32Vop2(const MachineInst *inst)
-    : Vop2("v_or_b32_e32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VOrB32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_or_b32_dpp"
+               : "v_or_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VOrB32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1648,8 +1697,10 @@ void VOrB32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VXorB32Vop2::VXorB32Vop2(const MachineInst *inst)
-    : Vop2("v_xor_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VXorB32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_xor_b32_dpp"
+               : "v_xor_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXorB32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1719,8 +1770,10 @@ void VXorB32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VXnorB32Vop2::VXnorB32Vop2(const MachineInst *inst)
-    : Vop2("v_xnor_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VXnorB32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_xnor_b32_dpp"
+               : "v_xnor_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXnorB32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1790,8 +1843,10 @@ void VXnorB32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMacF32Vop2::VMacF32Vop2(const MachineInst *inst)
-    : Vop2("v_mac_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMacF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mac_f32_dpp"
+               : "v_mac_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMacF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1838,8 +1893,10 @@ void VMacF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMadmkF32Vop2::VMadmkF32Vop2(const MachineInst *inst)
-    : Vop2("v_madmk_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMadmkF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_madmk_f32_dpp"
+               : "v_madmk_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMadmkF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       simm32(32, OperandType::OPR_SIMM32, 0),
@@ -1870,8 +1927,10 @@ void VMadmkF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMadakF32Vop2::VMadakF32Vop2(const MachineInst *inst)
-    : Vop2("v_madak_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMadakF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_madak_f32_dpp"
+               : "v_madak_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMadakF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -1902,8 +1961,10 @@ void VMadakF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddNcU32Vop2::VAddNcU32Vop2(const MachineInst *inst)
-    : Vop2("v_add_nc_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAddNcU32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_nc_u32_dpp"
+               : "v_add_nc_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddNcU32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1973,8 +2034,10 @@ void VAddNcU32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubNcU32Vop2::VSubNcU32Vop2(const MachineInst *inst)
-    : Vop2("v_sub_nc_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubNcU32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_nc_u32_dpp"
+               : "v_sub_nc_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubNcU32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2044,8 +2107,10 @@ void VSubNcU32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubrevNcU32Vop2::VSubrevNcU32Vop2(const MachineInst *inst)
-    : Vop2("v_subrev_nc_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubrevNcU32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_subrev_nc_u32_dpp"
+               : "v_subrev_nc_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubrevNcU32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_NOLDS, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2115,8 +2180,10 @@ void VSubrevNcU32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddCoCiU32Vop2::VAddCoCiU32Vop2(const MachineInst *inst)
-    : Vop2("v_add_co_ci_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAddCoCiU32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_co_ci_u32_dpp"
+               : "v_add_co_ci_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddCoCiU32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -2192,8 +2259,10 @@ void VAddCoCiU32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubCoCiU32Vop2::VSubCoCiU32Vop2(const MachineInst *inst)
-    : Vop2("v_sub_co_ci_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubCoCiU32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_co_ci_u32_dpp"
+               : "v_sub_co_ci_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubCoCiU32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -2269,8 +2338,10 @@ void VSubCoCiU32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubrevCoCiU32Vop2::VSubrevCoCiU32Vop2(const MachineInst *inst)
-    : Vop2("v_subrev_co_ci_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubrevCoCiU32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_subrev_co_ci_u32_dpp"
+               : "v_subrev_co_ci_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubrevCoCiU32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC_NOLDS, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -2346,8 +2417,10 @@ void VSubrevCoCiU32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmacF32Vop2::VFmacF32Vop2(const MachineInst *inst)
-    : Vop2("v_fmac_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFmacF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmac_f32_dpp"
+               : "v_fmac_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmacF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2394,8 +2467,10 @@ void VFmacF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmamkF32Vop2::VFmamkF32Vop2(const MachineInst *inst)
-    : Vop2("v_fmamk_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFmamkF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmamk_f32_dpp"
+               : "v_fmamk_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmamkF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       simm32(32, OperandType::OPR_SIMM32, 0),
@@ -2426,8 +2501,10 @@ void VFmamkF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmaakF32Vop2::VFmaakF32Vop2(const MachineInst *inst)
-    : Vop2("v_fmaak_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFmaakF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmaak_f32_dpp"
+               : "v_fmaak_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmaakF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -2458,8 +2535,10 @@ void VFmaakF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkrtzF16F32Vop2::VCvtPkrtzF16F32Vop2(const MachineInst *inst)
-    : Vop2("v_cvt_pkrtz_f16_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkrtzF16F32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pkrtz_f16_f32_dpp"
+               : "v_cvt_pkrtz_f16_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkrtzF16F32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2529,8 +2608,10 @@ void VCvtPkrtzF16F32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddF16Vop2::VAddF16Vop2(const MachineInst *inst)
-    : Vop2("v_add_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAddF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_f16_dpp"
+               : "v_add_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2607,8 +2688,10 @@ void VAddF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubF16Vop2::VSubF16Vop2(const MachineInst *inst)
-    : Vop2("v_sub_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_f16_dpp"
+               : "v_sub_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2685,8 +2768,10 @@ void VSubF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubrevF16Vop2::VSubrevF16Vop2(const MachineInst *inst)
-    : Vop2("v_subrev_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubrevF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_subrev_f16_dpp"
+               : "v_subrev_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubrevF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC_NOLDS, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2763,8 +2848,10 @@ void VSubrevF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulF16Vop2::VMulF16Vop2(const MachineInst *inst)
-    : Vop2("v_mul_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_f16_dpp"
+               : "v_mul_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2841,8 +2928,10 @@ void VMulF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmacF16Vop2::VFmacF16Vop2(const MachineInst *inst)
-    : Vop2("v_fmac_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFmacF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmac_f16_dpp"
+               : "v_fmac_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmacF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2896,8 +2985,10 @@ void VFmacF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmamkF16Vop2::VFmamkF16Vop2(const MachineInst *inst)
-    : Vop2("v_fmamk_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFmamkF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmamk_f16_dpp"
+               : "v_fmamk_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmamkF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       simm32(16, OperandType::OPR_SIMM32, 0),
@@ -2936,8 +3027,10 @@ void VFmamkF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmaakF16Vop2::VFmaakF16Vop2(const MachineInst *inst)
-    : Vop2("v_fmaak_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFmaakF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmaak_f16_dpp"
+               : "v_fmaak_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmaakF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -2976,8 +3069,10 @@ void VFmaakF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxF16Vop2::VMaxF16Vop2(const MachineInst *inst)
-    : Vop2("v_max_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaxF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_f16_dpp"
+               : "v_max_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3054,8 +3149,10 @@ void VMaxF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinF16Vop2::VMinF16Vop2(const MachineInst *inst)
-    : Vop2("v_min_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_f16_dpp"
+               : "v_min_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3132,8 +3229,10 @@ void VMinF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLdexpF16Vop2::VLdexpF16Vop2(const MachineInst *inst)
-    : Vop2("v_ldexp_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLdexpF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ldexp_f16_dpp"
+               : "v_ldexp_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLdexpF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3210,8 +3309,10 @@ void VLdexpF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkFmacF16Vop2::VPkFmacF16Vop2(const MachineInst *inst)
-    : Vop2("v_pk_fmac_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VPkFmacF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_pk_fmac_f16_dpp"
+               : "v_pk_fmac_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkFmacF16Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/encodings.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/encodings.cpp
@@ -137,6 +137,11 @@ Vop1::Vop1(std::string_view mnemonic, const Vop1MachineInst *inst, ExecuteFn exe
   raw_encoding_ = raw_words_.data();
 }
 
+void Vop1::build_modifiers(std::string &out) const {
+  if (amdgpu::dpp::is_src_dpp8(inst_.src0))
+    amdgpu::dpp::append_dpp8_disassembly(out, dpp8_lane_sel_, dpp_fi_);
+}
+
 void Vop1::implicit_uses(RegisterSet &uses) const {
   bool sdwa_preserve =
       sdwa_dst_sel_ != amdgpu::sdwa::DWORD && sdwa_dst_unused_ == amdgpu::sdwa::UNUSED_PRESERVE;
@@ -189,6 +194,11 @@ Vop2::Vop2(std::string_view mnemonic, const Vop2MachineInst *inst, ExecuteFn exe
     literal_ = reinterpret_cast<const uint32_t *>(inst)[1];
   std::memcpy(raw_words_.data(), inst, size_);
   raw_encoding_ = raw_words_.data();
+}
+
+void Vop2::build_modifiers(std::string &out) const {
+  if (amdgpu::dpp::is_src_dpp8(inst_.src0))
+    amdgpu::dpp::append_dpp8_disassembly(out, dpp8_lane_sel_, dpp_fi_);
 }
 
 void Vop2::implicit_uses(RegisterSet &uses) const {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/encodings.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/encodings.h
@@ -425,6 +425,7 @@ public:
 class Vop1 : public IsaInstruction<Isa> {
 public:
   Vop1(std::string_view mnemonic, const Vop1MachineInst *inst, ExecuteFn exec_fn);
+  void build_modifiers(std::string &out) const override;
   void implicit_uses(RegisterSet &uses) const override;
   bool default_encoding();
   bool has_lit();
@@ -482,6 +483,7 @@ public:
 class Vop2 : public IsaInstruction<Isa> {
 public:
   Vop2(std::string_view mnemonic, const Vop2MachineInst *inst, ExecuteFn exec_fn);
+  void build_modifiers(std::string &out) const override;
   void implicit_uses(RegisterSet &uses) const override;
   bool default_encoding();
   bool has_lit();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/vop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/vop1.cpp
@@ -22,7 +22,9 @@ namespace rocjitsu {
 namespace rdna2 {
 
 VNopVop1::VNopVop1(const MachineInst *inst)
-    : Vop1("v_nop_e32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VNopVop1>()) {
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0) ? "v_nop_dpp"
+                                                                                      : "v_nop_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VNopVop1>()) {
   num_src_ = 0;
   num_dst_ = 0;
 }
@@ -30,8 +32,10 @@ VNopVop1::VNopVop1(const MachineInst *inst)
 void VNopVop1::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_nop_vop1(*this, wf); }
 
 VMovB32Vop1::VMovB32Vop1(const MachineInst *inst)
-    : Vop1("v_mov_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMovB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mov_b32_dpp"
+               : "v_mov_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -92,8 +96,10 @@ void VMovB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VReadfirstlaneB32Vop1::VReadfirstlaneB32Vop1(const MachineInst *inst)
-    : Vop1("v_readfirstlane_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VReadfirstlaneB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_readfirstlane_b32_dpp"
+               : "v_readfirstlane_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VReadfirstlaneB32Vop1>()),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -124,8 +130,10 @@ void VReadfirstlaneB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtI32F64Vop1::VCvtI32F64Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_i32_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtI32F64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_i32_f64_dpp"
+               : "v_cvt_i32_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtI32F64Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_NOLDS, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -149,8 +157,10 @@ void VCvtI32F64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF64I32Vop1::VCvtF64I32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f64_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF64I32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f64_i32_dpp"
+               : "v_cvt_f64_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF64I32Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -173,8 +183,10 @@ void VCvtF64I32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32I32Vop1::VCvtF32I32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32I32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_i32_dpp"
+               : "v_cvt_f32_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32I32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -235,8 +247,10 @@ void VCvtF32I32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32U32Vop1::VCvtF32U32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32U32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_u32_dpp"
+               : "v_cvt_f32_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32U32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -297,8 +311,10 @@ void VCvtF32U32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtU32F32Vop1::VCvtU32F32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_u32_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtU32F32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_u32_f32_dpp"
+               : "v_cvt_u32_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtU32F32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -359,8 +375,10 @@ void VCvtU32F32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtI32F32Vop1::VCvtI32F32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_i32_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtI32F32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_i32_f32_dpp"
+               : "v_cvt_i32_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtI32F32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -421,8 +439,10 @@ void VCvtI32F32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF16F32Vop1::VCvtF16F32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f16_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF16F32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f16_f32_dpp"
+               : "v_cvt_f16_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF16F32Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -489,8 +509,10 @@ void VCvtF16F32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32F16Vop1::VCvtF32F16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32F16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_f16_dpp"
+               : "v_cvt_f32_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32F16Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -552,8 +574,10 @@ void VCvtF32F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtRpiI32F32Vop1::VCvtRpiI32F32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_rpi_i32_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtRpiI32F32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_rpi_i32_f32_dpp"
+               : "v_cvt_rpi_i32_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtRpiI32F32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -614,8 +638,10 @@ void VCvtRpiI32F32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtFlrI32F32Vop1::VCvtFlrI32F32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_flr_i32_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtFlrI32F32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_flr_i32_f32_dpp"
+               : "v_cvt_flr_i32_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtFlrI32F32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -676,8 +702,10 @@ void VCvtFlrI32F32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtOffF32I4Vop1::VCvtOffF32I4Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_off_f32_i4_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtOffF32I4Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_off_f32_i4_dpp"
+               : "v_cvt_off_f32_i4_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtOffF32I4Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -738,8 +766,10 @@ void VCvtOffF32I4Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32F64Vop1::VCvtF32F64Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32F64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_f64_dpp"
+               : "v_cvt_f32_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32F64Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_NOLDS, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -763,8 +793,10 @@ void VCvtF32F64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF64F32Vop1::VCvtF64F32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f64_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF64F32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f64_f32_dpp"
+               : "v_cvt_f64_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF64F32Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -787,8 +819,10 @@ void VCvtF64F32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32Ubyte0Vop1::VCvtF32Ubyte0Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_ubyte0_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32Ubyte0Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_ubyte0_dpp"
+               : "v_cvt_f32_ubyte0_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32Ubyte0Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -849,8 +883,10 @@ void VCvtF32Ubyte0Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32Ubyte1Vop1::VCvtF32Ubyte1Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_ubyte1_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32Ubyte1Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_ubyte1_dpp"
+               : "v_cvt_f32_ubyte1_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32Ubyte1Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -911,8 +947,10 @@ void VCvtF32Ubyte1Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32Ubyte2Vop1::VCvtF32Ubyte2Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_ubyte2_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32Ubyte2Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_ubyte2_dpp"
+               : "v_cvt_f32_ubyte2_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32Ubyte2Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -973,8 +1011,10 @@ void VCvtF32Ubyte2Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32Ubyte3Vop1::VCvtF32Ubyte3Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_ubyte3_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32Ubyte3Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_ubyte3_dpp"
+               : "v_cvt_f32_ubyte3_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32Ubyte3Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1035,8 +1075,10 @@ void VCvtF32Ubyte3Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtU32F64Vop1::VCvtU32F64Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_u32_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtU32F64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_u32_f64_dpp"
+               : "v_cvt_u32_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtU32F64Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_NOLDS, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1060,8 +1102,10 @@ void VCvtU32F64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF64U32Vop1::VCvtF64U32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f64_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF64U32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f64_u32_dpp"
+               : "v_cvt_f64_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF64U32Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1084,8 +1128,10 @@ void VCvtF64U32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VTruncF64Vop1::VTruncF64Vop1(const MachineInst *inst)
-    : Vop1("v_trunc_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VTruncF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_trunc_f64_dpp"
+               : "v_trunc_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VTruncF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_NOLDS, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1109,8 +1155,10 @@ void VTruncF64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCeilF64Vop1::VCeilF64Vop1(const MachineInst *inst)
-    : Vop1("v_ceil_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCeilF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ceil_f64_dpp"
+               : "v_ceil_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCeilF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_NOLDS, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1134,8 +1182,10 @@ void VCeilF64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRndneF64Vop1::VRndneF64Vop1(const MachineInst *inst)
-    : Vop1("v_rndne_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRndneF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rndne_f64_dpp"
+               : "v_rndne_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRndneF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_NOLDS, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1159,8 +1209,10 @@ void VRndneF64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFloorF64Vop1::VFloorF64Vop1(const MachineInst *inst)
-    : Vop1("v_floor_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFloorF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_floor_f64_dpp"
+               : "v_floor_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFloorF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_NOLDS, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1184,8 +1236,10 @@ void VFloorF64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPipeflushVop1::VPipeflushVop1(const MachineInst *inst)
-    : Vop1("v_pipeflush_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VPipeflushVop1>()) {
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_pipeflush_dpp"
+               : "v_pipeflush_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPipeflushVop1>()) {
   num_src_ = 0;
   num_dst_ = 0;
 }
@@ -1195,8 +1249,10 @@ void VPipeflushVop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFractF32Vop1::VFractF32Vop1(const MachineInst *inst)
-    : Vop1("v_fract_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFractF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fract_f32_dpp"
+               : "v_fract_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFractF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1257,8 +1313,10 @@ void VFractF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VTruncF32Vop1::VTruncF32Vop1(const MachineInst *inst)
-    : Vop1("v_trunc_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VTruncF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_trunc_f32_dpp"
+               : "v_trunc_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VTruncF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1319,8 +1377,10 @@ void VTruncF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCeilF32Vop1::VCeilF32Vop1(const MachineInst *inst)
-    : Vop1("v_ceil_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCeilF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ceil_f32_dpp"
+               : "v_ceil_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCeilF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1381,8 +1441,10 @@ void VCeilF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRndneF32Vop1::VRndneF32Vop1(const MachineInst *inst)
-    : Vop1("v_rndne_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRndneF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rndne_f32_dpp"
+               : "v_rndne_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRndneF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1443,8 +1505,10 @@ void VRndneF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFloorF32Vop1::VFloorF32Vop1(const MachineInst *inst)
-    : Vop1("v_floor_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFloorF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_floor_f32_dpp"
+               : "v_floor_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFloorF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1505,8 +1569,10 @@ void VFloorF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VExpF32Vop1::VExpF32Vop1(const MachineInst *inst)
-    : Vop1("v_exp_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VExpF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_exp_f32_dpp"
+               : "v_exp_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VExpF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1567,8 +1633,10 @@ void VExpF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLogF32Vop1::VLogF32Vop1(const MachineInst *inst)
-    : Vop1("v_log_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLogF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_log_f32_dpp"
+               : "v_log_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLogF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1629,8 +1697,10 @@ void VLogF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRcpF32Vop1::VRcpF32Vop1(const MachineInst *inst)
-    : Vop1("v_rcp_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRcpF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_f32_dpp"
+               : "v_rcp_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1691,8 +1761,10 @@ void VRcpF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRcpIflagF32Vop1::VRcpIflagF32Vop1(const MachineInst *inst)
-    : Vop1("v_rcp_iflag_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRcpIflagF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_iflag_f32_dpp"
+               : "v_rcp_iflag_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpIflagF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1753,8 +1825,10 @@ void VRcpIflagF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRsqF32Vop1::VRsqF32Vop1(const MachineInst *inst)
-    : Vop1("v_rsq_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRsqF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rsq_f32_dpp"
+               : "v_rsq_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRsqF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1815,8 +1889,10 @@ void VRsqF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRcpF64Vop1::VRcpF64Vop1(const MachineInst *inst)
-    : Vop1("v_rcp_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRcpF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_f64_dpp"
+               : "v_rcp_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_NOLDS, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1838,8 +1914,10 @@ VRcpF64Vop1::VRcpF64Vop1(const MachineInst *inst)
 void VRcpF64Vop1::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_rcp_f64_vop1(*this, wf); }
 
 VRsqF64Vop1::VRsqF64Vop1(const MachineInst *inst)
-    : Vop1("v_rsq_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRsqF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rsq_f64_dpp"
+               : "v_rsq_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRsqF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_NOLDS, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1861,8 +1939,10 @@ VRsqF64Vop1::VRsqF64Vop1(const MachineInst *inst)
 void VRsqF64Vop1::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_rsq_f64_vop1(*this, wf); }
 
 VSqrtF32Vop1::VSqrtF32Vop1(const MachineInst *inst)
-    : Vop1("v_sqrt_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSqrtF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sqrt_f32_dpp"
+               : "v_sqrt_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSqrtF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1923,8 +2003,10 @@ void VSqrtF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSqrtF64Vop1::VSqrtF64Vop1(const MachineInst *inst)
-    : Vop1("v_sqrt_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSqrtF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sqrt_f64_dpp"
+               : "v_sqrt_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSqrtF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_NOLDS, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1948,8 +2030,10 @@ void VSqrtF64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSinF32Vop1::VSinF32Vop1(const MachineInst *inst)
-    : Vop1("v_sin_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSinF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sin_f32_dpp"
+               : "v_sin_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSinF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2010,8 +2094,10 @@ void VSinF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCosF32Vop1::VCosF32Vop1(const MachineInst *inst)
-    : Vop1("v_cos_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCosF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cos_f32_dpp"
+               : "v_cos_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCosF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2072,8 +2158,10 @@ void VCosF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VNotB32Vop1::VNotB32Vop1(const MachineInst *inst)
-    : Vop1("v_not_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VNotB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_not_b32_dpp"
+               : "v_not_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VNotB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2134,8 +2222,10 @@ void VNotB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VBfrevB32Vop1::VBfrevB32Vop1(const MachineInst *inst)
-    : Vop1("v_bfrev_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VBfrevB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_bfrev_b32_dpp"
+               : "v_bfrev_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VBfrevB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2196,8 +2286,10 @@ void VBfrevB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFfbhU32Vop1::VFfbhU32Vop1(const MachineInst *inst)
-    : Vop1("v_ffbh_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFfbhU32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ffbh_u32_dpp"
+               : "v_ffbh_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFfbhU32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2258,8 +2350,10 @@ void VFfbhU32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFfblB32Vop1::VFfblB32Vop1(const MachineInst *inst)
-    : Vop1("v_ffbl_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFfblB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ffbl_b32_dpp"
+               : "v_ffbl_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFfblB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2320,8 +2414,10 @@ void VFfblB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFfbhI32Vop1::VFfbhI32Vop1(const MachineInst *inst)
-    : Vop1("v_ffbh_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFfbhI32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ffbh_i32_dpp"
+               : "v_ffbh_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFfbhI32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2382,8 +2478,10 @@ void VFfbhI32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpExpI32F64Vop1::VFrexpExpI32F64Vop1(const MachineInst *inst)
-    : Vop1("v_frexp_exp_i32_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpExpI32F64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_exp_i32_f64_dpp"
+               : "v_frexp_exp_i32_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpExpI32F64Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_NOLDS, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2407,8 +2505,10 @@ void VFrexpExpI32F64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpMantF64Vop1::VFrexpMantF64Vop1(const MachineInst *inst)
-    : Vop1("v_frexp_mant_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpMantF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_mant_f64_dpp"
+               : "v_frexp_mant_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpMantF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_NOLDS, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2432,8 +2532,10 @@ void VFrexpMantF64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFractF64Vop1::VFractF64Vop1(const MachineInst *inst)
-    : Vop1("v_fract_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFractF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fract_f64_dpp"
+               : "v_fract_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFractF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_NOLDS, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2457,8 +2559,10 @@ void VFractF64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpExpI32F32Vop1::VFrexpExpI32F32Vop1(const MachineInst *inst)
-    : Vop1("v_frexp_exp_i32_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpExpI32F32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_exp_i32_f32_dpp"
+               : "v_frexp_exp_i32_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpExpI32F32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2519,8 +2623,10 @@ void VFrexpExpI32F32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpMantF32Vop1::VFrexpMantF32Vop1(const MachineInst *inst)
-    : Vop1("v_frexp_mant_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpMantF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_mant_f32_dpp"
+               : "v_frexp_mant_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpMantF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2581,8 +2687,10 @@ void VFrexpMantF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VClrexcpVop1::VClrexcpVop1(const MachineInst *inst)
-    : Vop1("v_clrexcp_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VClrexcpVop1>()) {
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_clrexcp_dpp"
+               : "v_clrexcp_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VClrexcpVop1>()) {
   num_src_ = 0;
   num_dst_ = 0;
 }
@@ -2592,8 +2700,10 @@ void VClrexcpVop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMovreldB32Vop1::VMovreldB32Vop1(const MachineInst *inst)
-    : Vop1("v_movreld_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMovreldB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_movreld_b32_dpp"
+               : "v_movreld_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovreldB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 124) {
@@ -2670,8 +2780,10 @@ void VMovreldB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMovrelsB32Vop1::VMovrelsB32Vop1(const MachineInst *inst)
-    : Vop1("v_movrels_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMovrelsB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_movrels_b32_dpp"
+               : "v_movrels_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovrelsB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 124) {
@@ -2748,8 +2860,10 @@ void VMovrelsB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMovrelsdB32Vop1::VMovrelsdB32Vop1(const MachineInst *inst)
-    : Vop1("v_movrelsd_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMovrelsdB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_movrelsd_b32_dpp"
+               : "v_movrelsd_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovrelsdB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 124) {
@@ -2803,8 +2917,10 @@ void VMovrelsdB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMovrelsd2B32Vop1::VMovrelsd2B32Vop1(const MachineInst *inst)
-    : Vop1("v_movrelsd_2_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMovrelsd2B32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_movrelsd_2_b32_dpp"
+               : "v_movrelsd_2_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovrelsd2B32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 124) {
@@ -2858,8 +2974,10 @@ void VMovrelsd2B32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF16U16Vop1::VCvtF16U16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f16_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF16U16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f16_u16_dpp"
+               : "v_cvt_f16_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF16U16Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2927,8 +3045,10 @@ void VCvtF16U16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF16I16Vop1::VCvtF16I16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f16_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF16I16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f16_i16_dpp"
+               : "v_cvt_f16_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF16I16Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2996,8 +3116,10 @@ void VCvtF16I16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtU16F16Vop1::VCvtU16F16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_u16_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtU16F16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_u16_f16_dpp"
+               : "v_cvt_u16_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtU16F16Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3065,8 +3187,10 @@ void VCvtU16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtI16F16Vop1::VCvtI16F16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_i16_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtI16F16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_i16_f16_dpp"
+               : "v_cvt_i16_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtI16F16Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3134,8 +3258,10 @@ void VCvtI16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRcpF16Vop1::VRcpF16Vop1(const MachineInst *inst)
-    : Vop1("v_rcp_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRcpF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_f16_dpp"
+               : "v_rcp_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3203,8 +3329,10 @@ void VRcpF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSqrtF16Vop1::VSqrtF16Vop1(const MachineInst *inst)
-    : Vop1("v_sqrt_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSqrtF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sqrt_f16_dpp"
+               : "v_sqrt_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSqrtF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3272,8 +3400,10 @@ void VSqrtF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRsqF16Vop1::VRsqF16Vop1(const MachineInst *inst)
-    : Vop1("v_rsq_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRsqF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rsq_f16_dpp"
+               : "v_rsq_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRsqF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3341,8 +3471,10 @@ void VRsqF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLogF16Vop1::VLogF16Vop1(const MachineInst *inst)
-    : Vop1("v_log_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLogF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_log_f16_dpp"
+               : "v_log_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLogF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3410,8 +3542,10 @@ void VLogF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VExpF16Vop1::VExpF16Vop1(const MachineInst *inst)
-    : Vop1("v_exp_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VExpF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_exp_f16_dpp"
+               : "v_exp_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VExpF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3479,8 +3613,10 @@ void VExpF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpMantF16Vop1::VFrexpMantF16Vop1(const MachineInst *inst)
-    : Vop1("v_frexp_mant_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpMantF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_mant_f16_dpp"
+               : "v_frexp_mant_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpMantF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3548,8 +3684,10 @@ void VFrexpMantF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpExpI16F16Vop1::VFrexpExpI16F16Vop1(const MachineInst *inst)
-    : Vop1("v_frexp_exp_i16_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpExpI16F16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_exp_i16_f16_dpp"
+               : "v_frexp_exp_i16_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpExpI16F16Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3617,8 +3755,10 @@ void VFrexpExpI16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFloorF16Vop1::VFloorF16Vop1(const MachineInst *inst)
-    : Vop1("v_floor_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFloorF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_floor_f16_dpp"
+               : "v_floor_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFloorF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3686,8 +3826,10 @@ void VFloorF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCeilF16Vop1::VCeilF16Vop1(const MachineInst *inst)
-    : Vop1("v_ceil_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCeilF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ceil_f16_dpp"
+               : "v_ceil_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCeilF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3755,8 +3897,10 @@ void VCeilF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VTruncF16Vop1::VTruncF16Vop1(const MachineInst *inst)
-    : Vop1("v_trunc_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VTruncF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_trunc_f16_dpp"
+               : "v_trunc_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VTruncF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3824,8 +3968,10 @@ void VTruncF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRndneF16Vop1::VRndneF16Vop1(const MachineInst *inst)
-    : Vop1("v_rndne_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRndneF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rndne_f16_dpp"
+               : "v_rndne_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRndneF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3893,8 +4039,10 @@ void VRndneF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFractF16Vop1::VFractF16Vop1(const MachineInst *inst)
-    : Vop1("v_fract_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFractF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fract_f16_dpp"
+               : "v_fract_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFractF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3962,8 +4110,10 @@ void VFractF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSinF16Vop1::VSinF16Vop1(const MachineInst *inst)
-    : Vop1("v_sin_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSinF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sin_f16_dpp"
+               : "v_sin_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSinF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -4031,8 +4181,10 @@ void VSinF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCosF16Vop1::VCosF16Vop1(const MachineInst *inst)
-    : Vop1("v_cos_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCosF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cos_f16_dpp"
+               : "v_cos_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCosF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -4100,8 +4252,10 @@ void VCosF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSatPkU8I16Vop1::VSatPkU8I16Vop1(const MachineInst *inst)
-    : Vop1("v_sat_pk_u8_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSatPkU8I16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sat_pk_u8_i16_dpp"
+               : "v_sat_pk_u8_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSatPkU8I16Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -4152,8 +4306,10 @@ void VSatPkU8I16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtNormI16F16Vop1::VCvtNormI16F16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_norm_i16_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtNormI16F16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_norm_i16_f16_dpp"
+               : "v_cvt_norm_i16_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtNormI16F16Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -4221,8 +4377,10 @@ void VCvtNormI16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtNormU16F16Vop1::VCvtNormU16F16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_norm_u16_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtNormU16F16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_norm_u16_f16_dpp"
+               : "v_cvt_norm_u16_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtNormU16F16Vop1>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -4290,8 +4448,10 @@ void VCvtNormU16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSwapB32Vop1::VSwapB32Vop1(const MachineInst *inst)
-    : Vop1("v_swap_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSwapB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_swap_b32_dpp"
+               : "v_swap_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSwapB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   src_operands_[0] = &vdst;
@@ -4324,8 +4484,10 @@ void VSwapB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSwaprelB32Vop1::VSwaprelB32Vop1(const MachineInst *inst)
-    : Vop1("v_swaprel_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSwaprelB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_swaprel_b32_dpp"
+               : "v_swaprel_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSwaprelB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 124) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/vop2.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/vop2.cpp
@@ -22,8 +22,10 @@ namespace rocjitsu {
 namespace rdna2 {
 
 VCndmaskB32Vop2::VCndmaskB32Vop2(const MachineInst *inst)
-    : Vop2("v_cndmask_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCndmaskB32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cndmask_b32_dpp"
+               : "v_cndmask_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCndmaskB32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -96,8 +98,10 @@ void VCndmaskB32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDot2cF32F16Vop2::VDot2cF32F16Vop2(const MachineInst *inst)
-    : Vop2("v_dot2c_f32_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VDot2cF32F16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_dot2c_f32_f16_dpp"
+               : "v_dot2c_f32_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDot2cF32F16Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -144,8 +148,10 @@ void VDot2cF32F16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddF32Vop2::VAddF32Vop2(const MachineInst *inst)
-    : Vop2("v_add_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAddF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_f32_dpp"
+               : "v_add_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -215,8 +221,10 @@ void VAddF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubF32Vop2::VSubF32Vop2(const MachineInst *inst)
-    : Vop2("v_sub_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_f32_dpp"
+               : "v_sub_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -286,8 +294,10 @@ void VSubF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubrevF32Vop2::VSubrevF32Vop2(const MachineInst *inst)
-    : Vop2("v_subrev_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubrevF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_subrev_f32_dpp"
+               : "v_subrev_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubrevF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_NOLDS, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -357,8 +367,10 @@ void VSubrevF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmacLegacyF32Vop2::VFmacLegacyF32Vop2(const MachineInst *inst)
-    : Vop2("v_fmac_legacy_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFmacLegacyF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmac_legacy_f32_dpp"
+               : "v_fmac_legacy_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmacLegacyF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -394,8 +406,10 @@ void VFmacLegacyF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulLegacyF32Vop2::VMulLegacyF32Vop2(const MachineInst *inst)
-    : Vop2("v_mul_legacy_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulLegacyF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_legacy_f32_dpp"
+               : "v_mul_legacy_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulLegacyF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -465,8 +479,10 @@ void VMulLegacyF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulF32Vop2::VMulF32Vop2(const MachineInst *inst)
-    : Vop2("v_mul_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_f32_dpp"
+               : "v_mul_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -536,8 +552,10 @@ void VMulF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulI32I24Vop2::VMulI32I24Vop2(const MachineInst *inst)
-    : Vop2("v_mul_i32_i24_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulI32I24Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_i32_i24_dpp"
+               : "v_mul_i32_i24_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulI32I24Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -607,8 +625,10 @@ void VMulI32I24Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulHiI32I24Vop2::VMulHiI32I24Vop2(const MachineInst *inst)
-    : Vop2("v_mul_hi_i32_i24_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulHiI32I24Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_hi_i32_i24_dpp"
+               : "v_mul_hi_i32_i24_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulHiI32I24Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -678,8 +698,10 @@ void VMulHiI32I24Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulU32U24Vop2::VMulU32U24Vop2(const MachineInst *inst)
-    : Vop2("v_mul_u32_u24_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulU32U24Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_u32_u24_dpp"
+               : "v_mul_u32_u24_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulU32U24Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -749,8 +771,10 @@ void VMulU32U24Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulHiU32U24Vop2::VMulHiU32U24Vop2(const MachineInst *inst)
-    : Vop2("v_mul_hi_u32_u24_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulHiU32U24Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_hi_u32_u24_dpp"
+               : "v_mul_hi_u32_u24_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulHiU32U24Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -820,8 +844,10 @@ void VMulHiU32U24Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDot4cI32I8Vop2::VDot4cI32I8Vop2(const MachineInst *inst)
-    : Vop2("v_dot4c_i32_i8_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VDot4cI32I8Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_dot4c_i32_i8_dpp"
+               : "v_dot4c_i32_i8_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDot4cI32I8Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -868,8 +894,10 @@ void VDot4cI32I8Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinF32Vop2::VMinF32Vop2(const MachineInst *inst)
-    : Vop2("v_min_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_f32_dpp"
+               : "v_min_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -939,8 +967,10 @@ void VMinF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxF32Vop2::VMaxF32Vop2(const MachineInst *inst)
-    : Vop2("v_max_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaxF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_f32_dpp"
+               : "v_max_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1010,8 +1040,10 @@ void VMaxF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinI32Vop2::VMinI32Vop2(const MachineInst *inst)
-    : Vop2("v_min_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinI32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_i32_dpp"
+               : "v_min_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinI32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1081,8 +1113,10 @@ void VMinI32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxI32Vop2::VMaxI32Vop2(const MachineInst *inst)
-    : Vop2("v_max_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaxI32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_i32_dpp"
+               : "v_max_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxI32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1152,8 +1186,10 @@ void VMaxI32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinU32Vop2::VMinU32Vop2(const MachineInst *inst)
-    : Vop2("v_min_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinU32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_u32_dpp"
+               : "v_min_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinU32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1223,8 +1259,10 @@ void VMinU32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxU32Vop2::VMaxU32Vop2(const MachineInst *inst)
-    : Vop2("v_max_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaxU32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_u32_dpp"
+               : "v_max_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxU32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1294,8 +1332,10 @@ void VMaxU32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLshrrevB32Vop2::VLshrrevB32Vop2(const MachineInst *inst)
-    : Vop2("v_lshrrev_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLshrrevB32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshrrev_b32_dpp"
+               : "v_lshrrev_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLshrrevB32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_NOLDS, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1365,8 +1405,10 @@ void VLshrrevB32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAshrrevI32Vop2::VAshrrevI32Vop2(const MachineInst *inst)
-    : Vop2("v_ashrrev_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAshrrevI32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ashrrev_i32_dpp"
+               : "v_ashrrev_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAshrrevI32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_NOLDS, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1436,8 +1478,10 @@ void VAshrrevI32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLshlrevB32Vop2::VLshlrevB32Vop2(const MachineInst *inst)
-    : Vop2("v_lshlrev_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLshlrevB32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshlrev_b32_dpp"
+               : "v_lshlrev_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLshlrevB32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_NOLDS, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1507,8 +1551,10 @@ void VLshlrevB32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAndB32Vop2::VAndB32Vop2(const MachineInst *inst)
-    : Vop2("v_and_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAndB32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_and_b32_dpp"
+               : "v_and_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAndB32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1578,7 +1624,10 @@ void VAndB32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VOrB32Vop2::VOrB32Vop2(const MachineInst *inst)
-    : Vop2("v_or_b32_e32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VOrB32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_or_b32_dpp"
+               : "v_or_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VOrB32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1648,8 +1697,10 @@ void VOrB32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VXorB32Vop2::VXorB32Vop2(const MachineInst *inst)
-    : Vop2("v_xor_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VXorB32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_xor_b32_dpp"
+               : "v_xor_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXorB32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1719,8 +1770,10 @@ void VXorB32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VXnorB32Vop2::VXnorB32Vop2(const MachineInst *inst)
-    : Vop2("v_xnor_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VXnorB32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_xnor_b32_dpp"
+               : "v_xnor_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXnorB32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1790,8 +1843,10 @@ void VXnorB32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddNcU32Vop2::VAddNcU32Vop2(const MachineInst *inst)
-    : Vop2("v_add_nc_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAddNcU32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_nc_u32_dpp"
+               : "v_add_nc_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddNcU32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1861,8 +1916,10 @@ void VAddNcU32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubNcU32Vop2::VSubNcU32Vop2(const MachineInst *inst)
-    : Vop2("v_sub_nc_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubNcU32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_nc_u32_dpp"
+               : "v_sub_nc_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubNcU32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1932,8 +1989,10 @@ void VSubNcU32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubrevNcU32Vop2::VSubrevNcU32Vop2(const MachineInst *inst)
-    : Vop2("v_subrev_nc_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubrevNcU32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_subrev_nc_u32_dpp"
+               : "v_subrev_nc_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubrevNcU32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_NOLDS, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2003,8 +2062,10 @@ void VSubrevNcU32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddCoCiU32Vop2::VAddCoCiU32Vop2(const MachineInst *inst)
-    : Vop2("v_add_co_ci_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAddCoCiU32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_co_ci_u32_dpp"
+               : "v_add_co_ci_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddCoCiU32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -2080,8 +2141,10 @@ void VAddCoCiU32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubCoCiU32Vop2::VSubCoCiU32Vop2(const MachineInst *inst)
-    : Vop2("v_sub_co_ci_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubCoCiU32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_co_ci_u32_dpp"
+               : "v_sub_co_ci_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubCoCiU32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -2157,8 +2220,10 @@ void VSubCoCiU32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubrevCoCiU32Vop2::VSubrevCoCiU32Vop2(const MachineInst *inst)
-    : Vop2("v_subrev_co_ci_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubrevCoCiU32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_subrev_co_ci_u32_dpp"
+               : "v_subrev_co_ci_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubrevCoCiU32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC_NOLDS, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -2234,8 +2299,10 @@ void VSubrevCoCiU32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmacF32Vop2::VFmacF32Vop2(const MachineInst *inst)
-    : Vop2("v_fmac_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFmacF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmac_f32_dpp"
+               : "v_fmac_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmacF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2282,8 +2349,10 @@ void VFmacF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmamkF32Vop2::VFmamkF32Vop2(const MachineInst *inst)
-    : Vop2("v_fmamk_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFmamkF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmamk_f32_dpp"
+               : "v_fmamk_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmamkF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       simm32(32, OperandType::OPR_SIMM32, 0),
@@ -2314,8 +2383,10 @@ void VFmamkF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmaakF32Vop2::VFmaakF32Vop2(const MachineInst *inst)
-    : Vop2("v_fmaak_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFmaakF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmaak_f32_dpp"
+               : "v_fmaak_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmaakF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -2346,8 +2417,10 @@ void VFmaakF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkrtzF16F32Vop2::VCvtPkrtzF16F32Vop2(const MachineInst *inst)
-    : Vop2("v_cvt_pkrtz_f16_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkrtzF16F32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pkrtz_f16_f32_dpp"
+               : "v_cvt_pkrtz_f16_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkrtzF16F32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2417,8 +2490,10 @@ void VCvtPkrtzF16F32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddF16Vop2::VAddF16Vop2(const MachineInst *inst)
-    : Vop2("v_add_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAddF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_f16_dpp"
+               : "v_add_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2495,8 +2570,10 @@ void VAddF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubF16Vop2::VSubF16Vop2(const MachineInst *inst)
-    : Vop2("v_sub_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_f16_dpp"
+               : "v_sub_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2573,8 +2650,10 @@ void VSubF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubrevF16Vop2::VSubrevF16Vop2(const MachineInst *inst)
-    : Vop2("v_subrev_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubrevF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_subrev_f16_dpp"
+               : "v_subrev_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubrevF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC_NOLDS, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2651,8 +2730,10 @@ void VSubrevF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulF16Vop2::VMulF16Vop2(const MachineInst *inst)
-    : Vop2("v_mul_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_f16_dpp"
+               : "v_mul_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2729,8 +2810,10 @@ void VMulF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmacF16Vop2::VFmacF16Vop2(const MachineInst *inst)
-    : Vop2("v_fmac_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFmacF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmac_f16_dpp"
+               : "v_fmac_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmacF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2784,8 +2867,10 @@ void VFmacF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmamkF16Vop2::VFmamkF16Vop2(const MachineInst *inst)
-    : Vop2("v_fmamk_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFmamkF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmamk_f16_dpp"
+               : "v_fmamk_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmamkF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       simm32(16, OperandType::OPR_SIMM32, 0),
@@ -2824,8 +2909,10 @@ void VFmamkF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmaakF16Vop2::VFmaakF16Vop2(const MachineInst *inst)
-    : Vop2("v_fmaak_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFmaakF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmaak_f16_dpp"
+               : "v_fmaak_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmaakF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -2864,8 +2951,10 @@ void VFmaakF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxF16Vop2::VMaxF16Vop2(const MachineInst *inst)
-    : Vop2("v_max_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaxF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_f16_dpp"
+               : "v_max_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2942,8 +3031,10 @@ void VMaxF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinF16Vop2::VMinF16Vop2(const MachineInst *inst)
-    : Vop2("v_min_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_f16_dpp"
+               : "v_min_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3020,8 +3111,10 @@ void VMinF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLdexpF16Vop2::VLdexpF16Vop2(const MachineInst *inst)
-    : Vop2("v_ldexp_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLdexpF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ldexp_f16_dpp"
+               : "v_ldexp_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLdexpF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3098,8 +3191,10 @@ void VLdexpF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkFmacF16Vop2::VPkFmacF16Vop2(const MachineInst *inst)
-    : Vop2("v_pk_fmac_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VPkFmacF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_pk_fmac_f16_dpp"
+               : "v_pk_fmac_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkFmacF16Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/encodings.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/encodings.cpp
@@ -137,6 +137,11 @@ Vop1::Vop1(std::string_view mnemonic, const Vop1MachineInst *inst, ExecuteFn exe
   raw_encoding_ = raw_words_.data();
 }
 
+void Vop1::build_modifiers(std::string &out) const {
+  if (amdgpu::dpp::is_src_dpp8(inst_.src0))
+    amdgpu::dpp::append_dpp8_disassembly(out, dpp8_lane_sel_, dpp_fi_);
+}
+
 void Vop1::implicit_uses(RegisterSet &uses) const {
   bool sdwa_preserve =
       sdwa_dst_sel_ != amdgpu::sdwa::DWORD && sdwa_dst_unused_ == amdgpu::sdwa::UNUSED_PRESERVE;
@@ -169,6 +174,11 @@ Vopc::Vopc(std::string_view mnemonic, const VopcMachineInst *inst, ExecuteFn exe
   raw_encoding_ = raw_words_.data();
 }
 
+void Vopc::build_modifiers(std::string &out) const {
+  if (amdgpu::dpp::is_src_dpp8(inst_.src0))
+    amdgpu::dpp::append_dpp8_disassembly(out, dpp8_lane_sel_, dpp_fi_);
+}
+
 bool Vopc::default_encoding() {
   return inst_.src0 != 250 && inst_.src0 != 233 && inst_.src0 != 234 && inst_.src0 != 255;
 }
@@ -187,6 +197,11 @@ Vop2::Vop2(std::string_view mnemonic, const Vop2MachineInst *inst, ExecuteFn exe
     literal_ = reinterpret_cast<const uint32_t *>(inst)[1];
   std::memcpy(raw_words_.data(), inst, size_);
   raw_encoding_ = raw_words_.data();
+}
+
+void Vop2::build_modifiers(std::string &out) const {
+  if (amdgpu::dpp::is_src_dpp8(inst_.src0))
+    amdgpu::dpp::append_dpp8_disassembly(out, dpp8_lane_sel_, dpp_fi_);
 }
 
 void Vop2::implicit_uses(RegisterSet &uses) const {
@@ -226,6 +241,11 @@ Vop3::Vop3(std::string_view mnemonic, const Vop3MachineInst *inst, ExecuteFn exe
     size_ += sizeof(MachineInst);
   std::memcpy(raw_words_.data(), inst, size_);
   raw_encoding_ = raw_words_.data();
+}
+
+void Vop3::build_modifiers(std::string &out) const {
+  if (amdgpu::dpp::is_src_dpp8(inst_.src0))
+    amdgpu::dpp::append_dpp8_disassembly(out, dpp8_lane_sel_, dpp_fi_);
 }
 
 void Vop3::implicit_uses(RegisterSet &uses) const {
@@ -282,6 +302,11 @@ Vop3p::Vop3p(std::string_view mnemonic, const Vop3pMachineInst *inst, ExecuteFn 
     size_ += sizeof(MachineInst);
   std::memcpy(raw_words_.data(), inst, size_);
   raw_encoding_ = raw_words_.data();
+}
+
+void Vop3p::build_modifiers(std::string &out) const {
+  if (amdgpu::dpp::is_src_dpp8(inst_.src0))
+    amdgpu::dpp::append_dpp8_disassembly(out, dpp8_lane_sel_, dpp_fi_);
 }
 
 void Vop3p::implicit_uses(RegisterSet &uses) const {
@@ -465,6 +490,11 @@ Vop3SdstEnc::Vop3SdstEnc(std::string_view mnemonic, const Vop3SdstEncMachineInst
     size_ += sizeof(MachineInst);
   std::memcpy(raw_words_.data(), inst, size_);
   raw_encoding_ = raw_words_.data();
+}
+
+void Vop3SdstEnc::build_modifiers(std::string &out) const {
+  if (amdgpu::dpp::is_src_dpp8(inst_.src0))
+    amdgpu::dpp::append_dpp8_disassembly(out, dpp8_lane_sel_, dpp_fi_);
 }
 
 void Vop3SdstEnc::implicit_uses(RegisterSet &uses) const {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/encodings.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/encodings.h
@@ -403,6 +403,7 @@ public:
 class Vop1 : public IsaInstruction<Isa> {
 public:
   Vop1(std::string_view mnemonic, const Vop1MachineInst *inst, ExecuteFn exec_fn);
+  void build_modifiers(std::string &out) const override;
   void implicit_uses(RegisterSet &uses) const override;
   bool default_encoding();
   bool has_lit();
@@ -433,6 +434,7 @@ public:
 class Vopc : public IsaInstruction<Isa> {
 public:
   Vopc(std::string_view mnemonic, const VopcMachineInst *inst, ExecuteFn exec_fn);
+  void build_modifiers(std::string &out) const override;
   bool default_encoding();
   bool has_lit();
   using OpEncoding = VopcMachineInst;
@@ -461,6 +463,7 @@ public:
 class Vop2 : public IsaInstruction<Isa> {
 public:
   Vop2(std::string_view mnemonic, const Vop2MachineInst *inst, ExecuteFn exec_fn);
+  void build_modifiers(std::string &out) const override;
   void implicit_uses(RegisterSet &uses) const override;
   bool default_encoding();
   bool has_lit();
@@ -493,6 +496,7 @@ public:
 class Vop3 : public IsaInstruction<Isa> {
 public:
   Vop3(std::string_view mnemonic, const Vop3MachineInst *inst, ExecuteFn exec_fn);
+  void build_modifiers(std::string &out) const override;
   void implicit_uses(RegisterSet &uses) const override;
   bool has_lit_0();
   bool has_lit_1();
@@ -517,6 +521,7 @@ public:
 class Vop3p : public IsaInstruction<Isa> {
 public:
   Vop3p(std::string_view mnemonic, const Vop3pMachineInst *inst, ExecuteFn exec_fn);
+  void build_modifiers(std::string &out) const override;
   void implicit_uses(RegisterSet &uses) const override;
   bool has_lit_0();
   bool has_lit_1();
@@ -604,6 +609,7 @@ public:
 class Vop3SdstEnc : public IsaInstruction<Isa> {
 public:
   Vop3SdstEnc(std::string_view mnemonic, const Vop3SdstEncMachineInst *inst, ExecuteFn exec_fn);
+  void build_modifiers(std::string &out) const override;
   void implicit_uses(RegisterSet &uses) const override;
   bool has_lit_0();
   bool has_lit_1();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/vop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/vop1.cpp
@@ -22,7 +22,9 @@ namespace rocjitsu {
 namespace rdna3 {
 
 VNopVop1::VNopVop1(const MachineInst *inst)
-    : Vop1("v_nop_e32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VNopVop1>()) {
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0) ? "v_nop_dpp"
+                                                                                      : "v_nop_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VNopVop1>()) {
   num_src_ = 0;
   num_dst_ = 0;
 }
@@ -30,8 +32,10 @@ VNopVop1::VNopVop1(const MachineInst *inst)
 void VNopVop1::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_nop_vop1(*this, wf); }
 
 VMovB32Vop1::VMovB32Vop1(const MachineInst *inst)
-    : Vop1("v_mov_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMovB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mov_b32_dpp"
+               : "v_mov_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -72,8 +76,10 @@ void VMovB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VReadfirstlaneB32Vop1::VReadfirstlaneB32Vop1(const MachineInst *inst)
-    : Vop1("v_readfirstlane_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VReadfirstlaneB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_readfirstlane_b32_dpp"
+               : "v_readfirstlane_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VReadfirstlaneB32Vop1>()),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -102,8 +108,10 @@ void VReadfirstlaneB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtI32F64Vop1::VCvtI32F64Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_i32_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtI32F64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_i32_f64_dpp"
+               : "v_cvt_i32_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtI32F64Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -125,8 +133,10 @@ void VCvtI32F64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF64I32Vop1::VCvtF64I32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f64_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF64I32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f64_i32_dpp"
+               : "v_cvt_f64_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF64I32Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -147,8 +157,10 @@ void VCvtF64I32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32I32Vop1::VCvtF32I32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32I32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_i32_dpp"
+               : "v_cvt_f32_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32I32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -189,8 +201,10 @@ void VCvtF32I32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32U32Vop1::VCvtF32U32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32U32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_u32_dpp"
+               : "v_cvt_f32_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32U32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -231,8 +245,10 @@ void VCvtF32U32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtU32F32Vop1::VCvtU32F32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_u32_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtU32F32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_u32_f32_dpp"
+               : "v_cvt_u32_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtU32F32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -273,8 +289,10 @@ void VCvtU32F32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtI32F32Vop1::VCvtI32F32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_i32_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtI32F32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_i32_f32_dpp"
+               : "v_cvt_i32_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtI32F32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -315,8 +333,10 @@ void VCvtI32F32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF16F32Vop1::VCvtF16F32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f16_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF16F32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f16_f32_dpp"
+               : "v_cvt_f16_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF16F32Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -374,8 +394,10 @@ void VCvtF16F32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32F16Vop1::VCvtF32F16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32F16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_f16_dpp"
+               : "v_cvt_f32_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32F16Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true) {
@@ -418,8 +440,10 @@ void VCvtF32F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtNearestI32F32Vop1::VCvtNearestI32F32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_nearest_i32_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtNearestI32F32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_nearest_i32_f32_dpp"
+               : "v_cvt_nearest_i32_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtNearestI32F32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -460,8 +484,10 @@ void VCvtNearestI32F32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtFloorI32F32Vop1::VCvtFloorI32F32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_floor_i32_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtFloorI32F32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_floor_i32_f32_dpp"
+               : "v_cvt_floor_i32_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtFloorI32F32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -502,8 +528,10 @@ void VCvtFloorI32F32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtOffF32I4Vop1::VCvtOffF32I4Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_off_f32_i4_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtOffF32I4Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_off_f32_i4_dpp"
+               : "v_cvt_off_f32_i4_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtOffF32I4Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -544,8 +572,10 @@ void VCvtOffF32I4Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32F64Vop1::VCvtF32F64Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32F64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_f64_dpp"
+               : "v_cvt_f32_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32F64Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -567,8 +597,10 @@ void VCvtF32F64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF64F32Vop1::VCvtF64F32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f64_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF64F32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f64_f32_dpp"
+               : "v_cvt_f64_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF64F32Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -589,8 +621,10 @@ void VCvtF64F32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32Ubyte0Vop1::VCvtF32Ubyte0Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_ubyte0_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32Ubyte0Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_ubyte0_dpp"
+               : "v_cvt_f32_ubyte0_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32Ubyte0Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -631,8 +665,10 @@ void VCvtF32Ubyte0Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32Ubyte1Vop1::VCvtF32Ubyte1Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_ubyte1_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32Ubyte1Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_ubyte1_dpp"
+               : "v_cvt_f32_ubyte1_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32Ubyte1Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -673,8 +709,10 @@ void VCvtF32Ubyte1Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32Ubyte2Vop1::VCvtF32Ubyte2Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_ubyte2_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32Ubyte2Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_ubyte2_dpp"
+               : "v_cvt_f32_ubyte2_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32Ubyte2Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -715,8 +753,10 @@ void VCvtF32Ubyte2Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32Ubyte3Vop1::VCvtF32Ubyte3Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_ubyte3_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32Ubyte3Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_ubyte3_dpp"
+               : "v_cvt_f32_ubyte3_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32Ubyte3Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -757,8 +797,10 @@ void VCvtF32Ubyte3Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtU32F64Vop1::VCvtU32F64Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_u32_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtU32F64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_u32_f64_dpp"
+               : "v_cvt_u32_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtU32F64Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -780,8 +822,10 @@ void VCvtU32F64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF64U32Vop1::VCvtF64U32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f64_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF64U32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f64_u32_dpp"
+               : "v_cvt_f64_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF64U32Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -802,8 +846,10 @@ void VCvtF64U32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VTruncF64Vop1::VTruncF64Vop1(const MachineInst *inst)
-    : Vop1("v_trunc_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VTruncF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_trunc_f64_dpp"
+               : "v_trunc_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VTruncF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -825,8 +871,10 @@ void VTruncF64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCeilF64Vop1::VCeilF64Vop1(const MachineInst *inst)
-    : Vop1("v_ceil_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCeilF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ceil_f64_dpp"
+               : "v_ceil_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCeilF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -848,8 +896,10 @@ void VCeilF64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRndneF64Vop1::VRndneF64Vop1(const MachineInst *inst)
-    : Vop1("v_rndne_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRndneF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rndne_f64_dpp"
+               : "v_rndne_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRndneF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -871,8 +921,10 @@ void VRndneF64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFloorF64Vop1::VFloorF64Vop1(const MachineInst *inst)
-    : Vop1("v_floor_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFloorF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_floor_f64_dpp"
+               : "v_floor_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFloorF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -894,8 +946,10 @@ void VFloorF64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPipeflushVop1::VPipeflushVop1(const MachineInst *inst)
-    : Vop1("v_pipeflush_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VPipeflushVop1>()) {
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_pipeflush_dpp"
+               : "v_pipeflush_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPipeflushVop1>()) {
   num_src_ = 0;
   num_dst_ = 0;
 }
@@ -905,8 +959,10 @@ void VPipeflushVop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMovB16Vop1::VMovB16Vop1(const MachineInst *inst)
-    : Vop1("v_mov_b16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMovB16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mov_b16_dpp"
+               : "v_mov_b16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovB16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -965,8 +1021,10 @@ void VMovB16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFractF32Vop1::VFractF32Vop1(const MachineInst *inst)
-    : Vop1("v_fract_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFractF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fract_f32_dpp"
+               : "v_fract_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFractF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1007,8 +1065,10 @@ void VFractF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VTruncF32Vop1::VTruncF32Vop1(const MachineInst *inst)
-    : Vop1("v_trunc_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VTruncF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_trunc_f32_dpp"
+               : "v_trunc_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VTruncF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1049,8 +1109,10 @@ void VTruncF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCeilF32Vop1::VCeilF32Vop1(const MachineInst *inst)
-    : Vop1("v_ceil_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCeilF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ceil_f32_dpp"
+               : "v_ceil_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCeilF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1091,8 +1153,10 @@ void VCeilF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRndneF32Vop1::VRndneF32Vop1(const MachineInst *inst)
-    : Vop1("v_rndne_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRndneF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rndne_f32_dpp"
+               : "v_rndne_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRndneF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1133,8 +1197,10 @@ void VRndneF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFloorF32Vop1::VFloorF32Vop1(const MachineInst *inst)
-    : Vop1("v_floor_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFloorF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_floor_f32_dpp"
+               : "v_floor_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFloorF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1175,8 +1241,10 @@ void VFloorF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VExpF32Vop1::VExpF32Vop1(const MachineInst *inst)
-    : Vop1("v_exp_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VExpF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_exp_f32_dpp"
+               : "v_exp_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VExpF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1217,8 +1285,10 @@ void VExpF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLogF32Vop1::VLogF32Vop1(const MachineInst *inst)
-    : Vop1("v_log_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLogF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_log_f32_dpp"
+               : "v_log_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLogF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1259,8 +1329,10 @@ void VLogF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRcpF32Vop1::VRcpF32Vop1(const MachineInst *inst)
-    : Vop1("v_rcp_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRcpF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_f32_dpp"
+               : "v_rcp_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1301,8 +1373,10 @@ void VRcpF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRcpIflagF32Vop1::VRcpIflagF32Vop1(const MachineInst *inst)
-    : Vop1("v_rcp_iflag_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRcpIflagF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_iflag_f32_dpp"
+               : "v_rcp_iflag_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpIflagF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1343,8 +1417,10 @@ void VRcpIflagF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRsqF32Vop1::VRsqF32Vop1(const MachineInst *inst)
-    : Vop1("v_rsq_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRsqF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rsq_f32_dpp"
+               : "v_rsq_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRsqF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1385,8 +1461,10 @@ void VRsqF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRcpF64Vop1::VRcpF64Vop1(const MachineInst *inst)
-    : Vop1("v_rcp_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRcpF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_f64_dpp"
+               : "v_rcp_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1406,8 +1484,10 @@ VRcpF64Vop1::VRcpF64Vop1(const MachineInst *inst)
 void VRcpF64Vop1::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_rcp_f64_vop1(*this, wf); }
 
 VRsqF64Vop1::VRsqF64Vop1(const MachineInst *inst)
-    : Vop1("v_rsq_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRsqF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rsq_f64_dpp"
+               : "v_rsq_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRsqF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1427,8 +1507,10 @@ VRsqF64Vop1::VRsqF64Vop1(const MachineInst *inst)
 void VRsqF64Vop1::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_rsq_f64_vop1(*this, wf); }
 
 VSqrtF32Vop1::VSqrtF32Vop1(const MachineInst *inst)
-    : Vop1("v_sqrt_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSqrtF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sqrt_f32_dpp"
+               : "v_sqrt_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSqrtF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1469,8 +1551,10 @@ void VSqrtF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSqrtF64Vop1::VSqrtF64Vop1(const MachineInst *inst)
-    : Vop1("v_sqrt_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSqrtF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sqrt_f64_dpp"
+               : "v_sqrt_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSqrtF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1492,8 +1576,10 @@ void VSqrtF64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSinF32Vop1::VSinF32Vop1(const MachineInst *inst)
-    : Vop1("v_sin_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSinF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sin_f32_dpp"
+               : "v_sin_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSinF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1534,8 +1620,10 @@ void VSinF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCosF32Vop1::VCosF32Vop1(const MachineInst *inst)
-    : Vop1("v_cos_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCosF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cos_f32_dpp"
+               : "v_cos_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCosF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1576,8 +1664,10 @@ void VCosF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VNotB32Vop1::VNotB32Vop1(const MachineInst *inst)
-    : Vop1("v_not_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VNotB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_not_b32_dpp"
+               : "v_not_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VNotB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1618,8 +1708,10 @@ void VNotB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VBfrevB32Vop1::VBfrevB32Vop1(const MachineInst *inst)
-    : Vop1("v_bfrev_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VBfrevB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_bfrev_b32_dpp"
+               : "v_bfrev_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VBfrevB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1660,8 +1752,10 @@ void VBfrevB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VClzI32U32Vop1::VClzI32U32Vop1(const MachineInst *inst)
-    : Vop1("v_clz_i32_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VClzI32U32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_clz_i32_u32_dpp"
+               : "v_clz_i32_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VClzI32U32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1702,8 +1796,10 @@ void VClzI32U32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCtzI32B32Vop1::VCtzI32B32Vop1(const MachineInst *inst)
-    : Vop1("v_ctz_i32_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCtzI32B32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ctz_i32_b32_dpp"
+               : "v_ctz_i32_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCtzI32B32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1744,8 +1840,10 @@ void VCtzI32B32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VClsI32Vop1::VClsI32Vop1(const MachineInst *inst)
-    : Vop1("v_cls_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VClsI32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cls_i32_dpp"
+               : "v_cls_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VClsI32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1786,8 +1884,10 @@ void VClsI32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpExpI32F64Vop1::VFrexpExpI32F64Vop1(const MachineInst *inst)
-    : Vop1("v_frexp_exp_i32_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpExpI32F64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_exp_i32_f64_dpp"
+               : "v_frexp_exp_i32_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpExpI32F64Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1809,8 +1909,10 @@ void VFrexpExpI32F64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpMantF64Vop1::VFrexpMantF64Vop1(const MachineInst *inst)
-    : Vop1("v_frexp_mant_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpMantF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_mant_f64_dpp"
+               : "v_frexp_mant_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpMantF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1832,8 +1934,10 @@ void VFrexpMantF64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFractF64Vop1::VFractF64Vop1(const MachineInst *inst)
-    : Vop1("v_fract_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFractF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fract_f64_dpp"
+               : "v_fract_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFractF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1855,8 +1959,10 @@ void VFractF64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpExpI32F32Vop1::VFrexpExpI32F32Vop1(const MachineInst *inst)
-    : Vop1("v_frexp_exp_i32_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpExpI32F32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_exp_i32_f32_dpp"
+               : "v_frexp_exp_i32_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpExpI32F32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1897,8 +2003,10 @@ void VFrexpExpI32F32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpMantF32Vop1::VFrexpMantF32Vop1(const MachineInst *inst)
-    : Vop1("v_frexp_mant_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpMantF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_mant_f32_dpp"
+               : "v_frexp_mant_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpMantF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1939,8 +2047,10 @@ void VFrexpMantF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMovreldB32Vop1::VMovreldB32Vop1(const MachineInst *inst)
-    : Vop1("v_movreld_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMovreldB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_movreld_b32_dpp"
+               : "v_movreld_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovreldB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -1997,8 +2107,10 @@ void VMovreldB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMovrelsB32Vop1::VMovrelsB32Vop1(const MachineInst *inst)
-    : Vop1("v_movrels_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMovrelsB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_movrels_b32_dpp"
+               : "v_movrels_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovrelsB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -2055,8 +2167,10 @@ void VMovrelsB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMovrelsdB32Vop1::VMovrelsdB32Vop1(const MachineInst *inst)
-    : Vop1("v_movrelsd_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMovrelsdB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_movrelsd_b32_dpp"
+               : "v_movrelsd_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovrelsdB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -2095,8 +2209,10 @@ void VMovrelsdB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMovrelsd2B32Vop1::VMovrelsd2B32Vop1(const MachineInst *inst)
-    : Vop1("v_movrelsd_2_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMovrelsd2B32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_movrelsd_2_b32_dpp"
+               : "v_movrelsd_2_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovrelsd2B32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -2135,8 +2251,10 @@ void VMovrelsd2B32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF16U16Vop1::VCvtF16U16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f16_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF16U16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f16_u16_dpp"
+               : "v_cvt_f16_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF16U16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2196,8 +2314,10 @@ void VCvtF16U16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF16I16Vop1::VCvtF16I16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f16_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF16I16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f16_i16_dpp"
+               : "v_cvt_f16_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF16I16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2257,8 +2377,10 @@ void VCvtF16I16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtU16F16Vop1::VCvtU16F16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_u16_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtU16F16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_u16_f16_dpp"
+               : "v_cvt_u16_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtU16F16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2322,8 +2444,10 @@ void VCvtU16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtI16F16Vop1::VCvtI16F16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_i16_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtI16F16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_i16_f16_dpp"
+               : "v_cvt_i16_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtI16F16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2389,8 +2513,10 @@ void VCvtI16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRcpF16Vop1::VRcpF16Vop1(const MachineInst *inst)
-    : Vop1("v_rcp_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRcpF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_f16_dpp"
+               : "v_rcp_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2451,8 +2577,10 @@ void VRcpF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSqrtF16Vop1::VSqrtF16Vop1(const MachineInst *inst)
-    : Vop1("v_sqrt_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSqrtF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sqrt_f16_dpp"
+               : "v_sqrt_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSqrtF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2513,8 +2641,10 @@ void VSqrtF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRsqF16Vop1::VRsqF16Vop1(const MachineInst *inst)
-    : Vop1("v_rsq_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRsqF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rsq_f16_dpp"
+               : "v_rsq_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRsqF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2575,8 +2705,10 @@ void VRsqF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLogF16Vop1::VLogF16Vop1(const MachineInst *inst)
-    : Vop1("v_log_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLogF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_log_f16_dpp"
+               : "v_log_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLogF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2637,8 +2769,10 @@ void VLogF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VExpF16Vop1::VExpF16Vop1(const MachineInst *inst)
-    : Vop1("v_exp_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VExpF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_exp_f16_dpp"
+               : "v_exp_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VExpF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2699,8 +2833,10 @@ void VExpF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpMantF16Vop1::VFrexpMantF16Vop1(const MachineInst *inst)
-    : Vop1("v_frexp_mant_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpMantF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_mant_f16_dpp"
+               : "v_frexp_mant_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpMantF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2765,8 +2901,10 @@ void VFrexpMantF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpExpI16F16Vop1::VFrexpExpI16F16Vop1(const MachineInst *inst)
-    : Vop1("v_frexp_exp_i16_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpExpI16F16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_exp_i16_f16_dpp"
+               : "v_frexp_exp_i16_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpExpI16F16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2832,8 +2970,10 @@ void VFrexpExpI16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFloorF16Vop1::VFloorF16Vop1(const MachineInst *inst)
-    : Vop1("v_floor_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFloorF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_floor_f16_dpp"
+               : "v_floor_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFloorF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2893,8 +3033,10 @@ void VFloorF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCeilF16Vop1::VCeilF16Vop1(const MachineInst *inst)
-    : Vop1("v_ceil_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCeilF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ceil_f16_dpp"
+               : "v_ceil_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCeilF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2954,8 +3096,10 @@ void VCeilF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VTruncF16Vop1::VTruncF16Vop1(const MachineInst *inst)
-    : Vop1("v_trunc_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VTruncF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_trunc_f16_dpp"
+               : "v_trunc_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VTruncF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -3015,8 +3159,10 @@ void VTruncF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRndneF16Vop1::VRndneF16Vop1(const MachineInst *inst)
-    : Vop1("v_rndne_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRndneF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rndne_f16_dpp"
+               : "v_rndne_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRndneF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -3076,8 +3222,10 @@ void VRndneF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFractF16Vop1::VFractF16Vop1(const MachineInst *inst)
-    : Vop1("v_fract_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFractF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fract_f16_dpp"
+               : "v_fract_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFractF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -3140,8 +3288,10 @@ void VFractF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSinF16Vop1::VSinF16Vop1(const MachineInst *inst)
-    : Vop1("v_sin_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSinF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sin_f16_dpp"
+               : "v_sin_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSinF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -3202,8 +3352,10 @@ void VSinF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCosF16Vop1::VCosF16Vop1(const MachineInst *inst)
-    : Vop1("v_cos_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCosF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cos_f16_dpp"
+               : "v_cos_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCosF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -3264,8 +3416,10 @@ void VCosF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSatPkU8I16Vop1::VSatPkU8I16Vop1(const MachineInst *inst)
-    : Vop1("v_sat_pk_u8_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSatPkU8I16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sat_pk_u8_i16_dpp"
+               : "v_sat_pk_u8_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSatPkU8I16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -3309,8 +3463,10 @@ void VSatPkU8I16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtNormI16F16Vop1::VCvtNormI16F16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_norm_i16_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtNormI16F16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_norm_i16_f16_dpp"
+               : "v_cvt_norm_i16_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtNormI16F16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -3373,8 +3529,10 @@ void VCvtNormI16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtNormU16F16Vop1::VCvtNormU16F16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_norm_u16_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtNormU16F16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_norm_u16_f16_dpp"
+               : "v_cvt_norm_u16_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtNormU16F16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -3437,8 +3595,10 @@ void VCvtNormU16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSwapB32Vop1::VSwapB32Vop1(const MachineInst *inst)
-    : Vop1("v_swap_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSwapB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_swap_b32_dpp"
+               : "v_swap_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSwapB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   src_operands_[0] = &vdst;
@@ -3469,8 +3629,10 @@ void VSwapB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSwapB16Vop1::VSwapB16Vop1(const MachineInst *inst)
-    : Vop1("v_swap_b16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSwapB16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_swap_b16_dpp"
+               : "v_swap_b16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSwapB16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), true,
            true),
@@ -3515,8 +3677,10 @@ void VSwapB16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPermlane64B32Vop1::VPermlane64B32Vop1(const MachineInst *inst)
-    : Vop1("v_permlane64_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VPermlane64B32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_permlane64_b32_dpp"
+               : "v_permlane64_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPermlane64B32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3537,8 +3701,10 @@ void VPermlane64B32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSwaprelB32Vop1::VSwaprelB32Vop1(const MachineInst *inst)
-    : Vop1("v_swaprel_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSwaprelB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_swaprel_b32_dpp"
+               : "v_swaprel_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSwaprelB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -3565,8 +3731,10 @@ void VSwaprelB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VNotB16Vop1::VNotB16Vop1(const MachineInst *inst)
-    : Vop1("v_not_b16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VNotB16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_not_b16_dpp"
+               : "v_not_b16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VNotB16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -3624,8 +3792,10 @@ void VNotB16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtI32I16Vop1::VCvtI32I16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_i32_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtI32I16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_i32_i16_dpp"
+               : "v_cvt_i32_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtI32I16Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true) {
@@ -3668,8 +3838,10 @@ void VCvtI32I16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtU32U16Vop1::VCvtU32U16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_u32_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtU32U16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_u32_u16_dpp"
+               : "v_cvt_u32_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtU32U16Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/vop2.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/vop2.cpp
@@ -22,8 +22,10 @@ namespace rocjitsu {
 namespace rdna3 {
 
 VCndmaskB32Vop2::VCndmaskB32Vop2(const MachineInst *inst)
-    : Vop2("v_cndmask_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCndmaskB32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cndmask_b32_dpp"
+               : "v_cndmask_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCndmaskB32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -70,8 +72,10 @@ void VCndmaskB32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDot2accF32F16Vop2::VDot2accF32F16Vop2(const MachineInst *inst)
-    : Vop2("v_dot2acc_f32_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VDot2accF32F16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_dot2acc_f32_f16_dpp"
+               : "v_dot2acc_f32_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDot2accF32F16Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -116,8 +120,10 @@ void VDot2accF32F16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddF32Vop2::VAddF32Vop2(const MachineInst *inst)
-    : Vop2("v_add_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAddF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_f32_dpp"
+               : "v_add_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -161,8 +167,10 @@ void VAddF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubF32Vop2::VSubF32Vop2(const MachineInst *inst)
-    : Vop2("v_sub_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_f32_dpp"
+               : "v_sub_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -206,8 +214,10 @@ void VSubF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubrevF32Vop2::VSubrevF32Vop2(const MachineInst *inst)
-    : Vop2("v_subrev_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubrevF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_subrev_f32_dpp"
+               : "v_subrev_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubrevF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -251,8 +261,10 @@ void VSubrevF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmacDx9ZeroF32Vop2::VFmacDx9ZeroF32Vop2(const MachineInst *inst)
-    : Vop2("v_fmac_dx9_zero_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFmacDx9ZeroF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmac_dx9_zero_f32_dpp"
+               : "v_fmac_dx9_zero_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmacDx9ZeroF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -276,8 +288,10 @@ void VFmacDx9ZeroF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulDx9ZeroF32Vop2::VMulDx9ZeroF32Vop2(const MachineInst *inst)
-    : Vop2("v_mul_dx9_zero_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulDx9ZeroF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_dx9_zero_f32_dpp"
+               : "v_mul_dx9_zero_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulDx9ZeroF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -321,8 +335,10 @@ void VMulDx9ZeroF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulF32Vop2::VMulF32Vop2(const MachineInst *inst)
-    : Vop2("v_mul_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_f32_dpp"
+               : "v_mul_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -366,8 +382,10 @@ void VMulF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulI32I24Vop2::VMulI32I24Vop2(const MachineInst *inst)
-    : Vop2("v_mul_i32_i24_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulI32I24Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_i32_i24_dpp"
+               : "v_mul_i32_i24_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulI32I24Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -411,8 +429,10 @@ void VMulI32I24Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulHiI32I24Vop2::VMulHiI32I24Vop2(const MachineInst *inst)
-    : Vop2("v_mul_hi_i32_i24_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulHiI32I24Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_hi_i32_i24_dpp"
+               : "v_mul_hi_i32_i24_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulHiI32I24Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -456,8 +476,10 @@ void VMulHiI32I24Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulU32U24Vop2::VMulU32U24Vop2(const MachineInst *inst)
-    : Vop2("v_mul_u32_u24_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulU32U24Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_u32_u24_dpp"
+               : "v_mul_u32_u24_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulU32U24Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -501,8 +523,10 @@ void VMulU32U24Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulHiU32U24Vop2::VMulHiU32U24Vop2(const MachineInst *inst)
-    : Vop2("v_mul_hi_u32_u24_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulHiU32U24Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_hi_u32_u24_dpp"
+               : "v_mul_hi_u32_u24_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulHiU32U24Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -546,8 +570,10 @@ void VMulHiU32U24Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinF32Vop2::VMinF32Vop2(const MachineInst *inst)
-    : Vop2("v_min_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_f32_dpp"
+               : "v_min_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -591,8 +617,10 @@ void VMinF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxF32Vop2::VMaxF32Vop2(const MachineInst *inst)
-    : Vop2("v_max_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaxF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_f32_dpp"
+               : "v_max_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -636,8 +664,10 @@ void VMaxF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinI32Vop2::VMinI32Vop2(const MachineInst *inst)
-    : Vop2("v_min_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinI32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_i32_dpp"
+               : "v_min_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinI32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -681,8 +711,10 @@ void VMinI32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxI32Vop2::VMaxI32Vop2(const MachineInst *inst)
-    : Vop2("v_max_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaxI32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_i32_dpp"
+               : "v_max_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxI32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -726,8 +758,10 @@ void VMaxI32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinU32Vop2::VMinU32Vop2(const MachineInst *inst)
-    : Vop2("v_min_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinU32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_u32_dpp"
+               : "v_min_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinU32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -771,8 +805,10 @@ void VMinU32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxU32Vop2::VMaxU32Vop2(const MachineInst *inst)
-    : Vop2("v_max_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaxU32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_u32_dpp"
+               : "v_max_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxU32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -816,8 +852,10 @@ void VMaxU32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLshlrevB32Vop2::VLshlrevB32Vop2(const MachineInst *inst)
-    : Vop2("v_lshlrev_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLshlrevB32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshlrev_b32_dpp"
+               : "v_lshlrev_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLshlrevB32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -861,8 +899,10 @@ void VLshlrevB32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLshrrevB32Vop2::VLshrrevB32Vop2(const MachineInst *inst)
-    : Vop2("v_lshrrev_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLshrrevB32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshrrev_b32_dpp"
+               : "v_lshrrev_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLshrrevB32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -906,8 +946,10 @@ void VLshrrevB32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAshrrevI32Vop2::VAshrrevI32Vop2(const MachineInst *inst)
-    : Vop2("v_ashrrev_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAshrrevI32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ashrrev_i32_dpp"
+               : "v_ashrrev_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAshrrevI32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -951,8 +993,10 @@ void VAshrrevI32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAndB32Vop2::VAndB32Vop2(const MachineInst *inst)
-    : Vop2("v_and_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAndB32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_and_b32_dpp"
+               : "v_and_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAndB32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -996,7 +1040,10 @@ void VAndB32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VOrB32Vop2::VOrB32Vop2(const MachineInst *inst)
-    : Vop2("v_or_b32_e32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VOrB32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_or_b32_dpp"
+               : "v_or_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VOrB32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1040,8 +1087,10 @@ void VOrB32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VXorB32Vop2::VXorB32Vop2(const MachineInst *inst)
-    : Vop2("v_xor_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VXorB32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_xor_b32_dpp"
+               : "v_xor_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXorB32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1085,8 +1134,10 @@ void VXorB32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VXnorB32Vop2::VXnorB32Vop2(const MachineInst *inst)
-    : Vop2("v_xnor_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VXnorB32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_xnor_b32_dpp"
+               : "v_xnor_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXnorB32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1130,8 +1181,10 @@ void VXnorB32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddCoCiU32Vop2::VAddCoCiU32Vop2(const MachineInst *inst)
-    : Vop2("v_add_co_ci_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAddCoCiU32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_co_ci_u32_dpp"
+               : "v_add_co_ci_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddCoCiU32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -1181,8 +1234,10 @@ void VAddCoCiU32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubCoCiU32Vop2::VSubCoCiU32Vop2(const MachineInst *inst)
-    : Vop2("v_sub_co_ci_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubCoCiU32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_co_ci_u32_dpp"
+               : "v_sub_co_ci_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubCoCiU32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -1232,8 +1287,10 @@ void VSubCoCiU32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubrevCoCiU32Vop2::VSubrevCoCiU32Vop2(const MachineInst *inst)
-    : Vop2("v_subrev_co_ci_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubrevCoCiU32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_subrev_co_ci_u32_dpp"
+               : "v_subrev_co_ci_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubrevCoCiU32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -1283,8 +1340,10 @@ void VSubrevCoCiU32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddNcU32Vop2::VAddNcU32Vop2(const MachineInst *inst)
-    : Vop2("v_add_nc_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAddNcU32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_nc_u32_dpp"
+               : "v_add_nc_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddNcU32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1328,8 +1387,10 @@ void VAddNcU32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubNcU32Vop2::VSubNcU32Vop2(const MachineInst *inst)
-    : Vop2("v_sub_nc_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubNcU32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_nc_u32_dpp"
+               : "v_sub_nc_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubNcU32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1373,8 +1434,10 @@ void VSubNcU32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubrevNcU32Vop2::VSubrevNcU32Vop2(const MachineInst *inst)
-    : Vop2("v_subrev_nc_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubrevNcU32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_subrev_nc_u32_dpp"
+               : "v_subrev_nc_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubrevNcU32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1418,8 +1481,10 @@ void VSubrevNcU32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmacF32Vop2::VFmacF32Vop2(const MachineInst *inst)
-    : Vop2("v_fmac_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFmacF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmac_f32_dpp"
+               : "v_fmac_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmacF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1464,8 +1529,10 @@ void VFmacF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmamkF32Vop2::VFmamkF32Vop2(const MachineInst *inst)
-    : Vop2("v_fmamk_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFmamkF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmamk_f32_dpp"
+               : "v_fmamk_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmamkF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       simm32(32, OperandType::OPR_SIMM32, 0),
@@ -1494,8 +1561,10 @@ void VFmamkF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmaakF32Vop2::VFmaakF32Vop2(const MachineInst *inst)
-    : Vop2("v_fmaak_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFmaakF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmaak_f32_dpp"
+               : "v_fmaak_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmaakF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -1524,8 +1593,10 @@ void VFmaakF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkRtzF16F32Vop2::VCvtPkRtzF16F32Vop2(const MachineInst *inst)
-    : Vop2("v_cvt_pk_rtz_f16_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkRtzF16F32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_rtz_f16_f32_dpp"
+               : "v_cvt_pk_rtz_f16_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkRtzF16F32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1569,8 +1640,10 @@ void VCvtPkRtzF16F32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddF16Vop2::VAddF16Vop2(const MachineInst *inst)
-    : Vop2("v_add_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAddF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_f16_dpp"
+               : "v_add_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -1636,8 +1709,10 @@ void VAddF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubF16Vop2::VSubF16Vop2(const MachineInst *inst)
-    : Vop2("v_sub_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_f16_dpp"
+               : "v_sub_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -1703,8 +1778,10 @@ void VSubF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubrevF16Vop2::VSubrevF16Vop2(const MachineInst *inst)
-    : Vop2("v_subrev_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubrevF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_subrev_f16_dpp"
+               : "v_subrev_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubrevF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -1770,8 +1847,10 @@ void VSubrevF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulF16Vop2::VMulF16Vop2(const MachineInst *inst)
-    : Vop2("v_mul_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_f16_dpp"
+               : "v_mul_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -1837,8 +1916,10 @@ void VMulF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmacF16Vop2::VFmacF16Vop2(const MachineInst *inst)
-    : Vop2("v_fmac_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFmacF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmac_f16_dpp"
+               : "v_fmac_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmacF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), true,
            true),
@@ -1907,8 +1988,10 @@ void VFmacF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmamkF16Vop2::VFmamkF16Vop2(const MachineInst *inst)
-    : Vop2("v_fmamk_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFmamkF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmamk_f16_dpp"
+               : "v_fmamk_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmamkF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -1960,8 +2043,10 @@ void VFmamkF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmaakF16Vop2::VFmaakF16Vop2(const MachineInst *inst)
-    : Vop2("v_fmaak_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFmaakF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmaak_f16_dpp"
+               : "v_fmaak_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmaakF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2012,8 +2097,10 @@ void VFmaakF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxF16Vop2::VMaxF16Vop2(const MachineInst *inst)
-    : Vop2("v_max_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaxF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_f16_dpp"
+               : "v_max_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2079,8 +2166,10 @@ void VMaxF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinF16Vop2::VMinF16Vop2(const MachineInst *inst)
-    : Vop2("v_min_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_f16_dpp"
+               : "v_min_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2146,8 +2235,10 @@ void VMinF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLdexpF16Vop2::VLdexpF16Vop2(const MachineInst *inst)
-    : Vop2("v_ldexp_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLdexpF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ldexp_f16_dpp"
+               : "v_ldexp_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLdexpF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2213,8 +2304,10 @@ void VLdexpF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkFmacF16Vop2::VPkFmacF16Vop2(const MachineInst *inst)
-    : Vop2("v_pk_fmac_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VPkFmacF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_pk_fmac_f16_dpp"
+               : "v_pk_fmac_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkFmacF16Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/vop3.cpp
@@ -22,7 +22,10 @@ namespace rocjitsu {
 namespace rdna3 {
 
 VNopVop3::VNopVop3(const MachineInst *inst)
-    : Vop3("v_nop", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VNopVop3>()) {
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_nop_e64_dpp"
+               : "v_nop",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VNopVop3>()) {
   num_src_ = 0;
   num_dst_ = 0;
 }
@@ -30,7 +33,10 @@ VNopVop3::VNopVop3(const MachineInst *inst)
 void VNopVop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_nop_vop3(*this, wf); }
 
 VMovB32Vop3::VMovB32Vop3(const MachineInst *inst)
-    : Vop3("v_mov_b32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mov_b32_e64_dpp"
+               : "v_mov_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -71,8 +77,10 @@ void VMovB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VReadfirstlaneB32Vop3::VReadfirstlaneB32Vop3(const MachineInst *inst)
-    : Vop3("v_readfirstlane_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VReadfirstlaneB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_readfirstlane_b32_e64_dpp"
+               : "v_readfirstlane_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VReadfirstlaneB32Vop3>()),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -101,8 +109,10 @@ void VReadfirstlaneB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtI32F64Vop3::VCvtI32F64Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_i32_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtI32F64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_i32_f64_e64_dpp"
+               : "v_cvt_i32_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtI32F64Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -124,8 +134,10 @@ void VCvtI32F64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF64I32Vop3::VCvtF64I32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f64_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF64I32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f64_i32_e64_dpp"
+               : "v_cvt_f64_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF64I32Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -146,8 +158,10 @@ void VCvtF64I32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32I32Vop3::VCvtF32I32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f32_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32I32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_i32_e64_dpp"
+               : "v_cvt_f32_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32I32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -188,8 +202,10 @@ void VCvtF32I32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32U32Vop3::VCvtF32U32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f32_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32U32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_u32_e64_dpp"
+               : "v_cvt_f32_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32U32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -230,8 +246,10 @@ void VCvtF32U32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtU32F32Vop3::VCvtU32F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_u32_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtU32F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_u32_f32_e64_dpp"
+               : "v_cvt_u32_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtU32F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -272,8 +290,10 @@ void VCvtU32F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtI32F32Vop3::VCvtI32F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_i32_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtI32F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_i32_f32_e64_dpp"
+               : "v_cvt_i32_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtI32F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -314,8 +334,10 @@ void VCvtI32F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF16F32Vop3::VCvtF16F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f16_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF16F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f16_f32_e64_dpp"
+               : "v_cvt_f16_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF16F32Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -374,8 +396,10 @@ void VCvtF16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32F16Vop3::VCvtF32F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f32_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32F16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_f16_e64_dpp"
+               : "v_cvt_f32_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32F16Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -436,8 +460,10 @@ void VCvtF32F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtNearestI32F32Vop3::VCvtNearestI32F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_nearest_i32_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtNearestI32F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_nearest_i32_f32_e64_dpp"
+               : "v_cvt_nearest_i32_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtNearestI32F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -478,8 +504,10 @@ void VCvtNearestI32F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtFloorI32F32Vop3::VCvtFloorI32F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_floor_i32_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtFloorI32F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_floor_i32_f32_e64_dpp"
+               : "v_cvt_floor_i32_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtFloorI32F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -520,8 +548,10 @@ void VCvtFloorI32F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtOffF32I4Vop3::VCvtOffF32I4Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_off_f32_i4", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtOffF32I4Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_off_f32_i4_e64_dpp"
+               : "v_cvt_off_f32_i4",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtOffF32I4Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -562,8 +592,10 @@ void VCvtOffF32I4Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32F64Vop3::VCvtF32F64Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f32_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32F64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_f64_e64_dpp"
+               : "v_cvt_f32_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32F64Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -585,8 +617,10 @@ void VCvtF32F64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF64F32Vop3::VCvtF64F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f64_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF64F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f64_f32_e64_dpp"
+               : "v_cvt_f64_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF64F32Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -607,8 +641,10 @@ void VCvtF64F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32Ubyte0Vop3::VCvtF32Ubyte0Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f32_ubyte0", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32Ubyte0Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_ubyte0_e64_dpp"
+               : "v_cvt_f32_ubyte0",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32Ubyte0Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -649,8 +685,10 @@ void VCvtF32Ubyte0Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32Ubyte1Vop3::VCvtF32Ubyte1Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f32_ubyte1", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32Ubyte1Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_ubyte1_e64_dpp"
+               : "v_cvt_f32_ubyte1",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32Ubyte1Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -691,8 +729,10 @@ void VCvtF32Ubyte1Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32Ubyte2Vop3::VCvtF32Ubyte2Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f32_ubyte2", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32Ubyte2Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_ubyte2_e64_dpp"
+               : "v_cvt_f32_ubyte2",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32Ubyte2Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -733,8 +773,10 @@ void VCvtF32Ubyte2Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32Ubyte3Vop3::VCvtF32Ubyte3Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f32_ubyte3", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32Ubyte3Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_ubyte3_e64_dpp"
+               : "v_cvt_f32_ubyte3",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32Ubyte3Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -775,8 +817,10 @@ void VCvtF32Ubyte3Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtU32F64Vop3::VCvtU32F64Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_u32_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtU32F64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_u32_f64_e64_dpp"
+               : "v_cvt_u32_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtU32F64Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -798,8 +842,10 @@ void VCvtU32F64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF64U32Vop3::VCvtF64U32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f64_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF64U32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f64_u32_e64_dpp"
+               : "v_cvt_f64_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF64U32Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -820,8 +866,10 @@ void VCvtF64U32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VTruncF64Vop3::VTruncF64Vop3(const MachineInst *inst)
-    : Vop3("v_trunc_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VTruncF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_trunc_f64_e64_dpp"
+               : "v_trunc_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VTruncF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -843,7 +891,10 @@ void VTruncF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCeilF64Vop3::VCeilF64Vop3(const MachineInst *inst)
-    : Vop3("v_ceil_f64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCeilF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ceil_f64_e64_dpp"
+               : "v_ceil_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCeilF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -865,8 +916,10 @@ void VCeilF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRndneF64Vop3::VRndneF64Vop3(const MachineInst *inst)
-    : Vop3("v_rndne_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRndneF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rndne_f64_e64_dpp"
+               : "v_rndne_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRndneF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -888,8 +941,10 @@ void VRndneF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFloorF64Vop3::VFloorF64Vop3(const MachineInst *inst)
-    : Vop3("v_floor_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFloorF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_floor_f64_e64_dpp"
+               : "v_floor_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFloorF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -911,8 +966,10 @@ void VFloorF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPipeflushVop3::VPipeflushVop3(const MachineInst *inst)
-    : Vop3("v_pipeflush", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VPipeflushVop3>()) {
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_pipeflush_e64_dpp"
+               : "v_pipeflush",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPipeflushVop3>()) {
   num_src_ = 0;
   num_dst_ = 0;
 }
@@ -922,7 +979,10 @@ void VPipeflushVop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMovB16Vop3::VMovB16Vop3(const MachineInst *inst)
-    : Vop3("v_mov_b16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovB16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mov_b16_e64_dpp"
+               : "v_mov_b16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovB16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -986,8 +1046,10 @@ void VMovB16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFractF32Vop3::VFractF32Vop3(const MachineInst *inst)
-    : Vop3("v_fract_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFractF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fract_f32_e64_dpp"
+               : "v_fract_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFractF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1028,8 +1090,10 @@ void VFractF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VTruncF32Vop3::VTruncF32Vop3(const MachineInst *inst)
-    : Vop3("v_trunc_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VTruncF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_trunc_f32_e64_dpp"
+               : "v_trunc_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VTruncF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1070,7 +1134,10 @@ void VTruncF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCeilF32Vop3::VCeilF32Vop3(const MachineInst *inst)
-    : Vop3("v_ceil_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCeilF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ceil_f32_e64_dpp"
+               : "v_ceil_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCeilF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1111,8 +1178,10 @@ void VCeilF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRndneF32Vop3::VRndneF32Vop3(const MachineInst *inst)
-    : Vop3("v_rndne_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRndneF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rndne_f32_e64_dpp"
+               : "v_rndne_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRndneF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1153,8 +1222,10 @@ void VRndneF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFloorF32Vop3::VFloorF32Vop3(const MachineInst *inst)
-    : Vop3("v_floor_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFloorF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_floor_f32_e64_dpp"
+               : "v_floor_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFloorF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1195,7 +1266,10 @@ void VFloorF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VExpF32Vop3::VExpF32Vop3(const MachineInst *inst)
-    : Vop3("v_exp_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VExpF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_exp_f32_e64_dpp"
+               : "v_exp_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VExpF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1236,7 +1310,10 @@ void VExpF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLogF32Vop3::VLogF32Vop3(const MachineInst *inst)
-    : Vop3("v_log_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLogF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_log_f32_e64_dpp"
+               : "v_log_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLogF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1277,7 +1354,10 @@ void VLogF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRcpF32Vop3::VRcpF32Vop3(const MachineInst *inst)
-    : Vop3("v_rcp_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_f32_e64_dpp"
+               : "v_rcp_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1318,8 +1398,10 @@ void VRcpF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRcpIflagF32Vop3::VRcpIflagF32Vop3(const MachineInst *inst)
-    : Vop3("v_rcp_iflag_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRcpIflagF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_iflag_f32_e64_dpp"
+               : "v_rcp_iflag_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpIflagF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1360,7 +1442,10 @@ void VRcpIflagF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRsqF32Vop3::VRsqF32Vop3(const MachineInst *inst)
-    : Vop3("v_rsq_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRsqF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rsq_f32_e64_dpp"
+               : "v_rsq_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRsqF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1401,7 +1486,10 @@ void VRsqF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRcpF64Vop3::VRcpF64Vop3(const MachineInst *inst)
-    : Vop3("v_rcp_f64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_f64_e64_dpp"
+               : "v_rcp_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1421,7 +1509,10 @@ VRcpF64Vop3::VRcpF64Vop3(const MachineInst *inst)
 void VRcpF64Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_rcp_f64_vop3(*this, wf); }
 
 VRsqF64Vop3::VRsqF64Vop3(const MachineInst *inst)
-    : Vop3("v_rsq_f64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRsqF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rsq_f64_e64_dpp"
+               : "v_rsq_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRsqF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1441,7 +1532,10 @@ VRsqF64Vop3::VRsqF64Vop3(const MachineInst *inst)
 void VRsqF64Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_rsq_f64_vop3(*this, wf); }
 
 VSqrtF32Vop3::VSqrtF32Vop3(const MachineInst *inst)
-    : Vop3("v_sqrt_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSqrtF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sqrt_f32_e64_dpp"
+               : "v_sqrt_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSqrtF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1482,7 +1576,10 @@ void VSqrtF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSqrtF64Vop3::VSqrtF64Vop3(const MachineInst *inst)
-    : Vop3("v_sqrt_f64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSqrtF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sqrt_f64_e64_dpp"
+               : "v_sqrt_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSqrtF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1504,7 +1601,10 @@ void VSqrtF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSinF32Vop3::VSinF32Vop3(const MachineInst *inst)
-    : Vop3("v_sin_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSinF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sin_f32_e64_dpp"
+               : "v_sin_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSinF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1545,7 +1645,10 @@ void VSinF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCosF32Vop3::VCosF32Vop3(const MachineInst *inst)
-    : Vop3("v_cos_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCosF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cos_f32_e64_dpp"
+               : "v_cos_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCosF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1586,7 +1689,10 @@ void VCosF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VNotB32Vop3::VNotB32Vop3(const MachineInst *inst)
-    : Vop3("v_not_b32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VNotB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_not_b32_e64_dpp"
+               : "v_not_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VNotB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1627,8 +1733,10 @@ void VNotB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VBfrevB32Vop3::VBfrevB32Vop3(const MachineInst *inst)
-    : Vop3("v_bfrev_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VBfrevB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_bfrev_b32_e64_dpp"
+               : "v_bfrev_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VBfrevB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1669,8 +1777,10 @@ void VBfrevB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VClzI32U32Vop3::VClzI32U32Vop3(const MachineInst *inst)
-    : Vop3("v_clz_i32_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VClzI32U32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_clz_i32_u32_e64_dpp"
+               : "v_clz_i32_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VClzI32U32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1711,8 +1821,10 @@ void VClzI32U32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCtzI32B32Vop3::VCtzI32B32Vop3(const MachineInst *inst)
-    : Vop3("v_ctz_i32_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCtzI32B32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ctz_i32_b32_e64_dpp"
+               : "v_ctz_i32_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCtzI32B32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1753,7 +1865,10 @@ void VCtzI32B32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VClsI32Vop3::VClsI32Vop3(const MachineInst *inst)
-    : Vop3("v_cls_i32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VClsI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cls_i32_e64_dpp"
+               : "v_cls_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VClsI32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1794,8 +1909,10 @@ void VClsI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpExpI32F64Vop3::VFrexpExpI32F64Vop3(const MachineInst *inst)
-    : Vop3("v_frexp_exp_i32_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpExpI32F64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_exp_i32_f64_e64_dpp"
+               : "v_frexp_exp_i32_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpExpI32F64Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1817,8 +1934,10 @@ void VFrexpExpI32F64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpMantF64Vop3::VFrexpMantF64Vop3(const MachineInst *inst)
-    : Vop3("v_frexp_mant_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpMantF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_mant_f64_e64_dpp"
+               : "v_frexp_mant_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpMantF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1840,8 +1959,10 @@ void VFrexpMantF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFractF64Vop3::VFractF64Vop3(const MachineInst *inst)
-    : Vop3("v_fract_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFractF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fract_f64_e64_dpp"
+               : "v_fract_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFractF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1863,8 +1984,10 @@ void VFractF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpExpI32F32Vop3::VFrexpExpI32F32Vop3(const MachineInst *inst)
-    : Vop3("v_frexp_exp_i32_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpExpI32F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_exp_i32_f32_e64_dpp"
+               : "v_frexp_exp_i32_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpExpI32F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1905,8 +2028,10 @@ void VFrexpExpI32F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpMantF32Vop3::VFrexpMantF32Vop3(const MachineInst *inst)
-    : Vop3("v_frexp_mant_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpMantF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_mant_f32_e64_dpp"
+               : "v_frexp_mant_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpMantF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1947,8 +2072,10 @@ void VFrexpMantF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMovreldB32Vop3::VMovreldB32Vop3(const MachineInst *inst)
-    : Vop3("v_movreld_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMovreldB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_movreld_b32_e64_dpp"
+               : "v_movreld_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovreldB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -2005,8 +2132,10 @@ void VMovreldB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMovrelsB32Vop3::VMovrelsB32Vop3(const MachineInst *inst)
-    : Vop3("v_movrels_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMovrelsB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_movrels_b32_e64_dpp"
+               : "v_movrels_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovrelsB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -2063,8 +2192,10 @@ void VMovrelsB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMovrelsdB32Vop3::VMovrelsdB32Vop3(const MachineInst *inst)
-    : Vop3("v_movrelsd_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMovrelsdB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_movrelsd_b32_e64_dpp"
+               : "v_movrelsd_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovrelsdB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -2103,8 +2234,10 @@ void VMovrelsdB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMovrelsd2B32Vop3::VMovrelsd2B32Vop3(const MachineInst *inst)
-    : Vop3("v_movrelsd_2_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMovrelsd2B32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_movrelsd_2_b32_e64_dpp"
+               : "v_movrelsd_2_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovrelsd2B32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -2143,8 +2276,10 @@ void VMovrelsd2B32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF16U16Vop3::VCvtF16U16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f16_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF16U16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f16_u16_e64_dpp"
+               : "v_cvt_f16_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF16U16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2209,8 +2344,10 @@ void VCvtF16U16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF16I16Vop3::VCvtF16I16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f16_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF16I16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f16_i16_e64_dpp"
+               : "v_cvt_f16_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF16I16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2275,8 +2412,10 @@ void VCvtF16I16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtU16F16Vop3::VCvtU16F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_u16_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtU16F16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_u16_f16_e64_dpp"
+               : "v_cvt_u16_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtU16F16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2346,8 +2485,10 @@ void VCvtU16F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtI16F16Vop3::VCvtI16F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_i16_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtI16F16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_i16_f16_e64_dpp"
+               : "v_cvt_i16_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtI16F16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2419,7 +2560,10 @@ void VCvtI16F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRcpF16Vop3::VRcpF16Vop3(const MachineInst *inst)
-    : Vop3("v_rcp_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_f16_e64_dpp"
+               : "v_rcp_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2507,7 +2651,10 @@ void VRcpF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSqrtF16Vop3::VSqrtF16Vop3(const MachineInst *inst)
-    : Vop3("v_sqrt_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSqrtF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sqrt_f16_e64_dpp"
+               : "v_sqrt_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSqrtF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2600,7 +2747,10 @@ void VSqrtF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRsqF16Vop3::VRsqF16Vop3(const MachineInst *inst)
-    : Vop3("v_rsq_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRsqF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rsq_f16_e64_dpp"
+               : "v_rsq_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRsqF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2688,7 +2838,10 @@ void VRsqF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLogF16Vop3::VLogF16Vop3(const MachineInst *inst)
-    : Vop3("v_log_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLogF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_log_f16_e64_dpp"
+               : "v_log_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLogF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2776,7 +2929,10 @@ void VLogF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VExpF16Vop3::VExpF16Vop3(const MachineInst *inst)
-    : Vop3("v_exp_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VExpF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_exp_f16_e64_dpp"
+               : "v_exp_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VExpF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2864,8 +3020,10 @@ void VExpF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpMantF16Vop3::VFrexpMantF16Vop3(const MachineInst *inst)
-    : Vop3("v_frexp_mant_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpMantF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_mant_f16_e64_dpp"
+               : "v_frexp_mant_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpMantF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2959,8 +3117,10 @@ void VFrexpMantF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpExpI16F16Vop3::VFrexpExpI16F16Vop3(const MachineInst *inst)
-    : Vop3("v_frexp_exp_i16_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpExpI16F16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_exp_i16_f16_e64_dpp"
+               : "v_frexp_exp_i16_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpExpI16F16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3057,8 +3217,10 @@ void VFrexpExpI16F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFloorF16Vop3::VFloorF16Vop3(const MachineInst *inst)
-    : Vop3("v_floor_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFloorF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_floor_f16_e64_dpp"
+               : "v_floor_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFloorF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3146,7 +3308,10 @@ void VFloorF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCeilF16Vop3::VCeilF16Vop3(const MachineInst *inst)
-    : Vop3("v_ceil_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCeilF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ceil_f16_e64_dpp"
+               : "v_ceil_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCeilF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3234,8 +3399,10 @@ void VCeilF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VTruncF16Vop3::VTruncF16Vop3(const MachineInst *inst)
-    : Vop3("v_trunc_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VTruncF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_trunc_f16_e64_dpp"
+               : "v_trunc_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VTruncF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3323,8 +3490,10 @@ void VTruncF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRndneF16Vop3::VRndneF16Vop3(const MachineInst *inst)
-    : Vop3("v_rndne_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRndneF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rndne_f16_e64_dpp"
+               : "v_rndne_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRndneF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3412,8 +3581,10 @@ void VRndneF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFractF16Vop3::VFractF16Vop3(const MachineInst *inst)
-    : Vop3("v_fract_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFractF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fract_f16_e64_dpp"
+               : "v_fract_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFractF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3504,7 +3675,10 @@ void VFractF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSinF16Vop3::VSinF16Vop3(const MachineInst *inst)
-    : Vop3("v_sin_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSinF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sin_f16_e64_dpp"
+               : "v_sin_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSinF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3590,7 +3764,10 @@ void VSinF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCosF16Vop3::VCosF16Vop3(const MachineInst *inst)
-    : Vop3("v_cos_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCosF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cos_f16_e64_dpp"
+               : "v_cos_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCosF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3676,8 +3853,10 @@ void VCosF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSatPkU8I16Vop3::VSatPkU8I16Vop3(const MachineInst *inst)
-    : Vop3("v_sat_pk_u8_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSatPkU8I16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sat_pk_u8_i16_e64_dpp"
+               : "v_sat_pk_u8_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSatPkU8I16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3719,8 +3898,10 @@ void VSatPkU8I16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtNormI16F16Vop3::VCvtNormI16F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_norm_i16_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtNormI16F16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_norm_i16_f16_e64_dpp"
+               : "v_cvt_norm_i16_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtNormI16F16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3789,8 +3970,10 @@ void VCvtNormI16F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtNormU16F16Vop3::VCvtNormU16F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_norm_u16_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtNormU16F16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_norm_u16_f16_e64_dpp"
+               : "v_cvt_norm_u16_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtNormU16F16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3859,7 +4042,10 @@ void VCvtNormU16F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VNotB16Vop3::VNotB16Vop3(const MachineInst *inst)
-    : Vop3("v_not_b16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VNotB16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_not_b16_e64_dpp"
+               : "v_not_b16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VNotB16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3923,8 +4109,10 @@ void VNotB16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtI32I16Vop3::VCvtI32I16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_i32_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtI32I16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_i32_i16_e64_dpp"
+               : "v_cvt_i32_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtI32I16Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3980,8 +4168,10 @@ void VCvtI32I16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtU32U16Vop3::VCvtU32U16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_u32_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtU32U16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_u32_u16_e64_dpp"
+               : "v_cvt_u32_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtU32U16Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -4036,8 +4226,10 @@ void VCvtU32U16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCndmaskB32Vop3::VCndmaskB32Vop3(const MachineInst *inst)
-    : Vop3("v_cndmask_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCndmaskB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cndmask_b32_e64_dpp"
+               : "v_cndmask_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCndmaskB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4092,7 +4284,10 @@ void VCndmaskB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddF32Vop3::VAddF32Vop3(const MachineInst *inst)
-    : Vop3("v_add_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_f32_e64_dpp"
+               : "v_add_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4140,7 +4335,10 @@ void VAddF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubF32Vop3::VSubF32Vop3(const MachineInst *inst)
-    : Vop3("v_sub_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_f32_e64_dpp"
+               : "v_sub_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4188,8 +4386,10 @@ void VSubF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubrevF32Vop3::VSubrevF32Vop3(const MachineInst *inst)
-    : Vop3("v_subrev_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubrevF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_subrev_f32_e64_dpp"
+               : "v_subrev_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubrevF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4237,8 +4437,10 @@ void VSubrevF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmacDx9ZeroF32Vop3::VFmacDx9ZeroF32Vop3(const MachineInst *inst)
-    : Vop3("v_fmac_dx9_zero_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFmacDx9ZeroF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmac_dx9_zero_f32_e64_dpp"
+               : "v_fmac_dx9_zero_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmacDx9ZeroF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4266,8 +4468,10 @@ void VFmacDx9ZeroF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulDx9ZeroF32Vop3::VMulDx9ZeroF32Vop3(const MachineInst *inst)
-    : Vop3("v_mul_dx9_zero_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulDx9ZeroF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_dx9_zero_f32_e64_dpp"
+               : "v_mul_dx9_zero_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulDx9ZeroF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4315,7 +4519,10 @@ void VMulDx9ZeroF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulF32Vop3::VMulF32Vop3(const MachineInst *inst)
-    : Vop3("v_mul_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_f32_e64_dpp"
+               : "v_mul_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4363,8 +4570,10 @@ void VMulF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulI32I24Vop3::VMulI32I24Vop3(const MachineInst *inst)
-    : Vop3("v_mul_i32_i24", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulI32I24Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_i32_i24_e64_dpp"
+               : "v_mul_i32_i24",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulI32I24Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4412,8 +4621,10 @@ void VMulI32I24Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulHiI32I24Vop3::VMulHiI32I24Vop3(const MachineInst *inst)
-    : Vop3("v_mul_hi_i32_i24", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulHiI32I24Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_hi_i32_i24_e64_dpp"
+               : "v_mul_hi_i32_i24",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulHiI32I24Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4461,8 +4672,10 @@ void VMulHiI32I24Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulU32U24Vop3::VMulU32U24Vop3(const MachineInst *inst)
-    : Vop3("v_mul_u32_u24", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulU32U24Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_u32_u24_e64_dpp"
+               : "v_mul_u32_u24",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulU32U24Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4510,8 +4723,10 @@ void VMulU32U24Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulHiU32U24Vop3::VMulHiU32U24Vop3(const MachineInst *inst)
-    : Vop3("v_mul_hi_u32_u24", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulHiU32U24Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_hi_u32_u24_e64_dpp"
+               : "v_mul_hi_u32_u24",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulHiU32U24Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4559,7 +4774,10 @@ void VMulHiU32U24Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinF32Vop3::VMinF32Vop3(const MachineInst *inst)
-    : Vop3("v_min_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_f32_e64_dpp"
+               : "v_min_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4607,7 +4825,10 @@ void VMinF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxF32Vop3::VMaxF32Vop3(const MachineInst *inst)
-    : Vop3("v_max_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_f32_e64_dpp"
+               : "v_max_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4655,7 +4876,10 @@ void VMaxF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinI32Vop3::VMinI32Vop3(const MachineInst *inst)
-    : Vop3("v_min_i32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_i32_e64_dpp"
+               : "v_min_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinI32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4703,7 +4927,10 @@ void VMinI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxI32Vop3::VMaxI32Vop3(const MachineInst *inst)
-    : Vop3("v_max_i32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_i32_e64_dpp"
+               : "v_max_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxI32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4751,7 +4978,10 @@ void VMaxI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinU32Vop3::VMinU32Vop3(const MachineInst *inst)
-    : Vop3("v_min_u32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_u32_e64_dpp"
+               : "v_min_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4799,7 +5029,10 @@ void VMinU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxU32Vop3::VMaxU32Vop3(const MachineInst *inst)
-    : Vop3("v_max_u32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_u32_e64_dpp"
+               : "v_max_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4847,8 +5080,10 @@ void VMaxU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLshlrevB32Vop3::VLshlrevB32Vop3(const MachineInst *inst)
-    : Vop3("v_lshlrev_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLshlrevB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshlrev_b32_e64_dpp"
+               : "v_lshlrev_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLshlrevB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4896,8 +5131,10 @@ void VLshlrevB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLshrrevB32Vop3::VLshrrevB32Vop3(const MachineInst *inst)
-    : Vop3("v_lshrrev_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLshrrevB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshrrev_b32_e64_dpp"
+               : "v_lshrrev_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLshrrevB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4945,8 +5182,10 @@ void VLshrrevB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAshrrevI32Vop3::VAshrrevI32Vop3(const MachineInst *inst)
-    : Vop3("v_ashrrev_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAshrrevI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ashrrev_i32_e64_dpp"
+               : "v_ashrrev_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAshrrevI32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4994,7 +5233,10 @@ void VAshrrevI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAndB32Vop3::VAndB32Vop3(const MachineInst *inst)
-    : Vop3("v_and_b32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAndB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_and_b32_e64_dpp"
+               : "v_and_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAndB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5042,7 +5284,10 @@ void VAndB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VOrB32Vop3::VOrB32Vop3(const MachineInst *inst)
-    : Vop3("v_or_b32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VOrB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_or_b32_e64_dpp"
+               : "v_or_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VOrB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5090,7 +5335,10 @@ void VOrB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VXorB32Vop3::VXorB32Vop3(const MachineInst *inst)
-    : Vop3("v_xor_b32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXorB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_xor_b32_e64_dpp"
+               : "v_xor_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXorB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5138,7 +5386,10 @@ void VXorB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VXnorB32Vop3::VXnorB32Vop3(const MachineInst *inst)
-    : Vop3("v_xnor_b32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXnorB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_xnor_b32_e64_dpp"
+               : "v_xnor_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXnorB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5186,8 +5437,10 @@ void VXnorB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddNcU32Vop3::VAddNcU32Vop3(const MachineInst *inst)
-    : Vop3("v_add_nc_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAddNcU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_nc_u32_e64_dpp"
+               : "v_add_nc_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddNcU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5235,8 +5488,10 @@ void VAddNcU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubNcU32Vop3::VSubNcU32Vop3(const MachineInst *inst)
-    : Vop3("v_sub_nc_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubNcU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_nc_u32_e64_dpp"
+               : "v_sub_nc_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubNcU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5284,8 +5539,10 @@ void VSubNcU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubrevNcU32Vop3::VSubrevNcU32Vop3(const MachineInst *inst)
-    : Vop3("v_subrev_nc_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubrevNcU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_subrev_nc_u32_e64_dpp"
+               : "v_subrev_nc_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubrevNcU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5333,7 +5590,10 @@ void VSubrevNcU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmacF32Vop3::VFmacF32Vop3(const MachineInst *inst)
-    : Vop3("v_fmac_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmacF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmac_f32_e64_dpp"
+               : "v_fmac_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmacF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5382,8 +5642,10 @@ void VFmacF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkRtzF16F32Vop3::VCvtPkRtzF16F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_rtz_f16_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkRtzF16F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_rtz_f16_f32_e64_dpp"
+               : "v_cvt_pk_rtz_f16_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkRtzF16F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5431,7 +5693,10 @@ void VCvtPkRtzF16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddF16Vop3::VAddF16Vop3(const MachineInst *inst)
-    : Vop3("v_add_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_f16_e64_dpp"
+               : "v_add_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5547,7 +5812,10 @@ void VAddF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubF16Vop3::VSubF16Vop3(const MachineInst *inst)
-    : Vop3("v_sub_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_f16_e64_dpp"
+               : "v_sub_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5663,8 +5931,10 @@ void VSubF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubrevF16Vop3::VSubrevF16Vop3(const MachineInst *inst)
-    : Vop3("v_subrev_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubrevF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_subrev_f16_e64_dpp"
+               : "v_subrev_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubrevF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5780,7 +6050,10 @@ void VSubrevF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulF16Vop3::VMulF16Vop3(const MachineInst *inst)
-    : Vop3("v_mul_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_f16_e64_dpp"
+               : "v_mul_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5896,7 +6169,10 @@ void VMulF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmacF16Vop3::VFmacF16Vop3(const MachineInst *inst)
-    : Vop3("v_fmac_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmacF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmac_f16_e64_dpp"
+               : "v_fmac_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmacF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6010,7 +6286,10 @@ void VFmacF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxF16Vop3::VMaxF16Vop3(const MachineInst *inst)
-    : Vop3("v_max_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_f16_e64_dpp"
+               : "v_max_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6129,7 +6408,10 @@ void VMaxF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinF16Vop3::VMinF16Vop3(const MachineInst *inst)
-    : Vop3("v_min_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_f16_e64_dpp"
+               : "v_min_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6248,8 +6530,10 @@ void VMinF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLdexpF16Vop3::VLdexpF16Vop3(const MachineInst *inst)
-    : Vop3("v_ldexp_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLdexpF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ldexp_f16_e64_dpp"
+               : "v_ldexp_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLdexpF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6367,8 +6651,10 @@ void VLdexpF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmaDx9ZeroF32Vop3::VFmaDx9ZeroF32Vop3(const MachineInst *inst)
-    : Vop3("v_fma_dx9_zero_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFmaDx9ZeroF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fma_dx9_zero_f32_e64_dpp"
+               : "v_fma_dx9_zero_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmaDx9ZeroF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6422,8 +6708,10 @@ void VFmaDx9ZeroF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMadI32I24Vop3::VMadI32I24Vop3(const MachineInst *inst)
-    : Vop3("v_mad_i32_i24", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMadI32I24Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mad_i32_i24_e64_dpp"
+               : "v_mad_i32_i24",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMadI32I24Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(24, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(24, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6477,8 +6765,10 @@ void VMadI32I24Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMadU32U24Vop3::VMadU32U24Vop3(const MachineInst *inst)
-    : Vop3("v_mad_u32_u24", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMadU32U24Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mad_u32_u24_e64_dpp"
+               : "v_mad_u32_u24",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMadU32U24Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(24, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(24, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6532,8 +6822,10 @@ void VMadU32U24Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCubeidF32Vop3::VCubeidF32Vop3(const MachineInst *inst)
-    : Vop3("v_cubeid_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCubeidF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cubeid_f32_e64_dpp"
+               : "v_cubeid_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCubeidF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6587,8 +6879,10 @@ void VCubeidF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCubescF32Vop3::VCubescF32Vop3(const MachineInst *inst)
-    : Vop3("v_cubesc_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCubescF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cubesc_f32_e64_dpp"
+               : "v_cubesc_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCubescF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6642,8 +6936,10 @@ void VCubescF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCubetcF32Vop3::VCubetcF32Vop3(const MachineInst *inst)
-    : Vop3("v_cubetc_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCubetcF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cubetc_f32_e64_dpp"
+               : "v_cubetc_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCubetcF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6697,8 +6993,10 @@ void VCubetcF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCubemaF32Vop3::VCubemaF32Vop3(const MachineInst *inst)
-    : Vop3("v_cubema_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCubemaF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cubema_f32_e64_dpp"
+               : "v_cubema_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCubemaF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6752,7 +7050,10 @@ void VCubemaF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VBfeU32Vop3::VBfeU32Vop3(const MachineInst *inst)
-    : Vop3("v_bfe_u32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VBfeU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_bfe_u32_e64_dpp"
+               : "v_bfe_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VBfeU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6806,7 +7107,10 @@ void VBfeU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VBfeI32Vop3::VBfeI32Vop3(const MachineInst *inst)
-    : Vop3("v_bfe_i32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VBfeI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_bfe_i32_e64_dpp"
+               : "v_bfe_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VBfeI32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6860,7 +7164,10 @@ void VBfeI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VBfiB32Vop3::VBfiB32Vop3(const MachineInst *inst)
-    : Vop3("v_bfi_b32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VBfiB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_bfi_b32_e64_dpp"
+               : "v_bfi_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VBfiB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6914,7 +7221,10 @@ void VBfiB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmaF32Vop3::VFmaF32Vop3(const MachineInst *inst)
-    : Vop3("v_fma_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmaF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fma_f32_e64_dpp"
+               : "v_fma_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmaF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6968,7 +7278,10 @@ void VFmaF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmaF64Vop3::VFmaF64Vop3(const MachineInst *inst)
-    : Vop3("v_fma_f64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmaF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fma_f64_e64_dpp"
+               : "v_fma_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmaF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7002,7 +7315,10 @@ VFmaF64Vop3::VFmaF64Vop3(const MachineInst *inst)
 void VFmaF64Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_fma_f64_vop3(*this, wf); }
 
 VLerpU8Vop3::VLerpU8Vop3(const MachineInst *inst)
-    : Vop3("v_lerp_u8", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLerpU8Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lerp_u8_e64_dpp"
+               : "v_lerp_u8",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLerpU8Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7056,8 +7372,10 @@ void VLerpU8Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAlignbitB32Vop3::VAlignbitB32Vop3(const MachineInst *inst)
-    : Vop3("v_alignbit_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAlignbitB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_alignbit_b32_e64_dpp"
+               : "v_alignbit_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAlignbitB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7136,8 +7454,10 @@ void VAlignbitB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAlignbyteB32Vop3::VAlignbyteB32Vop3(const MachineInst *inst)
-    : Vop3("v_alignbyte_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAlignbyteB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_alignbyte_b32_e64_dpp"
+               : "v_alignbyte_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAlignbyteB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7216,8 +7536,10 @@ void VAlignbyteB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMullitF32Vop3::VMullitF32Vop3(const MachineInst *inst)
-    : Vop3("v_mullit_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMullitF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mullit_f32_e64_dpp"
+               : "v_mullit_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMullitF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7265,7 +7587,10 @@ void VMullitF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMin3F32Vop3::VMin3F32Vop3(const MachineInst *inst)
-    : Vop3("v_min3_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMin3F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min3_f32_e64_dpp"
+               : "v_min3_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMin3F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7319,7 +7644,10 @@ void VMin3F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMin3I32Vop3::VMin3I32Vop3(const MachineInst *inst)
-    : Vop3("v_min3_i32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMin3I32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min3_i32_e64_dpp"
+               : "v_min3_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMin3I32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7373,7 +7701,10 @@ void VMin3I32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMin3U32Vop3::VMin3U32Vop3(const MachineInst *inst)
-    : Vop3("v_min3_u32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMin3U32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min3_u32_e64_dpp"
+               : "v_min3_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMin3U32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7427,7 +7758,10 @@ void VMin3U32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMax3F32Vop3::VMax3F32Vop3(const MachineInst *inst)
-    : Vop3("v_max3_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMax3F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max3_f32_e64_dpp"
+               : "v_max3_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMax3F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7481,7 +7815,10 @@ void VMax3F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMax3I32Vop3::VMax3I32Vop3(const MachineInst *inst)
-    : Vop3("v_max3_i32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMax3I32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max3_i32_e64_dpp"
+               : "v_max3_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMax3I32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7535,7 +7872,10 @@ void VMax3I32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMax3U32Vop3::VMax3U32Vop3(const MachineInst *inst)
-    : Vop3("v_max3_u32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMax3U32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max3_u32_e64_dpp"
+               : "v_max3_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMax3U32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7589,7 +7929,10 @@ void VMax3U32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMed3F32Vop3::VMed3F32Vop3(const MachineInst *inst)
-    : Vop3("v_med3_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMed3F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_med3_f32_e64_dpp"
+               : "v_med3_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMed3F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7643,7 +7986,10 @@ void VMed3F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMed3I32Vop3::VMed3I32Vop3(const MachineInst *inst)
-    : Vop3("v_med3_i32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMed3I32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_med3_i32_e64_dpp"
+               : "v_med3_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMed3I32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7697,7 +8043,10 @@ void VMed3I32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMed3U32Vop3::VMed3U32Vop3(const MachineInst *inst)
-    : Vop3("v_med3_u32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMed3U32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_med3_u32_e64_dpp"
+               : "v_med3_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMed3U32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7751,7 +8100,10 @@ void VMed3U32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSadU8Vop3::VSadU8Vop3(const MachineInst *inst)
-    : Vop3("v_sad_u8", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSadU8Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sad_u8_e64_dpp"
+               : "v_sad_u8",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSadU8Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7805,7 +8157,10 @@ void VSadU8Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSadHiU8Vop3::VSadHiU8Vop3(const MachineInst *inst)
-    : Vop3("v_sad_hi_u8", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSadHiU8Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sad_hi_u8_e64_dpp"
+               : "v_sad_hi_u8",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSadHiU8Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7859,7 +8214,10 @@ void VSadHiU8Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSadU16Vop3::VSadU16Vop3(const MachineInst *inst)
-    : Vop3("v_sad_u16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSadU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sad_u16_e64_dpp"
+               : "v_sad_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSadU16Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7913,7 +8271,10 @@ void VSadU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSadU32Vop3::VSadU32Vop3(const MachineInst *inst)
-    : Vop3("v_sad_u32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSadU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sad_u32_e64_dpp"
+               : "v_sad_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSadU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7967,8 +8328,10 @@ void VSadU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkU8F32Vop3::VCvtPkU8F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_u8_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkU8F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_u8_f32_e64_dpp"
+               : "v_cvt_pk_u8_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkU8F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8022,8 +8385,10 @@ void VCvtPkU8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDivFixupF32Vop3::VDivFixupF32Vop3(const MachineInst *inst)
-    : Vop3("v_div_fixup_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VDivFixupF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_div_fixup_f32_e64_dpp"
+               : "v_div_fixup_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDivFixupF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8056,8 +8421,10 @@ void VDivFixupF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDivFixupF64Vop3::VDivFixupF64Vop3(const MachineInst *inst)
-    : Vop3("v_div_fixup_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VDivFixupF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_div_fixup_f64_e64_dpp"
+               : "v_div_fixup_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDivFixupF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8093,8 +8460,10 @@ void VDivFixupF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDivFmasF32Vop3::VDivFmasF32Vop3(const MachineInst *inst)
-    : Vop3("v_div_fmas_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VDivFmasF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_div_fmas_f32_e64_dpp"
+               : "v_div_fmas_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDivFmasF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8130,8 +8499,10 @@ void VDivFmasF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDivFmasF64Vop3::VDivFmasF64Vop3(const MachineInst *inst)
-    : Vop3("v_div_fmas_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VDivFmasF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_div_fmas_f64_e64_dpp"
+               : "v_div_fmas_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDivFmasF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8170,7 +8541,10 @@ void VDivFmasF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMsadU8Vop3::VMsadU8Vop3(const MachineInst *inst)
-    : Vop3("v_msad_u8", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMsadU8Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_msad_u8_e64_dpp"
+               : "v_msad_u8",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMsadU8Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8224,8 +8598,10 @@ void VMsadU8Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VQsadPkU16U8Vop3::VQsadPkU16U8Vop3(const MachineInst *inst)
-    : Vop3("v_qsad_pk_u16_u8", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VQsadPkU16U8Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_qsad_pk_u16_u8_e64_dpp"
+               : "v_qsad_pk_u16_u8",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VQsadPkU16U8Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8261,8 +8637,10 @@ void VQsadPkU16U8Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMqsadPkU16U8Vop3::VMqsadPkU16U8Vop3(const MachineInst *inst)
-    : Vop3("v_mqsad_pk_u16_u8", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMqsadPkU16U8Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mqsad_pk_u16_u8_e64_dpp"
+               : "v_mqsad_pk_u16_u8",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMqsadPkU16U8Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8298,8 +8676,10 @@ void VMqsadPkU16U8Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMqsadU32U8Vop3::VMqsadU32U8Vop3(const MachineInst *inst)
-    : Vop3("v_mqsad_u32_u8", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMqsadU32U8Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mqsad_u32_u8_e64_dpp"
+               : "v_mqsad_u32_u8",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMqsadU32U8Vop3>()),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8334,7 +8714,10 @@ void VMqsadU32U8Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VXor3B32Vop3::VXor3B32Vop3(const MachineInst *inst)
-    : Vop3("v_xor3_b32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXor3B32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_xor3_b32_e64_dpp"
+               : "v_xor3_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXor3B32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8388,7 +8771,10 @@ void VXor3B32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMadU16Vop3::VMadU16Vop3(const MachineInst *inst)
-    : Vop3("v_mad_u16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMadU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mad_u16_e64_dpp"
+               : "v_mad_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMadU16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8472,7 +8858,10 @@ void VMadU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPermB32Vop3::VPermB32Vop3(const MachineInst *inst)
-    : Vop3("v_perm_b32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPermB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_perm_b32_e64_dpp"
+               : "v_perm_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPermB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8526,7 +8915,10 @@ void VPermB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VXadU32Vop3::VXadU32Vop3(const MachineInst *inst)
-    : Vop3("v_xad_u32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXadU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_xad_u32_e64_dpp"
+               : "v_xad_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXadU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8580,8 +8972,10 @@ void VXadU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLshlAddU32Vop3::VLshlAddU32Vop3(const MachineInst *inst)
-    : Vop3("v_lshl_add_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLshlAddU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshl_add_u32_e64_dpp"
+               : "v_lshl_add_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLshlAddU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8635,8 +9029,10 @@ void VLshlAddU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddLshlU32Vop3::VAddLshlU32Vop3(const MachineInst *inst)
-    : Vop3("v_add_lshl_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAddLshlU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_lshl_u32_e64_dpp"
+               : "v_add_lshl_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddLshlU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8690,7 +9086,10 @@ void VAddLshlU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmaF16Vop3::VFmaF16Vop3(const MachineInst *inst)
-    : Vop3("v_fma_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmaF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fma_f16_e64_dpp"
+               : "v_fma_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmaF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8819,7 +9218,10 @@ void VFmaF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMin3F16Vop3::VMin3F16Vop3(const MachineInst *inst)
-    : Vop3("v_min3_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMin3F16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min3_f16_e64_dpp"
+               : "v_min3_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMin3F16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8949,7 +9351,10 @@ void VMin3F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMin3I16Vop3::VMin3I16Vop3(const MachineInst *inst)
-    : Vop3("v_min3_i16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMin3I16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min3_i16_e64_dpp"
+               : "v_min3_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMin3I16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -9049,7 +9454,10 @@ void VMin3I16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMin3U16Vop3::VMin3U16Vop3(const MachineInst *inst)
-    : Vop3("v_min3_u16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMin3U16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min3_u16_e64_dpp"
+               : "v_min3_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMin3U16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -9146,7 +9554,10 @@ void VMin3U16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMax3F16Vop3::VMax3F16Vop3(const MachineInst *inst)
-    : Vop3("v_max3_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMax3F16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max3_f16_e64_dpp"
+               : "v_max3_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMax3F16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -9276,7 +9687,10 @@ void VMax3F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMax3I16Vop3::VMax3I16Vop3(const MachineInst *inst)
-    : Vop3("v_max3_i16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMax3I16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max3_i16_e64_dpp"
+               : "v_max3_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMax3I16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -9376,7 +9790,10 @@ void VMax3I16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMax3U16Vop3::VMax3U16Vop3(const MachineInst *inst)
-    : Vop3("v_max3_u16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMax3U16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max3_u16_e64_dpp"
+               : "v_max3_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMax3U16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -9473,7 +9890,10 @@ void VMax3U16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMed3F16Vop3::VMed3F16Vop3(const MachineInst *inst)
-    : Vop3("v_med3_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMed3F16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_med3_f16_e64_dpp"
+               : "v_med3_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMed3F16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -9605,7 +10025,10 @@ void VMed3F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMed3I16Vop3::VMed3I16Vop3(const MachineInst *inst)
-    : Vop3("v_med3_i16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMed3I16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_med3_i16_e64_dpp"
+               : "v_med3_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMed3I16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -9707,7 +10130,10 @@ void VMed3I16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMed3U16Vop3::VMed3U16Vop3(const MachineInst *inst)
-    : Vop3("v_med3_u16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMed3U16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_med3_u16_e64_dpp"
+               : "v_med3_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMed3U16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -9807,7 +10233,10 @@ void VMed3U16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMadI16Vop3::VMadI16Vop3(const MachineInst *inst)
-    : Vop3("v_mad_i16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMadI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mad_i16_e64_dpp"
+               : "v_mad_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMadI16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -9894,8 +10323,10 @@ void VMadI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDivFixupF16Vop3::VDivFixupF16Vop3(const MachineInst *inst)
-    : Vop3("v_div_fixup_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VDivFixupF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_div_fixup_f16_e64_dpp"
+               : "v_div_fixup_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDivFixupF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -10030,7 +10461,10 @@ void VDivFixupF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAdd3U32Vop3::VAdd3U32Vop3(const MachineInst *inst)
-    : Vop3("v_add3_u32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAdd3U32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add3_u32_e64_dpp"
+               : "v_add3_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAdd3U32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -10084,8 +10518,10 @@ void VAdd3U32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLshlOrB32Vop3::VLshlOrB32Vop3(const MachineInst *inst)
-    : Vop3("v_lshl_or_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLshlOrB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshl_or_b32_e64_dpp"
+               : "v_lshl_or_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLshlOrB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -10139,8 +10575,10 @@ void VLshlOrB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAndOrB32Vop3::VAndOrB32Vop3(const MachineInst *inst)
-    : Vop3("v_and_or_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAndOrB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_and_or_b32_e64_dpp"
+               : "v_and_or_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAndOrB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -10194,7 +10632,10 @@ void VAndOrB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VOr3B32Vop3::VOr3B32Vop3(const MachineInst *inst)
-    : Vop3("v_or3_b32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VOr3B32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_or3_b32_e64_dpp"
+               : "v_or3_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VOr3B32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -10248,8 +10689,10 @@ void VOr3B32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMadU32U16Vop3::VMadU32U16Vop3(const MachineInst *inst)
-    : Vop3("v_mad_u32_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMadU32U16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mad_u32_u16_e64_dpp"
+               : "v_mad_u32_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMadU32U16Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -10325,8 +10768,10 @@ void VMadU32U16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMadI32I16Vop3::VMadI32I16Vop3(const MachineInst *inst)
-    : Vop3("v_mad_i32_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMadI32I16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mad_i32_i16_e64_dpp"
+               : "v_mad_i32_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMadI32I16Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -10409,8 +10854,10 @@ void VMadI32I16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPermlane16B32Vop3::VPermlane16B32Vop3(const MachineInst *inst)
-    : Vop3("v_permlane16_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VPermlane16B32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_permlane16_b32_e64_dpp"
+               : "v_permlane16_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPermlane16B32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -10466,8 +10913,10 @@ void VPermlane16B32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPermlanex16B32Vop3::VPermlanex16B32Vop3(const MachineInst *inst)
-    : Vop3("v_permlanex16_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VPermlanex16B32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_permlanex16_b32_e64_dpp"
+               : "v_permlanex16_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPermlanex16B32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -10525,8 +10974,10 @@ void VPermlanex16B32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCndmaskB16Vop3::VCndmaskB16Vop3(const MachineInst *inst)
-    : Vop3("v_cndmask_b16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCndmaskB16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cndmask_b16_e64_dpp"
+               : "v_cndmask_b16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCndmaskB16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -10612,8 +11063,10 @@ void VCndmaskB16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxminF32Vop3::VMaxminF32Vop3(const MachineInst *inst)
-    : Vop3("v_maxmin_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaxminF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_maxmin_f32_e64_dpp"
+               : "v_maxmin_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxminF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -10667,8 +11120,10 @@ void VMaxminF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinmaxF32Vop3::VMinmaxF32Vop3(const MachineInst *inst)
-    : Vop3("v_minmax_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinmaxF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_minmax_f32_e64_dpp"
+               : "v_minmax_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinmaxF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -10722,8 +11177,10 @@ void VMinmaxF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxminF16Vop3::VMaxminF16Vop3(const MachineInst *inst)
-    : Vop3("v_maxmin_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaxminF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_maxmin_f16_e64_dpp"
+               : "v_maxmin_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxminF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -10853,8 +11310,10 @@ void VMaxminF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinmaxF16Vop3::VMinmaxF16Vop3(const MachineInst *inst)
-    : Vop3("v_minmax_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinmaxF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_minmax_f16_e64_dpp"
+               : "v_minmax_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinmaxF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -10984,8 +11443,10 @@ void VMinmaxF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxminU32Vop3::VMaxminU32Vop3(const MachineInst *inst)
-    : Vop3("v_maxmin_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaxminU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_maxmin_u32_e64_dpp"
+               : "v_maxmin_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxminU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -11039,8 +11500,10 @@ void VMaxminU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinmaxU32Vop3::VMinmaxU32Vop3(const MachineInst *inst)
-    : Vop3("v_minmax_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinmaxU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_minmax_u32_e64_dpp"
+               : "v_minmax_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinmaxU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -11094,8 +11557,10 @@ void VMinmaxU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxminI32Vop3::VMaxminI32Vop3(const MachineInst *inst)
-    : Vop3("v_maxmin_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaxminI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_maxmin_i32_e64_dpp"
+               : "v_maxmin_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxminI32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -11149,8 +11614,10 @@ void VMaxminI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinmaxI32Vop3::VMinmaxI32Vop3(const MachineInst *inst)
-    : Vop3("v_minmax_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinmaxI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_minmax_i32_e64_dpp"
+               : "v_minmax_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinmaxI32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -11204,8 +11671,10 @@ void VMinmaxI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDot2F16F16Vop3::VDot2F16F16Vop3(const MachineInst *inst)
-    : Vop3("v_dot2_f16_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VDot2F16F16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_dot2_f16_f16_e64_dpp"
+               : "v_dot2_f16_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDot2F16F16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -11313,8 +11782,10 @@ void VDot2F16F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDot2Bf16Bf16Vop3::VDot2Bf16Bf16Vop3(const MachineInst *inst)
-    : Vop3("v_dot2_bf16_bf16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VDot2Bf16Bf16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_dot2_bf16_bf16_e64_dpp"
+               : "v_dot2_bf16_bf16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDot2Bf16Bf16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -11422,8 +11893,10 @@ void VDot2Bf16Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddNcU16Vop3::VAddNcU16Vop3(const MachineInst *inst)
-    : Vop3("v_add_nc_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAddNcU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_nc_u16_e64_dpp"
+               : "v_add_nc_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddNcU16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -11500,8 +11973,10 @@ void VAddNcU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubNcU16Vop3::VSubNcU16Vop3(const MachineInst *inst)
-    : Vop3("v_sub_nc_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubNcU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_nc_u16_e64_dpp"
+               : "v_sub_nc_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubNcU16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -11578,8 +12053,10 @@ void VSubNcU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulLoU16Vop3::VMulLoU16Vop3(const MachineInst *inst)
-    : Vop3("v_mul_lo_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulLoU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_lo_u16_e64_dpp"
+               : "v_mul_lo_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulLoU16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -11657,8 +12134,10 @@ void VMulLoU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkI16F32Vop3::VCvtPkI16F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_i16_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkI16F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_i16_f32_e64_dpp"
+               : "v_cvt_pk_i16_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkI16F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -11717,8 +12196,10 @@ void VCvtPkI16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkU16F32Vop3::VCvtPkU16F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_u16_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkU16F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_u16_f32_e64_dpp"
+               : "v_cvt_pk_u16_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkU16F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -11777,7 +12258,10 @@ void VCvtPkU16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxU16Vop3::VMaxU16Vop3(const MachineInst *inst)
-    : Vop3("v_max_u16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_u16_e64_dpp"
+               : "v_max_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxU16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -11855,7 +12339,10 @@ void VMaxU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxI16Vop3::VMaxI16Vop3(const MachineInst *inst)
-    : Vop3("v_max_i16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_i16_e64_dpp"
+               : "v_max_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxI16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -11933,7 +12420,10 @@ void VMaxI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinU16Vop3::VMinU16Vop3(const MachineInst *inst)
-    : Vop3("v_min_u16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_u16_e64_dpp"
+               : "v_min_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinU16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -12011,7 +12501,10 @@ void VMinU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinI16Vop3::VMinI16Vop3(const MachineInst *inst)
-    : Vop3("v_min_i16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_i16_e64_dpp"
+               : "v_min_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinI16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -12089,8 +12582,10 @@ void VMinI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddNcI16Vop3::VAddNcI16Vop3(const MachineInst *inst)
-    : Vop3("v_add_nc_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAddNcI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_nc_i16_e64_dpp"
+               : "v_add_nc_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddNcI16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -12166,8 +12661,10 @@ void VAddNcI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubNcI16Vop3::VSubNcI16Vop3(const MachineInst *inst)
-    : Vop3("v_sub_nc_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubNcI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_nc_i16_e64_dpp"
+               : "v_sub_nc_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubNcI16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -12243,8 +12740,10 @@ void VSubNcI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPackB32F16Vop3::VPackB32F16Vop3(const MachineInst *inst)
-    : Vop3("v_pack_b32_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VPackB32F16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_pack_b32_f16_e64_dpp"
+               : "v_pack_b32_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPackB32F16Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -12312,8 +12811,10 @@ void VPackB32F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkNormI16F16Vop3::VCvtPkNormI16F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_norm_i16_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkNormI16F16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_norm_i16_f16_e64_dpp"
+               : "v_cvt_pk_norm_i16_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkNormI16F16Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -12397,8 +12898,10 @@ void VCvtPkNormI16F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkNormU16F16Vop3::VCvtPkNormU16F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_norm_u16_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkNormU16F16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_norm_u16_f16_e64_dpp"
+               : "v_cvt_pk_norm_u16_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkNormU16F16Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -12480,8 +12983,10 @@ void VCvtPkNormU16F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLdexpF32Vop3::VLdexpF32Vop3(const MachineInst *inst)
-    : Vop3("v_ldexp_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLdexpF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ldexp_f32_e64_dpp"
+               : "v_ldexp_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLdexpF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -12529,7 +13034,10 @@ void VLdexpF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VBfmB32Vop3::VBfmB32Vop3(const MachineInst *inst)
-    : Vop3("v_bfm_b32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VBfmB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_bfm_b32_e64_dpp"
+               : "v_bfm_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VBfmB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -12577,8 +13085,10 @@ void VBfmB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VBcntU32B32Vop3::VBcntU32B32Vop3(const MachineInst *inst)
-    : Vop3("v_bcnt_u32_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VBcntU32B32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_bcnt_u32_b32_e64_dpp"
+               : "v_bcnt_u32_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VBcntU32B32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -12626,8 +13136,10 @@ void VBcntU32B32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMbcntLoU32B32Vop3::VMbcntLoU32B32Vop3(const MachineInst *inst)
-    : Vop3("v_mbcnt_lo_u32_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMbcntLoU32B32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mbcnt_lo_u32_b32_e64_dpp"
+               : "v_mbcnt_lo_u32_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMbcntLoU32B32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -12675,8 +13187,10 @@ void VMbcntLoU32B32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMbcntHiU32B32Vop3::VMbcntHiU32B32Vop3(const MachineInst *inst)
-    : Vop3("v_mbcnt_hi_u32_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMbcntHiU32B32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mbcnt_hi_u32_b32_e64_dpp"
+               : "v_mbcnt_hi_u32_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMbcntHiU32B32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -12724,8 +13238,10 @@ void VMbcntHiU32B32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkNormI16F32Vop3::VCvtPkNormI16F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_norm_i16_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkNormI16F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_norm_i16_f32_e64_dpp"
+               : "v_cvt_pk_norm_i16_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkNormI16F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -12773,8 +13289,10 @@ void VCvtPkNormI16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkNormU16F32Vop3::VCvtPkNormU16F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_norm_u16_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkNormU16F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_norm_u16_f32_e64_dpp"
+               : "v_cvt_pk_norm_u16_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkNormU16F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -12822,8 +13340,10 @@ void VCvtPkNormU16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkU16U32Vop3::VCvtPkU16U32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_u16_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkU16U32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_u16_u32_e64_dpp"
+               : "v_cvt_pk_u16_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkU16U32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -12871,8 +13391,10 @@ void VCvtPkU16U32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkI16I32Vop3::VCvtPkI16I32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_i16_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkI16I32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_i16_i32_e64_dpp"
+               : "v_cvt_pk_i16_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkI16I32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -12920,8 +13442,10 @@ void VCvtPkI16I32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubNcI32Vop3::VSubNcI32Vop3(const MachineInst *inst)
-    : Vop3("v_sub_nc_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubNcI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_nc_i32_e64_dpp"
+               : "v_sub_nc_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubNcI32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -12969,8 +13493,10 @@ void VSubNcI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddNcI32Vop3::VAddNcI32Vop3(const MachineInst *inst)
-    : Vop3("v_add_nc_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAddNcI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_nc_i32_e64_dpp"
+               : "v_add_nc_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddNcI32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13018,7 +13544,10 @@ void VAddNcI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddF64Vop3::VAddF64Vop3(const MachineInst *inst)
-    : Vop3("v_add_f64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_f64_e64_dpp"
+               : "v_add_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13045,7 +13574,10 @@ VAddF64Vop3::VAddF64Vop3(const MachineInst *inst)
 void VAddF64Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_add_f64_vop3(*this, wf); }
 
 VMulF64Vop3::VMulF64Vop3(const MachineInst *inst)
-    : Vop3("v_mul_f64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_f64_e64_dpp"
+               : "v_mul_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13072,7 +13604,10 @@ VMulF64Vop3::VMulF64Vop3(const MachineInst *inst)
 void VMulF64Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_mul_f64_vop3(*this, wf); }
 
 VMinF64Vop3::VMinF64Vop3(const MachineInst *inst)
-    : Vop3("v_min_f64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_f64_e64_dpp"
+               : "v_min_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13099,7 +13634,10 @@ VMinF64Vop3::VMinF64Vop3(const MachineInst *inst)
 void VMinF64Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_min_f64_vop3(*this, wf); }
 
 VMaxF64Vop3::VMaxF64Vop3(const MachineInst *inst)
-    : Vop3("v_max_f64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_f64_e64_dpp"
+               : "v_max_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13126,8 +13664,10 @@ VMaxF64Vop3::VMaxF64Vop3(const MachineInst *inst)
 void VMaxF64Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_max_f64_vop3(*this, wf); }
 
 VLdexpF64Vop3::VLdexpF64Vop3(const MachineInst *inst)
-    : Vop3("v_ldexp_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLdexpF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ldexp_f64_e64_dpp"
+               : "v_ldexp_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLdexpF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13155,8 +13695,10 @@ void VLdexpF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulLoU32Vop3::VMulLoU32Vop3(const MachineInst *inst)
-    : Vop3("v_mul_lo_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulLoU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_lo_u32_e64_dpp"
+               : "v_mul_lo_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulLoU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13183,8 +13725,10 @@ void VMulLoU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulHiU32Vop3::VMulHiU32Vop3(const MachineInst *inst)
-    : Vop3("v_mul_hi_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulHiU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_hi_u32_e64_dpp"
+               : "v_mul_hi_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulHiU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13211,8 +13755,10 @@ void VMulHiU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulHiI32Vop3::VMulHiI32Vop3(const MachineInst *inst)
-    : Vop3("v_mul_hi_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulHiI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_hi_i32_e64_dpp"
+               : "v_mul_hi_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulHiI32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13239,8 +13785,10 @@ void VMulHiI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VTrigPreopF64Vop3::VTrigPreopF64Vop3(const MachineInst *inst)
-    : Vop3("v_trig_preop_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VTrigPreopF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_trig_preop_f64_e64_dpp"
+               : "v_trig_preop_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VTrigPreopF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13269,8 +13817,10 @@ void VTrigPreopF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLshlrevB16Vop3::VLshlrevB16Vop3(const MachineInst *inst)
-    : Vop3("v_lshlrev_b16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLshlrevB16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshlrev_b16_e64_dpp"
+               : "v_lshlrev_b16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLshlrevB16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13343,8 +13893,10 @@ void VLshlrevB16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLshrrevB16Vop3::VLshrrevB16Vop3(const MachineInst *inst)
-    : Vop3("v_lshrrev_b16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLshrrevB16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshrrev_b16_e64_dpp"
+               : "v_lshrrev_b16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLshrrevB16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13417,8 +13969,10 @@ void VLshrrevB16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAshrrevI16Vop3::VAshrrevI16Vop3(const MachineInst *inst)
-    : Vop3("v_ashrrev_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAshrrevI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ashrrev_i16_e64_dpp"
+               : "v_ashrrev_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAshrrevI16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13493,8 +14047,10 @@ void VAshrrevI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLshlrevB64Vop3::VLshlrevB64Vop3(const MachineInst *inst)
-    : Vop3("v_lshlrev_b64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLshlrevB64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshlrev_b64_e64_dpp"
+               : "v_lshlrev_b64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLshlrevB64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13522,8 +14078,10 @@ void VLshlrevB64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLshrrevB64Vop3::VLshrrevB64Vop3(const MachineInst *inst)
-    : Vop3("v_lshrrev_b64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLshrrevB64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshrrev_b64_e64_dpp"
+               : "v_lshrrev_b64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLshrrevB64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13551,8 +14109,10 @@ void VLshrrevB64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAshrrevI64Vop3::VAshrrevI64Vop3(const MachineInst *inst)
-    : Vop3("v_ashrrev_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAshrrevI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ashrrev_i64_e64_dpp"
+               : "v_ashrrev_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAshrrevI64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13580,8 +14140,10 @@ void VAshrrevI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VReadlaneB32Vop3::VReadlaneB32Vop3(const MachineInst *inst)
-    : Vop3("v_readlane_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VReadlaneB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_readlane_b32_e64_dpp"
+               : "v_readlane_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VReadlaneB32Vop3>()),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SSRC_LANESEL, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13609,8 +14171,10 @@ void VReadlaneB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VWritelaneB32Vop3::VWritelaneB32Vop3(const MachineInst *inst)
-    : Vop3("v_writelane_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VWritelaneB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_writelane_b32_e64_dpp"
+               : "v_writelane_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VWritelaneB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SSRC_LANESEL, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13640,7 +14204,10 @@ void VWritelaneB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAndB16Vop3::VAndB16Vop3(const MachineInst *inst)
-    : Vop3("v_and_b16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAndB16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_and_b16_e64_dpp"
+               : "v_and_b16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAndB16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13717,7 +14284,10 @@ void VAndB16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VOrB16Vop3::VOrB16Vop3(const MachineInst *inst)
-    : Vop3("v_or_b16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VOrB16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_or_b16_e64_dpp"
+               : "v_or_b16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VOrB16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13794,7 +14364,10 @@ void VOrB16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VXorB16Vop3::VXorB16Vop3(const MachineInst *inst)
-    : Vop3("v_xor_b16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXorB16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_xor_b16_e64_dpp"
+               : "v_xor_b16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXorB16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13871,7 +14444,10 @@ void VXorB16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpFF16Vop3::VCmpFF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_f_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_f_f16_e64_dpp"
+               : "v_cmp_f_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13940,8 +14516,10 @@ void VCmpFF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtF16Vop3::VCmpLtF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lt_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_f16_e64_dpp"
+               : "v_cmp_lt_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14027,8 +14605,10 @@ void VCmpLtF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqF16Vop3::VCmpEqF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_eq_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_f16_e64_dpp"
+               : "v_cmp_eq_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14114,8 +14694,10 @@ void VCmpEqF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeF16Vop3::VCmpLeF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_le_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_f16_e64_dpp"
+               : "v_cmp_le_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14201,8 +14783,10 @@ void VCmpLeF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtF16Vop3::VCmpGtF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_gt_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_f16_e64_dpp"
+               : "v_cmp_gt_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14288,8 +14872,10 @@ void VCmpGtF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLgF16Vop3::VCmpLgF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lg_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLgF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lg_f16_e64_dpp"
+               : "v_cmp_lg_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLgF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14378,8 +14964,10 @@ void VCmpLgF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeF16Vop3::VCmpGeF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ge_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_f16_e64_dpp"
+               : "v_cmp_ge_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14465,7 +15053,10 @@ void VCmpGeF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpOF16Vop3::VCmpOF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_o_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpOF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_o_f16_e64_dpp"
+               : "v_cmp_o_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpOF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14552,7 +15143,10 @@ void VCmpOF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpUF16Vop3::VCmpUF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_u_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpUF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_u_f16_e64_dpp"
+               : "v_cmp_u_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpUF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14639,8 +15233,10 @@ void VCmpUF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNgeF16Vop3::VCmpNgeF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nge_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNgeF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nge_f16_e64_dpp"
+               : "v_cmp_nge_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNgeF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14726,8 +15322,10 @@ void VCmpNgeF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNlgF16Vop3::VCmpNlgF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nlg_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNlgF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlg_f16_e64_dpp"
+               : "v_cmp_nlg_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNlgF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14816,8 +15414,10 @@ void VCmpNlgF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNgtF16Vop3::VCmpNgtF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ngt_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNgtF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ngt_f16_e64_dpp"
+               : "v_cmp_ngt_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNgtF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14903,8 +15503,10 @@ void VCmpNgtF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNleF16Vop3::VCmpNleF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nle_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNleF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nle_f16_e64_dpp"
+               : "v_cmp_nle_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNleF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14990,8 +15592,10 @@ void VCmpNleF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeqF16Vop3::VCmpNeqF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_neq_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeqF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_neq_f16_e64_dpp"
+               : "v_cmp_neq_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeqF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15077,8 +15681,10 @@ void VCmpNeqF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNltF16Vop3::VCmpNltF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nlt_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNltF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlt_f16_e64_dpp"
+               : "v_cmp_nlt_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNltF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15164,7 +15770,10 @@ void VCmpNltF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpTF16Vop3::VCmpTF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_t_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_t_f16_e64_dpp"
+               : "v_cmp_t_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15233,7 +15842,10 @@ void VCmpTF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpFF32Vop3::VCmpFF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_f_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_f_f32_e64_dpp"
+               : "v_cmp_f_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15281,8 +15893,10 @@ void VCmpFF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtF32Vop3::VCmpLtF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lt_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_f32_e64_dpp"
+               : "v_cmp_lt_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15330,8 +15944,10 @@ void VCmpLtF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqF32Vop3::VCmpEqF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_eq_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_f32_e64_dpp"
+               : "v_cmp_eq_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15379,8 +15995,10 @@ void VCmpEqF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeF32Vop3::VCmpLeF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_le_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_f32_e64_dpp"
+               : "v_cmp_le_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15428,8 +16046,10 @@ void VCmpLeF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtF32Vop3::VCmpGtF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_gt_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_f32_e64_dpp"
+               : "v_cmp_gt_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15477,8 +16097,10 @@ void VCmpGtF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLgF32Vop3::VCmpLgF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lg_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLgF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lg_f32_e64_dpp"
+               : "v_cmp_lg_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLgF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15526,8 +16148,10 @@ void VCmpLgF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeF32Vop3::VCmpGeF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ge_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_f32_e64_dpp"
+               : "v_cmp_ge_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15575,7 +16199,10 @@ void VCmpGeF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpOF32Vop3::VCmpOF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_o_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpOF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_o_f32_e64_dpp"
+               : "v_cmp_o_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpOF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15623,7 +16250,10 @@ void VCmpOF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpUF32Vop3::VCmpUF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_u_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpUF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_u_f32_e64_dpp"
+               : "v_cmp_u_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpUF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15671,8 +16301,10 @@ void VCmpUF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNgeF32Vop3::VCmpNgeF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nge_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNgeF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nge_f32_e64_dpp"
+               : "v_cmp_nge_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNgeF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15720,8 +16352,10 @@ void VCmpNgeF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNlgF32Vop3::VCmpNlgF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nlg_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNlgF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlg_f32_e64_dpp"
+               : "v_cmp_nlg_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNlgF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15769,8 +16403,10 @@ void VCmpNlgF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNgtF32Vop3::VCmpNgtF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ngt_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNgtF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ngt_f32_e64_dpp"
+               : "v_cmp_ngt_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNgtF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15818,8 +16454,10 @@ void VCmpNgtF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNleF32Vop3::VCmpNleF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nle_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNleF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nle_f32_e64_dpp"
+               : "v_cmp_nle_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNleF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15867,8 +16505,10 @@ void VCmpNleF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeqF32Vop3::VCmpNeqF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_neq_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeqF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_neq_f32_e64_dpp"
+               : "v_cmp_neq_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeqF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15916,8 +16556,10 @@ void VCmpNeqF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNltF32Vop3::VCmpNltF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nlt_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNltF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlt_f32_e64_dpp"
+               : "v_cmp_nlt_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNltF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15965,7 +16607,10 @@ void VCmpNltF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpTF32Vop3::VCmpTF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_t_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_t_f32_e64_dpp"
+               : "v_cmp_t_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16013,7 +16658,10 @@ void VCmpTF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpFF64Vop3::VCmpFF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_f_f64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_f_f64_e64_dpp"
+               : "v_cmp_f_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16042,8 +16690,10 @@ void VCmpFF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtF64Vop3::VCmpLtF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lt_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_f64_e64_dpp"
+               : "v_cmp_lt_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16072,8 +16722,10 @@ void VCmpLtF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqF64Vop3::VCmpEqF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_eq_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_f64_e64_dpp"
+               : "v_cmp_eq_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16102,8 +16754,10 @@ void VCmpEqF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeF64Vop3::VCmpLeF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_le_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_f64_e64_dpp"
+               : "v_cmp_le_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16132,8 +16786,10 @@ void VCmpLeF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtF64Vop3::VCmpGtF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_gt_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_f64_e64_dpp"
+               : "v_cmp_gt_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16162,8 +16818,10 @@ void VCmpGtF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLgF64Vop3::VCmpLgF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lg_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLgF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lg_f64_e64_dpp"
+               : "v_cmp_lg_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLgF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16192,8 +16850,10 @@ void VCmpLgF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeF64Vop3::VCmpGeF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ge_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_f64_e64_dpp"
+               : "v_cmp_ge_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16222,7 +16882,10 @@ void VCmpGeF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpOF64Vop3::VCmpOF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_o_f64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpOF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_o_f64_e64_dpp"
+               : "v_cmp_o_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpOF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16251,7 +16914,10 @@ void VCmpOF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpUF64Vop3::VCmpUF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_u_f64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpUF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_u_f64_e64_dpp"
+               : "v_cmp_u_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpUF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16280,8 +16946,10 @@ void VCmpUF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNgeF64Vop3::VCmpNgeF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nge_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNgeF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nge_f64_e64_dpp"
+               : "v_cmp_nge_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNgeF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16310,8 +16978,10 @@ void VCmpNgeF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNlgF64Vop3::VCmpNlgF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nlg_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNlgF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlg_f64_e64_dpp"
+               : "v_cmp_nlg_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNlgF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16340,8 +17010,10 @@ void VCmpNlgF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNgtF64Vop3::VCmpNgtF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ngt_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNgtF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ngt_f64_e64_dpp"
+               : "v_cmp_ngt_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNgtF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16370,8 +17042,10 @@ void VCmpNgtF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNleF64Vop3::VCmpNleF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nle_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNleF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nle_f64_e64_dpp"
+               : "v_cmp_nle_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNleF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16400,8 +17074,10 @@ void VCmpNleF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeqF64Vop3::VCmpNeqF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_neq_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeqF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_neq_f64_e64_dpp"
+               : "v_cmp_neq_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeqF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16430,8 +17106,10 @@ void VCmpNeqF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNltF64Vop3::VCmpNltF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nlt_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNltF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlt_f64_e64_dpp"
+               : "v_cmp_nlt_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNltF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16460,7 +17138,10 @@ void VCmpNltF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpTF64Vop3::VCmpTF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_t_f64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_t_f64_e64_dpp"
+               : "v_cmp_t_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16489,8 +17170,10 @@ void VCmpTF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtI16Vop3::VCmpLtI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lt_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_i16_e64_dpp"
+               : "v_cmp_lt_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtI16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16558,8 +17241,10 @@ void VCmpLtI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqI16Vop3::VCmpEqI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_eq_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_i16_e64_dpp"
+               : "v_cmp_eq_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqI16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16627,8 +17312,10 @@ void VCmpEqI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeI16Vop3::VCmpLeI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_le_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_i16_e64_dpp"
+               : "v_cmp_le_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeI16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16696,8 +17383,10 @@ void VCmpLeI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtI16Vop3::VCmpGtI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_gt_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_i16_e64_dpp"
+               : "v_cmp_gt_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtI16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16765,8 +17454,10 @@ void VCmpGtI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeI16Vop3::VCmpNeI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ne_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_i16_e64_dpp"
+               : "v_cmp_ne_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeI16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16834,8 +17525,10 @@ void VCmpNeI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeI16Vop3::VCmpGeI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ge_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_i16_e64_dpp"
+               : "v_cmp_ge_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeI16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16903,8 +17596,10 @@ void VCmpGeI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtU16Vop3::VCmpLtU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lt_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_u16_e64_dpp"
+               : "v_cmp_lt_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtU16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16972,8 +17667,10 @@ void VCmpLtU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqU16Vop3::VCmpEqU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_eq_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_u16_e64_dpp"
+               : "v_cmp_eq_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqU16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17042,8 +17739,10 @@ void VCmpEqU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeU16Vop3::VCmpLeU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_le_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_u16_e64_dpp"
+               : "v_cmp_le_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeU16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17112,8 +17811,10 @@ void VCmpLeU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtU16Vop3::VCmpGtU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_gt_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_u16_e64_dpp"
+               : "v_cmp_gt_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtU16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17181,8 +17882,10 @@ void VCmpGtU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeU16Vop3::VCmpNeU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ne_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_u16_e64_dpp"
+               : "v_cmp_ne_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeU16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17251,8 +17954,10 @@ void VCmpNeU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeU16Vop3::VCmpGeU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ge_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_u16_e64_dpp"
+               : "v_cmp_ge_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeU16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17321,7 +18026,10 @@ void VCmpGeU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpFI32Vop3::VCmpFI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_f_i32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_f_i32_e64_dpp"
+               : "v_cmp_f_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFI32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17369,8 +18077,10 @@ void VCmpFI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtI32Vop3::VCmpLtI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lt_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_i32_e64_dpp"
+               : "v_cmp_lt_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtI32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17418,8 +18128,10 @@ void VCmpLtI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqI32Vop3::VCmpEqI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_eq_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_i32_e64_dpp"
+               : "v_cmp_eq_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqI32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17467,8 +18179,10 @@ void VCmpEqI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeI32Vop3::VCmpLeI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_le_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_i32_e64_dpp"
+               : "v_cmp_le_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeI32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17516,8 +18230,10 @@ void VCmpLeI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtI32Vop3::VCmpGtI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_gt_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_i32_e64_dpp"
+               : "v_cmp_gt_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtI32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17565,8 +18281,10 @@ void VCmpGtI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeI32Vop3::VCmpNeI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ne_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_i32_e64_dpp"
+               : "v_cmp_ne_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeI32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17614,8 +18332,10 @@ void VCmpNeI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeI32Vop3::VCmpGeI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ge_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_i32_e64_dpp"
+               : "v_cmp_ge_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeI32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17663,7 +18383,10 @@ void VCmpGeI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpTI32Vop3::VCmpTI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_t_i32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_t_i32_e64_dpp"
+               : "v_cmp_t_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTI32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17711,7 +18434,10 @@ void VCmpTI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpFU32Vop3::VCmpFU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_f_u32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_f_u32_e64_dpp"
+               : "v_cmp_f_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFU32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17759,8 +18485,10 @@ void VCmpFU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtU32Vop3::VCmpLtU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lt_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_u32_e64_dpp"
+               : "v_cmp_lt_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtU32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17808,8 +18536,10 @@ void VCmpLtU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqU32Vop3::VCmpEqU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_eq_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_u32_e64_dpp"
+               : "v_cmp_eq_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqU32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17857,8 +18587,10 @@ void VCmpEqU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeU32Vop3::VCmpLeU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_le_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_u32_e64_dpp"
+               : "v_cmp_le_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeU32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17906,8 +18638,10 @@ void VCmpLeU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtU32Vop3::VCmpGtU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_gt_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_u32_e64_dpp"
+               : "v_cmp_gt_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtU32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17955,8 +18689,10 @@ void VCmpGtU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeU32Vop3::VCmpNeU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ne_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_u32_e64_dpp"
+               : "v_cmp_ne_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeU32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18004,8 +18740,10 @@ void VCmpNeU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeU32Vop3::VCmpGeU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ge_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_u32_e64_dpp"
+               : "v_cmp_ge_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeU32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18053,7 +18791,10 @@ void VCmpGeU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpTU32Vop3::VCmpTU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_t_u32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_t_u32_e64_dpp"
+               : "v_cmp_t_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTU32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18101,7 +18842,10 @@ void VCmpTU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpFI64Vop3::VCmpFI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_f_i64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_f_i64_e64_dpp"
+               : "v_cmp_f_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFI64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18130,8 +18874,10 @@ void VCmpFI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtI64Vop3::VCmpLtI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lt_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_i64_e64_dpp"
+               : "v_cmp_lt_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtI64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18160,8 +18906,10 @@ void VCmpLtI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqI64Vop3::VCmpEqI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_eq_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_i64_e64_dpp"
+               : "v_cmp_eq_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqI64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18190,8 +18938,10 @@ void VCmpEqI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeI64Vop3::VCmpLeI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_le_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_i64_e64_dpp"
+               : "v_cmp_le_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeI64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18220,8 +18970,10 @@ void VCmpLeI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtI64Vop3::VCmpGtI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_gt_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_i64_e64_dpp"
+               : "v_cmp_gt_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtI64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18250,8 +19002,10 @@ void VCmpGtI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeI64Vop3::VCmpNeI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ne_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_i64_e64_dpp"
+               : "v_cmp_ne_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeI64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18280,8 +19034,10 @@ void VCmpNeI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeI64Vop3::VCmpGeI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ge_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_i64_e64_dpp"
+               : "v_cmp_ge_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeI64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18310,7 +19066,10 @@ void VCmpGeI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpTI64Vop3::VCmpTI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_t_i64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_t_i64_e64_dpp"
+               : "v_cmp_t_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTI64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18339,7 +19098,10 @@ void VCmpTI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpFU64Vop3::VCmpFU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_f_u64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_f_u64_e64_dpp"
+               : "v_cmp_f_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFU64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18368,8 +19130,10 @@ void VCmpFU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtU64Vop3::VCmpLtU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lt_u64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_u64_e64_dpp"
+               : "v_cmp_lt_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtU64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18398,8 +19162,10 @@ void VCmpLtU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqU64Vop3::VCmpEqU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_eq_u64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_u64_e64_dpp"
+               : "v_cmp_eq_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqU64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18428,8 +19194,10 @@ void VCmpEqU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeU64Vop3::VCmpLeU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_le_u64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_u64_e64_dpp"
+               : "v_cmp_le_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeU64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18458,8 +19226,10 @@ void VCmpLeU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtU64Vop3::VCmpGtU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_gt_u64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_u64_e64_dpp"
+               : "v_cmp_gt_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtU64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18488,8 +19258,10 @@ void VCmpGtU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeU64Vop3::VCmpNeU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ne_u64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_u64_e64_dpp"
+               : "v_cmp_ne_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeU64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18518,8 +19290,10 @@ void VCmpNeU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeU64Vop3::VCmpGeU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ge_u64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_u64_e64_dpp"
+               : "v_cmp_ge_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeU64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18548,7 +19322,10 @@ void VCmpGeU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpTU64Vop3::VCmpTU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_t_u64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_t_u64_e64_dpp"
+               : "v_cmp_t_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTU64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18577,8 +19354,10 @@ void VCmpTU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpClassF16Vop3::VCmpClassF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_class_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpClassF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_class_f16_e64_dpp"
+               : "v_cmp_class_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpClassF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18707,8 +19486,10 @@ void VCmpClassF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpClassF32Vop3::VCmpClassF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_class_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpClassF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_class_f32_e64_dpp"
+               : "v_cmp_class_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpClassF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18756,8 +19537,10 @@ void VCmpClassF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpClassF64Vop3::VCmpClassF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_class_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpClassF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_class_f64_e64_dpp"
+               : "v_cmp_class_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpClassF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18785,8 +19568,10 @@ void VCmpClassF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxFF16Vop3::VCmpxFF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_f_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxFF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_f_f16_e64_dpp"
+               : "v_cmpx_f_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxFF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -18855,8 +19640,10 @@ void VCmpxFF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtF16Vop3::VCmpxLtF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lt_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_f16_e64_dpp"
+               : "v_cmpx_lt_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -18939,8 +19726,10 @@ void VCmpxLtF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqF16Vop3::VCmpxEqF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_eq_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_f16_e64_dpp"
+               : "v_cmpx_eq_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -19023,8 +19812,10 @@ void VCmpxEqF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeF16Vop3::VCmpxLeF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_le_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_f16_e64_dpp"
+               : "v_cmpx_le_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -19107,8 +19898,10 @@ void VCmpxLeF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtF16Vop3::VCmpxGtF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_gt_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_f16_e64_dpp"
+               : "v_cmpx_gt_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -19191,8 +19984,10 @@ void VCmpxGtF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLgF16Vop3::VCmpxLgF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lg_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLgF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lg_f16_e64_dpp"
+               : "v_cmpx_lg_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLgF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -19275,8 +20070,10 @@ void VCmpxLgF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeF16Vop3::VCmpxGeF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ge_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_f16_e64_dpp"
+               : "v_cmpx_ge_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -19359,8 +20156,10 @@ void VCmpxGeF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxOF16Vop3::VCmpxOF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_o_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxOF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_o_f16_e64_dpp"
+               : "v_cmpx_o_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxOF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -19443,8 +20242,10 @@ void VCmpxOF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxUF16Vop3::VCmpxUF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_u_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxUF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_u_f16_e64_dpp"
+               : "v_cmpx_u_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxUF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -19527,8 +20328,10 @@ void VCmpxUF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNgeF16Vop3::VCmpxNgeF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nge_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNgeF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nge_f16_e64_dpp"
+               : "v_cmpx_nge_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNgeF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -19611,8 +20414,10 @@ void VCmpxNgeF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNlgF16Vop3::VCmpxNlgF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nlg_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNlgF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlg_f16_e64_dpp"
+               : "v_cmpx_nlg_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNlgF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -19695,8 +20500,10 @@ void VCmpxNlgF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNgtF16Vop3::VCmpxNgtF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ngt_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNgtF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ngt_f16_e64_dpp"
+               : "v_cmpx_ngt_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNgtF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -19779,8 +20586,10 @@ void VCmpxNgtF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNleF16Vop3::VCmpxNleF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nle_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNleF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nle_f16_e64_dpp"
+               : "v_cmpx_nle_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNleF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -19863,8 +20672,10 @@ void VCmpxNleF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeqF16Vop3::VCmpxNeqF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_neq_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeqF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_neq_f16_e64_dpp"
+               : "v_cmpx_neq_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeqF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -19947,8 +20758,10 @@ void VCmpxNeqF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNltF16Vop3::VCmpxNltF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nlt_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNltF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlt_f16_e64_dpp"
+               : "v_cmpx_nlt_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNltF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -20031,8 +20844,10 @@ void VCmpxNltF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxTF16Vop3::VCmpxTF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_t_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxTF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_t_f16_e64_dpp"
+               : "v_cmpx_t_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxTF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -20101,8 +20916,10 @@ void VCmpxTF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxFF32Vop3::VCmpxFF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_f_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxFF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_f_f32_e64_dpp"
+               : "v_cmpx_f_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxFF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -20161,8 +20978,10 @@ void VCmpxFF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtF32Vop3::VCmpxLtF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lt_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_f32_e64_dpp"
+               : "v_cmpx_lt_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -20232,8 +21051,10 @@ void VCmpxLtF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqF32Vop3::VCmpxEqF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_eq_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_f32_e64_dpp"
+               : "v_cmpx_eq_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -20303,8 +21124,10 @@ void VCmpxEqF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeF32Vop3::VCmpxLeF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_le_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_f32_e64_dpp"
+               : "v_cmpx_le_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -20374,8 +21197,10 @@ void VCmpxLeF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtF32Vop3::VCmpxGtF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_gt_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_f32_e64_dpp"
+               : "v_cmpx_gt_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -20445,8 +21270,10 @@ void VCmpxGtF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLgF32Vop3::VCmpxLgF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lg_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLgF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lg_f32_e64_dpp"
+               : "v_cmpx_lg_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLgF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -20516,8 +21343,10 @@ void VCmpxLgF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeF32Vop3::VCmpxGeF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ge_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_f32_e64_dpp"
+               : "v_cmpx_ge_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -20587,8 +21416,10 @@ void VCmpxGeF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxOF32Vop3::VCmpxOF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_o_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxOF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_o_f32_e64_dpp"
+               : "v_cmpx_o_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxOF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -20658,8 +21489,10 @@ void VCmpxOF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxUF32Vop3::VCmpxUF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_u_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxUF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_u_f32_e64_dpp"
+               : "v_cmpx_u_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxUF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -20729,8 +21562,10 @@ void VCmpxUF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNgeF32Vop3::VCmpxNgeF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nge_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNgeF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nge_f32_e64_dpp"
+               : "v_cmpx_nge_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNgeF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -20800,8 +21635,10 @@ void VCmpxNgeF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNlgF32Vop3::VCmpxNlgF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nlg_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNlgF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlg_f32_e64_dpp"
+               : "v_cmpx_nlg_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNlgF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -20871,8 +21708,10 @@ void VCmpxNlgF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNgtF32Vop3::VCmpxNgtF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ngt_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNgtF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ngt_f32_e64_dpp"
+               : "v_cmpx_ngt_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNgtF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -20942,8 +21781,10 @@ void VCmpxNgtF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNleF32Vop3::VCmpxNleF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nle_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNleF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nle_f32_e64_dpp"
+               : "v_cmpx_nle_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNleF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21013,8 +21854,10 @@ void VCmpxNleF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeqF32Vop3::VCmpxNeqF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_neq_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeqF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_neq_f32_e64_dpp"
+               : "v_cmpx_neq_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeqF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21084,8 +21927,10 @@ void VCmpxNeqF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNltF32Vop3::VCmpxNltF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nlt_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNltF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlt_f32_e64_dpp"
+               : "v_cmpx_nlt_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNltF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21155,8 +22000,10 @@ void VCmpxNltF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxTF32Vop3::VCmpxTF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_t_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxTF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_t_f32_e64_dpp"
+               : "v_cmpx_t_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxTF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21215,8 +22062,10 @@ void VCmpxTF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxFF64Vop3::VCmpxFF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_f_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxFF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_f_f64_e64_dpp"
+               : "v_cmpx_f_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxFF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21256,8 +22105,10 @@ void VCmpxFF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtF64Vop3::VCmpxLtF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lt_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_f64_e64_dpp"
+               : "v_cmpx_lt_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21308,8 +22159,10 @@ void VCmpxLtF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqF64Vop3::VCmpxEqF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_eq_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_f64_e64_dpp"
+               : "v_cmpx_eq_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21360,8 +22213,10 @@ void VCmpxEqF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeF64Vop3::VCmpxLeF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_le_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_f64_e64_dpp"
+               : "v_cmpx_le_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21412,8 +22267,10 @@ void VCmpxLeF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtF64Vop3::VCmpxGtF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_gt_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_f64_e64_dpp"
+               : "v_cmpx_gt_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21464,8 +22321,10 @@ void VCmpxGtF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLgF64Vop3::VCmpxLgF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lg_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLgF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lg_f64_e64_dpp"
+               : "v_cmpx_lg_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLgF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21516,8 +22375,10 @@ void VCmpxLgF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeF64Vop3::VCmpxGeF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ge_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_f64_e64_dpp"
+               : "v_cmpx_ge_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21568,8 +22429,10 @@ void VCmpxGeF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxOF64Vop3::VCmpxOF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_o_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxOF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_o_f64_e64_dpp"
+               : "v_cmpx_o_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxOF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21620,8 +22483,10 @@ void VCmpxOF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxUF64Vop3::VCmpxUF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_u_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxUF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_u_f64_e64_dpp"
+               : "v_cmpx_u_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxUF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21672,8 +22537,10 @@ void VCmpxUF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNgeF64Vop3::VCmpxNgeF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nge_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNgeF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nge_f64_e64_dpp"
+               : "v_cmpx_nge_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNgeF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21724,8 +22591,10 @@ void VCmpxNgeF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNlgF64Vop3::VCmpxNlgF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nlg_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNlgF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlg_f64_e64_dpp"
+               : "v_cmpx_nlg_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNlgF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21776,8 +22645,10 @@ void VCmpxNlgF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNgtF64Vop3::VCmpxNgtF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ngt_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNgtF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ngt_f64_e64_dpp"
+               : "v_cmpx_ngt_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNgtF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21828,8 +22699,10 @@ void VCmpxNgtF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNleF64Vop3::VCmpxNleF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nle_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNleF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nle_f64_e64_dpp"
+               : "v_cmpx_nle_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNleF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21880,8 +22753,10 @@ void VCmpxNleF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeqF64Vop3::VCmpxNeqF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_neq_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeqF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_neq_f64_e64_dpp"
+               : "v_cmpx_neq_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeqF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21932,8 +22807,10 @@ void VCmpxNeqF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNltF64Vop3::VCmpxNltF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nlt_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNltF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlt_f64_e64_dpp"
+               : "v_cmpx_nlt_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNltF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21984,8 +22861,10 @@ void VCmpxNltF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxTF64Vop3::VCmpxTF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_t_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxTF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_t_f64_e64_dpp"
+               : "v_cmpx_t_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxTF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22025,8 +22904,10 @@ void VCmpxTF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtI16Vop3::VCmpxLtI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lt_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_i16_e64_dpp"
+               : "v_cmpx_lt_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtI16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22105,8 +22986,10 @@ void VCmpxLtI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqI16Vop3::VCmpxEqI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_eq_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_i16_e64_dpp"
+               : "v_cmpx_eq_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqI16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22185,8 +23068,10 @@ void VCmpxEqI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeI16Vop3::VCmpxLeI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_le_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_i16_e64_dpp"
+               : "v_cmpx_le_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeI16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22265,8 +23150,10 @@ void VCmpxLeI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtI16Vop3::VCmpxGtI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_gt_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_i16_e64_dpp"
+               : "v_cmpx_gt_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtI16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22345,8 +23232,10 @@ void VCmpxGtI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeI16Vop3::VCmpxNeI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ne_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_i16_e64_dpp"
+               : "v_cmpx_ne_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeI16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22425,8 +23314,10 @@ void VCmpxNeI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeI16Vop3::VCmpxGeI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ge_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_i16_e64_dpp"
+               : "v_cmpx_ge_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeI16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22505,8 +23396,10 @@ void VCmpxGeI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtU16Vop3::VCmpxLtU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lt_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_u16_e64_dpp"
+               : "v_cmpx_lt_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtU16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22585,8 +23478,10 @@ void VCmpxLtU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqU16Vop3::VCmpxEqU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_eq_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_u16_e64_dpp"
+               : "v_cmpx_eq_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqU16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22665,8 +23560,10 @@ void VCmpxEqU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeU16Vop3::VCmpxLeU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_le_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_u16_e64_dpp"
+               : "v_cmpx_le_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeU16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22745,8 +23642,10 @@ void VCmpxLeU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtU16Vop3::VCmpxGtU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_gt_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_u16_e64_dpp"
+               : "v_cmpx_gt_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtU16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22825,8 +23724,10 @@ void VCmpxGtU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeU16Vop3::VCmpxNeU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ne_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_u16_e64_dpp"
+               : "v_cmpx_ne_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeU16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22905,8 +23806,10 @@ void VCmpxNeU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeU16Vop3::VCmpxGeU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ge_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_u16_e64_dpp"
+               : "v_cmpx_ge_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeU16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22985,8 +23888,10 @@ void VCmpxGeU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxFI32Vop3::VCmpxFI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_f_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxFI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_f_i32_e64_dpp"
+               : "v_cmpx_f_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxFI32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23045,8 +23950,10 @@ void VCmpxFI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtI32Vop3::VCmpxLtI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lt_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_i32_e64_dpp"
+               : "v_cmpx_lt_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtI32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23108,8 +24015,10 @@ void VCmpxLtI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqI32Vop3::VCmpxEqI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_eq_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_i32_e64_dpp"
+               : "v_cmpx_eq_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqI32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23171,8 +24080,10 @@ void VCmpxEqI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeI32Vop3::VCmpxLeI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_le_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_i32_e64_dpp"
+               : "v_cmpx_le_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeI32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23234,8 +24145,10 @@ void VCmpxLeI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtI32Vop3::VCmpxGtI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_gt_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_i32_e64_dpp"
+               : "v_cmpx_gt_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtI32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23297,8 +24210,10 @@ void VCmpxGtI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeI32Vop3::VCmpxNeI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ne_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_i32_e64_dpp"
+               : "v_cmpx_ne_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeI32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23360,8 +24275,10 @@ void VCmpxNeI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeI32Vop3::VCmpxGeI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ge_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_i32_e64_dpp"
+               : "v_cmpx_ge_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeI32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23423,8 +24340,10 @@ void VCmpxGeI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxTI32Vop3::VCmpxTI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_t_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxTI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_t_i32_e64_dpp"
+               : "v_cmpx_t_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxTI32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23483,8 +24402,10 @@ void VCmpxTI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxFU32Vop3::VCmpxFU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_f_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxFU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_f_u32_e64_dpp"
+               : "v_cmpx_f_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxFU32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23543,8 +24464,10 @@ void VCmpxFU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtU32Vop3::VCmpxLtU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lt_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_u32_e64_dpp"
+               : "v_cmpx_lt_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtU32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23606,8 +24529,10 @@ void VCmpxLtU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqU32Vop3::VCmpxEqU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_eq_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_u32_e64_dpp"
+               : "v_cmpx_eq_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqU32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23669,8 +24594,10 @@ void VCmpxEqU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeU32Vop3::VCmpxLeU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_le_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_u32_e64_dpp"
+               : "v_cmpx_le_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeU32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23732,8 +24659,10 @@ void VCmpxLeU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtU32Vop3::VCmpxGtU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_gt_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_u32_e64_dpp"
+               : "v_cmpx_gt_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtU32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23795,8 +24724,10 @@ void VCmpxGtU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeU32Vop3::VCmpxNeU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ne_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_u32_e64_dpp"
+               : "v_cmpx_ne_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeU32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23858,8 +24789,10 @@ void VCmpxNeU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeU32Vop3::VCmpxGeU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ge_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_u32_e64_dpp"
+               : "v_cmpx_ge_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeU32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23921,8 +24854,10 @@ void VCmpxGeU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxTU32Vop3::VCmpxTU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_t_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxTU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_t_u32_e64_dpp"
+               : "v_cmpx_t_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxTU32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23981,8 +24916,10 @@ void VCmpxTU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxFI64Vop3::VCmpxFI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_f_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxFI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_f_i64_e64_dpp"
+               : "v_cmpx_f_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxFI64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24022,8 +24959,10 @@ void VCmpxFI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtI64Vop3::VCmpxLtI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lt_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_i64_e64_dpp"
+               : "v_cmpx_lt_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtI64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24066,8 +25005,10 @@ void VCmpxLtI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqI64Vop3::VCmpxEqI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_eq_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_i64_e64_dpp"
+               : "v_cmpx_eq_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqI64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24110,8 +25051,10 @@ void VCmpxEqI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeI64Vop3::VCmpxLeI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_le_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_i64_e64_dpp"
+               : "v_cmpx_le_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeI64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24154,8 +25097,10 @@ void VCmpxLeI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtI64Vop3::VCmpxGtI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_gt_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_i64_e64_dpp"
+               : "v_cmpx_gt_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtI64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24198,8 +25143,10 @@ void VCmpxGtI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeI64Vop3::VCmpxNeI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ne_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_i64_e64_dpp"
+               : "v_cmpx_ne_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeI64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24242,8 +25189,10 @@ void VCmpxNeI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeI64Vop3::VCmpxGeI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ge_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_i64_e64_dpp"
+               : "v_cmpx_ge_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeI64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24286,8 +25235,10 @@ void VCmpxGeI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxTI64Vop3::VCmpxTI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_t_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxTI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_t_i64_e64_dpp"
+               : "v_cmpx_t_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxTI64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24327,8 +25278,10 @@ void VCmpxTI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxFU64Vop3::VCmpxFU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_f_u64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxFU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_f_u64_e64_dpp"
+               : "v_cmpx_f_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxFU64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24368,8 +25321,10 @@ void VCmpxFU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtU64Vop3::VCmpxLtU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lt_u64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_u64_e64_dpp"
+               : "v_cmpx_lt_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtU64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24412,8 +25367,10 @@ void VCmpxLtU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqU64Vop3::VCmpxEqU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_eq_u64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_u64_e64_dpp"
+               : "v_cmpx_eq_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqU64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24456,8 +25413,10 @@ void VCmpxEqU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeU64Vop3::VCmpxLeU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_le_u64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_u64_e64_dpp"
+               : "v_cmpx_le_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeU64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24500,8 +25459,10 @@ void VCmpxLeU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtU64Vop3::VCmpxGtU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_gt_u64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_u64_e64_dpp"
+               : "v_cmpx_gt_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtU64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24544,8 +25505,10 @@ void VCmpxGtU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeU64Vop3::VCmpxNeU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ne_u64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_u64_e64_dpp"
+               : "v_cmpx_ne_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeU64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24588,8 +25551,10 @@ void VCmpxNeU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeU64Vop3::VCmpxGeU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ge_u64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_u64_e64_dpp"
+               : "v_cmpx_ge_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeU64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24632,8 +25597,10 @@ void VCmpxGeU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxTU64Vop3::VCmpxTU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_t_u64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxTU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_t_u64_e64_dpp"
+               : "v_cmpx_t_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxTU64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24673,8 +25640,10 @@ void VCmpxTU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxClassF16Vop3::VCmpxClassF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_class_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxClassF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_class_f16_e64_dpp"
+               : "v_cmpx_class_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxClassF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24781,8 +25750,10 @@ void VCmpxClassF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxClassF32Vop3::VCmpxClassF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_class_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxClassF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_class_f32_e64_dpp"
+               : "v_cmpx_class_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxClassF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24871,8 +25842,10 @@ void VCmpxClassF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxClassF64Vop3::VCmpxClassF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_class_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxClassF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_class_f64_e64_dpp"
+               : "v_cmpx_class_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxClassF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24943,7 +25916,10 @@ void VCmpxClassF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddCoCiU32Vop3SdstEnc::VAddCoCiU32Vop3SdstEnc(const MachineInst *inst)
-    : Vop3SdstEnc("v_add_co_ci_u32", reinterpret_cast<const OpEncoding *>(inst),
+    : Vop3SdstEnc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                      ? "v_add_co_ci_u32_e64_dpp"
+                      : "v_add_co_ci_u32",
+                  reinterpret_cast<const OpEncoding *>(inst),
                   make_exec_fn<VAddCoCiU32Vop3SdstEnc>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
@@ -25002,7 +25978,10 @@ void VAddCoCiU32Vop3SdstEnc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubCoCiU32Vop3SdstEnc::VSubCoCiU32Vop3SdstEnc(const MachineInst *inst)
-    : Vop3SdstEnc("v_sub_co_ci_u32", reinterpret_cast<const OpEncoding *>(inst),
+    : Vop3SdstEnc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                      ? "v_sub_co_ci_u32_e64_dpp"
+                      : "v_sub_co_ci_u32",
+                  reinterpret_cast<const OpEncoding *>(inst),
                   make_exec_fn<VSubCoCiU32Vop3SdstEnc>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
@@ -25061,7 +26040,10 @@ void VSubCoCiU32Vop3SdstEnc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubrevCoCiU32Vop3SdstEnc::VSubrevCoCiU32Vop3SdstEnc(const MachineInst *inst)
-    : Vop3SdstEnc("v_subrev_co_ci_u32", reinterpret_cast<const OpEncoding *>(inst),
+    : Vop3SdstEnc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                      ? "v_subrev_co_ci_u32_e64_dpp"
+                      : "v_subrev_co_ci_u32",
+                  reinterpret_cast<const OpEncoding *>(inst),
                   make_exec_fn<VSubrevCoCiU32Vop3SdstEnc>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
@@ -25120,7 +26102,10 @@ void VSubrevCoCiU32Vop3SdstEnc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDivScaleF32Vop3SdstEnc::VDivScaleF32Vop3SdstEnc(const MachineInst *inst)
-    : Vop3SdstEnc("v_div_scale_f32", reinterpret_cast<const OpEncoding *>(inst),
+    : Vop3SdstEnc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                      ? "v_div_scale_f32_e64_dpp"
+                      : "v_div_scale_f32",
+                  reinterpret_cast<const OpEncoding *>(inst),
                   make_exec_fn<VDivScaleF32Vop3SdstEnc>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(64, OperandType::OPR_SDST, reinterpret_cast<const OpEncoding *>(inst)->sdst),
@@ -25156,7 +26141,10 @@ void VDivScaleF32Vop3SdstEnc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDivScaleF64Vop3SdstEnc::VDivScaleF64Vop3SdstEnc(const MachineInst *inst)
-    : Vop3SdstEnc("v_div_scale_f64", reinterpret_cast<const OpEncoding *>(inst),
+    : Vop3SdstEnc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                      ? "v_div_scale_f64_e64_dpp"
+                      : "v_div_scale_f64",
+                  reinterpret_cast<const OpEncoding *>(inst),
                   make_exec_fn<VDivScaleF64Vop3SdstEnc>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(64, OperandType::OPR_SDST, reinterpret_cast<const OpEncoding *>(inst)->sdst),
@@ -25198,7 +26186,10 @@ void VDivScaleF64Vop3SdstEnc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMadU64U32Vop3SdstEnc::VMadU64U32Vop3SdstEnc(const MachineInst *inst)
-    : Vop3SdstEnc("v_mad_u64_u32", reinterpret_cast<const OpEncoding *>(inst),
+    : Vop3SdstEnc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                      ? "v_mad_u64_u32_e64_dpp"
+                      : "v_mad_u64_u32",
+                  reinterpret_cast<const OpEncoding *>(inst),
                   make_exec_fn<VMadU64U32Vop3SdstEnc>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
@@ -25236,7 +26227,10 @@ void VMadU64U32Vop3SdstEnc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMadI64I32Vop3SdstEnc::VMadI64I32Vop3SdstEnc(const MachineInst *inst)
-    : Vop3SdstEnc("v_mad_i64_i32", reinterpret_cast<const OpEncoding *>(inst),
+    : Vop3SdstEnc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                      ? "v_mad_i64_i32_e64_dpp"
+                      : "v_mad_i64_i32",
+                  reinterpret_cast<const OpEncoding *>(inst),
                   make_exec_fn<VMadI64I32Vop3SdstEnc>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
@@ -25274,8 +26268,10 @@ void VMadI64I32Vop3SdstEnc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddCoU32Vop3SdstEnc::VAddCoU32Vop3SdstEnc(const MachineInst *inst)
-    : Vop3SdstEnc("v_add_co_u32", reinterpret_cast<const OpEncoding *>(inst),
-                  make_exec_fn<VAddCoU32Vop3SdstEnc>()),
+    : Vop3SdstEnc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                      ? "v_add_co_u32_e64_dpp"
+                      : "v_add_co_u32",
+                  reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddCoU32Vop3SdstEnc>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -25325,8 +26321,10 @@ void VAddCoU32Vop3SdstEnc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubCoU32Vop3SdstEnc::VSubCoU32Vop3SdstEnc(const MachineInst *inst)
-    : Vop3SdstEnc("v_sub_co_u32", reinterpret_cast<const OpEncoding *>(inst),
-                  make_exec_fn<VSubCoU32Vop3SdstEnc>()),
+    : Vop3SdstEnc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                      ? "v_sub_co_u32_e64_dpp"
+                      : "v_sub_co_u32",
+                  reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubCoU32Vop3SdstEnc>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -25376,7 +26374,10 @@ void VSubCoU32Vop3SdstEnc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubrevCoU32Vop3SdstEnc::VSubrevCoU32Vop3SdstEnc(const MachineInst *inst)
-    : Vop3SdstEnc("v_subrev_co_u32", reinterpret_cast<const OpEncoding *>(inst),
+    : Vop3SdstEnc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                      ? "v_subrev_co_u32_e64_dpp"
+                      : "v_subrev_co_u32",
+                  reinterpret_cast<const OpEncoding *>(inst),
                   make_exec_fn<VSubrevCoU32Vop3SdstEnc>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/vop3p.cpp
@@ -23,8 +23,10 @@ namespace rocjitsu {
 namespace rdna3 {
 
 VPkMadI16Vop3p::VPkMadI16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_mad_i16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkMadI16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_mad_i16_e64_dpp"
+                : "v_pk_mad_i16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkMadI16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -57,8 +59,10 @@ void VPkMadI16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkMulLoU16Vop3p::VPkMulLoU16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_mul_lo_u16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkMulLoU16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_mul_lo_u16_e64_dpp"
+                : "v_pk_mul_lo_u16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkMulLoU16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -85,8 +89,10 @@ void VPkMulLoU16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkAddI16Vop3p::VPkAddI16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_add_i16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkAddI16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_add_i16_e64_dpp"
+                : "v_pk_add_i16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkAddI16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -113,8 +119,10 @@ void VPkAddI16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkSubI16Vop3p::VPkSubI16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_sub_i16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkSubI16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_sub_i16_e64_dpp"
+                : "v_pk_sub_i16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkSubI16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -141,8 +149,10 @@ void VPkSubI16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkLshlrevB16Vop3p::VPkLshlrevB16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_lshlrev_b16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkLshlrevB16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_lshlrev_b16_e64_dpp"
+                : "v_pk_lshlrev_b16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkLshlrevB16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -169,8 +179,10 @@ void VPkLshlrevB16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkLshrrevB16Vop3p::VPkLshrrevB16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_lshrrev_b16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkLshrrevB16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_lshrrev_b16_e64_dpp"
+                : "v_pk_lshrrev_b16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkLshrrevB16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -197,8 +209,10 @@ void VPkLshrrevB16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkAshrrevI16Vop3p::VPkAshrrevI16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_ashrrev_i16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkAshrrevI16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_ashrrev_i16_e64_dpp"
+                : "v_pk_ashrrev_i16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkAshrrevI16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -225,8 +239,10 @@ void VPkAshrrevI16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkMaxI16Vop3p::VPkMaxI16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_max_i16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkMaxI16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_max_i16_e64_dpp"
+                : "v_pk_max_i16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkMaxI16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -253,8 +269,10 @@ void VPkMaxI16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkMinI16Vop3p::VPkMinI16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_min_i16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkMinI16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_min_i16_e64_dpp"
+                : "v_pk_min_i16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkMinI16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -281,8 +299,10 @@ void VPkMinI16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkMadU16Vop3p::VPkMadU16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_mad_u16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkMadU16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_mad_u16_e64_dpp"
+                : "v_pk_mad_u16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkMadU16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -315,8 +335,10 @@ void VPkMadU16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkAddU16Vop3p::VPkAddU16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_add_u16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkAddU16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_add_u16_e64_dpp"
+                : "v_pk_add_u16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkAddU16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -343,8 +365,10 @@ void VPkAddU16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkSubU16Vop3p::VPkSubU16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_sub_u16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkSubU16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_sub_u16_e64_dpp"
+                : "v_pk_sub_u16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkSubU16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -371,8 +395,10 @@ void VPkSubU16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkMaxU16Vop3p::VPkMaxU16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_max_u16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkMaxU16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_max_u16_e64_dpp"
+                : "v_pk_max_u16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkMaxU16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -399,8 +425,10 @@ void VPkMaxU16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkMinU16Vop3p::VPkMinU16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_min_u16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkMinU16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_min_u16_e64_dpp"
+                : "v_pk_min_u16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkMinU16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -427,8 +455,10 @@ void VPkMinU16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkFmaF16Vop3p::VPkFmaF16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_fma_f16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkFmaF16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_fma_f16_e64_dpp"
+                : "v_pk_fma_f16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkFmaF16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -461,8 +491,10 @@ void VPkFmaF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkAddF16Vop3p::VPkAddF16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_add_f16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkAddF16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_add_f16_e64_dpp"
+                : "v_pk_add_f16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkAddF16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -489,8 +521,10 @@ void VPkAddF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkMulF16Vop3p::VPkMulF16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_mul_f16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkMulF16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_mul_f16_e64_dpp"
+                : "v_pk_mul_f16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkMulF16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -517,8 +551,10 @@ void VPkMulF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkMinF16Vop3p::VPkMinF16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_min_f16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkMinF16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_min_f16_e64_dpp"
+                : "v_pk_min_f16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkMinF16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -545,8 +581,10 @@ void VPkMinF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkMaxF16Vop3p::VPkMaxF16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_max_f16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkMaxF16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_max_f16_e64_dpp"
+                : "v_pk_max_f16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkMaxF16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -573,8 +611,10 @@ void VPkMaxF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDot2F32F16Vop3p::VDot2F32F16Vop3p(const MachineInst *inst)
-    : Vop3p("v_dot2_f32_f16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VDot2F32F16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_dot2_f32_f16_e64_dpp"
+                : "v_dot2_f32_f16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDot2F32F16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -628,8 +668,10 @@ void VDot2F32F16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDot4I32Iu8Vop3p::VDot4I32Iu8Vop3p(const MachineInst *inst)
-    : Vop3p("v_dot4_i32_iu8", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VDot4I32Iu8Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_dot4_i32_iu8_e64_dpp"
+                : "v_dot4_i32_iu8",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDot4I32Iu8Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -662,8 +704,10 @@ void VDot4I32Iu8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDot4U32U8Vop3p::VDot4U32U8Vop3p(const MachineInst *inst)
-    : Vop3p("v_dot4_u32_u8", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VDot4U32U8Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_dot4_u32_u8_e64_dpp"
+                : "v_dot4_u32_u8",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDot4U32U8Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -696,8 +740,10 @@ void VDot4U32U8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDot8I32Iu4Vop3p::VDot8I32Iu4Vop3p(const MachineInst *inst)
-    : Vop3p("v_dot8_i32_iu4", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VDot8I32Iu4Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_dot8_i32_iu4_e64_dpp"
+                : "v_dot8_i32_iu4",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDot8I32Iu4Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -730,8 +776,10 @@ void VDot8I32Iu4Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDot8U32U4Vop3p::VDot8U32U4Vop3p(const MachineInst *inst)
-    : Vop3p("v_dot8_u32_u4", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VDot8U32U4Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_dot8_u32_u4_e64_dpp"
+                : "v_dot8_u32_u4",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDot8U32U4Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -764,8 +812,10 @@ void VDot8U32U4Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDot2F32Bf16Vop3p::VDot2F32Bf16Vop3p(const MachineInst *inst)
-    : Vop3p("v_dot2_f32_bf16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VDot2F32Bf16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_dot2_f32_bf16_e64_dpp"
+                : "v_dot2_f32_bf16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDot2F32Bf16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -819,8 +869,10 @@ void VDot2F32Bf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmaMixF32Vop3p::VFmaMixF32Vop3p(const MachineInst *inst)
-    : Vop3p("v_fma_mix_f32", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VFmaMixF32Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_fma_mix_f32_e64_dpp"
+                : "v_fma_mix_f32",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmaMixF32Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -874,8 +926,10 @@ void VFmaMixF32Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmaMixloF16Vop3p::VFmaMixloF16Vop3p(const MachineInst *inst)
-    : Vop3p("v_fma_mixlo_f16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VFmaMixloF16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_fma_mixlo_f16_e64_dpp"
+                : "v_fma_mixlo_f16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmaMixloF16Vop3p>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -936,8 +990,10 @@ void VFmaMixloF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmaMixhiF16Vop3p::VFmaMixhiF16Vop3p(const MachineInst *inst)
-    : Vop3p("v_fma_mixhi_f16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VFmaMixhiF16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_fma_mixhi_f16_e64_dpp"
+                : "v_fma_mixhi_f16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmaMixhiF16Vop3p>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -998,8 +1054,10 @@ void VFmaMixhiF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VWmmaF3216x16x16F16Vop3p::VWmmaF3216x16x16F16Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_f32_16x16x16_f16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VWmmaF3216x16x16F16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_f32_16x16x16_f16_e64_dpp"
+                : "v_wmma_f32_16x16x16_f16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VWmmaF3216x16x16F16Vop3p>()),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1042,8 +1100,10 @@ void VWmmaF3216x16x16F16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VWmmaF3216x16x16Bf16Vop3p::VWmmaF3216x16x16Bf16Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_f32_16x16x16_bf16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VWmmaF3216x16x16Bf16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_f32_16x16x16_bf16_e64_dpp"
+                : "v_wmma_f32_16x16x16_bf16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VWmmaF3216x16x16Bf16Vop3p>()),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1086,8 +1146,10 @@ void VWmmaF3216x16x16Bf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VWmmaF1616x16x16F16Vop3p::VWmmaF1616x16x16F16Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_f16_16x16x16_f16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VWmmaF1616x16x16F16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_f16_16x16x16_f16_e64_dpp"
+                : "v_wmma_f16_16x16x16_f16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VWmmaF1616x16x16F16Vop3p>()),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1130,8 +1192,10 @@ void VWmmaF1616x16x16F16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VWmmaBf1616x16x16Bf16Vop3p::VWmmaBf1616x16x16Bf16Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_bf16_16x16x16_bf16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VWmmaBf1616x16x16Bf16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_bf16_16x16x16_bf16_e64_dpp"
+                : "v_wmma_bf16_16x16x16_bf16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VWmmaBf1616x16x16Bf16Vop3p>()),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1174,8 +1238,10 @@ void VWmmaBf1616x16x16Bf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VWmmaI3216x16x16Iu8Vop3p::VWmmaI3216x16x16Iu8Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_i32_16x16x16_iu8", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VWmmaI3216x16x16Iu8Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_i32_16x16x16_iu8_e64_dpp"
+                : "v_wmma_i32_16x16x16_iu8",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VWmmaI3216x16x16Iu8Vop3p>()),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1225,8 +1291,10 @@ void VWmmaI3216x16x16Iu8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VWmmaI3216x16x16Iu4Vop3p::VWmmaI3216x16x16Iu4Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_i32_16x16x16_iu4", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VWmmaI3216x16x16Iu4Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_i32_16x16x16_iu4_e64_dpp"
+                : "v_wmma_i32_16x16x16_iu4",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VWmmaI3216x16x16Iu4Vop3p>()),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/vopc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/vopc.cpp
@@ -22,8 +22,10 @@ namespace rocjitsu {
 namespace rdna3 {
 
 VCmpFF16Vopc::VCmpFF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_f_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpFF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_f_f16_dpp"
+               : "v_cmp_f_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -82,8 +84,10 @@ void VCmpFF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtF16Vopc::VCmpLtF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lt_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_f16_dpp"
+               : "v_cmp_lt_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -142,8 +146,10 @@ void VCmpLtF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqF16Vopc::VCmpEqF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_eq_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_f16_dpp"
+               : "v_cmp_eq_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -202,8 +208,10 @@ void VCmpEqF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeF16Vopc::VCmpLeF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_le_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_f16_dpp"
+               : "v_cmp_le_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -262,8 +270,10 @@ void VCmpLeF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtF16Vopc::VCmpGtF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_gt_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_f16_dpp"
+               : "v_cmp_gt_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -322,8 +332,10 @@ void VCmpGtF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLgF16Vopc::VCmpLgF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lg_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLgF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lg_f16_dpp"
+               : "v_cmp_lg_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLgF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -382,8 +394,10 @@ void VCmpLgF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeF16Vopc::VCmpGeF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ge_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_f16_dpp"
+               : "v_cmp_ge_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -442,8 +456,10 @@ void VCmpGeF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpOF16Vopc::VCmpOF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_o_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpOF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_o_f16_dpp"
+               : "v_cmp_o_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpOF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -502,8 +518,10 @@ void VCmpOF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpUF16Vopc::VCmpUF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_u_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpUF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_u_f16_dpp"
+               : "v_cmp_u_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpUF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -562,8 +580,10 @@ void VCmpUF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNgeF16Vopc::VCmpNgeF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nge_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNgeF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nge_f16_dpp"
+               : "v_cmp_nge_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNgeF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -622,8 +642,10 @@ void VCmpNgeF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNlgF16Vopc::VCmpNlgF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nlg_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNlgF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlg_f16_dpp"
+               : "v_cmp_nlg_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNlgF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -682,8 +704,10 @@ void VCmpNlgF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNgtF16Vopc::VCmpNgtF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ngt_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNgtF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ngt_f16_dpp"
+               : "v_cmp_ngt_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNgtF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -742,8 +766,10 @@ void VCmpNgtF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNleF16Vopc::VCmpNleF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nle_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNleF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nle_f16_dpp"
+               : "v_cmp_nle_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNleF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -802,8 +828,10 @@ void VCmpNleF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeqF16Vopc::VCmpNeqF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_neq_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeqF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_neq_f16_dpp"
+               : "v_cmp_neq_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeqF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -862,8 +890,10 @@ void VCmpNeqF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNltF16Vopc::VCmpNltF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nlt_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNltF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlt_f16_dpp"
+               : "v_cmp_nlt_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNltF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -922,8 +952,10 @@ void VCmpNltF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpTF16Vopc::VCmpTF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_t_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpTF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_t_f16_dpp"
+               : "v_cmp_t_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -982,8 +1014,10 @@ void VCmpTF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpFF32Vopc::VCmpFF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_f_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpFF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_f_f32_dpp"
+               : "v_cmp_f_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1039,8 +1073,10 @@ void VCmpFF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtF32Vopc::VCmpLtF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lt_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_f32_dpp"
+               : "v_cmp_lt_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1096,8 +1132,10 @@ void VCmpLtF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqF32Vopc::VCmpEqF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_eq_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_f32_dpp"
+               : "v_cmp_eq_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1153,8 +1191,10 @@ void VCmpEqF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeF32Vopc::VCmpLeF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_le_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_f32_dpp"
+               : "v_cmp_le_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1210,8 +1250,10 @@ void VCmpLeF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtF32Vopc::VCmpGtF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_gt_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_f32_dpp"
+               : "v_cmp_gt_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1267,8 +1309,10 @@ void VCmpGtF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLgF32Vopc::VCmpLgF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lg_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLgF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lg_f32_dpp"
+               : "v_cmp_lg_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLgF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1324,8 +1368,10 @@ void VCmpLgF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeF32Vopc::VCmpGeF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ge_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_f32_dpp"
+               : "v_cmp_ge_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1381,8 +1427,10 @@ void VCmpGeF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpOF32Vopc::VCmpOF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_o_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpOF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_o_f32_dpp"
+               : "v_cmp_o_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpOF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1438,8 +1486,10 @@ void VCmpOF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpUF32Vopc::VCmpUF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_u_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpUF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_u_f32_dpp"
+               : "v_cmp_u_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpUF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1495,8 +1545,10 @@ void VCmpUF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNgeF32Vopc::VCmpNgeF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nge_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNgeF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nge_f32_dpp"
+               : "v_cmp_nge_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNgeF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1552,8 +1604,10 @@ void VCmpNgeF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNlgF32Vopc::VCmpNlgF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nlg_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNlgF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlg_f32_dpp"
+               : "v_cmp_nlg_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNlgF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1609,8 +1663,10 @@ void VCmpNlgF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNgtF32Vopc::VCmpNgtF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ngt_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNgtF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ngt_f32_dpp"
+               : "v_cmp_ngt_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNgtF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1666,8 +1722,10 @@ void VCmpNgtF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNleF32Vopc::VCmpNleF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nle_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNleF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nle_f32_dpp"
+               : "v_cmp_nle_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNleF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1723,8 +1781,10 @@ void VCmpNleF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeqF32Vopc::VCmpNeqF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_neq_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeqF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_neq_f32_dpp"
+               : "v_cmp_neq_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeqF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1780,8 +1840,10 @@ void VCmpNeqF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNltF32Vopc::VCmpNltF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nlt_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNltF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlt_f32_dpp"
+               : "v_cmp_nlt_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNltF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1837,8 +1899,10 @@ void VCmpNltF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpTF32Vopc::VCmpTF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_t_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpTF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_t_f32_dpp"
+               : "v_cmp_t_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1894,8 +1958,10 @@ void VCmpTF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpFF64Vopc::VCmpFF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_f_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpFF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_f_f64_dpp"
+               : "v_cmp_f_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1920,8 +1986,10 @@ void VCmpFF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtF64Vopc::VCmpLtF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lt_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_f64_dpp"
+               : "v_cmp_lt_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1946,8 +2014,10 @@ void VCmpLtF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqF64Vopc::VCmpEqF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_eq_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_f64_dpp"
+               : "v_cmp_eq_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1972,8 +2042,10 @@ void VCmpEqF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeF64Vopc::VCmpLeF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_le_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_f64_dpp"
+               : "v_cmp_le_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1998,8 +2070,10 @@ void VCmpLeF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtF64Vopc::VCmpGtF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_gt_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_f64_dpp"
+               : "v_cmp_gt_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2024,8 +2098,10 @@ void VCmpGtF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLgF64Vopc::VCmpLgF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lg_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLgF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lg_f64_dpp"
+               : "v_cmp_lg_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLgF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2050,8 +2126,10 @@ void VCmpLgF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeF64Vopc::VCmpGeF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ge_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_f64_dpp"
+               : "v_cmp_ge_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2076,8 +2154,10 @@ void VCmpGeF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpOF64Vopc::VCmpOF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_o_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpOF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_o_f64_dpp"
+               : "v_cmp_o_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpOF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2102,8 +2182,10 @@ void VCmpOF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpUF64Vopc::VCmpUF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_u_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpUF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_u_f64_dpp"
+               : "v_cmp_u_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpUF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2128,8 +2210,10 @@ void VCmpUF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNgeF64Vopc::VCmpNgeF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nge_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNgeF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nge_f64_dpp"
+               : "v_cmp_nge_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNgeF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2154,8 +2238,10 @@ void VCmpNgeF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNlgF64Vopc::VCmpNlgF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nlg_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNlgF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlg_f64_dpp"
+               : "v_cmp_nlg_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNlgF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2180,8 +2266,10 @@ void VCmpNlgF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNgtF64Vopc::VCmpNgtF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ngt_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNgtF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ngt_f64_dpp"
+               : "v_cmp_ngt_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNgtF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2206,8 +2294,10 @@ void VCmpNgtF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNleF64Vopc::VCmpNleF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nle_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNleF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nle_f64_dpp"
+               : "v_cmp_nle_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNleF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2232,8 +2322,10 @@ void VCmpNleF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeqF64Vopc::VCmpNeqF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_neq_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeqF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_neq_f64_dpp"
+               : "v_cmp_neq_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeqF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2258,8 +2350,10 @@ void VCmpNeqF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNltF64Vopc::VCmpNltF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nlt_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNltF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlt_f64_dpp"
+               : "v_cmp_nlt_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNltF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2284,8 +2378,10 @@ void VCmpNltF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpTF64Vopc::VCmpTF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_t_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpTF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_t_f64_dpp"
+               : "v_cmp_t_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2310,8 +2406,10 @@ void VCmpTF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtI16Vopc::VCmpLtI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lt_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtI16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_i16_dpp"
+               : "v_cmp_lt_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtI16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2370,8 +2468,10 @@ void VCmpLtI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqI16Vopc::VCmpEqI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_eq_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqI16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_i16_dpp"
+               : "v_cmp_eq_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqI16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2430,8 +2530,10 @@ void VCmpEqI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeI16Vopc::VCmpLeI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_le_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeI16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_i16_dpp"
+               : "v_cmp_le_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeI16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2490,8 +2592,10 @@ void VCmpLeI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtI16Vopc::VCmpGtI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_gt_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtI16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_i16_dpp"
+               : "v_cmp_gt_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtI16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2550,8 +2654,10 @@ void VCmpGtI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeI16Vopc::VCmpNeI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ne_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeI16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_i16_dpp"
+               : "v_cmp_ne_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeI16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2610,8 +2716,10 @@ void VCmpNeI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeI16Vopc::VCmpGeI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ge_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeI16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_i16_dpp"
+               : "v_cmp_ge_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeI16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2670,8 +2778,10 @@ void VCmpGeI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtU16Vopc::VCmpLtU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lt_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtU16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_u16_dpp"
+               : "v_cmp_lt_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtU16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2730,8 +2840,10 @@ void VCmpLtU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqU16Vopc::VCmpEqU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_eq_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqU16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_u16_dpp"
+               : "v_cmp_eq_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqU16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2790,8 +2902,10 @@ void VCmpEqU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeU16Vopc::VCmpLeU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_le_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeU16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_u16_dpp"
+               : "v_cmp_le_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeU16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2850,8 +2964,10 @@ void VCmpLeU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtU16Vopc::VCmpGtU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_gt_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtU16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_u16_dpp"
+               : "v_cmp_gt_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtU16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2910,8 +3026,10 @@ void VCmpGtU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeU16Vopc::VCmpNeU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ne_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeU16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_u16_dpp"
+               : "v_cmp_ne_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeU16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2970,8 +3088,10 @@ void VCmpNeU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeU16Vopc::VCmpGeU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ge_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeU16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_u16_dpp"
+               : "v_cmp_ge_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeU16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -3030,8 +3150,10 @@ void VCmpGeU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpFI32Vopc::VCmpFI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_f_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpFI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_f_i32_dpp"
+               : "v_cmp_f_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFI32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3087,8 +3209,10 @@ void VCmpFI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtI32Vopc::VCmpLtI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lt_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_i32_dpp"
+               : "v_cmp_lt_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtI32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3144,8 +3268,10 @@ void VCmpLtI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqI32Vopc::VCmpEqI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_eq_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_i32_dpp"
+               : "v_cmp_eq_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqI32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3201,8 +3327,10 @@ void VCmpEqI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeI32Vopc::VCmpLeI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_le_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_i32_dpp"
+               : "v_cmp_le_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeI32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3258,8 +3386,10 @@ void VCmpLeI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtI32Vopc::VCmpGtI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_gt_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_i32_dpp"
+               : "v_cmp_gt_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtI32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3315,8 +3445,10 @@ void VCmpGtI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeI32Vopc::VCmpNeI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ne_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_i32_dpp"
+               : "v_cmp_ne_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeI32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3372,8 +3504,10 @@ void VCmpNeI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeI32Vopc::VCmpGeI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ge_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_i32_dpp"
+               : "v_cmp_ge_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeI32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3429,8 +3563,10 @@ void VCmpGeI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpTI32Vopc::VCmpTI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_t_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpTI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_t_i32_dpp"
+               : "v_cmp_t_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTI32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3486,8 +3622,10 @@ void VCmpTI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpFU32Vopc::VCmpFU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_f_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpFU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_f_u32_dpp"
+               : "v_cmp_f_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFU32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3543,8 +3681,10 @@ void VCmpFU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtU32Vopc::VCmpLtU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lt_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_u32_dpp"
+               : "v_cmp_lt_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtU32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3600,8 +3740,10 @@ void VCmpLtU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqU32Vopc::VCmpEqU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_eq_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_u32_dpp"
+               : "v_cmp_eq_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqU32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3657,8 +3799,10 @@ void VCmpEqU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeU32Vopc::VCmpLeU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_le_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_u32_dpp"
+               : "v_cmp_le_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeU32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3714,8 +3858,10 @@ void VCmpLeU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtU32Vopc::VCmpGtU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_gt_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_u32_dpp"
+               : "v_cmp_gt_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtU32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3771,8 +3917,10 @@ void VCmpGtU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeU32Vopc::VCmpNeU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ne_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_u32_dpp"
+               : "v_cmp_ne_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeU32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3828,8 +3976,10 @@ void VCmpNeU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeU32Vopc::VCmpGeU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ge_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_u32_dpp"
+               : "v_cmp_ge_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeU32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3885,8 +4035,10 @@ void VCmpGeU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpTU32Vopc::VCmpTU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_t_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpTU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_t_u32_dpp"
+               : "v_cmp_t_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTU32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3942,8 +4094,10 @@ void VCmpTU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpFI64Vopc::VCmpFI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_f_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpFI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_f_i64_dpp"
+               : "v_cmp_f_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFI64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3968,8 +4122,10 @@ void VCmpFI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtI64Vopc::VCmpLtI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lt_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_i64_dpp"
+               : "v_cmp_lt_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtI64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3994,8 +4150,10 @@ void VCmpLtI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqI64Vopc::VCmpEqI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_eq_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_i64_dpp"
+               : "v_cmp_eq_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqI64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -4020,8 +4178,10 @@ void VCmpEqI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeI64Vopc::VCmpLeI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_le_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_i64_dpp"
+               : "v_cmp_le_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeI64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -4046,8 +4206,10 @@ void VCmpLeI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtI64Vopc::VCmpGtI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_gt_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_i64_dpp"
+               : "v_cmp_gt_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtI64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -4072,8 +4234,10 @@ void VCmpGtI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeI64Vopc::VCmpNeI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ne_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_i64_dpp"
+               : "v_cmp_ne_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeI64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -4098,8 +4262,10 @@ void VCmpNeI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeI64Vopc::VCmpGeI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ge_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_i64_dpp"
+               : "v_cmp_ge_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeI64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -4124,8 +4290,10 @@ void VCmpGeI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpTI64Vopc::VCmpTI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_t_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpTI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_t_i64_dpp"
+               : "v_cmp_t_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTI64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -4150,8 +4318,10 @@ void VCmpTI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpFU64Vopc::VCmpFU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_f_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpFU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_f_u64_dpp"
+               : "v_cmp_f_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFU64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -4176,8 +4346,10 @@ void VCmpFU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtU64Vopc::VCmpLtU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lt_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_u64_dpp"
+               : "v_cmp_lt_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtU64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -4202,8 +4374,10 @@ void VCmpLtU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqU64Vopc::VCmpEqU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_eq_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_u64_dpp"
+               : "v_cmp_eq_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqU64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -4228,8 +4402,10 @@ void VCmpEqU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeU64Vopc::VCmpLeU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_le_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_u64_dpp"
+               : "v_cmp_le_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeU64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -4254,8 +4430,10 @@ void VCmpLeU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtU64Vopc::VCmpGtU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_gt_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_u64_dpp"
+               : "v_cmp_gt_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtU64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -4280,8 +4458,10 @@ void VCmpGtU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeU64Vopc::VCmpNeU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ne_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_u64_dpp"
+               : "v_cmp_ne_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeU64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -4306,8 +4486,10 @@ void VCmpNeU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeU64Vopc::VCmpGeU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ge_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_u64_dpp"
+               : "v_cmp_ge_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeU64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -4332,8 +4514,10 @@ void VCmpGeU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpTU64Vopc::VCmpTU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_t_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpTU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_t_u64_dpp"
+               : "v_cmp_t_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTU64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -4358,8 +4542,10 @@ void VCmpTU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpClassF16Vopc::VCmpClassF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_class_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpClassF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_class_f16_dpp"
+               : "v_cmp_class_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpClassF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -4418,8 +4604,10 @@ void VCmpClassF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpClassF32Vopc::VCmpClassF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_class_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpClassF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_class_f32_dpp"
+               : "v_cmp_class_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpClassF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -4475,8 +4663,10 @@ void VCmpClassF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpClassF64Vopc::VCmpClassF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_class_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpClassF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_class_f64_dpp"
+               : "v_cmp_class_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpClassF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -4501,8 +4691,10 @@ void VCmpClassF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxFF16Vopc::VCmpxFF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_f_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxFF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_f_f16_dpp"
+               : "v_cmpx_f_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxFF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -4576,8 +4768,10 @@ void VCmpxFF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtF16Vopc::VCmpxLtF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lt_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_f16_dpp"
+               : "v_cmpx_lt_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -4656,8 +4850,10 @@ void VCmpxLtF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqF16Vopc::VCmpxEqF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_eq_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_f16_dpp"
+               : "v_cmpx_eq_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -4736,8 +4932,10 @@ void VCmpxEqF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeF16Vopc::VCmpxLeF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_le_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_f16_dpp"
+               : "v_cmpx_le_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -4816,8 +5014,10 @@ void VCmpxLeF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtF16Vopc::VCmpxGtF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_gt_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_f16_dpp"
+               : "v_cmpx_gt_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -4896,8 +5096,10 @@ void VCmpxGtF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLgF16Vopc::VCmpxLgF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lg_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLgF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lg_f16_dpp"
+               : "v_cmpx_lg_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLgF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -4976,8 +5178,10 @@ void VCmpxLgF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeF16Vopc::VCmpxGeF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ge_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_f16_dpp"
+               : "v_cmpx_ge_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -5056,8 +5260,10 @@ void VCmpxGeF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxOF16Vopc::VCmpxOF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_o_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxOF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_o_f16_dpp"
+               : "v_cmpx_o_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxOF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -5136,8 +5342,10 @@ void VCmpxOF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxUF16Vopc::VCmpxUF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_u_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxUF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_u_f16_dpp"
+               : "v_cmpx_u_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxUF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -5216,8 +5424,10 @@ void VCmpxUF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNgeF16Vopc::VCmpxNgeF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nge_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNgeF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nge_f16_dpp"
+               : "v_cmpx_nge_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNgeF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -5296,8 +5506,10 @@ void VCmpxNgeF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNlgF16Vopc::VCmpxNlgF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nlg_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNlgF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlg_f16_dpp"
+               : "v_cmpx_nlg_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNlgF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -5376,8 +5588,10 @@ void VCmpxNlgF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNgtF16Vopc::VCmpxNgtF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ngt_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNgtF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ngt_f16_dpp"
+               : "v_cmpx_ngt_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNgtF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -5456,8 +5670,10 @@ void VCmpxNgtF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNleF16Vopc::VCmpxNleF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nle_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNleF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nle_f16_dpp"
+               : "v_cmpx_nle_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNleF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -5536,8 +5752,10 @@ void VCmpxNleF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeqF16Vopc::VCmpxNeqF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_neq_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeqF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_neq_f16_dpp"
+               : "v_cmpx_neq_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeqF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -5616,8 +5834,10 @@ void VCmpxNeqF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNltF16Vopc::VCmpxNltF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nlt_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNltF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlt_f16_dpp"
+               : "v_cmpx_nlt_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNltF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -5696,8 +5916,10 @@ void VCmpxNltF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxTF16Vopc::VCmpxTF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_t_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxTF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_t_f16_dpp"
+               : "v_cmpx_t_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxTF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -5771,8 +5993,10 @@ void VCmpxTF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxFF32Vopc::VCmpxFF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_f_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxFF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_f_f32_dpp"
+               : "v_cmpx_f_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxFF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -5843,8 +6067,10 @@ void VCmpxFF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtF32Vopc::VCmpxLtF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lt_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_f32_dpp"
+               : "v_cmpx_lt_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -5918,8 +6144,10 @@ void VCmpxLtF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqF32Vopc::VCmpxEqF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_eq_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_f32_dpp"
+               : "v_cmpx_eq_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -5993,8 +6221,10 @@ void VCmpxEqF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeF32Vopc::VCmpxLeF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_le_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_f32_dpp"
+               : "v_cmpx_le_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6068,8 +6298,10 @@ void VCmpxLeF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtF32Vopc::VCmpxGtF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_gt_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_f32_dpp"
+               : "v_cmpx_gt_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6143,8 +6375,10 @@ void VCmpxGtF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLgF32Vopc::VCmpxLgF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lg_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLgF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lg_f32_dpp"
+               : "v_cmpx_lg_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLgF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6218,8 +6452,10 @@ void VCmpxLgF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeF32Vopc::VCmpxGeF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ge_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_f32_dpp"
+               : "v_cmpx_ge_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6293,8 +6529,10 @@ void VCmpxGeF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxOF32Vopc::VCmpxOF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_o_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxOF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_o_f32_dpp"
+               : "v_cmpx_o_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxOF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6368,8 +6606,10 @@ void VCmpxOF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxUF32Vopc::VCmpxUF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_u_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxUF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_u_f32_dpp"
+               : "v_cmpx_u_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxUF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6443,8 +6683,10 @@ void VCmpxUF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNgeF32Vopc::VCmpxNgeF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nge_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNgeF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nge_f32_dpp"
+               : "v_cmpx_nge_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNgeF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6518,8 +6760,10 @@ void VCmpxNgeF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNlgF32Vopc::VCmpxNlgF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nlg_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNlgF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlg_f32_dpp"
+               : "v_cmpx_nlg_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNlgF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6593,8 +6837,10 @@ void VCmpxNlgF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNgtF32Vopc::VCmpxNgtF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ngt_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNgtF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ngt_f32_dpp"
+               : "v_cmpx_ngt_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNgtF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6668,8 +6914,10 @@ void VCmpxNgtF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNleF32Vopc::VCmpxNleF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nle_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNleF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nle_f32_dpp"
+               : "v_cmpx_nle_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNleF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6743,8 +6991,10 @@ void VCmpxNleF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeqF32Vopc::VCmpxNeqF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_neq_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeqF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_neq_f32_dpp"
+               : "v_cmpx_neq_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeqF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6818,8 +7068,10 @@ void VCmpxNeqF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNltF32Vopc::VCmpxNltF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nlt_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNltF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlt_f32_dpp"
+               : "v_cmpx_nlt_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNltF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6893,8 +7145,10 @@ void VCmpxNltF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxTF32Vopc::VCmpxTF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_t_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxTF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_t_f32_dpp"
+               : "v_cmpx_t_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxTF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6965,8 +7219,10 @@ void VCmpxTF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxFF64Vopc::VCmpxFF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_f_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxFF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_f_f64_dpp"
+               : "v_cmpx_f_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxFF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -7002,8 +7258,10 @@ void VCmpxFF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtF64Vopc::VCmpxLtF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lt_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_f64_dpp"
+               : "v_cmpx_lt_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -7042,8 +7300,10 @@ void VCmpxLtF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqF64Vopc::VCmpxEqF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_eq_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_f64_dpp"
+               : "v_cmpx_eq_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -7082,8 +7342,10 @@ void VCmpxEqF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeF64Vopc::VCmpxLeF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_le_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_f64_dpp"
+               : "v_cmpx_le_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -7122,8 +7384,10 @@ void VCmpxLeF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtF64Vopc::VCmpxGtF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_gt_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_f64_dpp"
+               : "v_cmpx_gt_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -7162,8 +7426,10 @@ void VCmpxGtF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLgF64Vopc::VCmpxLgF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lg_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLgF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lg_f64_dpp"
+               : "v_cmpx_lg_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLgF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -7202,8 +7468,10 @@ void VCmpxLgF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeF64Vopc::VCmpxGeF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ge_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_f64_dpp"
+               : "v_cmpx_ge_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -7242,8 +7510,10 @@ void VCmpxGeF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxOF64Vopc::VCmpxOF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_o_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxOF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_o_f64_dpp"
+               : "v_cmpx_o_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxOF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -7282,8 +7552,10 @@ void VCmpxOF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxUF64Vopc::VCmpxUF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_u_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxUF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_u_f64_dpp"
+               : "v_cmpx_u_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxUF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -7322,8 +7594,10 @@ void VCmpxUF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNgeF64Vopc::VCmpxNgeF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nge_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNgeF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nge_f64_dpp"
+               : "v_cmpx_nge_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNgeF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -7362,8 +7636,10 @@ void VCmpxNgeF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNlgF64Vopc::VCmpxNlgF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nlg_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNlgF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlg_f64_dpp"
+               : "v_cmpx_nlg_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNlgF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -7402,8 +7678,10 @@ void VCmpxNlgF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNgtF64Vopc::VCmpxNgtF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ngt_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNgtF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ngt_f64_dpp"
+               : "v_cmpx_ngt_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNgtF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -7442,8 +7720,10 @@ void VCmpxNgtF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNleF64Vopc::VCmpxNleF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nle_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNleF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nle_f64_dpp"
+               : "v_cmpx_nle_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNleF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -7482,8 +7762,10 @@ void VCmpxNleF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeqF64Vopc::VCmpxNeqF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_neq_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeqF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_neq_f64_dpp"
+               : "v_cmpx_neq_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeqF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -7522,8 +7804,10 @@ void VCmpxNeqF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNltF64Vopc::VCmpxNltF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nlt_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNltF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlt_f64_dpp"
+               : "v_cmpx_nlt_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNltF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -7562,8 +7846,10 @@ void VCmpxNltF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxTF64Vopc::VCmpxTF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_t_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxTF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_t_f64_dpp"
+               : "v_cmpx_t_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxTF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -7599,8 +7885,10 @@ void VCmpxTF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtI16Vopc::VCmpxLtI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lt_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtI16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_i16_dpp"
+               : "v_cmpx_lt_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtI16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -7677,8 +7965,10 @@ void VCmpxLtI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqI16Vopc::VCmpxEqI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_eq_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqI16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_i16_dpp"
+               : "v_cmpx_eq_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqI16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -7755,8 +8045,10 @@ void VCmpxEqI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeI16Vopc::VCmpxLeI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_le_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeI16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_i16_dpp"
+               : "v_cmpx_le_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeI16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -7833,8 +8125,10 @@ void VCmpxLeI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtI16Vopc::VCmpxGtI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_gt_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtI16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_i16_dpp"
+               : "v_cmpx_gt_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtI16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -7911,8 +8205,10 @@ void VCmpxGtI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeI16Vopc::VCmpxNeI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ne_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeI16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_i16_dpp"
+               : "v_cmpx_ne_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeI16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -7989,8 +8285,10 @@ void VCmpxNeI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeI16Vopc::VCmpxGeI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ge_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeI16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_i16_dpp"
+               : "v_cmpx_ge_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeI16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -8067,8 +8365,10 @@ void VCmpxGeI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtU16Vopc::VCmpxLtU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lt_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtU16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_u16_dpp"
+               : "v_cmpx_lt_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtU16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -8145,8 +8445,10 @@ void VCmpxLtU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqU16Vopc::VCmpxEqU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_eq_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqU16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_u16_dpp"
+               : "v_cmpx_eq_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqU16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -8223,8 +8525,10 @@ void VCmpxEqU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeU16Vopc::VCmpxLeU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_le_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeU16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_u16_dpp"
+               : "v_cmpx_le_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeU16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -8301,8 +8605,10 @@ void VCmpxLeU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtU16Vopc::VCmpxGtU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_gt_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtU16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_u16_dpp"
+               : "v_cmpx_gt_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtU16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -8379,8 +8685,10 @@ void VCmpxGtU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeU16Vopc::VCmpxNeU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ne_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeU16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_u16_dpp"
+               : "v_cmpx_ne_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeU16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -8457,8 +8765,10 @@ void VCmpxNeU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeU16Vopc::VCmpxGeU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ge_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeU16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_u16_dpp"
+               : "v_cmpx_ge_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeU16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -8535,8 +8845,10 @@ void VCmpxGeU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxFI32Vopc::VCmpxFI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_f_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxFI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_f_i32_dpp"
+               : "v_cmpx_f_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxFI32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -8607,8 +8919,10 @@ void VCmpxFI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtI32Vopc::VCmpxLtI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lt_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_i32_dpp"
+               : "v_cmpx_lt_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtI32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -8682,8 +8996,10 @@ void VCmpxLtI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqI32Vopc::VCmpxEqI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_eq_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_i32_dpp"
+               : "v_cmpx_eq_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqI32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -8757,8 +9073,10 @@ void VCmpxEqI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeI32Vopc::VCmpxLeI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_le_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_i32_dpp"
+               : "v_cmpx_le_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeI32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -8832,8 +9150,10 @@ void VCmpxLeI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtI32Vopc::VCmpxGtI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_gt_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_i32_dpp"
+               : "v_cmpx_gt_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtI32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -8907,8 +9227,10 @@ void VCmpxGtI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeI32Vopc::VCmpxNeI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ne_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_i32_dpp"
+               : "v_cmpx_ne_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeI32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -8982,8 +9304,10 @@ void VCmpxNeI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeI32Vopc::VCmpxGeI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ge_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_i32_dpp"
+               : "v_cmpx_ge_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeI32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -9057,8 +9381,10 @@ void VCmpxGeI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxTI32Vopc::VCmpxTI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_t_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxTI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_t_i32_dpp"
+               : "v_cmpx_t_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxTI32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -9129,8 +9455,10 @@ void VCmpxTI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxFU32Vopc::VCmpxFU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_f_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxFU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_f_u32_dpp"
+               : "v_cmpx_f_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxFU32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -9201,8 +9529,10 @@ void VCmpxFU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtU32Vopc::VCmpxLtU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lt_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_u32_dpp"
+               : "v_cmpx_lt_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtU32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -9276,8 +9606,10 @@ void VCmpxLtU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqU32Vopc::VCmpxEqU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_eq_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_u32_dpp"
+               : "v_cmpx_eq_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqU32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -9351,8 +9683,10 @@ void VCmpxEqU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeU32Vopc::VCmpxLeU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_le_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_u32_dpp"
+               : "v_cmpx_le_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeU32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -9426,8 +9760,10 @@ void VCmpxLeU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtU32Vopc::VCmpxGtU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_gt_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_u32_dpp"
+               : "v_cmpx_gt_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtU32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -9501,8 +9837,10 @@ void VCmpxGtU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeU32Vopc::VCmpxNeU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ne_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_u32_dpp"
+               : "v_cmpx_ne_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeU32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -9576,8 +9914,10 @@ void VCmpxNeU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeU32Vopc::VCmpxGeU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ge_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_u32_dpp"
+               : "v_cmpx_ge_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeU32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -9651,8 +9991,10 @@ void VCmpxGeU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxTU32Vopc::VCmpxTU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_t_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxTU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_t_u32_dpp"
+               : "v_cmpx_t_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxTU32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -9723,8 +10065,10 @@ void VCmpxTU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxFI64Vopc::VCmpxFI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_f_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxFI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_f_i64_dpp"
+               : "v_cmpx_f_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxFI64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -9760,8 +10104,10 @@ void VCmpxFI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtI64Vopc::VCmpxLtI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lt_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_i64_dpp"
+               : "v_cmpx_lt_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtI64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -9800,8 +10146,10 @@ void VCmpxLtI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqI64Vopc::VCmpxEqI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_eq_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_i64_dpp"
+               : "v_cmpx_eq_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqI64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -9840,8 +10188,10 @@ void VCmpxEqI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeI64Vopc::VCmpxLeI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_le_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_i64_dpp"
+               : "v_cmpx_le_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeI64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -9880,8 +10230,10 @@ void VCmpxLeI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtI64Vopc::VCmpxGtI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_gt_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_i64_dpp"
+               : "v_cmpx_gt_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtI64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -9920,8 +10272,10 @@ void VCmpxGtI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeI64Vopc::VCmpxNeI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ne_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_i64_dpp"
+               : "v_cmpx_ne_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeI64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -9960,8 +10314,10 @@ void VCmpxNeI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeI64Vopc::VCmpxGeI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ge_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_i64_dpp"
+               : "v_cmpx_ge_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeI64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -10000,8 +10356,10 @@ void VCmpxGeI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxTI64Vopc::VCmpxTI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_t_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxTI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_t_i64_dpp"
+               : "v_cmpx_t_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxTI64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -10037,8 +10395,10 @@ void VCmpxTI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxFU64Vopc::VCmpxFU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_f_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxFU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_f_u64_dpp"
+               : "v_cmpx_f_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxFU64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -10074,8 +10434,10 @@ void VCmpxFU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtU64Vopc::VCmpxLtU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lt_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_u64_dpp"
+               : "v_cmpx_lt_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtU64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -10114,8 +10476,10 @@ void VCmpxLtU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqU64Vopc::VCmpxEqU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_eq_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_u64_dpp"
+               : "v_cmpx_eq_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqU64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -10154,8 +10518,10 @@ void VCmpxEqU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeU64Vopc::VCmpxLeU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_le_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_u64_dpp"
+               : "v_cmpx_le_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeU64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -10194,8 +10560,10 @@ void VCmpxLeU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtU64Vopc::VCmpxGtU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_gt_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_u64_dpp"
+               : "v_cmpx_gt_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtU64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -10234,8 +10602,10 @@ void VCmpxGtU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeU64Vopc::VCmpxNeU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ne_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_u64_dpp"
+               : "v_cmpx_ne_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeU64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -10274,8 +10644,10 @@ void VCmpxNeU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeU64Vopc::VCmpxGeU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ge_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_u64_dpp"
+               : "v_cmpx_ge_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeU64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -10314,8 +10686,10 @@ void VCmpxGeU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxTU64Vopc::VCmpxTU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_t_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxTU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_t_u64_dpp"
+               : "v_cmpx_t_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxTU64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -10351,8 +10725,10 @@ void VCmpxTU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxClassF16Vopc::VCmpxClassF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_class_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxClassF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_class_f16_dpp"
+               : "v_cmpx_class_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxClassF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -10458,8 +10834,10 @@ void VCmpxClassF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxClassF32Vopc::VCmpxClassF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_class_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxClassF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_class_f32_dpp"
+               : "v_cmpx_class_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxClassF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -10556,8 +10934,10 @@ void VCmpxClassF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxClassF64Vopc::VCmpxClassF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_class_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxClassF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_class_f64_dpp"
+               : "v_cmpx_class_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxClassF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/encodings.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/encodings.cpp
@@ -141,6 +141,11 @@ Vop1::Vop1(std::string_view mnemonic, const Vop1MachineInst *inst, ExecuteFn exe
   raw_encoding_ = raw_words_.data();
 }
 
+void Vop1::build_modifiers(std::string &out) const {
+  if (amdgpu::dpp::is_src_dpp8(inst_.src0))
+    amdgpu::dpp::append_dpp8_disassembly(out, dpp8_lane_sel_, dpp_fi_);
+}
+
 void Vop1::implicit_uses(RegisterSet &uses) const {
   bool sdwa_preserve =
       sdwa_dst_sel_ != amdgpu::sdwa::DWORD && sdwa_dst_unused_ == amdgpu::sdwa::UNUSED_PRESERVE;
@@ -173,6 +178,11 @@ Vopc::Vopc(std::string_view mnemonic, const VopcMachineInst *inst, ExecuteFn exe
   raw_encoding_ = raw_words_.data();
 }
 
+void Vopc::build_modifiers(std::string &out) const {
+  if (amdgpu::dpp::is_src_dpp8(inst_.src0))
+    amdgpu::dpp::append_dpp8_disassembly(out, dpp8_lane_sel_, dpp_fi_);
+}
+
 bool Vopc::default_encoding() {
   return inst_.src0 != 250 && inst_.src0 != 233 && inst_.src0 != 234 && inst_.src0 != 255;
 }
@@ -191,6 +201,11 @@ Vop2::Vop2(std::string_view mnemonic, const Vop2MachineInst *inst, ExecuteFn exe
     literal_ = reinterpret_cast<const uint32_t *>(inst)[1];
   std::memcpy(raw_words_.data(), inst, size_);
   raw_encoding_ = raw_words_.data();
+}
+
+void Vop2::build_modifiers(std::string &out) const {
+  if (amdgpu::dpp::is_src_dpp8(inst_.src0))
+    amdgpu::dpp::append_dpp8_disassembly(out, dpp8_lane_sel_, dpp_fi_);
 }
 
 void Vop2::implicit_uses(RegisterSet &uses) const {
@@ -230,6 +245,11 @@ Vop3::Vop3(std::string_view mnemonic, const Vop3MachineInst *inst, ExecuteFn exe
     size_ += sizeof(MachineInst);
   std::memcpy(raw_words_.data(), inst, size_);
   raw_encoding_ = raw_words_.data();
+}
+
+void Vop3::build_modifiers(std::string &out) const {
+  if (amdgpu::dpp::is_src_dpp8(inst_.src0))
+    amdgpu::dpp::append_dpp8_disassembly(out, dpp8_lane_sel_, dpp_fi_);
 }
 
 void Vop3::implicit_uses(RegisterSet &uses) const {
@@ -286,6 +306,11 @@ Vop3p::Vop3p(std::string_view mnemonic, const Vop3pMachineInst *inst, ExecuteFn 
     size_ += sizeof(MachineInst);
   std::memcpy(raw_words_.data(), inst, size_);
   raw_encoding_ = raw_words_.data();
+}
+
+void Vop3p::build_modifiers(std::string &out) const {
+  if (amdgpu::dpp::is_src_dpp8(inst_.src0))
+    amdgpu::dpp::append_dpp8_disassembly(out, dpp8_lane_sel_, dpp_fi_);
 }
 
 void Vop3p::implicit_uses(RegisterSet &uses) const {
@@ -469,6 +494,11 @@ Vop3SdstEnc::Vop3SdstEnc(std::string_view mnemonic, const Vop3SdstEncMachineInst
     size_ += sizeof(MachineInst);
   std::memcpy(raw_words_.data(), inst, size_);
   raw_encoding_ = raw_words_.data();
+}
+
+void Vop3SdstEnc::build_modifiers(std::string &out) const {
+  if (amdgpu::dpp::is_src_dpp8(inst_.src0))
+    amdgpu::dpp::append_dpp8_disassembly(out, dpp8_lane_sel_, dpp_fi_);
 }
 
 void Vop3SdstEnc::implicit_uses(RegisterSet &uses) const {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/encodings.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/encodings.h
@@ -418,6 +418,7 @@ public:
 class Vop1 : public IsaInstruction<Isa> {
 public:
   Vop1(std::string_view mnemonic, const Vop1MachineInst *inst, ExecuteFn exec_fn);
+  void build_modifiers(std::string &out) const override;
   void implicit_uses(RegisterSet &uses) const override;
   bool default_encoding();
   bool has_lit();
@@ -448,6 +449,7 @@ public:
 class Vopc : public IsaInstruction<Isa> {
 public:
   Vopc(std::string_view mnemonic, const VopcMachineInst *inst, ExecuteFn exec_fn);
+  void build_modifiers(std::string &out) const override;
   bool default_encoding();
   bool has_lit();
   using OpEncoding = VopcMachineInst;
@@ -476,6 +478,7 @@ public:
 class Vop2 : public IsaInstruction<Isa> {
 public:
   Vop2(std::string_view mnemonic, const Vop2MachineInst *inst, ExecuteFn exec_fn);
+  void build_modifiers(std::string &out) const override;
   void implicit_uses(RegisterSet &uses) const override;
   bool default_encoding();
   bool has_lit();
@@ -508,6 +511,7 @@ public:
 class Vop3 : public IsaInstruction<Isa> {
 public:
   Vop3(std::string_view mnemonic, const Vop3MachineInst *inst, ExecuteFn exec_fn);
+  void build_modifiers(std::string &out) const override;
   void implicit_uses(RegisterSet &uses) const override;
   bool has_lit_0();
   bool has_lit_1();
@@ -532,6 +536,7 @@ public:
 class Vop3p : public IsaInstruction<Isa> {
 public:
   Vop3p(std::string_view mnemonic, const Vop3pMachineInst *inst, ExecuteFn exec_fn);
+  void build_modifiers(std::string &out) const override;
   void implicit_uses(RegisterSet &uses) const override;
   bool has_lit_0();
   bool has_lit_1();
@@ -619,6 +624,7 @@ public:
 class Vop3SdstEnc : public IsaInstruction<Isa> {
 public:
   Vop3SdstEnc(std::string_view mnemonic, const Vop3SdstEncMachineInst *inst, ExecuteFn exec_fn);
+  void build_modifiers(std::string &out) const override;
   void implicit_uses(RegisterSet &uses) const override;
   bool has_lit_0();
   bool has_lit_1();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vop1.cpp
@@ -22,7 +22,9 @@ namespace rocjitsu {
 namespace rdna3_5 {
 
 VNopVop1::VNopVop1(const MachineInst *inst)
-    : Vop1("v_nop_e32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VNopVop1>()) {
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0) ? "v_nop_dpp"
+                                                                                      : "v_nop_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VNopVop1>()) {
   num_src_ = 0;
   num_dst_ = 0;
 }
@@ -30,8 +32,10 @@ VNopVop1::VNopVop1(const MachineInst *inst)
 void VNopVop1::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_nop_vop1(*this, wf); }
 
 VMovB32Vop1::VMovB32Vop1(const MachineInst *inst)
-    : Vop1("v_mov_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMovB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mov_b32_dpp"
+               : "v_mov_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -72,8 +76,10 @@ void VMovB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VReadfirstlaneB32Vop1::VReadfirstlaneB32Vop1(const MachineInst *inst)
-    : Vop1("v_readfirstlane_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VReadfirstlaneB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_readfirstlane_b32_dpp"
+               : "v_readfirstlane_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VReadfirstlaneB32Vop1>()),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -102,8 +108,10 @@ void VReadfirstlaneB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtI32F64Vop1::VCvtI32F64Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_i32_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtI32F64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_i32_f64_dpp"
+               : "v_cvt_i32_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtI32F64Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -125,8 +133,10 @@ void VCvtI32F64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF64I32Vop1::VCvtF64I32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f64_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF64I32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f64_i32_dpp"
+               : "v_cvt_f64_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF64I32Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -147,8 +157,10 @@ void VCvtF64I32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32I32Vop1::VCvtF32I32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32I32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_i32_dpp"
+               : "v_cvt_f32_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32I32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -189,8 +201,10 @@ void VCvtF32I32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32U32Vop1::VCvtF32U32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32U32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_u32_dpp"
+               : "v_cvt_f32_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32U32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -231,8 +245,10 @@ void VCvtF32U32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtU32F32Vop1::VCvtU32F32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_u32_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtU32F32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_u32_f32_dpp"
+               : "v_cvt_u32_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtU32F32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -273,8 +289,10 @@ void VCvtU32F32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtI32F32Vop1::VCvtI32F32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_i32_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtI32F32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_i32_f32_dpp"
+               : "v_cvt_i32_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtI32F32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -315,8 +333,10 @@ void VCvtI32F32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF16F32Vop1::VCvtF16F32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f16_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF16F32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f16_f32_dpp"
+               : "v_cvt_f16_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF16F32Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -374,8 +394,10 @@ void VCvtF16F32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32F16Vop1::VCvtF32F16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32F16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_f16_dpp"
+               : "v_cvt_f32_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32F16Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true) {
@@ -418,8 +440,10 @@ void VCvtF32F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtNearestI32F32Vop1::VCvtNearestI32F32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_nearest_i32_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtNearestI32F32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_nearest_i32_f32_dpp"
+               : "v_cvt_nearest_i32_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtNearestI32F32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -460,8 +484,10 @@ void VCvtNearestI32F32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtFloorI32F32Vop1::VCvtFloorI32F32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_floor_i32_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtFloorI32F32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_floor_i32_f32_dpp"
+               : "v_cvt_floor_i32_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtFloorI32F32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -502,8 +528,10 @@ void VCvtFloorI32F32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtOffF32I4Vop1::VCvtOffF32I4Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_off_f32_i4_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtOffF32I4Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_off_f32_i4_dpp"
+               : "v_cvt_off_f32_i4_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtOffF32I4Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -544,8 +572,10 @@ void VCvtOffF32I4Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32F64Vop1::VCvtF32F64Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32F64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_f64_dpp"
+               : "v_cvt_f32_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32F64Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -567,8 +597,10 @@ void VCvtF32F64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF64F32Vop1::VCvtF64F32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f64_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF64F32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f64_f32_dpp"
+               : "v_cvt_f64_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF64F32Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -589,8 +621,10 @@ void VCvtF64F32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32Ubyte0Vop1::VCvtF32Ubyte0Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_ubyte0_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32Ubyte0Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_ubyte0_dpp"
+               : "v_cvt_f32_ubyte0_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32Ubyte0Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -631,8 +665,10 @@ void VCvtF32Ubyte0Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32Ubyte1Vop1::VCvtF32Ubyte1Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_ubyte1_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32Ubyte1Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_ubyte1_dpp"
+               : "v_cvt_f32_ubyte1_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32Ubyte1Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -673,8 +709,10 @@ void VCvtF32Ubyte1Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32Ubyte2Vop1::VCvtF32Ubyte2Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_ubyte2_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32Ubyte2Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_ubyte2_dpp"
+               : "v_cvt_f32_ubyte2_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32Ubyte2Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -715,8 +753,10 @@ void VCvtF32Ubyte2Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32Ubyte3Vop1::VCvtF32Ubyte3Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_ubyte3_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32Ubyte3Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_ubyte3_dpp"
+               : "v_cvt_f32_ubyte3_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32Ubyte3Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -757,8 +797,10 @@ void VCvtF32Ubyte3Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtU32F64Vop1::VCvtU32F64Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_u32_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtU32F64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_u32_f64_dpp"
+               : "v_cvt_u32_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtU32F64Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -780,8 +822,10 @@ void VCvtU32F64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF64U32Vop1::VCvtF64U32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f64_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF64U32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f64_u32_dpp"
+               : "v_cvt_f64_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF64U32Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -802,8 +846,10 @@ void VCvtF64U32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VTruncF64Vop1::VTruncF64Vop1(const MachineInst *inst)
-    : Vop1("v_trunc_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VTruncF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_trunc_f64_dpp"
+               : "v_trunc_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VTruncF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -825,8 +871,10 @@ void VTruncF64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCeilF64Vop1::VCeilF64Vop1(const MachineInst *inst)
-    : Vop1("v_ceil_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCeilF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ceil_f64_dpp"
+               : "v_ceil_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCeilF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -848,8 +896,10 @@ void VCeilF64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRndneF64Vop1::VRndneF64Vop1(const MachineInst *inst)
-    : Vop1("v_rndne_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRndneF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rndne_f64_dpp"
+               : "v_rndne_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRndneF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -871,8 +921,10 @@ void VRndneF64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFloorF64Vop1::VFloorF64Vop1(const MachineInst *inst)
-    : Vop1("v_floor_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFloorF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_floor_f64_dpp"
+               : "v_floor_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFloorF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -894,8 +946,10 @@ void VFloorF64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPipeflushVop1::VPipeflushVop1(const MachineInst *inst)
-    : Vop1("v_pipeflush_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VPipeflushVop1>()) {
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_pipeflush_dpp"
+               : "v_pipeflush_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPipeflushVop1>()) {
   num_src_ = 0;
   num_dst_ = 0;
 }
@@ -905,8 +959,10 @@ void VPipeflushVop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMovB16Vop1::VMovB16Vop1(const MachineInst *inst)
-    : Vop1("v_mov_b16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMovB16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mov_b16_dpp"
+               : "v_mov_b16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovB16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -965,8 +1021,10 @@ void VMovB16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFractF32Vop1::VFractF32Vop1(const MachineInst *inst)
-    : Vop1("v_fract_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFractF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fract_f32_dpp"
+               : "v_fract_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFractF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1007,8 +1065,10 @@ void VFractF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VTruncF32Vop1::VTruncF32Vop1(const MachineInst *inst)
-    : Vop1("v_trunc_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VTruncF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_trunc_f32_dpp"
+               : "v_trunc_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VTruncF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1049,8 +1109,10 @@ void VTruncF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCeilF32Vop1::VCeilF32Vop1(const MachineInst *inst)
-    : Vop1("v_ceil_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCeilF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ceil_f32_dpp"
+               : "v_ceil_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCeilF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1091,8 +1153,10 @@ void VCeilF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRndneF32Vop1::VRndneF32Vop1(const MachineInst *inst)
-    : Vop1("v_rndne_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRndneF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rndne_f32_dpp"
+               : "v_rndne_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRndneF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1133,8 +1197,10 @@ void VRndneF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFloorF32Vop1::VFloorF32Vop1(const MachineInst *inst)
-    : Vop1("v_floor_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFloorF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_floor_f32_dpp"
+               : "v_floor_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFloorF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1175,8 +1241,10 @@ void VFloorF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VExpF32Vop1::VExpF32Vop1(const MachineInst *inst)
-    : Vop1("v_exp_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VExpF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_exp_f32_dpp"
+               : "v_exp_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VExpF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1217,8 +1285,10 @@ void VExpF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLogF32Vop1::VLogF32Vop1(const MachineInst *inst)
-    : Vop1("v_log_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLogF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_log_f32_dpp"
+               : "v_log_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLogF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1259,8 +1329,10 @@ void VLogF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRcpF32Vop1::VRcpF32Vop1(const MachineInst *inst)
-    : Vop1("v_rcp_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRcpF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_f32_dpp"
+               : "v_rcp_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1301,8 +1373,10 @@ void VRcpF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRcpIflagF32Vop1::VRcpIflagF32Vop1(const MachineInst *inst)
-    : Vop1("v_rcp_iflag_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRcpIflagF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_iflag_f32_dpp"
+               : "v_rcp_iflag_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpIflagF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1343,8 +1417,10 @@ void VRcpIflagF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRsqF32Vop1::VRsqF32Vop1(const MachineInst *inst)
-    : Vop1("v_rsq_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRsqF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rsq_f32_dpp"
+               : "v_rsq_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRsqF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1385,8 +1461,10 @@ void VRsqF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRcpF64Vop1::VRcpF64Vop1(const MachineInst *inst)
-    : Vop1("v_rcp_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRcpF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_f64_dpp"
+               : "v_rcp_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1406,8 +1484,10 @@ VRcpF64Vop1::VRcpF64Vop1(const MachineInst *inst)
 void VRcpF64Vop1::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_rcp_f64_vop1(*this, wf); }
 
 VRsqF64Vop1::VRsqF64Vop1(const MachineInst *inst)
-    : Vop1("v_rsq_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRsqF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rsq_f64_dpp"
+               : "v_rsq_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRsqF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1427,8 +1507,10 @@ VRsqF64Vop1::VRsqF64Vop1(const MachineInst *inst)
 void VRsqF64Vop1::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_rsq_f64_vop1(*this, wf); }
 
 VSqrtF32Vop1::VSqrtF32Vop1(const MachineInst *inst)
-    : Vop1("v_sqrt_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSqrtF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sqrt_f32_dpp"
+               : "v_sqrt_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSqrtF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1469,8 +1551,10 @@ void VSqrtF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSqrtF64Vop1::VSqrtF64Vop1(const MachineInst *inst)
-    : Vop1("v_sqrt_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSqrtF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sqrt_f64_dpp"
+               : "v_sqrt_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSqrtF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1492,8 +1576,10 @@ void VSqrtF64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSinF32Vop1::VSinF32Vop1(const MachineInst *inst)
-    : Vop1("v_sin_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSinF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sin_f32_dpp"
+               : "v_sin_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSinF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1534,8 +1620,10 @@ void VSinF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCosF32Vop1::VCosF32Vop1(const MachineInst *inst)
-    : Vop1("v_cos_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCosF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cos_f32_dpp"
+               : "v_cos_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCosF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1576,8 +1664,10 @@ void VCosF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VNotB32Vop1::VNotB32Vop1(const MachineInst *inst)
-    : Vop1("v_not_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VNotB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_not_b32_dpp"
+               : "v_not_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VNotB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1618,8 +1708,10 @@ void VNotB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VBfrevB32Vop1::VBfrevB32Vop1(const MachineInst *inst)
-    : Vop1("v_bfrev_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VBfrevB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_bfrev_b32_dpp"
+               : "v_bfrev_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VBfrevB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1660,8 +1752,10 @@ void VBfrevB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VClzI32U32Vop1::VClzI32U32Vop1(const MachineInst *inst)
-    : Vop1("v_clz_i32_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VClzI32U32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_clz_i32_u32_dpp"
+               : "v_clz_i32_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VClzI32U32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1702,8 +1796,10 @@ void VClzI32U32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCtzI32B32Vop1::VCtzI32B32Vop1(const MachineInst *inst)
-    : Vop1("v_ctz_i32_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCtzI32B32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ctz_i32_b32_dpp"
+               : "v_ctz_i32_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCtzI32B32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1744,8 +1840,10 @@ void VCtzI32B32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VClsI32Vop1::VClsI32Vop1(const MachineInst *inst)
-    : Vop1("v_cls_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VClsI32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cls_i32_dpp"
+               : "v_cls_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VClsI32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1786,8 +1884,10 @@ void VClsI32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpExpI32F64Vop1::VFrexpExpI32F64Vop1(const MachineInst *inst)
-    : Vop1("v_frexp_exp_i32_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpExpI32F64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_exp_i32_f64_dpp"
+               : "v_frexp_exp_i32_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpExpI32F64Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1809,8 +1909,10 @@ void VFrexpExpI32F64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpMantF64Vop1::VFrexpMantF64Vop1(const MachineInst *inst)
-    : Vop1("v_frexp_mant_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpMantF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_mant_f64_dpp"
+               : "v_frexp_mant_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpMantF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1832,8 +1934,10 @@ void VFrexpMantF64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFractF64Vop1::VFractF64Vop1(const MachineInst *inst)
-    : Vop1("v_fract_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFractF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fract_f64_dpp"
+               : "v_fract_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFractF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1855,8 +1959,10 @@ void VFractF64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpExpI32F32Vop1::VFrexpExpI32F32Vop1(const MachineInst *inst)
-    : Vop1("v_frexp_exp_i32_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpExpI32F32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_exp_i32_f32_dpp"
+               : "v_frexp_exp_i32_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpExpI32F32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1897,8 +2003,10 @@ void VFrexpExpI32F32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpMantF32Vop1::VFrexpMantF32Vop1(const MachineInst *inst)
-    : Vop1("v_frexp_mant_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpMantF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_mant_f32_dpp"
+               : "v_frexp_mant_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpMantF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1939,8 +2047,10 @@ void VFrexpMantF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMovreldB32Vop1::VMovreldB32Vop1(const MachineInst *inst)
-    : Vop1("v_movreld_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMovreldB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_movreld_b32_dpp"
+               : "v_movreld_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovreldB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -1997,8 +2107,10 @@ void VMovreldB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMovrelsB32Vop1::VMovrelsB32Vop1(const MachineInst *inst)
-    : Vop1("v_movrels_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMovrelsB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_movrels_b32_dpp"
+               : "v_movrels_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovrelsB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -2055,8 +2167,10 @@ void VMovrelsB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMovrelsdB32Vop1::VMovrelsdB32Vop1(const MachineInst *inst)
-    : Vop1("v_movrelsd_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMovrelsdB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_movrelsd_b32_dpp"
+               : "v_movrelsd_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovrelsdB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -2095,8 +2209,10 @@ void VMovrelsdB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMovrelsd2B32Vop1::VMovrelsd2B32Vop1(const MachineInst *inst)
-    : Vop1("v_movrelsd_2_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMovrelsd2B32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_movrelsd_2_b32_dpp"
+               : "v_movrelsd_2_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovrelsd2B32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -2135,8 +2251,10 @@ void VMovrelsd2B32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF16U16Vop1::VCvtF16U16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f16_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF16U16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f16_u16_dpp"
+               : "v_cvt_f16_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF16U16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2196,8 +2314,10 @@ void VCvtF16U16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF16I16Vop1::VCvtF16I16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f16_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF16I16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f16_i16_dpp"
+               : "v_cvt_f16_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF16I16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2257,8 +2377,10 @@ void VCvtF16I16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtU16F16Vop1::VCvtU16F16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_u16_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtU16F16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_u16_f16_dpp"
+               : "v_cvt_u16_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtU16F16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2322,8 +2444,10 @@ void VCvtU16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtI16F16Vop1::VCvtI16F16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_i16_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtI16F16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_i16_f16_dpp"
+               : "v_cvt_i16_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtI16F16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2389,8 +2513,10 @@ void VCvtI16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRcpF16Vop1::VRcpF16Vop1(const MachineInst *inst)
-    : Vop1("v_rcp_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRcpF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_f16_dpp"
+               : "v_rcp_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2451,8 +2577,10 @@ void VRcpF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSqrtF16Vop1::VSqrtF16Vop1(const MachineInst *inst)
-    : Vop1("v_sqrt_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSqrtF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sqrt_f16_dpp"
+               : "v_sqrt_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSqrtF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2513,8 +2641,10 @@ void VSqrtF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRsqF16Vop1::VRsqF16Vop1(const MachineInst *inst)
-    : Vop1("v_rsq_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRsqF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rsq_f16_dpp"
+               : "v_rsq_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRsqF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2575,8 +2705,10 @@ void VRsqF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLogF16Vop1::VLogF16Vop1(const MachineInst *inst)
-    : Vop1("v_log_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLogF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_log_f16_dpp"
+               : "v_log_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLogF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2637,8 +2769,10 @@ void VLogF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VExpF16Vop1::VExpF16Vop1(const MachineInst *inst)
-    : Vop1("v_exp_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VExpF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_exp_f16_dpp"
+               : "v_exp_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VExpF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2699,8 +2833,10 @@ void VExpF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpMantF16Vop1::VFrexpMantF16Vop1(const MachineInst *inst)
-    : Vop1("v_frexp_mant_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpMantF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_mant_f16_dpp"
+               : "v_frexp_mant_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpMantF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2765,8 +2901,10 @@ void VFrexpMantF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpExpI16F16Vop1::VFrexpExpI16F16Vop1(const MachineInst *inst)
-    : Vop1("v_frexp_exp_i16_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpExpI16F16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_exp_i16_f16_dpp"
+               : "v_frexp_exp_i16_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpExpI16F16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2832,8 +2970,10 @@ void VFrexpExpI16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFloorF16Vop1::VFloorF16Vop1(const MachineInst *inst)
-    : Vop1("v_floor_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFloorF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_floor_f16_dpp"
+               : "v_floor_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFloorF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2893,8 +3033,10 @@ void VFloorF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCeilF16Vop1::VCeilF16Vop1(const MachineInst *inst)
-    : Vop1("v_ceil_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCeilF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ceil_f16_dpp"
+               : "v_ceil_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCeilF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2954,8 +3096,10 @@ void VCeilF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VTruncF16Vop1::VTruncF16Vop1(const MachineInst *inst)
-    : Vop1("v_trunc_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VTruncF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_trunc_f16_dpp"
+               : "v_trunc_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VTruncF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -3015,8 +3159,10 @@ void VTruncF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRndneF16Vop1::VRndneF16Vop1(const MachineInst *inst)
-    : Vop1("v_rndne_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRndneF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rndne_f16_dpp"
+               : "v_rndne_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRndneF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -3076,8 +3222,10 @@ void VRndneF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFractF16Vop1::VFractF16Vop1(const MachineInst *inst)
-    : Vop1("v_fract_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFractF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fract_f16_dpp"
+               : "v_fract_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFractF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -3140,8 +3288,10 @@ void VFractF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSinF16Vop1::VSinF16Vop1(const MachineInst *inst)
-    : Vop1("v_sin_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSinF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sin_f16_dpp"
+               : "v_sin_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSinF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -3202,8 +3352,10 @@ void VSinF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCosF16Vop1::VCosF16Vop1(const MachineInst *inst)
-    : Vop1("v_cos_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCosF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cos_f16_dpp"
+               : "v_cos_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCosF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -3264,8 +3416,10 @@ void VCosF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSatPkU8I16Vop1::VSatPkU8I16Vop1(const MachineInst *inst)
-    : Vop1("v_sat_pk_u8_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSatPkU8I16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sat_pk_u8_i16_dpp"
+               : "v_sat_pk_u8_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSatPkU8I16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -3309,8 +3463,10 @@ void VSatPkU8I16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtNormI16F16Vop1::VCvtNormI16F16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_norm_i16_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtNormI16F16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_norm_i16_f16_dpp"
+               : "v_cvt_norm_i16_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtNormI16F16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -3373,8 +3529,10 @@ void VCvtNormI16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtNormU16F16Vop1::VCvtNormU16F16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_norm_u16_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtNormU16F16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_norm_u16_f16_dpp"
+               : "v_cvt_norm_u16_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtNormU16F16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -3437,8 +3595,10 @@ void VCvtNormU16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSwapB32Vop1::VSwapB32Vop1(const MachineInst *inst)
-    : Vop1("v_swap_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSwapB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_swap_b32_dpp"
+               : "v_swap_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSwapB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   src_operands_[0] = &vdst;
@@ -3469,8 +3629,10 @@ void VSwapB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSwapB16Vop1::VSwapB16Vop1(const MachineInst *inst)
-    : Vop1("v_swap_b16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSwapB16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_swap_b16_dpp"
+               : "v_swap_b16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSwapB16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), true,
            true),
@@ -3515,8 +3677,10 @@ void VSwapB16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPermlane64B32Vop1::VPermlane64B32Vop1(const MachineInst *inst)
-    : Vop1("v_permlane64_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VPermlane64B32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_permlane64_b32_dpp"
+               : "v_permlane64_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPermlane64B32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3537,8 +3701,10 @@ void VPermlane64B32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSwaprelB32Vop1::VSwaprelB32Vop1(const MachineInst *inst)
-    : Vop1("v_swaprel_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSwaprelB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_swaprel_b32_dpp"
+               : "v_swaprel_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSwaprelB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -3565,8 +3731,10 @@ void VSwaprelB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VNotB16Vop1::VNotB16Vop1(const MachineInst *inst)
-    : Vop1("v_not_b16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VNotB16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_not_b16_dpp"
+               : "v_not_b16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VNotB16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -3624,8 +3792,10 @@ void VNotB16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtI32I16Vop1::VCvtI32I16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_i32_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtI32I16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_i32_i16_dpp"
+               : "v_cvt_i32_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtI32I16Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true) {
@@ -3668,8 +3838,10 @@ void VCvtI32I16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtU32U16Vop1::VCvtU32U16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_u32_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtU32U16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_u32_u16_dpp"
+               : "v_cvt_u32_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtU32U16Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vop2.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vop2.cpp
@@ -22,8 +22,10 @@ namespace rocjitsu {
 namespace rdna3_5 {
 
 VCndmaskB32Vop2::VCndmaskB32Vop2(const MachineInst *inst)
-    : Vop2("v_cndmask_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCndmaskB32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cndmask_b32_dpp"
+               : "v_cndmask_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCndmaskB32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -70,8 +72,10 @@ void VCndmaskB32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDot2accF32F16Vop2::VDot2accF32F16Vop2(const MachineInst *inst)
-    : Vop2("v_dot2acc_f32_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VDot2accF32F16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_dot2acc_f32_f16_dpp"
+               : "v_dot2acc_f32_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDot2accF32F16Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -116,8 +120,10 @@ void VDot2accF32F16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddF32Vop2::VAddF32Vop2(const MachineInst *inst)
-    : Vop2("v_add_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAddF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_f32_dpp"
+               : "v_add_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -161,8 +167,10 @@ void VAddF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubF32Vop2::VSubF32Vop2(const MachineInst *inst)
-    : Vop2("v_sub_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_f32_dpp"
+               : "v_sub_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -206,8 +214,10 @@ void VSubF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubrevF32Vop2::VSubrevF32Vop2(const MachineInst *inst)
-    : Vop2("v_subrev_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubrevF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_subrev_f32_dpp"
+               : "v_subrev_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubrevF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -251,8 +261,10 @@ void VSubrevF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmacDx9ZeroF32Vop2::VFmacDx9ZeroF32Vop2(const MachineInst *inst)
-    : Vop2("v_fmac_dx9_zero_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFmacDx9ZeroF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmac_dx9_zero_f32_dpp"
+               : "v_fmac_dx9_zero_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmacDx9ZeroF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -276,8 +288,10 @@ void VFmacDx9ZeroF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulDx9ZeroF32Vop2::VMulDx9ZeroF32Vop2(const MachineInst *inst)
-    : Vop2("v_mul_dx9_zero_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulDx9ZeroF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_dx9_zero_f32_dpp"
+               : "v_mul_dx9_zero_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulDx9ZeroF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -321,8 +335,10 @@ void VMulDx9ZeroF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulF32Vop2::VMulF32Vop2(const MachineInst *inst)
-    : Vop2("v_mul_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_f32_dpp"
+               : "v_mul_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -366,8 +382,10 @@ void VMulF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulI32I24Vop2::VMulI32I24Vop2(const MachineInst *inst)
-    : Vop2("v_mul_i32_i24_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulI32I24Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_i32_i24_dpp"
+               : "v_mul_i32_i24_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulI32I24Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -411,8 +429,10 @@ void VMulI32I24Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulHiI32I24Vop2::VMulHiI32I24Vop2(const MachineInst *inst)
-    : Vop2("v_mul_hi_i32_i24_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulHiI32I24Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_hi_i32_i24_dpp"
+               : "v_mul_hi_i32_i24_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulHiI32I24Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -456,8 +476,10 @@ void VMulHiI32I24Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulU32U24Vop2::VMulU32U24Vop2(const MachineInst *inst)
-    : Vop2("v_mul_u32_u24_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulU32U24Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_u32_u24_dpp"
+               : "v_mul_u32_u24_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulU32U24Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -501,8 +523,10 @@ void VMulU32U24Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulHiU32U24Vop2::VMulHiU32U24Vop2(const MachineInst *inst)
-    : Vop2("v_mul_hi_u32_u24_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulHiU32U24Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_hi_u32_u24_dpp"
+               : "v_mul_hi_u32_u24_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulHiU32U24Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -546,8 +570,10 @@ void VMulHiU32U24Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinF32Vop2::VMinF32Vop2(const MachineInst *inst)
-    : Vop2("v_min_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_f32_dpp"
+               : "v_min_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -591,8 +617,10 @@ void VMinF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxF32Vop2::VMaxF32Vop2(const MachineInst *inst)
-    : Vop2("v_max_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaxF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_f32_dpp"
+               : "v_max_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -636,8 +664,10 @@ void VMaxF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinI32Vop2::VMinI32Vop2(const MachineInst *inst)
-    : Vop2("v_min_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinI32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_i32_dpp"
+               : "v_min_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinI32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -681,8 +711,10 @@ void VMinI32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxI32Vop2::VMaxI32Vop2(const MachineInst *inst)
-    : Vop2("v_max_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaxI32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_i32_dpp"
+               : "v_max_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxI32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -726,8 +758,10 @@ void VMaxI32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinU32Vop2::VMinU32Vop2(const MachineInst *inst)
-    : Vop2("v_min_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinU32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_u32_dpp"
+               : "v_min_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinU32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -771,8 +805,10 @@ void VMinU32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxU32Vop2::VMaxU32Vop2(const MachineInst *inst)
-    : Vop2("v_max_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaxU32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_u32_dpp"
+               : "v_max_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxU32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -816,8 +852,10 @@ void VMaxU32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLshlrevB32Vop2::VLshlrevB32Vop2(const MachineInst *inst)
-    : Vop2("v_lshlrev_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLshlrevB32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshlrev_b32_dpp"
+               : "v_lshlrev_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLshlrevB32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -861,8 +899,10 @@ void VLshlrevB32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLshrrevB32Vop2::VLshrrevB32Vop2(const MachineInst *inst)
-    : Vop2("v_lshrrev_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLshrrevB32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshrrev_b32_dpp"
+               : "v_lshrrev_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLshrrevB32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -906,8 +946,10 @@ void VLshrrevB32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAshrrevI32Vop2::VAshrrevI32Vop2(const MachineInst *inst)
-    : Vop2("v_ashrrev_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAshrrevI32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ashrrev_i32_dpp"
+               : "v_ashrrev_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAshrrevI32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -951,8 +993,10 @@ void VAshrrevI32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAndB32Vop2::VAndB32Vop2(const MachineInst *inst)
-    : Vop2("v_and_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAndB32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_and_b32_dpp"
+               : "v_and_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAndB32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -996,7 +1040,10 @@ void VAndB32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VOrB32Vop2::VOrB32Vop2(const MachineInst *inst)
-    : Vop2("v_or_b32_e32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VOrB32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_or_b32_dpp"
+               : "v_or_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VOrB32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1040,8 +1087,10 @@ void VOrB32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VXorB32Vop2::VXorB32Vop2(const MachineInst *inst)
-    : Vop2("v_xor_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VXorB32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_xor_b32_dpp"
+               : "v_xor_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXorB32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1085,8 +1134,10 @@ void VXorB32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VXnorB32Vop2::VXnorB32Vop2(const MachineInst *inst)
-    : Vop2("v_xnor_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VXnorB32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_xnor_b32_dpp"
+               : "v_xnor_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXnorB32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1130,8 +1181,10 @@ void VXnorB32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddCoCiU32Vop2::VAddCoCiU32Vop2(const MachineInst *inst)
-    : Vop2("v_add_co_ci_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAddCoCiU32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_co_ci_u32_dpp"
+               : "v_add_co_ci_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddCoCiU32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -1181,8 +1234,10 @@ void VAddCoCiU32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubCoCiU32Vop2::VSubCoCiU32Vop2(const MachineInst *inst)
-    : Vop2("v_sub_co_ci_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubCoCiU32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_co_ci_u32_dpp"
+               : "v_sub_co_ci_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubCoCiU32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -1232,8 +1287,10 @@ void VSubCoCiU32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubrevCoCiU32Vop2::VSubrevCoCiU32Vop2(const MachineInst *inst)
-    : Vop2("v_subrev_co_ci_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubrevCoCiU32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_subrev_co_ci_u32_dpp"
+               : "v_subrev_co_ci_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubrevCoCiU32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -1283,8 +1340,10 @@ void VSubrevCoCiU32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddNcU32Vop2::VAddNcU32Vop2(const MachineInst *inst)
-    : Vop2("v_add_nc_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAddNcU32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_nc_u32_dpp"
+               : "v_add_nc_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddNcU32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1328,8 +1387,10 @@ void VAddNcU32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubNcU32Vop2::VSubNcU32Vop2(const MachineInst *inst)
-    : Vop2("v_sub_nc_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubNcU32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_nc_u32_dpp"
+               : "v_sub_nc_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubNcU32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1373,8 +1434,10 @@ void VSubNcU32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubrevNcU32Vop2::VSubrevNcU32Vop2(const MachineInst *inst)
-    : Vop2("v_subrev_nc_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubrevNcU32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_subrev_nc_u32_dpp"
+               : "v_subrev_nc_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubrevNcU32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1418,8 +1481,10 @@ void VSubrevNcU32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmacF32Vop2::VFmacF32Vop2(const MachineInst *inst)
-    : Vop2("v_fmac_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFmacF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmac_f32_dpp"
+               : "v_fmac_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmacF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1464,8 +1529,10 @@ void VFmacF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmamkF32Vop2::VFmamkF32Vop2(const MachineInst *inst)
-    : Vop2("v_fmamk_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFmamkF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmamk_f32_dpp"
+               : "v_fmamk_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmamkF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       simm32(32, OperandType::OPR_SIMM32, 0),
@@ -1494,8 +1561,10 @@ void VFmamkF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmaakF32Vop2::VFmaakF32Vop2(const MachineInst *inst)
-    : Vop2("v_fmaak_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFmaakF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmaak_f32_dpp"
+               : "v_fmaak_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmaakF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -1524,8 +1593,10 @@ void VFmaakF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkRtzF16F32Vop2::VCvtPkRtzF16F32Vop2(const MachineInst *inst)
-    : Vop2("v_cvt_pk_rtz_f16_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkRtzF16F32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_rtz_f16_f32_dpp"
+               : "v_cvt_pk_rtz_f16_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkRtzF16F32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1569,8 +1640,10 @@ void VCvtPkRtzF16F32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddF16Vop2::VAddF16Vop2(const MachineInst *inst)
-    : Vop2("v_add_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAddF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_f16_dpp"
+               : "v_add_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -1636,8 +1709,10 @@ void VAddF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubF16Vop2::VSubF16Vop2(const MachineInst *inst)
-    : Vop2("v_sub_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_f16_dpp"
+               : "v_sub_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -1703,8 +1778,10 @@ void VSubF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubrevF16Vop2::VSubrevF16Vop2(const MachineInst *inst)
-    : Vop2("v_subrev_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubrevF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_subrev_f16_dpp"
+               : "v_subrev_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubrevF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -1770,8 +1847,10 @@ void VSubrevF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulF16Vop2::VMulF16Vop2(const MachineInst *inst)
-    : Vop2("v_mul_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_f16_dpp"
+               : "v_mul_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -1837,8 +1916,10 @@ void VMulF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmacF16Vop2::VFmacF16Vop2(const MachineInst *inst)
-    : Vop2("v_fmac_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFmacF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmac_f16_dpp"
+               : "v_fmac_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmacF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), true,
            true),
@@ -1907,8 +1988,10 @@ void VFmacF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmamkF16Vop2::VFmamkF16Vop2(const MachineInst *inst)
-    : Vop2("v_fmamk_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFmamkF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmamk_f16_dpp"
+               : "v_fmamk_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmamkF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -1960,8 +2043,10 @@ void VFmamkF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmaakF16Vop2::VFmaakF16Vop2(const MachineInst *inst)
-    : Vop2("v_fmaak_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFmaakF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmaak_f16_dpp"
+               : "v_fmaak_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmaakF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2012,8 +2097,10 @@ void VFmaakF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxF16Vop2::VMaxF16Vop2(const MachineInst *inst)
-    : Vop2("v_max_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaxF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_f16_dpp"
+               : "v_max_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2079,8 +2166,10 @@ void VMaxF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinF16Vop2::VMinF16Vop2(const MachineInst *inst)
-    : Vop2("v_min_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_f16_dpp"
+               : "v_min_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2146,8 +2235,10 @@ void VMinF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLdexpF16Vop2::VLdexpF16Vop2(const MachineInst *inst)
-    : Vop2("v_ldexp_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLdexpF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ldexp_f16_dpp"
+               : "v_ldexp_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLdexpF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2213,8 +2304,10 @@ void VLdexpF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkFmacF16Vop2::VPkFmacF16Vop2(const MachineInst *inst)
-    : Vop2("v_pk_fmac_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VPkFmacF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_pk_fmac_f16_dpp"
+               : "v_pk_fmac_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkFmacF16Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vop3.cpp
@@ -22,7 +22,10 @@ namespace rocjitsu {
 namespace rdna3_5 {
 
 VNopVop3::VNopVop3(const MachineInst *inst)
-    : Vop3("v_nop", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VNopVop3>()) {
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_nop_e64_dpp"
+               : "v_nop",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VNopVop3>()) {
   num_src_ = 0;
   num_dst_ = 0;
 }
@@ -30,7 +33,10 @@ VNopVop3::VNopVop3(const MachineInst *inst)
 void VNopVop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_nop_vop3(*this, wf); }
 
 VMovB32Vop3::VMovB32Vop3(const MachineInst *inst)
-    : Vop3("v_mov_b32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mov_b32_e64_dpp"
+               : "v_mov_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -71,8 +77,10 @@ void VMovB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VReadfirstlaneB32Vop3::VReadfirstlaneB32Vop3(const MachineInst *inst)
-    : Vop3("v_readfirstlane_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VReadfirstlaneB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_readfirstlane_b32_e64_dpp"
+               : "v_readfirstlane_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VReadfirstlaneB32Vop3>()),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -101,8 +109,10 @@ void VReadfirstlaneB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtI32F64Vop3::VCvtI32F64Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_i32_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtI32F64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_i32_f64_e64_dpp"
+               : "v_cvt_i32_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtI32F64Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -124,8 +134,10 @@ void VCvtI32F64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF64I32Vop3::VCvtF64I32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f64_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF64I32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f64_i32_e64_dpp"
+               : "v_cvt_f64_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF64I32Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -146,8 +158,10 @@ void VCvtF64I32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32I32Vop3::VCvtF32I32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f32_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32I32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_i32_e64_dpp"
+               : "v_cvt_f32_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32I32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -188,8 +202,10 @@ void VCvtF32I32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32U32Vop3::VCvtF32U32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f32_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32U32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_u32_e64_dpp"
+               : "v_cvt_f32_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32U32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -230,8 +246,10 @@ void VCvtF32U32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtU32F32Vop3::VCvtU32F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_u32_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtU32F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_u32_f32_e64_dpp"
+               : "v_cvt_u32_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtU32F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -272,8 +290,10 @@ void VCvtU32F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtI32F32Vop3::VCvtI32F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_i32_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtI32F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_i32_f32_e64_dpp"
+               : "v_cvt_i32_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtI32F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -314,8 +334,10 @@ void VCvtI32F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF16F32Vop3::VCvtF16F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f16_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF16F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f16_f32_e64_dpp"
+               : "v_cvt_f16_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF16F32Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -374,8 +396,10 @@ void VCvtF16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32F16Vop3::VCvtF32F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f32_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32F16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_f16_e64_dpp"
+               : "v_cvt_f32_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32F16Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -436,8 +460,10 @@ void VCvtF32F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtNearestI32F32Vop3::VCvtNearestI32F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_nearest_i32_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtNearestI32F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_nearest_i32_f32_e64_dpp"
+               : "v_cvt_nearest_i32_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtNearestI32F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -478,8 +504,10 @@ void VCvtNearestI32F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtFloorI32F32Vop3::VCvtFloorI32F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_floor_i32_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtFloorI32F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_floor_i32_f32_e64_dpp"
+               : "v_cvt_floor_i32_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtFloorI32F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -520,8 +548,10 @@ void VCvtFloorI32F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtOffF32I4Vop3::VCvtOffF32I4Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_off_f32_i4", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtOffF32I4Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_off_f32_i4_e64_dpp"
+               : "v_cvt_off_f32_i4",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtOffF32I4Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -562,8 +592,10 @@ void VCvtOffF32I4Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32F64Vop3::VCvtF32F64Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f32_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32F64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_f64_e64_dpp"
+               : "v_cvt_f32_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32F64Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -585,8 +617,10 @@ void VCvtF32F64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF64F32Vop3::VCvtF64F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f64_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF64F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f64_f32_e64_dpp"
+               : "v_cvt_f64_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF64F32Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -607,8 +641,10 @@ void VCvtF64F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32Ubyte0Vop3::VCvtF32Ubyte0Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f32_ubyte0", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32Ubyte0Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_ubyte0_e64_dpp"
+               : "v_cvt_f32_ubyte0",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32Ubyte0Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -649,8 +685,10 @@ void VCvtF32Ubyte0Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32Ubyte1Vop3::VCvtF32Ubyte1Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f32_ubyte1", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32Ubyte1Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_ubyte1_e64_dpp"
+               : "v_cvt_f32_ubyte1",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32Ubyte1Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -691,8 +729,10 @@ void VCvtF32Ubyte1Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32Ubyte2Vop3::VCvtF32Ubyte2Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f32_ubyte2", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32Ubyte2Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_ubyte2_e64_dpp"
+               : "v_cvt_f32_ubyte2",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32Ubyte2Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -733,8 +773,10 @@ void VCvtF32Ubyte2Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32Ubyte3Vop3::VCvtF32Ubyte3Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f32_ubyte3", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32Ubyte3Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_ubyte3_e64_dpp"
+               : "v_cvt_f32_ubyte3",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32Ubyte3Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -775,8 +817,10 @@ void VCvtF32Ubyte3Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtU32F64Vop3::VCvtU32F64Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_u32_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtU32F64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_u32_f64_e64_dpp"
+               : "v_cvt_u32_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtU32F64Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -798,8 +842,10 @@ void VCvtU32F64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF64U32Vop3::VCvtF64U32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f64_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF64U32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f64_u32_e64_dpp"
+               : "v_cvt_f64_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF64U32Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -820,8 +866,10 @@ void VCvtF64U32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VTruncF64Vop3::VTruncF64Vop3(const MachineInst *inst)
-    : Vop3("v_trunc_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VTruncF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_trunc_f64_e64_dpp"
+               : "v_trunc_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VTruncF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -843,7 +891,10 @@ void VTruncF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCeilF64Vop3::VCeilF64Vop3(const MachineInst *inst)
-    : Vop3("v_ceil_f64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCeilF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ceil_f64_e64_dpp"
+               : "v_ceil_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCeilF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -865,8 +916,10 @@ void VCeilF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRndneF64Vop3::VRndneF64Vop3(const MachineInst *inst)
-    : Vop3("v_rndne_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRndneF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rndne_f64_e64_dpp"
+               : "v_rndne_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRndneF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -888,8 +941,10 @@ void VRndneF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFloorF64Vop3::VFloorF64Vop3(const MachineInst *inst)
-    : Vop3("v_floor_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFloorF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_floor_f64_e64_dpp"
+               : "v_floor_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFloorF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -911,8 +966,10 @@ void VFloorF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPipeflushVop3::VPipeflushVop3(const MachineInst *inst)
-    : Vop3("v_pipeflush", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VPipeflushVop3>()) {
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_pipeflush_e64_dpp"
+               : "v_pipeflush",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPipeflushVop3>()) {
   num_src_ = 0;
   num_dst_ = 0;
 }
@@ -922,7 +979,10 @@ void VPipeflushVop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMovB16Vop3::VMovB16Vop3(const MachineInst *inst)
-    : Vop3("v_mov_b16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovB16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mov_b16_e64_dpp"
+               : "v_mov_b16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovB16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -986,8 +1046,10 @@ void VMovB16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFractF32Vop3::VFractF32Vop3(const MachineInst *inst)
-    : Vop3("v_fract_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFractF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fract_f32_e64_dpp"
+               : "v_fract_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFractF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1028,8 +1090,10 @@ void VFractF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VTruncF32Vop3::VTruncF32Vop3(const MachineInst *inst)
-    : Vop3("v_trunc_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VTruncF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_trunc_f32_e64_dpp"
+               : "v_trunc_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VTruncF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1070,7 +1134,10 @@ void VTruncF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCeilF32Vop3::VCeilF32Vop3(const MachineInst *inst)
-    : Vop3("v_ceil_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCeilF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ceil_f32_e64_dpp"
+               : "v_ceil_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCeilF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1111,8 +1178,10 @@ void VCeilF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRndneF32Vop3::VRndneF32Vop3(const MachineInst *inst)
-    : Vop3("v_rndne_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRndneF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rndne_f32_e64_dpp"
+               : "v_rndne_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRndneF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1153,8 +1222,10 @@ void VRndneF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFloorF32Vop3::VFloorF32Vop3(const MachineInst *inst)
-    : Vop3("v_floor_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFloorF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_floor_f32_e64_dpp"
+               : "v_floor_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFloorF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1195,7 +1266,10 @@ void VFloorF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VExpF32Vop3::VExpF32Vop3(const MachineInst *inst)
-    : Vop3("v_exp_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VExpF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_exp_f32_e64_dpp"
+               : "v_exp_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VExpF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1236,7 +1310,10 @@ void VExpF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLogF32Vop3::VLogF32Vop3(const MachineInst *inst)
-    : Vop3("v_log_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLogF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_log_f32_e64_dpp"
+               : "v_log_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLogF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1277,7 +1354,10 @@ void VLogF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRcpF32Vop3::VRcpF32Vop3(const MachineInst *inst)
-    : Vop3("v_rcp_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_f32_e64_dpp"
+               : "v_rcp_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1318,8 +1398,10 @@ void VRcpF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRcpIflagF32Vop3::VRcpIflagF32Vop3(const MachineInst *inst)
-    : Vop3("v_rcp_iflag_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRcpIflagF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_iflag_f32_e64_dpp"
+               : "v_rcp_iflag_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpIflagF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1360,7 +1442,10 @@ void VRcpIflagF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRsqF32Vop3::VRsqF32Vop3(const MachineInst *inst)
-    : Vop3("v_rsq_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRsqF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rsq_f32_e64_dpp"
+               : "v_rsq_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRsqF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1401,7 +1486,10 @@ void VRsqF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRcpF64Vop3::VRcpF64Vop3(const MachineInst *inst)
-    : Vop3("v_rcp_f64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_f64_e64_dpp"
+               : "v_rcp_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1421,7 +1509,10 @@ VRcpF64Vop3::VRcpF64Vop3(const MachineInst *inst)
 void VRcpF64Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_rcp_f64_vop3(*this, wf); }
 
 VRsqF64Vop3::VRsqF64Vop3(const MachineInst *inst)
-    : Vop3("v_rsq_f64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRsqF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rsq_f64_e64_dpp"
+               : "v_rsq_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRsqF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1441,7 +1532,10 @@ VRsqF64Vop3::VRsqF64Vop3(const MachineInst *inst)
 void VRsqF64Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_rsq_f64_vop3(*this, wf); }
 
 VSqrtF32Vop3::VSqrtF32Vop3(const MachineInst *inst)
-    : Vop3("v_sqrt_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSqrtF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sqrt_f32_e64_dpp"
+               : "v_sqrt_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSqrtF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1482,7 +1576,10 @@ void VSqrtF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSqrtF64Vop3::VSqrtF64Vop3(const MachineInst *inst)
-    : Vop3("v_sqrt_f64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSqrtF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sqrt_f64_e64_dpp"
+               : "v_sqrt_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSqrtF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1504,7 +1601,10 @@ void VSqrtF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSinF32Vop3::VSinF32Vop3(const MachineInst *inst)
-    : Vop3("v_sin_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSinF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sin_f32_e64_dpp"
+               : "v_sin_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSinF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1545,7 +1645,10 @@ void VSinF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCosF32Vop3::VCosF32Vop3(const MachineInst *inst)
-    : Vop3("v_cos_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCosF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cos_f32_e64_dpp"
+               : "v_cos_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCosF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1586,7 +1689,10 @@ void VCosF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VNotB32Vop3::VNotB32Vop3(const MachineInst *inst)
-    : Vop3("v_not_b32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VNotB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_not_b32_e64_dpp"
+               : "v_not_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VNotB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1627,8 +1733,10 @@ void VNotB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VBfrevB32Vop3::VBfrevB32Vop3(const MachineInst *inst)
-    : Vop3("v_bfrev_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VBfrevB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_bfrev_b32_e64_dpp"
+               : "v_bfrev_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VBfrevB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1669,8 +1777,10 @@ void VBfrevB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VClzI32U32Vop3::VClzI32U32Vop3(const MachineInst *inst)
-    : Vop3("v_clz_i32_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VClzI32U32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_clz_i32_u32_e64_dpp"
+               : "v_clz_i32_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VClzI32U32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1711,8 +1821,10 @@ void VClzI32U32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCtzI32B32Vop3::VCtzI32B32Vop3(const MachineInst *inst)
-    : Vop3("v_ctz_i32_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCtzI32B32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ctz_i32_b32_e64_dpp"
+               : "v_ctz_i32_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCtzI32B32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1753,7 +1865,10 @@ void VCtzI32B32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VClsI32Vop3::VClsI32Vop3(const MachineInst *inst)
-    : Vop3("v_cls_i32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VClsI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cls_i32_e64_dpp"
+               : "v_cls_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VClsI32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1794,8 +1909,10 @@ void VClsI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpExpI32F64Vop3::VFrexpExpI32F64Vop3(const MachineInst *inst)
-    : Vop3("v_frexp_exp_i32_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpExpI32F64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_exp_i32_f64_e64_dpp"
+               : "v_frexp_exp_i32_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpExpI32F64Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1817,8 +1934,10 @@ void VFrexpExpI32F64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpMantF64Vop3::VFrexpMantF64Vop3(const MachineInst *inst)
-    : Vop3("v_frexp_mant_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpMantF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_mant_f64_e64_dpp"
+               : "v_frexp_mant_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpMantF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1840,8 +1959,10 @@ void VFrexpMantF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFractF64Vop3::VFractF64Vop3(const MachineInst *inst)
-    : Vop3("v_fract_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFractF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fract_f64_e64_dpp"
+               : "v_fract_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFractF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1863,8 +1984,10 @@ void VFractF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpExpI32F32Vop3::VFrexpExpI32F32Vop3(const MachineInst *inst)
-    : Vop3("v_frexp_exp_i32_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpExpI32F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_exp_i32_f32_e64_dpp"
+               : "v_frexp_exp_i32_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpExpI32F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1905,8 +2028,10 @@ void VFrexpExpI32F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpMantF32Vop3::VFrexpMantF32Vop3(const MachineInst *inst)
-    : Vop3("v_frexp_mant_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpMantF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_mant_f32_e64_dpp"
+               : "v_frexp_mant_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpMantF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1947,8 +2072,10 @@ void VFrexpMantF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMovreldB32Vop3::VMovreldB32Vop3(const MachineInst *inst)
-    : Vop3("v_movreld_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMovreldB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_movreld_b32_e64_dpp"
+               : "v_movreld_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovreldB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -2005,8 +2132,10 @@ void VMovreldB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMovrelsB32Vop3::VMovrelsB32Vop3(const MachineInst *inst)
-    : Vop3("v_movrels_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMovrelsB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_movrels_b32_e64_dpp"
+               : "v_movrels_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovrelsB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -2063,8 +2192,10 @@ void VMovrelsB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMovrelsdB32Vop3::VMovrelsdB32Vop3(const MachineInst *inst)
-    : Vop3("v_movrelsd_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMovrelsdB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_movrelsd_b32_e64_dpp"
+               : "v_movrelsd_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovrelsdB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -2103,8 +2234,10 @@ void VMovrelsdB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMovrelsd2B32Vop3::VMovrelsd2B32Vop3(const MachineInst *inst)
-    : Vop3("v_movrelsd_2_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMovrelsd2B32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_movrelsd_2_b32_e64_dpp"
+               : "v_movrelsd_2_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovrelsd2B32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -2143,8 +2276,10 @@ void VMovrelsd2B32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF16U16Vop3::VCvtF16U16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f16_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF16U16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f16_u16_e64_dpp"
+               : "v_cvt_f16_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF16U16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2209,8 +2344,10 @@ void VCvtF16U16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF16I16Vop3::VCvtF16I16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f16_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF16I16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f16_i16_e64_dpp"
+               : "v_cvt_f16_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF16I16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2275,8 +2412,10 @@ void VCvtF16I16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtU16F16Vop3::VCvtU16F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_u16_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtU16F16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_u16_f16_e64_dpp"
+               : "v_cvt_u16_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtU16F16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2346,8 +2485,10 @@ void VCvtU16F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtI16F16Vop3::VCvtI16F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_i16_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtI16F16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_i16_f16_e64_dpp"
+               : "v_cvt_i16_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtI16F16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2419,7 +2560,10 @@ void VCvtI16F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRcpF16Vop3::VRcpF16Vop3(const MachineInst *inst)
-    : Vop3("v_rcp_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_f16_e64_dpp"
+               : "v_rcp_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2507,7 +2651,10 @@ void VRcpF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSqrtF16Vop3::VSqrtF16Vop3(const MachineInst *inst)
-    : Vop3("v_sqrt_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSqrtF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sqrt_f16_e64_dpp"
+               : "v_sqrt_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSqrtF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2600,7 +2747,10 @@ void VSqrtF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRsqF16Vop3::VRsqF16Vop3(const MachineInst *inst)
-    : Vop3("v_rsq_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRsqF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rsq_f16_e64_dpp"
+               : "v_rsq_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRsqF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2688,7 +2838,10 @@ void VRsqF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLogF16Vop3::VLogF16Vop3(const MachineInst *inst)
-    : Vop3("v_log_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLogF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_log_f16_e64_dpp"
+               : "v_log_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLogF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2776,7 +2929,10 @@ void VLogF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VExpF16Vop3::VExpF16Vop3(const MachineInst *inst)
-    : Vop3("v_exp_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VExpF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_exp_f16_e64_dpp"
+               : "v_exp_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VExpF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2864,8 +3020,10 @@ void VExpF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpMantF16Vop3::VFrexpMantF16Vop3(const MachineInst *inst)
-    : Vop3("v_frexp_mant_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpMantF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_mant_f16_e64_dpp"
+               : "v_frexp_mant_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpMantF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2959,8 +3117,10 @@ void VFrexpMantF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpExpI16F16Vop3::VFrexpExpI16F16Vop3(const MachineInst *inst)
-    : Vop3("v_frexp_exp_i16_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpExpI16F16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_exp_i16_f16_e64_dpp"
+               : "v_frexp_exp_i16_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpExpI16F16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3057,8 +3217,10 @@ void VFrexpExpI16F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFloorF16Vop3::VFloorF16Vop3(const MachineInst *inst)
-    : Vop3("v_floor_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFloorF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_floor_f16_e64_dpp"
+               : "v_floor_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFloorF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3146,7 +3308,10 @@ void VFloorF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCeilF16Vop3::VCeilF16Vop3(const MachineInst *inst)
-    : Vop3("v_ceil_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCeilF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ceil_f16_e64_dpp"
+               : "v_ceil_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCeilF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3234,8 +3399,10 @@ void VCeilF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VTruncF16Vop3::VTruncF16Vop3(const MachineInst *inst)
-    : Vop3("v_trunc_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VTruncF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_trunc_f16_e64_dpp"
+               : "v_trunc_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VTruncF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3323,8 +3490,10 @@ void VTruncF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRndneF16Vop3::VRndneF16Vop3(const MachineInst *inst)
-    : Vop3("v_rndne_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRndneF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rndne_f16_e64_dpp"
+               : "v_rndne_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRndneF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3412,8 +3581,10 @@ void VRndneF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFractF16Vop3::VFractF16Vop3(const MachineInst *inst)
-    : Vop3("v_fract_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFractF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fract_f16_e64_dpp"
+               : "v_fract_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFractF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3504,7 +3675,10 @@ void VFractF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSinF16Vop3::VSinF16Vop3(const MachineInst *inst)
-    : Vop3("v_sin_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSinF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sin_f16_e64_dpp"
+               : "v_sin_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSinF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3590,7 +3764,10 @@ void VSinF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCosF16Vop3::VCosF16Vop3(const MachineInst *inst)
-    : Vop3("v_cos_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCosF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cos_f16_e64_dpp"
+               : "v_cos_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCosF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3676,8 +3853,10 @@ void VCosF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSatPkU8I16Vop3::VSatPkU8I16Vop3(const MachineInst *inst)
-    : Vop3("v_sat_pk_u8_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSatPkU8I16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sat_pk_u8_i16_e64_dpp"
+               : "v_sat_pk_u8_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSatPkU8I16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3719,8 +3898,10 @@ void VSatPkU8I16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtNormI16F16Vop3::VCvtNormI16F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_norm_i16_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtNormI16F16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_norm_i16_f16_e64_dpp"
+               : "v_cvt_norm_i16_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtNormI16F16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3789,8 +3970,10 @@ void VCvtNormI16F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtNormU16F16Vop3::VCvtNormU16F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_norm_u16_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtNormU16F16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_norm_u16_f16_e64_dpp"
+               : "v_cvt_norm_u16_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtNormU16F16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3859,7 +4042,10 @@ void VCvtNormU16F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VNotB16Vop3::VNotB16Vop3(const MachineInst *inst)
-    : Vop3("v_not_b16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VNotB16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_not_b16_e64_dpp"
+               : "v_not_b16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VNotB16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3923,8 +4109,10 @@ void VNotB16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtI32I16Vop3::VCvtI32I16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_i32_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtI32I16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_i32_i16_e64_dpp"
+               : "v_cvt_i32_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtI32I16Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3980,8 +4168,10 @@ void VCvtI32I16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtU32U16Vop3::VCvtU32U16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_u32_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtU32U16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_u32_u16_e64_dpp"
+               : "v_cvt_u32_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtU32U16Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -4036,8 +4226,10 @@ void VCvtU32U16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCndmaskB32Vop3::VCndmaskB32Vop3(const MachineInst *inst)
-    : Vop3("v_cndmask_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCndmaskB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cndmask_b32_e64_dpp"
+               : "v_cndmask_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCndmaskB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4092,7 +4284,10 @@ void VCndmaskB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddF32Vop3::VAddF32Vop3(const MachineInst *inst)
-    : Vop3("v_add_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_f32_e64_dpp"
+               : "v_add_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4140,7 +4335,10 @@ void VAddF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubF32Vop3::VSubF32Vop3(const MachineInst *inst)
-    : Vop3("v_sub_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_f32_e64_dpp"
+               : "v_sub_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4188,8 +4386,10 @@ void VSubF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubrevF32Vop3::VSubrevF32Vop3(const MachineInst *inst)
-    : Vop3("v_subrev_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubrevF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_subrev_f32_e64_dpp"
+               : "v_subrev_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubrevF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4237,8 +4437,10 @@ void VSubrevF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmacDx9ZeroF32Vop3::VFmacDx9ZeroF32Vop3(const MachineInst *inst)
-    : Vop3("v_fmac_dx9_zero_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFmacDx9ZeroF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmac_dx9_zero_f32_e64_dpp"
+               : "v_fmac_dx9_zero_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmacDx9ZeroF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4266,8 +4468,10 @@ void VFmacDx9ZeroF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulDx9ZeroF32Vop3::VMulDx9ZeroF32Vop3(const MachineInst *inst)
-    : Vop3("v_mul_dx9_zero_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulDx9ZeroF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_dx9_zero_f32_e64_dpp"
+               : "v_mul_dx9_zero_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulDx9ZeroF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4315,7 +4519,10 @@ void VMulDx9ZeroF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulF32Vop3::VMulF32Vop3(const MachineInst *inst)
-    : Vop3("v_mul_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_f32_e64_dpp"
+               : "v_mul_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4363,8 +4570,10 @@ void VMulF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulI32I24Vop3::VMulI32I24Vop3(const MachineInst *inst)
-    : Vop3("v_mul_i32_i24", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulI32I24Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_i32_i24_e64_dpp"
+               : "v_mul_i32_i24",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulI32I24Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4412,8 +4621,10 @@ void VMulI32I24Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulHiI32I24Vop3::VMulHiI32I24Vop3(const MachineInst *inst)
-    : Vop3("v_mul_hi_i32_i24", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulHiI32I24Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_hi_i32_i24_e64_dpp"
+               : "v_mul_hi_i32_i24",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulHiI32I24Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4461,8 +4672,10 @@ void VMulHiI32I24Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulU32U24Vop3::VMulU32U24Vop3(const MachineInst *inst)
-    : Vop3("v_mul_u32_u24", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulU32U24Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_u32_u24_e64_dpp"
+               : "v_mul_u32_u24",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulU32U24Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4510,8 +4723,10 @@ void VMulU32U24Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulHiU32U24Vop3::VMulHiU32U24Vop3(const MachineInst *inst)
-    : Vop3("v_mul_hi_u32_u24", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulHiU32U24Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_hi_u32_u24_e64_dpp"
+               : "v_mul_hi_u32_u24",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulHiU32U24Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4559,7 +4774,10 @@ void VMulHiU32U24Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinF32Vop3::VMinF32Vop3(const MachineInst *inst)
-    : Vop3("v_min_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_f32_e64_dpp"
+               : "v_min_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4607,7 +4825,10 @@ void VMinF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxF32Vop3::VMaxF32Vop3(const MachineInst *inst)
-    : Vop3("v_max_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_f32_e64_dpp"
+               : "v_max_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4655,7 +4876,10 @@ void VMaxF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinI32Vop3::VMinI32Vop3(const MachineInst *inst)
-    : Vop3("v_min_i32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_i32_e64_dpp"
+               : "v_min_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinI32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4703,7 +4927,10 @@ void VMinI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxI32Vop3::VMaxI32Vop3(const MachineInst *inst)
-    : Vop3("v_max_i32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_i32_e64_dpp"
+               : "v_max_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxI32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4751,7 +4978,10 @@ void VMaxI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinU32Vop3::VMinU32Vop3(const MachineInst *inst)
-    : Vop3("v_min_u32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_u32_e64_dpp"
+               : "v_min_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4799,7 +5029,10 @@ void VMinU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxU32Vop3::VMaxU32Vop3(const MachineInst *inst)
-    : Vop3("v_max_u32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_u32_e64_dpp"
+               : "v_max_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4847,8 +5080,10 @@ void VMaxU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLshlrevB32Vop3::VLshlrevB32Vop3(const MachineInst *inst)
-    : Vop3("v_lshlrev_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLshlrevB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshlrev_b32_e64_dpp"
+               : "v_lshlrev_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLshlrevB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4896,8 +5131,10 @@ void VLshlrevB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLshrrevB32Vop3::VLshrrevB32Vop3(const MachineInst *inst)
-    : Vop3("v_lshrrev_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLshrrevB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshrrev_b32_e64_dpp"
+               : "v_lshrrev_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLshrrevB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4945,8 +5182,10 @@ void VLshrrevB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAshrrevI32Vop3::VAshrrevI32Vop3(const MachineInst *inst)
-    : Vop3("v_ashrrev_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAshrrevI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ashrrev_i32_e64_dpp"
+               : "v_ashrrev_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAshrrevI32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4994,7 +5233,10 @@ void VAshrrevI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAndB32Vop3::VAndB32Vop3(const MachineInst *inst)
-    : Vop3("v_and_b32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAndB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_and_b32_e64_dpp"
+               : "v_and_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAndB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5042,7 +5284,10 @@ void VAndB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VOrB32Vop3::VOrB32Vop3(const MachineInst *inst)
-    : Vop3("v_or_b32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VOrB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_or_b32_e64_dpp"
+               : "v_or_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VOrB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5090,7 +5335,10 @@ void VOrB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VXorB32Vop3::VXorB32Vop3(const MachineInst *inst)
-    : Vop3("v_xor_b32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXorB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_xor_b32_e64_dpp"
+               : "v_xor_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXorB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5138,7 +5386,10 @@ void VXorB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VXnorB32Vop3::VXnorB32Vop3(const MachineInst *inst)
-    : Vop3("v_xnor_b32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXnorB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_xnor_b32_e64_dpp"
+               : "v_xnor_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXnorB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5186,8 +5437,10 @@ void VXnorB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddNcU32Vop3::VAddNcU32Vop3(const MachineInst *inst)
-    : Vop3("v_add_nc_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAddNcU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_nc_u32_e64_dpp"
+               : "v_add_nc_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddNcU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5235,8 +5488,10 @@ void VAddNcU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubNcU32Vop3::VSubNcU32Vop3(const MachineInst *inst)
-    : Vop3("v_sub_nc_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubNcU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_nc_u32_e64_dpp"
+               : "v_sub_nc_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubNcU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5284,8 +5539,10 @@ void VSubNcU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubrevNcU32Vop3::VSubrevNcU32Vop3(const MachineInst *inst)
-    : Vop3("v_subrev_nc_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubrevNcU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_subrev_nc_u32_e64_dpp"
+               : "v_subrev_nc_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubrevNcU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5333,7 +5590,10 @@ void VSubrevNcU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmacF32Vop3::VFmacF32Vop3(const MachineInst *inst)
-    : Vop3("v_fmac_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmacF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmac_f32_e64_dpp"
+               : "v_fmac_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmacF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5382,8 +5642,10 @@ void VFmacF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkRtzF16F32Vop3::VCvtPkRtzF16F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_rtz_f16_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkRtzF16F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_rtz_f16_f32_e64_dpp"
+               : "v_cvt_pk_rtz_f16_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkRtzF16F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5431,7 +5693,10 @@ void VCvtPkRtzF16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddF16Vop3::VAddF16Vop3(const MachineInst *inst)
-    : Vop3("v_add_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_f16_e64_dpp"
+               : "v_add_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5547,7 +5812,10 @@ void VAddF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubF16Vop3::VSubF16Vop3(const MachineInst *inst)
-    : Vop3("v_sub_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_f16_e64_dpp"
+               : "v_sub_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5663,8 +5931,10 @@ void VSubF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubrevF16Vop3::VSubrevF16Vop3(const MachineInst *inst)
-    : Vop3("v_subrev_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubrevF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_subrev_f16_e64_dpp"
+               : "v_subrev_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubrevF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5780,7 +6050,10 @@ void VSubrevF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulF16Vop3::VMulF16Vop3(const MachineInst *inst)
-    : Vop3("v_mul_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_f16_e64_dpp"
+               : "v_mul_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5896,7 +6169,10 @@ void VMulF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmacF16Vop3::VFmacF16Vop3(const MachineInst *inst)
-    : Vop3("v_fmac_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmacF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmac_f16_e64_dpp"
+               : "v_fmac_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmacF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6010,7 +6286,10 @@ void VFmacF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxF16Vop3::VMaxF16Vop3(const MachineInst *inst)
-    : Vop3("v_max_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_f16_e64_dpp"
+               : "v_max_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6129,7 +6408,10 @@ void VMaxF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinF16Vop3::VMinF16Vop3(const MachineInst *inst)
-    : Vop3("v_min_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_f16_e64_dpp"
+               : "v_min_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6248,8 +6530,10 @@ void VMinF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLdexpF16Vop3::VLdexpF16Vop3(const MachineInst *inst)
-    : Vop3("v_ldexp_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLdexpF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ldexp_f16_e64_dpp"
+               : "v_ldexp_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLdexpF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6367,8 +6651,10 @@ void VLdexpF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmaDx9ZeroF32Vop3::VFmaDx9ZeroF32Vop3(const MachineInst *inst)
-    : Vop3("v_fma_dx9_zero_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFmaDx9ZeroF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fma_dx9_zero_f32_e64_dpp"
+               : "v_fma_dx9_zero_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmaDx9ZeroF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6422,8 +6708,10 @@ void VFmaDx9ZeroF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMadI32I24Vop3::VMadI32I24Vop3(const MachineInst *inst)
-    : Vop3("v_mad_i32_i24", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMadI32I24Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mad_i32_i24_e64_dpp"
+               : "v_mad_i32_i24",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMadI32I24Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(24, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(24, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6477,8 +6765,10 @@ void VMadI32I24Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMadU32U24Vop3::VMadU32U24Vop3(const MachineInst *inst)
-    : Vop3("v_mad_u32_u24", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMadU32U24Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mad_u32_u24_e64_dpp"
+               : "v_mad_u32_u24",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMadU32U24Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(24, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(24, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6532,8 +6822,10 @@ void VMadU32U24Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCubeidF32Vop3::VCubeidF32Vop3(const MachineInst *inst)
-    : Vop3("v_cubeid_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCubeidF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cubeid_f32_e64_dpp"
+               : "v_cubeid_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCubeidF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6587,8 +6879,10 @@ void VCubeidF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCubescF32Vop3::VCubescF32Vop3(const MachineInst *inst)
-    : Vop3("v_cubesc_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCubescF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cubesc_f32_e64_dpp"
+               : "v_cubesc_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCubescF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6642,8 +6936,10 @@ void VCubescF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCubetcF32Vop3::VCubetcF32Vop3(const MachineInst *inst)
-    : Vop3("v_cubetc_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCubetcF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cubetc_f32_e64_dpp"
+               : "v_cubetc_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCubetcF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6697,8 +6993,10 @@ void VCubetcF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCubemaF32Vop3::VCubemaF32Vop3(const MachineInst *inst)
-    : Vop3("v_cubema_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCubemaF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cubema_f32_e64_dpp"
+               : "v_cubema_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCubemaF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6752,7 +7050,10 @@ void VCubemaF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VBfeU32Vop3::VBfeU32Vop3(const MachineInst *inst)
-    : Vop3("v_bfe_u32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VBfeU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_bfe_u32_e64_dpp"
+               : "v_bfe_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VBfeU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6806,7 +7107,10 @@ void VBfeU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VBfeI32Vop3::VBfeI32Vop3(const MachineInst *inst)
-    : Vop3("v_bfe_i32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VBfeI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_bfe_i32_e64_dpp"
+               : "v_bfe_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VBfeI32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6860,7 +7164,10 @@ void VBfeI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VBfiB32Vop3::VBfiB32Vop3(const MachineInst *inst)
-    : Vop3("v_bfi_b32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VBfiB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_bfi_b32_e64_dpp"
+               : "v_bfi_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VBfiB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6914,7 +7221,10 @@ void VBfiB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmaF32Vop3::VFmaF32Vop3(const MachineInst *inst)
-    : Vop3("v_fma_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmaF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fma_f32_e64_dpp"
+               : "v_fma_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmaF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6968,7 +7278,10 @@ void VFmaF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmaF64Vop3::VFmaF64Vop3(const MachineInst *inst)
-    : Vop3("v_fma_f64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmaF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fma_f64_e64_dpp"
+               : "v_fma_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmaF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7002,7 +7315,10 @@ VFmaF64Vop3::VFmaF64Vop3(const MachineInst *inst)
 void VFmaF64Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_fma_f64_vop3(*this, wf); }
 
 VLerpU8Vop3::VLerpU8Vop3(const MachineInst *inst)
-    : Vop3("v_lerp_u8", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLerpU8Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lerp_u8_e64_dpp"
+               : "v_lerp_u8",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLerpU8Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7056,8 +7372,10 @@ void VLerpU8Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAlignbitB32Vop3::VAlignbitB32Vop3(const MachineInst *inst)
-    : Vop3("v_alignbit_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAlignbitB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_alignbit_b32_e64_dpp"
+               : "v_alignbit_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAlignbitB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7136,8 +7454,10 @@ void VAlignbitB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAlignbyteB32Vop3::VAlignbyteB32Vop3(const MachineInst *inst)
-    : Vop3("v_alignbyte_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAlignbyteB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_alignbyte_b32_e64_dpp"
+               : "v_alignbyte_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAlignbyteB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7216,8 +7536,10 @@ void VAlignbyteB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMullitF32Vop3::VMullitF32Vop3(const MachineInst *inst)
-    : Vop3("v_mullit_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMullitF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mullit_f32_e64_dpp"
+               : "v_mullit_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMullitF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7265,7 +7587,10 @@ void VMullitF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMin3F32Vop3::VMin3F32Vop3(const MachineInst *inst)
-    : Vop3("v_min3_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMin3F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min3_f32_e64_dpp"
+               : "v_min3_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMin3F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7319,7 +7644,10 @@ void VMin3F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMin3I32Vop3::VMin3I32Vop3(const MachineInst *inst)
-    : Vop3("v_min3_i32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMin3I32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min3_i32_e64_dpp"
+               : "v_min3_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMin3I32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7373,7 +7701,10 @@ void VMin3I32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMin3U32Vop3::VMin3U32Vop3(const MachineInst *inst)
-    : Vop3("v_min3_u32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMin3U32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min3_u32_e64_dpp"
+               : "v_min3_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMin3U32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7427,7 +7758,10 @@ void VMin3U32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMax3F32Vop3::VMax3F32Vop3(const MachineInst *inst)
-    : Vop3("v_max3_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMax3F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max3_f32_e64_dpp"
+               : "v_max3_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMax3F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7481,7 +7815,10 @@ void VMax3F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMax3I32Vop3::VMax3I32Vop3(const MachineInst *inst)
-    : Vop3("v_max3_i32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMax3I32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max3_i32_e64_dpp"
+               : "v_max3_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMax3I32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7535,7 +7872,10 @@ void VMax3I32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMax3U32Vop3::VMax3U32Vop3(const MachineInst *inst)
-    : Vop3("v_max3_u32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMax3U32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max3_u32_e64_dpp"
+               : "v_max3_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMax3U32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7589,7 +7929,10 @@ void VMax3U32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMed3F32Vop3::VMed3F32Vop3(const MachineInst *inst)
-    : Vop3("v_med3_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMed3F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_med3_f32_e64_dpp"
+               : "v_med3_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMed3F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7643,7 +7986,10 @@ void VMed3F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMed3I32Vop3::VMed3I32Vop3(const MachineInst *inst)
-    : Vop3("v_med3_i32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMed3I32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_med3_i32_e64_dpp"
+               : "v_med3_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMed3I32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7697,7 +8043,10 @@ void VMed3I32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMed3U32Vop3::VMed3U32Vop3(const MachineInst *inst)
-    : Vop3("v_med3_u32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMed3U32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_med3_u32_e64_dpp"
+               : "v_med3_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMed3U32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7751,7 +8100,10 @@ void VMed3U32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSadU8Vop3::VSadU8Vop3(const MachineInst *inst)
-    : Vop3("v_sad_u8", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSadU8Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sad_u8_e64_dpp"
+               : "v_sad_u8",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSadU8Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7805,7 +8157,10 @@ void VSadU8Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSadHiU8Vop3::VSadHiU8Vop3(const MachineInst *inst)
-    : Vop3("v_sad_hi_u8", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSadHiU8Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sad_hi_u8_e64_dpp"
+               : "v_sad_hi_u8",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSadHiU8Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7859,7 +8214,10 @@ void VSadHiU8Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSadU16Vop3::VSadU16Vop3(const MachineInst *inst)
-    : Vop3("v_sad_u16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSadU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sad_u16_e64_dpp"
+               : "v_sad_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSadU16Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7913,7 +8271,10 @@ void VSadU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSadU32Vop3::VSadU32Vop3(const MachineInst *inst)
-    : Vop3("v_sad_u32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSadU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sad_u32_e64_dpp"
+               : "v_sad_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSadU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7967,8 +8328,10 @@ void VSadU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkU8F32Vop3::VCvtPkU8F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_u8_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkU8F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_u8_f32_e64_dpp"
+               : "v_cvt_pk_u8_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkU8F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8022,8 +8385,10 @@ void VCvtPkU8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDivFixupF32Vop3::VDivFixupF32Vop3(const MachineInst *inst)
-    : Vop3("v_div_fixup_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VDivFixupF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_div_fixup_f32_e64_dpp"
+               : "v_div_fixup_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDivFixupF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8056,8 +8421,10 @@ void VDivFixupF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDivFixupF64Vop3::VDivFixupF64Vop3(const MachineInst *inst)
-    : Vop3("v_div_fixup_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VDivFixupF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_div_fixup_f64_e64_dpp"
+               : "v_div_fixup_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDivFixupF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8093,8 +8460,10 @@ void VDivFixupF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDivFmasF32Vop3::VDivFmasF32Vop3(const MachineInst *inst)
-    : Vop3("v_div_fmas_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VDivFmasF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_div_fmas_f32_e64_dpp"
+               : "v_div_fmas_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDivFmasF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8130,8 +8499,10 @@ void VDivFmasF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDivFmasF64Vop3::VDivFmasF64Vop3(const MachineInst *inst)
-    : Vop3("v_div_fmas_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VDivFmasF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_div_fmas_f64_e64_dpp"
+               : "v_div_fmas_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDivFmasF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8170,7 +8541,10 @@ void VDivFmasF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMsadU8Vop3::VMsadU8Vop3(const MachineInst *inst)
-    : Vop3("v_msad_u8", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMsadU8Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_msad_u8_e64_dpp"
+               : "v_msad_u8",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMsadU8Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8224,8 +8598,10 @@ void VMsadU8Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VQsadPkU16U8Vop3::VQsadPkU16U8Vop3(const MachineInst *inst)
-    : Vop3("v_qsad_pk_u16_u8", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VQsadPkU16U8Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_qsad_pk_u16_u8_e64_dpp"
+               : "v_qsad_pk_u16_u8",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VQsadPkU16U8Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8261,8 +8637,10 @@ void VQsadPkU16U8Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMqsadPkU16U8Vop3::VMqsadPkU16U8Vop3(const MachineInst *inst)
-    : Vop3("v_mqsad_pk_u16_u8", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMqsadPkU16U8Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mqsad_pk_u16_u8_e64_dpp"
+               : "v_mqsad_pk_u16_u8",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMqsadPkU16U8Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8298,8 +8676,10 @@ void VMqsadPkU16U8Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMqsadU32U8Vop3::VMqsadU32U8Vop3(const MachineInst *inst)
-    : Vop3("v_mqsad_u32_u8", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMqsadU32U8Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mqsad_u32_u8_e64_dpp"
+               : "v_mqsad_u32_u8",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMqsadU32U8Vop3>()),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8334,7 +8714,10 @@ void VMqsadU32U8Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VXor3B32Vop3::VXor3B32Vop3(const MachineInst *inst)
-    : Vop3("v_xor3_b32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXor3B32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_xor3_b32_e64_dpp"
+               : "v_xor3_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXor3B32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8388,7 +8771,10 @@ void VXor3B32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMadU16Vop3::VMadU16Vop3(const MachineInst *inst)
-    : Vop3("v_mad_u16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMadU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mad_u16_e64_dpp"
+               : "v_mad_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMadU16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8472,7 +8858,10 @@ void VMadU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPermB32Vop3::VPermB32Vop3(const MachineInst *inst)
-    : Vop3("v_perm_b32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPermB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_perm_b32_e64_dpp"
+               : "v_perm_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPermB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8526,7 +8915,10 @@ void VPermB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VXadU32Vop3::VXadU32Vop3(const MachineInst *inst)
-    : Vop3("v_xad_u32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXadU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_xad_u32_e64_dpp"
+               : "v_xad_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXadU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8580,8 +8972,10 @@ void VXadU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLshlAddU32Vop3::VLshlAddU32Vop3(const MachineInst *inst)
-    : Vop3("v_lshl_add_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLshlAddU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshl_add_u32_e64_dpp"
+               : "v_lshl_add_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLshlAddU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8635,8 +9029,10 @@ void VLshlAddU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddLshlU32Vop3::VAddLshlU32Vop3(const MachineInst *inst)
-    : Vop3("v_add_lshl_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAddLshlU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_lshl_u32_e64_dpp"
+               : "v_add_lshl_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddLshlU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8690,7 +9086,10 @@ void VAddLshlU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmaF16Vop3::VFmaF16Vop3(const MachineInst *inst)
-    : Vop3("v_fma_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmaF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fma_f16_e64_dpp"
+               : "v_fma_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmaF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8819,7 +9218,10 @@ void VFmaF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMin3F16Vop3::VMin3F16Vop3(const MachineInst *inst)
-    : Vop3("v_min3_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMin3F16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min3_f16_e64_dpp"
+               : "v_min3_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMin3F16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8949,7 +9351,10 @@ void VMin3F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMin3I16Vop3::VMin3I16Vop3(const MachineInst *inst)
-    : Vop3("v_min3_i16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMin3I16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min3_i16_e64_dpp"
+               : "v_min3_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMin3I16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -9049,7 +9454,10 @@ void VMin3I16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMin3U16Vop3::VMin3U16Vop3(const MachineInst *inst)
-    : Vop3("v_min3_u16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMin3U16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min3_u16_e64_dpp"
+               : "v_min3_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMin3U16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -9146,7 +9554,10 @@ void VMin3U16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMax3F16Vop3::VMax3F16Vop3(const MachineInst *inst)
-    : Vop3("v_max3_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMax3F16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max3_f16_e64_dpp"
+               : "v_max3_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMax3F16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -9276,7 +9687,10 @@ void VMax3F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMax3I16Vop3::VMax3I16Vop3(const MachineInst *inst)
-    : Vop3("v_max3_i16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMax3I16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max3_i16_e64_dpp"
+               : "v_max3_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMax3I16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -9376,7 +9790,10 @@ void VMax3I16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMax3U16Vop3::VMax3U16Vop3(const MachineInst *inst)
-    : Vop3("v_max3_u16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMax3U16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max3_u16_e64_dpp"
+               : "v_max3_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMax3U16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -9473,7 +9890,10 @@ void VMax3U16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMed3F16Vop3::VMed3F16Vop3(const MachineInst *inst)
-    : Vop3("v_med3_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMed3F16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_med3_f16_e64_dpp"
+               : "v_med3_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMed3F16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -9605,7 +10025,10 @@ void VMed3F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMed3I16Vop3::VMed3I16Vop3(const MachineInst *inst)
-    : Vop3("v_med3_i16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMed3I16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_med3_i16_e64_dpp"
+               : "v_med3_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMed3I16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -9707,7 +10130,10 @@ void VMed3I16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMed3U16Vop3::VMed3U16Vop3(const MachineInst *inst)
-    : Vop3("v_med3_u16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMed3U16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_med3_u16_e64_dpp"
+               : "v_med3_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMed3U16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -9807,7 +10233,10 @@ void VMed3U16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMadI16Vop3::VMadI16Vop3(const MachineInst *inst)
-    : Vop3("v_mad_i16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMadI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mad_i16_e64_dpp"
+               : "v_mad_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMadI16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -9894,8 +10323,10 @@ void VMadI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDivFixupF16Vop3::VDivFixupF16Vop3(const MachineInst *inst)
-    : Vop3("v_div_fixup_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VDivFixupF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_div_fixup_f16_e64_dpp"
+               : "v_div_fixup_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDivFixupF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -10030,7 +10461,10 @@ void VDivFixupF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAdd3U32Vop3::VAdd3U32Vop3(const MachineInst *inst)
-    : Vop3("v_add3_u32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAdd3U32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add3_u32_e64_dpp"
+               : "v_add3_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAdd3U32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -10084,8 +10518,10 @@ void VAdd3U32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLshlOrB32Vop3::VLshlOrB32Vop3(const MachineInst *inst)
-    : Vop3("v_lshl_or_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLshlOrB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshl_or_b32_e64_dpp"
+               : "v_lshl_or_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLshlOrB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -10139,8 +10575,10 @@ void VLshlOrB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAndOrB32Vop3::VAndOrB32Vop3(const MachineInst *inst)
-    : Vop3("v_and_or_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAndOrB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_and_or_b32_e64_dpp"
+               : "v_and_or_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAndOrB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -10194,7 +10632,10 @@ void VAndOrB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VOr3B32Vop3::VOr3B32Vop3(const MachineInst *inst)
-    : Vop3("v_or3_b32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VOr3B32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_or3_b32_e64_dpp"
+               : "v_or3_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VOr3B32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -10248,8 +10689,10 @@ void VOr3B32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMadU32U16Vop3::VMadU32U16Vop3(const MachineInst *inst)
-    : Vop3("v_mad_u32_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMadU32U16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mad_u32_u16_e64_dpp"
+               : "v_mad_u32_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMadU32U16Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -10325,8 +10768,10 @@ void VMadU32U16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMadI32I16Vop3::VMadI32I16Vop3(const MachineInst *inst)
-    : Vop3("v_mad_i32_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMadI32I16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mad_i32_i16_e64_dpp"
+               : "v_mad_i32_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMadI32I16Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -10409,8 +10854,10 @@ void VMadI32I16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPermlane16B32Vop3::VPermlane16B32Vop3(const MachineInst *inst)
-    : Vop3("v_permlane16_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VPermlane16B32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_permlane16_b32_e64_dpp"
+               : "v_permlane16_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPermlane16B32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -10466,8 +10913,10 @@ void VPermlane16B32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPermlanex16B32Vop3::VPermlanex16B32Vop3(const MachineInst *inst)
-    : Vop3("v_permlanex16_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VPermlanex16B32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_permlanex16_b32_e64_dpp"
+               : "v_permlanex16_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPermlanex16B32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -10525,8 +10974,10 @@ void VPermlanex16B32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCndmaskB16Vop3::VCndmaskB16Vop3(const MachineInst *inst)
-    : Vop3("v_cndmask_b16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCndmaskB16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cndmask_b16_e64_dpp"
+               : "v_cndmask_b16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCndmaskB16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -10612,8 +11063,10 @@ void VCndmaskB16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxminF32Vop3::VMaxminF32Vop3(const MachineInst *inst)
-    : Vop3("v_maxmin_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaxminF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_maxmin_f32_e64_dpp"
+               : "v_maxmin_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxminF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -10667,8 +11120,10 @@ void VMaxminF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinmaxF32Vop3::VMinmaxF32Vop3(const MachineInst *inst)
-    : Vop3("v_minmax_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinmaxF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_minmax_f32_e64_dpp"
+               : "v_minmax_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinmaxF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -10722,8 +11177,10 @@ void VMinmaxF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxminF16Vop3::VMaxminF16Vop3(const MachineInst *inst)
-    : Vop3("v_maxmin_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaxminF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_maxmin_f16_e64_dpp"
+               : "v_maxmin_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxminF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -10853,8 +11310,10 @@ void VMaxminF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinmaxF16Vop3::VMinmaxF16Vop3(const MachineInst *inst)
-    : Vop3("v_minmax_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinmaxF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_minmax_f16_e64_dpp"
+               : "v_minmax_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinmaxF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -10984,8 +11443,10 @@ void VMinmaxF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxminU32Vop3::VMaxminU32Vop3(const MachineInst *inst)
-    : Vop3("v_maxmin_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaxminU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_maxmin_u32_e64_dpp"
+               : "v_maxmin_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxminU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -11039,8 +11500,10 @@ void VMaxminU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinmaxU32Vop3::VMinmaxU32Vop3(const MachineInst *inst)
-    : Vop3("v_minmax_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinmaxU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_minmax_u32_e64_dpp"
+               : "v_minmax_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinmaxU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -11094,8 +11557,10 @@ void VMinmaxU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxminI32Vop3::VMaxminI32Vop3(const MachineInst *inst)
-    : Vop3("v_maxmin_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaxminI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_maxmin_i32_e64_dpp"
+               : "v_maxmin_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxminI32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -11149,8 +11614,10 @@ void VMaxminI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinmaxI32Vop3::VMinmaxI32Vop3(const MachineInst *inst)
-    : Vop3("v_minmax_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinmaxI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_minmax_i32_e64_dpp"
+               : "v_minmax_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinmaxI32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -11204,8 +11671,10 @@ void VMinmaxI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDot2F16F16Vop3::VDot2F16F16Vop3(const MachineInst *inst)
-    : Vop3("v_dot2_f16_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VDot2F16F16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_dot2_f16_f16_e64_dpp"
+               : "v_dot2_f16_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDot2F16F16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -11313,8 +11782,10 @@ void VDot2F16F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDot2Bf16Bf16Vop3::VDot2Bf16Bf16Vop3(const MachineInst *inst)
-    : Vop3("v_dot2_bf16_bf16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VDot2Bf16Bf16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_dot2_bf16_bf16_e64_dpp"
+               : "v_dot2_bf16_bf16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDot2Bf16Bf16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -11422,8 +11893,10 @@ void VDot2Bf16Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddNcU16Vop3::VAddNcU16Vop3(const MachineInst *inst)
-    : Vop3("v_add_nc_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAddNcU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_nc_u16_e64_dpp"
+               : "v_add_nc_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddNcU16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -11500,8 +11973,10 @@ void VAddNcU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubNcU16Vop3::VSubNcU16Vop3(const MachineInst *inst)
-    : Vop3("v_sub_nc_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubNcU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_nc_u16_e64_dpp"
+               : "v_sub_nc_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubNcU16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -11578,8 +12053,10 @@ void VSubNcU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulLoU16Vop3::VMulLoU16Vop3(const MachineInst *inst)
-    : Vop3("v_mul_lo_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulLoU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_lo_u16_e64_dpp"
+               : "v_mul_lo_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulLoU16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -11657,8 +12134,10 @@ void VMulLoU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkI16F32Vop3::VCvtPkI16F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_i16_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkI16F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_i16_f32_e64_dpp"
+               : "v_cvt_pk_i16_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkI16F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -11717,8 +12196,10 @@ void VCvtPkI16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkU16F32Vop3::VCvtPkU16F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_u16_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkU16F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_u16_f32_e64_dpp"
+               : "v_cvt_pk_u16_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkU16F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -11777,7 +12258,10 @@ void VCvtPkU16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxU16Vop3::VMaxU16Vop3(const MachineInst *inst)
-    : Vop3("v_max_u16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_u16_e64_dpp"
+               : "v_max_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxU16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -11855,7 +12339,10 @@ void VMaxU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxI16Vop3::VMaxI16Vop3(const MachineInst *inst)
-    : Vop3("v_max_i16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_i16_e64_dpp"
+               : "v_max_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxI16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -11933,7 +12420,10 @@ void VMaxI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinU16Vop3::VMinU16Vop3(const MachineInst *inst)
-    : Vop3("v_min_u16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_u16_e64_dpp"
+               : "v_min_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinU16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -12011,7 +12501,10 @@ void VMinU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinI16Vop3::VMinI16Vop3(const MachineInst *inst)
-    : Vop3("v_min_i16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_i16_e64_dpp"
+               : "v_min_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinI16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -12089,8 +12582,10 @@ void VMinI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddNcI16Vop3::VAddNcI16Vop3(const MachineInst *inst)
-    : Vop3("v_add_nc_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAddNcI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_nc_i16_e64_dpp"
+               : "v_add_nc_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddNcI16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -12166,8 +12661,10 @@ void VAddNcI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubNcI16Vop3::VSubNcI16Vop3(const MachineInst *inst)
-    : Vop3("v_sub_nc_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubNcI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_nc_i16_e64_dpp"
+               : "v_sub_nc_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubNcI16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -12243,8 +12740,10 @@ void VSubNcI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPackB32F16Vop3::VPackB32F16Vop3(const MachineInst *inst)
-    : Vop3("v_pack_b32_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VPackB32F16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_pack_b32_f16_e64_dpp"
+               : "v_pack_b32_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPackB32F16Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -12312,8 +12811,10 @@ void VPackB32F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkNormI16F16Vop3::VCvtPkNormI16F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_norm_i16_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkNormI16F16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_norm_i16_f16_e64_dpp"
+               : "v_cvt_pk_norm_i16_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkNormI16F16Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -12397,8 +12898,10 @@ void VCvtPkNormI16F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkNormU16F16Vop3::VCvtPkNormU16F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_norm_u16_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkNormU16F16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_norm_u16_f16_e64_dpp"
+               : "v_cvt_pk_norm_u16_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkNormU16F16Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -12480,8 +12983,10 @@ void VCvtPkNormU16F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLdexpF32Vop3::VLdexpF32Vop3(const MachineInst *inst)
-    : Vop3("v_ldexp_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLdexpF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ldexp_f32_e64_dpp"
+               : "v_ldexp_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLdexpF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -12529,7 +13034,10 @@ void VLdexpF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VBfmB32Vop3::VBfmB32Vop3(const MachineInst *inst)
-    : Vop3("v_bfm_b32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VBfmB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_bfm_b32_e64_dpp"
+               : "v_bfm_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VBfmB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -12577,8 +13085,10 @@ void VBfmB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VBcntU32B32Vop3::VBcntU32B32Vop3(const MachineInst *inst)
-    : Vop3("v_bcnt_u32_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VBcntU32B32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_bcnt_u32_b32_e64_dpp"
+               : "v_bcnt_u32_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VBcntU32B32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -12626,8 +13136,10 @@ void VBcntU32B32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMbcntLoU32B32Vop3::VMbcntLoU32B32Vop3(const MachineInst *inst)
-    : Vop3("v_mbcnt_lo_u32_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMbcntLoU32B32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mbcnt_lo_u32_b32_e64_dpp"
+               : "v_mbcnt_lo_u32_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMbcntLoU32B32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -12675,8 +13187,10 @@ void VMbcntLoU32B32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMbcntHiU32B32Vop3::VMbcntHiU32B32Vop3(const MachineInst *inst)
-    : Vop3("v_mbcnt_hi_u32_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMbcntHiU32B32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mbcnt_hi_u32_b32_e64_dpp"
+               : "v_mbcnt_hi_u32_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMbcntHiU32B32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -12724,8 +13238,10 @@ void VMbcntHiU32B32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkNormI16F32Vop3::VCvtPkNormI16F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_norm_i16_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkNormI16F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_norm_i16_f32_e64_dpp"
+               : "v_cvt_pk_norm_i16_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkNormI16F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -12773,8 +13289,10 @@ void VCvtPkNormI16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkNormU16F32Vop3::VCvtPkNormU16F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_norm_u16_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkNormU16F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_norm_u16_f32_e64_dpp"
+               : "v_cvt_pk_norm_u16_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkNormU16F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -12822,8 +13340,10 @@ void VCvtPkNormU16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkU16U32Vop3::VCvtPkU16U32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_u16_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkU16U32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_u16_u32_e64_dpp"
+               : "v_cvt_pk_u16_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkU16U32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -12871,8 +13391,10 @@ void VCvtPkU16U32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkI16I32Vop3::VCvtPkI16I32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_i16_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkI16I32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_i16_i32_e64_dpp"
+               : "v_cvt_pk_i16_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkI16I32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -12920,8 +13442,10 @@ void VCvtPkI16I32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubNcI32Vop3::VSubNcI32Vop3(const MachineInst *inst)
-    : Vop3("v_sub_nc_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubNcI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_nc_i32_e64_dpp"
+               : "v_sub_nc_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubNcI32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -12969,8 +13493,10 @@ void VSubNcI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddNcI32Vop3::VAddNcI32Vop3(const MachineInst *inst)
-    : Vop3("v_add_nc_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAddNcI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_nc_i32_e64_dpp"
+               : "v_add_nc_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddNcI32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13018,7 +13544,10 @@ void VAddNcI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddF64Vop3::VAddF64Vop3(const MachineInst *inst)
-    : Vop3("v_add_f64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_f64_e64_dpp"
+               : "v_add_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13045,7 +13574,10 @@ VAddF64Vop3::VAddF64Vop3(const MachineInst *inst)
 void VAddF64Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_add_f64_vop3(*this, wf); }
 
 VMulF64Vop3::VMulF64Vop3(const MachineInst *inst)
-    : Vop3("v_mul_f64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_f64_e64_dpp"
+               : "v_mul_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13072,7 +13604,10 @@ VMulF64Vop3::VMulF64Vop3(const MachineInst *inst)
 void VMulF64Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_mul_f64_vop3(*this, wf); }
 
 VMinF64Vop3::VMinF64Vop3(const MachineInst *inst)
-    : Vop3("v_min_f64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_f64_e64_dpp"
+               : "v_min_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13099,7 +13634,10 @@ VMinF64Vop3::VMinF64Vop3(const MachineInst *inst)
 void VMinF64Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_min_f64_vop3(*this, wf); }
 
 VMaxF64Vop3::VMaxF64Vop3(const MachineInst *inst)
-    : Vop3("v_max_f64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_f64_e64_dpp"
+               : "v_max_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13126,8 +13664,10 @@ VMaxF64Vop3::VMaxF64Vop3(const MachineInst *inst)
 void VMaxF64Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_max_f64_vop3(*this, wf); }
 
 VLdexpF64Vop3::VLdexpF64Vop3(const MachineInst *inst)
-    : Vop3("v_ldexp_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLdexpF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ldexp_f64_e64_dpp"
+               : "v_ldexp_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLdexpF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13155,8 +13695,10 @@ void VLdexpF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulLoU32Vop3::VMulLoU32Vop3(const MachineInst *inst)
-    : Vop3("v_mul_lo_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulLoU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_lo_u32_e64_dpp"
+               : "v_mul_lo_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulLoU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13183,8 +13725,10 @@ void VMulLoU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulHiU32Vop3::VMulHiU32Vop3(const MachineInst *inst)
-    : Vop3("v_mul_hi_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulHiU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_hi_u32_e64_dpp"
+               : "v_mul_hi_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulHiU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13211,8 +13755,10 @@ void VMulHiU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulHiI32Vop3::VMulHiI32Vop3(const MachineInst *inst)
-    : Vop3("v_mul_hi_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulHiI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_hi_i32_e64_dpp"
+               : "v_mul_hi_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulHiI32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13239,8 +13785,10 @@ void VMulHiI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VTrigPreopF64Vop3::VTrigPreopF64Vop3(const MachineInst *inst)
-    : Vop3("v_trig_preop_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VTrigPreopF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_trig_preop_f64_e64_dpp"
+               : "v_trig_preop_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VTrigPreopF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13269,8 +13817,10 @@ void VTrigPreopF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLshlrevB16Vop3::VLshlrevB16Vop3(const MachineInst *inst)
-    : Vop3("v_lshlrev_b16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLshlrevB16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshlrev_b16_e64_dpp"
+               : "v_lshlrev_b16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLshlrevB16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13343,8 +13893,10 @@ void VLshlrevB16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLshrrevB16Vop3::VLshrrevB16Vop3(const MachineInst *inst)
-    : Vop3("v_lshrrev_b16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLshrrevB16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshrrev_b16_e64_dpp"
+               : "v_lshrrev_b16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLshrrevB16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13417,8 +13969,10 @@ void VLshrrevB16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAshrrevI16Vop3::VAshrrevI16Vop3(const MachineInst *inst)
-    : Vop3("v_ashrrev_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAshrrevI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ashrrev_i16_e64_dpp"
+               : "v_ashrrev_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAshrrevI16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13493,8 +14047,10 @@ void VAshrrevI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLshlrevB64Vop3::VLshlrevB64Vop3(const MachineInst *inst)
-    : Vop3("v_lshlrev_b64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLshlrevB64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshlrev_b64_e64_dpp"
+               : "v_lshlrev_b64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLshlrevB64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13522,8 +14078,10 @@ void VLshlrevB64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLshrrevB64Vop3::VLshrrevB64Vop3(const MachineInst *inst)
-    : Vop3("v_lshrrev_b64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLshrrevB64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshrrev_b64_e64_dpp"
+               : "v_lshrrev_b64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLshrrevB64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13551,8 +14109,10 @@ void VLshrrevB64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAshrrevI64Vop3::VAshrrevI64Vop3(const MachineInst *inst)
-    : Vop3("v_ashrrev_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAshrrevI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ashrrev_i64_e64_dpp"
+               : "v_ashrrev_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAshrrevI64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13580,8 +14140,10 @@ void VAshrrevI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VReadlaneB32Vop3::VReadlaneB32Vop3(const MachineInst *inst)
-    : Vop3("v_readlane_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VReadlaneB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_readlane_b32_e64_dpp"
+               : "v_readlane_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VReadlaneB32Vop3>()),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SSRC_LANESEL, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13609,8 +14171,10 @@ void VReadlaneB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VWritelaneB32Vop3::VWritelaneB32Vop3(const MachineInst *inst)
-    : Vop3("v_writelane_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VWritelaneB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_writelane_b32_e64_dpp"
+               : "v_writelane_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VWritelaneB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SSRC_LANESEL, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13640,7 +14204,10 @@ void VWritelaneB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAndB16Vop3::VAndB16Vop3(const MachineInst *inst)
-    : Vop3("v_and_b16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAndB16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_and_b16_e64_dpp"
+               : "v_and_b16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAndB16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13717,7 +14284,10 @@ void VAndB16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VOrB16Vop3::VOrB16Vop3(const MachineInst *inst)
-    : Vop3("v_or_b16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VOrB16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_or_b16_e64_dpp"
+               : "v_or_b16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VOrB16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13794,7 +14364,10 @@ void VOrB16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VXorB16Vop3::VXorB16Vop3(const MachineInst *inst)
-    : Vop3("v_xor_b16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXorB16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_xor_b16_e64_dpp"
+               : "v_xor_b16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXorB16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13871,7 +14444,10 @@ void VXorB16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpFF16Vop3::VCmpFF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_f_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_f_f16_e64_dpp"
+               : "v_cmp_f_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13940,8 +14516,10 @@ void VCmpFF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtF16Vop3::VCmpLtF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lt_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_f16_e64_dpp"
+               : "v_cmp_lt_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14027,8 +14605,10 @@ void VCmpLtF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqF16Vop3::VCmpEqF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_eq_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_f16_e64_dpp"
+               : "v_cmp_eq_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14114,8 +14694,10 @@ void VCmpEqF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeF16Vop3::VCmpLeF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_le_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_f16_e64_dpp"
+               : "v_cmp_le_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14201,8 +14783,10 @@ void VCmpLeF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtF16Vop3::VCmpGtF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_gt_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_f16_e64_dpp"
+               : "v_cmp_gt_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14288,8 +14872,10 @@ void VCmpGtF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLgF16Vop3::VCmpLgF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lg_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLgF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lg_f16_e64_dpp"
+               : "v_cmp_lg_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLgF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14378,8 +14964,10 @@ void VCmpLgF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeF16Vop3::VCmpGeF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ge_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_f16_e64_dpp"
+               : "v_cmp_ge_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14465,7 +15053,10 @@ void VCmpGeF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpOF16Vop3::VCmpOF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_o_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpOF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_o_f16_e64_dpp"
+               : "v_cmp_o_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpOF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14552,7 +15143,10 @@ void VCmpOF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpUF16Vop3::VCmpUF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_u_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpUF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_u_f16_e64_dpp"
+               : "v_cmp_u_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpUF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14639,8 +15233,10 @@ void VCmpUF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNgeF16Vop3::VCmpNgeF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nge_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNgeF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nge_f16_e64_dpp"
+               : "v_cmp_nge_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNgeF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14726,8 +15322,10 @@ void VCmpNgeF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNlgF16Vop3::VCmpNlgF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nlg_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNlgF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlg_f16_e64_dpp"
+               : "v_cmp_nlg_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNlgF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14816,8 +15414,10 @@ void VCmpNlgF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNgtF16Vop3::VCmpNgtF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ngt_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNgtF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ngt_f16_e64_dpp"
+               : "v_cmp_ngt_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNgtF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14903,8 +15503,10 @@ void VCmpNgtF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNleF16Vop3::VCmpNleF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nle_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNleF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nle_f16_e64_dpp"
+               : "v_cmp_nle_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNleF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14990,8 +15592,10 @@ void VCmpNleF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeqF16Vop3::VCmpNeqF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_neq_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeqF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_neq_f16_e64_dpp"
+               : "v_cmp_neq_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeqF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15077,8 +15681,10 @@ void VCmpNeqF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNltF16Vop3::VCmpNltF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nlt_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNltF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlt_f16_e64_dpp"
+               : "v_cmp_nlt_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNltF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15164,7 +15770,10 @@ void VCmpNltF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpTF16Vop3::VCmpTF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_t_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_t_f16_e64_dpp"
+               : "v_cmp_t_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15233,7 +15842,10 @@ void VCmpTF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpFF32Vop3::VCmpFF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_f_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_f_f32_e64_dpp"
+               : "v_cmp_f_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15281,8 +15893,10 @@ void VCmpFF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtF32Vop3::VCmpLtF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lt_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_f32_e64_dpp"
+               : "v_cmp_lt_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15330,8 +15944,10 @@ void VCmpLtF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqF32Vop3::VCmpEqF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_eq_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_f32_e64_dpp"
+               : "v_cmp_eq_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15379,8 +15995,10 @@ void VCmpEqF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeF32Vop3::VCmpLeF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_le_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_f32_e64_dpp"
+               : "v_cmp_le_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15428,8 +16046,10 @@ void VCmpLeF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtF32Vop3::VCmpGtF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_gt_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_f32_e64_dpp"
+               : "v_cmp_gt_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15477,8 +16097,10 @@ void VCmpGtF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLgF32Vop3::VCmpLgF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lg_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLgF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lg_f32_e64_dpp"
+               : "v_cmp_lg_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLgF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15526,8 +16148,10 @@ void VCmpLgF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeF32Vop3::VCmpGeF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ge_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_f32_e64_dpp"
+               : "v_cmp_ge_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15575,7 +16199,10 @@ void VCmpGeF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpOF32Vop3::VCmpOF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_o_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpOF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_o_f32_e64_dpp"
+               : "v_cmp_o_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpOF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15623,7 +16250,10 @@ void VCmpOF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpUF32Vop3::VCmpUF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_u_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpUF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_u_f32_e64_dpp"
+               : "v_cmp_u_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpUF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15671,8 +16301,10 @@ void VCmpUF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNgeF32Vop3::VCmpNgeF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nge_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNgeF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nge_f32_e64_dpp"
+               : "v_cmp_nge_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNgeF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15720,8 +16352,10 @@ void VCmpNgeF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNlgF32Vop3::VCmpNlgF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nlg_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNlgF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlg_f32_e64_dpp"
+               : "v_cmp_nlg_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNlgF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15769,8 +16403,10 @@ void VCmpNlgF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNgtF32Vop3::VCmpNgtF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ngt_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNgtF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ngt_f32_e64_dpp"
+               : "v_cmp_ngt_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNgtF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15818,8 +16454,10 @@ void VCmpNgtF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNleF32Vop3::VCmpNleF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nle_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNleF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nle_f32_e64_dpp"
+               : "v_cmp_nle_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNleF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15867,8 +16505,10 @@ void VCmpNleF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeqF32Vop3::VCmpNeqF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_neq_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeqF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_neq_f32_e64_dpp"
+               : "v_cmp_neq_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeqF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15916,8 +16556,10 @@ void VCmpNeqF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNltF32Vop3::VCmpNltF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nlt_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNltF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlt_f32_e64_dpp"
+               : "v_cmp_nlt_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNltF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15965,7 +16607,10 @@ void VCmpNltF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpTF32Vop3::VCmpTF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_t_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_t_f32_e64_dpp"
+               : "v_cmp_t_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16013,7 +16658,10 @@ void VCmpTF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpFF64Vop3::VCmpFF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_f_f64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_f_f64_e64_dpp"
+               : "v_cmp_f_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16042,8 +16690,10 @@ void VCmpFF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtF64Vop3::VCmpLtF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lt_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_f64_e64_dpp"
+               : "v_cmp_lt_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16072,8 +16722,10 @@ void VCmpLtF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqF64Vop3::VCmpEqF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_eq_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_f64_e64_dpp"
+               : "v_cmp_eq_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16102,8 +16754,10 @@ void VCmpEqF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeF64Vop3::VCmpLeF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_le_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_f64_e64_dpp"
+               : "v_cmp_le_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16132,8 +16786,10 @@ void VCmpLeF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtF64Vop3::VCmpGtF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_gt_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_f64_e64_dpp"
+               : "v_cmp_gt_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16162,8 +16818,10 @@ void VCmpGtF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLgF64Vop3::VCmpLgF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lg_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLgF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lg_f64_e64_dpp"
+               : "v_cmp_lg_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLgF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16192,8 +16850,10 @@ void VCmpLgF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeF64Vop3::VCmpGeF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ge_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_f64_e64_dpp"
+               : "v_cmp_ge_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16222,7 +16882,10 @@ void VCmpGeF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpOF64Vop3::VCmpOF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_o_f64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpOF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_o_f64_e64_dpp"
+               : "v_cmp_o_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpOF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16251,7 +16914,10 @@ void VCmpOF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpUF64Vop3::VCmpUF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_u_f64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpUF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_u_f64_e64_dpp"
+               : "v_cmp_u_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpUF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16280,8 +16946,10 @@ void VCmpUF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNgeF64Vop3::VCmpNgeF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nge_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNgeF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nge_f64_e64_dpp"
+               : "v_cmp_nge_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNgeF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16310,8 +16978,10 @@ void VCmpNgeF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNlgF64Vop3::VCmpNlgF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nlg_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNlgF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlg_f64_e64_dpp"
+               : "v_cmp_nlg_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNlgF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16340,8 +17010,10 @@ void VCmpNlgF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNgtF64Vop3::VCmpNgtF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ngt_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNgtF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ngt_f64_e64_dpp"
+               : "v_cmp_ngt_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNgtF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16370,8 +17042,10 @@ void VCmpNgtF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNleF64Vop3::VCmpNleF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nle_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNleF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nle_f64_e64_dpp"
+               : "v_cmp_nle_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNleF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16400,8 +17074,10 @@ void VCmpNleF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeqF64Vop3::VCmpNeqF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_neq_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeqF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_neq_f64_e64_dpp"
+               : "v_cmp_neq_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeqF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16430,8 +17106,10 @@ void VCmpNeqF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNltF64Vop3::VCmpNltF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nlt_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNltF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlt_f64_e64_dpp"
+               : "v_cmp_nlt_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNltF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16460,7 +17138,10 @@ void VCmpNltF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpTF64Vop3::VCmpTF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_t_f64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_t_f64_e64_dpp"
+               : "v_cmp_t_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16489,8 +17170,10 @@ void VCmpTF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtI16Vop3::VCmpLtI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lt_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_i16_e64_dpp"
+               : "v_cmp_lt_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtI16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16558,8 +17241,10 @@ void VCmpLtI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqI16Vop3::VCmpEqI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_eq_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_i16_e64_dpp"
+               : "v_cmp_eq_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqI16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16627,8 +17312,10 @@ void VCmpEqI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeI16Vop3::VCmpLeI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_le_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_i16_e64_dpp"
+               : "v_cmp_le_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeI16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16696,8 +17383,10 @@ void VCmpLeI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtI16Vop3::VCmpGtI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_gt_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_i16_e64_dpp"
+               : "v_cmp_gt_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtI16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16765,8 +17454,10 @@ void VCmpGtI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeI16Vop3::VCmpNeI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ne_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_i16_e64_dpp"
+               : "v_cmp_ne_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeI16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16834,8 +17525,10 @@ void VCmpNeI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeI16Vop3::VCmpGeI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ge_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_i16_e64_dpp"
+               : "v_cmp_ge_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeI16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16903,8 +17596,10 @@ void VCmpGeI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtU16Vop3::VCmpLtU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lt_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_u16_e64_dpp"
+               : "v_cmp_lt_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtU16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16972,8 +17667,10 @@ void VCmpLtU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqU16Vop3::VCmpEqU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_eq_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_u16_e64_dpp"
+               : "v_cmp_eq_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqU16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17042,8 +17739,10 @@ void VCmpEqU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeU16Vop3::VCmpLeU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_le_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_u16_e64_dpp"
+               : "v_cmp_le_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeU16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17112,8 +17811,10 @@ void VCmpLeU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtU16Vop3::VCmpGtU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_gt_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_u16_e64_dpp"
+               : "v_cmp_gt_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtU16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17181,8 +17882,10 @@ void VCmpGtU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeU16Vop3::VCmpNeU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ne_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_u16_e64_dpp"
+               : "v_cmp_ne_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeU16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17251,8 +17954,10 @@ void VCmpNeU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeU16Vop3::VCmpGeU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ge_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_u16_e64_dpp"
+               : "v_cmp_ge_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeU16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17321,7 +18026,10 @@ void VCmpGeU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpFI32Vop3::VCmpFI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_f_i32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_f_i32_e64_dpp"
+               : "v_cmp_f_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFI32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17369,8 +18077,10 @@ void VCmpFI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtI32Vop3::VCmpLtI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lt_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_i32_e64_dpp"
+               : "v_cmp_lt_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtI32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17418,8 +18128,10 @@ void VCmpLtI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqI32Vop3::VCmpEqI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_eq_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_i32_e64_dpp"
+               : "v_cmp_eq_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqI32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17467,8 +18179,10 @@ void VCmpEqI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeI32Vop3::VCmpLeI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_le_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_i32_e64_dpp"
+               : "v_cmp_le_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeI32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17516,8 +18230,10 @@ void VCmpLeI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtI32Vop3::VCmpGtI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_gt_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_i32_e64_dpp"
+               : "v_cmp_gt_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtI32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17565,8 +18281,10 @@ void VCmpGtI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeI32Vop3::VCmpNeI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ne_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_i32_e64_dpp"
+               : "v_cmp_ne_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeI32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17614,8 +18332,10 @@ void VCmpNeI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeI32Vop3::VCmpGeI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ge_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_i32_e64_dpp"
+               : "v_cmp_ge_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeI32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17663,7 +18383,10 @@ void VCmpGeI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpTI32Vop3::VCmpTI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_t_i32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_t_i32_e64_dpp"
+               : "v_cmp_t_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTI32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17711,7 +18434,10 @@ void VCmpTI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpFU32Vop3::VCmpFU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_f_u32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_f_u32_e64_dpp"
+               : "v_cmp_f_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFU32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17759,8 +18485,10 @@ void VCmpFU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtU32Vop3::VCmpLtU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lt_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_u32_e64_dpp"
+               : "v_cmp_lt_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtU32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17808,8 +18536,10 @@ void VCmpLtU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqU32Vop3::VCmpEqU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_eq_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_u32_e64_dpp"
+               : "v_cmp_eq_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqU32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17857,8 +18587,10 @@ void VCmpEqU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeU32Vop3::VCmpLeU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_le_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_u32_e64_dpp"
+               : "v_cmp_le_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeU32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17906,8 +18638,10 @@ void VCmpLeU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtU32Vop3::VCmpGtU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_gt_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_u32_e64_dpp"
+               : "v_cmp_gt_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtU32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17955,8 +18689,10 @@ void VCmpGtU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeU32Vop3::VCmpNeU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ne_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_u32_e64_dpp"
+               : "v_cmp_ne_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeU32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18004,8 +18740,10 @@ void VCmpNeU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeU32Vop3::VCmpGeU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ge_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_u32_e64_dpp"
+               : "v_cmp_ge_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeU32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18053,7 +18791,10 @@ void VCmpGeU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpTU32Vop3::VCmpTU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_t_u32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_t_u32_e64_dpp"
+               : "v_cmp_t_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTU32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18101,7 +18842,10 @@ void VCmpTU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpFI64Vop3::VCmpFI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_f_i64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_f_i64_e64_dpp"
+               : "v_cmp_f_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFI64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18130,8 +18874,10 @@ void VCmpFI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtI64Vop3::VCmpLtI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lt_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_i64_e64_dpp"
+               : "v_cmp_lt_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtI64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18160,8 +18906,10 @@ void VCmpLtI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqI64Vop3::VCmpEqI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_eq_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_i64_e64_dpp"
+               : "v_cmp_eq_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqI64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18190,8 +18938,10 @@ void VCmpEqI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeI64Vop3::VCmpLeI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_le_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_i64_e64_dpp"
+               : "v_cmp_le_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeI64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18220,8 +18970,10 @@ void VCmpLeI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtI64Vop3::VCmpGtI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_gt_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_i64_e64_dpp"
+               : "v_cmp_gt_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtI64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18250,8 +19002,10 @@ void VCmpGtI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeI64Vop3::VCmpNeI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ne_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_i64_e64_dpp"
+               : "v_cmp_ne_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeI64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18280,8 +19034,10 @@ void VCmpNeI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeI64Vop3::VCmpGeI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ge_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_i64_e64_dpp"
+               : "v_cmp_ge_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeI64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18310,7 +19066,10 @@ void VCmpGeI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpTI64Vop3::VCmpTI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_t_i64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_t_i64_e64_dpp"
+               : "v_cmp_t_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTI64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18339,7 +19098,10 @@ void VCmpTI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpFU64Vop3::VCmpFU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_f_u64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_f_u64_e64_dpp"
+               : "v_cmp_f_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFU64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18368,8 +19130,10 @@ void VCmpFU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtU64Vop3::VCmpLtU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lt_u64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_u64_e64_dpp"
+               : "v_cmp_lt_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtU64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18398,8 +19162,10 @@ void VCmpLtU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqU64Vop3::VCmpEqU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_eq_u64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_u64_e64_dpp"
+               : "v_cmp_eq_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqU64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18428,8 +19194,10 @@ void VCmpEqU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeU64Vop3::VCmpLeU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_le_u64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_u64_e64_dpp"
+               : "v_cmp_le_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeU64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18458,8 +19226,10 @@ void VCmpLeU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtU64Vop3::VCmpGtU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_gt_u64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_u64_e64_dpp"
+               : "v_cmp_gt_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtU64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18488,8 +19258,10 @@ void VCmpGtU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeU64Vop3::VCmpNeU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ne_u64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_u64_e64_dpp"
+               : "v_cmp_ne_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeU64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18518,8 +19290,10 @@ void VCmpNeU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeU64Vop3::VCmpGeU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ge_u64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_u64_e64_dpp"
+               : "v_cmp_ge_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeU64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18548,7 +19322,10 @@ void VCmpGeU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpTU64Vop3::VCmpTU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_t_u64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_t_u64_e64_dpp"
+               : "v_cmp_t_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTU64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18577,8 +19354,10 @@ void VCmpTU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpClassF16Vop3::VCmpClassF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_class_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpClassF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_class_f16_e64_dpp"
+               : "v_cmp_class_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpClassF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18707,8 +19486,10 @@ void VCmpClassF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpClassF32Vop3::VCmpClassF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_class_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpClassF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_class_f32_e64_dpp"
+               : "v_cmp_class_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpClassF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18756,8 +19537,10 @@ void VCmpClassF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpClassF64Vop3::VCmpClassF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_class_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpClassF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_class_f64_e64_dpp"
+               : "v_cmp_class_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpClassF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18785,8 +19568,10 @@ void VCmpClassF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxFF16Vop3::VCmpxFF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_f_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxFF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_f_f16_e64_dpp"
+               : "v_cmpx_f_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxFF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -18855,8 +19640,10 @@ void VCmpxFF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtF16Vop3::VCmpxLtF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lt_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_f16_e64_dpp"
+               : "v_cmpx_lt_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -18939,8 +19726,10 @@ void VCmpxLtF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqF16Vop3::VCmpxEqF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_eq_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_f16_e64_dpp"
+               : "v_cmpx_eq_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -19023,8 +19812,10 @@ void VCmpxEqF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeF16Vop3::VCmpxLeF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_le_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_f16_e64_dpp"
+               : "v_cmpx_le_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -19107,8 +19898,10 @@ void VCmpxLeF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtF16Vop3::VCmpxGtF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_gt_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_f16_e64_dpp"
+               : "v_cmpx_gt_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -19191,8 +19984,10 @@ void VCmpxGtF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLgF16Vop3::VCmpxLgF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lg_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLgF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lg_f16_e64_dpp"
+               : "v_cmpx_lg_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLgF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -19275,8 +20070,10 @@ void VCmpxLgF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeF16Vop3::VCmpxGeF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ge_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_f16_e64_dpp"
+               : "v_cmpx_ge_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -19359,8 +20156,10 @@ void VCmpxGeF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxOF16Vop3::VCmpxOF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_o_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxOF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_o_f16_e64_dpp"
+               : "v_cmpx_o_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxOF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -19443,8 +20242,10 @@ void VCmpxOF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxUF16Vop3::VCmpxUF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_u_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxUF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_u_f16_e64_dpp"
+               : "v_cmpx_u_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxUF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -19527,8 +20328,10 @@ void VCmpxUF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNgeF16Vop3::VCmpxNgeF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nge_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNgeF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nge_f16_e64_dpp"
+               : "v_cmpx_nge_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNgeF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -19611,8 +20414,10 @@ void VCmpxNgeF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNlgF16Vop3::VCmpxNlgF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nlg_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNlgF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlg_f16_e64_dpp"
+               : "v_cmpx_nlg_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNlgF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -19695,8 +20500,10 @@ void VCmpxNlgF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNgtF16Vop3::VCmpxNgtF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ngt_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNgtF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ngt_f16_e64_dpp"
+               : "v_cmpx_ngt_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNgtF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -19779,8 +20586,10 @@ void VCmpxNgtF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNleF16Vop3::VCmpxNleF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nle_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNleF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nle_f16_e64_dpp"
+               : "v_cmpx_nle_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNleF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -19863,8 +20672,10 @@ void VCmpxNleF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeqF16Vop3::VCmpxNeqF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_neq_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeqF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_neq_f16_e64_dpp"
+               : "v_cmpx_neq_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeqF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -19947,8 +20758,10 @@ void VCmpxNeqF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNltF16Vop3::VCmpxNltF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nlt_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNltF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlt_f16_e64_dpp"
+               : "v_cmpx_nlt_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNltF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -20031,8 +20844,10 @@ void VCmpxNltF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxTF16Vop3::VCmpxTF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_t_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxTF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_t_f16_e64_dpp"
+               : "v_cmpx_t_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxTF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -20101,8 +20916,10 @@ void VCmpxTF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxFF32Vop3::VCmpxFF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_f_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxFF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_f_f32_e64_dpp"
+               : "v_cmpx_f_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxFF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -20161,8 +20978,10 @@ void VCmpxFF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtF32Vop3::VCmpxLtF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lt_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_f32_e64_dpp"
+               : "v_cmpx_lt_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -20232,8 +21051,10 @@ void VCmpxLtF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqF32Vop3::VCmpxEqF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_eq_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_f32_e64_dpp"
+               : "v_cmpx_eq_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -20303,8 +21124,10 @@ void VCmpxEqF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeF32Vop3::VCmpxLeF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_le_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_f32_e64_dpp"
+               : "v_cmpx_le_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -20374,8 +21197,10 @@ void VCmpxLeF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtF32Vop3::VCmpxGtF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_gt_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_f32_e64_dpp"
+               : "v_cmpx_gt_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -20445,8 +21270,10 @@ void VCmpxGtF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLgF32Vop3::VCmpxLgF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lg_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLgF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lg_f32_e64_dpp"
+               : "v_cmpx_lg_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLgF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -20516,8 +21343,10 @@ void VCmpxLgF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeF32Vop3::VCmpxGeF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ge_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_f32_e64_dpp"
+               : "v_cmpx_ge_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -20587,8 +21416,10 @@ void VCmpxGeF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxOF32Vop3::VCmpxOF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_o_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxOF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_o_f32_e64_dpp"
+               : "v_cmpx_o_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxOF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -20658,8 +21489,10 @@ void VCmpxOF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxUF32Vop3::VCmpxUF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_u_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxUF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_u_f32_e64_dpp"
+               : "v_cmpx_u_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxUF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -20729,8 +21562,10 @@ void VCmpxUF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNgeF32Vop3::VCmpxNgeF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nge_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNgeF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nge_f32_e64_dpp"
+               : "v_cmpx_nge_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNgeF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -20800,8 +21635,10 @@ void VCmpxNgeF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNlgF32Vop3::VCmpxNlgF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nlg_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNlgF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlg_f32_e64_dpp"
+               : "v_cmpx_nlg_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNlgF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -20871,8 +21708,10 @@ void VCmpxNlgF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNgtF32Vop3::VCmpxNgtF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ngt_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNgtF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ngt_f32_e64_dpp"
+               : "v_cmpx_ngt_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNgtF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -20942,8 +21781,10 @@ void VCmpxNgtF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNleF32Vop3::VCmpxNleF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nle_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNleF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nle_f32_e64_dpp"
+               : "v_cmpx_nle_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNleF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21013,8 +21854,10 @@ void VCmpxNleF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeqF32Vop3::VCmpxNeqF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_neq_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeqF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_neq_f32_e64_dpp"
+               : "v_cmpx_neq_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeqF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21084,8 +21927,10 @@ void VCmpxNeqF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNltF32Vop3::VCmpxNltF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nlt_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNltF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlt_f32_e64_dpp"
+               : "v_cmpx_nlt_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNltF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21155,8 +22000,10 @@ void VCmpxNltF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxTF32Vop3::VCmpxTF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_t_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxTF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_t_f32_e64_dpp"
+               : "v_cmpx_t_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxTF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21215,8 +22062,10 @@ void VCmpxTF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxFF64Vop3::VCmpxFF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_f_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxFF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_f_f64_e64_dpp"
+               : "v_cmpx_f_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxFF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21256,8 +22105,10 @@ void VCmpxFF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtF64Vop3::VCmpxLtF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lt_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_f64_e64_dpp"
+               : "v_cmpx_lt_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21308,8 +22159,10 @@ void VCmpxLtF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqF64Vop3::VCmpxEqF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_eq_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_f64_e64_dpp"
+               : "v_cmpx_eq_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21360,8 +22213,10 @@ void VCmpxEqF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeF64Vop3::VCmpxLeF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_le_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_f64_e64_dpp"
+               : "v_cmpx_le_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21412,8 +22267,10 @@ void VCmpxLeF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtF64Vop3::VCmpxGtF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_gt_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_f64_e64_dpp"
+               : "v_cmpx_gt_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21464,8 +22321,10 @@ void VCmpxGtF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLgF64Vop3::VCmpxLgF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lg_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLgF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lg_f64_e64_dpp"
+               : "v_cmpx_lg_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLgF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21516,8 +22375,10 @@ void VCmpxLgF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeF64Vop3::VCmpxGeF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ge_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_f64_e64_dpp"
+               : "v_cmpx_ge_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21568,8 +22429,10 @@ void VCmpxGeF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxOF64Vop3::VCmpxOF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_o_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxOF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_o_f64_e64_dpp"
+               : "v_cmpx_o_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxOF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21620,8 +22483,10 @@ void VCmpxOF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxUF64Vop3::VCmpxUF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_u_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxUF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_u_f64_e64_dpp"
+               : "v_cmpx_u_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxUF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21672,8 +22537,10 @@ void VCmpxUF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNgeF64Vop3::VCmpxNgeF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nge_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNgeF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nge_f64_e64_dpp"
+               : "v_cmpx_nge_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNgeF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21724,8 +22591,10 @@ void VCmpxNgeF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNlgF64Vop3::VCmpxNlgF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nlg_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNlgF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlg_f64_e64_dpp"
+               : "v_cmpx_nlg_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNlgF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21776,8 +22645,10 @@ void VCmpxNlgF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNgtF64Vop3::VCmpxNgtF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ngt_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNgtF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ngt_f64_e64_dpp"
+               : "v_cmpx_ngt_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNgtF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21828,8 +22699,10 @@ void VCmpxNgtF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNleF64Vop3::VCmpxNleF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nle_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNleF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nle_f64_e64_dpp"
+               : "v_cmpx_nle_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNleF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21880,8 +22753,10 @@ void VCmpxNleF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeqF64Vop3::VCmpxNeqF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_neq_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeqF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_neq_f64_e64_dpp"
+               : "v_cmpx_neq_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeqF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21932,8 +22807,10 @@ void VCmpxNeqF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNltF64Vop3::VCmpxNltF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nlt_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNltF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlt_f64_e64_dpp"
+               : "v_cmpx_nlt_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNltF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21984,8 +22861,10 @@ void VCmpxNltF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxTF64Vop3::VCmpxTF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_t_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxTF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_t_f64_e64_dpp"
+               : "v_cmpx_t_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxTF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22025,8 +22904,10 @@ void VCmpxTF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtI16Vop3::VCmpxLtI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lt_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_i16_e64_dpp"
+               : "v_cmpx_lt_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtI16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22105,8 +22986,10 @@ void VCmpxLtI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqI16Vop3::VCmpxEqI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_eq_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_i16_e64_dpp"
+               : "v_cmpx_eq_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqI16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22185,8 +23068,10 @@ void VCmpxEqI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeI16Vop3::VCmpxLeI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_le_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_i16_e64_dpp"
+               : "v_cmpx_le_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeI16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22265,8 +23150,10 @@ void VCmpxLeI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtI16Vop3::VCmpxGtI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_gt_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_i16_e64_dpp"
+               : "v_cmpx_gt_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtI16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22345,8 +23232,10 @@ void VCmpxGtI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeI16Vop3::VCmpxNeI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ne_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_i16_e64_dpp"
+               : "v_cmpx_ne_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeI16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22425,8 +23314,10 @@ void VCmpxNeI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeI16Vop3::VCmpxGeI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ge_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_i16_e64_dpp"
+               : "v_cmpx_ge_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeI16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22505,8 +23396,10 @@ void VCmpxGeI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtU16Vop3::VCmpxLtU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lt_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_u16_e64_dpp"
+               : "v_cmpx_lt_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtU16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22585,8 +23478,10 @@ void VCmpxLtU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqU16Vop3::VCmpxEqU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_eq_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_u16_e64_dpp"
+               : "v_cmpx_eq_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqU16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22665,8 +23560,10 @@ void VCmpxEqU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeU16Vop3::VCmpxLeU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_le_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_u16_e64_dpp"
+               : "v_cmpx_le_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeU16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22745,8 +23642,10 @@ void VCmpxLeU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtU16Vop3::VCmpxGtU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_gt_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_u16_e64_dpp"
+               : "v_cmpx_gt_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtU16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22825,8 +23724,10 @@ void VCmpxGtU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeU16Vop3::VCmpxNeU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ne_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_u16_e64_dpp"
+               : "v_cmpx_ne_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeU16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22905,8 +23806,10 @@ void VCmpxNeU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeU16Vop3::VCmpxGeU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ge_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_u16_e64_dpp"
+               : "v_cmpx_ge_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeU16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22985,8 +23888,10 @@ void VCmpxGeU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxFI32Vop3::VCmpxFI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_f_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxFI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_f_i32_e64_dpp"
+               : "v_cmpx_f_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxFI32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23045,8 +23950,10 @@ void VCmpxFI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtI32Vop3::VCmpxLtI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lt_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_i32_e64_dpp"
+               : "v_cmpx_lt_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtI32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23108,8 +24015,10 @@ void VCmpxLtI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqI32Vop3::VCmpxEqI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_eq_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_i32_e64_dpp"
+               : "v_cmpx_eq_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqI32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23171,8 +24080,10 @@ void VCmpxEqI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeI32Vop3::VCmpxLeI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_le_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_i32_e64_dpp"
+               : "v_cmpx_le_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeI32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23234,8 +24145,10 @@ void VCmpxLeI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtI32Vop3::VCmpxGtI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_gt_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_i32_e64_dpp"
+               : "v_cmpx_gt_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtI32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23297,8 +24210,10 @@ void VCmpxGtI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeI32Vop3::VCmpxNeI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ne_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_i32_e64_dpp"
+               : "v_cmpx_ne_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeI32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23360,8 +24275,10 @@ void VCmpxNeI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeI32Vop3::VCmpxGeI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ge_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_i32_e64_dpp"
+               : "v_cmpx_ge_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeI32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23423,8 +24340,10 @@ void VCmpxGeI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxTI32Vop3::VCmpxTI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_t_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxTI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_t_i32_e64_dpp"
+               : "v_cmpx_t_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxTI32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23483,8 +24402,10 @@ void VCmpxTI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxFU32Vop3::VCmpxFU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_f_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxFU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_f_u32_e64_dpp"
+               : "v_cmpx_f_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxFU32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23543,8 +24464,10 @@ void VCmpxFU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtU32Vop3::VCmpxLtU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lt_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_u32_e64_dpp"
+               : "v_cmpx_lt_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtU32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23606,8 +24529,10 @@ void VCmpxLtU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqU32Vop3::VCmpxEqU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_eq_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_u32_e64_dpp"
+               : "v_cmpx_eq_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqU32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23669,8 +24594,10 @@ void VCmpxEqU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeU32Vop3::VCmpxLeU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_le_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_u32_e64_dpp"
+               : "v_cmpx_le_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeU32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23732,8 +24659,10 @@ void VCmpxLeU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtU32Vop3::VCmpxGtU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_gt_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_u32_e64_dpp"
+               : "v_cmpx_gt_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtU32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23795,8 +24724,10 @@ void VCmpxGtU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeU32Vop3::VCmpxNeU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ne_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_u32_e64_dpp"
+               : "v_cmpx_ne_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeU32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23858,8 +24789,10 @@ void VCmpxNeU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeU32Vop3::VCmpxGeU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ge_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_u32_e64_dpp"
+               : "v_cmpx_ge_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeU32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23921,8 +24854,10 @@ void VCmpxGeU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxTU32Vop3::VCmpxTU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_t_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxTU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_t_u32_e64_dpp"
+               : "v_cmpx_t_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxTU32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23981,8 +24916,10 @@ void VCmpxTU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxFI64Vop3::VCmpxFI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_f_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxFI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_f_i64_e64_dpp"
+               : "v_cmpx_f_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxFI64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24022,8 +24959,10 @@ void VCmpxFI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtI64Vop3::VCmpxLtI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lt_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_i64_e64_dpp"
+               : "v_cmpx_lt_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtI64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24066,8 +25005,10 @@ void VCmpxLtI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqI64Vop3::VCmpxEqI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_eq_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_i64_e64_dpp"
+               : "v_cmpx_eq_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqI64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24110,8 +25051,10 @@ void VCmpxEqI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeI64Vop3::VCmpxLeI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_le_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_i64_e64_dpp"
+               : "v_cmpx_le_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeI64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24154,8 +25097,10 @@ void VCmpxLeI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtI64Vop3::VCmpxGtI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_gt_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_i64_e64_dpp"
+               : "v_cmpx_gt_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtI64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24198,8 +25143,10 @@ void VCmpxGtI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeI64Vop3::VCmpxNeI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ne_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_i64_e64_dpp"
+               : "v_cmpx_ne_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeI64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24242,8 +25189,10 @@ void VCmpxNeI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeI64Vop3::VCmpxGeI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ge_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_i64_e64_dpp"
+               : "v_cmpx_ge_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeI64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24286,8 +25235,10 @@ void VCmpxGeI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxTI64Vop3::VCmpxTI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_t_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxTI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_t_i64_e64_dpp"
+               : "v_cmpx_t_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxTI64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24327,8 +25278,10 @@ void VCmpxTI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxFU64Vop3::VCmpxFU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_f_u64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxFU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_f_u64_e64_dpp"
+               : "v_cmpx_f_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxFU64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24368,8 +25321,10 @@ void VCmpxFU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtU64Vop3::VCmpxLtU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lt_u64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_u64_e64_dpp"
+               : "v_cmpx_lt_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtU64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24412,8 +25367,10 @@ void VCmpxLtU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqU64Vop3::VCmpxEqU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_eq_u64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_u64_e64_dpp"
+               : "v_cmpx_eq_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqU64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24456,8 +25413,10 @@ void VCmpxEqU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeU64Vop3::VCmpxLeU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_le_u64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_u64_e64_dpp"
+               : "v_cmpx_le_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeU64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24500,8 +25459,10 @@ void VCmpxLeU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtU64Vop3::VCmpxGtU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_gt_u64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_u64_e64_dpp"
+               : "v_cmpx_gt_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtU64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24544,8 +25505,10 @@ void VCmpxGtU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeU64Vop3::VCmpxNeU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ne_u64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_u64_e64_dpp"
+               : "v_cmpx_ne_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeU64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24588,8 +25551,10 @@ void VCmpxNeU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeU64Vop3::VCmpxGeU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ge_u64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_u64_e64_dpp"
+               : "v_cmpx_ge_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeU64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24632,8 +25597,10 @@ void VCmpxGeU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxTU64Vop3::VCmpxTU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_t_u64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxTU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_t_u64_e64_dpp"
+               : "v_cmpx_t_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxTU64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24673,8 +25640,10 @@ void VCmpxTU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxClassF16Vop3::VCmpxClassF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_class_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxClassF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_class_f16_e64_dpp"
+               : "v_cmpx_class_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxClassF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24781,8 +25750,10 @@ void VCmpxClassF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxClassF32Vop3::VCmpxClassF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_class_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxClassF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_class_f32_e64_dpp"
+               : "v_cmpx_class_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxClassF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24871,8 +25842,10 @@ void VCmpxClassF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxClassF64Vop3::VCmpxClassF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_class_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxClassF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_class_f64_e64_dpp"
+               : "v_cmpx_class_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxClassF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24943,7 +25916,10 @@ void VCmpxClassF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddCoCiU32Vop3SdstEnc::VAddCoCiU32Vop3SdstEnc(const MachineInst *inst)
-    : Vop3SdstEnc("v_add_co_ci_u32", reinterpret_cast<const OpEncoding *>(inst),
+    : Vop3SdstEnc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                      ? "v_add_co_ci_u32_e64_dpp"
+                      : "v_add_co_ci_u32",
+                  reinterpret_cast<const OpEncoding *>(inst),
                   make_exec_fn<VAddCoCiU32Vop3SdstEnc>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
@@ -25002,7 +25978,10 @@ void VAddCoCiU32Vop3SdstEnc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubCoCiU32Vop3SdstEnc::VSubCoCiU32Vop3SdstEnc(const MachineInst *inst)
-    : Vop3SdstEnc("v_sub_co_ci_u32", reinterpret_cast<const OpEncoding *>(inst),
+    : Vop3SdstEnc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                      ? "v_sub_co_ci_u32_e64_dpp"
+                      : "v_sub_co_ci_u32",
+                  reinterpret_cast<const OpEncoding *>(inst),
                   make_exec_fn<VSubCoCiU32Vop3SdstEnc>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
@@ -25061,7 +26040,10 @@ void VSubCoCiU32Vop3SdstEnc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubrevCoCiU32Vop3SdstEnc::VSubrevCoCiU32Vop3SdstEnc(const MachineInst *inst)
-    : Vop3SdstEnc("v_subrev_co_ci_u32", reinterpret_cast<const OpEncoding *>(inst),
+    : Vop3SdstEnc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                      ? "v_subrev_co_ci_u32_e64_dpp"
+                      : "v_subrev_co_ci_u32",
+                  reinterpret_cast<const OpEncoding *>(inst),
                   make_exec_fn<VSubrevCoCiU32Vop3SdstEnc>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
@@ -25120,7 +26102,10 @@ void VSubrevCoCiU32Vop3SdstEnc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDivScaleF32Vop3SdstEnc::VDivScaleF32Vop3SdstEnc(const MachineInst *inst)
-    : Vop3SdstEnc("v_div_scale_f32", reinterpret_cast<const OpEncoding *>(inst),
+    : Vop3SdstEnc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                      ? "v_div_scale_f32_e64_dpp"
+                      : "v_div_scale_f32",
+                  reinterpret_cast<const OpEncoding *>(inst),
                   make_exec_fn<VDivScaleF32Vop3SdstEnc>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(64, OperandType::OPR_SDST, reinterpret_cast<const OpEncoding *>(inst)->sdst),
@@ -25156,7 +26141,10 @@ void VDivScaleF32Vop3SdstEnc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDivScaleF64Vop3SdstEnc::VDivScaleF64Vop3SdstEnc(const MachineInst *inst)
-    : Vop3SdstEnc("v_div_scale_f64", reinterpret_cast<const OpEncoding *>(inst),
+    : Vop3SdstEnc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                      ? "v_div_scale_f64_e64_dpp"
+                      : "v_div_scale_f64",
+                  reinterpret_cast<const OpEncoding *>(inst),
                   make_exec_fn<VDivScaleF64Vop3SdstEnc>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(64, OperandType::OPR_SDST, reinterpret_cast<const OpEncoding *>(inst)->sdst),
@@ -25198,7 +26186,10 @@ void VDivScaleF64Vop3SdstEnc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMadU64U32Vop3SdstEnc::VMadU64U32Vop3SdstEnc(const MachineInst *inst)
-    : Vop3SdstEnc("v_mad_u64_u32", reinterpret_cast<const OpEncoding *>(inst),
+    : Vop3SdstEnc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                      ? "v_mad_u64_u32_e64_dpp"
+                      : "v_mad_u64_u32",
+                  reinterpret_cast<const OpEncoding *>(inst),
                   make_exec_fn<VMadU64U32Vop3SdstEnc>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
@@ -25236,7 +26227,10 @@ void VMadU64U32Vop3SdstEnc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMadI64I32Vop3SdstEnc::VMadI64I32Vop3SdstEnc(const MachineInst *inst)
-    : Vop3SdstEnc("v_mad_i64_i32", reinterpret_cast<const OpEncoding *>(inst),
+    : Vop3SdstEnc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                      ? "v_mad_i64_i32_e64_dpp"
+                      : "v_mad_i64_i32",
+                  reinterpret_cast<const OpEncoding *>(inst),
                   make_exec_fn<VMadI64I32Vop3SdstEnc>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
@@ -25274,8 +26268,10 @@ void VMadI64I32Vop3SdstEnc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddCoU32Vop3SdstEnc::VAddCoU32Vop3SdstEnc(const MachineInst *inst)
-    : Vop3SdstEnc("v_add_co_u32", reinterpret_cast<const OpEncoding *>(inst),
-                  make_exec_fn<VAddCoU32Vop3SdstEnc>()),
+    : Vop3SdstEnc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                      ? "v_add_co_u32_e64_dpp"
+                      : "v_add_co_u32",
+                  reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddCoU32Vop3SdstEnc>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -25325,8 +26321,10 @@ void VAddCoU32Vop3SdstEnc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubCoU32Vop3SdstEnc::VSubCoU32Vop3SdstEnc(const MachineInst *inst)
-    : Vop3SdstEnc("v_sub_co_u32", reinterpret_cast<const OpEncoding *>(inst),
-                  make_exec_fn<VSubCoU32Vop3SdstEnc>()),
+    : Vop3SdstEnc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                      ? "v_sub_co_u32_e64_dpp"
+                      : "v_sub_co_u32",
+                  reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubCoU32Vop3SdstEnc>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -25376,7 +26374,10 @@ void VSubCoU32Vop3SdstEnc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubrevCoU32Vop3SdstEnc::VSubrevCoU32Vop3SdstEnc(const MachineInst *inst)
-    : Vop3SdstEnc("v_subrev_co_u32", reinterpret_cast<const OpEncoding *>(inst),
+    : Vop3SdstEnc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                      ? "v_subrev_co_u32_e64_dpp"
+                      : "v_subrev_co_u32",
+                  reinterpret_cast<const OpEncoding *>(inst),
                   make_exec_fn<VSubrevCoU32Vop3SdstEnc>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vop3p.cpp
@@ -23,8 +23,10 @@ namespace rocjitsu {
 namespace rdna3_5 {
 
 VPkMadI16Vop3p::VPkMadI16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_mad_i16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkMadI16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_mad_i16_e64_dpp"
+                : "v_pk_mad_i16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkMadI16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -57,8 +59,10 @@ void VPkMadI16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkMulLoU16Vop3p::VPkMulLoU16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_mul_lo_u16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkMulLoU16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_mul_lo_u16_e64_dpp"
+                : "v_pk_mul_lo_u16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkMulLoU16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -85,8 +89,10 @@ void VPkMulLoU16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkAddI16Vop3p::VPkAddI16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_add_i16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkAddI16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_add_i16_e64_dpp"
+                : "v_pk_add_i16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkAddI16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -113,8 +119,10 @@ void VPkAddI16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkSubI16Vop3p::VPkSubI16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_sub_i16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkSubI16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_sub_i16_e64_dpp"
+                : "v_pk_sub_i16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkSubI16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -141,8 +149,10 @@ void VPkSubI16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkLshlrevB16Vop3p::VPkLshlrevB16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_lshlrev_b16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkLshlrevB16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_lshlrev_b16_e64_dpp"
+                : "v_pk_lshlrev_b16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkLshlrevB16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -169,8 +179,10 @@ void VPkLshlrevB16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkLshrrevB16Vop3p::VPkLshrrevB16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_lshrrev_b16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkLshrrevB16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_lshrrev_b16_e64_dpp"
+                : "v_pk_lshrrev_b16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkLshrrevB16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -197,8 +209,10 @@ void VPkLshrrevB16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkAshrrevI16Vop3p::VPkAshrrevI16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_ashrrev_i16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkAshrrevI16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_ashrrev_i16_e64_dpp"
+                : "v_pk_ashrrev_i16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkAshrrevI16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -225,8 +239,10 @@ void VPkAshrrevI16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkMaxI16Vop3p::VPkMaxI16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_max_i16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkMaxI16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_max_i16_e64_dpp"
+                : "v_pk_max_i16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkMaxI16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -253,8 +269,10 @@ void VPkMaxI16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkMinI16Vop3p::VPkMinI16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_min_i16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkMinI16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_min_i16_e64_dpp"
+                : "v_pk_min_i16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkMinI16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -281,8 +299,10 @@ void VPkMinI16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkMadU16Vop3p::VPkMadU16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_mad_u16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkMadU16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_mad_u16_e64_dpp"
+                : "v_pk_mad_u16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkMadU16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -315,8 +335,10 @@ void VPkMadU16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkAddU16Vop3p::VPkAddU16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_add_u16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkAddU16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_add_u16_e64_dpp"
+                : "v_pk_add_u16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkAddU16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -343,8 +365,10 @@ void VPkAddU16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkSubU16Vop3p::VPkSubU16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_sub_u16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkSubU16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_sub_u16_e64_dpp"
+                : "v_pk_sub_u16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkSubU16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -371,8 +395,10 @@ void VPkSubU16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkMaxU16Vop3p::VPkMaxU16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_max_u16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkMaxU16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_max_u16_e64_dpp"
+                : "v_pk_max_u16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkMaxU16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -399,8 +425,10 @@ void VPkMaxU16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkMinU16Vop3p::VPkMinU16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_min_u16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkMinU16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_min_u16_e64_dpp"
+                : "v_pk_min_u16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkMinU16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -427,8 +455,10 @@ void VPkMinU16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkFmaF16Vop3p::VPkFmaF16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_fma_f16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkFmaF16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_fma_f16_e64_dpp"
+                : "v_pk_fma_f16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkFmaF16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -461,8 +491,10 @@ void VPkFmaF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkAddF16Vop3p::VPkAddF16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_add_f16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkAddF16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_add_f16_e64_dpp"
+                : "v_pk_add_f16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkAddF16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -489,8 +521,10 @@ void VPkAddF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkMulF16Vop3p::VPkMulF16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_mul_f16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkMulF16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_mul_f16_e64_dpp"
+                : "v_pk_mul_f16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkMulF16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -517,8 +551,10 @@ void VPkMulF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkMinF16Vop3p::VPkMinF16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_min_f16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkMinF16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_min_f16_e64_dpp"
+                : "v_pk_min_f16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkMinF16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -545,8 +581,10 @@ void VPkMinF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkMaxF16Vop3p::VPkMaxF16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_max_f16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkMaxF16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_max_f16_e64_dpp"
+                : "v_pk_max_f16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkMaxF16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -573,8 +611,10 @@ void VPkMaxF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDot2F32F16Vop3p::VDot2F32F16Vop3p(const MachineInst *inst)
-    : Vop3p("v_dot2_f32_f16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VDot2F32F16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_dot2_f32_f16_e64_dpp"
+                : "v_dot2_f32_f16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDot2F32F16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -628,8 +668,10 @@ void VDot2F32F16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDot4I32Iu8Vop3p::VDot4I32Iu8Vop3p(const MachineInst *inst)
-    : Vop3p("v_dot4_i32_iu8", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VDot4I32Iu8Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_dot4_i32_iu8_e64_dpp"
+                : "v_dot4_i32_iu8",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDot4I32Iu8Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -662,8 +704,10 @@ void VDot4I32Iu8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDot4U32U8Vop3p::VDot4U32U8Vop3p(const MachineInst *inst)
-    : Vop3p("v_dot4_u32_u8", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VDot4U32U8Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_dot4_u32_u8_e64_dpp"
+                : "v_dot4_u32_u8",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDot4U32U8Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -696,8 +740,10 @@ void VDot4U32U8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDot8I32Iu4Vop3p::VDot8I32Iu4Vop3p(const MachineInst *inst)
-    : Vop3p("v_dot8_i32_iu4", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VDot8I32Iu4Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_dot8_i32_iu4_e64_dpp"
+                : "v_dot8_i32_iu4",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDot8I32Iu4Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -730,8 +776,10 @@ void VDot8I32Iu4Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDot8U32U4Vop3p::VDot8U32U4Vop3p(const MachineInst *inst)
-    : Vop3p("v_dot8_u32_u4", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VDot8U32U4Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_dot8_u32_u4_e64_dpp"
+                : "v_dot8_u32_u4",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDot8U32U4Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -764,8 +812,10 @@ void VDot8U32U4Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDot2F32Bf16Vop3p::VDot2F32Bf16Vop3p(const MachineInst *inst)
-    : Vop3p("v_dot2_f32_bf16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VDot2F32Bf16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_dot2_f32_bf16_e64_dpp"
+                : "v_dot2_f32_bf16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDot2F32Bf16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -819,8 +869,10 @@ void VDot2F32Bf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmaMixF32Vop3p::VFmaMixF32Vop3p(const MachineInst *inst)
-    : Vop3p("v_fma_mix_f32", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VFmaMixF32Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_fma_mix_f32_e64_dpp"
+                : "v_fma_mix_f32",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmaMixF32Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -874,8 +926,10 @@ void VFmaMixF32Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmaMixloF16Vop3p::VFmaMixloF16Vop3p(const MachineInst *inst)
-    : Vop3p("v_fma_mixlo_f16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VFmaMixloF16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_fma_mixlo_f16_e64_dpp"
+                : "v_fma_mixlo_f16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmaMixloF16Vop3p>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -936,8 +990,10 @@ void VFmaMixloF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmaMixhiF16Vop3p::VFmaMixhiF16Vop3p(const MachineInst *inst)
-    : Vop3p("v_fma_mixhi_f16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VFmaMixhiF16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_fma_mixhi_f16_e64_dpp"
+                : "v_fma_mixhi_f16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmaMixhiF16Vop3p>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -998,8 +1054,10 @@ void VFmaMixhiF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VWmmaF3216x16x16F16Vop3p::VWmmaF3216x16x16F16Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_f32_16x16x16_f16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VWmmaF3216x16x16F16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_f32_16x16x16_f16_e64_dpp"
+                : "v_wmma_f32_16x16x16_f16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VWmmaF3216x16x16F16Vop3p>()),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1042,8 +1100,10 @@ void VWmmaF3216x16x16F16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VWmmaF3216x16x16Bf16Vop3p::VWmmaF3216x16x16Bf16Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_f32_16x16x16_bf16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VWmmaF3216x16x16Bf16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_f32_16x16x16_bf16_e64_dpp"
+                : "v_wmma_f32_16x16x16_bf16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VWmmaF3216x16x16Bf16Vop3p>()),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1086,8 +1146,10 @@ void VWmmaF3216x16x16Bf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VWmmaF1616x16x16F16Vop3p::VWmmaF1616x16x16F16Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_f16_16x16x16_f16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VWmmaF1616x16x16F16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_f16_16x16x16_f16_e64_dpp"
+                : "v_wmma_f16_16x16x16_f16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VWmmaF1616x16x16F16Vop3p>()),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1130,8 +1192,10 @@ void VWmmaF1616x16x16F16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VWmmaBf1616x16x16Bf16Vop3p::VWmmaBf1616x16x16Bf16Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_bf16_16x16x16_bf16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VWmmaBf1616x16x16Bf16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_bf16_16x16x16_bf16_e64_dpp"
+                : "v_wmma_bf16_16x16x16_bf16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VWmmaBf1616x16x16Bf16Vop3p>()),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1174,8 +1238,10 @@ void VWmmaBf1616x16x16Bf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VWmmaI3216x16x16Iu8Vop3p::VWmmaI3216x16x16Iu8Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_i32_16x16x16_iu8", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VWmmaI3216x16x16Iu8Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_i32_16x16x16_iu8_e64_dpp"
+                : "v_wmma_i32_16x16x16_iu8",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VWmmaI3216x16x16Iu8Vop3p>()),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1225,8 +1291,10 @@ void VWmmaI3216x16x16Iu8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VWmmaI3216x16x16Iu4Vop3p::VWmmaI3216x16x16Iu4Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_i32_16x16x16_iu4", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VWmmaI3216x16x16Iu4Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_i32_16x16x16_iu4_e64_dpp"
+                : "v_wmma_i32_16x16x16_iu4",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VWmmaI3216x16x16Iu4Vop3p>()),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vopc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vopc.cpp
@@ -22,8 +22,10 @@ namespace rocjitsu {
 namespace rdna3_5 {
 
 VCmpFF16Vopc::VCmpFF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_f_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpFF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_f_f16_dpp"
+               : "v_cmp_f_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -82,8 +84,10 @@ void VCmpFF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtF16Vopc::VCmpLtF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lt_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_f16_dpp"
+               : "v_cmp_lt_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -142,8 +146,10 @@ void VCmpLtF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqF16Vopc::VCmpEqF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_eq_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_f16_dpp"
+               : "v_cmp_eq_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -202,8 +208,10 @@ void VCmpEqF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeF16Vopc::VCmpLeF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_le_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_f16_dpp"
+               : "v_cmp_le_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -262,8 +270,10 @@ void VCmpLeF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtF16Vopc::VCmpGtF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_gt_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_f16_dpp"
+               : "v_cmp_gt_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -322,8 +332,10 @@ void VCmpGtF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLgF16Vopc::VCmpLgF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lg_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLgF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lg_f16_dpp"
+               : "v_cmp_lg_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLgF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -382,8 +394,10 @@ void VCmpLgF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeF16Vopc::VCmpGeF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ge_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_f16_dpp"
+               : "v_cmp_ge_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -442,8 +456,10 @@ void VCmpGeF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpOF16Vopc::VCmpOF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_o_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpOF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_o_f16_dpp"
+               : "v_cmp_o_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpOF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -502,8 +518,10 @@ void VCmpOF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpUF16Vopc::VCmpUF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_u_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpUF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_u_f16_dpp"
+               : "v_cmp_u_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpUF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -562,8 +580,10 @@ void VCmpUF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNgeF16Vopc::VCmpNgeF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nge_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNgeF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nge_f16_dpp"
+               : "v_cmp_nge_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNgeF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -622,8 +642,10 @@ void VCmpNgeF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNlgF16Vopc::VCmpNlgF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nlg_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNlgF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlg_f16_dpp"
+               : "v_cmp_nlg_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNlgF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -682,8 +704,10 @@ void VCmpNlgF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNgtF16Vopc::VCmpNgtF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ngt_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNgtF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ngt_f16_dpp"
+               : "v_cmp_ngt_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNgtF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -742,8 +766,10 @@ void VCmpNgtF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNleF16Vopc::VCmpNleF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nle_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNleF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nle_f16_dpp"
+               : "v_cmp_nle_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNleF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -802,8 +828,10 @@ void VCmpNleF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeqF16Vopc::VCmpNeqF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_neq_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeqF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_neq_f16_dpp"
+               : "v_cmp_neq_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeqF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -862,8 +890,10 @@ void VCmpNeqF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNltF16Vopc::VCmpNltF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nlt_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNltF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlt_f16_dpp"
+               : "v_cmp_nlt_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNltF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -922,8 +952,10 @@ void VCmpNltF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpTF16Vopc::VCmpTF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_t_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpTF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_t_f16_dpp"
+               : "v_cmp_t_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -982,8 +1014,10 @@ void VCmpTF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpFF32Vopc::VCmpFF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_f_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpFF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_f_f32_dpp"
+               : "v_cmp_f_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1039,8 +1073,10 @@ void VCmpFF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtF32Vopc::VCmpLtF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lt_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_f32_dpp"
+               : "v_cmp_lt_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1096,8 +1132,10 @@ void VCmpLtF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqF32Vopc::VCmpEqF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_eq_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_f32_dpp"
+               : "v_cmp_eq_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1153,8 +1191,10 @@ void VCmpEqF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeF32Vopc::VCmpLeF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_le_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_f32_dpp"
+               : "v_cmp_le_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1210,8 +1250,10 @@ void VCmpLeF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtF32Vopc::VCmpGtF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_gt_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_f32_dpp"
+               : "v_cmp_gt_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1267,8 +1309,10 @@ void VCmpGtF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLgF32Vopc::VCmpLgF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lg_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLgF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lg_f32_dpp"
+               : "v_cmp_lg_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLgF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1324,8 +1368,10 @@ void VCmpLgF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeF32Vopc::VCmpGeF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ge_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_f32_dpp"
+               : "v_cmp_ge_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1381,8 +1427,10 @@ void VCmpGeF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpOF32Vopc::VCmpOF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_o_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpOF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_o_f32_dpp"
+               : "v_cmp_o_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpOF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1438,8 +1486,10 @@ void VCmpOF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpUF32Vopc::VCmpUF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_u_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpUF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_u_f32_dpp"
+               : "v_cmp_u_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpUF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1495,8 +1545,10 @@ void VCmpUF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNgeF32Vopc::VCmpNgeF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nge_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNgeF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nge_f32_dpp"
+               : "v_cmp_nge_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNgeF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1552,8 +1604,10 @@ void VCmpNgeF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNlgF32Vopc::VCmpNlgF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nlg_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNlgF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlg_f32_dpp"
+               : "v_cmp_nlg_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNlgF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1609,8 +1663,10 @@ void VCmpNlgF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNgtF32Vopc::VCmpNgtF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ngt_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNgtF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ngt_f32_dpp"
+               : "v_cmp_ngt_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNgtF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1666,8 +1722,10 @@ void VCmpNgtF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNleF32Vopc::VCmpNleF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nle_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNleF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nle_f32_dpp"
+               : "v_cmp_nle_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNleF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1723,8 +1781,10 @@ void VCmpNleF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeqF32Vopc::VCmpNeqF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_neq_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeqF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_neq_f32_dpp"
+               : "v_cmp_neq_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeqF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1780,8 +1840,10 @@ void VCmpNeqF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNltF32Vopc::VCmpNltF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nlt_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNltF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlt_f32_dpp"
+               : "v_cmp_nlt_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNltF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1837,8 +1899,10 @@ void VCmpNltF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpTF32Vopc::VCmpTF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_t_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpTF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_t_f32_dpp"
+               : "v_cmp_t_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1894,8 +1958,10 @@ void VCmpTF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpFF64Vopc::VCmpFF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_f_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpFF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_f_f64_dpp"
+               : "v_cmp_f_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1920,8 +1986,10 @@ void VCmpFF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtF64Vopc::VCmpLtF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lt_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_f64_dpp"
+               : "v_cmp_lt_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1946,8 +2014,10 @@ void VCmpLtF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqF64Vopc::VCmpEqF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_eq_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_f64_dpp"
+               : "v_cmp_eq_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1972,8 +2042,10 @@ void VCmpEqF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeF64Vopc::VCmpLeF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_le_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_f64_dpp"
+               : "v_cmp_le_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1998,8 +2070,10 @@ void VCmpLeF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtF64Vopc::VCmpGtF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_gt_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_f64_dpp"
+               : "v_cmp_gt_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2024,8 +2098,10 @@ void VCmpGtF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLgF64Vopc::VCmpLgF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lg_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLgF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lg_f64_dpp"
+               : "v_cmp_lg_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLgF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2050,8 +2126,10 @@ void VCmpLgF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeF64Vopc::VCmpGeF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ge_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_f64_dpp"
+               : "v_cmp_ge_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2076,8 +2154,10 @@ void VCmpGeF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpOF64Vopc::VCmpOF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_o_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpOF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_o_f64_dpp"
+               : "v_cmp_o_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpOF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2102,8 +2182,10 @@ void VCmpOF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpUF64Vopc::VCmpUF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_u_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpUF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_u_f64_dpp"
+               : "v_cmp_u_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpUF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2128,8 +2210,10 @@ void VCmpUF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNgeF64Vopc::VCmpNgeF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nge_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNgeF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nge_f64_dpp"
+               : "v_cmp_nge_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNgeF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2154,8 +2238,10 @@ void VCmpNgeF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNlgF64Vopc::VCmpNlgF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nlg_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNlgF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlg_f64_dpp"
+               : "v_cmp_nlg_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNlgF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2180,8 +2266,10 @@ void VCmpNlgF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNgtF64Vopc::VCmpNgtF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ngt_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNgtF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ngt_f64_dpp"
+               : "v_cmp_ngt_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNgtF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2206,8 +2294,10 @@ void VCmpNgtF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNleF64Vopc::VCmpNleF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nle_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNleF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nle_f64_dpp"
+               : "v_cmp_nle_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNleF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2232,8 +2322,10 @@ void VCmpNleF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeqF64Vopc::VCmpNeqF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_neq_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeqF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_neq_f64_dpp"
+               : "v_cmp_neq_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeqF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2258,8 +2350,10 @@ void VCmpNeqF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNltF64Vopc::VCmpNltF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nlt_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNltF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlt_f64_dpp"
+               : "v_cmp_nlt_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNltF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2284,8 +2378,10 @@ void VCmpNltF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpTF64Vopc::VCmpTF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_t_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpTF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_t_f64_dpp"
+               : "v_cmp_t_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2310,8 +2406,10 @@ void VCmpTF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtI16Vopc::VCmpLtI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lt_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtI16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_i16_dpp"
+               : "v_cmp_lt_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtI16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2370,8 +2468,10 @@ void VCmpLtI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqI16Vopc::VCmpEqI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_eq_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqI16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_i16_dpp"
+               : "v_cmp_eq_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqI16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2430,8 +2530,10 @@ void VCmpEqI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeI16Vopc::VCmpLeI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_le_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeI16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_i16_dpp"
+               : "v_cmp_le_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeI16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2490,8 +2592,10 @@ void VCmpLeI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtI16Vopc::VCmpGtI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_gt_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtI16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_i16_dpp"
+               : "v_cmp_gt_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtI16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2550,8 +2654,10 @@ void VCmpGtI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeI16Vopc::VCmpNeI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ne_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeI16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_i16_dpp"
+               : "v_cmp_ne_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeI16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2610,8 +2716,10 @@ void VCmpNeI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeI16Vopc::VCmpGeI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ge_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeI16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_i16_dpp"
+               : "v_cmp_ge_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeI16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2670,8 +2778,10 @@ void VCmpGeI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtU16Vopc::VCmpLtU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lt_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtU16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_u16_dpp"
+               : "v_cmp_lt_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtU16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2730,8 +2840,10 @@ void VCmpLtU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqU16Vopc::VCmpEqU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_eq_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqU16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_u16_dpp"
+               : "v_cmp_eq_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqU16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2790,8 +2902,10 @@ void VCmpEqU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeU16Vopc::VCmpLeU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_le_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeU16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_u16_dpp"
+               : "v_cmp_le_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeU16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2850,8 +2964,10 @@ void VCmpLeU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtU16Vopc::VCmpGtU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_gt_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtU16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_u16_dpp"
+               : "v_cmp_gt_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtU16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2910,8 +3026,10 @@ void VCmpGtU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeU16Vopc::VCmpNeU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ne_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeU16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_u16_dpp"
+               : "v_cmp_ne_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeU16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2970,8 +3088,10 @@ void VCmpNeU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeU16Vopc::VCmpGeU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ge_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeU16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_u16_dpp"
+               : "v_cmp_ge_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeU16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -3030,8 +3150,10 @@ void VCmpGeU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpFI32Vopc::VCmpFI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_f_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpFI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_f_i32_dpp"
+               : "v_cmp_f_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFI32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3087,8 +3209,10 @@ void VCmpFI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtI32Vopc::VCmpLtI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lt_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_i32_dpp"
+               : "v_cmp_lt_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtI32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3144,8 +3268,10 @@ void VCmpLtI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqI32Vopc::VCmpEqI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_eq_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_i32_dpp"
+               : "v_cmp_eq_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqI32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3201,8 +3327,10 @@ void VCmpEqI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeI32Vopc::VCmpLeI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_le_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_i32_dpp"
+               : "v_cmp_le_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeI32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3258,8 +3386,10 @@ void VCmpLeI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtI32Vopc::VCmpGtI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_gt_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_i32_dpp"
+               : "v_cmp_gt_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtI32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3315,8 +3445,10 @@ void VCmpGtI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeI32Vopc::VCmpNeI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ne_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_i32_dpp"
+               : "v_cmp_ne_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeI32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3372,8 +3504,10 @@ void VCmpNeI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeI32Vopc::VCmpGeI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ge_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_i32_dpp"
+               : "v_cmp_ge_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeI32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3429,8 +3563,10 @@ void VCmpGeI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpTI32Vopc::VCmpTI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_t_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpTI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_t_i32_dpp"
+               : "v_cmp_t_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTI32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3486,8 +3622,10 @@ void VCmpTI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpFU32Vopc::VCmpFU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_f_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpFU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_f_u32_dpp"
+               : "v_cmp_f_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFU32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3543,8 +3681,10 @@ void VCmpFU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtU32Vopc::VCmpLtU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lt_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_u32_dpp"
+               : "v_cmp_lt_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtU32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3600,8 +3740,10 @@ void VCmpLtU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqU32Vopc::VCmpEqU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_eq_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_u32_dpp"
+               : "v_cmp_eq_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqU32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3657,8 +3799,10 @@ void VCmpEqU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeU32Vopc::VCmpLeU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_le_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_u32_dpp"
+               : "v_cmp_le_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeU32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3714,8 +3858,10 @@ void VCmpLeU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtU32Vopc::VCmpGtU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_gt_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_u32_dpp"
+               : "v_cmp_gt_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtU32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3771,8 +3917,10 @@ void VCmpGtU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeU32Vopc::VCmpNeU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ne_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_u32_dpp"
+               : "v_cmp_ne_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeU32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3828,8 +3976,10 @@ void VCmpNeU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeU32Vopc::VCmpGeU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ge_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_u32_dpp"
+               : "v_cmp_ge_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeU32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3885,8 +4035,10 @@ void VCmpGeU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpTU32Vopc::VCmpTU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_t_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpTU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_t_u32_dpp"
+               : "v_cmp_t_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTU32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3942,8 +4094,10 @@ void VCmpTU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpFI64Vopc::VCmpFI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_f_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpFI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_f_i64_dpp"
+               : "v_cmp_f_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFI64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3968,8 +4122,10 @@ void VCmpFI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtI64Vopc::VCmpLtI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lt_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_i64_dpp"
+               : "v_cmp_lt_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtI64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3994,8 +4150,10 @@ void VCmpLtI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqI64Vopc::VCmpEqI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_eq_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_i64_dpp"
+               : "v_cmp_eq_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqI64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -4020,8 +4178,10 @@ void VCmpEqI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeI64Vopc::VCmpLeI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_le_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_i64_dpp"
+               : "v_cmp_le_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeI64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -4046,8 +4206,10 @@ void VCmpLeI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtI64Vopc::VCmpGtI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_gt_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_i64_dpp"
+               : "v_cmp_gt_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtI64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -4072,8 +4234,10 @@ void VCmpGtI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeI64Vopc::VCmpNeI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ne_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_i64_dpp"
+               : "v_cmp_ne_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeI64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -4098,8 +4262,10 @@ void VCmpNeI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeI64Vopc::VCmpGeI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ge_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_i64_dpp"
+               : "v_cmp_ge_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeI64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -4124,8 +4290,10 @@ void VCmpGeI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpTI64Vopc::VCmpTI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_t_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpTI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_t_i64_dpp"
+               : "v_cmp_t_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTI64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -4150,8 +4318,10 @@ void VCmpTI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpFU64Vopc::VCmpFU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_f_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpFU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_f_u64_dpp"
+               : "v_cmp_f_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpFU64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -4176,8 +4346,10 @@ void VCmpFU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtU64Vopc::VCmpLtU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lt_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_u64_dpp"
+               : "v_cmp_lt_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtU64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -4202,8 +4374,10 @@ void VCmpLtU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqU64Vopc::VCmpEqU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_eq_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_u64_dpp"
+               : "v_cmp_eq_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqU64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -4228,8 +4402,10 @@ void VCmpEqU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeU64Vopc::VCmpLeU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_le_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_u64_dpp"
+               : "v_cmp_le_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeU64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -4254,8 +4430,10 @@ void VCmpLeU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtU64Vopc::VCmpGtU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_gt_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_u64_dpp"
+               : "v_cmp_gt_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtU64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -4280,8 +4458,10 @@ void VCmpGtU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeU64Vopc::VCmpNeU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ne_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_u64_dpp"
+               : "v_cmp_ne_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeU64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -4306,8 +4486,10 @@ void VCmpNeU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeU64Vopc::VCmpGeU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ge_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_u64_dpp"
+               : "v_cmp_ge_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeU64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -4332,8 +4514,10 @@ void VCmpGeU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpTU64Vopc::VCmpTU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_t_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpTU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_t_u64_dpp"
+               : "v_cmp_t_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpTU64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -4358,8 +4542,10 @@ void VCmpTU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpClassF16Vopc::VCmpClassF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_class_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpClassF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_class_f16_dpp"
+               : "v_cmp_class_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpClassF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -4418,8 +4604,10 @@ void VCmpClassF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpClassF32Vopc::VCmpClassF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_class_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpClassF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_class_f32_dpp"
+               : "v_cmp_class_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpClassF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -4475,8 +4663,10 @@ void VCmpClassF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpClassF64Vopc::VCmpClassF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_class_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpClassF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_class_f64_dpp"
+               : "v_cmp_class_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpClassF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -4501,8 +4691,10 @@ void VCmpClassF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxFF16Vopc::VCmpxFF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_f_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxFF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_f_f16_dpp"
+               : "v_cmpx_f_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxFF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -4576,8 +4768,10 @@ void VCmpxFF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtF16Vopc::VCmpxLtF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lt_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_f16_dpp"
+               : "v_cmpx_lt_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -4656,8 +4850,10 @@ void VCmpxLtF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqF16Vopc::VCmpxEqF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_eq_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_f16_dpp"
+               : "v_cmpx_eq_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -4736,8 +4932,10 @@ void VCmpxEqF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeF16Vopc::VCmpxLeF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_le_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_f16_dpp"
+               : "v_cmpx_le_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -4816,8 +5014,10 @@ void VCmpxLeF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtF16Vopc::VCmpxGtF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_gt_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_f16_dpp"
+               : "v_cmpx_gt_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -4896,8 +5096,10 @@ void VCmpxGtF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLgF16Vopc::VCmpxLgF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lg_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLgF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lg_f16_dpp"
+               : "v_cmpx_lg_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLgF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -4976,8 +5178,10 @@ void VCmpxLgF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeF16Vopc::VCmpxGeF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ge_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_f16_dpp"
+               : "v_cmpx_ge_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -5056,8 +5260,10 @@ void VCmpxGeF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxOF16Vopc::VCmpxOF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_o_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxOF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_o_f16_dpp"
+               : "v_cmpx_o_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxOF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -5136,8 +5342,10 @@ void VCmpxOF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxUF16Vopc::VCmpxUF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_u_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxUF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_u_f16_dpp"
+               : "v_cmpx_u_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxUF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -5216,8 +5424,10 @@ void VCmpxUF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNgeF16Vopc::VCmpxNgeF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nge_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNgeF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nge_f16_dpp"
+               : "v_cmpx_nge_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNgeF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -5296,8 +5506,10 @@ void VCmpxNgeF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNlgF16Vopc::VCmpxNlgF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nlg_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNlgF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlg_f16_dpp"
+               : "v_cmpx_nlg_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNlgF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -5376,8 +5588,10 @@ void VCmpxNlgF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNgtF16Vopc::VCmpxNgtF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ngt_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNgtF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ngt_f16_dpp"
+               : "v_cmpx_ngt_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNgtF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -5456,8 +5670,10 @@ void VCmpxNgtF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNleF16Vopc::VCmpxNleF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nle_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNleF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nle_f16_dpp"
+               : "v_cmpx_nle_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNleF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -5536,8 +5752,10 @@ void VCmpxNleF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeqF16Vopc::VCmpxNeqF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_neq_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeqF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_neq_f16_dpp"
+               : "v_cmpx_neq_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeqF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -5616,8 +5834,10 @@ void VCmpxNeqF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNltF16Vopc::VCmpxNltF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nlt_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNltF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlt_f16_dpp"
+               : "v_cmpx_nlt_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNltF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -5696,8 +5916,10 @@ void VCmpxNltF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxTF16Vopc::VCmpxTF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_t_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxTF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_t_f16_dpp"
+               : "v_cmpx_t_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxTF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -5771,8 +5993,10 @@ void VCmpxTF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxFF32Vopc::VCmpxFF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_f_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxFF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_f_f32_dpp"
+               : "v_cmpx_f_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxFF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -5843,8 +6067,10 @@ void VCmpxFF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtF32Vopc::VCmpxLtF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lt_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_f32_dpp"
+               : "v_cmpx_lt_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -5918,8 +6144,10 @@ void VCmpxLtF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqF32Vopc::VCmpxEqF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_eq_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_f32_dpp"
+               : "v_cmpx_eq_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -5993,8 +6221,10 @@ void VCmpxEqF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeF32Vopc::VCmpxLeF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_le_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_f32_dpp"
+               : "v_cmpx_le_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6068,8 +6298,10 @@ void VCmpxLeF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtF32Vopc::VCmpxGtF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_gt_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_f32_dpp"
+               : "v_cmpx_gt_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6143,8 +6375,10 @@ void VCmpxGtF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLgF32Vopc::VCmpxLgF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lg_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLgF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lg_f32_dpp"
+               : "v_cmpx_lg_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLgF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6218,8 +6452,10 @@ void VCmpxLgF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeF32Vopc::VCmpxGeF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ge_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_f32_dpp"
+               : "v_cmpx_ge_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6293,8 +6529,10 @@ void VCmpxGeF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxOF32Vopc::VCmpxOF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_o_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxOF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_o_f32_dpp"
+               : "v_cmpx_o_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxOF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6368,8 +6606,10 @@ void VCmpxOF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxUF32Vopc::VCmpxUF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_u_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxUF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_u_f32_dpp"
+               : "v_cmpx_u_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxUF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6443,8 +6683,10 @@ void VCmpxUF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNgeF32Vopc::VCmpxNgeF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nge_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNgeF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nge_f32_dpp"
+               : "v_cmpx_nge_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNgeF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6518,8 +6760,10 @@ void VCmpxNgeF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNlgF32Vopc::VCmpxNlgF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nlg_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNlgF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlg_f32_dpp"
+               : "v_cmpx_nlg_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNlgF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6593,8 +6837,10 @@ void VCmpxNlgF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNgtF32Vopc::VCmpxNgtF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ngt_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNgtF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ngt_f32_dpp"
+               : "v_cmpx_ngt_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNgtF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6668,8 +6914,10 @@ void VCmpxNgtF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNleF32Vopc::VCmpxNleF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nle_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNleF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nle_f32_dpp"
+               : "v_cmpx_nle_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNleF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6743,8 +6991,10 @@ void VCmpxNleF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeqF32Vopc::VCmpxNeqF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_neq_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeqF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_neq_f32_dpp"
+               : "v_cmpx_neq_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeqF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6818,8 +7068,10 @@ void VCmpxNeqF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNltF32Vopc::VCmpxNltF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nlt_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNltF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlt_f32_dpp"
+               : "v_cmpx_nlt_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNltF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6893,8 +7145,10 @@ void VCmpxNltF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxTF32Vopc::VCmpxTF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_t_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxTF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_t_f32_dpp"
+               : "v_cmpx_t_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxTF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6965,8 +7219,10 @@ void VCmpxTF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxFF64Vopc::VCmpxFF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_f_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxFF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_f_f64_dpp"
+               : "v_cmpx_f_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxFF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -7002,8 +7258,10 @@ void VCmpxFF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtF64Vopc::VCmpxLtF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lt_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_f64_dpp"
+               : "v_cmpx_lt_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -7042,8 +7300,10 @@ void VCmpxLtF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqF64Vopc::VCmpxEqF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_eq_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_f64_dpp"
+               : "v_cmpx_eq_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -7082,8 +7342,10 @@ void VCmpxEqF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeF64Vopc::VCmpxLeF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_le_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_f64_dpp"
+               : "v_cmpx_le_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -7122,8 +7384,10 @@ void VCmpxLeF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtF64Vopc::VCmpxGtF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_gt_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_f64_dpp"
+               : "v_cmpx_gt_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -7162,8 +7426,10 @@ void VCmpxGtF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLgF64Vopc::VCmpxLgF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lg_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLgF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lg_f64_dpp"
+               : "v_cmpx_lg_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLgF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -7202,8 +7468,10 @@ void VCmpxLgF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeF64Vopc::VCmpxGeF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ge_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_f64_dpp"
+               : "v_cmpx_ge_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -7242,8 +7510,10 @@ void VCmpxGeF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxOF64Vopc::VCmpxOF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_o_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxOF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_o_f64_dpp"
+               : "v_cmpx_o_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxOF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -7282,8 +7552,10 @@ void VCmpxOF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxUF64Vopc::VCmpxUF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_u_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxUF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_u_f64_dpp"
+               : "v_cmpx_u_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxUF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -7322,8 +7594,10 @@ void VCmpxUF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNgeF64Vopc::VCmpxNgeF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nge_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNgeF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nge_f64_dpp"
+               : "v_cmpx_nge_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNgeF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -7362,8 +7636,10 @@ void VCmpxNgeF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNlgF64Vopc::VCmpxNlgF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nlg_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNlgF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlg_f64_dpp"
+               : "v_cmpx_nlg_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNlgF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -7402,8 +7678,10 @@ void VCmpxNlgF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNgtF64Vopc::VCmpxNgtF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ngt_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNgtF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ngt_f64_dpp"
+               : "v_cmpx_ngt_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNgtF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -7442,8 +7720,10 @@ void VCmpxNgtF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNleF64Vopc::VCmpxNleF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nle_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNleF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nle_f64_dpp"
+               : "v_cmpx_nle_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNleF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -7482,8 +7762,10 @@ void VCmpxNleF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeqF64Vopc::VCmpxNeqF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_neq_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeqF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_neq_f64_dpp"
+               : "v_cmpx_neq_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeqF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -7522,8 +7804,10 @@ void VCmpxNeqF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNltF64Vopc::VCmpxNltF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nlt_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNltF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlt_f64_dpp"
+               : "v_cmpx_nlt_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNltF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -7562,8 +7846,10 @@ void VCmpxNltF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxTF64Vopc::VCmpxTF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_t_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxTF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_t_f64_dpp"
+               : "v_cmpx_t_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxTF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -7599,8 +7885,10 @@ void VCmpxTF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtI16Vopc::VCmpxLtI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lt_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtI16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_i16_dpp"
+               : "v_cmpx_lt_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtI16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -7677,8 +7965,10 @@ void VCmpxLtI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqI16Vopc::VCmpxEqI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_eq_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqI16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_i16_dpp"
+               : "v_cmpx_eq_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqI16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -7755,8 +8045,10 @@ void VCmpxEqI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeI16Vopc::VCmpxLeI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_le_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeI16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_i16_dpp"
+               : "v_cmpx_le_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeI16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -7833,8 +8125,10 @@ void VCmpxLeI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtI16Vopc::VCmpxGtI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_gt_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtI16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_i16_dpp"
+               : "v_cmpx_gt_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtI16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -7911,8 +8205,10 @@ void VCmpxGtI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeI16Vopc::VCmpxNeI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ne_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeI16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_i16_dpp"
+               : "v_cmpx_ne_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeI16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -7989,8 +8285,10 @@ void VCmpxNeI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeI16Vopc::VCmpxGeI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ge_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeI16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_i16_dpp"
+               : "v_cmpx_ge_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeI16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -8067,8 +8365,10 @@ void VCmpxGeI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtU16Vopc::VCmpxLtU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lt_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtU16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_u16_dpp"
+               : "v_cmpx_lt_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtU16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -8145,8 +8445,10 @@ void VCmpxLtU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqU16Vopc::VCmpxEqU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_eq_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqU16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_u16_dpp"
+               : "v_cmpx_eq_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqU16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -8223,8 +8525,10 @@ void VCmpxEqU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeU16Vopc::VCmpxLeU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_le_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeU16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_u16_dpp"
+               : "v_cmpx_le_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeU16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -8301,8 +8605,10 @@ void VCmpxLeU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtU16Vopc::VCmpxGtU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_gt_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtU16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_u16_dpp"
+               : "v_cmpx_gt_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtU16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -8379,8 +8685,10 @@ void VCmpxGtU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeU16Vopc::VCmpxNeU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ne_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeU16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_u16_dpp"
+               : "v_cmpx_ne_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeU16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -8457,8 +8765,10 @@ void VCmpxNeU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeU16Vopc::VCmpxGeU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ge_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeU16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_u16_dpp"
+               : "v_cmpx_ge_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeU16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -8535,8 +8845,10 @@ void VCmpxGeU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxFI32Vopc::VCmpxFI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_f_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxFI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_f_i32_dpp"
+               : "v_cmpx_f_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxFI32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -8607,8 +8919,10 @@ void VCmpxFI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtI32Vopc::VCmpxLtI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lt_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_i32_dpp"
+               : "v_cmpx_lt_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtI32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -8682,8 +8996,10 @@ void VCmpxLtI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqI32Vopc::VCmpxEqI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_eq_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_i32_dpp"
+               : "v_cmpx_eq_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqI32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -8757,8 +9073,10 @@ void VCmpxEqI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeI32Vopc::VCmpxLeI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_le_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_i32_dpp"
+               : "v_cmpx_le_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeI32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -8832,8 +9150,10 @@ void VCmpxLeI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtI32Vopc::VCmpxGtI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_gt_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_i32_dpp"
+               : "v_cmpx_gt_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtI32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -8907,8 +9227,10 @@ void VCmpxGtI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeI32Vopc::VCmpxNeI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ne_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_i32_dpp"
+               : "v_cmpx_ne_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeI32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -8982,8 +9304,10 @@ void VCmpxNeI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeI32Vopc::VCmpxGeI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ge_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_i32_dpp"
+               : "v_cmpx_ge_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeI32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -9057,8 +9381,10 @@ void VCmpxGeI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxTI32Vopc::VCmpxTI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_t_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxTI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_t_i32_dpp"
+               : "v_cmpx_t_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxTI32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -9129,8 +9455,10 @@ void VCmpxTI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxFU32Vopc::VCmpxFU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_f_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxFU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_f_u32_dpp"
+               : "v_cmpx_f_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxFU32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -9201,8 +9529,10 @@ void VCmpxFU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtU32Vopc::VCmpxLtU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lt_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_u32_dpp"
+               : "v_cmpx_lt_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtU32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -9276,8 +9606,10 @@ void VCmpxLtU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqU32Vopc::VCmpxEqU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_eq_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_u32_dpp"
+               : "v_cmpx_eq_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqU32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -9351,8 +9683,10 @@ void VCmpxEqU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeU32Vopc::VCmpxLeU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_le_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_u32_dpp"
+               : "v_cmpx_le_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeU32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -9426,8 +9760,10 @@ void VCmpxLeU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtU32Vopc::VCmpxGtU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_gt_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_u32_dpp"
+               : "v_cmpx_gt_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtU32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -9501,8 +9837,10 @@ void VCmpxGtU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeU32Vopc::VCmpxNeU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ne_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_u32_dpp"
+               : "v_cmpx_ne_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeU32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -9576,8 +9914,10 @@ void VCmpxNeU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeU32Vopc::VCmpxGeU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ge_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_u32_dpp"
+               : "v_cmpx_ge_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeU32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -9651,8 +9991,10 @@ void VCmpxGeU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxTU32Vopc::VCmpxTU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_t_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxTU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_t_u32_dpp"
+               : "v_cmpx_t_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxTU32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -9723,8 +10065,10 @@ void VCmpxTU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxFI64Vopc::VCmpxFI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_f_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxFI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_f_i64_dpp"
+               : "v_cmpx_f_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxFI64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -9760,8 +10104,10 @@ void VCmpxFI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtI64Vopc::VCmpxLtI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lt_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_i64_dpp"
+               : "v_cmpx_lt_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtI64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -9800,8 +10146,10 @@ void VCmpxLtI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqI64Vopc::VCmpxEqI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_eq_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_i64_dpp"
+               : "v_cmpx_eq_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqI64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -9840,8 +10188,10 @@ void VCmpxEqI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeI64Vopc::VCmpxLeI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_le_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_i64_dpp"
+               : "v_cmpx_le_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeI64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -9880,8 +10230,10 @@ void VCmpxLeI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtI64Vopc::VCmpxGtI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_gt_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_i64_dpp"
+               : "v_cmpx_gt_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtI64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -9920,8 +10272,10 @@ void VCmpxGtI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeI64Vopc::VCmpxNeI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ne_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_i64_dpp"
+               : "v_cmpx_ne_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeI64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -9960,8 +10314,10 @@ void VCmpxNeI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeI64Vopc::VCmpxGeI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ge_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_i64_dpp"
+               : "v_cmpx_ge_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeI64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -10000,8 +10356,10 @@ void VCmpxGeI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxTI64Vopc::VCmpxTI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_t_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxTI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_t_i64_dpp"
+               : "v_cmpx_t_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxTI64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -10037,8 +10395,10 @@ void VCmpxTI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxFU64Vopc::VCmpxFU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_f_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxFU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_f_u64_dpp"
+               : "v_cmpx_f_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxFU64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -10074,8 +10434,10 @@ void VCmpxFU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtU64Vopc::VCmpxLtU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lt_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_u64_dpp"
+               : "v_cmpx_lt_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtU64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -10114,8 +10476,10 @@ void VCmpxLtU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqU64Vopc::VCmpxEqU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_eq_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_u64_dpp"
+               : "v_cmpx_eq_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqU64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -10154,8 +10518,10 @@ void VCmpxEqU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeU64Vopc::VCmpxLeU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_le_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_u64_dpp"
+               : "v_cmpx_le_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeU64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -10194,8 +10560,10 @@ void VCmpxLeU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtU64Vopc::VCmpxGtU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_gt_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_u64_dpp"
+               : "v_cmpx_gt_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtU64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -10234,8 +10602,10 @@ void VCmpxGtU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeU64Vopc::VCmpxNeU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ne_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_u64_dpp"
+               : "v_cmpx_ne_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeU64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -10274,8 +10644,10 @@ void VCmpxNeU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeU64Vopc::VCmpxGeU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ge_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_u64_dpp"
+               : "v_cmpx_ge_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeU64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -10314,8 +10686,10 @@ void VCmpxGeU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxTU64Vopc::VCmpxTU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_t_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxTU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_t_u64_dpp"
+               : "v_cmpx_t_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxTU64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -10351,8 +10725,10 @@ void VCmpxTU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxClassF16Vopc::VCmpxClassF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_class_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxClassF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_class_f16_dpp"
+               : "v_cmpx_class_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxClassF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -10458,8 +10834,10 @@ void VCmpxClassF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxClassF32Vopc::VCmpxClassF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_class_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxClassF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_class_f32_dpp"
+               : "v_cmpx_class_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxClassF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -10556,8 +10934,10 @@ void VCmpxClassF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxClassF64Vopc::VCmpxClassF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_class_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxClassF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_class_f64_dpp"
+               : "v_cmpx_class_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxClassF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/encodings.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/encodings.cpp
@@ -128,6 +128,11 @@ Vop1::Vop1(std::string_view mnemonic, const Vop1MachineInst *inst, ExecuteFn exe
   raw_encoding_ = raw_words_.data();
 }
 
+void Vop1::build_modifiers(std::string &out) const {
+  if (amdgpu::dpp::is_src_dpp8(inst_.src0))
+    amdgpu::dpp::append_dpp8_disassembly(out, dpp8_lane_sel_, dpp_fi_);
+}
+
 void Vop1::implicit_uses(RegisterSet &uses) const {
   bool sdwa_preserve =
       sdwa_dst_sel_ != amdgpu::sdwa::DWORD && sdwa_dst_unused_ == amdgpu::sdwa::UNUSED_PRESERVE;
@@ -160,6 +165,11 @@ Vopc::Vopc(std::string_view mnemonic, const VopcMachineInst *inst, ExecuteFn exe
   raw_encoding_ = raw_words_.data();
 }
 
+void Vopc::build_modifiers(std::string &out) const {
+  if (amdgpu::dpp::is_src_dpp8(inst_.src0))
+    amdgpu::dpp::append_dpp8_disassembly(out, dpp8_lane_sel_, dpp_fi_);
+}
+
 bool Vopc::default_encoding() {
   return inst_.src0 != 250 && inst_.src0 != 233 && inst_.src0 != 234 && inst_.src0 != 255;
 }
@@ -178,6 +188,11 @@ Vop2::Vop2(std::string_view mnemonic, const Vop2MachineInst *inst, ExecuteFn exe
     literal_ = reinterpret_cast<const uint32_t *>(inst)[1];
   std::memcpy(raw_words_.data(), inst, size_);
   raw_encoding_ = raw_words_.data();
+}
+
+void Vop2::build_modifiers(std::string &out) const {
+  if (amdgpu::dpp::is_src_dpp8(inst_.src0))
+    amdgpu::dpp::append_dpp8_disassembly(out, dpp8_lane_sel_, dpp_fi_);
 }
 
 void Vop2::implicit_uses(RegisterSet &uses) const {
@@ -217,6 +232,11 @@ Vop3::Vop3(std::string_view mnemonic, const Vop3MachineInst *inst, ExecuteFn exe
     size_ += sizeof(MachineInst);
   std::memcpy(raw_words_.data(), inst, size_);
   raw_encoding_ = raw_words_.data();
+}
+
+void Vop3::build_modifiers(std::string &out) const {
+  if (amdgpu::dpp::is_src_dpp8(inst_.src0))
+    amdgpu::dpp::append_dpp8_disassembly(out, dpp8_lane_sel_, dpp_fi_);
 }
 
 void Vop3::implicit_uses(RegisterSet &uses) const {
@@ -273,6 +293,11 @@ Vop3p::Vop3p(std::string_view mnemonic, const Vop3pMachineInst *inst, ExecuteFn 
     size_ += sizeof(MachineInst);
   std::memcpy(raw_words_.data(), inst, size_);
   raw_encoding_ = raw_words_.data();
+}
+
+void Vop3p::build_modifiers(std::string &out) const {
+  if (amdgpu::dpp::is_src_dpp8(inst_.src0))
+    amdgpu::dpp::append_dpp8_disassembly(out, dpp8_lane_sel_, dpp_fi_);
 }
 
 void Vop3p::implicit_uses(RegisterSet &uses) const {
@@ -447,6 +472,11 @@ Vop3SdstEnc::Vop3SdstEnc(std::string_view mnemonic, const Vop3SdstEncMachineInst
     size_ += sizeof(MachineInst);
   std::memcpy(raw_words_.data(), inst, size_);
   raw_encoding_ = raw_words_.data();
+}
+
+void Vop3SdstEnc::build_modifiers(std::string &out) const {
+  if (amdgpu::dpp::is_src_dpp8(inst_.src0))
+    amdgpu::dpp::append_dpp8_disassembly(out, dpp8_lane_sel_, dpp_fi_);
 }
 
 void Vop3SdstEnc::implicit_uses(RegisterSet &uses) const {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/encodings.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/encodings.h
@@ -435,6 +435,7 @@ public:
 class Vop1 : public IsaInstruction<Isa> {
 public:
   Vop1(std::string_view mnemonic, const Vop1MachineInst *inst, ExecuteFn exec_fn);
+  void build_modifiers(std::string &out) const override;
   void implicit_uses(RegisterSet &uses) const override;
   bool default_encoding();
   bool has_lit();
@@ -465,6 +466,7 @@ public:
 class Vopc : public IsaInstruction<Isa> {
 public:
   Vopc(std::string_view mnemonic, const VopcMachineInst *inst, ExecuteFn exec_fn);
+  void build_modifiers(std::string &out) const override;
   bool default_encoding();
   bool has_lit();
   using OpEncoding = VopcMachineInst;
@@ -493,6 +495,7 @@ public:
 class Vop2 : public IsaInstruction<Isa> {
 public:
   Vop2(std::string_view mnemonic, const Vop2MachineInst *inst, ExecuteFn exec_fn);
+  void build_modifiers(std::string &out) const override;
   void implicit_uses(RegisterSet &uses) const override;
   bool default_encoding();
   bool has_lit();
@@ -525,6 +528,7 @@ public:
 class Vop3 : public IsaInstruction<Isa> {
 public:
   Vop3(std::string_view mnemonic, const Vop3MachineInst *inst, ExecuteFn exec_fn);
+  void build_modifiers(std::string &out) const override;
   void implicit_uses(RegisterSet &uses) const override;
   bool has_lit_0();
   bool has_lit_1();
@@ -549,6 +553,7 @@ public:
 class Vop3p : public IsaInstruction<Isa> {
 public:
   Vop3p(std::string_view mnemonic, const Vop3pMachineInst *inst, ExecuteFn exec_fn);
+  void build_modifiers(std::string &out) const override;
   void implicit_uses(RegisterSet &uses) const override;
   bool has_lit_0();
   bool has_lit_1();
@@ -648,6 +653,7 @@ public:
 class Vop3SdstEnc : public IsaInstruction<Isa> {
 public:
   Vop3SdstEnc(std::string_view mnemonic, const Vop3SdstEncMachineInst *inst, ExecuteFn exec_fn);
+  void build_modifiers(std::string &out) const override;
   void implicit_uses(RegisterSet &uses) const override;
   bool has_lit_0();
   bool has_lit_1();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vop1.cpp
@@ -22,7 +22,9 @@ namespace rocjitsu {
 namespace rdna4 {
 
 VNopVop1::VNopVop1(const MachineInst *inst)
-    : Vop1("v_nop_e32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VNopVop1>()) {
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0) ? "v_nop_dpp"
+                                                                                      : "v_nop_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VNopVop1>()) {
   num_src_ = 0;
   num_dst_ = 0;
 }
@@ -30,8 +32,10 @@ VNopVop1::VNopVop1(const MachineInst *inst)
 void VNopVop1::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_nop_vop1(*this, wf); }
 
 VMovB32Vop1::VMovB32Vop1(const MachineInst *inst)
-    : Vop1("v_mov_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMovB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mov_b32_dpp"
+               : "v_mov_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -72,8 +76,10 @@ void VMovB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VReadfirstlaneB32Vop1::VReadfirstlaneB32Vop1(const MachineInst *inst)
-    : Vop1("v_readfirstlane_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VReadfirstlaneB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_readfirstlane_b32_dpp"
+               : "v_readfirstlane_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VReadfirstlaneB32Vop1>()),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -102,8 +108,10 @@ void VReadfirstlaneB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtI32F64Vop1::VCvtI32F64Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_i32_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtI32F64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_i32_f64_dpp"
+               : "v_cvt_i32_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtI32F64Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -125,8 +133,10 @@ void VCvtI32F64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF64I32Vop1::VCvtF64I32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f64_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF64I32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f64_i32_dpp"
+               : "v_cvt_f64_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF64I32Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -147,8 +157,10 @@ void VCvtF64I32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32I32Vop1::VCvtF32I32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32I32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_i32_dpp"
+               : "v_cvt_f32_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32I32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -189,8 +201,10 @@ void VCvtF32I32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32U32Vop1::VCvtF32U32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32U32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_u32_dpp"
+               : "v_cvt_f32_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32U32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -231,8 +245,10 @@ void VCvtF32U32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtU32F32Vop1::VCvtU32F32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_u32_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtU32F32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_u32_f32_dpp"
+               : "v_cvt_u32_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtU32F32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -273,8 +289,10 @@ void VCvtU32F32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtI32F32Vop1::VCvtI32F32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_i32_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtI32F32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_i32_f32_dpp"
+               : "v_cvt_i32_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtI32F32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -315,8 +333,10 @@ void VCvtI32F32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF16F32Vop1::VCvtF16F32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f16_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF16F32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f16_f32_dpp"
+               : "v_cvt_f16_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF16F32Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -374,8 +394,10 @@ void VCvtF16F32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32F16Vop1::VCvtF32F16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32F16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_f16_dpp"
+               : "v_cvt_f32_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32F16Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true) {
@@ -418,8 +440,10 @@ void VCvtF32F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtNearestI32F32Vop1::VCvtNearestI32F32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_nearest_i32_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtNearestI32F32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_nearest_i32_f32_dpp"
+               : "v_cvt_nearest_i32_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtNearestI32F32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -460,8 +484,10 @@ void VCvtNearestI32F32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtFloorI32F32Vop1::VCvtFloorI32F32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_floor_i32_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtFloorI32F32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_floor_i32_f32_dpp"
+               : "v_cvt_floor_i32_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtFloorI32F32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -502,8 +528,10 @@ void VCvtFloorI32F32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtOffF32I4Vop1::VCvtOffF32I4Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_off_f32_i4_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtOffF32I4Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_off_f32_i4_dpp"
+               : "v_cvt_off_f32_i4_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtOffF32I4Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -544,8 +572,10 @@ void VCvtOffF32I4Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32F64Vop1::VCvtF32F64Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32F64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_f64_dpp"
+               : "v_cvt_f32_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32F64Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -567,8 +597,10 @@ void VCvtF32F64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF64F32Vop1::VCvtF64F32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f64_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF64F32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f64_f32_dpp"
+               : "v_cvt_f64_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF64F32Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -589,8 +621,10 @@ void VCvtF64F32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32Ubyte0Vop1::VCvtF32Ubyte0Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_ubyte0_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32Ubyte0Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_ubyte0_dpp"
+               : "v_cvt_f32_ubyte0_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32Ubyte0Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -631,8 +665,10 @@ void VCvtF32Ubyte0Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32Ubyte1Vop1::VCvtF32Ubyte1Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_ubyte1_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32Ubyte1Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_ubyte1_dpp"
+               : "v_cvt_f32_ubyte1_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32Ubyte1Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -673,8 +709,10 @@ void VCvtF32Ubyte1Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32Ubyte2Vop1::VCvtF32Ubyte2Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_ubyte2_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32Ubyte2Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_ubyte2_dpp"
+               : "v_cvt_f32_ubyte2_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32Ubyte2Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -715,8 +753,10 @@ void VCvtF32Ubyte2Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32Ubyte3Vop1::VCvtF32Ubyte3Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_ubyte3_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32Ubyte3Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_ubyte3_dpp"
+               : "v_cvt_f32_ubyte3_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32Ubyte3Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -757,8 +797,10 @@ void VCvtF32Ubyte3Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtU32F64Vop1::VCvtU32F64Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_u32_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtU32F64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_u32_f64_dpp"
+               : "v_cvt_u32_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtU32F64Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -780,8 +822,10 @@ void VCvtU32F64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF64U32Vop1::VCvtF64U32Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f64_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF64U32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f64_u32_dpp"
+               : "v_cvt_f64_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF64U32Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -802,8 +846,10 @@ void VCvtF64U32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VTruncF64Vop1::VTruncF64Vop1(const MachineInst *inst)
-    : Vop1("v_trunc_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VTruncF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_trunc_f64_dpp"
+               : "v_trunc_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VTruncF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -825,8 +871,10 @@ void VTruncF64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCeilF64Vop1::VCeilF64Vop1(const MachineInst *inst)
-    : Vop1("v_ceil_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCeilF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ceil_f64_dpp"
+               : "v_ceil_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCeilF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -848,8 +896,10 @@ void VCeilF64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRndneF64Vop1::VRndneF64Vop1(const MachineInst *inst)
-    : Vop1("v_rndne_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRndneF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rndne_f64_dpp"
+               : "v_rndne_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRndneF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -871,8 +921,10 @@ void VRndneF64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFloorF64Vop1::VFloorF64Vop1(const MachineInst *inst)
-    : Vop1("v_floor_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFloorF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_floor_f64_dpp"
+               : "v_floor_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFloorF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -894,8 +946,10 @@ void VFloorF64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPipeflushVop1::VPipeflushVop1(const MachineInst *inst)
-    : Vop1("v_pipeflush_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VPipeflushVop1>()) {
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_pipeflush_dpp"
+               : "v_pipeflush_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPipeflushVop1>()) {
   num_src_ = 0;
   num_dst_ = 0;
 }
@@ -905,8 +959,10 @@ void VPipeflushVop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMovB16Vop1::VMovB16Vop1(const MachineInst *inst)
-    : Vop1("v_mov_b16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMovB16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mov_b16_dpp"
+               : "v_mov_b16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovB16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -965,8 +1021,10 @@ void VMovB16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFractF32Vop1::VFractF32Vop1(const MachineInst *inst)
-    : Vop1("v_fract_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFractF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fract_f32_dpp"
+               : "v_fract_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFractF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1007,8 +1065,10 @@ void VFractF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VTruncF32Vop1::VTruncF32Vop1(const MachineInst *inst)
-    : Vop1("v_trunc_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VTruncF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_trunc_f32_dpp"
+               : "v_trunc_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VTruncF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1049,8 +1109,10 @@ void VTruncF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCeilF32Vop1::VCeilF32Vop1(const MachineInst *inst)
-    : Vop1("v_ceil_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCeilF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ceil_f32_dpp"
+               : "v_ceil_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCeilF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1091,8 +1153,10 @@ void VCeilF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRndneF32Vop1::VRndneF32Vop1(const MachineInst *inst)
-    : Vop1("v_rndne_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRndneF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rndne_f32_dpp"
+               : "v_rndne_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRndneF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1133,8 +1197,10 @@ void VRndneF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFloorF32Vop1::VFloorF32Vop1(const MachineInst *inst)
-    : Vop1("v_floor_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFloorF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_floor_f32_dpp"
+               : "v_floor_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFloorF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1175,8 +1241,10 @@ void VFloorF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VExpF32Vop1::VExpF32Vop1(const MachineInst *inst)
-    : Vop1("v_exp_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VExpF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_exp_f32_dpp"
+               : "v_exp_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VExpF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1217,8 +1285,10 @@ void VExpF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLogF32Vop1::VLogF32Vop1(const MachineInst *inst)
-    : Vop1("v_log_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLogF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_log_f32_dpp"
+               : "v_log_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLogF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1259,8 +1329,10 @@ void VLogF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRcpF32Vop1::VRcpF32Vop1(const MachineInst *inst)
-    : Vop1("v_rcp_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRcpF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_f32_dpp"
+               : "v_rcp_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1301,8 +1373,10 @@ void VRcpF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRcpIflagF32Vop1::VRcpIflagF32Vop1(const MachineInst *inst)
-    : Vop1("v_rcp_iflag_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRcpIflagF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_iflag_f32_dpp"
+               : "v_rcp_iflag_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpIflagF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1343,8 +1417,10 @@ void VRcpIflagF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRsqF32Vop1::VRsqF32Vop1(const MachineInst *inst)
-    : Vop1("v_rsq_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRsqF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rsq_f32_dpp"
+               : "v_rsq_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRsqF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1385,8 +1461,10 @@ void VRsqF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRcpF64Vop1::VRcpF64Vop1(const MachineInst *inst)
-    : Vop1("v_rcp_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRcpF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_f64_dpp"
+               : "v_rcp_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1406,8 +1484,10 @@ VRcpF64Vop1::VRcpF64Vop1(const MachineInst *inst)
 void VRcpF64Vop1::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_rcp_f64_vop1(*this, wf); }
 
 VRsqF64Vop1::VRsqF64Vop1(const MachineInst *inst)
-    : Vop1("v_rsq_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRsqF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rsq_f64_dpp"
+               : "v_rsq_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRsqF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1427,8 +1507,10 @@ VRsqF64Vop1::VRsqF64Vop1(const MachineInst *inst)
 void VRsqF64Vop1::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_rsq_f64_vop1(*this, wf); }
 
 VSqrtF32Vop1::VSqrtF32Vop1(const MachineInst *inst)
-    : Vop1("v_sqrt_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSqrtF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sqrt_f32_dpp"
+               : "v_sqrt_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSqrtF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1469,8 +1551,10 @@ void VSqrtF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSqrtF64Vop1::VSqrtF64Vop1(const MachineInst *inst)
-    : Vop1("v_sqrt_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSqrtF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sqrt_f64_dpp"
+               : "v_sqrt_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSqrtF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1492,8 +1576,10 @@ void VSqrtF64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSinF32Vop1::VSinF32Vop1(const MachineInst *inst)
-    : Vop1("v_sin_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSinF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sin_f32_dpp"
+               : "v_sin_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSinF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1534,8 +1620,10 @@ void VSinF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCosF32Vop1::VCosF32Vop1(const MachineInst *inst)
-    : Vop1("v_cos_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCosF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cos_f32_dpp"
+               : "v_cos_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCosF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1576,8 +1664,10 @@ void VCosF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VNotB32Vop1::VNotB32Vop1(const MachineInst *inst)
-    : Vop1("v_not_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VNotB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_not_b32_dpp"
+               : "v_not_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VNotB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1618,8 +1708,10 @@ void VNotB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VBfrevB32Vop1::VBfrevB32Vop1(const MachineInst *inst)
-    : Vop1("v_bfrev_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VBfrevB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_bfrev_b32_dpp"
+               : "v_bfrev_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VBfrevB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1660,8 +1752,10 @@ void VBfrevB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VClzI32U32Vop1::VClzI32U32Vop1(const MachineInst *inst)
-    : Vop1("v_clz_i32_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VClzI32U32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_clz_i32_u32_dpp"
+               : "v_clz_i32_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VClzI32U32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1702,8 +1796,10 @@ void VClzI32U32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCtzI32B32Vop1::VCtzI32B32Vop1(const MachineInst *inst)
-    : Vop1("v_ctz_i32_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCtzI32B32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ctz_i32_b32_dpp"
+               : "v_ctz_i32_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCtzI32B32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1744,8 +1840,10 @@ void VCtzI32B32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VClsI32Vop1::VClsI32Vop1(const MachineInst *inst)
-    : Vop1("v_cls_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VClsI32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cls_i32_dpp"
+               : "v_cls_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VClsI32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1786,8 +1884,10 @@ void VClsI32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpExpI32F64Vop1::VFrexpExpI32F64Vop1(const MachineInst *inst)
-    : Vop1("v_frexp_exp_i32_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpExpI32F64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_exp_i32_f64_dpp"
+               : "v_frexp_exp_i32_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpExpI32F64Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1809,8 +1909,10 @@ void VFrexpExpI32F64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpMantF64Vop1::VFrexpMantF64Vop1(const MachineInst *inst)
-    : Vop1("v_frexp_mant_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpMantF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_mant_f64_dpp"
+               : "v_frexp_mant_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpMantF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1832,8 +1934,10 @@ void VFrexpMantF64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFractF64Vop1::VFractF64Vop1(const MachineInst *inst)
-    : Vop1("v_fract_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFractF64Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fract_f64_dpp"
+               : "v_fract_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFractF64Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1855,8 +1959,10 @@ void VFractF64Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpExpI32F32Vop1::VFrexpExpI32F32Vop1(const MachineInst *inst)
-    : Vop1("v_frexp_exp_i32_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpExpI32F32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_exp_i32_f32_dpp"
+               : "v_frexp_exp_i32_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpExpI32F32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1897,8 +2003,10 @@ void VFrexpExpI32F32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpMantF32Vop1::VFrexpMantF32Vop1(const MachineInst *inst)
-    : Vop1("v_frexp_mant_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpMantF32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_mant_f32_dpp"
+               : "v_frexp_mant_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpMantF32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1939,8 +2047,10 @@ void VFrexpMantF32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMovreldB32Vop1::VMovreldB32Vop1(const MachineInst *inst)
-    : Vop1("v_movreld_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMovreldB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_movreld_b32_dpp"
+               : "v_movreld_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovreldB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -1997,8 +2107,10 @@ void VMovreldB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMovrelsB32Vop1::VMovrelsB32Vop1(const MachineInst *inst)
-    : Vop1("v_movrels_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMovrelsB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_movrels_b32_dpp"
+               : "v_movrels_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovrelsB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -2055,8 +2167,10 @@ void VMovrelsB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMovrelsdB32Vop1::VMovrelsdB32Vop1(const MachineInst *inst)
-    : Vop1("v_movrelsd_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMovrelsdB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_movrelsd_b32_dpp"
+               : "v_movrelsd_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovrelsdB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -2095,8 +2209,10 @@ void VMovrelsdB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMovrelsd2B32Vop1::VMovrelsd2B32Vop1(const MachineInst *inst)
-    : Vop1("v_movrelsd_2_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMovrelsd2B32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_movrelsd_2_b32_dpp"
+               : "v_movrelsd_2_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovrelsd2B32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -2135,8 +2251,10 @@ void VMovrelsd2B32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF16U16Vop1::VCvtF16U16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f16_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF16U16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f16_u16_dpp"
+               : "v_cvt_f16_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF16U16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2196,8 +2314,10 @@ void VCvtF16U16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF16I16Vop1::VCvtF16I16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f16_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF16I16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f16_i16_dpp"
+               : "v_cvt_f16_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF16I16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2257,8 +2377,10 @@ void VCvtF16I16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtU16F16Vop1::VCvtU16F16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_u16_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtU16F16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_u16_f16_dpp"
+               : "v_cvt_u16_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtU16F16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2322,8 +2444,10 @@ void VCvtU16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtI16F16Vop1::VCvtI16F16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_i16_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtI16F16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_i16_f16_dpp"
+               : "v_cvt_i16_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtI16F16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2389,8 +2513,10 @@ void VCvtI16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRcpF16Vop1::VRcpF16Vop1(const MachineInst *inst)
-    : Vop1("v_rcp_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRcpF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_f16_dpp"
+               : "v_rcp_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2451,8 +2577,10 @@ void VRcpF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSqrtF16Vop1::VSqrtF16Vop1(const MachineInst *inst)
-    : Vop1("v_sqrt_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSqrtF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sqrt_f16_dpp"
+               : "v_sqrt_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSqrtF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2513,8 +2641,10 @@ void VSqrtF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRsqF16Vop1::VRsqF16Vop1(const MachineInst *inst)
-    : Vop1("v_rsq_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRsqF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rsq_f16_dpp"
+               : "v_rsq_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRsqF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2575,8 +2705,10 @@ void VRsqF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLogF16Vop1::VLogF16Vop1(const MachineInst *inst)
-    : Vop1("v_log_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLogF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_log_f16_dpp"
+               : "v_log_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLogF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2637,8 +2769,10 @@ void VLogF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VExpF16Vop1::VExpF16Vop1(const MachineInst *inst)
-    : Vop1("v_exp_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VExpF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_exp_f16_dpp"
+               : "v_exp_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VExpF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2699,8 +2833,10 @@ void VExpF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpMantF16Vop1::VFrexpMantF16Vop1(const MachineInst *inst)
-    : Vop1("v_frexp_mant_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpMantF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_mant_f16_dpp"
+               : "v_frexp_mant_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpMantF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2765,8 +2901,10 @@ void VFrexpMantF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpExpI16F16Vop1::VFrexpExpI16F16Vop1(const MachineInst *inst)
-    : Vop1("v_frexp_exp_i16_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpExpI16F16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_exp_i16_f16_dpp"
+               : "v_frexp_exp_i16_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpExpI16F16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2832,8 +2970,10 @@ void VFrexpExpI16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFloorF16Vop1::VFloorF16Vop1(const MachineInst *inst)
-    : Vop1("v_floor_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFloorF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_floor_f16_dpp"
+               : "v_floor_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFloorF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2893,8 +3033,10 @@ void VFloorF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCeilF16Vop1::VCeilF16Vop1(const MachineInst *inst)
-    : Vop1("v_ceil_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCeilF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ceil_f16_dpp"
+               : "v_ceil_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCeilF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2954,8 +3096,10 @@ void VCeilF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VTruncF16Vop1::VTruncF16Vop1(const MachineInst *inst)
-    : Vop1("v_trunc_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VTruncF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_trunc_f16_dpp"
+               : "v_trunc_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VTruncF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -3015,8 +3159,10 @@ void VTruncF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRndneF16Vop1::VRndneF16Vop1(const MachineInst *inst)
-    : Vop1("v_rndne_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRndneF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rndne_f16_dpp"
+               : "v_rndne_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRndneF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -3076,8 +3222,10 @@ void VRndneF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFractF16Vop1::VFractF16Vop1(const MachineInst *inst)
-    : Vop1("v_fract_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFractF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fract_f16_dpp"
+               : "v_fract_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFractF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -3140,8 +3288,10 @@ void VFractF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSinF16Vop1::VSinF16Vop1(const MachineInst *inst)
-    : Vop1("v_sin_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSinF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sin_f16_dpp"
+               : "v_sin_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSinF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -3202,8 +3352,10 @@ void VSinF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCosF16Vop1::VCosF16Vop1(const MachineInst *inst)
-    : Vop1("v_cos_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCosF16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cos_f16_dpp"
+               : "v_cos_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCosF16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -3264,8 +3416,10 @@ void VCosF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSatPkU8I16Vop1::VSatPkU8I16Vop1(const MachineInst *inst)
-    : Vop1("v_sat_pk_u8_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSatPkU8I16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sat_pk_u8_i16_dpp"
+               : "v_sat_pk_u8_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSatPkU8I16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -3309,8 +3463,10 @@ void VSatPkU8I16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtNormI16F16Vop1::VCvtNormI16F16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_norm_i16_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtNormI16F16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_norm_i16_f16_dpp"
+               : "v_cvt_norm_i16_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtNormI16F16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -3373,8 +3529,10 @@ void VCvtNormI16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtNormU16F16Vop1::VCvtNormU16F16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_norm_u16_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtNormU16F16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_norm_u16_f16_dpp"
+               : "v_cvt_norm_u16_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtNormU16F16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -3437,8 +3595,10 @@ void VCvtNormU16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSwapB32Vop1::VSwapB32Vop1(const MachineInst *inst)
-    : Vop1("v_swap_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSwapB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_swap_b32_dpp"
+               : "v_swap_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSwapB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   src_operands_[0] = &vdst;
@@ -3469,8 +3629,10 @@ void VSwapB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSwapB16Vop1::VSwapB16Vop1(const MachineInst *inst)
-    : Vop1("v_swap_b16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSwapB16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_swap_b16_dpp"
+               : "v_swap_b16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSwapB16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), true,
            true),
@@ -3515,8 +3677,10 @@ void VSwapB16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPermlane64B32Vop1::VPermlane64B32Vop1(const MachineInst *inst)
-    : Vop1("v_permlane64_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VPermlane64B32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_permlane64_b32_dpp"
+               : "v_permlane64_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPermlane64B32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3547,8 +3711,10 @@ void VPermlane64B32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSwaprelB32Vop1::VSwaprelB32Vop1(const MachineInst *inst)
-    : Vop1("v_swaprel_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSwaprelB32Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_swaprel_b32_dpp"
+               : "v_swaprel_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSwaprelB32Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -3575,8 +3741,10 @@ void VSwaprelB32Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VNotB16Vop1::VNotB16Vop1(const MachineInst *inst)
-    : Vop1("v_not_b16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VNotB16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_not_b16_dpp"
+               : "v_not_b16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VNotB16Vop1>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -3634,8 +3802,10 @@ void VNotB16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtI32I16Vop1::VCvtI32I16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_i32_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtI32I16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_i32_i16_dpp"
+               : "v_cvt_i32_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtI32I16Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true) {
@@ -3678,8 +3848,10 @@ void VCvtI32I16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtU32U16Vop1::VCvtU32U16Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_u32_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtU32U16Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_u32_u16_dpp"
+               : "v_cvt_u32_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtU32U16Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true) {
@@ -3722,8 +3894,10 @@ void VCvtU32U16Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32Fp8Vop1::VCvtF32Fp8Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_fp8_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32Fp8Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_fp8_dpp"
+               : "v_cvt_f32_fp8_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32Fp8Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(8, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3772,8 +3946,10 @@ void VCvtF32Fp8Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32Bf8Vop1::VCvtF32Bf8Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_f32_bf8_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32Bf8Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_bf8_dpp"
+               : "v_cvt_f32_bf8_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32Bf8Vop1>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(8, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3822,8 +3998,10 @@ void VCvtF32Bf8Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkF32Fp8Vop1::VCvtPkF32Fp8Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_pk_f32_fp8_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkF32Fp8Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_f32_fp8_dpp"
+               : "v_cvt_pk_f32_fp8_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkF32Fp8Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true) {
@@ -3860,8 +4038,10 @@ void VCvtPkF32Fp8Vop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkF32Bf8Vop1::VCvtPkF32Bf8Vop1(const MachineInst *inst)
-    : Vop1("v_cvt_pk_f32_bf8_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkF32Bf8Vop1>()),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_f32_bf8_dpp"
+               : "v_cvt_pk_f32_bf8_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkF32Bf8Vop1>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vop2.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vop2.cpp
@@ -22,8 +22,10 @@ namespace rocjitsu {
 namespace rdna4 {
 
 VCndmaskB32Vop2::VCndmaskB32Vop2(const MachineInst *inst)
-    : Vop2("v_cndmask_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCndmaskB32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cndmask_b32_dpp"
+               : "v_cndmask_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCndmaskB32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -70,8 +72,10 @@ void VCndmaskB32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddF64Vop2::VAddF64Vop2(const MachineInst *inst)
-    : Vop2("v_add_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAddF64Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_f64_dpp"
+               : "v_add_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddF64Vop2>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -93,8 +97,10 @@ VAddF64Vop2::VAddF64Vop2(const MachineInst *inst)
 void VAddF64Vop2::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_add_f64_vop2(*this, wf); }
 
 VAddF32Vop2::VAddF32Vop2(const MachineInst *inst)
-    : Vop2("v_add_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAddF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_f32_dpp"
+               : "v_add_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -138,8 +144,10 @@ void VAddF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubF32Vop2::VSubF32Vop2(const MachineInst *inst)
-    : Vop2("v_sub_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_f32_dpp"
+               : "v_sub_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -183,8 +191,10 @@ void VSubF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubrevF32Vop2::VSubrevF32Vop2(const MachineInst *inst)
-    : Vop2("v_subrev_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubrevF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_subrev_f32_dpp"
+               : "v_subrev_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubrevF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -228,8 +238,10 @@ void VSubrevF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulF64Vop2::VMulF64Vop2(const MachineInst *inst)
-    : Vop2("v_mul_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulF64Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_f64_dpp"
+               : "v_mul_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulF64Vop2>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -251,8 +263,10 @@ VMulF64Vop2::VMulF64Vop2(const MachineInst *inst)
 void VMulF64Vop2::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_mul_f64_vop2(*this, wf); }
 
 VMulDx9ZeroF32Vop2::VMulDx9ZeroF32Vop2(const MachineInst *inst)
-    : Vop2("v_mul_dx9_zero_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulDx9ZeroF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_dx9_zero_f32_dpp"
+               : "v_mul_dx9_zero_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulDx9ZeroF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -296,8 +310,10 @@ void VMulDx9ZeroF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulF32Vop2::VMulF32Vop2(const MachineInst *inst)
-    : Vop2("v_mul_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_f32_dpp"
+               : "v_mul_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -341,8 +357,10 @@ void VMulF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulI32I24Vop2::VMulI32I24Vop2(const MachineInst *inst)
-    : Vop2("v_mul_i32_i24_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulI32I24Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_i32_i24_dpp"
+               : "v_mul_i32_i24_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulI32I24Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -386,8 +404,10 @@ void VMulI32I24Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulHiI32I24Vop2::VMulHiI32I24Vop2(const MachineInst *inst)
-    : Vop2("v_mul_hi_i32_i24_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulHiI32I24Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_hi_i32_i24_dpp"
+               : "v_mul_hi_i32_i24_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulHiI32I24Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -431,8 +451,10 @@ void VMulHiI32I24Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulU32U24Vop2::VMulU32U24Vop2(const MachineInst *inst)
-    : Vop2("v_mul_u32_u24_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulU32U24Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_u32_u24_dpp"
+               : "v_mul_u32_u24_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulU32U24Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -476,8 +498,10 @@ void VMulU32U24Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulHiU32U24Vop2::VMulHiU32U24Vop2(const MachineInst *inst)
-    : Vop2("v_mul_hi_u32_u24_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulHiU32U24Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_hi_u32_u24_dpp"
+               : "v_mul_hi_u32_u24_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulHiU32U24Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -521,8 +545,10 @@ void VMulHiU32U24Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinNumF64Vop2::VMinNumF64Vop2(const MachineInst *inst)
-    : Vop2("v_min_num_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinNumF64Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_num_f64_dpp"
+               : "v_min_num_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinNumF64Vop2>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -546,8 +572,10 @@ void VMinNumF64Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxNumF64Vop2::VMaxNumF64Vop2(const MachineInst *inst)
-    : Vop2("v_max_num_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaxNumF64Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_num_f64_dpp"
+               : "v_max_num_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxNumF64Vop2>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -571,8 +599,10 @@ void VMaxNumF64Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinI32Vop2::VMinI32Vop2(const MachineInst *inst)
-    : Vop2("v_min_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinI32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_i32_dpp"
+               : "v_min_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinI32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -616,8 +646,10 @@ void VMinI32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxI32Vop2::VMaxI32Vop2(const MachineInst *inst)
-    : Vop2("v_max_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaxI32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_i32_dpp"
+               : "v_max_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxI32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -661,8 +693,10 @@ void VMaxI32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinU32Vop2::VMinU32Vop2(const MachineInst *inst)
-    : Vop2("v_min_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinU32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_u32_dpp"
+               : "v_min_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinU32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -706,8 +740,10 @@ void VMinU32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxU32Vop2::VMaxU32Vop2(const MachineInst *inst)
-    : Vop2("v_max_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaxU32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_u32_dpp"
+               : "v_max_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxU32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -751,8 +787,10 @@ void VMaxU32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinNumF32Vop2::VMinNumF32Vop2(const MachineInst *inst)
-    : Vop2("v_min_num_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinNumF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_num_f32_dpp"
+               : "v_min_num_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinNumF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -796,8 +834,10 @@ void VMinNumF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxNumF32Vop2::VMaxNumF32Vop2(const MachineInst *inst)
-    : Vop2("v_max_num_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaxNumF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_num_f32_dpp"
+               : "v_max_num_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxNumF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -841,8 +881,10 @@ void VMaxNumF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLshlrevB32Vop2::VLshlrevB32Vop2(const MachineInst *inst)
-    : Vop2("v_lshlrev_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLshlrevB32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshlrev_b32_dpp"
+               : "v_lshlrev_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLshlrevB32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -886,8 +928,10 @@ void VLshlrevB32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLshrrevB32Vop2::VLshrrevB32Vop2(const MachineInst *inst)
-    : Vop2("v_lshrrev_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLshrrevB32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshrrev_b32_dpp"
+               : "v_lshrrev_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLshrrevB32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -931,8 +975,10 @@ void VLshrrevB32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAshrrevI32Vop2::VAshrrevI32Vop2(const MachineInst *inst)
-    : Vop2("v_ashrrev_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAshrrevI32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ashrrev_i32_dpp"
+               : "v_ashrrev_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAshrrevI32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -976,8 +1022,10 @@ void VAshrrevI32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAndB32Vop2::VAndB32Vop2(const MachineInst *inst)
-    : Vop2("v_and_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAndB32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_and_b32_dpp"
+               : "v_and_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAndB32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1021,7 +1069,10 @@ void VAndB32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VOrB32Vop2::VOrB32Vop2(const MachineInst *inst)
-    : Vop2("v_or_b32_e32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VOrB32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_or_b32_dpp"
+               : "v_or_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VOrB32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1065,8 +1116,10 @@ void VOrB32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VXorB32Vop2::VXorB32Vop2(const MachineInst *inst)
-    : Vop2("v_xor_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VXorB32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_xor_b32_dpp"
+               : "v_xor_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXorB32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1110,8 +1163,10 @@ void VXorB32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VXnorB32Vop2::VXnorB32Vop2(const MachineInst *inst)
-    : Vop2("v_xnor_b32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VXnorB32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_xnor_b32_dpp"
+               : "v_xnor_b32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXnorB32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1155,8 +1210,10 @@ void VXnorB32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLshlrevB64Vop2::VLshlrevB64Vop2(const MachineInst *inst)
-    : Vop2("v_lshlrev_b64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLshlrevB64Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshlrev_b64_dpp"
+               : "v_lshlrev_b64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLshlrevB64Vop2>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1179,8 +1236,10 @@ void VLshlrevB64Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddCoCiU32Vop2::VAddCoCiU32Vop2(const MachineInst *inst)
-    : Vop2("v_add_co_ci_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAddCoCiU32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_co_ci_u32_dpp"
+               : "v_add_co_ci_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddCoCiU32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -1230,8 +1289,10 @@ void VAddCoCiU32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubCoCiU32Vop2::VSubCoCiU32Vop2(const MachineInst *inst)
-    : Vop2("v_sub_co_ci_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubCoCiU32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_co_ci_u32_dpp"
+               : "v_sub_co_ci_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubCoCiU32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -1281,8 +1342,10 @@ void VSubCoCiU32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubrevCoCiU32Vop2::VSubrevCoCiU32Vop2(const MachineInst *inst)
-    : Vop2("v_subrev_co_ci_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubrevCoCiU32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_subrev_co_ci_u32_dpp"
+               : "v_subrev_co_ci_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubrevCoCiU32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -1332,8 +1395,10 @@ void VSubrevCoCiU32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddNcU32Vop2::VAddNcU32Vop2(const MachineInst *inst)
-    : Vop2("v_add_nc_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAddNcU32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_nc_u32_dpp"
+               : "v_add_nc_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddNcU32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1377,8 +1442,10 @@ void VAddNcU32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubNcU32Vop2::VSubNcU32Vop2(const MachineInst *inst)
-    : Vop2("v_sub_nc_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubNcU32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_nc_u32_dpp"
+               : "v_sub_nc_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubNcU32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1422,8 +1489,10 @@ void VSubNcU32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubrevNcU32Vop2::VSubrevNcU32Vop2(const MachineInst *inst)
-    : Vop2("v_subrev_nc_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubrevNcU32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_subrev_nc_u32_dpp"
+               : "v_subrev_nc_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubrevNcU32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1467,8 +1536,10 @@ void VSubrevNcU32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmacF32Vop2::VFmacF32Vop2(const MachineInst *inst)
-    : Vop2("v_fmac_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFmacF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmac_f32_dpp"
+               : "v_fmac_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmacF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1513,8 +1584,10 @@ void VFmacF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmamkF32Vop2::VFmamkF32Vop2(const MachineInst *inst)
-    : Vop2("v_fmamk_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFmamkF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmamk_f32_dpp"
+               : "v_fmamk_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmamkF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       simm32(32, OperandType::OPR_SIMM32, 0),
@@ -1543,8 +1616,10 @@ void VFmamkF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmaakF32Vop2::VFmaakF32Vop2(const MachineInst *inst)
-    : Vop2("v_fmaak_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFmaakF32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmaak_f32_dpp"
+               : "v_fmaak_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmaakF32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -1573,8 +1648,10 @@ void VFmaakF32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkRtzF16F32Vop2::VCvtPkRtzF16F32Vop2(const MachineInst *inst)
-    : Vop2("v_cvt_pk_rtz_f16_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkRtzF16F32Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_rtz_f16_f32_dpp"
+               : "v_cvt_pk_rtz_f16_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkRtzF16F32Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1618,8 +1695,10 @@ void VCvtPkRtzF16F32Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinNumF16Vop2::VMinNumF16Vop2(const MachineInst *inst)
-    : Vop2("v_min_num_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinNumF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_num_f16_dpp"
+               : "v_min_num_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinNumF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -1685,8 +1764,10 @@ void VMinNumF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxNumF16Vop2::VMaxNumF16Vop2(const MachineInst *inst)
-    : Vop2("v_max_num_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaxNumF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_num_f16_dpp"
+               : "v_max_num_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxNumF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -1752,8 +1833,10 @@ void VMaxNumF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddF16Vop2::VAddF16Vop2(const MachineInst *inst)
-    : Vop2("v_add_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAddF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_f16_dpp"
+               : "v_add_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -1819,8 +1902,10 @@ void VAddF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubF16Vop2::VSubF16Vop2(const MachineInst *inst)
-    : Vop2("v_sub_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_f16_dpp"
+               : "v_sub_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -1886,8 +1971,10 @@ void VSubF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubrevF16Vop2::VSubrevF16Vop2(const MachineInst *inst)
-    : Vop2("v_subrev_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubrevF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_subrev_f16_dpp"
+               : "v_subrev_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubrevF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -1953,8 +2040,10 @@ void VSubrevF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulF16Vop2::VMulF16Vop2(const MachineInst *inst)
-    : Vop2("v_mul_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_f16_dpp"
+               : "v_mul_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2020,8 +2109,10 @@ void VMulF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmacF16Vop2::VFmacF16Vop2(const MachineInst *inst)
-    : Vop2("v_fmac_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFmacF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmac_f16_dpp"
+               : "v_fmac_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmacF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), true,
            true),
@@ -2090,8 +2181,10 @@ void VFmacF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmamkF16Vop2::VFmamkF16Vop2(const MachineInst *inst)
-    : Vop2("v_fmamk_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFmamkF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmamk_f16_dpp"
+               : "v_fmamk_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmamkF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2143,8 +2236,10 @@ void VFmamkF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmaakF16Vop2::VFmaakF16Vop2(const MachineInst *inst)
-    : Vop2("v_fmaak_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFmaakF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmaak_f16_dpp"
+               : "v_fmaak_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmaakF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2195,8 +2290,10 @@ void VFmaakF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLdexpF16Vop2::VLdexpF16Vop2(const MachineInst *inst)
-    : Vop2("v_ldexp_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLdexpF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ldexp_f16_dpp"
+               : "v_ldexp_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLdexpF16Vop2>()),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), false,
            true),
@@ -2262,8 +2359,10 @@ void VLdexpF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkFmacF16Vop2::VPkFmacF16Vop2(const MachineInst *inst)
-    : Vop2("v_pk_fmac_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VPkFmacF16Vop2>()),
+    : Vop2(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_pk_fmac_f16_dpp"
+               : "v_pk_fmac_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkFmacF16Vop2>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vop3.cpp
@@ -22,7 +22,10 @@ namespace rocjitsu {
 namespace rdna4 {
 
 VNopVop3::VNopVop3(const MachineInst *inst)
-    : Vop3("v_nop", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VNopVop3>()) {
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_nop_e64_dpp"
+               : "v_nop",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VNopVop3>()) {
   num_src_ = 0;
   num_dst_ = 0;
 }
@@ -30,7 +33,10 @@ VNopVop3::VNopVop3(const MachineInst *inst)
 void VNopVop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_nop_vop3(*this, wf); }
 
 VMovB32Vop3::VMovB32Vop3(const MachineInst *inst)
-    : Vop3("v_mov_b32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mov_b32_e64_dpp"
+               : "v_mov_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -71,8 +77,10 @@ void VMovB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VReadfirstlaneB32Vop3::VReadfirstlaneB32Vop3(const MachineInst *inst)
-    : Vop3("v_readfirstlane_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VReadfirstlaneB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_readfirstlane_b32_e64_dpp"
+               : "v_readfirstlane_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VReadfirstlaneB32Vop3>()),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -101,8 +109,10 @@ void VReadfirstlaneB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtI32F64Vop3::VCvtI32F64Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_i32_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtI32F64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_i32_f64_e64_dpp"
+               : "v_cvt_i32_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtI32F64Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -124,8 +134,10 @@ void VCvtI32F64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF64I32Vop3::VCvtF64I32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f64_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF64I32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f64_i32_e64_dpp"
+               : "v_cvt_f64_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF64I32Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -146,8 +158,10 @@ void VCvtF64I32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32I32Vop3::VCvtF32I32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f32_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32I32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_i32_e64_dpp"
+               : "v_cvt_f32_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32I32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -188,8 +202,10 @@ void VCvtF32I32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32U32Vop3::VCvtF32U32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f32_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32U32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_u32_e64_dpp"
+               : "v_cvt_f32_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32U32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -230,8 +246,10 @@ void VCvtF32U32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtU32F32Vop3::VCvtU32F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_u32_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtU32F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_u32_f32_e64_dpp"
+               : "v_cvt_u32_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtU32F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -272,8 +290,10 @@ void VCvtU32F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtI32F32Vop3::VCvtI32F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_i32_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtI32F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_i32_f32_e64_dpp"
+               : "v_cvt_i32_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtI32F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -314,8 +334,10 @@ void VCvtI32F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF16F32Vop3::VCvtF16F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f16_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF16F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f16_f32_e64_dpp"
+               : "v_cvt_f16_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF16F32Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -374,8 +396,10 @@ void VCvtF16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32F16Vop3::VCvtF32F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f32_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32F16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_f16_e64_dpp"
+               : "v_cvt_f32_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32F16Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -436,8 +460,10 @@ void VCvtF32F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtNearestI32F32Vop3::VCvtNearestI32F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_nearest_i32_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtNearestI32F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_nearest_i32_f32_e64_dpp"
+               : "v_cvt_nearest_i32_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtNearestI32F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -478,8 +504,10 @@ void VCvtNearestI32F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtFloorI32F32Vop3::VCvtFloorI32F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_floor_i32_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtFloorI32F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_floor_i32_f32_e64_dpp"
+               : "v_cvt_floor_i32_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtFloorI32F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -520,8 +548,10 @@ void VCvtFloorI32F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtOffF32I4Vop3::VCvtOffF32I4Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_off_f32_i4", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtOffF32I4Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_off_f32_i4_e64_dpp"
+               : "v_cvt_off_f32_i4",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtOffF32I4Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -562,8 +592,10 @@ void VCvtOffF32I4Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32F64Vop3::VCvtF32F64Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f32_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32F64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_f64_e64_dpp"
+               : "v_cvt_f32_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32F64Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -585,8 +617,10 @@ void VCvtF32F64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF64F32Vop3::VCvtF64F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f64_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF64F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f64_f32_e64_dpp"
+               : "v_cvt_f64_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF64F32Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -607,8 +641,10 @@ void VCvtF64F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32Ubyte0Vop3::VCvtF32Ubyte0Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f32_ubyte0", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32Ubyte0Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_ubyte0_e64_dpp"
+               : "v_cvt_f32_ubyte0",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32Ubyte0Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -649,8 +685,10 @@ void VCvtF32Ubyte0Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32Ubyte1Vop3::VCvtF32Ubyte1Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f32_ubyte1", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32Ubyte1Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_ubyte1_e64_dpp"
+               : "v_cvt_f32_ubyte1",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32Ubyte1Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -691,8 +729,10 @@ void VCvtF32Ubyte1Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32Ubyte2Vop3::VCvtF32Ubyte2Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f32_ubyte2", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32Ubyte2Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_ubyte2_e64_dpp"
+               : "v_cvt_f32_ubyte2",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32Ubyte2Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -733,8 +773,10 @@ void VCvtF32Ubyte2Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32Ubyte3Vop3::VCvtF32Ubyte3Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f32_ubyte3", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32Ubyte3Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_ubyte3_e64_dpp"
+               : "v_cvt_f32_ubyte3",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32Ubyte3Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -775,8 +817,10 @@ void VCvtF32Ubyte3Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtU32F64Vop3::VCvtU32F64Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_u32_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtU32F64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_u32_f64_e64_dpp"
+               : "v_cvt_u32_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtU32F64Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -798,8 +842,10 @@ void VCvtU32F64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF64U32Vop3::VCvtF64U32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f64_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF64U32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f64_u32_e64_dpp"
+               : "v_cvt_f64_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF64U32Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -820,8 +866,10 @@ void VCvtF64U32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VTruncF64Vop3::VTruncF64Vop3(const MachineInst *inst)
-    : Vop3("v_trunc_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VTruncF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_trunc_f64_e64_dpp"
+               : "v_trunc_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VTruncF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -843,7 +891,10 @@ void VTruncF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCeilF64Vop3::VCeilF64Vop3(const MachineInst *inst)
-    : Vop3("v_ceil_f64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCeilF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ceil_f64_e64_dpp"
+               : "v_ceil_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCeilF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -865,8 +916,10 @@ void VCeilF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRndneF64Vop3::VRndneF64Vop3(const MachineInst *inst)
-    : Vop3("v_rndne_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRndneF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rndne_f64_e64_dpp"
+               : "v_rndne_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRndneF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -888,8 +941,10 @@ void VRndneF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFloorF64Vop3::VFloorF64Vop3(const MachineInst *inst)
-    : Vop3("v_floor_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFloorF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_floor_f64_e64_dpp"
+               : "v_floor_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFloorF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -911,8 +966,10 @@ void VFloorF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPipeflushVop3::VPipeflushVop3(const MachineInst *inst)
-    : Vop3("v_pipeflush", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VPipeflushVop3>()) {
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_pipeflush_e64_dpp"
+               : "v_pipeflush",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPipeflushVop3>()) {
   num_src_ = 0;
   num_dst_ = 0;
 }
@@ -922,7 +979,10 @@ void VPipeflushVop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMovB16Vop3::VMovB16Vop3(const MachineInst *inst)
-    : Vop3("v_mov_b16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovB16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mov_b16_e64_dpp"
+               : "v_mov_b16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovB16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -986,8 +1046,10 @@ void VMovB16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFractF32Vop3::VFractF32Vop3(const MachineInst *inst)
-    : Vop3("v_fract_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFractF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fract_f32_e64_dpp"
+               : "v_fract_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFractF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1028,8 +1090,10 @@ void VFractF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VTruncF32Vop3::VTruncF32Vop3(const MachineInst *inst)
-    : Vop3("v_trunc_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VTruncF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_trunc_f32_e64_dpp"
+               : "v_trunc_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VTruncF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1070,7 +1134,10 @@ void VTruncF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCeilF32Vop3::VCeilF32Vop3(const MachineInst *inst)
-    : Vop3("v_ceil_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCeilF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ceil_f32_e64_dpp"
+               : "v_ceil_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCeilF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1111,8 +1178,10 @@ void VCeilF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRndneF32Vop3::VRndneF32Vop3(const MachineInst *inst)
-    : Vop3("v_rndne_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRndneF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rndne_f32_e64_dpp"
+               : "v_rndne_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRndneF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1153,8 +1222,10 @@ void VRndneF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFloorF32Vop3::VFloorF32Vop3(const MachineInst *inst)
-    : Vop3("v_floor_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFloorF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_floor_f32_e64_dpp"
+               : "v_floor_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFloorF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1195,7 +1266,10 @@ void VFloorF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VExpF32Vop3::VExpF32Vop3(const MachineInst *inst)
-    : Vop3("v_exp_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VExpF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_exp_f32_e64_dpp"
+               : "v_exp_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VExpF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1236,7 +1310,10 @@ void VExpF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLogF32Vop3::VLogF32Vop3(const MachineInst *inst)
-    : Vop3("v_log_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLogF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_log_f32_e64_dpp"
+               : "v_log_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLogF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1277,7 +1354,10 @@ void VLogF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRcpF32Vop3::VRcpF32Vop3(const MachineInst *inst)
-    : Vop3("v_rcp_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_f32_e64_dpp"
+               : "v_rcp_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1318,8 +1398,10 @@ void VRcpF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRcpIflagF32Vop3::VRcpIflagF32Vop3(const MachineInst *inst)
-    : Vop3("v_rcp_iflag_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRcpIflagF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_iflag_f32_e64_dpp"
+               : "v_rcp_iflag_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpIflagF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1360,7 +1442,10 @@ void VRcpIflagF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRsqF32Vop3::VRsqF32Vop3(const MachineInst *inst)
-    : Vop3("v_rsq_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRsqF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rsq_f32_e64_dpp"
+               : "v_rsq_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRsqF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1401,7 +1486,10 @@ void VRsqF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRcpF64Vop3::VRcpF64Vop3(const MachineInst *inst)
-    : Vop3("v_rcp_f64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_f64_e64_dpp"
+               : "v_rcp_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1421,7 +1509,10 @@ VRcpF64Vop3::VRcpF64Vop3(const MachineInst *inst)
 void VRcpF64Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_rcp_f64_vop3(*this, wf); }
 
 VRsqF64Vop3::VRsqF64Vop3(const MachineInst *inst)
-    : Vop3("v_rsq_f64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRsqF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rsq_f64_e64_dpp"
+               : "v_rsq_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRsqF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1441,7 +1532,10 @@ VRsqF64Vop3::VRsqF64Vop3(const MachineInst *inst)
 void VRsqF64Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_rsq_f64_vop3(*this, wf); }
 
 VSqrtF32Vop3::VSqrtF32Vop3(const MachineInst *inst)
-    : Vop3("v_sqrt_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSqrtF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sqrt_f32_e64_dpp"
+               : "v_sqrt_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSqrtF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1482,7 +1576,10 @@ void VSqrtF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSqrtF64Vop3::VSqrtF64Vop3(const MachineInst *inst)
-    : Vop3("v_sqrt_f64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSqrtF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sqrt_f64_e64_dpp"
+               : "v_sqrt_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSqrtF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1504,7 +1601,10 @@ void VSqrtF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSinF32Vop3::VSinF32Vop3(const MachineInst *inst)
-    : Vop3("v_sin_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSinF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sin_f32_e64_dpp"
+               : "v_sin_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSinF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1545,7 +1645,10 @@ void VSinF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCosF32Vop3::VCosF32Vop3(const MachineInst *inst)
-    : Vop3("v_cos_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCosF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cos_f32_e64_dpp"
+               : "v_cos_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCosF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1586,7 +1689,10 @@ void VCosF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VNotB32Vop3::VNotB32Vop3(const MachineInst *inst)
-    : Vop3("v_not_b32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VNotB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_not_b32_e64_dpp"
+               : "v_not_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VNotB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1627,8 +1733,10 @@ void VNotB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VBfrevB32Vop3::VBfrevB32Vop3(const MachineInst *inst)
-    : Vop3("v_bfrev_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VBfrevB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_bfrev_b32_e64_dpp"
+               : "v_bfrev_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VBfrevB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1669,8 +1777,10 @@ void VBfrevB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VClzI32U32Vop3::VClzI32U32Vop3(const MachineInst *inst)
-    : Vop3("v_clz_i32_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VClzI32U32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_clz_i32_u32_e64_dpp"
+               : "v_clz_i32_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VClzI32U32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1711,8 +1821,10 @@ void VClzI32U32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCtzI32B32Vop3::VCtzI32B32Vop3(const MachineInst *inst)
-    : Vop3("v_ctz_i32_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCtzI32B32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ctz_i32_b32_e64_dpp"
+               : "v_ctz_i32_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCtzI32B32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1753,7 +1865,10 @@ void VCtzI32B32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VClsI32Vop3::VClsI32Vop3(const MachineInst *inst)
-    : Vop3("v_cls_i32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VClsI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cls_i32_e64_dpp"
+               : "v_cls_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VClsI32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1794,8 +1909,10 @@ void VClsI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpExpI32F64Vop3::VFrexpExpI32F64Vop3(const MachineInst *inst)
-    : Vop3("v_frexp_exp_i32_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpExpI32F64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_exp_i32_f64_e64_dpp"
+               : "v_frexp_exp_i32_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpExpI32F64Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1817,8 +1934,10 @@ void VFrexpExpI32F64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpMantF64Vop3::VFrexpMantF64Vop3(const MachineInst *inst)
-    : Vop3("v_frexp_mant_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpMantF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_mant_f64_e64_dpp"
+               : "v_frexp_mant_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpMantF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1840,8 +1959,10 @@ void VFrexpMantF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFractF64Vop3::VFractF64Vop3(const MachineInst *inst)
-    : Vop3("v_fract_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFractF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fract_f64_e64_dpp"
+               : "v_fract_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFractF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1863,8 +1984,10 @@ void VFractF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpExpI32F32Vop3::VFrexpExpI32F32Vop3(const MachineInst *inst)
-    : Vop3("v_frexp_exp_i32_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpExpI32F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_exp_i32_f32_e64_dpp"
+               : "v_frexp_exp_i32_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpExpI32F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1905,8 +2028,10 @@ void VFrexpExpI32F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpMantF32Vop3::VFrexpMantF32Vop3(const MachineInst *inst)
-    : Vop3("v_frexp_mant_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpMantF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_mant_f32_e64_dpp"
+               : "v_frexp_mant_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpMantF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -1947,8 +2072,10 @@ void VFrexpMantF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMovreldB32Vop3::VMovreldB32Vop3(const MachineInst *inst)
-    : Vop3("v_movreld_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMovreldB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_movreld_b32_e64_dpp"
+               : "v_movreld_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovreldB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -2005,8 +2132,10 @@ void VMovreldB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMovrelsB32Vop3::VMovrelsB32Vop3(const MachineInst *inst)
-    : Vop3("v_movrels_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMovrelsB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_movrels_b32_e64_dpp"
+               : "v_movrels_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovrelsB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -2063,8 +2192,10 @@ void VMovrelsB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMovrelsdB32Vop3::VMovrelsdB32Vop3(const MachineInst *inst)
-    : Vop3("v_movrelsd_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMovrelsdB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_movrelsd_b32_e64_dpp"
+               : "v_movrelsd_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovrelsdB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -2103,8 +2234,10 @@ void VMovrelsdB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMovrelsd2B32Vop3::VMovrelsd2B32Vop3(const MachineInst *inst)
-    : Vop3("v_movrelsd_2_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMovrelsd2B32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_movrelsd_2_b32_e64_dpp"
+               : "v_movrelsd_2_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMovrelsd2B32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       m0(32, OperandType::OPR_SDST_M0, 125) {
@@ -2143,8 +2276,10 @@ void VMovrelsd2B32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF16U16Vop3::VCvtF16U16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f16_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF16U16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f16_u16_e64_dpp"
+               : "v_cvt_f16_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF16U16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2209,8 +2344,10 @@ void VCvtF16U16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF16I16Vop3::VCvtF16I16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f16_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF16I16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f16_i16_e64_dpp"
+               : "v_cvt_f16_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF16I16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2275,8 +2412,10 @@ void VCvtF16I16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtU16F16Vop3::VCvtU16F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_u16_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtU16F16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_u16_f16_e64_dpp"
+               : "v_cvt_u16_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtU16F16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2346,8 +2485,10 @@ void VCvtU16F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtI16F16Vop3::VCvtI16F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_i16_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtI16F16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_i16_f16_e64_dpp"
+               : "v_cvt_i16_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtI16F16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2419,7 +2560,10 @@ void VCvtI16F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRcpF16Vop3::VRcpF16Vop3(const MachineInst *inst)
-    : Vop3("v_rcp_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rcp_f16_e64_dpp"
+               : "v_rcp_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2507,7 +2651,10 @@ void VRcpF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSqrtF16Vop3::VSqrtF16Vop3(const MachineInst *inst)
-    : Vop3("v_sqrt_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSqrtF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sqrt_f16_e64_dpp"
+               : "v_sqrt_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSqrtF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2600,7 +2747,10 @@ void VSqrtF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRsqF16Vop3::VRsqF16Vop3(const MachineInst *inst)
-    : Vop3("v_rsq_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRsqF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rsq_f16_e64_dpp"
+               : "v_rsq_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRsqF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2688,7 +2838,10 @@ void VRsqF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLogF16Vop3::VLogF16Vop3(const MachineInst *inst)
-    : Vop3("v_log_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLogF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_log_f16_e64_dpp"
+               : "v_log_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLogF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2776,7 +2929,10 @@ void VLogF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VExpF16Vop3::VExpF16Vop3(const MachineInst *inst)
-    : Vop3("v_exp_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VExpF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_exp_f16_e64_dpp"
+               : "v_exp_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VExpF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2864,8 +3020,10 @@ void VExpF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpMantF16Vop3::VFrexpMantF16Vop3(const MachineInst *inst)
-    : Vop3("v_frexp_mant_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpMantF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_mant_f16_e64_dpp"
+               : "v_frexp_mant_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpMantF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -2959,8 +3117,10 @@ void VFrexpMantF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFrexpExpI16F16Vop3::VFrexpExpI16F16Vop3(const MachineInst *inst)
-    : Vop3("v_frexp_exp_i16_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFrexpExpI16F16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_frexp_exp_i16_f16_e64_dpp"
+               : "v_frexp_exp_i16_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFrexpExpI16F16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3057,8 +3217,10 @@ void VFrexpExpI16F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFloorF16Vop3::VFloorF16Vop3(const MachineInst *inst)
-    : Vop3("v_floor_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFloorF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_floor_f16_e64_dpp"
+               : "v_floor_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFloorF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3146,7 +3308,10 @@ void VFloorF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCeilF16Vop3::VCeilF16Vop3(const MachineInst *inst)
-    : Vop3("v_ceil_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCeilF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ceil_f16_e64_dpp"
+               : "v_ceil_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCeilF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3234,8 +3399,10 @@ void VCeilF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VTruncF16Vop3::VTruncF16Vop3(const MachineInst *inst)
-    : Vop3("v_trunc_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VTruncF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_trunc_f16_e64_dpp"
+               : "v_trunc_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VTruncF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3323,8 +3490,10 @@ void VTruncF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VRndneF16Vop3::VRndneF16Vop3(const MachineInst *inst)
-    : Vop3("v_rndne_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VRndneF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_rndne_f16_e64_dpp"
+               : "v_rndne_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRndneF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3412,8 +3581,10 @@ void VRndneF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFractF16Vop3::VFractF16Vop3(const MachineInst *inst)
-    : Vop3("v_fract_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFractF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fract_f16_e64_dpp"
+               : "v_fract_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFractF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3504,7 +3675,10 @@ void VFractF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSinF16Vop3::VSinF16Vop3(const MachineInst *inst)
-    : Vop3("v_sin_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSinF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sin_f16_e64_dpp"
+               : "v_sin_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSinF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3590,7 +3764,10 @@ void VSinF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCosF16Vop3::VCosF16Vop3(const MachineInst *inst)
-    : Vop3("v_cos_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCosF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cos_f16_e64_dpp"
+               : "v_cos_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCosF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3676,8 +3853,10 @@ void VCosF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSatPkU8I16Vop3::VSatPkU8I16Vop3(const MachineInst *inst)
-    : Vop3("v_sat_pk_u8_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSatPkU8I16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sat_pk_u8_i16_e64_dpp"
+               : "v_sat_pk_u8_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSatPkU8I16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3719,8 +3898,10 @@ void VSatPkU8I16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtNormI16F16Vop3::VCvtNormI16F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_norm_i16_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtNormI16F16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_norm_i16_f16_e64_dpp"
+               : "v_cvt_norm_i16_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtNormI16F16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3789,8 +3970,10 @@ void VCvtNormI16F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtNormU16F16Vop3::VCvtNormU16F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_norm_u16_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtNormU16F16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_norm_u16_f16_e64_dpp"
+               : "v_cvt_norm_u16_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtNormU16F16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3859,7 +4042,10 @@ void VCvtNormU16F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VNotB16Vop3::VNotB16Vop3(const MachineInst *inst)
-    : Vop3("v_not_b16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VNotB16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_not_b16_e64_dpp"
+               : "v_not_b16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VNotB16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3923,8 +4109,10 @@ void VNotB16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtI32I16Vop3::VCvtI32I16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_i32_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtI32I16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_i32_i16_e64_dpp"
+               : "v_cvt_i32_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtI32I16Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -3980,8 +4168,10 @@ void VCvtI32I16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtU32U16Vop3::VCvtU32U16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_u32_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtU32U16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_u32_u16_e64_dpp"
+               : "v_cvt_u32_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtU32U16Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -4036,8 +4226,10 @@ void VCvtU32U16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32Fp8Vop3::VCvtF32Fp8Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f32_fp8", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32Fp8Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_fp8_e64_dpp"
+               : "v_cvt_f32_fp8",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32Fp8Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(8, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -4097,8 +4289,10 @@ void VCvtF32Fp8Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtF32Bf8Vop3::VCvtF32Bf8Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_f32_bf8", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtF32Bf8Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_f32_bf8_e64_dpp"
+               : "v_cvt_f32_bf8",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtF32Bf8Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(8, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -4151,8 +4345,10 @@ void VCvtF32Bf8Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkF32Fp8Vop3::VCvtPkF32Fp8Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_f32_fp8", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkF32Fp8Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_f32_fp8_e64_dpp"
+               : "v_cvt_pk_f32_fp8",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkF32Fp8Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -4191,8 +4387,10 @@ void VCvtPkF32Fp8Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkF32Bf8Vop3::VCvtPkF32Bf8Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_f32_bf8", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkF32Bf8Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_f32_bf8_e64_dpp"
+               : "v_cvt_pk_f32_bf8",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkF32Bf8Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -4231,8 +4429,10 @@ void VCvtPkF32Bf8Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCndmaskB32Vop3::VCndmaskB32Vop3(const MachineInst *inst)
-    : Vop3("v_cndmask_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCndmaskB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cndmask_b32_e64_dpp"
+               : "v_cndmask_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCndmaskB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -4287,7 +4487,10 @@ void VCndmaskB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddF64Vop3::VAddF64Vop3(const MachineInst *inst)
-    : Vop3("v_add_f64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_f64_e64_dpp"
+               : "v_add_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4314,7 +4517,10 @@ VAddF64Vop3::VAddF64Vop3(const MachineInst *inst)
 void VAddF64Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_add_f64_vop3(*this, wf); }
 
 VAddF32Vop3::VAddF32Vop3(const MachineInst *inst)
-    : Vop3("v_add_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_f32_e64_dpp"
+               : "v_add_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4362,7 +4568,10 @@ void VAddF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubF32Vop3::VSubF32Vop3(const MachineInst *inst)
-    : Vop3("v_sub_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_f32_e64_dpp"
+               : "v_sub_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4410,8 +4619,10 @@ void VSubF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubrevF32Vop3::VSubrevF32Vop3(const MachineInst *inst)
-    : Vop3("v_subrev_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubrevF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_subrev_f32_e64_dpp"
+               : "v_subrev_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubrevF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4459,7 +4670,10 @@ void VSubrevF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulF64Vop3::VMulF64Vop3(const MachineInst *inst)
-    : Vop3("v_mul_f64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_f64_e64_dpp"
+               : "v_mul_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4486,8 +4700,10 @@ VMulF64Vop3::VMulF64Vop3(const MachineInst *inst)
 void VMulF64Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_mul_f64_vop3(*this, wf); }
 
 VMulDx9ZeroF32Vop3::VMulDx9ZeroF32Vop3(const MachineInst *inst)
-    : Vop3("v_mul_dx9_zero_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulDx9ZeroF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_dx9_zero_f32_e64_dpp"
+               : "v_mul_dx9_zero_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulDx9ZeroF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4535,7 +4751,10 @@ void VMulDx9ZeroF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulF32Vop3::VMulF32Vop3(const MachineInst *inst)
-    : Vop3("v_mul_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_f32_e64_dpp"
+               : "v_mul_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4583,8 +4802,10 @@ void VMulF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulI32I24Vop3::VMulI32I24Vop3(const MachineInst *inst)
-    : Vop3("v_mul_i32_i24", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulI32I24Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_i32_i24_e64_dpp"
+               : "v_mul_i32_i24",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulI32I24Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4632,8 +4853,10 @@ void VMulI32I24Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulHiI32I24Vop3::VMulHiI32I24Vop3(const MachineInst *inst)
-    : Vop3("v_mul_hi_i32_i24", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulHiI32I24Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_hi_i32_i24_e64_dpp"
+               : "v_mul_hi_i32_i24",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulHiI32I24Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4681,8 +4904,10 @@ void VMulHiI32I24Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulU32U24Vop3::VMulU32U24Vop3(const MachineInst *inst)
-    : Vop3("v_mul_u32_u24", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulU32U24Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_u32_u24_e64_dpp"
+               : "v_mul_u32_u24",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulU32U24Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4730,8 +4955,10 @@ void VMulU32U24Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulHiU32U24Vop3::VMulHiU32U24Vop3(const MachineInst *inst)
-    : Vop3("v_mul_hi_u32_u24", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulHiU32U24Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_hi_u32_u24_e64_dpp"
+               : "v_mul_hi_u32_u24",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulHiU32U24Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4779,8 +5006,10 @@ void VMulHiU32U24Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinNumF64Vop3::VMinNumF64Vop3(const MachineInst *inst)
-    : Vop3("v_min_num_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinNumF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_num_f64_e64_dpp"
+               : "v_min_num_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinNumF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4809,8 +5038,10 @@ void VMinNumF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxNumF64Vop3::VMaxNumF64Vop3(const MachineInst *inst)
-    : Vop3("v_max_num_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaxNumF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_num_f64_e64_dpp"
+               : "v_max_num_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxNumF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4839,7 +5070,10 @@ void VMaxNumF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinI32Vop3::VMinI32Vop3(const MachineInst *inst)
-    : Vop3("v_min_i32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_i32_e64_dpp"
+               : "v_min_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinI32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4887,7 +5121,10 @@ void VMinI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxI32Vop3::VMaxI32Vop3(const MachineInst *inst)
-    : Vop3("v_max_i32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_i32_e64_dpp"
+               : "v_max_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxI32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4935,7 +5172,10 @@ void VMaxI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinU32Vop3::VMinU32Vop3(const MachineInst *inst)
-    : Vop3("v_min_u32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_u32_e64_dpp"
+               : "v_min_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -4983,7 +5223,10 @@ void VMinU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxU32Vop3::VMaxU32Vop3(const MachineInst *inst)
-    : Vop3("v_max_u32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_u32_e64_dpp"
+               : "v_max_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5031,8 +5274,10 @@ void VMaxU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinNumF32Vop3::VMinNumF32Vop3(const MachineInst *inst)
-    : Vop3("v_min_num_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinNumF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_num_f32_e64_dpp"
+               : "v_min_num_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinNumF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5080,8 +5325,10 @@ void VMinNumF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxNumF32Vop3::VMaxNumF32Vop3(const MachineInst *inst)
-    : Vop3("v_max_num_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaxNumF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_num_f32_e64_dpp"
+               : "v_max_num_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxNumF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5129,8 +5376,10 @@ void VMaxNumF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLshlrevB32Vop3::VLshlrevB32Vop3(const MachineInst *inst)
-    : Vop3("v_lshlrev_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLshlrevB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshlrev_b32_e64_dpp"
+               : "v_lshlrev_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLshlrevB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5178,8 +5427,10 @@ void VLshlrevB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLshrrevB32Vop3::VLshrrevB32Vop3(const MachineInst *inst)
-    : Vop3("v_lshrrev_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLshrrevB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshrrev_b32_e64_dpp"
+               : "v_lshrrev_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLshrrevB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5227,8 +5478,10 @@ void VLshrrevB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAshrrevI32Vop3::VAshrrevI32Vop3(const MachineInst *inst)
-    : Vop3("v_ashrrev_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAshrrevI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ashrrev_i32_e64_dpp"
+               : "v_ashrrev_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAshrrevI32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5276,7 +5529,10 @@ void VAshrrevI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAndB32Vop3::VAndB32Vop3(const MachineInst *inst)
-    : Vop3("v_and_b32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAndB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_and_b32_e64_dpp"
+               : "v_and_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAndB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5324,7 +5580,10 @@ void VAndB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VOrB32Vop3::VOrB32Vop3(const MachineInst *inst)
-    : Vop3("v_or_b32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VOrB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_or_b32_e64_dpp"
+               : "v_or_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VOrB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5372,7 +5631,10 @@ void VOrB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VXorB32Vop3::VXorB32Vop3(const MachineInst *inst)
-    : Vop3("v_xor_b32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXorB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_xor_b32_e64_dpp"
+               : "v_xor_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXorB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5420,7 +5682,10 @@ void VXorB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VXnorB32Vop3::VXnorB32Vop3(const MachineInst *inst)
-    : Vop3("v_xnor_b32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXnorB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_xnor_b32_e64_dpp"
+               : "v_xnor_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXnorB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5468,8 +5733,10 @@ void VXnorB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLshlrevB64Vop3::VLshlrevB64Vop3(const MachineInst *inst)
-    : Vop3("v_lshlrev_b64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLshlrevB64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshlrev_b64_e64_dpp"
+               : "v_lshlrev_b64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLshlrevB64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5497,8 +5764,10 @@ void VLshlrevB64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddNcU32Vop3::VAddNcU32Vop3(const MachineInst *inst)
-    : Vop3("v_add_nc_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAddNcU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_nc_u32_e64_dpp"
+               : "v_add_nc_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddNcU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5546,8 +5815,10 @@ void VAddNcU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubNcU32Vop3::VSubNcU32Vop3(const MachineInst *inst)
-    : Vop3("v_sub_nc_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubNcU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_nc_u32_e64_dpp"
+               : "v_sub_nc_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubNcU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5595,8 +5866,10 @@ void VSubNcU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubrevNcU32Vop3::VSubrevNcU32Vop3(const MachineInst *inst)
-    : Vop3("v_subrev_nc_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubrevNcU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_subrev_nc_u32_e64_dpp"
+               : "v_subrev_nc_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubrevNcU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5644,7 +5917,10 @@ void VSubrevNcU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmacF32Vop3::VFmacF32Vop3(const MachineInst *inst)
-    : Vop3("v_fmac_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmacF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmac_f32_e64_dpp"
+               : "v_fmac_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmacF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5693,8 +5969,10 @@ void VFmacF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkRtzF16F32Vop3::VCvtPkRtzF16F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_rtz_f16_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkRtzF16F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_rtz_f16_f32_e64_dpp"
+               : "v_cvt_pk_rtz_f16_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkRtzF16F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5742,8 +6020,10 @@ void VCvtPkRtzF16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinNumF16Vop3::VMinNumF16Vop3(const MachineInst *inst)
-    : Vop3("v_min_num_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinNumF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_num_f16_e64_dpp"
+               : "v_min_num_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinNumF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5862,8 +6142,10 @@ void VMinNumF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxNumF16Vop3::VMaxNumF16Vop3(const MachineInst *inst)
-    : Vop3("v_max_num_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaxNumF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_num_f16_e64_dpp"
+               : "v_max_num_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxNumF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -5982,7 +6264,10 @@ void VMaxNumF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddF16Vop3::VAddF16Vop3(const MachineInst *inst)
-    : Vop3("v_add_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_f16_e64_dpp"
+               : "v_add_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6098,7 +6383,10 @@ void VAddF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubF16Vop3::VSubF16Vop3(const MachineInst *inst)
-    : Vop3("v_sub_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_f16_e64_dpp"
+               : "v_sub_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6214,8 +6502,10 @@ void VSubF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubrevF16Vop3::VSubrevF16Vop3(const MachineInst *inst)
-    : Vop3("v_subrev_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubrevF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_subrev_f16_e64_dpp"
+               : "v_subrev_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubrevF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6331,7 +6621,10 @@ void VSubrevF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulF16Vop3::VMulF16Vop3(const MachineInst *inst)
-    : Vop3("v_mul_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_f16_e64_dpp"
+               : "v_mul_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6447,7 +6740,10 @@ void VMulF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmacF16Vop3::VFmacF16Vop3(const MachineInst *inst)
-    : Vop3("v_fmac_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmacF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fmac_f16_e64_dpp"
+               : "v_fmac_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmacF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6561,8 +6857,10 @@ void VFmacF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLdexpF16Vop3::VLdexpF16Vop3(const MachineInst *inst)
-    : Vop3("v_ldexp_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLdexpF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ldexp_f16_e64_dpp"
+               : "v_ldexp_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLdexpF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -6680,8 +6978,10 @@ void VLdexpF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmaDx9ZeroF32Vop3::VFmaDx9ZeroF32Vop3(const MachineInst *inst)
-    : Vop3("v_fma_dx9_zero_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VFmaDx9ZeroF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fma_dx9_zero_f32_e64_dpp"
+               : "v_fma_dx9_zero_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmaDx9ZeroF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6735,8 +7035,10 @@ void VFmaDx9ZeroF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMadI32I24Vop3::VMadI32I24Vop3(const MachineInst *inst)
-    : Vop3("v_mad_i32_i24", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMadI32I24Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mad_i32_i24_e64_dpp"
+               : "v_mad_i32_i24",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMadI32I24Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(24, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(24, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6790,8 +7092,10 @@ void VMadI32I24Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMadU32U24Vop3::VMadU32U24Vop3(const MachineInst *inst)
-    : Vop3("v_mad_u32_u24", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMadU32U24Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mad_u32_u24_e64_dpp"
+               : "v_mad_u32_u24",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMadU32U24Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(24, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(24, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6845,8 +7149,10 @@ void VMadU32U24Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCubeidF32Vop3::VCubeidF32Vop3(const MachineInst *inst)
-    : Vop3("v_cubeid_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCubeidF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cubeid_f32_e64_dpp"
+               : "v_cubeid_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCubeidF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6900,8 +7206,10 @@ void VCubeidF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCubescF32Vop3::VCubescF32Vop3(const MachineInst *inst)
-    : Vop3("v_cubesc_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCubescF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cubesc_f32_e64_dpp"
+               : "v_cubesc_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCubescF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -6955,8 +7263,10 @@ void VCubescF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCubetcF32Vop3::VCubetcF32Vop3(const MachineInst *inst)
-    : Vop3("v_cubetc_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCubetcF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cubetc_f32_e64_dpp"
+               : "v_cubetc_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCubetcF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7010,8 +7320,10 @@ void VCubetcF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCubemaF32Vop3::VCubemaF32Vop3(const MachineInst *inst)
-    : Vop3("v_cubema_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCubemaF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cubema_f32_e64_dpp"
+               : "v_cubema_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCubemaF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7065,7 +7377,10 @@ void VCubemaF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VBfeU32Vop3::VBfeU32Vop3(const MachineInst *inst)
-    : Vop3("v_bfe_u32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VBfeU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_bfe_u32_e64_dpp"
+               : "v_bfe_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VBfeU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7119,7 +7434,10 @@ void VBfeU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VBfeI32Vop3::VBfeI32Vop3(const MachineInst *inst)
-    : Vop3("v_bfe_i32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VBfeI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_bfe_i32_e64_dpp"
+               : "v_bfe_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VBfeI32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7173,7 +7491,10 @@ void VBfeI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VBfiB32Vop3::VBfiB32Vop3(const MachineInst *inst)
-    : Vop3("v_bfi_b32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VBfiB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_bfi_b32_e64_dpp"
+               : "v_bfi_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VBfiB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7227,7 +7548,10 @@ void VBfiB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmaF32Vop3::VFmaF32Vop3(const MachineInst *inst)
-    : Vop3("v_fma_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmaF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fma_f32_e64_dpp"
+               : "v_fma_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmaF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7281,7 +7605,10 @@ void VFmaF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmaF64Vop3::VFmaF64Vop3(const MachineInst *inst)
-    : Vop3("v_fma_f64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmaF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fma_f64_e64_dpp"
+               : "v_fma_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmaF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7315,7 +7642,10 @@ VFmaF64Vop3::VFmaF64Vop3(const MachineInst *inst)
 void VFmaF64Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_fma_f64_vop3(*this, wf); }
 
 VLerpU8Vop3::VLerpU8Vop3(const MachineInst *inst)
-    : Vop3("v_lerp_u8", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLerpU8Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lerp_u8_e64_dpp"
+               : "v_lerp_u8",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLerpU8Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7369,8 +7699,10 @@ void VLerpU8Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAlignbitB32Vop3::VAlignbitB32Vop3(const MachineInst *inst)
-    : Vop3("v_alignbit_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAlignbitB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_alignbit_b32_e64_dpp"
+               : "v_alignbit_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAlignbitB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7449,8 +7781,10 @@ void VAlignbitB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAlignbyteB32Vop3::VAlignbyteB32Vop3(const MachineInst *inst)
-    : Vop3("v_alignbyte_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAlignbyteB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_alignbyte_b32_e64_dpp"
+               : "v_alignbyte_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAlignbyteB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7529,8 +7863,10 @@ void VAlignbyteB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMullitF32Vop3::VMullitF32Vop3(const MachineInst *inst)
-    : Vop3("v_mullit_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMullitF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mullit_f32_e64_dpp"
+               : "v_mullit_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMullitF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7578,7 +7914,10 @@ void VMullitF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMin3I32Vop3::VMin3I32Vop3(const MachineInst *inst)
-    : Vop3("v_min3_i32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMin3I32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min3_i32_e64_dpp"
+               : "v_min3_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMin3I32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7632,7 +7971,10 @@ void VMin3I32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMin3U32Vop3::VMin3U32Vop3(const MachineInst *inst)
-    : Vop3("v_min3_u32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMin3U32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min3_u32_e64_dpp"
+               : "v_min3_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMin3U32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7686,7 +8028,10 @@ void VMin3U32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMax3I32Vop3::VMax3I32Vop3(const MachineInst *inst)
-    : Vop3("v_max3_i32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMax3I32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max3_i32_e64_dpp"
+               : "v_max3_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMax3I32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7740,7 +8085,10 @@ void VMax3I32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMax3U32Vop3::VMax3U32Vop3(const MachineInst *inst)
-    : Vop3("v_max3_u32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMax3U32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max3_u32_e64_dpp"
+               : "v_max3_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMax3U32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7794,7 +8142,10 @@ void VMax3U32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMed3I32Vop3::VMed3I32Vop3(const MachineInst *inst)
-    : Vop3("v_med3_i32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMed3I32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_med3_i32_e64_dpp"
+               : "v_med3_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMed3I32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7848,7 +8199,10 @@ void VMed3I32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMed3U32Vop3::VMed3U32Vop3(const MachineInst *inst)
-    : Vop3("v_med3_u32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMed3U32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_med3_u32_e64_dpp"
+               : "v_med3_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMed3U32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7902,7 +8256,10 @@ void VMed3U32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSadU8Vop3::VSadU8Vop3(const MachineInst *inst)
-    : Vop3("v_sad_u8", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSadU8Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sad_u8_e64_dpp"
+               : "v_sad_u8",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSadU8Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -7956,7 +8313,10 @@ void VSadU8Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSadHiU8Vop3::VSadHiU8Vop3(const MachineInst *inst)
-    : Vop3("v_sad_hi_u8", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSadHiU8Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sad_hi_u8_e64_dpp"
+               : "v_sad_hi_u8",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSadHiU8Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8010,7 +8370,10 @@ void VSadHiU8Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSadU16Vop3::VSadU16Vop3(const MachineInst *inst)
-    : Vop3("v_sad_u16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSadU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sad_u16_e64_dpp"
+               : "v_sad_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSadU16Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8064,7 +8427,10 @@ void VSadU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSadU32Vop3::VSadU32Vop3(const MachineInst *inst)
-    : Vop3("v_sad_u32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSadU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sad_u32_e64_dpp"
+               : "v_sad_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSadU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8118,8 +8484,10 @@ void VSadU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkU8F32Vop3::VCvtPkU8F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_u8_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkU8F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_u8_f32_e64_dpp"
+               : "v_cvt_pk_u8_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkU8F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8173,8 +8541,10 @@ void VCvtPkU8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDivFixupF32Vop3::VDivFixupF32Vop3(const MachineInst *inst)
-    : Vop3("v_div_fixup_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VDivFixupF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_div_fixup_f32_e64_dpp"
+               : "v_div_fixup_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDivFixupF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8207,8 +8577,10 @@ void VDivFixupF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDivFixupF64Vop3::VDivFixupF64Vop3(const MachineInst *inst)
-    : Vop3("v_div_fixup_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VDivFixupF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_div_fixup_f64_e64_dpp"
+               : "v_div_fixup_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDivFixupF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8244,8 +8616,10 @@ void VDivFixupF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMin3NumF32Vop3::VMin3NumF32Vop3(const MachineInst *inst)
-    : Vop3("v_min3_num_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMin3NumF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min3_num_f32_e64_dpp"
+               : "v_min3_num_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMin3NumF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8299,8 +8673,10 @@ void VMin3NumF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMax3NumF32Vop3::VMax3NumF32Vop3(const MachineInst *inst)
-    : Vop3("v_max3_num_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMax3NumF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max3_num_f32_e64_dpp"
+               : "v_max3_num_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMax3NumF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8354,8 +8730,10 @@ void VMax3NumF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMin3NumF16Vop3::VMin3NumF16Vop3(const MachineInst *inst)
-    : Vop3("v_min3_num_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMin3NumF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min3_num_f16_e64_dpp"
+               : "v_min3_num_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMin3NumF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8485,8 +8863,10 @@ void VMin3NumF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMax3NumF16Vop3::VMax3NumF16Vop3(const MachineInst *inst)
-    : Vop3("v_max3_num_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMax3NumF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max3_num_f16_e64_dpp"
+               : "v_max3_num_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMax3NumF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8616,8 +8996,10 @@ void VMax3NumF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinimum3F32Vop3::VMinimum3F32Vop3(const MachineInst *inst)
-    : Vop3("v_minimum3_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinimum3F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_minimum3_f32_e64_dpp"
+               : "v_minimum3_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinimum3F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8671,8 +9053,10 @@ void VMinimum3F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaximum3F32Vop3::VMaximum3F32Vop3(const MachineInst *inst)
-    : Vop3("v_maximum3_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaximum3F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_maximum3_f32_e64_dpp"
+               : "v_maximum3_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaximum3F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8726,8 +9110,10 @@ void VMaximum3F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinimum3F16Vop3::VMinimum3F16Vop3(const MachineInst *inst)
-    : Vop3("v_minimum3_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinimum3F16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_minimum3_f16_e64_dpp"
+               : "v_minimum3_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinimum3F16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8862,8 +9248,10 @@ void VMinimum3F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaximum3F16Vop3::VMaximum3F16Vop3(const MachineInst *inst)
-    : Vop3("v_maximum3_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaximum3F16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_maximum3_f16_e64_dpp"
+               : "v_maximum3_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaximum3F16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -8998,8 +9386,10 @@ void VMaximum3F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMed3NumF32Vop3::VMed3NumF32Vop3(const MachineInst *inst)
-    : Vop3("v_med3_num_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMed3NumF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_med3_num_f32_e64_dpp"
+               : "v_med3_num_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMed3NumF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -9053,8 +9443,10 @@ void VMed3NumF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMed3NumF16Vop3::VMed3NumF16Vop3(const MachineInst *inst)
-    : Vop3("v_med3_num_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMed3NumF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_med3_num_f16_e64_dpp"
+               : "v_med3_num_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMed3NumF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -9182,8 +9574,10 @@ void VMed3NumF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDivFmasF32Vop3::VDivFmasF32Vop3(const MachineInst *inst)
-    : Vop3("v_div_fmas_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VDivFmasF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_div_fmas_f32_e64_dpp"
+               : "v_div_fmas_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDivFmasF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -9219,8 +9613,10 @@ void VDivFmasF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDivFmasF64Vop3::VDivFmasF64Vop3(const MachineInst *inst)
-    : Vop3("v_div_fmas_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VDivFmasF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_div_fmas_f64_e64_dpp"
+               : "v_div_fmas_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDivFmasF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -9259,7 +9655,10 @@ void VDivFmasF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMsadU8Vop3::VMsadU8Vop3(const MachineInst *inst)
-    : Vop3("v_msad_u8", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMsadU8Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_msad_u8_e64_dpp"
+               : "v_msad_u8",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMsadU8Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -9313,8 +9712,10 @@ void VMsadU8Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VQsadPkU16U8Vop3::VQsadPkU16U8Vop3(const MachineInst *inst)
-    : Vop3("v_qsad_pk_u16_u8", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VQsadPkU16U8Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_qsad_pk_u16_u8_e64_dpp"
+               : "v_qsad_pk_u16_u8",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VQsadPkU16U8Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -9350,8 +9751,10 @@ void VQsadPkU16U8Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMqsadPkU16U8Vop3::VMqsadPkU16U8Vop3(const MachineInst *inst)
-    : Vop3("v_mqsad_pk_u16_u8", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMqsadPkU16U8Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mqsad_pk_u16_u8_e64_dpp"
+               : "v_mqsad_pk_u16_u8",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMqsadPkU16U8Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -9387,8 +9790,10 @@ void VMqsadPkU16U8Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMqsadU32U8Vop3::VMqsadU32U8Vop3(const MachineInst *inst)
-    : Vop3("v_mqsad_u32_u8", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMqsadU32U8Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mqsad_u32_u8_e64_dpp"
+               : "v_mqsad_u32_u8",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMqsadU32U8Vop3>()),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -9423,7 +9828,10 @@ void VMqsadU32U8Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VXor3B32Vop3::VXor3B32Vop3(const MachineInst *inst)
-    : Vop3("v_xor3_b32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXor3B32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_xor3_b32_e64_dpp"
+               : "v_xor3_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXor3B32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -9477,7 +9885,10 @@ void VXor3B32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMadU16Vop3::VMadU16Vop3(const MachineInst *inst)
-    : Vop3("v_mad_u16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMadU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mad_u16_e64_dpp"
+               : "v_mad_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMadU16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -9561,7 +9972,10 @@ void VMadU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPermB32Vop3::VPermB32Vop3(const MachineInst *inst)
-    : Vop3("v_perm_b32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPermB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_perm_b32_e64_dpp"
+               : "v_perm_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPermB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -9615,7 +10029,10 @@ void VPermB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VXadU32Vop3::VXadU32Vop3(const MachineInst *inst)
-    : Vop3("v_xad_u32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXadU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_xad_u32_e64_dpp"
+               : "v_xad_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXadU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -9669,8 +10086,10 @@ void VXadU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLshlAddU32Vop3::VLshlAddU32Vop3(const MachineInst *inst)
-    : Vop3("v_lshl_add_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLshlAddU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshl_add_u32_e64_dpp"
+               : "v_lshl_add_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLshlAddU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -9724,8 +10143,10 @@ void VLshlAddU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddLshlU32Vop3::VAddLshlU32Vop3(const MachineInst *inst)
-    : Vop3("v_add_lshl_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAddLshlU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_lshl_u32_e64_dpp"
+               : "v_add_lshl_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddLshlU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -9779,7 +10200,10 @@ void VAddLshlU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmaF16Vop3::VFmaF16Vop3(const MachineInst *inst)
-    : Vop3("v_fma_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmaF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_fma_f16_e64_dpp"
+               : "v_fma_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmaF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -9908,7 +10332,10 @@ void VFmaF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMin3I16Vop3::VMin3I16Vop3(const MachineInst *inst)
-    : Vop3("v_min3_i16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMin3I16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min3_i16_e64_dpp"
+               : "v_min3_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMin3I16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -10008,7 +10435,10 @@ void VMin3I16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMin3U16Vop3::VMin3U16Vop3(const MachineInst *inst)
-    : Vop3("v_min3_u16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMin3U16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min3_u16_e64_dpp"
+               : "v_min3_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMin3U16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -10105,7 +10535,10 @@ void VMin3U16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMax3I16Vop3::VMax3I16Vop3(const MachineInst *inst)
-    : Vop3("v_max3_i16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMax3I16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max3_i16_e64_dpp"
+               : "v_max3_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMax3I16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -10205,7 +10638,10 @@ void VMax3I16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMax3U16Vop3::VMax3U16Vop3(const MachineInst *inst)
-    : Vop3("v_max3_u16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMax3U16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max3_u16_e64_dpp"
+               : "v_max3_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMax3U16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -10302,7 +10738,10 @@ void VMax3U16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMed3I16Vop3::VMed3I16Vop3(const MachineInst *inst)
-    : Vop3("v_med3_i16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMed3I16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_med3_i16_e64_dpp"
+               : "v_med3_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMed3I16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -10404,7 +10843,10 @@ void VMed3I16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMed3U16Vop3::VMed3U16Vop3(const MachineInst *inst)
-    : Vop3("v_med3_u16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMed3U16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_med3_u16_e64_dpp"
+               : "v_med3_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMed3U16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -10504,7 +10946,10 @@ void VMed3U16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMadI16Vop3::VMadI16Vop3(const MachineInst *inst)
-    : Vop3("v_mad_i16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMadI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mad_i16_e64_dpp"
+               : "v_mad_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMadI16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -10591,8 +11036,10 @@ void VMadI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDivFixupF16Vop3::VDivFixupF16Vop3(const MachineInst *inst)
-    : Vop3("v_div_fixup_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VDivFixupF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_div_fixup_f16_e64_dpp"
+               : "v_div_fixup_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDivFixupF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -10727,7 +11174,10 @@ void VDivFixupF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAdd3U32Vop3::VAdd3U32Vop3(const MachineInst *inst)
-    : Vop3("v_add3_u32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAdd3U32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add3_u32_e64_dpp"
+               : "v_add3_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAdd3U32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -10781,8 +11231,10 @@ void VAdd3U32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLshlOrB32Vop3::VLshlOrB32Vop3(const MachineInst *inst)
-    : Vop3("v_lshl_or_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLshlOrB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshl_or_b32_e64_dpp"
+               : "v_lshl_or_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLshlOrB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -10836,8 +11288,10 @@ void VLshlOrB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAndOrB32Vop3::VAndOrB32Vop3(const MachineInst *inst)
-    : Vop3("v_and_or_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAndOrB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_and_or_b32_e64_dpp"
+               : "v_and_or_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAndOrB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -10891,7 +11345,10 @@ void VAndOrB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VOr3B32Vop3::VOr3B32Vop3(const MachineInst *inst)
-    : Vop3("v_or3_b32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VOr3B32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_or3_b32_e64_dpp"
+               : "v_or3_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VOr3B32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -10945,8 +11402,10 @@ void VOr3B32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMadU32U16Vop3::VMadU32U16Vop3(const MachineInst *inst)
-    : Vop3("v_mad_u32_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMadU32U16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mad_u32_u16_e64_dpp"
+               : "v_mad_u32_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMadU32U16Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -11022,8 +11481,10 @@ void VMadU32U16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMadI32I16Vop3::VMadI32I16Vop3(const MachineInst *inst)
-    : Vop3("v_mad_i32_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMadI32I16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mad_i32_i16_e64_dpp"
+               : "v_mad_i32_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMadI32I16Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -11106,8 +11567,10 @@ void VMadI32I16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPermlane16B32Vop3::VPermlane16B32Vop3(const MachineInst *inst)
-    : Vop3("v_permlane16_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VPermlane16B32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_permlane16_b32_e64_dpp"
+               : "v_permlane16_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPermlane16B32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -11163,8 +11626,10 @@ void VPermlane16B32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPermlanex16B32Vop3::VPermlanex16B32Vop3(const MachineInst *inst)
-    : Vop3("v_permlanex16_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VPermlanex16B32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_permlanex16_b32_e64_dpp"
+               : "v_permlanex16_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPermlanex16B32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -11222,8 +11687,10 @@ void VPermlanex16B32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCndmaskB16Vop3::VCndmaskB16Vop3(const MachineInst *inst)
-    : Vop3("v_cndmask_b16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCndmaskB16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cndmask_b16_e64_dpp"
+               : "v_cndmask_b16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCndmaskB16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -11309,8 +11776,10 @@ void VCndmaskB16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxminU32Vop3::VMaxminU32Vop3(const MachineInst *inst)
-    : Vop3("v_maxmin_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaxminU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_maxmin_u32_e64_dpp"
+               : "v_maxmin_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxminU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -11364,8 +11833,10 @@ void VMaxminU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinmaxU32Vop3::VMinmaxU32Vop3(const MachineInst *inst)
-    : Vop3("v_minmax_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinmaxU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_minmax_u32_e64_dpp"
+               : "v_minmax_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinmaxU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -11419,8 +11890,10 @@ void VMinmaxU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxminI32Vop3::VMaxminI32Vop3(const MachineInst *inst)
-    : Vop3("v_maxmin_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaxminI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_maxmin_i32_e64_dpp"
+               : "v_maxmin_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxminI32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -11474,8 +11947,10 @@ void VMaxminI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinmaxI32Vop3::VMinmaxI32Vop3(const MachineInst *inst)
-    : Vop3("v_minmax_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinmaxI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_minmax_i32_e64_dpp"
+               : "v_minmax_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinmaxI32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -11529,8 +12004,10 @@ void VMinmaxI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDot2F16F16Vop3::VDot2F16F16Vop3(const MachineInst *inst)
-    : Vop3("v_dot2_f16_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VDot2F16F16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_dot2_f16_f16_e64_dpp"
+               : "v_dot2_f16_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDot2F16F16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -11638,8 +12115,10 @@ void VDot2F16F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDot2Bf16Bf16Vop3::VDot2Bf16Bf16Vop3(const MachineInst *inst)
-    : Vop3("v_dot2_bf16_bf16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VDot2Bf16Bf16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_dot2_bf16_bf16_e64_dpp"
+               : "v_dot2_bf16_bf16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDot2Bf16Bf16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -11747,8 +12226,10 @@ void VDot2Bf16Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinmaxNumF32Vop3::VMinmaxNumF32Vop3(const MachineInst *inst)
-    : Vop3("v_minmax_num_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinmaxNumF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_minmax_num_f32_e64_dpp"
+               : "v_minmax_num_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinmaxNumF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -11802,8 +12283,10 @@ void VMinmaxNumF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxminNumF32Vop3::VMaxminNumF32Vop3(const MachineInst *inst)
-    : Vop3("v_maxmin_num_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaxminNumF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_maxmin_num_f32_e64_dpp"
+               : "v_maxmin_num_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxminNumF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -11857,8 +12340,10 @@ void VMaxminNumF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinmaxNumF16Vop3::VMinmaxNumF16Vop3(const MachineInst *inst)
-    : Vop3("v_minmax_num_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinmaxNumF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_minmax_num_f16_e64_dpp"
+               : "v_minmax_num_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinmaxNumF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -11988,8 +12473,10 @@ void VMinmaxNumF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxminNumF16Vop3::VMaxminNumF16Vop3(const MachineInst *inst)
-    : Vop3("v_maxmin_num_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaxminNumF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_maxmin_num_f16_e64_dpp"
+               : "v_maxmin_num_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxminNumF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -12119,8 +12606,10 @@ void VMaxminNumF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinimummaximumF32Vop3::VMinimummaximumF32Vop3(const MachineInst *inst)
-    : Vop3("v_minimummaximum_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinimummaximumF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_minimummaximum_f32_e64_dpp"
+               : "v_minimummaximum_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinimummaximumF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -12174,8 +12663,10 @@ void VMinimummaximumF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaximumminimumF32Vop3::VMaximumminimumF32Vop3(const MachineInst *inst)
-    : Vop3("v_maximumminimum_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaximumminimumF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_maximumminimum_f32_e64_dpp"
+               : "v_maximumminimum_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaximumminimumF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -12229,8 +12720,10 @@ void VMaximumminimumF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinimummaximumF16Vop3::VMinimummaximumF16Vop3(const MachineInst *inst)
-    : Vop3("v_minimummaximum_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinimummaximumF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_minimummaximum_f16_e64_dpp"
+               : "v_minimummaximum_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinimummaximumF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -12365,8 +12858,10 @@ void VMinimummaximumF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaximumminimumF16Vop3::VMaximumminimumF16Vop3(const MachineInst *inst)
-    : Vop3("v_maximumminimum_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaximumminimumF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_maximumminimum_f16_e64_dpp"
+               : "v_maximumminimum_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaximumminimumF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -12501,7 +12996,10 @@ void VMaximumminimumF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSExpF32Vop3::VSExpF32Vop3(const MachineInst *inst)
-    : Vop3("v_s_exp_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSExpF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_s_exp_f32_e64_dpp"
+               : "v_s_exp_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSExpF32Vop3>()),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -12524,7 +13022,10 @@ void VSExpF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSExpF16Vop3::VSExpF16Vop3(const MachineInst *inst)
-    : Vop3("v_s_exp_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSExpF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_s_exp_f16_e64_dpp"
+               : "v_s_exp_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSExpF16Vop3>()),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SREG_LITERAL, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -12554,7 +13055,10 @@ void VSExpF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSLogF32Vop3::VSLogF32Vop3(const MachineInst *inst)
-    : Vop3("v_s_log_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSLogF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_s_log_f32_e64_dpp"
+               : "v_s_log_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSLogF32Vop3>()),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -12577,7 +13081,10 @@ void VSLogF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSLogF16Vop3::VSLogF16Vop3(const MachineInst *inst)
-    : Vop3("v_s_log_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSLogF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_s_log_f16_e64_dpp"
+               : "v_s_log_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSLogF16Vop3>()),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SREG_LITERAL, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -12607,7 +13114,10 @@ void VSLogF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSRcpF32Vop3::VSRcpF32Vop3(const MachineInst *inst)
-    : Vop3("v_s_rcp_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSRcpF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_s_rcp_f32_e64_dpp"
+               : "v_s_rcp_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSRcpF32Vop3>()),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -12630,7 +13140,10 @@ void VSRcpF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSRcpF16Vop3::VSRcpF16Vop3(const MachineInst *inst)
-    : Vop3("v_s_rcp_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSRcpF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_s_rcp_f16_e64_dpp"
+               : "v_s_rcp_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSRcpF16Vop3>()),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SREG_LITERAL, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -12660,7 +13173,10 @@ void VSRcpF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSRsqF32Vop3::VSRsqF32Vop3(const MachineInst *inst)
-    : Vop3("v_s_rsq_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSRsqF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_s_rsq_f32_e64_dpp"
+               : "v_s_rsq_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSRsqF32Vop3>()),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -12683,7 +13199,10 @@ void VSRsqF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSRsqF16Vop3::VSRsqF16Vop3(const MachineInst *inst)
-    : Vop3("v_s_rsq_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSRsqF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_s_rsq_f16_e64_dpp"
+               : "v_s_rsq_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSRsqF16Vop3>()),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SREG_LITERAL, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -12713,8 +13232,10 @@ void VSRsqF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSSqrtF32Vop3::VSSqrtF32Vop3(const MachineInst *inst)
-    : Vop3("v_s_sqrt_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSSqrtF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_s_sqrt_f32_e64_dpp"
+               : "v_s_sqrt_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSSqrtF32Vop3>()),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -12737,8 +13258,10 @@ void VSSqrtF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSSqrtF16Vop3::VSSqrtF16Vop3(const MachineInst *inst)
-    : Vop3("v_s_sqrt_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSSqrtF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_s_sqrt_f16_e64_dpp"
+               : "v_s_sqrt_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSSqrtF16Vop3>()),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SREG_LITERAL, reinterpret_cast<const OpEncoding *>(inst)->src0) {
   dst_operands_[0] = &vdst;
@@ -12768,8 +13291,10 @@ void VSSqrtF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddNcU16Vop3::VAddNcU16Vop3(const MachineInst *inst)
-    : Vop3("v_add_nc_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAddNcU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_nc_u16_e64_dpp"
+               : "v_add_nc_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddNcU16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -12846,8 +13371,10 @@ void VAddNcU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubNcU16Vop3::VSubNcU16Vop3(const MachineInst *inst)
-    : Vop3("v_sub_nc_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubNcU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_nc_u16_e64_dpp"
+               : "v_sub_nc_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubNcU16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -12924,8 +13451,10 @@ void VSubNcU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulLoU16Vop3::VMulLoU16Vop3(const MachineInst *inst)
-    : Vop3("v_mul_lo_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulLoU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_lo_u16_e64_dpp"
+               : "v_mul_lo_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulLoU16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13003,8 +13532,10 @@ void VMulLoU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkI16F32Vop3::VCvtPkI16F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_i16_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkI16F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_i16_f32_e64_dpp"
+               : "v_cvt_pk_i16_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkI16F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13063,8 +13594,10 @@ void VCvtPkI16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkU16F32Vop3::VCvtPkU16F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_u16_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkU16F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_u16_f32_e64_dpp"
+               : "v_cvt_pk_u16_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkU16F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13123,7 +13656,10 @@ void VCvtPkU16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxU16Vop3::VMaxU16Vop3(const MachineInst *inst)
-    : Vop3("v_max_u16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_u16_e64_dpp"
+               : "v_max_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxU16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13201,7 +13737,10 @@ void VMaxU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaxI16Vop3::VMaxI16Vop3(const MachineInst *inst)
-    : Vop3("v_max_i16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_max_i16_e64_dpp"
+               : "v_max_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxI16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13279,7 +13818,10 @@ void VMaxI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinU16Vop3::VMinU16Vop3(const MachineInst *inst)
-    : Vop3("v_min_u16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_u16_e64_dpp"
+               : "v_min_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinU16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13357,7 +13899,10 @@ void VMinU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinI16Vop3::VMinI16Vop3(const MachineInst *inst)
-    : Vop3("v_min_i16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_min_i16_e64_dpp"
+               : "v_min_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinI16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13435,8 +13980,10 @@ void VMinI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddNcI16Vop3::VAddNcI16Vop3(const MachineInst *inst)
-    : Vop3("v_add_nc_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAddNcI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_nc_i16_e64_dpp"
+               : "v_add_nc_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddNcI16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13512,8 +14059,10 @@ void VAddNcI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubNcI16Vop3::VSubNcI16Vop3(const MachineInst *inst)
-    : Vop3("v_sub_nc_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubNcI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_nc_i16_e64_dpp"
+               : "v_sub_nc_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubNcI16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13589,8 +14138,10 @@ void VSubNcI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPermlane16VarB32Vop3::VPermlane16VarB32Vop3(const MachineInst *inst)
-    : Vop3("v_permlane16_var_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VPermlane16VarB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_permlane16_var_b32_e64_dpp"
+               : "v_permlane16_var_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPermlane16VarB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13637,8 +14188,10 @@ void VPermlane16VarB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPermlanex16VarB32Vop3::VPermlanex16VarB32Vop3(const MachineInst *inst)
-    : Vop3("v_permlanex16_var_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VPermlanex16VarB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_permlanex16_var_b32_e64_dpp"
+               : "v_permlanex16_var_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPermlanex16VarB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13687,8 +14240,10 @@ void VPermlanex16VarB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPackB32F16Vop3::VPackB32F16Vop3(const MachineInst *inst)
-    : Vop3("v_pack_b32_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VPackB32F16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_pack_b32_f16_e64_dpp"
+               : "v_pack_b32_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPackB32F16Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13756,8 +14311,10 @@ void VPackB32F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkNormI16F16Vop3::VCvtPkNormI16F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_norm_i16_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkNormI16F16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_norm_i16_f16_e64_dpp"
+               : "v_cvt_pk_norm_i16_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkNormI16F16Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13841,8 +14398,10 @@ void VCvtPkNormI16F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkNormU16F16Vop3::VCvtPkNormU16F16Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_norm_u16_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkNormU16F16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_norm_u16_f16_e64_dpp"
+               : "v_cvt_pk_norm_u16_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkNormU16F16Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13924,8 +14483,10 @@ void VCvtPkNormU16F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLdexpF32Vop3::VLdexpF32Vop3(const MachineInst *inst)
-    : Vop3("v_ldexp_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLdexpF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ldexp_f32_e64_dpp"
+               : "v_ldexp_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLdexpF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -13973,7 +14534,10 @@ void VLdexpF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VBfmB32Vop3::VBfmB32Vop3(const MachineInst *inst)
-    : Vop3("v_bfm_b32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VBfmB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_bfm_b32_e64_dpp"
+               : "v_bfm_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VBfmB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14021,8 +14585,10 @@ void VBfmB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VBcntU32B32Vop3::VBcntU32B32Vop3(const MachineInst *inst)
-    : Vop3("v_bcnt_u32_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VBcntU32B32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_bcnt_u32_b32_e64_dpp"
+               : "v_bcnt_u32_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VBcntU32B32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14070,8 +14636,10 @@ void VBcntU32B32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMbcntLoU32B32Vop3::VMbcntLoU32B32Vop3(const MachineInst *inst)
-    : Vop3("v_mbcnt_lo_u32_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMbcntLoU32B32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mbcnt_lo_u32_b32_e64_dpp"
+               : "v_mbcnt_lo_u32_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMbcntLoU32B32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14119,8 +14687,10 @@ void VMbcntLoU32B32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMbcntHiU32B32Vop3::VMbcntHiU32B32Vop3(const MachineInst *inst)
-    : Vop3("v_mbcnt_hi_u32_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMbcntHiU32B32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mbcnt_hi_u32_b32_e64_dpp"
+               : "v_mbcnt_hi_u32_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMbcntHiU32B32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14168,8 +14738,10 @@ void VMbcntHiU32B32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkNormI16F32Vop3::VCvtPkNormI16F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_norm_i16_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkNormI16F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_norm_i16_f32_e64_dpp"
+               : "v_cvt_pk_norm_i16_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkNormI16F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14217,8 +14789,10 @@ void VCvtPkNormI16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkNormU16F32Vop3::VCvtPkNormU16F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_norm_u16_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkNormU16F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_norm_u16_f32_e64_dpp"
+               : "v_cvt_pk_norm_u16_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkNormU16F32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14266,8 +14840,10 @@ void VCvtPkNormU16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkU16U32Vop3::VCvtPkU16U32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_u16_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkU16U32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_u16_u32_e64_dpp"
+               : "v_cvt_pk_u16_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkU16U32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14315,8 +14891,10 @@ void VCvtPkU16U32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkI16I32Vop3::VCvtPkI16I32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_i16_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkI16I32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_i16_i32_e64_dpp"
+               : "v_cvt_pk_i16_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkI16I32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14364,8 +14942,10 @@ void VCvtPkI16I32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubNcI32Vop3::VSubNcI32Vop3(const MachineInst *inst)
-    : Vop3("v_sub_nc_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubNcI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_sub_nc_i32_e64_dpp"
+               : "v_sub_nc_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubNcI32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14413,8 +14993,10 @@ void VSubNcI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddNcI32Vop3::VAddNcI32Vop3(const MachineInst *inst)
-    : Vop3("v_add_nc_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAddNcI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_add_nc_i32_e64_dpp"
+               : "v_add_nc_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddNcI32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14462,8 +15044,10 @@ void VAddNcI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLdexpF64Vop3::VLdexpF64Vop3(const MachineInst *inst)
-    : Vop3("v_ldexp_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLdexpF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ldexp_f64_e64_dpp"
+               : "v_ldexp_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLdexpF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14491,8 +15075,10 @@ void VLdexpF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulLoU32Vop3::VMulLoU32Vop3(const MachineInst *inst)
-    : Vop3("v_mul_lo_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulLoU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_lo_u32_e64_dpp"
+               : "v_mul_lo_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulLoU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14519,8 +15105,10 @@ void VMulLoU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulHiU32Vop3::VMulHiU32Vop3(const MachineInst *inst)
-    : Vop3("v_mul_hi_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulHiU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_hi_u32_e64_dpp"
+               : "v_mul_hi_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulHiU32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14547,8 +15135,10 @@ void VMulHiU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMulHiI32Vop3::VMulHiI32Vop3(const MachineInst *inst)
-    : Vop3("v_mul_hi_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulHiI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_mul_hi_i32_e64_dpp"
+               : "v_mul_hi_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMulHiI32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14575,8 +15165,10 @@ void VMulHiI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VTrigPreopF64Vop3::VTrigPreopF64Vop3(const MachineInst *inst)
-    : Vop3("v_trig_preop_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VTrigPreopF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_trig_preop_f64_e64_dpp"
+               : "v_trig_preop_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VTrigPreopF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14605,8 +15197,10 @@ void VTrigPreopF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLshlrevB16Vop3::VLshlrevB16Vop3(const MachineInst *inst)
-    : Vop3("v_lshlrev_b16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLshlrevB16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshlrev_b16_e64_dpp"
+               : "v_lshlrev_b16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLshlrevB16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14679,8 +15273,10 @@ void VLshlrevB16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLshrrevB16Vop3::VLshrrevB16Vop3(const MachineInst *inst)
-    : Vop3("v_lshrrev_b16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLshrrevB16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshrrev_b16_e64_dpp"
+               : "v_lshrrev_b16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLshrrevB16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14753,8 +15349,10 @@ void VLshrrevB16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAshrrevI16Vop3::VAshrrevI16Vop3(const MachineInst *inst)
-    : Vop3("v_ashrrev_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAshrrevI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ashrrev_i16_e64_dpp"
+               : "v_ashrrev_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAshrrevI16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14829,8 +15427,10 @@ void VAshrrevI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VLshrrevB64Vop3::VLshrrevB64Vop3(const MachineInst *inst)
-    : Vop3("v_lshrrev_b64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VLshrrevB64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_lshrrev_b64_e64_dpp"
+               : "v_lshrrev_b64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLshrrevB64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14858,8 +15458,10 @@ void VLshrrevB64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAshrrevI64Vop3::VAshrrevI64Vop3(const MachineInst *inst)
-    : Vop3("v_ashrrev_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAshrrevI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_ashrrev_i64_e64_dpp"
+               : "v_ashrrev_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAshrrevI64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14887,8 +15489,10 @@ void VAshrrevI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinimumF64Vop3::VMinimumF64Vop3(const MachineInst *inst)
-    : Vop3("v_minimum_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinimumF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_minimum_f64_e64_dpp"
+               : "v_minimum_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinimumF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14917,8 +15521,10 @@ void VMinimumF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaximumF64Vop3::VMaximumF64Vop3(const MachineInst *inst)
-    : Vop3("v_maximum_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaximumF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_maximum_f64_e64_dpp"
+               : "v_maximum_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaximumF64Vop3>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14947,8 +15553,10 @@ void VMaximumF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VReadlaneB32Vop3::VReadlaneB32Vop3(const MachineInst *inst)
-    : Vop3("v_readlane_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VReadlaneB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_readlane_b32_e64_dpp"
+               : "v_readlane_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VReadlaneB32Vop3>()),
       vdst(32, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SSRC_LANESEL, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -14976,8 +15584,10 @@ void VReadlaneB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VWritelaneB32Vop3::VWritelaneB32Vop3(const MachineInst *inst)
-    : Vop3("v_writelane_b32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VWritelaneB32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_writelane_b32_e64_dpp"
+               : "v_writelane_b32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VWritelaneB32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SSRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SSRC_LANESEL, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15007,7 +15617,10 @@ void VWritelaneB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAndB16Vop3::VAndB16Vop3(const MachineInst *inst)
-    : Vop3("v_and_b16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAndB16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_and_b16_e64_dpp"
+               : "v_and_b16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAndB16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15084,7 +15697,10 @@ void VAndB16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VOrB16Vop3::VOrB16Vop3(const MachineInst *inst)
-    : Vop3("v_or_b16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VOrB16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_or_b16_e64_dpp"
+               : "v_or_b16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VOrB16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15161,7 +15777,10 @@ void VOrB16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VXorB16Vop3::VXorB16Vop3(const MachineInst *inst)
-    : Vop3("v_xor_b16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXorB16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_xor_b16_e64_dpp"
+               : "v_xor_b16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXorB16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15238,8 +15857,10 @@ void VXorB16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinimumF32Vop3::VMinimumF32Vop3(const MachineInst *inst)
-    : Vop3("v_minimum_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinimumF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_minimum_f32_e64_dpp"
+               : "v_minimum_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinimumF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15287,8 +15908,10 @@ void VMinimumF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaximumF32Vop3::VMaximumF32Vop3(const MachineInst *inst)
-    : Vop3("v_maximum_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaximumF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_maximum_f32_e64_dpp"
+               : "v_maximum_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaximumF32Vop3>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15336,8 +15959,10 @@ void VMaximumF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMinimumF16Vop3::VMinimumF16Vop3(const MachineInst *inst)
-    : Vop3("v_minimum_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMinimumF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_minimum_f16_e64_dpp"
+               : "v_minimum_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinimumF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15450,8 +16075,10 @@ void VMinimumF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMaximumF16Vop3::VMaximumF16Vop3(const MachineInst *inst)
-    : Vop3("v_maximum_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMaximumF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_maximum_f16_e64_dpp"
+               : "v_maximum_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaximumF16Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15564,8 +16191,10 @@ void VMaximumF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkFp8F32Vop3::VCvtPkFp8F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_fp8_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkFp8F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_fp8_f32_e64_dpp"
+               : "v_cvt_pk_fp8_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkFp8F32Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15629,8 +16258,10 @@ void VCvtPkFp8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtPkBf8F32Vop3::VCvtPkBf8F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_bf8_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkBf8F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_pk_bf8_f32_e64_dpp"
+               : "v_cvt_pk_bf8_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtPkBf8F32Vop3>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15694,8 +16325,10 @@ void VCvtPkBf8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtSrFp8F32Vop3::VCvtSrFp8F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_sr_fp8_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtSrFp8F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_sr_fp8_f32_e64_dpp"
+               : "v_cvt_sr_fp8_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtSrFp8F32Vop3>()),
       vdst(8, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15763,8 +16396,10 @@ void VCvtSrFp8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCvtSrBf8F32Vop3::VCvtSrBf8F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_sr_bf8_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtSrBf8F32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cvt_sr_bf8_f32_e64_dpp"
+               : "v_cvt_sr_bf8_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCvtSrBf8F32Vop3>()),
       vdst(8, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15832,8 +16467,10 @@ void VCvtSrBf8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtF16Vop3::VCmpLtF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lt_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_f16_e64_dpp"
+               : "v_cmp_lt_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -15919,8 +16556,10 @@ void VCmpLtF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqF16Vop3::VCmpEqF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_eq_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_f16_e64_dpp"
+               : "v_cmp_eq_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16006,8 +16645,10 @@ void VCmpEqF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeF16Vop3::VCmpLeF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_le_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_f16_e64_dpp"
+               : "v_cmp_le_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16093,8 +16734,10 @@ void VCmpLeF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtF16Vop3::VCmpGtF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_gt_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_f16_e64_dpp"
+               : "v_cmp_gt_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16180,8 +16823,10 @@ void VCmpGtF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLgF16Vop3::VCmpLgF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lg_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLgF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lg_f16_e64_dpp"
+               : "v_cmp_lg_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLgF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16270,8 +16915,10 @@ void VCmpLgF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeF16Vop3::VCmpGeF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ge_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_f16_e64_dpp"
+               : "v_cmp_ge_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16357,7 +17004,10 @@ void VCmpGeF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpOF16Vop3::VCmpOF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_o_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpOF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_o_f16_e64_dpp"
+               : "v_cmp_o_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpOF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16444,7 +17094,10 @@ void VCmpOF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpUF16Vop3::VCmpUF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_u_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpUF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_u_f16_e64_dpp"
+               : "v_cmp_u_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpUF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16531,8 +17184,10 @@ void VCmpUF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNgeF16Vop3::VCmpNgeF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nge_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNgeF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nge_f16_e64_dpp"
+               : "v_cmp_nge_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNgeF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16618,8 +17273,10 @@ void VCmpNgeF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNlgF16Vop3::VCmpNlgF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nlg_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNlgF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlg_f16_e64_dpp"
+               : "v_cmp_nlg_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNlgF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16708,8 +17365,10 @@ void VCmpNlgF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNgtF16Vop3::VCmpNgtF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ngt_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNgtF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ngt_f16_e64_dpp"
+               : "v_cmp_ngt_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNgtF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16795,8 +17454,10 @@ void VCmpNgtF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNleF16Vop3::VCmpNleF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nle_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNleF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nle_f16_e64_dpp"
+               : "v_cmp_nle_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNleF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16882,8 +17543,10 @@ void VCmpNleF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeqF16Vop3::VCmpNeqF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_neq_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeqF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_neq_f16_e64_dpp"
+               : "v_cmp_neq_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeqF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -16969,8 +17632,10 @@ void VCmpNeqF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNltF16Vop3::VCmpNltF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nlt_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNltF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlt_f16_e64_dpp"
+               : "v_cmp_nlt_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNltF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17056,8 +17721,10 @@ void VCmpNltF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtF32Vop3::VCmpLtF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lt_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_f32_e64_dpp"
+               : "v_cmp_lt_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17105,8 +17772,10 @@ void VCmpLtF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqF32Vop3::VCmpEqF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_eq_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_f32_e64_dpp"
+               : "v_cmp_eq_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17154,8 +17823,10 @@ void VCmpEqF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeF32Vop3::VCmpLeF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_le_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_f32_e64_dpp"
+               : "v_cmp_le_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17203,8 +17874,10 @@ void VCmpLeF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtF32Vop3::VCmpGtF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_gt_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_f32_e64_dpp"
+               : "v_cmp_gt_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17252,8 +17925,10 @@ void VCmpGtF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLgF32Vop3::VCmpLgF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lg_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLgF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lg_f32_e64_dpp"
+               : "v_cmp_lg_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLgF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17301,8 +17976,10 @@ void VCmpLgF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeF32Vop3::VCmpGeF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ge_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_f32_e64_dpp"
+               : "v_cmp_ge_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17350,7 +18027,10 @@ void VCmpGeF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpOF32Vop3::VCmpOF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_o_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpOF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_o_f32_e64_dpp"
+               : "v_cmp_o_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpOF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17398,7 +18078,10 @@ void VCmpOF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpUF32Vop3::VCmpUF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_u_f32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpUF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_u_f32_e64_dpp"
+               : "v_cmp_u_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpUF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17446,8 +18129,10 @@ void VCmpUF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNgeF32Vop3::VCmpNgeF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nge_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNgeF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nge_f32_e64_dpp"
+               : "v_cmp_nge_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNgeF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17495,8 +18180,10 @@ void VCmpNgeF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNlgF32Vop3::VCmpNlgF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nlg_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNlgF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlg_f32_e64_dpp"
+               : "v_cmp_nlg_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNlgF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17544,8 +18231,10 @@ void VCmpNlgF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNgtF32Vop3::VCmpNgtF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ngt_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNgtF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ngt_f32_e64_dpp"
+               : "v_cmp_ngt_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNgtF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17593,8 +18282,10 @@ void VCmpNgtF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNleF32Vop3::VCmpNleF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nle_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNleF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nle_f32_e64_dpp"
+               : "v_cmp_nle_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNleF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17642,8 +18333,10 @@ void VCmpNleF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeqF32Vop3::VCmpNeqF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_neq_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeqF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_neq_f32_e64_dpp"
+               : "v_cmp_neq_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeqF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17691,8 +18384,10 @@ void VCmpNeqF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNltF32Vop3::VCmpNltF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nlt_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNltF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlt_f32_e64_dpp"
+               : "v_cmp_nlt_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNltF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17740,8 +18435,10 @@ void VCmpNltF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtF64Vop3::VCmpLtF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lt_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_f64_e64_dpp"
+               : "v_cmp_lt_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17770,8 +18467,10 @@ void VCmpLtF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqF64Vop3::VCmpEqF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_eq_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_f64_e64_dpp"
+               : "v_cmp_eq_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17800,8 +18499,10 @@ void VCmpEqF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeF64Vop3::VCmpLeF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_le_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_f64_e64_dpp"
+               : "v_cmp_le_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17830,8 +18531,10 @@ void VCmpLeF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtF64Vop3::VCmpGtF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_gt_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_f64_e64_dpp"
+               : "v_cmp_gt_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17860,8 +18563,10 @@ void VCmpGtF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLgF64Vop3::VCmpLgF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lg_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLgF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lg_f64_e64_dpp"
+               : "v_cmp_lg_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLgF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17890,8 +18595,10 @@ void VCmpLgF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeF64Vop3::VCmpGeF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ge_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_f64_e64_dpp"
+               : "v_cmp_ge_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17920,7 +18627,10 @@ void VCmpGeF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpOF64Vop3::VCmpOF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_o_f64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpOF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_o_f64_e64_dpp"
+               : "v_cmp_o_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpOF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17949,7 +18659,10 @@ void VCmpOF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpUF64Vop3::VCmpUF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_u_f64", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpUF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_u_f64_e64_dpp"
+               : "v_cmp_u_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpUF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -17978,8 +18691,10 @@ void VCmpUF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNgeF64Vop3::VCmpNgeF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nge_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNgeF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nge_f64_e64_dpp"
+               : "v_cmp_nge_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNgeF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18008,8 +18723,10 @@ void VCmpNgeF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNlgF64Vop3::VCmpNlgF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nlg_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNlgF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlg_f64_e64_dpp"
+               : "v_cmp_nlg_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNlgF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18038,8 +18755,10 @@ void VCmpNlgF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNgtF64Vop3::VCmpNgtF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ngt_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNgtF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ngt_f64_e64_dpp"
+               : "v_cmp_ngt_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNgtF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18068,8 +18787,10 @@ void VCmpNgtF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNleF64Vop3::VCmpNleF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nle_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNleF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nle_f64_e64_dpp"
+               : "v_cmp_nle_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNleF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18098,8 +18819,10 @@ void VCmpNleF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeqF64Vop3::VCmpNeqF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_neq_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeqF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_neq_f64_e64_dpp"
+               : "v_cmp_neq_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeqF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18128,8 +18851,10 @@ void VCmpNeqF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNltF64Vop3::VCmpNltF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_nlt_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNltF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlt_f64_e64_dpp"
+               : "v_cmp_nlt_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNltF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18158,8 +18883,10 @@ void VCmpNltF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtI16Vop3::VCmpLtI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lt_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_i16_e64_dpp"
+               : "v_cmp_lt_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtI16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18227,8 +18954,10 @@ void VCmpLtI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqI16Vop3::VCmpEqI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_eq_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_i16_e64_dpp"
+               : "v_cmp_eq_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqI16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18296,8 +19025,10 @@ void VCmpEqI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeI16Vop3::VCmpLeI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_le_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_i16_e64_dpp"
+               : "v_cmp_le_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeI16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18365,8 +19096,10 @@ void VCmpLeI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtI16Vop3::VCmpGtI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_gt_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_i16_e64_dpp"
+               : "v_cmp_gt_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtI16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18434,8 +19167,10 @@ void VCmpGtI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeI16Vop3::VCmpNeI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ne_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_i16_e64_dpp"
+               : "v_cmp_ne_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeI16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18503,8 +19238,10 @@ void VCmpNeI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeI16Vop3::VCmpGeI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ge_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_i16_e64_dpp"
+               : "v_cmp_ge_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeI16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18572,8 +19309,10 @@ void VCmpGeI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtU16Vop3::VCmpLtU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lt_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_u16_e64_dpp"
+               : "v_cmp_lt_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtU16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18641,8 +19380,10 @@ void VCmpLtU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqU16Vop3::VCmpEqU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_eq_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_u16_e64_dpp"
+               : "v_cmp_eq_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqU16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18711,8 +19452,10 @@ void VCmpEqU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeU16Vop3::VCmpLeU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_le_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_u16_e64_dpp"
+               : "v_cmp_le_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeU16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18781,8 +19524,10 @@ void VCmpLeU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtU16Vop3::VCmpGtU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_gt_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_u16_e64_dpp"
+               : "v_cmp_gt_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtU16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18850,8 +19595,10 @@ void VCmpGtU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeU16Vop3::VCmpNeU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ne_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_u16_e64_dpp"
+               : "v_cmp_ne_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeU16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18920,8 +19667,10 @@ void VCmpNeU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeU16Vop3::VCmpGeU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ge_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_u16_e64_dpp"
+               : "v_cmp_ge_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeU16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -18990,8 +19739,10 @@ void VCmpGeU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtI32Vop3::VCmpLtI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lt_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_i32_e64_dpp"
+               : "v_cmp_lt_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtI32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -19039,8 +19790,10 @@ void VCmpLtI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqI32Vop3::VCmpEqI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_eq_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_i32_e64_dpp"
+               : "v_cmp_eq_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqI32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -19088,8 +19841,10 @@ void VCmpEqI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeI32Vop3::VCmpLeI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_le_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_i32_e64_dpp"
+               : "v_cmp_le_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeI32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -19137,8 +19892,10 @@ void VCmpLeI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtI32Vop3::VCmpGtI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_gt_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_i32_e64_dpp"
+               : "v_cmp_gt_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtI32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -19186,8 +19943,10 @@ void VCmpGtI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeI32Vop3::VCmpNeI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ne_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_i32_e64_dpp"
+               : "v_cmp_ne_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeI32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -19235,8 +19994,10 @@ void VCmpNeI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeI32Vop3::VCmpGeI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ge_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_i32_e64_dpp"
+               : "v_cmp_ge_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeI32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -19284,8 +20045,10 @@ void VCmpGeI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtU32Vop3::VCmpLtU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lt_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_u32_e64_dpp"
+               : "v_cmp_lt_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtU32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -19333,8 +20096,10 @@ void VCmpLtU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqU32Vop3::VCmpEqU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_eq_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_u32_e64_dpp"
+               : "v_cmp_eq_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqU32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -19382,8 +20147,10 @@ void VCmpEqU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeU32Vop3::VCmpLeU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_le_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_u32_e64_dpp"
+               : "v_cmp_le_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeU32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -19431,8 +20198,10 @@ void VCmpLeU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtU32Vop3::VCmpGtU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_gt_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_u32_e64_dpp"
+               : "v_cmp_gt_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtU32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -19480,8 +20249,10 @@ void VCmpGtU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeU32Vop3::VCmpNeU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ne_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_u32_e64_dpp"
+               : "v_cmp_ne_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeU32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -19529,8 +20300,10 @@ void VCmpNeU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeU32Vop3::VCmpGeU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ge_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_u32_e64_dpp"
+               : "v_cmp_ge_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeU32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -19578,8 +20351,10 @@ void VCmpGeU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtI64Vop3::VCmpLtI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lt_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_i64_e64_dpp"
+               : "v_cmp_lt_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtI64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -19608,8 +20383,10 @@ void VCmpLtI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqI64Vop3::VCmpEqI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_eq_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_i64_e64_dpp"
+               : "v_cmp_eq_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqI64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -19638,8 +20415,10 @@ void VCmpEqI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeI64Vop3::VCmpLeI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_le_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_i64_e64_dpp"
+               : "v_cmp_le_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeI64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -19668,8 +20447,10 @@ void VCmpLeI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtI64Vop3::VCmpGtI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_gt_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_i64_e64_dpp"
+               : "v_cmp_gt_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtI64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -19698,8 +20479,10 @@ void VCmpGtI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeI64Vop3::VCmpNeI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ne_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_i64_e64_dpp"
+               : "v_cmp_ne_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeI64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -19728,8 +20511,10 @@ void VCmpNeI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeI64Vop3::VCmpGeI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ge_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_i64_e64_dpp"
+               : "v_cmp_ge_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeI64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -19758,8 +20543,10 @@ void VCmpGeI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtU64Vop3::VCmpLtU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_lt_u64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_u64_e64_dpp"
+               : "v_cmp_lt_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtU64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -19788,8 +20575,10 @@ void VCmpLtU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqU64Vop3::VCmpEqU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_eq_u64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_u64_e64_dpp"
+               : "v_cmp_eq_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqU64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -19818,8 +20607,10 @@ void VCmpEqU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeU64Vop3::VCmpLeU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_le_u64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_u64_e64_dpp"
+               : "v_cmp_le_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeU64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -19848,8 +20639,10 @@ void VCmpLeU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtU64Vop3::VCmpGtU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_gt_u64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_u64_e64_dpp"
+               : "v_cmp_gt_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtU64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -19878,8 +20671,10 @@ void VCmpGtU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeU64Vop3::VCmpNeU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ne_u64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_u64_e64_dpp"
+               : "v_cmp_ne_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeU64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -19908,8 +20703,10 @@ void VCmpNeU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeU64Vop3::VCmpGeU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_ge_u64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_u64_e64_dpp"
+               : "v_cmp_ge_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeU64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -19938,8 +20735,10 @@ void VCmpGeU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpClassF16Vop3::VCmpClassF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_class_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpClassF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_class_f16_e64_dpp"
+               : "v_cmp_class_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpClassF16Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -20068,8 +20867,10 @@ void VCmpClassF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpClassF32Vop3::VCmpClassF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_class_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpClassF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_class_f32_e64_dpp"
+               : "v_cmp_class_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpClassF32Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -20117,8 +20918,10 @@ void VCmpClassF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpClassF64Vop3::VCmpClassF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmp_class_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpClassF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_class_f64_e64_dpp"
+               : "v_cmp_class_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpClassF64Vop3>()),
       vdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -20146,8 +20949,10 @@ void VCmpClassF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtF16Vop3::VCmpxLtF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lt_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_f16_e64_dpp"
+               : "v_cmpx_lt_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -20230,8 +21035,10 @@ void VCmpxLtF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqF16Vop3::VCmpxEqF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_eq_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_f16_e64_dpp"
+               : "v_cmpx_eq_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -20314,8 +21121,10 @@ void VCmpxEqF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeF16Vop3::VCmpxLeF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_le_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_f16_e64_dpp"
+               : "v_cmpx_le_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -20398,8 +21207,10 @@ void VCmpxLeF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtF16Vop3::VCmpxGtF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_gt_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_f16_e64_dpp"
+               : "v_cmpx_gt_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -20482,8 +21293,10 @@ void VCmpxGtF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLgF16Vop3::VCmpxLgF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lg_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLgF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lg_f16_e64_dpp"
+               : "v_cmpx_lg_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLgF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -20566,8 +21379,10 @@ void VCmpxLgF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeF16Vop3::VCmpxGeF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ge_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_f16_e64_dpp"
+               : "v_cmpx_ge_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -20650,8 +21465,10 @@ void VCmpxGeF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxOF16Vop3::VCmpxOF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_o_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxOF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_o_f16_e64_dpp"
+               : "v_cmpx_o_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxOF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -20734,8 +21551,10 @@ void VCmpxOF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxUF16Vop3::VCmpxUF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_u_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxUF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_u_f16_e64_dpp"
+               : "v_cmpx_u_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxUF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -20818,8 +21637,10 @@ void VCmpxUF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNgeF16Vop3::VCmpxNgeF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nge_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNgeF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nge_f16_e64_dpp"
+               : "v_cmpx_nge_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNgeF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -20902,8 +21723,10 @@ void VCmpxNgeF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNlgF16Vop3::VCmpxNlgF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nlg_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNlgF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlg_f16_e64_dpp"
+               : "v_cmpx_nlg_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNlgF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -20986,8 +21809,10 @@ void VCmpxNlgF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNgtF16Vop3::VCmpxNgtF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ngt_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNgtF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ngt_f16_e64_dpp"
+               : "v_cmpx_ngt_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNgtF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21070,8 +21895,10 @@ void VCmpxNgtF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNleF16Vop3::VCmpxNleF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nle_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNleF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nle_f16_e64_dpp"
+               : "v_cmpx_nle_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNleF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21154,8 +21981,10 @@ void VCmpxNleF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeqF16Vop3::VCmpxNeqF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_neq_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeqF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_neq_f16_e64_dpp"
+               : "v_cmpx_neq_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeqF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21238,8 +22067,10 @@ void VCmpxNeqF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNltF16Vop3::VCmpxNltF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nlt_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNltF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlt_f16_e64_dpp"
+               : "v_cmpx_nlt_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNltF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21322,8 +22153,10 @@ void VCmpxNltF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtF32Vop3::VCmpxLtF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lt_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_f32_e64_dpp"
+               : "v_cmpx_lt_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21393,8 +22226,10 @@ void VCmpxLtF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqF32Vop3::VCmpxEqF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_eq_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_f32_e64_dpp"
+               : "v_cmpx_eq_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21464,8 +22299,10 @@ void VCmpxEqF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeF32Vop3::VCmpxLeF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_le_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_f32_e64_dpp"
+               : "v_cmpx_le_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21535,8 +22372,10 @@ void VCmpxLeF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtF32Vop3::VCmpxGtF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_gt_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_f32_e64_dpp"
+               : "v_cmpx_gt_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21606,8 +22445,10 @@ void VCmpxGtF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLgF32Vop3::VCmpxLgF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lg_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLgF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lg_f32_e64_dpp"
+               : "v_cmpx_lg_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLgF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21677,8 +22518,10 @@ void VCmpxLgF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeF32Vop3::VCmpxGeF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ge_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_f32_e64_dpp"
+               : "v_cmpx_ge_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21748,8 +22591,10 @@ void VCmpxGeF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxOF32Vop3::VCmpxOF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_o_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxOF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_o_f32_e64_dpp"
+               : "v_cmpx_o_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxOF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21819,8 +22664,10 @@ void VCmpxOF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxUF32Vop3::VCmpxUF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_u_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxUF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_u_f32_e64_dpp"
+               : "v_cmpx_u_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxUF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21890,8 +22737,10 @@ void VCmpxUF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNgeF32Vop3::VCmpxNgeF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nge_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNgeF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nge_f32_e64_dpp"
+               : "v_cmpx_nge_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNgeF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -21961,8 +22810,10 @@ void VCmpxNgeF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNlgF32Vop3::VCmpxNlgF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nlg_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNlgF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlg_f32_e64_dpp"
+               : "v_cmpx_nlg_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNlgF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22032,8 +22883,10 @@ void VCmpxNlgF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNgtF32Vop3::VCmpxNgtF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ngt_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNgtF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ngt_f32_e64_dpp"
+               : "v_cmpx_ngt_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNgtF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22103,8 +22956,10 @@ void VCmpxNgtF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNleF32Vop3::VCmpxNleF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nle_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNleF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nle_f32_e64_dpp"
+               : "v_cmpx_nle_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNleF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22174,8 +23029,10 @@ void VCmpxNleF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeqF32Vop3::VCmpxNeqF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_neq_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeqF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_neq_f32_e64_dpp"
+               : "v_cmpx_neq_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeqF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22245,8 +23102,10 @@ void VCmpxNeqF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNltF32Vop3::VCmpxNltF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nlt_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNltF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlt_f32_e64_dpp"
+               : "v_cmpx_nlt_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNltF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22316,8 +23175,10 @@ void VCmpxNltF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtF64Vop3::VCmpxLtF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lt_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_f64_e64_dpp"
+               : "v_cmpx_lt_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22368,8 +23229,10 @@ void VCmpxLtF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqF64Vop3::VCmpxEqF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_eq_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_f64_e64_dpp"
+               : "v_cmpx_eq_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22420,8 +23283,10 @@ void VCmpxEqF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeF64Vop3::VCmpxLeF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_le_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_f64_e64_dpp"
+               : "v_cmpx_le_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22472,8 +23337,10 @@ void VCmpxLeF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtF64Vop3::VCmpxGtF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_gt_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_f64_e64_dpp"
+               : "v_cmpx_gt_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22524,8 +23391,10 @@ void VCmpxGtF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLgF64Vop3::VCmpxLgF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lg_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLgF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lg_f64_e64_dpp"
+               : "v_cmpx_lg_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLgF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22576,8 +23445,10 @@ void VCmpxLgF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeF64Vop3::VCmpxGeF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ge_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_f64_e64_dpp"
+               : "v_cmpx_ge_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22628,8 +23499,10 @@ void VCmpxGeF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxOF64Vop3::VCmpxOF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_o_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxOF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_o_f64_e64_dpp"
+               : "v_cmpx_o_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxOF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22680,8 +23553,10 @@ void VCmpxOF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxUF64Vop3::VCmpxUF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_u_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxUF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_u_f64_e64_dpp"
+               : "v_cmpx_u_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxUF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22732,8 +23607,10 @@ void VCmpxUF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNgeF64Vop3::VCmpxNgeF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nge_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNgeF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nge_f64_e64_dpp"
+               : "v_cmpx_nge_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNgeF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22784,8 +23661,10 @@ void VCmpxNgeF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNlgF64Vop3::VCmpxNlgF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nlg_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNlgF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlg_f64_e64_dpp"
+               : "v_cmpx_nlg_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNlgF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22836,8 +23715,10 @@ void VCmpxNlgF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNgtF64Vop3::VCmpxNgtF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ngt_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNgtF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ngt_f64_e64_dpp"
+               : "v_cmpx_ngt_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNgtF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22888,8 +23769,10 @@ void VCmpxNgtF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNleF64Vop3::VCmpxNleF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nle_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNleF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nle_f64_e64_dpp"
+               : "v_cmpx_nle_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNleF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22940,8 +23823,10 @@ void VCmpxNleF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeqF64Vop3::VCmpxNeqF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_neq_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeqF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_neq_f64_e64_dpp"
+               : "v_cmpx_neq_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeqF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -22992,8 +23877,10 @@ void VCmpxNeqF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNltF64Vop3::VCmpxNltF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nlt_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNltF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlt_f64_e64_dpp"
+               : "v_cmpx_nlt_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNltF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23044,8 +23931,10 @@ void VCmpxNltF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtI16Vop3::VCmpxLtI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lt_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_i16_e64_dpp"
+               : "v_cmpx_lt_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtI16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23124,8 +24013,10 @@ void VCmpxLtI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqI16Vop3::VCmpxEqI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_eq_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_i16_e64_dpp"
+               : "v_cmpx_eq_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqI16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23204,8 +24095,10 @@ void VCmpxEqI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeI16Vop3::VCmpxLeI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_le_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_i16_e64_dpp"
+               : "v_cmpx_le_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeI16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23284,8 +24177,10 @@ void VCmpxLeI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtI16Vop3::VCmpxGtI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_gt_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_i16_e64_dpp"
+               : "v_cmpx_gt_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtI16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23364,8 +24259,10 @@ void VCmpxGtI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeI16Vop3::VCmpxNeI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ne_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_i16_e64_dpp"
+               : "v_cmpx_ne_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeI16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23444,8 +24341,10 @@ void VCmpxNeI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeI16Vop3::VCmpxGeI16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ge_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeI16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_i16_e64_dpp"
+               : "v_cmpx_ge_i16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeI16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23524,8 +24423,10 @@ void VCmpxGeI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtU16Vop3::VCmpxLtU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lt_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_u16_e64_dpp"
+               : "v_cmpx_lt_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtU16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23604,8 +24505,10 @@ void VCmpxLtU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqU16Vop3::VCmpxEqU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_eq_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_u16_e64_dpp"
+               : "v_cmpx_eq_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqU16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23684,8 +24587,10 @@ void VCmpxEqU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeU16Vop3::VCmpxLeU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_le_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_u16_e64_dpp"
+               : "v_cmpx_le_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeU16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23764,8 +24669,10 @@ void VCmpxLeU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtU16Vop3::VCmpxGtU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_gt_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_u16_e64_dpp"
+               : "v_cmpx_gt_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtU16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23844,8 +24751,10 @@ void VCmpxGtU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeU16Vop3::VCmpxNeU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ne_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_u16_e64_dpp"
+               : "v_cmpx_ne_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeU16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -23924,8 +24833,10 @@ void VCmpxNeU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeU16Vop3::VCmpxGeU16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ge_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeU16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_u16_e64_dpp"
+               : "v_cmpx_ge_u16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeU16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24004,8 +24915,10 @@ void VCmpxGeU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtI32Vop3::VCmpxLtI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lt_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_i32_e64_dpp"
+               : "v_cmpx_lt_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtI32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24067,8 +24980,10 @@ void VCmpxLtI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqI32Vop3::VCmpxEqI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_eq_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_i32_e64_dpp"
+               : "v_cmpx_eq_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqI32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24130,8 +25045,10 @@ void VCmpxEqI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeI32Vop3::VCmpxLeI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_le_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_i32_e64_dpp"
+               : "v_cmpx_le_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeI32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24193,8 +25110,10 @@ void VCmpxLeI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtI32Vop3::VCmpxGtI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_gt_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_i32_e64_dpp"
+               : "v_cmpx_gt_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtI32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24256,8 +25175,10 @@ void VCmpxGtI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeI32Vop3::VCmpxNeI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ne_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_i32_e64_dpp"
+               : "v_cmpx_ne_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeI32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24319,8 +25240,10 @@ void VCmpxNeI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeI32Vop3::VCmpxGeI32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ge_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeI32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_i32_e64_dpp"
+               : "v_cmpx_ge_i32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeI32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24382,8 +25305,10 @@ void VCmpxGeI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtU32Vop3::VCmpxLtU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lt_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_u32_e64_dpp"
+               : "v_cmpx_lt_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtU32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24445,8 +25370,10 @@ void VCmpxLtU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqU32Vop3::VCmpxEqU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_eq_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_u32_e64_dpp"
+               : "v_cmpx_eq_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqU32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24508,8 +25435,10 @@ void VCmpxEqU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeU32Vop3::VCmpxLeU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_le_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_u32_e64_dpp"
+               : "v_cmpx_le_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeU32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24571,8 +25500,10 @@ void VCmpxLeU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtU32Vop3::VCmpxGtU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_gt_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_u32_e64_dpp"
+               : "v_cmpx_gt_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtU32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24634,8 +25565,10 @@ void VCmpxGtU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeU32Vop3::VCmpxNeU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ne_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_u32_e64_dpp"
+               : "v_cmpx_ne_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeU32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24697,8 +25630,10 @@ void VCmpxNeU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeU32Vop3::VCmpxGeU32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ge_u32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeU32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_u32_e64_dpp"
+               : "v_cmpx_ge_u32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeU32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24760,8 +25695,10 @@ void VCmpxGeU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtI64Vop3::VCmpxLtI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lt_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_i64_e64_dpp"
+               : "v_cmpx_lt_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtI64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24804,8 +25741,10 @@ void VCmpxLtI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqI64Vop3::VCmpxEqI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_eq_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_i64_e64_dpp"
+               : "v_cmpx_eq_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqI64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24848,8 +25787,10 @@ void VCmpxEqI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeI64Vop3::VCmpxLeI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_le_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_i64_e64_dpp"
+               : "v_cmpx_le_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeI64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24892,8 +25833,10 @@ void VCmpxLeI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtI64Vop3::VCmpxGtI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_gt_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_i64_e64_dpp"
+               : "v_cmpx_gt_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtI64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24936,8 +25879,10 @@ void VCmpxGtI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeI64Vop3::VCmpxNeI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ne_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_i64_e64_dpp"
+               : "v_cmpx_ne_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeI64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -24980,8 +25925,10 @@ void VCmpxNeI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeI64Vop3::VCmpxGeI64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ge_i64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeI64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_i64_e64_dpp"
+               : "v_cmpx_ge_i64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeI64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -25024,8 +25971,10 @@ void VCmpxGeI64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtU64Vop3::VCmpxLtU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lt_u64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_u64_e64_dpp"
+               : "v_cmpx_lt_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtU64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -25068,8 +26017,10 @@ void VCmpxLtU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqU64Vop3::VCmpxEqU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_eq_u64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_u64_e64_dpp"
+               : "v_cmpx_eq_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqU64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -25112,8 +26063,10 @@ void VCmpxEqU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeU64Vop3::VCmpxLeU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_le_u64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_u64_e64_dpp"
+               : "v_cmpx_le_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeU64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -25156,8 +26109,10 @@ void VCmpxLeU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtU64Vop3::VCmpxGtU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_gt_u64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_u64_e64_dpp"
+               : "v_cmpx_gt_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtU64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -25200,8 +26155,10 @@ void VCmpxGtU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeU64Vop3::VCmpxNeU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ne_u64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_u64_e64_dpp"
+               : "v_cmpx_ne_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeU64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -25244,8 +26201,10 @@ void VCmpxNeU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeU64Vop3::VCmpxGeU64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ge_u64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeU64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_u64_e64_dpp"
+               : "v_cmpx_ge_u64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeU64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -25288,8 +26247,10 @@ void VCmpxGeU64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxClassF16Vop3::VCmpxClassF16Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_class_f16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxClassF16Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_class_f16_e64_dpp"
+               : "v_cmpx_class_f16",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxClassF16Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -25396,8 +26357,10 @@ void VCmpxClassF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxClassF32Vop3::VCmpxClassF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_class_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxClassF32Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_class_f32_e64_dpp"
+               : "v_cmpx_class_f32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxClassF32Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -25486,8 +26449,10 @@ void VCmpxClassF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxClassF64Vop3::VCmpxClassF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_class_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxClassF64Vop3>()),
+    : Vop3(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_class_f64_e64_dpp"
+               : "v_cmpx_class_f64",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxClassF64Vop3>()),
       vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -25558,7 +26523,10 @@ void VCmpxClassF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddCoCiU32Vop3SdstEnc::VAddCoCiU32Vop3SdstEnc(const MachineInst *inst)
-    : Vop3SdstEnc("v_add_co_ci_u32", reinterpret_cast<const OpEncoding *>(inst),
+    : Vop3SdstEnc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                      ? "v_add_co_ci_u32_e64_dpp"
+                      : "v_add_co_ci_u32",
+                  reinterpret_cast<const OpEncoding *>(inst),
                   make_exec_fn<VAddCoCiU32Vop3SdstEnc>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
@@ -25617,7 +26585,10 @@ void VAddCoCiU32Vop3SdstEnc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubCoCiU32Vop3SdstEnc::VSubCoCiU32Vop3SdstEnc(const MachineInst *inst)
-    : Vop3SdstEnc("v_sub_co_ci_u32", reinterpret_cast<const OpEncoding *>(inst),
+    : Vop3SdstEnc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                      ? "v_sub_co_ci_u32_e64_dpp"
+                      : "v_sub_co_ci_u32",
+                  reinterpret_cast<const OpEncoding *>(inst),
                   make_exec_fn<VSubCoCiU32Vop3SdstEnc>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
@@ -25676,7 +26647,10 @@ void VSubCoCiU32Vop3SdstEnc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubrevCoCiU32Vop3SdstEnc::VSubrevCoCiU32Vop3SdstEnc(const MachineInst *inst)
-    : Vop3SdstEnc("v_subrev_co_ci_u32", reinterpret_cast<const OpEncoding *>(inst),
+    : Vop3SdstEnc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                      ? "v_subrev_co_ci_u32_e64_dpp"
+                      : "v_subrev_co_ci_u32",
+                  reinterpret_cast<const OpEncoding *>(inst),
                   make_exec_fn<VSubrevCoCiU32Vop3SdstEnc>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
@@ -25735,7 +26709,10 @@ void VSubrevCoCiU32Vop3SdstEnc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDivScaleF32Vop3SdstEnc::VDivScaleF32Vop3SdstEnc(const MachineInst *inst)
-    : Vop3SdstEnc("v_div_scale_f32", reinterpret_cast<const OpEncoding *>(inst),
+    : Vop3SdstEnc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                      ? "v_div_scale_f32_e64_dpp"
+                      : "v_div_scale_f32",
+                  reinterpret_cast<const OpEncoding *>(inst),
                   make_exec_fn<VDivScaleF32Vop3SdstEnc>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
@@ -25771,7 +26748,10 @@ void VDivScaleF32Vop3SdstEnc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDivScaleF64Vop3SdstEnc::VDivScaleF64Vop3SdstEnc(const MachineInst *inst)
-    : Vop3SdstEnc("v_div_scale_f64", reinterpret_cast<const OpEncoding *>(inst),
+    : Vop3SdstEnc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                      ? "v_div_scale_f64_e64_dpp"
+                      : "v_div_scale_f64",
+                  reinterpret_cast<const OpEncoding *>(inst),
                   make_exec_fn<VDivScaleF64Vop3SdstEnc>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
@@ -25813,7 +26793,10 @@ void VDivScaleF64Vop3SdstEnc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMadCoU64U32Vop3SdstEnc::VMadCoU64U32Vop3SdstEnc(const MachineInst *inst)
-    : Vop3SdstEnc("v_mad_co_u64_u32", reinterpret_cast<const OpEncoding *>(inst),
+    : Vop3SdstEnc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                      ? "v_mad_co_u64_u32_e64_dpp"
+                      : "v_mad_co_u64_u32",
+                  reinterpret_cast<const OpEncoding *>(inst),
                   make_exec_fn<VMadCoU64U32Vop3SdstEnc>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
@@ -25851,7 +26834,10 @@ void VMadCoU64U32Vop3SdstEnc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VMadCoI64I32Vop3SdstEnc::VMadCoI64I32Vop3SdstEnc(const MachineInst *inst)
-    : Vop3SdstEnc("v_mad_co_i64_i32", reinterpret_cast<const OpEncoding *>(inst),
+    : Vop3SdstEnc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                      ? "v_mad_co_i64_i32_e64_dpp"
+                      : "v_mad_co_i64_i32",
+                  reinterpret_cast<const OpEncoding *>(inst),
                   make_exec_fn<VMadCoI64I32Vop3SdstEnc>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
@@ -25889,8 +26875,10 @@ void VMadCoI64I32Vop3SdstEnc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VAddCoU32Vop3SdstEnc::VAddCoU32Vop3SdstEnc(const MachineInst *inst)
-    : Vop3SdstEnc("v_add_co_u32", reinterpret_cast<const OpEncoding *>(inst),
-                  make_exec_fn<VAddCoU32Vop3SdstEnc>()),
+    : Vop3SdstEnc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                      ? "v_add_co_u32_e64_dpp"
+                      : "v_add_co_u32",
+                  reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAddCoU32Vop3SdstEnc>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -25940,8 +26928,10 @@ void VAddCoU32Vop3SdstEnc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubCoU32Vop3SdstEnc::VSubCoU32Vop3SdstEnc(const MachineInst *inst)
-    : Vop3SdstEnc("v_sub_co_u32", reinterpret_cast<const OpEncoding *>(inst),
-                  make_exec_fn<VSubCoU32Vop3SdstEnc>()),
+    : Vop3SdstEnc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                      ? "v_sub_co_u32_e64_dpp"
+                      : "v_sub_co_u32",
+                  reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubCoU32Vop3SdstEnc>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -25991,7 +26981,10 @@ void VSubCoU32Vop3SdstEnc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSubrevCoU32Vop3SdstEnc::VSubrevCoU32Vop3SdstEnc(const MachineInst *inst)
-    : Vop3SdstEnc("v_subrev_co_u32", reinterpret_cast<const OpEncoding *>(inst),
+    : Vop3SdstEnc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                      ? "v_subrev_co_u32_e64_dpp"
+                      : "v_subrev_co_u32",
+                  reinterpret_cast<const OpEncoding *>(inst),
                   make_exec_fn<VSubrevCoU32Vop3SdstEnc>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       sdst(64, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->sdst),

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vop3p.cpp
@@ -22,8 +22,10 @@ namespace rocjitsu {
 namespace rdna4 {
 
 VPkMadI16Vop3p::VPkMadI16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_mad_i16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkMadI16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_mad_i16_e64_dpp"
+                : "v_pk_mad_i16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkMadI16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -79,8 +81,10 @@ void VPkMadI16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkMulLoU16Vop3p::VPkMulLoU16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_mul_lo_u16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkMulLoU16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_mul_lo_u16_e64_dpp"
+                : "v_pk_mul_lo_u16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkMulLoU16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -125,8 +129,10 @@ void VPkMulLoU16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkAddI16Vop3p::VPkAddI16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_add_i16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkAddI16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_add_i16_e64_dpp"
+                : "v_pk_add_i16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkAddI16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -171,8 +177,10 @@ void VPkAddI16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkSubI16Vop3p::VPkSubI16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_sub_i16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkSubI16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_sub_i16_e64_dpp"
+                : "v_pk_sub_i16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkSubI16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -217,8 +225,10 @@ void VPkSubI16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkLshlrevB16Vop3p::VPkLshlrevB16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_lshlrev_b16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkLshlrevB16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_lshlrev_b16_e64_dpp"
+                : "v_pk_lshlrev_b16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkLshlrevB16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -263,8 +273,10 @@ void VPkLshlrevB16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkLshrrevB16Vop3p::VPkLshrrevB16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_lshrrev_b16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkLshrrevB16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_lshrrev_b16_e64_dpp"
+                : "v_pk_lshrrev_b16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkLshrrevB16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -309,8 +321,10 @@ void VPkLshrrevB16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkAshrrevI16Vop3p::VPkAshrrevI16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_ashrrev_i16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkAshrrevI16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_ashrrev_i16_e64_dpp"
+                : "v_pk_ashrrev_i16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkAshrrevI16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -355,8 +369,10 @@ void VPkAshrrevI16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkMaxI16Vop3p::VPkMaxI16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_max_i16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkMaxI16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_max_i16_e64_dpp"
+                : "v_pk_max_i16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkMaxI16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -401,8 +417,10 @@ void VPkMaxI16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkMinI16Vop3p::VPkMinI16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_min_i16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkMinI16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_min_i16_e64_dpp"
+                : "v_pk_min_i16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkMinI16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -447,8 +465,10 @@ void VPkMinI16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkMadU16Vop3p::VPkMadU16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_mad_u16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkMadU16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_mad_u16_e64_dpp"
+                : "v_pk_mad_u16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkMadU16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -504,8 +524,10 @@ void VPkMadU16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkAddU16Vop3p::VPkAddU16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_add_u16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkAddU16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_add_u16_e64_dpp"
+                : "v_pk_add_u16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkAddU16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -550,8 +572,10 @@ void VPkAddU16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkSubU16Vop3p::VPkSubU16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_sub_u16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkSubU16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_sub_u16_e64_dpp"
+                : "v_pk_sub_u16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkSubU16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -596,8 +620,10 @@ void VPkSubU16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkMaxU16Vop3p::VPkMaxU16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_max_u16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkMaxU16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_max_u16_e64_dpp"
+                : "v_pk_max_u16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkMaxU16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -642,8 +668,10 @@ void VPkMaxU16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkMinU16Vop3p::VPkMinU16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_min_u16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkMinU16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_min_u16_e64_dpp"
+                : "v_pk_min_u16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkMinU16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -688,8 +716,10 @@ void VPkMinU16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkFmaF16Vop3p::VPkFmaF16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_fma_f16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkFmaF16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_fma_f16_e64_dpp"
+                : "v_pk_fma_f16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkFmaF16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -765,8 +795,10 @@ void VPkFmaF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkAddF16Vop3p::VPkAddF16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_add_f16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkAddF16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_add_f16_e64_dpp"
+                : "v_pk_add_f16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkAddF16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -825,8 +857,10 @@ void VPkAddF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkMulF16Vop3p::VPkMulF16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_mul_f16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkMulF16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_mul_f16_e64_dpp"
+                : "v_pk_mul_f16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkMulF16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -885,8 +919,10 @@ void VPkMulF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDot2F32F16Vop3p::VDot2F32F16Vop3p(const MachineInst *inst)
-    : Vop3p("v_dot2_f32_f16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VDot2F32F16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_dot2_f32_f16_e64_dpp"
+                : "v_dot2_f32_f16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDot2F32F16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -969,8 +1005,10 @@ void VDot2F32F16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDot4I32Iu8Vop3p::VDot4I32Iu8Vop3p(const MachineInst *inst)
-    : Vop3p("v_dot4_i32_iu8", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VDot4I32Iu8Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_dot4_i32_iu8_e64_dpp"
+                : "v_dot4_i32_iu8",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDot4I32Iu8Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1027,8 +1065,10 @@ void VDot4I32Iu8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDot4U32U8Vop3p::VDot4U32U8Vop3p(const MachineInst *inst)
-    : Vop3p("v_dot4_u32_u8", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VDot4U32U8Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_dot4_u32_u8_e64_dpp"
+                : "v_dot4_u32_u8",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDot4U32U8Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1075,8 +1115,10 @@ void VDot4U32U8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDot8I32Iu4Vop3p::VDot8I32Iu4Vop3p(const MachineInst *inst)
-    : Vop3p("v_dot8_i32_iu4", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VDot8I32Iu4Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_dot8_i32_iu4_e64_dpp"
+                : "v_dot8_i32_iu4",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDot8I32Iu4Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1133,8 +1175,10 @@ void VDot8I32Iu4Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDot8U32U4Vop3p::VDot8U32U4Vop3p(const MachineInst *inst)
-    : Vop3p("v_dot8_u32_u4", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VDot8U32U4Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_dot8_u32_u4_e64_dpp"
+                : "v_dot8_u32_u4",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDot8U32U4Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1181,8 +1225,10 @@ void VDot8U32U4Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDot2F32Bf16Vop3p::VDot2F32Bf16Vop3p(const MachineInst *inst)
-    : Vop3p("v_dot2_f32_bf16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VDot2F32Bf16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_dot2_f32_bf16_e64_dpp"
+                : "v_dot2_f32_bf16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDot2F32Bf16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1265,8 +1311,10 @@ void VDot2F32Bf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkMinNumF16Vop3p::VPkMinNumF16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_min_num_f16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkMinNumF16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_min_num_f16_e64_dpp"
+                : "v_pk_min_num_f16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkMinNumF16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1325,8 +1373,10 @@ void VPkMinNumF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkMaxNumF16Vop3p::VPkMaxNumF16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_max_num_f16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkMaxNumF16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_max_num_f16_e64_dpp"
+                : "v_pk_max_num_f16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkMaxNumF16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1385,8 +1435,10 @@ void VPkMaxNumF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkMinimumF16Vop3p::VPkMinimumF16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_minimum_f16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkMinimumF16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_minimum_f16_e64_dpp"
+                : "v_pk_minimum_f16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkMinimumF16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1445,8 +1497,10 @@ void VPkMinimumF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VPkMaximumF16Vop3p::VPkMaximumF16Vop3p(const MachineInst *inst)
-    : Vop3p("v_pk_maximum_f16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VPkMaximumF16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_pk_maximum_f16_e64_dpp"
+                : "v_pk_maximum_f16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VPkMaximumF16Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
@@ -1505,8 +1559,10 @@ void VPkMaximumF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmaMixF32Vop3p::VFmaMixF32Vop3p(const MachineInst *inst)
-    : Vop3p("v_fma_mix_f32", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VFmaMixF32Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_fma_mix_f32_e64_dpp"
+                : "v_fma_mix_f32",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmaMixF32Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1595,8 +1651,10 @@ void VFmaMixF32Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmaMixloF16Vop3p::VFmaMixloF16Vop3p(const MachineInst *inst)
-    : Vop3p("v_fma_mixlo_f16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VFmaMixloF16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_fma_mixlo_f16_e64_dpp"
+                : "v_fma_mixlo_f16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmaMixloF16Vop3p>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1693,8 +1751,10 @@ void VFmaMixloF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VFmaMixhiF16Vop3p::VFmaMixhiF16Vop3p(const MachineInst *inst)
-    : Vop3p("v_fma_mixhi_f16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VFmaMixhiF16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_fma_mixhi_f16_e64_dpp"
+                : "v_fma_mixhi_f16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmaMixhiF16Vop3p>()),
       vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1791,8 +1851,10 @@ void VFmaMixhiF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDot4F32Fp8Bf8Vop3p::VDot4F32Fp8Bf8Vop3p(const MachineInst *inst)
-    : Vop3p("v_dot4_f32_fp8_bf8", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VDot4F32Fp8Bf8Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_dot4_f32_fp8_bf8_e64_dpp"
+                : "v_dot4_f32_fp8_bf8",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDot4F32Fp8Bf8Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1838,8 +1900,10 @@ void VDot4F32Fp8Bf8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDot4F32Bf8Fp8Vop3p::VDot4F32Bf8Fp8Vop3p(const MachineInst *inst)
-    : Vop3p("v_dot4_f32_bf8_fp8", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VDot4F32Bf8Fp8Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_dot4_f32_bf8_fp8_e64_dpp"
+                : "v_dot4_f32_bf8_fp8",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDot4F32Bf8Fp8Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1885,8 +1949,10 @@ void VDot4F32Bf8Fp8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDot4F32Fp8Fp8Vop3p::VDot4F32Fp8Fp8Vop3p(const MachineInst *inst)
-    : Vop3p("v_dot4_f32_fp8_fp8", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VDot4F32Fp8Fp8Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_dot4_f32_fp8_fp8_e64_dpp"
+                : "v_dot4_f32_fp8_fp8",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDot4F32Fp8Fp8Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1932,8 +1998,10 @@ void VDot4F32Fp8Fp8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VDot4F32Bf8Bf8Vop3p::VDot4F32Bf8Bf8Vop3p(const MachineInst *inst)
-    : Vop3p("v_dot4_f32_bf8_bf8", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VDot4F32Bf8Bf8Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_dot4_f32_bf8_bf8_e64_dpp"
+                : "v_dot4_f32_bf8_bf8",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VDot4F32Bf8Bf8Vop3p>()),
       vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -1979,8 +2047,10 @@ void VDot4F32Bf8Bf8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VWmmaF3216x16x16F16Vop3p::VWmmaF3216x16x16F16Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_f32_16x16x16_f16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VWmmaF3216x16x16F16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_f32_16x16x16_f16_e64_dpp"
+                : "v_wmma_f32_16x16x16_f16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VWmmaF3216x16x16F16Vop3p>()),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2023,8 +2093,10 @@ void VWmmaF3216x16x16F16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VWmmaF3216x16x16Bf16Vop3p::VWmmaF3216x16x16Bf16Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_f32_16x16x16_bf16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VWmmaF3216x16x16Bf16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_f32_16x16x16_bf16_e64_dpp"
+                : "v_wmma_f32_16x16x16_bf16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VWmmaF3216x16x16Bf16Vop3p>()),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2067,8 +2139,10 @@ void VWmmaF3216x16x16Bf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VWmmaF1616x16x16F16Vop3p::VWmmaF1616x16x16F16Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_f16_16x16x16_f16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VWmmaF1616x16x16F16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_f16_16x16x16_f16_e64_dpp"
+                : "v_wmma_f16_16x16x16_f16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VWmmaF1616x16x16F16Vop3p>()),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2110,8 +2184,10 @@ void VWmmaF1616x16x16F16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VWmmaBf1616x16x16Bf16Vop3p::VWmmaBf1616x16x16Bf16Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_bf16_16x16x16_bf16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VWmmaBf1616x16x16Bf16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_bf16_16x16x16_bf16_e64_dpp"
+                : "v_wmma_bf16_16x16x16_bf16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VWmmaBf1616x16x16Bf16Vop3p>()),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2153,8 +2229,10 @@ void VWmmaBf1616x16x16Bf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VWmmaI3216x16x16Iu8Vop3p::VWmmaI3216x16x16Iu8Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_i32_16x16x16_iu8", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VWmmaI3216x16x16Iu8Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_i32_16x16x16_iu8_e64_dpp"
+                : "v_wmma_i32_16x16x16_iu8",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VWmmaI3216x16x16Iu8Vop3p>()),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2206,8 +2284,10 @@ void VWmmaI3216x16x16Iu8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VWmmaI3216x16x16Iu4Vop3p::VWmmaI3216x16x16Iu4Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_i32_16x16x16_iu4", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VWmmaI3216x16x16Iu4Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_i32_16x16x16_iu4_e64_dpp"
+                : "v_wmma_i32_16x16x16_iu4",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VWmmaI3216x16x16Iu4Vop3p>()),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2257,7 +2337,10 @@ void VWmmaI3216x16x16Iu4Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VWmmaF3216x16x16Fp8Fp8Vop3p::VWmmaF3216x16x16Fp8Fp8Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_f32_16x16x16_fp8_fp8", reinterpret_cast<const OpEncoding *>(inst),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_f32_16x16x16_fp8_fp8_e64_dpp"
+                : "v_wmma_f32_16x16x16_fp8_fp8",
+            reinterpret_cast<const OpEncoding *>(inst),
             make_exec_fn<VWmmaF3216x16x16Fp8Fp8Vop3p>()),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -2303,7 +2386,10 @@ void VWmmaF3216x16x16Fp8Fp8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VWmmaF3216x16x16Fp8Bf8Vop3p::VWmmaF3216x16x16Fp8Bf8Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_f32_16x16x16_fp8_bf8", reinterpret_cast<const OpEncoding *>(inst),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_f32_16x16x16_fp8_bf8_e64_dpp"
+                : "v_wmma_f32_16x16x16_fp8_bf8",
+            reinterpret_cast<const OpEncoding *>(inst),
             make_exec_fn<VWmmaF3216x16x16Fp8Bf8Vop3p>()),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -2349,7 +2435,10 @@ void VWmmaF3216x16x16Fp8Bf8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VWmmaF3216x16x16Bf8Fp8Vop3p::VWmmaF3216x16x16Bf8Fp8Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_f32_16x16x16_bf8_fp8", reinterpret_cast<const OpEncoding *>(inst),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_f32_16x16x16_bf8_fp8_e64_dpp"
+                : "v_wmma_f32_16x16x16_bf8_fp8",
+            reinterpret_cast<const OpEncoding *>(inst),
             make_exec_fn<VWmmaF3216x16x16Bf8Fp8Vop3p>()),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -2395,7 +2484,10 @@ void VWmmaF3216x16x16Bf8Fp8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VWmmaF3216x16x16Bf8Bf8Vop3p::VWmmaF3216x16x16Bf8Bf8Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_f32_16x16x16_bf8_bf8", reinterpret_cast<const OpEncoding *>(inst),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_f32_16x16x16_bf8_bf8_e64_dpp"
+                : "v_wmma_f32_16x16x16_bf8_bf8",
+            reinterpret_cast<const OpEncoding *>(inst),
             make_exec_fn<VWmmaF3216x16x16Bf8Bf8Vop3p>()),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -2441,8 +2533,10 @@ void VWmmaF3216x16x16Bf8Bf8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VWmmaI3216x16x32Iu4Vop3p::VWmmaI3216x16x32Iu4Vop3p(const MachineInst *inst)
-    : Vop3p("v_wmma_i32_16x16x32_iu4", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VWmmaI3216x16x32Iu4Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_wmma_i32_16x16x32_iu4_e64_dpp"
+                : "v_wmma_i32_16x16x32_iu4",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VWmmaI3216x16x32Iu4Vop3p>()),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2494,8 +2588,10 @@ void VWmmaI3216x16x32Iu4Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSwmmacF3216x16x32F16Vop3p::VSwmmacF3216x16x32F16Vop3p(const MachineInst *inst)
-    : Vop3p("v_swmmac_f32_16x16x32_f16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VSwmmacF3216x16x32F16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_swmmac_f32_16x16x32_f16_e64_dpp"
+                : "v_swmmac_f32_16x16x32_f16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSwmmacF3216x16x32F16Vop3p>()),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2538,7 +2634,10 @@ void VSwmmacF3216x16x32F16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSwmmacF3216x16x32Bf16Vop3p::VSwmmacF3216x16x32Bf16Vop3p(const MachineInst *inst)
-    : Vop3p("v_swmmac_f32_16x16x32_bf16", reinterpret_cast<const OpEncoding *>(inst),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_swmmac_f32_16x16x32_bf16_e64_dpp"
+                : "v_swmmac_f32_16x16x32_bf16",
+            reinterpret_cast<const OpEncoding *>(inst),
             make_exec_fn<VSwmmacF3216x16x32Bf16Vop3p>()),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -2582,8 +2681,10 @@ void VSwmmacF3216x16x32Bf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSwmmacF1616x16x32F16Vop3p::VSwmmacF1616x16x32F16Vop3p(const MachineInst *inst)
-    : Vop3p("v_swmmac_f16_16x16x32_f16", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VSwmmacF1616x16x32F16Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_swmmac_f16_16x16x32_f16_e64_dpp"
+                : "v_swmmac_f16_16x16x32_f16",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSwmmacF1616x16x32F16Vop3p>()),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(256, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2626,7 +2727,10 @@ void VSwmmacF1616x16x32F16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSwmmacBf1616x16x32Bf16Vop3p::VSwmmacBf1616x16x32Bf16Vop3p(const MachineInst *inst)
-    : Vop3p("v_swmmac_bf16_16x16x32_bf16", reinterpret_cast<const OpEncoding *>(inst),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_swmmac_bf16_16x16x32_bf16_e64_dpp"
+                : "v_swmmac_bf16_16x16x32_bf16",
+            reinterpret_cast<const OpEncoding *>(inst),
             make_exec_fn<VSwmmacBf1616x16x32Bf16Vop3p>()),
       vdst(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -2671,8 +2775,10 @@ void VSwmmacBf1616x16x32Bf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSwmmacI3216x16x32Iu8Vop3p::VSwmmacI3216x16x32Iu8Vop3p(const MachineInst *inst)
-    : Vop3p("v_swmmac_i32_16x16x32_iu8", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VSwmmacI3216x16x32Iu8Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_swmmac_i32_16x16x32_iu8_e64_dpp"
+                : "v_swmmac_i32_16x16x32_iu8",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSwmmacI3216x16x32Iu8Vop3p>()),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2724,8 +2830,10 @@ void VSwmmacI3216x16x32Iu8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSwmmacI3216x16x32Iu4Vop3p::VSwmmacI3216x16x32Iu4Vop3p(const MachineInst *inst)
-    : Vop3p("v_swmmac_i32_16x16x32_iu4", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VSwmmacI3216x16x32Iu4Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_swmmac_i32_16x16x32_iu4_e64_dpp"
+                : "v_swmmac_i32_16x16x32_iu4",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSwmmacI3216x16x32Iu4Vop3p>()),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(32, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(64, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2777,8 +2885,10 @@ void VSwmmacI3216x16x32Iu4Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSwmmacI3216x16x64Iu4Vop3p::VSwmmacI3216x16x64Iu4Vop3p(const MachineInst *inst)
-    : Vop3p("v_swmmac_i32_16x16x64_iu4", reinterpret_cast<const OpEncoding *>(inst),
-            make_exec_fn<VSwmmacI3216x16x64Iu4Vop3p>()),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_swmmac_i32_16x16x64_iu4_e64_dpp"
+                : "v_swmmac_i32_16x16x64_iu4",
+            reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSwmmacI3216x16x64Iu4Vop3p>()),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
       src1(128, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src1),
@@ -2830,7 +2940,10 @@ void VSwmmacI3216x16x64Iu4Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSwmmacF3216x16x32Fp8Fp8Vop3p::VSwmmacF3216x16x32Fp8Fp8Vop3p(const MachineInst *inst)
-    : Vop3p("v_swmmac_f32_16x16x32_fp8_fp8", reinterpret_cast<const OpEncoding *>(inst),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_swmmac_f32_16x16x32_fp8_fp8_e64_dpp"
+                : "v_swmmac_f32_16x16x32_fp8_fp8",
+            reinterpret_cast<const OpEncoding *>(inst),
             make_exec_fn<VSwmmacF3216x16x32Fp8Fp8Vop3p>()),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -2875,7 +2988,10 @@ void VSwmmacF3216x16x32Fp8Fp8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSwmmacF3216x16x32Fp8Bf8Vop3p::VSwmmacF3216x16x32Fp8Bf8Vop3p(const MachineInst *inst)
-    : Vop3p("v_swmmac_f32_16x16x32_fp8_bf8", reinterpret_cast<const OpEncoding *>(inst),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_swmmac_f32_16x16x32_fp8_bf8_e64_dpp"
+                : "v_swmmac_f32_16x16x32_fp8_bf8",
+            reinterpret_cast<const OpEncoding *>(inst),
             make_exec_fn<VSwmmacF3216x16x32Fp8Bf8Vop3p>()),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -2920,7 +3036,10 @@ void VSwmmacF3216x16x32Fp8Bf8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSwmmacF3216x16x32Bf8Fp8Vop3p::VSwmmacF3216x16x32Bf8Fp8Vop3p(const MachineInst *inst)
-    : Vop3p("v_swmmac_f32_16x16x32_bf8_fp8", reinterpret_cast<const OpEncoding *>(inst),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_swmmac_f32_16x16x32_bf8_fp8_e64_dpp"
+                : "v_swmmac_f32_16x16x32_bf8_fp8",
+            reinterpret_cast<const OpEncoding *>(inst),
             make_exec_fn<VSwmmacF3216x16x32Bf8Fp8Vop3p>()),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),
@@ -2965,7 +3084,10 @@ void VSwmmacF3216x16x32Bf8Fp8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VSwmmacF3216x16x32Bf8Bf8Vop3p::VSwmmacF3216x16x32Bf8Bf8Vop3p(const MachineInst *inst)
-    : Vop3p("v_swmmac_f32_16x16x32_bf8_bf8", reinterpret_cast<const OpEncoding *>(inst),
+    : Vop3p(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+                ? "v_swmmac_f32_16x16x32_bf8_bf8_e64_dpp"
+                : "v_swmmac_f32_16x16x32_bf8_bf8",
+            reinterpret_cast<const OpEncoding *>(inst),
             make_exec_fn<VSwmmacF3216x16x32Bf8Bf8Vop3p>()),
       vdst(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
       src0(64, OperandType::OPR_SRC_VGPR, reinterpret_cast<const OpEncoding *>(inst)->src0),

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vopc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vopc.cpp
@@ -22,8 +22,10 @@ namespace rocjitsu {
 namespace rdna4 {
 
 VCmpLtF16Vopc::VCmpLtF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lt_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_f16_dpp"
+               : "v_cmp_lt_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -82,8 +84,10 @@ void VCmpLtF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqF16Vopc::VCmpEqF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_eq_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_f16_dpp"
+               : "v_cmp_eq_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -142,8 +146,10 @@ void VCmpEqF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeF16Vopc::VCmpLeF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_le_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_f16_dpp"
+               : "v_cmp_le_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -202,8 +208,10 @@ void VCmpLeF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtF16Vopc::VCmpGtF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_gt_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_f16_dpp"
+               : "v_cmp_gt_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -262,8 +270,10 @@ void VCmpGtF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLgF16Vopc::VCmpLgF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lg_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLgF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lg_f16_dpp"
+               : "v_cmp_lg_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLgF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -322,8 +332,10 @@ void VCmpLgF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeF16Vopc::VCmpGeF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ge_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_f16_dpp"
+               : "v_cmp_ge_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -382,8 +394,10 @@ void VCmpGeF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpOF16Vopc::VCmpOF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_o_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpOF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_o_f16_dpp"
+               : "v_cmp_o_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpOF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -442,8 +456,10 @@ void VCmpOF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpUF16Vopc::VCmpUF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_u_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpUF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_u_f16_dpp"
+               : "v_cmp_u_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpUF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -502,8 +518,10 @@ void VCmpUF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNgeF16Vopc::VCmpNgeF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nge_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNgeF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nge_f16_dpp"
+               : "v_cmp_nge_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNgeF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -562,8 +580,10 @@ void VCmpNgeF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNlgF16Vopc::VCmpNlgF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nlg_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNlgF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlg_f16_dpp"
+               : "v_cmp_nlg_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNlgF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -622,8 +642,10 @@ void VCmpNlgF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNgtF16Vopc::VCmpNgtF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ngt_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNgtF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ngt_f16_dpp"
+               : "v_cmp_ngt_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNgtF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -682,8 +704,10 @@ void VCmpNgtF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNleF16Vopc::VCmpNleF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nle_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNleF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nle_f16_dpp"
+               : "v_cmp_nle_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNleF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -742,8 +766,10 @@ void VCmpNleF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeqF16Vopc::VCmpNeqF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_neq_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeqF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_neq_f16_dpp"
+               : "v_cmp_neq_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeqF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -802,8 +828,10 @@ void VCmpNeqF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNltF16Vopc::VCmpNltF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nlt_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNltF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlt_f16_dpp"
+               : "v_cmp_nlt_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNltF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -862,8 +890,10 @@ void VCmpNltF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtF32Vopc::VCmpLtF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lt_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_f32_dpp"
+               : "v_cmp_lt_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -919,8 +949,10 @@ void VCmpLtF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqF32Vopc::VCmpEqF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_eq_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_f32_dpp"
+               : "v_cmp_eq_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -976,8 +1008,10 @@ void VCmpEqF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeF32Vopc::VCmpLeF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_le_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_f32_dpp"
+               : "v_cmp_le_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1033,8 +1067,10 @@ void VCmpLeF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtF32Vopc::VCmpGtF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_gt_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_f32_dpp"
+               : "v_cmp_gt_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1090,8 +1126,10 @@ void VCmpGtF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLgF32Vopc::VCmpLgF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lg_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLgF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lg_f32_dpp"
+               : "v_cmp_lg_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLgF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1147,8 +1185,10 @@ void VCmpLgF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeF32Vopc::VCmpGeF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ge_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_f32_dpp"
+               : "v_cmp_ge_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1204,8 +1244,10 @@ void VCmpGeF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpOF32Vopc::VCmpOF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_o_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpOF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_o_f32_dpp"
+               : "v_cmp_o_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpOF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1261,8 +1303,10 @@ void VCmpOF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpUF32Vopc::VCmpUF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_u_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpUF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_u_f32_dpp"
+               : "v_cmp_u_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpUF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1318,8 +1362,10 @@ void VCmpUF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNgeF32Vopc::VCmpNgeF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nge_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNgeF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nge_f32_dpp"
+               : "v_cmp_nge_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNgeF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1375,8 +1421,10 @@ void VCmpNgeF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNlgF32Vopc::VCmpNlgF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nlg_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNlgF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlg_f32_dpp"
+               : "v_cmp_nlg_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNlgF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1432,8 +1480,10 @@ void VCmpNlgF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNgtF32Vopc::VCmpNgtF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ngt_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNgtF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ngt_f32_dpp"
+               : "v_cmp_ngt_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNgtF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1489,8 +1539,10 @@ void VCmpNgtF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNleF32Vopc::VCmpNleF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nle_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNleF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nle_f32_dpp"
+               : "v_cmp_nle_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNleF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1546,8 +1598,10 @@ void VCmpNleF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeqF32Vopc::VCmpNeqF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_neq_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeqF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_neq_f32_dpp"
+               : "v_cmp_neq_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeqF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1603,8 +1657,10 @@ void VCmpNeqF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNltF32Vopc::VCmpNltF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nlt_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNltF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlt_f32_dpp"
+               : "v_cmp_nlt_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNltF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1660,8 +1716,10 @@ void VCmpNltF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtF64Vopc::VCmpLtF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lt_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_f64_dpp"
+               : "v_cmp_lt_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1686,8 +1744,10 @@ void VCmpLtF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqF64Vopc::VCmpEqF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_eq_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_f64_dpp"
+               : "v_cmp_eq_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1712,8 +1772,10 @@ void VCmpEqF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeF64Vopc::VCmpLeF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_le_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_f64_dpp"
+               : "v_cmp_le_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1738,8 +1800,10 @@ void VCmpLeF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtF64Vopc::VCmpGtF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_gt_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_f64_dpp"
+               : "v_cmp_gt_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1764,8 +1828,10 @@ void VCmpGtF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLgF64Vopc::VCmpLgF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lg_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLgF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lg_f64_dpp"
+               : "v_cmp_lg_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLgF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1790,8 +1856,10 @@ void VCmpLgF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeF64Vopc::VCmpGeF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ge_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_f64_dpp"
+               : "v_cmp_ge_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1816,8 +1884,10 @@ void VCmpGeF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpOF64Vopc::VCmpOF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_o_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpOF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_o_f64_dpp"
+               : "v_cmp_o_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpOF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1842,8 +1912,10 @@ void VCmpOF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpUF64Vopc::VCmpUF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_u_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpUF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_u_f64_dpp"
+               : "v_cmp_u_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpUF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1868,8 +1940,10 @@ void VCmpUF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNgeF64Vopc::VCmpNgeF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nge_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNgeF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nge_f64_dpp"
+               : "v_cmp_nge_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNgeF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1894,8 +1968,10 @@ void VCmpNgeF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNlgF64Vopc::VCmpNlgF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nlg_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNlgF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlg_f64_dpp"
+               : "v_cmp_nlg_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNlgF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1920,8 +1996,10 @@ void VCmpNlgF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNgtF64Vopc::VCmpNgtF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ngt_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNgtF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ngt_f64_dpp"
+               : "v_cmp_ngt_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNgtF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1946,8 +2024,10 @@ void VCmpNgtF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNleF64Vopc::VCmpNleF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nle_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNleF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nle_f64_dpp"
+               : "v_cmp_nle_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNleF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1972,8 +2052,10 @@ void VCmpNleF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeqF64Vopc::VCmpNeqF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_neq_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeqF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_neq_f64_dpp"
+               : "v_cmp_neq_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeqF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -1998,8 +2080,10 @@ void VCmpNeqF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNltF64Vopc::VCmpNltF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_nlt_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNltF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_nlt_f64_dpp"
+               : "v_cmp_nlt_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNltF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2024,8 +2108,10 @@ void VCmpNltF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtI16Vopc::VCmpLtI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lt_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtI16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_i16_dpp"
+               : "v_cmp_lt_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtI16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2084,8 +2170,10 @@ void VCmpLtI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqI16Vopc::VCmpEqI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_eq_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqI16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_i16_dpp"
+               : "v_cmp_eq_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqI16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2144,8 +2232,10 @@ void VCmpEqI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeI16Vopc::VCmpLeI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_le_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeI16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_i16_dpp"
+               : "v_cmp_le_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeI16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2204,8 +2294,10 @@ void VCmpLeI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtI16Vopc::VCmpGtI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_gt_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtI16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_i16_dpp"
+               : "v_cmp_gt_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtI16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2264,8 +2356,10 @@ void VCmpGtI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeI16Vopc::VCmpNeI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ne_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeI16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_i16_dpp"
+               : "v_cmp_ne_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeI16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2324,8 +2418,10 @@ void VCmpNeI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeI16Vopc::VCmpGeI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ge_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeI16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_i16_dpp"
+               : "v_cmp_ge_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeI16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2384,8 +2480,10 @@ void VCmpGeI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtU16Vopc::VCmpLtU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lt_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtU16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_u16_dpp"
+               : "v_cmp_lt_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtU16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2444,8 +2542,10 @@ void VCmpLtU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqU16Vopc::VCmpEqU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_eq_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqU16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_u16_dpp"
+               : "v_cmp_eq_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqU16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2504,8 +2604,10 @@ void VCmpEqU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeU16Vopc::VCmpLeU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_le_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeU16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_u16_dpp"
+               : "v_cmp_le_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeU16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2564,8 +2666,10 @@ void VCmpLeU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtU16Vopc::VCmpGtU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_gt_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtU16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_u16_dpp"
+               : "v_cmp_gt_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtU16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2624,8 +2728,10 @@ void VCmpGtU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeU16Vopc::VCmpNeU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ne_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeU16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_u16_dpp"
+               : "v_cmp_ne_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeU16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2684,8 +2790,10 @@ void VCmpNeU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeU16Vopc::VCmpGeU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ge_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeU16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_u16_dpp"
+               : "v_cmp_ge_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeU16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -2744,8 +2852,10 @@ void VCmpGeU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtI32Vopc::VCmpLtI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lt_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_i32_dpp"
+               : "v_cmp_lt_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtI32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2801,8 +2911,10 @@ void VCmpLtI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqI32Vopc::VCmpEqI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_eq_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_i32_dpp"
+               : "v_cmp_eq_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqI32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2858,8 +2970,10 @@ void VCmpEqI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeI32Vopc::VCmpLeI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_le_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_i32_dpp"
+               : "v_cmp_le_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeI32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2915,8 +3029,10 @@ void VCmpLeI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtI32Vopc::VCmpGtI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_gt_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_i32_dpp"
+               : "v_cmp_gt_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtI32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -2972,8 +3088,10 @@ void VCmpGtI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeI32Vopc::VCmpNeI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ne_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_i32_dpp"
+               : "v_cmp_ne_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeI32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3029,8 +3147,10 @@ void VCmpNeI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeI32Vopc::VCmpGeI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ge_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_i32_dpp"
+               : "v_cmp_ge_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeI32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3086,8 +3206,10 @@ void VCmpGeI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtU32Vopc::VCmpLtU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lt_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_u32_dpp"
+               : "v_cmp_lt_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtU32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3143,8 +3265,10 @@ void VCmpLtU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqU32Vopc::VCmpEqU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_eq_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_u32_dpp"
+               : "v_cmp_eq_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqU32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3200,8 +3324,10 @@ void VCmpEqU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeU32Vopc::VCmpLeU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_le_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_u32_dpp"
+               : "v_cmp_le_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeU32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3257,8 +3383,10 @@ void VCmpLeU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtU32Vopc::VCmpGtU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_gt_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_u32_dpp"
+               : "v_cmp_gt_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtU32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3314,8 +3442,10 @@ void VCmpGtU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeU32Vopc::VCmpNeU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ne_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_u32_dpp"
+               : "v_cmp_ne_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeU32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3371,8 +3501,10 @@ void VCmpNeU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeU32Vopc::VCmpGeU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ge_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_u32_dpp"
+               : "v_cmp_ge_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeU32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3428,8 +3560,10 @@ void VCmpGeU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtI64Vopc::VCmpLtI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lt_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_i64_dpp"
+               : "v_cmp_lt_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtI64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3454,8 +3588,10 @@ void VCmpLtI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqI64Vopc::VCmpEqI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_eq_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_i64_dpp"
+               : "v_cmp_eq_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqI64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3480,8 +3616,10 @@ void VCmpEqI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeI64Vopc::VCmpLeI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_le_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_i64_dpp"
+               : "v_cmp_le_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeI64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3506,8 +3644,10 @@ void VCmpLeI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtI64Vopc::VCmpGtI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_gt_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_i64_dpp"
+               : "v_cmp_gt_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtI64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3532,8 +3672,10 @@ void VCmpGtI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeI64Vopc::VCmpNeI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ne_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_i64_dpp"
+               : "v_cmp_ne_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeI64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3558,8 +3700,10 @@ void VCmpNeI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeI64Vopc::VCmpGeI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ge_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_i64_dpp"
+               : "v_cmp_ge_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeI64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3584,8 +3728,10 @@ void VCmpGeI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLtU64Vopc::VCmpLtU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_lt_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLtU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_lt_u64_dpp"
+               : "v_cmp_lt_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLtU64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3610,8 +3756,10 @@ void VCmpLtU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpEqU64Vopc::VCmpEqU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_eq_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpEqU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_eq_u64_dpp"
+               : "v_cmp_eq_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpEqU64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3636,8 +3784,10 @@ void VCmpEqU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpLeU64Vopc::VCmpLeU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_le_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpLeU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_le_u64_dpp"
+               : "v_cmp_le_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpLeU64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3662,8 +3812,10 @@ void VCmpLeU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGtU64Vopc::VCmpGtU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_gt_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGtU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_gt_u64_dpp"
+               : "v_cmp_gt_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGtU64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3688,8 +3840,10 @@ void VCmpGtU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpNeU64Vopc::VCmpNeU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ne_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpNeU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ne_u64_dpp"
+               : "v_cmp_ne_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpNeU64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3714,8 +3868,10 @@ void VCmpNeU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpGeU64Vopc::VCmpGeU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_ge_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpGeU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_ge_u64_dpp"
+               : "v_cmp_ge_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpGeU64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3740,8 +3896,10 @@ void VCmpGeU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpClassF16Vopc::VCmpClassF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_class_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpClassF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_class_f16_dpp"
+               : "v_cmp_class_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpClassF16Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -3800,8 +3958,10 @@ void VCmpClassF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpClassF32Vopc::VCmpClassF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_class_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpClassF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_class_f32_dpp"
+               : "v_cmp_class_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpClassF32Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3857,8 +4017,10 @@ void VCmpClassF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpClassF64Vopc::VCmpClassF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmp_class_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpClassF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmp_class_f64_dpp"
+               : "v_cmp_class_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpClassF64Vopc>()),
       vcc(64, OperandType::OPR_VCC, 106),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1) {
@@ -3883,8 +4045,10 @@ void VCmpClassF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtF16Vopc::VCmpxLtF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lt_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_f16_dpp"
+               : "v_cmpx_lt_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -3963,8 +4127,10 @@ void VCmpxLtF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqF16Vopc::VCmpxEqF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_eq_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_f16_dpp"
+               : "v_cmpx_eq_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -4043,8 +4209,10 @@ void VCmpxEqF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeF16Vopc::VCmpxLeF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_le_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_f16_dpp"
+               : "v_cmpx_le_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -4123,8 +4291,10 @@ void VCmpxLeF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtF16Vopc::VCmpxGtF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_gt_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_f16_dpp"
+               : "v_cmpx_gt_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -4203,8 +4373,10 @@ void VCmpxGtF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLgF16Vopc::VCmpxLgF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lg_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLgF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lg_f16_dpp"
+               : "v_cmpx_lg_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLgF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -4283,8 +4455,10 @@ void VCmpxLgF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeF16Vopc::VCmpxGeF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ge_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_f16_dpp"
+               : "v_cmpx_ge_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -4363,8 +4537,10 @@ void VCmpxGeF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxOF16Vopc::VCmpxOF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_o_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxOF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_o_f16_dpp"
+               : "v_cmpx_o_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxOF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -4443,8 +4619,10 @@ void VCmpxOF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxUF16Vopc::VCmpxUF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_u_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxUF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_u_f16_dpp"
+               : "v_cmpx_u_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxUF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -4523,8 +4701,10 @@ void VCmpxUF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNgeF16Vopc::VCmpxNgeF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nge_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNgeF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nge_f16_dpp"
+               : "v_cmpx_nge_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNgeF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -4603,8 +4783,10 @@ void VCmpxNgeF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNlgF16Vopc::VCmpxNlgF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nlg_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNlgF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlg_f16_dpp"
+               : "v_cmpx_nlg_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNlgF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -4683,8 +4865,10 @@ void VCmpxNlgF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNgtF16Vopc::VCmpxNgtF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ngt_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNgtF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ngt_f16_dpp"
+               : "v_cmpx_ngt_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNgtF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -4763,8 +4947,10 @@ void VCmpxNgtF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNleF16Vopc::VCmpxNleF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nle_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNleF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nle_f16_dpp"
+               : "v_cmpx_nle_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNleF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -4843,8 +5029,10 @@ void VCmpxNleF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeqF16Vopc::VCmpxNeqF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_neq_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeqF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_neq_f16_dpp"
+               : "v_cmpx_neq_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeqF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -4923,8 +5111,10 @@ void VCmpxNeqF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNltF16Vopc::VCmpxNltF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nlt_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNltF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlt_f16_dpp"
+               : "v_cmpx_nlt_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNltF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -5003,8 +5193,10 @@ void VCmpxNltF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtF32Vopc::VCmpxLtF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lt_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_f32_dpp"
+               : "v_cmpx_lt_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -5078,8 +5270,10 @@ void VCmpxLtF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqF32Vopc::VCmpxEqF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_eq_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_f32_dpp"
+               : "v_cmpx_eq_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -5153,8 +5347,10 @@ void VCmpxEqF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeF32Vopc::VCmpxLeF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_le_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_f32_dpp"
+               : "v_cmpx_le_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -5228,8 +5424,10 @@ void VCmpxLeF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtF32Vopc::VCmpxGtF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_gt_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_f32_dpp"
+               : "v_cmpx_gt_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -5303,8 +5501,10 @@ void VCmpxGtF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLgF32Vopc::VCmpxLgF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lg_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLgF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lg_f32_dpp"
+               : "v_cmpx_lg_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLgF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -5378,8 +5578,10 @@ void VCmpxLgF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeF32Vopc::VCmpxGeF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ge_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_f32_dpp"
+               : "v_cmpx_ge_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -5453,8 +5655,10 @@ void VCmpxGeF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxOF32Vopc::VCmpxOF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_o_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxOF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_o_f32_dpp"
+               : "v_cmpx_o_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxOF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -5528,8 +5732,10 @@ void VCmpxOF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxUF32Vopc::VCmpxUF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_u_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxUF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_u_f32_dpp"
+               : "v_cmpx_u_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxUF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -5603,8 +5809,10 @@ void VCmpxUF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNgeF32Vopc::VCmpxNgeF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nge_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNgeF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nge_f32_dpp"
+               : "v_cmpx_nge_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNgeF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -5678,8 +5886,10 @@ void VCmpxNgeF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNlgF32Vopc::VCmpxNlgF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nlg_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNlgF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlg_f32_dpp"
+               : "v_cmpx_nlg_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNlgF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -5753,8 +5963,10 @@ void VCmpxNlgF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNgtF32Vopc::VCmpxNgtF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ngt_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNgtF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ngt_f32_dpp"
+               : "v_cmpx_ngt_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNgtF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -5828,8 +6040,10 @@ void VCmpxNgtF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNleF32Vopc::VCmpxNleF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nle_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNleF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nle_f32_dpp"
+               : "v_cmpx_nle_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNleF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -5903,8 +6117,10 @@ void VCmpxNleF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeqF32Vopc::VCmpxNeqF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_neq_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeqF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_neq_f32_dpp"
+               : "v_cmpx_neq_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeqF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -5978,8 +6194,10 @@ void VCmpxNeqF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNltF32Vopc::VCmpxNltF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nlt_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNltF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlt_f32_dpp"
+               : "v_cmpx_nlt_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNltF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6053,8 +6271,10 @@ void VCmpxNltF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtF64Vopc::VCmpxLtF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lt_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_f64_dpp"
+               : "v_cmpx_lt_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6093,8 +6313,10 @@ void VCmpxLtF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqF64Vopc::VCmpxEqF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_eq_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_f64_dpp"
+               : "v_cmpx_eq_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6133,8 +6355,10 @@ void VCmpxEqF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeF64Vopc::VCmpxLeF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_le_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_f64_dpp"
+               : "v_cmpx_le_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6173,8 +6397,10 @@ void VCmpxLeF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtF64Vopc::VCmpxGtF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_gt_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_f64_dpp"
+               : "v_cmpx_gt_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6213,8 +6439,10 @@ void VCmpxGtF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLgF64Vopc::VCmpxLgF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lg_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLgF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lg_f64_dpp"
+               : "v_cmpx_lg_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLgF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6253,8 +6481,10 @@ void VCmpxLgF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeF64Vopc::VCmpxGeF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ge_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_f64_dpp"
+               : "v_cmpx_ge_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6293,8 +6523,10 @@ void VCmpxGeF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxOF64Vopc::VCmpxOF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_o_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxOF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_o_f64_dpp"
+               : "v_cmpx_o_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxOF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6333,8 +6565,10 @@ void VCmpxOF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxUF64Vopc::VCmpxUF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_u_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxUF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_u_f64_dpp"
+               : "v_cmpx_u_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxUF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6373,8 +6607,10 @@ void VCmpxUF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNgeF64Vopc::VCmpxNgeF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nge_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNgeF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nge_f64_dpp"
+               : "v_cmpx_nge_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNgeF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6413,8 +6649,10 @@ void VCmpxNgeF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNlgF64Vopc::VCmpxNlgF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nlg_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNlgF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlg_f64_dpp"
+               : "v_cmpx_nlg_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNlgF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6453,8 +6691,10 @@ void VCmpxNlgF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNgtF64Vopc::VCmpxNgtF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ngt_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNgtF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ngt_f64_dpp"
+               : "v_cmpx_ngt_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNgtF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6493,8 +6733,10 @@ void VCmpxNgtF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNleF64Vopc::VCmpxNleF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nle_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNleF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nle_f64_dpp"
+               : "v_cmpx_nle_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNleF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6533,8 +6775,10 @@ void VCmpxNleF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeqF64Vopc::VCmpxNeqF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_neq_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeqF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_neq_f64_dpp"
+               : "v_cmpx_neq_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeqF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6573,8 +6817,10 @@ void VCmpxNeqF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNltF64Vopc::VCmpxNltF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_nlt_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNltF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_nlt_f64_dpp"
+               : "v_cmpx_nlt_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNltF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -6613,8 +6859,10 @@ void VCmpxNltF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtI16Vopc::VCmpxLtI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lt_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtI16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_i16_dpp"
+               : "v_cmpx_lt_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtI16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -6691,8 +6939,10 @@ void VCmpxLtI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqI16Vopc::VCmpxEqI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_eq_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqI16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_i16_dpp"
+               : "v_cmpx_eq_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqI16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -6769,8 +7019,10 @@ void VCmpxEqI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeI16Vopc::VCmpxLeI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_le_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeI16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_i16_dpp"
+               : "v_cmpx_le_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeI16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -6847,8 +7099,10 @@ void VCmpxLeI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtI16Vopc::VCmpxGtI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_gt_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtI16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_i16_dpp"
+               : "v_cmpx_gt_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtI16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -6925,8 +7179,10 @@ void VCmpxGtI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeI16Vopc::VCmpxNeI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ne_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeI16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_i16_dpp"
+               : "v_cmpx_ne_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeI16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -7003,8 +7259,10 @@ void VCmpxNeI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeI16Vopc::VCmpxGeI16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ge_i16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeI16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_i16_dpp"
+               : "v_cmpx_ge_i16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeI16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -7081,8 +7339,10 @@ void VCmpxGeI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtU16Vopc::VCmpxLtU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lt_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtU16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_u16_dpp"
+               : "v_cmpx_lt_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtU16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -7159,8 +7419,10 @@ void VCmpxLtU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqU16Vopc::VCmpxEqU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_eq_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqU16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_u16_dpp"
+               : "v_cmpx_eq_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqU16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -7237,8 +7499,10 @@ void VCmpxEqU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeU16Vopc::VCmpxLeU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_le_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeU16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_u16_dpp"
+               : "v_cmpx_le_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeU16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -7315,8 +7579,10 @@ void VCmpxLeU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtU16Vopc::VCmpxGtU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_gt_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtU16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_u16_dpp"
+               : "v_cmpx_gt_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtU16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -7393,8 +7659,10 @@ void VCmpxGtU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeU16Vopc::VCmpxNeU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ne_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeU16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_u16_dpp"
+               : "v_cmpx_ne_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeU16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -7471,8 +7739,10 @@ void VCmpxNeU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeU16Vopc::VCmpxGeU16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ge_u16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeU16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_u16_dpp"
+               : "v_cmpx_ge_u16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeU16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -7549,8 +7819,10 @@ void VCmpxGeU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtI32Vopc::VCmpxLtI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lt_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_i32_dpp"
+               : "v_cmpx_lt_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtI32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -7624,8 +7896,10 @@ void VCmpxLtI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqI32Vopc::VCmpxEqI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_eq_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_i32_dpp"
+               : "v_cmpx_eq_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqI32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -7699,8 +7973,10 @@ void VCmpxEqI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeI32Vopc::VCmpxLeI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_le_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_i32_dpp"
+               : "v_cmpx_le_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeI32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -7774,8 +8050,10 @@ void VCmpxLeI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtI32Vopc::VCmpxGtI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_gt_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_i32_dpp"
+               : "v_cmpx_gt_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtI32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -7849,8 +8127,10 @@ void VCmpxGtI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeI32Vopc::VCmpxNeI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ne_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_i32_dpp"
+               : "v_cmpx_ne_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeI32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -7924,8 +8204,10 @@ void VCmpxNeI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeI32Vopc::VCmpxGeI32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ge_i32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeI32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_i32_dpp"
+               : "v_cmpx_ge_i32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeI32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -7999,8 +8281,10 @@ void VCmpxGeI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtU32Vopc::VCmpxLtU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lt_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_u32_dpp"
+               : "v_cmpx_lt_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtU32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -8074,8 +8358,10 @@ void VCmpxLtU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqU32Vopc::VCmpxEqU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_eq_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_u32_dpp"
+               : "v_cmpx_eq_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqU32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -8149,8 +8435,10 @@ void VCmpxEqU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeU32Vopc::VCmpxLeU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_le_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_u32_dpp"
+               : "v_cmpx_le_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeU32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -8224,8 +8512,10 @@ void VCmpxLeU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtU32Vopc::VCmpxGtU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_gt_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_u32_dpp"
+               : "v_cmpx_gt_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtU32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -8299,8 +8589,10 @@ void VCmpxGtU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeU32Vopc::VCmpxNeU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ne_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_u32_dpp"
+               : "v_cmpx_ne_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeU32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -8374,8 +8666,10 @@ void VCmpxNeU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeU32Vopc::VCmpxGeU32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ge_u32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeU32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_u32_dpp"
+               : "v_cmpx_ge_u32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeU32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -8449,8 +8743,10 @@ void VCmpxGeU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtI64Vopc::VCmpxLtI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lt_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_i64_dpp"
+               : "v_cmpx_lt_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtI64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -8489,8 +8785,10 @@ void VCmpxLtI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqI64Vopc::VCmpxEqI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_eq_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_i64_dpp"
+               : "v_cmpx_eq_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqI64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -8529,8 +8827,10 @@ void VCmpxEqI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeI64Vopc::VCmpxLeI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_le_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_i64_dpp"
+               : "v_cmpx_le_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeI64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -8569,8 +8869,10 @@ void VCmpxLeI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtI64Vopc::VCmpxGtI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_gt_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_i64_dpp"
+               : "v_cmpx_gt_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtI64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -8609,8 +8911,10 @@ void VCmpxGtI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeI64Vopc::VCmpxNeI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ne_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_i64_dpp"
+               : "v_cmpx_ne_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeI64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -8649,8 +8953,10 @@ void VCmpxNeI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeI64Vopc::VCmpxGeI64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ge_i64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeI64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_i64_dpp"
+               : "v_cmpx_ge_i64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeI64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -8689,8 +8995,10 @@ void VCmpxGeI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLtU64Vopc::VCmpxLtU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_lt_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_lt_u64_dpp"
+               : "v_cmpx_lt_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLtU64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -8729,8 +9037,10 @@ void VCmpxLtU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxEqU64Vopc::VCmpxEqU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_eq_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_eq_u64_dpp"
+               : "v_cmpx_eq_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxEqU64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -8769,8 +9079,10 @@ void VCmpxEqU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxLeU64Vopc::VCmpxLeU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_le_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_le_u64_dpp"
+               : "v_cmpx_le_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxLeU64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -8809,8 +9121,10 @@ void VCmpxLeU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGtU64Vopc::VCmpxGtU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_gt_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_gt_u64_dpp"
+               : "v_cmpx_gt_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGtU64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -8849,8 +9163,10 @@ void VCmpxGtU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxNeU64Vopc::VCmpxNeU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ne_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ne_u64_dpp"
+               : "v_cmpx_ne_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxNeU64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -8889,8 +9205,10 @@ void VCmpxNeU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxGeU64Vopc::VCmpxGeU64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_ge_u64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeU64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_ge_u64_dpp"
+               : "v_cmpx_ge_u64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxGeU64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -8929,8 +9247,10 @@ void VCmpxGeU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxClassF16Vopc::VCmpxClassF16Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_class_f16_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxClassF16Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_class_f16_dpp"
+               : "v_cmpx_class_f16_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxClassF16Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(16, OperandType::OPR_SRC,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0), true),
@@ -9036,8 +9356,10 @@ void VCmpxClassF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxClassF32Vopc::VCmpxClassF32Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_class_f32_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxClassF32Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_class_f32_dpp"
+               : "v_cmpx_class_f32_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxClassF32Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),
@@ -9134,8 +9456,10 @@ void VCmpxClassF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 VCmpxClassF64Vopc::VCmpxClassF64Vopc(const MachineInst *inst)
-    : Vopc("v_cmpx_class_f64_e32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxClassF64Vopc>()),
+    : Vopc(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_cmpx_class_f64_dpp"
+               : "v_cmpx_class_f64_e32",
+           reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VCmpxClassF64Vopc>()),
       exec(64, OperandType::OPR_EXEC, 126),
       src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
       vsrc1(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vsrc1),

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h
@@ -8,6 +8,7 @@
 #define ROCJITSU_ISA_ARCH_AMDGPU_SHARED_INSTRUCTION_ENCODING_H_
 
 #include <cstdint>
+#include <string>
 
 namespace rocjitsu {
 namespace amdgpu {
@@ -59,6 +60,19 @@ inline bool dpp_ctrl_produces_oob(uint32_t dpp_ctrl) {
 inline bool is_src_dpp8(uint32_t src0) { return src0 == SRC_DPP8_FI_0 || src0 == SRC_DPP8_FI_1; }
 
 inline uint32_t src_dpp8_fi(uint32_t src0) { return src0 == SRC_DPP8_FI_1 ? 1u : 0u; }
+
+/// @brief Add the lane selectors for a DPP8 instruction.
+inline void append_dpp8_disassembly(std::string &out, uint32_t lane_sel, uint32_t fi) {
+  out += " dpp8:[";
+  for (uint32_t lane = 0; lane < 8; ++lane) {
+    if (lane != 0)
+      out += ',';
+    out += std::to_string((lane_sel >> (lane * 3)) & 0x7);
+  }
+  out += ']';
+  if (fi != 0)
+    out += " fi:1";
+}
 
 } // namespace dpp
 

--- a/emulation/rocjitsu/tests/decode_smoke_test.cpp
+++ b/emulation/rocjitsu/tests/decode_smoke_test.cpp
@@ -104,6 +104,21 @@ TEST_P(DecoderSmokeTest, DecodesCorrectly) {
   EXPECT_EQ(inst->size(), tc.expected_size_bytes) << "Wrong size for arch=" << tc.arch_name;
 }
 
+TEST(Gfx1250DecodeTest, DisassemblesDpp8Selectors) {
+  const uint32_t words[] = {
+      0x7E0040EAu, // v_fract_f32 with the DPP8FI source selector.
+      0x000040CCu, // v204, dpp8:[0,0,1,0,0,0,0,0].
+  };
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  ASSERT_NE(inst, nullptr);
+  EXPECT_EQ(inst->size(), 8);
+  EXPECT_EQ(inst->mnemonic(), "v_fract_f32_dpp");
+  EXPECT_EQ(inst->disassemble(), "v_fract_f32_dpp v0, v204 dpp8:[0,0,1,0,0,0,0,0] fi:1");
+}
+
 // AMDGPU ISAs × 2 instructions.
 // CDNA1/2/3/4 and RDNA1/2 share the GFX9/GFX10 s_endpgm encoding (op=1).
 // RDNA3/3.5/4 use the GFX11/GFX12 encoding where s_endpgm moved to op=48.

--- a/emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
+++ b/emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
@@ -1365,7 +1365,8 @@ TEST(Gfx1250Dpp8Test, Vop2AddF16UsesPermutedSourceLanes) {
   };
   std::unique_ptr<Instruction> inst(decoder->decode(add_f16_dpp8_words));
   ASSERT_NE(inst, nullptr);
-  ASSERT_EQ(std::string_view(inst->mnemonic()), "v_add_f16_e32");
+  ASSERT_EQ(std::string_view(inst->mnemonic()), "v_add_f16_dpp");
+  EXPECT_EQ(inst->disassemble(), "v_add_f16_dpp v4.l, v2, v3.l dpp8:[7,0,3,2,5,4,1,6]");
   cu->execute_instruction(inst.get(), *wf);
 
   for (uint32_t lane = 0; lane < wf->wf_size(); ++lane) {
@@ -2698,7 +2699,8 @@ TEST(Rdna4True16Vop3Test, UnaryDpp8ScalarAndSimdMatchPermutedLanes) {
     auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
     std::unique_ptr<Instruction> inst(decoder->decode(reinterpret_cast<const uint32_t *>(&raw)));
     ASSERT_NE(inst, nullptr);
-    ASSERT_EQ(std::string_view(inst->mnemonic()), "v_rcp_f16");
+    ASSERT_EQ(std::string_view(inst->mnemonic()), "v_rcp_f16_e64_dpp");
+    EXPECT_EQ(inst->disassemble(), "v_rcp_f16_e64_dpp v2, v0 dpp8:[7,0,5,2,3,6,1,4] fi:1");
     cu->execute_instruction(inst.get(), *wf);
     for (uint32_t lane = 0; lane < kWaveSize; ++lane)
       outputs[mode][lane] = cu->read_vgpr(vb + kDst, lane);


### PR DESCRIPTION
Retain DPP8 extension state in generated encoding classes, select the DPP mnemonic suffix, and print all eight lane selectors plus FI during disassembly.

Generate this support for every AMDGPU profile that exposes DPP8 and cover gfx1250 textual output with a decode regression.