### PR TITLE
fix(clr): hipModule* APIs can have pointer to unknown buffer sizes

### DIFF
--- a/projects/clr/hipamd/src/hip_fatbin.cpp
+++ b/projects/clr/hipamd/src/hip_fatbin.cpp
@@ -444,17 +444,13 @@ hipError_t FatBinaryInfo::ExtractFatBinaryUsingCOMGR(const std::vector<hip::Devi
     if (fdesc != amd::Os::FDescInit()) amd::Os::CloseFileHandle(fdesc);
   });
 
-  // hipModuleLoadData has no length parameter. For pointer inputs, the remaining
-  // readable mapping is a safety ceiling; file loads have an exact size.
-  size_t image_bound = 0;
+  // Pointer inputs (hipModuleLoadData) carry no length, so no bound is known.
+  // File loads below set the exact size.
+  size_t image_bound = amd::Elf::kUnknownSize;
   if (image_ != nullptr) {
-    if (!amd::Os::FindFileNameFromAddress(image_, &fname_, &foffset_, &image_bound)) {
+    if (!amd::Os::FindFileNameFromAddress(image_, &fname_, &foffset_)) {
       fname_ = std::string("");
       foffset_ = 0;
-    }
-    if (image_bound == 0) {
-      LogError("Cannot determine a readable bound for fat binary input");
-      return hipErrorInvalidImage;
     }
   } else {
     size_t fsize = 0;
@@ -484,9 +480,12 @@ hipError_t FatBinaryInfo::ExtractFatBinaryUsingCOMGR(const std::vector<hip::Devi
       auto elf_size = amd::Elf::getElfSize(image_, image_bound);
       // If we got 0, validation has failed.
       if (elf_size == 0) {
-        LogPrintfError(
-            "Invalid ELF code object: failed size/bounds validation, image bound is: %zu",
-            image_bound);
+        if (image_bound == amd::Elf::kUnknownSize) {
+          LogError("Invalid ELF code object: failed self-consistency validation");
+        } else {
+          LogPrintfError("Invalid ELF code object: failed size/bounds validation, image size: %zu",
+                         image_bound);
+        }
         return hipErrorInvalidImage;
       }
       for (auto* device : devices) {

--- a/projects/clr/rocclr/elf/elf.cpp
+++ b/projects/clr/rocclr/elf/elf.cpp
@@ -800,16 +800,24 @@ bool Elf::dumpImage(std::istream& is, char** buff, size_t* len) const {
   return true;
 }
 
+// Returns the extent of the ELF image at `emi`, or 0 if validation fails.
+// With kUnknownSize only length-independent checks apply, so a malformed image
+// on that path is undefined behavior (see hipModuleLoadData).
 uint64_t Elf::getElfSize(const void* emi, const size_t buf_size) {
-  // Fail closed: never parse without a known upper bound on the buffer.
   if (emi == nullptr || buf_size <= EI_CLASS) {
     return 0;
   }
+  const bool size_known = (buf_size != kUnknownSize);
   const unsigned char eclass = static_cast<const unsigned char*>(emi)[EI_CLASS];
   // Only 64-bit AMDGPU code objects are supported.
   if (eclass != ELFCLASS64 || buf_size < sizeof(Elf64_Ehdr)) {
     return 0;
   }
+
+  // Handle for unknown cap size
+  const uint64_t addr_space_limit =
+      ~uint64_t(0) - reinterpret_cast<uintptr_t>(emi);
+  const uint64_t limit = size_known ? buf_size : addr_space_limit;
 
   // end = off + sz, returns false on overflow.
   auto checked_end = [](uint64_t off, uint64_t sz, uint64_t& end) -> bool {
@@ -827,47 +835,49 @@ uint64_t Elf::getElfSize(const void* emi, const size_t buf_size) {
 
   // Validate and bound the section-header table before any dereference.
   if (ehdr->e_shnum != 0) {
-    if (ehdr->e_shentsize != sizeof(Elf64_Shdr) || ehdr->e_shoff >= buf_size) {
+    if (ehdr->e_shentsize != sizeof(Elf64_Shdr) || ehdr->e_shoff >= limit) {
       return 0;
     }
     uint64_t shtab = static_cast<uint64_t>(ehdr->e_shnum) * sizeof(Elf64_Shdr);
-    if (shtab > buf_size - ehdr->e_shoff) {
+    uint64_t shtab_end;
+    if (!checked_end(ehdr->e_shoff, shtab, shtab_end) || shtab_end > limit) {
       return 0;
     }
-    if (ehdr->e_shoff + shtab > total_size) total_size = ehdr->e_shoff + shtab;
+    if (shtab_end > total_size) total_size = shtab_end;
 
     auto shdr = reinterpret_cast<const Elf64_Shdr*>(static_cast<const char*>(emi) + ehdr->e_shoff);
     for (uint64_t i = 0; i < ehdr->e_shnum; ++i) {
       if (SHT_NOBITS == shdr[i].sh_type) continue;
       uint64_t end;
       if (!checked_end(shdr[i].sh_offset, shdr[i].sh_size, end)) return 0;
-      if (end > buf_size) return 0;
+      if (end > limit) return 0;
       if (end > total_size) total_size = end;
     }
   }
 
   // Validate and bound the program-header table before any dereference.
   if (ehdr->e_phnum != 0) {
-    if (ehdr->e_phentsize != sizeof(Elf64_Phdr) || ehdr->e_phoff >= buf_size) {
+    if (ehdr->e_phentsize != sizeof(Elf64_Phdr) || ehdr->e_phoff >= limit) {
       return 0;
     }
     uint64_t phtab = static_cast<uint64_t>(ehdr->e_phnum) * sizeof(Elf64_Phdr);
-    if (phtab > buf_size - ehdr->e_phoff) {
+    uint64_t phtab_end;
+    if (!checked_end(ehdr->e_phoff, phtab, phtab_end) || phtab_end > limit) {
       return 0;
     }
-    if (ehdr->e_phoff + phtab > total_size) total_size = ehdr->e_phoff + phtab;
+    if (phtab_end > total_size) total_size = phtab_end;
 
     auto phdr = reinterpret_cast<const Elf64_Phdr*>(static_cast<const char*>(emi) + ehdr->e_phoff);
     for (uint64_t i = 0; i < ehdr->e_phnum; ++i) {
       if (PT_NULL == phdr[i].p_type) continue;
       uint64_t end;
       if (!checked_end(phdr[i].p_offset, phdr[i].p_filesz, end)) return 0;
-      if (end > buf_size) return 0;
+      if (end > limit) return 0;
       if (end > total_size) total_size = end;
     }
   }
 
-  return (total_size > buf_size) ? 0 : total_size;
+  return (total_size > limit) ? 0 : total_size;
 }
 
 bool Elf::isElfMagic(const char* p) {

--- a/projects/clr/rocclr/elf/elf.hpp
+++ b/projects/clr/rocclr/elf/elf.hpp
@@ -299,6 +299,10 @@ class Elf {
   /* Return segment at index */
   bool getSegment(const unsigned int index, segment*& seg) const;
 
+  /* Pass as getElfSize()'s `size` when the buffer length is unknown, e.g.
+     hipModuleLoadData, which takes a pointer with no length. */
+  static constexpr size_t kUnknownSize = static_cast<size_t>(-1);
+
   /* Return size of elf file */
   static uint64_t getElfSize(const void* emi, const size_t size);
 

--- a/projects/clr/rocclr/os/os.hpp
+++ b/projects/clr/rocclr/os/os.hpp
@@ -55,11 +55,8 @@ class Os : AllStatic {
   static bool GetFileHandle(const char* fname, FileDesc* fd_ptr, size_t* sz_ptr);
 
   // Returns the file name & file offset of mapped memory if the file is mapped.
-  // If region_bound_ptr is non-null and 'image' lies in a readable mapping, it is
-  // set to the number of readable bytes from 'image' to the end of that mapping
-  // (populated for anonymous mappings too, even when no file name is resolved).
   static bool FindFileNameFromAddress(const void* image, std::string* fname_ptr,
-                                      size_t* foffset_ptr, size_t* region_bound_ptr = nullptr);
+                                      size_t* foffset_ptr);
 
   // Given a valid file descriptor returns mmaped memory for size and offset
   static bool MemoryMapFileDesc(FileDesc fdesc, size_t fsize, size_t foffset,

--- a/projects/clr/rocclr/os/os_posix.cpp
+++ b/projects/clr/rocclr/os/os_posix.cpp
@@ -876,11 +876,7 @@ bool Os::GetFileHandle(const char* fname, FileDesc* fd_ptr, size_t* sz_ptr) {
 }
 
 bool amd::Os::FindFileNameFromAddress(const void* image, std::string* fname_ptr,
-                                      size_t* foffset_ptr, size_t* region_bound_ptr) {
-  // Fail closed: callers must never read a stale bound on any early-return path.
-  if (region_bound_ptr != nullptr) {
-    *region_bound_ptr = 0;
-  }
+                                      size_t* foffset_ptr) {
   // Get the list of mapped file list
   bool ret_value = false;
   std::ifstream proc_maps;
@@ -909,11 +905,6 @@ bool amd::Os::FindFileNameFromAddress(const void* image, std::string* fname_ptr,
       uint64_t inode;
       tokens >> permissions >> std::hex >> offset >> std::dec >> device >> inode;
       std::getline(tokens >> std::ws, uri_file_path);
-
-      // Readable bytes from image to the end of this mapping (anonymous or not).
-      if (region_bound_ptr != nullptr && !permissions.empty() && permissions[0] == 'r') {
-        *region_bound_ptr = static_cast<size_t>(high_address - address);
-      }
 
       if (inode == 0 || uri_file_path.empty()) {
         return ret_value;

--- a/projects/clr/rocclr/os/os_win32.cpp
+++ b/projects/clr/rocclr/os/os_win32.cpp
@@ -675,31 +675,7 @@ bool Os::MemoryMapFileTruncated(const char* fname, const void** mmap_ptr, size_t
   return true;
 }
 
-bool Os::FindFileNameFromAddress(const void* image, std::string* fname_ptr, size_t* foffset_ptr,
-                                 size_t* region_bound_ptr) {
-  // Fail closed: callers must never read a stale bound if we can't compute one.
-  if (region_bound_ptr != nullptr) {
-    *region_bound_ptr = 0;
-  }
-  // Readable bytes from image to the end of its committed region (anonymous or not).
-  if (region_bound_ptr != nullptr && image != nullptr) {
-    MEMORY_BASIC_INFORMATION mbi = {};
-    if (VirtualQuery(image, &mbi, sizeof(mbi)) == sizeof(mbi) && mbi.State == MEM_COMMIT &&
-        (mbi.Protect & (PAGE_GUARD | PAGE_NOACCESS)) == 0) {
-      const DWORD protection = mbi.Protect & 0xFF;
-      const bool readable = protection == PAGE_READONLY || protection == PAGE_READWRITE ||
-                            protection == PAGE_WRITECOPY || protection == PAGE_EXECUTE_READ ||
-                            protection == PAGE_EXECUTE_READWRITE ||
-                            protection == PAGE_EXECUTE_WRITECOPY;
-      const uintptr_t base = reinterpret_cast<uintptr_t>(mbi.BaseAddress);
-      const uintptr_t address = reinterpret_cast<uintptr_t>(image);
-      const uintptr_t end = base + static_cast<uintptr_t>(mbi.RegionSize);
-      if (readable && address >= base && end >= base && end > address) {
-        *region_bound_ptr = static_cast<size_t>(end - address);
-      }
-    }
-  }
-
+bool Os::FindFileNameFromAddress(const void* image, std::string* fname_ptr, size_t* foffset_ptr) {
   HMODULE hm = NULL;
   if (!GetModuleHandleExA(
           GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,

--- a/projects/hip-tests/catch/config/configs/unit/oob.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/oob.yaml
@@ -12,10 +12,6 @@ oob:
     <<: *level_4
     disabled: [windows, amd_windows, nvidia_linux, nvidia_windows]
     tags: [oob]
-  OOB_hipModuleLoadData_Negative_TruncatedImages:
-    <<: *level_4
-    disabled: [windows, amd_windows, nvidia_linux, nvidia_windows]
-    tags: [oob]
   OOB_hipModuleLoadData_Positive_ValidFileBackedImage:
     <<: *level_4
     disabled: [windows, amd_windows, nvidia_linux, nvidia_windows]

--- a/projects/hip-tests/catch/unit/module/hipModuleLoadMalformedFatBinary.cc
+++ b/projects/hip-tests/catch/unit/module/hipModuleLoadMalformedFatBinary.cc
@@ -93,12 +93,10 @@ void ExpectFileLoadRejected(const std::vector<uint8_t>& bundle) {
 HIP_TEST_CASE(Unit_hipModuleLoad_Negative_MalformedFatBinaryBounds) {
   HIP_CHECK(hipFree(nullptr));
 
+  // hipModuleLoadData is not checked here: it has no length parameter, so a
+  // malformed image on that path is undefined behavior.
   SECTION("code object offset is outside the readable image") {
-    const auto bundle = BuildBundle(kOutOfBoundsOffset, kCodeObjectSize);
-
-    hipModule_t module = nullptr;
-    HIP_CHECK_ERROR(hipModuleLoadData(&module, bundle.data()), hipErrorInvalidImage);
-    ExpectFileLoadRejected(bundle);
+    ExpectFileLoadRejected(BuildBundle(kOutOfBoundsOffset, kCodeObjectSize));
   }
 
   SECTION("code object size crosses the mapped file boundary") {

--- a/projects/hip-tests/catch/unit/oob/oob_module.cc
+++ b/projects/hip-tests/catch/unit/oob/oob_module.cc
@@ -196,18 +196,11 @@ HIP_TEST_CASE(OOB_hip_module_load_over) {
   }
 }
 
-// In-memory path: hipModuleLoadData(image) - no length, bound is derived from the
-// mapping that contains the (anonymous heap) buffer. These cases reject in
-// getElfSize before any device/arch check, so they are arch-independent. The valid
-// in-memory load is covered by OOB_hiprtc_roundtrip_loads, which is arch-correct.
+// In-memory path: hipModuleLoadData carries no length, so only malformations
+// detectable without one can be asserted. Length-dependent cases (e.g. a
+// corrupt e_shoff) are covered against the file path in OOB_hip_module_load_over.
 HIP_TEST_CASE(OOB_hip_module_load_data_over) {
   Bytes elf = ExtractElf(ReadFile(kValidModule));
-
-  SECTION("bad shoff in-memory") {
-    Bytes buf = MakeBadShoff(elf);
-    hipModule_t module{};
-    HIP_CHECK_ERROR(hipModuleLoadData(&module, buf.data()), hipErrorInvalidImage);
-  }
 
   SECTION("sh overflow in-memory") {
     Bytes buf = MakeShOverflow(elf);
@@ -242,28 +235,15 @@ HIP_TEST_CASE(OOB_hiprtc_roundtrip_loads) {
 }
 
 // ---------------------------------------------------------------------------
-// Readable-size bounds tests for fat-binary parsing.
-//
-// Pointer-based load APIs carry no length, so the runtime can only bound
-// parsing when the image comes from a file-backed mapping.
-//
-// Malformed pointer inputs are tail-mapped before a no-access guard page so
-// over-reads fault instead of silently succeeding, while correct parsing
-// returns hipErrorInvalidImage. The bundle-header/magic and ELF-header-size
-// bounds exercised here complement the getElfSize ELF-internal cases above.
+// Size-bounds tests for fat-binary parsing. Only file-backed loads have an
+// exact size, so bounds are asserted there; pointer inputs carry no length.
 // ---------------------------------------------------------------------------
 #if HT_AMD
 
 namespace {
 
-// Magic strings for ROCm clang offload bundles.
+// Magic string for ROCm compressed clang offload bundles.
 constexpr char kCompressedBundleMagic[] = "CCOB";
-constexpr char kUncompressedBundleMagic[] = "__CLANG_OFFLOAD_BUNDLE__";
-
-// AMDGPU ELF identity values the runtime checks. Defined locally so this test
-// stays independent of runtime headers.
-constexpr unsigned char kElfOsabiAmdgpuHsa = 64;  // ELFOSABI_AMDGPU_HSA
-constexpr unsigned char kEmAmdgpuLowByte = 224;   // EM_AMDGPU (0x00E0), low byte
 
 // Builds a `size`-byte compressed offload bundle: the "CCOB" magic with
 // `total_size` written to the totalSize field (offset 8); remaining bytes zero.
@@ -272,24 +252,6 @@ Bytes MakeCompressedBundle(size_t size, uint32_t total_size) {
   Bytes image(size, 0);
   std::memcpy(image.data(), kCompressedBundleMagic, 4);
   std::memcpy(image.data() + 8, &total_size, sizeof(total_size));
-  return image;
-}
-
-// Builds a `size`-byte little-endian AMDGPU ELFCLASS64 image whose identity
-// fields (EM_AMDGPU + ELFOSABI_AMDGPU_HSA) pass the runtime's ELF check. Only
-// the e_ident bytes and e_machine are set; all other fields are zero.
-Bytes MakeAmdgpuElf64Image(size_t size) {
-  REQUIRE(size >= 20);  // the last field written, spans offsets 18-19
-  Bytes image(size, 0);
-  image[0] = 0x7f;
-  image[1] = 'E';
-  image[2] = 'L';
-  image[3] = 'F';
-  image[4] = 2;  // EI_CLASS   = ELFCLASS64
-  image[5] = 1;  // EI_DATA    = ELFDATA2LSB (little-endian)
-  image[6] = 1;  // EI_VERSION = EV_CURRENT
-  image[7] = static_cast<char>(kElfOsabiAmdgpuHsa);  // EI_OSABI
-  image[18] = static_cast<char>(kEmAmdgpuLowByte);   // e_machine low byte (little-endian)
   return image;
 }
 
@@ -330,146 +292,7 @@ class FileBackedMapping {
   size_t size_ = 0;
 };
 
-// Places `payload` at the end of a file-backed page immediately followed by a
-// no-access guard page. The runtime then sees exactly payload.size() readable
-// bytes, and any read past the payload faults instead of succeeding silently.
-class TailMappedImage {
- public:
-  explicit TailMappedImage(const Bytes& payload) {
-    page_size_ = static_cast<size_t>(sysconf(_SC_PAGESIZE));
-    REQUIRE(!payload.empty());
-    REQUIRE(payload.size() <= page_size_);
-
-    char tmpl[] = "/tmp/hip_fatbin_bounds_XXXXXX";
-    fd_ = mkstemp(tmpl);
-    REQUIRE(fd_ >= 0);
-    path_ = tmpl;
-
-    // Back the image with a one-page file holding the payload at its very end
-    // (leading bytes zero-padded). Mapped at a page boundary below, this puts
-    // the payload's last byte flush against the page boundary.
-    Bytes file_bytes(page_size_, 0);
-    std::memcpy(file_bytes.data() + (page_size_ - payload.size()), payload.data(),
-                payload.size());
-    REQUIRE(write(fd_, file_bytes.data(), file_bytes.size()) ==
-            static_cast<ssize_t>(file_bytes.size()));
-
-    // Reserve two adjacent pages with no access. The second one stays
-    // unmapped/no-access as a guard page, so any read past the first page faults.
-    region_len_ = 2 * page_size_;
-    region_ = mmap(nullptr, region_len_, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-    REQUIRE(region_ != MAP_FAILED);
-
-    // Map the file read-only over the first page only, leaving the guard page
-    // intact immediately after it.
-    void* file_page = mmap(region_, page_size_, PROT_READ, MAP_PRIVATE | MAP_FIXED, fd_, 0);
-    REQUIRE(file_page == region_);
-
-    // Point at the payload's start; image_ + payload.size() lands exactly on
-    // the guard page, so reads past the payload fault.
-    image_ = static_cast<char*>(region_) + (page_size_ - payload.size());
-  }
-
-  ~TailMappedImage() {
-    if (region_ != nullptr && region_ != MAP_FAILED) {
-      munmap(region_, region_len_);
-    }
-    if (fd_ >= 0) {
-      close(fd_);
-    }
-    if (!path_.empty()) {
-      unlink(path_.c_str());
-    }
-  }
-
-  TailMappedImage(const TailMappedImage&) = delete;
-  TailMappedImage& operator=(const TailMappedImage&) = delete;
-
-  const void* image() const { return image_; }
-
- private:
-  size_t page_size_ = 0;
-  int fd_ = -1;
-  std::string path_;
-  void* region_ = nullptr;
-  size_t region_len_ = 0;
-  char* image_ = nullptr;
-};
-
 }  // namespace
-
-/**
- * Feeds guard-page-backed malformed images to hipModuleLoadData and
- * expects hipErrorInvalidImage instead of an out-of-bounds read.
- */
-HIP_TEST_CASE(OOB_hipModuleLoadData_Negative_TruncatedImages) {
-  hipModule_t module = nullptr;
-
-  SECTION("compressed magic shorter than the magic itself") {
-    // Only 3 readable bytes, fewer than the 4-byte compressed magic. Checks that
-    // the magic comparison doesn't read past the image.
-    const Bytes payload(kCompressedBundleMagic, kCompressedBundleMagic + 3);
-    TailMappedImage img(payload);
-    HIP_CHECK_ERROR(hipModuleLoadData(&module, img.image()), hipErrorInvalidImage);
-  }
-
-  SECTION("compressed magic with too little readable image") {
-    // Only 4 readable bytes (magic, no header). Checks that probing for a header
-    // doesn't read past the image.
-    const Bytes payload(kCompressedBundleMagic, kCompressedBundleMagic + 4);
-    TailMappedImage img(payload);
-    HIP_CHECK_ERROR(hipModuleLoadData(&module, img.image()), hipErrorInvalidImage);
-  }
-
-  SECTION("compressed header with out-of-bounds totalSize") {
-    // Valid 32-byte header, but its declared totalSize (offset 8) claims a far
-    // larger image than exists. Checks that the runtime doesn't trust that size
-    // and read past the image.
-    const Bytes payload = MakeCompressedBundle(32, 0xFFFFFFFFu);
-    TailMappedImage img(payload);
-    HIP_CHECK_ERROR(hipModuleLoadData(&module, img.image()), hipErrorInvalidImage);
-  }
-
-  SECTION("AMDGPU ELF header smaller than Elf64_Ehdr") {
-    // 40-byte AMDGPU ELF header: big enough that the magic checks stay in
-    // bounds, but smaller than a full Elf64_Ehdr (64 bytes). Checks that reading
-    // ELF header fields doesn't read past the image.
-    const Bytes payload = MakeAmdgpuElf64Image(40);
-    TailMappedImage img(payload);
-    HIP_CHECK_ERROR(hipModuleLoadData(&module, img.image()), hipErrorInvalidImage);
-  }
-
-  SECTION("uncompressed bundle magic truncated below magic length") {
-    // Only 10 readable bytes of the 24-byte uncompressed magic. Checks that
-    // comparing the full magic doesn't read past the image.
-    const Bytes payload(kUncompressedBundleMagic, kUncompressedBundleMagic + 10);
-    TailMappedImage img(payload);
-    HIP_CHECK_ERROR(hipModuleLoadData(&module, img.image()), hipErrorInvalidImage);
-  }
-
-  SECTION("AMDGPU ELF whose declared size exceeds the readable image") {
-    // Full 64-byte Elf64_Ehdr so the header checks pass, but e_shoff points a
-    // section table far past the image. e_shnum stays 0 so computing the ELF
-    // size does not itself walk out of bounds; the computed size is what is out
-    // of bounds. Checks that the oversized size isn't used to read past the image
-    // when the code object is handed off for loading.
-    Bytes payload = MakeAmdgpuElf64Image(64);
-    Wr16(payload, kEShentsize, 64);
-    Wr64(payload, kEShoff, uint64_t(1) << 24);  // e_shoff: table far past 64 bytes
-    Wr16(payload, kEShnum, 1);                  // one entry
-    TailMappedImage img(payload);
-    HIP_CHECK_ERROR(hipModuleLoadData(&module, img.image()), hipErrorInvalidImage);
-  }
-
-  SECTION("uncompressed bundle magic with no readable body") {
-    // Exactly the 24-byte magic and nothing else. Checks that reading the bundle
-    // header is clamped to the readable size rather than a fixed 4096-byte slice
-    // that reads past the image.
-    const Bytes payload(kUncompressedBundleMagic, kUncompressedBundleMagic + 24);
-    TailMappedImage img(payload);
-    HIP_CHECK_ERROR(hipModuleLoadData(&module, img.image()), hipErrorInvalidImage);
-  }
-}
 
 /**
  * Loads a valid file-backed compressed module and runs its kernel, guarding


### PR DESCRIPTION
## Motivation

Some inputs to hipModule APIs, their bounds can not be known. This is a known limitation of these APIs and hip needs to handle them accordingly.

## Technical Details

Currently we are rejecting the buffer, if we can not establish the bounds. HIP need to accept these buffers (where size is not known). Its UB to pass malformed code object to the API.

## Issue Tracking

JIRA ID: ROCM-29159

## Test Plan

Will ask the issue reporter to validate with this change.

## Test Result

Awaiting results.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
