### PR TITLE
[RCCL] JIRA FBA-1079 add runtime-selectable 512-thread gfx950 kernel set 

### DIFF
--- a/projects/rccl/cmake/DeviceLinker.cmake
+++ b/projects/rccl/cmake/DeviceLinker.cmake
@@ -58,6 +58,27 @@ foreach(_gpu_raw ${GPU_TARGETS})
 endforeach()
 message(STATUS "Device Linker: GPU targets = ${DL_GPU_TARGETS}")
 
+# [RCCL] The alternate gfx950 512-thread kernel set is built only when gfx950 is
+# among the GPU targets. It re-compiles the device sources with -DRCCL_NTHREADS_512
+# into a distinct symbol namespace (see src/include/device.h) and links both sets
+# into the gfx950 device ELF. The host selects the set at runtime via
+# RCCL_GFX950_NTHREADS (see enqueue.cc / rccl_wrap.cc).
+set(RCCL_BUILD_GFX950_512 FALSE)
+if("gfx950" IN_LIST DL_GPU_TARGETS)
+  set(RCCL_BUILD_GFX950_512 TRUE)
+  message(STATUS "Device Linker: gfx950 512-thread kernel set ENABLED (RCCL_ENABLE_GFX950_512)")
+  # Let the host launch path (enqueue.cc / rccl_wrap.cc) reference the *_512
+  # generic kernels and the runtime selection logic.
+  target_compile_definitions(rccl PRIVATE RCCL_ENABLE_GFX950_512)
+endif()
+
+# Host-side defines: expose the second kernel set to the host launch path and make
+# the fat-binary host compile emit host stubs for the *_512 generic kernels.
+set(DL_HOST_512_DEFS "")
+if(RCCL_BUILD_GFX950_512)
+  list(APPEND DL_HOST_512_DEFS -DRCCL_ENABLE_GFX950_512 -DRCCL_HOST_FATBIN_COMPILE)
+endif()
+
 # ---------------------------------------------------------------------------
 # Optimization flags (passed to both compile and link modes of the driver)
 # ---------------------------------------------------------------------------
@@ -250,6 +271,45 @@ foreach(DL_GPU_TARGET ${DL_GPU_TARGETS})
   endif()
 
   # =========================================================================
+  # [RCCL] gfx950 only: second OBJECT library compiled with -DRCCL_NTHREADS_512.
+  # Produces the *_512 device functions (distinct symbols) that the 512-thread
+  # dispatcher links against. Emitted alongside the default 256-thread set.
+  # =========================================================================
+  set(_dl_link_512_flags "")
+  set(_dl_link_512_depends "")
+  if(RCCL_BUILD_GFX950_512 AND DL_GPU_TARGET STREQUAL "gfx950")
+    set(_dev_target_512 "rccl_device_${DL_GPU_TARGET}_512")
+
+    add_library(${_dev_target_512} OBJECT ${ARCH_SOURCES})
+    set_target_properties(${_dev_target_512} PROPERTIES LINKER_LANGUAGE RCCLDEV)
+
+    target_compile_options(${_dev_target_512} PRIVATE
+      --arch=${DL_GPU_TARGET}
+      --clang=${DL_CLANG}
+      ${DL_OPT_FLAGS}
+      -std=c++17
+      ${DL_HIP_COMPILER_FLAGS}
+    )
+    target_compile_definitions(${_dev_target_512} PRIVATE RCCL_DEVICE_LINKER RCCL_NTHREADS_512)
+    target_link_libraries(${_dev_target_512} PRIVATE rccl_device_defs)
+
+    add_dependencies(${_dev_target_512} hipify_all copy_nccl_device_headers)
+    if(ENABLE_ROCSHMEM AND TARGET rocshmem_static)
+      add_dependencies(${_dev_target_512} rocshmem_static)
+    endif()
+
+    set(_link_rsp_512 "${DL_ARCH_DIR}/link_objects_512.rsp")
+    file(GENERATE OUTPUT "${_link_rsp_512}"
+      CONTENT "$<JOIN:$<TARGET_OBJECTS:${_dev_target_512}>,\n>\n")
+
+    set(_dl_link_512_flags
+      --dispatcher-512=${HIPIFY_DIR}/src/device/common.cu.cpp
+      --objects-512-rsp=${_link_rsp_512}
+    )
+    set(_dl_link_512_depends ${_dev_target_512})
+  endif()
+
+  # =========================================================================
   # Link step: driver --link mode produces device.elf
   # =========================================================================
   set(ARCH_DEVICE_ELF "${DL_ARCH_DIR}/device.elf")
@@ -317,6 +377,7 @@ foreach(DL_GPU_TARGET ${DL_GPU_TARGETS})
       --clang=${DL_CLANG}
       ${DL_HIP_COMPILER_FLAGS}
       --dispatcher=${HIPIFY_DIR}/src/device/common.cu.cpp
+      ${_dl_link_512_flags}
       ${_rocshmem_bitcode_arg}
       ${_link_def_flags}
       ${_link_inc_flags}
@@ -324,7 +385,7 @@ foreach(DL_GPU_TARGET ${DL_GPU_TARGETS})
       -std=c++17
       -o ${ARCH_DEVICE_ELF}
       @${_link_rsp}
-    DEPENDS ${_dev_target} ${HIPIFY_DIR}/src/device/common.cu.cpp ${_rocshmem_link_depends}
+    DEPENDS ${_dev_target} ${_dl_link_512_depends} ${HIPIFY_DIR}/src/device/common.cu.cpp ${_rocshmem_link_depends}
     COMMENT "DL [${DL_GPU_TARGET}] link: device.elf"
     VERBATIM
     COMMAND_EXPAND_LISTS
@@ -435,6 +496,7 @@ add_custom_command(
     ${DL_HIP_COMPILER_FLAGS}
     -Xclang -fcuda-include-gpubinary -Xclang ${DEVICE_HIPFB}
     -DRCCL_DEVICE_LINKER
+    ${DL_HOST_512_DEFS}
     ${_link_def_flags}
     ${_host_inc_flags}
     ${DL_OPT_FLAGS}

--- a/projects/rccl/cmake/DeviceLinker.cmake
+++ b/projects/rccl/cmake/DeviceLinker.cmake
@@ -236,6 +236,17 @@ file(STRINGS "${SPECIALIZED_FILES_TXT}" SPECIALIZED_ENTRIES)
 list(LENGTH SPECIALIZED_ENTRIES DL_KERNEL_COUNT)
 message(STATUS "Device Linker: ${DL_KERNEL_COUNT} specialized kernels")
 
+# [RCCL] Shorter source list for the gfx950 512-thread kernel set: only the
+# unroll factors that set is built for (see unrolls_512 in generate.py). Used
+# below to build rccl_device_gfx950_512 from far fewer shards.
+set(SPECIALIZED_FILES_512_TXT "${GEN_DIR}/specialized_files_512.txt")
+set(SPECIALIZED_ENTRIES_512 "")
+if(EXISTS "${SPECIALIZED_FILES_512_TXT}")
+  file(STRINGS "${SPECIALIZED_FILES_512_TXT}" SPECIALIZED_ENTRIES_512)
+  list(LENGTH SPECIALIZED_ENTRIES_512 DL_KERNEL_COUNT_512)
+  message(STATUS "Device Linker: ${DL_KERNEL_COUNT_512} specialized kernels for gfx950 512-thread set")
+endif()
+
 # ---------------------------------------------------------------------------
 # Guard evaluation: skip kernels whose #if guard excludes a GPU target.
 # ---------------------------------------------------------------------------
@@ -354,7 +365,34 @@ foreach(DL_GPU_TARGET ${DL_GPU_TARGETS})
   if(RCCL_BUILD_GFX950_512 AND DL_GPU_TARGET STREQUAL "gfx950")
     set(_dev_target_512 "rccl_device_${DL_GPU_TARGET}_512")
 
-    add_library(${_dev_target_512} OBJECT ${ARCH_SOURCES})
+    # [RCCL] Build the 512-thread set from the shorter unroll-2-only source list.
+    # The unroll-1 (single-node, capped at 256 threads) and unroll-4 (never
+    # auto-selected) kernels reuse the 256-thread set at runtime, so compiling
+    # their *_512 variants would be dead weight. Reuses the guard filtering (the
+    # arch is always gfx950 here). Falls back to the full list if the 512 file is
+    # missing (older generate.py).
+    set(ARCH_SOURCES_512 "")
+    if(SPECIALIZED_ENTRIES_512)
+      foreach(ENTRY ${SPECIALIZED_ENTRIES_512})
+        if(NOT ENTRY MATCHES "^([^ ]+) +([^ ]+) *(.*)")
+          continue()
+        endif()
+        set(CPP_FILE "${CMAKE_MATCH_1}")
+        set(_entry_guard "${CMAKE_MATCH_3}")
+        dl_evaluate_guard("${_entry_guard}" "${DL_GPU_TARGET}" _guard_ok)
+        if(NOT _guard_ok)
+          continue()
+        endif()
+        list(APPEND ARCH_SOURCES_512 "${SPECIALIZED_DIR}/${CPP_FILE}")
+      endforeach()
+    else()
+      set(ARCH_SOURCES_512 ${ARCH_SOURCES})
+    endif()
+    list(LENGTH ARCH_SOURCES_512 _dl_built_512)
+    message(STATUS "Device Linker [${DL_GPU_TARGET} 512]: ${_dl_built_512} kernels to build (unroll-2 only)")
+
+    add_library(${_dev_target_512} OBJECT ${ARCH_SOURCES_512})
+    set_source_files_properties(${ARCH_SOURCES_512} PROPERTIES LANGUAGE RCCLDEV)
     set_target_properties(${_dev_target_512} PROPERTIES LINKER_LANGUAGE RCCLDEV)
 
     target_compile_options(${_dev_target_512} PRIVATE

--- a/projects/rccl/cmake/DeviceLinker.cmake
+++ b/projects/rccl/cmake/DeviceLinker.cmake
@@ -64,14 +64,13 @@ message(STATUS "Device Linker: GPU targets = ${DL_GPU_TARGETS}")
 # into the gfx950 device ELF. The host selects the set at runtime via
 # RCCL_GFX950_NTHREADS (see enqueue.cc / rccl_wrap.cc).
 #
-# Additional gating (both conditions must hold, else the 512 set is NOT built):
-#   1. ROCm version <= 7.0.2. On these releases the gfx950 512-thread kernels need
-#      the LLVM codegen workaround `-mllvm -amdgpu-agpr-bug-fix=1`, which only
-#      exists there.
-#   2. The compiler actually accepts that option (probed below). If unavailable
-#      the 512 device kernels would miscompile, so we decline to build the set.
-# When enabled, the 512 device kernels are COMPILED with `-mllvm -amdgpu-agpr-bug-fix=1`
-# (carried in RCCL_GFX950_512_AGPR_FLAGS).
+# ROCm-version gating (in addition to the opt-in switch and gfx950 being a target):
+#   - ROCm  > 7.0.2: the AGPR codegen bug is fixed, so the 512 set builds with no
+#     workaround (enabled directly; testable on current/future ROCm).
+#   - ROCm <= 7.0.2 (or undetected): the set needs the LLVM codegen workaround
+#     `-mllvm -amdgpu-agpr-bug-fix=1` and is built only if the compiler accepts it
+#     (probed below); when enabled it is COMPILED with that flag
+#     (carried in RCCL_GFX950_512_AGPR_FLAGS).
 # Opt-in build switch (install.sh --build-gfx950-512-threads-kernels). Default OFF:
 # without it the 512-thread set is never built regardless of arch/ROCm/linker.
 option(BUILD_GFX950_512_THREADS_KERNELS
@@ -100,43 +99,49 @@ if(BUILD_GFX950_512_THREADS_KERNELS AND "gfx950" IN_LIST DL_GPU_TARGETS)
     endif()
   endif()
 
-  set(_dl_rocm_ver_ok FALSE)
-  if(_dl_rocm_ver AND (_dl_rocm_ver VERSION_LESS_EQUAL "7.0.2"))
-    set(_dl_rocm_ver_ok TRUE)
+  # ROCm > 7.0.2: the AGPR codegen bug is fixed upstream, so the 512-thread set
+  # builds directly with no workaround. This lets the set be enabled/tested on
+  # current and future ROCm. ROCm <= 7.0.2 (or an undetected version) needs the
+  # `-mllvm -amdgpu-agpr-bug-fix=1` codegen workaround and is gated on the
+  # compiler accepting it.
+  set(_dl_rocm_gt_702 FALSE)
+  if(_dl_rocm_ver AND (_dl_rocm_ver VERSION_GREATER "7.0.2"))
+    set(_dl_rocm_gt_702 TRUE)
   endif()
 
-  # --- Probe: does the compiler accept `-mllvm -amdgpu-agpr-bug-fix=1` for gfx950? ---
-  # This is an AMDGPU codegen option, so we probe it at compile time: compile a
-  # trivial device kernel for gfx950 with the option. A valid option compiles
-  # cleanly (rc=0); an unknown one makes LLVM exit non-zero.
-  set(_dl_agpr_ok FALSE)
-  set(_dl_agpr_probe_src "${PROJECT_BINARY_DIR}/rccl_agpr_probe.hip")
-  file(WRITE "${_dl_agpr_probe_src}" "__global__ void rccl_agpr_probe_kernel() {}\n")
-  execute_process(
-    COMMAND "${DL_CLANG}" -x hip --offload-device-only --offload-arch=gfx950
-            -mllvm -amdgpu-agpr-bug-fix=1 ${DL_HIP_COMPILER_FLAGS}
-            -std=c++17 -S -o /dev/null "${_dl_agpr_probe_src}"
-    RESULT_VARIABLE _dl_agpr_cc_rc OUTPUT_QUIET ERROR_VARIABLE _dl_agpr_cc_err
-  )
-  if(_dl_agpr_cc_rc EQUAL 0)
-    set(_dl_agpr_ok TRUE)
-  endif()
-
-  if(_dl_rocm_ver_ok AND _dl_agpr_ok)
+  if(_dl_rocm_gt_702)
     set(RCCL_BUILD_GFX950_512 TRUE)
-    set(RCCL_GFX950_512_AGPR_FLAGS -mllvm -amdgpu-agpr-bug-fix=1)
+    set(RCCL_GFX950_512_AGPR_FLAGS "")
     message(STATUS "Device Linker: gfx950 512-thread kernel set ENABLED (RCCL_ENABLE_GFX950_512) "
-                   "[ROCm ${_dl_rocm_ver}, -mllvm -amdgpu-agpr-bug-fix available]")
-    # Let the host launch path (enqueue.cc / rccl_wrap.cc) reference the *_512
-    # generic kernels and the runtime selection logic.
+                   "[ROCm ${_dl_rocm_ver} > 7.0.2, no agpr workaround needed]")
     target_compile_definitions(rccl PRIVATE RCCL_ENABLE_GFX950_512)
   else()
-    if(NOT _dl_rocm_ver_ok)
-      message(STATUS "Device Linker: gfx950 512-thread kernel set DISABLED "
-                     "(ROCm version '${_dl_rocm_ver}' is not <= 7.0.2)")
+    # --- Probe: does the compiler accept `-mllvm -amdgpu-agpr-bug-fix=1` for gfx950? ---
+    # AMDGPU codegen option, so probe it at compile time: compile a trivial gfx950
+    # device kernel with the option. Valid -> rc=0; unknown -> LLVM exits non-zero.
+    set(_dl_agpr_ok FALSE)
+    set(_dl_agpr_probe_src "${PROJECT_BINARY_DIR}/rccl_agpr_probe.hip")
+    file(WRITE "${_dl_agpr_probe_src}" "__global__ void rccl_agpr_probe_kernel() {}\n")
+    execute_process(
+      COMMAND "${DL_CLANG}" -x hip --offload-device-only --offload-arch=gfx950
+              -mllvm -amdgpu-agpr-bug-fix=1 ${DL_HIP_COMPILER_FLAGS}
+              -std=c++17 -S -o /dev/null "${_dl_agpr_probe_src}"
+      RESULT_VARIABLE _dl_agpr_cc_rc OUTPUT_QUIET ERROR_VARIABLE _dl_agpr_cc_err
+    )
+    if(_dl_agpr_cc_rc EQUAL 0)
+      set(_dl_agpr_ok TRUE)
+    endif()
+
+    if(_dl_agpr_ok)
+      set(RCCL_BUILD_GFX950_512 TRUE)
+      set(RCCL_GFX950_512_AGPR_FLAGS -mllvm -amdgpu-agpr-bug-fix=1)
+      message(STATUS "Device Linker: gfx950 512-thread kernel set ENABLED (RCCL_ENABLE_GFX950_512) "
+                     "[ROCm ${_dl_rocm_ver} <= 7.0.2, applying -mllvm -amdgpu-agpr-bug-fix]")
+      target_compile_definitions(rccl PRIVATE RCCL_ENABLE_GFX950_512)
     else()
       message(STATUS "Device Linker: gfx950 512-thread kernel set DISABLED "
-                     "(compiler does not accept -mllvm -amdgpu-agpr-bug-fix)")
+                     "(ROCm '${_dl_rocm_ver}' <= 7.0.2 requires -mllvm -amdgpu-agpr-bug-fix, "
+                     "which the compiler does not accept)")
     endif()
   endif()
 endif()

--- a/projects/rccl/cmake/DeviceLinker.cmake
+++ b/projects/rccl/cmake/DeviceLinker.cmake
@@ -63,13 +63,82 @@ message(STATUS "Device Linker: GPU targets = ${DL_GPU_TARGETS}")
 # into a distinct symbol namespace (see src/include/device.h) and links both sets
 # into the gfx950 device ELF. The host selects the set at runtime via
 # RCCL_GFX950_NTHREADS (see enqueue.cc / rccl_wrap.cc).
+#
+# Additional gating (both conditions must hold, else the 512 set is NOT built):
+#   1. ROCm version <= 7.0.2. On these releases the gfx950 512-thread kernels need
+#      the LLVM codegen workaround `-mllvm -amdgpu-agpr-bug-fix=1`, which only
+#      exists there.
+#   2. The compiler actually accepts that option (probed below). If unavailable
+#      the 512 device kernels would miscompile, so we decline to build the set.
+# When enabled, the 512 device kernels are COMPILED with `-mllvm -amdgpu-agpr-bug-fix=1`
+# (carried in RCCL_GFX950_512_AGPR_FLAGS).
+# Opt-in build switch (install.sh --build-gfx950-512-threads-kernels). Default OFF:
+# without it the 512-thread set is never built regardless of arch/ROCm/linker.
+option(BUILD_GFX950_512_THREADS_KERNELS
+       "Build the runtime-selectable gfx950 512-thread kernel set" OFF)
+
 set(RCCL_BUILD_GFX950_512 FALSE)
-if("gfx950" IN_LIST DL_GPU_TARGETS)
-  set(RCCL_BUILD_GFX950_512 TRUE)
-  message(STATUS "Device Linker: gfx950 512-thread kernel set ENABLED (RCCL_ENABLE_GFX950_512)")
-  # Let the host launch path (enqueue.cc / rccl_wrap.cc) reference the *_512
-  # generic kernels and the runtime selection logic.
-  target_compile_definitions(rccl PRIVATE RCCL_ENABLE_GFX950_512)
+set(RCCL_GFX950_512_AGPR_FLAGS "")
+if(BUILD_GFX950_512_THREADS_KERNELS AND "gfx950" IN_LIST DL_GPU_TARGETS)
+  # --- Detect ROCm version (same sources as tools/topo_expl/get_rocm_version.cmake) ---
+  set(_dl_rocm_ver "")
+  set(_dl_rocm_ver_file "${ROCM_PATH}/lib/cmake/rocm-core/rocm-core-config-version.cmake")
+  if(EXISTS "${_dl_rocm_ver_file}")
+    file(STRINGS "${_dl_rocm_ver_file}" _dl_vline REGEX "^set\\(PACKAGE_VERSION")
+    if(_dl_vline)
+      string(REGEX MATCH "([0-9]+(\\.[0-9]+)+)" _dl_vmatch "${_dl_vline}")
+      if(CMAKE_MATCH_1)
+        set(_dl_rocm_ver "${CMAKE_MATCH_1}")
+      endif()
+    endif()
+  endif()
+  if(NOT _dl_rocm_ver AND EXISTS "${ROCM_PATH}/.info/version")
+    file(READ "${ROCM_PATH}/.info/version" _dl_vstr)
+    string(REGEX MATCH "([0-9]+(\\.[0-9]+)+)" _dl_vmatch "${_dl_vstr}")
+    if(CMAKE_MATCH_1)
+      set(_dl_rocm_ver "${CMAKE_MATCH_1}")
+    endif()
+  endif()
+
+  set(_dl_rocm_ver_ok FALSE)
+  if(_dl_rocm_ver AND (_dl_rocm_ver VERSION_LESS_EQUAL "7.0.2"))
+    set(_dl_rocm_ver_ok TRUE)
+  endif()
+
+  # --- Probe: does the compiler accept `-mllvm -amdgpu-agpr-bug-fix=1` for gfx950? ---
+  # This is an AMDGPU codegen option, so we probe it at compile time: compile a
+  # trivial device kernel for gfx950 with the option. A valid option compiles
+  # cleanly (rc=0); an unknown one makes LLVM exit non-zero.
+  set(_dl_agpr_ok FALSE)
+  set(_dl_agpr_probe_src "${PROJECT_BINARY_DIR}/rccl_agpr_probe.hip")
+  file(WRITE "${_dl_agpr_probe_src}" "__global__ void rccl_agpr_probe_kernel() {}\n")
+  execute_process(
+    COMMAND "${DL_CLANG}" -x hip --offload-device-only --offload-arch=gfx950
+            -mllvm -amdgpu-agpr-bug-fix=1 ${DL_HIP_COMPILER_FLAGS}
+            -std=c++17 -S -o /dev/null "${_dl_agpr_probe_src}"
+    RESULT_VARIABLE _dl_agpr_cc_rc OUTPUT_QUIET ERROR_VARIABLE _dl_agpr_cc_err
+  )
+  if(_dl_agpr_cc_rc EQUAL 0)
+    set(_dl_agpr_ok TRUE)
+  endif()
+
+  if(_dl_rocm_ver_ok AND _dl_agpr_ok)
+    set(RCCL_BUILD_GFX950_512 TRUE)
+    set(RCCL_GFX950_512_AGPR_FLAGS -mllvm -amdgpu-agpr-bug-fix=1)
+    message(STATUS "Device Linker: gfx950 512-thread kernel set ENABLED (RCCL_ENABLE_GFX950_512) "
+                   "[ROCm ${_dl_rocm_ver}, -mllvm -amdgpu-agpr-bug-fix available]")
+    # Let the host launch path (enqueue.cc / rccl_wrap.cc) reference the *_512
+    # generic kernels and the runtime selection logic.
+    target_compile_definitions(rccl PRIVATE RCCL_ENABLE_GFX950_512)
+  else()
+    if(NOT _dl_rocm_ver_ok)
+      message(STATUS "Device Linker: gfx950 512-thread kernel set DISABLED "
+                     "(ROCm version '${_dl_rocm_ver}' is not <= 7.0.2)")
+    else()
+      message(STATUS "Device Linker: gfx950 512-thread kernel set DISABLED "
+                     "(compiler does not accept -mllvm -amdgpu-agpr-bug-fix)")
+    endif()
+  endif()
 endif()
 
 # Host-side defines: expose the second kernel set to the host launch path and make
@@ -289,6 +358,7 @@ foreach(DL_GPU_TARGET ${DL_GPU_TARGETS})
       ${DL_OPT_FLAGS}
       -std=c++17
       ${DL_HIP_COMPILER_FLAGS}
+      ${RCCL_GFX950_512_AGPR_FLAGS}
     )
     target_compile_definitions(${_dev_target_512} PRIVATE RCCL_DEVICE_LINKER RCCL_NTHREADS_512)
     target_link_libraries(${_dev_target_512} PRIVATE rccl_device_defs)
@@ -306,6 +376,11 @@ foreach(DL_GPU_TARGET ${DL_GPU_TARGETS})
       --dispatcher-512=${HIPIFY_DIR}/src/device/common.cu.cpp
       --objects-512-rsp=${_link_rsp_512}
     )
+    # Forward the AGPR bug-fix workaround to the 512-thread dispatcher compile
+    # inside the driver's --link step (one --compile-512-flag per token).
+    foreach(_agpr_f IN LISTS RCCL_GFX950_512_AGPR_FLAGS)
+      list(APPEND _dl_link_512_flags "--compile-512-flag=${_agpr_f}")
+    endforeach()
     set(_dl_link_512_depends ${_dev_target_512})
   endif()
 

--- a/projects/rccl/install.sh
+++ b/projects/rccl/install.sh
@@ -54,7 +54,7 @@ function display_help()
     echo " Options:"
     echo "       --address-sanitizer     Build with address sanitizer enabled"
     echo "       --amdgpu_targets        Only compile for specified GPU architecture(s). For multiple targets, separate by ';' (builds for all supported GPU architectures by default)"
-    echo "       --build-gfx950-512-threads-kernels  Build the runtime-selectable gfx950 512-thread kernel set (default off; also requires ROCm <= 7.0.2 and compiler support for -mllvm -amdgpu-agpr-bug-fix)"
+    echo "       --build-gfx950-512-threads-kernels  Build the runtime-selectable gfx950 512-thread kernel set (default off; on ROCm <= 7.0.2 also requires compiler support for -mllvm -amdgpu-agpr-bug-fix)"
     echo "       --cmake-options         Pass additional CMake options (e.g. --cmake-options \"-DFOO=BAR -DBAZ=ON\")"
     echo "       --debug                 Build debug library"
     echo "       --debug-fast            Build debug library with lto optimization disabled (fast build times)"

--- a/projects/rccl/install.sh
+++ b/projects/rccl/install.sh
@@ -39,6 +39,7 @@ force_reduce_pipeline=false
 generate_sym_kernels=true
 device_linker=true
 warp_speed_enabled=true # note that this flag will be overridden to false for non MI350/MI300 platforms
+build_gfx950_512_threads_kernels=false
 quiet_warnings=false
 build_rocshmem_support=false
 rocshmem_mono_hash="0e2998b11f99e8302c72f1ac2ce9f2b8c1816587"
@@ -53,6 +54,7 @@ function display_help()
     echo " Options:"
     echo "       --address-sanitizer     Build with address sanitizer enabled"
     echo "       --amdgpu_targets        Only compile for specified GPU architecture(s). For multiple targets, separate by ';' (builds for all supported GPU architectures by default)"
+    echo "       --build-gfx950-512-threads-kernels  Build the runtime-selectable gfx950 512-thread kernel set (default off; also requires ROCm <= 7.0.2 and compiler support for -mllvm -amdgpu-agpr-bug-fix)"
     echo "       --cmake-options         Pass additional CMake options (e.g. --cmake-options \"-DFOO=BAR -DBAZ=ON\")"
     echo "       --debug                 Build debug library"
     echo "       --debug-fast            Build debug library with lto optimization disabled (fast build times)"
@@ -116,7 +118,7 @@ function display_help()
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ "$?" -eq 4 ]]; then
-    GETOPT_PARSE=$(getopt --name "${0}" --options cdfhij:lprtq --longoptions address-sanitizer,amdgpu_targets:,cmake-options:,debug,debug-fast,dependencies,device-linker,disable-roctx,disable-sym-kernels,disable-warp-speed,dump-asm,enable-code-coverage,enable_backtrace,enable-mpi-tests,fast,force-reduce-pipeline,generate-sym-kernels,help,install,jobs:,kernel-resource-use,local_gpu_only,log-trace,ninja,no_clean,no-device-linker,openmp-test-enable,package_build,prefix:,quiet-warnings,rm-legacy-include-dir,rocshmem,roctx-enable,run_tests_all,run_tests_quick,static,tests_build,time-trace,verbose -- "$@")
+    GETOPT_PARSE=$(getopt --name "${0}" --options cdfhij:lprtq --longoptions address-sanitizer,amdgpu_targets:,build-gfx950-512-threads-kernels,cmake-options:,debug,debug-fast,dependencies,device-linker,disable-roctx,disable-sym-kernels,disable-warp-speed,dump-asm,enable-code-coverage,enable_backtrace,enable-mpi-tests,fast,force-reduce-pipeline,generate-sym-kernels,help,install,jobs:,kernel-resource-use,local_gpu_only,log-trace,ninja,no_clean,no-device-linker,openmp-test-enable,package_build,prefix:,quiet-warnings,rm-legacy-include-dir,rocshmem,roctx-enable,run_tests_all,run_tests_quick,static,tests_build,time-trace,verbose -- "$@")
 else
     echo "Need a new version of getopt"
     exit 1
@@ -133,6 +135,7 @@ while true; do
     case "${1}" in
          --address-sanitizer)        build_address_sanitizer=true;                                                                     shift ;;
          --amdgpu_targets)           build_amdgpu_targets=${2};                                                                        shift 2 ;;
+         --build-gfx950-512-threads-kernels) build_gfx950_512_threads_kernels=true;                                                    shift ;;
          --cmake-options)            custom_cmake_options=${2};                                                                        shift 2 ;;
          --debug)                    build_release=false;                                                                              shift ;;
          --debug-fast)               build_release=false; debug_fast=true;                                                             shift ;;
@@ -404,6 +407,13 @@ fi
 # Enable WARP_SPEED only on MI350/MI300 platforms
 if [[ "${warp_speed_enabled}" == true ]]; then
     cmake_common_options="${cmake_common_options} -DENABLE_WARP_SPEED=ON"
+fi
+
+# Opt-in: build the second, runtime-selectable gfx950 512-thread kernel set.
+# Off by default; the device linker further gates it on ROCm <= 7.0.2 and ld.lld
+# support for -mllvm amdgpu-agpr-bug-fix.
+if [[ "${build_gfx950_512_threads_kernels}" == true ]]; then
+    cmake_common_options="${cmake_common_options} -DBUILD_GFX950_512_THREADS_KERNELS=ON"
 fi
 
 # Suppress Warnings

--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -144,6 +144,7 @@ set(SRC_FILES
   include/debug.h
   include/dev_runtime.h
   include/device.h
+  include/rccl_nt_sym.h
   include/env.h
   include/device_buffer.h
   include/enqueue.h

--- a/projects/rccl/src/device/common.cu
+++ b/projects/rccl/src/device/common.cu
@@ -22,18 +22,26 @@ struct RunWorkNop {
 // RCCL_NT_SYM() renames these to *_512 when compiling the alternate gfx950
 // 512-thread device dispatcher (-DRCCL_NTHREADS_512), giving distinct __global__
 // entry points and a distinct 512-thread func table (see device.h / common.h).
+//
+// The 512-thread set is built for unroll 2 only (single-node/unroll-1 is capped
+// at 256 threads and unroll 4 is never selected on gfx950), so the unroll-1 and
+// unroll-4 generic dispatchers are emitted only for the default 256-thread set.
+#ifndef RCCL_NTHREADS_512
 __launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__
   void RCCL_NT_SYM(ncclDevKernel_Generic_1)(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {
   ncclKernelMain<-1, RunWorkNop, /*Unroll*/ 1>(&argsStorage.args);
 }
+#endif
 __launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__
   void RCCL_NT_SYM(ncclDevKernel_Generic_2)(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {
   ncclKernelMain<-1, RunWorkNop, /*Unroll*/ 2>(&argsStorage.args);
 }
+#ifndef RCCL_NTHREADS_512
 __launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__
   void RCCL_NT_SYM(ncclDevKernel_Generic_4)(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {
   ncclKernelMain<-1, RunWorkNop, /*Unroll*/ 4>(&argsStorage.args);
 }
+#endif
 
 // [RCCL] Host-side stubs for the 512-thread generic kernels. The host launch
 // path (enqueue.cc) takes the address of these symbols to launch the 512-thread
@@ -41,18 +49,12 @@ __launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__
 // compiling common.cu.cpp for the host with the embedded fat binary
 // (RCCL_HOST_FATBIN_COMPILE) so the device dispatcher compiles above emit exactly
 // one kernel set each (avoiding duplicate device symbols at link time).
+// Only the unroll-2 stub is emitted: the 512-thread set is built for unroll 2
+// only (see the device dispatcher above and enqueue.cc/ncclKerns512).
 #if defined(RCCL_ENABLE_GFX950_512) && defined(RCCL_HOST_FATBIN_COMPILE)
-__launch_bounds__(512, 1) __global__
-  void ncclDevKernel_Generic_1_512(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {
-  ncclKernelMain<-1, RunWorkNop, /*Unroll*/ 1>(&argsStorage.args);
-}
 __launch_bounds__(512, 1) __global__
   void ncclDevKernel_Generic_2_512(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {
   ncclKernelMain<-1, RunWorkNop, /*Unroll*/ 2>(&argsStorage.args);
-}
-__launch_bounds__(512, 1) __global__
-  void ncclDevKernel_Generic_4_512(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {
-  ncclKernelMain<-1, RunWorkNop, /*Unroll*/ 4>(&argsStorage.args);
 }
 #endif
 

--- a/projects/rccl/src/device/common.cu
+++ b/projects/rccl/src/device/common.cu
@@ -19,27 +19,53 @@ struct RunWorkNop {
   __device__ void run() {}
 };
 
+// RCCL_NT_SYM() renames these to *_512 when compiling the alternate gfx950
+// 512-thread device dispatcher (-DRCCL_NTHREADS_512), giving distinct __global__
+// entry points and a distinct 512-thread func table (see device.h / common.h).
 __launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__
-  void ncclDevKernel_Generic_1(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {
+  void RCCL_NT_SYM(ncclDevKernel_Generic_1)(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {
   ncclKernelMain<-1, RunWorkNop, /*Unroll*/ 1>(&argsStorage.args);
 }
 __launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__
-  void ncclDevKernel_Generic_2(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {
+  void RCCL_NT_SYM(ncclDevKernel_Generic_2)(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {
   ncclKernelMain<-1, RunWorkNop, /*Unroll*/ 2>(&argsStorage.args);
 }
 __launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__
-  void ncclDevKernel_Generic_4(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {
+  void RCCL_NT_SYM(ncclDevKernel_Generic_4)(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {
   ncclKernelMain<-1, RunWorkNop, /*Unroll*/ 4>(&argsStorage.args);
 }
 
+// [RCCL] Host-side stubs for the 512-thread generic kernels. The host launch
+// path (enqueue.cc) takes the address of these symbols to launch the 512-thread
+// device kernels that live in the gfx950 device ELF. They are emitted only when
+// compiling common.cu.cpp for the host with the embedded fat binary
+// (RCCL_HOST_FATBIN_COMPILE) so the device dispatcher compiles above emit exactly
+// one kernel set each (avoiding duplicate device symbols at link time).
+#if defined(RCCL_ENABLE_GFX950_512) && defined(RCCL_HOST_FATBIN_COMPILE)
+__launch_bounds__(512, 1) __global__
+  void ncclDevKernel_Generic_1_512(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {
+  ncclKernelMain<-1, RunWorkNop, /*Unroll*/ 1>(&argsStorage.args);
+}
+__launch_bounds__(512, 1) __global__
+  void ncclDevKernel_Generic_2_512(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {
+  ncclKernelMain<-1, RunWorkNop, /*Unroll*/ 2>(&argsStorage.args);
+}
+__launch_bounds__(512, 1) __global__
+  void ncclDevKernel_Generic_4_512(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {
+  ncclKernelMain<-1, RunWorkNop, /*Unroll*/ 4>(&argsStorage.args);
+}
+#endif
+
+// RCCL_NT_SYM() keeps this in the same symbol namespace as the rest of the set
+// (base or _512), so the two gfx950 dispatchers don't emit a duplicate definition.
 #if defined(USE_INDIRECT_FUNCTION_CALL) || defined(RCCL_DEVICE_LINKER)
-__device__ void ncclDevFunc_Nop();
+__device__ void RCCL_NT_SYM(ncclDevFunc_Nop)();
 #else
-__device__ __attribute__((noinline)) void ncclDevFunc_Nop();
+__device__ __attribute__((noinline)) void RCCL_NT_SYM(ncclDevFunc_Nop)();
 #endif
 
 // [RCCL] Body for the no-op device func. RCCL's common.cu declares ncclDevFunc_Nop
 // above (mode-aware attributes); generate.py excludes "Nop" from the generated
 // per-impl/specialized files, so the definition must live here (as in upstream and
 // the v2.29.7-1 base). The generated ncclDevFuncTable references this symbol.
-__device__ void ncclDevFunc_Nop() {}
+__device__ void RCCL_NT_SYM(ncclDevFunc_Nop)() {}

--- a/projects/rccl/src/device/common.h
+++ b/projects/rccl/src/device/common.h
@@ -596,9 +596,16 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
       SpecializedRunWorkBatch().run();
     } else {
 #if defined(USE_INDIRECT_FUNCTION_CALL) || defined(RCCL_DEVICE_LINKER)
+#if defined(RCCL_NTHREADS_512)
+      // [RCCL] The gfx950 512-thread set is built for unroll 2 only (single-node
+      // is capped at 256 threads and unroll 4 is never selected on gfx950), so
+      // the unroll-1/4 dispatch tables are not compiled into this set.
+      RCCL_NT_SYM(ncclDevFuncTable_2)[ncclShmem.funcId]();
+#else
       if (COLL_UNROLL == 1) RCCL_NT_SYM(ncclDevFuncTable_1)[ncclShmem.funcId]();
       else if (COLL_UNROLL == 2) RCCL_NT_SYM(ncclDevFuncTable_2)[ncclShmem.funcId]();
       else RCCL_NT_SYM(ncclDevFuncTable_4)[ncclShmem.funcId]();
+#endif
 #else
       if (COLL_UNROLL == 1) NCCL_CALL_FUNCTIONS_1(ncclShmem.funcId);
       else if (COLL_UNROLL == 2) NCCL_CALL_FUNCTIONS_2(ncclShmem.funcId);
@@ -635,9 +642,13 @@ __global__ void ncclDevKernel_Generic_4(ncclDevKernelArgsDefaultStorage NCCL_GRI
 // in a distinct symbol namespace (see src/include/device.h). Selected at runtime
 // via RCCL_GFX950_NTHREADS=512 (comm->use512Kernels). Only present in the gfx950
 // device image; launching these on other arches is never attempted.
-__global__ void ncclDevKernel_Generic_1_512(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage);
+//
+// Only the unroll-2 kernel is built: the 512-thread set only benefits launches
+// that actually use more than 256 threads, which on gfx950 is the multi-node
+// (unroll 2) path. Single-node uses unroll 1 but is capped at 256 threads
+// (RCCL_SINGLE_NODE_MAX_NTHREADS) and unroll 4 is never auto-selected, so those
+// fall back to the 256-thread kernels (see rcclSelectKernelFn in enqueue.cc).
 __global__ void ncclDevKernel_Generic_2_512(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage);
-__global__ void ncclDevKernel_Generic_4_512(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage);
 #endif
 
 #define DEFINE_ncclDevKernel_nop(suffix, coll, redop, ty, algo, proto, specializedFnId) \

--- a/projects/rccl/src/device/common.h
+++ b/projects/rccl/src/device/common.h
@@ -111,7 +111,10 @@ extern __shared__ ulong2
 #endif
 
 #ifdef ENABLE_FAULT_INJECTION
-__device__ inline void insert_random_delay_per_warp() {
+// __forceinline__: references ncclShmem, whose layout/name differs between the
+// 256 and 512 kernel sets. Forcing inline prevents a comdat symbol that would
+// otherwise be deduplicated across the two coexisting sets. See device.h.
+__device__ __forceinline__ void insert_random_delay_per_warp() {
   if ((ncclShmem.faults & RANDOM_DELAY_ON_WARP_START) && (threadIdx.x % WARP_SIZE == 0)) {
     switch ((wall_clock64() >> (threadIdx.x / WARP_SIZE * 2)) & 0x3) {
     case 0:
@@ -132,7 +135,9 @@ __device__ inline void insert_random_delay_per_warp() {
 }
 #endif
 
-__device__ inline void* ncclScratchForWarp(int warp) {
+// __forceinline__: references ncclShmemPerWarp (renamed per kernel set), so it must
+// not emit a shared comdat symbol across the 256/512 sets. See device.h.
+__device__ __forceinline__ void* ncclScratchForWarp(int warp) {
   return (char*)ncclShmemPerWarp + warp * ncclShmemScratchWarpSize();
 }
 
@@ -593,9 +598,9 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
       SpecializedRunWorkBatch().run();
     } else {
 #if defined(USE_INDIRECT_FUNCTION_CALL) || defined(RCCL_DEVICE_LINKER)
-      if (COLL_UNROLL == 1) ncclDevFuncTable_1[ncclShmem.funcId]();
-      else if (COLL_UNROLL == 2) ncclDevFuncTable_2[ncclShmem.funcId]();
-      else ncclDevFuncTable_4[ncclShmem.funcId]();
+      if (COLL_UNROLL == 1) RCCL_NT_SYM(ncclDevFuncTable_1)[ncclShmem.funcId]();
+      else if (COLL_UNROLL == 2) RCCL_NT_SYM(ncclDevFuncTable_2)[ncclShmem.funcId]();
+      else RCCL_NT_SYM(ncclDevFuncTable_4)[ncclShmem.funcId]();
 #else
       if (COLL_UNROLL == 1) NCCL_CALL_FUNCTIONS_1(ncclShmem.funcId);
       else if (COLL_UNROLL == 2) NCCL_CALL_FUNCTIONS_2(ncclShmem.funcId);
@@ -631,14 +636,16 @@ __global__ void ncclDevKernel_Generic_4(ncclDevKernelArgsDefaultStorage NCCL_GRI
   __global__ void ncclDevKernel_##suffix(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {}
 
 // noinline iff RCCL_DEVICE_LINKER (each devfunc is a standalone shard).
+// RCCL_NT_SYM() suffixes the symbol with _512 when building the alternate
+// gfx950 512-thread kernel set (see device.h).
 #ifdef RCCL_DEVICE_LINKER
 #define DEFINE_ncclDevFunc(suffix, coll, redop, ty, algo, proto, acc, pipeline, unroll, userreg) \
-  __device__ __attribute__((noinline)) void ncclDevFunc_##suffix() { \
+  __device__ __attribute__((noinline)) void RCCL_NT_SYM(ncclDevFunc_##suffix)() { \
     RunWorkBatch<coll, ty, redop<ty>, algo, proto, acc, unroll, pipeline, userreg>().run(); \
   }
 #else
 #define DEFINE_ncclDevFunc(suffix, coll, redop, ty, algo, proto, acc, pipeline, unroll, userreg) \
-  __device__ void ncclDevFunc_##suffix() { \
+  __device__ void RCCL_NT_SYM(ncclDevFunc_##suffix)() { \
     RunWorkBatch<coll, ty, redop<ty>, algo, proto, acc, unroll, pipeline, userreg>().run(); \
   }
 #endif

--- a/projects/rccl/src/device/common.h
+++ b/projects/rccl/src/device/common.h
@@ -111,9 +111,8 @@ extern __shared__ ulong2
 #endif
 
 #ifdef ENABLE_FAULT_INJECTION
-// __forceinline__: references ncclShmem, whose layout/name differs between the
-// 256 and 512 kernel sets. Forcing inline prevents a comdat symbol that would
-// otherwise be deduplicated across the two coexisting sets. See device.h.
+// __forceinline__ so no comdat symbol is emitted that could be deduplicated
+// across the coexisting 256/512 kernel sets (references ncclShmem; see device.h).
 __device__ __forceinline__ void insert_random_delay_per_warp() {
   if ((ncclShmem.faults & RANDOM_DELAY_ON_WARP_START) && (threadIdx.x % WARP_SIZE == 0)) {
     switch ((wall_clock64() >> (threadIdx.x / WARP_SIZE * 2)) & 0x3) {
@@ -135,8 +134,7 @@ __device__ __forceinline__ void insert_random_delay_per_warp() {
 }
 #endif
 
-// __forceinline__: references ncclShmemPerWarp (renamed per kernel set), so it must
-// not emit a shared comdat symbol across the 256/512 sets. See device.h.
+// __forceinline__ for the same reason as above (references ncclShmemPerWarp).
 __device__ __forceinline__ void* ncclScratchForWarp(int warp) {
   return (char*)ncclShmemPerWarp + warp * ncclShmemScratchWarpSize();
 }
@@ -636,8 +634,6 @@ __global__ void ncclDevKernel_Generic_4(ncclDevKernelArgsDefaultStorage NCCL_GRI
   __global__ void ncclDevKernel_##suffix(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {}
 
 // noinline iff RCCL_DEVICE_LINKER (each devfunc is a standalone shard).
-// RCCL_NT_SYM() suffixes the symbol with _512 when building the alternate
-// gfx950 512-thread kernel set (see device.h).
 #ifdef RCCL_DEVICE_LINKER
 #define DEFINE_ncclDevFunc(suffix, coll, redop, ty, algo, proto, acc, pipeline, unroll, userreg) \
   __device__ __attribute__((noinline)) void RCCL_NT_SYM(ncclDevFunc_##suffix)() { \

--- a/projects/rccl/src/device/common.h
+++ b/projects/rccl/src/device/common.h
@@ -630,6 +630,16 @@ __global__ void ncclDevKernel_Generic_1(ncclDevKernelArgsDefaultStorage NCCL_GRI
 __global__ void ncclDevKernel_Generic_2(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage);
 __global__ void ncclDevKernel_Generic_4(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage);
 
+#ifdef RCCL_ENABLE_GFX950_512
+// [RCCL] Alternate gfx950 kernel set compiled with 512 threads per block, living
+// in a distinct symbol namespace (see src/include/device.h). Selected at runtime
+// via RCCL_GFX950_NTHREADS=512 (comm->use512Kernels). Only present in the gfx950
+// device image; launching these on other arches is never attempted.
+__global__ void ncclDevKernel_Generic_1_512(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage);
+__global__ void ncclDevKernel_Generic_2_512(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage);
+__global__ void ncclDevKernel_Generic_4_512(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage);
+#endif
+
 #define DEFINE_ncclDevKernel_nop(suffix, coll, redop, ty, algo, proto, specializedFnId) \
   __global__ void ncclDevKernel_##suffix(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {}
 

--- a/projects/rccl/src/device/generate.py
+++ b/projects/rccl/src/device/generate.py
@@ -433,9 +433,6 @@ with open(os.path.join(gensrc, "device_table.h"), "w") as f:
   for fn in primary_funcs:
     sym = "ncclDevFunc_" + fn_sym(fn)
     guard = get_arch_guard(fn)
-    # RCCL_NT_SYM() suffixes the symbol with _512 when this header is compiled for
-    # the alternate gfx950 512-thread kernel set (-DRCCL_NTHREADS_512); otherwise
-    # it is the identity. See src/include/device.h.
     if guard:
       out("#if %s\n__device__ void RCCL_NT_SYM(%s)();\n#endif\n" % (guard, sym))
     else:
@@ -673,9 +670,6 @@ for fn in primary_funcs:
     out('#include "%s.h"\n\n' % lower_coll)
     if guard:
       out("#if %s\n" % guard)
-    # RCCL_NT_SYM() suffixes the kernel wrapper and the called device function with
-    # _512 when compiling the alternate gfx950 512-thread set (-DRCCL_NTHREADS_512),
-    # keeping the two coexisting sets in distinct symbol namespaces. See device.h.
     out(
       "DEFINE_ncclDevFunc({sym}, ncclFunc{coll}, {redop_cxx}, {ty_cxx}, "
       "NCCL_ALGO_{algo}, NCCL_PROTO_{proto}, {acc}, {pipeline}, {unroll}, {reg})\n\n"

--- a/projects/rccl/src/device/generate.py
+++ b/projects/rccl/src/device/generate.py
@@ -433,10 +433,13 @@ with open(os.path.join(gensrc, "device_table.h"), "w") as f:
   for fn in primary_funcs:
     sym = "ncclDevFunc_" + fn_sym(fn)
     guard = get_arch_guard(fn)
+    # RCCL_NT_SYM() suffixes the symbol with _512 when this header is compiled for
+    # the alternate gfx950 512-thread kernel set (-DRCCL_NTHREADS_512); otherwise
+    # it is the identity. See src/include/device.h.
     if guard:
-      out("#if %s\n__device__ void %s();\n#endif\n" % (guard, sym))
+      out("#if %s\n__device__ void RCCL_NT_SYM(%s)();\n#endif\n" % (guard, sym))
     else:
-      out("__device__ void %s();\n" % sym)
+      out("__device__ void RCCL_NT_SYM(%s)();\n" % sym)
   out("\n")
 
   index = {val: None for val in all_unrolls}
@@ -447,15 +450,15 @@ with open(os.path.join(gensrc, "device_table.h"), "w") as f:
   out("typedef void(*ncclDevFuncPtr_t)();\n\n")
   for unroll in all_unrolls:
     index[unroll] = 0
-    out("static __device__ ncclDevFuncPtr_t const ncclDevFuncTable_%s[] = {\n" % unroll)
+    out("static __device__ ncclDevFuncPtr_t const RCCL_NT_SYM(ncclDevFuncTable_%s)[] = {\n" % unroll)
     for fn in primary_funcs:
       if fn.unroll != unroll: continue
       sym = "ncclDevFunc_" + fn_sym(fn)
       guard = get_arch_guard(fn)
       if guard:
-        out("#if %s\n/*%4d*/ %s,\n#else\n/*%4d*/ nullptr,\n#endif\n" % (guard, index[unroll], sym, index[unroll]))
+        out("#if %s\n/*%4d*/ RCCL_NT_SYM(%s),\n#else\n/*%4d*/ nullptr,\n#endif\n" % (guard, index[unroll], sym, index[unroll]))
       else:
-        out("/*%4d*/ %s,\n" % (index[unroll], sym))
+        out("/*%4d*/ RCCL_NT_SYM(%s),\n" % (index[unroll], sym))
       index[unroll] += 1
     out("nullptr};\n")
     out("\n")
@@ -670,14 +673,17 @@ for fn in primary_funcs:
     out('#include "%s.h"\n\n' % lower_coll)
     if guard:
       out("#if %s\n" % guard)
+    # RCCL_NT_SYM() suffixes the kernel wrapper and the called device function with
+    # _512 when compiling the alternate gfx950 512-thread set (-DRCCL_NTHREADS_512),
+    # keeping the two coexisting sets in distinct symbol namespaces. See device.h.
     out(
       "DEFINE_ncclDevFunc({sym}, ncclFunc{coll}, {redop_cxx}, {ty_cxx}, "
       "NCCL_ALGO_{algo}, NCCL_PROTO_{proto}, {acc}, {pipeline}, {unroll}, {reg})\n\n"
       "__launch_bounds__(NCCL_MAX_NTHREADS, 1)\n"
-      "__global__ void ncclDevKernel_{sym}_Specialized(\n"
+      "__global__ void RCCL_NT_SYM(ncclDevKernel_{sym}_Specialized)(\n"
       "    ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {{\n"
       "  ncclShmemPerWarp[0].x = 0;\n"
-      "  {func_name}();\n"
+      "  RCCL_NT_SYM({func_name})();\n"
       "}}\n"
       .format(sym=sym, coll=fn.coll, redop_cxx=redop_to_cxx[fn.redop],
               ty_cxx=ty_to_cxx[fn.ty], algo=(fn.algo or "RING"),

--- a/projects/rccl/src/device/generate.py
+++ b/projects/rccl/src/device/generate.py
@@ -15,6 +15,16 @@ all_algos     = ["TREE","RING", "", "", "", "", "PAT"]
 all_accs      = ["0", "1"]
 all_pipelines = ["0", "1"]
 all_unrolls   = ["1", "2", "4"]
+# [RCCL] Unroll factors that the alternate gfx950 512-thread-per-block kernel set
+# is built for. The 512-thread set only helps launches that actually run with
+# more than 256 threads, which on gfx950 is the multi-node path (unroll 2). The
+# single-node path uses unroll 1 but is capped at 256 threads
+# (RCCL_SINGLE_NODE_MAX_NTHREADS, see rcclOptThreadBlockSize), and unroll 4 is
+# never auto-selected on gfx950 (see commSetUnrollFactor). So the 512 set is
+# built for unroll 2 only; the host falls back to the 256-thread kernels for the
+# other unrolls (see rcclSelectKernelFn in enqueue.cc). These sources are gated
+# at compile time by -DRCCL_NTHREADS_512 (device_table.h / common.h / common.cu).
+unrolls_512   = ["2"]
 # User-buffer registration mode (compile-time UserRegMode template parameter):
 #   "0" = runtime / not-applicable (single kernel, current behavior)
 #   "1" = registered user buffer   (LL128 Direct path bypasses cache)
@@ -447,6 +457,12 @@ with open(os.path.join(gensrc, "device_table.h"), "w") as f:
   out("typedef void(*ncclDevFuncPtr_t)();\n\n")
   for unroll in all_unrolls:
     index[unroll] = 0
+    # [RCCL] The gfx950 512-thread set (-DRCCL_NTHREADS_512) only builds/dispatches
+    # unroll 2 (see unrolls_512), so the other unroll tables would reference *_512
+    # specialized symbols that are never compiled into that set. Gate them out.
+    table_needs_512_guard = unroll not in unrolls_512
+    if table_needs_512_guard:
+      out("#ifndef RCCL_NTHREADS_512\n")
     out("static __device__ ncclDevFuncPtr_t const RCCL_NT_SYM(ncclDevFuncTable_%s)[] = {\n" % unroll)
     for fn in primary_funcs:
       if fn.unroll != unroll: continue
@@ -458,6 +474,8 @@ with open(os.path.join(gensrc, "device_table.h"), "w") as f:
         out("/*%4d*/ RCCL_NT_SYM(%s),\n" % (index[unroll], sym))
       index[unroll] += 1
     out("nullptr};\n")
+    if table_needs_512_guard:
+      out("#endif\n")
     out("\n")
   out("#endif // USE_INDIRECT_FUNCTION_CALL || RCCL_DEVICE_LINKER\n\n")
 
@@ -710,4 +728,16 @@ with open(os.path.join(gensrc, "specialized_files.txt"), "w") as f:
   for filename, func_name, guard, _ in specialized_filelist:
     f.write("%s %s %s\n" % (filename, func_name, guard or ""))
 
+# [RCCL] Subset of specialized files needed by the gfx950 512-thread kernel set.
+# Only the unroll factors in unrolls_512 are compiled with -DRCCL_NTHREADS_512
+# (the single-node/unroll-1 and unroll-4 paths reuse the 256-thread kernels), so
+# the 512 object library builds from this shorter list to save build time and
+# binary size. See cmake/DeviceLinker.cmake (rccl_device_gfx950_512).
+specialized_filelist_512 = [e for e in specialized_filelist if e[3].unroll in unrolls_512]
+with open(os.path.join(gensrc, "specialized_files_512.txt"), "w") as f:
+  for filename, func_name, guard, _ in specialized_filelist_512:
+    f.write("%s %s %s\n" % (filename, func_name, guard or ""))
+
 print("-- Generated %d specialized kernel files in %s" % (len(specialized_filelist), specialized_dir))
+print("-- gfx950 512-thread set uses %d of them (unroll %s)" %
+      (len(specialized_filelist_512), ",".join(unrolls_512)))

--- a/projects/rccl/src/device/test_generate_device_table.py
+++ b/projects/rccl/src/device/test_generate_device_table.py
@@ -18,6 +18,7 @@ generated text rather than compiling it.
 """
 
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -25,6 +26,7 @@ import unittest
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 GENERATE_PY = os.path.join(HERE, "generate.py")
+DEVICE_H = os.path.join(HERE, "..", "include", "device.h")
 
 # A small, fast slice of collectives. "AllReduce RING SIMPLE Sum f32" expands to
 # both an unguarded primary and an arch-guarded variant, which exercises the
@@ -59,7 +61,10 @@ class DeviceTableGenerationTest(unittest.TestCase):
         # RCCL_DEVICE_LINKER. The generated forward declarations must stay plain:
         # a stray noinline here leaks into the definition (attribute is a union
         # across decl+def) and would force pure-RDC funcs noinline.
-        self.assertIn("__device__ void ncclDevFunc_", self.header)
+        # Symbols are wrapped in RCCL_NT_SYM() so the alternate gfx950 512-thread
+        # kernel set (-DRCCL_NTHREADS_512) gets a distinct symbol namespace; with
+        # the macro undefined RCCL_NT_SYM(x) == x.
+        self.assertIn("__device__ void RCCL_NT_SYM(ncclDevFunc_", self.header)
         self.assertNotIn("noinline", self.header)
         self.assertNotIn("RCCL_DEVFUNC_ATTR", self.header)
 
@@ -69,7 +74,7 @@ class DeviceTableGenerationTest(unittest.TestCase):
             "#if defined(USE_INDIRECT_FUNCTION_CALL) || defined(RCCL_DEVICE_LINKER)",
             self.header,
         )
-        self.assertIn("static __device__ ncclDevFuncPtr_t const ncclDevFuncTable_", self.header)
+        self.assertIn("static __device__ ncclDevFuncPtr_t const RCCL_NT_SYM(ncclDevFuncTable_", self.header)
 
     def test_pure_rdc_dispatch_block_present(self):
         # Compile-time binary search only when NEITHER runtime-dispatch macro is set.
@@ -104,7 +109,99 @@ class DeviceTableGenerationTest(unittest.TestCase):
         # table is still emitted and the pure-RDC dispatcher is not.
         with tempfile.TemporaryDirectory(prefix="rccl_devtable_ifc_") as d:
             header = _generate(d, ifc="ON")
-        self.assertIn("static __device__ ncclDevFuncPtr_t const ncclDevFuncTable_", header)
+        self.assertIn("static __device__ ncclDevFuncPtr_t const RCCL_NT_SYM(ncclDevFuncTable_", header)
+
+
+def _extract_nt_sym_macros():
+    """Pull the RCCL_NT_SYM() macro machinery verbatim out of device.h.
+
+    Extracting (rather than duplicating) the definitions keeps this behavioral
+    test honest: if the macros in device.h change, the test exercises the change.
+    """
+    with open(DEVICE_H) as f:
+        text = f.read()
+    start = text.index("#define RCCL_CAT_(")
+    last = text.index("#define RCCL_NT_SYM(name)")
+    end = text.index("\n", last)
+    return text[start:end + 1]
+
+
+def _cpp_expand(macro_block, body, define512):
+    """Preprocess body (prefixed with the extracted macros), optionally with
+    -DRCCL_NTHREADS_512, and return stdout."""
+    src = macro_block + "\n" + body + "\n"
+    cmd = ["cpp", "-P"]
+    if define512:
+        cmd.append("-DRCCL_NTHREADS_512")
+    cmd.append("-")
+    return subprocess.run(cmd, input=src, capture_output=True, text=True, check=True).stdout
+
+
+class Gfx950ThreadVariantTest(unittest.TestCase):
+    """The alternate gfx950 512-thread kernel set (RCCL_GFX950_NTHREADS=512) is
+    produced by recompiling the same generated sources with -DRCCL_NTHREADS_512.
+    For both sets to coexist in one device ELF, every device symbol the generator
+    emits must be wrapped in RCCL_NT_SYM() so the 512 build lands in a distinct
+    (_512) symbol namespace. These tests guard that contract.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.exists(GENERATE_PY):
+            raise unittest.SkipTest("generate.py not found next to test")
+        cls._dir = tempfile.mkdtemp(prefix="rccl_devtable_512_")
+        cls.header = _generate(cls._dir)
+        spec_dir = os.path.join(cls._dir, "specialized")
+        specs = sorted(os.listdir(spec_dir))
+        if not specs:
+            raise unittest.SkipTest("no specialized files generated")
+        with open(os.path.join(spec_dir, specs[0])) as f:
+            cls.spec = f.read()
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls._dir, ignore_errors=True)
+
+    def test_generated_symbols_are_nt_sym_wrapped(self):
+        # device_table.h: forward declarations and the function-pointer table.
+        self.assertIn("__device__ void RCCL_NT_SYM(ncclDevFunc_", self.header)
+        self.assertIn("static __device__ ncclDevFuncPtr_t const RCCL_NT_SYM(ncclDevFuncTable_", self.header)
+        # specialized shard: the kernel wrapper and the called device function.
+        self.assertIn("RCCL_NT_SYM(ncclDevKernel_", self.spec)
+        self.assertIn("RCCL_NT_SYM(ncclDevFunc_", self.spec)
+
+    def test_nt_sym_yields_distinct_symbol_namespaces(self):
+        if shutil.which("cpp") is None:
+            self.skipTest("cpp not available")
+        macros = _extract_nt_sym_macros()
+        body = (
+            "TABLE RCCL_NT_SYM(ncclDevFuncTable_1)\n"
+            "FUNC RCCL_NT_SYM(ncclDevFunc_AllReduce_RING_SIMPLE_Sum_f32_0_0_4)\n"
+            "KERNEL RCCL_NT_SYM(ncclDevKernel_Generic_1)\n"
+            "SHMEM ncclShmem\n"
+            "PERWARP ncclShmemPerWarp\n"
+        )
+        base = _cpp_expand(macros, body, define512=False)
+        v512 = _cpp_expand(macros, body, define512=True)
+
+        # Default build: RCCL_NT_SYM(x) == x, shmem identifiers untouched.
+        self.assertRegex(base, r"TABLE\s+ncclDevFuncTable_1\b")
+        self.assertRegex(base, r"FUNC\s+ncclDevFunc_AllReduce_RING_SIMPLE_Sum_f32_0_0_4\b")
+        self.assertRegex(base, r"KERNEL\s+ncclDevKernel_Generic_1\b")
+        self.assertRegex(base, r"SHMEM\s+ncclShmem\b")
+        self.assertRegex(base, r"PERWARP\s+ncclShmemPerWarp\b")
+
+        # 512 build: every symbol gains the _512 suffix / rename.
+        self.assertRegex(v512, r"TABLE\s+ncclDevFuncTable_1_512\b")
+        self.assertRegex(v512, r"FUNC\s+ncclDevFunc_AllReduce_RING_SIMPLE_Sum_f32_0_0_4_512\b")
+        self.assertRegex(v512, r"KERNEL\s+ncclDevKernel_Generic_1_512\b")
+        self.assertRegex(v512, r"SHMEM\s+ncclShmem_512\b")
+        self.assertRegex(v512, r"PERWARP\s+ncclShmemPerWarp_512\b")
+
+        # The two sets must not collide: the 512 build emits no bare base names.
+        self.assertNotRegex(v512, r"\bncclDevFuncTable_1\b")
+        self.assertNotRegex(v512, r"\bncclDevKernel_Generic_1\b")
+        self.assertNotRegex(v512, r"\bncclShmem\b")
 
 
 if __name__ == "__main__":

--- a/projects/rccl/src/device/test_generate_device_table.py
+++ b/projects/rccl/src/device/test_generate_device_table.py
@@ -28,6 +28,7 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 GENERATE_PY = os.path.join(HERE, "generate.py")
 DEVICE_H = os.path.join(HERE, "..", "include", "device.h")
 NT_SYM_H = os.path.join(HERE, "..", "include", "rccl_nt_sym.h")
+DEVICE_LINKER_CMAKE = os.path.join(HERE, "..", "..", "cmake", "DeviceLinker.cmake")
 
 # A small, fast slice of collectives. "AllReduce RING SIMPLE Sum f32" expands to
 # both an unguarded primary and an arch-guarded variant, which exercises the
@@ -200,6 +201,58 @@ class Gfx950ThreadVariantTest(unittest.TestCase):
         self.assertNotRegex(v512, r"\bncclDevFuncTable_1\b")
         self.assertNotRegex(v512, r"\bncclDevKernel_Generic_1\b")
         self.assertNotRegex(v512, r"\bncclShmem\b")
+
+
+class Gfx950Build512GatingTest(unittest.TestCase):
+    """The opt-in gfx950 512-thread kernel set must not build on ROCm <= 7.0.2
+    unless the compiler accepts the -mllvm -amdgpu-agpr-bug-fix=1 codegen
+    workaround; on ROCm > 7.0.2 the AGPR bug is fixed upstream and it builds
+    directly. This guards that version gating in cmake/DeviceLinker.cmake, which
+    cannot be unit-compiled here, so we assert its structure (matching the
+    generated-text style of the tests above).
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.exists(DEVICE_LINKER_CMAKE):
+            raise unittest.SkipTest("DeviceLinker.cmake not found")
+        with open(DEVICE_LINKER_CMAKE) as f:
+            cls.text = f.read()
+
+    def test_opt_in_defaults_off_and_result_starts_disabled(self):
+        # The build switch is off by default and the result variable starts
+        # FALSE, so nothing is built without the explicit opt-in.
+        self.assertRegex(self.text, r"option\(BUILD_GFX950_512_THREADS_KERNELS[^)]*\bOFF\b")
+        self.assertIn("set(RCCL_BUILD_GFX950_512 FALSE)", self.text)
+        # Everything below is scoped to the opt-in AND gfx950 being a target.
+        self.assertIn(
+            'if(BUILD_GFX950_512_THREADS_KERNELS AND "gfx950" IN_LIST DL_GPU_TARGETS)',
+            self.text,
+        )
+
+    def test_rocm_version_gate_present(self):
+        self.assertRegex(self.text, r'VERSION_GREATER\s+"7\.0\.2"')
+
+    def test_enabled_only_when_rocm_gt_702_or_agpr_probe_passes(self):
+        guard = 'if(BUILD_GFX950_512_THREADS_KERNELS AND "gfx950" IN_LIST DL_GPU_TARGETS)'
+        body = self.text[self.text.index(guard):]
+
+        # The set is enabled in exactly two spots -- never unconditionally: the
+        # ROCm > 7.0.2 branch, and the ROCm <= 7.0.2 branch after the probe.
+        self.assertEqual(body.count("set(RCCL_BUILD_GFX950_512 TRUE)"), 2)
+
+        # On ROCm <= 7.0.2 (the else branch of if(_dl_rocm_gt_702)) the set is
+        # enabled only inside if(_dl_agpr_ok) -- i.e. gated on the compiler
+        # accepting the workaround, so "flag set but old ROCm" alone won't build.
+        gt702_idx = body.index("if(_dl_rocm_gt_702)")
+        else_body = body[body.index("else()", gt702_idx):]
+        probe_idx = else_body.index("if(_dl_agpr_ok)")
+        enable_idx = else_body.index("set(RCCL_BUILD_GFX950_512 TRUE)")
+        self.assertLess(
+            probe_idx,
+            enable_idx,
+            "on ROCm <= 7.0.2 the 512 set must be enabled only after the agpr probe succeeds",
+        )
 
 
 if __name__ == "__main__":

--- a/projects/rccl/src/device/test_generate_device_table.py
+++ b/projects/rccl/src/device/test_generate_device_table.py
@@ -27,6 +27,7 @@ import unittest
 HERE = os.path.dirname(os.path.abspath(__file__))
 GENERATE_PY = os.path.join(HERE, "generate.py")
 DEVICE_H = os.path.join(HERE, "..", "include", "device.h")
+NT_SYM_H = os.path.join(HERE, "..", "include", "rccl_nt_sym.h")
 
 # A small, fast slice of collectives. "AllReduce RING SIMPLE Sum f32" expands to
 # both an unguarded primary and an arch-guarded variant, which exercises the
@@ -61,9 +62,6 @@ class DeviceTableGenerationTest(unittest.TestCase):
         # RCCL_DEVICE_LINKER. The generated forward declarations must stay plain:
         # a stray noinline here leaks into the definition (attribute is a union
         # across decl+def) and would force pure-RDC funcs noinline.
-        # Symbols are wrapped in RCCL_NT_SYM() so the alternate gfx950 512-thread
-        # kernel set (-DRCCL_NTHREADS_512) gets a distinct symbol namespace; with
-        # the macro undefined RCCL_NT_SYM(x) == x.
         self.assertIn("__device__ void RCCL_NT_SYM(ncclDevFunc_", self.header)
         self.assertNotIn("noinline", self.header)
         self.assertNotIn("RCCL_DEVFUNC_ATTR", self.header)
@@ -113,12 +111,12 @@ class DeviceTableGenerationTest(unittest.TestCase):
 
 
 def _extract_nt_sym_macros():
-    """Pull the RCCL_NT_SYM() macro machinery verbatim out of device.h.
+    """Pull the RCCL_NT_SYM() macro machinery verbatim out of rccl_nt_sym.h.
 
     Extracting (rather than duplicating) the definitions keeps this behavioral
-    test honest: if the macros in device.h change, the test exercises the change.
+    test honest: if the macros change, the test exercises the change.
     """
-    with open(DEVICE_H) as f:
+    with open(NT_SYM_H) as f:
         text = f.read()
     start = text.index("#define RCCL_CAT_(")
     last = text.index("#define RCCL_NT_SYM(name)")

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -186,28 +186,43 @@ ncclResult_t ncclInitKernelsForDevice(int cudaArch, int maxSharedMem, size_t* ma
 #endif
 
 #ifdef RCCL_ENABLE_GFX950_512
-  // [RCCL] Configure the alternate gfx950 512-thread generic kernels. On non-gfx950
-  // devices these symbols are not in the loaded image, so cudaFuncGetAttributes
-  // fails and we simply skip them.
-  for (int k = 0; k < (int)(sizeof(ncclKerns512) / sizeof(ncclKerns512[0])); k++) {
-    void* fn = ncclKerns512[k].kernelFn;
-    cudaFuncAttributes attr = {0};
-    if (fn == nullptr) continue;
-    if (!CUDASUCCESS(cudaFuncGetAttributes(&attr, fn))) continue; // not present on this arch
-    if (maxStackSize && attr.localSizeBytes > *maxStackSize) *maxStackSize = attr.localSizeBytes;
-    if (carveout) {
-      CUDACHECKGOTO(cudaFuncSetAttribute(fn, cudaFuncAttributePreferredSharedMemoryCarveout, carveout), result,
-                    ignore512);
-    ignore512:;
-    }
-    if (ncclMaxSharedMem != 0) {
-      int sharedMemSize = ncclMaxSharedMem;
-      if (sharedMemSize <= (maxSharedMem - attr.sharedSizeBytes)) {
+  // [RCCL] Defensive guard: only touch the alternate 512-thread generic kernels
+  // when the device being initialized is gfx950. In a multi-arch build (e.g.
+  // gfx942;gfx950) the *_512 host stubs are registered process-wide but the
+  // matching device symbols exist only in the gfx950 device image, so we must
+  // not query/configure them on any other arch. Detect via the gcnArchName
+  // (matches the IsArchMatch(...,"gfx950") convention used elsewhere).
+  bool isGfx950 = false;
+  {
+    int dev = 0;
+    hipDeviceProp_t prop;
+    if (CUDASUCCESS(hipGetDevice(&dev)) && CUDASUCCESS(hipGetDeviceProperties(&prop, dev)))
+      isGfx950 = IsArchMatch(prop.gcnArchName, "gfx950");
+  }
+  if (isGfx950) {
+    for (int k = 0; k < (int)(sizeof(ncclKerns512) / sizeof(ncclKerns512[0])); k++) {
+      void* fn = ncclKerns512[k].kernelFn;
+      cudaFuncAttributes attr = {0};
+      if (fn == nullptr) continue;
+      if (!CUDASUCCESS(cudaFuncGetAttributes(&attr, fn))) continue; // not present on this arch
+      if (maxStackSize && attr.localSizeBytes > *maxStackSize) *maxStackSize = attr.localSizeBytes;
+      if (carveout) {
+        CUDACHECKGOTO(cudaFuncSetAttribute(fn, cudaFuncAttributePreferredSharedMemoryCarveout, carveout), result,
+                      ignore512);
+      ignore512:;
+      }
+      if (ncclMaxSharedMem != 0) {
+        int sharedMemSize = ncclMaxSharedMem;
+        if (sharedMemSize > (maxSharedMem - attr.sharedSizeBytes)) {
+          WARN("cudaArch %d ncclMaxSharedMem %d exceeds device/fn maxSharedMem %zu", cudaArch, sharedMemSize,
+               maxSharedMem - attr.sharedSizeBytes);
+          return ncclSystemError;
+        }
         CUDACHECKGOTO(cudaFuncSetAttribute(fn, cudaFuncAttributeMaxDynamicSharedMemorySize, sharedMemSize), result,
                       next_kernel512);
       }
+    next_kernel512:;
     }
-  next_kernel512:;
   }
 #endif
 

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -55,13 +55,8 @@ static ncclKernelMatch const ncclKerns[3] = {
 };
 
 #ifdef RCCL_ENABLE_GFX950_512
-// [RCCL] Alternate gfx950 kernel set compiled with 512 threads per block, living
-// in a distinct symbol namespace (see src/include/device.h). Selected at runtime
-// via RCCL_GFX950_NTHREADS=512 (comm->use512Kernels). Only present in the gfx950
-// device image; launching these on other arches is never attempted.
-__global__ void ncclDevKernel_Generic_1_512(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage);
-__global__ void ncclDevKernel_Generic_2_512(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage);
-__global__ void ncclDevKernel_Generic_4_512(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage);
+// [RCCL] Alternate gfx950 512-thread kernel set (declarations in device/common.h).
+// Selected at runtime via RCCL_GFX950_NTHREADS=512 (comm->use512Kernels).
 static ncclKernelMatch const ncclKerns512[3] = {
   {(void*)ncclDevKernel_Generic_1_512, true}, {(void*)ncclDevKernel_Generic_2_512, true},
   {(void*)ncclDevKernel_Generic_4_512, true}
@@ -190,16 +185,8 @@ ncclResult_t ncclInitKernelsForDevice(int cudaArch, int maxSharedMem, size_t* ma
   // when the device being initialized is gfx950. In a multi-arch build (e.g.
   // gfx942;gfx950) the *_512 host stubs are registered process-wide but the
   // matching device symbols exist only in the gfx950 device image, so we must
-  // not query/configure them on any other arch. Detect via the gcnArchName
-  // (matches the IsArchMatch(...,"gfx950") convention used elsewhere).
-  bool isGfx950 = false;
-  {
-    int dev = 0;
-    hipDeviceProp_t prop;
-    if (CUDASUCCESS(hipGetDevice(&dev)) && CUDASUCCESS(hipGetDeviceProperties(&prop, dev)))
-      isGfx950 = IsArchMatch(prop.gcnArchName, "gfx950");
-  }
-  if (isGfx950) {
+  // not query/configure them on any other arch.
+  if (cudaArch == 950) {
     for (int k = 0; k < (int)(sizeof(ncclKerns512) / sizeof(ncclKerns512[0])); k++) {
       void* fn = ncclKerns512[k].kernelFn;
       cudaFuncAttributes attr = {0};

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -55,20 +55,27 @@ static ncclKernelMatch const ncclKerns[3] = {
 };
 
 #ifdef RCCL_ENABLE_GFX950_512
-// [RCCL] Alternate gfx950 512-thread kernel set (declarations in device/common.h).
+// [RCCL] Alternate gfx950 512-thread kernel set (declaration in device/common.h).
 // Selected at runtime via RCCL_GFX950_NTHREADS=512 (comm->use512Kernels).
+//
+// Only the unroll-2 kernel is built: the 512-thread set only benefits launches
+// that actually run with more than 256 threads, which on gfx950 is the
+// multi-node (unroll 2) path. Single-node uses unroll 1 but is capped at 256
+// threads (RCCL_SINGLE_NODE_MAX_NTHREADS) and unroll 4 is never auto-selected on
+// gfx950 (see commSetUnrollFactor), so those slots stay null and fall back to
+// the 256-thread kernels below. Indexed by ncclGetKernelIndex(comm) == unroll.
 static ncclKernelMatch const ncclKerns512[3] = {
-  {(void*)ncclDevKernel_Generic_1_512, true}, {(void*)ncclDevKernel_Generic_2_512, true},
-  {(void*)ncclDevKernel_Generic_4_512, true}
+  {nullptr, true}, {(void*)ncclDevKernel_Generic_2_512, true}, {nullptr, true}
 };
 #endif
 
 // Select the host launch stub for this comm's unroll factor, honoring the gfx950
-// 512-thread kernel set when enabled at runtime.
+// 512-thread kernel set when enabled at runtime. Unroll factors without a
+// 512-thread kernel (see ncclKerns512) fall back to the default 256-thread set.
 static inline void* rcclSelectKernelFn(struct ncclComm* comm) {
   int idx = ncclGetKernelIndex(comm);
 #ifdef RCCL_ENABLE_GFX950_512
-  if (comm->use512Kernels) return ncclKerns512[idx].kernelFn;
+  if (comm->use512Kernels && ncclKerns512[idx].kernelFn != nullptr) return ncclKerns512[idx].kernelFn;
 #endif
   return ncclKerns[idx].kernelFn;
 }

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -58,24 +58,25 @@ static ncclKernelMatch const ncclKerns[3] = {
 // [RCCL] Alternate gfx950 512-thread kernel set (declaration in device/common.h).
 // Selected at runtime via RCCL_GFX950_NTHREADS=512 (comm->use512Kernels).
 //
-// Only the unroll-2 kernel is built: the 512-thread set only benefits launches
-// that actually run with more than 256 threads, which on gfx950 is the
-// multi-node (unroll 2) path. Single-node uses unroll 1 but is capped at 256
-// threads (RCCL_SINGLE_NODE_MAX_NTHREADS) and unroll 4 is never auto-selected on
-// gfx950 (see commSetUnrollFactor), so those slots stay null and fall back to
-// the 256-thread kernels below. Indexed by ncclGetKernelIndex(comm) == unroll.
+// Only the unroll-2 kernel is built at 512 threads: that is the only path that
+// runs with more than 256 threads on gfx950 (the multi-node path). Single-node
+// uses unroll 1 but is capped at 256 threads (RCCL_SINGLE_NODE_MAX_NTHREADS) and
+// unroll 4 is never auto-selected on gfx950 (see commSetUnrollFactor). Rather
+// than leave those slots null (a launch-time footgun), point them at the
+// matching 256-thread kernels so every slot holds a launchable stub and
+// selection can never dereference a null. Indexed by ncclGetKernelIndex(comm).
 static ncclKernelMatch const ncclKerns512[3] = {
-  {nullptr, true}, {(void*)ncclDevKernel_Generic_2_512, true}, {nullptr, true}
+  {(void*)ncclDevKernel_Generic_1, true}, {(void*)ncclDevKernel_Generic_2_512, true}, {(void*)ncclDevKernel_Generic_4, true}
 };
 #endif
 
 // Select the host launch stub for this comm's unroll factor, honoring the gfx950
 // 512-thread kernel set when enabled at runtime. Unroll factors without a
-// 512-thread kernel (see ncclKerns512) fall back to the default 256-thread set.
+// 512-thread kernel (see ncclKerns512) reuse the default 256-thread kernel.
 static inline void* rcclSelectKernelFn(struct ncclComm* comm) {
   int idx = ncclGetKernelIndex(comm);
 #ifdef RCCL_ENABLE_GFX950_512
-  if (comm->use512Kernels && ncclKerns512[idx].kernelFn != nullptr) return ncclKerns512[idx].kernelFn;
+  if (comm->use512Kernels) return ncclKerns512[idx].kernelFn;
 #endif
   return ncclKerns[idx].kernelFn;
 }

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -54,6 +54,30 @@ static ncclKernelMatch const ncclKerns[3] = {
   {(void*)ncclDevKernel_Generic_1, true}, {(void*)ncclDevKernel_Generic_2, true}, {(void*)ncclDevKernel_Generic_4, true}
 };
 
+#ifdef RCCL_ENABLE_GFX950_512
+// [RCCL] Alternate gfx950 kernel set compiled with 512 threads per block, living
+// in a distinct symbol namespace (see src/include/device.h). Selected at runtime
+// via RCCL_GFX950_NTHREADS=512 (comm->use512Kernels). Only present in the gfx950
+// device image; launching these on other arches is never attempted.
+__global__ void ncclDevKernel_Generic_1_512(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage);
+__global__ void ncclDevKernel_Generic_2_512(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage);
+__global__ void ncclDevKernel_Generic_4_512(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage);
+static ncclKernelMatch const ncclKerns512[3] = {
+  {(void*)ncclDevKernel_Generic_1_512, true}, {(void*)ncclDevKernel_Generic_2_512, true},
+  {(void*)ncclDevKernel_Generic_4_512, true}
+};
+#endif
+
+// Select the host launch stub for this comm's unroll factor, honoring the gfx950
+// 512-thread kernel set when enabled at runtime.
+static inline void* rcclSelectKernelFn(struct ncclComm* comm) {
+  int idx = ncclGetKernelIndex(comm);
+#ifdef RCCL_ENABLE_GFX950_512
+  if (comm->use512Kernels) return ncclKerns512[idx].kernelFn;
+#endif
+  return ncclKerns[idx].kernelFn;
+}
+
 static int rcclProtoGrainSize(int proto, ncclComm* comm) {
   switch (proto) {
   case NCCL_PROTO_LL:
@@ -160,6 +184,33 @@ ncclResult_t ncclInitKernelsForDevice(int cudaArch, int maxSharedMem, size_t* ma
 #ifdef GENERATE_SYM_KERNELS
   }
 #endif
+
+#ifdef RCCL_ENABLE_GFX950_512
+  // [RCCL] Configure the alternate gfx950 512-thread generic kernels. On non-gfx950
+  // devices these symbols are not in the loaded image, so cudaFuncGetAttributes
+  // fails and we simply skip them.
+  for (int k = 0; k < (int)(sizeof(ncclKerns512) / sizeof(ncclKerns512[0])); k++) {
+    void* fn = ncclKerns512[k].kernelFn;
+    cudaFuncAttributes attr = {0};
+    if (fn == nullptr) continue;
+    if (!CUDASUCCESS(cudaFuncGetAttributes(&attr, fn))) continue; // not present on this arch
+    if (maxStackSize && attr.localSizeBytes > *maxStackSize) *maxStackSize = attr.localSizeBytes;
+    if (carveout) {
+      CUDACHECKGOTO(cudaFuncSetAttribute(fn, cudaFuncAttributePreferredSharedMemoryCarveout, carveout), result,
+                    ignore512);
+    ignore512:;
+    }
+    if (ncclMaxSharedMem != 0) {
+      int sharedMemSize = ncclMaxSharedMem;
+      if (sharedMemSize <= (maxSharedMem - attr.sharedSizeBytes)) {
+        CUDACHECKGOTO(cudaFuncSetAttribute(fn, cudaFuncAttributeMaxDynamicSharedMemorySize, sharedMemSize), result,
+                      next_kernel512);
+      }
+    }
+  next_kernel512:;
+  }
+#endif
+
   return result;
 }
 
@@ -1048,7 +1099,7 @@ static ncclResult_t scheduleCollTasksToPlan(struct ncclComm* comm, struct ncclKe
     plan->threadPerBlock = std::max(plan->threadPerBlock, 192 /* 3*WARP_SIZE */);
 #endif
     if (!plan->kernelSpecialized) {
-      plan->kernelFn = ncclKerns[ncclGetKernelIndex(comm)].kernelFn;
+      plan->kernelFn = rcclSelectKernelFn(comm);
       plan->kernelSpecialized = ncclKerns[ncclGetKernelIndex(comm)].specialized;
     }
     // Profiler
@@ -1468,7 +1519,7 @@ static ncclResult_t scheduleP2pTasksToPlan(struct ncclComm* comm, int* p2pEpoch,
   plan->threadPerBlock = std::max(plan->threadPerBlock, NCCL_MAX_NTHREADS);
 #endif
   if (!plan->kernelSpecialized) {
-    plan->kernelFn = ncclKerns[ncclGetKernelIndex(comm)].kernelFn;
+    plan->kernelFn = rcclSelectKernelFn(comm);
     plan->kernelSpecialized = ncclKerns[ncclGetKernelIndex(comm)].specialized;
   }
 
@@ -2725,7 +2776,7 @@ void ncclAddWorkBatchToPlan(struct ncclComm* comm, struct ncclKernelPlan* plan, 
 }
 
 void ncclPlanSetDefaultKernel(struct ncclComm* comm, struct ncclKernelPlan* plan) {
-  plan->kernelFn = ncclKerns[ncclGetKernelIndex(comm)].kernelFn;
+  plan->kernelFn = rcclSelectKernelFn(comm);
   plan->kernelSpecialized = ncclKerns[ncclGetKernelIndex(comm)].specialized;
 }
 

--- a/projects/rccl/src/graph/tuning.cc
+++ b/projects/rccl/src/graph/tuning.cc
@@ -1148,11 +1148,14 @@ ncclResult_t ncclTopoTuneModel(struct ncclComm* comm, int minCompCap, int maxCom
   // [RCCL] Decide the gfx950 kernel-thread variant before the thread caps below
   // are computed/cached, so rcclGetMaxNthreads sees comm->use512Kernels.
   rcclSetKernelVariant(comm);
-  static int rcclMaxThreads[NCCL_NUM_PROTOCOLS] = {0};
-  if (rcclMaxThreads[NCCL_PROTO_SIMPLE] == 0) rcclGetMaxNthreads(comm, rcclMaxThreads);
-  static int maxNthreads = rcclMaxThreads[NCCL_PROTO_SIMPLE];
-  static int maxLL128Nthreads = rcclMaxThreads[NCCL_PROTO_LL128];
-  static int maxLLThreads = rcclMaxThreads[NCCL_PROTO_LL];
+  // Not cached in statics: rcclGetMaxNthreads is variant- and arch-dependent
+  // (comm->use512Kernels, gfx950), which can differ across comms/devices in one
+  // process, so recompute per comm.
+  int rcclMaxThreads[NCCL_NUM_PROTOCOLS] = {0};
+  rcclGetMaxNthreads(comm, rcclMaxThreads);
+  int maxNthreads = rcclMaxThreads[NCCL_PROTO_SIMPLE];
+  int maxLL128Nthreads = rcclMaxThreads[NCCL_PROTO_LL128];
+  int maxLLThreads = rcclMaxThreads[NCCL_PROTO_LL];
   int simpleDefaultThreads =
     (graphs[NCCL_ALGO_RING]->bwIntra * graphs[NCCL_ALGO_RING]->nChannels <= PCI_BW) ? 256 : maxNthreads;
   comm->maxThreads[NCCL_ALGO_RING][NCCL_PROTO_SIMPLE] = getNthreads(

--- a/projects/rccl/src/graph/tuning.cc
+++ b/projects/rccl/src/graph/tuning.cc
@@ -1145,6 +1145,9 @@ ncclResult_t ncclTopoInitTunerConstants(struct ncclComm* comm) {
 
 ncclResult_t ncclTopoTuneModel(struct ncclComm* comm, int minCompCap, int maxCompCap, struct ncclTopoGraph** graphs) {
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+  // [RCCL] Decide the gfx950 kernel-thread variant before the thread caps below
+  // are computed/cached, so rcclGetMaxNthreads sees comm->use512Kernels.
+  rcclSetKernelVariant(comm);
   static int rcclMaxThreads[NCCL_NUM_PROTOCOLS] = {0};
   if (rcclMaxThreads[NCCL_PROTO_SIMPLE] == 0) rcclGetMaxNthreads(comm, rcclMaxThreads);
   static int maxNthreads = rcclMaxThreads[NCCL_PROTO_SIMPLE];
@@ -1162,6 +1165,11 @@ ncclResult_t ncclTopoTuneModel(struct ncclComm* comm, int minCompCap, int maxCom
   comm->maxThreads[NCCL_ALGO_RING][NCCL_PROTO_LL128] = comm->maxThreads[NCCL_ALGO_TREE][NCCL_PROTO_LL128] =
     getNthreads("NCCL_LL128_NTHREADS", ncclParamLl128Nthreads(), 4 * comm->WarpSize, maxLL128Nthreads, maxLL128Nthreads,
                 comm->WarpSize);
+  // [RCCL] Surface the resolved max threads per block so the selected gfx950
+  // kernel set (256 vs 512, see RCCL_GFX950_NTHREADS) is visible in the log.
+  INFO(NCCL_INIT, "RCCL max threads/block: SIMPLE(Ring)=%d LL=%d LL128=%d [%s kernel set]",
+       comm->maxThreads[NCCL_ALGO_RING][NCCL_PROTO_SIMPLE], comm->maxThreads[NCCL_ALGO_RING][NCCL_PROTO_LL],
+       comm->maxThreads[NCCL_ALGO_RING][NCCL_PROTO_LL128], comm->use512Kernels ? "512-thread" : "256-thread");
 #else
   int simpleDefaultThreads =
     (graphs[NCCL_ALGO_RING]->bwIntra * graphs[NCCL_ALGO_RING]->nChannels <= PCI_BW) ? 256 : NCCL_MAX_NTHREADS;

--- a/projects/rccl/src/include/comm.h
+++ b/projects/rccl/src/include/comm.h
@@ -923,6 +923,10 @@ struct ncclComm {
 
   // unroll factor for comm [RCCL]
   int unroll;
+  // [RCCL] gfx950: use the alternate 512-thread-per-block compiled kernel set
+  // (RCCL_GFX950_NTHREADS=512). Only ever true when RCCL_ENABLE_GFX950_512 was
+  // built and the device arch is gfx950.
+  bool use512Kernels;
   // custom collective [RCCL]
   bool enableCustColl;
   int

--- a/projects/rccl/src/include/device.h
+++ b/projects/rccl/src/include/device.h
@@ -149,25 +149,9 @@ union ncclLLFifoLine {
 #define NCCL_MAX_GROUPS (NCCL_MAX_NTHREADS / WARP_SIZE)
 #endif
 
-// [RCCL] Device-symbol suffixing for the alternate gfx950 512-thread kernel set.
-// When the device sources are compiled with -DRCCL_NTHREADS_512, every device
-// symbol that must be unique across the two coexisting kernel sets is renamed
-// with a "_512" suffix via RCCL_NT_SYM(). This lets both the default 256-thread
-// set and the 512-thread set live in the same device ELF without collisions.
-// When RCCL_NTHREADS_512 is not defined, RCCL_NT_SYM(x) == x (no change).
-#define RCCL_CAT_(a, b) a##b
-#define RCCL_CAT(a, b) RCCL_CAT_(a, b)
-#if defined(RCCL_NTHREADS_512)
-#define RCCL_NT_SUFFIX _512
-// Redirect the shared-memory objects too: their layout depends on NCCL_MAX_GROUPS,
-// so the 512 set needs its own LDS allocation. Renaming the identifier here means
-// every reference in the (unmodified) device sources resolves to the _512 object.
-#define ncclShmem ncclShmem_512
-#define ncclShmemPerWarp ncclShmemPerWarp_512
-#else
-#define RCCL_NT_SUFFIX
-#endif
-#define RCCL_NT_SYM(name) RCCL_CAT(name, RCCL_NT_SUFFIX)
+// [RCCL] RCCL_NT_SYM() device-symbol suffixing for the alternate gfx950
+// 512-thread kernel set (see rccl_nt_sym.h).
+#include "rccl_nt_sym.h"
 
 #ifdef ENABLE_WARP_SPEED
 #define MAXCHANNELS 512

--- a/projects/rccl/src/include/device.h
+++ b/projects/rccl/src/include/device.h
@@ -124,7 +124,13 @@ union ncclLLFifoLine {
 #else
 #define WARP_SIZE 32
 #endif
-#if defined(__gfx950__)
+// [RCCL] gfx950 supports two compiled kernel variants selectable at runtime:
+// the default 256-thread set, and a 512-thread set built into a separate symbol
+// namespace (see RCCL_NT_SYM below). The 512 set is produced by re-compiling the
+// device sources with -DRCCL_NTHREADS_512.
+#if defined(__gfx950__) && defined(RCCL_NTHREADS_512)
+#define NCCL_MAX_NTHREADS 512
+#elif defined(__gfx950__)
 #define NCCL_MAX_NTHREADS 256
 #else
 #define NCCL_MAX_NTHREADS 256
@@ -142,6 +148,26 @@ union ncclLLFifoLine {
   // Number of named barriers supported by CUDA
 #define NCCL_MAX_GROUPS (NCCL_MAX_NTHREADS / WARP_SIZE)
 #endif
+
+// [RCCL] Device-symbol suffixing for the alternate gfx950 512-thread kernel set.
+// When the device sources are compiled with -DRCCL_NTHREADS_512, every device
+// symbol that must be unique across the two coexisting kernel sets is renamed
+// with a "_512" suffix via RCCL_NT_SYM(). This lets both the default 256-thread
+// set and the 512-thread set live in the same device ELF without collisions.
+// When RCCL_NTHREADS_512 is not defined, RCCL_NT_SYM(x) == x (no change).
+#define RCCL_CAT_(a, b) a##b
+#define RCCL_CAT(a, b) RCCL_CAT_(a, b)
+#if defined(RCCL_NTHREADS_512)
+#define RCCL_NT_SUFFIX _512
+// Redirect the shared-memory objects too: their layout depends on NCCL_MAX_GROUPS,
+// so the 512 set needs its own LDS allocation. Renaming the identifier here means
+// every reference in the (unmodified) device sources resolves to the _512 object.
+#define ncclShmem ncclShmem_512
+#define ncclShmemPerWarp ncclShmemPerWarp_512
+#else
+#define RCCL_NT_SUFFIX
+#endif
+#define RCCL_NT_SYM(name) RCCL_CAT(name, RCCL_NT_SUFFIX)
 
 #ifdef ENABLE_WARP_SPEED
 #define MAXCHANNELS 512

--- a/projects/rccl/src/include/rccl_common.h
+++ b/projects/rccl/src/include/rccl_common.h
@@ -47,7 +47,8 @@ typedef enum RcclTunableColls {
 #define RCCL_PROTOCOL_THREAD_THRESHOLD_IDX 3
 
 #define RCCL_SINGLE_NODE_MAX_NTHREADS 256
-#define RCCL_GFX950_MAX_NTHREADS 256  // for Simple and LL64/LL128 gfx950
+#define RCCL_GFX950_MAX_NTHREADS 256  // for Simple and LL64/LL128 gfx950 (default kernel set)
+#define RCCL_GFX950_MAX_NTHREADS_512 512 // for Simple and LL128 gfx950 when RCCL_GFX950_NTHREADS=512
 #define RCCL_DEFAULT_MAX_NTHREADS 256 // for Simple and LL64/LL128 other archs
 #define RCCL_LL_MAX_NTHREADS 256
 #define RCCL_P2P_MAX_NTHREADS 256
@@ -119,6 +120,9 @@ void rcclUpdateThreadThreshold(struct ncclComm* comm, size_t const& nBytes, stru
                                int& threadThreshold);
 void rcclSetPipelining(struct ncclComm* comm, size_t const& nBytes, struct ncclTaskColl* info);
 void rcclGetMaxNthreads(struct ncclComm* comm, int maxNthreads[]);
+// [RCCL] Decide whether this comm uses the gfx950 512-thread kernel set, based on
+// RCCL_GFX950_NTHREADS and the device arch. Sets comm->use512Kernels.
+void rcclSetKernelVariant(struct ncclComm* comm);
 void rcclOptThreadBlockSize(struct ncclComm* comm, struct ncclTaskColl* info, size_t nBytes, int& nThreads);
 void rcclSetDefaultBuffSizes(struct ncclComm* comm, int defaultBuffSizes[]);
 NCCL_API(ncclResult_t, rcclGetAlgoInfo, struct ncclComm* comm, ncclFunc_t coll, uint64_t count, ncclDataType_t dataType,

--- a/projects/rccl/src/include/rccl_nt_sym.h
+++ b/projects/rccl/src/include/rccl_nt_sym.h
@@ -1,0 +1,33 @@
+/*************************************************************************
+ * Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+ * Modifications Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#ifndef RCCL_NT_SYM_H_
+#define RCCL_NT_SYM_H_
+
+// [RCCL] Device-symbol suffixing for the alternate gfx950 512-thread kernel set.
+// When the device sources are compiled with -DRCCL_NTHREADS_512, every device
+// symbol that must be unique across the two coexisting kernel sets is renamed
+// with a "_512" suffix via RCCL_NT_SYM(). This lets both the default 256-thread
+// set and the 512-thread set live in the same device ELF without collisions.
+// When RCCL_NTHREADS_512 is not defined, RCCL_NT_SYM(x) == x (no change).
+//
+// Kept in its own header (included from device.h) to minimize merge conflicts.
+#define RCCL_CAT_(a, b) a##b
+#define RCCL_CAT(a, b) RCCL_CAT_(a, b)
+#if defined(RCCL_NTHREADS_512)
+#define RCCL_NT_SUFFIX _512
+// Redirect the shared-memory objects too: their layout depends on NCCL_MAX_GROUPS,
+// so the 512 set needs its own LDS allocation. Renaming the identifier here means
+// every reference in the (unmodified) device sources resolves to the _512 object.
+#define ncclShmem ncclShmem_512
+#define ncclShmemPerWarp ncclShmemPerWarp_512
+#else
+#define RCCL_NT_SUFFIX
+#endif
+#define RCCL_NT_SYM(name) RCCL_CAT(name, RCCL_NT_SUFFIX)
+
+#endif // RCCL_NT_SYM_H_

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -1191,6 +1191,10 @@ NCCL_PARAM(P2pNvlChunkSize, "P2P_NVL_CHUNKSIZE", (1 << 19)); /* 512 kB */
 static ncclResult_t computeBuffSizes(struct ncclComm* comm) {
   int64_t envs[NCCL_NUM_PROTOCOLS] = {ncclParamLlBuffSize(), ncclParamLl128BuffSize(), ncclParamBuffSize()};
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+  // [RCCL] Determine the gfx950 kernel-thread variant before buffer sizes are
+  // computed: LL/LL128 FIFO sizing scales with the max threads per block, which is
+  // higher (512) when the 512-thread kernel set is selected. (Idempotent.)
+  rcclSetKernelVariant(comm);
   int defaults[NCCL_NUM_PROTOCOLS];
   rcclSetDefaultBuffSizes(comm, defaults);
 #else

--- a/projects/rccl/src/rccl_wrap.cc
+++ b/projects/rccl/src/rccl_wrap.cc
@@ -875,7 +875,7 @@ void rcclSetKernelVariant(struct ncclComm* comm) {
   if (rcclParamGfx950Nthreads() == 512 && IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950")) {
     WARN("RCCL_GFX950_NTHREADS=512 requested but the 512-thread kernel set was not built "
          "(not enabled via --build-gfx950-512-threads-kernels, gfx950 not in GPU_TARGETS, "
-         "device linker disabled, or ROCm/compiler lacks -mllvm -amdgpu-agpr-bug-fix); "
+         "device linker disabled, or on ROCm <= 7.0.2 the compiler lacks -mllvm -amdgpu-agpr-bug-fix); "
          "using default 256-thread kernels");
   }
 #endif

--- a/projects/rccl/src/rccl_wrap.cc
+++ b/projects/rccl/src/rccl_wrap.cc
@@ -44,6 +44,10 @@ RCCL_PARAM(DirectReduceScatterDisable, "DIRECT_REDUCE_SCATTER_DISABLE", 0);
 RCCL_PARAM(DirectAllGatherDisable, "DIRECT_ALLGATHER_DISABLE", 0);
 RCCL_PARAM(ThreadsPerBlock, "THREADS_PER_BLOCK", -1);
 RCCL_PARAM(UnrollFactor, "UNROLL_FACTOR", -1);
+// [RCCL] gfx950: select the compiled kernel set / max threads per block. 256 (default)
+// uses the register-spill-optimized 256-thread kernels; 512 selects the alternate
+// 512-thread kernel set (only available when RCCL_ENABLE_GFX950_512 was built).
+RCCL_PARAM(Gfx950Nthreads, "GFX950_NTHREADS", 256);
 #ifdef ENABLE_WARP_SPEED
 RCCL_PARAM(WarpSpeedCuCount, "WARP_SPEED_CU_COUNT", 0);
 RCCL_PARAM(WarpSpeedAutoMode, "WARP_SPEED_AUTO", 1);
@@ -860,9 +864,28 @@ int rcclWarpSpeedAdjustChannels(struct ncclComm* comm, struct ncclTaskColl* info
 }
 #endif
 
+void rcclSetKernelVariant(struct ncclComm* comm) {
+  comm->use512Kernels = false;
+#ifdef RCCL_ENABLE_GFX950_512
+  if (rcclParamGfx950Nthreads() == 512 && IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950")) {
+    comm->use512Kernels = true;
+    INFO(NCCL_INIT, "RCCL gfx950: using 512-thread-per-block kernel set (RCCL_GFX950_NTHREADS=512)");
+  }
+#else
+  if (rcclParamGfx950Nthreads() == 512 && IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950")) {
+    WARN("RCCL_GFX950_NTHREADS=512 requested but the 512-thread kernel set was not built "
+         "(gfx950 not in GPU_TARGETS or device linker disabled); using default 256-thread kernels");
+  }
+#endif
+}
+
 void rcclGetMaxNthreads(struct ncclComm* comm, int maxNthreads[]) {
   if (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950")) {
-    maxNthreads[NCCL_PROTO_SIMPLE] = maxNthreads[NCCL_PROTO_LL128] = RCCL_GFX950_MAX_NTHREADS;
+    int simpleMax = RCCL_GFX950_MAX_NTHREADS;
+#ifdef RCCL_ENABLE_GFX950_512
+    if (comm->use512Kernels) simpleMax = RCCL_GFX950_MAX_NTHREADS_512;
+#endif
+    maxNthreads[NCCL_PROTO_SIMPLE] = maxNthreads[NCCL_PROTO_LL128] = simpleMax;
   } else {
     maxNthreads[NCCL_PROTO_SIMPLE] = maxNthreads[NCCL_PROTO_LL128] = RCCL_DEFAULT_MAX_NTHREADS;
   }

--- a/projects/rccl/src/rccl_wrap.cc
+++ b/projects/rccl/src/rccl_wrap.cc
@@ -874,7 +874,9 @@ void rcclSetKernelVariant(struct ncclComm* comm) {
 #else
   if (rcclParamGfx950Nthreads() == 512 && IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950")) {
     WARN("RCCL_GFX950_NTHREADS=512 requested but the 512-thread kernel set was not built "
-         "(gfx950 not in GPU_TARGETS or device linker disabled); using default 256-thread kernels");
+         "(not enabled via --build-gfx950-512-threads-kernels, gfx950 not in GPU_TARGETS, "
+         "device linker disabled, or ROCm/compiler lacks -mllvm -amdgpu-agpr-bug-fix); "
+         "using default 256-thread kernels");
   }
 #endif
 }

--- a/projects/rccl/src/rccl_wrap.cc
+++ b/projects/rccl/src/rccl_wrap.cc
@@ -895,8 +895,11 @@ void rcclGetMaxNthreads(struct ncclComm* comm, int maxNthreads[]) {
 }
 
 void rcclOptThreadBlockSize(struct ncclComm* comm, struct ncclTaskColl* info, size_t nBytes, int& nThreads) {
-  static int maxNthreads[NCCL_NUM_PROTOCOLS] = {0};
-  if (maxNthreads[NCCL_PROTO_SIMPLE] == 0) rcclGetMaxNthreads(comm, maxNthreads);
+  // Not cached in a static: rcclGetMaxNthreads is variant/arch dependent
+  // (comm->use512Kernels, gfx950), which can differ across comms/devices in one
+  // process, so recompute per comm.
+  int maxNthreads[NCCL_NUM_PROTOCOLS];
+  rcclGetMaxNthreads(comm, maxNthreads);
   if (rcclParamThreadsPerBlock() != -1) {
     nThreads = rcclParamThreadsPerBlock();
     if (nThreads % comm->WarpSize != 0) {
@@ -925,8 +928,11 @@ void rcclOptThreadBlockSize(struct ncclComm* comm, struct ncclTaskColl* info, si
 }
 
 void rcclSetDefaultBuffSizes(struct ncclComm* comm, int defaultBuffSizes[]) {
-  static int maxNthreads[NCCL_NUM_PROTOCOLS] = {0};
-  if (maxNthreads[NCCL_PROTO_SIMPLE] == 0) rcclGetMaxNthreads(comm, maxNthreads);
+  // Not cached in a static: rcclGetMaxNthreads is variant/arch dependent
+  // (comm->use512Kernels, gfx950), which can differ across comms/devices in one
+  // process, so recompute per comm.
+  int maxNthreads[NCCL_NUM_PROTOCOLS];
+  rcclGetMaxNthreads(comm, maxNthreads);
   defaultBuffSizes[NCCL_PROTO_LL] =
     NCCL_LL_LINES_PER_THREAD * maxNthreads[NCCL_PROTO_LL] * NCCL_STEPS * sizeof(union ncclLLFifoLine);
   defaultBuffSizes[NCCL_PROTO_LL128] =

--- a/projects/rccl/tools/rccl-device-compile
+++ b/projects/rccl/tools/rccl-device-compile
@@ -593,6 +593,8 @@ def do_link(args, forwarded_flags):
     rocshmem_bitcode = getattr(args, 'rocshmem_bitcode', None)
     dispatcher_512 = getattr(args, 'dispatcher_512', None)
     objects_512_rsp = getattr(args, 'objects_512_rsp', None)
+    # Extra compile flags for the 512-thread set (e.g. -mllvm -amdgpu-agpr-bug-fix=1).
+    compile_512_flags = list(getattr(args, 'compile_512_flags', []) or [])
 
     if not dispatcher:
         raise SystemExit("ERROR: --link requires --dispatcher=<source>")
@@ -669,8 +671,10 @@ def do_link(args, forwarded_flags):
         # -DRCCL_NTHREADS_512 and patch it with the 512-set aggregated resources.
         built_512 = False
         if max_res_512 is not None:
+            # compile_512_flags carries e.g. `-mllvm -amdgpu-agpr-bug-fix=1` so the
+            # 512-thread dispatcher codegen matches its object set.
             _build_dispatcher(clang, arch, dispatcher_512, forwarded_flags,
-                              ['-DRCCL_NTHREADS_512'], max_res_512,
+                              ['-DRCCL_NTHREADS_512'] + compile_512_flags, max_res_512,
                               disp512_asm, disp512_patched, disp512_obj, "512-thread")
             built_512 = True
 
@@ -773,6 +777,11 @@ def parse_compiler_flags(argv):
         elif arg == '--objects-512-rsp' and i + 1 < len(argv):
             our_args.extend([arg, argv[i + 1]])
             i += 1
+        elif arg.startswith('--compile-512-flag='):
+            our_args.append(arg)
+        elif arg == '--compile-512-flag' and i + 1 < len(argv):
+            our_args.extend([arg, argv[i + 1]])
+            i += 1
         elif arg.startswith('--rocshmem-bitcode='):
             our_args.append(arg)
         elif arg == '--rocshmem-bitcode' and i + 1 < len(argv):
@@ -825,6 +834,8 @@ def main():
     parser.add_argument('--dispatcher', default=None)
     parser.add_argument('--dispatcher-512', default=None, dest='dispatcher_512')
     parser.add_argument('--objects-512-rsp', default=None, dest='objects_512_rsp')
+    parser.add_argument('--compile-512-flag', action='append', default=[],
+                        dest='compile_512_flags')
     parser.add_argument('--rocshmem-bitcode', default=None, dest='rocshmem_bitcode')
     parser.add_argument('-o', '--output', required=False)
     parser.add_argument('--keep-temps', action='store_true')

--- a/projects/rccl/tools/rccl-device-compile
+++ b/projects/rccl/tools/rccl-device-compile
@@ -538,6 +538,51 @@ def do_compile(args, forwarded_flags):
 # Link mode: objects -> device.elf
 # ---------------------------------------------------------------------------
 
+def _collect_resources(objects):
+    """Collect resource JSON dicts written alongside each object file."""
+    resource_list = []
+    for obj in objects:
+        json_path = os.path.splitext(obj)[0] + '.resources.json'
+        if os.path.exists(json_path):
+            with open(json_path) as f:
+                resource_list.append(json.load(f))
+    return resource_list
+
+
+def _build_dispatcher(clang, arch, dispatcher_src, forwarded_flags, extra_flags,
+                      max_res, disp_asm, disp_patched, disp_obj, tag):
+    """Compile -> patch -> assemble one dispatcher source into disp_obj.
+
+    extra_flags lets the caller inject e.g. -DRCCL_NTHREADS_512 so the alternate
+    512-thread generic kernels/table are emitted into a distinct symbol set.
+    """
+    disp_compile_cmd = [
+        clang,
+        '-x', 'hip',
+        '--offload-device-only',
+        f'--offload-arch={arch}',
+        '-g', '-w',
+    ] + forwarded_flags + list(extra_flags) + [
+        '-S', '-o', disp_asm, dispatcher_src,
+    ]
+    run(disp_compile_cmd, f"compile {tag} dispatcher for {arch}")
+
+    with open(disp_asm) as f:
+        disp_lines = f.readlines()
+    patched_lines = patch_dispatcher(disp_lines, max_res)
+    with open(disp_patched, 'w') as f:
+        f.writelines(patched_lines)
+
+    disp_assemble_cmd = [
+        clang,
+        '-x', 'assembler',
+        '-target', 'amdgcn-amd-amdhsa',
+        f'-mcpu={arch}',
+        '-c', '-o', disp_obj, disp_patched,
+    ]
+    run(disp_assemble_cmd, f"assemble {tag} dispatcher for {arch}")
+
+
 def do_link(args, forwarded_flags):
     clang, lld = discover_tools(args.clang)
     arch = args.arch
@@ -546,33 +591,60 @@ def do_link(args, forwarded_flags):
     dispatcher = args.dispatcher
     keep_temps = args.keep_temps
     rocshmem_bitcode = getattr(args, 'rocshmem_bitcode', None)
+    dispatcher_512 = getattr(args, 'dispatcher_512', None)
+    objects_512_rsp = getattr(args, 'objects_512_rsp', None)
 
     if not dispatcher:
         raise SystemExit("ERROR: --link requires --dispatcher=<source>")
 
-    # Collect resource JSONs from alongside each .o
-    resource_list = []
-    for obj in objects:
-        json_path = os.path.splitext(obj)[0] + '.resources.json'
-        if os.path.exists(json_path):
-            with open(json_path) as f:
-                resource_list.append(json.load(f))
+    # [RCCL] Optional second (512-thread) kernel set for gfx950. Its objects are
+    # passed via --objects-512-rsp (a response file listing .o paths); they are
+    # aggregated and dispatched separately so the 512 generic kernels reserve
+    # resources based only on the 512-thread func implementations.
+    objects_512 = []
+    if objects_512_rsp:
+        if not os.path.exists(objects_512_rsp):
+            raise SystemExit(f"ERROR: --objects-512-rsp file not found: {objects_512_rsp}")
+        with open(objects_512_rsp) as f:
+            objects_512 = [line.strip() for line in f if line.strip()]
 
+    # Collect resource JSONs from alongside each .o
+    resource_list = _collect_resources(objects)
     if not resource_list:
         raise SystemExit(f"ERROR: no .resources.json files found alongside input objects")
 
-    # Step 1: Aggregate resources
+    # Step 1: Aggregate resources (default 256-thread set)
     max_res = aggregate_resources(resource_list, arch)
     print(f"[{arch}] Aggregated {len(resource_list)} resources: "
           f"VGPR={max_res['vgpr_count']}, AGPR={max_res['agpr_count']}, "
           f"SGPR={max_res['sgpr_count']}, "
           f"scratch={max_res['private_segment_fixed_size']}")
 
+    max_res_512 = None
+    if dispatcher_512 and objects_512:
+        resource_list_512 = _collect_resources(objects_512)
+        if not resource_list_512:
+            raise SystemExit("ERROR: --dispatcher-512 given but no .resources.json found for 512 objects")
+        max_res_512 = aggregate_resources(resource_list_512, arch)
+        print(f"[{arch}] Aggregated {len(resource_list_512)} resources (512-thread set): "
+              f"VGPR={max_res_512['vgpr_count']}, AGPR={max_res_512['agpr_count']}, "
+              f"SGPR={max_res_512['sgpr_count']}, "
+              f"scratch={max_res_512['private_segment_fixed_size']}")
+        # Explicit scratch (register-spill) comparison between the two kernel sets,
+        # mirroring the measurement in the original 256-thread change (#5425).
+        _s256 = max_res['private_segment_fixed_size']
+        _s512 = max_res_512['private_segment_fixed_size']
+        print(f"[{arch}] Scratch [bytes/lane]: 256-thread set = {_s256}, "
+              f"512-thread set = {_s512} (delta {_s512 - _s256:+d})")
+
     output_dir = os.path.dirname(output) or '.'
     if keep_temps:
         disp_asm = os.path.join(output_dir, f'dispatcher_{arch}.s')
         disp_patched = os.path.join(output_dir, f'dispatcher_{arch}_patched.s')
         disp_obj = os.path.join(output_dir, f'dispatcher_{arch}.o')
+        disp512_asm = os.path.join(output_dir, f'dispatcher_{arch}_512.s')
+        disp512_patched = os.path.join(output_dir, f'dispatcher_{arch}_512_patched.s')
+        disp512_obj = os.path.join(output_dir, f'dispatcher_{arch}_512.o')
         rocshmem_obj = os.path.join(output_dir, f'rocshmem_device_{arch}.o') if rocshmem_bitcode else None
         cleanup = []
     else:
@@ -580,40 +652,27 @@ def do_link(args, forwarded_flags):
         disp_asm = os.path.join(tmpdir, 'dispatcher.s')
         disp_patched = os.path.join(tmpdir, 'dispatcher_patched.s')
         disp_obj = os.path.join(tmpdir, 'dispatcher.o')
+        disp512_asm = os.path.join(tmpdir, 'dispatcher_512.s')
+        disp512_patched = os.path.join(tmpdir, 'dispatcher_512_patched.s')
+        disp512_obj = os.path.join(tmpdir, 'dispatcher_512.o')
         rocshmem_obj = os.path.join(tmpdir, 'rocshmem_device.o') if rocshmem_bitcode else None
-        cleanup = [disp_asm, disp_patched, disp_obj, tmpdir]
+        cleanup = [disp_asm, disp_patched, disp_obj, disp512_asm, disp512_patched, disp512_obj, tmpdir]
         if rocshmem_obj:
             cleanup.insert(-1, rocshmem_obj)  # remove before rmdir
 
     try:
-        # Step 2: Compile dispatcher to assembly
-        disp_compile_cmd = [
-            clang,
-            '-x', 'hip',
-            '--offload-device-only',
-            f'--offload-arch={arch}',
-            '-g', '-w',
-        ] + forwarded_flags + [
-            '-S', '-o', disp_asm, dispatcher,
-        ]
-        run(disp_compile_cmd, f"compile dispatcher for {arch}")
+        # Steps 2-4: Compile, patch, and assemble the default (256-thread) dispatcher
+        _build_dispatcher(clang, arch, dispatcher, forwarded_flags, [],
+                          max_res, disp_asm, disp_patched, disp_obj, "256-thread")
 
-        # Step 3: Patch dispatcher with aggregated resources
-        with open(disp_asm) as f:
-            disp_lines = f.readlines()
-        patched_lines = patch_dispatcher(disp_lines, max_res)
-        with open(disp_patched, 'w') as f:
-            f.writelines(patched_lines)
-
-        # Step 4: Assemble patched dispatcher
-        disp_assemble_cmd = [
-            clang,
-            '-x', 'assembler',
-            '-target', 'amdgcn-amd-amdhsa',
-            f'-mcpu={arch}',
-            '-c', '-o', disp_obj, disp_patched,
-        ]
-        run(disp_assemble_cmd, f"assemble dispatcher for {arch}")
+        # Steps 2-4 (512-thread set): compile the alternate dispatcher with
+        # -DRCCL_NTHREADS_512 and patch it with the 512-set aggregated resources.
+        built_512 = False
+        if max_res_512 is not None:
+            _build_dispatcher(clang, arch, dispatcher_512, forwarded_flags,
+                              ['-DRCCL_NTHREADS_512'], max_res_512,
+                              disp512_asm, disp512_patched, disp512_obj, "512-thread")
+            built_512 = True
 
         # Step 5: Compile rocSHMEM device bitcode to an amdgcn object (if provided).
         # rocSHMEM device API symbols (rocshmem::*_wg, rocshmem_n_pes, …) have
@@ -640,7 +699,11 @@ def do_link(args, forwarded_flags):
         rsp_path = os.path.join(output_dir, f'link_{arch}.rsp')
         with open(rsp_path, 'w') as f:
             f.write(disp_obj + '\n')
+            if built_512:
+                f.write(disp512_obj + '\n')
             for obj in objects:
+                f.write(obj + '\n')
+            for obj in objects_512:
                 f.write(obj + '\n')
             if rocshmem_obj:
                 f.write(rocshmem_obj + '\n')
@@ -700,6 +763,16 @@ def parse_compiler_flags(argv):
         elif arg == '--dispatcher' and i + 1 < len(argv):
             our_args.extend([arg, argv[i + 1]])
             i += 1
+        elif arg.startswith('--dispatcher-512='):
+            our_args.append(arg)
+        elif arg == '--dispatcher-512' and i + 1 < len(argv):
+            our_args.extend([arg, argv[i + 1]])
+            i += 1
+        elif arg.startswith('--objects-512-rsp='):
+            our_args.append(arg)
+        elif arg == '--objects-512-rsp' and i + 1 < len(argv):
+            our_args.extend([arg, argv[i + 1]])
+            i += 1
         elif arg.startswith('--rocshmem-bitcode='):
             our_args.append(arg)
         elif arg == '--rocshmem-bitcode' and i + 1 < len(argv):
@@ -750,6 +823,8 @@ def main():
     parser.add_argument('--arch', required=False)
     parser.add_argument('--clang', default=None)
     parser.add_argument('--dispatcher', default=None)
+    parser.add_argument('--dispatcher-512', default=None, dest='dispatcher_512')
+    parser.add_argument('--objects-512-rsp', default=None, dest='objects_512_rsp')
     parser.add_argument('--rocshmem-bitcode', default=None, dest='rocshmem_bitcode')
     parser.add_argument('-o', '--output', required=False)
     parser.add_argument('--keep-temps', action='store_true')

--- a/projects/rccl/tools/rccl-device-compile
+++ b/projects/rccl/tools/rccl-device-compile
@@ -599,6 +599,19 @@ def do_link(args, forwarded_flags):
     if not dispatcher:
         raise SystemExit("ERROR: --link requires --dispatcher=<source>")
 
+    # [RCCL] The 512-thread kernel set is all-or-nothing: linking its objects
+    # without building its dispatcher (or vice versa) produces a misconfigured ELF
+    # whose 512 kernels are never resource-patched, so require both together.
+    # Compile-only flags for that set are meaningless without it.
+    if bool(dispatcher_512) != bool(objects_512_rsp):
+        raise SystemExit(
+            "ERROR: --dispatcher-512 and --objects-512-rsp must be provided together "
+            "(got --dispatcher-512=%r, --objects-512-rsp=%r)" % (dispatcher_512, objects_512_rsp))
+    if compile_512_flags and not dispatcher_512:
+        raise SystemExit(
+            "ERROR: --compile-512-flag requires the 512-thread set "
+            "(--dispatcher-512 and --objects-512-rsp)")
+
     # [RCCL] Optional second (512-thread) kernel set for gfx950. Its objects are
     # passed via --objects-512-rsp (a response file listing .o paths); they are
     # aggregated and dispatched separately so the 512 generic kernels reserve


### PR DESCRIPTION
## Motivation

Following #5425 (256 threads/block on gfx950 to cut register spills), build a second gfx950 device kernel set at 512 threads/block and select between them at runtime via RCCL_GFX950_NTHREADS={256|512} (default 256).

The alternate set is produced by recompiling the same generated device sources with -DRCCL_NTHREADS_512, which (a) bumps NCCL_MAX_NTHREADS to 512 and (b) routes every emitted device symbol through the new RCCL_NT_SYM() macro so it lands in a distinct _512 namespace (kernels, dispatch tables, device functions, ncclShmem/ncclShmemPerWarp). Both sets thus coexist in one device ELF without symbol/ODR collisions. Two shared-memory helpers are forced __forceinline__ to avoid comdat dedup across sets.

Build: DeviceLinker.cmake adds a gfx950 _512 object library and links both dispatchers; rccl-device-compile aggregates register/scratch usage per set and patches each dispatcher independently. Host side reads the env var per comm (use512Kernels), swaps in the ncclKerns512 launch table, and raises the thread cap to 512 so LL/LL128 FIFO sizing stays consistent.

## Issue Tracking

FBA-1079

## Test Plan

Add generator unit tests (test_generate_device_table.py) verifying symbols are RCCL_NT_SYM-wrapped and that preprocessing the extracted device.h macros yields distinct 256 vs 512 symbol namespaces with no base-name collisions.

## Technical Details
## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
