### PR TITLE
fix(rccl): FBA-1079 use LL128 for latency-bound P2P send/recv incl. internode

### DIFF
--- a/projects/rccl/docs/userguide/source/env.rst
+++ b/projects/rccl/docs/userguide/source/env.rst
@@ -1574,7 +1574,7 @@ NCCL_P2P_LL_THRESHOLD
 ---------------------
 (since 2.14)
 
-The ``NCCL_P2P_LL_THRESHOLD`` is the maximum message size that NCCL will use the LL protocol for P2P operations.
+The ``NCCL_P2P_LL_THRESHOLD`` is the maximum per-channel message size (in bytes) at or below which RCCL uses the low-latency protocol for P2P (send/recv) operations. Above this size, RCCL uses the SIMPLE protocol. RCCL's P2P send/recv uses the LL128 protocol for these latency-bound sizes on both the intranode and internode paths (LL128 replaces the older LL protocol for send/recv).
 
 Values accepted
 ^^^^^^^^^^^^^^^
@@ -1584,8 +1584,8 @@ NCCL_ALLOC_P2P_NET_LL_BUFFERS
 -----------------------------
 (since 2.14)
 
-``NCCL_ALLOC_P2P_NET_LL_BUFFERS`` instructs communicators to allocate dedicated LL buffers for all P2P network connections. This enables all ranks to use the LL protocol for latency-bound send and receive operations below ``NCCL_P2P_LL_THRESHOLD`` sizes.
-Intranode P2P transfers always have dedicated LL buffers allocated. If running all-to-all workloads with high numbers of ranks, this will result in a high scaling memory overhead.
+``NCCL_ALLOC_P2P_NET_LL_BUFFERS`` instructs communicators to allocate dedicated low-latency buffers for all P2P network connections. This enables all ranks to use the low-latency (LL128) protocol for latency-bound send and receive operations below ``NCCL_P2P_LL_THRESHOLD`` sizes over the network.
+Intranode P2P transfers always have dedicated low-latency buffers allocated. If running all-to-all workloads with high numbers of ranks, this will result in a high scaling memory overhead.
 
 Values accepted
 ^^^^^^^^^^^^^^^

--- a/projects/rccl/src/device/sendrecv.h
+++ b/projects/rccl/src/device/sendrecv.h
@@ -173,8 +173,8 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
         subtid, subtn, 0, false, 1, &work->sendAddr, 1, &work->recvAddr, (ssize_t)work->sendBytes);
 #endif
   } else if (isSend) {
-    if (work->sendProtoLL) {
-      runSend<ProtoLL>(subtid, subtn, group, work);
+    if (work->sendProtoLL128) {
+      runSend<ProtoLL128>(subtid, subtn, group, work);
     } else {
 #if defined(__gfx90a__)
       runSend<ProtoSimple<1, 1, 0, 8>>(subtid, subtn, group, work);
@@ -185,8 +185,8 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
 #endif
     }
   } else {
-    if (work->recvProtoLL) {
-      runRecv<ProtoLL>(subtid, subtn, group, work);
+    if (work->recvProtoLL128) {
+      runRecv<ProtoLL128>(subtid, subtn, group, work);
     } else {
 #if defined(__gfx90a__)
       runRecv<ProtoSimple<1, 1, 0, 8>>(subtid, subtn, group, work);

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -1110,7 +1110,11 @@ static ncclResult_t scheduleCollTasksToPlan(struct ncclComm* comm, struct ncclKe
   return ncclSuccess;
 }
 
-NCCL_PARAM(P2pLLThreshold, "P2P_LL_THRESHOLD", 8192);
+// Per-channel payload (in bytes) at/below which P2P send/recv uses the LL128 protocol; above it SIMPLE.
+// Default 16 KiB: internode alltoall/scatter/gather sweeps (1-16 nodes) show LL128 is faster than
+// SIMPLE for every per-peer size <= 16 KiB at all scales, with the crossover at ~32 KiB; LL128's low
+// (~1/16) flag overhead keeps it beneficial well past the legacy-LL 8 KiB cutoff.
+NCCL_PARAM(P2pLLThreshold, "P2P_LL_THRESHOLD", 16384);
 RCCL_PARAM(P2pNetThreshold, "P2P_NET_THRESHOLD", 131072);
 NCCL_PARAM(ChunkSize, "CHUNK_SIZE", 0);
 
@@ -1146,7 +1150,7 @@ static ncclResult_t addP2pToPlan(struct ncclComm* comm, struct ncclKernelPlan* p
   // recv: dir=0, send: dir=1
   void* addrs[2] = {recvAddr, sendAddr};
   ssize_t bytes[2] = {recvBytes, sendBytes};
-  bool protoLL[2] = {!selfSend, !selfSend};
+  bool protoLL128[2] = {!selfSend, !selfSend};
   bool network[2] = {false, false};
   bool proxySameProcess[2] = {true, true};
   void** handles[2] = {NULL, NULL};
@@ -1179,8 +1183,12 @@ static ncclResult_t addP2pToPlan(struct ncclComm* comm, struct ncclKernelPlan* p
         int peerRank = dir ? sendRank : recvRank;
         struct ncclConnector* conn =
           dir ? &channelPeers[peerRank]->send[connIndex[dir]] : &channelPeers[peerRank]->recv[connIndex[dir]];
-        protoLL[dir] &=
-          conn->conn.buffs[NCCL_PROTO_LL] != nullptr && !IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx12");
+        // SendRecv uses LL128 (in place of LL) for latency-bound sizes on both the intranode and
+        // internode paths. It requires the LL128 staging buffer to exist on the connection. For
+        // intranode P2P these are always allocated; for network connections they are allocated when
+        // NCCL_ALLOC_P2P_NET_LL_BUFFERS is enabled.
+        protoLL128[dir] &= conn->conn.buffs[NCCL_PROTO_LL128] != nullptr &&
+                           !IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx12");
         network[dir] |= conn->transportComm == (dir ? &netTransport.send : &netTransport.recv);
         proxySameProcess[dir] &= conn->proxyConn.sameProcess;
       }
@@ -1222,9 +1230,9 @@ static ncclResult_t addP2pToPlan(struct ncclComm* comm, struct ncclKernelPlan* p
     // Update number of channels propagated to the profiler
     if (p2pTasks[dir]) p2pTasks[dir]->nChannels = nChannels[dir];
 
-    // Select protocol (LL vs SIMPLE) used based on payload per channel
-    if (bytes[dir] != -1) protoLL[dir] &= bytes[dir] <= nChannels[dir] * ncclParamP2pLLThreshold();
-    protocol[dir] = protoLL[dir] ? NCCL_PROTO_LL : NCCL_PROTO_SIMPLE;
+    // Select protocol based on per-channel payload: <= P2P_LL_THRESHOLD uses LL128, else SIMPLE.
+    if (bytes[dir] != -1) protoLL128[dir] &= bytes[dir] <= nChannels[dir] * ncclParamP2pLLThreshold();
+    protocol[dir] = protoLL128[dir] ? NCCL_PROTO_LL128 : NCCL_PROTO_SIMPLE;
 
     stepSize[dir] = comm->buffSizes[protocol[dir]] / NCCL_STEPS;
     if (protocol[dir] == NCCL_PROTO_SIMPLE) stepSize[dir] = comm->p2pChunkSize;
@@ -1238,11 +1246,15 @@ static ncclResult_t addP2pToPlan(struct ncclComm* comm, struct ncclKernelPlan* p
     }
 
     chunkDataSize[dir] = chunkSize[dir];
-    if (protocol[dir] == NCCL_PROTO_LL) chunkDataSize[dir] /= 2;
+    // Convert wire chunk size to data (payload) chunk size for LL128 (data lines carry a flag word).
+    if (protocol[dir] == NCCL_PROTO_LL128)
+      chunkDataSize[dir] = (chunkDataSize[dir] / comm->ll128LineElems) * comm->ll128DataElems;
     chunkDataSize_u32fp8[dir] = u32fp8Encode(chunkDataSize[dir]);
     chunkDataSize[dir] = u32fp8Decode(chunkDataSize_u32fp8[dir]);
     chunkSize[dir] = chunkDataSize[dir];
-    if (protocol[dir] == NCCL_PROTO_LL) chunkSize[dir] *= 2;
+    // Convert data chunk size back to wire chunk size (used for proxy chunk steps).
+    if (protocol[dir] == NCCL_PROTO_LL128)
+      chunkSize[dir] = (chunkSize[dir] / comm->ll128DataElems) * comm->ll128LineElems;
 
     if (p2pTasks[dir] && p2pTasks[dir]->allowUB) {
       if (network[dir]) {
@@ -1322,7 +1334,7 @@ static ncclResult_t addP2pToPlan(struct ncclComm* comm, struct ncclKernelPlan* p
   work->nP2pChannels = comm->p2pnChannels;
   work->channelBase = base;
   work->nSendChannels = nChannels[1];
-  work->sendProtoLL = protoLL[1];
+  work->sendProtoLL128 = protoLL128[1];
   work->sendNetReg = netRegistered[1];
   work->sendIpcReg = ipcRegistered[1];
   work->sendChunkSize_u32fp8 = chunkDataSize_u32fp8[1];
@@ -1332,7 +1344,7 @@ static ncclResult_t addP2pToPlan(struct ncclComm* comm, struct ncclKernelPlan* p
   work->sendConnIndex = connIndex[1];
   work->sendOpCount = sendOpCount;
   work->nRecvChannels = nChannels[0];
-  work->recvProtoLL = protoLL[0];
+  work->recvProtoLL128 = protoLL128[0];
   work->recvNetReg = netRegistered[0];
   work->recvIpcReg = ipcRegistered[0];
   work->recvChunkSize_u32fp8 = chunkDataSize_u32fp8[0];
@@ -1418,9 +1430,10 @@ static ncclResult_t addP2pToPlan(struct ncclComm* comm, struct ncclKernelPlan* p
           proxyOps[dir].nsteps = divUp(partEnd - partBeg, chunkDataSize);
           proxyOps[dir].nbytes = std::min(partEnd - partBeg, chunkDataSize);
         }
-        if (proxyOps[dir].protocol == NCCL_PROTO_LL) {
-          proxyOps[dir].nbytes *= 2;
-          proxyOps[dir].nbytes = roundUp(proxyOps[dir].nbytes, sizeof(union ncclLLFifoLine));
+        if (proxyOps[dir].protocol == NCCL_PROTO_LL128) {
+          // Convert data bytes to wire bytes (data lines carry an extra flag word).
+          proxyOps[dir].nbytes = divUp(proxyOps[dir].nbytes, comm->ll128DataElems * sizeof(uint64_t)) *
+                                 comm->ll128LineElems * sizeof(uint64_t);
         }
       }
 

--- a/projects/rccl/src/include/device.h
+++ b/projects/rccl/src/include/device.h
@@ -348,7 +348,8 @@ struct alignas(16) ncclDevWorkP2p {
   // Chunk size stored in 8 bits via u32fp8Encode/Decode.
   uint8_t sendChunkSize_u32fp8, recvChunkSize_u32fp8;
 
-  uint8_t sendProtoLL:1, recvProtoLL:1;
+  // SendRecv uses the LL128 protocol (instead of SIMPLE) for latency-bound sizes.
+  uint8_t sendProtoLL128:1, recvProtoLL128:1;
   uint8_t sendNetReg:1, recvNetReg:1;
   uint8_t sendIpcReg:1, recvIpcReg:1;
 

--- a/projects/rccl/src/transport/net.cc
+++ b/projects/rccl/src/transport/net.cc
@@ -1212,6 +1212,12 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
       NCCL_NET_MAP_ADD_POINTER(map, 0, 0 /*p == NCCL_PROTO_LL*/, proxyState->buffSizes[NCCL_PROTO_LL],
                                buffs[NCCL_PROTO_LL]);
       resources->buffSizes[NCCL_PROTO_LL] = proxyState->buffSizes[NCCL_PROTO_LL];
+      // SendRecv uses LL128 (in place of LL) for latency-bound sizes; allocate its staging buffer too.
+      // LL128 (unlike LL) lives in device memory when GDR is enabled, matching the collective net path
+      // and the proxy's LL128 fast-path (ready = useGdr).
+      NCCL_NET_MAP_ADD_POINTER(map, 0, resources->useGdr ? 1 : 0, proxyState->buffSizes[NCCL_PROTO_LL128],
+                               buffs[NCCL_PROTO_LL128]);
+      resources->buffSizes[NCCL_PROTO_LL128] = proxyState->buffSizes[NCCL_PROTO_LL128];
     }
 
     NCCL_NET_MAP_ADD_POINTER(map, 1, resources->useGdr ? 1 : 0, mapMem->size, buffs[NCCL_PROTO_SIMPLE]);
@@ -1222,7 +1228,11 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
 
   map->mems[NCCL_NET_MAP_DEVMEM].dmaBufFd = -1; // Initialize to invalid fd
   if (map->mems[NCCL_NET_MAP_DEVMEM].size) {
-    if (resources->shared == 0) {
+    // Ring/tree (shared==0) always need dedicated device buffers. Shared p2p connections
+    // normally have no dedicated device memory, but when NCCL_ALLOC_P2P_NET_LL_BUFFERS is on
+    // the LL128 staging buffer lives here (device memory + GDR, like the collective net path),
+    // so the bank must be backed for shared connections too.
+    if (resources->shared == 0 || proxyState->allocP2pNetLLBuffers) {
       if (!map->sameProcess || ncclCuMemEnable()) {
         ALIGN_SIZE(map->mems[NCCL_NET_MAP_DEVMEM].size, CUDA_IPC_MIN);
         NCCLCHECK(ncclP2pAllocateShareableBuffer(
@@ -1465,14 +1475,26 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
   NCCL_NET_MAP_ADD_POINTER(map, 0, 0, sizeof(struct ncclSendMem), sendMem);
   NCCL_NET_MAP_ADD_POINTER(map, 0, 0, sizeof(struct ncclRecvMem), recvMem);
 
-  if (proxyState->allocP2pNetLLBuffers) {
+  // Only P2P (shared) net connections need the LL/LL128 staging buffers. Guarding on
+  // resources->shared != 0 keeps ring/tree (shared==0) collective connections from
+  // allocating an unused GDR-resident LL128 buffer, which otherwise enlarges their DEVMEM
+  // bank and degrades collective GDR performance (e.g. all_reduce). Mirrors the send side.
+  if (resources->shared != 0 && proxyState->allocP2pNetLLBuffers) {
     NCCL_NET_MAP_ADD_POINTER(map, 0, 0 /*devMem*/, proxyState->buffSizes[NCCL_PROTO_LL], buffs[NCCL_PROTO_LL]);
     resources->buffSizes[NCCL_PROTO_LL] = proxyState->buffSizes[NCCL_PROTO_LL];
+    // SendRecv uses LL128 (in place of LL) for latency-bound sizes; allocate its staging buffer too.
+    // LL128 (unlike LL) lives in device memory when GDR is enabled, matching the collective net path
+    // and the proxy's LL128 fast-path (ready = useGdr).
+    NCCL_NET_MAP_ADD_POINTER(map, 0, resources->useGdr ? 1 : 0, proxyState->buffSizes[NCCL_PROTO_LL128],
+                             buffs[NCCL_PROTO_LL128]);
+    resources->buffSizes[NCCL_PROTO_LL128] = proxyState->buffSizes[NCCL_PROTO_LL128];
   }
 
   map->mems[NCCL_NET_MAP_DEVMEM].dmaBufFd = -1; // Initialize to invalid fd
   if (map->mems[NCCL_NET_MAP_DEVMEM].size) {
-    if (resources->shared == 0) {
+    // See sendProxyConnect: shared p2p connections need the dedicated device bank backed when
+    // NCCL_ALLOC_P2P_NET_LL_BUFFERS is on so the LL128 staging buffer is valid.
+    if (resources->shared == 0 || proxyState->allocP2pNetLLBuffers) {
       if (ncclCuMemEnable()) {
         NCCLCHECK(ncclP2pAllocateShareableBuffer(
           map->mems[NCCL_NET_MAP_DEVMEM].size, 0, &map->mems[NCCL_NET_MAP_DEVMEM].ipcDesc,

--- a/projects/rccl/test/SendRecvTests.cpp
+++ b/projects/rccl/test/SendRecvTests.cpp
@@ -108,6 +108,156 @@ namespace RcclUnitTesting
     testBed.Finalize();
   }
 
+  // Shared sweep body for the LL128 latency-bound P2P send/recv regression tests.
+  //
+  // RCCL's P2P send/recv uses the LL128 protocol (in place of the legacy LL) for per-channel
+  // payloads <= NCCL_P2P_LL_THRESHOLD, and SIMPLE above it. The switch requires converting between
+  // LL128 "wire" chunk sizes (data lines carry an extra flag word) and "data" chunk sizes in the
+  // enqueue path, plus matching proxy byte accounting. Those conversions are size-sensitive, so a
+  // bug typically corrupts data only at specific sizes near the protocol boundary or at sizes that
+  // are not a multiple of the LL128 line/data granularity.
+  //
+  // This sweeps awkward element counts straddling the LL128/SIMPLE threshold using datatypes of
+  // different element sizes (so the per-channel byte payload crosses the threshold at different
+  // element counts, exercising both protocol selections and the wire<->data conversion), and
+  // validates end-to-end correctness for every send/recv pair. The caller pins
+  // NCCL_ALLOC_P2P_NET_LL_BUFFERS and, to force intranode send/recv onto the network transport on a
+  // single node, disables the P2P and SHM transports (disabling P2P alone routes via SHM; only
+  // disabling both P2P and SHM falls through to NET/IB, where NCCL_ALLOC_P2P_NET_LL_BUFFERS actually
+  // governs LL/LL128 staging-buffer allocation).
+  static void RunLL128BoundarySweep(TestBed& testBed)
+  {
+    // Configuration: int8 (1B) and float32 (4B) so the 16 KiB/channel LL128 threshold is crossed at
+    // 16384 and 4096 elements respectively; sizes below pick LL128, sizes above pick SIMPLE.
+    std::vector<ncclDataType_t> const& testDataTypes = {ncclInt8, ncclFloat32};
+    // Awkward counts around the boundary (non-power-of-2 / prime), plus a clearly-SIMPLE large size.
+    // Kept small because these variants force transfers over the (slower) network loopback path.
+    std::vector<int>            const  numElements   = {262144, 16385, 4097, 1};
+    bool                        const  inPlace       = false;
+    bool                        const  useManagedMem = false;
+
+    OptionalColArgs options;
+
+    std::vector<ncclDataType_t> dataTypes;
+    testBed.GetSupportedDataTypes(dataTypes, testDataTypes);
+    if (dataTypes.empty()) {
+      GTEST_SKIP() << "Skipping... test datatypes excluded by UT_DATATYPES.";
+    }
+    if (testBed.ev.maxGpus < 2) {
+      GTEST_SKIP() << "Skipping... SendRecv.LL128LatencyBoundarySizes requires at least 2 GPUs (detected "
+                   << testBed.ev.maxGpus << ")";
+    }
+
+    bool isCorrect = true;
+    int numGpus = testBed.ev.maxGpus;
+    for (int rpg = 0; rpg < 2 && isCorrect; ++rpg)
+    for (int isMultiProcess = 0; isMultiProcess <= 1 && isCorrect; ++isMultiProcess)
+    {
+      if (!(testBed.ev.processMask & (1 << isMultiProcess))) continue;
+      int ranksPerGpu = rpg == 0 ? 1 : testBed.ev.maxRanksPerGpu;
+      int totalRanks = numGpus * ranksPerGpu;
+      int const numProcesses = isMultiProcess ? numGpus : 1;
+      const std::vector<int>& gpuPriorityOrder = testBed.ev.GetGpuPriorityOrder();
+      testBed.InitComms(TestBed::GetDeviceIdsList(numProcesses, numGpus, ranksPerGpu, gpuPriorityOrder),
+                        {1,2}, //two group, second group sendrecv to self, has 2 coll
+                        testBed.GetNumStreamsPerGroup(1,2),
+                        2);
+
+      for (int dataIdx = 0; dataIdx < dataTypes.size() && isCorrect; ++dataIdx)
+      for (int numIdx = 0; numIdx < numElements.size() && isCorrect; ++numIdx)
+      for (int sendRank = 0; sendRank < totalRanks; ++sendRank)
+      {
+        for (int recvRank = 0; recvRank < totalRanks; ++recvRank)
+        {
+          options.root = recvRank;
+          int groupCallId = sendRank == recvRank; //self sendrecv group has two coll
+          int recvId      = sendRank == recvRank; //where recv will be second coll
+          testBed.SetCollectiveArgs(ncclCollSend,
+                                    dataTypes[dataIdx],
+                                    numElements[numIdx],
+                                    numElements[numIdx],
+                                    options,
+                                    0,
+                                    groupCallId,
+                                    sendRank);
+          if (recvRank == 0)
+          {
+            testBed.SetCollectiveArgs(ncclCollSend,
+                                      dataTypes[dataIdx],
+                                      numElements[numIdx],
+                                      numElements[numIdx],
+                                      options,
+                                      0,
+                                      !groupCallId,
+                                      sendRank);
+            testBed.AllocateMem(inPlace, useManagedMem, 0, 0, sendRank);
+            testBed.PrepareData(0, 0, sendRank);
+            testBed.AllocateMem(inPlace, useManagedMem, 1, 0, sendRank);
+            testBed.PrepareData(1, 0, sendRank);
+          }
+
+          if (testBed.ev.showNames) // Show test names
+            TEST_INFO("%s Datatype: %s LL128 boundary SendReceive Rank %d -> Rank %d for %d Elements",
+                 isMultiProcess ? "MP" : "SP",
+                 ncclDataTypeNames[dataTypes[dataIdx]],
+                 sendRank,
+                 recvRank,
+                 numElements[numIdx]);
+          options.root = sendRank;
+
+          testBed.SetCollectiveArgs(ncclCollRecv,
+                                    dataTypes[dataIdx],
+                                    numElements[numIdx],
+                                    numElements[numIdx],
+                                    options,
+                                    recvId,
+                                    groupCallId,
+                                    recvRank);
+          testBed.AllocateMem(inPlace, useManagedMem, groupCallId, recvId, recvRank);
+          testBed.PrepareData(groupCallId, recvId, recvRank);
+          testBed.ExecuteCollectives({sendRank, recvRank}, groupCallId);
+          testBed.ValidateResults(isCorrect, groupCallId, recvId, recvRank);
+          testBed.DeallocateMem(groupCallId, recvId, recvRank);
+        }
+        testBed.DeallocateMem(0, 0, sendRank);
+        testBed.DeallocateMem(1, 0, sendRank);
+      }
+      testBed.DestroyComms();
+    }
+    testBed.Finalize();
+  }
+
+  // NCCL_ALLOC_P2P_NET_LL_BUFFERS=0: no dedicated LL/LL128 net staging buffers are allocated for P2P
+  // network connections, so send/recv falls back to SIMPLE over the network. Verifies correctness of
+  // the guarded allocation path when P2P net LL buffers are disabled.
+  TEST(SendRecv, LL128NetBuffersDisabled)
+  {
+    setenv("NCCL_P2P_DISABLE", "1", 1);              // disable P2P/IPC so send/recv does not use it
+    setenv("NCCL_SHM_DISABLE", "1", 1);              // disable SHM so send/recv falls through to NET
+    setenv("NCCL_ALLOC_P2P_NET_LL_BUFFERS", "0", 1); // disabled case
+    TestBed testBed;
+    RunLL128BoundarySweep(testBed);
+    unsetenv("NCCL_ALLOC_P2P_NET_LL_BUFFERS");
+    unsetenv("NCCL_SHM_DISABLE");
+    unsetenv("NCCL_P2P_DISABLE");
+  }
+
+  // NCCL_ALLOC_P2P_NET_LL_BUFFERS=1: dedicated LL/LL128 net staging buffers are allocated for P2P
+  // (shared) network connections, enabling LL128 for latency-bound send/recv over the network.
+  // Verifies correctness of the changed net allocation + LL128 dispatch path when enabled (and, with
+  // the accompanying fix, that ring/tree collective connections do not allocate these buffers).
+  TEST(SendRecv, LL128NetBuffersEnabled)
+  {
+    setenv("NCCL_P2P_DISABLE", "1", 1);              // disable P2P/IPC so send/recv does not use it
+    setenv("NCCL_SHM_DISABLE", "1", 1);              // disable SHM so send/recv falls through to NET
+    setenv("NCCL_ALLOC_P2P_NET_LL_BUFFERS", "1", 1); // enabled case
+    TestBed testBed;
+    RunLL128BoundarySweep(testBed);
+    unsetenv("NCCL_ALLOC_P2P_NET_LL_BUFFERS");
+    unsetenv("NCCL_SHM_DISABLE");
+    unsetenv("NCCL_P2P_DISABLE");
+  }
+
   TEST(SendRecv, UserBufferRegister)
   {
     setenv("RCCL_ENABLE_INTRANET", "1", 1);


### PR DESCRIPTION
## Motivation

Improve performance of small and medium data sizes sendrecv collectives

## Technical Details

Switch P2P send/recv from the legacy LL protocol to LL128 for latency-bound sizes (<= NCCL_P2P_LL_THRESHOLD per channel) on both the intranode and internode paths:

- device: dispatch runSend/runRecv with ProtoLL128 (was ProtoLL), and rename the ncclDevWorkP2p sendProtoLL/recvProtoLL bitfields to sendProtoLL128/recvProtoLL128.
- enqueue: select LL128 vs SIMPLE based on per-channel payload, gate on the LL128 staging buffer being present, and convert wire<->data chunk sizes and proxy byte counts using the LL128 line/data element ratio (data lines carry a flag word) instead of the LL x2 factor. Raise the default P2P_LL_THRESHOLD from 8 KiB to 16 KiB (LL128's ~1/16 flag overhead keeps it faster than SIMPLE through 16 KiB/channel).
- net: allocate the LL128 P2P staging buffer for network connections (device memory + GDR, matching the collective net path) and back the dedicated DEVMEM bank for shared p2p connections when NCCL_ALLOC_P2P_NET_LL_BUFFERS is enabled.

Only allocate the P2P LL/LL128 net staging buffers on P2P (shared) connections. The recv-side allocP2pNetLLBuffers block in recvProxyConnect was outside the shared==0 guard, so ring/tree collective net connections also allocated an unused GDR-resident LL128 staging buffer that collectives never use. Guard on resources->shared != 0 to mirror the send side (sendProxyConnect), so only P2P (shared) connections get the LL/LL128 staging buffers. Docs updated to reflect LL128 usage for P2P.

## Issue Tracking

FBA-1079

## Test Plan

Add SendRecv LL128 boundary unit tests: a shared sweep over awkward element counts straddling the LL128/SIMPLE per-channel threshold across datatypes of different element sizes, run as two cases that pin NCCL_ALLOC_P2P_NET_LL_BUFFERS to 0 and 1 (with the P2P and SHM transports disabled so the network path is exercised). Validates end-to-end correctness of the LL128 dispatch, the wire<->data chunk-size conversions, and the guarded net staging-buffer allocation for both disabled and enabled cases.

## Test Result

All passed

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
