### PR TITLE
fix(rccl): fix schema validation failures in test_runner config files

### DIFF
--- a/projects/rccl/tools/scripts/test_runner/configs/mi300_mellanox_ib_func.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300_mellanox_ib_func.json
@@ -2658,7 +2658,7 @@
       "test_dir": "test/nccl4py",
       "num_ranks": 1,
       "num_nodes": 1,
-      "num_gpus": 0,
+      "num_gpus": "auto",
       "timeout": 600,
       "tests": [
         {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce.json
@@ -2024,7 +2024,7 @@
       "test_dir": "test/nccl4py",
       "num_ranks": 1,
       "num_nodes": 1,
-      "num_gpus": 0,
+      "num_gpus": "auto",
       "timeout": 600,
       "tests": [
         {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce_func.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce_func.json
@@ -2639,7 +2639,7 @@
       "test_dir": "test/nccl4py",
       "num_ranks": 1,
       "num_nodes": 1,
-      "num_gpus": 0,
+      "num_gpus": "auto",
       "timeout": 600,
       "tests": [
         {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce.json
@@ -2648,7 +2648,7 @@
       "test_dir": "test/nccl4py",
       "num_ranks": 1,
       "num_nodes": 1,
-      "num_gpus": 0,
+      "num_gpus": "auto",
       "timeout": 600,
       "tests": [
         {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce_func.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce_func.json
@@ -2633,7 +2633,7 @@
       "test_dir": "test/nccl4py",
       "num_ranks": 1,
       "num_nodes": 1,
-      "num_gpus": 0,
+      "num_gpus": "auto",
       "timeout": 600,
       "tests": [
         {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi455x_perf.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi455x_perf.json
@@ -24,7 +24,6 @@
     "--bind-to none"
   ],
   "build_configuration": {
-    "enabled": false,
     "_comment": "perf binaries come from rccl_tests_build_configuration / external build"
   },
   "test_configurations": {

--- a/projects/rccl/tools/scripts/test_runner/lib/schema.json
+++ b/projects/rccl/tools/scripts/test_runner/lib/schema.json
@@ -61,10 +61,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "enabled": {
-          "type": "boolean",
-          "description": "Set to false to skip the RCCL build step entirely. Default: true when the section is present."
-        },
         "_comment": {
           "type": "string",
           "description": "Inline documentation comment (not interpreted by the runner)"

--- a/projects/rccl/tools/scripts/test_runner/lib/schema.json
+++ b/projects/rccl/tools/scripts/test_runner/lib/schema.json
@@ -61,6 +61,14 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Set to false to skip the RCCL build step entirely. Default: true when the section is present."
+        },
+        "_comment": {
+          "type": "string",
+          "description": "Inline documentation comment (not interpreted by the runner)"
+        },
         "install_flags": {
           "type": "array",
           "items": { "type": "string" },
@@ -272,6 +280,10 @@
         "description": {
           "type": "string",
           "description": "Human-readable description of this configuration block (not interpreted by the runner)"
+        },
+        "_comment": {
+          "type": "string",
+          "description": "Inline documentation comment (not interpreted by the runner)"
         },
         "tests": {
           "type": "array",


### PR DESCRIPTION
## Motivation

Five RCCL test runner config files failed JSON schema validation due to two issues discovered after PR #9682 fixed the same problem in mi300x_mellanox_ib.json:

1. "num_gpus": 0 in nccl4py_build_smoke — the schema requires num_gpus to be an integer ≥ 1 or "auto"; zero is invalid.

2. _comment and enabled fields used in test_configuration and build_configuration blocks were not listed as allowed properties
  in the schema, which has "additionalProperties": false.

## Technical Details

- tools/scripts/test_runner/configs/mi355x_thor2_roce.json: change "num_gpus": 0 to "num_gpus": "auto" in nccl4py_build_smoke
- tools/scripts/test_runner/configs/mi300_mellanox_ib_func.json: same
- tools/scripts/test_runner/configs/mi355x_thor2_roce_func.json: same
- tools/scripts/test_runner/configs/mi455_ainic_roce_func.json: same
- tools/scripts/test_runner/configs/mi455_ainic_roce.json: same
- tools/scripts/test_runner/lib/schema.json: add optional _comment (string) to test_configuration and build_configuration; add
  optional enabled (boolean) to build_configuration

Follows up on PR #9682 which fixed the same num_gpus issue in mi300x_mellanox_ib.json.

## Issue Tracking

JIRA ID:  AICOMRCCL-1866

## Test Plan

1. Validate all configs using jsonschema directly:
  ```
python3 -c "
  import json, jsonschema, glob
  schema = json.load(open('projects/rccl/tools/scripts/test_runner/lib/schema.json'))
  for f in sorted(glob.glob('projects/rccl/tools/scripts/test_runner/configs/*.json')):
      errors = list(jsonschema.Draft7Validator(schema).iter_errors(json.load(open(f))))
      print(f.split('/')[-1] + ': ' + ('PASS' if not errors else 'FAIL'))
  "
```

  2. Validate all configs using the test runner:
 ```
 for f in projects/rccl/tools/scripts/test_runner/configs/*.json; do
    result=$(python3 projects/rccl/tools/scripts/test_runner/test_runner.py \
      --config "$f" --no-build --skip-tests 2>&1 | head -1)
    echo "$(basename $f): $result"
  done

```
## Test Result

1. jsonschema direct — all 15 configs: PASS

2. Test runner schema check — all 15 configs: Configuration loaded and validated
  (mi455x_perf.json passes schema but has a pre-existing missing test_suites key unrelated to this change)

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
