### PR TITLE
fix(rccl): gate unroll 8/16/32 selection to gfx1250 to prevent crash on other arches

### DIFF
--- a/projects/rccl/src/rccl_wrap.cc
+++ b/projects/rccl/src/rccl_wrap.cc
@@ -968,6 +968,23 @@ ncclResult_t rcclFuncMaxSendRecvCount(ncclFunc_t func, int nRanks, size_t count,
   return ncclSuccess;
 }
 
+// ncclDevFuncUnrollGenerated[] is emitted build-wide (generate.py), not per
+// architecture: in any normal multi-arch build it reports unroll 8/16/32 as
+// "generated" as soon as gfx1250 is one of the build's targets, even though
+// the actual ncclDevFuncTable_8/16/32[] entries are only compiled under
+// `defined(__gfx1250__)` (see generate.py's get_arch_guard). Without this
+// extra arch check, RCCL_UNROLL_FACTOR=3/4/5 (or the gfx1250 default falling
+// back) on any other arch passes the table check and then dispatches through
+// a null/absent function-table slot for that arch -> device-side crash.
+static bool ncclUnrollFactorAvailableForArch(struct ncclComm* comm, int unroll) {
+  if (!ncclDevFuncUnrollGenerated[unroll]) return false;
+  if ((unroll == NCCL_UNROLL_8 || unroll == NCCL_UNROLL_16 || unroll == NCCL_UNROLL_32) &&
+      !IsArchMatch(comm->archName, "gfx1250")) {
+    return false;
+  }
+  return true;
+}
+
 ncclResult_t commSetUnrollFactor(struct ncclComm* comm) {
   if (rcclParamUnrollFactor() != -1) {
     comm->unroll = rcclParamUnrollFactor(); //-1 to map to 0 based indexing
@@ -977,7 +994,7 @@ ncclResult_t commSetUnrollFactor(struct ncclComm* comm) {
            comm->unroll, NCCL_NUM_UNROLLS - 1);
       return ncclInvalidArgument;
     }
-    if (!ncclDevFuncUnrollGenerated[comm->unroll]) {
+    if (!ncclUnrollFactorAvailableForArch(comm, comm->unroll)) {
       WARN("RCCL_UNROLL_FACTOR %d (unroll %d) was not built for arch %s; its device function table is empty and "
            "dispatching to it would crash. "
            "Rebuild with this unroll factor, or select one that was generated for this build.",
@@ -997,10 +1014,10 @@ ncclResult_t commSetUnrollFactor(struct ncclComm* comm) {
 
   // Guard against a default that wasn't built for this arch (e.g. the generation
   // matrix was narrowed). Fall back to any generated unroll rather than segfault.
-  if (!ncclDevFuncUnrollGenerated[comm->unroll]) {
+  if (!ncclUnrollFactorAvailableForArch(comm, comm->unroll)) {
     int fallback = -1;
     for (int u = NCCL_NUM_UNROLLS - 1; u >= NCCL_UNROLL_1; u--) {
-      if (ncclDevFuncUnrollGenerated[u]) {
+      if (ncclUnrollFactorAvailableForArch(comm, u)) {
         fallback = u;
         break;
       }

--- a/projects/rccl/test/RcclWrapTests.cpp
+++ b/projects/rccl/test/RcclWrapTests.cpp
@@ -14,6 +14,7 @@
 #include "common/ErrCode.hpp"
 #include "common/ProcessIsolatedTestRunner.hpp"
 #include "debug.h"
+#include "device.h"
 #include "graph/topo.h"
 #include "net.h"
 #include "rccl_common.h"
@@ -1651,6 +1652,124 @@ TEST(RcclCeGraphLatch, NeverLatchedAllowsCeAllReduceByDefault)
     comm.ceColl.graphModeSeen = false;
 
     EXPECT_TRUE(rcclCeAllReduceAllowed(&comm));
+}
+
+// ---------------------------------------------------------------------------
+// commSetUnrollFactor() (rccl_wrap.cc)
+//
+// ncclDevFuncUnrollGenerated[] is emitted build-wide by generate.py: in a
+// normal (non local-arch-restricted) build it reports unroll 8/16/32 as
+// "generated" as soon as gfx1250 is one of the build's targets, regardless of
+// which architecture a given communicator actually runs on. The device
+// function tables for those unroll factors are only compiled under
+// `defined(__gfx1250__)`, so without an explicit per-arch check,
+// RCCL_UNROLL_FACTOR=3/4/5 on any other architecture passes the table check
+// and then dispatches through an absent function-table slot -> crash/hang.
+//
+// These tests exercise commSetUnrollFactor()'s user-override path directly on
+// plain (non-topology) mock communicators; no GPU/topology is required since
+// the function only reads comm->archName / nNodes / cuCount. Each case is
+// process-isolated (RUN_ISOLATED_TEST_WITH_ENV) because rcclParamUnrollFactor()
+// caches RCCL_UNROLL_FACTOR in a static on first read.
+// ---------------------------------------------------------------------------
+
+TEST(CommSetUnrollFactor, RejectsUnroll8OnNonGfx1250Arch)
+{
+    RUN_ISOLATED_TEST_WITH_ENV(
+        "RejectsUnroll8OnNonGfx1250Arch",
+        []()
+        {
+            ncclComm comm{};
+            comm.archName = const_cast<char*>("gfx942");
+            comm.nNodes   = 1;
+
+            EXPECT_EQ(commSetUnrollFactor(&comm), ncclInvalidArgument);
+        },
+        {{"RCCL_UNROLL_FACTOR", "3"}} // NCCL_UNROLL_8
+    );
+}
+
+TEST(CommSetUnrollFactor, RejectsUnroll16OnNonGfx1250Arch)
+{
+    RUN_ISOLATED_TEST_WITH_ENV(
+        "RejectsUnroll16OnNonGfx1250Arch",
+        []()
+        {
+            ncclComm comm{};
+            comm.archName = const_cast<char*>("gfx950");
+            comm.nNodes   = 1;
+
+            EXPECT_EQ(commSetUnrollFactor(&comm), ncclInvalidArgument);
+        },
+        {{"RCCL_UNROLL_FACTOR", "4"}} // NCCL_UNROLL_16
+    );
+}
+
+// Mirrors the real-hardware reproduction: RCCL_UNROLL_FACTOR=5 on gfx942
+// previously passed this check (table says "generated") and then hung the
+// device on dispatch into a null function-table slot.
+TEST(CommSetUnrollFactor, RejectsUnroll32OnNonGfx1250Arch)
+{
+    RUN_ISOLATED_TEST_WITH_ENV(
+        "RejectsUnroll32OnNonGfx1250Arch",
+        []()
+        {
+            ncclComm comm{};
+            comm.archName = const_cast<char*>("gfx942");
+            comm.nNodes   = 1;
+
+            EXPECT_EQ(commSetUnrollFactor(&comm), ncclInvalidArgument);
+        },
+        {{"RCCL_UNROLL_FACTOR", "5"}} // NCCL_UNROLL_32
+    );
+}
+
+// Control: unroll factors below 8 are compiled for every architecture, so the
+// new gfx1250-only check must not affect them. Proves the fix is precise
+// rather than blocking RCCL_UNROLL_FACTOR overrides outright.
+TEST(CommSetUnrollFactor, AllowsUnroll1OnNonGfx1250Arch)
+{
+    RUN_ISOLATED_TEST_WITH_ENV(
+        "AllowsUnroll1OnNonGfx1250Arch",
+        []()
+        {
+            ncclComm comm{};
+            comm.archName = const_cast<char*>("gfx942");
+            comm.nNodes   = 1;
+
+            ASSERT_EQ(commSetUnrollFactor(&comm), ncclSuccess);
+            EXPECT_EQ(comm.unroll, NCCL_UNROLL_1);
+        },
+        {{"RCCL_UNROLL_FACTOR", "0"}} // NCCL_UNROLL_1
+    );
+}
+
+// Positive control: on the architecture the fix targets, unroll 32 must still
+// be accepted whenever this build actually generated it. Skips (rather than
+// fails) if this particular build's table doesn't have it, since that table
+// is a build-time artifact this test cannot control.
+TEST(CommSetUnrollFactor, AllowsUnroll32OnGfx1250WhenGenerated)
+{
+    RUN_ISOLATED_TEST_WITH_ENV(
+        "AllowsUnroll32OnGfx1250WhenGenerated",
+        []()
+        {
+            if(!ncclDevFuncUnrollGenerated[NCCL_UNROLL_32])
+            {
+                GTEST_SKIP() << "This build did not generate unroll-32 device "
+                                "function tables (e.g. gfx1250 not in target "
+                                "arch list); nothing to verify.";
+            }
+
+            ncclComm comm{};
+            comm.archName = const_cast<char*>("gfx1250");
+            comm.nNodes   = 1;
+
+            ASSERT_EQ(commSetUnrollFactor(&comm), ncclSuccess);
+            EXPECT_EQ(comm.unroll, NCCL_UNROLL_32);
+        },
+        {{"RCCL_UNROLL_FACTOR", "5"}} // NCCL_UNROLL_32
+    );
 }
 
 #ifdef ENABLE_WARP_SPEED


### PR DESCRIPTION
## Motivation

ncclDevFuncUnrollGenerated[] is generated build-wide, so it reports unroll factors 8/16/32 as available whenever gfx1250 is a build target, even though those device function tables are only compiled for gfx1250 specifically. This lets RCCL_UNROLL_FACTOR=3/4/5 be accepted on other architectures (e.g. gfx942, gfx950) and dispatch into an empty function table, causing a hang or crash.

## Technical Details

Added ncclUnrollFactorAvailableForArch() in rccl_wrap.cc, which checks the existing generated-table lookup plus, for unroll 8/16/32 only, requires the arch to match gfx1250. commSetUnrollFactor() now uses this helper at all three call sites (user override, default fallback trigger, fallback loop), so unsupported requests return ncclInvalidArgument with a clear warning instead of reaching the device.

## Issue Tracking

JIRA ID: AICOMRCCL-1807

## Test Plan

Added 5 unit tests to test/RcclWrapTests.cpp that call commSetUnrollFactor() on mock communicators with RCCL_UNROLL_FACTOR set via the isolated-env test helper. Three verify unroll 8/16/32 are rejected on non-gfx1250 archs,  one control test confirms unroll 1 (compiled for every arch) is unaffected; one positive-control test confirms gfx1250 itself still gets unroll 32 when the build generated it, skipping gracefully otherwise.

## Test Result

All 5 new tests pass, and the existing Rcclwrap/RcclCeGraphLatch suites remain green. Temporarily reverting the arch check caused exactly the 3 targeted tests to fail while the controls stayed green, confirming the tests catch the bug; all 5 passed again once the fix was restored.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
