### PR TITLE
[rocjitsu] Add AMDGPU decoder fuzzing

### DIFF
--- a/emulation/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/CMakeLists.txt
@@ -400,6 +400,7 @@ add_dependencies(rocjitsu_shared flatbuffers_schemas)
 
 # Developer and test workflow tools.
 add_subdirectory(tools)
+add_subdirectory(fuzz/decode)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     add_subdirectory(tools/rocjitsu)

--- a/emulation/rocjitsu/docs/isa-target-providers.md
+++ b/emulation/rocjitsu/docs/isa-target-providers.md
@@ -70,7 +70,7 @@ list:
 
 ```cmake
 rj_add_isa_target_registry(
-    errata_isa_registry
+    translation_isa_registry
     PROVIDERS rocjitsu_isa_gfx1250_model
 )
 ```

--- a/emulation/rocjitsu/fuzz/decode/CMakeLists.txt
+++ b/emulation/rocjitsu/fuzz/decode/CMakeLists.txt
@@ -1,0 +1,33 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+add_library(rj_decode_fuzz_core STATIC decode_fuzz_core.cpp)
+get_property(
+    _rj_decode_fuzz_providers
+    GLOBAL
+    PROPERTY RJ_BUILTIN_AMDGPU_ISA_PROVIDERS
+)
+list(REMOVE_ITEM _rj_decode_fuzz_providers rocjitsu_isa_gfx1250)
+list(APPEND _rj_decode_fuzz_providers rocjitsu_isa_gfx1250_model)
+rj_add_isa_target_registry(
+    rj_decode_fuzz_registry
+    PROVIDERS ${_rj_decode_fuzz_providers}
+)
+target_include_directories(
+    rj_decode_fuzz_core
+    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+)
+target_link_libraries(
+    rj_decode_fuzz_core
+    PUBLIC
+        rocjitsu_dbt_internal
+        rj_decode_fuzz_registry
+        rocjitsu_vm_amdgpu
+        simdojo
+        simdojo_headers
+)
+rj_configure_target(rj_decode_fuzz_core PRIVATE_INCLUDES WARNINGS)
+
+add_executable(rj_decode_fuzz decode_fuzz_main.cpp)
+target_link_libraries(rj_decode_fuzz PRIVATE rj_decode_fuzz_core)
+rj_configure_target(rj_decode_fuzz PRIVATE_INCLUDES WARNINGS)

--- a/emulation/rocjitsu/fuzz/decode/README.md
+++ b/emulation/rocjitsu/fuzz/decode/README.md
@@ -1,0 +1,114 @@
+# Decoder fuzzing
+
+This directory keeps the coverage-guided decoder loop independent of LLVM. The
+hot path supports every target in rocjitsu's statically composed registry and
+accepts an exact 16-byte little-endian instruction window. Sixteen bytes cover
+the largest supported encoding while letting the decoder report the actual 4,
+8, 12, or 16-byte instruction length. The registry contains AMDGPU targets
+only. Canonical target IDs and their registered aliases are accepted, including
+`gfx950`, `gfx1201`, and `gfx1250`.
+
+LLVM comparison is a separate offline process. `decode_differential.py` invokes
+a caller-selected `llvm-mc`, compares only the first instruction in each
+window, and writes structured mismatch records. LLVM is therefore neither a
+configure-time nor a link-time dependency.
+
+## Build and test
+
+From this directory's project root (`emulation/rocjitsu`):
+
+```sh
+cmake -S . -B build-decode -GNinja \
+  -DBUILD_TESTING=ON
+ninja -C build-decode rj_decode_fuzz rj_decode_fuzz_test
+ctest --test-dir build-decode -j4 \
+  -R '^Decode(Fuzz(Core|Targets)Test\.|DifferentialUnitTest$|SeedExtractorUnitTest$|FuzzCliTest$)' \
+  --output-on-failure
+```
+
+Generate model-derived seeds:
+
+```sh
+build-decode/fuzz/decode/rj_decode_fuzz \
+  --emit-seeds decode-seeds --target gfx1201
+```
+
+The destination must be absent or empty so stale non-window files cannot enter
+the AFL++ corpus.
+
+Object files can supply additional seeds without putting ELF parsing in the
+fuzz loop. The extractor samples aligned `.text` windows deterministically and
+records their source offsets:
+
+```sh
+python3 fuzz/decode/prepare_decode_seeds.py \
+  --input /path/to/object-corpus --output object-seeds \
+  --llvm-objcopy /path/to/llvm-objcopy
+```
+
+Inputs must be unbundled AMDGPU ELF code objects. Other ELF machine types and
+host executables containing bundled device code are skipped.
+
+The extractor writes provenance beside the seed directory as
+`object-seeds.manifest.json`, keeping the AFL++ input directory binary-only.
+Generated test encodings currently provide at most two populated DWORDs for
+most targets; use object-derived seeds to seed broader 12- and 16-byte windows.
+
+## AFL++ with sanitizers
+
+Configure the entire model with the AFL++ compiler wrappers so coverage reaches
+the generated decoder code:
+
+```sh
+AFL_ROOT=/path/to/AFLplusplus
+cmake -S . -B build-decode-afl -GNinja \
+  -DCMAKE_C_COMPILER="$AFL_ROOT/afl-clang-fast" \
+  -DCMAKE_CXX_COMPILER="$AFL_ROOT/afl-clang-fast++" \
+  -DBUILD_TESTING=ON \
+  -DRJ_ENABLE_ASAN=ON -DRJ_ENABLE_UBSAN=ON
+ninja -C build-decode-afl rj_decode_fuzz
+
+"$AFL_ROOT/afl-fuzz" -i decode-seeds -o decode-findings \
+  -g 16 -G 16 -m none -- \
+  build-decode-afl/fuzz/decode/rj_decode_fuzz --afl --target gfx1250
+```
+
+`InvalidInst` is an ordinary rejection. Other exceptions, signals, sanitizer
+findings, and decoder invariant failures remain crashes for AFL++ to retain.
+
+## Offline LLVM comparison
+
+Compare an AFL++ queue or a single minimized crash using a pinned tool path:
+
+```sh
+python3 fuzz/decode/decode_differential.py \
+  --decoder build-decode-afl/fuzz/decode/rj_decode_fuzz \
+  --llvm-mc /path/to/llvm-mc \
+  --target gfx1201 \
+  --corpus decode-findings/default/queue \
+  --output decode-mismatches.jsonl \
+  --llvm-revision LLVM_SOURCE_COMMIT
+```
+
+The comparator checks acceptance, consumed byte count, mnemonic, numeric
+tokens, and the full ordered textual form. It normalizes case, whitespace, and
+equivalent decimal/hexadecimal integer spelling only. Register ranges,
+mnemonic suffixes, operand order, floating-point spelling, punctuation, and
+modifier order remain significant. Every mismatch contains both raw and
+normalized text, tool revisions, and replay commands. A decoder or `llvm-mc`
+process failure is recorded as its own mismatch category without stopping the
+rest of the corpus. Failures seen only while probing shorter instruction
+prefixes are retained separately as `llvm_prefix_tool_failure` records.
+Expect even generated seeds to produce a high mismatch rate, potentially around
+half the corpus. Common noise includes encoding suffixes, tied implicit
+operands, default `op_sel_hi` modifiers, and true16 register-half spelling.
+
+Raw mutated encodings are not proof that an instruction is executable. Leave
+the default `--input-qualification unqualified` for AFL++ queues and use
+`generated-unqualified` for generated opcode seeds. Generated seeds can still
+contain unusable zero-filled operand fields. Use `manual-qualified` only after
+checking the complete instruction. Textual, operand, or acceptance differences
+from unqualified inputs are investigation leads; qualify them against the
+public ISA manual before treating either decoder as incorrect. Crashes,
+sanitizer findings, and invariant violations do not require that semantic
+qualification.

--- a/emulation/rocjitsu/fuzz/decode/decode_differential.py
+++ b/emulation/rocjitsu/fuzz/decode/decode_differential.py
@@ -1,0 +1,500 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Compare rocjitsu decoder results with llvm-mc."""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import json
+import os
+from pathlib import Path
+import re
+import shlex
+import subprocess
+import sys
+from typing import Any, Iterable
+
+WINDOW_SIZE = 16
+LLVM_CPUS = {
+    "cdna1": "gfx908",
+    "cdna2": "gfx90a",
+    "gfx90a": "gfx90a",
+    "cdna3": "gfx942",
+    "gfx942": "gfx942",
+    "cdna4": "gfx950",
+    "gfx950": "gfx950",
+    "rdna1": "gfx1010",
+    "rdna2": "gfx1030",
+    "rdna3": "gfx1100",
+    "rdna3_5": "gfx1150",
+    "rdna4": "gfx1201",
+    "gfx1200": "gfx1200",
+    "gfx1201": "gfx1201",
+    "gfx1250": "gfx1250",
+}
+SUPPORTED_TARGETS = tuple(LLVM_CPUS)
+ENCODING_RE = re.compile(r";\s*encoding:\s*\[([^]]+)\]")
+INTEGER_RE = re.compile(r"(?<![a-z0-9_])[+-]?(?:0x[0-9a-f]+|[0-9]+)(?![a-z0-9_])")
+
+
+def _canonical_integer(match: re.Match[str]) -> str:
+    token = match.group(0)
+    sign = 1
+    if token.startswith(("-", "+")):
+        if token[0] == "-":
+            sign = -1
+        token = token[1:]
+    base = 16 if token.startswith("0x") else 10
+    return str(sign * int(token, base))
+
+
+def canonicalize_text(text: str) -> str:
+    """Normalize presentation only; preserve spelling, token order, and modifiers."""
+    result = " ".join(text.lower().split())
+    result = INTEGER_RE.sub(_canonical_integer, result)
+    result = re.sub(r"\s*([,\[\]:])\s*", r"\1", result)
+    return result
+
+
+def numeric_tokens(text: str) -> list[str]:
+    lowered = text.lower()
+    return [_canonical_integer(match) for match in INTEGER_RE.finditer(lowered)]
+
+
+def parse_llvm_output(stdout: str, stderr: str) -> dict[str, Any]:
+    """Parse only the first instruction in one llvm-mc byte-stream line."""
+    invalid_at_start = re.search(
+        r"^[^\n]*:1:1: (?:warning|error): invalid instruction encoding\s*$",
+        stderr,
+        flags=re.MULTILINE,
+    )
+    if invalid_at_start:
+        return {"status": "invalid", "diagnostic": invalid_at_start.group(0)}
+
+    for line in stdout.splitlines():
+        encoding = ENCODING_RE.search(line)
+        if not encoding:
+            continue
+        disassembly = line[: encoding.start()].strip()
+        encoded_bytes = re.findall(r"0x[0-9a-fA-F]{2}", encoding.group(1))
+        if not disassembly or not encoded_bytes:
+            continue
+        if re.search(r"/\*\s*invalid", disassembly, flags=re.IGNORECASE):
+            comparable_disassembly = re.sub(
+                r"/\*\s*invalid.*?\*/", "", disassembly, flags=re.IGNORECASE
+            ).strip()
+            return {
+                "status": "operand_rejected",
+                "size": len(encoded_bytes),
+                "mnemonic": comparable_disassembly.split(maxsplit=1)[0],
+                "disassembly": comparable_disassembly,
+                "annotated_disassembly": disassembly,
+                "diagnostic": "LLVM rejected an operand while decoding the instruction",
+            }
+        return {
+            "status": "valid",
+            "size": len(encoded_bytes),
+            "mnemonic": disassembly.split(maxsplit=1)[0],
+            "disassembly": disassembly,
+        }
+
+    return {
+        "status": "invalid",
+        "diagnostic": stderr.strip() or "no decoded instruction",
+    }
+
+
+def _llvm_input(data: bytes) -> str:
+    return " ".join(f"0x{byte:02x}" for byte in data) + "\n"
+
+
+def llvm_args(target: str) -> tuple[str, ...]:
+    return (
+        "--triple=amdgcn-amd-amdhsa",
+        f"--mcpu={LLVM_CPUS[target]}",
+        "--disassemble",
+        "--show-encoding",
+    )
+
+
+def _run_llvm(
+    llvm_mc: Path, data: bytes, timeout: float, target: str
+) -> subprocess.CompletedProcess[str] | None:
+    try:
+        return subprocess.run(
+            [str(llvm_mc), *llvm_args(target)],
+            input=_llvm_input(data),
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return None
+
+
+def llvm_consumed_size(
+    data: bytes,
+    llvm_mc: Path,
+    timeout: float,
+    expected_disassembly: str,
+    probe_failures: list[dict[str, Any]] | None = None,
+    target: str = "gfx1250",
+) -> int | None:
+    """Find the shortest DWORD prefix LLVM accepts as the same instruction.
+
+    llvm-mc's --show-encoding output is a canonical re-encoding. Its byte count
+    can differ from the input bytes consumed, particularly for literal forms.
+    A shorter prefix can also decode as a different instruction, so acceptance
+    alone is insufficient for identifying the full decode's input size.
+
+    If a tool failure prevents proving which prefix is the shortest accepted
+    one, return ``None`` while preserving its details in ``probe_failures``.
+    """
+    expected = canonicalize_text(expected_disassembly)
+    saw_tool_failure = False
+    for size in range(4, len(data), 4):
+        process = _run_llvm(llvm_mc, data[:size], timeout, target)
+        if process is None:
+            saw_tool_failure = True
+            if probe_failures is not None:
+                probe_failures.append(
+                    {
+                        "size": size,
+                        "returncode": None,
+                        "stderr": f"timed out after {timeout:g} seconds",
+                    }
+                )
+            continue
+        if process.returncode != 0:
+            saw_tool_failure = True
+            if probe_failures is not None:
+                probe_failures.append(
+                    {
+                        "size": size,
+                        "returncode": process.returncode,
+                        "stderr": process.stderr.strip(),
+                    }
+                )
+            continue
+        record = parse_llvm_output(process.stdout, process.stderr)
+        if record["status"] in ("valid", "operand_rejected") and (
+            canonicalize_text(record["disassembly"]) == expected
+        ):
+            return None if saw_tool_failure else size
+    return None if saw_tool_failure else len(data)
+
+
+def compare_records(rocjitsu: dict[str, Any], llvm: dict[str, Any]) -> list[str]:
+    categories: list[str] = []
+    if rocjitsu["status"] == "tool_failure":
+        categories.append("rocjitsu_tool_failure")
+    if llvm["status"] == "tool_failure":
+        categories.append("llvm_tool_failure")
+    if categories:
+        return categories
+    llvm_status = llvm["status"]
+    if llvm_status == "operand_rejected":
+        categories.append("llvm_operand_rejected")
+        llvm_status = "valid"
+    if llvm.get("prefix_tool_failures"):
+        categories.append("llvm_prefix_tool_failure")
+    if rocjitsu["status"] != llvm_status:
+        categories.append("acceptance_mismatch")
+        return categories
+    if rocjitsu["status"] == "invalid":
+        return categories
+    if llvm.get("size") is not None and rocjitsu["size"] != llvm["size"]:
+        categories.append("size_mismatch")
+    if rocjitsu["mnemonic"].lower() != llvm["mnemonic"].lower():
+        categories.append("mnemonic_mismatch")
+    if numeric_tokens(rocjitsu["disassembly"]) != numeric_tokens(llvm["disassembly"]):
+        categories.append("numeric_token_mismatch")
+    if canonicalize_text(rocjitsu["disassembly"]) != canonicalize_text(
+        llvm["disassembly"]
+    ):
+        categories.append("text_mismatch")
+    return categories
+
+
+def _run_checked(command: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+    process = subprocess.run(
+        command, text=True, capture_output=True, check=False, **kwargs
+    )
+    if process.returncode != 0:
+        rendered = shlex.join(command)
+        raise RuntimeError(
+            f"command failed ({process.returncode}): {rendered}\n{process.stderr}"
+        )
+    return process
+
+
+def run_one(
+    path: Path,
+    decoder: Path,
+    llvm_mc: Path,
+    target: str,
+    input_qualification: str,
+    timeout: float = 10.0,
+) -> dict[str, Any]:
+    data = path.read_bytes()
+    if len(data) != WINDOW_SIZE:
+        raise RuntimeError(f"input is not exactly {WINDOW_SIZE} bytes: {path}")
+
+    try:
+        roc_process = subprocess.run(
+            [
+                str(decoder),
+                "--input",
+                str(path),
+                "--json",
+                "--target",
+                target,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        roc_process = None
+    if roc_process is None:
+        roc_record = {
+            "status": "tool_failure",
+            "returncode": None,
+            "stderr": f"timed out after {timeout:g} seconds",
+        }
+    elif roc_process.returncode == 0:
+        try:
+            roc_record = json.loads(roc_process.stdout)
+        except json.JSONDecodeError as error:
+            roc_record = {
+                "status": "tool_failure",
+                "returncode": 0,
+                "stderr": f"invalid replay JSON: {error}",
+                "stdout": roc_process.stdout,
+            }
+    else:
+        roc_record = {
+            "status": "tool_failure",
+            "returncode": roc_process.returncode,
+            "stderr": roc_process.stderr.strip(),
+        }
+    llvm_input = _llvm_input(data)
+    llvm_process = _run_llvm(llvm_mc, data, timeout, target)
+    if llvm_process is None:
+        llvm_record = {
+            "status": "tool_failure",
+            "returncode": None,
+            "stderr": f"timed out after {timeout:g} seconds",
+        }
+    elif llvm_process.returncode == 0:
+        llvm_record = parse_llvm_output(llvm_process.stdout, llvm_process.stderr)
+        if llvm_record["status"] in ("valid", "operand_rejected"):
+            llvm_record["shown_encoding_size"] = llvm_record["size"]
+            prefix_tool_failures: list[dict[str, Any]] = []
+            llvm_record["size"] = llvm_consumed_size(
+                data,
+                llvm_mc,
+                timeout,
+                llvm_record["disassembly"],
+                prefix_tool_failures,
+                target,
+            )
+            if prefix_tool_failures:
+                llvm_record["prefix_tool_failures"] = prefix_tool_failures
+    else:
+        llvm_record = {
+            "status": "tool_failure",
+            "returncode": llvm_process.returncode,
+            "stderr": llvm_process.stderr.strip(),
+        }
+    categories = compare_records(roc_record, llvm_record)
+    return {
+        "input": str(path),
+        "bytes": data.hex(),
+        "target": target,
+        "input_qualification": input_qualification,
+        "categories": categories,
+        "rocjitsu": roc_record,
+        "llvm": llvm_record,
+        "normalized": {
+            "rocjitsu": canonicalize_text(roc_record.get("disassembly", "")),
+            "llvm": canonicalize_text(llvm_record.get("disassembly", "")),
+        },
+        "reproduce": {
+            "rocjitsu": shlex.join(
+                [
+                    str(decoder),
+                    "--input",
+                    str(path),
+                    "--json",
+                    "--target",
+                    target,
+                ]
+            ),
+            "llvm": (
+                f"printf '%s\\n' {shlex.quote(llvm_input.rstrip())} | "
+                f"{shlex.join([str(llvm_mc), *llvm_args(target)])}"
+            ),
+        },
+    }
+
+
+def _revision(command: list[str], fallback: str) -> str:
+    try:
+        lines = [
+            line.strip()
+            for line in _run_checked(command).stdout.splitlines()
+            if line.strip()
+        ]
+        version_line = next((line for line in lines if "version" in line.lower()), None)
+        return version_line or lines[0]
+    except (OSError, RuntimeError, IndexError):
+        return fallback
+
+
+def _git_revision(repository: Path) -> str:
+    revision = _revision(["git", "-C", str(repository), "rev-parse", "HEAD"], "unknown")
+    status = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repository),
+            "status",
+            "--porcelain",
+            "--untracked-files=no",
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    return revision + ("+dirty" if status.returncode == 0 and status.stdout else "")
+
+
+def _inputs(single_input: Path | None, corpus: Path | None) -> list[Path]:
+    if single_input:
+        paths = [single_input]
+    else:
+        assert corpus is not None
+        paths = sorted(
+            path
+            for path in corpus.rglob("*")
+            if path.is_file()
+            and path.name != "README.txt"
+            and not any(part.startswith(".") for part in path.relative_to(corpus).parts)
+        )
+    wrong_size = [path for path in paths if path.stat().st_size != WINDOW_SIZE]
+    if wrong_size:
+        examples = ", ".join(str(path) for path in wrong_size[:3])
+        raise RuntimeError(f"corpus contains non-{WINDOW_SIZE}-byte inputs: {examples}")
+    if not paths:
+        raise RuntimeError("no inputs found")
+    return paths
+
+
+def parse_args(argv: Iterable[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--input", type=Path, help="compare one exact 16-byte input")
+    source.add_argument(
+        "--corpus", type=Path, help="recursively compare a window corpus"
+    )
+    parser.add_argument(
+        "--decoder", type=Path, required=True, help="rj_decode_fuzz executable"
+    )
+    parser.add_argument(
+        "--llvm-mc", type=Path, required=True, help="pinned llvm-mc executable"
+    )
+    parser.add_argument(
+        "--target",
+        choices=SUPPORTED_TARGETS,
+        default="gfx1250",
+        help="rocjitsu target profile (default: gfx1250)",
+    )
+    parser.add_argument(
+        "--input-qualification",
+        choices=("unqualified", "generated-unqualified", "manual-qualified"),
+        default="unqualified",
+        help=(
+            "record how instruction provenance and validity were established; "
+            "generated opcode seeds and raw AFL mutations are not manual qualification"
+        ),
+    )
+    parser.add_argument(
+        "--output", type=Path, required=True, help="mismatch JSONL path"
+    )
+    parser.add_argument("--jobs", type=int, default=min(os.cpu_count() or 1, 8))
+    parser.add_argument(
+        "--timeout", type=float, default=10.0, help="per-tool timeout in seconds"
+    )
+    parser.add_argument(
+        "--rocjitsu-revision", help="override the auto-detected source revision"
+    )
+    parser.add_argument(
+        "--llvm-revision", help="record the pinned LLVM source revision"
+    )
+    parser.add_argument("--allow-mismatches", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = parse_args(argv if argv is not None else sys.argv[1:])
+    paths = _inputs(args.input, args.corpus)
+    if args.jobs < 1 or args.timeout <= 0:
+        raise RuntimeError("--jobs and --timeout must be positive")
+
+    project_root = Path(__file__).resolve().parents[2]
+    revisions = {
+        "rocjitsu": args.rocjitsu_revision or _git_revision(project_root),
+        "llvm": args.llvm_revision
+        or _revision([str(args.llvm_mc), "--version"], "unknown"),
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    counts: dict[str, int] = {}
+    mismatches = 0
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as executor:
+        results = executor.map(
+            lambda path: run_one(
+                path,
+                args.decoder,
+                args.llvm_mc,
+                args.target,
+                args.input_qualification,
+                args.timeout,
+            ),
+            paths,
+        )
+        with args.output.open("w", encoding="utf-8") as output:
+            for result in results:
+                if not result["categories"]:
+                    continue
+                mismatches += 1
+                for category in result["categories"]:
+                    counts[category] = counts.get(category, 0) + 1
+                result["revisions"] = revisions
+                json.dump(result, output, sort_keys=True)
+                output.write("\n")
+
+    summary = {
+        "inputs": len(paths),
+        "target": args.target,
+        "input_qualification": args.input_qualification,
+        "mismatches": mismatches,
+        "categories": counts,
+        "output": str(args.output),
+        "revisions": revisions,
+    }
+    print(json.dumps(summary, sort_keys=True))
+    return 0 if mismatches == 0 or args.allow_mismatches else 1
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, RuntimeError, json.JSONDecodeError) as error:
+        print(f"decode_differential.py: {error}", file=sys.stderr)
+        raise SystemExit(2) from error

--- a/emulation/rocjitsu/fuzz/decode/decode_fuzz_core.cpp
+++ b/emulation/rocjitsu/fuzz/decode/decode_fuzz_core.cpp
@@ -1,0 +1,193 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "decode_fuzz_core.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/isa/operand.h"
+#include "rocjitsu/isa/target_registry.h"
+#include "util/except.h"
+
+#include <array>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+
+namespace rocjitsu::decode_fuzz {
+namespace {
+
+[[noreturn]] void fail_invariant(std::string_view message) {
+  std::cerr << "rj_decode_fuzz invariant failed: " << message << '\n';
+  std::abort();
+}
+
+std::string json_escape(std::string_view value) {
+  std::ostringstream out;
+  for (const unsigned char c : value) {
+    switch (c) {
+    case '"':
+      out << "\\\"";
+      break;
+    case '\\':
+      out << "\\\\";
+      break;
+    case '\b':
+      out << "\\b";
+      break;
+    case '\f':
+      out << "\\f";
+      break;
+    case '\n':
+      out << "\\n";
+      break;
+    case '\r':
+      out << "\\r";
+      break;
+    case '\t':
+      out << "\\t";
+      break;
+    default:
+      if (c < 0x20) {
+        out << "\\u" << std::hex << std::setw(4) << std::setfill('0')
+            << static_cast<unsigned int>(c) << std::dec;
+      } else {
+        out << c;
+      }
+    }
+  }
+  return out.str();
+}
+
+void emit_string_array(std::ostringstream &out, const std::vector<std::string> &values) {
+  out << '[';
+  for (size_t i = 0; i < values.size(); ++i) {
+    if (i != 0)
+      out << ',';
+    out << '"' << json_escape(values[i]) << '"';
+  }
+  out << ']';
+}
+
+} // namespace
+
+std::unique_ptr<Decoder> create_decoder(std::string_view target) {
+  std::unique_ptr<Decoder> decoder = Decoder::create(default_isa_target_registry(), target);
+  if (!decoder)
+    throw std::invalid_argument("unsupported decoder target: " + std::string(target));
+  return decoder;
+}
+
+DecodeRecord decode_window(Decoder &decoder, std::span<const uint8_t> bytes) {
+  if (bytes.size() != kWindowSize)
+    throw std::invalid_argument("decoder input must be exactly 16 bytes");
+
+  std::array<uint32_t, kWindowSize / sizeof(uint32_t)> words{};
+  for (size_t word = 0; word < words.size(); ++word) {
+    for (size_t byte = 0; byte < sizeof(uint32_t); ++byte)
+      words[word] |= static_cast<uint32_t>(bytes[word * sizeof(uint32_t) + byte]) << (byte * 8);
+  }
+
+  std::unique_ptr<Instruction> inst;
+  try {
+    inst.reset(decoder.decode(words.data()));
+  } catch (const util::InvalidInst &error) {
+    DecodeRecord record;
+    record.rejection = error.what();
+    return record;
+  }
+
+  if (!inst)
+    fail_invariant("a successful decode returned null");
+
+  const int size = inst->size();
+  if (size != 4 && size != 8 && size != 12 && size != 16)
+    fail_invariant("instruction size is outside {4, 8, 12, 16}");
+  if (!inst->raw_encoding())
+    fail_invariant("instruction has no raw encoding");
+  // AMDGPU decoders retain the base word, but do not uniformly expose extension
+  // words as contiguous storage. Keep this invariant to the common contract.
+  if (inst->raw_encoding()[0] != words[0]) {
+    std::ostringstream message;
+    message << "raw encoding differs at word 0 for " << inst->mnemonic() << " (size " << size
+            << "): got 0x" << std::hex << inst->raw_encoding()[0] << ", expected 0x" << words[0];
+    fail_invariant(message.str());
+  }
+  if (inst->mnemonic().empty())
+    fail_invariant("instruction mnemonic is empty");
+  for (int i = 0; i < inst->num_dst_operands(); ++i) {
+    if (!inst->dst_operand(i))
+      fail_invariant("destination operand is null");
+  }
+  for (int i = 0; i < inst->num_src_operands(); ++i) {
+    if (!inst->src_operand(i))
+      fail_invariant("source operand is null");
+  }
+
+  const std::string disassembly = inst->disassemble();
+  if (disassembly.empty())
+    fail_invariant("instruction disassembly is empty");
+  const std::string_view mnemonic = inst->mnemonic();
+  const size_t dual_separator = mnemonic.find(" :: ");
+  const bool mnemonic_matches =
+      dual_separator == std::string_view::npos
+          ? disassembly.starts_with(mnemonic)
+          : disassembly.starts_with(mnemonic.substr(0, dual_separator)) &&
+                disassembly.find(mnemonic.substr(dual_separator)) != std::string::npos;
+  if (!mnemonic_matches) {
+    std::ostringstream message;
+    message << "disassembly does not start with mnemonic '" << inst->mnemonic() << "': '"
+            << disassembly << '\'';
+    fail_invariant(message.str());
+  }
+
+  DecodeRecord record;
+  record.valid = true;
+  record.size = size;
+  record.encoding_id = inst->encoding_id();
+  record.opcode = inst->opcode();
+  record.mnemonic = inst->mnemonic();
+  record.disassembly = disassembly;
+  for (int i = 0; i < inst->num_dst_operands(); ++i) {
+    const Operand *operand = inst->dst_operand(i);
+    if (!operand)
+      fail_invariant("destination operand is null");
+    record.destinations.emplace_back(operand->name());
+  }
+  for (int i = 0; i < inst->num_src_operands(); ++i) {
+    const Operand *operand = inst->src_operand(i);
+    if (!operand)
+      fail_invariant("source operand is null");
+    record.sources.emplace_back(operand->name());
+  }
+  return record;
+}
+
+std::string record_json(const DecodeRecord &record, std::span<const uint8_t> bytes,
+                        std::string_view input_name) {
+  std::ostringstream out;
+  out << '{';
+  if (!input_name.empty())
+    out << "\"input\":\"" << json_escape(input_name) << "\",";
+  out << "\"bytes\":\"";
+  for (const uint8_t byte : bytes)
+    out << std::hex << std::setw(2) << std::setfill('0') << static_cast<unsigned int>(byte);
+  out << std::dec << "\",\"status\":\"" << (record.valid ? "valid" : "invalid") << '"';
+  if (record.valid) {
+    out << ",\"size\":" << record.size << ",\"encoding_id\":" << record.encoding_id
+        << ",\"opcode\":" << record.opcode << ",\"mnemonic\":\"" << json_escape(record.mnemonic)
+        << "\",\"disassembly\":\"" << json_escape(record.disassembly) << "\",\"destinations\":";
+    emit_string_array(out, record.destinations);
+    out << ",\"sources\":";
+    emit_string_array(out, record.sources);
+  } else {
+    out << ",\"rejection\":\"" << json_escape(record.rejection) << '"';
+  }
+  out << '}';
+  return out.str();
+}
+
+} // namespace rocjitsu::decode_fuzz

--- a/emulation/rocjitsu/fuzz/decode/decode_fuzz_core.h
+++ b/emulation/rocjitsu/fuzz/decode/decode_fuzz_core.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#ifndef ROCJITSU_FUZZ_DECODE_DECODE_FUZZ_CORE_H_
+#define ROCJITSU_FUZZ_DECODE_DECODE_FUZZ_CORE_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace rocjitsu {
+
+class Decoder;
+
+namespace decode_fuzz {
+
+inline constexpr size_t kWindowSize = 16;
+
+struct DecodeRecord {
+  bool valid = false;
+  int size = 0;
+  uint16_t encoding_id = 0;
+  uint16_t opcode = 0;
+  std::string mnemonic;
+  std::string disassembly;
+  std::string rejection;
+  std::vector<std::string> destinations;
+  std::vector<std::string> sources;
+};
+
+std::unique_ptr<Decoder> create_decoder(std::string_view target);
+DecodeRecord decode_window(Decoder &decoder, std::span<const uint8_t> bytes);
+std::string record_json(const DecodeRecord &record, std::span<const uint8_t> bytes,
+                        std::string_view input_name = {});
+
+} // namespace decode_fuzz
+} // namespace rocjitsu
+
+#endif // ROCJITSU_FUZZ_DECODE_DECODE_FUZZ_CORE_H_

--- a/emulation/rocjitsu/fuzz/decode/decode_fuzz_main.cpp
+++ b/emulation/rocjitsu/fuzz/decode/decode_fuzz_main.cpp
@@ -1,0 +1,250 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "decode_fuzz_core.h"
+
+#include "rocjitsu/isa/arch/amdgpu/generated/cdna1/test_encodings.h"
+#include "rocjitsu/isa/arch/amdgpu/generated/cdna2/test_encodings.h"
+#include "rocjitsu/isa/arch/amdgpu/generated/cdna3/test_encodings.h"
+#include "rocjitsu/isa/arch/amdgpu/generated/cdna4/test_encodings.h"
+#include "rocjitsu/isa/arch/amdgpu/generated/gfx1250/test_encodings.h"
+#include "rocjitsu/isa/arch/amdgpu/generated/rdna1/test_encodings.h"
+#include "rocjitsu/isa/arch/amdgpu/generated/rdna2/test_encodings.h"
+#include "rocjitsu/isa/arch/amdgpu/generated/rdna3/test_encodings.h"
+#include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/test_encodings.h"
+#include "rocjitsu/isa/arch/amdgpu/generated/rdna4/test_encodings.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/target_registry.h"
+
+#include <array>
+#include <cctype>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <set>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#ifdef __AFL_HAVE_MANUAL_CONTROL
+__AFL_FUZZ_INIT();
+#endif
+
+namespace {
+
+using Window = std::array<uint8_t, rocjitsu::decode_fuzz::kWindowSize>;
+
+void usage(std::ostream &out) {
+  out << "Usage:\n"
+         "  rj_decode_fuzz --afl [--target TARGET]\n"
+         "  rj_decode_fuzz --input FILE --json [--target TARGET]\n"
+         "  rj_decode_fuzz --emit-seeds DIRECTORY [--target TARGET]\n"
+         "\n"
+         "TARGET is a canonical AMDGPU target ID or registered alias.\n";
+}
+
+Window words_to_window(std::span<const uint32_t> words) {
+  if (words.size() > Window{}.size() / sizeof(uint32_t))
+    throw std::runtime_error("seed encoding exceeds the 16-byte decoder window");
+  Window result{};
+  for (size_t word = 0; word < words.size(); ++word) {
+    for (size_t byte = 0; byte < sizeof(uint32_t); ++byte) {
+      result[word * sizeof(uint32_t) + byte] =
+          static_cast<uint8_t>((words[word] >> (byte * 8)) & 0xffu);
+    }
+  }
+  return result;
+}
+
+Window read_window(const std::filesystem::path &path) {
+  std::ifstream input(path, std::ios::binary | std::ios::ate);
+  if (!input)
+    throw std::runtime_error("cannot open input: " + path.string());
+  const std::streamsize size = input.tellg();
+  if (size != static_cast<std::streamsize>(Window{}.size()))
+    throw std::runtime_error("input must be exactly 16 bytes: " + path.string());
+  input.seekg(0);
+  Window window{};
+  if (!input.read(reinterpret_cast<char *>(window.data()), size))
+    throw std::runtime_error("cannot read input: " + path.string());
+  return window;
+}
+
+std::string safe_name(std::string_view mnemonic) {
+  std::string result;
+  result.reserve(mnemonic.size());
+  for (const unsigned char c : mnemonic)
+    result += std::isalnum(c) || c == '_' ? static_cast<char>(c) : '_';
+  return result;
+}
+
+size_t emit_seeds(const std::filesystem::path &directory, std::string_view target) {
+  if (std::filesystem::exists(directory)) {
+    if (!std::filesystem::is_directory(directory))
+      throw std::runtime_error("seed destination is not a directory: " + directory.string());
+    if (std::filesystem::directory_iterator(directory) != std::filesystem::directory_iterator())
+      throw std::runtime_error("seed destination is not empty: " + directory.string());
+  }
+  std::filesystem::create_directories(directory);
+  std::set<Window> seen;
+  size_t index = 0;
+  const auto write = [&](std::string_view name, const Window &window) {
+    if (!seen.insert(window).second)
+      return;
+    std::string filename = std::to_string(index++);
+    filename += '_';
+    filename += safe_name(name);
+    filename += ".bin";
+    std::ofstream output(directory / filename, std::ios::binary);
+    if (!output.write(reinterpret_cast<const char *>(window.data()), window.size()))
+      throw std::runtime_error("cannot write seed: " + (directory / filename).string());
+  };
+
+  const auto write_encodings = [&](const auto &encodings) {
+    for (const auto &encoding : encodings)
+      write(encoding.mnemonic, words_to_window(encoding.words));
+  };
+  if (target == "cdna1")
+    write_encodings(rocjitsu::cdna1::test_data::ENCODINGS);
+  else if (target == "cdna2")
+    write_encodings(rocjitsu::cdna2::test_data::ENCODINGS);
+  else if (target == "cdna3")
+    write_encodings(rocjitsu::cdna3::test_data::ENCODINGS);
+  else if (target == "cdna4")
+    write_encodings(rocjitsu::cdna4::test_data::ENCODINGS);
+  else if (target == "rdna1")
+    write_encodings(rocjitsu::rdna1::test_data::ENCODINGS);
+  else if (target == "rdna2")
+    write_encodings(rocjitsu::rdna2::test_data::ENCODINGS);
+  else if (target == "rdna3")
+    write_encodings(rocjitsu::rdna3::test_data::ENCODINGS);
+  else if (target == "rdna3_5")
+    write_encodings(rocjitsu::rdna3_5::test_data::ENCODINGS);
+  else if (target == "rdna4")
+    write_encodings(rocjitsu::rdna4::test_data::ENCODINGS);
+  else if (target == "gfx1250")
+    write_encodings(rocjitsu::gfx1250::test_data::ENCODINGS);
+  else
+    throw std::runtime_error("unsupported decoder target: " + std::string(target));
+
+  if (target == "gfx1250") {
+    // Generated test encodings currently hold two words. Keep representative
+    // literal and paired four-word forms in the initial corpus explicitly.
+    constexpr std::array<uint32_t, 3> kFmamkF64 = {0x46040504u, 0x00000000u, 0xC1F00000u};
+    constexpr std::array<uint32_t, 3> kFmaakF64 = {0x48040504u, 0x00000000u, 0xC1F00000u};
+    constexpr std::array<uint32_t, 3> kTrue16Literal = {0xD7620086u, 0x02030CFFu, 0x000000FFu};
+    constexpr std::array<uint32_t, 4> kWmmaScale = {0xCC350000u, 0x02020900u, 0xCC330006u,
+                                                    0x02026912u};
+    write("v_fmamk_f64_literal", words_to_window(kFmamkF64));
+    write("v_fmaak_f64_literal", words_to_window(kFmaakF64));
+    write("v_and_b16_true16_literal", words_to_window(kTrue16Literal));
+    write("v_wmma_scale_f32", words_to_window(kWmmaScale));
+  }
+  return index;
+}
+
+int run_replay(const std::filesystem::path &path, std::string_view target) {
+  const Window window = read_window(path);
+  std::unique_ptr<rocjitsu::Decoder> decoder = rocjitsu::decode_fuzz::create_decoder(target);
+  if (!decoder)
+    throw std::runtime_error(std::string(target) + " decoder is unavailable");
+  const auto record = rocjitsu::decode_fuzz::decode_window(*decoder, window);
+  std::cout << rocjitsu::decode_fuzz::record_json(record, window, path.string()) << '\n';
+  return 0;
+}
+
+} // namespace
+
+int run_afl(std::string_view target) {
+#ifdef __AFL_HAVE_MANUAL_CONTROL
+  std::unique_ptr<rocjitsu::Decoder> decoder = rocjitsu::decode_fuzz::create_decoder(target);
+  if (!decoder)
+    throw std::runtime_error(std::string(target) + " decoder is unavailable");
+
+  __AFL_INIT();
+  unsigned char *buffer = __AFL_FUZZ_TESTCASE_BUF;
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu-statement-expression-from-macro-expansion"
+#endif
+  while (__AFL_LOOP(10000)) {
+    const int size = __AFL_FUZZ_TESTCASE_LEN;
+    if (size != static_cast<int>(rocjitsu::decode_fuzz::kWindowSize))
+      continue;
+    const auto bytes = std::span<const uint8_t>(buffer, static_cast<size_t>(size));
+    (void)rocjitsu::decode_fuzz::decode_window(*decoder, bytes);
+  }
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+  return 0;
+#else
+  (void)target;
+  std::cerr << "rj_decode_fuzz was not compiled with an AFL++ compiler wrapper\n";
+  return 2;
+#endif
+}
+
+int main(int argc, char **argv) {
+  bool afl = false;
+  bool json = false;
+  std::string input;
+  std::string seed_directory;
+  std::string target = "gfx1250";
+
+  for (int i = 1; i < argc; ++i) {
+    const std::string_view argument(argv[i]);
+    if (argument == "--afl") {
+      afl = true;
+    } else if (argument == "--json") {
+      json = true;
+    } else if (argument == "--input" && i + 1 < argc) {
+      input = argv[++i];
+    } else if (argument == "--emit-seeds" && i + 1 < argc) {
+      seed_directory = argv[++i];
+    } else if (argument == "--target" && i + 1 < argc) {
+      target = argv[++i];
+    } else if (argument == "--help") {
+      usage(std::cout);
+      return 0;
+    } else {
+      usage(std::cerr);
+      return 2;
+    }
+  }
+
+  const int modes = static_cast<int>(afl) + static_cast<int>(!input.empty()) +
+                    static_cast<int>(!seed_directory.empty());
+  const bool replay = !input.empty();
+  if (modes != 1 || json != replay) {
+    usage(std::cerr);
+    return 2;
+  }
+
+  const auto *descriptor = rocjitsu::default_isa_target_registry().find(target);
+  if (descriptor == nullptr) {
+    std::cerr << "rj_decode_fuzz: unsupported decoder target: " << target << '\n';
+    return 2;
+  }
+  const std::string_view canonical_target = descriptor->id;
+
+  // Unexpected decoder exceptions must terminate the AFL child by signal so
+  // AFL++ retains the input. Replay and seed modes keep friendly diagnostics.
+  if (afl)
+    return run_afl(canonical_target);
+
+  try {
+    if (!seed_directory.empty()) {
+      std::cout << "wrote " << emit_seeds(seed_directory, canonical_target) << ' '
+                << canonical_target << " seeds\n";
+      return 0;
+    }
+    return run_replay(input, canonical_target);
+  } catch (const std::exception &error) {
+    std::cerr << "rj_decode_fuzz: " << error.what() << '\n';
+    return 2;
+  }
+}

--- a/emulation/rocjitsu/fuzz/decode/prepare_decode_seeds.py
+++ b/emulation/rocjitsu/fuzz/decode/prepare_decode_seeds.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Extract deterministic 16-byte AFL++ seeds from ELF .text sections."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import heapq
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+from typing import Iterable
+
+WINDOW_SIZE = 16
+ALIGNMENT = 4
+ELF_MACHINE_AMDGPU = 224
+EF_AMDGPU_MACH = 0x0FF
+
+
+def input_files(paths: Iterable[Path]) -> list[Path]:
+    result: list[Path] = []
+    for path in paths:
+        if path.is_dir():
+            result.extend(
+                candidate for candidate in path.rglob("*") if candidate.is_file()
+            )
+        elif path.is_file():
+            result.append(path)
+        else:
+            raise RuntimeError(f"input does not exist: {path}")
+    return sorted(set(result))
+
+
+def extract_text(llvm_objcopy: Path, source: Path, destination: Path) -> bool:
+    process = subprocess.run(
+        [str(llvm_objcopy), f"--dump-section=.text={destination}", str(source)],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    return process.returncode == 0 and destination.is_file()
+
+
+def elf_identity(source: Path) -> tuple[int, int] | None:
+    try:
+        with source.open("rb") as stream:
+            header = stream.read(52)
+    except OSError:
+        return None
+    if len(header) < 20 or header[:4] != b"\x7fELF":
+        return None
+    if header[5] == 1:
+        byteorder = "little"
+    elif header[5] == 2:
+        byteorder = "big"
+    else:
+        return None
+    if header[4] == 1:
+        flags_offset = 36
+    elif header[4] == 2:
+        flags_offset = 48
+    else:
+        return None
+    if len(header) < flags_offset + 4:
+        return None
+    machine = int.from_bytes(header[18:20], byteorder)
+    flags = int.from_bytes(header[flags_offset : flags_offset + 4], byteorder)
+    return machine, flags & EF_AMDGPU_MACH
+
+
+def add_text_windows(
+    selected: list[tuple[int, bytes, str, int]],
+    selected_windows: set[bytes],
+    source: Path,
+    data: bytes,
+    max_seeds: int,
+    max_windows_per_object: int,
+) -> None:
+    positions = max(0, (len(data) - WINDOW_SIZE) // ALIGNMENT + 1)
+    step = max(1, (positions + max_windows_per_object - 1) // max_windows_per_object)
+    for position in range(0, positions, step):
+        offset = position * ALIGNMENT
+        window = data[offset : offset + WINDOW_SIZE]
+        if window in selected_windows:
+            continue
+        score = int.from_bytes(hashlib.blake2b(window, digest_size=8).digest(), "big")
+        item = (-score, window, str(source), offset)
+        if len(selected) < max_seeds:
+            heapq.heappush(selected, item)
+            selected_windows.add(window)
+        elif item > selected[0]:
+            removed = heapq.heapreplace(selected, item)
+            selected_windows.remove(removed[1])
+            selected_windows.add(window)
+
+
+def tool_version(tool: Path) -> str:
+    process = subprocess.run(
+        [str(tool), "--version"], text=True, capture_output=True, check=False
+    )
+    lines = [line.strip() for line in process.stdout.splitlines() if line.strip()]
+    return " | ".join(lines[:2]) if process.returncode == 0 and lines else "unknown"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--input",
+        type=Path,
+        action="append",
+        required=True,
+        help="ELF file or recursive corpus directory; may be repeated",
+    )
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--llvm-objcopy", type=Path, required=True)
+    parser.add_argument("--max-seeds", type=int, default=4096)
+    parser.add_argument("--max-windows-per-object", type=int, default=8192)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.max_seeds < 1 or args.max_windows_per_object < 1:
+        raise RuntimeError("seed limits must be positive")
+    if args.output.exists():
+        if not args.output.is_dir():
+            raise RuntimeError(f"output path is not a directory: {args.output}")
+        if any(args.output.iterdir()):
+            raise RuntimeError(f"output directory is not empty: {args.output}")
+
+    # The heap retains the globally lowest content hashes, making selection
+    # deterministic and independent of filesystem enumeration details.
+    selected: list[tuple[int, bytes, str, int]] = []
+    selected_windows: set[bytes] = set()
+    source_machines: dict[str, int] = {}
+    examined_objects = 0
+    extracted_objects = 0
+    extraction_failures = 0
+    skipped_inputs = 0
+    skipped_elf_machines: set[int] = set()
+    with tempfile.TemporaryDirectory(prefix="rj-decode-seeds-") as temporary:
+        temporary_path = Path(temporary)
+        for object_index, source in enumerate(input_files(args.input)):
+            examined_objects += 1
+            identity = elf_identity(source)
+            if identity is None or identity[0] != ELF_MACHINE_AMDGPU:
+                skipped_inputs += 1
+                if identity is not None:
+                    skipped_elf_machines.add(identity[0])
+                continue
+            source_machines[str(source)] = identity[1]
+            text_path = temporary_path / f"{object_index}.text"
+            if not extract_text(args.llvm_objcopy, source, text_path):
+                extraction_failures += 1
+                continue
+            extracted_objects += 1
+            data = text_path.read_bytes()
+            add_text_windows(
+                selected,
+                selected_windows,
+                source,
+                data,
+                args.max_seeds,
+                args.max_windows_per_object,
+            )
+
+    if not selected:
+        observed = ", ".join(str(machine) for machine in sorted(skipped_elf_machines))
+        detail = f"; observed e_machine values: {observed}" if observed else ""
+        raise RuntimeError(
+            f"no 16-byte AMDGPU .text windows found (examined {examined_objects}, "
+            f"skipped {skipped_inputs} non-AMDGPU or malformed ELF inputs, "
+            f"{extraction_failures} .text extraction failures{detail})"
+        )
+    args.output.mkdir(parents=True, exist_ok=True)
+    manifest = []
+    for index, (_, window, source, offset) in enumerate(sorted(selected, reverse=True)):
+        name = f"{index:05d}_{hashlib.sha256(window).hexdigest()[:16]}.bin"
+        (args.output / name).write_bytes(window)
+        manifest.append(
+            {
+                "file": name,
+                "source": source,
+                "text_offset": offset,
+                "ef_amdgpu_mach": source_machines[source],
+            }
+        )
+    manifest_path = args.output.parent / f"{args.output.name}.manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "window_size": WINDOW_SIZE,
+                "alignment": ALIGNMENT,
+                "examined_objects": examined_objects,
+                "objects_with_text": extracted_objects,
+                "extraction_failures": extraction_failures,
+                "skipped_inputs": skipped_inputs,
+                "skipped_elf_machines": sorted(skipped_elf_machines),
+                "llvm_objcopy": str(args.llvm_objcopy),
+                "llvm_objcopy_version": tool_version(args.llvm_objcopy),
+                "seeds": manifest,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    print(
+        json.dumps(
+            {
+                "examined_objects": examined_objects,
+                "objects_with_text": extracted_objects,
+                "extraction_failures": extraction_failures,
+                "skipped_inputs": skipped_inputs,
+                "seeds": len(manifest),
+                "output": str(args.output),
+                "manifest": str(manifest_path),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, RuntimeError) as error:
+        raise SystemExit(f"prepare_decode_seeds.py: {error}") from error

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.cpp
@@ -231,9 +231,9 @@ void gfx1250_b0_to_a0_append_wmma_completion_wait_if_needed(
 
 bool gfx1250_b0_to_a0_is_deferred_family(std::string_view mnemonic) {
   // s_sleep and s_sleep_var are deliberately absent. They behave identically on
-  // A0 and B0: the only sleep-family A0 erratum is DEGFXMI400-12268, which is
-  // specific to s_monitor_sleep('forever') with MWAIT=0. Copying a plain sleep
-  // through is the correct translation, not an unimplemented one, so reporting
+  // A0 and B0. Only s_monitor_sleep('forever') with MWAIT=0 requires an A0
+  // translation. Copying a plain sleep through is the correct translation, not
+  // an unimplemented one, so reporting
   // it said nothing and buried the reports that do name a real gap -- one RCCL
   // all_reduce run emitted 104,831 of them.
   return mnemonic == "s_get_barrier_state" || mnemonic == "s_monitor_sleep";

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.h
@@ -37,9 +37,9 @@ struct InstructionLegalization;
 /// confirmation of the exact translated set.
 ///
 /// @details The barrier-state query and s_monitor_sleep may need
-/// target-specific translation that is not yet implemented -- the latter
-/// because of DEGFXMI400-12268, where s_monitor_sleep('forever') with MWAIT=0
-/// can hang the wave. Rather than fail closed, they are passed through
+/// target-specific translation that is not yet implemented. For
+/// s_monitor_sleep, the affected case is the 'forever' form with MWAIT=0,
+/// which can hang the wave. Rather than fail closed, they are passed through
 /// unchanged and the caller reports the omission so it is visible rather than
 /// silent. Revisit once the precise set is confirmed; if translation is
 /// required, move the relevant members into the fail-closed classification.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/CMakeLists.txt
@@ -39,6 +39,10 @@ get_property(
     GLOBAL
     PROPERTY RJ_BUILTIN_ISA_PROVIDERS
 )
+set_property(
+    GLOBAL
+    PROPERTY RJ_BUILTIN_AMDGPU_ISA_PROVIDERS ${_rj_builtin_amdgpu_isa_providers}
+)
 rj_add_isa_target_registry(
     rocjitsu_amdgpu_isa_registry
     PROVIDERS ${_rj_builtin_amdgpu_isa_providers}

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -319,6 +319,36 @@ endfunction()
 
 # --- Unit / integration test suite ---
 
+add_executable(rj_decode_fuzz_test fuzz/decode/decode_fuzz_test.cpp)
+target_link_libraries(
+    rj_decode_fuzz_test
+    PRIVATE rj_decode_fuzz_core GTest::gtest_main
+)
+rj_configure_target(rj_decode_fuzz_test PRIVATE_INCLUDES WARNINGS)
+add_dependencies(rj_decode_fuzz_test rj_decode_fuzz)
+rj_add_gtest_tests(rj_decode_fuzz_test)
+
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+add_test(
+    NAME DecodeDifferentialUnitTest
+    COMMAND
+        ${Python3_EXECUTABLE}
+        ${CMAKE_CURRENT_SOURCE_DIR}/fuzz/decode/test_decode_differential.py -v
+)
+add_test(
+    NAME DecodeSeedExtractorUnitTest
+    COMMAND
+        ${Python3_EXECUTABLE}
+        ${CMAKE_CURRENT_SOURCE_DIR}/fuzz/decode/test_prepare_decode_seeds.py -v
+)
+add_test(
+    NAME DecodeFuzzCliTest
+    COMMAND
+        ${CMAKE_COMMAND} -E env RJ_DECODE_FUZZ=$<TARGET_FILE:rj_decode_fuzz>
+        ${Python3_EXECUTABLE}
+        ${CMAKE_CURRENT_SOURCE_DIR}/fuzz/decode/test_decode_cli.py -v
+)
+
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(PLUGIN_LOADER_FIXTURE_DIR
         "${CMAKE_CURRENT_BINARY_DIR}/plugin_loader_fixtures"

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -16335,7 +16335,7 @@ translate_gfx1250_b0_to_a0_result(rocjitsu::BinaryTranslator &translator,
                                rocjitsu::ProcessorRevision::Gfx1250A0));
 }
 
-/// @brief An s_monitor_sleep, whose A0 handling is deferred (DEGFXMI400-12268).
+/// @brief An s_monitor_sleep whose A0 handling is deferred.
 [[nodiscard]] uint32_t gfx1250_deferred_word() {
   return gfx1250::build_sopp(gfx1250::kSMonitorSleepSopp, {.simm16 = 1})[0];
 }
@@ -16418,7 +16418,7 @@ TEST(BinaryTranslatorE2E, Gfx1250DeferredFamilyReportCarriesOffsetAndMnemonic) {
 }
 
 // s_sleep and s_sleep_var behave identically on A0 and B0. The only sleep-family
-// A0 erratum, DEGFXMI400-12268, is specific to s_monitor_sleep('forever') with
+// A0 translation requirement is specific to s_monitor_sleep('forever') with
 // MWAIT=0. Copying a plain sleep through is therefore the correct translation,
 // not an unimplemented one, and reporting it drowned the reports that do name a
 // real gap: one RCCL all_reduce run emitted 104,831 of them.

--- a/emulation/rocjitsu/tests/fuzz/decode/decode_fuzz_test.cpp
+++ b/emulation/rocjitsu/tests/fuzz/decode/decode_fuzz_test.cpp
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "decode_fuzz_core.h"
+
+#include "rocjitsu/isa/decoder.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <stdexcept>
+
+namespace rocjitsu::decode_fuzz {
+namespace {
+
+template <size_t N>
+std::array<uint8_t, kWindowSize> make_window(const std::array<uint32_t, N> &words) {
+  std::array<uint8_t, kWindowSize> result{};
+  for (size_t word = 0; word < words.size(); ++word) {
+    for (size_t byte = 0; byte < sizeof(uint32_t); ++byte)
+      result[word * sizeof(uint32_t) + byte] =
+          static_cast<uint8_t>((words[word] >> (byte * 8)) & 0xffu);
+  }
+  return result;
+}
+
+class DecodeFuzzCoreTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    decoder = create_decoder("gfx1250");
+    ASSERT_NE(decoder, nullptr);
+  }
+
+  std::unique_ptr<Decoder> decoder;
+};
+
+TEST(DecodeFuzzTargetsTest, CreatesEachSupportedDecoder) {
+  constexpr std::string_view targets[] = {"cdna1", "cdna2", "cdna3",   "cdna4", "rdna1",
+                                          "rdna2", "rdna3", "rdna3_5", "rdna4", "gfx1250"};
+  for (const std::string_view target : targets) {
+    SCOPED_TRACE(target);
+    EXPECT_NE(create_decoder(target), nullptr);
+  }
+}
+
+TEST(DecodeFuzzTargetsTest, CreatesRegisteredGpuAliases) {
+  constexpr std::string_view targets[] = {"gfx90a", "gfx942", "gfx950", "gfx1200", "gfx1201"};
+  for (const std::string_view target : targets) {
+    SCOPED_TRACE(target);
+    EXPECT_NE(create_decoder(target), nullptr);
+  }
+}
+
+TEST(DecodeFuzzTargetsTest, RejectsUnknownTarget) {
+  EXPECT_THROW((void)create_decoder("unknown"), std::invalid_argument);
+}
+
+TEST_F(DecodeFuzzCoreTest, RejectsShortWindowBeforeDecode) {
+  std::array<uint8_t, kWindowSize - 1> input{};
+  EXPECT_THROW((void)decode_window(*decoder, input), std::invalid_argument);
+}
+
+TEST_F(DecodeFuzzCoreTest, TreatsInvalidInstructionAsNormalRejection) {
+  const auto input = make_window(std::array<uint32_t, 1>{0xffffffffu});
+  const DecodeRecord record = decode_window(*decoder, input);
+  EXPECT_FALSE(record.valid);
+  EXPECT_FALSE(record.rejection.empty());
+}
+
+TEST_F(DecodeFuzzCoreTest, DecodesFourByteInstruction) {
+  const auto input = make_window(std::array<uint32_t, 1>{0xBF800000u});
+  const DecodeRecord record = decode_window(*decoder, input);
+  ASSERT_TRUE(record.valid);
+  EXPECT_EQ(record.size, 4);
+  EXPECT_EQ(record.mnemonic, "s_nop");
+  EXPECT_EQ(record.disassembly, "s_nop 0");
+}
+
+TEST_F(DecodeFuzzCoreTest, PreservesTwelveByteLiteral) {
+  const auto input = make_window(std::array<uint32_t, 3>{0x46040504u, 0x00000000u, 0xC1F00000u});
+  const DecodeRecord record = decode_window(*decoder, input);
+  ASSERT_TRUE(record.valid);
+  EXPECT_EQ(record.size, 12);
+  EXPECT_EQ(record.mnemonic, "v_fmamk_f64_e32");
+  EXPECT_EQ(record.disassembly, "v_fmamk_f64_e32 v[2:3], v[4:5], 0xc1f0000000000000, v[2:3]");
+}
+
+TEST_F(DecodeFuzzCoreTest, DecodesSopTwoWithLiteralWithoutAborting) {
+  const auto input =
+      make_window(std::array<uint32_t, 4>{0x9842FFB4u, 0xFD9670E6u, 0x673F885Eu, 0x2036829Bu});
+  const DecodeRecord record = decode_window(*decoder, input);
+  ASSERT_TRUE(record.valid);
+  EXPECT_EQ(record.size, 8);
+  EXPECT_EQ(record.mnemonic, "s_cselect_b32");
+}
+
+TEST_F(DecodeFuzzCoreTest, PreservesSixteenByteInstruction) {
+  const auto input =
+      make_window(std::array<uint32_t, 4>{0xCC350000u, 0x02020900u, 0xCC330006u, 0x02026912u});
+  const DecodeRecord record = decode_window(*decoder, input);
+  ASSERT_TRUE(record.valid);
+  EXPECT_EQ(record.size, 16);
+  EXPECT_EQ(record.mnemonic, "v_wmma_scale_f32_16x16x128_f8f6f4");
+  EXPECT_EQ(record.disassembly,
+            "v_wmma_scale_f32_16x16x128_f8f6f4 v[6:13], v[18:33], v[52:67], 0, v0, v4");
+}
+
+TEST_F(DecodeFuzzCoreTest, AcceptsCompoundMnemonicDisassembly) {
+  const auto input = make_window(std::array<uint32_t, 2>{0xCA500501u, 0x02000080u});
+  const DecodeRecord record = decode_window(*decoder, input);
+  ASSERT_TRUE(record.valid);
+  EXPECT_EQ(record.size, 8);
+  EXPECT_EQ(record.mnemonic, "v_dual_cndmask_b32 :: v_dual_mov_b32");
+  EXPECT_EQ(record.disassembly, "v_dual_cndmask_b32 v2, v1, v2 :: v_dual_mov_b32 v1, 0");
+}
+
+TEST_F(DecodeFuzzCoreTest, ReusesDecoderAcrossManyIterations) {
+  const auto input = make_window(std::array<uint32_t, 1>{0xBF800000u});
+  for (int iteration = 0; iteration < 1000; ++iteration)
+    ASSERT_TRUE(decode_window(*decoder, input).valid);
+}
+
+} // namespace
+} // namespace rocjitsu::decode_fuzz

--- a/emulation/rocjitsu/tests/fuzz/decode/test_decode_cli.py
+++ b/emulation/rocjitsu/tests/fuzz/decode/test_decode_cli.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+import json
+import os
+from pathlib import Path
+import struct
+import subprocess
+import tempfile
+import unittest
+
+
+class DecodeCliTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        decoder = os.environ.get("RJ_DECODE_FUZZ")
+        if not decoder:
+            raise unittest.SkipTest("RJ_DECODE_FUZZ is not set")
+        cls.decoder = Path(decoder)
+
+    def run_decoder(self, *arguments: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [str(self.decoder), *arguments],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_replays_exact_window_as_json(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            sample = Path(temporary) / "s_nop.bin"
+            sample.write_bytes(struct.pack("<4I", 0xBF800000, 0, 0, 0))
+            process = self.run_decoder("--input", str(sample), "--json")
+            self.assertEqual(process.returncode, 0, process.stderr)
+            record = json.loads(process.stdout)
+            self.assertEqual(record["status"], "valid")
+            self.assertEqual(record["mnemonic"], "s_nop")
+
+    def test_rejects_wrong_sized_replay(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            sample = Path(temporary) / "short.bin"
+            sample.write_bytes(bytes(15))
+            process = self.run_decoder("--input", str(sample), "--json")
+            self.assertEqual(process.returncode, 2)
+            self.assertIn("exactly 16 bytes", process.stderr)
+
+    def test_rejects_non_amdgpu_target(self):
+        process = self.run_decoder("--emit-seeds", "unused", "--target", "risc-v")
+        self.assertEqual(process.returncode, 2)
+        self.assertIn("unsupported decoder target", process.stderr)
+
+    def test_rejects_json_outside_replay_mode(self):
+        for arguments in (("--afl", "--json"), ("--emit-seeds", "unused", "--json")):
+            with self.subTest(arguments=arguments):
+                process = self.run_decoder(*arguments)
+                self.assertEqual(process.returncode, 2)
+                self.assertIn("Usage:", process.stderr)
+
+    def test_emits_and_rejects_reusing_seed_directory(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            seeds = Path(temporary) / "seeds"
+            first = self.run_decoder("--emit-seeds", str(seeds), "--target", "gfx950")
+            self.assertEqual(first.returncode, 0, first.stderr)
+            files = sorted(seeds.iterdir())
+            self.assertGreater(len(files), 100)
+            self.assertTrue(all(path.stat().st_size == 16 for path in files))
+
+            second = self.run_decoder("--emit-seeds", str(seeds), "--target", "gfx950")
+            self.assertEqual(second.returncode, 2)
+            self.assertIn("not empty", second.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/emulation/rocjitsu/tests/fuzz/decode/test_decode_differential.py
+++ b/emulation/rocjitsu/tests/fuzz/decode/test_decode_differential.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "fuzz" / "decode"))
+from decode_differential import (
+    _git_revision,
+    _inputs,
+    canonicalize_text,
+    compare_records,
+    llvm_args,
+    llvm_consumed_size,
+    parse_llvm_output,
+    run_one,
+)
+
+
+class LlvmArgsTest(unittest.TestCase):
+    def test_selects_requested_target(self):
+        self.assertIn("--mcpu=gfx950", llvm_args("gfx950"))
+        self.assertIn("--mcpu=gfx1201", llvm_args("gfx1201"))
+
+    def test_maps_architecture_to_representative_processor(self):
+        self.assertIn("--mcpu=gfx908", llvm_args("cdna1"))
+        self.assertIn("--mcpu=gfx1150", llvm_args("rdna3_5"))
+
+
+class ParseLlvmOutputTest(unittest.TestCase):
+    def test_parses_first_valid_instruction_and_size(self):
+        output = (
+            "\tv_add_f32_e32 v0, v1, v2 ; "
+            "encoding: [0x01,0x05,0x00,0x02]\n"
+            "\tv_illegal ; encoding: [0x00,0x00,0x00,0x00]\n"
+        )
+        self.assertEqual(
+            parse_llvm_output(output, ""),
+            {
+                "status": "valid",
+                "size": 4,
+                "mnemonic": "v_add_f32_e32",
+                "disassembly": "v_add_f32_e32 v0, v1, v2",
+            },
+        )
+
+    def test_column_one_warning_rejects_first_instruction(self):
+        warning = "<stdin>:1:1: warning: invalid instruction encoding\n0xff 0xff 0xff 0xff\n^\n"
+        result = parse_llvm_output(
+            "\ts_nop 0 ; encoding: [0x00,0x00,0x80,0xbf]\n", warning
+        )
+        self.assertEqual(result["status"], "invalid")
+
+    def test_later_warning_does_not_reject_first_instruction(self):
+        warning = "<stdin>:1:22: warning: invalid instruction encoding\ninput\n                     ^\n"
+        result = parse_llvm_output(
+            "\ts_nop 0 ; encoding: [0x00,0x00,0x80,0xbf]\n", warning
+        )
+        self.assertEqual(result["status"], "valid")
+        self.assertEqual(result["size"], 4)
+
+    def test_classifies_inline_operand_rejection(self):
+        output = (
+            "\tv_readlane_b32 s0, s0/*invalid register*/, s0 ; "
+            "encoding: [0x00,0x00,0x00,0x00]\n"
+        )
+        result = parse_llvm_output(output, "")
+        self.assertEqual(result["status"], "operand_rejected")
+        self.assertIn("/*invalid register*/", result["annotated_disassembly"])
+        self.assertEqual(
+            compare_records(
+                {
+                    "status": "valid",
+                    "size": 4,
+                    "mnemonic": "v_readlane_b32",
+                    "disassembly": "v_readlane_b32 s0, s0, s0",
+                },
+                result,
+            ),
+            ["llvm_operand_rejected"],
+        )
+
+    def test_operand_rejection_preserves_other_differences(self):
+        llvm = {
+            "status": "operand_rejected",
+            "size": 8,
+            "mnemonic": "v_movrels_b32_e64",
+            "disassembly": "v_movrels_b32_e64 v0, s0",
+            "annotated_disassembly": "v_movrels_b32_e64 v0, s0/*invalid register*/",
+        }
+        roc = {
+            "status": "valid",
+            "size": 4,
+            "mnemonic": "v_movrels_b32",
+            "disassembly": "v_movrels_b32 v0, s0",
+        }
+        self.assertEqual(
+            compare_records(roc, llvm),
+            [
+                "llvm_operand_rejected",
+                "size_mismatch",
+                "mnemonic_mismatch",
+                "text_mismatch",
+            ],
+        )
+
+
+class LlvmConsumedSizeTest(unittest.TestCase):
+    @mock.patch("decode_differential.subprocess.run")
+    def test_uses_shortest_accepted_prefix_not_shown_encoding(self, run):
+        invalid = subprocess.CompletedProcess(
+            [], 0, "", "<stdin>:1:1: warning: invalid instruction encoding\n"
+        )
+        valid = subprocess.CompletedProcess(
+            [],
+            0,
+            "\ts_add_nc_u64 s[4:5], s[0:1], 1 ; "
+            "encoding: [0x00,0xfe,0x84,0xa9,0x01,0x00,0x00,0x00,"
+            "0x00,0x00,0x00,0x00]\n",
+            "",
+        )
+        run.side_effect = [invalid, valid]
+
+        self.assertEqual(
+            llvm_consumed_size(
+                bytes(16),
+                Path("llvm-mc"),
+                1,
+                "s_add_nc_u64 s[4:5], s[0:1], 1",
+            ),
+            8,
+        )
+        self.assertEqual(
+            [len(call.kwargs["input"].split()) for call in run.call_args_list],
+            [4, 8],
+        )
+
+    @mock.patch("decode_differential.subprocess.run")
+    def test_rejects_prefix_that_decodes_as_a_different_instruction(self, run):
+        invalid = subprocess.CompletedProcess(
+            [], 0, "", "<stdin>:1:1: warning: invalid instruction encoding\n"
+        )
+        short = subprocess.CompletedProcess(
+            [],
+            0,
+            "\tv_wmma_ld_scale_paired_b32 v0, v4 ; "
+            "encoding: [0x00,0x00,0x35,0xcc,0x00,0x09,0x02,0x02]\n",
+            "",
+        )
+        run.side_effect = [invalid, short]
+
+        self.assertEqual(
+            llvm_consumed_size(
+                bytes(12),
+                Path("llvm-mc"),
+                1,
+                "v_wmma_scale_f32_16x16x128_f8f6f4 v[6:13], v[18:33], "
+                "v[52:67], 0, v0, v4",
+            ),
+            12,
+        )
+
+    @mock.patch("decode_differential.subprocess.run")
+    def test_failed_prefix_makes_consumed_size_unknown(self, run):
+        invalid = subprocess.CompletedProcess(
+            [], 0, "", "<stdin>:1:1: warning: invalid instruction encoding\n"
+        )
+        crashed = subprocess.CompletedProcess([], -11, "", "stack trace")
+        valid = subprocess.CompletedProcess(
+            [],
+            0,
+            "\tv_fract_f32_dpp v0, v204 dpp8:[0,0,1,0,0,0,0,0] fi:1 ; "
+            "encoding: [0xea,0x40,0x00,0x7e,0xcc,0x40,0x00,0x00]\n",
+            "",
+        )
+        run.side_effect = [invalid, crashed, valid]
+        failures = []
+
+        self.assertEqual(
+            llvm_consumed_size(
+                bytes(16),
+                Path("llvm-mc"),
+                1,
+                "v_fract_f32_dpp v0, v204 dpp8:[0,0,1,0,0,0,0,0] fi:1",
+                failures,
+            ),
+            None,
+        )
+        self.assertEqual(
+            failures, [{"size": 8, "returncode": -11, "stderr": "stack trace"}]
+        )
+
+
+class RunOneTest(unittest.TestCase):
+    @mock.patch("decode_differential._run_llvm")
+    @mock.patch("decode_differential.subprocess.run")
+    def test_operand_rejection_preserves_prefix_tool_failure(self, run, run_llvm):
+        data = bytes.fromhex("860061d7ff0c0302ff00000000000000")
+        rocjitsu = {
+            "status": "valid",
+            "size": 12,
+            "mnemonic": "v_readlane_b32",
+            "disassembly": "v_readlane_b32 s0, s0, s0",
+        }
+        run.return_value = subprocess.CompletedProcess([], 0, json.dumps(rocjitsu), "")
+        invalid = subprocess.CompletedProcess(
+            [], 0, "", "<stdin>:1:1: warning: invalid instruction encoding\n"
+        )
+        crashed = subprocess.CompletedProcess([], -11, "", "stack trace")
+        operand_rejected = subprocess.CompletedProcess(
+            [],
+            0,
+            "\tv_readlane_b32 s0, s0/*invalid register*/, s0 ; "
+            "encoding: [0x86,0x00,0x61,0xd7,0xff,0x0c,0x03,0x02,"
+            "0xff,0x00,0x00,0x00]\n",
+            "",
+        )
+        run_llvm.side_effect = [operand_rejected, invalid, crashed, operand_rejected]
+
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "prefix-crash.bin"
+            path.write_bytes(data)
+            result = run_one(
+                path,
+                Path("rj_decode_fuzz"),
+                Path("llvm-mc"),
+                "gfx1250",
+                "manual-qualified",
+            )
+
+        self.assertEqual(
+            result["categories"],
+            ["llvm_operand_rejected", "llvm_prefix_tool_failure"],
+        )
+        self.assertEqual(result["llvm"]["shown_encoding_size"], 12)
+        self.assertIsNone(result["llvm"]["size"])
+        self.assertEqual(
+            result["llvm"]["prefix_tool_failures"],
+            [{"size": 8, "returncode": -11, "stderr": "stack trace"}],
+        )
+        self.assertEqual(
+            [len(call.args[1]) for call in run_llvm.call_args_list], [16, 4, 8, 12]
+        )
+
+
+class ComparisonTest(unittest.TestCase):
+    def test_integer_spelling_and_whitespace_are_normalized(self):
+        self.assertEqual(
+            canonicalize_text("V_ADD_U32 v[0 : 1], 0x10"),
+            canonicalize_text("v_add_u32  v[0:1],16"),
+        )
+
+    def test_modifier_order_remains_significant(self):
+        self.assertNotEqual(
+            canonicalize_text("v_add_f32 v0, v1 clamp mul:2"),
+            canonicalize_text("v_add_f32 v0, v1 mul:2 clamp"),
+        )
+
+    def test_reports_structured_mismatch_categories(self):
+        roc = {
+            "status": "valid",
+            "size": 12,
+            "mnemonic": "v_fmamk_f64_e32",
+            "disassembly": "v_fmamk_f64_e32 v[2:3], v[4:5], 0xc1f0000000000000, v[2:3]",
+        }
+        llvm = {
+            "status": "valid",
+            "size": 12,
+            "mnemonic": "v_fmamk_f64",
+            "disassembly": "v_fmamk_f64 v[2:3], v[4:5], 0xc1f00000, v[2:3]",
+        }
+        self.assertEqual(
+            compare_records(roc, llvm),
+            ["mnemonic_mismatch", "numeric_token_mismatch", "text_mismatch"],
+        )
+
+    def test_reports_acceptance_without_text_noise(self):
+        self.assertEqual(
+            compare_records({"status": "invalid"}, {"status": "valid"}),
+            ["acceptance_mismatch"],
+        )
+
+    def test_reports_each_failed_process(self):
+        self.assertEqual(
+            compare_records(
+                {"status": "tool_failure"},
+                {"status": "tool_failure"},
+            ),
+            ["rocjitsu_tool_failure", "llvm_tool_failure"],
+        )
+
+
+class CorpusTest(unittest.TestCase):
+    def test_ignores_hidden_afl_state(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            corpus = Path(temporary)
+            queue_input = corpus / "id:000000"
+            queue_input.write_bytes(bytes(16))
+            (corpus / "README.txt").write_text("AFL metadata", encoding="utf-8")
+            state = corpus / ".state" / "deterministic_done"
+            state.mkdir(parents=True)
+            (state / queue_input.name).write_bytes(b"")
+            self.assertEqual(_inputs(None, corpus), [queue_input])
+
+
+class RevisionTest(unittest.TestCase):
+    def test_ignores_untracked_outputs_but_records_tracked_changes(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            repository = Path(temporary)
+            subprocess.run(["git", "init", "--quiet", str(repository)], check=True)
+            subprocess.run(
+                ["git", "-C", str(repository), "config", "user.name", "Test"],
+                check=True,
+            )
+            subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(repository),
+                    "config",
+                    "user.email",
+                    "test@example.com",
+                ],
+                check=True,
+            )
+            source = repository / "tracked.txt"
+            source.write_text("original\n", encoding="utf-8")
+            subprocess.run(
+                ["git", "-C", str(repository), "add", "tracked.txt"], check=True
+            )
+            subprocess.run(
+                [
+                    "git",
+                    "-c",
+                    "commit.gpgSign=false",
+                    "-C",
+                    str(repository),
+                    "commit",
+                    "--quiet",
+                    "-m",
+                    "initial",
+                ],
+                check=True,
+            )
+
+            (repository / "build-decode").mkdir()
+            self.assertNotIn("+dirty", _git_revision(repository))
+
+            source.write_text("modified\n", encoding="utf-8")
+            self.assertTrue(_git_revision(repository).endswith("+dirty"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/emulation/rocjitsu/tests/fuzz/decode/test_prepare_decode_seeds.py
+++ b/emulation/rocjitsu/tests/fuzz/decode/test_prepare_decode_seeds.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+from argparse import Namespace
+from contextlib import redirect_stdout
+import io
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "fuzz" / "decode"))
+import prepare_decode_seeds
+
+
+def write_elf_header(path: Path, machine: int, flags: int = 0) -> None:
+    header = bytearray(52)
+    header[:4] = b"\x7fELF"
+    header[4] = 2
+    header[5] = 1
+    header[6] = 1
+    header[18:20] = machine.to_bytes(2, "little")
+    header[48:52] = flags.to_bytes(4, "little")
+    path.write_bytes(header)
+
+
+class ElfIdentityTest(unittest.TestCase):
+    def test_reads_little_endian_machine_and_processor_flags(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary) / "kernel.co"
+            write_elf_header(source, prepare_decode_seeds.ELF_MACHINE_AMDGPU, 0x134E)
+            self.assertEqual(
+                prepare_decode_seeds.elf_identity(source),
+                (prepare_decode_seeds.ELF_MACHINE_AMDGPU, 0x4E),
+            )
+
+    def test_rejects_non_elf_input(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary) / "not-elf"
+            source.write_bytes(b"not an ELF")
+            self.assertIsNone(prepare_decode_seeds.elf_identity(source))
+
+
+class WindowSelectionTest(unittest.TestCase):
+    def select(self, sections, max_seeds=3, max_windows=8192):
+        selected = []
+        selected_windows = set()
+        for source, data in sections:
+            prepare_decode_seeds.add_text_windows(
+                selected,
+                selected_windows,
+                Path(source),
+                data,
+                max_seeds,
+                max_windows,
+            )
+        return selected, selected_windows
+
+    def test_selection_is_deterministic_and_bounded(self):
+        data = bytes(range(40))
+        first, first_windows = self.select([("a.co", data)], max_seeds=2)
+        second, second_windows = self.select([("a.co", data)], max_seeds=2)
+        self.assertEqual(first, second)
+        self.assertEqual(first_windows, second_windows)
+        self.assertEqual(len(first), 2)
+
+    def test_deduplicates_windows_across_objects(self):
+        data = bytes(range(24))
+        selected, windows = self.select([("a.co", data), ("b.co", data)])
+        self.assertEqual(len(selected), len(windows))
+        self.assertEqual(len(selected), 3)
+
+    def test_short_sections_add_no_windows(self):
+        selected, windows = self.select([("short.co", bytes(15))])
+        self.assertEqual(selected, [])
+        self.assertEqual(windows, set())
+
+
+class MainTest(unittest.TestCase):
+    def test_skips_non_amdgpu_elf_and_records_machine(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            gpu = root / "gpu.co"
+            failed_gpu = root / "failed-gpu.co"
+            host = root / "host"
+            write_elf_header(gpu, prepare_decode_seeds.ELF_MACHINE_AMDGPU, 0x4F)
+            write_elf_header(failed_gpu, prepare_decode_seeds.ELF_MACHINE_AMDGPU, 0x50)
+            write_elf_header(host, 62)
+            output = root / "seeds"
+            args = Namespace(
+                input=[root],
+                output=output,
+                llvm_objcopy=Path("llvm-objcopy"),
+                max_seeds=4,
+                max_windows_per_object=8,
+            )
+
+            def extract(_tool, source, destination):
+                if source == failed_gpu:
+                    return False
+                self.assertEqual(source, gpu)
+                destination.write_bytes(bytes(range(32)))
+                return True
+
+            with (
+                mock.patch.object(
+                    prepare_decode_seeds, "parse_args", return_value=args
+                ),
+                mock.patch.object(
+                    prepare_decode_seeds,
+                    "input_files",
+                    return_value=[gpu, failed_gpu, host],
+                ),
+                mock.patch.object(
+                    prepare_decode_seeds, "extract_text", side_effect=extract
+                ) as extract_mock,
+                mock.patch.object(
+                    prepare_decode_seeds, "tool_version", return_value="LLVM test"
+                ),
+                redirect_stdout(io.StringIO()),
+            ):
+                self.assertEqual(prepare_decode_seeds.main(), 0)
+
+            self.assertEqual(extract_mock.call_count, 2)
+            manifest = json.loads((root / "seeds.manifest.json").read_text())
+            self.assertEqual(manifest["examined_objects"], 3)
+            self.assertEqual(manifest["objects_with_text"], 1)
+            self.assertEqual(manifest["extraction_failures"], 1)
+            self.assertEqual(manifest["skipped_inputs"], 1)
+            self.assertEqual(manifest["skipped_elf_machines"], [62])
+            self.assertTrue(manifest["seeds"])
+            self.assertTrue(
+                all(seed["ef_amdgpu_mach"] == 0x4F for seed in manifest["seeds"])
+            )
+
+    def test_reports_why_all_inputs_were_skipped(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            host = root / "host"
+            write_elf_header(host, 62)
+            args = Namespace(
+                input=[host],
+                output=root / "seeds",
+                llvm_objcopy=Path("llvm-objcopy"),
+                max_seeds=4,
+                max_windows_per_object=8,
+            )
+            with mock.patch.object(
+                prepare_decode_seeds, "parse_args", return_value=args
+            ):
+                with self.assertRaisesRegex(
+                    RuntimeError, r"examined 1, skipped 1.*e_machine values: 62"
+                ):
+                    prepare_decode_seeds.main()
+
+    def test_reports_when_all_text_extractions_fail(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            gpu = root / "gpu.co"
+            write_elf_header(gpu, prepare_decode_seeds.ELF_MACHINE_AMDGPU)
+            args = Namespace(
+                input=[gpu],
+                output=root / "seeds",
+                llvm_objcopy=Path("llvm-objcopy"),
+                max_seeds=4,
+                max_windows_per_object=8,
+            )
+            with (
+                mock.patch.object(
+                    prepare_decode_seeds, "parse_args", return_value=args
+                ),
+                mock.patch.object(
+                    prepare_decode_seeds, "extract_text", return_value=False
+                ),
+            ):
+                with self.assertRaisesRegex(
+                    RuntimeError, r"examined 1, skipped 0.*1 \.text extraction failures"
+                ):
+                    prepare_decode_seeds.main()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Build a persistent-mode AFL++ harness for every registered AMDGPU decoder target while keeping the target in the default build.

Keep LLVM comparison in an offline command-line runner, retain prefix-probe failures, and distinguish operand rejection from text differences. Add deterministic model and AMDGPU object seeds with processor provenance, structured replay output, and focused core, CLI, comparator, and extractor tests.