### PR TITLE
feat(rocr): expose SDMA queue pointer addresses via hsa_amd_queue_get…

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/functional/queue_create.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/queue_create.cc
@@ -310,6 +310,32 @@ void QueueCreateTest::SdmaQueueCreateDestroyTest() {
     EXPECT_NE(desc.queue->base_address, nullptr) << label;
     EXPECT_NE(desc.queue->doorbell_signal.handle, 0) << label;
 
+    uint64_t read_pointer = 0;
+    uint64_t write_pointer = 0;
+    uint64_t doorbell_pointer = 0;
+    ASSERT_SUCCESS(
+        hsa_amd_queue_get_info(desc.queue, HSA_AMD_QUEUE_INFO_READ_POINTER, &read_pointer));
+    ASSERT_SUCCESS(
+        hsa_amd_queue_get_info(desc.queue, HSA_AMD_QUEUE_INFO_WRITE_POINTER, &write_pointer));
+    ASSERT_SUCCESS(
+        hsa_amd_queue_get_info(desc.queue, HSA_AMD_QUEUE_INFO_DOORBELL_ID, &doorbell_pointer));
+    ASSERT_NE(read_pointer, 0u);
+    ASSERT_NE(write_pointer, 0u);
+    ASSERT_NE(doorbell_pointer, 0u);
+
+    auto* raw_read_pointer = reinterpret_cast<volatile uint64_t*>(read_pointer);
+    auto* raw_write_pointer = reinterpret_cast<volatile uint64_t*>(write_pointer);
+    EXPECT_EQ(hsa_queue_load_read_index_relaxed(desc.queue), *raw_read_pointer);
+
+    hsa_queue_store_write_index_relaxed(desc.queue, 64);
+    EXPECT_EQ(hsa_queue_load_write_index_relaxed(desc.queue), 64u);
+    EXPECT_EQ(*raw_write_pointer, 64u);
+    EXPECT_EQ(hsa_queue_add_write_index_relaxed(desc.queue, 32), 64u);
+    EXPECT_EQ(*raw_write_pointer, 96u);
+    EXPECT_EQ(hsa_queue_cas_write_index_relaxed(desc.queue, 96, 128), 96u);
+    EXPECT_EQ(*raw_write_pointer, 128u);
+    hsa_queue_store_write_index_relaxed(desc.queue, 0);
+
     ASSERT_SUCCESS(hsa_queue_destroy(desc.queue)) << label;
   };
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_sdma_queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_sdma_queue.h
@@ -30,32 +30,21 @@ class GpuAgent;
 /// protocol, including ring-space checks, wrap/no-op handling, packet writes,
 /// and ordered doorbell publication.
 ///
-/// Write-pointer model (important): an SDMA queue tracks the write position in
-/// two distinct places, unlike an AQL queue.
-///   1. @c amd_queue_.write_dispatch_id is the *software* write index. It is a
-///      monotonically increasing byte count (SDMA pointers are byte offsets)
-///      and backs the public hsa_queue_load/store/add/cas_write_index helpers.
-///      The SDMA engine never reads it.
-///   2. @c queue_wptr_ (the KFD-provided @c HsaQueueResource::Queue_write_ptr)
-///      is the *hardware* write pointer the SDMA engine actually consumes.
-/// For an AQL queue these two are the same memory, because KFD is told to use
-/// @c write_dispatch_id directly as the hardware write pointer. For an SDMA
-/// queue KFD allocates its own write-pointer location, so the software index
-/// must be explicitly copied into @c queue_wptr_ at publish time.
+/// Write-pointer model: the KFD-provided @c queue_wptr_ is the canonical
+/// monotonically increasing byte index. Public load/store/add/CAS write-index
+/// operations access it directly. A caller writes complete packets, advances
+/// this pointer, then rings the doorbell to notify the engine.
 ///
 /// Submission protocol (single producer, performed by the caller per
 /// submission, matching BlitSdma's AcquireWriteAddress/ReleaseWriteAddress):
-///   a. Read the current write index (LoadWriteIndex* -> write_dispatch_id).
+///   a. Read the current write index (LoadWriteIndex* -> queue_wptr_).
 ///   b. Ensure ring space against the read index (queue_rptr_) and pad to the
 ///      ring end with SDMA no-ops if the request would wrap.
 ///   c. Write complete packets into base_address + (index % size).
-///   d. Advance the software write index (StoreWriteIndex*/AddWriteIndex*).
-///   e. Publish via the doorbell signal store, which routes to RingDoorbell():
-///      that is the *only* step that updates the hardware write pointer
-///      (queue_wptr_) and the doorbell, in that order, after a release fence.
-/// Steps (a)-(d) only touch the software index; the engine observes nothing
-/// until (e). Callers must serialize a-e (e.g. a lock) because the index
-/// accessors here do not implement a reservation/commit handshake.
+///   d. Advance queue_wptr_ (StoreWriteIndex*/AddWriteIndex*).
+///   e. Publish via the doorbell signal store after a release fence.
+/// Callers must serialize a-e (e.g. a lock) because the index accessors here
+/// do not implement a reservation/commit handshake.
 class SdmaQueue : public core::Queue, private core::LocalSignal, public core::DoorbellSignal {
  public:
   static __forceinline bool IsType(core::Queue* queue) { return queue->IsType(&rtti_id()); }
@@ -91,9 +80,8 @@ class SdmaQueue : public core::Queue, private core::LocalSignal, public core::Do
   uint64_t CasWriteIndexRelaxed(uint64_t expected, uint64_t value) override;
   uint64_t CasWriteIndexRelease(uint64_t expected, uint64_t value) override;
 
-  // Implemented to satisfy the core::Queue interface and public hsa_queue_t
-  // helpers. These update only the descriptor's software write index; they do
-  // not reserve SDMA ring space or make SDMA submission multi-producer safe.
+  // These operate on queue_wptr_ directly. They do not reserve SDMA ring space
+  // or make SDMA submission multi-producer safe.
   uint64_t AddWriteIndexAcqRel(uint64_t value) override;
   uint64_t AddWriteIndexAcquire(uint64_t value) override;
   uint64_t AddWriteIndexRelaxed(uint64_t value) override;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_sdma_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_sdma_queue.cpp
@@ -37,9 +37,9 @@ core::SharedQueue* AllocateSdmaSharedQueue(core::Agent* agent, uint64_t flags) {
         sizeof(core::SharedQueue),
         core::MemoryRegion::AllocateUncached | core::MemoryRegion::AllocateQueueObject));
   } else {
-    shared_queue = static_cast<core::SharedQueue*>(gpu_agent->system_allocator()(
-        sizeof(core::SharedQueue), MemoryRegion::GetPageSize(),
-        core::MemoryRegion::AllocateQueueObject));
+    shared_queue = static_cast<core::SharedQueue*>(
+        gpu_agent->system_allocator()(sizeof(core::SharedQueue), MemoryRegion::GetPageSize(),
+                                      core::MemoryRegion::AllocateQueueObject));
   }
 
   if (shared_queue == nullptr) {
@@ -83,9 +83,7 @@ SdmaQueue::~SdmaQueue() {
   }
 }
 
-AMD::GpuAgent* SdmaQueue::gpu_agent() const {
-  return static_cast<AMD::GpuAgent*>(agent_);
-}
+AMD::GpuAgent* SdmaQueue::gpu_agent() const { return static_cast<AMD::GpuAgent*>(agent_); }
 
 hsa_status_t SdmaQueue::AllocateQueueBuffer() {
   if (queue_start_addr_ != nullptr) {
@@ -96,12 +94,13 @@ hsa_status_t SdmaQueue::AllocateQueueBuffer() {
     if (!gpu_agent()->LargeBarEnabled()) {
       return HSA_STATUS_ERROR_INVALID_QUEUE_CREATION;
     }
-    queue_start_addr_ = reinterpret_cast<char*>(
-        gpu_agent()->coarsegrain_allocator()(queue_size_, core::MemoryRegion::AllocateExecutable));
+    queue_start_addr_ = reinterpret_cast<char*>(gpu_agent()->coarsegrain_allocator()(
+        queue_size_,
+        core::MemoryRegion::AllocateExecutable | core::MemoryRegion::AllocateUncached));
   } else {
-    queue_start_addr_ = reinterpret_cast<char*>(
-        gpu_agent()->system_allocator()(queue_size_, 0x1000,
-                                        core::MemoryRegion::AllocateExecutable));
+    queue_start_addr_ = reinterpret_cast<char*>(gpu_agent()->system_allocator()(
+        queue_size_, 0x1000,
+        core::MemoryRegion::AllocateExecutable | core::MemoryRegion::AllocateUncached));
   }
   if (queue_start_addr_ == nullptr) {
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
@@ -148,9 +147,8 @@ hsa_status_t SdmaQueue::Initialize() {
   // Resolve the engine: an explicit id is used as-is; automatic selection
   // rotates round-robin across all SDMA engines so concurrently created queues
   // spread across the hardware.
-  const uint32_t engine_id = (sdma_engine_id_ >= 0)
-                                 ? static_cast<uint32_t>(sdma_engine_id_)
-                                 : agent->NextSdmaUserQueueEngineId();
+  const uint32_t engine_id = (sdma_engine_id_ >= 0) ? static_cast<uint32_t>(sdma_engine_id_)
+                                                    : agent->NextSdmaUserQueueEngineId();
   sdma_engine_id_ = static_cast<int32_t>(engine_id);
 
   const uint32_t kQueuePercent = 100;  // Request the full KFD queue scheduling allocation.
@@ -214,6 +212,15 @@ hsa_status_t SdmaQueue::GetInfo(hsa_queue_info_attribute_t attribute, void* valu
     case HSA_AMD_QUEUE_INFO_SDMA_ENGINE_ID:
       *static_cast<uint32_t*>(value) = static_cast<uint32_t>(sdma_engine_id_);
       return HSA_STATUS_SUCCESS;
+    case HSA_AMD_QUEUE_INFO_DOORBELL_ID:
+      *static_cast<uint64_t*>(value) = reinterpret_cast<uint64_t>(queue_doorbell_);
+      return HSA_STATUS_SUCCESS;
+    case HSA_AMD_QUEUE_INFO_READ_POINTER:
+      *static_cast<uint64_t*>(value) = reinterpret_cast<uint64_t>(queue_rptr_);
+      return HSA_STATUS_SUCCESS;
+    case HSA_AMD_QUEUE_INFO_WRITE_POINTER:
+      *static_cast<uint64_t*>(value) = reinterpret_cast<uint64_t>(queue_wptr_);
+      return HSA_STATUS_SUCCESS;
     default:
       return HSA_STATUS_ERROR_INVALID_ARGUMENT;
   }
@@ -228,12 +235,8 @@ hsa_status_t SdmaQueue::RingDoorbell(uint64_t write_index) {
   // synchronized: by the time the doorbell is stored the caller must have
   // written complete packets into the ring and handled wrap/space checks.
   //
-  // This is the only place the hardware write pointer advances. Order matches
-  // BlitSdma::ReleaseWriteAddress: update the software mirror, then the KFD
-  // hardware write pointer (queue_wptr_) the SDMA engine reads, issue a release
-  // fence so the engine cannot observe the doorbell before the wptr/packets,
-  // and finally ring the doorbell with the new byte index.
-  atomic::Store(&amd_queue_.write_dispatch_id, write_index, std::memory_order_release);
+  // The public write-index operations use queue_wptr_ directly. Ensure the
+  // canonical write pointer and packet stores are visible before the doorbell.
   atomic::Store(queue_wptr_, write_index, std::memory_order_release);
   std::atomic_thread_fence(std::memory_order_release);
   *queue_doorbell_ = write_index;
@@ -246,13 +249,9 @@ hsa_status_t SdmaQueue::RingDoorbell(uint64_t write_index) {
   return HSA_STATUS_SUCCESS;
 }
 
-// Write-index accessors below operate on the *software* write index
-// (amd_queue_.write_dispatch_id), not the hardware write pointer. They back the
-// public hsa_queue_*_write_index helpers so a caller can stage a submission
-// (read index -> write packets -> advance index) without the SDMA engine
-// observing anything. The hardware write pointer (queue_wptr_) is published
-// only in RingDoorbell(). Read-index accessors mirror the hardware read pointer
-// (queue_rptr_) the engine advances as it consumes packets.
+// Public read/write-index operations use KFD's canonical hardware control
+// words. Updating the write pointer stages work; the engine is notified only
+// when the caller subsequently rings the doorbell.
 uint64_t SdmaQueue::LoadReadIndexAcquire() {
   return atomic::Load(queue_rptr_, std::memory_order_acquire);
 }
@@ -262,11 +261,11 @@ uint64_t SdmaQueue::LoadReadIndexRelaxed() {
 }
 
 uint64_t SdmaQueue::LoadWriteIndexAcquire() {
-  return atomic::Load(&amd_queue_.write_dispatch_id, std::memory_order_acquire);
+  return atomic::Load(queue_wptr_, std::memory_order_acquire);
 }
 
 uint64_t SdmaQueue::LoadWriteIndexRelaxed() {
-  return atomic::Load(&amd_queue_.write_dispatch_id, std::memory_order_relaxed);
+  return atomic::Load(queue_wptr_, std::memory_order_relaxed);
 }
 
 void SdmaQueue::StoreReadIndexRelaxed(uint64_t value) {
@@ -278,46 +277,46 @@ void SdmaQueue::StoreReadIndexRelease(uint64_t value) {
 }
 
 void SdmaQueue::StoreWriteIndexRelaxed(uint64_t value) {
-  atomic::Store(&amd_queue_.write_dispatch_id, value, std::memory_order_relaxed);
+  atomic::Store(queue_wptr_, value, std::memory_order_relaxed);
 }
 
 void SdmaQueue::StoreWriteIndexRelease(uint64_t value) {
-  atomic::Store(&amd_queue_.write_dispatch_id, value, std::memory_order_release);
+  atomic::Store(queue_wptr_, value, std::memory_order_release);
 }
 
 // SDMA is exposed as HSA_QUEUE_TYPE_SINGLE. The CAS/add operations are present
 // only because hsa_queue_t helpers dispatch through core::Queue; callers must
 // not treat them as a BlitSdma-style multi-producer reservation protocol.
 uint64_t SdmaQueue::CasWriteIndexAcqRel(uint64_t expected, uint64_t value) {
-  return atomic::Cas(&amd_queue_.write_dispatch_id, value, expected, std::memory_order_acq_rel);
+  return atomic::Cas(queue_wptr_, value, expected, std::memory_order_acq_rel);
 }
 
 uint64_t SdmaQueue::CasWriteIndexAcquire(uint64_t expected, uint64_t value) {
-  return atomic::Cas(&amd_queue_.write_dispatch_id, value, expected, std::memory_order_acquire);
+  return atomic::Cas(queue_wptr_, value, expected, std::memory_order_acquire);
 }
 
 uint64_t SdmaQueue::CasWriteIndexRelaxed(uint64_t expected, uint64_t value) {
-  return atomic::Cas(&amd_queue_.write_dispatch_id, value, expected, std::memory_order_relaxed);
+  return atomic::Cas(queue_wptr_, value, expected, std::memory_order_relaxed);
 }
 
 uint64_t SdmaQueue::CasWriteIndexRelease(uint64_t expected, uint64_t value) {
-  return atomic::Cas(&amd_queue_.write_dispatch_id, value, expected, std::memory_order_release);
+  return atomic::Cas(queue_wptr_, value, expected, std::memory_order_release);
 }
 
 uint64_t SdmaQueue::AddWriteIndexAcqRel(uint64_t value) {
-  return atomic::Add(&amd_queue_.write_dispatch_id, value, std::memory_order_acq_rel);
+  return atomic::Add(queue_wptr_, value, std::memory_order_acq_rel);
 }
 
 uint64_t SdmaQueue::AddWriteIndexAcquire(uint64_t value) {
-  return atomic::Add(&amd_queue_.write_dispatch_id, value, std::memory_order_acquire);
+  return atomic::Add(queue_wptr_, value, std::memory_order_acquire);
 }
 
 uint64_t SdmaQueue::AddWriteIndexRelaxed(uint64_t value) {
-  return atomic::Add(&amd_queue_.write_dispatch_id, value, std::memory_order_relaxed);
+  return atomic::Add(queue_wptr_, value, std::memory_order_relaxed);
 }
 
 uint64_t SdmaQueue::AddWriteIndexRelease(uint64_t value) {
-  return atomic::Add(&amd_queue_.write_dispatch_id, value, std::memory_order_release);
+  return atomic::Add(queue_wptr_, value, std::memory_order_release);
 }
 
 void SdmaQueue::StoreRelaxed(hsa_signal_value_t value) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
@@ -82,9 +82,10 @@
  * - 1.28 - hsa_amd_agent_info_t: HSA_AMD_AGENT_INFO_HOST_ALLOC_DMABUF_SUPPORTED
  * - 1.29 - hsa_amd_image_create_v2, hsa_amd_interop_map_buffer_with_size
  * - 1.30 - hsa_amd_queue_get_info: engine type and SDMA engine ID
+ * - 1.31 - hsa_amd_queue_get_info: queue read/write pointer addresses
  */
 #define HSA_AMD_INTERFACE_VERSION_MAJOR 1
-#define HSA_AMD_INTERFACE_VERSION_MINOR 30
+#define HSA_AMD_INTERFACE_VERSION_MINOR 31
 
 #ifdef __cplusplus
 extern "C" {
@@ -4942,6 +4943,18 @@ typedef enum {
    * The type of this attribute is uint32_t.
    */
   HSA_AMD_QUEUE_INFO_SDMA_ENGINE_ID,
+  /*
+   * Address of the queue's monotonic hardware read pointer. The returned
+   * uint64_t contains an address usable by agents that can directly submit to
+   * this queue. Unsupported queue types return HSA_STATUS_ERROR_INVALID_ARGUMENT.
+   */
+  HSA_AMD_QUEUE_INFO_READ_POINTER,
+  /*
+   * Address of the queue's canonical monotonic write pointer. The returned
+   * uint64_t contains an address usable by agents that can directly submit to
+   * this queue. Unsupported queue types return HSA_STATUS_ERROR_INVALID_ARGUMENT.
+   */
+  HSA_AMD_QUEUE_INFO_WRITE_POINTER,
 } hsa_queue_info_attribute_t;
 
 hsa_status_t hsa_amd_queue_get_info(hsa_queue_t* queue, hsa_queue_info_attribute_t attribute,


### PR DESCRIPTION
…_info

Add HSA_AMD_QUEUE_INFO_READ_POINTER and HSA_AMD_QUEUE_INFO_WRITE_POINTER (HSA AMD interface v1.31) so host-side SDMA submitters can query KFD's canonical read/write pointer addresses and doorbell for user queues.

Align SdmaQueue write-index accessors with the hardware write pointer (queue_wptr_) instead of a separate software mirror, and allocate SDMA queue ring buffers uncached. Extend rocrtst queue_create to verify the new query attributes and that public write-index helpers update the hardware write pointer directly.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
JIRA ID: AIRUNTIME-1

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
