### PR TITLE
feat(clr): per-stream AQL barrier-bit optimization on shared HW queues

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -3546,6 +3546,7 @@ hsa_queue_t* Device::acquireQueue(uint32_t queue_size_hint, bool coop_queue,
   auto populateExtras = [&]() {
     QueueExtras extras;
     extras.deviceMemRingBuf = (desc.flags & HSA_AMD_QUEUE_CREATE_DEVICE_MEM_RING_BUF) != 0;
+    extras.largestAqlBarrierBitSlot = std::make_shared<std::atomic<uint64_t>>(kInvalidAqlSlot);
     hsa_amd_queue_get_info(queue, HSA_AMD_QUEUE_INFO_PREFETCH_METADATA_RING_BUFFER,
                            &extras.metadataRingBuffer);
     if (DEBUG_CLR_DIRECT_DOORBELL) {

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -601,6 +601,8 @@ class Device : public NullDevice {
     //! Cached hardware doorbell (UC MMIO), only set when DEBUG_CLR_DIRECT_DOORBELL is enabled.
     volatile uint64_t* doorbellPtr = nullptr;
     bool deviceMemRingBuf = false;
+    //! Largest barrier-bit slot shared by every VirtualGPU using this physical queue.
+    std::shared_ptr<std::atomic<uint64_t>> largestAqlBarrierBitSlot;
   };
 
   //! Acquire HSA queue. This method can create a new HSA queue or

--- a/projects/clr/rocclr/device/rocm/rocsettings.cpp
+++ b/projects/clr/rocclr/device/rocm/rocsettings.cpp
@@ -82,6 +82,7 @@ Settings::Settings() {
   blocking_blit_ = amd::IS_HIP;
 
   max_hw_queues_ = GPU_MAX_HW_QUEUES;
+  aql_barrier_opt_ = amd::IS_HIP && DEBUG_CLR_AQL_BARRIER_OPT;
 
   queue_pipe_dist_ = false;
 }

--- a/projects/clr/rocclr/device/rocm/rocsettings.hpp
+++ b/projects/clr/rocclr/device/rocm/rocsettings.hpp
@@ -38,7 +38,8 @@ class Settings : public device::Settings {
       uint blocking_blit_ : 1;         //!< Blit ops can be blocking on CPU
       uint queue_pipe_dist_ : 1;       //!< gfx94x queue pipe distribution
       uint ext_dispatch_packet_ : 1;   //!< Uses new ext dispatch packet for all launches
-      uint reserved_ : 18;
+      uint aql_barrier_opt_ : 1;       //!< Per-stream barrier-bit optimization
+      uint reserved_ : 17;
     };
     uint value_;
   };

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -104,6 +104,8 @@ static constexpr hsa_barrier_and_packet_t kBarrierAcquirePacket = {
 static constexpr hsa_barrier_and_packet_t kBarrierReleasePacket = {
     kBarrierPacketReleaseHeader, 0, 0, {{0}}, 0, {0}};
 
+static constexpr uint16_t kBarrierBit = 1 << HSA_PACKET_HEADER_BARRIER;
+
 namespace {
 
 void CL_CALLBACK ReleasePinnedMemoryCallback(cl_event event, int32_t command_exec_status,
@@ -1229,6 +1231,9 @@ bool VirtualGPU::processMemObjects(const amd::Kernel& kernel, const_address para
 
 // ================================================================================================
 void VirtualGPU::SetGpuQueue(hsa_queue_t* queue) {
+  if (gpu_queue_ != queue) {
+    last_aql_packet_slot_ = kInvalidAqlSlot;
+  }
   gpu_queue_ = queue;
 
   cached_read_dispatch_id_ = 0;
@@ -1244,12 +1249,14 @@ void VirtualGPU::SetGpuQueue(hsa_queue_t* queue) {
     device_mem_ring_buf_ = extras.deviceMemRingBuf;
     use_movdir64b_ = roc_device_.info().movdir64b_ && device_mem_ring_buf_;
     doorbell_ptr_ = extras.doorbellPtr;
+    largest_aql_barrier_bit_slot_ = extras.largestAqlBarrierBitSlot;
     metadata_preloader_.SetQueueBase(extras.metadataRingBuffer,
                                      roc_device_.MetadataVersionHeader());
   } else {
     device_mem_ring_buf_ = false;
     use_movdir64b_ = false;
     doorbell_ptr_ = nullptr;
+    largest_aql_barrier_bit_slot_.reset();
     metadata_preloader_.SetQueueBase(nullptr, roc_device_.MetadataVersionHeader());
   }
 }
@@ -1411,16 +1418,72 @@ void VirtualGPU::ringQueueDoorbell(uint64_t index) {
 }
 
 // ================================================================================================
+AqlSlotReservation VirtualGPU::ReserveAqlSlots(size_t packet_count) {
+  assert(packet_count > 0);
+  assert(largest_aql_barrier_bit_slot_ != nullptr);
+
+  const uint64_t barrier_bit_slot_before_reservation =
+      largest_aql_barrier_bit_slot_->load(std::memory_order_acquire);
+  const uint64_t start_slot = Hsa::queue_add_write_index_screlease(gpu_queue_, packet_count);
+  return {start_slot, packet_count, barrier_bit_slot_before_reservation};
+}
+
+// ================================================================================================
+void VirtualGPU::OptimizeStreamOrderingBarrier(
+    uint16_t& header, const AqlSlotReservation& reservation) const {
+  if (!roc_device_.settings().aql_barrier_opt_) {
+    return;
+  }
+
+  const bool needs_stream_ordering_barrier =
+      last_aql_packet_slot_ != kInvalidAqlSlot &&
+      (reservation.barrier_bit_slot_before_reservation == kInvalidAqlSlot ||
+       reservation.barrier_bit_slot_before_reservation <= last_aql_packet_slot_);
+  if (!needs_stream_ordering_barrier) {
+    header &= ~kBarrierBit;
+  }
+}
+
+// ================================================================================================
+void VirtualGPU::RecordAqlPacketHeader(const AqlSlotReservation& reservation,
+                                       size_t packet_offset, uint16_t header) {
+  assert(packet_offset < reservation.packet_count);
+  assert(largest_aql_barrier_bit_slot_ != nullptr);
+  if ((header & kBarrierBit) != 0) {
+    const uint64_t barrier_bit_slot = reservation.start_slot + packet_offset;
+    uint64_t largest_barrier_bit_slot =
+        largest_aql_barrier_bit_slot_->load(std::memory_order_relaxed);
+    while ((largest_barrier_bit_slot == kInvalidAqlSlot ||
+            largest_barrier_bit_slot < barrier_bit_slot) &&
+           !largest_aql_barrier_bit_slot_->compare_exchange_weak(
+               largest_barrier_bit_slot, barrier_bit_slot, std::memory_order_release,
+               std::memory_order_relaxed)) {
+    }
+  }
+}
+
+// ================================================================================================
+void VirtualGPU::CompleteAqlSubmission(const AqlSlotReservation& reservation) {
+  last_aql_packet_slot_ = reservation.start_slot + reservation.packet_count - 1;
+}
+
+// ================================================================================================
 template <typename AqlPacket>
 bool VirtualGPU::dispatchGenericAqlPacket(AqlPacket* packet, uint16_t header, uint16_t rest,
-                                          bool blocking, bool attach_signal, bool cluster_launch) {
+                                          bool blocking, bool attach_signal) {
   const uint32_t queueSize = gpu_queue_->size;
   const uint32_t queueMask = queueSize - 1;
   const uint32_t sw_queue_size = queueMask;
 
-  // Check for queue full and wait if needed.
-  uint64_t index = Hsa::queue_add_write_index_screlease(gpu_queue_, 1);
+  const bool header_requested_barrier = (header & kBarrierBit) != 0;
+  AqlSlotReservation reservation = ReserveAqlSlots(1);
+  const uint64_t index = reservation.start_slot;
   adjustHeader(header);
+  if (header_requested_barrier) {
+    OptimizeStreamOrderingBarrier(header, reservation);
+  }
+  RecordAqlPacketHeader(reservation, 0, header);
+  CompleteAqlSubmission(reservation);
 
   bool attachSignal = timestamp_ != nullptr || attach_signal;
   // Get active signal for current dispatch if profiling is necessary
@@ -1523,7 +1586,12 @@ void VirtualGPU::adjustHeader(uint16_t& header) {
 
   if (fence_state_ == amd::Device::kCacheStateSystem &&
       expected_fence_state == amd::Device::kCacheStateSystem) {
+    // honor an explicit any-order
+    const bool any_order = (header & kBarrierBit) == 0;
     header = dispatchPacketHeader_;
+    if (any_order) {
+      header &= ~kBarrierBit;
+    }
     setFenceDirty(true);
   }
 
@@ -1580,12 +1648,6 @@ bool VirtualGPU::dispatchAqlPacket(AqlPacket* packet, uint16_t header,
     return dispatchGenericAqlPacket(packet, header, rest, blocking, attach_signal);
   }
 }
-// ================================================================================================
-bool VirtualGPU::dispatchAqlPacket(hsa_barrier_and_packet_t* packet, uint16_t header, uint16_t rest,
-                                   bool blocking, bool attach_signal) {
-  return dispatchGenericAqlPacket(packet, header, rest, blocking, attach_signal);
-}
-
 // ================================================================================================
 // Publish one metadata-prefetch packet (256B = 4 x 64B segments) to the metadata ring at |dst|.
 // |src| is the captured metadata packet with valid headers already baked into each segment
@@ -1661,6 +1723,14 @@ bool VirtualGPU::dispatchAqlPacketBatchFlat(const amd::AlignedVector64<uint8_t>&
   uint16_t firstHeader = static_cast<uint16_t>(validFullHeaders[0]);
   uint16_t firstSetup  = static_cast<uint16_t>(validFullHeaders[0] >> 16);
   uint16_t lastHeader  = static_cast<uint16_t>(validFullHeaders[numPackets - 1]);
+  const uint8_t firstPacketType =
+      extractAqlBits(firstHeader, HSA_PACKET_HEADER_TYPE, HSA_PACKET_HEADER_WIDTH_TYPE);
+  const bool firstPacketIsKernel =
+      firstPacketType == HSA_PACKET_TYPE_KERNEL_DISPATCH ||
+      (firstPacketType == HSA_PACKET_TYPE_VENDOR_SPECIFIC &&
+       (firstSetup & 0xFF) == HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH);
+  const bool firstHeaderRequestedBarrier =
+      firstPacketIsKernel && ((firstHeader & kBarrierBit) != 0);
   if (addSystemScope_) {
     firstHeader &= ~(HSA_FENCE_SCOPE_AGENT << HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE);
     firstHeader |= (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE);
@@ -1683,7 +1753,13 @@ bool VirtualGPU::dispatchAqlPacketBatchFlat(const amd::AlignedVector64<uint8_t>&
   // Per-chunk: yield if the queue is full (handles graphs larger than the queue), then
   // memcpy + per-packet fixups + headers + doorbell.  For graphs that fit in the queue
   // the yield never fires.
-  uint64_t startIndex = Hsa::queue_add_write_index_screlease(gpu_queue_, numPackets);
+  AqlSlotReservation reservation = ReserveAqlSlots(numPackets);
+  const uint64_t startIndex = reservation.start_slot;
+  if (firstHeaderRequestedBarrier) {
+    OptimizeStreamOrderingBarrier(firstHeader, reservation);
+  }
+
+  CompleteAqlSubmission(reservation);
   setFenceDirty(true);
 
   // Update cached fence state from the last packet's release scope.
@@ -1760,7 +1836,9 @@ bool VirtualGPU::dispatchAqlPacketBatchFlat(const amd::AlignedVector64<uint8_t>&
   auto logBatchPacket = [&](size_t i, uint64_t slotIdx) {
     const auto* hostPkt = reinterpret_cast<const hsa_kernel_dispatch_packet_t*>(
         flatPacketData.data() + i * kPacketSize);
-    const uint16_t hdr = static_cast<uint16_t>(validFullHeaders[i]);
+    const uint16_t hdr =
+        i == 0 ? firstHeader
+               : (i == numPackets - 1 ? lastHeader : static_cast<uint16_t>(validFullHeaders[i]));
     const uint8_t pktType =
         extractAqlBits(hdr, HSA_PACKET_HEADER_TYPE, HSA_PACKET_HEADER_WIDTH_TYPE);
     const uint8_t amdFormat = static_cast<uint8_t>((validFullHeaders[i] >> 16) & 0xFF);
@@ -2011,7 +2089,11 @@ void VirtualGPU::dispatchBarrierPacket(uint16_t packetHeader, bool skipSignal,
     }
   }
 
-  uint64_t index = Hsa::queue_add_write_index_screlease(gpu_queue_, 1);
+  AqlSlotReservation reservation = ReserveAqlSlots(1);
+  const uint64_t index = reservation.start_slot;
+  OptimizeStreamOrderingBarrier(packetHeader, reservation);
+  RecordAqlPacketHeader(reservation, 0, packetHeader);
+  CompleteAqlSubmission(reservation);
 
   setFenceDirty(true);
   auto cache_state = extractAqlBits(packetHeader, HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE,
@@ -2110,7 +2192,11 @@ void VirtualGPU::dispatchBarrierValuePacket(uint16_t packetHeader, bool resolveD
     setFenceDirty(false);
   }
 
-  uint64_t index = Hsa::queue_add_write_index_screlease(gpu_queue_, 1);
+  AqlSlotReservation reservation = ReserveAqlSlots(1);
+  const uint64_t index = reservation.start_slot;
+  OptimizeStreamOrderingBarrier(packetHeader, reservation);
+  RecordAqlPacketHeader(reservation, 0, packetHeader);
+  CompleteAqlSubmission(reservation);
 
   TrackQueueProgress(barrier_value_packet_, index, external_signal);
 

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -18,6 +18,7 @@
 #include "os/os.hpp"
 #include <atomic>
 #include <condition_variable>
+#include <memory>
 #include <mutex>
 #include <stack>
 #include <string>
@@ -29,6 +30,14 @@ class Device;
 class Memory;
 struct ProfilingSignal;
 class Timestamp;
+
+constexpr static uint64_t kInvalidAqlSlot = std::numeric_limits<uint64_t>::max();
+
+struct AqlSlotReservation {
+  uint64_t start_slot;
+  size_t packet_count;
+  uint64_t barrier_bit_slot_before_reservation;
+};
 
 //! True while the calling thread is inside HsaAmdSignalHandler (async-events thread).
 bool InAsyncSignalHandler();
@@ -707,11 +716,9 @@ class VirtualGPU : public device::VirtualDevice {
 
   //! Dispatch (or capture, when graph-capturing) a kernel dispatch packet.
   //! Handles both hsa_kernel_dispatch_packet_t and hsa_amd_ext_kernel_dispatch_packet_t.
-  template <typename AqlPacket>
-  bool dispatchAqlPacket(AqlPacket* packet, uint16_t header, uint16_t rest,
-                         bool blocking = true, bool attach_signal = false);
-  bool dispatchAqlPacket(hsa_barrier_and_packet_t* packet, uint16_t header, uint16_t rest,
-                         bool blocking = true, bool attach_signal = false);
+  template <typename AqlPacket> bool dispatchAqlPacket(AqlPacket* packet, uint16_t header,
+                                                       uint16_t rest, bool blocking = true,
+                                                       bool attach_signal = false);
 
   //! Fast-path dispatch: pre-built flat contiguous buffer
   bool dispatchAqlPacketBatchFlat(const amd::AlignedVector64<uint8_t>& flatPacketData,
@@ -724,8 +731,7 @@ class VirtualGPU : public device::VirtualDevice {
 
   template <typename AqlPacket> bool dispatchGenericAqlPacket(AqlPacket* packet, uint16_t header,
                                                               uint16_t rest, bool blocking,
-                                                              bool attach_signal = false,
-                                                              bool cluster_launch = false);
+                                                              bool attach_signal = false);
 
   bool dispatchCounterAqlPacket(hsa_ext_amd_aql_pm4_packet_t* packet, const uint32_t gfxVersion,
                                 bool blocking, const hsa_ven_amd_aqlprofile_1_00_pfn_t* extApi);
@@ -748,6 +754,20 @@ class VirtualGPU : public device::VirtualDevice {
 
   //! Ring the queue doorbell via direct UC store or ROCr signal.
   void ringQueueDoorbell(uint64_t index);
+
+  //! Snapshot shared barrier state before atomically reserving AQL queue slots.
+  AqlSlotReservation ReserveAqlSlots(size_t packet_count);
+
+  //! Clear a caller-requested barrier when prior queue state already preserves stream ordering.
+  void OptimizeStreamOrderingBarrier(uint16_t& header,
+                                     const AqlSlotReservation& reservation) const;
+
+  //! Record a final packet header in the shared HW-queue barrier state.
+  void RecordAqlPacketHeader(const AqlSlotReservation& reservation, size_t packet_offset,
+                             uint16_t header);
+
+  //! Record the final slot in a submission as this VirtualGPU's previous packet.
+  void CompleteAqlSubmission(const AqlSlotReservation& reservation);
 
   void resetKernArgPool() { managed_kernarg_buffer_.ResetPool(); }
 
@@ -875,6 +895,10 @@ class VirtualGPU : public device::VirtualDevice {
   //! Cached hardware doorbell for the active queue (UC MMIO). Non-null only when
   //! DEBUG_CLR_DIRECT_DOORBELL is enabled and the doorbell id query succeeded.
   volatile uint64_t* doorbell_ptr_ = nullptr;
+  //! Largest barrier-bit slot shared by every VirtualGPU using the physical HW queue.
+  std::shared_ptr<std::atomic<uint64_t>> largest_aql_barrier_bit_slot_;
+  //! Final AQL slot submitted by this stream, or kInvalidAqlSlot before its first packet.
+  uint64_t last_aql_packet_slot_ = kInvalidAqlSlot;
   alignas(64) hsa_barrier_and_packet_t barrier_packet_ {};
   alignas(64) hsa_amd_barrier_value_packet_t barrier_value_packet_ {};
 

--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -139,6 +139,8 @@ release(uint, GPU_MAX_COMMAND_BUFFERS, 8,                                     \
          "The maximum number of command buffers allocated per queue")         \
 release(uint, GPU_MAX_HW_QUEUES, 4,                                           \
          "The maximum number of HW queues allocated per device")              \
+release(bool, DEBUG_CLR_AQL_BARRIER_OPT, true,                                 \
+        "Enable per-stream AQL barrier-bit optimization on shared HW queues")   \
 release(bool, GPU_IMAGE_BUFFER_WAR, true,                                     \
         "Enables image buffer workaround")                                    \
 release(cstring, HIP_VISIBLE_DEVICES, "",                                     \

--- a/projects/hip-tests/catch/config/configs/unit/stream.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/stream.yaml
@@ -36,6 +36,9 @@ stream:
   Unit_hipMultiStream_sameDevice:
     <<: *level_2
     tags: [lifecycle]
+  Unit_hipMultiStream_SharedHwQueuePacketOrdering:
+    <<: *level_2
+    tags: [synchronization]
   Unit_hipMultiStream_multimeDevice:
     <<: *level_2
     tags: [lifecycle]
@@ -118,6 +121,16 @@ stream:
     # AMD_LOG AQL output, so AMD/Linux only.
     disabled: [amd_windows, amd_wsl, nvidia_linux, nvidia_windows]
     tags: [lifecycle]
+  Unit_hipStreamAqlBarrierBit_ChildWorkload:
+    <<: *level_2
+    # Internal helper invoked by the parent test via re-exec.
+    disabled: [amd_linux, amd_windows, amd_wsl, nvidia_linux, nvidia_windows]
+    tags: [synchronization]
+  Unit_hipStreamAqlBarrierBit_Scenarios:
+    <<: *level_2
+    # Parses AMD AQL logs and requires fork/exec.
+    disabled: [amd_windows, amd_wsl, nvidia_linux, nvidia_windows]
+    tags: [synchronization]
   Unit_hipStreamDestroy_Default:
     <<: *level_2
     tags: [lifecycle, smoke]

--- a/projects/hip-tests/catch/unit/stream/hipMultiStream.cc
+++ b/projects/hip-tests/catch/unit/stream/hipMultiStream.cc
@@ -5,7 +5,9 @@
  */
 
 #include <hip_test_common.hh>
+#include <atomic>
 #include <iostream>
+#include <thread>
 #include <vector>
 constexpr int NN = 1 << 21;
 __global__ void kernel_do_nothing(__attribute__((unused)) int a) {
@@ -24,6 +26,112 @@ __global__ void nKernel(float* y) {
   size_t tid{threadIdx.x};
   y[tid] = y[tid] + 1.0f;
 }
+
+__global__ void verifyStreamPacketOrder(uint32_t* sequence_value, uint32_t expected_value,
+                                        uint32_t* ordering_errors, uint64_t delay_cycles) {
+  if (blockIdx.x != 0 || threadIdx.x != 0) {
+    return;
+  }
+
+  if (atomicAdd(sequence_value, 0u) != expected_value) {
+    atomicAdd(ordering_errors, 1u);
+  }
+
+  const uint64_t start_cycle = wall_clock64();
+  while (wall_clock64() - start_cycle < delay_cycles) {
+  }
+  atomicExch(sequence_value, expected_value + 1);
+}
+
+HIP_TEST_CASE(Unit_hipMultiStream_SharedHwQueuePacketOrdering) {
+  constexpr uint32_t num_streams = 8;
+  constexpr uint32_t rounds_per_phase = 8;
+  const uint64_t delay_cycles = isQuickLevel() ? 100000 : 1000000;
+
+  std::vector<hipStream_t> streams(num_streams);
+  uint32_t* sequence_values = nullptr;
+  uint32_t* ordering_errors = nullptr;
+  HIP_CHECK(hipMalloc(&sequence_values, num_streams * sizeof(*sequence_values)));
+  HIP_CHECK(hipMalloc(&ordering_errors, sizeof(*ordering_errors)));
+  HIP_CHECK(hipMemset(sequence_values, 0, num_streams * sizeof(*sequence_values)));
+  HIP_CHECK(hipMemset(ordering_errors, 0, sizeof(*ordering_errors)));
+
+  for (uint32_t stream_idx = 0; stream_idx < num_streams; ++stream_idx) {
+    HIP_CHECK(hipStreamCreate(&streams[stream_idx]));
+  }
+
+  auto submit_phase = [&](uint32_t first_expected_value) {
+    std::atomic<uint32_t> num_ready_threads{0};
+    std::atomic<uint32_t> num_round_arrivals{0};
+    std::atomic<uint32_t> completed_rounds{0};
+    std::atomic<uint32_t> submission_errors{0};
+    std::atomic<bool> start_submissions{false};
+    std::vector<std::thread> submission_threads;
+    submission_threads.reserve(num_streams);
+
+    for (uint32_t stream_idx = 0; stream_idx < num_streams; ++stream_idx) {
+      submission_threads.emplace_back([&, stream_idx] {
+        num_ready_threads.fetch_add(1, std::memory_order_release);
+        while (!start_submissions.load(std::memory_order_acquire)) {
+          std::this_thread::yield();
+        }
+
+        for (uint32_t round_idx = 0; round_idx < rounds_per_phase; ++round_idx) {
+          hipLaunchKernelGGL(verifyStreamPacketOrder, dim3(1), dim3(1), 0, streams[stream_idx],
+                             sequence_values + stream_idx, first_expected_value + round_idx,
+                             ordering_errors, delay_cycles);
+          if (hipGetLastError() != hipSuccess) {
+            submission_errors.fetch_add(1, std::memory_order_relaxed);
+          }
+
+          if (num_round_arrivals.fetch_add(1, std::memory_order_acq_rel) + 1 == num_streams) {
+            num_round_arrivals.store(0, std::memory_order_relaxed);
+            completed_rounds.fetch_add(1, std::memory_order_release);
+          } else {
+            while (completed_rounds.load(std::memory_order_acquire) == round_idx) {
+              std::this_thread::yield();
+            }
+          }
+        }
+      });
+    }
+
+    while (num_ready_threads.load(std::memory_order_acquire) != num_streams) {
+      std::this_thread::yield();
+    }
+    start_submissions.store(true, std::memory_order_release);
+
+    for (auto& submission_thread : submission_threads) {
+      submission_thread.join();
+    }
+    REQUIRE(submission_errors.load(std::memory_order_relaxed) == 0);
+  };
+
+  submit_phase(0);
+  for (uint32_t stream_idx = 0; stream_idx < num_streams; ++stream_idx) {
+    HIP_CHECK(hipStreamSynchronize(streams[stream_idx]));
+    HIP_CHECK(hipStreamQuery(streams[stream_idx]));
+  }
+
+  // Submit again after synchronization/query gives the runtime an opportunity to release and
+  // dynamically reacquire each stream's HW queue.
+  submit_phase(rounds_per_phase);
+  for (uint32_t stream_idx = 0; stream_idx < num_streams; ++stream_idx) {
+    HIP_CHECK(hipStreamSynchronize(streams[stream_idx]));
+  }
+
+  uint32_t host_ordering_errors = 0;
+  HIP_CHECK(hipMemcpy(&host_ordering_errors, ordering_errors, sizeof(host_ordering_errors),
+                      hipMemcpyDeviceToHost));
+  REQUIRE(host_ordering_errors == 0);
+
+  for (uint32_t stream_idx = 0; stream_idx < num_streams; ++stream_idx) {
+    HIP_CHECK(hipStreamDestroy(streams[stream_idx]));
+  }
+  HIP_CHECK(hipFree(ordering_errors));
+  HIP_CHECK(hipFree(sequence_values));
+}
+
 HIP_TEST_CASE(Unit_hipMultiStream_sameDevice) {
   constexpr int num_streams{8};
   hipStream_t streams[num_streams];

--- a/projects/hip-tests/catch/unit/stream/hipStreamPriorityAqlLog.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamPriorityAqlLog.cc
@@ -28,14 +28,26 @@
 #include <fstream>
 #include <sstream>
 #include <string>
+#include <vector>
 
 namespace {
 
 // Env marker that tells a re-executed instance to run the kernel workload that
 // produces AQL packets, instead of driving a child.
 constexpr char kChildEnv[] = "HIP_TEST_AQL_PRIORITY_CHILD";
+constexpr char kBarrierChildEnv[] = "HIP_TEST_AQL_BARRIER_CHILD";
+constexpr char kBarrierScenarioEnv[] = "HIP_TEST_AQL_BARRIER_SCENARIO";
 
 __global__ void noopKernel() {}
+
+__global__ void delayedNoopKernel(uint64_t delay_cycles) {
+  if (blockIdx.x != 0 || threadIdx.x != 0) {
+    return;
+  }
+  const uint64_t start_cycle = wall_clock64();
+  while (wall_clock64() - start_cycle < delay_cycles) {
+  }
+}
 
 // Launch a kernel on a stream created at the given priority and synchronize, so
 // the runtime emits AQL dispatch/barrier packets tagged with that priority.
@@ -54,6 +66,125 @@ std::string selfExePath() {
   if (n <= 0) return std::string{};
   buf[n] = '\0';
   return std::string(buf);
+}
+
+void launchBarrierTestKernel(hipStream_t stream, uint32_t workgroup_size) {
+  hipLaunchKernelGGL(noopKernel, dim3(1), dim3(workgroup_size), 0, stream);
+  HIP_CHECK(hipGetLastError());
+}
+
+void runBarrierScenario(const std::string& scenario) {
+  hipStream_t stream_a = nullptr;
+  hipStream_t stream_b = nullptr;
+  hipStream_t stream_c = nullptr;
+  HIP_CHECK(hipStreamCreate(&stream_a));
+
+  if (scenario == "same_stream") {
+    launchBarrierTestKernel(stream_a, 17);
+    launchBarrierTestKernel(stream_a, 18);
+    launchBarrierTestKernel(stream_a, 19);
+  } else {
+    HIP_CHECK(hipStreamCreate(&stream_b));
+    if (scenario == "interleaved_aba") {
+      launchBarrierTestKernel(stream_a, 17);
+      launchBarrierTestKernel(stream_b, 18);
+      launchBarrierTestKernel(stream_a, 19);
+    } else if (scenario == "interleaved_abb") {
+      launchBarrierTestKernel(stream_a, 17);
+      launchBarrierTestKernel(stream_b, 18);
+      launchBarrierTestKernel(stream_b, 19);
+    } else if (scenario == "three_streams") {
+      HIP_CHECK(hipStreamCreate(&stream_c));
+      launchBarrierTestKernel(stream_a, 17);
+      launchBarrierTestKernel(stream_b, 18);
+      launchBarrierTestKernel(stream_c, 19);
+      launchBarrierTestKernel(stream_a, 20);
+    } else if (scenario == "event_wait") {
+      hipEvent_t event = nullptr;
+      HIP_CHECK(hipEventCreateWithFlags(&event, hipEventDisableTiming));
+      constexpr uint64_t kEventWaitDelayCycles = 100000000;
+      hipLaunchKernelGGL(delayedNoopKernel, dim3(1), dim3(17), 0, stream_a, kEventWaitDelayCycles);
+      HIP_CHECK(hipGetLastError());
+      launchBarrierTestKernel(stream_b, 18);
+      HIP_CHECK(hipEventRecord(event, stream_a));
+      HIP_CHECK(hipStreamWaitEvent(stream_b, event, 0));
+      launchBarrierTestKernel(stream_b, 19);
+      HIP_CHECK(hipEventDestroy(event));
+    } else {
+      FAIL("Unknown AQL barrier-bit scenario: " << scenario);
+    }
+  }
+
+  HIP_CHECK(hipDeviceSynchronize());
+  if (stream_c != nullptr) {
+    HIP_CHECK(hipStreamDestroy(stream_c));
+  }
+  if (stream_b != nullptr) {
+    HIP_CHECK(hipStreamDestroy(stream_b));
+  }
+  HIP_CHECK(hipStreamDestroy(stream_a));
+}
+
+std::string runBarrierScenarioChild(const std::string& scenario) {
+  const std::string self = selfExePath();
+  REQUIRE_FALSE(self.empty());
+  const std::string log_file =
+      "hip_aql_barrier_" + scenario + "_" + std::to_string(getpid()) + ".log";
+
+  const pid_t child_pid = fork();
+  REQUIRE(child_pid >= 0);
+  if (child_pid == 0) {
+    setenv(kBarrierChildEnv, "1", 1);
+    setenv(kBarrierScenarioEnv, scenario.c_str(), 1);
+    setenv("GPU_MAX_HW_QUEUES", "1", 1);
+    setenv("DEBUG_CLR_AQL_BARRIER_OPT", "1", 1);
+    setenv("AMD_LOG_LEVEL", "5", 1);
+    setenv("AMD_LOG_MASK", "8", 1);
+
+    const int log_fd = open(log_file.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (log_fd < 0) _exit(127);
+    dup2(log_fd, STDERR_FILENO);
+    const int dev_null = open("/dev/null", O_WRONLY);
+    if (dev_null >= 0) dup2(dev_null, STDOUT_FILENO);
+
+    const char* child_argv[] = {
+        self.c_str(), "Unit_hipStreamAqlBarrierBit_ChildWorkload", nullptr};
+    execv(self.c_str(), const_cast<char* const*>(child_argv));
+    _exit(127);
+  }
+
+  int child_status = 0;
+  REQUIRE(waitpid(child_pid, &child_status, 0) == child_pid);
+  REQUIRE(WIFEXITED(child_status));
+  REQUIRE(WEXITSTATUS(child_status) == 0);
+
+  std::ifstream log_stream(log_file);
+  REQUIRE(log_stream.good());
+  std::stringstream log_contents;
+  log_contents << log_stream.rdbuf();
+  log_stream.close();
+  std::remove(log_file.c_str());
+  return log_contents.str();
+}
+
+int dispatchBarrierBitForWorkgroup(const std::string& log, uint32_t workgroup_size) {
+  const std::string workgroup_token =
+      "workgroup=[" + std::to_string(workgroup_size) + ", 1, 1]";
+  std::istringstream log_lines(log);
+  std::string log_line;
+  while (std::getline(log_lines, log_line)) {
+    if (log_line.find("Dispatch Header") == std::string::npos ||
+        log_line.find(workgroup_token) == std::string::npos) {
+      continue;
+    }
+    if (log_line.find("barrier=0") != std::string::npos) {
+      return 0;
+    }
+    if (log_line.find("barrier=1") != std::string::npos) {
+      return 1;
+    }
+  }
+  return -1;
 }
 
 }  // namespace
@@ -177,6 +308,79 @@ HIP_TEST_CASE(Unit_hipStreamPriorityAqlLog_TraceReportsPriority) {
   REQUIRE(hwqLineHasPriority(3));  // High
   REQUIRE(hwqLineHasPriority(1));  // Normal
   REQUIRE(hwqLineHasPriority(0));  // Low
+}
+
+HIP_TEST_CASE(Unit_hipStreamAqlBarrierBit_ChildWorkload) {
+  if (std::getenv(kBarrierChildEnv) == nullptr) {
+    SUCCEED("Skipping child workload outside of parent-driven run");
+    return;
+  }
+
+  const char* scenario = std::getenv(kBarrierScenarioEnv);
+  REQUIRE(scenario != nullptr);
+  runBarrierScenario(scenario);
+}
+
+HIP_TEST_CASE(Unit_hipStreamAqlBarrierBit_Scenarios) {
+  if (std::getenv(kBarrierChildEnv) != nullptr) {
+    SUCCEED("Skipping parent driver inside child invocation");
+    return;
+  }
+
+  SECTION("Same stream") {
+    const std::string log = runBarrierScenarioChild("same_stream");
+    REQUIRE(dispatchBarrierBitForWorkgroup(log, 17) == 0);
+    REQUIRE(dispatchBarrierBitForWorkgroup(log, 18) == 1);
+    REQUIRE(dispatchBarrierBitForWorkgroup(log, 19) == 1);
+  }
+
+  SECTION("Interleaved streams A B A") {
+    const std::string log = runBarrierScenarioChild("interleaved_aba");
+    REQUIRE(dispatchBarrierBitForWorkgroup(log, 17) == 0);
+    REQUIRE(dispatchBarrierBitForWorkgroup(log, 18) == 0);
+    REQUIRE(dispatchBarrierBitForWorkgroup(log, 19) == 1);
+  }
+
+  SECTION("Interleaved streams A B B") {
+    const std::string log = runBarrierScenarioChild("interleaved_abb");
+    REQUIRE(dispatchBarrierBitForWorkgroup(log, 17) == 0);
+    REQUIRE(dispatchBarrierBitForWorkgroup(log, 18) == 0);
+    REQUIRE(dispatchBarrierBitForWorkgroup(log, 19) == 1);
+  }
+
+  SECTION("Three streams A B C A") {
+    const std::string log = runBarrierScenarioChild("three_streams");
+    REQUIRE(dispatchBarrierBitForWorkgroup(log, 17) == 0);
+    REQUIRE(dispatchBarrierBitForWorkgroup(log, 18) == 0);
+    REQUIRE(dispatchBarrierBitForWorkgroup(log, 19) == 0);
+    REQUIRE(dispatchBarrierBitForWorkgroup(log, 20) == 1);
+  }
+
+  SECTION("Event record and wait preserve stream ordering") {
+    const std::string log = runBarrierScenarioChild("event_wait");
+    REQUIRE(dispatchBarrierBitForWorkgroup(log, 17) == 0);
+    REQUIRE(dispatchBarrierBitForWorkgroup(log, 18) == 0);
+    REQUIRE(dispatchBarrierBitForWorkgroup(log, 19) == 1);
+
+    std::vector<int> barrier_bits;
+    std::istringstream log_lines(log);
+    std::string log_line;
+    while (std::getline(log_lines, log_line)) {
+      if (log_line.find("Barrier-AND Header") == std::string::npos &&
+          log_line.find("BarrierValue Header") == std::string::npos) {
+        continue;
+      }
+      if (log_line.find("barrier=0") != std::string::npos) {
+        barrier_bits.push_back(0);
+      } else {
+        REQUIRE(log_line.find("barrier=1") != std::string::npos);
+        barrier_bits.push_back(1);
+      }
+    }
+    REQUIRE(barrier_bits.size() >= 2);
+    REQUIRE(barrier_bits[0] == 1);
+    REQUIRE(barrier_bits[1] == 0);
+  }
 }
 
 /**


### PR DESCRIPTION
## Motivation

HIP streams share a limited pool of physical HSA queues (`GPU_MAX_HW_QUEUES`, default 4). Setting the AQL barrier bit on every dispatch forces each packet to wait for all earlier packets on the same physical queue, unnecessarily serializing otherwise independent streams.

This change preserves ordering within each HIP stream while allowing independent streams sharing a hardware queue to overlap.

## Technical Details

### Decision rule

The runtime tracks:

- The newest slot containing `barrier=1` for each physical HSA queue.
- The last AQL packet slot submitted by each `VirtualGPU` on its current physical queue.

Before reserving a packet slot, the runtime snapshots the queue's latest barrier slot. The new packet retains its barrier when:

```
needs_barrier = has_previous_stream_packet &&
                (barrier_slot_before_reservation == UINT64_MAX ||
                 barrier_slot_before_reservation <= previous_stream_slot)
```

The first packet from a stream can clear its barrier because it has no in-stream predecessor. A later packet can clear its barrier only when a newer queue barrier already covers its previous stream packet.

### Race safety and state lifetime

- Queue barrier state is snapshotted before the atomic write-index reservation, preventing a later producer from affecting the current reservation's decision.
- Per-queue state uses one atomic slot value; `UINT64_MAX` represents “no barrier recorded.”
- Queue state is owned by `QueueExtras::largestAqlBarrierBitSlot` and follows the physical queue lifetime.
- Per-stream packet history resets when a `VirtualGPU` changes or releases its physical queue.
- Non-HIP and disabled configurations skip ordering-state atomics.

### AQL path coverage

One uniform rule applies to every packet type, regardless of kind: clear the barrier bit whenever the stream's ordering is already guaranteed by a preceding queue barrier. Common reservation and tracking helpers cover:

- Generic single-packet dispatches.
- Barrier packets.
- Barrier-value packets.
- Flat graph batches, which optimize the first dispatch header and otherwise submit conservatively.

Explicit any-order submissions remain unchanged.

### Runtime control

`DEBUG_CLR_AQL_BARRIER_OPT` controls the optimization and is enabled by default.

## Issue Tracking

JIRA ID: AIRUNTIME-74

## Test Plan

- Exercise exact AQL barrier-bit patterns for:
  - Same-stream submissions.
  - Interleaved A-B-A and A-B-B submissions.
  - Three streams sharing one hardware queue.
  - Event record/wait synchronization.
- Stress concurrent host-thread submissions from eight streams.
- Verify dynamic hardware-queue release and reacquisition.
- Run shared-queue ordering with `GPU_MAX_HW_QUEUES=1` and `4`.

## Test Result

- CLR build and installation: passed.
- StreamTest build: passed.
- AQL barrier-bit scenarios: passed, 51 assertions.
- Shared-HW-queue packet ordering with `GPU_MAX_HW_QUEUES=1`: passed.
- Shared-HW-queue packet ordering with `GPU_MAX_HW_QUEUES=4`: passed.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
