### PR TITLE
[AILITOOLS-297] amdsmi: add C/C++ and Python code-coverage tooling

### DIFF
--- a/projects/amdsmi/.codespellrc
+++ b/projects/amdsmi/.codespellrc
@@ -6,7 +6,8 @@
 # bootup = AMDSMI_PWR_PROF_PRST_BOOTUP_DEFAULT enum context
 # DEBUGG = intentional invalid log level for CLI failure test
 # reenable = valid systemctl command in packaging scripts
-ignore-words-list = hsa,valu,inout,cant,indx,traid,ue,wite,esponse,renderD,OURCE,utiliz,bootup,DEBUGG,reenable,buildd,nd,subtile,subtiles,hAV,AER
+# DNE = "Does Not Exist" -- coverage summary legend key (tests/coverage)
+ignore-words-list = hsa,valu,inout,cant,indx,traid,ue,wite,esponse,renderD,OURCE,utiliz,bootup,DEBUGG,reenable,buildd,nd,subtile,subtiles,hAV,AER,dne
 # Skip generated files, build artifacts, external dependencies
 # Note that pre-commit hook for codespell ignores these. You have to modify the regex in .pre-commit-config.yaml.
 skip = build,.git,esmi_ib_library,third_party

--- a/projects/amdsmi/CMakeLists.txt
+++ b/projects/amdsmi/CMakeLists.txt
@@ -283,6 +283,19 @@ endif()
 # Intentionally leave out -Wsign-promo. It causes spurious warnings.
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Woverloaded-virtual -Wreorder")
 
+# Code-coverage instrumentation (gcov/gcovr). Pair with BUILD_TESTS=ON, run the
+# test binary to emit .gcda, then report with gcovr. -O0 keeps line/branch
+# mapping accurate (overrides the Release -O3). Must be set before the target
+# subdirectories are added so every target inherits it.
+option(ENABLE_COVERAGE "Instrument the C/C++ build for gcov/gcovr coverage" OFF)
+if(ENABLE_COVERAGE)
+    message(STATUS "Code coverage instrumentation enabled (--coverage -O0 -g)")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage -O0 -g")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -O0 -g")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} --coverage")
+endif()
+
 set(ROCM_SRC_DIR "${PROJECT_SOURCE_DIR}/rocm_smi/src")
 set(ROCM_INC_DIR "${PROJECT_SOURCE_DIR}/rocm_smi/include/rocm_smi")
 set(SHR_MUTEX_DIR "${PROJECT_SOURCE_DIR}/third_party/shared_mutex")

--- a/projects/amdsmi/rocm_smi/src/rocm_smi.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi.cc
@@ -3479,8 +3479,10 @@ rsmi_status_t rsmi_dev_temp_metric_get(uint32_t dv_ind, uint32_t sensor_type,
   }
   std::shared_ptr<amd::smi::Monitor> m = dev->monitor();
 
-  // getTempSensorIndex will throw an out of range exception if sensor_type is
-  // not found
+  // TODO(SPLIT-FROM-AILITOOLS-297): pairs with the rocm_smi_monitor.cc sentinel
+  // change; split out together.
+  // getTempSensorIndex returns RSMI_TEMP_TYPE_INVALID
+  // for a sensor_type that isn't a valid key (e.g. *_LAST boundary values)
   uint32_t sensor_index = m->getTempSensorIndex(static_cast<rsmi_temperature_type_t>(sensor_type));
 
   // Check if sensor_index is valid (not RSMI_TEMP_TYPE_INVALID)

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_monitor.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_monitor.cc
@@ -465,14 +465,22 @@ static int get_supported_sensors(std::string dir_path, std::string fn_reg_ex,
 }
 
 uint32_t Monitor::getTempSensorIndex(rsmi_temperature_type_t type) {
+  // TODO(SPLIT-FROM-AILITOOLS-297): unrelated to the coverage tooling ticket;
+  // move this map-guard trio (getTempSensorIndex/getTempSensorEnum/
+  // getVoltSensorIndex) to its own PR + ticket. Boundary/sentinel enums (e.g.
+  // *_LAST) aren't keys; return the INVALID sentinel the caller already checks
+  // for instead of throwing out_of_range.
+  if (temp_type_index_map_.count(type) == 0) return RSMI_TEMP_TYPE_INVALID;
   return temp_type_index_map_.at(type);
 }
 
 rsmi_temperature_type_t Monitor::getTempSensorEnum(uint64_t ind) {
+  if (index_temp_type_map_.count(ind) == 0) return RSMI_TEMP_TYPE_INVALID;
   return index_temp_type_map_.at(ind);
 }
 
 uint32_t Monitor::getVoltSensorIndex(rsmi_voltage_type_t type) {
+  if (volt_type_index_map_.count(type) == 0) return RSMI_VOLT_TYPE_INVALID;
   return volt_type_index_map_.at(type);
 }
 

--- a/projects/amdsmi/src/CMakeLists.txt
+++ b/projects/amdsmi/src/CMakeLists.txt
@@ -95,7 +95,11 @@ else()
 endif()
 file(GLOB RAS_DECODE_INCLUDES "${RAS_DECODE_INC_DIR}/*.h")
 file(GLOB RAS_DECODE_SOURCES "${RAS_DECODE_SRC_DIR}/*.c")
-list(REMOVE_ITEM RAS_DECODE_SOURCES "main.c")
+# TODO(SPLIT-FROM-AILITOOLS-297): build-correctness fix unrelated to coverage;
+# move to its own PR. Exclude ras-decode main.c by absolute path -- the bare
+# "main.c" was a no-op against the GLOB'd absolute paths and leaked a second
+# main() into libamd_smi.
+list(REMOVE_ITEM RAS_DECODE_SOURCES "${RAS_DECODE_SRC_DIR}/main.c")
 
 set(SRC_LIST ${SRC_LIST} ${RAS_DECODE_SOURCES})
 set(INC_LIST ${INC_LIST} ${RAS_DECODE_INCLUDES})

--- a/projects/amdsmi/tests/amd_smi_test/unit/gpu/monitor_sensor_map_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/unit/gpu/monitor_sensor_map_test.cc
@@ -1,0 +1,302 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+// TODO(SPLIT-FROM-AILITOOLS-297): slightly related, coverage allowed us
+// to proc the behavior during the coverage tooling ticket
+
+// AILITOOLS-299: Monitor's sensor lookups call std::map::at() without checking
+// that the key exists, so an out-of-range sensor type escapes as
+// std::out_of_range and every rsmi_* entry point converts it (via TRY/CATCH ->
+// handleException) into RSMI_STATUS_INTERNAL_EXCEPTION / AMDSMI_STATUS_INTERNAL_EXCEPTION
+// instead of a meaningful NOT_SUPPORTED.
+//
+// These are characterization tests: as written they assert the CURRENT
+// (defective) behavior so the bug is pinned down and reproducible without a GPU.
+// When the .count() guards are restored in rocm_smi_monitor.cc, flip
+// kSensorMapGuardsLanded to true and the same tests assert the fixed behavior.
+// Leaving the flag false while the guards are in place makes these tests FAIL,
+// which is the intended signal that the fix landed.
+//
+// Driver-free: a temp directory stands in for an amdgpu hwmon node.
+
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <map>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <system_error>
+
+#include "amd_smi/amdsmi.h"
+#include "amd_smi/impl/amd_smi_common.h"
+#include "rocm_smi/rocm_smi.h"
+#include "rocm_smi/rocm_smi_monitor.h"
+#include "rocm_smi/rocm_smi_utils.h"
+
+namespace {
+
+// Set to true in the same change that restores the guards.
+constexpr bool kSensorMapGuardsLanded = true;  // This is how the code responded before the fixes
+                                               // Release builds allowed try/catches to
+                                               // return AMDSMI_STATUS_INTERNAL_EXCEPTION
+                                               // instead of properly handling
+
+// amdsmi_temperature_type_t pads its group sentinels to round numbers (249),
+// while rsmi_temperature_type_t aliases BASEBOARD_LAST to the last real member
+// (BASEBOARD_IBC, 222). amdsmi_get_temp_metric forwards the value unchanged, so
+// 249 reaches the rsmi layer as a type that was never seeded into the map.
+constexpr auto kPaddedBaseboardLast =
+    static_cast<rsmi_temperature_type_t>(AMDSMI_TEMPERATURE_TYPE_BASEBOARD_LAST);
+
+// index_temp_type_map_ is only populated for file indices inside the four
+// group ranges, leaving a hole between GENERAL_LAST (7) and GPUBOARD_NODE_FIRST (100).
+constexpr uint64_t kUnmappedTempFileIndex = RSMI_TEMP_TYPE_GENERAL_LAST + 1;
+
+// Mirrors the range predicate in setTempSensorLabelMap(). Kept as an independent
+// copy on purpose: if the production ranges change, this test should notice.
+bool IsSeededTempFileIndex(uint64_t i) {
+  return (i >= 1 && i <= RSMI_TEMP_TYPE_GENERAL_LAST) ||
+         (i >= RSMI_TEMP_TYPE_GPUBOARD_NODE_FIRST && i <= RSMI_TEMP_TYPE_GPUBOARD_NODE_LAST) ||
+         (i >= RSMI_TEMP_TYPE_GPUBOARD_VR_FIRST && i <= RSMI_TEMP_TYPE_GPUBOARD_LAST) ||
+         (i >= RSMI_TEMP_TYPE_BASEBOARD_FIRST && i <= RSMI_TEMP_TYPE_BASEBOARD_LAST);
+}
+
+// The only labels kTempSensorNameMap recognizes, and the files the fixture writes.
+const std::map<uint64_t, rsmi_temperature_type_t> kLabeledTempFileIndices = {
+    {1, RSMI_TEMP_TYPE_EDGE},
+    {2, RSMI_TEMP_TYPE_JUNCTION},
+    {3, RSMI_TEMP_TYPE_MEMORY},
+};
+
+// Stands in for an amdgpu hwmon node. Deliberately mirrors real hardware:
+// temp1..temp3 carry labels, and only in0 does -- which is what leaves
+// VDDBOARD out of volt_type_index_map_ entirely.
+class FakeHwmonNode {
+ public:
+  FakeHwmonNode() {
+    const auto* info = ::testing::UnitTest::GetInstance()->current_test_info();
+    dir_ =
+        std::filesystem::temp_directory_path() / ("amdsmi_hwmon_" + std::to_string(getpid()) + "_" +
+                                                  (info != nullptr ? info->name() : "anon"));
+    std::error_code ec;
+    std::filesystem::remove_all(dir_, ec);
+    if (!std::filesystem::create_directories(dir_, ec)) {
+      return;
+    }
+    ok_ = Write("name", "amdgpu") && Write("temp1_label", "edge") &&
+          Write("temp2_label", "junction") && Write("temp3_label", "mem") &&
+          Write("in0_label", "vddgfx");
+    if (!ok_) {
+      return;
+    }
+    mon_ = std::make_unique<amd::smi::Monitor>(dir_.string(), &env_vars_);
+    ok_ = (mon_->setTempSensorLabelMap() == 0) && (mon_->setVoltSensorLabelMap() == 0);
+  }
+
+  ~FakeHwmonNode() {
+    std::error_code ec;
+    std::filesystem::remove_all(dir_, ec);
+  }
+
+  FakeHwmonNode(const FakeHwmonNode&) = delete;
+  FakeHwmonNode& operator=(const FakeHwmonNode&) = delete;
+
+  bool ok() const { return ok_; }
+  amd::smi::Monitor* monitor() const { return mon_.get(); }
+
+ private:
+  bool Write(const std::string& name, const std::string& contents) {
+    std::ofstream file(dir_ / name);
+    if (!file.is_open()) {
+      return false;
+    }
+    file << contents << "\n";
+    return file.good();
+  }
+
+  std::filesystem::path dir_;
+  ::RocmSMI_env_vars env_vars_{};
+  std::unique_ptr<amd::smi::Monitor> mon_;
+  bool ok_ = false;
+};
+
+// The root cause, asserted directly: the two enums disagree on BASEBOARD_LAST.
+// Aligning them is an alternative fix, and would fail here on purpose.
+TEST(GpuUnit, MonitorTempSentinelsDivergeBetweenAmdsmiAndRsmi) {
+  EXPECT_EQ(static_cast<uint32_t>(AMDSMI_TEMPERATURE_TYPE_BASEBOARD_LAST), 249U);
+  EXPECT_GT(static_cast<uint32_t>(AMDSMI_TEMPERATURE_TYPE_BASEBOARD_LAST),
+            static_cast<uint32_t>(RSMI_TEMP_TYPE_LAST))
+      << "amdsmi pads BASEBOARD_LAST past the highest type rsmi ever seeds";
+}
+
+TEST(GpuUnit, MonitorGetTempSensorIndexPaddedSentinelThrows) {
+  FakeHwmonNode node;
+  ASSERT_TRUE(node.ok());
+
+  if (kSensorMapGuardsLanded) {
+    EXPECT_EQ(node.monitor()->getTempSensorIndex(kPaddedBaseboardLast),
+              static_cast<uint32_t>(RSMI_TEMP_TYPE_INVALID));
+  } else {
+    EXPECT_THROW(static_cast<void>(node.monitor()->getTempSensorIndex(kPaddedBaseboardLast)),
+                 std::out_of_range);
+  }
+}
+
+// Control: BASEBOARD_IBC (222) IS seeded, so it already returns the INVALID
+// sentinel rather than throwing. This is why the CLI reports NOT_SUPPORTED for
+// every real baseboard type and INTERNAL_EXCEPTION only for *_LAST.
+TEST(GpuUnit, MonitorGetTempSensorIndexSeededTypeReturnsInvalid) {
+  FakeHwmonNode node;
+  ASSERT_TRUE(node.ok());
+
+  EXPECT_EQ(node.monitor()->getTempSensorIndex(RSMI_TEMP_TYPE_BASEBOARD_IBC),
+            static_cast<uint32_t>(RSMI_TEMP_TYPE_INVALID));
+  EXPECT_EQ(node.monitor()->getTempSensorIndex(RSMI_TEMP_TYPE_EDGE), 1U);
+}
+
+TEST(GpuUnit, MonitorGetTempSensorEnumUnmappedFileIndexThrows) {
+  FakeHwmonNode node;
+  ASSERT_TRUE(node.ok());
+
+  if (kSensorMapGuardsLanded) {
+    EXPECT_EQ(node.monitor()->getTempSensorEnum(kUnmappedTempFileIndex), RSMI_TEMP_TYPE_INVALID);
+  } else {
+    EXPECT_THROW((void)node.monitor()->getTempSensorEnum(kUnmappedTempFileIndex),
+                 std::out_of_range);
+  }
+}
+
+// Sweeps every temperature file index the library can ask about: labelled ones
+// resolve to their type, seeded-but-unlabelled ones resolve to INVALID, and the
+// holes between the four groups are where the unguarded .at() escapes.
+TEST(GpuUnit, MonitorGetTempSensorEnumCoversEveryFileIndex) {
+  FakeHwmonNode node;
+  ASSERT_TRUE(node.ok());
+
+  std::size_t labeled = 0;
+  std::size_t seeded_unlabeled = 0;
+  std::size_t gaps = 0;
+
+  for (uint64_t i = 1; i <= static_cast<uint64_t>(RSMI_TEMP_TYPE_LAST) + 1; ++i) {
+    SCOPED_TRACE("temp file index " + std::to_string(i));
+    const auto labeled_it = kLabeledTempFileIndices.find(i);
+
+    if (IsSeededTempFileIndex(i)) {
+      if (labeled_it != kLabeledTempFileIndices.end()) {
+        ++labeled;
+        EXPECT_EQ(node.monitor()->getTempSensorEnum(i), labeled_it->second);
+      } else {
+        ++seeded_unlabeled;
+        EXPECT_EQ(node.monitor()->getTempSensorEnum(i), RSMI_TEMP_TYPE_INVALID);
+      }
+      continue;
+    }
+
+    ++gaps;
+    if (kSensorMapGuardsLanded) {
+      EXPECT_EQ(node.monitor()->getTempSensorEnum(i), RSMI_TEMP_TYPE_INVALID);
+    } else {
+      EXPECT_THROW(static_cast<void>(node.monitor()->getTempSensorEnum(i)), std::out_of_range);
+    }
+  }
+
+  EXPECT_EQ(labeled, kLabeledTempFileIndices.size());
+  EXPECT_GT(seeded_unlabeled, 0U);
+  EXPECT_GT(gaps, 0U) << "no unmapped indices means the bug surface disappeared";
+}
+
+// volt_type_index_map_ is never pre-seeded: a type is a key only when its
+// in<N>_label file exists. With only in0_label present, VDDBOARD is absent.
+TEST(GpuUnit, MonitorGetVoltSensorIndexUnlabeledTypeThrows) {
+  FakeHwmonNode node;
+  ASSERT_TRUE(node.ok());
+
+  if (kSensorMapGuardsLanded) {
+    EXPECT_EQ(node.monitor()->getVoltSensorIndex(RSMI_VOLT_TYPE_VDDBOARD),
+              static_cast<uint32_t>(RSMI_VOLT_TYPE_INVALID));
+  } else {
+    EXPECT_THROW((void)node.monitor()->getVoltSensorIndex(RSMI_VOLT_TYPE_VDDBOARD),
+                 std::out_of_range);
+  }
+}
+
+TEST(GpuUnit, MonitorGetVoltSensorIndexLabeledTypeReturnsIndex) {
+  FakeHwmonNode node;
+  ASSERT_TRUE(node.ok());
+
+  EXPECT_EQ(node.monitor()->getVoltSensorIndex(RSMI_VOLT_TYPE_VDDGFX), 0U);
+}
+
+// getVoltSensorEnum already carries the guard the other three lack; it is the
+// precedent for the fix and must keep working.
+TEST(GpuUnit, MonitorGetVoltSensorEnumUnknownIndexIsAlreadyGuarded) {
+  FakeHwmonNode node;
+  ASSERT_TRUE(node.ok());
+
+  EXPECT_NO_THROW({ EXPECT_EQ(node.monitor()->getVoltSensorEnum(1), RSMI_VOLT_TYPE_INVALID); });
+}
+
+// End-to-end status translation, mirroring the TRY/CATCH wrapper that every
+// rsmi_* entry point uses. This is the AMDSMI_STATUS_INTERNAL_EXCEPTION (16)
+// the CLI and Python suites report, reproduced with no GPU present.
+TEST(GpuUnit, MonitorMapOutOfRangeSurfacesAsInternalException) {
+  FakeHwmonNode node;
+  ASSERT_TRUE(node.ok());
+
+  auto caught_status = [&](auto&& call) {
+    rsmi_status_t ret = RSMI_STATUS_SUCCESS;
+    try {
+      call();
+    } catch (...) {
+      ret = amd::smi::handleException();
+    }
+    return ret;
+  };
+
+  const rsmi_status_t temp_index_ret =
+      caught_status([&] { (void)node.monitor()->getTempSensorIndex(kPaddedBaseboardLast); });
+  const rsmi_status_t temp_enum_ret =
+      caught_status([&] { (void)node.monitor()->getTempSensorEnum(kUnmappedTempFileIndex); });
+  const rsmi_status_t volt_index_ret =
+      caught_status([&] { (void)node.monitor()->getVoltSensorIndex(RSMI_VOLT_TYPE_VDDBOARD); });
+
+  if (kSensorMapGuardsLanded) {
+    EXPECT_EQ(temp_index_ret, RSMI_STATUS_SUCCESS);
+    EXPECT_EQ(temp_enum_ret, RSMI_STATUS_SUCCESS);
+    EXPECT_EQ(volt_index_ret, RSMI_STATUS_SUCCESS);
+  } else {
+    EXPECT_EQ(temp_index_ret, RSMI_STATUS_INTERNAL_EXCEPTION);
+    EXPECT_EQ(temp_enum_ret, RSMI_STATUS_INTERNAL_EXCEPTION);
+    EXPECT_EQ(volt_index_ret, RSMI_STATUS_INTERNAL_EXCEPTION);
+
+    EXPECT_EQ(amd::smi::rsmi_to_amdsmi_status(temp_index_ret), AMDSMI_STATUS_INTERNAL_EXCEPTION);
+    EXPECT_EQ(amd::smi::rsmi_to_amdsmi_status(temp_enum_ret), AMDSMI_STATUS_INTERNAL_EXCEPTION);
+    EXPECT_EQ(amd::smi::rsmi_to_amdsmi_status(volt_index_ret), AMDSMI_STATUS_INTERNAL_EXCEPTION);
+  }
+}
+
+}  // namespace

--- a/projects/amdsmi/tests/coverage/.coveragerc
+++ b/projects/amdsmi/tests/coverage/.coveragerc
@@ -1,0 +1,42 @@
+# Canonical coverage.py config for the amd-smi Python test suites.
+#
+# Manual use:
+#   cd tests/python
+#   python3 -m coverage run --rcfile=../coverage/.coveragerc \
+#       --source=$(python3 -c "import amdsmi,os;print(os.path.dirname(amdsmi.__file__))") \
+#       unit_tests.py -q
+#   python3 -m coverage combine
+#   python3 -m coverage report --rcfile=../coverage/.coveragerc
+#
+# The run_coverage.sh helper injects the machine-specific `source` list (the
+# installed amdsmi binding + the amdsmi_cli dir) in place of the __SOURCE__
+# marker below, so CLI subprocesses measured via COVERAGE_PROCESS_START pick up
+# the same source scope.
+[run]
+branch = True
+parallel = True
+# __SOURCE__ (run_coverage.sh replaces this marker with a resolved source = list)
+omit =
+    # Auto-generated ctypes wrapper: 1:1 with the C header, not hand-written logic.
+    */amdsmi_wrapper.py
+    # The test code itself should not count toward product coverage.
+    */tests/*
+
+[paths]
+# Fold the installed copies back onto the git source tree so reports show
+# repo-relative paths regardless of where the package was imported from.
+binding =
+    py-interface/
+    */dist-packages/amdsmi/
+    */site-packages/amdsmi/
+    */share/amd_smi/amdsmi/
+cli =
+    amdsmi_cli/
+    */libexec/amdsmi_cli/
+
+[report]
+show_missing = True
+skip_empty = True
+exclude_lines =
+    pragma: no cover
+    if __name__ == .__main__.:

--- a/projects/amdsmi/tests/coverage/README.md
+++ b/projects/amdsmi/tests/coverage/README.md
@@ -1,0 +1,404 @@
+# amd-smi code-coverage tooling
+
+Line/branch coverage for the amd-smi C/C++ library and Python (binding + CLI),
+complementing the API-level metric produced by `tests/api_summary.py`.
+
+- **C/C++** → [gcovr](https://gcovr.com/) reading clang's gcov data via `llvm-cov`.
+- **Python** → [coverage.py](https://coverage.readthedocs.io/) (branch mode,
+  including the `amd-smi` CLI subprocesses).
+
+Everything is driven by [`run_coverage.sh`](run_coverage.sh); reports land in
+`<repo>/coverage-report/`.
+
+## Scope — what each tool measures
+
+The two tiers are **complementary and do not overlap**: Python covers the
+hand-written Python wrappers, C/C++ covers the compiled library. Neither sees
+inside the other (coverage.py stops at the ctypes boundary).
+
+**C/C++ (gcov/gcovr)** — the compiled amd-smi library, filtered to:
+
+- `src/` — the amd-smi implementation (`amd_smi/*.cc`, the NIC `amdsmi_unified`
+  sources).
+- `rocm_smi/src/` — the bundled rocm-smi backend the library links against.
+
+Excluded: test sources (`*_test.cc`), examples, GoogleTest, and the third-party
+esmi library. Exercised by the `amdsmitst` GoogleTest suite (unit + functional)
+running against the GPUs as root.
+
+**Python (coverage.py)** — the hand-written amd-smi Python, two trees:
+
+- Binding: `py-interface/` (installed as `amdsmi/`) — `amdsmi_interface.py`,
+  `amdsmi_interface_utils.py`, `amdsmi_exception.py`, `__init__.py`.
+- CLI: `amdsmi_cli/` — `amdsmi_cli.py`, `amdsmi_parser.py`, `amdsmi_commands.py`,
+  `amdsmi_helpers.py`, `subcommands/*.py`.
+
+Excluded: the generated `amdsmi_wrapper.py` (ctypes, 1:1 with the C header) and
+test files. **Not** included: the compiled `libamd_smi.so` — when the binding
+calls into the `.so` via ctypes, coverage.py counts the Python line making the
+call but never the C/C++ implementation behind it (measure that with the C/C++
+tier). Exercised by `unit_tests.py` (binding, mock-based), `integration_test.py`
+(functional, against live GPUs) and `cli_unit_test.py` (spawns the real `amd-smi`
+CLI). `UNIT_ONLY=1` runs only `unit_tests.py`.
+
+## Prerequisites
+
+### C/C++ tier
+
+- **A compiler + a matching `gcov` reader.** The `.gcda`/`.gcno` data must be
+  read by a `gcov` whose major version matches the compiler that produced it; a
+  mismatch is silent and reports **0/0** (see “Choosing the gcov reader”). Use
+  **either** toolchain — both are supported:
+
+  - **GCC** (simplest — the `libgcov` runtime ships with gcc, nothing extra):
+
+    ```bash
+    sudo apt-get install -y gcc g++          # usually already present
+    ```
+
+    Reader: plain `gcov`, matched to your gcc (e.g. `gcov` 9 for gcc 9).
+
+  - **clang** (needs the compiler-rt *profile* runtime, or the link fails with
+    `cannot find libclang_rt.profile-x86_64.a`):
+
+    ```bash
+    sudo apt-get install -y clang-16 llvm-16 libclang-rt-16-dev
+    ```
+
+    Reader: `llvm-cov-16 gcov` (its major version must match the clang you build with).
+
+  > On this box plain `clang`/`clang++` resolve to **clang 10**, so always build
+  > with an explicit versioned driver (e.g. `clang-16`/`clang++-16`) and a
+  > matching `GCOV_TOOL`. clang-16 and clang-10 have their profile runtime
+  > installed; clang-14 does **not** (add `libclang-rt-14-dev` if you want 14).
+- **gcovr** for the Python 3.8 interpreter:
+
+  ```bash
+  python3 -m pip install --user gcovr
+  ```
+
+### Python tier
+
+- **coverage.py** for the *same* `python3` the tests run under (3.8 here; a stray
+  `~/.local/bin/coverage` built for another Python fails with
+  `No module named coverage`):
+
+  ```bash
+  python3 -m pip install --user coverage
+  ```
+- **The `amd-smi-lib` + `amd-smi-lib-tests` packages installed** — coverage.py
+  measures the *installed* binding/CLI and needs the test suites present. Build
+  with tests and install the package:
+
+  ```bash
+  cmake -S . -B build -DBUILD_TESTS=ON
+  cmake --build build -j"$(nproc)"
+  ( cd build && make package && sudo dpkg -i amd-smi-lib*.deb )   # DEB distros
+  ```
+
+## Quick start
+
+```bash
+# from projects/amdsmi -- run as your normal user, not under sudo
+tests/coverage/run_coverage.sh all     # C/C++ + Python
+tests/coverage/run_coverage.sh cpp     # C/C++ only
+tests/coverage/run_coverage.sh py      # Python only
+```
+
+The tests themselves need root (hardware access, plus the Python runners'
+`geteuid()==0` check), but the script escalates **only the test processes** with
+`sudo` and keeps `gcovr`/`coverage` running as you (root can't import your
+user-site tools), then hands the reports back.
+
+**How the escalation is decided — and why a root container is fine:** the script
+checks `id -u`. If you're **already root** (a Docker container running as root,
+or you launched it with `sudo`), `id -u` is `0`, so it runs everything directly
+with **no `sudo` call and no password prompt**. If you're a normal user, it
+prepends `sudo` to just the test steps, prompting for your password once (unless
+sudo is passwordless or already cached). So nothing here is too strict for a
+root container — in that case it never shells out to `sudo` at all.
+
+## Build + run in one command (opt-in)
+
+By default the script only **runs** (against an existing instrumented build /
+installed package). Two opt-in flags fold the build in so you don't have to
+match `GCOV_TOOL` by hand or install to `/opt/rocm`:
+
+```bash
+# Build an instrumented build-cov with the given toolchain, then run.
+# Auto-sets BUILD_DIR=build-cov and GCOV_TOOL to match the compiler.
+tests/coverage/run_coverage.sh --build=clang-16 cpp
+tests/coverage/run_coverage.sh --build=gcc cpp
+
+# Build + stage-install to a user-writable prefix, then run BOTH tiers against
+# the staged tree -- no `dpkg -i`, no /opt/rocm mutation, no stale-install skew.
+tests/coverage/run_coverage.sh --build=clang-16 --stage all
+```
+
+- `--build[=gcc|clang|clang-NN]` — configures + builds `build-cov`
+  (`-DCMAKE_BUILD_TYPE=Debug -DENABLE_COVERAGE=ON`) and points `BUILD_DIR` +
+  `GCOV_TOOL` at it. Default toolchain is `clang-16`. Builds only `amdsmitst`
+  unless `--stage` is also set (which needs the full tree).
+- `--stage[=DIR]` — `cmake --install`s the build into `DIR` (default
+  `build-cov-stage`), which reproduces the install-tree layout the Python tests
+  expect (`share/amd_smi/amdsmi`, `libexec/amdsmi_cli`, `bin/amd-smi`,
+  `lib/libamd_smi.so`), and wires the Python tier there via `AMDSMI_PATH` /
+  `LD_LIBRARY_PATH` / `PATH`. The Python tests then measure exactly what you
+  built. **Root is still required to *run*** (the `geteuid()==0` gate); staging
+  only removes the *install* root requirement. Auto-enabled when `--build` is
+  combined with the Python tier (`all`/`py`), since a fresh build is the only
+  correct thing to measure — pass `--installed` to opt out.
+- `--installed` — Python tier measures the **system-installed** amd-smi package
+  instead of staging. Opts out of the auto-stage above; may be stale relative to
+  a fresh `--build`.
+
+`install`-to-`/opt/rocm` is intentionally left out of the script (system-mutating,
+needs `dpkg`); use `--stage` for a throwaway prefix, or the manual package
+install in Prerequisites if you specifically want the system package.
+
+## Summary table
+
+Every run prints a combined C++/Python table at the very bottom and writes it to
+`coverage-report/amdsmi_cc_summary.md` (Markdown) +
+`coverage-report/amdsmi_cc_summary.txt` (text):
+
+```
+================  AMD SMI Code Coverage  ================
+Date:         08-11-2026
+C++ compiler: g++ 9.4.0
+C compiler:   gcc 9.4.0
+
+Metric    | C++                    | Python
+--------- | ---------------------- | -----------------------
+Lines     | 25.0% (6,026 / 24,068) | 51.6% (8,018 / 15,538)
+Branches  | 15.5% (6,646 / 43,014) | 41.5% (2,972 / 7,163)
+Functions | 32.1% (521 / 1,625)    | DNE
+
+N/A   - tier not selected for this run.
+ERROR - tier selected but no data (e.g. no .gcda; tests did not run).
+DNE   - metric does not exist (coverage.py has no per-function metric).
+```
+
+- **Date** / **compiler** — the `C++ compiler` / `C compiler` lines record the
+  drivers CMake used for `build-cov` (`CMAKE_CXX_COMPILER` / `CMAKE_C_COMPILER`),
+  rendered as `<driver> <version>` (e.g. `g++ 9.4.0`, `clang++-16 16.0.6`).
+  amd-smi has both `.cc` and `.c` sources, so both front-ends of the toolchain are
+  used; they are normally the same version (e.g. `g++`/`gcc`, `clang++`/`clang`).
+  When the C/C++ tier is not run the line collapses to a single `Compiler: N/A`.
+  This matters because gcov's line/branch model is **compiler-specific** — GCC and
+  Clang count "lines" and "branches" differently, so the numbers are only
+  comparable **within the same compiler**, not across compilers (pick one as your
+  canonical toolchain).
+- **numbers** — the tier ran and produced data.
+- **N/A** — the tier wasn't selected this run (e.g. C++ column under `py`).
+- **ERROR** — the tier was selected but produced no data on our side (e.g. no
+  `.gcda`; the C/C++ tests didn't run).
+- **DNE** — the metric doesn't exist (Python `Functions`; coverage.py has no
+  per-function metric).
+
+## C/C++ coverage
+
+### 1. Build with instrumentation
+
+`ENABLE_COVERAGE` (top-level `CMakeLists.txt`) adds `--coverage -O0 -g` to the
+compile and link flags. Use a dedicated build dir so it doesn't disturb your
+normal build, and only build the test target (much faster than the full
+package/install path). Build with **either** toolchain:
+
+**GCC:**
+
+```bash
+CC=gcc CXX=g++ cmake -S . -B build-cov \
+  -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DENABLE_COVERAGE=ON \
+  -DBUILD_EXAMPLES=OFF
+cmake --build build-cov --target amdsmitst -j"$(nproc)"
+```
+
+**clang-16:**
+
+```bash
+CC=clang-16 CXX=clang++-16 cmake -S . -B build-cov \
+  -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DENABLE_COVERAGE=ON \
+  -DBUILD_EXAMPLES=OFF
+cmake --build build-cov --target amdsmitst -j"$(nproc)"
+```
+
+### 2. Run + report
+
+Match the reader (`GCOV_TOOL`) to the compiler you built with — the script
+default is `llvm-cov-14 gcov`:
+
+```bash
+# GCC build:
+GCOV_TOOL="gcov" BUILD_DIR=build-cov tests/coverage/run_coverage.sh cpp
+
+# clang-16 build:
+GCOV_TOOL="llvm-cov-16 gcov" BUILD_DIR=build-cov tests/coverage/run_coverage.sh cpp
+```
+
+This runs `amdsmitst` (emitting `.gcda` next to the objects) and then `gcovr`.
+Output:
+
+- `coverage-report/cpp/index.html` — browsable HTML.
+- `coverage-report/cpp-summary.txt` — text summary.
+
+### Choosing the gcov reader (important)
+
+The `.gcda`/`.gcno` files must be read by a `gcov` whose version matches the
+**compiler that produced them**. Mismatch is silent: the reader prints
+`Unexpected version: ... Invalid .gcno File!` and gcovr then reports **0/0**.
+
+- Built with **GCC** → plain `gcov`, matched to your gcc: `GCOV_TOOL="gcov"`.
+- Built with **clang N** → `llvm-cov-N gcov`: e.g. `GCOV_TOOL="llvm-cov-16 gcov"`.
+- The script default is `llvm-cov-14 gcov`; override via `GCOV_TOOL` to match
+  whatever you built with.
+
+To confirm a reader matches, run it on a single note file:
+
+```bash
+llvm-cov-16 gcov -b <build>/…/some_file.cpp.gcno   # clang build — prints coverage = good
+gcov         -b <build>/…/some_file.cpp.gcno       # GCC build
+```
+
+## Python coverage
+
+No build step — coverage.py instruments at runtime against the **installed**
+package:
+
+```bash
+tests/coverage/run_coverage.sh py
+```
+
+- Config: [`.coveragerc`](.coveragerc) (branch mode; omits the generated
+  `amdsmi_wrapper.py` and the test files; maps installed copies back to the
+  `py-interface/` and `amdsmi_cli/` source trees for reporting).
+- Covers both the binding (`amdsmi_interface`) and the `amd-smi` CLI, including
+  code that runs in spawned CLI **subprocesses** (via `COVERAGE_PROCESS_START` +
+  a `sitecustomize` hook), then `coverage combine`.
+- Output: `coverage-report/py/html/index.html` and `coverage-report/py-summary.txt`
+  (the summary file also gets a **gcovr-style** `lines` + `branches` covered/total
+  block appended, derived from `coverage json`, to match the C/C++ table).
+
+## Environment knobs
+
+| Var | Default | Meaning |
+|-----|---------|---------|
+| `BUILD_DIR` | `<repo>/build` | Build tree holding the instrumented `amdsmitst`. |
+| `OUT_DIR` | `<repo>/coverage-report` | Where reports are written. |
+| `GCOV_TOOL` | `llvm-cov-14 gcov` | gcov reader matching the build compiler. |
+| `CLI_SRC` | `/opt/rocm/libexec/amdsmi_cli` | amd-smi CLI source dir for Python coverage. |
+| `TEST_FILTER` | *(all)* | `--gtest_filter` passed to `amdsmitst`. |
+| `UNIT_ONLY` | `0` | `1` = coverage from the **unit tests only** (C/C++ gtest filter `*Unit*`; Python skips `cli_unit_test.py`). Set `OUT_DIR` too so it doesn't overwrite the full-suite report. |
+| `VERBOSE` | `0` | `1` (or the `--verbose`/`-v` flag) logs **per-test** Python output (`-v`: every test name + skip reason) instead of `-q`. C/C++ gtest already lists each `[RUN]`/`[OK]`/`[SKIPPED]`. |
+
+Each test suite is also bracketed with `>>> START <suite>` / `<<< END <suite> (exit N)`
+markers and the exact command, so you can see what ran and attribute any library
+stderr (e.g. `Exception caught: …`) to the suite that produced it. Combine with
+`--verbose` to see which individual tests ran or skipped:
+
+```bash
+tests/coverage/run_coverage.sh --verbose py
+```
+
+Unit-only vs full-suite measure different things: the full suite (default)
+reports how much code the whole test suite exercises — for C/C++ that's mostly
+the **functional** GPU tests hitting hardware, so unit-only will be much lower.
+Example:
+
+```bash
+# unit-only, written to a separate dir
+UNIT_ONLY=1 OUT_DIR=coverage-report-unit tests/coverage/run_coverage.sh all
+```
+
+The C/C++ run resets accumulated `.gcda` counters first, so each invocation's
+report reflects only the tests it ran.
+
+## Gotchas
+
+- **Runners require root.** `unit_tests.py` / `cli_unit_test.py` /
+  `integration_test.py` (via `common.run_test_dir`) `sys.exit(1)` when not
+  `euid==0`, so without escalation they exit before running a single test and
+  coverage reports **0%** with `No data was collected`. The script handles this
+  automatically (see Quick start); if you invoke coverage manually, run the
+  suites under `sudo`.
+- **Match the Python version.** `coverage`/`gcovr` must be importable by the
+  same `python3` the tests use (3.8 here). A `~/.local/bin/coverage` from a
+  different Python silently fails with `No module named coverage`.
+- **gcov version mismatch → 0/0.** See “Choosing the gcov reader” above.
+- **Root-owned report dirs.** If you run the whole script as root (e.g. `sudo`
+  or a root container), the report dirs are created root-owned; a later run as a
+  normal user then hits `Permission denied`. Clean with
+  `sudo rm -rf coverage-report` and re-run.
+
+## Cleaning up generated files
+
+Coverage leaves three kinds of artifacts; none are tracked by git (all live
+under `coverage-report/`, `build*/`, or as loose `.coverage*` files).
+
+The script can do this for you (each must be used **alone**, no other args):
+
+- `tests/coverage/run_coverage.sh --clean` — removes the build/intermediate
+  artifacts (`build-cov/`, `build-cov-stage/`, loose `.coverage*`) but **keeps
+  the whole `coverage-report/`** (HTML, summaries, JSON) so you can still view it.
+- `tests/coverage/run_coverage.sh --clean-all` — removes everything, including
+  `coverage-report/`.
+
+Both only ever touch coverage-owned paths and are sudo-aware for root-owned
+artifacts — never a user `BUILD_DIR`. The manual commands below do the same by
+hand, if you'd rather pick and choose:
+
+```bash
+# 1. Reports (HTML + text + coverage.py data + effective rc). Prepend sudo if a
+#    root run left them root-owned.
+rm -rf coverage-report            # or: sudo rm -rf coverage-report
+
+# 2. C/C++ runtime data (.gcda) — clears the counts but keeps the instrumented
+#    build, so the next `cpp` run just re-executes the binary (no recompile).
+find build-cov -name '*.gcda' -delete
+#    Also drop the compile-time notes (.gcno) for a full reset:
+find build-cov \( -name '*.gcda' -o -name '*.gcno' \) -delete
+
+# 3. Stray coverage.py data files, if a manual run wrote them outside OUT_DIR.
+rm -f .coverage .coverage.*
+```
+
+To remove the instrumentation entirely, delete the dedicated coverage build dir
+(the next report needs a fresh `-DENABLE_COVERAGE=ON` build):
+
+```bash
+rm -rf build-cov
+```
+
+Nuke everything in one line:
+
+```bash
+sudo rm -rf coverage-report build-cov build-cov-stage && rm -f .coverage .coverage.*
+```
+
+## Baseline (2026-08-11, full suite as root, gcc 9.4.0)
+
+Snapshot from a full `run_coverage.sh --build gcc all` run; see
+[Scope — what each tool measures](#scope--what-each-tool-measures) for exactly
+which sources each tier covers and what drives them. The two percentages measure
+**disjoint** code — the compiled library vs. the hand-written Python wrappers —
+and are **not** additive. gcov's line/branch model is compiler-specific, so these
+C/C++ figures are **gcc's**; a clang build reports different totals.
+
+**C/C++** (`g++` / `gcc` 9.4.0):
+
+| Metric | Coverage | Covered / Total |
+|--------|----------|-----------------|
+| Lines | 25.0% | 6,026 / 24,068 |
+| Branches | 15.5% | 6,646 / 43,014 |
+| Functions | 32.1% | 521 / 1,625 |
+
+**Python** (coverage.py, compiler-independent):
+
+| Metric | Coverage | Covered / Total |
+|--------|----------|-----------------|
+| Lines | 51.6% | 8,018 / 15,538 |
+| Branches | 41.5% | 2,972 / 7,163 (956 partial) |
+| Functions | N/A | coverage.py has no per-function metric |
+
+Open the HTML reports (`coverage-report/cpp/index.html`,
+`coverage-report/py/html/index.html`) for the per-file breakdown.

--- a/projects/amdsmi/tests/coverage/run_coverage.sh
+++ b/projects/amdsmi/tests/coverage/run_coverage.sh
@@ -1,0 +1,607 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) Advanced Micro Devices. All rights reserved.
+#
+#>>>HELP
+# Generate code-coverage reports for amd-smi:
+#   C/C++  -> gcovr (reads gcov data via llvm-cov / gcov)
+#   Python -> coverage.py (branch coverage, incl. amd-smi CLI subprocesses)
+#
+# Usage:
+#   run_coverage.sh [--verbose|--quiet] [--build[=TC]] [--stage[=DIR]|--installed] [all|cpp|py]
+#   run_coverage.sh --clean | --clean-all
+#
+# Modes (positional, default: all):
+#   all   C/C++ + Python
+#   cpp   C/C++ only
+#   py    Python only
+#
+# Flags:
+#   -v, --verbose   per-test Python logging (-v shows every test name + skip reason)
+#   -q, --quiet     terse Python logging (-q); the default
+#   --build[=TC]    configure + build an instrumented build-cov with toolchain TC
+#                   (gcc | clang | clang-NN; default clang-16), auto-matching GCOV_TOOL
+#   --stage[=DIR]   cmake --install the build into DIR (default <repo>/build-cov-stage)
+#                   and run the Python tier against it (no dpkg / no /opt/rocm changes).
+#                   Auto-enabled when --build is combined with the Python tier (all/py).
+#   --installed     Python tier measures the system-installed amd-smi package instead
+#                   of staging (opts out of auto-stage; may be stale vs a fresh --build)
+#   --clean         remove build artifacts (build-cov, build-cov-stage, .coverage*)
+#                   but KEEP the coverage-report/ outputs; use alone.
+#                   Only touches coverage-owned dirs (never a user BUILD_DIR).
+#   --clean-all     remove everything, coverage-report/ included; use alone.
+#   -h, --help      show this help
+#
+# Environment knobs:
+#   BUILD_DIR     instrumented build tree            (default: <repo>/build)
+#   OUT_DIR       where reports are written          (default: <repo>/coverage-report)
+#   GCOV_TOOL     gcov reader matching the compiler  (default: "llvm-cov-14 gcov";
+#                 gcc -> "gcov", clang-N -> "llvm-cov-N gcov"; mismatch => silent 0/0)
+#   CLI_SRC       amd-smi CLI source dir             (default: /opt/rocm/libexec/amdsmi_cli)
+#   TEST_FILTER   gtest --gtest_filter for amdsmitst (default: run all)
+#   UNIT_ONLY     1 = unit tests only (C/C++ '*Unit*'; Python skips cli_unit_test.py)
+#   VERBOSE       1 = same as --verbose
+#   STAGE_DIR     staged-install prefix for --stage  (default: <repo>/build-cov-stage)
+#
+# Examples:
+#   # Build (clang-16) + C/C++ only:
+#   run_coverage.sh --build=clang-16 cpp
+#
+#   # Build + stage-install + BOTH tiers, verbose (no system install):
+#   run_coverage.sh --build=clang-16 --stage --verbose all
+#
+#   # GCC build (reader auto-set to gcov):
+#   run_coverage.sh --build=gcc cpp
+#
+#   # Reuse an existing build with a custom reader:
+#   GCOV_TOOL="llvm-cov-16 gcov" BUILD_DIR=build-cov run_coverage.sh cpp
+#
+#   # Unit-only into a separate report dir:
+#   UNIT_ONLY=1 OUT_DIR=coverage-report-unit run_coverage.sh all
+#
+#   # Clean up (each used alone)- keep the coverage-report/ outputs or wipe all:
+#   run_coverage.sh --clean
+#   run_coverage.sh --clean-all
+#
+# Prereqs:
+#   - pip install --user gcovr coverage. C/C++ needs an instrumented build
+#     (or pass --build)
+#   - Python needs the amd-smi-lib package installed (or pass --stage).
+#
+# Runnable from any directory -- paths resolve relative to the script's location.
+#<<<HELP
+set +x
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"            # projects/amdsmi
+BUILD_DIR="${BUILD_DIR:-$REPO_ROOT/build}"
+# Normalize to an absolute path: run_cpp `cd`s into BUILD_DIR before running the
+# binary, so a relative BUILD_DIR (e.g. "build-cov") would otherwise resolve the
+# test path against the wrong dir and the binary would never run (0 .gcda).
+BUILD_DIR="$(cd "$BUILD_DIR" 2>/dev/null && pwd || echo "$BUILD_DIR")"
+OUT_DIR="${OUT_DIR:-$REPO_ROOT/coverage-report}"
+GCOV_TOOL="${GCOV_TOOL:-llvm-cov-14 gcov}"
+CLI_SRC="${CLI_SRC:-/opt/rocm/libexec/amdsmi_cli}"
+TEST_FILTER="${TEST_FILTER:-}"
+UNIT_ONLY="${UNIT_ONLY:-0}"
+VERBOSE="${VERBOSE:-0}"
+DO_BUILD=0; BUILD_TC=""
+DO_STAGE=0; STAGE_DIR="${STAGE_DIR:-$REPO_ROOT/build-cov-stage}"
+DO_INSTALLED=0
+DO_CLEAN=0; CLEAN_ALL=0
+STAGED=0
+
+# Parse optional flags around the positional mode. usage() prints the HELP block
+# from the file header, so --help and the in-file docs stay in sync.
+MODE=""
+usage() { sed -n '/^#>>>HELP$/,/^#<<<HELP$/p' "$0" | sed '1d;$d; s/^#//; s/^ //'; }
+argc=$#
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -v|--verbose) VERBOSE=1 ;;
+        -q|--quiet)   VERBOSE=0 ;;
+        --build)      DO_BUILD=1 ;;
+        --build=*)    DO_BUILD=1; BUILD_TC="${1#*=}" ;;
+        --stage)      DO_STAGE=1 ;;
+        --stage=*)    DO_STAGE=1; STAGE_DIR="${1#*=}" ;;
+        --installed)  DO_INSTALLED=1 ;;
+        --clean)      DO_CLEAN=1 ;;
+        --clean-all)  DO_CLEAN=1; CLEAN_ALL=1 ;;
+        all|cpp|py)   MODE="$1" ;;
+        -h|--help)    usage; exit 0 ;;
+        *) echo "Unknown argument: $1" >&2
+           echo "Run '$(basename "$0") --help' for usage." >&2; exit 2 ;;
+    esac
+    shift
+done
+# --clean/--clean-all are destructive standalone actions: refuse to combine them
+# with a mode or any build/run flag so they can never trigger a run.
+if [[ "$DO_CLEAN" == "1" && "$argc" -ne 1 ]]; then
+    echo "--clean/--clean-all must be used alone (no other arguments)." >&2
+    exit 2
+fi
+MODE="${MODE:-all}"
+
+# The Python tier needs an importable binding + CLI. If you just built a fresh
+# instrumented tree (--build) and want Python coverage, the only correct thing to
+# measure is that build (a system install would be stale/uninstrumented), so
+# auto-enable staging. --installed opts out to measure the system package instead.
+if [[ "$MODE" != "cpp" && "$DO_INSTALLED" != "1" && "$DO_BUILD" == "1" && "$DO_STAGE" != "1" ]]; then
+    DO_STAGE=1
+    echo "(--build + Python tier: auto-staging to measure the freshly built binding;"
+    echo " pass --installed to measure the system amd-smi package instead)"
+fi
+if [[ "$DO_INSTALLED" == "1" && "$DO_BUILD" == "1" ]]; then
+    echo "(--installed: measuring the system amd-smi package, which may be stale vs your --build)" >&2
+fi
+
+# UNIT_ONLY scopes both tiers to unit tests. For C/C++ that's a gtest filter
+# (unit suites are named '*Unit*', e.g. GpuUnit/SystemUnit); an explicit
+# TEST_FILTER always wins.
+if [[ "$UNIT_ONLY" == "1" && -z "$TEST_FILTER" ]]; then
+    TEST_FILTER='*Unit*'
+fi
+
+# Locate gcovr. gcovr is a user-site pip install, so under sudo $HOME is /root
+# and it won't be found there -- fall back to the invoking user's ~/.local.
+resolve_gcovr() {
+    command -v gcovr 2>/dev/null && return 0
+    local homes=("$HOME")
+    [[ -n "${SUDO_USER:-}" ]] && homes+=("$(getent passwd "$SUDO_USER" | cut -d: -f6)")
+    for h in "${homes[@]}"; do
+        [[ -x "$h/.local/bin/gcovr" ]] && { echo "$h/.local/bin/gcovr"; return 0; }
+    done
+    echo gcovr  # last resort; errors clearly if truly absent
+}
+GCOVR="$(resolve_gcovr)"
+
+# --build: configure + build an instrumented build-cov with the chosen toolchain,
+# then point BUILD_DIR/GCOV_TOOL at it so the reader always matches the compiler.
+build_cov() {
+    local tc="${BUILD_TC:-clang-16}" cc cxx
+    case "$tc" in
+        gcc)     cc=gcc;   cxx=g++ ;;
+        clang)   cc=clang; cxx=clang++ ;;
+        clang-*) cc="clang-${tc#clang-}"; cxx="clang++-${tc#clang-}" ;;
+        *) echo "ERROR: --build toolchain '$tc' not recognized (use gcc|clang|clang-NN)." >&2; return 2 ;;
+    esac
+    local bdir="$REPO_ROOT/build-cov"
+    echo "=================  Building instrumented tree ($tc)  ================="
+    # CMake pins the compiler in the cache on first configure and refuses to change
+    # it in place, so switching toolchains (e.g. clang-16 -> gcc) on an existing
+    # build-cov errors out. If the cached compiler differs from the requested one,
+    # wipe for a clean configure; same compiler reuses the cache (fast incremental).
+    if [[ -f "$bdir/CMakeCache.txt" ]]; then
+        local cached want
+        cached="$(sed -n 's/^CMAKE_CXX_COMPILER:[^=]*=//p' "$bdir/CMakeCache.txt")"
+        want="$(command -v "$cxx" 2>/dev/null || echo "$cxx")"
+        if [[ -n "$cached" \
+              && "$(readlink -f "$cached" 2>/dev/null || echo "$cached")" \
+              != "$(readlink -f "$want" 2>/dev/null || echo "$want")" ]]; then
+            echo "(toolchain changed: cached '$cached' != requested '$want'; wiping $bdir)"
+            rm -rf "$bdir"
+        fi
+    fi
+    CC="$cc" CXX="$cxx" cmake -S "$REPO_ROOT" -B "$bdir" \
+        -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DENABLE_COVERAGE=ON -DBUILD_EXAMPLES=OFF
+    # Staging installs the whole tree (lib + python pkg + CLI); a plain cpp run
+    # only needs the test binary.
+    if [[ "$DO_STAGE" == "1" ]]; then
+        cmake --build "$bdir" -j"$(nproc)"
+    else
+        cmake --build "$bdir" --target amdsmitst -j"$(nproc)"
+    fi
+    BUILD_DIR="$bdir"
+    case "$tc" in
+        gcc)     GCOV_TOOL="gcov" ;;
+        clang)   GCOV_TOOL="llvm-cov gcov" ;;
+        clang-*) GCOV_TOOL="llvm-cov-${tc#clang-} gcov" ;;
+    esac
+    echo "(auto-set BUILD_DIR=$BUILD_DIR, GCOV_TOOL='$GCOV_TOOL')"
+}
+
+# --stage: cmake --install the build into a user-writable prefix (install-tree
+# layout the Python tests expect) so the Python tier runs against exactly what we
+# built -- no 'dpkg -i', no /opt/rocm mutation. Wires the tests to the staged tree.
+stage_install() {
+    echo "=================  Staging install -> $STAGE_DIR  ================="
+    # A prior staged run under sudo can leave root-owned __pycache__ here, which a
+    # plain (non-root) rm can't remove -> fall back to sudo.
+    rm -rf "$STAGE_DIR" 2>/dev/null || sudo rm -rf "$STAGE_DIR"
+    if ! cmake --install "$BUILD_DIR" --prefix "$STAGE_DIR" >/dev/null 2>&1; then
+        echo "ERROR: 'cmake --install $BUILD_DIR' failed -- the tree may be only partly" >&2
+        echo "  built. Build the FULL tree first (e.g. add '--build', which does so)." >&2
+        return 1
+    fi
+    # sudo strips LD_LIBRARY_PATH/PATH; run_py re-passes these via `env` (below).
+    export AMDSMI_PATH="$STAGE_DIR/share/amd_smi"
+    export LD_LIBRARY_PATH="$STAGE_DIR/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+    export PATH="$STAGE_DIR/bin:$PATH"
+    CLI_SRC="$STAGE_DIR/libexec/amdsmi_cli"
+    STAGED=1
+    echo "(Python tier -> staged tree: AMDSMI_PATH=$AMDSMI_PATH)"
+}
+
+run_cpp() {
+    echo "=================  C/C++ coverage (gcovr)  ================="
+    local tst="$BUILD_DIR/tests/amd_smi_test/amdsmitst"
+    if [[ ! -x "$tst" ]]; then
+        echo "ERROR: $tst not found." >&2
+        echo "Configure + build with:  cmake -S . -B build -DBUILD_TESTS=ON -DENABLE_COVERAGE=ON && cmake --build build" >&2
+        return 1
+    fi
+    mkdir -p "$OUT_DIR/cpp"
+    # Drop any stale machine-readable summary so a failed run this time reads as
+    # ERROR (absent) rather than showing last run's numbers.
+    rm -f "$OUT_DIR/cpp/summary.json"
+    # The functional gtests need root for hardware access, so escalate just the
+    # binary; gcovr must stay as the invoking user (root can't import the
+    # user-site gcovr). Run this script WITHOUT sudo so gcovr resolves correctly.
+    local sudo_prefix=()
+    if [[ "$(id -u)" -ne 0 ]]; then
+        sudo_prefix=(sudo -E)
+        echo "(escalating just the test binary via 'sudo -E'; gcovr runs as $USER)"
+    fi
+    # Run the suite to emit .gcda next to the objects. Coverage is the goal, so a
+    # failing/skipped test (no hardware) must not abort the report.
+    # Reset accumulated counters first so the report reflects only this run's
+    # tests (gcov .gcda counts accumulate across runs otherwise).
+    find "$BUILD_DIR" -name '*.gcda' -delete 2>/dev/null || true
+    [[ -n "$TEST_FILTER" ]] && echo "(gtest filter: $TEST_FILTER)"
+    local cpp_cmd=( "${sudo_prefix[@]}" "$tst" ${TEST_FILTER:+--gtest_filter="$TEST_FILTER"} )
+    echo ">>> [$(date '+%H:%M:%S')] START amdsmitst"
+    echo "    cmd: ( cd $BUILD_DIR && ${cpp_cmd[*]} )"
+    local cpp_rc=0
+    ( cd "$BUILD_DIR" && "${cpp_cmd[@]}" ) || cpp_rc=$?
+    echo "<<< [$(date '+%H:%M:%S')] END   amdsmitst (exit $cpp_rc)"
+
+    # No .gcda => the binary never reached a normal exit (sudo not completed, or a
+    # crash before gcov flushes at exit). gcovr would then silently report 0% for
+    # every file, which looks like "coverage is just low" -- fail loudly instead.
+    local gcda_count
+    gcda_count=$(find "$BUILD_DIR" -name '*.gcda' 2>/dev/null | wc -l)
+    if [[ "$gcda_count" -eq 0 ]]; then
+        echo "ERROR: no .gcda were produced under $BUILD_DIR." >&2
+        echo "  The tests did not run to a normal exit, so there is NO coverage data" >&2
+        echo "  (gcovr would report 0% for everything). Likely causes:" >&2
+        echo "    * the 'sudo' escalation didn't run the binary (password not entered)," >&2
+        echo "    * amdsmitst crashed/was killed before exit (no gcov flush), or" >&2
+        echo "    * BUILD_DIR points at a build without -DENABLE_COVERAGE=ON." >&2
+        echo "  Run it directly and watch it finish, then re-run coverage:" >&2
+        echo "    ${sudo_prefix[*]:+${sudo_prefix[*]} }$tst" >&2
+        # Leave a machine-readable note in place of the report so the final
+        # summary shows the C/C++ report couldn't be generated.
+        mkdir -p "$OUT_DIR"
+        {
+            echo "C/C++ coverage report NOT generated."
+            echo "Reason: no .gcda produced under $BUILD_DIR (amdsmitst exit=$cpp_rc; tests did not run)."
+            echo "See the ERROR details above in the run log."
+        } > "$OUT_DIR/cpp-summary.txt"
+        rm -f "$OUT_DIR/cpp/index.html" 2>/dev/null || true
+        return 1
+    fi
+    echo "(collected $gcda_count .gcda files)"
+    # .gcda written by the root-run binary are 0644, so gcovr reads them fine.
+    "$GCOVR" \
+        --root "$REPO_ROOT" \
+        --gcov-executable "$GCOV_TOOL" \
+        --filter "$REPO_ROOT/src/" \
+        --filter "$REPO_ROOT/rocm_smi/src/" \
+        --exclude '.*_test\.cc' \
+        --print-summary \
+        --txt "$OUT_DIR/cpp-summary.txt" \
+        --json-summary-pretty \
+        --json-summary "$OUT_DIR/cpp/summary.json" \
+        --html-details "$OUT_DIR/cpp/index.html" \
+        "$BUILD_DIR"
+}
+
+run_py() {
+    echo "=================  Python coverage (coverage.py)  ================="
+    # Resolve the binding the SAME way the tests do. common.common may stage a
+    # copy (e.g. /opt/rocm/share/amd_smi/amdsmi) ahead of the dist-packages one
+    # on sys.path; measuring a plain `import amdsmi` would target the wrong copy
+    # and silently report 0% (the tests exercise the staged copy).
+    local binding
+    binding="$(cd "$REPO_ROOT/tests/python" \
+        && python3 -c 'import common.common as c, os; print(os.path.dirname(c.amdsmi.__file__))' 2>/dev/null)"
+    [[ -z "$binding" ]] && \
+        binding="$(python3 -c 'import amdsmi, os; print(os.path.dirname(amdsmi.__file__))' 2>/dev/null)"
+    if [[ -z "$binding" ]]; then
+        echo "ERROR: Python tier could not import 'amdsmi' -- no binding to measure." >&2
+        echo "  Pick one:" >&2
+        echo "    --stage      measure a throwaway install of your tree (with --build to build it)" >&2
+        echo "    --installed  measure the system amd-smi package (install amd-smi-lib first)" >&2
+        echo "  e.g.  run_coverage.sh --build=gcc --stage all" >&2
+        return 1
+    fi
+    echo "(binding source: $binding)"
+
+    local pydir="$OUT_DIR/py"
+    rm -rf "$pydir"
+    mkdir -p "$pydir/_bootstrap"
+
+    # Build an effective rc that pins the resolved source dirs. Both the parent
+    # process and any spawned `amd-smi` subprocess read this same file.
+    local eff_rc="$pydir/coveragerc.effective"
+    python3 - "$HERE/.coveragerc" "$eff_rc" "$binding" "$CLI_SRC" <<'PY'
+import sys
+base, out, binding, cli = sys.argv[1:5]
+src = f"source =\n    {binding}\n    {cli}"
+text = open(base).read().replace(
+    "# __SOURCE__ (run_coverage.sh replaces this marker with a resolved source = list)",
+    src,
+)
+open(out, "w").write(text)
+PY
+
+    # Capture coverage from spawned amd-smi CLI subprocesses: a sitecustomize on
+    # PYTHONPATH calls coverage.process_startup() when COVERAGE_PROCESS_START is set.
+    printf 'import coverage\ncoverage.process_startup()\n' > "$pydir/_bootstrap/sitecustomize.py"
+
+    # The runners (common.run_test_dir) sys.exit(1) unless euid==0, so the suites
+    # only execute product code under root. Run coverage under sudo, but keep the
+    # user site-packages on PYTHONPATH so both `coverage` and the bootstrap's
+    # process_startup() resolve for root and for the amd-smi subprocesses.
+    local user_site
+    user_site="$(python3 -c 'import site; print(site.getusersitepackages())')"
+    local pypath="$pydir/_bootstrap:$user_site${PYTHONPATH:+:$PYTHONPATH}"
+    local cov_file="$pydir/.coverage"
+    local sudo_prefix=()
+    if [[ "$(id -u)" -ne 0 ]]; then
+        sudo_prefix=(sudo -E)
+        echo "(not root -> running the Python suites under 'sudo -E'; the runners require it)"
+    fi
+    # Pass the coverage env explicitly through `env` so sudo can't strip it.
+    # PYTHONDONTWRITEBYTECODE: the suites run under sudo, so any __pycache__ they
+    # write would be root-owned and break a later (non-root) cleanup of the stage.
+    local cov_env=(
+        "PYTHONPATH=$pypath"
+        "COVERAGE_PROCESS_START=$eff_rc"
+        "COVERAGE_FILE=$cov_file"
+        "PYTHONDONTWRITEBYTECODE=1"
+    )
+    # Staged run: the tests import the binding/CLI from the staged prefix. sudo
+    # drops LD_LIBRARY_PATH/PATH, so pass them (and AMDSMI_PATH) explicitly via env.
+    if [[ "$STAGED" == "1" ]]; then
+        cov_env+=(
+            "AMDSMI_PATH=$AMDSMI_PATH"
+            "LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
+            "PATH=$PATH"
+        )
+    fi
+    covpy() { "${sudo_prefix[@]}" env "${cov_env[@]}" python3 -m coverage "$@"; }
+    # Log start/stop + the exact command for each suite so library stderr (e.g.
+    # "Exception caught: map::at") can be attributed to the suite that triggered it.
+    local vflag="-q"; [[ "$VERBOSE" == "1" ]] && vflag="-v"
+    [[ "$VERBOSE" == "1" ]] && echo "(verbose: passing '$vflag' -> per-test names + skip reasons)"
+    covrun() {
+        local f="$1"
+        echo ""
+        echo ">>> [$(date '+%H:%M:%S')] START $f  ($vflag)"
+        echo "    cmd: ${sudo_prefix[*]:+${sudo_prefix[*]} }env <coverage-env> python3 -m coverage run --rcfile=$eff_rc $f $vflag"
+        local rc=0
+        covpy run --rcfile="$eff_rc" "$f" "$vflag" || rc=$?
+        echo "<<< [$(date '+%H:%M:%S')] END   $f (exit $rc)"
+    }
+
+    local tests_py="$REPO_ROOT/tests/python"
+    pushd "$tests_py" >/dev/null
+    # -q keeps the console readable; failures on absent hardware are fine, we only
+    # need the executed-line data, so don't let a non-zero exit abort the report.
+    covrun unit_tests.py
+    # integration_test.py (functional, live-HW) and cli_unit_test.py (spawns the
+    # real amd-smi binary) exercise far more of the binding/CLI than the mock
+    # unit tests -- include them in the full run, skip under UNIT_ONLY.
+    if [[ "$UNIT_ONLY" == "1" ]]; then
+        echo "(UNIT_ONLY=1 -> skipping integration_test.py + cli_unit_test.py; unit tests only)"
+    else
+        covrun integration_test.py
+        covrun cli_unit_test.py
+    fi
+    popd >/dev/null
+
+    # combine/report resolve the [paths] source-tree aliases relative to CWD.
+    pushd "$REPO_ROOT" >/dev/null
+    covpy combine --rcfile="$eff_rc" || true
+    covpy report --rcfile="$eff_rc" | tee "$OUT_DIR/py-summary.txt"
+    covpy html --rcfile="$eff_rc" -d "$pydir/html"
+    # gcovr-style per-metric covered/total. `coverage report` only prints the
+    # blended % + raw branch counts; `coverage json` exposes the line & branch
+    # numerators/denominators, so we format them like the C/C++ gcovr table.
+    covpy json --rcfile="$eff_rc" -o "$pydir/coverage.json" || true
+    python3 - "$pydir/coverage.json" <<'PY' | tee -a "$OUT_DIR/py-summary.txt"
+import json, sys
+try:
+    t = json.load(open(sys.argv[1]))["totals"]
+except Exception as e:
+    print(f"\n(gcovr-style summary unavailable: {e})"); raise SystemExit(0)
+pct = lambda c, n: f"{100.0*c/n:.1f}%" if n else "n/a"
+sl = t.get("num_statements", 0)
+cl = t.get("covered_lines", sl - t.get("missing_lines", 0))
+nb = t.get("num_branches", 0)
+cb = t.get("covered_branches", 0)
+pb = t.get("num_partial_branches", 0)
+print("\n=== gcovr-style summary (from coverage json) ===")
+print(f"lines:     {pct(cl, sl):>6} ({cl:,} / {sl:,})")
+print(f"branches:  {pct(cb, nb):>6} ({cb:,} / {nb:,}; {pb:,} partial)")
+print("functions: n/a (coverage.py has no per-function metric)")
+PY
+    popd >/dev/null
+
+    # Data + reports were written as root; hand them back to the invoking user.
+    if [[ ${#sudo_prefix[@]} -gt 0 ]]; then
+        sudo chown -R "$(id -u):$(id -g)" "$OUT_DIR" || true
+    fi
+}
+
+# List every artifact that was actually produced, so the paths are easy to find.
+print_outputs() {
+    echo
+    echo "================  Output files  ================"
+    echo "All reports under: $OUT_DIR"
+    # C/C++: show the report, or a NOT-generated note if the run left the marker.
+    if [[ -f "$OUT_DIR/cpp-summary.txt" ]] && grep -q "NOT generated" "$OUT_DIR/cpp-summary.txt"; then
+        echo "  C/C++  report:  !! NOT GENERATED -- cannot generate report (see error"
+        echo "                  details above); note written to $OUT_DIR/cpp-summary.txt"
+    else
+        [[ -f "$OUT_DIR/cpp/index.html"  ]] && echo "  C/C++  HTML:    $OUT_DIR/cpp/index.html"
+        [[ -f "$OUT_DIR/cpp-summary.txt" ]] && echo "  C/C++  summary: $OUT_DIR/cpp-summary.txt"
+    fi
+    [[ -f "$OUT_DIR/py/html/index.html" ]] && echo "  Python HTML:    $OUT_DIR/py/html/index.html"
+    [[ -f "$OUT_DIR/py-summary.txt"    ]] && echo "  Python summary: $OUT_DIR/py-summary.txt"
+    [[ -f "$OUT_DIR/py/coverage.json"  ]] && echo "  Python JSON:    $OUT_DIR/py/coverage.json"
+    [[ -f "$OUT_DIR/amdsmi_cc_summary.md" ]] && echo "  AMD SMI Summary (md):   $OUT_DIR/amdsmi_cc_summary.md"
+    return 0   # never let a false [[ -f ... ]] test above become the exit code
+}
+
+# Build the combined C++/Python coverage table -> amdsmi_cc_summary.md + .txt.
+# Per tier: real numbers if it ran, N/A if not selected this run, ERROR if it was
+# selected but produced no data (e.g. no .gcda).
+# Render "<driver> <version>" (e.g. "clang++-16 16.0.6", "g++ 9.4.0") from a
+# compiler path, dropping distro noise like "Ubuntu clang version ... (++hash)".
+pretty_compiler() {
+    local p="$1" ver
+    [[ -x "$p" ]] || { echo "unknown"; return; }
+    ver="$("$p" -dumpfullversion 2>/dev/null || true)"          # gcc/g++ -> 9.4.0
+    [[ -z "$ver" ]] && ver="$("$p" -dumpversion 2>/dev/null || true)"  # clang -> 16.0.6
+    [[ -z "$ver" ]] && ver="$("$p" --version 2>/dev/null | head -1 || true)"
+    echo "$(basename "$p") $ver"
+}
+write_summary_files() {
+    local date_str cxx_comp c_comp cxx_path c_path comp_txt comp_md
+    date_str="$(date +%m-%d-%Y)"
+    cxx_comp="N/A (C/C++ tier not run)"; c_comp="$cxx_comp"
+    if [[ "$MODE" != "py" ]]; then
+        # gcc/clang ship separate C and C++ front-ends (gcc/g++, clang/clang++);
+        # the library has both .c and .cc, so report each driver CMake used.
+        cxx_path="$(sed -n 's/^CMAKE_CXX_COMPILER:[^=]*=//p' "$BUILD_DIR/CMakeCache.txt" 2>/dev/null)"
+        c_path="$(sed -n 's/^CMAKE_C_COMPILER:[^=]*=//p' "$BUILD_DIR/CMakeCache.txt" 2>/dev/null)"
+        cxx_comp="$(pretty_compiler "$cxx_path")"
+        c_comp="$(pretty_compiler "$c_path")"
+    fi
+    if [[ "$cxx_comp" == N/A* ]]; then
+        comp_txt="Compiler:     $cxx_comp"
+        comp_md="**Compiler:** $cxx_comp"
+    else
+        comp_txt="C++ compiler: $cxx_comp"$'\n'"C compiler:   $c_comp"
+        comp_md="**C++ compiler:** $cxx_comp  "$'\n'"**C compiler:** $c_comp"
+    fi
+    python3 - "$MODE" "$OUT_DIR/cpp/summary.json" "$OUT_DIR/py/coverage.json" \
+        "$OUT_DIR/amdsmi_cc_summary.md" "$OUT_DIR/amdsmi_cc_summary.txt" \
+        "$date_str" "$comp_txt" "$comp_md" <<'PY'
+import json, sys
+mode, cpp_json, py_json, out_md, out_txt, date_str, comp_txt, comp_md = sys.argv[1:9]
+cpp_sel = mode in ("cpp", "all")
+py_sel = mode in ("py", "all")
+
+def pc(cov, tot):
+    return "0.0% (0 / 0)" if not tot else f"{100.0*cov/tot:.1f}% ({cov:,} / {tot:,})"
+
+def cpp_vals():
+    if not cpp_sel:
+        return "N/A"
+    try:
+        d = json.load(open(cpp_json))
+        return {
+            "Lines": pc(d["line_covered"], d["line_total"]),
+            "Branches": pc(d["branch_covered"], d["branch_total"]),
+            "Functions": pc(d["function_covered"], d["function_total"]),
+        }
+    except Exception:
+        return "ERROR"
+
+def py_vals():
+    if not py_sel:
+        return "N/A"
+    try:
+        t = json.load(open(py_json))["totals"]
+        return {
+            "Lines": pc(t.get("covered_lines", 0), t.get("num_statements", 0)),
+            "Branches": pc(t.get("covered_branches", 0), t.get("num_branches", 0)),
+            "Functions": "DNE",  # coverage.py has no per-function metric
+        }
+    except Exception:
+        return "ERROR"
+
+c, p = cpp_vals(), py_vals()
+rows = ["Lines", "Branches", "Functions"]
+def cell(v, k):
+    return v if isinstance(v, str) else v[k]
+
+legend = [
+    "N/A   - tier not selected for this run.",
+    "ERROR - tier selected but no data (e.g. no .gcda; tests did not run).",
+    "DNE   - metric does not exist (coverage.py has no per-function metric).",
+]
+
+mw = max(len(x) for x in rows + ["Metric"])
+cells = [cell(c, r) for r in rows] + [cell(p, r) for r in rows] + ["C++", "Python"]
+cw = max(len(x) for x in cells)
+def row(a, b, d):
+    return f"{a:<{mw}} | {b:<{cw}} | {d:<{cw}}"
+txt = [
+    "================  AMD SMI Code Coverage  ================",
+    f"Date:         {date_str}",
+] + comp_txt.split("\n") + [
+    "",
+    row("Metric", "C++", "Python"),
+    row("-" * mw, "-" * cw, "-" * cw),
+]
+txt += [row(r, cell(c, r), cell(p, r)) for r in rows]
+txt += [""] + legend
+open(out_txt, "w").write("\n".join(txt) + "\n")
+
+md = [
+    "# AMD SMI Code Coverage",
+    "",
+    f"**Date:** {date_str}  ",
+] + comp_md.split("\n") + [
+    "",
+    "| Metric | C++ | Python |",
+    "|--------|-----|--------|",
+]
+md += [f"| {r} | {cell(c, r)} | {cell(p, r)} |" for r in rows]
+md += [
+    "",
+    "- **N/A** - tier not selected for this run.",
+    "- **ERROR** - tier selected but no data (e.g. no `.gcda`; tests did not run).",
+    "- **DNE** - metric does not exist (coverage.py has no per-function metric).",
+]
+open(out_md, "w").write("\n".join(md) + "\n")
+PY
+}
+
+# sudo-aware removal: a prior root/staged run can leave root-owned artifacts.
+rm_rf() { rm -rf "$@" 2>/dev/null || sudo rm -rf "$@"; }
+
+# --clean drops the build/intermediate artifacts (build-cov, build-cov-stage,
+# loose .coverage*) but keeps the whole coverage-report/ output; --clean-all also
+# removes coverage-report/. Only ever touches coverage-owned paths -- never a
+# user BUILD_DIR.
+clean() {
+    if [[ "$CLEAN_ALL" == "1" ]]; then
+        rm_rf "$OUT_DIR"; echo "Removed $OUT_DIR"
+    else
+        echo "Kept report files under $OUT_DIR"
+    fi
+    rm_rf "$REPO_ROOT/build-cov" "$STAGE_DIR"
+    rm -f "$REPO_ROOT"/.coverage "$REPO_ROOT"/.coverage.* 2>/dev/null || true
+    echo "Removed build-cov, $STAGE_DIR, and loose .coverage* files"
+}
+
+if [[ "$DO_CLEAN" == "1" ]]; then clean; exit 0; fi
+mkdir -p "$OUT_DIR"
+if [[ "$DO_BUILD" == "1" ]]; then build_cov; fi
+if [[ "$DO_STAGE" == "1" && "$MODE" != "cpp" ]]; then stage_install; fi
+case "$MODE" in
+    cpp) run_cpp ;;
+    py)  run_py ;;
+    all) run_cpp || true; run_py ;;
+    *)   usage >&2; exit 2 ;;
+esac
+write_summary_files
+print_outputs
+echo
+cat "$OUT_DIR/amdsmi_cc_summary.txt" 2>/dev/null || true

--- a/projects/amdsmi/tests/python/cli/base.py
+++ b/projects/amdsmi/tests/python/cli/base.py
@@ -86,11 +86,16 @@ class TestCliBase(unittest.TestCase):
         TestCliBase.partition_data = baseline["partition_data"]
         TestCliBase.gpus = baseline["gpus"]
         TestCliBase.sub_args = baseline["sub_args"]
-        TestCliBase._initialized = True
-
+        # TODO(SPLIT-FROM-AILITOOLS-297): regression fix from #7844 (AILITOOLS-270),
+        # unrelated to the coverage ticket -- split to its own PR. Must assign on
+        # TestCliBase (not cls) before _initialized so every CLI subclass inherits
+        # it past the early-return guard.
         # TODO: Remove this condition when CLI supports User automated input
-        # Commands that need User permission to run
-        cls.cmds_need_permission = {"set": ["--fan", "--memory-partition", "--compute-partition"]}
+        # Commands that need User permission to run.
+        TestCliBase.cmds_need_permission = {
+            "set": ["--fan", "--memory-partition", "--compute-partition"]
+        }
+        TestCliBase._initialized = True
 
     @classmethod
     def _build_baseline(cls):


### PR DESCRIPTION
## Summary
Adds self-contained code-coverage tooling for amd-smi under
`projects/amdsmi/tests/coverage/`, plus a few fixes the coverage runs
surfaced. The surfaced fixes are unrelated to the coverage feature and are
tagged `TODO(SPLIT-FROM-AILITOOLS-297)` so they can be split into their own
PRs later (kept here for now for a single working branch).

Jira: https://amd-hub.atlassian.net/browse/AILITOOLS-297

## Coverage tooling (the feature)
- **`tests/coverage/run_coverage.sh`** — one driver for both tiers:
  - C/C++ (gcovr) over `src/` + `rocm_smi/src/`, driven by `amdsmitst`.
  - Python (coverage.py, branch mode) over `py-interface/` + `amdsmi_cli/`,
    including spawned `amd-smi` CLI subprocesses.
  - `--build[=gcc|clang|clang-NN]` instruments a throwaway `build-cov` and
    auto-matches the gcov reader to the compiler.
  - `--stage[=DIR]` cmake-installs to a user-writable prefix and runs the
    Python tier against it (no `dpkg`, no `/opt/rocm` mutation).
  - Combined summary table (`amdsmi_cc_summary.{md,txt}`) stamped with the
    date and the C/C++ compiler.
  - `--clean` (keep `coverage-report/`) and `--clean-all` (remove all).
- **`.coveragerc`**, **`README.md`** — config + full usage/gotchas docs.
- **`CMakeLists.txt`** — `ENABLE_COVERAGE` option (`--coverage -O0 -g`).

## Fixes surfaced by coverage (tagged to split out later)
Grep `SPLIT-FROM-AILITOOLS-297` to find these:
- `src/CMakeLists.txt`: exclude `ras-decode/main.c` via absolute path (the
  bare `"main.c"` removal was a no-op and leaked a second `main()` into
  `libamd_smi`).
- `rocm_smi_monitor.cc`: return `*_INVALID` (already handled by callers)
  instead of throwing `out_of_range` on boundary sensor enums; removes an
  exception flood surfaced by the coverage tests.
- `rocm_smi.cc`: comment fixed to match.
- `tests/python/cli/base.py`: fix a regression from #7844 (AILITOOLS-270).
  `cmds_need_permission` was moved onto `cls` and placed after
  `TestCliBase._initialized = True`; because `setUpClass` early-returns once
  `_initialized` is set, later CLI subclasses (e.g. `test_set.py`) never
  inherited it and crashed with `AttributeError`. Restored to `TestCliBase`
  before the flag. Exposed by the coverage Python tier running the full CLI
  suite.

## Testing
- `run_coverage.sh --build=gcc --stage all` and `--build=clang-16 --stage all`
  both produce C/C++ + Python reports; the full CLI suite now passes.
- Baseline (gcc 9.4.0, full suite as root): C/C++ ~25% lines / 15% branches /
  32% functions; Python ~50% lines / 40% branches.

## Notes
- Coverage builds must use Debug (Release `-O3` would override `-O0`).
- The `SPLIT-FROM-AILITOOLS-297`-tagged changes will move to dedicated PRs
  (`base.py` → ref #7844 / AILITOOLS-270; `monitor.cc`/`rocm_smi.cc` → new
  ticket).
