### PR TITLE
fix(rocprofiler-sdk): Fix race condition in SPM

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/core/spm_v2.cpp
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/core/spm_v2.cpp
@@ -62,6 +62,7 @@ struct spm_state_t : public spm_set_dest_buffer_args
     std::mutex                work_mutex{};
     std::condition_variable   work_cond{};
     std::atomic<bool>         data_ready{};
+    std::atomic<bool>         cons_buf_free{true};
 
     std::atomic<int>   signal_data_loss{};
     std::atomic<bool>  stop_prod_thread{};
@@ -541,6 +542,12 @@ producer(std::shared_ptr<spm_state_t> s)
 
         {
             std::unique_lock<std::mutex> lock(s->work_mutex);
+
+            // Wait until consumer has finished reading cons_buf
+            // before rotating, so we don't overwrite data it is still processing.
+            s->work_cond.wait(
+                lock, [&s]() { return s->cons_buf_free || s->stop_cons_thread; });
+
             s->dest_buf = s->prod_buf.exchange(s->cons_buf.exchange(s->dest_buf));
 
             // In the initial XCC SPM design, 'size_copied' and 'is_data_loss' are stored in
@@ -560,6 +567,7 @@ producer(std::shared_ptr<spm_state_t> s)
             }
             s->signal_data_loss.fetch_or(s->is_data_loss);
 
+            s->cons_buf_free = false;
             consumer_handle.notify();
         }
 
@@ -599,6 +607,8 @@ consumer(std::shared_ptr<spm_state_t> s, aqlprofile_spm_data_callback_t callback
         char* base  = (char*) s->cons_buf.load();
         int   flags = s->signal_data_loss.exchange(0) << AQLPROFILE_SPM_DATA_FLAGS_DATA_LOSS;
 
+        lock.unlock();
+
         for(int i = 0; i < s->num_xcc; i++)
         {
             auto buf_info = (kfd_ioctl_spm_buffer_header*) base;
@@ -607,6 +617,13 @@ consumer(std::shared_ptr<spm_state_t> s, aqlprofile_spm_data_callback_t callback
 
             base += s->buf_size_xcc;
         }
+
+        // Signal producer that cons_buf is now free for rotation
+        {
+            std::lock_guard<std::mutex> lk(s->work_mutex);
+            s->cons_buf_free = true;
+        }
+        s->work_cond.notify_one();
     }
 }
 

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/core/spm_v2.cpp
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/core/spm_v2.cpp
@@ -545,8 +545,7 @@ producer(std::shared_ptr<spm_state_t> s)
 
             // Wait until consumer has finished reading cons_buf
             // before rotating, so we don't overwrite data it is still processing.
-            s->work_cond.wait(
-                lock, [&s]() { return s->cons_buf_free || s->stop_cons_thread; });
+            s->work_cond.wait(lock, [&s]() { return s->cons_buf_free || s->stop_cons_thread; });
 
             s->dest_buf = s->prod_buf.exchange(s->cons_buf.exchange(s->dest_buf));
 

--- a/projects/rocprofiler-sdk/tests/spm/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/spm/CMakeLists.txt
@@ -31,7 +31,7 @@ set(IS_DISABLED True)
 
 rocprofiler_add_integration_execute_test(
     test-spm-dispatch-collection-execute
-    TARGET simple-transpose
+    TARGET vector-ops
     TIMEOUT 60
     LABELS "integration-tests"
     PRELOAD "$<TARGET_FILE:rocprofiler-sdk-json-tool>"
@@ -45,7 +45,7 @@ rocprofiler_add_integration_execute_test(
 
 rocprofiler_add_integration_execute_test(
     test-spm-dispatch-buffer-collection-execute
-    TARGET simple-transpose
+    TARGET vector-ops
     TIMEOUT 45
     LABELS "integration-tests"
     PRELOAD "$<TARGET_FILE:rocprofiler-sdk-json-tool>"

--- a/projects/rocprofiler-sdk/tests/spm/validate.py
+++ b/projects/rocprofiler-sdk/tests/spm/validate.py
@@ -61,6 +61,41 @@ def test_spm_counter_values(input_data):
         _validate_callback_counter_values(data)
 
 
+def test_spm_counter_consistency(input_data):
+
+    data = input_data["rocprofiler-sdk-json-tool"]
+
+    if is_buffered(input_data):
+        return
+
+    counter_info = data["counter_info"]
+    counter_data = data["callback_records"]["spm_records"]
+
+    def get_name(counter_id):
+        for itr in counter_info:
+            if itr["id"]["handle"] == counter_id:
+                return itr["name"]
+
+    dispatch_counter_map = defaultdict(dict)
+    for record in counter_data:
+        dispatch_id = record["dispatch_id"]
+        counter_name = get_name(record["counter_id"]["handle"])
+        _accumulate_counter(
+            dispatch_counter_map[dispatch_id], counter_name, record["value"]
+        )
+
+    assert len(dispatch_counter_map) > 0, "No SPM dispatch data found"
+
+    counter_name = "TA_TA_BUSY"
+    for dispatch_id, counter_map in dispatch_counter_map.items():
+        assert (
+            counter_name in counter_map
+        ), f"Dispatch {dispatch_id} missing {counter_name}"
+        assert (
+            counter_map[counter_name]["value"] > 0
+        ), f"Dispatch {dispatch_id} has zero {counter_name}"
+
+
 def _get_counter_value(counters, name):
     for itr in counters:
         if itr["name"] == name:
@@ -76,12 +111,12 @@ def _validate_dispatch_counters(dispatch_id, counters):
         100
         * _get_counter_value(counters, "SQC_ICACHE_MISSES")
         / _get_counter_value(counters, "SQC_ICACHE_REQ")
-    ) < 100
+    ) <= 100
     assert (
         100
         * _get_counter_value(counters, "SQC_ICACHE_HITS")
         / _get_counter_value(counters, "SQC_ICACHE_REQ")
-    ) < 100
+    ) <= 100
 
 
 def _accumulate_counter(counter_map, name, value):


### PR DESCRIPTION
## Motivation

Fixes a data loss bug in aqlprofile_spm_start/aqlprofile_spm_stop (spm_v2.cpp) where the triple-buffer rotation could overwrite data before the consumer processed it. Added cons_buf_free flag for producer-consumer synchronization

## Technical Details

Fix: Added cons_buf_free (atomic bool, init true) to spm_state_t.

- Producer: waits on cons_buf_free == true before rotating, sets it to false after rotation
- Consumer: unlocks mutex before callbacks, sets cons_buf_free = true and notifies after callbacks complete

## Issue Tracking
JIRA ID: AIPROFSDK-1021

## Test Plan

Added integration test to check for counter value per dispatch to be non-zero

## Test Result

Existing tests pass
Newly added integration test pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
