### PR TITLE
feat(rocprofiler-sdk): scope dispatch ATT to configured agents

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
@@ -294,16 +294,11 @@ start_context(rocprofiler_context_id_t context_id)
             // conflicting context
             return ROCPROFILER_STATUS_ERROR_CONTEXT_CONFLICT;
         }
-        else if(cfg->dispatch_thread_trace && itr->dispatch_thread_trace)
+        else if(cfg->dispatch_thread_trace && itr->dispatch_thread_trace &&
+                cfg->dispatch_thread_trace->intersects(*itr->dispatch_thread_trace))
         {
-            // Single-context-only is a hard invariant for dispatch thread trace, and it now needs
-            // enforcing. Previously it held by accident: the per-queue callback registry registered
-            // one global client, so a second concurrent ATT context silently did nothing. With the
-            // registry gone the hooks iterate every active ATT context, and
-            // DispatchThreadTracer::post_kernel_call identifies packets by dynamic_cast plus agent
-            // lookup with no per-context ownership check, decrementing post_move_data before it
-            // verifies agent ownership -- so two ATT contexts on one agent would cross-talk and
-            // mis-refcount rather than one being ignored.
+            // Two dispatch ATT contexts can run concurrently as long as they target disjoint
+            // sets of GPU agents. Overlapping agent sets would cross-talk in post_kernel_call.
             return ROCPROFILER_STATUS_ERROR_CONTEXT_CONFLICT;
         }
     }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
@@ -483,8 +483,7 @@ QueueController::update_serialization(const agent_handle_set_t& agents, bool ena
                 {
                     auto itr = was_enabled.find(agent_id);
                     if(itr == was_enabled.end()) continue;
-                    if(itr->second != state.enabled(agent_id))
-                        transitioned.emplace_back(agent_id);
+                    if(itr->second != state.enabled(agent_id)) transitioned.emplace_back(agent_id);
                 }
             });
 
@@ -543,8 +542,7 @@ bool
 QueueController::is_serialization_enabled(rocprofiler_agent_id_t agent_id) const
 {
     bool enabled = false;
-    _serialization_refcount.rlock(
-        [&](const auto& state) { enabled = state.enabled(agent_id); });
+    _serialization_refcount.rlock([&](const auto& state) { enabled = state.enabled(agent_id); });
     return enabled;
 }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
@@ -391,10 +391,19 @@ common::Synchronized<hsa::profiler_serializer>&
 QueueController::serializer(const Queue* queue)
 {
     CHECK(queue);
+    const auto agent_id = queue->get_agent().get_rocp_agent()->id;
+
+    // Read the refcount before taking the serializer lock: update_serialization() acquires
+    // them in that order, and reversing it here would deadlock. A concurrent enable/disable
+    // for this agent can therefore race with the creation below, exactly as the previous
+    // _serialized_enabled load could, and is resolved the same way -- the next transition
+    // through update_serialization() reaches the entry once it is in the map.
+    const bool should_serialize = is_serialization_enabled(agent_id);
+
     common::Synchronized<hsa::profiler_serializer>* ret = nullptr;
     _profiler_serializer.ulock(
         [&](const auto& m) {
-            if(auto ptr = m.find(queue->get_agent().get_rocp_agent()->id); ptr != m.end())
+            if(auto ptr = m.find(agent_id); ptr != m.end())
             {
                 ret = ptr->second.get();
                 return true;
@@ -402,10 +411,10 @@ QueueController::serializer(const Queue* queue)
             return false;
         },
         [&](auto& m) {
-            ret = m.emplace(queue->get_agent().get_rocp_agent()->id,
+            ret = m.emplace(agent_id,
                             std::make_shared<common::Synchronized<hsa::profiler_serializer>>())
                       .first->second.get();
-            if(_serialized_enabled.load() == true)
+            if(should_serialize)
             {
                 ret->wlock([&](auto& serializer) { serializer.enable({}); });
             }
@@ -429,47 +438,114 @@ per_dev_map(const QueueController::queue_map_t& _queues_v)
 };  // namespace
 
 void
-QueueController::disable_serialization()
+QueueController::update_serialization(const agent_handle_set_t& agents, bool enable)
 {
     _queues.rlock([&](const queue_map_t& _queues_v) {
-        _serialized_enabled.store(false);
         auto pd_map = per_dev_map(_queues_v);
-        _profiler_serializer.wlock([&](auto& m) {
-            for(auto& [k, v] : m)
+
+        // Agents whose effective refcount crossed zero in this call; only those get their
+        // serializer toggled. Collected under the refcount lock, applied under the serializer
+        // lock.
+        auto transitioned = std::vector<rocprofiler_agent_id_t>{};
+        bool any_enabled  = false;
+
+        _serialization_refcount.wlock([&](auto& state) {
+            // An agent can be covered by `all` and by an explicit entry at the same time, so
+            // the transition has to be decided by comparing effective counts across the
+            // update rather than by watching a single counter hit zero.
+            auto was_enabled = std::unordered_map<rocprofiler_agent_id_t, bool>{};
+            _profiler_serializer.rlock([&](const auto& serializers) {
+                for(const auto& [agent_id, _] : serializers)
+                    was_enabled.emplace(agent_id, state.enabled(agent_id));
+            });
+
+            if(agents.empty())
             {
-                if(auto it = pd_map.find(k); it != pd_map.end())
+                if(enable)
+                    ++state.all;
+                else if(state.all > 0)
+                    --state.all;
+            }
+            else
+            {
+                for(const auto& agent_id : agents)
                 {
-                    v->wlock([&](auto& serializer) { serializer.disable(it->second); });
+                    auto& count = state.per_agent[agent_id];
+                    if(enable)
+                        ++count;
+                    else if(count > 0)
+                        --count;
                 }
-                else
+            }
+
+            _profiler_serializer.rlock([&](const auto& serializers) {
+                for(const auto& [agent_id, _] : serializers)
                 {
-                    v->wlock([&](auto& serializer) { serializer.disable({}); });
+                    auto itr = was_enabled.find(agent_id);
+                    if(itr == was_enabled.end()) continue;
+                    if(itr->second != state.enabled(agent_id))
+                        transitioned.emplace_back(agent_id);
                 }
+            });
+
+            any_enabled = state.any();
+        });
+
+        _serialized_enabled.store(any_enabled);
+
+        if(transitioned.empty()) return;
+
+        _profiler_serializer.wlock([&](auto& m) {
+            for(const auto& agent_id : transitioned)
+            {
+                auto itr = m.find(agent_id);
+                if(itr == m.end() || !itr->second) continue;
+
+                auto queues = hsa_barrier::queue_map_ptr_t{};
+                if(auto it = pd_map.find(agent_id); it != pd_map.end()) queues = it->second;
+
+                itr->second->wlock([&](auto& serializer) {
+                    if(enable)
+                        serializer.enable(queues);
+                    else
+                        serializer.disable(queues);
+                });
             }
         });
     });
 }
 
 void
+QueueController::disable_serialization()
+{
+    update_serialization({}, false);
+}
+
+void
 QueueController::enable_serialization()
 {
-    _queues.rlock([&](const queue_map_t& _queues_v) {
-        _serialized_enabled.store(true);
-        auto pd_map = per_dev_map(_queues_v);
-        _profiler_serializer.wlock([&](auto& m) {
-            for(auto& [k, v] : m)
-            {
-                if(auto it = pd_map.find(k); it != pd_map.end())
-                {
-                    v->wlock([&](auto& serializer) { serializer.enable(it->second); });
-                }
-                else
-                {
-                    v->wlock([&](auto& serializer) { serializer.enable({}); });
-                }
-            }
-        });
-    });
+    update_serialization({}, true);
+}
+
+void
+QueueController::disable_serialization(const agent_handle_set_t& agents)
+{
+    update_serialization(agents, false);
+}
+
+void
+QueueController::enable_serialization(const agent_handle_set_t& agents)
+{
+    update_serialization(agents, true);
+}
+
+bool
+QueueController::is_serialization_enabled(rocprofiler_agent_id_t agent_id) const
+{
+    bool enabled = false;
+    _serialization_refcount.rlock(
+        [&](const auto& state) { enabled = state.enabled(agent_id); });
+    return enabled;
 }
 
 void

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.hpp
@@ -29,11 +29,13 @@
 
 #include <rocprofiler-sdk/fwd.h>
 #include <rocprofiler-sdk/cxx/hash.hpp>
+#include <rocprofiler-sdk/cxx/operators.hpp>
 
 #include <cstdint>
 #include <functional>
 #include <optional>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace rocprofiler
@@ -89,13 +91,27 @@ public:
 
     common::Synchronized<hsa::profiler_serializer>& serializer(const Queue*);
 
+    // An empty set means every GPU agent.
+    using agent_handle_set_t = std::unordered_set<rocprofiler_agent_id_t>;
+
     /**
-     * Disable serialization for QueueController, has no effect if counter collection
-     * is not in use (which defaults to no serialization mechanism). Should only be used for
-     * testing.
+     * Enable/disable serialization for QueueController, has no effect if counter collection
+     * is not in use (which defaults to no serialization mechanism).
+     *
+     * Serialization is reference counted per agent. Counter collection, thread trace and SPM
+     * each enable it independently, so an agent stays serialized until every subsystem that
+     * asked for it has released it -- otherwise whichever service stops first would silently
+     * unserialize the ones still running. The no-argument overloads apply to every GPU agent,
+     * which is the behavior every caller had before agents could be scoped.
      */
     void enable_serialization();
     void disable_serialization();
+    void enable_serialization(const agent_handle_set_t& agents);
+    void disable_serialization(const agent_handle_set_t& agents);
+
+    // Whether the given agent currently has serialization enabled. Exposed for tests and for
+    // callers that need to reason about scope rather than trigger a transition.
+    bool is_serialization_enabled(rocprofiler_agent_id_t agent_id) const;
 
     // Prints current state of signals for queues, used for debugging. Only prints
     // serialization related signals if not compiled in debug mode.
@@ -121,6 +137,39 @@ private:
         std::unordered_map<rocprofiler_agent_id_t,
                            std::shared_ptr<common::Synchronized<hsa::profiler_serializer>>>>
         _profiler_serializer;
+    // How many subsystems currently want serialization, per agent. `all` counts the callers
+    // that asked for every agent; it is kept separate from `per_agent` because an agent's
+    // serializer is created lazily on first use and an unscoped request has to cover agents
+    // that do not exist yet.
+    struct serialization_refcount
+    {
+        int64_t all = 0;
+        std::unordered_map<rocprofiler_agent_id_t, int64_t> per_agent = {};
+
+        int64_t count(rocprofiler_agent_id_t agent_id) const
+        {
+            auto itr = per_agent.find(agent_id);
+            return all + ((itr == per_agent.end()) ? 0 : itr->second);
+        }
+
+        bool enabled(rocprofiler_agent_id_t agent_id) const { return count(agent_id) > 0; }
+
+        bool any() const
+        {
+            if(all > 0) return true;
+            for(const auto& [agent_id, count] : per_agent)
+            {
+                if(count > 0) return true;
+            }
+            return false;
+        }
+    };
+
+    common::Synchronized<serialization_refcount> _serialization_refcount;
+
+    // Applies a +1/-1 to the refcount of each agent in `agents` (empty == all GPU agents) and
+    // toggles only the serializers whose effective count crossed zero.
+    void update_serialization(const agent_handle_set_t& agents, bool enable);
 };
 
 QueueController*

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.hpp
@@ -143,7 +143,7 @@ private:
     // that do not exist yet.
     struct serialization_refcount
     {
-        int64_t all = 0;
+        int64_t                                             all       = 0;
         std::unordered_map<rocprofiler_agent_id_t, int64_t> per_agent = {};
 
         int64_t count(rocprofiler_agent_id_t agent_id) const

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
@@ -482,14 +482,44 @@ DispatchThreadTracer::post_kernel_call(DispatchThreadTracer::inst_pkt_t& aql,
     }
 }
 
+std::unordered_set<rocprofiler_agent_id_t>
+DispatchThreadTracer::configured_agents() const
+{
+    auto result = std::unordered_set<rocprofiler_agent_id_t>{};
+    std::shared_lock<std::shared_mutex> lk(agents_map_mut);
+    for(const auto& [agent_id, _] : params)
+        result.insert(agent_id);
+    return result;
+}
+
+bool
+DispatchThreadTracer::collects_on(rocprofiler_agent_id_t agent_id) const
+{
+    std::shared_lock<std::shared_mutex> lk(agents_map_mut);
+    return params.count(agent_id) > 0;
+}
+
+bool
+DispatchThreadTracer::intersects(const DispatchThreadTracer& rhs) const
+{
+    std::shared_lock<std::shared_mutex>       lk(agents_map_mut);
+    std::shared_lock<std::shared_mutex>       lk_rhs(rhs.agents_map_mut);
+    for(const auto& [agent_id, _] : params)
+    {
+        if(rhs.params.count(agent_id) > 0) return true;
+    }
+    return false;
+}
+
 void
 DispatchThreadTracer::start_context()
 {
     // Thread trace no longer registers a per-queue callback with the queue controller; the
     // HSA write interceptor now calls thread_trace::write_hook / signal_completion_hook
-    // directly (see hsa/queue.cpp). We only need to enable kernel serialization here. This is
-    // safe to call before hsa_init.
-    CHECK_NOTNULL(hsa::get_queue_controller())->enable_serialization();
+    // directly (see hsa/queue.cpp). Scope serialization to the agents configured on this
+    // context. An empty set still means every agent.
+    const auto agents = configured_agents();
+    CHECK_NOTNULL(hsa::get_queue_controller())->enable_serialization(agents);
 }
 
 void
@@ -498,9 +528,8 @@ DispatchThreadTracer::stop_context()  // NOLINT(readability-convert-member-funct
     auto* controller = hsa::get_queue_controller();
     if(!controller) return;
 
-    // Thread trace no longer registers a per-queue callback (see start_context); there is
-    // nothing to remove from the queue controller here.
-    controller->disable_serialization();
+    const auto agents = configured_agents();
+    controller->disable_serialization(agents);
 }
 
 DeviceThreadTracer::DeviceThreadTracer()

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
@@ -485,7 +485,7 @@ DispatchThreadTracer::post_kernel_call(DispatchThreadTracer::inst_pkt_t& aql,
 std::unordered_set<rocprofiler_agent_id_t>
 DispatchThreadTracer::configured_agents() const
 {
-    auto result = std::unordered_set<rocprofiler_agent_id_t>{};
+    auto                                result = std::unordered_set<rocprofiler_agent_id_t>{};
     std::shared_lock<std::shared_mutex> lk(agents_map_mut);
     for(const auto& [agent_id, _] : params)
         result.insert(agent_id);
@@ -502,8 +502,8 @@ DispatchThreadTracer::collects_on(rocprofiler_agent_id_t agent_id) const
 bool
 DispatchThreadTracer::intersects(const DispatchThreadTracer& rhs) const
 {
-    std::shared_lock<std::shared_mutex>       lk(agents_map_mut);
-    std::shared_lock<std::shared_mutex>       lk_rhs(rhs.agents_map_mut);
+    std::shared_lock<std::shared_mutex> lk(agents_map_mut);
+    std::shared_lock<std::shared_mutex> lk_rhs(rhs.agents_map_mut);
     for(const auto& [agent_id, _] : params)
     {
         if(rhs.params.count(agent_id) > 0) return true;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
@@ -518,8 +518,8 @@ DispatchThreadTracer::start_context()
     // HSA write interceptor now calls thread_trace::write_hook / signal_completion_hook
     // directly (see hsa/queue.cpp). Scope serialization to the agents configured on this
     // context. An empty set still means every agent.
-    const auto agents = configured_agents();
-    CHECK_NOTNULL(hsa::get_queue_controller())->enable_serialization(agents);
+    const auto serialization_agents = configured_agents();
+    CHECK_NOTNULL(hsa::get_queue_controller())->enable_serialization(serialization_agents);
 }
 
 void
@@ -528,8 +528,8 @@ DispatchThreadTracer::stop_context()  // NOLINT(readability-convert-member-funct
     auto* controller = hsa::get_queue_controller();
     if(!controller) return;
 
-    const auto agents = configured_agents();
-    controller->disable_serialization(agents);
+    const auto serialization_agents = configured_agents();
+    controller->disable_serialization(serialization_agents);
 }
 
 DeviceThreadTracer::DeviceThreadTracer()

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.hpp
@@ -43,9 +43,9 @@
 #include <mutex>
 #include <shared_mutex>
 #include <string>
-#include <unordered_set>
 #include <tuple>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace rocprofiler
@@ -184,8 +184,8 @@ private:
     std::unordered_map<hsa_agent_t, std::unique_ptr<ThreadTracerAgent>>     agents{};
     std::unordered_map<rocprofiler_agent_id_t, thread_trace_parameter_pack> params{};
 
-    std::shared_mutex agents_map_mut{};
-    std::atomic<int>  post_move_data{0};
+    mutable std::shared_mutex agents_map_mut{};
+    std::atomic<int>          post_move_data{0};
 };
 
 class DeviceThreadTracer

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.hpp
@@ -43,6 +43,7 @@
 #include <mutex>
 #include <shared_mutex>
 #include <string>
+#include <unordered_set>
 #include <tuple>
 #include <unordered_map>
 #include <vector>
@@ -157,6 +158,9 @@ public:
     void resource_init();
     void resource_deinit();
 
+    bool collects_on(rocprofiler_agent_id_t agent_id) const;
+    bool intersects(const DispatchThreadTracer& rhs) const;
+
     void add_agent(rocprofiler_agent_id_t agent, thread_trace_parameter_pack pack)
     {
         auto lk       = std::unique_lock{agents_map_mut};
@@ -173,6 +177,8 @@ public:
                                  const hsa::queue_info_session_t& session,
                                  const hsa::packet_data_t&        packet_data);
     const auto& get_agents() const { return agents; }
+
+    std::unordered_set<rocprofiler_agent_id_t> configured_agents() const;
 
 private:
     std::unordered_map<hsa_agent_t, std::unique_ptr<ThreadTracerAgent>>     agents{};

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/queue_hooks.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/queue_hooks.cpp
@@ -21,6 +21,8 @@
 // THE SOFTWARE.
 
 #include "lib/rocprofiler-sdk/thread_trace/queue_hooks.hpp"
+#include "lib/rocprofiler-sdk/hsa/agent_cache.hpp"
+#include "lib/rocprofiler-sdk/hsa/queue.hpp"
 #include "lib/rocprofiler-sdk/hsa/queue_hooks/client_ids.hpp"
 #include "lib/rocprofiler-sdk/thread_trace/core.hpp"
 
@@ -50,10 +52,14 @@ write_hook(const hsa::Queue& queue,
            hsa::inst_pkt_t&               inst_pkt,
            bool&                          is_serialized)
 {
+    const auto agent_id = CHECK_NOTNULL(queue.get_agent().get_rocp_agent())->id;
+
     auto active = context::get_active_contexts(active_thread_trace_contexts_filter());
     for(auto* ctx : active)
     {
         auto& tracer = *ctx->dispatch_thread_trace;
+        if(!tracer.collects_on(agent_id)) continue;
+
         auto [packet, bSerial] =
             tracer.pre_kernel_call(queue, kernel_id, dispatch_id, user_data, correlation_id);
         if(packet)


### PR DESCRIPTION


## Motivation


<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

This PR applies per-agent scoping from PR #9868 to the thread-trace callback-removal branch.

## Technical Details

- Per-agent serialization ref-counting in queue_controller
- DispatchThreadTracer configured_agents/collects_on/intersects helpers
- Scoped enable/disable serialization in start_context/stop_context
- Agent filtering in thread_trace::write_hook
- Disjoint dispatch ATT context conflict rules

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
