### PR TITLE
fix(clr): Split large batch into multiple dispatches

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -2836,8 +2836,14 @@ bool KernelBlitManager::ShaderCopyBufferBatchRaw(
   const size_t kernarg_reservation = (kCBAlignment - 1) +
                                      (gpu_kernel.KernargSegmentAlignment() - 1) +
                                      gpu_kernel.KernargSegmentByteSize();
+  const size_t kernarg_pool_chunk_size = gpu().KernArgPoolChunkSize();
+  if (kernarg_reservation > kernarg_pool_chunk_size ||
+      kernarg_pool_chunk_size - kernarg_reservation < sizeof(CopyBufferBatchDescriptor)) {
+    LogError("Kernarg pool chunk is too small for a batch copy dispatch");
+    return false;
+  }
   const size_t max_operations_per_dispatch =
-      (gpu().KernArgPoolChunkSize() - kernarg_reservation) / sizeof(CopyBufferBatchDescriptor);
+      (kernarg_pool_chunk_size - kernarg_reservation) / sizeof(CopyBufferBatchDescriptor);
   const size_t descriptor_buffer_bytes =
       max_operations_per_dispatch * sizeof(CopyBufferBatchDescriptor);
   bool attach_signal = false;

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -2831,69 +2831,77 @@ bool KernelBlitManager::ShaderCopyBufferBatchRaw(
 
   constexpr uint32_t kMaxAlignment = 2 * sizeof(uint64_t);
   constexpr uint32_t kLocalWorkSize = 512;
-  const uint32_t max_workgroups_per_copy = std::max<uint32_t>(
-      dev().settings().limit_blit_wg_ / copy_operations.size(), 1);
-  const size_t descriptor_bytes =
-      copy_operations.size() * sizeof(CopyBufferBatchDescriptor);
-  void *descriptor_buffer = gpu().allocKernArg(descriptor_bytes, kCBAlignment);
-  CopyBufferBatchDescriptor *descriptors =
-      static_cast<CopyBufferBatchDescriptor *>(descriptor_buffer);
-  size_t descriptor_index = 0;
-  uint64_t max_aligned_element_count = 0;
-  bool needs_system_scope = false;
+  amd::Kernel* const kernel = kernels_[BlitCopyBufferBatch];
+  const Kernel& gpu_kernel = static_cast<const Kernel&>(*kernel->getDeviceKernel(dev()));
+  const size_t kernarg_reservation = (kCBAlignment - 1) +
+                                     (gpu_kernel.KernargSegmentAlignment() - 1) +
+                                     gpu_kernel.KernargSegmentByteSize();
+  const size_t max_operations_per_dispatch =
+      (gpu().KernArgPoolChunkSize() - kernarg_reservation) / sizeof(CopyBufferBatchDescriptor);
+  const size_t descriptor_buffer_bytes =
+      max_operations_per_dispatch * sizeof(CopyBufferBatchDescriptor);
   bool attach_signal = false;
 
-  for (const auto &copy_operation : copy_operations) {
-    const uint64_t source_address = reinterpret_cast<uint64_t>(copy_operation.src);
-    const uint64_t destination_address = reinterpret_cast<uint64_t>(copy_operation.dst);
-    needs_system_scope |= copy_operation.needs_system_scope || !copy_operation.metadata.isAsync_;
-    attach_signal |= copy_operation.attach_signal || !copy_operation.metadata.isAsync_;
-    const bool addresses_aligned = ((source_address % kMaxAlignment) == 0) &&
-                                   ((destination_address % kMaxAlignment) == 0);
-    const uint32_t aligned_element_size =
-        (addresses_aligned) ? kMaxAlignment : sizeof(uint32_t);
-    const uint64_t aligned_element_count =
-        copy_operation.size / aligned_element_size;
-    const uint32_t trailing_byte_count =
-        copy_operation.size % aligned_element_size;
-    max_aligned_element_count =
-        std::max(max_aligned_element_count, aligned_element_count);
+  for (size_t operation_offset = 0; operation_offset < copy_operations.size();
+       operation_offset += max_operations_per_dispatch) {
+    const size_t operation_count =
+        std::min(max_operations_per_dispatch, copy_operations.size() - operation_offset);
+    void* descriptor_buffer = gpu().allocKernArg(descriptor_buffer_bytes, kCBAlignment);
+    CopyBufferBatchDescriptor* descriptors =
+        static_cast<CopyBufferBatchDescriptor*>(descriptor_buffer);
+    uint64_t max_aligned_element_count = 0;
+    bool needs_system_scope = false;
 
-    descriptors[descriptor_index++] = {
-        source_address, destination_address, aligned_element_count,
-        aligned_element_size, trailing_byte_count};
+    for (size_t descriptor_index = 0; descriptor_index < operation_count; ++descriptor_index) {
+      const BatchRawCopyOp& copy_operation = copy_operations[operation_offset + descriptor_index];
+      const uint64_t source_address = reinterpret_cast<uint64_t>(copy_operation.src);
+      const uint64_t destination_address = reinterpret_cast<uint64_t>(copy_operation.dst);
+      needs_system_scope |= copy_operation.needs_system_scope || !copy_operation.metadata.isAsync_;
+      attach_signal |= copy_operation.attach_signal || !copy_operation.metadata.isAsync_;
+      const bool addresses_aligned =
+          ((source_address % kMaxAlignment) == 0) && ((destination_address % kMaxAlignment) == 0);
+      const uint32_t aligned_element_size = (addresses_aligned) ? kMaxAlignment : sizeof(uint32_t);
+      const uint64_t aligned_element_count = copy_operation.size / aligned_element_size;
+      const uint32_t trailing_byte_count = copy_operation.size % aligned_element_size;
+      max_aligned_element_count = std::max(max_aligned_element_count, aligned_element_count);
+
+      descriptors[descriptor_index] = {source_address, destination_address, aligned_element_count,
+                                       aligned_element_size, trailing_byte_count};
+    }
+
+    const uint32_t max_workgroups_per_copy = std::max<uint32_t>(
+        dev().settings().limit_blit_wg_ / static_cast<uint32_t>(operation_count), 1);
+    uint32_t workgroup_count = static_cast<uint32_t>(std::min<uint64_t>(
+        max_workgroups_per_copy,
+        amd::alignUp(max_aligned_element_count, static_cast<uint64_t>(kLocalWorkSize)) /
+            kLocalWorkSize));
+    workgroup_count = std::max<uint32_t>(workgroup_count, 1);
+    const uint32_t copy_stride = workgroup_count * kLocalWorkSize;
+
+    constexpr bool kDirectVa = true;
+    setArgument(kernel, 0, sizeof(cl_mem), descriptor_buffer, 0, nullptr, kDirectVa);
+    setArgument(kernel, 1, sizeof(kLocalWorkSize), &kLocalWorkSize);
+    setArgument(kernel, 2, sizeof(copy_stride), &copy_stride);
+
+    size_t global_work_size[2] = {copy_stride, operation_count};
+    size_t local_work_size[2] = {kLocalWorkSize, 1};
+    amd::NDRangeContainer nd_range(2, nullptr, global_work_size, local_work_size);
+
+    address parameters = captureArguments(kernel);
+    if (needs_system_scope) {
+      gpu().addSystemScope();
+    }
+    const bool is_last_dispatch = (operation_offset + operation_count) == copy_operations.size();
+    const bool submit_result =
+        gpu().submitKernelInternal(nd_range, *kernel, parameters, nullptr, 0, nullptr, nullptr,
+                                   is_last_dispatch && attach_signal);
+    releaseArguments(parameters);
+    if (!submit_result) {
+      return false;
+    }
   }
 
-  uint32_t workgroup_count = static_cast<uint32_t>(
-      std::min<uint64_t>(max_workgroups_per_copy,
-                         amd::alignUp(max_aligned_element_count,
-                                      static_cast<uint64_t>(kLocalWorkSize)) /
-                             kLocalWorkSize));
-  workgroup_count = std::max<uint32_t>(workgroup_count, 1);
-  const uint32_t copy_stride = workgroup_count * kLocalWorkSize;
-
-  amd::Kernel *const kernel = kernels_[BlitCopyBufferBatch];
-  constexpr bool kDirectVa = true;
-  setArgument(kernel, 0, sizeof(cl_mem), descriptor_buffer, 0, nullptr,
-              kDirectVa);
-
-  setArgument(kernel, 1, sizeof(kLocalWorkSize), &kLocalWorkSize);
-  setArgument(kernel, 2, sizeof(copy_stride), &copy_stride);
-
-  size_t global_work_size[2] = {copy_stride, copy_operations.size()};
-  size_t local_work_size[2] = {kLocalWorkSize, 1};
-  amd::NDRangeContainer nd_range(2, nullptr, global_work_size, local_work_size);
-
-  address parameters = captureArguments(kernel);
-  if (needs_system_scope) {
-    gpu().addSystemScope();
-  }
-  bool submit_result =
-      gpu().submitKernelInternal(nd_range, *kernel, parameters, nullptr, 0,
-                                 nullptr, nullptr, attach_signal);
-  releaseArguments(parameters);
-
-  return submit_result;
+  return true;
 }
 
 // ================================================================================================

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -2501,6 +2501,11 @@ void* VirtualGPU::allocKernArg(size_t size, size_t alignment) {
 }
 
 // ================================================================================================
+size_t VirtualGPU::KernArgPoolChunkSize() const {
+  return roc_device_.settings().kernargPoolSize_ / kKernArgPoolNumSignals;
+}
+
+// ================================================================================================
 address VirtualGPU::allocKernelArguments(size_t size, size_t alignment) {
   if (ROC_SKIP_KERNEL_ARG_COPY) {
     // Make sure VirtualGPU has an exclusive access to the resources

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -648,6 +648,8 @@ class VirtualGPU : public device::VirtualDevice {
   amd::Command* command() const { return command_; }
 
   void* allocKernArg(size_t size, size_t alignment);
+  //! Returns the size of one managed kernarg pool chunk.
+  size_t KernArgPoolChunkSize() const;
   bool isFenceDirty() const { return fence_dirty_.load(std::memory_order_acquire); }
   void setFenceDirty(bool state) { fence_dirty_.store(state, std::memory_order_release); }
   void WaitCompleteSignal(hsa_signal_t signal);

--- a/projects/hip-tests/catch/config/configs/unit/memory.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/memory.yaml
@@ -834,6 +834,7 @@ memory:
     <<: *level_2
     tags: [transfer]
   Unit_hipMemcpyBatchAsync_D2D_Functional: *level_2
+  Unit_hipMemcpyBatchAsync_D2D_LargeBatch: *level_2
   Unit_hipMemcpyBatchAsync_Swap:
     <<: *level_2
     tags: [transfer]

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
@@ -121,15 +121,15 @@ void VerifyArrayFromBothEnds(const int* values, size_t copy_elements, int expect
     const size_t front_index = offset;
     const size_t back_index = copy_elements - 1 - offset;
 
-    INFO("Array failure at copy index " << copy_index << ", element " << front_index);
-    REQUIRE(values[front_index] == expected);
-
-    if (front_index == back_index) {
-      continue;
+    if (values[front_index] != expected) {
+      INFO("Array failure at copy index " << copy_index << ", element " << front_index);
+      REQUIRE(values[front_index] == expected);
     }
 
-    INFO("Array failure at copy index " << copy_index << ", element " << back_index);
-    REQUIRE(values[back_index] == expected);
+    if (front_index != back_index && values[back_index] != expected) {
+      INFO("Array failure at copy index " << copy_index << ", element " << back_index);
+      REQUIRE(values[back_index] == expected);
+    }
   }
 }
 
@@ -1053,6 +1053,51 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_IndirectDst) {
     HIP_CHECK(status);
     HIP_CHECK(hipStreamSynchronize(stream_guard.stream()));
     VerifyArrayFromBothEnds(dst.host_ptr(), copy_elements, kPatternValue, 0);
+  }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ * - Verifies a large D2D batch through the shader and SDMA copy paths.
+ * Test source
+ * ------------------------
+ * - catch/unit/memory/hipMemcpyBatchAsync.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 7.1
+ */
+HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_D2D_LargeBatch) {
+  constexpr size_t copy_count = 1024 * 32;
+  constexpr size_t copy_size = 64;
+  constexpr size_t total_size = copy_count * copy_size;
+  constexpr size_t copy_elements = copy_size / sizeof(int);
+  const hipMemcpyFlags flag = GENERATE(hipMemcpyFlagDefault, hipMemcpyFlagExtPreferCE);
+
+  StreamGuard stream_guard(Streams::created);
+  LinearAllocGuard<int> src(LinearAllocs::hipMalloc, total_size);
+  LinearAllocGuard<int> dst(LinearAllocs::hipMalloc, total_size);
+  std::vector<void*> src_ptrs(copy_count);
+  std::vector<void*> dst_ptrs(copy_count);
+  std::vector<size_t> sizes(copy_count, copy_size);
+  std::vector<int> values(total_size / sizeof(int));
+  hipMemcpyAttributes attr{hipMemcpySrcAccessOrderAny, {}, {}, static_cast<unsigned int>(flag)};
+  size_t attrs_idx = 0;
+
+  for (size_t i = 0; i < copy_count; ++i) {
+    src_ptrs[i] = reinterpret_cast<char*>(src.ptr()) + i * copy_size;
+    dst_ptrs[i] = reinterpret_cast<char*>(dst.ptr()) + i * copy_size;
+    std::fill_n(values.data() + i * copy_elements, copy_elements,
+                kPatternValue + static_cast<int>(i));
+  }
+  HIP_CHECK(hipMemcpy(src.ptr(), values.data(), total_size, hipMemcpyHostToDevice));
+  HIP_CHECK(hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(), copy_count, &attr,
+                                &attrs_idx, 1, nullptr, stream_guard.stream()));
+  HIP_CHECK(hipStreamSynchronize(stream_guard.stream()));
+  HIP_CHECK(hipMemcpy(values.data(), dst.ptr(), total_size, hipMemcpyDeviceToHost));
+  for (size_t i = 0; i < copy_count; ++i) {
+    VerifyArrayFromBothEnds(values.data() + i * copy_elements, copy_elements,
+                            kPatternValue + static_cast<int>(i), i);
   }
 }
 #endif


### PR DESCRIPTION
## Motivation

- Batches with more than 8192 copies requires more than one kernel argument pool chunk, but span over multiple chunks is not supported. Which results in later segfaults.

## Technical Details

- Split one large batch into multiple kernel dispatches based on how many descriptors could fit in a single chunk. 

## Issue Tracking

ISSUE ID
AIRUNTIME-2622

## Test Plan

- Run new test that exercise more than 8192 copies per batch with both SDMA and Shader copy paths.

## Test Result

- Test passed on all platforms.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
