### PR TITLE
ci(rocjitsu): Add near-timeout warnings for corpus tests

### DIFF
--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -343,6 +343,7 @@ jobs:
             --soft-timeout 15 \
             --hard-timeout 30 \
             --rerun-failed \
+            --warn-perf \
           )
           bash "${ROCJITSU_SOURCE_DIR}/tests/corpus/run-corpus-tests.sh" "${corpus_test_flags[@]}" || corpus_test_status=$?
           exit "${corpus_test_status}"

--- a/emulation/rocjitsu/tests/corpus/README.md
+++ b/emulation/rocjitsu/tests/corpus/README.md
@@ -48,3 +48,8 @@ declared exclusions. It streams each output through a temporary file and
 retains only its size and SHA-256. Its `finalize` command requires every pinned
 corpus input to have either a successful pair or a matching declared
 exclusion, which prevents partial runs from becoming a develop baseline.
+
+## Near-timeout reporting
+
+With `--warn-perf`, `run-corpus-tests.sh` warns about passing tests whose
+runtime approaches the pytest timeout.

--- a/emulation/rocjitsu/tests/corpus/report-near-timeout-tests.py
+++ b/emulation/rocjitsu/tests/corpus/report-near-timeout-tests.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Report passing corpus tests that ran close to their per-test timeout."""
+
+# The reports are ranked together rather than per report, so one run of one
+# simulated target does not hide a slower test on another. They must be
+# produced with `junit_duration_report=call` so that the recorded duration
+# covers the same phase as `timeout_func_only=true`.
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Iterator
+import math
+from pathlib import Path
+import re
+import sys
+from typing import NamedTuple
+from xml.etree import ElementTree
+
+DEFAULT_NEAR_TIMEOUT_RATIO = 0.9
+
+MAX_LISTED_TESTS = 10
+NON_PASSING_OUTCOME_TAGS = ("error", "failure", "skipped")
+WHITESPACE_RE = re.compile(r"\s+")
+ERROR = 1
+
+
+class NearTimeoutTest(NamedTuple):
+    target: str
+    case_id: str
+    duration: float
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        _validate_args(args)
+        near_timeout_tests = collect_near_timeout_tests(
+            args.reports, args.timeout, args.near_timeout_ratio
+        )
+    except (OSError, ValueError, ElementTree.ParseError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return ERROR
+    report_near_timeout_tests(near_timeout_tests, args.timeout, args.near_timeout_ratio)
+    return 0
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "reports",
+        nargs="+",
+        type=Path,
+        metavar="REPORT",
+        help="pytest JUnit XML report",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        required=True,
+        help="per-test timeout in seconds that the reported runs enforced",
+    )
+    parser.add_argument(
+        "--near-timeout-ratio",
+        type=float,
+        default=DEFAULT_NEAR_TIMEOUT_RATIO,
+        help="report a passing test once it uses this fraction of the timeout "
+        f"(default: {DEFAULT_NEAR_TIMEOUT_RATIO})",
+    )
+    return parser.parse_args(argv)
+
+
+def _validate_args(args: argparse.Namespace) -> None:
+    if not math.isfinite(args.timeout) or args.timeout <= 0:
+        raise ValueError("--timeout must be a positive number of seconds")
+    ratio = args.near_timeout_ratio
+    if not math.isfinite(ratio) or not 0 < ratio <= 1:
+        raise ValueError("--near-timeout-ratio must be greater than 0 and at most 1")
+
+
+def collect_near_timeout_tests(
+    reports: list[Path], timeout: float, ratio: float
+) -> list[NearTimeoutTest]:
+    threshold = timeout * ratio
+    near_timeout_tests = []
+    for report in reports:
+        if not report.is_file():
+            raise ValueError(f"JUnit XML report is not a file: {report}")
+        target = _sanitized(report.stem)
+        for case in _passing_cases(report):
+            duration = _case_duration(case, report)
+            if duration < threshold:
+                continue
+            near_timeout_tests.append(
+                NearTimeoutTest(
+                    target=target, case_id=_case_id(case), duration=duration
+                )
+            )
+    near_timeout_tests.sort(
+        key=lambda test: (-test.duration, test.case_id, test.target)
+    )
+    return near_timeout_tests
+
+
+def report_near_timeout_tests(
+    near_timeout_tests: list[NearTimeoutTest], timeout: float, ratio: float
+) -> None:
+    if not near_timeout_tests:
+        print(
+            f"No passing corpus test used {ratio:.0%} or more of the "
+            f"{timeout:g}s timeout."
+        )
+        return
+
+    summary = (
+        f"{len(near_timeout_tests)} test(s) ran close to the {timeout:g}s "
+        f"timeout, using {ratio:.0%} or more of it"
+    )
+    print(f"Warning: {summary}.")
+    for test in near_timeout_tests[:MAX_LISTED_TESTS]:
+        print(f"{test.duration:g}s, {test.case_id}")
+    unlisted = len(near_timeout_tests) - MAX_LISTED_TESTS
+    if unlisted > 0:
+        print(f"... and {unlisted} more not listed.")
+
+
+def _passing_cases(report: Path) -> Iterator[ElementTree.Element]:
+    root = ElementTree.parse(report).getroot()
+    for case in root.iter("testcase"):
+        if any(case.find(tag) is not None for tag in NON_PASSING_OUTCOME_TAGS):
+            continue
+        yield case
+
+
+def _case_duration(case: ElementTree.Element, report: Path) -> float:
+    raw_duration = case.get("time")
+    if raw_duration is None:
+        raise ValueError(f"{report}: {_case_id(case)} has no duration")
+    try:
+        duration = float(raw_duration)
+    except ValueError as error:
+        raise ValueError(
+            f"{report}: {_case_id(case)} has a non-numeric duration {raw_duration!r}"
+        ) from error
+    if not math.isfinite(duration) or duration < 0:
+        raise ValueError(
+            f"{report}: {_case_id(case)} has an out-of-range duration {raw_duration!r}"
+        )
+    return duration
+
+
+def _case_id(case: ElementTree.Element) -> str:
+    classname = case.get("classname", "")
+    name = case.get("name", "<unnamed>")
+    identifier = f"{classname}::{name}" if classname else name
+    return _sanitized(identifier)
+
+
+def _sanitized(value: str) -> str:
+    # Keep each reported name on one line.
+    return WHITESPACE_RE.sub(" ", value).strip()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/emulation/rocjitsu/tests/corpus/report-near-timeout-tests.py
+++ b/emulation/rocjitsu/tests/corpus/report-near-timeout-tests.py
@@ -24,9 +24,9 @@ from xml.etree import ElementTree
 DEFAULT_NEAR_TIMEOUT_RATIO = 0.9
 
 MAX_LISTED_TESTS = 10
+NEAR_TIMEOUT_TESTS_FOUND_EXIT_STATUS = 3
 NON_PASSING_OUTCOME_TAGS = ("error", "failure", "skipped")
 WHITESPACE_RE = re.compile(r"\s+")
-ERROR = 1
 
 
 class NearTimeoutTest(NamedTuple):
@@ -44,8 +44,10 @@ def main(argv: list[str] | None = None) -> int:
         )
     except (OSError, ValueError, ElementTree.ParseError) as error:
         print(f"error: {error}", file=sys.stderr)
-        return ERROR
+        return 1
     report_near_timeout_tests(near_timeout_tests, args.timeout, args.near_timeout_ratio)
+    if near_timeout_tests:
+        return NEAR_TIMEOUT_TESTS_FOUND_EXIT_STATUS
     return 0
 
 
@@ -122,7 +124,7 @@ def report_near_timeout_tests(
     )
     print(f"Warning: {summary}.")
     for test in near_timeout_tests[:MAX_LISTED_TESTS]:
-        print(f"{test.duration:g}s, {test.case_id}")
+        print(f"{test.duration:g}s, {test.target}, {test.case_id}")
     unlisted = len(near_timeout_tests) - MAX_LISTED_TESTS
     if unlisted > 0:
         print(f"... and {unlisted} more not listed.")

--- a/emulation/rocjitsu/tests/corpus/run-corpus-tests.sh
+++ b/emulation/rocjitsu/tests/corpus/run-corpus-tests.sh
@@ -110,8 +110,7 @@ for target in "${targets[@]}"; do
     -o "junit_duration_report=call"
   )
 
-  # Only the soft-timeout pass writes a report; a rerun would drop every test
-  # that it does not select.
+  # Only the soft-timeout run is configured to output a JUnit XML report.
   first_run_status=0
   "${pytest_cmd[@]}" --timeout "${soft_timeout_seconds}" \
     --junitxml "${junit_xml}" || first_run_status=$?

--- a/emulation/rocjitsu/tests/corpus/run-corpus-tests.sh
+++ b/emulation/rocjitsu/tests/corpus/run-corpus-tests.sh
@@ -150,10 +150,21 @@ if [[ "${warn_perf}" == true ]]; then
   echo "::group::Check for test cases close to the timeout"
   if (( ${#junit_xml_paths[@]} == 0 )); then
     echo "No JUnit report was written; near-timeout reporting has no input."
-  elif ! python3 "${ROCJITSU_SOURCE_DIR}/tests/corpus/report-near-timeout-tests.py" \
-    --timeout "${soft_timeout_seconds}" \
-    "${junit_xml_paths[@]}"; then
-    echo "::warning::Near-timeout reporting failed."
+  else
+    report_status=0
+    python3 "${ROCJITSU_SOURCE_DIR}/tests/corpus/report-near-timeout-tests.py" \
+      --timeout "${soft_timeout_seconds}" \
+      "${junit_xml_paths[@]}" || report_status=$?
+    case "${report_status}" in
+      0)
+        ;;
+      3)
+        echo "::warning::Near-timeout tests found."
+        ;;
+      *)
+        echo "::warning::Near-timeout reporting failed."
+        ;;
+    esac
   fi
   echo "::endgroup::"
 fi

--- a/emulation/rocjitsu/tests/corpus/run-corpus-tests.sh
+++ b/emulation/rocjitsu/tests/corpus/run-corpus-tests.sh
@@ -13,11 +13,17 @@
 #   --workers N          Number of pytest-xdist workers (default: 8)
 #   --soft-timeout N     Per-test timeout for the first run (default: 30)
 #   --hard-timeout N     Per-test timeout for failed-test reruns (default: 60)
-#   --rerun-failed       Rerun only tests that failed the first pass
+#   --rerun-failed       Rerun only tests that failed the soft-timeout pass
+#   --warn-perf          Warn about passing tests close to the soft timeout
 #
 # Environment variables:
 #   ROCM_PATH            Required ROCm installation root
 #   ROCJITSU_SOURCE_DIR  Required rocjitsu source directory
+#
+# Outputs:
+#   .pytest-artifacts/<target>/           Corpus harness logs and artifacts
+#   .pytest-artifacts/junit/<target>.xml  Soft-timeout JUnit report per target
+#   .pytest-cache/<target>/               Pytest cache with the lastfailed list
 
 set -euo pipefail
 
@@ -28,9 +34,10 @@ worker_count=8
 soft_timeout_seconds=30
 hard_timeout_seconds=60
 rerun_failed=false
+warn_perf=false
 
 usage() {
-  echo "Usage: $0 [--workers N] [--soft-timeout N] [--hard-timeout N] [--rerun-failed]" >&2
+  echo "Usage: $0 [--workers N] [--soft-timeout N] [--hard-timeout N] [--rerun-failed] [--warn-perf]" >&2
 }
 
 targets=(
@@ -59,6 +66,10 @@ while (( $# )); do
       rerun_failed=true
       shift
       ;;
+    --warn-perf)
+      warn_perf=true
+      shift
+      ;;
     *)
       echo "Unknown option: $1" >&2
       exit 1
@@ -68,6 +79,11 @@ done
 
 corpus_test_status=0
 corpus_work_dir="$(pwd -P)"
+junit_dir="${corpus_work_dir}/.pytest-artifacts/junit"
+junit_xml_paths=()
+
+# A report left by an earlier run would otherwise be reported as this run's.
+rm -rf "${junit_dir}"
 
 for target in "${targets[@]}"; do
   read -r name rocjitsu_config skip_tests_config <<< "${target}"
@@ -77,6 +93,7 @@ for target in "${targets[@]}"; do
   skip_tests_config_path="${ROCJITSU_SOURCE_DIR}/tests/corpus/${skip_tests_config}"
   artifact_dir="${corpus_work_dir}/.pytest-artifacts/${name}"
   cache_dir="${corpus_work_dir}/.pytest-cache/${name}"
+  junit_xml="${junit_dir}/${name}.xml"
 
   pytest_cmd=(
     rocjitsu --config "${rocjitsu_config_path}" -- pytest tests/test_corpus.py
@@ -90,9 +107,19 @@ for target in "${targets[@]}"; do
     --tb=short
     -n "${worker_count}"
     -o "timeout_func_only=true"
+    -o "junit_duration_report=call"
   )
 
-  if "${pytest_cmd[@]}" --timeout "${soft_timeout_seconds}"; then
+  # Only the soft-timeout pass writes a report; a rerun would drop every test
+  # that it does not select.
+  first_run_status=0
+  "${pytest_cmd[@]}" --timeout "${soft_timeout_seconds}" \
+    --junitxml "${junit_xml}" || first_run_status=$?
+  if [[ -f "${junit_xml}" ]]; then
+    junit_xml_paths+=("${junit_xml}")
+  fi
+
+  if (( first_run_status == 0 )); then
     echo "::endgroup::"
     echo "All (${name}) tests passed."
     continue
@@ -118,5 +145,18 @@ for target in "${targets[@]}"; do
   fi
   echo "::endgroup::"
 done
+
+# The reporting script's return code does not affect the corpus test status.
+if [[ "${warn_perf}" == true ]]; then
+  echo "::group::Check for test cases close to the timeout"
+  if (( ${#junit_xml_paths[@]} == 0 )); then
+    echo "No JUnit report was written; near-timeout reporting has no input."
+  elif ! python3 "${ROCJITSU_SOURCE_DIR}/tests/corpus/report-near-timeout-tests.py" \
+    --timeout "${soft_timeout_seconds}" \
+    "${junit_xml_paths[@]}"; then
+    echo "::warning::Near-timeout reporting failed."
+  fi
+  echo "::endgroup::"
+fi
 
 exit "${corpus_test_status}"


### PR DESCRIPTION
## Motivation

Record near-timeout test runtimes, leave some notes to the github CI log, making it easier to identify when a perf regression began, for example, sinch which PR/timestamp, a test is pushed persistently close to the timeout.

## Technical Details

- Utilize pytest's existing junit xml plugin, analyze test results by parsing the report.
- The test perf warning step is optional, it doesn't affect the CI status.
- Report max 10 near-timeout tests.
- Report tests used `timeout*0.9`s (13.5s).

## Issue Tracking

Issue ID: https://github.com/ROCm/rocm-systems/issues/7891

## Test Plan
Run CI, no extra test needed for the python helper script, because the result is used as a reference, and the it doesn't affect original CI test's passing status.