### PR TITLE
fix(rocr): retain KFD allocation behind VMM shareable handles

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -707,18 +707,18 @@ hsa_status_t KfdDriver::CreateShareableHandle(core::DriverMemoryHandle* handle,
 hsa_status_t KfdDriver::DestroyMemoryHandle(core::DriverMemoryHandle* handle) {
   hsa_status_t ret = rocr::os::DmaBufClose(&handle->dmabuf_fd);
 
+  // Attempt every release even if an earlier one fails, so a failure to free the imported BO
+  // does not leak the KFD allocation retained by CreateShareableHandle.
   auto memhandle = reinterpret_cast<HsaMemoryObjectHandle>(handle->handle);
-  if (memhandle != nullptr) {
-    HSAKMT_STATUS status = HSAKMT_CALL(hsaKmtMemHandleFree(memhandle));
-    if (status != HSAKMT_STATUS_SUCCESS) {
-      return HSA_STATUS_ERROR;
-    }
+  if (memhandle != nullptr &&
+      HSAKMT_CALL(hsaKmtMemHandleFree(memhandle)) != HSAKMT_STATUS_SUCCESS) {
+    ret = HSA_STATUS_ERROR;
   }
 
   // Release the KFD allocation retained by CreateShareableHandle, if any.
   if (handle->vaddr != nullptr &&
       HSAKMT_CALL(hsaKmtFreeMemory(handle->vaddr, handle->size)) != HSAKMT_STATUS_SUCCESS) {
-    return HSA_STATUS_ERROR;
+    ret = HSA_STATUS_ERROR;
   }
 
   *handle = {};

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -671,17 +671,6 @@ hsa_status_t KfdDriver::CreateShareableHandle(core::DriverMemoryHandle* handle,
     return ret;
   assert(targetHandle.size == size);
 
-#if defined(__linux__)
-  /*
-   * We converted mem into a driver handle. The driver handle will keep the reference count
-   * inside the KMD so we can free the original KFD allocation.
-   */
-  if (HSAKMT_CALL(hsaKmtFreeMemory(mem, size)) != HSAKMT_STATUS_SUCCESS) {
-    DestroyMemoryHandle(&targetHandle);
-    return HSA_STATUS_ERROR;
-  }
-#endif
-
   const auto devhandle = static_cast<const GpuAgent&>(agent).libThunkDev();
   const auto memhandle = reinterpret_cast<HsaMemoryObjectHandle>(targetHandle.handle);
   if (HSAKMT_CALL(hsaKmtMemoryGetCpuAddr(devhandle, memhandle, &handle->mmap_offset)) != HSAKMT_STATUS_SUCCESS) {
@@ -691,6 +680,22 @@ hsa_status_t KfdDriver::CreateShareableHandle(core::DriverMemoryHandle* handle,
 
   // handle->handle is replaced by the imported BO; handle->size carries over from allocation.
   handle->handle = targetHandle.handle;
+#if defined(__linux__)
+  /*
+   * Keep the original KFD allocation alive in handle->vaddr; DestroyMemoryHandle releases it.
+   *
+   * The DRM import alone keeps the buffer's reference count up, but a buffer that KFD no longer
+   * tracks is only revalidated from the command submission path. ROCr dispatches through KFD user
+   * mode queues and never submits through amdgpu_cs, so a peer dma-buf attach that migrates the
+   * buffer would leave the exporting agent with stale page table entries. While the KFD allocation
+   * exists the buffer carries KFD's eviction fence, so the migration goes through KFD
+   * evict/restore, which also revalidates the mappings KFD does not manage.
+   */
+  handle->vaddr = mem;
+#else
+  // Windows KFD and DRM handles are equivalent, so targetHandle already owns the allocation.
+  handle->vaddr = nullptr;
+#endif
   /*
    * Do not hold a shareable dmabuf_fd open for the lifetime of the handle. It is created lazily
    * (and closed again) when access is set in Runtime::VMemorySetAccessPerHandle.
@@ -709,6 +714,13 @@ hsa_status_t KfdDriver::DestroyMemoryHandle(core::DriverMemoryHandle* handle) {
       return HSA_STATUS_ERROR;
     }
   }
+
+  // Release the KFD allocation retained by CreateShareableHandle, if any.
+  if (handle->vaddr != nullptr &&
+      HSAKMT_CALL(hsaKmtFreeMemory(handle->vaddr, handle->size)) != HSAKMT_STATUS_SUCCESS) {
+    return HSA_STATUS_ERROR;
+  }
+
   *handle = {};
   return ret;
 }


### PR DESCRIPTION
## Summary

`hsa_amd_vmem_set_access` was order dependent: when several agents were granted
access to the same VA range, the owning agent read unrelated pages unless it
happened to be granted access last.

`KfdDriver::CreateShareableHandle` released the original KFD allocation once the
buffer had been imported into DRM, on the reasoning that the DRM handle keeps
the reference count up inside the KMD. The reference count does survive, but
KFD's tracking of the buffer does not, and a buffer that KFD no longer owns is
only revalidated from the command submission path. ROCr dispatches through KFD
user mode queues and never goes through `amdgpu_cs`, so when a peer imports the
dma-buf and amdgpu migrates the buffer, the exporting agent's page table entries
are invalidated with nothing left to refresh them.

This keeps the KFD allocation alive for the lifetime of the handle
(`DriverMemoryHandle::vaddr`, released in `DestroyMemoryHandle`) so the buffer
still carries KFD's eviction fence. The migration then goes through KFD
evict/restore, which also revalidates the mappings KFD does not manage.

The behaviour was introduced by 4584915208d98aa355bc42c60e2c8aa75fec1ab1.
Windows is unaffected: KFD and DRM handles are equivalent there, so the imported
handle already owns the allocation and `vaddr` is cleared.

## JIRA ID

JIRA ID : ROCM-28878

## Test plan

Validated on three systems, comparing a build of this branch against a build of
`develop` with only this change reverted.

- [x] gfx942 x8, amdgpu 6.19.14 (reproduces the bug): the XLA-derived reproducer
      from the ticket goes from failing every run to 20/20 passing; peer-grant
      probes and a VMM ordering regression suite (owner-first / owner-last, host
      and device memory, aliased mappings, permission transitions) all pass;
      `rocrtst` VirtMemory + IPC 10/10; wider `rocrtstFunc.*`/`rocrtstNeg.*`
      sweep 71/71.
- [x] gfx942 x8, amdgpu 6.19.4: does not reproduce the bug, used as a regression
      check. Baseline and this branch are indistinguishable, including the same
      67 passed / 4 pre-existing `rocrtstNeg.Queue_Validation_*` failures.
- [x] gfx1100 x1, amdgpu 6.18.10: baseline and this branch match on the probes,
      the ordering regression suite, `rocrtst` VirtMemory + IPC 10/10, and HIP
      `VirtualMemoryManagementTest`.
- [x] No leak from the longer-lived allocation: 300 iterations of
      allocate / map / set-access / unmap / release return the agent's free
      memory to its starting value exactly, and `VirtMemory_Accounting_Test`
      passes.

Made with [Cursor](https://cursor.com)