### PR TITLE
feat(rocdbgapi): introduce amd_dbgapi_process_enable_traps

### DIFF
--- a/projects/rocdbgapi/CMakeLists.txt
+++ b/projects/rocdbgapi/CMakeLists.txt
@@ -62,7 +62,7 @@
 
 cmake_minimum_required(VERSION 3.8)
 
-project(amd-dbgapi VERSION 0.80.0)
+project(amd-dbgapi VERSION 0.81.0)
 
 include(CheckIncludeFile)
 include(CheckIncludeFiles)

--- a/projects/rocdbgapi/include/amd-dbgapi.h.in
+++ b/projects/rocdbgapi/include/amd-dbgapi.h.in
@@ -665,6 +665,12 @@ typedef unsigned long amd_dbgapi_DWORD;
  */
 #define AMD_DBGAPI_VERSION_0_80
 
+/**
+ * The function was introduced in version 0.81 of the interface and has the
+ * symbol version string of ``"@AMD_DBGAPI_NAME@_0.81"``.
+ */
+#define AMD_DBGAPI_VERSION_0_81
+
 /** @} */
 
 /** \ingroup callbacks_group
@@ -2197,6 +2203,65 @@ typedef enum
 } amd_dbgapi_wave_creation_t;
 
 /**
+ * The traps that can be enabled or disabled.
+ *
+ * This is a bit mask: the values may be combined with bitwise-or to enable
+ * more than one trap at a time.  A wave that hits an enabled trap is reported
+ * as stopped.  The floating-point and integer exception traps are reported
+ * when the corresponding exception is raised, while
+ * ::AMD_DBGAPI_WAVE_ENABLE_TRAP_ON_ENTRY is raised for all new waves, before
+ * any instruction executes.
+ *
+ * This setting applies to all agents of the specified process and affects all
+ * waves.
+ */
+typedef enum
+{
+  /**
+   * No trap is enabled. Waves execute normally.
+   */
+  AMD_DBGAPI_WAVE_ENABLE_TRAP_NONE = 0,
+  /**
+   * Trap on an invalid floating-point operation, i.e. an operation that has no
+   * meaningful result, such as 0/0, inf - inf, sqrt of a negative number, or an
+   * operation with a signaling NaN operand.
+   */
+  AMD_DBGAPI_WAVE_ENABLE_TRAP_FP_INVALID = 1 << 0,
+  /**
+   * Trap when a denormal floating-point value is passed as input.
+   */
+  AMD_DBGAPI_WAVE_ENABLE_TRAP_FP_INPUT_DENORMAL = 1 << 1,
+  /**
+   * Trap when a finite non-zero number is divided by zero.
+   */
+  AMD_DBGAPI_WAVE_ENABLE_TRAP_FP_DIVIDE_BY_ZERO = 1 << 2,
+  /**
+   * Trap when the rounded result would be larger than the largest finite
+   * number.
+   */
+  AMD_DBGAPI_WAVE_ENABLE_TRAP_FP_OVERFLOW = 1 << 3,
+  /**
+   * Trap when the rounded result would be smaller than the smallest normal
+   * number.
+   */
+  AMD_DBGAPI_WAVE_ENABLE_TRAP_FP_UNDERFLOW = 1 << 4,
+  /**
+   * Trap when the rounded result is different from the infinitely precise
+   * result.
+   */
+  AMD_DBGAPI_WAVE_ENABLE_TRAP_FP_INEXACT = 1 << 5,
+  /**
+   * Trap when an integer is divided by zero.
+   */
+  AMD_DBGAPI_WAVE_ENABLE_TRAP_INT_DIVIDE_BY_ZERO = 1 << 6,
+  /**
+   * Trap on entry. Waves trap immediately upon launch before executing any
+   * instructions.
+   */
+  AMD_DBGAPI_WAVE_ENABLE_TRAP_ON_ENTRY = 1 << 7,
+} amd_dbgapi_wave_enable_trap_t;
+
+/**
  * Set the wave creation mode for a process.
  *
  * The setting applies to all agents of the specified process.
@@ -2227,6 +2292,59 @@ typedef enum
 amd_dbgapi_status_t AMD_DBGAPI amd_dbgapi_process_set_wave_creation (
     amd_dbgapi_process_id_t process_id,
     amd_dbgapi_wave_creation_t creation) AMD_DBGAPI_VERSION_0_76;
+
+/**
+ * Set the wave trap override setting for a process.
+ *
+ * This is a read-modify-write operation over the process's set of enabled
+ * traps.  Both \p enabled_traps and \p mask are bit masks built from
+ * ::amd_dbgapi_wave_enable_trap_t values.  \p mask selects which traps are
+ * affected: only traps present in \p mask are modified, and traps absent from
+ * \p mask retain their current setting.  For each trap in \p mask, the trap is
+ * enabled if it is also present in \p enabled_traps, and disabled otherwise.
+ *
+ * The setting applies to all agents of the specified process and takes effect
+ * immediately.  It can be changed at any time, including while waves are
+ * executing.
+ *
+ * The floating-point and integer exception traps are applied both to waves
+ * created after this call and to waves that already exist, so they can be
+ * toggled mid-execution (for example, while the client is stepping through a
+ * kernel).
+ *
+ * \param[in] process_id The process being controlled.
+ *
+ * \param[in] enabled_traps The desired state of the traps selected by \p mask.
+ *
+ * \param[in] mask The set of traps to modify.  Traps not in \p mask are left
+ * unchanged.
+ *
+ * \retval ::AMD_DBGAPI_STATUS_SUCCESS The function has been executed
+ * successfully and the enabled traps have been set.
+ *
+ * \retval ::AMD_DBGAPI_STATUS_FATAL A fatal error occurred.  The library is
+ * left uninitialized.
+ *
+ * \retval ::AMD_DBGAPI_STATUS_ERROR_NOT_INITIALIZED The library is not
+ * initialized.  The library is left uninitialized.
+ *
+ * \retval ::AMD_DBGAPI_STATUS_ERROR_INVALID_PROCESS_ID \p process_id is
+ * invalid.  The enabled traps are not changed.
+ *
+ * \retval ::AMD_DBGAPI_STATUS_ERROR_INVALID_ARGUMENT \p enabled_traps or \p
+ * mask contains an unknown bit.  The enabled traps are not changed.
+ *
+ * \retval ::AMD_DBGAPI_STATUS_ERROR_PROCESS_FROZEN The process is frozen.
+ * The enabled traps cannot be changed.
+ *
+ * \retval ::AMD_DBGAPI_STATUS_ERROR_NOT_SUPPORTED One or more of the requested
+ * traps in \p enabled_traps is not supported for \p process_id.  No
+ * configuration is changed.
+ */
+amd_dbgapi_status_t AMD_DBGAPI amd_dbgapi_process_set_trap_override (
+  amd_dbgapi_process_id_t process_id,
+  amd_dbgapi_wave_enable_trap_t enabled_traps,
+  amd_dbgapi_wave_enable_trap_t mask) AMD_DBGAPI_VERSION_0_81;
 
 /** \defgroup coredump_support Generating a core dump of a process
  *

--- a/projects/rocdbgapi/src/architecture.cpp
+++ b/projects/rocdbgapi/src/architecture.cpp
@@ -1506,8 +1506,11 @@ amdgcn_architecture_t::wave_get_state (wave_t &wave) const
   uint32_t ttmp6;
   wave.read_register (amdgpu_regnum_t::ttmp6, &ttmp6);
   const bool is_stopped = (ttmp6 & ttmp6_wave_stopped_mask) != 0;
+  const bool is_halted = wave_get_halt (wave);
 
-  if (!is_stopped)
+  /* The wave may be halted but not stopped.  In that case, still report
+     exceptions.  */
+  if (!is_stopped && !is_halted)
     /* The wave is still running, nothing to do.  */
     return { wave.state (), AMD_DBGAPI_WAVE_STOP_REASON_NONE };
 
@@ -1520,7 +1523,8 @@ amdgcn_architecture_t::wave_get_state (wave_t &wave) const
      fill the stop_reason with the exceptions that have caused the wave to
      enter the trap handler.  */
 
-  if (park_stopped_waves (wave.process ().runtime_rdebug_version ()))
+  if (is_stopped
+      && park_stopped_waves (wave.process ().runtime_rdebug_version ()))
     wave.write_register (amdgpu_regnum_t::pc, saved_parked_pc (wave));
 
   amd_dbgapi_wave_stop_reasons_t stop_reason
@@ -1584,7 +1588,8 @@ amdgcn_architecture_t::wave_get_state (wave_t &wave) const
      raising a bit in the trapsts register, some don't, and in the absence of
      any other stop reason, a single-step is assumed.  */
 
-  return { AMD_DBGAPI_WAVE_STATE_STOP, stop_reason };
+  return { is_stopped ? AMD_DBGAPI_WAVE_STATE_STOP : AMD_DBGAPI_WAVE_STATE_RUN,
+           stop_reason };
 }
 
 void

--- a/projects/rocdbgapi/src/exportmap.in
+++ b/projects/rocdbgapi/src/exportmap.in
@@ -105,3 +105,7 @@ global:	amd_dbgapi_address_dependency;
 @AMD_DBGAPI_NAME@_0.80 {
 global: amd_dbgapi_process_get_info;
 } @AMD_DBGAPI_NAME@_0.79;
+
+@AMD_DBGAPI_NAME@_0.81 {
+global: amd_dbgapi_process_set_trap_override;
+} @AMD_DBGAPI_NAME@_0.80;

--- a/projects/rocdbgapi/src/os_driver.h
+++ b/projects/rocdbgapi/src/os_driver.h
@@ -389,6 +389,7 @@ enum class os_wave_launch_trap_mask_t : uint32_t
   wave_start = 1 << 30,
   wave_end = 1u << 31
 };
+
 template <> struct is_flag<os_wave_launch_trap_mask_t> : std::true_type
 {
 };

--- a/projects/rocdbgapi/src/process.cpp
+++ b/projects/rocdbgapi/src/process.cpp
@@ -450,8 +450,18 @@ process_t::set_wave_launch_mode (os_wave_launch_mode_t wave_launch_mode)
         if (wave.visibility ()
             == wave_t::visibility_t::hidden_halted_at_launch)
           {
-            wave.set_state (AMD_DBGAPI_WAVE_STATE_RUN);
-            wave.set_visibility (wave_t::visibility_t::visible);
+            if (wave.stop_reason () != AMD_DBGAPI_WAVE_STOP_REASON_NONE)
+              {
+                /* keep state as stop, make visible and report exceptions  */
+                wave.report_stop_at_launch ();
+              }
+            else
+              {
+                /* The wave was halted at launch with no exception, it can now
+                   be resumed and reported to the client.  */
+                wave.set_state (AMD_DBGAPI_WAVE_STATE_RUN);
+                wave.set_visibility (wave_t::visibility_t::visible);
+              }
           }
 
       /* Changing the launch mode before resuming the queues ensures that none

--- a/projects/rocdbgapi/src/process.cpp
+++ b/projects/rocdbgapi/src/process.cpp
@@ -562,6 +562,98 @@ process_t::set_precise_alu_exceptions (bool enabled)
                  to_cstring (status));
 }
 
+void
+process_t::set_user_trap_override (
+  amd_dbgapi_wave_enable_trap_t requested_traps,
+  amd_dbgapi_wave_enable_trap_t requested_mask)
+{
+  os_wave_launch_trap_mask_t value{}, mask{};
+
+  /* Generic conversion from amd_dbgapi_wave_enable_trap_t to
+     os_wave_launch_trap_mask_t.  */
+  auto convert
+    = [] (os_wave_launch_trap_mask_t &out, amd_dbgapi_wave_enable_trap_t flag)
+  {
+    switch (flag)
+      {
+      case AMD_DBGAPI_WAVE_ENABLE_TRAP_NONE:
+        break;
+      case AMD_DBGAPI_WAVE_ENABLE_TRAP_FP_INVALID:
+        out |= os_wave_launch_trap_mask_t::fp_invalid;
+        break;
+      case AMD_DBGAPI_WAVE_ENABLE_TRAP_FP_INPUT_DENORMAL:
+        out |= os_wave_launch_trap_mask_t::fp_input_denormal;
+        break;
+      case AMD_DBGAPI_WAVE_ENABLE_TRAP_FP_DIVIDE_BY_ZERO:
+        out |= os_wave_launch_trap_mask_t::fp_divide_by_zero;
+        break;
+      case AMD_DBGAPI_WAVE_ENABLE_TRAP_FP_OVERFLOW:
+        out |= os_wave_launch_trap_mask_t::fp_overflow;
+        break;
+      case AMD_DBGAPI_WAVE_ENABLE_TRAP_FP_UNDERFLOW:
+        out |= os_wave_launch_trap_mask_t::fp_underflow;
+        break;
+      case AMD_DBGAPI_WAVE_ENABLE_TRAP_FP_INEXACT:
+        out |= os_wave_launch_trap_mask_t::fp_inexact;
+        break;
+      case AMD_DBGAPI_WAVE_ENABLE_TRAP_INT_DIVIDE_BY_ZERO:
+        out |= os_wave_launch_trap_mask_t::int_divide_by_zero;
+        break;
+      case AMD_DBGAPI_WAVE_ENABLE_TRAP_ON_ENTRY:
+        out |= os_wave_launch_trap_mask_t::wave_start;
+        break;
+      default:
+        throw api_error_t (AMD_DBGAPI_STATUS_ERROR_INVALID_ARGUMENT);
+      }
+  };
+
+  utils::for_each_flag (requested_traps, [&value, &convert] (auto flag)
+                        { convert (value, flag); });
+  utils::for_each_flag (requested_mask, [&mask, &convert] (auto flag)
+                        { convert (mask, flag); });
+
+  value = (m_requested_wave_trap_mask & ~mask) | (value & mask);
+
+  auto set_requested_traps = utils::make_scope_success (
+    [=] () { m_requested_wave_trap_mask = value; });
+
+  /* If this is called before the runtime is loaded (or after the runtime is
+     unloaded), only record the setting in the process_t instance. The actual
+     change to the configuration will be done when the runtime is loaded and
+     the debug mode is activated.  */
+  if (m_runtime_state != AMD_DBGAPI_RUNTIME_STATE_LOADED_SUCCESS)
+    return;
+
+  if ((value & ~m_supported_wave_trap_mask) != 0)
+    throw api_error_t (AMD_DBGAPI_STATUS_ERROR_NOT_SUPPORTED);
+
+  /* Nothing to update on existing waves if the traps are already applied.  */
+  if (value == m_requested_wave_trap_mask)
+    return;
+
+  set_wave_launch_trap_override (value, mask);
+
+  update_queues ();
+
+  std::vector<queue_t *> queues;
+  queues.reserve (count<queue_t> ());
+
+  for (auto &&queue : range<queue_t> ())
+    if (!queue.is_suspended ())
+      queues.emplace_back (&queue);
+
+  suspend_queues (queues, "set enabled traps");
+
+  for (auto &&wave : range<wave_t> ())
+    {
+      wave.architecture ().wave_enable_traps (wave, value);
+      wave.architecture ().wave_disable_traps (wave, mask & ~value);
+    }
+
+  if (forward_progress_needed ())
+    resume_queues (queues, "set enabled traps");
+}
+
 std::vector<process_t *>
 process_t::match (amd_dbgapi_process_id_t process_id)
 {
@@ -1654,23 +1746,30 @@ process_t::runtime_enable (os_runtime_info_t runtime_info)
     fatal_error ("Could not set the wave launch mode for %s (%s).",
                  to_cstring (id ()), to_cstring (status));
 
-  os_wave_launch_trap_mask_t supported_wave_trap_mask;
   status = os_driver ().set_wave_launch_trap_override (
     os_wave_launch_trap_override_t::apply, os_wave_launch_trap_mask_t::none,
-    os_wave_launch_trap_mask_t::none, nullptr, &supported_wave_trap_mask);
+    os_wave_launch_trap_mask_t::none, nullptr, &m_supported_wave_trap_mask);
   if (status != AMD_DBGAPI_STATUS_SUCCESS
       && status != AMD_DBGAPI_STATUS_ERROR_PROCESS_EXITED)
     fatal_error ("Could not set the wave launch trap override for %s (%s).",
                  to_cstring (id ()), to_cstring (status));
 
-  if ((m_wave_trap_mask & ~supported_wave_trap_mask) != 0)
+  if ((m_wave_trap_mask & ~m_supported_wave_trap_mask) != 0)
     fatal_error ("Unsupported wave trap mask (%s) requested for %s",
-                 to_cstring (m_wave_trap_mask & ~supported_wave_trap_mask),
+                 to_cstring (m_wave_trap_mask & ~m_supported_wave_trap_mask),
                  to_cstring (id ()));
 
+  if ((m_requested_wave_trap_mask & ~m_supported_wave_trap_mask) != 0)
+    log_info (
+      "Unsupported wave trap mask (%s) requested for %s",
+      to_cstring (m_requested_wave_trap_mask & ~m_supported_wave_trap_mask),
+      to_cstring (id ()));
+
+  /* Enable both m_wave_trap_mask (trap mask as required by dbgapi) and
+     m_requested_wave_trap_mask (trap mask required by the user).  */
   status = os_driver ().set_wave_launch_trap_override (
-    os_wave_launch_trap_override_t::apply, m_wave_trap_mask,
-    supported_wave_trap_mask);
+    os_wave_launch_trap_override_t::apply,
+    m_wave_trap_mask | m_requested_wave_trap_mask, m_supported_wave_trap_mask);
   if (status != AMD_DBGAPI_STATUS_SUCCESS
       && status != AMD_DBGAPI_STATUS_ERROR_PROCESS_EXITED)
     fatal_error ("Could not set the wave launch trap override for %s (%s).",
@@ -2564,6 +2663,37 @@ amd_dbgapi_process_unfreeze (amd_dbgapi_process_id_t process_id)
          AMD_DBGAPI_STATUS_ERROR_INVALID_PROCESS_ID,
          AMD_DBGAPI_STATUS_ERROR_PROCESS_NOT_FROZEN,
          AMD_DBGAPI_STATUS_ERROR_NOT_IMPLEMENTED);
+  TRACE_END ();
+}
+
+amd_dbgapi_status_t AMD_DBGAPI
+amd_dbgapi_process_set_trap_override (
+  amd_dbgapi_process_id_t process_id,
+  amd_dbgapi_wave_enable_trap_t enabled_traps,
+  amd_dbgapi_wave_enable_trap_t mask)
+{
+  TRACE_BEGIN (param_in (process_id), param_in (enabled_traps),
+               param_in (mask));
+  TRY
+  {
+    if (!detail::is_initialized)
+      THROW (AMD_DBGAPI_STATUS_ERROR_NOT_INITIALIZED);
+
+    process_t *process = process_t::find (process_id);
+
+    if (process == nullptr)
+      THROW (AMD_DBGAPI_STATUS_ERROR_INVALID_PROCESS_ID);
+
+    if (process->is_frozen ())
+      THROW (AMD_DBGAPI_STATUS_ERROR_PROCESS_FROZEN);
+
+    process->set_user_trap_override (enabled_traps, mask);
+  }
+  CATCH (AMD_DBGAPI_STATUS_ERROR_NOT_INITIALIZED,
+         AMD_DBGAPI_STATUS_ERROR_INVALID_PROCESS_ID,
+         AMD_DBGAPI_STATUS_ERROR_INVALID_ARGUMENT,
+         AMD_DBGAPI_STATUS_ERROR_PROCESS_FROZEN,
+         AMD_DBGAPI_STATUS_ERROR_NOT_SUPPORTED);
   TRACE_END ();
 }
 

--- a/projects/rocdbgapi/src/process.h
+++ b/projects/rocdbgapi/src/process.h
@@ -116,6 +116,9 @@ private:
 
   bool m_supports_precise_alu_exceptions{ false };
 
+  os_wave_launch_trap_mask_t m_supported_wave_trap_mask{};
+  os_wave_launch_trap_mask_t m_requested_wave_trap_mask{};
+
   os_process_flags_t m_process_flags{};
 
   bool m_forward_progress_needed{ true };
@@ -286,6 +289,9 @@ public:
   void set_precise_memory (bool enabled);
 
   void set_precise_alu_exceptions (bool enabled);
+
+  void set_user_trap_override (amd_dbgapi_wave_enable_trap_t enabled_traps,
+                               amd_dbgapi_wave_enable_trap_t mask);
 
   /* Suspend/resume a list of queues.  Queues may become invalid as a result of
      suspension/resumption, but not destroyed.  Queues made invalid will

--- a/projects/rocdbgapi/src/queue.cpp
+++ b/projects/rocdbgapi/src/queue.cpp
@@ -354,7 +354,7 @@ compute_queue_t::update_waves ()
        changed since the queue was last suspended (or the wave is new).  */
     wave->update (std::move (cwsr_record));
 
-    if (wave->state () != AMD_DBGAPI_WAVE_STATE_STOP)
+    if (wave->state () != AMD_DBGAPI_WAVE_STATE_STOP && ! wave->is_halted ())
       ++*m_waves_running;
 
     /* Hide new waves halted at launch until the process' wave creation mode is
@@ -370,8 +370,16 @@ compute_queue_t::update_waves ()
         log_verbose ("%s is halted at launch", to_cstring (wave->id ()));
 
         wave->set_visibility (wave_t::visibility_t::hidden_halted_at_launch);
-        wave->set_halted (false);
-        wave->set_state (AMD_DBGAPI_WAVE_STATE_STOP);
+
+        /* The wave may be spawned with exceptions, in which case we do not
+           want to report them.  The process will trigger
+           wave_t::report_stop_at_launch () when resuming a wave that is hidden
+           at launch.  */
+        if (wave->stop_reason () == AMD_DBGAPI_WAVE_STOP_REASON_NONE)
+          {
+            wave->set_halted (false);
+            wave->set_state (AMD_DBGAPI_WAVE_STATE_STOP);
+          }
       }
 
     /* This was the last wave in the group. Make sure we have a new group

--- a/projects/rocdbgapi/src/utils.h
+++ b/projects/rocdbgapi/src/utils.h
@@ -1174,6 +1174,11 @@ template <> struct is_flag<amd_dbgapi_wave_stop_reasons_t> : std::true_type
 {
 };
 
+/* Enable bitwise operations for amd_dbgapi_wave_enable_trap_t.  */
+template <> struct is_flag<amd_dbgapi_wave_enable_trap_t> : std::true_type
+{
+};
+
 /* A monotonic counter with wrap-around detection. Type must be an integral
    unsigned type. The WrapAroundCheck functor returns true if the counter has
    wrapped around. The default functor is (new_value > old_value).  */

--- a/projects/rocdbgapi/src/wave.cpp
+++ b/projects/rocdbgapi/src/wave.cpp
@@ -1040,6 +1040,24 @@ wave_t::get_info (amd_dbgapi_wave_info_t query, size_t value_size,
   throw api_error_t (AMD_DBGAPI_STATUS_ERROR_INVALID_ARGUMENT);
 }
 
+void
+wave_t::report_stop_at_launch ()
+{
+  dbgapi_assert (state () == AMD_DBGAPI_WAVE_STATE_RUN);
+  dbgapi_assert (visibility () != visibility_t::visible);
+  dbgapi_assert (m_stop_reason != AMD_DBGAPI_WAVE_STOP_REASON_NONE);
+
+  /* set_state (STOP) clears the stop reason, so save and restore it.  */
+  auto stop_reason = m_stop_reason;
+
+  set_halted (false);                     /* drop the launch halt */
+  set_state (AMD_DBGAPI_WAVE_STATE_STOP); /* hidden => no event */
+  m_stop_reason = stop_reason;
+
+  set_visibility (visibility_t::visible);
+  raise_event (AMD_DBGAPI_EVENT_KIND_WAVE_STOP);
+}
+
 } /* namespace amd::dbgapi */
 
 using namespace amd::dbgapi;

--- a/projects/rocdbgapi/src/wave.h
+++ b/projects/rocdbgapi/src/wave.h
@@ -239,6 +239,10 @@ public:
                        amd_dbgapi_lane_id_t lane_id, void *read,
                        const void *write, size_t size);
 
+  /* Raises an event to notify the client of a stopped wave at launch.  May
+     only be called if the wave had pending exceptions when created.   */
+  void report_stop_at_launch ();
+
   void get_info (amd_dbgapi_wave_info_t query, size_t value_size,
                  void *value) const;
 


### PR DESCRIPTION
## Motivation

This commit implements the new 'enable_traps' feature.  Users can now request
supported alu traps to be enabled for existing & future waves.  This can be
used to catch floating point exceptions as well as forcing waves to trap on
entry.

## Issue Tracking

JIRA ID : AIROCGDB-647

## Test Plan

Testing included in the ROCgdb PR

## Test Result

Tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
