### PR TITLE
SWDEV-420237 - workaround for Unit_Rtc_ReduceRandom on MI2xx

### DIFF
--- a/projects/hip-tests/catch/unit/rtc/rtc_reduce.cc
+++ b/projects/hip-tests/catch/unit/rtc/rtc_reduce.cc
@@ -114,7 +114,10 @@ void compileProgram(hiprtcProgram& prog, const std::tuple<>&) {
   size_t logSize;
   std::string scalarName, intrinsicName;
   hiprtcResult compileResult;
-  const char* options[] = {"-DHIP_ENABLE_WARP_SYNC_BUILTINS", "-DHIP_ENABLE_EXTRA_WARP_SYNC_TYPES"};
+  // NOTE: -O0 is passed only for now. But ideally this should be tested both with -O2/-O3 too;
+  // but at time of this writing the loop in reduceRtcKernel() might be optimized incorrectly
+  const char* options[] = {"-DHIP_ENABLE_WARP_SYNC_BUILTINS", "-DHIP_ENABLE_EXTRA_WARP_SYNC_TYPES",
+                           "-O0"};
 
   reduceOpToString<int, Op>(scalarName, intrinsicName);
   compileResult = hiprtcResult{hiprtcCompileProgram(prog, NELEMS(options), options)};


### PR DESCRIPTION
## Motivation

`Unit_Rtc_ReduceRandom` fails for the types `float` and `half` on MI200

## Technical Details

The test tries to compile this kernel via hiprtc:

```cpp
template <class T, class MaskType>
    __global__ void reduceRtcKernel(T* output, const T* input, const MaskType* masks, int* numReduces)
    {
      int tid = threadIdx.x;
      int laneId = tid % warpSize;

      for (int i = 0; i < *numReduces; i++) {
        int idx = warpSize * i + laneId;
        if (masks[i] & (1ull << laneId)) {
          // call the operator only if the lane is mentioned in the mask
          T& result = output[idx];
          result = )" +
              intrinsicName + R"((masks[i], input[idx]);
        }
      }
   }
```
If the kernel is compiled without specifying the optimization flags, or specifying with -O2 or -O3, the test would fail due to incorrect optimizations associated with the `numReduces` variable. Making numReduces `volatile` or adding the flag -O0 would make the test pass.

## Issue Tracking

TBD

## Test Plan

Tested on MI250X

## Test Result

All tests in the RTC binary pass after this change.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
