### PR TITLE
fix(rocjitsu): honor TDM tensor bounds across iterations

### DIFF
--- a/emulation/rocjitsu/README.md
+++ b/emulation/rocjitsu/README.md
@@ -133,6 +133,7 @@ See [docs/building.md](docs/building.md) for container setup with PyTorch.
 | [Simdojo Engine](docs/simdojo.md) | PDES simulation framework |
 | [DBT Design](docs/dbt-design.md) | Binary translator architecture |
 | [DBI Design](docs/dbi-design.md) | Binary instrumentation (in progress) |
+| [CDNA5 Tensor DMA](docs/tensor-dma.md) | gfx1250 tensor descriptor, bounds, iteration, gather, and padding model |
 | [Codegen](docs/codegen.md) | ISA codegen pipeline and regen commands |
 | [ISA Target Providers](docs/isa-target-providers.md) | Static target registration and per-component subsets |
 

--- a/emulation/rocjitsu/docs/tensor-dma.md
+++ b/emulation/rocjitsu/docs/tensor-dma.md
@@ -1,0 +1,192 @@
+# CDNA5 Tensor DMA model
+
+rocJITsu models the Tensor Data Mover (TDM) used by gfx1250/CDNA5
+`tensor_load_to_lds` and `tensor_store_from_lds` instructions. TDM moves a
+rectangular tile between global memory and LDS without routing element data
+through VGPRs.
+
+The primary architectural reference is the
+[AMD CDNA5 ISA Reference Guide](https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/instruction-set-architectures/amd-instinct-cdna5-instruction-set-architecture.pdf),
+especially sections 10.11.1 through 10.11.6. The descriptor field layout is
+also exposed by the ROCm HIP header
+`hip/amd_detail/amd_gfx1250_TDM.h`. LLVM's AMDGPU
+`make_dma_descriptor` lowering is the reference for descriptors produced from
+MLIR.
+
+This document covers descriptor coordinates, bounds, iteration, gather, LDS
+padding, and completion. Group 0 transfer enablement, process/VMID address
+translation, and cache visibility are separate runtime contracts.
+
+## Descriptor coordinate system
+
+Tensor dimensions are numbered from the contiguous dimension outward.
+Dimension zero has implicit element stride one. For an element coordinate
+`c`, the global element offset is:
+
+```text
+offset(c) =
+    c[0]
+  + c[1] * global_stride[0]
+  + c[2] * global_stride[1]
+  + c[3] * global_stride[2]
+  + c[4] * global_stride[3]
+```
+
+The byte address is:
+
+```text
+global_base + element_size * offset(c)
+```
+
+The stride fields are consumed literally. A zero stride aliases coordinates;
+it is not interpreted as an omitted dense stride. Logical dimension order and
+increasing memory-stride order may differ, so a descriptor can represent
+permuted or padded layouts.
+
+Normal descriptor rank is inferred from the highest active tile dimension.
+Gather mode is architecturally always rank two: `tile_dim0` is the contiguous
+row width, the descriptor's repurposed `tile_dim1` field is the number of
+gather indices, and `tensor_dim1` is the row bound. A null descriptor group is
+equivalent to a group whose SGPR values are zero; it does not remove an active
+dimension established by an earlier group.
+
+## Tile traversal and bounds
+
+For a non-gather tile, rocJITsu enumerates tile coordinates with dimension zero
+varying fastest. LDS receives or supplies one dense element stream. The global
+address uses the descriptor strides while the LDS stream uses the tile
+extents.
+
+The active tensor domain is:
+
+```text
+0 <= c[dimension] < tensor_extent[dimension]
+```
+
+If any active tensor extent is zero, the domain is empty. This follows directly
+from the ISA's positive-end bounds rule; zero is not an "unbounded" sentinel.
+
+For elements outside the active tensor domain:
+
+- a tensor load writes zero to the corresponding LDS element; and
+- a tensor store suppresses the corresponding global-memory write.
+
+The transfer still completes normally. In particular, it retires TENSORcnt and
+performs an enabled completion-barrier arrival even if every element is
+masked.
+
+## Descriptor iteration
+
+Iteration is available for rank-two and rank-three normal tensors. For
+iteration `i`, the descriptor advances the starting addresses by:
+
+```text
+global element offset = i * global_increment
+LDS element offset    = i * lds_increment
+```
+
+The ISA describes iteration as repeated row-skipping transfers but does not
+provide pseudocode for converting an arbitrary linear global increment back
+into tensor coordinates for bounds checking. rocJITsu makes that conversion
+explicit so that address generation and bounds use the same logical origin.
+
+For every active dimension whose extent is greater than one, rocJITsu
+constructs an address-varying axis:
+
+```text
+(logical dimension, tensor extent, element stride)
+```
+
+Extent-one dimensions remain active for rank and bounds but have only
+coordinate zero, so their stride cannot create overlap and does not consume a
+mixed-radix digit.
+
+The axes are sorted by increasing stride. A layout supports advancing
+iteration when every axis starts at or beyond the complete occupied span of
+all faster axes. Starting with an occupied span of one element:
+
+```text
+stride[axis] >= occupied_span
+occupied_span += stride[axis] * (extent[axis] - 1)
+```
+
+Saturating arithmetic is used for validation. This mixed-radix condition
+supports ordinary dense layouts, padding between rows or planes, and axis
+permutations while guaranteeing a unique greedy inverse.
+
+The iteration origin is decoded in decreasing-stride order:
+
+```text
+origin[axis] = remaining / stride[axis]
+remaining    = remaining % stride[axis]
+```
+
+Bounds are then checked using:
+
+```text
+origin[dimension] + tile_coordinate[dimension]
+    < tensor_extent[dimension]
+```
+
+rocJITsu rejects an advancing, non-empty iterating descriptor when its stride
+layout does not satisfy the invertibility condition. No inverse is required
+for:
+
+- a single iteration;
+- repeated iterations with `global_increment == 0`; or
+- an empty tensor domain.
+
+This rejection is a simulator support boundary, not an additional ISA
+restriction. Non-iterating descriptors may use overlapping or zero strides
+because their global addresses do not need to be inverted.
+
+## Gather and scatter
+
+Gather mode is a two-dimensional row operation. Each index selects a global
+row and transfers `tile_dim0` contiguous elements:
+
+```text
+global element offset =
+    contiguous_coordinate + gather_index * global_stride[0]
+```
+
+Rows are packed densely into LDS in index-list order. The same index list
+performs the reverse scatter for `tensor_store_from_lds`.
+
+The ISA allows repeated and non-monotonic indices, but only guarantees correct
+out-of-bounds behavior when the index list is nondecreasing. rocJITsu currently
+applies deterministic per-index bounds checks even for other index orders.
+
+## LDS padding
+
+Padding applies only to memory-to-LDS loads. It inserts periodic gaps in the
+dense LDS destination stream; skipped locations retain their previous values.
+
+For LDS-to-memory stores, the ISA specifies no de-padding operation. rocJITsu
+therefore ignores `pad_enable`, `pad_interval`, and `pad_amount` and reads the
+ordinary dense LDS source stream.
+
+## Completion and ordering
+
+Each tensor instruction increments TENSORcnt once for the complete descriptor,
+not once per element or iteration. Tensor operations from one wave complete in
+instruction order but are unordered with other memory-instruction classes.
+
+When `atomic_barrier_enable` is set, the LDS barrier arrival occurs after the
+complete tensor operation. It is a completion effect and is not conditional on
+the number of in-bounds elements.
+
+## Focused validation
+
+The `Gfx1250ExecutionTest.TensorDma*` tests in
+`tests/cdna5_tensor_dma_test.cpp` cover:
+
+- dense, padded, iterating, and gather load/store addressing;
+- sub-row, row, plane, padded, and permuted iteration origins;
+- truly overlapping versus merely permuted stride layouts;
+- aliased strides on extent-one dimensions;
+- zero extents in every modeled transfer form;
+- literal zero gather stride;
+- null descriptor groups;
+- out-of-bounds load zero-fill and store suppression; and
+- TENSORcnt and completion-barrier retirement.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/tensor_dma.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/tensor_dma.h
@@ -14,6 +14,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <span>
 
 namespace rocjitsu {
@@ -184,6 +185,35 @@ inline TensorDmaDescriptor parse_descriptor(std::array<uint32_t, 4> d0, std::arr
   return desc;
 }
 
+inline bool has_empty_active_extent(const TensorDmaDescriptor &desc, uint32_t rank) {
+  return std::any_of(desc.tensor_dims.begin(), desc.tensor_dims.begin() + rank,
+                     [](uint32_t extent) { return extent == 0; });
+}
+
+inline uint64_t saturating_add(uint64_t lhs, uint64_t rhs) {
+  return rhs > std::numeric_limits<uint64_t>::max() - lhs ? std::numeric_limits<uint64_t>::max()
+                                                          : lhs + rhs;
+}
+
+inline uint64_t saturating_multiply(uint64_t lhs, uint64_t rhs) {
+  return lhs != 0 && rhs > std::numeric_limits<uint64_t>::max() / lhs
+             ? std::numeric_limits<uint64_t>::max()
+             : lhs * rhs;
+}
+
+inline void validate_dense_iteration_layout(const TensorDmaDescriptor &desc, uint32_t rank) {
+  uint64_t occupied_span = desc.tensor_dims[0];
+  for (uint32_t dim = 1; dim < rank; ++dim) {
+    const uint64_t stride = desc.global_strides[dim - 1];
+    if (stride < occupied_span)
+      throw util::UnimplementedInst("tensor DMA iterate overlapping strides");
+
+    const uint64_t additional_span =
+        saturating_multiply(stride, static_cast<uint64_t>(desc.tensor_dims[dim] - 1));
+    occupied_span = saturating_add(occupied_span, additional_span);
+  }
+}
+
 inline void validate_supported_descriptor(const TensorDmaDescriptor &desc, bool store_from_lds) {
   // The in-tree HIP descriptor API and LLVM lowering only produce the boolean
   // count encodings 0 (disabled) and 1 (active).
@@ -213,10 +243,30 @@ inline void validate_supported_descriptor(const TensorDmaDescriptor &desc, bool 
   }
   if (desc.iterate && (rank < 2 || rank > 3))
     throw util::UnimplementedInst("tensor DMA iterate rank");
+  if (desc.iterate && desc.iteration_count > 1 && desc.global_increment != 0 &&
+      !has_empty_active_extent(desc, rank))
+    validate_dense_iteration_layout(desc, rank);
   for (uint32_t dim = 0; dim < rank; ++dim) {
     if (desc.tile_dims[dim] == 0)
       throw util::UnimplementedInst("tensor DMA sparse tile dimensions");
   }
+}
+
+inline std::array<uint64_t, 5> dense_iteration_origin(const TensorDmaDescriptor &desc,
+                                                      uint32_t rank, uint32_t iteration) {
+  std::array<uint64_t, 5> origin{};
+  if (iteration == 0 || desc.global_increment == 0)
+    return origin;
+
+  uint64_t remaining = static_cast<uint64_t>(iteration) * desc.global_increment;
+  for (uint32_t dim = rank; dim > 1; --dim) {
+    const uint32_t coordinate = dim - 1;
+    const uint64_t stride = desc.global_strides[coordinate - 1];
+    origin[coordinate] = remaining / stride;
+    remaining %= stride;
+  }
+  origin[0] = remaining;
+  return origin;
 }
 
 inline void copy_bytes(const TensorDmaDescriptor &desc, Wavefront &wf, uint64_t global_element,
@@ -255,21 +305,22 @@ inline void copy_gather_tensor(const TensorDmaDescriptor &desc, Wavefront &wf,
   const uint32_t rank = desc.rank();
   if (rank == 0)
     return;
+  const bool fully_masked = has_empty_active_extent(desc, rank);
 
   for (uint32_t idx = 0; idx < desc.valid_indices; ++idx) {
     const uint32_t gather_index = desc.gather_indices[idx];
     for (uint32_t coord0 = 0; coord0 < desc.tile_dims[0]; ++coord0) {
-      bool in_bounds = true;
+      bool in_bounds = !fully_masked;
       uint64_t global_element = coord0;
       if (rank == 1) {
         global_element += gather_index;
-        if (desc.tensor_dims[0] != 0 && global_element >= desc.tensor_dims[0])
+        if (global_element >= desc.tensor_dims[0])
           in_bounds = false;
       } else {
         global_element += static_cast<uint64_t>(gather_index) * desc.global_strides[0];
-        if (desc.tensor_dims[0] != 0 && coord0 >= desc.tensor_dims[0])
+        if (coord0 >= desc.tensor_dims[0])
           in_bounds = false;
-        if (desc.tensor_dims[1] != 0 && gather_index >= desc.tensor_dims[1])
+        if (gather_index >= desc.tensor_dims[1])
           in_bounds = false;
       }
 
@@ -284,6 +335,7 @@ inline void copy_dense_tensor(const TensorDmaDescriptor &desc, Wavefront &wf, bo
   const uint32_t rank = desc.rank();
   if (rank == 0)
     return;
+  const bool fully_masked = has_empty_active_extent(desc, rank);
 
   uint64_t element_count = 1;
   for (uint32_t dim = 0; dim < rank; ++dim)
@@ -291,18 +343,21 @@ inline void copy_dense_tensor(const TensorDmaDescriptor &desc, Wavefront &wf, bo
 
   const uint32_t iteration_count = desc.iterate ? desc.iteration_count : 1;
   for (uint32_t iter = 0; iter < iteration_count; ++iter) {
+    const auto iteration_origin =
+        desc.iterate ? dense_iteration_origin(desc, rank, iter) : std::array<uint64_t, 5>{};
     for (uint64_t linear = 0; linear < element_count; ++linear) {
       uint64_t remaining = linear;
       uint64_t global_element = static_cast<uint64_t>(iter) * desc.global_increment;
       uint64_t lds_element = static_cast<uint64_t>(iter) * desc.lds_increment;
       uint64_t lds_stride = 1;
-      bool in_bounds = true;
+      bool in_bounds = !fully_masked;
 
       for (uint32_t dim = 0; dim < rank; ++dim) {
         const uint32_t tile_dim = desc.tile_dims[dim];
         const uint32_t coord = static_cast<uint32_t>(remaining % tile_dim);
         remaining /= tile_dim;
-        if (desc.tensor_dims[dim] != 0 && coord >= desc.tensor_dims[dim])
+        const uint64_t tensor_coord = iteration_origin[dim] + coord;
+        if (tensor_coord >= desc.tensor_dims[dim])
           in_bounds = false;
         global_element += coord * (dim == 0 ? 1 : desc.global_strides[dim - 1]);
         lds_element += coord * lds_stride;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/tensor_dma.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/tensor_dma.h
@@ -10,7 +10,6 @@
 #include "rocjitsu/vm/amdgpu/wavefront.h"
 #include "util/except.h"
 
-#include <algorithm>
 #include <array>
 #include <cstddef>
 #include <cstdint>
@@ -22,6 +21,8 @@ namespace amdgpu {
 
 namespace tensor_dma_detail {
 
+// See docs/tensor-dma.md for the CDNA5 descriptor coordinate system,
+// ISA-backed behavior, and rocJITsu's advancing-iteration support boundary.
 constexpr int kSgprNull = 124;
 constexpr uint32_t kGlobalHighBitsMask = (1u << 25) - 1u;
 
@@ -74,6 +75,7 @@ struct TensorDmaDescriptor {
   uint32_t iteration_count = 1;
   uint32_t atomic_barrier_addr = 0;
   uint32_t valid_indices = 0;
+  uint32_t tensor_rank = 0;
   std::array<uint32_t, 16> gather_indices{};
   bool gather = false;
   bool gather_indices_32bit = false;
@@ -83,28 +85,8 @@ struct TensorDmaDescriptor {
 
   bool active() const { return count != 0; }
 
-  uint32_t rank() const {
-    if (gather) {
-      if (tensor_dims[1] != 0)
-        return 2;
-      if (tensor_dims[0] != 0 || tile_dims[0] != 0 || valid_indices != 0)
-        return 1;
-      return 0;
-    }
-    for (uint32_t i = static_cast<uint32_t>(tile_dims.size()); i > 0; --i) {
-      if (tile_dims[i - 1] != 0)
-        return i;
-    }
-    return 0;
-  }
+  uint32_t rank() const { return tensor_rank; }
 };
-
-inline uint64_t default_stride(const TensorDmaDescriptor &desc, uint32_t stride_index) {
-  uint64_t stride = 1;
-  for (uint32_t dim = 0; dim <= stride_index; ++dim)
-    stride *= std::max(desc.tensor_dims[dim], 1u);
-  return stride;
-}
 
 inline TensorDmaDescriptor parse_descriptor(std::array<uint32_t, 4> d0, std::array<uint32_t, 8> d1,
                                             std::array<uint32_t, 4> d2,
@@ -163,10 +145,20 @@ inline TensorDmaDescriptor parse_descriptor(std::array<uint32_t, 4> d0, std::arr
   else
     desc.global_strides[2] = read_bits(d2, 64, 48);
   desc.global_strides[3] = read_bits(d3, 0, 48);
-  for (uint32_t i = 0; i < desc.global_strides.size(); ++i) {
-    if (desc.global_strides[i] == 0)
-      desc.global_strides[i] = default_stride(desc, i);
+
+  if (desc.gather) {
+    // CDNA5 gather mode is always a 2D row gather/scatter. tensor_dim1 is the
+    // row bound even when its value is zero.
+    desc.tensor_rank = 2;
+  } else {
+    for (uint32_t dim = static_cast<uint32_t>(desc.tile_dims.size()); dim > 0; --dim) {
+      if (desc.tile_dims[dim - 1] != 0) {
+        desc.tensor_rank = dim;
+        break;
+      }
+    }
   }
+
   if (desc.gather) {
     if (desc.gather_indices_32bit) {
       for (uint32_t i = 0; i < 4; ++i)
@@ -185,11 +177,6 @@ inline TensorDmaDescriptor parse_descriptor(std::array<uint32_t, 4> d0, std::arr
   return desc;
 }
 
-inline bool has_empty_active_extent(const TensorDmaDescriptor &desc, uint32_t rank) {
-  return std::any_of(desc.tensor_dims.begin(), desc.tensor_dims.begin() + rank,
-                     [](uint32_t extent) { return extent == 0; });
-}
-
 inline uint64_t saturating_add(uint64_t lhs, uint64_t rhs) {
   return rhs > std::numeric_limits<uint64_t>::max() - lhs ? std::numeric_limits<uint64_t>::max()
                                                           : lhs + rhs;
@@ -201,36 +188,106 @@ inline uint64_t saturating_multiply(uint64_t lhs, uint64_t rhs) {
              : lhs * rhs;
 }
 
-inline void validate_dense_iteration_layout(const TensorDmaDescriptor &desc, uint32_t rank) {
-  uint64_t occupied_span = desc.tensor_dims[0];
-  for (uint32_t dim = 1; dim < rank; ++dim) {
-    const uint64_t stride = desc.global_strides[dim - 1];
-    if (stride < occupied_span)
-      throw util::UnimplementedInst("tensor DMA iterate overlapping strides");
+struct TensorDmaAxis {
+  uint32_t dimension = 0;
+  uint32_t extent = 0;
+  uint64_t stride = 0;
+};
 
-    const uint64_t additional_span =
-        saturating_multiply(stride, static_cast<uint64_t>(desc.tensor_dims[dim] - 1));
-    occupied_span = saturating_add(occupied_span, additional_span);
+class TensorDmaLayout {
+public:
+  explicit TensorDmaLayout(const TensorDmaDescriptor &desc) : rank_(desc.rank()) {
+    for (uint32_t dim = 0; dim < rank_; ++dim) {
+      const uint32_t extent = desc.tensor_dims[dim];
+      empty_ |= extent == 0;
+      if (extent > 1) {
+        axes_[axis_count_++] = {.dimension = dim,
+                                .extent = extent,
+                                .stride = dim == 0 ? 1 : desc.global_strides[dim - 1]};
+      }
+    }
+
+    // Logical dimension order and increasing memory-stride order may differ.
+    // Validation and inversion must use the same storage-ordered basis.
+    // Extent-one axes have only coordinate zero and consume no address span.
+    // Use a bounded insertion sort: GCC 13 can report a false-positive
+    // -Warray-bounds error when std::sort is optimized for this five-element array.
+    for (uint32_t axis_idx = 1; axis_idx < axis_count_; ++axis_idx) {
+      const TensorDmaAxis axis = axes_[axis_idx];
+      uint32_t insertion_idx = axis_idx;
+      while (insertion_idx > 0) {
+        const auto &previous = axes_[insertion_idx - 1];
+        const bool axis_precedes_previous =
+            axis.stride < previous.stride ||
+            (axis.stride == previous.stride && axis.dimension < previous.dimension);
+        if (!axis_precedes_previous)
+          break;
+        axes_[insertion_idx] = previous;
+        --insertion_idx;
+      }
+      axes_[insertion_idx] = axis;
+    }
   }
-}
 
-inline void validate_supported_descriptor(const TensorDmaDescriptor &desc, bool store_from_lds) {
+  uint32_t rank() const { return rank_; }
+  bool empty() const { return empty_; }
+
+  void validate_iteration_inverse() const {
+    if (empty_)
+      return;
+
+    uint64_t occupied_span = 1;
+    for (uint32_t axis_idx = 0; axis_idx < axis_count_; ++axis_idx) {
+      const auto &axis = axes_[axis_idx];
+      // Each axis must begin beyond the complete span of all faster axes for
+      // greedy mixed-radix inversion to be unique.
+      if (axis.stride < occupied_span)
+        throw util::UnimplementedInst("tensor DMA iterate non-invertible strides");
+
+      const uint64_t additional_span =
+          saturating_multiply(axis.stride, static_cast<uint64_t>(axis.extent - 1));
+      occupied_span = saturating_add(occupied_span, additional_span);
+    }
+  }
+
+  std::array<uint64_t, 5> origin_from_linear_offset(uint64_t linear_offset) const {
+    std::array<uint64_t, 5> origin{};
+    if (linear_offset == 0)
+      return origin;
+
+    for (uint32_t axis_idx = axis_count_; axis_idx > 0; --axis_idx) {
+      const auto &axis = axes_[axis_idx - 1];
+      origin[axis.dimension] = linear_offset / axis.stride;
+      linear_offset %= axis.stride;
+    }
+    // Dimension zero has implicit stride one. If it was omitted because its
+    // extent is one, preserve any padding remainder there so bounds masking
+    // rejects offsets outside the tensor domain.
+    if (linear_offset != 0)
+      origin[0] = linear_offset;
+    return origin;
+  }
+
+private:
+  std::array<TensorDmaAxis, 5> axes_{};
+  uint32_t rank_ = 0;
+  uint32_t axis_count_ = 0;
+  bool empty_ = false;
+};
+
+inline void validate_supported_descriptor(const TensorDmaDescriptor &desc,
+                                          const TensorDmaLayout &layout) {
   // The in-tree HIP descriptor API and LLVM lowering only produce the boolean
   // count encodings 0 (disabled) and 1 (active).
   if (desc.count > 1)
     throw util::UnimplementedInst("tensor DMA count encoding");
-  // LLVM MLIR's AMDGPU dialect documents padding only for memory-to-LDS copies.
-  if (desc.pad && store_from_lds)
-    throw util::UnimplementedInst("tensor DMA padded store descriptor");
   if (desc.elem_size != 1 && desc.elem_size != 2 && desc.elem_size != 4 && desc.elem_size != 8)
     throw util::UnimplementedInst("tensor DMA element size");
-  const uint32_t rank = desc.rank();
+  const uint32_t rank = layout.rank();
   if (!desc.gather && desc.gather_indices_32bit)
     throw util::UnimplementedInst("tensor DMA gather index-size bit without gather");
   if (desc.gather) {
-    if (rank == 0)
-      return;
-    if (rank > 2)
+    if (rank != 2)
       throw util::UnimplementedInst("tensor DMA gather rank");
     if (desc.tile_dims[0] == 0)
       throw util::UnimplementedInst("tensor DMA gather tile dimension");
@@ -243,30 +300,12 @@ inline void validate_supported_descriptor(const TensorDmaDescriptor &desc, bool 
   }
   if (desc.iterate && (rank < 2 || rank > 3))
     throw util::UnimplementedInst("tensor DMA iterate rank");
-  if (desc.iterate && desc.iteration_count > 1 && desc.global_increment != 0 &&
-      !has_empty_active_extent(desc, rank))
-    validate_dense_iteration_layout(desc, rank);
+  if (desc.iterate && desc.iteration_count > 1 && desc.global_increment != 0)
+    layout.validate_iteration_inverse();
   for (uint32_t dim = 0; dim < rank; ++dim) {
     if (desc.tile_dims[dim] == 0)
       throw util::UnimplementedInst("tensor DMA sparse tile dimensions");
   }
-}
-
-inline std::array<uint64_t, 5> dense_iteration_origin(const TensorDmaDescriptor &desc,
-                                                      uint32_t rank, uint32_t iteration) {
-  std::array<uint64_t, 5> origin{};
-  if (iteration == 0 || desc.global_increment == 0)
-    return origin;
-
-  uint64_t remaining = static_cast<uint64_t>(iteration) * desc.global_increment;
-  for (uint32_t dim = rank; dim > 1; --dim) {
-    const uint32_t coordinate = dim - 1;
-    const uint64_t stride = desc.global_strides[coordinate - 1];
-    origin[coordinate] = remaining / stride;
-    remaining %= stride;
-  }
-  origin[0] = remaining;
-  return origin;
 }
 
 inline void copy_bytes(const TensorDmaDescriptor &desc, Wavefront &wf, uint64_t global_element,
@@ -276,7 +315,9 @@ inline void copy_bytes(const TensorDmaDescriptor &desc, Wavefront &wf, uint64_t 
 
   const uint64_t global_addr = desc.global_base + global_element * desc.elem_size;
   uint64_t lds_byte = lds_element * desc.elem_size;
-  if (desc.pad) {
+  // The ISA applies descriptor padding only to memory-to-LDS transfers.
+  // Stores read the ordinary dense LDS stream and ignore the padding fields.
+  if (desc.pad && !store_from_lds) {
     const uint32_t pad_interval_bytes = desc.pad_interval * sizeof(uint32_t);
     const uint32_t pad_amount_bytes = desc.pad_amount * sizeof(uint32_t);
     lds_byte += (lds_byte / pad_interval_bytes) * pad_amount_bytes;
@@ -300,29 +341,18 @@ inline void copy_bytes(const TensorDmaDescriptor &desc, Wavefront &wf, uint64_t 
     wf.lds().write8(lds_addr + byte, element_bytes[byte]);
 }
 
-inline void copy_gather_tensor(const TensorDmaDescriptor &desc, Wavefront &wf,
-                               bool store_from_lds) {
-  const uint32_t rank = desc.rank();
-  if (rank == 0)
-    return;
-  const bool fully_masked = has_empty_active_extent(desc, rank);
-
+inline void copy_gather_tensor(const TensorDmaDescriptor &desc, const TensorDmaLayout &layout,
+                               Wavefront &wf, bool store_from_lds) {
   for (uint32_t idx = 0; idx < desc.valid_indices; ++idx) {
     const uint32_t gather_index = desc.gather_indices[idx];
     for (uint32_t coord0 = 0; coord0 < desc.tile_dims[0]; ++coord0) {
-      bool in_bounds = !fully_masked;
-      uint64_t global_element = coord0;
-      if (rank == 1) {
-        global_element += gather_index;
-        if (global_element >= desc.tensor_dims[0])
-          in_bounds = false;
-      } else {
-        global_element += static_cast<uint64_t>(gather_index) * desc.global_strides[0];
-        if (coord0 >= desc.tensor_dims[0])
-          in_bounds = false;
-        if (gather_index >= desc.tensor_dims[1])
-          in_bounds = false;
-      }
+      bool in_bounds = !layout.empty();
+      const uint64_t global_element =
+          coord0 + static_cast<uint64_t>(gather_index) * desc.global_strides[0];
+      if (coord0 >= desc.tensor_dims[0])
+        in_bounds = false;
+      if (gather_index >= desc.tensor_dims[1])
+        in_bounds = false;
 
       const uint64_t lds_element =
           static_cast<uint64_t>(idx) * desc.tile_dims[0] + static_cast<uint64_t>(coord0);
@@ -331,11 +361,11 @@ inline void copy_gather_tensor(const TensorDmaDescriptor &desc, Wavefront &wf,
   }
 }
 
-inline void copy_dense_tensor(const TensorDmaDescriptor &desc, Wavefront &wf, bool store_from_lds) {
-  const uint32_t rank = desc.rank();
+inline void copy_dense_tensor(const TensorDmaDescriptor &desc, const TensorDmaLayout &layout,
+                              Wavefront &wf, bool store_from_lds) {
+  const uint32_t rank = layout.rank();
   if (rank == 0)
     return;
-  const bool fully_masked = has_empty_active_extent(desc, rank);
 
   uint64_t element_count = 1;
   for (uint32_t dim = 0; dim < rank; ++dim)
@@ -343,14 +373,16 @@ inline void copy_dense_tensor(const TensorDmaDescriptor &desc, Wavefront &wf, bo
 
   const uint32_t iteration_count = desc.iterate ? desc.iteration_count : 1;
   for (uint32_t iter = 0; iter < iteration_count; ++iter) {
-    const auto iteration_origin =
-        desc.iterate ? dense_iteration_origin(desc, rank, iter) : std::array<uint64_t, 5>{};
+    const uint64_t iteration_offset = static_cast<uint64_t>(iter) * desc.global_increment;
+    const auto iteration_origin = desc.iterate && !layout.empty()
+                                      ? layout.origin_from_linear_offset(iteration_offset)
+                                      : std::array<uint64_t, 5>{};
     for (uint64_t linear = 0; linear < element_count; ++linear) {
       uint64_t remaining = linear;
-      uint64_t global_element = static_cast<uint64_t>(iter) * desc.global_increment;
+      uint64_t global_element = iteration_offset;
       uint64_t lds_element = static_cast<uint64_t>(iter) * desc.lds_increment;
       uint64_t lds_stride = 1;
-      bool in_bounds = !fully_masked;
+      bool in_bounds = !layout.empty();
 
       for (uint32_t dim = 0; dim < rank; ++dim) {
         const uint32_t tile_dim = desc.tile_dims[dim];
@@ -370,11 +402,12 @@ inline void copy_dense_tensor(const TensorDmaDescriptor &desc, Wavefront &wf, bo
 }
 
 inline void copy_tensor(const TensorDmaDescriptor &desc, Wavefront &wf, bool store_from_lds) {
-  validate_supported_descriptor(desc, store_from_lds);
+  const TensorDmaLayout layout(desc);
+  validate_supported_descriptor(desc, layout);
   if (desc.gather)
-    copy_gather_tensor(desc, wf, store_from_lds);
+    copy_gather_tensor(desc, layout, wf, store_from_lds);
   else
-    copy_dense_tensor(desc, wf, store_from_lds);
+    copy_dense_tensor(desc, layout, wf, store_from_lds);
 }
 
 inline void arrive_atomic_barrier(const TensorDmaDescriptor &desc, Wavefront &wf) {

--- a/emulation/rocjitsu/tests/cdna5_tensor_dma_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_tensor_dma_test.cpp
@@ -507,6 +507,496 @@ TEST(Gfx1250ExecutionTest, TensorDmaUnsupportedCountEncodingsAreRejected) {
   }
 }
 
+TEST(Gfx1250ExecutionTest, TensorDmaIterateMasksRowsBeyondTensorDimension) {
+  // Two iterations cover four rows, but the tensor has only three. The final
+  // repeated row must be zero-filled instead of copied from global memory.
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf, nullptr);
+  wf->set_lds_base(cu->allocate_lds(256));
+
+  constexpr uint64_t kGlobal = 0x131000;
+  constexpr uint32_t kCols = 2;
+  constexpr uint32_t kRows = 3;
+  constexpr uint32_t kTileRows = 2;
+  constexpr uint32_t kIterations = 2;
+  write_tensor_dma_d0(*cu, *wf, 0, kGlobal);
+  write_wave_sgpr(*cu, *wf, 12, (2u << 16) | (1u << 19)); // i32, iterate enabled.
+  write_wave_sgpr(*cu, *wf, 13, kCols << 16);             // tensor dim0.
+  write_wave_sgpr(*cu, *wf, 14, kRows << 16);             // tensor dim1.
+  write_wave_sgpr(*cu, *wf, 15, kCols << 16);             // tile dim0.
+  write_wave_sgpr(*cu, *wf, 16, kTileRows);               // tile dim1.
+  write_wave_sgpr(*cu, *wf, 17, kCols);                   // tensor dim0 stride.
+  write_wave_sgpr(*cu, *wf, 18, 0);
+  write_wave_sgpr(*cu, *wf, 19, 0);
+  write_wave_sgpr(*cu, *wf, 20, 0);
+  write_wave_sgpr(*cu, *wf, 21, kCols * kTileRows); // LDS increment in elements.
+  write_wave_sgpr(*cu, *wf, 22, kCols * kTileRows); // Global increment in elements.
+  write_wave_sgpr(*cu, *wf, 23, (kIterations - 1) << 16);
+
+  for (uint32_t row = 0; row < kTileRows * kIterations; ++row) {
+    for (uint32_t col = 0; col < kCols; ++col)
+      write_global_u32(*sim.memory, kGlobal + (row * kCols + col) * 4,
+                       0x45000000u + row * 0x100u + col);
+  }
+
+  const std::array<uint32_t, 3> load_words = {0xd0710001u, 0x7c000000u, 0x7c140c00u};
+  auto load = decode_gfx1250(load_words, "tensor_load_to_lds");
+  ASSERT_NE(load, nullptr);
+  load->execute(*load, wf);
+
+  for (uint32_t row = 0; row < kTileRows * kIterations; ++row) {
+    for (uint32_t col = 0; col < kCols; ++col) {
+      const uint32_t actual =
+          cu->lds().read32(wf->lds_base() + (row * kCols + col) * sizeof(uint32_t));
+      const uint32_t expected = row < kRows ? 0x45000000u + row * 0x100u + col : 0u;
+      EXPECT_EQ(actual, expected) << "row " << row << ", col " << col;
+    }
+  }
+}
+
+TEST(Gfx1250ExecutionTest, TensorDmaIterateStoreSkipsRowsBeyondTensorDimension) {
+  // Two iterations source four LDS rows, but the tensor has only three. The
+  // final repeated row must not overwrite global memory.
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf, nullptr);
+  wf->set_lds_base(cu->allocate_lds(256));
+
+  constexpr uint64_t kGlobal = 0x136000;
+  constexpr uint32_t kCols = 2;
+  constexpr uint32_t kRows = 3;
+  constexpr uint32_t kTileRows = 2;
+  constexpr uint32_t kIterations = 2;
+  constexpr uint32_t kSentinel = 0xAC1DAC1Du;
+  write_tensor_dma_d0(*cu, *wf, 0, kGlobal);
+  write_wave_sgpr(*cu, *wf, 12, (2u << 16) | (1u << 19)); // i32, iterate enabled.
+  write_wave_sgpr(*cu, *wf, 13, kCols << 16);             // tensor dim0.
+  write_wave_sgpr(*cu, *wf, 14, kRows << 16);             // tensor dim1.
+  write_wave_sgpr(*cu, *wf, 15, kCols << 16);             // tile dim0.
+  write_wave_sgpr(*cu, *wf, 16, kTileRows);               // tile dim1.
+  write_wave_sgpr(*cu, *wf, 17, kCols);                   // tensor dim0 stride.
+  write_wave_sgpr(*cu, *wf, 18, 0);
+  write_wave_sgpr(*cu, *wf, 19, 0);
+  write_wave_sgpr(*cu, *wf, 20, 0);
+  write_wave_sgpr(*cu, *wf, 21, kCols * kTileRows); // LDS increment in elements.
+  write_wave_sgpr(*cu, *wf, 22, kCols * kTileRows); // Global increment in elements.
+  write_wave_sgpr(*cu, *wf, 23, (kIterations - 1) << 16);
+
+  for (uint32_t row = 0; row < kTileRows * kIterations; ++row) {
+    for (uint32_t col = 0; col < kCols; ++col) {
+      write_global_u32(*sim.memory, kGlobal + (row * kCols + col) * 4, kSentinel);
+      cu->lds().write32(wf->lds_base() + (row * kCols + col) * sizeof(uint32_t),
+                        0x4B000000u + row * 0x100u + col);
+    }
+  }
+
+  const std::array<uint32_t, 3> store_words = {0xd0714001u, 0x7c000000u, 0x7c140c00u};
+  auto store = decode_gfx1250(store_words, "tensor_store_from_lds");
+  ASSERT_NE(store, nullptr);
+  store->execute(*store, wf);
+
+  for (uint32_t row = 0; row < kTileRows * kIterations; ++row) {
+    for (uint32_t col = 0; col < kCols; ++col) {
+      const uint32_t actual =
+          read_global_u32(*sim.memory, kGlobal + (row * kCols + col) * sizeof(uint32_t));
+      const uint32_t expected = row < kRows ? 0x4B000000u + row * 0x100u + col : kSentinel;
+      EXPECT_EQ(actual, expected) << "row " << row << ", col " << col;
+    }
+  }
+}
+
+TEST(Gfx1250ExecutionTest, TensorDmaZeroLengthDimensionMasksEntireTile) {
+  // Global memory contains data and LDS starts nonzero. A zero active tensor
+  // extent must actively zero-fill the tile rather than copy or do nothing.
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf, nullptr);
+  wf->set_lds_base(cu->allocate_lds(256));
+
+  constexpr uint64_t kGlobal = 0x132000;
+  constexpr uint32_t kCols = 2;
+  constexpr uint32_t kTileRows = 2;
+  constexpr uint32_t kSentinel = 0xDEADDEADu;
+  write_tensor_dma_d0(*cu, *wf, 0, kGlobal);
+  write_wave_sgpr(*cu, *wf, 12, 2u << 16);    // i32 elements.
+  write_wave_sgpr(*cu, *wf, 13, kCols << 16); // tensor dim0.
+  write_wave_sgpr(*cu, *wf, 14, 0);           // tensor dim1 has no valid rows.
+  write_wave_sgpr(*cu, *wf, 15, kCols << 16); // tile dim0.
+  write_wave_sgpr(*cu, *wf, 16, kTileRows);   // tile dim1.
+  write_wave_sgpr(*cu, *wf, 17, kCols);       // tensor dim0 stride.
+  write_wave_sgpr(*cu, *wf, 18, 0);
+  write_wave_sgpr(*cu, *wf, 19, 0);
+
+  for (uint32_t row = 0; row < kTileRows; ++row) {
+    for (uint32_t col = 0; col < kCols; ++col)
+      write_global_u32(*sim.memory, kGlobal + (row * kCols + col) * 4,
+                       0x46000000u + row * 0x100u + col);
+  }
+  for (uint32_t i = 0; i < kCols * kTileRows; ++i)
+    cu->lds().write32(wf->lds_base() + i * sizeof(uint32_t), kSentinel);
+
+  const std::array<uint32_t, 3> load_words = {0xd0710001u, 0x7c000000u, 0x18140c00u};
+  auto load = decode_gfx1250(load_words, "tensor_load_to_lds");
+  ASSERT_NE(load, nullptr);
+  load->execute(*load, wf);
+
+  for (uint32_t i = 0; i < kCols * kTileRows; ++i)
+    EXPECT_EQ(cu->lds().read32(wf->lds_base() + i * sizeof(uint32_t)), 0u) << "element " << i;
+}
+
+TEST(Gfx1250ExecutionTest, TensorDmaRankThreeNullD2MasksTransfersAndCompletes) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf, nullptr);
+  wf->set_lds_base(cu->allocate_lds(256));
+
+  constexpr uint64_t kGlobal = 0x137000;
+  constexpr uint32_t kElements = 2;
+  constexpr uint32_t kBarrierLdsAddr = 64;
+  constexpr uint32_t kGlobalSentinel = 0xAC1DAC1Du;
+  constexpr uint32_t kLdsSentinel = 0xDEADDEADu;
+  write_tensor_dma_d0(*cu, *wf, 0, kGlobal);
+  write_wave_sgpr(*cu, *wf, 12,
+                  (2u << 16) | (1u << 18)); // i32 elements, atomic barrier enabled.
+  write_wave_sgpr(*cu, *wf, 13,
+                  (2u << 16) | (kBarrierLdsAddr >> 3)); // tensor dim0 and barrier address.
+  write_wave_sgpr(*cu, *wf, 14, 1u << 16);              // tensor dim1.
+  write_wave_sgpr(*cu, *wf, 15, kElements << 16);       // tile dim0.
+  write_wave_sgpr(*cu, *wf, 16, 1u | (1u << 16));       // tile dim1 and dim2.
+  write_wave_sgpr(*cu, *wf, 17, 2u);                    // tensor dim0 stride.
+  write_wave_sgpr(*cu, *wf, 18, 2u << 16);              // tensor dim1 stride.
+  write_wave_sgpr(*cu, *wf, 19, 0);
+
+  for (uint32_t i = 0; i < kElements; ++i) {
+    write_global_u32(*sim.memory, kGlobal + i * sizeof(uint32_t), 0x4C000000u + i);
+    cu->lds().write32(wf->lds_base() + i * sizeof(uint32_t), kLdsSentinel);
+  }
+  cu->lds().write64(wf->lds_base() + kBarrierLdsAddr, 0);
+
+  const std::array<uint32_t, 3> load_words = {0xd0710001u, 0x7c000000u, 0x7c7c0c00u};
+  auto load = decode_gfx1250(load_words, "tensor_load_to_lds");
+  ASSERT_NE(load, nullptr);
+  load->execute(*load, wf);
+
+  for (uint32_t i = 0; i < kElements; ++i)
+    EXPECT_EQ(cu->lds().read32(wf->lds_base() + i * sizeof(uint32_t)), 0u) << "element " << i;
+  EXPECT_EQ(wf->wait_counters().tensorcnt, 0u);
+  EXPECT_TRUE(wf->wait_counters().empty());
+  uint64_t barrier_state = cu->lds().read64(wf->lds_base() + kBarrierLdsAddr);
+  EXPECT_EQ(barrier_state, 0xffffull << 16);
+  EXPECT_TRUE(amdgpu::lds_barrier_cell_phase_parity(barrier_state));
+
+  for (uint32_t i = 0; i < kElements; ++i) {
+    write_global_u32(*sim.memory, kGlobal + i * sizeof(uint32_t), kGlobalSentinel);
+    cu->lds().write32(wf->lds_base() + i * sizeof(uint32_t), 0x4D000000u + i);
+  }
+  cu->lds().write64(wf->lds_base() + kBarrierLdsAddr, 0);
+
+  const std::array<uint32_t, 3> store_words = {0xd0714001u, 0x7c000000u, 0x7c7c0c00u};
+  auto store = decode_gfx1250(store_words, "tensor_store_from_lds");
+  ASSERT_NE(store, nullptr);
+  store->execute(*store, wf);
+
+  for (uint32_t i = 0; i < kElements; ++i)
+    EXPECT_EQ(read_global_u32(*sim.memory, kGlobal + i * sizeof(uint32_t)), kGlobalSentinel)
+        << "element " << i;
+  EXPECT_EQ(wf->wait_counters().tensorcnt, 0u);
+  EXPECT_TRUE(wf->wait_counters().empty());
+  barrier_state = cu->lds().read64(wf->lds_base() + kBarrierLdsAddr);
+  EXPECT_EQ(barrier_state, 0xffffull << 16);
+  EXPECT_TRUE(amdgpu::lds_barrier_cell_phase_parity(barrier_state));
+}
+
+TEST(Gfx1250ExecutionTest, TensorDmaNonIteratingRankFiveAvoidsOriginDecomposition) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf, nullptr);
+  wf->set_lds_base(cu->allocate_lds(256));
+
+  constexpr uint64_t kGlobal = 0x138000;
+  constexpr uint32_t kValue = 0x4C000000u;
+  write_tensor_dma_d0(*cu, *wf, 0, kGlobal);
+  write_wave_sgpr(*cu, *wf, 12, 2u << 16); // i32 elements.
+  write_wave_sgpr(*cu, *wf, 13, 0);
+  write_wave_sgpr(*cu, *wf, 14, 1u);              // tensor dim0 = 65536.
+  write_wave_sgpr(*cu, *wf, 15, 1u | (1u << 16)); // tensor dim1 = 65536, tile dim0 = 1.
+  write_wave_sgpr(*cu, *wf, 16, 1u | (1u << 16)); // tile dim1 and dim2.
+  write_wave_sgpr(*cu, *wf, 17, 0);
+  write_wave_sgpr(*cu, *wf, 18, 0);
+  write_wave_sgpr(*cu, *wf, 19, 0);
+  write_wave_sgpr(*cu, *wf, 20, 65536u); // tensor dim2.
+  write_wave_sgpr(*cu, *wf, 21, 65536u); // tensor dim3.
+  write_wave_sgpr(*cu, *wf, 22, 0);
+  write_wave_sgpr(*cu, *wf, 23, 1u << 16); // tile dim3.
+  write_wave_sgpr(*cu, *wf, 24, 0);
+  write_wave_sgpr(*cu, *wf, 25, 1u << 16); // tensor dim4.
+  write_wave_sgpr(*cu, *wf, 26, 1u << 16); // tile dim4.
+  write_wave_sgpr(*cu, *wf, 27, 0);
+
+  write_global_u32(*sim.memory, kGlobal, kValue);
+  cu->lds().write32(wf->lds_base(), 0xDEADDEADu);
+
+  const std::array<uint32_t, 3> load_words = {0xd0710001u, 0x7c000000u, 0x18140c00u};
+  auto load = decode_gfx1250(load_words, "tensor_load_to_lds");
+  ASSERT_NE(load, nullptr);
+  load->execute(*load, wf);
+
+  EXPECT_EQ(cu->lds().read32(wf->lds_base()), kValue);
+}
+
+TEST(Gfx1250ExecutionTest, TensorDmaIterateMasksSubrowOriginBeyondTensor) {
+  // Three one-element iterations walk a 2x1 tensor. The first two origins are
+  // valid dim0 coordinates; the third carries into dim1 and must zero-fill.
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf, nullptr);
+  wf->set_lds_base(cu->allocate_lds(256));
+
+  constexpr uint64_t kGlobal = 0x133000;
+  constexpr uint32_t kSentinel = 0xBAD0BAD0u;
+  write_tensor_dma_d0(*cu, *wf, 0, kGlobal);
+  write_wave_sgpr(*cu, *wf, 12, (2u << 16) | (1u << 19)); // i32, iterate enabled.
+  write_wave_sgpr(*cu, *wf, 13, 2u << 16);                // tensor dim0.
+  write_wave_sgpr(*cu, *wf, 14, 1u << 16);                // tensor dim1.
+  write_wave_sgpr(*cu, *wf, 15, 1u << 16);                // tile dim0.
+  write_wave_sgpr(*cu, *wf, 16, 1u);                      // tile dim1.
+  write_wave_sgpr(*cu, *wf, 17, 2u);                      // tensor dim0 stride.
+  write_wave_sgpr(*cu, *wf, 18, 0);
+  write_wave_sgpr(*cu, *wf, 19, 0);
+  write_wave_sgpr(*cu, *wf, 20, 0);
+  write_wave_sgpr(*cu, *wf, 21, 1u);       // LDS increment in elements.
+  write_wave_sgpr(*cu, *wf, 22, 1u);       // Global increment in elements.
+  write_wave_sgpr(*cu, *wf, 23, 2u << 16); // iteration_count - 1.
+
+  for (uint32_t i = 0; i < 3; ++i) {
+    write_global_u32(*sim.memory, kGlobal + i * sizeof(uint32_t), 0x49000000u + i);
+    cu->lds().write32(wf->lds_base() + i * sizeof(uint32_t), kSentinel);
+  }
+
+  const std::array<uint32_t, 3> load_words = {0xd0710001u, 0x7c000000u, 0x7c140c00u};
+  auto load = decode_gfx1250(load_words, "tensor_load_to_lds");
+  ASSERT_NE(load, nullptr);
+  load->execute(*load, wf);
+
+  EXPECT_EQ(cu->lds().read32(wf->lds_base() + 0 * 4), 0x49000000u);
+  EXPECT_EQ(cu->lds().read32(wf->lds_base() + 1 * 4), 0x49000001u);
+  EXPECT_EQ(cu->lds().read32(wf->lds_base() + 2 * 4), 0u);
+}
+
+TEST(Gfx1250ExecutionTest, TensorDmaIterateMasksPlanesBeyondTensorDimension) {
+  // The descriptor iterates across two planes of a tensor whose depth is one.
+  // The second plane must be zero-filled rather than copied.
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf, nullptr);
+  wf->set_lds_base(cu->allocate_lds(256));
+
+  constexpr uint64_t kGlobal = 0x134000;
+  constexpr uint32_t kSentinel = 0xFACEFACEu;
+  write_tensor_dma_d0(*cu, *wf, 0, kGlobal);
+  write_wave_sgpr(*cu, *wf, 12, (2u << 16) | (1u << 19)); // i32, iterate enabled.
+  write_wave_sgpr(*cu, *wf, 13, 2u << 16);                // tensor dim0.
+  write_wave_sgpr(*cu, *wf, 14, 2u << 16);                // tensor dim1.
+  write_wave_sgpr(*cu, *wf, 15, 2u << 16);                // tile dim0.
+  write_wave_sgpr(*cu, *wf, 16, 1u | (1u << 16));         // tile dim1 and dim2.
+  write_wave_sgpr(*cu, *wf, 17, 2u);                      // tensor dim0 stride.
+  write_wave_sgpr(*cu, *wf, 18, 4u << 16);                // tensor dim1 stride.
+  write_wave_sgpr(*cu, *wf, 19, 0);
+  write_wave_sgpr(*cu, *wf, 20, 1u);       // tensor dim2.
+  write_wave_sgpr(*cu, *wf, 21, 2u);       // LDS increment in elements.
+  write_wave_sgpr(*cu, *wf, 22, 4u);       // Global increment in elements.
+  write_wave_sgpr(*cu, *wf, 23, 1u << 16); // iteration_count - 1.
+
+  for (uint32_t i = 0; i < 6; ++i)
+    write_global_u32(*sim.memory, kGlobal + i * sizeof(uint32_t), 0x4A000000u + i);
+  for (uint32_t i = 0; i < 4; ++i)
+    cu->lds().write32(wf->lds_base() + i * sizeof(uint32_t), kSentinel);
+
+  const std::array<uint32_t, 3> load_words = {0xd0710001u, 0x7c000000u, 0x7c140c00u};
+  auto load = decode_gfx1250(load_words, "tensor_load_to_lds");
+  ASSERT_NE(load, nullptr);
+  load->execute(*load, wf);
+
+  EXPECT_EQ(cu->lds().read32(wf->lds_base() + 0 * 4), 0x4A000000u);
+  EXPECT_EQ(cu->lds().read32(wf->lds_base() + 1 * 4), 0x4A000001u);
+  EXPECT_EQ(cu->lds().read32(wf->lds_base() + 2 * 4), 0u);
+  EXPECT_EQ(cu->lds().read32(wf->lds_base() + 3 * 4), 0u);
+}
+
+TEST(Gfx1250ExecutionTest, TensorDmaIterateRejectsOverlappingStrides) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf, nullptr);
+  wf->set_lds_base(cu->allocate_lds(256));
+
+  write_tensor_dma_d0(*cu, *wf, 0, 0x135000);
+  write_wave_sgpr(*cu, *wf, 12, (2u << 16) | (1u << 19)); // i32, iterate enabled.
+  write_wave_sgpr(*cu, *wf, 13, 2u << 16);                // tensor dim0.
+  write_wave_sgpr(*cu, *wf, 14, 2u << 16);                // tensor dim1.
+  write_wave_sgpr(*cu, *wf, 15, 1u << 16);                // tile dim0.
+  write_wave_sgpr(*cu, *wf, 16, 1u);                      // tile dim1.
+  write_wave_sgpr(*cu, *wf, 17, 1u);                      // Overlaps tensor dim0.
+  write_wave_sgpr(*cu, *wf, 18, 0);
+  write_wave_sgpr(*cu, *wf, 19, 0);
+  write_wave_sgpr(*cu, *wf, 20, 0);
+  write_wave_sgpr(*cu, *wf, 21, 1u);
+  write_wave_sgpr(*cu, *wf, 22, 1u);
+  write_wave_sgpr(*cu, *wf, 23, 1u << 16);
+
+  const std::array<uint32_t, 3> load_words = {0xd0710001u, 0x7c000000u, 0x7c140c00u};
+  auto load = decode_gfx1250(load_words, "tensor_load_to_lds");
+  ASSERT_NE(load, nullptr);
+  EXPECT_THROW(load->execute(*load, wf), util::UnimplementedInst);
+}
+
+TEST(Gfx1250ExecutionTest, TensorDmaIterateAllowsRepeatedOriginWithOverlappingStrides) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf, nullptr);
+  wf->set_lds_base(cu->allocate_lds(256));
+
+  constexpr uint64_t kGlobal = 0x139000;
+  constexpr uint32_t kValue = 0x4D000000u;
+  write_tensor_dma_d0(*cu, *wf, 0, kGlobal);
+  write_wave_sgpr(*cu, *wf, 12, (2u << 16) | (1u << 19)); // i32, iterate enabled.
+  write_wave_sgpr(*cu, *wf, 13, 2u << 16);                // tensor dim0.
+  write_wave_sgpr(*cu, *wf, 14, 2u << 16);                // tensor dim1.
+  write_wave_sgpr(*cu, *wf, 15, 1u << 16);                // tile dim0.
+  write_wave_sgpr(*cu, *wf, 16, 1u);                      // tile dim1.
+  write_wave_sgpr(*cu, *wf, 17, 1u);                      // overlapping tensor dim0 stride.
+  write_wave_sgpr(*cu, *wf, 18, 0);
+  write_wave_sgpr(*cu, *wf, 19, 0);
+  write_wave_sgpr(*cu, *wf, 20, 0);
+  write_wave_sgpr(*cu, *wf, 21, 1u);       // LDS increment in elements.
+  write_wave_sgpr(*cu, *wf, 22, 0);        // Global origin does not advance.
+  write_wave_sgpr(*cu, *wf, 23, 1u << 16); // iteration_count - 1.
+
+  write_global_u32(*sim.memory, kGlobal, kValue);
+  cu->lds().write32(wf->lds_base() + 0 * sizeof(uint32_t), 0xDEADDEADu);
+  cu->lds().write32(wf->lds_base() + 1 * sizeof(uint32_t), 0xDEADDEADu);
+
+  const std::array<uint32_t, 3> load_words = {0xd0710001u, 0x7c000000u, 0x7c140c00u};
+  auto load = decode_gfx1250(load_words, "tensor_load_to_lds");
+  ASSERT_NE(load, nullptr);
+  load->execute(*load, wf);
+
+  EXPECT_EQ(cu->lds().read32(wf->lds_base() + 0 * sizeof(uint32_t)), kValue);
+  EXPECT_EQ(cu->lds().read32(wf->lds_base() + 1 * sizeof(uint32_t)), kValue);
+}
+
+TEST(Gfx1250ExecutionTest, TensorDmaIterateAllowsPaddedRowPlaneStride) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf, nullptr);
+  wf->set_lds_base(cu->allocate_lds(256));
+
+  constexpr uint64_t kGlobal = 0x13A000;
+  constexpr uint32_t kSentinel = 0xDEADDEADu;
+  write_tensor_dma_d0(*cu, *wf, 0, kGlobal);
+  write_wave_sgpr(*cu, *wf, 12, (2u << 16) | (1u << 19)); // i32, iterate enabled.
+  write_wave_sgpr(*cu, *wf, 13, 2u << 16);                // tensor dim0.
+  write_wave_sgpr(*cu, *wf, 14, 2u << 16);                // tensor dim1.
+  write_wave_sgpr(*cu, *wf, 15, 1u << 16);                // tile dim0.
+  write_wave_sgpr(*cu, *wf, 16, 1u | (1u << 16));         // tile dim1 and dim2.
+  write_wave_sgpr(*cu, *wf, 17, 4u);                      // padded tensor dim0 stride.
+  write_wave_sgpr(*cu, *wf, 18, 6u << 16);                // occupied plane span.
+  write_wave_sgpr(*cu, *wf, 19, 0);
+  write_wave_sgpr(*cu, *wf, 20, 2u);       // tensor dim2.
+  write_wave_sgpr(*cu, *wf, 21, 1u);       // LDS increment in elements.
+  write_wave_sgpr(*cu, *wf, 22, 6u);       // Global plane increment in elements.
+  write_wave_sgpr(*cu, *wf, 23, 1u << 16); // iteration_count - 1.
+
+  write_global_u32(*sim.memory, kGlobal, 0x4E000000u);
+  write_global_u32(*sim.memory, kGlobal + 6 * sizeof(uint32_t), 0x4E000001u);
+  cu->lds().write32(wf->lds_base(), kSentinel);
+  cu->lds().write32(wf->lds_base() + sizeof(uint32_t), kSentinel);
+
+  const std::array<uint32_t, 3> load_words = {0xd0710001u, 0x7c000000u, 0x7c140c00u};
+  auto load = decode_gfx1250(load_words, "tensor_load_to_lds");
+  ASSERT_NE(load, nullptr);
+  load->execute(*load, wf);
+
+  EXPECT_EQ(cu->lds().read32(wf->lds_base()), 0x4E000000u);
+  EXPECT_EQ(cu->lds().read32(wf->lds_base() + sizeof(uint32_t)), 0x4E000001u);
+}
+
+TEST(Gfx1250ExecutionTest, TensorDmaIterateZeroExtentSkipsLayoutValidationAndCompletes) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf, nullptr);
+  wf->set_lds_base(cu->allocate_lds(256));
+
+  constexpr uint64_t kGlobal = 0x13B000;
+  constexpr uint32_t kElements = 4;
+  constexpr uint32_t kBarrierLdsAddr = 64;
+  constexpr uint32_t kGlobalSentinel = 0xAC1DAC1Du;
+  constexpr uint32_t kLdsSentinel = 0xDEADDEADu;
+  write_tensor_dma_d0(*cu, *wf, 0, kGlobal);
+  write_wave_sgpr(*cu, *wf, 12,
+                  (2u << 16) | (1u << 18) | (1u << 19)); // i32, atomic barrier and iterate enabled.
+  write_wave_sgpr(*cu, *wf, 13,
+                  (2u << 16) | (kBarrierLdsAddr >> 3)); // tensor dim0 and barrier address.
+  write_wave_sgpr(*cu, *wf, 14, 0);                     // tensor dim1 is empty.
+  write_wave_sgpr(*cu, *wf, 15, 2u << 16);              // tile dim0.
+  write_wave_sgpr(*cu, *wf, 16, 1u);                    // tile dim1.
+  write_wave_sgpr(*cu, *wf, 17, 1u);                    // overlaps tensor dim0.
+  write_wave_sgpr(*cu, *wf, 18, 0);
+  write_wave_sgpr(*cu, *wf, 19, 0);
+  write_wave_sgpr(*cu, *wf, 20, 0);
+  write_wave_sgpr(*cu, *wf, 21, 2u);       // LDS increment in elements.
+  write_wave_sgpr(*cu, *wf, 22, 1u);       // Global increment in elements.
+  write_wave_sgpr(*cu, *wf, 23, 1u << 16); // iteration_count - 1.
+
+  for (uint32_t i = 0; i < kElements; ++i)
+    cu->lds().write32(wf->lds_base() + i * sizeof(uint32_t), kLdsSentinel);
+  cu->lds().write64(wf->lds_base() + kBarrierLdsAddr, 0);
+
+  const std::array<uint32_t, 3> load_words = {0xd0710001u, 0x7c000000u, 0x7c140c00u};
+  auto load = decode_gfx1250(load_words, "tensor_load_to_lds");
+  ASSERT_NE(load, nullptr);
+  load->execute(*load, wf);
+
+  for (uint32_t i = 0; i < kElements; ++i)
+    EXPECT_EQ(cu->lds().read32(wf->lds_base() + i * sizeof(uint32_t)), 0u) << "element " << i;
+  EXPECT_EQ(wf->wait_counters().tensorcnt, 0u);
+  EXPECT_TRUE(wf->wait_counters().empty());
+  uint64_t barrier_state = cu->lds().read64(wf->lds_base() + kBarrierLdsAddr);
+  EXPECT_EQ(barrier_state, 0xffffull << 16);
+  EXPECT_TRUE(amdgpu::lds_barrier_cell_phase_parity(barrier_state));
+
+  for (uint32_t i = 0; i < 3; ++i)
+    write_global_u32(*sim.memory, kGlobal + i * sizeof(uint32_t), kGlobalSentinel);
+  for (uint32_t i = 0; i < kElements; ++i)
+    cu->lds().write32(wf->lds_base() + i * sizeof(uint32_t), 0x4F000000u + i);
+  cu->lds().write64(wf->lds_base() + kBarrierLdsAddr, 0);
+
+  const std::array<uint32_t, 3> store_words = {0xd0714001u, 0x7c000000u, 0x7c140c00u};
+  auto store = decode_gfx1250(store_words, "tensor_store_from_lds");
+  ASSERT_NE(store, nullptr);
+  store->execute(*store, wf);
+
+  for (uint32_t i = 0; i < 3; ++i)
+    EXPECT_EQ(read_global_u32(*sim.memory, kGlobal + i * sizeof(uint32_t)), kGlobalSentinel)
+        << "element " << i;
+  EXPECT_EQ(wf->wait_counters().tensorcnt, 0u);
+  EXPECT_TRUE(wf->wait_counters().empty());
+  barrier_state = cu->lds().read64(wf->lds_base() + kBarrierLdsAddr);
+  EXPECT_EQ(barrier_state, 0xffffull << 16);
+  EXPECT_TRUE(amdgpu::lds_barrier_cell_phase_parity(barrier_state));
+}
+
 TEST(Gfx1250ExecutionTest, TensorDmaAtomicBarrierArrivesAfterCopy) {
   Gfx1250Sim sim;
   auto *cu = sim.cu();
@@ -916,6 +1406,108 @@ TEST(Gfx1250ExecutionTest, TensorDmaGatherSupportsI16Indices) {
                 0x69000000u + src_row * 0x100u + col);
     }
   }
+}
+
+TEST(Gfx1250ExecutionTest, TensorDmaGatherZeroExtentMasksEntireTile) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf, nullptr);
+  wf->set_lds_base(cu->allocate_lds(256));
+
+  constexpr uint64_t kGlobal = 0x181000;
+  constexpr uint32_t kTileElements = 2;
+  constexpr uint32_t kSentinel = 0xDEADDEADu;
+  write_tensor_dma_d0(*cu, *wf, 0, kGlobal);
+  write_wave_sgpr(*cu, *wf, 0, 1u | (1u << 31)); // gather enabled.
+  write_wave_sgpr(*cu, *wf, 12, 2u << 16);       // i32 elements.
+  write_wave_sgpr(*cu, *wf, 13, 0);              // tensor dim0 is empty.
+  write_wave_sgpr(*cu, *wf, 14, 0);
+  write_wave_sgpr(*cu, *wf, 15, kTileElements << 16);
+  write_wave_sgpr(*cu, *wf, 16, 1u); // one valid gather index.
+  write_wave_sgpr(*cu, *wf, 17, 0);
+  write_wave_sgpr(*cu, *wf, 18, 0);
+  write_wave_sgpr(*cu, *wf, 19, 0);
+  write_wave_sgpr(*cu, *wf, 20, 1u); // gather index.
+  write_wave_sgpr(*cu, *wf, 21, 0);
+  write_wave_sgpr(*cu, *wf, 22, 0);
+  write_wave_sgpr(*cu, *wf, 23, 0);
+  write_wave_sgpr(*cu, *wf, 24, 0);
+  write_wave_sgpr(*cu, *wf, 25, 0);
+  write_wave_sgpr(*cu, *wf, 26, 0);
+  write_wave_sgpr(*cu, *wf, 27, 0);
+
+  for (uint32_t i = 0; i < 3; ++i)
+    write_global_u32(*sim.memory, kGlobal + i * sizeof(uint32_t), 0x6A000000u + i);
+  for (uint32_t i = 0; i < kTileElements; ++i)
+    cu->lds().write32(wf->lds_base() + i * sizeof(uint32_t), kSentinel);
+
+  const std::array<uint32_t, 3> load_words = {0xd0710001u, 0x7c000000u, 0x18140c00u};
+  auto load = decode_gfx1250(load_words, "tensor_load_to_lds");
+  ASSERT_NE(load, nullptr);
+  load->execute(*load, wf);
+
+  for (uint32_t i = 0; i < kTileElements; ++i)
+    EXPECT_EQ(cu->lds().read32(wf->lds_base() + i * sizeof(uint32_t)), 0u) << "element " << i;
+}
+
+TEST(Gfx1250ExecutionTest, TensorDmaGatherRankTwoZeroExtentMasksLoadAndStore) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf, nullptr);
+  wf->set_lds_base(cu->allocate_lds(256));
+
+  constexpr uint64_t kGlobal = 0x182000;
+  constexpr uint32_t kRows = 4;
+  constexpr uint32_t kTileElements = 2;
+  constexpr uint32_t kGlobalSentinel = 0xAC1DAC1Du;
+  constexpr uint32_t kLdsSentinel = 0xDEADDEADu;
+  write_tensor_dma_d0(*cu, *wf, 0, kGlobal);
+  write_wave_sgpr(*cu, *wf, 0, 1u | (1u << 31)); // gather enabled.
+  write_wave_sgpr(*cu, *wf, 12, 2u << 16);       // i32 elements.
+  write_wave_sgpr(*cu, *wf, 13, 0);              // tensor dim0 is empty.
+  write_wave_sgpr(*cu, *wf, 14, kRows << 16);    // tensor dim1 keeps rank two.
+  write_wave_sgpr(*cu, *wf, 15, kTileElements << 16);
+  write_wave_sgpr(*cu, *wf, 16, 1u); // one valid gather index.
+  write_wave_sgpr(*cu, *wf, 17, kTileElements);
+  write_wave_sgpr(*cu, *wf, 18, 0);
+  write_wave_sgpr(*cu, *wf, 19, 0);
+  write_wave_sgpr(*cu, *wf, 20, 1u); // gather index.
+  write_wave_sgpr(*cu, *wf, 21, 0);
+  write_wave_sgpr(*cu, *wf, 22, 0);
+  write_wave_sgpr(*cu, *wf, 23, 0);
+  write_wave_sgpr(*cu, *wf, 24, 0);
+  write_wave_sgpr(*cu, *wf, 25, 0);
+  write_wave_sgpr(*cu, *wf, 26, 0);
+  write_wave_sgpr(*cu, *wf, 27, 0);
+
+  for (uint32_t i = 0; i < kRows * kTileElements; ++i)
+    write_global_u32(*sim.memory, kGlobal + i * sizeof(uint32_t), 0x50000000u + i);
+  for (uint32_t i = 0; i < kTileElements; ++i)
+    cu->lds().write32(wf->lds_base() + i * sizeof(uint32_t), kLdsSentinel);
+
+  const std::array<uint32_t, 3> load_words = {0xd0710001u, 0x7c000000u, 0x18140c00u};
+  auto load = decode_gfx1250(load_words, "tensor_load_to_lds");
+  ASSERT_NE(load, nullptr);
+  load->execute(*load, wf);
+
+  for (uint32_t i = 0; i < kTileElements; ++i)
+    EXPECT_EQ(cu->lds().read32(wf->lds_base() + i * sizeof(uint32_t)), 0u) << "element " << i;
+
+  for (uint32_t i = 0; i < kRows * kTileElements; ++i)
+    write_global_u32(*sim.memory, kGlobal + i * sizeof(uint32_t), kGlobalSentinel);
+  for (uint32_t i = 0; i < kTileElements; ++i)
+    cu->lds().write32(wf->lds_base() + i * sizeof(uint32_t), 0x51000000u + i);
+
+  const std::array<uint32_t, 3> store_words = {0xd0714001u, 0x7c000000u, 0x18140c00u};
+  auto store = decode_gfx1250(store_words, "tensor_store_from_lds");
+  ASSERT_NE(store, nullptr);
+  store->execute(*store, wf);
+
+  for (uint32_t i = 0; i < kRows * kTileElements; ++i)
+    EXPECT_EQ(read_global_u32(*sim.memory, kGlobal + i * sizeof(uint32_t)), kGlobalSentinel)
+        << "element " << i;
 }
 
 } // namespace

--- a/emulation/rocjitsu/tests/cdna5_tensor_dma_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_tensor_dma_test.cpp
@@ -356,14 +356,16 @@ TEST(Gfx1250ExecutionTest, TensorDmaByteLoadUsesDwordPaddingUnits) {
   EXPECT_EQ(cu->lds().read8(wf->lds_base() + 275), 3u);
 }
 
-TEST(Gfx1250ExecutionTest, TensorDmaPaddedStoreIsRejected) {
+TEST(Gfx1250ExecutionTest, TensorDmaPaddedStoreIgnoresPadding) {
   Gfx1250Sim sim;
   auto *cu = sim.cu();
   auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
   ASSERT_NE(wf, nullptr);
   wf->set_lds_base(cu->allocate_lds(256));
 
-  write_tensor_dma_d0(*cu, *wf, 0, 0x121000);
+  constexpr uint64_t kGlobal = 0x122000;
+  constexpr uint32_t kSentinel = 0xAC1DAC1Du;
+  write_tensor_dma_d0(*cu, *wf, 0, kGlobal);
   write_wave_sgpr(*cu, *wf, 12, (2u << 16) | (1u << 20)); // i32, pad enabled.
   write_wave_sgpr(*cu, *wf, 13, 4u << 16);
   write_wave_sgpr(*cu, *wf, 14, 0);
@@ -373,9 +375,17 @@ TEST(Gfx1250ExecutionTest, TensorDmaPaddedStoreIsRejected) {
   write_wave_sgpr(*cu, *wf, 18, 0);
   write_wave_sgpr(*cu, *wf, 19, 0);
 
+  for (uint32_t i = 0; i < 4; ++i) {
+    write_global_u32(*sim.memory, kGlobal + i * sizeof(uint32_t), kSentinel);
+    cu->lds().write32(wf->lds_base() + i * sizeof(uint32_t), 0x34000000u + i);
+  }
+
   const std::array<uint32_t, 3> store_words = {0xd0714001u, 0x7c000000u, 0x7c7c0c00u};
   cdna5::TensorStoreFromLdsVimage store_inst(store_words.data());
-  EXPECT_THROW(store_inst.execute_impl(*wf), util::UnimplementedInst);
+  store_inst.execute_impl(*wf);
+
+  for (uint32_t i = 0; i < 4; ++i)
+    EXPECT_EQ(read_global_u32(*sim.memory, kGlobal + i * sizeof(uint32_t)), 0x34000000u + i);
 }
 
 TEST(Gfx1250ExecutionTest, TensorDmaIterateCopiesMultipleTiles) {
@@ -393,7 +403,7 @@ TEST(Gfx1250ExecutionTest, TensorDmaIterateCopiesMultipleTiles) {
   write_wave_sgpr(*cu, *wf, 14, 2u << 16);                // tensor dim1.
   write_wave_sgpr(*cu, *wf, 15, 2u << 16);                // tile dim0.
   write_wave_sgpr(*cu, *wf, 16, 1u);                      // tile dim1.
-  write_wave_sgpr(*cu, *wf, 17, 0);
+  write_wave_sgpr(*cu, *wf, 17, 2u);                      // tensor dim0 stride.
   write_wave_sgpr(*cu, *wf, 18, 0);
   write_wave_sgpr(*cu, *wf, 19, 0);
   write_wave_sgpr(*cu, *wf, 20, 0);
@@ -856,6 +866,77 @@ TEST(Gfx1250ExecutionTest, TensorDmaIterateRejectsOverlappingStrides) {
   auto load = decode_gfx1250(load_words, "tensor_load_to_lds");
   ASSERT_NE(load, nullptr);
   EXPECT_THROW(load->execute(*load, wf), util::UnimplementedInst);
+}
+
+TEST(Gfx1250ExecutionTest, TensorDmaIterateAllowsAliasedUnitExtent) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf, nullptr);
+  wf->set_lds_base(cu->allocate_lds(256));
+
+  constexpr uint64_t kGlobal = 0x185000;
+  write_tensor_dma_d0(*cu, *wf, 0, kGlobal);
+  write_wave_sgpr(*cu, *wf, 12, (2u << 16) | (1u << 19)); // i32, iterate enabled.
+  write_wave_sgpr(*cu, *wf, 13, 2u << 16);                // tensor dim0.
+  write_wave_sgpr(*cu, *wf, 14, 1u << 16);                // unit tensor dim1.
+  write_wave_sgpr(*cu, *wf, 15, 1u << 16);                // tile dim0.
+  write_wave_sgpr(*cu, *wf, 16, 1u);                      // tile dim1.
+  write_wave_sgpr(*cu, *wf, 17, 1u); // dim1 aliases dim0 but has only one coordinate.
+  write_wave_sgpr(*cu, *wf, 18, 0);
+  write_wave_sgpr(*cu, *wf, 19, 0);
+  write_wave_sgpr(*cu, *wf, 20, 0);
+  write_wave_sgpr(*cu, *wf, 21, 1u);       // LDS increment in elements.
+  write_wave_sgpr(*cu, *wf, 22, 1u);       // advance along tensor dim0.
+  write_wave_sgpr(*cu, *wf, 23, 1u << 16); // iteration_count - 1.
+
+  write_global_u32(*sim.memory, kGlobal, 0x55000000u);
+  write_global_u32(*sim.memory, kGlobal + sizeof(uint32_t), 0x55000001u);
+
+  const std::array<uint32_t, 3> load_words = {0xd0710001u, 0x7c000000u, 0x7c140c00u};
+  auto load = decode_gfx1250(load_words, "tensor_load_to_lds");
+  ASSERT_NE(load, nullptr);
+  load->execute(*load, wf);
+
+  EXPECT_EQ(cu->lds().read32(wf->lds_base()), 0x55000000u);
+  EXPECT_EQ(cu->lds().read32(wf->lds_base() + sizeof(uint32_t)), 0x55000001u);
+}
+
+TEST(Gfx1250ExecutionTest, TensorDmaIterateAllowsPermutedNonOverlappingStrides) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf, nullptr);
+  wf->set_lds_base(cu->allocate_lds(256));
+
+  constexpr uint64_t kGlobal = 0x183000;
+  constexpr uint32_t kSentinel = 0xDEADDEADu;
+  write_tensor_dma_d0(*cu, *wf, 0, kGlobal);
+  write_wave_sgpr(*cu, *wf, 12, (2u << 16) | (1u << 19)); // i32, iterate enabled.
+  write_wave_sgpr(*cu, *wf, 13, 2u << 16);                // tensor dim0.
+  write_wave_sgpr(*cu, *wf, 14, 2u << 16);                // tensor dim1.
+  write_wave_sgpr(*cu, *wf, 15, 1u << 16);                // tile dim0.
+  write_wave_sgpr(*cu, *wf, 16, 1u | (1u << 16));         // tile dim1 and dim2.
+  write_wave_sgpr(*cu, *wf, 17, 4u);                      // tensor dim1 stride.
+  write_wave_sgpr(*cu, *wf, 18, 2u << 16);                // tensor dim2 stride.
+  write_wave_sgpr(*cu, *wf, 19, 0);
+  write_wave_sgpr(*cu, *wf, 20, 2u);       // tensor dim2.
+  write_wave_sgpr(*cu, *wf, 21, 1u);       // LDS increment in elements.
+  write_wave_sgpr(*cu, *wf, 22, 2u);       // advance along tensor dim2.
+  write_wave_sgpr(*cu, *wf, 23, 1u << 16); // iteration_count - 1.
+
+  for (uint32_t i = 0; i < 8; ++i)
+    write_global_u32(*sim.memory, kGlobal + i * sizeof(uint32_t), 0x52000000u + i);
+  cu->lds().write32(wf->lds_base(), kSentinel);
+  cu->lds().write32(wf->lds_base() + sizeof(uint32_t), kSentinel);
+
+  const std::array<uint32_t, 3> load_words = {0xd0710001u, 0x7c000000u, 0x7c140c00u};
+  auto load = decode_gfx1250(load_words, "tensor_load_to_lds");
+  ASSERT_NE(load, nullptr);
+  load->execute(*load, wf);
+
+  EXPECT_EQ(cu->lds().read32(wf->lds_base()), 0x52000000u);
+  EXPECT_EQ(cu->lds().read32(wf->lds_base() + sizeof(uint32_t)), 0x52000002u);
 }
 
 TEST(Gfx1250ExecutionTest, TensorDmaIterateAllowsRepeatedOriginWithOverlappingStrides) {
@@ -1408,6 +1489,49 @@ TEST(Gfx1250ExecutionTest, TensorDmaGatherSupportsI16Indices) {
   }
 }
 
+TEST(Gfx1250ExecutionTest, TensorDmaGatherZeroStrideAliasesRows) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf, nullptr);
+  wf->set_lds_base(cu->allocate_lds(256));
+
+  constexpr uint64_t kGlobal = 0x180800;
+  constexpr uint32_t kCols = 2;
+  write_tensor_dma_d0(*cu, *wf, 0, kGlobal);
+  write_wave_sgpr(*cu, *wf, 0, 1u | (1u << 31)); // gather enabled.
+  write_wave_sgpr(*cu, *wf, 12, 2u << 16);       // i32 elements.
+  write_wave_sgpr(*cu, *wf, 13, kCols << 16);    // tensor dim0.
+  write_wave_sgpr(*cu, *wf, 14, 2u << 16);       // tensor dim1.
+  write_wave_sgpr(*cu, *wf, 15, kCols << 16);    // tile dim0.
+  write_wave_sgpr(*cu, *wf, 16, 2u);             // two valid gather indices.
+  write_wave_sgpr(*cu, *wf, 17, 0);              // literal zero row stride.
+  write_wave_sgpr(*cu, *wf, 18, 0);
+  write_wave_sgpr(*cu, *wf, 19, 0);
+  write_wave_sgpr(*cu, *wf, 20, 0u | (1u << 16)); // gather rows 0 and 1.
+  write_wave_sgpr(*cu, *wf, 21, 0);
+  write_wave_sgpr(*cu, *wf, 22, 0);
+  write_wave_sgpr(*cu, *wf, 23, 0);
+  write_wave_sgpr(*cu, *wf, 24, 0);
+  write_wave_sgpr(*cu, *wf, 25, 0);
+  write_wave_sgpr(*cu, *wf, 26, 0);
+  write_wave_sgpr(*cu, *wf, 27, 0);
+
+  for (uint32_t col = 0; col < kCols; ++col)
+    write_global_u32(*sim.memory, kGlobal + col * sizeof(uint32_t), 0x6B000000u + col);
+
+  const std::array<uint32_t, 3> load_words = {0xd0710001u, 0x7c000000u, 0x18140c00u};
+  auto load = decode_gfx1250(load_words, "tensor_load_to_lds");
+  ASSERT_NE(load, nullptr);
+  load->execute(*load, wf);
+
+  for (uint32_t row = 0; row < 2; ++row) {
+    for (uint32_t col = 0; col < kCols; ++col)
+      EXPECT_EQ(cu->lds().read32(wf->lds_base() + (row * kCols + col) * sizeof(uint32_t)),
+                0x6B000000u + col);
+  }
+}
+
 TEST(Gfx1250ExecutionTest, TensorDmaGatherZeroExtentMasksEntireTile) {
   Gfx1250Sim sim;
   auto *cu = sim.cu();
@@ -1506,6 +1630,64 @@ TEST(Gfx1250ExecutionTest, TensorDmaGatherRankTwoZeroExtentMasksLoadAndStore) {
   store->execute(*store, wf);
 
   for (uint32_t i = 0; i < kRows * kTileElements; ++i)
+    EXPECT_EQ(read_global_u32(*sim.memory, kGlobal + i * sizeof(uint32_t)), kGlobalSentinel)
+        << "element " << i;
+}
+
+TEST(Gfx1250ExecutionTest, TensorDmaGatherRankTwoZeroOuterExtentMasksLoadAndStore) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf, nullptr);
+  wf->set_lds_base(cu->allocate_lds(256));
+
+  constexpr uint64_t kGlobal = 0x184000;
+  constexpr uint32_t kTileElements = 2;
+  constexpr uint32_t kGlobalSentinel = 0xAC1DAC1Du;
+  constexpr uint32_t kLdsSentinel = 0xDEADDEADu;
+  write_tensor_dma_d0(*cu, *wf, 0, kGlobal);
+  write_wave_sgpr(*cu, *wf, 0, 1u | (1u << 31)); // gather enabled.
+  write_wave_sgpr(*cu, *wf, 12, 2u << 16);       // i32 elements.
+  write_wave_sgpr(*cu, *wf, 13, 2u << 16);       // tensor dim0.
+  write_wave_sgpr(*cu, *wf, 14, 0);              // tensor dim1 is empty.
+  write_wave_sgpr(*cu, *wf, 15, kTileElements << 16);
+  write_wave_sgpr(*cu, *wf, 16, 1u); // one valid gather index.
+  write_wave_sgpr(*cu, *wf, 17, kTileElements);
+  write_wave_sgpr(*cu, *wf, 18, 0);
+  write_wave_sgpr(*cu, *wf, 19, 0);
+  write_wave_sgpr(*cu, *wf, 20, 0); // gather index.
+  write_wave_sgpr(*cu, *wf, 21, 0);
+  write_wave_sgpr(*cu, *wf, 22, 0);
+  write_wave_sgpr(*cu, *wf, 23, 0);
+  write_wave_sgpr(*cu, *wf, 24, 0);
+  write_wave_sgpr(*cu, *wf, 25, 0);
+  write_wave_sgpr(*cu, *wf, 26, 0);
+  write_wave_sgpr(*cu, *wf, 27, 0);
+
+  for (uint32_t i = 0; i < kTileElements; ++i) {
+    write_global_u32(*sim.memory, kGlobal + i * sizeof(uint32_t), 0x53000000u + i);
+    cu->lds().write32(wf->lds_base() + i * sizeof(uint32_t), kLdsSentinel);
+  }
+
+  const std::array<uint32_t, 3> load_words = {0xd0710001u, 0x7c000000u, 0x18140c00u};
+  auto load = decode_gfx1250(load_words, "tensor_load_to_lds");
+  ASSERT_NE(load, nullptr);
+  load->execute(*load, wf);
+
+  for (uint32_t i = 0; i < kTileElements; ++i)
+    EXPECT_EQ(cu->lds().read32(wf->lds_base() + i * sizeof(uint32_t)), 0u) << "element " << i;
+
+  for (uint32_t i = 0; i < kTileElements; ++i) {
+    write_global_u32(*sim.memory, kGlobal + i * sizeof(uint32_t), kGlobalSentinel);
+    cu->lds().write32(wf->lds_base() + i * sizeof(uint32_t), 0x54000000u + i);
+  }
+
+  const std::array<uint32_t, 3> store_words = {0xd0714001u, 0x7c000000u, 0x18140c00u};
+  auto store = decode_gfx1250(store_words, "tensor_store_from_lds");
+  ASSERT_NE(store, nullptr);
+  store->execute(*store, wf);
+
+  for (uint32_t i = 0; i < kTileElements; ++i)
     EXPECT_EQ(read_global_u32(*sim.memory, kGlobal + i * sizeof(uint32_t)), kGlobalSentinel)
         << "element " << i;
 }


### PR DESCRIPTION
## Summary

This change fixes tensor-DMA bounds contracts exposed while reducing the stock gfx1250 TensileLite TDM tail failure tracked by #9935.

It is independent of the VMID correction in #9775 at the source level. Both changes are needed to advance the original workload through the currently known rocJITsu model gaps.

## Related producer-side evidence

- ROCm/rocm-libraries#7976 introduced TDM iterate mode and the `tdm_gfx1250.yaml` configuration lineage that exposed this gap.
- ROCm/rocm-libraries#8406 contains the same affected configuration after iterate mode was enabled and reports passing FFM and B0 validation. This is file-level evidence rather than a published per-solution trace.
- ROCm/rocm-libraries#9410 added iterate-mode edge cases with waves that have zero valid rows specifically to exercise descriptor bounds clamping, and reports passing FFM validation.

## Failure before this fix

Iterate mode advanced the starting global address for each repeated tile, but rocJITsu continued to apply bounds using tile-local coordinates. A final row outside the tensor was therefore copied into LDS instead of being zero-filled.

An active tensor extent of zero was treated as unbounded. The complete dense or gather tile could therefore be copied instead of being masked.

## Fixes

### Include iterate-mode address advancement in tensor bounds

The model decomposes each advancing iteration's linear global-address increment into an absolute tensor-coordinate origin, then applies one bounds predicate to that origin plus the tile-local coordinate.

This handles sub-row advances, row advances, and rank-3 plane advances through the same path. Overlapping-stride layouts are rejected only when multiple iterations actually advance the global origin; repeated-origin descriptors do not require inverse coordinate decomposition.

### Treat zero active tensor extents as empty

For an active dense or gather tile dimension, tensor extent zero masks the complete dimension. Loads zero-fill the affected LDS elements and stores suppress the corresponding global writes.

Optional null descriptor groups retain their architectural zero-filled value. A rank-3 tile with null D2 therefore has a zero third tensor extent: it masks the transfer without aborting execution, still completes an enabled barrier, and releases TENSORCNT normally.

### Avoid unnecessary origin decomposition

Non-iterating descriptors use an all-zero origin directly. This avoids inverse stride decomposition, including accepted rank-5 layouts whose large default strides can wrap.

## Test coverage

Focused decoded-instruction regressions verify:

- partial final-row load zero-fill and corresponding store suppression;
- active zero-length dense and gather extents;
- null-D2 rank-3 load masking and store suppression;
- completion-barrier arrival and TENSORCNT release for null D2;
- sub-row, row, and rank-3 plane iteration origins;
- rejection of advancing overlapping-stride layouts;
- acceptance of repeated-origin overlapping-stride layouts; and
- safe non-iterating rank-5 execution.

The complete `Gfx1250ExecutionTest.TensorDma*` test set and changed-file pre-commit checks pass locally.

## Workload status

This PR intentionally does not claim to fix the complete TensileLite reproducer. It removes independently testable descriptor-model discrepancies and gets the workload closer to the unresolved tail-loop semantic question.

## Issue tracking

Progress toward #9935.
