### PR TITLE
[rocjitsu] Recover banked lane-table calls

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/gfx1250_vgpr_msb.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/gfx1250_vgpr_msb.cpp
@@ -27,13 +27,12 @@ constexpr size_t kSrc0 = 0;
 constexpr size_t kSrc1 = 1;
 constexpr size_t kSrc2 = 2;
 constexpr size_t kDst = 3;
-constexpr size_t kRoleCount = 4;
 
 /// @brief Abstract state immediately before or after an instruction.
 struct VgprMsbState {
   bool reachable = false;
   // nullopt is the top value: more than one bank can reach this point.
-  std::array<std::optional<uint8_t>, kRoleCount> banks{};
+  amdgpu::VgprMsbBanks banks{};
 
   bool operator==(const VgprMsbState &) const = default;
 };
@@ -61,30 +60,6 @@ struct VgprMsbState {
   return std::nullopt;
 }
 
-/// @brief MODE bit offset of each two-bit bank field.
-///
-/// MODE[19:12] is ordered {SRC2,SRC1,SRC0,DST}, unlike the immediate
-/// S_SET_VGPR_MSB byte, which is ordered {DST,SRC2,SRC1,SRC0}.
-constexpr std::array<uint8_t, kRoleCount> kModeBitOffset = {14, 16, 18, 12};
-
-/// @brief The MODE hardware register id in an S_SETREG* HWREG immediate.
-constexpr uint16_t kModeHwreg = 1;
-
-/// @brief Decoded fields of an S_SETREG* HWREG immediate: register id, and the
-/// [begin, begin+width) bit slice it writes.
-struct HwregSlice {
-  uint16_t id;
-  uint16_t begin;
-  uint16_t width;
-};
-
-/// @brief Decode the HWREG immediate fields (id[5:0], offset[10:6], size-1[15:11]).
-[[nodiscard]] constexpr HwregSlice decode_hwreg(uint16_t hwreg) {
-  return HwregSlice{.id = static_cast<uint16_t>(hwreg & 0x3f),
-                    .begin = static_cast<uint16_t>((hwreg >> 6) & 0x1f),
-                    .width = static_cast<uint16_t>(((hwreg >> 11) & 0x1f) + 1)};
-}
-
 /// @brief Join @p incoming into @p destination.
 [[nodiscard]] bool merge_state(VgprMsbState &destination, const VgprMsbState &incoming) {
   if (!incoming.reachable)
@@ -104,63 +79,6 @@ struct HwregSlice {
     }
   }
   return changed;
-}
-
-/// @brief Apply a scalar write to one WAVE_MODE bit slice.
-void apply_mode_write(VgprMsbState &state, uint16_t hwreg, std::optional<uint32_t> value) {
-  const HwregSlice slice = decode_hwreg(hwreg);
-  const uint16_t begin = slice.begin;
-  if (slice.id != kModeHwreg || begin >= 32)
-    return;
-  const uint16_t width = std::min<uint16_t>(slice.width, static_cast<uint16_t>(32 - begin));
-  const uint16_t end = static_cast<uint16_t>(begin + width);
-
-  for (size_t role = 0; role < kRoleCount; ++role) {
-    const uint16_t field_begin = kModeBitOffset[role];
-    const uint16_t field_end = static_cast<uint16_t>(field_begin + 2);
-    if (begin >= field_end || field_begin >= end)
-      continue;
-
-    if (!value) {
-      state.banks[role] = std::nullopt;
-      continue;
-    }
-
-    const uint16_t overlap_begin = std::max(begin, field_begin);
-    const uint16_t overlap_end = std::min(end, field_end);
-    // A literal write covering both bits determines the bank even if the
-    // incoming state was ambiguous. A partial write can retain the untouched
-    // bit only when that incoming state is known.
-    if (overlap_begin == field_begin && overlap_end == field_end) {
-      const uint8_t source_bit = static_cast<uint8_t>(field_begin - begin);
-      state.banks[role] = static_cast<uint8_t>((*value >> source_bit) & 0x3u);
-      continue;
-    }
-    if (!state.banks[role])
-      continue;
-    uint8_t bank = *state.banks[role];
-    for (uint16_t mode_bit = overlap_begin; mode_bit < overlap_end; ++mode_bit) {
-      const uint8_t field_bit = static_cast<uint8_t>(mode_bit - field_begin);
-      const uint8_t source_bit = static_cast<uint8_t>(mode_bit - begin);
-      const uint8_t bit = static_cast<uint8_t>((*value >> source_bit) & 1u);
-      bank = static_cast<uint8_t>((bank & ~(uint8_t{1} << field_bit)) | (bit << field_bit));
-    }
-    state.banks[role] = bank;
-  }
-}
-
-/// @brief Model gfx1250's unmasked VGPR-MSB side effect for immediate MODE writes.
-///
-/// S_SETREG_IMM32_B32 targeting MODE updates MODE[19:12] from the same literal
-/// bits even when those fields are outside the instruction's requested bit
-/// slice. The intended banks are carried in literal bits [19:12]. Model that
-/// result rather than the architectural mask.
-void apply_immediate_mode_vgpr_msb_side_effect(VgprMsbState &state, uint16_t hwreg,
-                                               uint32_t literal) {
-  if (decode_hwreg(hwreg).id != kModeHwreg)
-    return;
-  for (size_t role = 0; role < kRoleCount; ++role)
-    state.banks[role] = static_cast<uint8_t>((literal >> kModeBitOffset[role]) & 0x3u);
 }
 
 /// @brief Read a 32-bit little-endian word from the .text image at @p offset.
@@ -199,7 +117,7 @@ void transfer_instruction(VgprMsbState &state, const Instruction &inst,
   if (inst.mnemonic() == "s_setreg_b32") {
     // The source SGPR is runtime data. Only bank fields intersecting the write
     // become unknown; disjoint MODE fields retain their proven values.
-    apply_mode_write(state, hwreg, std::nullopt);
+    amdgpu::apply_vgpr_msb_mode_write(state.banks, hwreg, std::nullopt);
     return;
   }
 
@@ -208,13 +126,10 @@ void transfer_instruction(VgprMsbState &state, const Instruction &inst,
   // the authoritative input for this analysis.
   const std::optional<uint32_t> literal = text_word_at(text, inst.src_loc() + sizeof(uint32_t));
   if (!literal || inst.size() < 2 * static_cast<int>(sizeof(uint32_t))) {
-    apply_mode_write(state, hwreg, std::nullopt);
-    if (decode_hwreg(hwreg).id == kModeHwreg)
-      state.banks.fill(std::nullopt);
+    amdgpu::apply_vgpr_msb_mode_write(state.banks, hwreg, std::nullopt);
     return;
   }
-  apply_mode_write(state, hwreg, *literal);
-  apply_immediate_mode_vgpr_msb_side_effect(state, hwreg, *literal);
+  amdgpu::apply_vgpr_msb_mode_write(state.banks, hwreg, *literal);
 }
 
 } // namespace

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
@@ -5,6 +5,7 @@
 
 #include "rocjitsu/analysis/control_flow.h"
 #include "rocjitsu/code/builders/instruction_builder.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/vgpr_msb.h"
 #include "rocjitsu/isa/instruction.h"
 #include "rocjitsu/isa/operand.h"
 #include "rocjitsu/isa/register_set.h"
@@ -17,11 +18,15 @@
 #include <cstdint>
 #include <cstring>
 #include <deque>
+#include <functional>
 #include <limits>
+#include <memory>
 #include <optional>
 #include <set>
 #include <string_view>
 #include <unordered_map>
+#include <unordered_set>
+#include <utility>
 #include <vector>
 
 namespace rocjitsu {
@@ -220,6 +225,20 @@ struct SgprWriteMask {
       set(static_cast<uint16_t>(ref.index + i));
   }
 
+  [[nodiscard]] bool test(uint16_t sgpr) const {
+    if (sgpr < 64)
+      return (lo & (uint64_t{1} << sgpr)) != 0;
+    if (sgpr < REGISTER_SET_MAX_SGPRS)
+      return (hi & (uint64_t{1} << (sgpr - 64))) != 0;
+    return false;
+  }
+
+  SgprWriteMask &operator|=(const SgprWriteMask &other) {
+    lo |= other.lo;
+    hi |= other.hi;
+    return *this;
+  }
+
   template <typename F> void for_each(F &&f) const {
     uint64_t bits = lo;
     while (bits != 0) {
@@ -234,6 +253,58 @@ struct SgprWriteMask {
       f(sgpr);
       bits &= bits - 1;
     }
+  }
+};
+
+struct CalleeSummary {
+  SgprWriteMask sgprs;
+  std::bitset<REGISTER_SET_MAX_VGPRS> vgprs;
+  std::optional<uint8_t> return_mode;
+  std::optional<bool> return_gpr_idx_enabled;
+
+  CalleeSummary &operator|=(const CalleeSummary &other) {
+    sgprs |= other.sgprs;
+    vgprs |= other.vgprs;
+    if (return_mode != other.return_mode)
+      return_mode = std::nullopt;
+    if (return_gpr_idx_enabled != other.return_gpr_idx_enabled)
+      return_gpr_idx_enabled = std::nullopt;
+    return *this;
+  }
+};
+
+struct CalleeSummaryCacheKey {
+  uint64_t target = 0;
+  uint16_t return_pair = 0;
+  std::optional<uint8_t> mode;
+  std::optional<bool> gpr_idx_enabled;
+
+  friend bool operator==(const CalleeSummaryCacheKey &, const CalleeSummaryCacheKey &) = default;
+};
+
+struct CalleeSummaryCacheKeyHash {
+  [[nodiscard]] size_t operator()(const CalleeSummaryCacheKey &key) const {
+    size_t hash = std::hash<uint64_t>{}(key.target);
+    hash ^= std::hash<uint16_t>{}(key.return_pair) + 0x9e3779b9u + (hash << 6) + (hash >> 2);
+    hash ^= std::hash<std::optional<uint8_t>>{}(key.mode) + 0x9e3779b9u + (hash << 6) + (hash >> 2);
+    hash ^= std::hash<std::optional<bool>>{}(key.gpr_idx_enabled) + 0x9e3779b9u + (hash << 6) +
+            (hash >> 2);
+    return hash;
+  }
+};
+
+struct CalleeSummaryGroupKey {
+  uint64_t target = 0;
+  uint16_t return_pair = 0;
+
+  friend bool operator==(const CalleeSummaryGroupKey &, const CalleeSummaryGroupKey &) = default;
+};
+
+struct CalleeSummaryGroupKeyHash {
+  [[nodiscard]] size_t operator()(const CalleeSummaryGroupKey &key) const {
+    size_t hash = std::hash<uint64_t>{}(key.target);
+    hash ^= std::hash<uint16_t>{}(key.return_pair) + 0x9e3779b9u + (hash << 6) + (hash >> 2);
+    return hash;
   }
 };
 
@@ -1982,12 +2053,343 @@ struct StashedPcHalf {
   friend bool operator==(const StashedPcHalf &, const StashedPcHalf &) = default;
 };
 
+/// @brief Copy-on-write lane facts propagated through the CFG.
+///
+/// @details Most blocks pass an unchanged lane table to their successors. Sharing
+/// that immutable table keeps the retained storage proportional to distinct
+/// transfer states instead of multiplying every live slot by every CFG block.
+class VectorLaneFacts {
+  using Map = std::unordered_map<VectorLaneSlot, StashedPcHalf, VectorLaneSlotHash>;
+
+public:
+  using ConstIterator = Map::const_iterator;
+
+  [[nodiscard]] ConstIterator find(VectorLaneSlot slot) const { return values().find(slot); }
+  [[nodiscard]] ConstIterator end() const { return values().end(); }
+  [[nodiscard]] bool empty() const { return !values_ || values_->empty(); }
+  [[nodiscard]] size_t size() const { return values_ ? values_->size() : 0; }
+
+  void set(VectorLaneSlot slot, StashedPcHalf half) {
+    if (values_) {
+      const auto found = values_->find(slot);
+      if (found != values_->end() && found->second == half)
+        return;
+    }
+    writable_values().insert_or_assign(slot, std::move(half));
+  }
+
+  void erase(VectorLaneSlot slot) {
+    if (!values_ || !values_->contains(slot))
+      return;
+    writable_values().erase(slot);
+    reset_if_empty();
+  }
+
+  template <typename Predicate> void erase_if(Predicate &&predicate) {
+    if (!values_ || std::ranges::none_of(*values_, predicate))
+      return;
+    std::erase_if(writable_values(), std::forward<Predicate>(predicate));
+    reset_if_empty();
+  }
+
+  void intersect_with(const VectorLaneFacts &other) {
+    if (!values_ || values_ == other.values_)
+      return;
+    const auto conflicts = [&](const auto &item) {
+      const auto incoming = other.find(item.first);
+      return incoming == other.end() || incoming->second != item.second;
+    };
+    erase_if(conflicts);
+  }
+
+  void clear() { values_.reset(); }
+
+  friend bool operator==(const VectorLaneFacts &lhs, const VectorLaneFacts &rhs) {
+    return lhs.values_ == rhs.values_ || lhs.values() == rhs.values();
+  }
+
+private:
+  [[nodiscard]] const Map &values() const {
+    static const Map empty;
+    return values_ ? *values_ : empty;
+  }
+
+  [[nodiscard]] Map &writable_values() {
+    if (!values_)
+      values_ = std::make_shared<Map>();
+    else if (!values_.unique())
+      values_ = std::make_shared<Map>(*values_);
+    return *values_;
+  }
+
+  void reset_if_empty() {
+    if (values_->empty())
+      values_.reset();
+  }
+
+  std::shared_ptr<Map> values_;
+};
+
+// Bound every variable-size fact retained by lane-table recovery. One unit is
+// deliberately large enough for a lane-map node or restored-SGPR entry. Exact
+// callee summaries are charged by their fixed object size, including a cache
+// node allowance. Logical state facts are charged once per entry/exit/call
+// state even when their backing storage is shared, so the bound is
+// conservative. Recovery is optional and fails closed on exhaustion.
+constexpr size_t kRetainedAnalysisUnitBytes = 64;
+constexpr size_t kMaxRetainedAnalysisUnits = size_t{1} << 20;
+constexpr size_t kMaxCalleeSummaryVariantsPerTarget = 8;
+constexpr size_t kCalleeSummaryCacheEntryUnits =
+    1 + (sizeof(CalleeSummaryCacheKey) + sizeof(std::optional<CalleeSummary>) + 3 * sizeof(void *) -
+         1) /
+            kRetainedAnalysisUnitBytes;
+
+/// @brief Sparse, canonically ordered SGPR facts carried between CFG blocks.
+///
+/// @details Lane-restored PC halves are uncommon and normally occupy one pair.
+/// Shared, ordered vectors keep copies of an unchanged flow state cheap while
+/// preserving deterministic equality and lookup. A mutation detaches only the
+/// affected state.
+class RestoredSgprFacts {
+  struct Entry {
+    uint16_t sgpr = 0;
+    StashedPcHalf half;
+
+    friend bool operator==(const Entry &, const Entry &) = default;
+  };
+
+  using Storage = std::vector<Entry>;
+
+public:
+  [[nodiscard]] const StashedPcHalf *find(uint16_t sgpr) const {
+    const Storage &current = values();
+    const auto it =
+        std::lower_bound(current.begin(), current.end(), sgpr,
+                         [](const Entry &entry, uint16_t value) { return entry.sgpr < value; });
+    return it != current.end() && it->sgpr == sgpr ? &it->half : nullptr;
+  }
+
+  void set(uint16_t sgpr, StashedPcHalf half) {
+    const Storage &current = values();
+    const auto found =
+        std::lower_bound(current.begin(), current.end(), sgpr,
+                         [](const Entry &entry, uint16_t value) { return entry.sgpr < value; });
+    const size_t index = static_cast<size_t>(found - current.begin());
+    if (found != current.end() && found->sgpr == sgpr) {
+      if (found->half == half)
+        return;
+      writable_values()[index].half = std::move(half);
+      return;
+    }
+    Storage &updated = writable_values();
+    updated.insert(updated.begin() + static_cast<Storage::difference_type>(index),
+                   Entry{.sgpr = sgpr, .half = std::move(half)});
+  }
+
+  void erase(uint16_t sgpr) {
+    if (!values_)
+      return;
+    const auto found =
+        std::lower_bound(values_->begin(), values_->end(), sgpr,
+                         [](const Entry &entry, uint16_t value) { return entry.sgpr < value; });
+    if (found == values_->end() || found->sgpr != sgpr)
+      return;
+    const size_t index = static_cast<size_t>(found - values_->begin());
+    Storage &updated = writable_values();
+    updated.erase(updated.begin() + static_cast<Storage::difference_type>(index));
+    reset_if_empty();
+  }
+
+  template <typename Predicate> void erase_if(Predicate &&predicate) {
+    if (!values_ ||
+        std::ranges::none_of(*values_, [&](const Entry &entry) { return predicate(entry.sgpr); }))
+      return;
+    std::erase_if(writable_values(), [&](const Entry &entry) { return predicate(entry.sgpr); });
+    reset_if_empty();
+  }
+
+  void intersect_with(const RestoredSgprFacts &other) {
+    if (!values_ || values_ == other.values_)
+      return;
+    const auto conflicts = [&](const Entry &entry) {
+      const StashedPcHalf *incoming = other.find(entry.sgpr);
+      return incoming == nullptr || *incoming != entry.half;
+    };
+    if (std::ranges::none_of(*values_, conflicts))
+      return;
+    std::erase_if(writable_values(), conflicts);
+    reset_if_empty();
+  }
+
+  [[nodiscard]] bool empty() const { return !values_ || values_->empty(); }
+  [[nodiscard]] size_t size() const { return values_ ? values_->size() : 0; }
+  void clear() { values_.reset(); }
+
+  friend bool operator==(const RestoredSgprFacts &lhs, const RestoredSgprFacts &rhs) {
+    return lhs.values_ == rhs.values_ || lhs.values() == rhs.values();
+  }
+
+private:
+  [[nodiscard]] const Storage &values() const {
+    static const Storage empty;
+    return values_ ? *values_ : empty;
+  }
+
+  [[nodiscard]] Storage &writable_values() {
+    if (!values_)
+      values_ = std::make_shared<Storage>();
+    else if (!values_.unique())
+      values_ = std::make_shared<Storage>(*values_);
+    return *values_;
+  }
+
+  void reset_if_empty() {
+    if (values_->empty())
+      values_.reset();
+  }
+
+  std::shared_ptr<Storage> values_;
+};
+
 struct VectorLaneFlowState {
-  std::unordered_map<VectorLaneSlot, StashedPcHalf, VectorLaneSlotHash> slots;
+  VectorLaneFacts slots;
+  RestoredSgprFacts restored_sgprs;
   std::optional<uint8_t> vgpr_msb_imm;
+  std::optional<bool> gpr_idx_enabled;
 
   friend bool operator==(const VectorLaneFlowState &, const VectorLaneFlowState &) = default;
 };
+
+/// @brief Call-only dataflow metadata, allocated only for blocks with call edges.
+struct CallEdgeInfo {
+  std::unordered_set<size_t> target_successors;
+  std::optional<size_t> continuation_successor;
+  std::optional<VectorLaneFlowState> entry_state;
+};
+
+// The pass also allocates dense per-instruction and per-block scaffolding before
+// retaining any logical facts. Bound that fixed footprint independently of the
+// fact budget below. The estimates use the actual value sizes plus conservative
+// pointer allowances for hash nodes, buckets, predecessor storage, and the
+// worklist. Optional recovery fails closed when either budget would be exceeded.
+constexpr size_t kMaxAnalysisScaffoldingBytes = size_t{256} << 20;
+constexpr size_t kInstructionScaffoldingBytes =
+    sizeof(std::pair<const uint64_t, size_t>) + 4 * sizeof(void *) + sizeof(size_t);
+constexpr size_t kBlockScaffoldingBytes =
+    sizeof(std::vector<size_t>) + 2 * sizeof(VectorLaneFlowState) + sizeof(CallEdgeInfo) +
+    6 * sizeof(void *) + 3 * sizeof(size_t) + 2 * sizeof(uint8_t);
+
+[[nodiscard]] constexpr bool hwreg_slice_overlaps_vgpr_msb(uint16_t hwreg) {
+  const amdgpu::HwregSlice slice = amdgpu::decode_vgpr_msb_hwreg(hwreg);
+  if (slice.id != amdgpu::MODE_HWREG)
+    return false;
+  const uint16_t end = static_cast<uint16_t>(
+      std::min<uint32_t>(32, static_cast<uint32_t>(slice.begin) + slice.width));
+  return slice.begin < amdgpu::VGPR_MSB_MODE_SHIFT + 8 && end > amdgpu::VGPR_MSB_MODE_SHIFT;
+}
+
+[[nodiscard]] constexpr bool hwreg_slice_overlaps_mode_bit(uint16_t hwreg, uint16_t bit) {
+  const amdgpu::HwregSlice slice = amdgpu::decode_vgpr_msb_hwreg(hwreg);
+  return slice.id == amdgpu::MODE_HWREG && slice.begin <= bit &&
+         static_cast<uint32_t>(slice.begin) + slice.width > bit;
+}
+
+[[nodiscard]] std::optional<uint8_t> vgpr_bank_for_role(std::optional<uint8_t> mode,
+                                                        amdgpu::VgprMsbRole role) {
+  return amdgpu::vgpr_msb_bank_for_role(mode, role);
+}
+
+[[nodiscard]] std::optional<uint32_t> instruction_literal(const Instruction &inst,
+                                                          std::span<const uint8_t> text);
+
+void update_vgpr_mode(std::optional<uint8_t> &mode, const Instruction &inst,
+                      std::span<const uint8_t> text) {
+  const std::string_view mnemonic = inst.mnemonic();
+  if (mnemonic == "s_set_vgpr_msb") {
+    if (const Operand *imm = inst.src_operand(0))
+      mode = static_cast<uint8_t>(imm->encoding_value() & 0xffu);
+    else
+      mode = std::nullopt;
+    return;
+  }
+  if (mnemonic != "s_setreg_b32" && mnemonic != "s_setreg_imm32_b32")
+    return;
+  const Operand *hwreg_operand = inst.dst_operand(0);
+  if (hwreg_operand == nullptr) {
+    mode = std::nullopt;
+    return;
+  }
+  const uint16_t hwreg = static_cast<uint16_t>(hwreg_operand->encoding_value());
+  if (mnemonic == "s_setreg_b32") {
+    if (hwreg_slice_overlaps_vgpr_msb(hwreg))
+      mode = std::nullopt;
+    return;
+  }
+  amdgpu::VgprMsbBanks banks = amdgpu::unpack_vgpr_msb_banks(mode);
+  amdgpu::apply_vgpr_msb_mode_write(banks, hwreg, instruction_literal(inst, text));
+  mode = amdgpu::pack_vgpr_msb_banks(banks);
+}
+
+void update_gpr_idx_enabled(std::optional<bool> &enabled, const Instruction &inst,
+                            std::span<const uint8_t> text) {
+  constexpr uint16_t kGprIdxEnableBit = 27;
+  const std::string_view mnemonic = inst.mnemonic();
+  if (mnemonic == "s_set_gpr_idx_on") {
+    enabled = true;
+    return;
+  }
+  if (mnemonic == "s_set_gpr_idx_off") {
+    enabled = false;
+    return;
+  }
+  if (mnemonic != "s_setreg_b32" && mnemonic != "s_setreg_imm32_b32")
+    return;
+  const Operand *hwreg_operand = inst.dst_operand(0);
+  if (hwreg_operand == nullptr) {
+    enabled = std::nullopt;
+    return;
+  }
+  const uint16_t hwreg = static_cast<uint16_t>(hwreg_operand->encoding_value());
+  if (!hwreg_slice_overlaps_mode_bit(hwreg, kGprIdxEnableBit))
+    return;
+  if (mnemonic == "s_setreg_b32") {
+    enabled = std::nullopt;
+    return;
+  }
+  const amdgpu::HwregSlice slice = amdgpu::decode_vgpr_msb_hwreg(hwreg);
+  const auto literal = instruction_literal(inst, text);
+  enabled = literal
+                ? std::optional<bool>{((*literal >> (kGprIdxEnableBit - slice.begin)) & 1u) != 0}
+                : std::nullopt;
+}
+
+[[nodiscard]] bool has_explicit_vgpr_destination(const Instruction &inst) {
+  for (int index = 0; index < inst.num_dst_operands(); ++index) {
+    const Operand *dst = inst.dst_operand(index);
+    const auto ref = dst ? dst->to_register_ref() : std::nullopt;
+    if (ref && ref->cls == RegClass::VGPR)
+      return true;
+  }
+  return false;
+}
+
+[[nodiscard]] bool has_runtime_relative_destination(std::string_view mnemonic) {
+  return mnemonic.starts_with("s_movreld") || mnemonic.starts_with("s_movrelsd") ||
+         mnemonic.starts_with("v_movreld") || mnemonic.starts_with("v_movrelsd") ||
+         mnemonic.starts_with("v_swaprel");
+}
+
+[[nodiscard]] std::optional<uint32_t> instruction_literal(const Instruction &inst,
+                                                          std::span<const uint8_t> text) {
+  const uint64_t literal_offset = inst.src_loc() + sizeof(uint32_t);
+  if (inst.size() < 2 * static_cast<int>(sizeof(uint32_t)) || literal_offset > text.size() ||
+      sizeof(uint32_t) > text.size() - literal_offset) {
+    return std::nullopt;
+  }
+  uint32_t literal = 0;
+  std::memcpy(&literal, text.data() + literal_offset, sizeof(literal));
+  return literal;
+}
 
 [[nodiscard]] std::optional<uint16_t> inline_lane(const Operand *operand) {
   if (operand == nullptr || operand->encoding_value() < kInlineInt0 ||
@@ -2024,6 +2426,7 @@ struct VectorLaneFlowState {
 // callee-saved and must fail closed rather than be masked down to its selector.
 
 void recover_vector_lane_stashed_pcs(AnalysisContext &ctx, const std::vector<AnalysisBlock> &blocks,
+                                     std::span<const IndirectCallFixup> known_fixups,
                                      std::vector<IndirectCallFixup> &recovered,
                                      std::span<const uint64_t> sorted_extra_leaders,
                                      ExternalEntryPolicy entry_policy) {
@@ -2054,41 +2457,264 @@ void recover_vector_lane_stashed_pcs(AnalysisContext &ctx, const std::vector<Ana
 
   if (blocks.empty())
     return;
+  if (ctx.insts.size() > kMaxAnalysisScaffoldingBytes / kInstructionScaffoldingBytes)
+    return;
+  const size_t instruction_scaffolding_bytes = ctx.insts.size() * kInstructionScaffoldingBytes;
+  const size_t remaining_scaffolding_bytes =
+      kMaxAnalysisScaffoldingBytes - instruction_scaffolding_bytes;
+  if (blocks.size() > remaining_scaffolding_bytes / kBlockScaffoldingBytes)
+    return;
+  const size_t initial_recovered_size = recovered.size();
   const std::vector<uint8_t> external_entries =
       explicit_external_entries(blocks, sorted_extra_leaders);
 
-  const auto changes_vgpr_msb_bank = [](std::string_view mnemonic) {
-    return mnemonic == "s_set_vgpr_msb" || mnemonic == "s_setreg_b32" ||
-           mnemonic == "s_setreg_imm32_b32";
+  std::unordered_map<uint64_t, size_t> instruction_by_offset;
+  instruction_by_offset.reserve(ctx.insts.size());
+  for (size_t index = 0; index < ctx.insts.size(); ++index)
+    instruction_by_offset.emplace(ctx.insts[index]->src_loc(), index);
+
+  std::vector<size_t> block_for_instruction(ctx.insts.size(), blocks.size());
+  for (size_t block_index = 0; block_index < blocks.size(); ++block_index) {
+    for (size_t index = blocks[block_index].first_index; index <= blocks[block_index].last_index;
+         ++index)
+      block_for_instruction[index] = block_index;
+  }
+
+  // Cache exact register clobbers for a statically recovered helper whose
+  // complete local CFG ends in returns through the call's destination pair (or
+  // in paths that do not return). Nested or still-unresolved control transfers
+  // fall back to the architecture's call-preserved register set below. The
+  // cache key also includes the caller's VGPR-MSB mode and GPR-index enable
+  // state because both can change the physical register named by an operand.
+  size_t retained_state_units = 0;
+  size_t retained_summary_units = 0;
+  bool analysis_budget_exhausted = false;
+  std::unordered_map<CalleeSummaryCacheKey, std::optional<CalleeSummary>, CalleeSummaryCacheKeyHash>
+      callee_summary_cache;
+  std::unordered_map<CalleeSummaryGroupKey, size_t, CalleeSummaryGroupKeyHash>
+      callee_summary_variants;
+  const auto statically_bounded_callee_summary =
+      [&](uint64_t target, uint16_t return_pair, std::optional<uint8_t> initial_mode,
+          std::optional<bool> initial_gpr_idx_enabled) -> std::optional<CalleeSummary> {
+    const CalleeSummaryCacheKey key{.target = target,
+                                    .return_pair = return_pair,
+                                    .mode = initial_mode,
+                                    .gpr_idx_enabled = initial_gpr_idx_enabled};
+    const CalleeSummaryGroupKey group{.target = target, .return_pair = return_pair};
+    auto group_variants = callee_summary_variants.find(group);
+    if (group_variants != callee_summary_variants.end() &&
+        group_variants->second > kMaxCalleeSummaryVariantsPerTarget)
+      return std::nullopt;
+    if (auto cached = callee_summary_cache.find(key); cached != callee_summary_cache.end())
+      return cached->second;
+    // Once a target/return pair needs more than the bounded number of MODE and
+    // GPR-index variants, permanently use the conservative ABI summary for the
+    // group. This loss of precision is monotone across the dataflow fixed point.
+    if (group_variants != callee_summary_variants.end() &&
+        group_variants->second == kMaxCalleeSummaryVariantsPerTarget) {
+      ++group_variants->second;
+      return std::nullopt;
+    }
+
+    std::optional<CalleeSummary> result;
+    auto start = instruction_by_offset.find(target);
+    if (start != instruction_by_offset.end() &&
+        block_for_instruction[start->second] != blocks.size() &&
+        blocks[block_for_instruction[start->second]].first_index == start->second) {
+      CalleeSummary summary;
+      struct WorkItem {
+        size_t block_index;
+        std::optional<uint8_t> mode;
+        std::optional<bool> gpr_idx_enabled;
+      };
+      std::vector<WorkItem> worklist{
+          {block_for_instruction[start->second], initial_mode, initial_gpr_idx_enabled}};
+      std::unordered_set<uint64_t> visited;
+      bool saw_return = false;
+      std::optional<uint8_t> return_mode;
+      std::optional<bool> return_gpr_idx_enabled;
+      bool unsupported = false;
+      while (!worklist.empty() && !unsupported) {
+        const WorkItem item = worklist.back();
+        worklist.pop_back();
+        const uint64_t mode_key = item.mode ? *item.mode : uint64_t{256};
+        const uint64_t gpr_idx_key = item.gpr_idx_enabled ? (*item.gpr_idx_enabled ? 1u : 0u) : 2u;
+        const uint64_t visit_key =
+            (static_cast<uint64_t>(item.block_index) << 11) | (gpr_idx_key << 9) | mode_key;
+        if (!visited.insert(visit_key).second)
+          continue;
+        // Bound malformed or unexpectedly broad callees. Falling back to the
+        // ABI is always safe and avoids turning one recovery into a whole-text
+        // traversal.
+        if (visited.size() > 4096) {
+          unsupported = true;
+          break;
+        }
+
+        const AnalysisBlock &block = blocks[item.block_index];
+        std::optional<uint8_t> mode = item.mode;
+        std::optional<bool> gpr_idx_enabled = item.gpr_idx_enabled;
+        const auto record_all_banks = [&](uint16_t selector) {
+          for (uint16_t bank = 0; bank < 4; ++bank)
+            summary.vgprs.set(static_cast<uint16_t>((selector & 0xffu) + bank * 256u));
+        };
+        for (size_t index = block.first_index; index <= block.last_index; ++index) {
+          const Instruction &inst = *ctx.insts[index];
+          const std::string_view mnemonic = inst.mnemonic();
+          // Relative-register operations can read or write a register selected
+          // at runtime. Likewise, an ordinary VGPR destination is not a static
+          // destination while GPR indexing may be enabled. An exact clobber
+          // summary cannot represent either case, so use the ABI fallback.
+          if (mnemonic.starts_with("s_movrel") || mnemonic.starts_with("v_movrel") ||
+              mnemonic.starts_with("v_swaprel") ||
+              (gpr_idx_enabled != std::optional<bool>{false} &&
+               has_explicit_vgpr_destination(inst))) {
+            unsupported = true;
+            break;
+          }
+          ensure_written_sgprs(ctx, index);
+          ctx.facts[index].written_sgprs.for_each([&](uint16_t sgpr) { summary.sgprs.set(sgpr); });
+          RegisterSet implicit_defs;
+          inst.implicit_defs(implicit_defs);
+          implicit_defs.for_each([&](RegisterRef ref) {
+            if (ref.cls == RegClass::VGPR)
+              for (uint16_t lane = 0; lane < std::max<uint16_t>(1, ref.width); ++lane)
+                record_all_banks(static_cast<uint16_t>(ref.index + lane));
+          });
+          for (int dst_index = 0; dst_index < inst.num_dst_operands(); ++dst_index) {
+            const Operand *dst = inst.dst_operand(dst_index);
+            if (dst == nullptr)
+              continue;
+            auto ref = dst->to_register_ref();
+            if (!ref || ref->cls != RegClass::VGPR)
+              continue;
+            const auto bank = vgpr_bank_for_role(mode, dst->vgpr_msb_role());
+            for (uint16_t lane = 0; lane < std::max<uint16_t>(1, ref->width); ++lane) {
+              const uint16_t selector = static_cast<uint16_t>(ref->index + lane);
+              if (!bank || selector >= 256) {
+                record_all_banks(selector);
+              } else {
+                summary.vgprs.set(
+                    static_cast<uint16_t>(selector + static_cast<uint16_t>(*bank) * 256u));
+              }
+            }
+          }
+          update_vgpr_mode(mode, inst, ctx.text);
+          update_gpr_idx_enabled(gpr_idx_enabled, inst, ctx.text);
+        }
+        if (unsupported)
+          break;
+
+        const Instruction &term = *ctx.insts[block.last_index];
+        const InstructionFacts &facts = ctx.facts[block.last_index];
+        if (facts.setpc_ssrc) {
+          if (*facts.setpc_ssrc != return_pair)
+            unsupported = true;
+          else if (!saw_return) {
+            return_mode = mode;
+            return_gpr_idx_enabled = gpr_idx_enabled;
+            saw_return = true;
+          } else {
+            if (return_mode != mode)
+              return_mode = std::nullopt;
+            if (return_gpr_idx_enabled != gpr_idx_enabled)
+              return_gpr_idx_enabled = std::nullopt;
+          }
+          continue;
+        }
+        if (facts.call_sdst || facts.swappc_ssrc || is_indirect_branch(term)) {
+          unsupported = true;
+          continue;
+        }
+        if (block.successors.empty()) {
+          if (!is_program_path_terminator(term))
+            unsupported = true;
+          continue;
+        }
+        for (size_t successor : block.successors)
+          worklist.push_back({successor, mode, gpr_idx_enabled});
+      }
+      // A transfer through the nominal return pair is only a proven return if
+      // the callee never repurposed either half. This deliberately rejects
+      // save-and-restore sequences that this summary does not value-track.
+      if (!unsupported && saw_return && !summary.sgprs.test(return_pair) &&
+          !summary.sgprs.test(static_cast<uint16_t>(return_pair + 1))) {
+        summary.return_mode = return_mode;
+        summary.return_gpr_idx_enabled = return_gpr_idx_enabled;
+        result = summary;
+      }
+    }
+    const size_t retained_units =
+        kCalleeSummaryCacheEntryUnits + (group_variants == callee_summary_variants.end() ? 1 : 0);
+    const size_t available_units =
+        kMaxRetainedAnalysisUnits - retained_state_units - retained_summary_units;
+    if (retained_units > available_units) {
+      analysis_budget_exhausted = true;
+      return std::nullopt;
+    }
+    callee_summary_cache.emplace(key, result);
+    if (group_variants == callee_summary_variants.end())
+      callee_summary_variants.emplace(group, 1);
+    else
+      ++group_variants->second;
+    retained_summary_units += retained_units;
+    return result;
   };
 
-  constexpr unsigned kDstBankShift = 6;  // s_set_vgpr_msb immediate DST field.
-  constexpr unsigned kSrc0BankShift = 0; // s_set_vgpr_msb immediate SRC0 field.
-
   const auto scan_block = [&](const AnalysisBlock &block, VectorLaneFlowState state,
-                              bool emit_fixups) {
+                              bool emit_fixups,
+                              std::optional<VectorLaneFlowState> *call_entry_state) {
     BlockState builders;
-    std::array<std::optional<StashedPcHalf>, REGISTER_SET_MAX_SGPRS> read_halves;
-    std::set<uint16_t> active_read_halves;
+    const auto publish_builders = [&]() {
+      for (uint16_t pair_lo : builders.active_pairs()) {
+        const PcValue *value = builders.builder(pair_lo);
+        if (value == nullptr || static_cast<size_t>(pair_lo) + 1 >= REGISTER_SET_MAX_SGPRS)
+          continue;
+        state.restored_sgprs.set(pair_lo, StashedPcHalf{.value = *value, .high = false});
+        state.restored_sgprs.set(static_cast<uint16_t>(pair_lo + 1),
+                                 StashedPcHalf{.value = *value, .high = true});
+      }
+    };
 
-    const auto physical_vgpr = [&](uint16_t low, unsigned bank_shift) -> std::optional<uint16_t> {
-      if (!state.vgpr_msb_imm)
+    const auto physical_vgpr = [&](uint16_t low,
+                                   amdgpu::VgprMsbRole role) -> std::optional<uint16_t> {
+      const auto bank = amdgpu::vgpr_msb_bank_for_role(state.vgpr_msb_imm, role);
+      if (!bank)
         return std::nullopt;
-      const uint8_t bank = static_cast<uint8_t>((*state.vgpr_msb_imm >> bank_shift) & 0x3u);
-      return static_cast<uint16_t>(low + static_cast<uint16_t>(bank) * 256u);
+      return static_cast<uint16_t>(low + static_cast<uint16_t>(*bank) * 256u);
     };
 
     for (size_t index = block.first_index; index <= block.last_index; ++index) {
       const Instruction &inst = *ctx.insts[index];
       const InstructionFacts &facts = ctx.facts[index];
       const std::string_view mnemonic = inst.mnemonic();
-
-      if (!active_read_halves.empty()) {
+      // Large dispatchers keep getpc-built targets in long-lived SGPRs, then
+      // copy selected pairs into short-lived call operands. Capture the source
+      // before generic destination invalidation and publish the copy only when
+      // both halves carry the same proven PC value.
+      std::optional<std::pair<uint16_t, PcValue>> copied_pair;
+      if (mnemonic == "s_mov_b64" && inst.num_dst_operands() == 1 && inst.num_src_operands() == 1) {
+        const Operand *dst_operand = inst.dst_operand(0);
+        const Operand *src_operand = inst.src_operand(0);
+        const auto dst = dst_operand ? dst_operand->to_register_ref() : std::nullopt;
+        const auto src = src_operand ? src_operand->to_register_ref() : std::nullopt;
+        if (dst && src && dst->cls == RegClass::SGPR && src->cls == RegClass::SGPR &&
+            dst->width == 2 && src->width == 2 && dst->index < kMaxTrackedSgprPair &&
+            src->index < kMaxTrackedSgprPair) {
+          const StashedPcHalf *lo = state.restored_sgprs.find(src->index);
+          const StashedPcHalf *hi =
+              state.restored_sgprs.find(static_cast<uint16_t>(src->index + 1));
+          if (lo != nullptr && hi != nullptr && !lo->high && hi->high && lo->value == hi->value) {
+            copied_pair = std::pair{dst->index, lo->value};
+          } else if (const PcValue *value = builders.builder(src->index)) {
+            copied_pair = std::pair{dst->index, *value};
+          }
+        }
+      }
+      if (!state.restored_sgprs.empty()) {
         ensure_written_sgprs(ctx, index);
-        ctx.facts[index].written_sgprs.for_each([&](uint16_t sgpr) {
-          read_halves[sgpr].reset();
-          active_read_halves.erase(sgpr);
-        });
+        ctx.facts[index].written_sgprs.for_each(
+            [&](uint16_t sgpr) { state.restored_sgprs.erase(sgpr); });
       }
 
       if (facts.getpc_sdst && *facts.getpc_sdst < kMaxTrackedSgprPair) {
@@ -2108,36 +2734,76 @@ void recover_vector_lane_stashed_pcs(AnalysisContext &ctx, const std::vector<Ana
         // context-sensitive return edge. Drop every stash in a caller-saved
         // VGPR; a conforming callee must preserve a callee-saved VGPR, so a
         // stash there survives (see is_callee_saved_vgpr).
-        std::erase_if(state.slots,
-                      [](const auto &item) { return !is_callee_saved_vgpr(item.first.vgpr); });
+        const uint16_t destination = *facts.call_sdst;
+        builders.invalidate_pair(destination);
+        state.restored_sgprs.erase(destination);
+        state.restored_sgprs.erase(static_cast<uint16_t>(destination + 1));
+        publish_builders();
+        if (call_entry_state != nullptr)
+          *call_entry_state = state;
+        const uint64_t next_offset = inst.src_loc() + static_cast<uint64_t>(inst.size());
+        const auto delta = inst.branch_offset_bytes();
+        const std::optional<CalleeSummary> callee_summary =
+            delta && static_cast<int64_t>(next_offset) + *delta >= 0
+                ? statically_bounded_callee_summary(
+                      static_cast<uint64_t>(static_cast<int64_t>(next_offset) + *delta),
+                      *facts.call_sdst, state.vgpr_msb_imm, state.gpr_idx_enabled)
+                : std::nullopt;
+        const auto survives_call = [&](uint16_t sgpr) {
+          return callee_summary ? !callee_summary->sgprs.test(sgpr) : is_callee_saved_sgpr(sgpr);
+        };
+        state.slots.erase_if([&](const auto &item) {
+          return callee_summary ? callee_summary->vgprs.test(item.first.vgpr)
+                                : !is_callee_saved_vgpr(item.first.vgpr);
+        });
+        state.restored_sgprs.erase_if([&](uint16_t sgpr) { return !survives_call(sgpr); });
+        const std::vector<uint16_t> active_pairs = builders.active_pairs();
+        for (uint16_t pair_lo : active_pairs) {
+          if (!survives_call(pair_lo) || !survives_call(static_cast<uint16_t>(pair_lo + 1)))
+            builders.invalidate_pair(pair_lo);
+        }
+        state.vgpr_msb_imm =
+            callee_summary ? callee_summary->return_mode : std::optional<uint8_t>{};
+        state.gpr_idx_enabled =
+            callee_summary ? callee_summary->return_gpr_idx_enabled : std::optional<bool>{};
       }
 
       if (mnemonic == "v_writelane_b32") {
         const auto dst = operand_register(inst.dst_operand(0), RegClass::VGPR);
         const auto src = operand_register(inst.src_operand(0), RegClass::SGPR);
         const auto lane = inline_lane(inst.src_operand(1));
-        const auto dst_phys = dst ? physical_vgpr(dst->index, kDstBankShift) : std::nullopt;
-        if (dst && lane) {
+        const auto dst_phys =
+            dst ? physical_vgpr(dst->index, inst.dst_operand(0)->vgpr_msb_role()) : std::nullopt;
+        if (dst && lane && state.gpr_idx_enabled == std::optional<bool>{false}) {
           if (dst_phys) {
             const VectorLaneSlot written_slot{*dst_phys, *lane};
             state.slots.erase(written_slot);
             if (src) {
-              for (uint16_t pair_lo : builders.active_pairs()) {
-                const PcValue *value = builders.builder(pair_lo);
-                if (value == nullptr || (src->index != pair_lo && src->index != pair_lo + 1))
-                  continue;
-                state.slots[written_slot] =
-                    StashedPcHalf{.value = *value, .high = src->index == pair_lo + 1};
-                break;
+              const StashedPcHalf *restored = state.restored_sgprs.find(src->index);
+              if (restored != nullptr) {
+                // Dispatchers can move a proven target from one lane table to
+                // callee-saved SGPRs and then re-stash it in another table.
+                state.slots.set(written_slot, *restored);
+              } else {
+                for (uint16_t pair_lo : builders.active_pairs()) {
+                  const PcValue *value = builders.builder(pair_lo);
+                  if (value == nullptr || (src->index != pair_lo && src->index != pair_lo + 1))
+                    continue;
+                  state.slots.set(written_slot, StashedPcHalf{.value = *value,
+                                                              .high = src->index == pair_lo + 1});
+                  break;
+                }
               }
             }
           } else {
             // The destination bank is unknown. It may overwrite any physical
             // register with this low selector, so invalidate all four banks.
-            std::erase_if(state.slots, [&](const auto &item) {
+            state.slots.erase_if([&](const auto &item) {
               return (item.first.vgpr & 0xffu) == (dst->index & 0xffu) && item.first.lane == *lane;
             });
           }
+        } else if (dst && lane) {
+          state.slots.clear();
         }
         invalidate_written_sgprs(ctx, index, builders);
         continue;
@@ -2148,23 +2814,21 @@ void recover_vector_lane_stashed_pcs(AnalysisContext &ctx, const std::vector<Ana
         const auto src = operand_register(inst.src_operand(0), RegClass::VGPR);
         const auto lane = inline_lane(inst.src_operand(1));
         invalidate_written_sgprs(ctx, index, builders);
-        const auto src_phys = src ? physical_vgpr(src->index, kSrc0BankShift) : std::nullopt;
-        if (dst && lane && src_phys) {
+        const auto src_phys =
+            src ? physical_vgpr(src->index, inst.src_operand(0)->vgpr_msb_role()) : std::nullopt;
+        if (dst && lane && src_phys && state.gpr_idx_enabled == std::optional<bool>{false}) {
           auto slot = state.slots.find(VectorLaneSlot{*src_phys, *lane});
-          if (slot != state.slots.end()) {
-            read_halves[dst->index] = slot->second;
-            active_read_halves.insert(dst->index);
-          }
+          if (slot != state.slots.end())
+            state.restored_sgprs.set(dst->index, slot->second);
         }
         continue;
       }
 
-      if (emit_fixups && is_lane_fixup_consumer(facts) &&
-          static_cast<size_t>(*facts.swappc_ssrc + 1) < read_halves.size()) {
+      if (emit_fixups && is_lane_fixup_consumer(facts)) {
         const uint16_t pair_lo = *facts.swappc_ssrc;
-        const auto &lo = read_halves[pair_lo];
-        const auto &hi = read_halves[pair_lo + 1];
-        if (lo && hi && !lo->high && hi->high && lo->value == hi->value) {
+        const StashedPcHalf *lo = state.restored_sgprs.find(pair_lo);
+        const StashedPcHalf *hi = state.restored_sgprs.find(static_cast<uint16_t>(pair_lo + 1));
+        if (lo != nullptr && hi != nullptr && !lo->high && hi->high && lo->value == hi->value) {
           if (auto fixup = fixup_for_value(ctx, index, pair_lo, lo->value))
             append_unique(recovered, *fixup);
         }
@@ -2176,49 +2840,148 @@ void recover_vector_lane_stashed_pcs(AnalysisContext &ctx, const std::vector<Ana
         // publishing the block exit so a callee-clobbered value cannot reach
         // the continuation. A callee-saved VGPR is preserved by a conforming
         // callee, so a stash there survives (see is_callee_saved_vgpr).
-        std::erase_if(state.slots,
-                      [](const auto &item) { return !is_callee_saved_vgpr(item.first.vgpr); });
+        const uint16_t pair_lo = *facts.swappc_ssrc;
+        std::vector<uint64_t> targets;
+        const StashedPcHalf *restored_lo = state.restored_sgprs.find(pair_lo);
+        const StashedPcHalf *restored_hi =
+            state.restored_sgprs.find(static_cast<uint16_t>(pair_lo + 1));
+        if (restored_lo != nullptr && restored_hi != nullptr && !restored_lo->high &&
+            restored_hi->high && restored_lo->value == restored_hi->value) {
+          if (restored_lo->value.offset >= 0)
+            targets.push_back(static_cast<uint64_t>(restored_lo->value.offset));
+        } else if (const PcValue *builder = builders.builder(pair_lo)) {
+          if (builder->offset >= 0)
+            targets.push_back(static_cast<uint64_t>(builder->offset));
+        }
+        if (targets.empty()) {
+          bool complete = true;
+          for (const IndirectCallFixup &fixup : known_fixups) {
+            if (fixup.source_call_offset != inst.src_loc())
+              continue;
+            if (fixup.source_incomplete) {
+              complete = false;
+              break;
+            }
+            targets.push_back(fixup.source_target_offset);
+          }
+          if (!complete)
+            targets.clear();
+        }
+        const uint16_t destination = *facts.swappc_sdst;
+        builders.invalidate_pair(destination);
+        state.restored_sgprs.erase(destination);
+        state.restored_sgprs.erase(static_cast<uint16_t>(destination + 1));
+        publish_builders();
+        if (call_entry_state != nullptr)
+          *call_entry_state = state;
+        std::ranges::sort(targets);
+        targets.erase(std::ranges::unique(targets).begin(), targets.end());
+        std::optional<CalleeSummary> callee_summary;
+        if (!targets.empty()) {
+          std::optional<CalleeSummary> combined;
+          bool all_bounded = true;
+          for (uint64_t target : targets) {
+            auto summary = statically_bounded_callee_summary(
+                target, *facts.swappc_sdst, state.vgpr_msb_imm, state.gpr_idx_enabled);
+            if (!summary) {
+              all_bounded = false;
+              break;
+            }
+            if (combined)
+              *combined |= *summary;
+            else
+              combined = *summary;
+          }
+          if (all_bounded)
+            callee_summary = combined;
+        }
+        const auto survives_call = [&](uint16_t sgpr) {
+          return callee_summary ? !callee_summary->sgprs.test(sgpr) : is_callee_saved_sgpr(sgpr);
+        };
+        state.slots.erase_if([&](const auto &item) {
+          return callee_summary ? callee_summary->vgprs.test(item.first.vgpr)
+                                : !is_callee_saved_vgpr(item.first.vgpr);
+        });
+        state.restored_sgprs.erase_if([&](uint16_t sgpr) { return !survives_call(sgpr); });
+        const std::vector<uint16_t> active_pairs = builders.active_pairs();
+        for (uint16_t active_pair : active_pairs) {
+          if (!survives_call(active_pair) || !survives_call(static_cast<uint16_t>(active_pair + 1)))
+            builders.invalidate_pair(active_pair);
+        }
+        state.vgpr_msb_imm =
+            callee_summary ? callee_summary->return_mode : std::optional<uint8_t>{};
+        state.gpr_idx_enabled =
+            callee_summary ? callee_summary->return_gpr_idx_enabled : std::optional<bool>{};
       }
 
       // VGPR defs are decoded only to invalidate tracked slots; no slots makes
-      // this entire region a no-op.
+      // this entire region a no-op. Explicit destinations use MODE's DST bank,
+      // so a bank-zero scratch address in v[0:1] does not clobber a lane table
+      // in v[256:257]. Implicit definitions have no operand role from which to
+      // select a bank and therefore conservatively invalidate every bank with
+      // the same low selector.
       if (!state.slots.empty()) {
-        RegisterSet vgpr_defs;
+        if ((has_runtime_relative_destination(mnemonic) && mnemonic.starts_with("v_")) ||
+            (state.gpr_idx_enabled != std::optional<bool>{false} &&
+             has_explicit_vgpr_destination(inst))) {
+          state.slots.clear();
+        }
+        const auto erase_selector_in_all_banks = [&](uint16_t selector) {
+          state.slots.erase_if(
+              [&](const auto &item) { return (item.first.vgpr & 0xffu) == (selector & 0xffu); });
+        };
         for (int dst_index = 0; dst_index < inst.num_dst_operands(); ++dst_index) {
           const Operand *op = inst.dst_operand(dst_index);
           if (op == nullptr)
             continue;
-          if (auto ref = op->to_register_ref(); ref && ref->cls == RegClass::VGPR)
-            vgpr_defs.expand(*ref);
+          auto ref = op->to_register_ref();
+          if (!ref || ref->cls != RegClass::VGPR)
+            continue;
+          for (uint16_t lane = 0; lane < std::max<uint16_t>(1, ref->width); ++lane) {
+            const uint32_t selector = static_cast<uint32_t>(ref->index) + lane;
+            if (selector >= 256) {
+              erase_selector_in_all_banks(static_cast<uint16_t>(selector));
+              continue;
+            }
+            const auto physical =
+                physical_vgpr(static_cast<uint16_t>(selector), op->vgpr_msb_role());
+            if (physical) {
+              state.slots.erase_if([&](const auto &item) { return item.first.vgpr == *physical; });
+            } else {
+              erase_selector_in_all_banks(static_cast<uint16_t>(selector));
+            }
+          }
         }
-        inst.implicit_defs(vgpr_defs);
-        vgpr_defs.for_each([&](RegisterRef ref) {
+        RegisterSet implicit_defs;
+        inst.implicit_defs(implicit_defs);
+        implicit_defs.for_each([&](RegisterRef ref) {
           if (ref.cls != RegClass::VGPR)
             return;
-          // Operand metadata does not expose a role for every implicit/wide def.
-          // Conservatively invalidate every physical bank sharing this selector.
-          std::erase_if(state.slots, [&](const auto &item) {
-            return (item.first.vgpr & 0xffu) == (ref.index & 0xffu);
-          });
+          erase_selector_in_all_banks(ref.index);
         });
       }
 
       if (!builders.active_pairs().empty())
         invalidate_written_sgprs(ctx, index, builders);
 
-      if (changes_vgpr_msb_bank(mnemonic)) {
-        if (mnemonic == "s_set_vgpr_msb") {
-          if (const auto *imm = inst.src_operand(0))
-            state.vgpr_msb_imm = static_cast<uint8_t>(imm->encoding_value() & 0xffu);
-          else
-            state.vgpr_msb_imm = std::nullopt;
-        } else {
-          // Without scalar constant propagation, a SETREG write to MODE makes
-          // the operand-bank mapping unknown. Physical slots remain intact.
-          state.vgpr_msb_imm = std::nullopt;
-        }
+      if (has_runtime_relative_destination(mnemonic) && mnemonic.starts_with("s_")) {
+        state.restored_sgprs.clear();
+        for (uint16_t pair_lo : builders.active_pairs())
+          builders.invalidate_pair(pair_lo);
       }
+
+      if (copied_pair) {
+        const uint16_t pair_lo = copied_pair->first;
+        state.restored_sgprs.set(pair_lo,
+                                 StashedPcHalf{.value = copied_pair->second, .high = false});
+        state.restored_sgprs.set(static_cast<uint16_t>(pair_lo + 1),
+                                 StashedPcHalf{.value = copied_pair->second, .high = true});
+      }
+
+      update_vgpr_mode(state.vgpr_msb_imm, inst, ctx.text);
+      update_gpr_idx_enabled(state.gpr_idx_enabled, inst, ctx.text);
     }
+    publish_builders();
     return state;
   };
 
@@ -2226,6 +2989,51 @@ void recover_vector_lane_stashed_pcs(AnalysisContext &ctx, const std::vector<Ana
   for (size_t block_index = 0; block_index < blocks.size(); ++block_index) {
     for (size_t successor : blocks[block_index].successors)
       predecessors[successor].push_back(block_index);
+  }
+
+  // A call block has two different outgoing states: the callee sees the
+  // pre-call register state, while the fallthrough continuation sees the
+  // summarized return state. AnalysisBlock stores both as ordinary successors,
+  // so classify target edges here and select the matching state during meet.
+  std::unordered_map<size_t, CallEdgeInfo> call_edges;
+  for (size_t block_index = 0; block_index < blocks.size(); ++block_index) {
+    const AnalysisBlock &block = blocks[block_index];
+    const Instruction &term = *ctx.insts[block.last_index];
+    const InstructionFacts &facts = ctx.facts[block.last_index];
+    if (!facts.call_sdst && !facts.swappc_sdst)
+      continue;
+    CallEdgeInfo &call = call_edges[block_index];
+    const uint64_t next_offset = term.src_loc() + static_cast<uint64_t>(term.size());
+    if (const auto next = instruction_by_offset.find(next_offset);
+        next != instruction_by_offset.end() && block_for_instruction[next->second] != blocks.size())
+      call.continuation_successor = block_for_instruction[next->second];
+    if (!facts.call_sdst)
+      continue;
+    const auto delta = term.branch_offset_bytes();
+    if (!delta || static_cast<int64_t>(next_offset) + *delta < 0)
+      continue;
+    const uint64_t target = static_cast<uint64_t>(static_cast<int64_t>(next_offset) + *delta);
+    if (const auto entry = instruction_by_offset.find(target);
+        entry != instruction_by_offset.end() &&
+        block_for_instruction[entry->second] != blocks.size())
+      call.target_successors.insert(block_for_instruction[entry->second]);
+  }
+  // Every known source offset was added as a leader before these blocks were
+  // built, so a recovered call is the first instruction in its source block
+  // and this classification matches add_recovered_successors(). Incomplete
+  // targets are still useful here: extra predecessor edges only weaken the
+  // entry-state meet.
+  for (const IndirectCallFixup &fixup : known_fixups) {
+    if (!fixup.source_is_call)
+      continue;
+    const auto source = instruction_by_offset.find(fixup.source_call_offset);
+    const auto target = instruction_by_offset.find(fixup.source_target_offset);
+    if (source == instruction_by_offset.end() || target == instruction_by_offset.end())
+      continue;
+    const size_t source_block = block_for_instruction[source->second];
+    const size_t target_block = block_for_instruction[target->second];
+    if (source_block < blocks.size() && target_block < blocks.size())
+      call_edges[source_block].target_successors.insert(target_block);
   }
 
   std::vector<VectorLaneFlowState> entry_states(blocks.size());
@@ -2236,7 +3044,17 @@ void recover_vector_lane_stashed_pcs(AnalysisContext &ctx, const std::vector<Ana
   for (size_t block_index = 0; block_index < blocks.size(); ++block_index)
     worklist.push_back(block_index);
 
+  const auto state_units = [](const VectorLaneFlowState &state) {
+    return state.slots.size() + state.restored_sgprs.size();
+  };
+  size_t worklist_visits = 0;
+  const size_t max_worklist_visits = std::max<size_t>(4096, blocks.size() * 64);
   while (!worklist.empty()) {
+    // Exact-summary selection is intentionally fail-closed, but switching
+    // between a state-derived target and the ABI fallback is not monotone.
+    // Abandon this optional recovery if malformed control flow oscillates.
+    if (++worklist_visits > max_worklist_visits)
+      return;
     const size_t block_index = worklist.front();
     worklist.pop_front();
     on_worklist[block_index] = 0;
@@ -2244,25 +3062,35 @@ void recover_vector_lane_stashed_pcs(AnalysisContext &ctx, const std::vector<Ana
     VectorLaneFlowState new_entry;
     bool new_reachable = false;
     bool have_predecessor_state = false;
+    const auto meet_predecessor = [&](const VectorLaneFlowState &incoming) {
+      new_reachable = true;
+      if (!have_predecessor_state) {
+        new_entry = incoming;
+        have_predecessor_state = true;
+        return;
+      }
+      new_entry.slots.intersect_with(incoming.slots);
+      new_entry.restored_sgprs.intersect_with(incoming.restored_sgprs);
+      if (new_entry.vgpr_msb_imm != incoming.vgpr_msb_imm)
+        new_entry.vgpr_msb_imm = std::nullopt;
+      if (new_entry.gpr_idx_enabled != incoming.gpr_idx_enabled)
+        new_entry.gpr_idx_enabled = std::nullopt;
+    };
     for (size_t predecessor : predecessors[block_index]) {
       if (!reachable[predecessor])
         continue;
-      new_reachable = true;
-      if (!have_predecessor_state) {
-        new_entry = exit_states[predecessor];
-        have_predecessor_state = true;
-        continue;
-      }
-
-      for (auto it = new_entry.slots.begin(); it != new_entry.slots.end();) {
-        auto incoming = exit_states[predecessor].slots.find(it->first);
-        if (incoming == exit_states[predecessor].slots.end() || incoming->second != it->second)
-          it = new_entry.slots.erase(it);
+      const auto call = call_edges.find(predecessor);
+      const bool call_target =
+          call != call_edges.end() && call->second.target_successors.contains(block_index);
+      if (call_target) {
+        if (call->second.entry_state)
+          meet_predecessor(*call->second.entry_state);
         else
-          ++it;
+          meet_predecessor(VectorLaneFlowState{});
       }
-      if (new_entry.vgpr_msb_imm != exit_states[predecessor].vgpr_msb_imm)
-        new_entry.vgpr_msb_imm = std::nullopt;
+      if (!call_target ||
+          (call != call_edges.end() && call->second.continuation_successor == block_index))
+        meet_predecessor(exit_states[predecessor]);
     }
 
     // Generic callers conservatively infer predecessorless device-function
@@ -2274,27 +3102,69 @@ void recover_vector_lane_stashed_pcs(AnalysisContext &ctx, const std::vector<Ana
     if (is_analysis_root(block_index, external_entries, predecessors, entry_policy)) {
       new_reachable = true;
       VectorLaneFlowState external_entry;
-      if (external_entries[block_index] != 0)
+      if (external_entries[block_index] != 0) {
         external_entry.vgpr_msb_imm = uint8_t{0};
+        external_entry.gpr_idx_enabled = false;
+      }
       if (!have_predecessor_state) {
         new_entry = std::move(external_entry);
       } else {
         new_entry.slots.clear();
+        new_entry.restored_sgprs.clear();
         if (new_entry.vgpr_msb_imm != external_entry.vgpr_msb_imm)
           new_entry.vgpr_msb_imm = std::nullopt;
+        if (new_entry.gpr_idx_enabled != external_entry.gpr_idx_enabled)
+          new_entry.gpr_idx_enabled = std::nullopt;
       }
     }
     if (!new_reachable)
       continue;
 
-    VectorLaneFlowState new_exit = scan_block(blocks[block_index], new_entry, false);
+    std::optional<VectorLaneFlowState> new_call_entry;
+    VectorLaneFlowState new_exit =
+        scan_block(blocks[block_index], new_entry, false, &new_call_entry);
+    if (analysis_budget_exhausted)
+      return;
+    auto call = call_edges.find(block_index);
+    const bool call_entry_unchanged =
+        new_call_entry ? call != call_edges.end() && call->second.entry_state == new_call_entry
+                       : call == call_edges.end() || !call->second.entry_state;
     if (reachable[block_index] && entry_states[block_index] == new_entry &&
-        exit_states[block_index] == new_exit)
+        exit_states[block_index] == new_exit && call_entry_unchanged)
       continue;
+
+    // Count logical facts rather than unique COW allocations. This makes the
+    // limit independent of sharing details and bounds both lane and restored
+    // SGPR state together with the summary-cache units already retained.
+    size_t next_retained_state_units = retained_state_units;
+    const auto replace_fact_count = [&](size_t old_count, size_t new_count) {
+      assert(next_retained_state_units >= old_count);
+      next_retained_state_units -= old_count;
+      if (new_count >
+          kMaxRetainedAnalysisUnits - retained_summary_units - next_retained_state_units)
+        return false;
+      next_retained_state_units += new_count;
+      return true;
+    };
+    if (!replace_fact_count(state_units(entry_states[block_index]), state_units(new_entry)) ||
+        !replace_fact_count(state_units(exit_states[block_index]), state_units(new_exit)))
+      return;
+    if (call != call_edges.end()) {
+      const size_t old_call_count =
+          call->second.entry_state ? state_units(*call->second.entry_state) : 0;
+      const size_t new_call_count = new_call_entry ? state_units(*new_call_entry) : 0;
+      if (!replace_fact_count(old_call_count, new_call_count))
+        return;
+    }
 
     reachable[block_index] = 1;
     entry_states[block_index] = std::move(new_entry);
     exit_states[block_index] = std::move(new_exit);
+    if (call != call_edges.end())
+      call->second.entry_state = std::move(new_call_entry);
+    else
+      assert(!new_call_entry);
+    retained_state_units = next_retained_state_units;
     for (size_t successor : blocks[block_index].successors) {
       if (on_worklist[successor])
         continue;
@@ -2314,8 +3184,13 @@ void recover_vector_lane_stashed_pcs(AnalysisContext &ctx, const std::vector<Ana
         break;
       }
     }
-    if (has_consumer)
-      (void)scan_block(block, entry_states[block_index], true);
+    if (has_consumer) {
+      (void)scan_block(block, entry_states[block_index], true, nullptr);
+      if (analysis_budget_exhausted) {
+        recovered.resize(initial_recovered_size);
+        return;
+      }
+    }
   }
 }
 
@@ -2457,8 +3332,8 @@ std::optional<uint16_t> s_call_sdst(const Instruction &inst, uint32_t word) {
     // edges proven in earlier rounds. Keep the sorted explicit entries separate
     // from leaders: recovered targets become reachable through those edges, not
     // by being promoted to external roots.
-    recover_vector_lane_stashed_pcs(ctx, blocks, iteration_recovered, sorted_extra_leaders,
-                                    entry_policy);
+    recover_vector_lane_stashed_pcs(ctx, blocks, recovered, iteration_recovered,
+                                    sorted_extra_leaders, entry_policy);
     // Recovered leaders can split a block between rounds, which changes where a
     // builder's block-exit value is observed. Keep only the final round's view
     // so the published records are internally consistent with one CFG.
@@ -2503,6 +3378,12 @@ std::optional<uint16_t> s_call_sdst(const Instruction &inst, uint32_t word) {
 
 bool is_callee_saved_vgpr(uint16_t phys_vgpr) {
   return phys_vgpr >= 40 && phys_vgpr <= 255 && ((phys_vgpr - 40) % 16) < 8;
+}
+
+bool is_callee_saved_sgpr(uint16_t sgpr) {
+  // Intersection of CSR_AMDGPU_SGPRs and CSR_AMDGPU_SI_Gfx_SGPRs.
+  return (sgpr >= 30 && sgpr <= 31) || (sgpr >= 64 && sgpr <= 71) || (sgpr >= 80 && sgpr <= 87) ||
+         (sgpr >= 96 && sgpr <= 105);
 }
 
 std::vector<IndirectCallFixup> discover_indirect_branch_edges(

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.h
@@ -109,6 +109,26 @@ struct PcAddressBuilder {
   friend bool operator==(const PcAddressBuilder &, const PcAddressBuilder &) = default;
 };
 
+/// @brief Whether an AMDGPU physical VGPR is callee-saved by the ABI.
+///
+/// @details A callee-saved VGPR keeps its value across a call, so a value stashed
+/// there is still the caller's after the callee returns. @p phys_vgpr is the
+/// resolved physical index; gfx1250 VGPR_MSB banking can push it past 255, and the
+/// ABI table only covers v0-v255, so a banked register above that range is not
+/// proven callee-saved and reports false. The default device and graphics
+/// conventions share this VGPR set, so unlike the SGPR rule below no explicit
+/// intersection is necessary.
+[[nodiscard]] bool is_callee_saved_vgpr(uint16_t phys_vgpr);
+
+/// @brief Whether an SGPR is preserved by every AMDGPU calling convention the
+/// translator may encounter for a device function.
+///
+/// @details Code objects do not record whether a particular helper uses the
+/// default device convention or the graphics convention. This predicate uses
+/// their intersection, so an unsummarized call cannot preserve a stale value
+/// merely because one convention saves the register.
+[[nodiscard]] bool is_callee_saved_sgpr(uint16_t sgpr);
+
 /// @brief Discover concrete targets for statically-built setpc/swappc consumers.
 ///
 /// @details This pass runs before BasicBlock storage is finalized because any
@@ -140,15 +160,6 @@ struct PcAddressBuilder {
 ///        section actually contains a recoverable indirect consumer, because a
 ///        section with no dynamic transfer has no stale-PC branch hazard to
 ///        prove anything about.
-/// @brief Whether an AMDGPU physical VGPR is callee-saved by the ABI.
-///
-/// @details A callee-saved VGPR keeps its value across a call, so a value stashed
-/// there is still the caller's after the callee returns. @p phys_vgpr is the
-/// resolved physical index; gfx1250 VGPR_MSB banking can push it past 255, and the
-/// ABI table only covers v0-v255, so a banked register above that range is not
-/// proven callee-saved and reports false.
-[[nodiscard]] bool is_callee_saved_vgpr(uint16_t phys_vgpr);
-
 /// @returns Recovered indirect branch/call metadata.
 [[nodiscard]] std::vector<IndirectCallFixup> discover_indirect_branch_edges(
     std::span<const Instruction *const> insts, std::span<const uint8_t> text, rj_code_arch_t arch,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/vgpr_msb.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/vgpr_msb.h
@@ -7,7 +7,11 @@
 #ifndef ROCJITSU_ISA_ARCH_AMDGPU_SHARED_VGPR_MSB_H_
 #define ROCJITSU_ISA_ARCH_AMDGPU_SHARED_VGPR_MSB_H_
 
+#include <algorithm>
+#include <array>
+#include <cstddef>
 #include <cstdint>
+#include <optional>
 
 namespace rocjitsu {
 namespace amdgpu {
@@ -23,6 +27,123 @@ enum class VgprMsbRole : uint8_t {
 
 constexpr uint32_t VGPR_MSB_MODE_SHIFT = 12;
 constexpr uint32_t VGPR_MSB_MODE_MASK = 0xffu << VGPR_MSB_MODE_SHIFT;
+constexpr uint16_t MODE_HWREG = 1;
+constexpr size_t VGPR_MSB_ROLE_COUNT = 4;
+
+/// @brief Known bank for each role in S_SET_VGPR_MSB field order.
+using VgprMsbBanks = std::array<std::optional<uint8_t>, VGPR_MSB_ROLE_COUNT>;
+
+/// @brief Return the packed S_SET_VGPR_MSB field index for an operand role.
+///
+/// A missing role is deliberately unknown rather than bank zero: explicit
+/// operands must declare how MODE selects their physical register.
+[[nodiscard]] constexpr std::optional<size_t> vgpr_msb_role_index(VgprMsbRole role) {
+  switch (role) {
+  case VgprMsbRole::Src0:
+    return 0;
+  case VgprMsbRole::Src1:
+    return 1;
+  case VgprMsbRole::Src2:
+    return 2;
+  case VgprMsbRole::Dst:
+    return 3;
+  case VgprMsbRole::None:
+    return std::nullopt;
+  }
+  return std::nullopt;
+}
+
+/// @brief Resolve one operand role from a packed S_SET_VGPR_MSB value.
+[[nodiscard]] constexpr std::optional<uint8_t> vgpr_msb_bank_for_role(std::optional<uint8_t> value,
+                                                                      VgprMsbRole role) {
+  const auto index = vgpr_msb_role_index(role);
+  if (!value || !index)
+    return std::nullopt;
+  return static_cast<uint8_t>((*value >> (2 * *index)) & 0x3u);
+}
+
+/// @brief Decoded fields of an S_SETREG* HWREG immediate.
+struct HwregSlice {
+  uint16_t id;
+  uint16_t begin;
+  uint16_t width;
+};
+
+/// @brief Decode HWREG id[5:0], offset[10:6], and size-1[15:11].
+[[nodiscard]] constexpr HwregSlice decode_vgpr_msb_hwreg(uint16_t hwreg) {
+  return HwregSlice{.id = static_cast<uint16_t>(hwreg & 0x3f),
+                    .begin = static_cast<uint16_t>((hwreg >> 6) & 0x1f),
+                    .width = static_cast<uint16_t>(((hwreg >> 11) & 0x1f) + 1)};
+}
+
+/// @brief Apply one right-justified S_SETREG value to MODE.VGPR_MSB fields.
+///
+/// @details Dynamic writes pass std::nullopt and make only overlapping bank
+/// fields unknown. Immediate writes replace the requested bit slice while
+/// preserving every disjoint field and any known untouched bit. S_SETREG
+/// sources are right-justified to the requested HWREG slice, matching the
+/// generic HWREG insertion used by the execution model.
+inline void apply_vgpr_msb_mode_write(VgprMsbBanks &banks, uint16_t hwreg,
+                                      std::optional<uint32_t> value) {
+  constexpr std::array<uint8_t, VGPR_MSB_ROLE_COUNT> mode_bit_offset = {14, 16, 18, 12};
+  const HwregSlice slice = decode_vgpr_msb_hwreg(hwreg);
+  const uint16_t begin = slice.begin;
+  if (slice.id != MODE_HWREG || begin >= 32)
+    return;
+  const uint16_t width = std::min<uint16_t>(slice.width, static_cast<uint16_t>(32 - begin));
+  const uint16_t end = static_cast<uint16_t>(begin + width);
+
+  for (size_t role = 0; role < banks.size(); ++role) {
+    const uint16_t field_begin = mode_bit_offset[role];
+    const uint16_t field_end = static_cast<uint16_t>(field_begin + 2);
+    if (begin >= field_end || field_begin >= end)
+      continue;
+    if (!value) {
+      banks[role] = std::nullopt;
+      continue;
+    }
+
+    const uint16_t overlap_begin = std::max(begin, field_begin);
+    const uint16_t overlap_end = std::min(end, field_end);
+    if (overlap_begin == field_begin && overlap_end == field_end) {
+      const uint8_t source_bit = static_cast<uint8_t>(field_begin - begin);
+      banks[role] = static_cast<uint8_t>((*value >> source_bit) & 0x3u);
+      continue;
+    }
+    if (!banks[role])
+      continue;
+    uint8_t bank = *banks[role];
+    for (uint16_t mode_bit = overlap_begin; mode_bit < overlap_end; ++mode_bit) {
+      const uint8_t field_bit = static_cast<uint8_t>(mode_bit - field_begin);
+      const uint8_t source_bit = static_cast<uint8_t>(mode_bit - begin);
+      const uint8_t bit = static_cast<uint8_t>((*value >> source_bit) & 1u);
+      bank = static_cast<uint8_t>((bank & ~(uint8_t{1} << field_bit)) | (bit << field_bit));
+    }
+    banks[role] = bank;
+  }
+}
+
+/// @brief Expand a packed S_SET_VGPR_MSB byte into independently-known roles.
+[[nodiscard]] inline VgprMsbBanks unpack_vgpr_msb_banks(std::optional<uint8_t> value) {
+  VgprMsbBanks banks;
+  banks.fill(std::nullopt);
+  if (!value)
+    return banks;
+  for (size_t role = 0; role < banks.size(); ++role)
+    banks[role] = static_cast<uint8_t>((*value >> (2 * role)) & 0x3u);
+  return banks;
+}
+
+/// @brief Pack independently-known roles, or return unknown if any role is unknown.
+[[nodiscard]] inline std::optional<uint8_t> pack_vgpr_msb_banks(const VgprMsbBanks &banks) {
+  uint8_t value = 0;
+  for (size_t role = 0; role < banks.size(); ++role) {
+    if (!banks[role])
+      return std::nullopt;
+    value = static_cast<uint8_t>(value | (*banks[role] << (2 * role)));
+  }
+  return value;
+}
 
 /// @brief Convert S_SET_VGPR_MSB layout to MODE[19:12] layout.
 ///

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -2196,6 +2196,50 @@ TEST(CfgAnalysis, Gfx1250WideVgprWriteInvalidatesStashedLane) {
   EXPECT_EQ(total_fixups, 0u);
 }
 
+TEST(CfgAnalysis, Gfx1250ExplicitVgprWriteInvalidatesOnlyItsDestinationBank) {
+  // Keep the lane stash in physical v256, temporarily switch the destination
+  // bank to zero for a wide write to v[0:1], then select physical v256 as the
+  // readlane source. The explicit bank-zero write must not invalidate the
+  // bank-one lane table.
+  constexpr auto set_dst_bank_one = cdna5::build_sopp(cdna5::kSSetVgprMsbSopp, {.simm16 = 0x40});
+  constexpr auto set_bank_zero = cdna5::build_sopp(cdna5::kSSetVgprMsbSopp, {.simm16 = 0});
+  constexpr auto set_src0_bank_one = cdna5::build_sopp(cdna5::kSSetVgprMsbSopp, {.simm16 = 1});
+  constexpr auto write_bank_zero =
+      cdna5::build_vop3(cdna5::kVMovB64Vop3, {.vdst = 0, .src0 = 256 + 2});
+  std::vector<uint32_t> words = {
+      0xBE804700u, // 0x00: s_get_pc_i64 s[0:1].
+      0xA980FE00u,
+      72u,
+      0u,                  // 0x04: s_add_nc_u64 ..., lit64(72) -> target 0x4c.
+      set_dst_bank_one[0], // 0x10: destination operands select bank one.
+      0xD7610000u,
+      0x02010000u, // 0x14: v_writelane_b32 physical v256, s0, 0.
+      0xD7610000u,
+      0x02010201u,      // 0x1c: v_writelane_b32 physical v256, s1, 1.
+      set_bank_zero[0], // 0x24: explicit destinations select bank zero.
+      write_bank_zero[0],
+      write_bank_zero[1],   // 0x28: v_mov_b64 physical v[0:1], v[2:3].
+      set_src0_bank_one[0], // 0x30: source-zero operands select bank one.
+      0xD7600000u,
+      0x02010100u, // 0x34: v_readlane_b32 s0, physical v256, 0.
+      0xD7600001u,
+      0x02010300u,                                // 0x3c: s1 <- physical v256 lane 1.
+      0xBE9E4900u,                                // 0x44: s_swap_pc_i64 s[30:31], s[0:1].
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x48: continuation.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x4c: target.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+
+  auto *consumer = block_starting_at(blocks, 68);
+  ASSERT_NE(consumer, nullptr);
+  ASSERT_EQ(consumer->static_indirect_call_fixups().size(), 1u);
+  EXPECT_EQ(consumer->static_indirect_call_fixups()[0].source_target_offset, 76u);
+}
+
 TEST(CfgAnalysis, Gfx1250CarriesLaneStashAcrossProvenBlockBoundary) {
   // Same stash idiom, but an unconditional branch separates the writelane stashes
   // from the readlane/swappc consumer. The sole predecessor carries the identical
@@ -2367,6 +2411,175 @@ TEST(CfgAnalysis, Gfx1250DirectCallKillsCarriedLaneStash) {
   EXPECT_EQ(total_fixups, 0u);
 }
 
+TEST(CfgAnalysis, Gfx1250ExactCalleeSummaryPreservesUnwrittenCallerSavedLaneStash) {
+  constexpr uint16_t kReturnSreg = 30;
+  constexpr auto unrelated_write = cdna5::build_vop1(cdna5::kVMovB32Vop1, {.src0 = 128, .vdst = 2});
+  for (const uint16_t stash_vgpr : {uint16_t{48}, uint16_t{192}}) {
+    SCOPED_TRACE(stash_vgpr);
+    std::vector<uint32_t> words = {
+        0xBE804700u, // 0x00: s_get_pc_i64 s[0:1].
+        0xA980FE00u, 56u,
+        0u, // 0x04: s_add_nc_u64 ..., lit64(56) -> target 0x3c.
+        0xD7610000u | stash_vgpr,
+        0x02010000u, // 0x10: v_writelane_b32 stash_vgpr, s0, 0.
+        0xD7610000u | stash_vgpr,
+        0x02010201u, // 0x18: v_writelane_b32 stash_vgpr, s1, 1.
+        rocjitsu::build_s_call_b64(kReturnSreg, 7, ROCJITSU_CODE_ARCH_GFX1250),
+        // 0x20: direct call -> callee at 0x40.
+        0xD7600000u,
+        0x02010100u | stash_vgpr, // 0x24: continuation reads the low half.
+        0xD7600001u,
+        0x02010300u | stash_vgpr,                   // 0x2c: reads the high half.
+        0xBE9E4900u,                                // 0x34: recovered s_swap_pc_i64.
+        build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x38: continuation.
+        build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x3c: stashed target.
+        unrelated_write[0],                         // 0x40: callee writes only v2.
+        rocjitsu::build_s_setpc_b64(kReturnSreg, ROCJITSU_CODE_ARCH_GFX1250),
+        // 0x44: callee return.
+    };
+
+    TestCodeObject co(std::move(words));
+    auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+    ASSERT_NE(decoder, nullptr);
+    auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+
+    const IndirectCallFixup *continuation_fixup = nullptr;
+    for (const auto &block : blocks) {
+      for (const auto &fixup : block->static_indirect_call_fixups()) {
+        if (fixup.source_call_offset == 52)
+          continuation_fixup = &fixup;
+      }
+    }
+    ASSERT_NE(continuation_fixup, nullptr);
+    EXPECT_EQ(continuation_fixup->source_target_offset, 60u);
+  }
+}
+
+TEST(CfgAnalysis, Gfx1250RelativeVgprDestinationDisablesExactCalleeSummary) {
+  constexpr uint16_t kReturnSreg = 30;
+  constexpr auto relative_write =
+      cdna5::build_vop1(cdna5::kVMovreldB32Vop1, {.src0 = 0, .vdst = 2});
+  std::vector<uint32_t> words = {
+      0xBE804700u, // 0x00: s_get_pc_i64 s[0:1].
+      0xA980FE00u, 56u,
+      0u, // 0x04: s_add_nc_u64 ..., lit64(56) -> target 0x3c.
+      0xD7610030u,
+      0x02010000u, // 0x10: v_writelane_b32 v48, s0, 0.
+      0xD7610030u,
+      0x02010201u, // 0x18: v_writelane_b32 v48, s1, 1.
+      rocjitsu::build_s_call_b64(kReturnSreg, 7, ROCJITSU_CODE_ARCH_GFX1250),
+      // 0x20: direct call -> callee at 0x40.
+      0xD7600000u,
+      0x02010130u, // 0x24: continuation reads the low half.
+      0xD7600001u,
+      0x02010330u,                                // 0x2c: reads the high half.
+      0xBE9E4900u,                                // 0x34: must not use a stale target.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x38: continuation.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x3c: stale target.
+      relative_write[0],                          // 0x40: runtime-selected VGPR destination.
+      rocjitsu::build_s_setpc_b64(kReturnSreg, ROCJITSU_CODE_ARCH_GFX1250),
+      // 0x44: callee return.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+
+  for (const auto &block : blocks) {
+    EXPECT_TRUE(std::ranges::none_of(
+        block->static_indirect_call_fixups(),
+        [](const IndirectCallFixup &fixup) { return fixup.source_call_offset == 52; }));
+  }
+}
+
+TEST(CfgAnalysis, Gfx1250GprIndexedVgprDestinationDisablesExactCalleeSummary) {
+  constexpr uint16_t kReturnSreg = 30;
+  constexpr uint16_t kModeGprIdxEnable = 1u | (27u << 6);
+  constexpr auto enable_with_literal =
+      cdna5::build_sopk(cdna5::kSSetregImm32B32Sopk, {.simm16 = kModeGprIdxEnable});
+  constexpr auto enable_dynamically =
+      cdna5::build_sopk(cdna5::kSSetregB32Sopk, {.simm16 = kModeGprIdxEnable, .sdst = 0});
+  constexpr auto ordinary_write = cdna5::build_vop1(cdna5::kVMovB32Vop1, {.src0 = 128, .vdst = 2});
+
+  for (std::vector<uint32_t> callee :
+       {std::vector<uint32_t>{enable_with_literal[0], 1u, ordinary_write[0]},
+        std::vector<uint32_t>{enable_dynamically[0], ordinary_write[0]}}) {
+    std::vector<uint32_t> words = {
+        0xBE804700u, // 0x00: s_get_pc_i64 s[0:1].
+        0xA980FE00u, 56u,
+        0u, // 0x04: s_add_nc_u64 ..., lit64(56) -> target 0x3c.
+        0xD7610030u,
+        0x02010000u, // 0x10: v_writelane_b32 v48, s0, 0.
+        0xD7610030u,
+        0x02010201u, // 0x18: v_writelane_b32 v48, s1, 1.
+        rocjitsu::build_s_call_b64(kReturnSreg, 7, ROCJITSU_CODE_ARCH_GFX1250),
+        // 0x20: direct call -> callee at 0x40.
+        0xD7600000u,
+        0x02010130u, // 0x24: continuation reads the low half.
+        0xD7600001u,
+        0x02010330u,                                // 0x2c: reads the high half.
+        0xBE9E4900u,                                // 0x34: must not use a stale target.
+        build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x38: continuation.
+        build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x3c: stale target.
+    };
+    words.insert(words.end(), callee.begin(), callee.end());
+    words.push_back(rocjitsu::build_s_setpc_b64(kReturnSreg, ROCJITSU_CODE_ARCH_GFX1250));
+
+    TestCodeObject co(std::move(words));
+    auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+    ASSERT_NE(decoder, nullptr);
+    auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+
+    for (const auto &block : blocks) {
+      EXPECT_TRUE(std::ranges::none_of(
+          block->static_indirect_call_fixups(),
+          [](const IndirectCallFixup &fixup) { return fixup.source_call_offset == 52; }));
+    }
+  }
+}
+
+TEST(CfgAnalysis, Gfx1250RelativeSgprDestinationDisablesExactCalleeSummary) {
+  constexpr uint16_t kReturnSreg = 30;
+  constexpr uint16_t kRestoredPair = 20;
+  constexpr auto relative_write =
+      cdna5::build_sop1(cdna5::kSMovreldB32Sop1, {.ssrc0 = 2, .sdst = 8});
+  std::vector<uint32_t> words = {
+      0xBE804700u, // 0x00: s_get_pc_i64 s[0:1].
+      0xA980FE00u, 64u,
+      0u, // 0x04: s_add_nc_u64 ..., lit64(64) -> target 0x44.
+      0xD761002Cu,
+      0x02010000u, // 0x10: v_writelane_b32 v44, s0, 0.
+      0xD761002Cu,
+      0x02010201u, // 0x18: v_writelane_b32 v44, s1, 1.
+      0xD7600000u | kRestoredPair,
+      0x0201012Cu, // 0x20: v_readlane_b32 s20, v44, 0.
+      0xD7600000u | static_cast<uint16_t>(kRestoredPair + 1),
+      0x0201032Cu, // 0x28: v_readlane_b32 s21, v44, 1.
+      rocjitsu::build_s_call_b64(kReturnSreg, 4, ROCJITSU_CODE_ARCH_GFX1250),
+      // 0x30: direct call -> callee at 0x44.
+      rocjitsu::build_s_swappc_b64(kReturnSreg, kRestoredPair, ROCJITSU_CODE_ARCH_GFX1250),
+      // 0x34: must not use a possibly overwritten restored pair.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x38: continuation.
+      build_s_nop(0, ROCJITSU_CODE_ARCH_GFX1250), // 0x3c: padding.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x40: padding.
+      relative_write[0],                          // 0x44: runtime-selected SGPR destination.
+      rocjitsu::build_s_setpc_b64(kReturnSreg, ROCJITSU_CODE_ARCH_GFX1250),
+      // 0x48: callee return.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+
+  for (const auto &block : blocks) {
+    EXPECT_TRUE(std::ranges::none_of(
+        block->static_indirect_call_fixups(),
+        [](const IndirectCallFixup &fixup) { return fixup.source_call_offset == 52; }));
+  }
+}
+
 TEST(CfgAnalysis, Gfx1250CalleeSavedLaneStashSurvivesDirectCall) {
   // Same shape as Gfx1250DirectCallKillsCarriedLaneStash, but the stash lives
   // in v44 (CALLEE-saved under CSR_AMDGPU_VGPRs). The synthetic callee writes
@@ -2412,17 +2625,21 @@ TEST(CfgAnalysis, Gfx1250CalleeSavedLaneStashSurvivesDirectCall) {
   EXPECT_EQ(continuation_fixup->source_target_offset, 60u); // 0x3c: the stashed target.
 }
 
-TEST(CfgAnalysis, Gfx1250BankedLaneStashDoesNotSurviveDirectCall) {
+TEST(CfgAnalysis, Gfx1250ExactCalleeSummaryPreservesBankedLaneStash) {
   // Select bank 1 for both DST and SRC0, so the v44 operands below consistently
-  // address physical v300. Although low selector v44 is callee-saved, the ABI
-  // table does not prove physical VGPRs above v255 are preserved. The call must
-  // therefore discard the stash rather than mask v300 down to v44.
+  // address physical v300. The ABI table does not cover physical VGPRs above
+  // v255. This local callee has a complete CFG and writes the same low selector
+  // only after selecting bank zero, so its exact physical-register summary
+  // proves that the bank-one stash survives.
   //
   // s_set_vgpr_msb immediate byte is {DST[7:6], SRC2[5:4], SRC1[3:2], SRC0[1:0]};
   // 0x41 selects bank 1 for DST and SRC0.
   constexpr uint16_t kReturnSreg = 30;
   constexpr auto set_dst_src0_bank_one =
       cdna5::build_sopp(cdna5::kSSetVgprMsbSopp, {.simm16 = 0x41});
+  constexpr auto set_all_banks_zero = cdna5::build_sopp(cdna5::kSSetVgprMsbSopp, {.simm16 = 0});
+  constexpr auto clobber_bank_zero =
+      cdna5::build_vop1(cdna5::kVMovB32Vop1, {.src0 = 128, .vdst = 44});
   std::vector<uint32_t> words = {
       0xBE804700u, // 0x00: s_get_pc_i64 s[0:1].
       0xA980FE00u, 60u,
@@ -2438,12 +2655,14 @@ TEST(CfgAnalysis, Gfx1250BankedLaneStashDoesNotSurviveDirectCall) {
       0x0201012Cu, // 0x28: continuation reads physical v300 lane 0.
       0xD7600001u,
       0x0201032Cu,                                // 0x30: reads physical v300 lane 1.
-      0xBE9E4900u,                                // 0x38: must remain dynamic.
+      0xBE9E4900u,                                // 0x38: recovered from physical v300.
       build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x3c: continuation.
       build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x40: stale target.
-      build_s_nop(0, ROCJITSU_CODE_ARCH_GFX1250), // 0x44: conforming callee body.
+      set_all_banks_zero[0],                      // 0x44: callee selects physical v44, not v300.
+      clobber_bank_zero[0],                       // 0x48: same low selector in a different bank.
+      set_dst_src0_bank_one[0],                   // 0x4c: restore the caller's bank selectors.
       rocjitsu::build_s_setpc_b64(kReturnSreg, ROCJITSU_CODE_ARCH_GFX1250),
-      // 0x48: callee return.
+      // 0x50: callee return.
   };
 
   TestCodeObject co(std::move(words));
@@ -2451,10 +2670,55 @@ TEST(CfgAnalysis, Gfx1250BankedLaneStashDoesNotSurviveDirectCall) {
   ASSERT_NE(decoder, nullptr);
   auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
 
-  size_t total_fixups = 0;
-  for (const auto &block : blocks)
-    total_fixups += block->static_indirect_call_fixups().size();
-  EXPECT_EQ(total_fixups, 0u);
+  const IndirectCallFixup *continuation_fixup = nullptr;
+  for (const auto &block : blocks) {
+    for (const auto &fixup : block->static_indirect_call_fixups()) {
+      if (fixup.source_call_offset == 56)
+        continuation_fixup = &fixup;
+    }
+  }
+  ASSERT_NE(continuation_fixup, nullptr);
+  EXPECT_EQ(continuation_fixup->source_target_offset, 64u);
+}
+
+TEST(CfgAnalysis, Gfx1250CalleeModeChangeInvalidatesContinuationBankSelection) {
+  constexpr uint16_t kReturnSreg = 30;
+  constexpr auto set_dst_src0_bank_one =
+      cdna5::build_sopp(cdna5::kSSetVgprMsbSopp, {.simm16 = 0x41});
+  constexpr auto set_all_banks_zero = cdna5::build_sopp(cdna5::kSSetVgprMsbSopp, {.simm16 = 0});
+  std::vector<uint32_t> words = {
+      0xBE804700u, // 0x00: s_get_pc_i64 s[0:1].
+      0xA980FE00u, 56u,
+      0u,                       // 0x04: target 0x3c.
+      set_dst_src0_bank_one[0], // 0x10: v44 resolves to physical v300.
+      0xD761002Cu,
+      0x02010000u, // 0x14: stash low half in physical v300.
+      0xD761002Cu,
+      0x02010201u, // 0x1c: stash high half in physical v300.
+      rocjitsu::build_s_call_b64(kReturnSreg, 7, ROCJITSU_CODE_ARCH_GFX1250),
+      // 0x24: direct call -> callee at 0x44.
+      0xD7600000u,
+      0x0201012Cu, // 0x28: MODE now maps this read to physical v44.
+      0xD7600001u,
+      0x0201032Cu,                                // 0x30: reads physical v44, not the stash.
+      0xBE9E4900u,                                // 0x38: must not recover a stale target.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x3c: would-be target.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x40: continuation.
+      set_all_banks_zero[0],                      // 0x44: persistent MODE change in callee.
+      rocjitsu::build_s_setpc_b64(kReturnSreg, ROCJITSU_CODE_ARCH_GFX1250),
+      // 0x48: callee return without restoring MODE.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+
+  for (const auto &block : blocks) {
+    EXPECT_TRUE(std::ranges::none_of(
+        block->static_indirect_call_fixups(),
+        [](const IndirectCallFixup &fixup) { return fixup.source_call_offset == 56; }));
+  }
 }
 
 TEST(CfgAnalysis, Gfx1250IndirectCallKillsCarriedLaneStash) {
@@ -2702,6 +2966,547 @@ TEST(CfgAnalysis, Gfx1250A0UsesLowByteOfVgprMsb) {
   ASSERT_NE(consumer, nullptr);
   ASSERT_EQ(consumer->static_indirect_call_fixups().size(), 1u);
   EXPECT_EQ(consumer->static_indirect_call_fixups()[0].source_target_offset, 60u);
+}
+
+TEST(CfgAnalysis, Gfx1250ImmediateModeWriteKeepsLaneStashBankKnown) {
+  // The hipTensor dispatcher writes WAVE_MODE bit 25 before restoring a
+  // PC from fixed VGPR lanes. The write is disjoint from MODE.VGPR_MSB, so a
+  // lane stash in bank one remains in physical v300 and is still recoverable.
+  constexpr auto set_dst_src0_bank_one =
+      cdna5::build_sopp(cdna5::kSSetVgprMsbSopp, {.simm16 = 0x41});
+  constexpr uint16_t kModeBit25Hwreg = 1u | (25u << 6);
+  constexpr auto set_mode_bit25 =
+      cdna5::build_sopk(cdna5::kSSetregImm32B32Sopk, {.simm16 = kModeBit25Hwreg});
+  std::vector<uint32_t> words = {
+      0xBE804700u, // 0x00: s_get_pc_i64 s[0:1].
+      0xA980FE00u,
+      60u,
+      0u, // 0x04: s_add_nc_u64 ..., lit64(60) -> target 0x40.
+      set_dst_src0_bank_one[0],
+      0xD761002Cu,
+      0x02010000u, // 0x14: v_writelane_b32 physical v300, s0, 0.
+      0xD761002Cu,
+      0x02010201u, // 0x1c: v_writelane_b32 physical v300, s1, 1.
+      set_mode_bit25[0],
+      1u, // 0x24: s_setreg_imm32_b32 hwreg(WAVE_MODE, 25, 1), 1.
+      0xD7600000u,
+      0x0201012Cu, // 0x2c: v_readlane_b32 s0, physical v300, 0.
+      0xD7600001u,
+      0x0201032Cu,                                // 0x34: v_readlane_b32 s1, physical v300, 1.
+      0xBE9E4900u,                                // 0x3c: s_swap_pc_i64 s[30:31], s[0:1].
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x40: target/continuation.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+
+  auto *consumer = block_starting_at(blocks, 60);
+  ASSERT_NE(consumer, nullptr);
+  ASSERT_EQ(consumer->static_indirect_call_fixups().size(), 1u);
+  EXPECT_EQ(consumer->static_indirect_call_fixups()[0].source_target_offset, 64u);
+}
+
+TEST(CfgAnalysis, Gfx1250LaneRestoreReachesConsumerAcrossBranch) {
+  constexpr auto branch = cdna5::build_sopp(cdna5::kSBranchSopp, {.simm16 = 0});
+  std::vector<uint32_t> words = {
+      0xBE804700u, // 0x00: s_get_pc_i64 s[0:1].
+      0xA980FE00u,
+      56u,
+      0u, // 0x04: s_add_nc_u64 ..., lit64(56) -> target 0x3c.
+      0xD761002Cu,
+      0x02010000u, // 0x10: v_writelane_b32 v44, s0, 0.
+      0xD761002Cu,
+      0x02010201u, // 0x18: v_writelane_b32 v44, s1, 1.
+      0xD7600014u,
+      0x0201012Cu, // 0x20: v_readlane_b32 s20, v44, 0.
+      0xD7600015u,
+      0x0201032Cu,                                // 0x28: v_readlane_b32 s21, v44, 1.
+      branch[0],                                  // 0x30: split the restore and consumer blocks.
+      0xBE9E4914u,                                // 0x34: s_swap_pc_i64 s[30:31], s[20:21].
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x38: continuation.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x3c: target.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+
+  auto *consumer = block_starting_at(blocks, 52);
+  ASSERT_NE(consumer, nullptr);
+  ASSERT_EQ(consumer->static_indirect_call_fixups().size(), 1u);
+  EXPECT_EQ(consumer->static_indirect_call_fixups()[0].source_target_offset, 60u);
+}
+
+TEST(CfgAnalysis, Gfx1250PcPairCopyReachesConsumer) {
+  constexpr uint16_t kSourceSreg = 20;
+  constexpr uint16_t kCopiedSreg = 54;
+  constexpr uint16_t kReturnSreg = 30;
+  constexpr auto getpc = cdna5::build_sop1(cdna5::kSGetPcI64Sop1, {.sdst = kSourceSreg});
+  constexpr auto add = cdna5::build_sop2(cdna5::kSAddNcU64Sop2,
+                                         {.ssrc0 = kSourceSreg, .ssrc1 = 254, .sdst = kSourceSreg});
+  constexpr auto copy = cdna5::build_sop1(
+      cdna5::kSMovB64Sop1, {.ssrc0 = static_cast<uint8_t>(kSourceSreg), .sdst = kCopiedSreg});
+  std::vector<uint32_t> words = {
+      getpc[0], // 0x00: s_get_pc_i64 s[20:21].
+      add[0], 24u,
+      0u,      // 0x04: s_add_nc_u64 ..., lit64(24) -> target 0x1c.
+      copy[0], // 0x10: s_mov_b64 s[54:55], s[20:21].
+      rocjitsu::build_s_swappc_b64(kReturnSreg, kCopiedSreg, ROCJITSU_CODE_ARCH_GFX1250),
+      // 0x14: call through the copied pair.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x18: continuation.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x1c: target.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+
+  const IndirectCallFixup *copied_call = nullptr;
+  for (const auto &block : blocks) {
+    for (const auto &fixup : block->static_indirect_call_fixups()) {
+      if (fixup.source_call_offset == 20)
+        copied_call = &fixup;
+    }
+  }
+  ASSERT_NE(copied_call, nullptr);
+  EXPECT_EQ(copied_call->source_target_offset, 28u);
+}
+
+TEST(CfgAnalysis, Gfx1250DirectCallOverwritesPcBuilderInReturnPair) {
+  constexpr uint16_t kReturnSreg = 30;
+  constexpr auto getpc = cdna5::build_sop1(cdna5::kSGetPcI64Sop1, {.sdst = kReturnSreg});
+  constexpr auto add = cdna5::build_sop2(cdna5::kSAddNcU64Sop2,
+                                         {.ssrc0 = kReturnSreg, .ssrc1 = 254, .sdst = kReturnSreg});
+  std::vector<uint32_t> words = {
+      getpc[0], // 0x00: s_get_pc_i64 s[30:31].
+      add[0], 32u,
+      0u, // 0x04: s_add_nc_u64 ..., lit64(32) -> stale target 0x24.
+      rocjitsu::build_s_call_b64(kReturnSreg, 2, ROCJITSU_CODE_ARCH_GFX1250),
+      // 0x10: direct call overwrites s[30:31] and enters 0x1c.
+      rocjitsu::build_s_swappc_b64(40, kReturnSreg, ROCJITSU_CODE_ARCH_GFX1250),
+      // 0x14: s[30:31] contains the return PC, not the old builder.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x18: continuation.
+      build_s_nop(0, ROCJITSU_CODE_ARCH_GFX1250), // 0x1c: callee body.
+      rocjitsu::build_s_setpc_b64(kReturnSreg, ROCJITSU_CODE_ARCH_GFX1250),
+      // 0x20: callee return.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x24: stale target.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+
+  for (const auto &block : blocks) {
+    EXPECT_TRUE(std::ranges::none_of(
+        block->static_indirect_call_fixups(),
+        [](const IndirectCallFixup &fixup) { return fixup.source_call_offset == 20; }));
+  }
+}
+
+TEST(CfgAnalysis, Gfx1250SwapPcOverwritesPcBuilderInReturnPair) {
+  constexpr uint16_t kTargetSreg = 0;
+  constexpr auto getpc = cdna5::build_sop1(cdna5::kSGetPcI64Sop1, {.sdst = kTargetSreg});
+  constexpr auto add = cdna5::build_sop2(cdna5::kSAddNcU64Sop2,
+                                         {.ssrc0 = kTargetSreg, .ssrc1 = 254, .sdst = kTargetSreg});
+  std::vector<uint32_t> words = {
+      getpc[0], // 0x00: s_get_pc_i64 s[0:1].
+      add[0], 24u,
+      0u, // 0x04: s_add_nc_u64 ..., lit64(24) -> callee at 0x1c.
+      rocjitsu::build_s_swappc_b64(kTargetSreg, kTargetSreg, ROCJITSU_CODE_ARCH_GFX1250),
+      // 0x10: call through s[0:1], then overwrite it with return PC 0x14.
+      rocjitsu::build_s_swappc_b64(30, kTargetSreg, ROCJITSU_CODE_ARCH_GFX1250),
+      // 0x14: must not reuse the pre-call target.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x18: continuation.
+      rocjitsu::build_s_setpc_b64(kTargetSreg, ROCJITSU_CODE_ARCH_GFX1250),
+      // 0x1c: callee return.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+
+  const IndirectCallFixup *first_call = nullptr;
+  for (const auto &block : blocks) {
+    for (const auto &fixup : block->static_indirect_call_fixups()) {
+      if (fixup.source_call_offset == 16)
+        first_call = &fixup;
+      EXPECT_NE(fixup.source_call_offset, 20u);
+    }
+  }
+  ASSERT_NE(first_call, nullptr);
+  EXPECT_EQ(first_call->source_target_offset, 28u);
+}
+
+TEST(CfgAnalysis, Gfx1250CalleeSummaryRejectsRepurposedReturnPair) {
+  constexpr uint16_t kTargetSreg = 0;
+  constexpr uint16_t kReturnSreg = 30;
+  constexpr uint16_t kSavedReturnSreg = 32;
+  constexpr auto set_mode_zero = cdna5::build_sopp(cdna5::kSSetVgprMsbSopp, {.simm16 = 0});
+  constexpr auto get_stashed_target =
+      cdna5::build_sop1(cdna5::kSGetPcI64Sop1, {.sdst = kTargetSreg});
+  constexpr auto add_stashed_target = cdna5::build_sop2(
+      cdna5::kSAddNcU64Sop2, {.ssrc0 = kTargetSreg, .ssrc1 = 254, .sdst = kTargetSreg});
+  constexpr auto save_return = cdna5::build_sop1(
+      cdna5::kSMovB64Sop1, {.ssrc0 = static_cast<uint8_t>(kReturnSreg), .sdst = kSavedReturnSreg});
+  constexpr auto get_tail_target = cdna5::build_sop1(cdna5::kSGetPcI64Sop1, {.sdst = kReturnSreg});
+  constexpr auto add_tail_target = cdna5::build_sop2(
+      cdna5::kSAddNcU64Sop2, {.ssrc0 = kReturnSreg, .ssrc1 = 254, .sdst = kReturnSreg});
+  constexpr auto clobber_stash = cdna5::build_vop1(cdna5::kVMovB32Vop1, {.src0 = 128, .vdst = 192});
+  std::vector<uint32_t> words = {
+      set_mode_zero[0],      // 0x00: use bank zero.
+      get_stashed_target[0], // 0x04: s_get_pc_i64 s[0:1].
+      add_stashed_target[0], 56u,
+      0u, // 0x08: s_add_nc_u64 ..., lit64(56) -> target 0x40.
+      0xD76100C0u,
+      0x02010000u, // 0x14: v_writelane_b32 v192, s0, 0.
+      0xD76100C0u,
+      0x02010201u, // 0x1c: v_writelane_b32 v192, s1, 1.
+      rocjitsu::build_s_call_b64(kReturnSreg, 7, ROCJITSU_CODE_ARCH_GFX1250),
+      // 0x24: direct call -> thunk at 0x44.
+      0xD7600000u,
+      0x020101C0u, // 0x28: restore the low half after the call.
+      0xD7600001u,
+      0x020103C0u, // 0x30: restore the high half after the call.
+      rocjitsu::build_s_swappc_b64(kReturnSreg, kTargetSreg, ROCJITSU_CODE_ARCH_GFX1250),
+      // 0x38: must not recover the stash clobbered by the tail target.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x3c: continuation.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x40: stashed target.
+      save_return[0],                             // 0x44: save caller return in s[32:33].
+      get_tail_target[0],                         // 0x48: rebuild s[30:31].
+      add_tail_target[0], 16u,
+      0u, // 0x4c: s_add_nc_u64 ..., lit64(16) -> tail target 0x5c.
+      rocjitsu::build_s_setpc_b64(kReturnSreg, ROCJITSU_CODE_ARCH_GFX1250),
+      // 0x58: tail transfer through the repurposed pair.
+      clobber_stash[0], // 0x5c: tail target clobbers v192.
+      rocjitsu::build_s_setpc_b64(kSavedReturnSreg, ROCJITSU_CODE_ARCH_GFX1250),
+      // 0x60: return through the saved pair.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+
+  for (const auto &block : blocks) {
+    EXPECT_TRUE(std::ranges::none_of(
+        block->static_indirect_call_fixups(),
+        [](const IndirectCallFixup &fixup) { return fixup.source_call_offset == 56; }));
+  }
+}
+
+TEST(CfgAnalysis, Gfx1250ExactCalleeSummaryPreservesUnwrittenRestoredSgprs) {
+  constexpr uint16_t kReturnSreg = 30;
+  for (const uint16_t restored_pair : {uint16_t{0}, uint16_t{20}}) {
+    SCOPED_TRACE(restored_pair);
+    std::vector<uint32_t> words = {
+        0xBE804700u, // 0x00: s_get_pc_i64 s[0:1].
+        0xA980FE00u, 60u,
+        0u, // 0x04: s_add_nc_u64 ..., lit64(60) -> target 0x40.
+        0xD761002Cu,
+        0x02010000u, // 0x10: v_writelane_b32 v44, s0, 0.
+        0xD761002Cu,
+        0x02010201u, // 0x18: v_writelane_b32 v44, s1, 1.
+        0xD7600000u | restored_pair,
+        0x0201012Cu, // 0x20: v_readlane_b32 restored_pair, v44, 0.
+        0xD7600000u | static_cast<uint16_t>(restored_pair + 1),
+        0x0201032Cu, // 0x28: v_readlane_b32 restored_pair+1, v44, 1.
+        rocjitsu::build_s_call_b64(kReturnSreg, 4, ROCJITSU_CODE_ARCH_GFX1250),
+        // 0x30: direct call -> callee at 0x44.
+        rocjitsu::build_s_swappc_b64(kReturnSreg, restored_pair, ROCJITSU_CODE_ARCH_GFX1250),
+        // 0x34: restored target consumer after the call returns.
+        build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x38: continuation.
+        build_s_nop(0, ROCJITSU_CODE_ARCH_GFX1250), // 0x3c: padding.
+        build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x40: stashed target.
+        build_s_nop(0, ROCJITSU_CODE_ARCH_GFX1250), // 0x44: callee body.
+        rocjitsu::build_s_setpc_b64(kReturnSreg, ROCJITSU_CODE_ARCH_GFX1250),
+        // 0x48: callee return.
+    };
+
+    TestCodeObject co(std::move(words));
+    auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+    ASSERT_NE(decoder, nullptr);
+    auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+
+    const IndirectCallFixup *fixup = nullptr;
+    for (const auto &block : blocks) {
+      for (const auto &candidate : block->static_indirect_call_fixups()) {
+        if (candidate.source_call_offset == 52)
+          fixup = &candidate;
+      }
+    }
+    ASSERT_NE(fixup, nullptr);
+    EXPECT_EQ(fixup->source_target_offset, 64u);
+  }
+}
+
+TEST(CfgAnalysis, Gfx1250CalleeSummaryVariantLimitFallsBackConservatively) {
+  constexpr uint16_t kTargetSreg = 0;
+  constexpr uint16_t kReturnSreg = 30;
+  constexpr uint16_t kStashVgpr = 48;
+
+  const auto discovers_fixup = [&](size_t variant_count) {
+    const auto getpc = cdna5::build_sop1(cdna5::kSGetPcI64Sop1, {.sdst = kTargetSreg});
+    const auto add = cdna5::build_sop2(cdna5::kSAddNcU64Sop2,
+                                       {.ssrc0 = kTargetSreg, .ssrc1 = 254, .sdst = kTargetSreg});
+    std::vector<uint32_t> words = {
+        cdna5::build_sopp(cdna5::kSSetVgprMsbSopp, {.simm16 = 0})[0],
+        getpc[0],
+        add[0],
+        0u,
+        0u,
+        0xD7610000u | kStashVgpr,
+        0x02010000u, // v_writelane_b32 v48, s0, 0.
+        0xD7610000u | kStashVgpr,
+        0x02010201u, // v_writelane_b32 v48, s1, 1.
+    };
+
+    std::vector<size_t> call_indices(variant_count);
+    for (size_t variant = 0; variant < variant_count; ++variant) {
+      words.push_back(cdna5::build_sopp(cdna5::kSSetVgprMsbSopp,
+                                        {.simm16 = static_cast<uint16_t>(variant)})[0]);
+      call_indices[variant] = words.size();
+      words.push_back(0u);
+    }
+    words.push_back(cdna5::build_sopp(cdna5::kSSetVgprMsbSopp, {.simm16 = 0})[0]);
+    words.push_back(0xD7600000u | kTargetSreg);
+    words.push_back(0x02010100u | kStashVgpr); // v_readlane_b32 s0, v48, 0.
+    words.push_back(0xD7600000u | static_cast<uint16_t>(kTargetSreg + 1));
+    words.push_back(0x02010300u | kStashVgpr); // v_readlane_b32 s1, v48, 1.
+    const uint64_t consumer_offset = words.size() * sizeof(uint32_t);
+    words.push_back(
+        rocjitsu::build_s_swappc_b64(kReturnSreg, kTargetSreg, ROCJITSU_CODE_ARCH_GFX1250));
+    words.push_back(build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250));
+    const uint64_t stashed_target_offset = words.size() * sizeof(uint32_t);
+    words.push_back(build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250));
+    const uint64_t callee_offset = words.size() * sizeof(uint32_t);
+    words.push_back(build_s_nop(0, ROCJITSU_CODE_ARCH_GFX1250));
+    words.push_back(rocjitsu::build_s_setpc_b64(kReturnSreg, ROCJITSU_CODE_ARCH_GFX1250));
+
+    // S_GET_PC_I64 at byte offset 4 materializes byte offset 8. Its following
+    // literal add therefore needs target-8. Each S_CALL immediate is measured in
+    // dwords from the instruction following the call.
+    words[3] = static_cast<uint32_t>(stashed_target_offset - 2 * sizeof(uint32_t));
+    for (size_t call_index : call_indices) {
+      const int64_t delta = static_cast<int64_t>(callee_offset) -
+                            static_cast<int64_t>((call_index + 1) * sizeof(uint32_t));
+      EXPECT_EQ(delta % static_cast<int64_t>(sizeof(uint32_t)), 0);
+      words[call_index] = rocjitsu::build_s_call_b64(
+          kReturnSreg, static_cast<int16_t>(delta / sizeof(uint32_t)), ROCJITSU_CODE_ARCH_GFX1250);
+    }
+
+    TestCodeObject co(std::move(words));
+    auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+    EXPECT_NE(decoder, nullptr);
+    auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+
+    return std::ranges::any_of(blocks, [&](const auto &block) {
+      return std::ranges::any_of(block->static_indirect_call_fixups(),
+                                 [&](const IndirectCallFixup &fixup) {
+                                   return fixup.source_call_offset == consumer_offset;
+                                 });
+    });
+  };
+
+  EXPECT_TRUE(discovers_fixup(8));
+  EXPECT_FALSE(discovers_fixup(9));
+}
+
+TEST(CfgAnalysis, Gfx1250ExactCalleeSummaryDropsWrittenRestoredSgprs) {
+  constexpr uint16_t kReturnSreg = 30;
+  for (const uint16_t restored_pair : {uint16_t{0}, uint16_t{20}}) {
+    SCOPED_TRACE(restored_pair);
+    std::vector<uint32_t> words = {
+        0xBE804700u, // 0x00: s_get_pc_i64 s[0:1].
+        0xA980FE00u, 64u,
+        0u, // 0x04: s_add_nc_u64 ..., lit64(64) -> target 0x44.
+        0xD761002Cu,
+        0x02010000u, // 0x10: v_writelane_b32 v44, s0, 0.
+        0xD761002Cu,
+        0x02010201u, // 0x18: v_writelane_b32 v44, s1, 1.
+        0xD7600000u | restored_pair,
+        0x0201012Cu, // 0x20: v_readlane_b32 restored_pair, v44, 0.
+        0xD7600000u | static_cast<uint16_t>(restored_pair + 1),
+        0x0201032Cu, // 0x28: v_readlane_b32 restored_pair+1, v44, 1.
+        rocjitsu::build_s_call_b64(kReturnSreg, 4, ROCJITSU_CODE_ARCH_GFX1250),
+        // 0x30: direct call -> callee at 0x44.
+        rocjitsu::build_s_swappc_b64(kReturnSreg, restored_pair, ROCJITSU_CODE_ARCH_GFX1250),
+        // 0x34: restored target consumer after the call returns.
+        build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x38: continuation.
+        build_s_nop(0, ROCJITSU_CODE_ARCH_GFX1250), // 0x3c: padding.
+        build_s_nop(0, ROCJITSU_CODE_ARCH_GFX1250), // 0x40: padding.
+        0xBE800080u,                                // 0x44: callee writes caller-saved s0.
+        rocjitsu::build_s_setpc_b64(kReturnSreg, ROCJITSU_CODE_ARCH_GFX1250),
+        // 0x48: callee return.
+    };
+
+    TestCodeObject co(std::move(words));
+    auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+    ASSERT_NE(decoder, nullptr);
+    auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+
+    const IndirectCallFixup *fixup = nullptr;
+    for (const auto &block : blocks) {
+      for (const auto &candidate : block->static_indirect_call_fixups()) {
+        if (candidate.source_call_offset == 52)
+          fixup = &candidate;
+      }
+    }
+    if (restored_pair == 20) {
+      ASSERT_NE(fixup, nullptr);
+      EXPECT_EQ(fixup->source_target_offset, 68u);
+    } else {
+      EXPECT_EQ(fixup, nullptr);
+    }
+  }
+}
+
+TEST(CfgAnalysis, Gfx1250UnsupportedCalleeSummaryFallsBackToCallPreservedSgprs) {
+  constexpr uint16_t kReturnSreg = 30;
+  for (const uint16_t restored_pair : {uint16_t{20}, uint16_t{64}}) {
+    SCOPED_TRACE(restored_pair);
+    std::vector<uint32_t> words = {
+        0xBE804700u, // 0x00: s_get_pc_i64 s[0:1].
+        0xA980FE00u, 64u,
+        0u, // 0x04: s_add_nc_u64 ..., lit64(64) -> target 0x44.
+        0xD761002Cu,
+        0x02010000u, // 0x10: v_writelane_b32 v44, s0, 0.
+        0xD761002Cu,
+        0x02010201u, // 0x18: v_writelane_b32 v44, s1, 1.
+        0xD7600000u | restored_pair,
+        0x0201012Cu, // 0x20: v_readlane_b32 restored_pair, v44, 0.
+        0xD7600000u | static_cast<uint16_t>(restored_pair + 1),
+        0x0201032Cu, // 0x28: v_readlane_b32 restored_pair+1, v44, 1.
+        rocjitsu::build_s_call_b64(kReturnSreg, 4, ROCJITSU_CODE_ARCH_GFX1250),
+        // 0x30: direct call -> callee at 0x44.
+        rocjitsu::build_s_swappc_b64(kReturnSreg, restored_pair, ROCJITSU_CODE_ARCH_GFX1250),
+        // 0x34: restored target consumer after the call returns.
+        build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x38: continuation.
+        build_s_nop(0, ROCJITSU_CODE_ARCH_GFX1250), // 0x3c: padding.
+        build_s_nop(0, ROCJITSU_CODE_ARCH_GFX1250), // 0x40: padding.
+        rocjitsu::build_s_swappc_b64(kReturnSreg, 2, ROCJITSU_CODE_ARCH_GFX1250),
+        // 0x44: unresolved nested call prevents an exact summary.
+        rocjitsu::build_s_setpc_b64(kReturnSreg, ROCJITSU_CODE_ARCH_GFX1250),
+        // 0x48: callee return.
+    };
+
+    TestCodeObject co(std::move(words));
+    auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+    ASSERT_NE(decoder, nullptr);
+    auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+
+    const IndirectCallFixup *fixup = nullptr;
+    for (const auto &block : blocks) {
+      for (const auto &candidate : block->static_indirect_call_fixups()) {
+        if (candidate.source_call_offset == 52)
+          fixup = &candidate;
+      }
+    }
+    if (restored_pair == 64) {
+      ASSERT_NE(fixup, nullptr);
+      EXPECT_EQ(fixup->source_target_offset, 68u);
+    } else {
+      EXPECT_EQ(fixup, nullptr);
+    }
+  }
+}
+
+TEST(CfgAnalysis, CalleeSavedSgprsUseCallingConventionIntersection) {
+  EXPECT_FALSE(is_callee_saved_sgpr(20));
+  EXPECT_TRUE(is_callee_saved_sgpr(30));
+  EXPECT_TRUE(is_callee_saved_sgpr(64));
+  EXPECT_FALSE(is_callee_saved_sgpr(72));
+  EXPECT_TRUE(is_callee_saved_sgpr(80));
+  EXPECT_FALSE(is_callee_saved_sgpr(88));
+  EXPECT_TRUE(is_callee_saved_sgpr(96));
+  EXPECT_FALSE(is_callee_saved_sgpr(106));
+}
+
+TEST(CfgAnalysis, Gfx1250RestashedLaneTargetRemainsRecoverable) {
+  std::vector<uint32_t> words = {
+      0xBE804700u, // 0x00: s_get_pc_i64 s[0:1].
+      0xA980FE00u,
+      84u,
+      0u, // 0x04: s_add_nc_u64 ..., lit64(84) -> target 0x58.
+      0xD761002Cu,
+      0x02010000u, // 0x10: v_writelane_b32 v44, s0, 0.
+      0xD761002Cu,
+      0x02010201u, // 0x18: v_writelane_b32 v44, s1, 1.
+      0xD760000Eu,
+      0x0201012Cu, // 0x20: v_readlane_b32 s14, v44, 0.
+      0xD760000Fu,
+      0x0201032Cu, // 0x28: v_readlane_b32 s15, v44, 1.
+      0xD7610030u,
+      0x0201000Eu, // 0x30: v_writelane_b32 v48, s14, 0.
+      0xD7610030u,
+      0x0201020Fu, // 0x38: v_writelane_b32 v48, s15, 1.
+      0xD7600000u,
+      0x02010130u, // 0x40: v_readlane_b32 s0, v48, 0.
+      0xD7600001u,
+      0x02010330u,                                // 0x48: v_readlane_b32 s1, v48, 1.
+      0xBE9E4900u,                                // 0x50: s_swap_pc_i64 s[30:31], s[0:1].
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x54: continuation.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x58: target.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+
+  auto *consumer = block_starting_at(blocks, 80);
+  ASSERT_NE(consumer, nullptr);
+  ASSERT_EQ(consumer->static_indirect_call_fixups().size(), 1u);
+  EXPECT_EQ(consumer->static_indirect_call_fixups()[0].source_target_offset, 88u);
+}
+
+TEST(CfgAnalysis, Gfx1250CalleeSavedPcBuilderCanBeStashedAfterCall) {
+  constexpr uint16_t kTargetSreg = 14;
+  constexpr uint16_t kReturnSreg = 30;
+  constexpr auto getpc = cdna5::build_sop1(cdna5::kSGetPcI64Sop1, {.sdst = kTargetSreg});
+  constexpr auto add = cdna5::build_sop2(cdna5::kSAddNcU64Sop2,
+                                         {.ssrc0 = kTargetSreg, .ssrc1 = 254, .sdst = kTargetSreg});
+  std::vector<uint32_t> words = {
+      getpc[0], // 0x00: s_get_pc_i64 s[14:15].
+      add[0], 56u,
+      0u, // 0x04: s_add_nc_u64 ..., lit64(56) -> callee at 0x3c.
+      rocjitsu::build_s_swappc_b64(kReturnSreg, kTargetSreg, ROCJITSU_CODE_ARCH_GFX1250),
+      // 0x10: first call through s[14:15].
+      0xD7610030u,
+      0x0201000Eu, // 0x14: v_writelane_b32 v48, s14, 0.
+      0xD7610030u,
+      0x0201020Fu, // 0x1c: v_writelane_b32 v48, s15, 1.
+      0xD7600000u,
+      0x02010130u, // 0x24: v_readlane_b32 s0, v48, 0.
+      0xD7600001u,
+      0x02010330u, // 0x2c: v_readlane_b32 s1, v48, 1.
+      rocjitsu::build_s_swappc_b64(kReturnSreg, 0, ROCJITSU_CODE_ARCH_GFX1250),
+      // 0x34: second call through the re-stashed target.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x38: continuation.
+      build_s_nop(0, ROCJITSU_CODE_ARCH_GFX1250), // 0x3c: callee body.
+      rocjitsu::build_s_setpc_b64(kReturnSreg, ROCJITSU_CODE_ARCH_GFX1250),
+      // 0x40: callee return.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+
+  const IndirectCallFixup *second_call = nullptr;
+  for (const auto &block : blocks) {
+    for (const auto &fixup : block->static_indirect_call_fixups()) {
+      if (fixup.source_call_offset == 52)
+        second_call = &fixup;
+    }
+  }
+  ASSERT_NE(second_call, nullptr);
+  EXPECT_EQ(second_call->source_target_offset, 60u);
 }
 
 TEST(CfgAnalysis, Gfx1250DoesNotRecoverLaneStashWithDifferingRoleBanks) {
@@ -3456,7 +4261,7 @@ TEST(LivenessAnalysis, Gfx1250FullLiteralModeWriteRecoversKnownBank) {
       cdna5::build_sopk(cdna5::kSSetregImm32B32Sopk, {.simm16 = kModeSrc0Hwreg});
   constexpr auto move = cdna5::build_vop1(cdna5::kVMovB32Vop1, {.src0 = 257, .vdst = 0});
   constexpr auto end = cdna5::build_sopp(cdna5::kSEndpgmSopp);
-  TestCodeObject co({dynamic_setreg[0], literal_setreg[0], 2u << 14, move[0], end[0]});
+  TestCodeObject co({dynamic_setreg[0], literal_setreg[0], 2u, move[0], end[0]});
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
   auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
@@ -3496,7 +4301,7 @@ TEST(LivenessAnalysis, Gfx1250TruncatedLiteralModeWriteMarksBanksAmbiguous) {
   // Full program (so decode sees a valid literal + terminator), but the analysis is
   // told the text ends right after the setreg encoding word at offset 4 (its
   // literal at offset 8 is out of range).
-  TestCodeObject co({set_bank_two[0], literal_setreg[0], 0xe4u << 12, move[0], end[0]});
+  TestCodeObject co({set_bank_two[0], literal_setreg[0], 0xe4u, move[0], end[0]});
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
   auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
@@ -3523,14 +4328,14 @@ TEST(LivenessAnalysis, Gfx1250TruncatedLiteralModeWriteMarksBanksAmbiguous) {
   EXPECT_EQ(liveness.vgpr_msb_bank_before(*instruction, amdgpu::VgprMsbRole::Src0), std::nullopt);
 }
 
-TEST(LivenessAnalysis, Gfx1250PartialLiteralModeWriteUsesUnmaskedVgprFields) {
+TEST(LivenessAnalysis, Gfx1250PartialLiteralModeWritePreservesUntouchedBankBit) {
   constexpr auto set_bank_one = cdna5::build_sopp(cdna5::kSSetVgprMsbSopp, {.simm16 = 1});
   constexpr uint16_t kModeSrc0HighBitHwreg = 1u | (15u << 6);
   constexpr auto literal_setreg =
       cdna5::build_sopk(cdna5::kSSetregImm32B32Sopk, {.simm16 = kModeSrc0HighBitHwreg});
   constexpr auto move = cdna5::build_vop1(cdna5::kVMovB32Vop1, {.src0 = 257, .vdst = 0});
   constexpr auto end = cdna5::build_sopp(cdna5::kSEndpgmSopp);
-  TestCodeObject co({set_bank_one[0], literal_setreg[0], 3u << 14, move[0], end[0]});
+  TestCodeObject co({set_bank_one[0], literal_setreg[0], 1u, move[0], end[0]});
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
   auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
@@ -3553,18 +4358,15 @@ TEST(LivenessAnalysis, Gfx1250PartialLiteralModeWriteUsesUnmaskedVgprFields) {
   EXPECT_TRUE(liveness.is_live_before(*instruction, {RegClass::VGPR, 769, 1}));
 }
 
-TEST(LivenessAnalysis, Gfx1250ImmediateModeWriteRecoversBanksOutsideRequestedSlice) {
-  constexpr uint16_t kModeSrc0Hwreg = 1u | (14u << 6) | (1u << 11);
-  constexpr auto dynamic_setreg =
-      cdna5::build_sopk(cdna5::kSSetregB32Sopk, {.simm16 = kModeSrc0Hwreg, .sdst = 0});
-  // Request a write to MODE bit zero. gfx1250 updates all VGPR-MSB fields from
-  // literal bits [19:12].
+TEST(LivenessAnalysis, Gfx1250ImmediateModeWritePreservesBanksOutsideRequestedSlice) {
+  constexpr auto set_bank_one = cdna5::build_sopp(cdna5::kSSetVgprMsbSopp, {.simm16 = 1});
+  // Request a write to MODE bit zero, disjoint from MODE.VGPR_MSB.
   constexpr uint16_t kModeBitZeroHwreg = 1u;
   constexpr auto literal_setreg =
       cdna5::build_sopk(cdna5::kSSetregImm32B32Sopk, {.simm16 = kModeBitZeroHwreg});
   constexpr auto move = cdna5::build_vop1(cdna5::kVMovB32Vop1, {.src0 = 257, .vdst = 0});
   constexpr auto end = cdna5::build_sopp(cdna5::kSEndpgmSopp);
-  TestCodeObject co({dynamic_setreg[0], literal_setreg[0], 2u << 14, move[0], end[0]});
+  TestCodeObject co({set_bank_one[0], literal_setreg[0], 0u, move[0], end[0]});
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
   auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
@@ -3582,7 +4384,7 @@ TEST(LivenessAnalysis, Gfx1250ImmediateModeWriteRecoversBanksOutsideRequestedSli
   auto instruction = blocks.front()->instructions().begin();
   std::advance(instruction, 2);
   ASSERT_NE(instruction, blocks.front()->instructions().end());
-  EXPECT_EQ(liveness.vgpr_msb_bank_before(*instruction, amdgpu::VgprMsbRole::Src0), 2);
+  EXPECT_EQ(liveness.vgpr_msb_bank_before(*instruction, amdgpu::VgprMsbRole::Src0), 1);
 }
 
 TEST(LivenessAnalysis, Gfx1250LiteralModeWriteTracksEveryRole) {
@@ -3590,7 +4392,7 @@ TEST(LivenessAnalysis, Gfx1250LiteralModeWriteTracksEveryRole) {
   constexpr auto literal_setreg =
       cdna5::build_sopk(cdna5::kSSetregImm32B32Sopk, {.simm16 = kAllVgprMsbFieldsHwreg});
   // MODE[19:12] is {src2=3, src1=2, src0=1, dst=0}.
-  constexpr uint32_t kModeFields = 0xe4u << 12;
+  constexpr uint32_t kModeFields = 0xe4u;
   constexpr auto move = cdna5::build_vop1(cdna5::kVMovB32Vop1, {.src0 = 257, .vdst = 0});
   constexpr auto end = cdna5::build_sopp(cdna5::kSEndpgmSopp);
   TestCodeObject co({literal_setreg[0], kModeFields, move[0], end[0]});

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -12972,7 +12972,7 @@ TEST(BinaryTranslatorE2E, Gfx1250GeneratedVgprMsbTransitionsCarryPreviousState) 
   constexpr auto addtid = cdna5::build_vds(cdna5::kDsStoreAddtidB32Vds, {.offset0 = 4, .data0 = 8});
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
   auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
-      {original_mode[0], 1u << 14, addtid[0], addtid[1], kGfx1250SEndpgm});
+      {original_mode[0], 1u << 2, addtid[0], addtid[1], kGfx1250SEndpgm});
   rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
   rocjitsu::BinaryTranslator translator(
       ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
@@ -13313,7 +13313,9 @@ TEST(BinaryTranslatorE2E, Gfx1250AddtidStoreModeUsesSrc1BankNotSrc0) {
   constexpr uint16_t kAllVgprMsbFieldsHwreg = 1u | (12u << 6) | (7u << 11);
   constexpr auto original_mode =
       cdna5::build_sopk(cdna5::kSSetregImm32B32Sopk, {.simm16 = kAllVgprMsbFieldsHwreg});
-  constexpr uint32_t kModeLiteral = (1u << 14) | (2u << 16); // SRC0 bank 1, SRC1 bank 2.
+  // The literal supplies the low eight bits written into MODE[19:12], whose
+  // layout is {SRC2,SRC1,SRC0,DST}.
+  constexpr uint32_t kModeLiteral = (1u << 2) | (2u << 4); // SRC0 bank 1, SRC1 bank 2.
   constexpr auto addtid = cdna5::build_vds(cdna5::kDsStoreAddtidB32Vds, {.offset0 = 4, .data0 = 8});
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
   auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(


### PR DESCRIPTION
Model right-justified MODE writes through shared VGPR-MSB helpers, then preserve lane-stashed PC values across control flow, register-pair copies, and calls when exact callee summaries prove the values survive.

Track physical destination banks, call-entry state, callee-saved register intersections, restored SGPR pairs, and returned VGPR-MSB mode. Add focused CFG and liveness coverage for conservative invalidation and recovered call targets.
