### PR TITLE
fix(clr): let the fat-binary readable bound span a split mapping

### DIFF
--- a/projects/clr/rocclr/os/os.hpp
+++ b/projects/clr/rocclr/os/os.hpp
@@ -56,8 +56,14 @@ class Os : AllStatic {
 
   // Returns the file name & file offset of mapped memory if the file is mapped.
   // If region_bound_ptr is non-null and 'image' lies in a readable mapping, it is
-  // set to the number of readable bytes from 'image' to the end of that mapping
-  // (populated for anonymous mappings too, even when no file name is resolved).
+  // set to the bytes readable from 'image' to the end of the run of adjacent
+  // mappings sharing its backing object (populated for anonymous mappings too,
+  // even when no file name is resolved). One allocation may span several
+  // mappings; the run stops at a gap, an unreadable mapping, or a different
+  // backing object.
+  //
+  // This is a page-granular no-fault ceiling, not an object length. Use it to
+  // keep parsing inside readable memory, never as a trust boundary.
   static bool FindFileNameFromAddress(const void* image, std::string* fname_ptr,
                                       size_t* foffset_ptr, size_t* region_bound_ptr = nullptr);
 

--- a/projects/clr/rocclr/os/os_posix.cpp
+++ b/projects/clr/rocclr/os/os_posix.cpp
@@ -910,9 +910,42 @@ bool amd::Os::FindFileNameFromAddress(const void* image, std::string* fname_ptr,
       tokens >> permissions >> std::hex >> offset >> std::dec >> device >> inode;
       std::getline(tokens >> std::ws, uri_file_path);
 
-      // Readable bytes from image to the end of this mapping (anonymous or not).
+      // Readable bytes from image to the end of the region holding it. One
+      // allocation can span several adjacent entries, so walk forward while the
+      // next one is adjacent, readable and has the same backing object. The cap
+      // keeps the cost off the size of the address space; stopping early only
+      // shortens the bound.
       if (region_bound_ptr != nullptr && !permissions.empty() && permissions[0] == 'r') {
-        *region_bound_ptr = static_cast<size_t>(high_address - address);
+        constexpr int kMaxCoalescedMappings = 32;
+        uintptr_t readable_end = high_address;
+        std::string next_line;
+        for (int examined = 0; examined < kMaxCoalescedMappings; ++examined) {
+          if (!std::getline(proc_maps, next_line)) {
+            break;
+          }
+          std::stringstream next_tokens(next_line);
+          uintptr_t next_low, next_high;
+          char next_dash;
+          next_tokens >> std::hex >> next_low >> std::dec >> next_dash >> std::hex >> next_high >>
+              std::dec;
+          // Stop on an unparsable line; skipping one would make a later mapping
+          // look adjacent.
+          if (next_tokens.fail() || next_dash != '-' || next_low != readable_end) {
+            break;
+          }
+          std::string next_permissions, next_device, next_path;
+          size_t next_offset;
+          uint64_t next_inode;
+          next_tokens >> next_permissions >> std::hex >> next_offset >> std::dec >> next_device >>
+              next_inode;
+          std::getline(next_tokens >> std::ws, next_path);
+          if (next_permissions.empty() || next_permissions[0] != 'r' || next_inode != inode ||
+              next_device != device || next_path != uri_file_path) {
+            break;
+          }
+          readable_end = next_high;
+        }
+        *region_bound_ptr = static_cast<size_t>(readable_end - address);
       }
 
       if (inode == 0 || uri_file_path.empty()) {

--- a/projects/hip-tests/catch/config/configs/unit/oob.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/oob.yaml
@@ -24,3 +24,7 @@ oob:
     <<: *level_4
     disabled: [windows, amd_windows, nvidia_linux, nvidia_windows]
     tags: [oob]
+  OOB_hipModuleLoadData_Positive_ImageSpansSplitMapping:
+    <<: *level_4
+    disabled: [windows, amd_windows, nvidia_linux, nvidia_windows]
+    tags: [oob]

--- a/projects/hip-tests/catch/unit/oob/oob_module.cc
+++ b/projects/hip-tests/catch/unit/oob/oob_module.cc
@@ -1,6 +1,7 @@
 #include <hip_test_common.hh>
 #include <hip/hiprtc.h>
 #include "hip_test_filesystem.hh"
+#include <algorithm>
 #include <cstdint>
 #include <cstring>
 #include <fstream>
@@ -240,6 +241,53 @@ HIP_TEST_CASE(OOB_hiprtc_roundtrip_loads) {
   HIP_CHECK(hipModuleLoadData(&module, code.data()));
   HIP_CHECK(hipModuleUnload(module));
 }
+
+#if HT_AMD
+// One allocation can span several kernel mappings, so a valid code object must
+// still load when it straddles the seam. mprotect splits the region here;
+// production hits the same shape through mbind() and friends.
+HIP_TEST_CASE(OOB_hipModuleLoadData_Positive_ImageSpansSplitMapping) {
+  static constexpr char kSource[] = "extern \"C\" __global__ void nop() {}\n";
+
+  hipDeviceProp_t props;
+  HIP_CHECK(hipGetDeviceProperties(&props, 0));
+  const std::string arch = std::string("--offload-arch=") + props.gcnArchName;
+  const char* options[] = {arch.c_str()};
+
+  hiprtcProgram prog;
+  HIPRTC_CHECK(hiprtcCreateProgram(&prog, kSource, "nop.cu", 0, nullptr, nullptr));
+  HIPRTC_CHECK(hiprtcCompileProgram(prog, 1, options));
+  size_t code_size = 0;
+  HIPRTC_CHECK(hiprtcGetCodeSize(prog, &code_size));
+  std::vector<char> code(code_size);
+  HIPRTC_CHECK(hiprtcGetCode(prog, code.data()));
+  HIPRTC_CHECK(hiprtcDestroyProgram(&prog));
+  REQUIRE(code_size > 1);
+
+  const size_t page = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+  // Start the image before the seam and end it after, whatever its size.
+  const size_t head = std::min(code_size / 2, page / 2);
+  const size_t start = page - head;
+  const size_t span = ((start + code_size + page - 1) / page + 1) * page;
+
+  char* region = static_cast<char*>(
+      mmap(nullptr, span, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+  REQUIRE(region != MAP_FAILED);
+
+  char* image = region + start;
+  std::memcpy(image, code.data(), code_size);
+  REQUIRE(mprotect(region + page, page, PROT_READ) == 0);
+  REQUIRE(std::memcmp(image, code.data(), code_size) == 0);
+
+  hipModule_t module{};
+  const hipError_t status = hipModuleLoadData(&module, image);
+  if (status == hipSuccess) {
+    HIP_CHECK(hipModuleUnload(module));
+  }
+  REQUIRE(munmap(region, span) == 0);
+  HIP_CHECK(status);
+}
+#endif  // HT_AMD
 
 // ---------------------------------------------------------------------------
 // Readable-size bounds tests for fat-binary parsing.


### PR DESCRIPTION
## Motivation

`hipModuleLoadData` rejects valid code objects with `hipErrorInvalidImage`. The
readable-size bound is measured to the end of one `/proc/self/maps` entry, but one
allocation can be split across several, so the bound comes back short.

### How it shows up in JAX

Random kernels fail to load part-way through a run, with no pattern to which ones.
A 16-process JAX test suite hits it within about 30 minutes. The same run also
fails inside MIOpen and in jaxlib's own FFI kernels, because all three load code
objects the same way.

### How to reproduce

Build a code object for your GPU:

```bash
echo '__global__ void k(float* p) { *p = 1.0f; }' > kernel.hip
hipcc --genco -x hip kernel.hip --offload-arch=$(rocminfo | grep -om1 'gfx[0-9a-z]*') -o kernel.co
```

`repro.cpp`:

```cpp
#include <hip/hip_runtime.h>
#include <malloc.h>
#include <numaif.h>
#include <unistd.h>

#include <cstdio>
#include <cstring>
#include <fstream>
#include <vector>

int main(int argc, char** argv) {
  std::ifstream f(argv[1], std::ios::binary | std::ios::ate);
  std::vector<char> co(f.tellg());
  f.seekg(0);
  f.read(co.data(), co.size());

  const size_t page = sysconf(_SC_PAGESIZE);
  mallopt(M_MMAP_THRESHOLD, 1 << 30);  // keep the buffer on the brk heap
  char* buf = static_cast<char*>(malloc(64 * page));
  memset(buf, 0, 64 * page);
  hipFree(nullptr);

  // Put the code object across a page boundary inside the allocation.
  const uintptr_t seam = (reinterpret_cast<uintptr_t>(buf) + 16 * page) & ~(page - 1);
  char* image = reinterpret_cast<char*>(seam - 2048);
  memcpy(image, co.data(), co.size());

  // Split [heap] the way libhsakmt does when it places memory on a NUMA node.
  unsigned long mask = 1;
  if (mbind(reinterpret_cast<void*>(seam), 8 * page, MPOL_PREFERRED, &mask, sizeof(mask) * 8, 0)) {
    printf("mbind blocked (seccomp?); cannot reproduce here\n");
    return 2;
  }

  // The image never moved and every byte is readable.
  volatile char sink = 0;
  for (size_t i = 0; i < co.size(); ++i) sink = image[i];
  printf("image %p, %zu bytes, all readable, memcmp %s\n", image, co.size(),
         memcmp(image, co.data(), co.size()) ? "FAILED" : "ok");

  hipModule_t m = nullptr;
  const hipError_t e = hipModuleLoadData(&m, image);
  printf("hipModuleLoadData -> %d (%s)\n", static_cast<int>(e), hipGetErrorString(e));
  return e != hipSuccess;
}
```

```bash
hipcc -O2 repro.cpp -o repro -lnuma
AMD_LOG_LEVEL=1 ./repro kernel.co
```

On `develop` today:

```
image 0x55c080759800, 9696 bytes, all readable, memcmp ok
:1:hip_fatbin.cpp :417 : Rejecting fat binary: code object for isa
  'amdgcn-amd-amdhsa--gfx942:sramecc+:xnack-' is out of bounds
  (offset=4096 size=5600 image bound=2048)
hipModuleLoadData -> 200 (device kernel image is invalid)
```

The image is 9696 bytes and every one of them was just read. The bound says 2048.

This needs `mbind` to be permitted. Docker's default seccomp blocks it, which
`libhsakmt` already works around at `fmm.c:2037`.

### Why the split happens

The kernel splits a mapping when part of it gets an attribute the rest does not
have, and the pieces do not merge back afterwards. A NUMA memory policy is one such
attribute, and it shows up in neither the `/proc/self/maps` line nor `smaps`
`VmFlags`, so the pieces look identical:

```
before:  562668960000-562669671000 rw-p 00000000 00:00 0   [heap]

after:   562668960000-562668a05000 rw-p 00000000 00:00 0   [heap]
         562668a05000-562668a0d000 rw-p 00000000 00:00 0   [heap]
         562668a0d000-562669671000 rw-p 00000000 00:00 0   [heap]
```

This is not something the application has to do. `libhsakmt` does it itself, in
`bind_mem_to_numa()` (`rocr-runtime/libhsakmt/src/fmm.c:2032`). 

An `strace` of a twenty-line JAX program shows 1290 `mbind(..., MPOL_PREFERRED, ...)` calls, plus
52039 `mprotect` and 124 `madvise(MADV_DONTFORK | MADV_HUGEPAGE)`, all of which
split mappings too.

### What the fix does

`FindFileNameFromAddress` walks forward from the entry holding the image while the
next one is directly adjacent, readable, and backed by the same object (same
device, inode, path), and reports the end of that run.

Requiring the same backing object keeps the bound inside the allocation instead of
letting it walk into whatever is mapped next. The walk stops after 32 entries so
its cost does not grow with the number of mappings in the process.

## Issue Tracking

JIRA ID: ROCM-29159

## Test Plan

New test, `OOB_hipModuleLoadData_Positive_ImageSpansSplitMapping` in
`catch/unit/oob/oob_module.cc`. It compiles a code object with hiprtc so the arch
is right, puts it across a split anonymous mapping, checks every byte is readable,
and requires the load to succeed. It fails on `develop` today.

## Test Result

| Suite | unmodified | patched |
|---|---|---|
| `oob_module`, 6 existing cases, 200 assertions | pass | pass |
| `Unit_hipModuleLoad_Negative_MalformedFatBinaryBounds` | pass | pass |
| `ModuleTest`, full run, 5,850,405 assertions | 9 pre-existing failures | same 9, byte-identical |
| `OOB_hipModuleLoadData_Positive_ImageSpansSplitMapping` (new) | **fail** | pass |

Latency, 2000 `hipModuleLoadData` iterations:

| mappings in the process | unmodified | patched |
|---|---|---|
| 219 | 2466 us | 2448 us |
| 10218 | 2004 us | 2017 us |
| 44218 | 2455 us | 2450 us |


End to end: the JAX UT passes with no flakes with this fix.

Not tested: Windows. I'm not sure about windows usecase, I'm open to suggestions.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
