### PR TITLE
[rocjitsu] Preserve gfx1250 WMMA FP16 overflow codegen

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/matrix.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/matrix.py
@@ -530,6 +530,11 @@ def gen_mfma(
                             f'  amdgpu::{spec}(cu, dst, src0_base, src1_base, s2, const_acc,'
                             f' amdgpu::wmma_c_modifier(inst_.neg, inst_.neg_hi));'
                         )
+                    elif spec.startswith('exec_wmma_f16_f8_spec'):
+                        L.append(
+                            f'  amdgpu::{spec}(cu, dst, src0_base, src1_base, s2, const_acc,'
+                            f' wf.fp16_ovfl());'
+                        )
                     else:
                         L.append(
                             f'  amdgpu::{spec}(cu, dst, src0_base, src1_base, s2, const_acc);'

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
@@ -1029,6 +1029,40 @@ def test_gfx1250_wmma_f32_passes_c_modifier_to_accumulator_helper():
     assert 'amdgpu::wmma_c_modifier(inst_.neg, inst_.neg_hi)' in body
 
 
+@pytest.mark.parametrize('k', [64, 128])
+@pytest.mark.parametrize(
+    ('input_type', 'a_fp8', 'b_fp8'),
+    [
+        ('FP8_FP8', 'true', 'true'),
+        ('FP8_BF8', 'true', 'false'),
+        ('BF8_FP8', 'false', 'true'),
+        ('BF8_BF8', 'false', 'false'),
+    ],
+)
+def test_gfx1250_wmma_f16_f8_passes_fp16_overflow_mode(
+    k: int, input_type: str, a_fp8: str, b_fp8: str
+) -> None:
+    inst = Instruction(
+        f'V_WMMA_F16_16X16X{k}_{input_type}', 'ENC_VOP3P', 0, []
+    )
+    body = gen_mfma(inst, ['vdst'], ['src0', 'src1', 'src2'], 'gfx1250')
+
+    assert (
+        f'amdgpu::exec_wmma_f16_f8_spec<16, 16, {k}, {a_fp8}, {b_fp8}>('
+        in body
+    )
+    assert 'const_acc, wf.fp16_ovfl());' in body
+
+
+def test_gfx1250_wmma_f16_overflow_mode_is_scoped_to_f8_helper() -> None:
+    inst = Instruction('V_WMMA_F16_16X16X32_F16', 'ENC_VOP3P', 0, [])
+    body = gen_mfma(inst, ['vdst'], ['src0', 'src1', 'src2'], 'gfx1250')
+
+    assert 'amdgpu::exec_wmma_f16_spec<16, 16, 32>(' in body
+    assert 's2, const_acc);' in body
+    assert 'wf.fp16_ovfl()' not in body
+
+
 def test_rdna_wmma_uses_arch_specific_wave32_operand_layout():
     operands = [
         Operand('vdst', 256, 'OPR_VGPR', False, True, False, False, 0),

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
@@ -1042,15 +1042,10 @@ def test_gfx1250_wmma_f32_passes_c_modifier_to_accumulator_helper():
 def test_gfx1250_wmma_f16_f8_passes_fp16_overflow_mode(
     k: int, input_type: str, a_fp8: str, b_fp8: str
 ) -> None:
-    inst = Instruction(
-        f'V_WMMA_F16_16X16X{k}_{input_type}', 'ENC_VOP3P', 0, []
-    )
+    inst = Instruction(f'V_WMMA_F16_16X16X{k}_{input_type}', 'ENC_VOP3P', 0, [])
     body = gen_mfma(inst, ['vdst'], ['src0', 'src1', 'src2'], 'gfx1250')
 
-    assert (
-        f'amdgpu::exec_wmma_f16_f8_spec<16, 16, {k}, {a_fp8}, {b_fp8}>('
-        in body
-    )
+    assert f'amdgpu::exec_wmma_f16_f8_spec<16, 16, {k}, {a_fp8}, {b_fp8}>(' in body
     assert 'const_acc, wf.fp16_ovfl());' in body
 
 


### PR DESCRIPTION
## Motivation

This PR moves that behavior into the generator so generated sources remain reproducible.

## Technical Details

- Update the gfx1250 matrix code generator to pass `wf.fp16_ovfl()` to specialized F16 FP8/BF8 WMMA executors.
- Limit the change to the affected helper signature, leaving other F16 and F32 WMMA generation unchanged.
- Add regression coverage for all FP8/BF8 input combinations at K=64 and K=128.
- Regenerate `gfx1250/vop3p_exec.cpp` and verify it retains the intended calls.

## Issue Tracking

N/A

## Test Plan

- Run the matrix code-generator unit tests.
- Regenerate the ISA sources
- Verify all eight affected instructions retain `wf.fp16_ovfl()`.
- Verify no unrelated generated files change.

## Test Result

All good

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
