### PR TITLE
[rocjitsu] Translate external function pointers

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
@@ -2505,6 +2505,12 @@ bool is_callee_saved_vgpr(uint16_t phys_vgpr) {
   return phys_vgpr >= 40 && phys_vgpr <= 255 && ((phys_vgpr - 40) % 16) < 8;
 }
 
+bool is_callee_saved_sgpr(uint16_t sgpr) {
+  // Intersection of CSR_AMDGPU_SGPRs and CSR_AMDGPU_SI_Gfx_SGPRs.
+  return (sgpr >= 30 && sgpr <= 31) || (sgpr >= 64 && sgpr <= 71) || (sgpr >= 80 && sgpr <= 87) ||
+         (sgpr >= 96 && sgpr <= 105);
+}
+
 std::vector<IndirectCallFixup> discover_indirect_branch_edges(
     std::span<const Instruction *const> insts, std::span<const uint8_t> text, rj_code_arch_t arch,
     std::span<const uint64_t> extra_leaders, ExternalEntryPolicy entry_policy,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.h
@@ -149,6 +149,15 @@ struct PcAddressBuilder {
 /// proven callee-saved and reports false.
 [[nodiscard]] bool is_callee_saved_vgpr(uint16_t phys_vgpr);
 
+/// @brief Whether an SGPR is preserved by every AMDGPU calling convention the
+/// translator may encounter for a device function.
+///
+/// @details Code objects do not record whether a particular helper uses the
+/// default device convention or the graphics convention. This predicate uses
+/// their intersection, so an unsummarized call cannot preserve a stale value
+/// merely because one convention saves the register.
+[[nodiscard]] bool is_callee_saved_sgpr(uint16_t sgpr);
+
 /// @returns Recovered indirect branch/call metadata.
 [[nodiscard]] std::vector<IndirectCallFixup> discover_indirect_branch_edges(
     std::span<const Instruction *const> insts, std::span<const uint8_t> text, rj_code_arch_t arch,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -3,6 +3,7 @@
 
 #include "rocjitsu/code/dbt/binary_translator.h"
 
+#include "rocjitsu/analysis/def_use_chain.h"
 #include "rocjitsu/analysis/exec_state.h"
 #include "rocjitsu/analysis/gfx1250_vgpr_msb.h"
 #include "rocjitsu/analysis/liveness.h"
@@ -45,6 +46,7 @@
 #include <limits>
 #include <memory>
 #include <optional>
+#include <queue>
 #include <set>
 #include <span>
 #include <sstream>
@@ -179,6 +181,21 @@ void append_diagnostics(std::vector<TranslationDiagnostic> &dst,
   dst.insert(dst.end(), src.begin(), src.end());
 }
 
+/// @brief Carry state established after the original descriptor translation into a recomputation.
+/// @returns Diagnostics produced by the recomputation itself.
+[[nodiscard]] std::vector<TranslationDiagnostic>
+preserve_descriptor_translation_state(KdTranslation &recomputed, const KdTranslation &established) {
+  std::vector<TranslationDiagnostic> fresh_diagnostics = std::move(recomputed.diagnostics);
+  recomputed.kernel_name = established.kernel_name;
+  recomputed.sidecar_descriptor = established.sidecar_descriptor;
+  recomputed.virtual_lds_lowering = established.virtual_lds_lowering;
+  recomputed.target_entry_text_offset = established.target_entry_text_offset;
+  recomputed.target_body_entry_text_offset = established.target_body_entry_text_offset;
+  recomputed.diagnostics = established.diagnostics;
+  append_diagnostics(recomputed.diagnostics, fresh_diagnostics);
+  return fresh_diagnostics;
+}
+
 /// @brief Return a human-readable kernel label for diagnostics.
 ///
 /// @details Some code objects carry empty kernel symbol names. Falling back to
@@ -265,6 +282,244 @@ struct KernelTranslationScope {
   BasicBlock *entry = nullptr;
   std::vector<BasicBlock *> blocks;
 };
+
+[[nodiscard]] std::optional<std::vector<uint64_t>>
+defined_text_function_offsets(const AmdGpuCodeObject &object) {
+  if (object.text_sections().size() != 1 || object.image_data() == nullptr)
+    return std::nullopt;
+  const auto image =
+      std::span(reinterpret_cast<const uint8_t *>(object.image_data()), object.image_size());
+  if (image.size() < sizeof(Elf64_Ehdr))
+    return std::nullopt;
+  Elf64_Ehdr ehdr{};
+  std::memcpy(&ehdr, image.data(), sizeof(ehdr));
+  if (ehdr.e_type != ET_DYN || ehdr.e_shentsize != sizeof(Elf64_Shdr) ||
+      ehdr.e_shoff > image.size() ||
+      static_cast<uint64_t>(ehdr.e_shnum) * sizeof(Elf64_Shdr) > image.size() - ehdr.e_shoff) {
+    return std::nullopt;
+  }
+  std::vector<Elf64_Shdr> sections(ehdr.e_shnum);
+  std::memcpy(sections.data(), image.data() + ehdr.e_shoff, sections.size() * sizeof(Elf64_Shdr));
+
+  const Section &text = *object.text_sections().front();
+  const auto text_section = std::ranges::find_if(sections, [&](const Elf64_Shdr &section) {
+    return section.sh_offset == text.sectionOffset() && section.sh_addr == text.vaddr() &&
+           section.sh_size == text.size() && (section.sh_flags & SHF_EXECINSTR) != 0;
+  });
+  if (text_section == sections.end())
+    return std::nullopt;
+  const uint16_t text_index = static_cast<uint16_t>(text_section - sections.begin());
+
+  std::vector<uint64_t> offsets;
+  bool saw_static_symbols = false;
+  for (const Elf64_Shdr &symbols : sections) {
+    if (symbols.sh_type != SHT_SYMTAB)
+      continue;
+    saw_static_symbols = true;
+    if (symbols.sh_size == 0)
+      continue;
+    if (symbols.sh_entsize != sizeof(Elf64_Sym) || symbols.sh_offset > image.size() ||
+        symbols.sh_size > image.size() - symbols.sh_offset ||
+        symbols.sh_size % sizeof(Elf64_Sym) != 0)
+      return std::nullopt;
+    const size_t count = symbols.sh_size / sizeof(Elf64_Sym);
+    for (size_t index = 0; index < count; ++index) {
+      Elf64_Sym symbol{};
+      std::memcpy(&symbol, image.data() + symbols.sh_offset + index * sizeof(Elf64_Sym),
+                  sizeof(symbol));
+      if (symbol.st_shndx != text_index || elf_symbol_type(symbol.st_info) != kElfSymbolTypeFunc)
+        continue;
+      if (symbol.st_value < text.vaddr())
+        continue;
+      const uint64_t offset = symbol.st_value - text.vaddr();
+      if (offset < text.size())
+        offsets.push_back(offset);
+    }
+  }
+  if (!saw_static_symbols)
+    return std::nullopt;
+  std::ranges::sort(offsets);
+  offsets.erase(std::ranges::unique(offsets).begin(), offsets.end());
+  return offsets;
+}
+
+enum class ExternalPairOrigin : uint8_t {
+  KernargAddress,
+  LoadedValue,
+};
+
+using ExternalPairState = std::unordered_map<uint16_t, ExternalPairOrigin>;
+
+[[nodiscard]] std::optional<uint16_t> sgpr_pair_operand(const Operand *operand) {
+  if (operand == nullptr)
+    return std::nullopt;
+  const auto ref = operand->to_register_ref();
+  if (!ref || ref->cls != RegClass::SGPR || ref->width < 2 ||
+      static_cast<uint32_t>(ref->index) + 1 >= REGISTER_SET_MAX_SGPRS) {
+    return std::nullopt;
+  }
+  return ref->index;
+}
+
+void transfer_external_pairs(ExternalPairState &state, const Instruction &inst,
+                             std::unordered_set<uint64_t> *calls) {
+  const std::string_view mnemonic = inst.mnemonic();
+  const auto dst = sgpr_pair_operand(inst.dst_operand(0));
+  const auto src0 = sgpr_pair_operand(inst.src_operand(0));
+  std::vector<std::pair<uint16_t, ExternalPairOrigin>> results;
+
+  if (mnemonic == "s_mov_b64" && dst && src0) {
+    if (const auto source = state.find(*src0); source != state.end())
+      results.emplace_back(*dst, source->second);
+  } else if (mnemonic == "s_add_nc_u64" && dst) {
+    const auto src1 = sgpr_pair_operand(inst.src_operand(1));
+    const std::optional<uint16_t> address =
+        src0 && *src0 == *dst ? src0 : (src1 && *src1 == *dst ? src1 : std::nullopt);
+    if (address) {
+      const auto source = state.find(*address);
+      if (source != state.end() && source->second == ExternalPairOrigin::KernargAddress)
+        results.emplace_back(*dst, source->second);
+    }
+  } else if (mnemonic.starts_with("s_load_b") && dst && src0) {
+    const auto base = state.find(*src0);
+    const auto dst_ref = inst.dst_operand(0)->to_register_ref();
+    if (base != state.end() && dst_ref && dst_ref->cls == RegClass::SGPR &&
+        (base->second == ExternalPairOrigin::KernargAddress ||
+         base->second == ExternalPairOrigin::LoadedValue)) {
+      const uint32_t end = static_cast<uint32_t>(dst_ref->index) + dst_ref->width;
+      for (uint32_t pair = dst_ref->index; pair + 1 < end; pair += 2)
+        results.emplace_back(static_cast<uint16_t>(pair), ExternalPairOrigin::LoadedValue);
+    }
+  }
+
+  if ((inst.flags() & INDIRECT_CALL) != 0 && src0) {
+    const auto target = state.find(*src0);
+    if (calls != nullptr && target != state.end() &&
+        target->second == ExternalPairOrigin::LoadedValue) {
+      calls->insert(inst.src_loc());
+    }
+  }
+
+  const InstDefUse def_use(inst);
+  std::erase_if(state, [&](const auto &item) {
+    return def_use.defs.contains(RegisterRef{RegClass::SGPR, item.first, 1}) ||
+           def_use.defs.contains(
+               RegisterRef{RegClass::SGPR, static_cast<uint16_t>(item.first + 1), 1});
+  });
+  for (const auto &[pair, origin] : results)
+    state[pair] = origin;
+
+  if ((inst.flags() & INDIRECT_CALL) != 0) {
+    std::erase_if(state, [](const auto &item) {
+      return !is_callee_saved_sgpr(item.first) ||
+             !is_callee_saved_sgpr(static_cast<uint16_t>(item.first + 1));
+    });
+  }
+}
+
+[[nodiscard]] ExternalPairState meet_external_predecessors(
+    const BasicBlock &block, const std::unordered_set<const BasicBlock *> &allowed,
+    const std::unordered_map<const BasicBlock *, size_t> &positions,
+    const std::vector<ExternalPairState> &out, const std::vector<bool> &initialized,
+    std::optional<uint16_t> entry_kernarg_pair, const BasicBlock *entry) {
+  ExternalPairState result;
+  bool have_input = false;
+  if (&block == entry && entry_kernarg_pair) {
+    result[*entry_kernarg_pair] = ExternalPairOrigin::KernargAddress;
+    have_input = true;
+  }
+  for (const BasicBlock *predecessor : block.predecessors()) {
+    const auto position = positions.find(predecessor);
+    if (!allowed.contains(predecessor) || position == positions.end() ||
+        !initialized[position->second]) {
+      continue;
+    }
+    if (!have_input) {
+      result = out[position->second];
+      have_input = true;
+      continue;
+    }
+    std::erase_if(result, [&](const auto &item) {
+      const auto incoming = out[position->second].find(item.first);
+      return incoming == out[position->second].end() || incoming->second != item.second;
+    });
+  }
+  return result;
+}
+
+[[nodiscard]] std::unordered_set<uint64_t>
+kernarg_loaded_indirect_calls(const KernelTranslationScope &scope) {
+  if (scope.translation == nullptr || scope.entry == nullptr ||
+      !scope.translation->source_has_kernarg_segment_ptr) {
+    return {};
+  }
+  bool has_indirect_call = false;
+  for (BasicBlock *block : scope.blocks) {
+    if (block == nullptr)
+      continue;
+    for (const Instruction &inst : block->instructions())
+      has_indirect_call |= (inst.flags() & INDIRECT_CALL) != 0;
+  }
+  if (!has_indirect_call)
+    return {};
+
+  std::unordered_map<const BasicBlock *, size_t> positions;
+  std::unordered_set<const BasicBlock *> allowed;
+  for (size_t index = 0; index < scope.blocks.size(); ++index) {
+    if (scope.blocks[index] != nullptr) {
+      positions.emplace(scope.blocks[index], index);
+      allowed.insert(scope.blocks[index]);
+    }
+  }
+  const auto entry_position = positions.find(scope.entry);
+  if (entry_position == positions.end())
+    return {};
+
+  std::vector<ExternalPairState> in(scope.blocks.size());
+  std::vector<ExternalPairState> out(scope.blocks.size());
+  std::vector<bool> initialized(scope.blocks.size(), false);
+  std::vector<bool> queued(scope.blocks.size(), false);
+  std::queue<size_t> worklist;
+  worklist.push(entry_position->second);
+  queued[entry_position->second] = true;
+  while (!worklist.empty()) {
+    const size_t index = worklist.front();
+    worklist.pop();
+    queued[index] = false;
+    BasicBlock *block = scope.blocks[index];
+    if (block == nullptr)
+      continue;
+    ExternalPairState next_in =
+        meet_external_predecessors(*block, allowed, positions, out, initialized,
+                                   scope.translation->kernarg_segment_ptr_sgpr, scope.entry);
+    ExternalPairState next_out = next_in;
+    for (const Instruction &inst : block->instructions())
+      transfer_external_pairs(next_out, inst, nullptr);
+    const bool changed = !initialized[index] || next_in != in[index] || next_out != out[index];
+    initialized[index] = true;
+    in[index] = std::move(next_in);
+    out[index] = std::move(next_out);
+    if (!changed)
+      continue;
+    for (BasicBlock *successor : block->successors()) {
+      const auto position = positions.find(successor);
+      if (position != positions.end() && !queued[position->second]) {
+        worklist.push(position->second);
+        queued[position->second] = true;
+      }
+    }
+  }
+
+  std::unordered_set<uint64_t> calls;
+  for (size_t index = 0; index < scope.blocks.size(); ++index) {
+    if (scope.blocks[index] == nullptr || !initialized[index])
+      continue;
+    ExternalPairState state = in[index];
+    for (const Instruction &inst : scope.blocks[index]->instructions())
+      transfer_external_pairs(state, inst, &calls);
+  }
+  return calls;
+}
 
 /// @brief Descriptor state mutated by one kernel-scope translation transaction.
 struct DescriptorVariantCheckpoint {
@@ -716,6 +971,7 @@ adopted_root_return_offsets(const BlockOffsetIndex &block_index,
 
     // Forward pass: collect the body's blocks and its candidate return terminators.
     std::vector<BasicBlock *> stack{entry};
+    const std::unordered_set<uint64_t> root_boundaries(adopted_roots.begin(), adopted_roots.end());
     std::unordered_set<BasicBlock *> body;
     std::vector<std::pair<BasicBlock *, uint16_t>> candidates;
     while (!stack.empty()) {
@@ -730,8 +986,11 @@ adopted_root_return_offsets(const BlockOffsetIndex &block_index,
           candidates.emplace_back(
               block, static_cast<uint16_t>(text_word_at(text, term->src_loc()) & 0xffu));
       }
-      for (BasicBlock *succ : block->successors())
+      for (BasicBlock *succ : block->successors()) {
+        if (succ != nullptr && succ != entry && root_boundaries.contains(succ->start_offset()))
+          continue;
         stack.push_back(succ);
+      }
     }
 
     // Whether (vgpr, lane) still holds what `v_writelane_b32` put there from `sgpr`, asked at one
@@ -1441,10 +1700,15 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   }
 
   const auto relocation_function_tables = discover_relocation_function_tables(obj);
+  const auto text_function_offsets = defined_text_function_offsets(obj);
   auto block_leaders = kernel_block_leaders(descriptor_translations, text);
   for (const RelocationFunctionTable &table : relocation_function_tables) {
     for (const RelocationFunctionPointer &entry : table.entries)
       block_leaders.push_back(entry.target_text_offset);
+  }
+  if (text_function_offsets) {
+    block_leaders.insert(block_leaders.end(), text_function_offsets->begin(),
+                         text_function_offsets->end());
   }
   std::ranges::sort(block_leaders);
   block_leaders.erase(std::ranges::unique(block_leaders).begin(), block_leaders.end());
@@ -1614,6 +1878,29 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     }
   }
 
+  std::unordered_map<uint64_t, std::unordered_set<uint64_t>> external_calls_by_scope;
+  bool has_externally_supplied_call = false;
+  for (const KernelTranslationScope &scope : scopes) {
+    auto calls = kernarg_loaded_indirect_calls(scope);
+    if (calls.empty() || scope.translation == nullptr)
+      continue;
+    has_externally_supplied_call = true;
+    external_calls_by_scope[kernel_scope_key(*scope.translation)] = std::move(calls);
+  }
+  if (has_externally_supplied_call && (!text_function_offsets || text_function_offsets->empty())) {
+    append_error(result.diagnostics, DiagnosticKind::Legalization,
+                 "the complete static device-function set could not be enumerated for a "
+                 "kernarg-loaded indirect "
+                 "call; leaving code object unchanged");
+    return leave_unchanged();
+  }
+  if (has_externally_supplied_call && scopes.size() != 1) {
+    append_error(result.diagnostics, DiagnosticKind::Legalization,
+                 "kernarg-loaded indirect calls require one compatible kernel translation scope; "
+                 "leaving code object unchanged");
+    return leave_unchanged();
+  }
+
   // A device function whose address is produced only by a data relocation -- a C++ vtable slot is
   // the common case -- is named by no decoded edge, so no kernel scope reaches it. Translated text
   // replaces .text wholesale, so leaving it unreached drops the body and strands the addend that
@@ -1659,8 +1946,25 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     };
 
     for (const RelocationFunctionTable &table : relocation_function_tables) {
-      for (const RelocationFunctionPointer &slot : table.entries)
+      for (const RelocationFunctionPointer &slot : table.entries) {
         adopt(slot.target_text_offset);
+      }
+    }
+    if (has_externally_supplied_call) {
+      // A function pointer freshly loaded from this launch's kernarg memory can
+      // name any defined device function with a compatible signature. Preserve
+      // one canonical copy of every STT_FUNC and retarget every symbol before
+      // admitting the unresolved runtime call.
+      for (uint64_t function_offset : *text_function_offsets) {
+        const BasicBlock *entry = block_for_offset(block_index, function_offset);
+        if (entry == nullptr || entry->start_offset() != function_offset) {
+          append_error(result.diagnostics, DiagnosticKind::Legalization,
+                       "defined device function is not an instruction boundary; leaving code "
+                       "object unchanged");
+          return leave_unchanged();
+        }
+        adopt(function_offset);
+      }
     }
     // A getpc that computes a code address makes that body address-taken just as surely as a
     // relocation slot does, so its target has to be accounted for before the rewrite is permitted.
@@ -1967,6 +2271,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     assert(scope.translation != nullptr && "kernel scope should have descriptor translation");
     if (scope.translation->skipped)
       continue;
+    const auto external_calls = external_calls_by_scope.find(kernel_scope_key(*scope.translation));
 
     const size_t output_begin = translated_text.size();
     const size_t text_relocations_begin = text_relocations.size();
@@ -2654,6 +2959,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
         const bool has_recovered_indirect_call = recovered_it != recovered_indirect_by_call.end();
         const bool has_relocation_table_call = relocation_table_calls.contains(offset);
         const bool recovered_indirect_return = valid_call_return_offsets.contains(offset);
+        const bool has_fresh_external_target = external_calls != external_calls_by_scope.end() &&
+                                               external_calls->second.contains(offset);
         const auto direct_branch_delta = inst.branch_offset_bytes();
         // A transfer through a value this object loaded from memory needs no per-target proof once
         // every code address the object can produce is relocated: the loaded word is either a
@@ -2662,31 +2969,36 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
         // vtable slot that no dataflow fact can name, and no amount of consumer-side analysis will
         // ever name it.
         //
-        // The permission is object-wide because the question it answers is. A consumer cannot tell
-        // where a loaded 64-bit word came from, so tying it to this transfer's provenance is not
-        // available; what makes it sound is that both routes into `.text` are covered. Addresses
-        // the object computes for itself are the ones code_addresses_fully_accounted ranges over.
-        // An address supplied from outside -- a kernarg holding a device function pointer, or a
-        // pointer another code object resolved -- can only have been obtained from a `.text`
-        // symbol, and relocate_text_symbols() rewrites those and refuses the whole object when a
-        // referenced text symbol has no exact offset map. Translation happens at load, so there is
-        // no window in which a caller could have captured a pre-translation value.
+        // The external permission is scoped to the kernel whose reaching-value
+        // analysis proved this transfer. What makes it sound is that both routes into `.text` are
+        // covered. Addresses the object computes for itself are the ones
+        // code_addresses_fully_accounted ranges over. An address supplied from outside -- a kernarg
+        // holding a device function pointer, or a pointer another code object resolved -- can only
+        // have been obtained from a `.text` symbol, and relocate_text_symbols() rewrites those and
+        // refuses the whole object when a referenced text symbol has no exact offset map.
+        // Translation happens at load, so there is no window in which a caller could have captured
+        // a pre-translation value.
         //
         // What that leaves is narrow and worth stating: a host that derives an entry from a symbol
         // plus a byte offset, and a symbol that is present but unreferenced, which
         // relocate_text_symbols() tolerates so debug labels in padding do not refuse the object.
+        // A target proven to come from an ordinary-launch kernarg load is the
+        // non-vacuous external counterpart: the pointer is created after this
+        // load-time translation, and all defined function bodies were adopted
+        // above. Requiring every text symbol to move closes the same symbol-plus-
+        // offset gap for that path.
         const bool target_is_relocated_by_construction =
             object_produces_code_addresses && code_addresses_fully_accounted;
         if ((inst.flags() & (INDIRECT_BRANCH | INDIRECT_CALL)) != 0 &&
             !has_recovered_indirect_call && !has_relocation_table_call &&
             !recovered_indirect_return && !direct_branch_delta &&
-            target_is_relocated_by_construction) {
+            (target_is_relocated_by_construction || has_fresh_external_target)) {
           relied_on_relocated_by_construction = true;
         }
         if ((inst.flags() & (INDIRECT_BRANCH | INDIRECT_CALL)) != 0 &&
             !has_recovered_indirect_call && !has_relocation_table_call &&
             !recovered_indirect_return && !direct_branch_delta &&
-            !target_is_relocated_by_construction) {
+            !target_is_relocated_by_construction && !has_fresh_external_target) {
           auto failure = make_kernel_failure(
               DiagnosticKind::Legalization,
               "indirect branch or call target recovery is not implemented for relocated kernel "
@@ -3426,9 +3738,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
           }
           return leave_unchanged();
         }
-        updated->kernel_name = translation.kernel_name;
-        updated->sidecar_descriptor = translation.sidecar_descriptor;
-        updated->virtual_lds_lowering = translation.virtual_lds_lowering;
+        const std::vector<TranslationDiagnostic> recompute_diagnostics =
+            preserve_descriptor_translation_state(*updated, translation);
         // Register feedback also recomputes ordinary, non-virtual descriptors.
         // Only a virtual-LDS variant owns a backing-pointer entry prologue;
         // asking an unrelated ISA pair to materialize one makes otherwise
@@ -3452,7 +3763,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
             auto failure = make_kernel_failure(DiagnosticKind::KernelDescriptor,
                                                "kernel descriptor translation requires unsupported "
                                                "resource or ABI virtualization");
-            for (const TranslationDiagnostic &diagnostic : updated->diagnostics) {
+            for (const TranslationDiagnostic &diagnostic : recompute_diagnostics) {
               if (diagnostic.severity != DiagnosticSeverity::Error)
                 continue;
               failure.kind = diagnostic.kind;
@@ -3469,13 +3780,13 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
               break;
             }
           }
-          append_diagnostics(result.diagnostics, updated->diagnostics);
+          append_diagnostics(result.diagnostics, recompute_diagnostics);
           append_error(result.diagnostics, DiagnosticKind::KernelDescriptor,
                        "kernel descriptor translation requires unsupported resource or ABI "
                        "virtualization; leaving code object unchanged");
           return leave_unchanged();
         }
-        append_diagnostics(result.diagnostics, updated->diagnostics);
+        append_diagnostics(result.diagnostics, recompute_diagnostics);
 
         if (updated->prologue_words != translation.prologue_words) {
           auto failure = make_kernel_failure(

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.h
@@ -173,6 +173,13 @@ struct TranslatedCodeObject {
 /// direct PC-relative branch immediates and recovered indirect transfer windows
 /// are patched through the kernel-local source-to-target block placement map.
 /// Fallthrough is preserved by emitting reachable blocks in original .text order.
+///
+/// Kernarg-supplied device-function pointers require a load-time environment
+/// that translates every GPU module before admitting it for execution. A
+/// pointer may name this object's relocated STT_FUNC body or an already-
+/// relocated body in another translated module; the code object alone cannot
+/// distinguish those origins. An embedding runtime must not mix translated
+/// modules with callable untranslated GPU modules.
 class BinaryTranslator {
 public:
   /// @brief Construct a translator for the given (guest, host) ISA pair.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/relocation_function_table.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/relocation_function_table.cpp
@@ -17,6 +17,7 @@
 #include <queue>
 #include <span>
 #include <string_view>
+#include <tuple>
 #include <unordered_map>
 #include <vector>
 
@@ -106,8 +107,11 @@ table_for_got_slot(std::span<const RelocationFunctionTable> tables, uint64_t vad
 table_at_address(std::span<const RelocationFunctionTable> tables, uint64_t vaddr) {
   for (size_t table_index = 0; table_index < tables.size(); ++table_index) {
     const RelocationFunctionTable &table = tables[table_index];
-    if (vaddr >= table.table_vaddr && vaddr - table.table_vaddr < table.table_size)
+    if ((table.exact_base_only && vaddr == table.table_vaddr) ||
+        (!table.exact_base_only && vaddr >= table.table_vaddr &&
+         vaddr - table.table_vaddr < table.table_size)) {
       return table_index;
+    }
   }
   return std::nullopt;
 }
@@ -310,6 +314,15 @@ discover_relocation_function_tables(const AmdGpuCodeObject &object) {
     }
   }
 
+  std::vector<RelocationFunctionTable> direct_function_pointers;
+  const auto allocated_data_contains = [&](uint64_t vaddr, uint64_t size) {
+    return std::ranges::any_of(sections, [&](const Elf64_Shdr &section) {
+      return (section.sh_flags & SHF_ALLOC) != 0 && (section.sh_flags & SHF_EXECINSTR) == 0 &&
+             vaddr >= section.sh_addr && vaddr - section.sh_addr <= section.sh_size &&
+             size <= section.sh_size - (vaddr - section.sh_addr);
+    });
+  };
+
   for (const Elf64_Shdr &relocations : sections) {
     if (relocations.sh_type != SHT_RELA || relocations.sh_entsize != sizeof(Elf64_Rela) ||
         !range_in_image(image, relocations.sh_offset, relocations.sh_size))
@@ -355,8 +368,7 @@ discover_relocation_function_tables(const AmdGpuCodeObject &object) {
       if (!read_object(image,
                        linked_symbols->sh_offset +
                            static_cast<uint64_t>(symbol_index) * sizeof(Elf64_Sym),
-                       symbol) ||
-          elf_symbol_type(symbol.st_info) != kElfSymbolTypeObject)
+                       symbol))
         continue;
       uint64_t target = symbol.st_value;
       if (rela.r_addend >= 0) {
@@ -371,6 +383,35 @@ discover_relocation_function_tables(const AmdGpuCodeObject &object) {
           continue;
         target -= magnitude;
       }
+      if (elf_symbol_type(symbol.st_info) == kElfSymbolTypeFunc) {
+        // A direct GOT entry for a defined device function is a finite one-slot
+        // dispatch table. The loader follows the relocated text symbol, while
+        // the translated caller reaches the slot through the same getpc/add/load
+        // sequence used for larger tables. Model it as a one-entry table so the
+        // existing CFG and relocation machinery can preserve both addresses.
+        if (rela.r_addend == 0 && symbol.st_shndx < sections.size() &&
+            (sections[symbol.st_shndx].sh_flags & SHF_EXECINSTR) != 0 && target >= text_vaddr &&
+            target - text_vaddr < text_size && (rela.r_offset % sizeof(uint64_t)) == 0 &&
+            allocated_data_contains(rela.r_offset, sizeof(uint64_t))) {
+          const RelocationFunctionPointer entry{.slot_vaddr = rela.r_offset,
+                                                .target_text_offset = target - text_vaddr,
+                                                .abi_function_symbol = true};
+          if (ObjectCandidate *candidate = containing_candidate(candidates, rela.r_offset);
+              candidate != nullptr &&
+              ((rela.r_offset - candidate->vaddr) % sizeof(uint64_t)) == 0) {
+            candidate->entries.push_back(entry);
+          } else {
+            direct_function_pointers.push_back({.table_vaddr = rela.r_offset,
+                                                .table_size = sizeof(uint64_t),
+                                                .exact_base_only = true,
+                                                .got_slot_vaddrs = {},
+                                                .entries = {entry}});
+          }
+        }
+        continue;
+      }
+      if (elf_symbol_type(symbol.st_info) != kElfSymbolTypeObject)
+        continue;
       const auto candidate = std::ranges::find_if(
           candidates, [&](const ObjectCandidate &item) { return item.vaddr == target; });
       if (candidate != candidates.end())
@@ -378,7 +419,7 @@ discover_relocation_function_tables(const AmdGpuCodeObject &object) {
     }
   }
 
-  std::vector<RelocationFunctionTable> tables;
+  std::vector<RelocationFunctionTable> tables = std::move(direct_function_pointers);
   for (ObjectCandidate &candidate : candidates) {
     // RCCL addresses its relocation-backed function tables directly from
     // executable text, so a GOT reference is useful evidence but not required.
@@ -390,11 +431,48 @@ discover_relocation_function_tables(const AmdGpuCodeObject &object) {
                               candidate.got_slots.end());
     tables.push_back({.table_vaddr = candidate.vaddr,
                       .table_size = candidate.size,
+                      .exact_base_only = false,
                       .got_slot_vaddrs = std::move(candidate.got_slots),
                       .entries = std::move(candidate.entries)});
   }
   std::ranges::sort(tables, {}, &RelocationFunctionTable::table_vaddr);
-  return tables;
+  std::vector<RelocationFunctionTable> merged;
+  for (RelocationFunctionTable &table : tables) {
+    if (merged.empty() || merged.back().table_vaddr != table.table_vaddr) {
+      merged.push_back(std::move(table));
+      continue;
+    }
+    RelocationFunctionTable &destination = merged.back();
+    destination.table_size = std::max(destination.table_size, table.table_size);
+    destination.exact_base_only = destination.exact_base_only && table.exact_base_only;
+    destination.got_slot_vaddrs.insert(destination.got_slot_vaddrs.end(),
+                                       table.got_slot_vaddrs.begin(), table.got_slot_vaddrs.end());
+    destination.entries.insert(destination.entries.end(), table.entries.begin(),
+                               table.entries.end());
+  }
+  // Normalize every table, including tables produced by a single discovery
+  // path as well as tables combined above.
+  for (RelocationFunctionTable &table : merged) {
+    std::ranges::sort(table.got_slot_vaddrs);
+    table.got_slot_vaddrs.erase(std::ranges::unique(table.got_slot_vaddrs).begin(),
+                                table.got_slot_vaddrs.end());
+    std::ranges::sort(table.entries, [](const RelocationFunctionPointer &lhs,
+                                        const RelocationFunctionPointer &rhs) {
+      return std::tie(lhs.slot_vaddr, lhs.target_text_offset) <
+             std::tie(rhs.slot_vaddr, rhs.target_text_offset);
+    });
+    std::vector<RelocationFunctionPointer> entries;
+    for (const RelocationFunctionPointer &entry : table.entries) {
+      if (!entries.empty() && entries.back().slot_vaddr == entry.slot_vaddr &&
+          entries.back().target_text_offset == entry.target_text_offset) {
+        entries.back().abi_function_symbol |= entry.abi_function_symbol;
+      } else {
+        entries.push_back(entry);
+      }
+    }
+    table.entries = std::move(entries);
+  }
+  return merged;
 }
 
 RelocationPairAnalysis analyze_relocation_pairs(std::span<const std::unique_ptr<BasicBlock>> blocks,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/relocation_function_table.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/relocation_function_table.h
@@ -31,16 +31,22 @@ struct RelocationFunctionPointer {
 
   /// Original `.text`-relative byte offset encoded by the relocation addend.
   uint64_t target_text_offset = 0;
+
+  /// True when the slot is an `R_AMDGPU_ABS64` reference to an `STT_FUNC`.
+  /// Such entries use the standard AMDGPU function ABI and return through
+  /// s[30:31], even when no in-object call site reaches the exported body.
+  bool abi_function_symbol = false;
 };
 
 /// @brief One finite data object populated with relocated device-function pointers.
 ///
-/// @details The object is identified structurally: an allocated, non-executable
-/// `STT_OBJECT` contains one or more aligned slots with symbol-less
-/// `R_AMDGPU_RELATIVE64` addends into `.text`. Code may materialize the table
-/// address directly or load it through a GOT slot. Consequently GOT references
-/// strengthen discovery but are optional and are recorded separately from the
-/// populated entries.
+/// @details The object is identified structurally: either an allocated,
+/// non-executable `STT_OBJECT` contains aligned slots with symbol-less
+/// `R_AMDGPU_RELATIVE64` addends into `.text`, or a single allocated data slot
+/// has an `R_AMDGPU_ABS64` relocation to an `STT_FUNC` in `.text`. Code may
+/// materialize a table address directly or load it through a GOT slot.
+/// Consequently GOT references strengthen multi-entry discovery but are
+/// optional and are recorded separately from the populated entries.
 struct RelocationFunctionTable {
   /// Original virtual address from the defining object's `st_value`.
   uint64_t table_vaddr = 0;
@@ -48,12 +54,18 @@ struct RelocationFunctionTable {
   /// Object extent from `st_size`, used to associate relocation places with this table.
   uint64_t table_size = 0;
 
+  /// True for a synthetic single-slot table that must match only its exact address.
+  bool exact_base_only = false;
+
   /// GOT relocation places whose `R_AMDGPU_ABS64` value resolves to this object.
   /// Empty when translated code addresses the table directly.
   std::vector<uint64_t> got_slot_vaddrs;
 
-  /// Populated slots, sorted by `slot_vaddr`. Slots without a qualifying text
-  /// relocation are not possible callees and do not appear here.
+  /// Populated callee entries, sorted by slot address and target offset. ABI
+  /// symbol provenance is combined for duplicate entries. A malformed input may relocate one slot
+  /// to multiple targets; those entries are retained as a conservative callee set rather than
+  /// interpreted as a one-to-one slot map. Slots without a qualifying text relocation are not
+  /// possible callees and do not appear here.
   std::vector<RelocationFunctionPointer> entries;
 };
 
@@ -130,13 +142,15 @@ analyze_relocation_pairs(std::span<const std::unique_ptr<BasicBlock>> blocks,
 
 /// @brief Discover finite device-call tables from ELF symbols and relocations.
 ///
-/// @details A candidate must be a non-empty `STT_OBJECT` whose size is a
-/// multiple of eight bytes. It must reside in an allocated, non-executable
-/// section and contain at least one aligned
-/// symbol-less `R_AMDGPU_RELATIVE64` relocation whose addend lands in the code
-/// object's single `.text` section. `R_AMDGPU_ABS64` references to the object
-/// are recorded as optional GOT slots. Discovery deliberately depends on ELF
-/// structure rather than table or application symbol names.
+/// @details A multi-entry candidate must be a non-empty `STT_OBJECT` whose size
+/// is a multiple of eight bytes. It must reside in an allocated, non-executable
+/// section and contain at least one aligned symbol-less `R_AMDGPU_RELATIVE64`
+/// relocation whose addend lands in the code object's single `.text` section.
+/// `R_AMDGPU_ABS64` references to the object are recorded as optional GOT
+/// slots. A direct `R_AMDGPU_ABS64` relocation from an aligned allocated data
+/// slot to an `STT_FUNC` in `.text` is represented as a one-entry table.
+/// Discovery deliberately depends on ELF structure rather than application
+/// symbol names.
 ///
 /// @returns Tables sorted by `table_vaddr`. Invalid, ambiguous, and unsupported
 /// ELF records are ignored; an object without a qualifying populated entry is

--- a/emulation/rocjitsu/tests/code/relocation_function_table_test.cpp
+++ b/emulation/rocjitsu/tests/code/relocation_function_table_test.cpp
@@ -319,6 +319,27 @@ void remove_got_reference(std::vector<uint8_t> &image) {
   std::memcpy(image.data() + rela->sh_offset, &first, sizeof(first));
 }
 
+void make_got_reference_target_function(std::vector<uint8_t> &image, uint64_t target_vaddr) {
+  Elf64_Ehdr ehdr{};
+  std::memcpy(&ehdr, image.data(), sizeof(ehdr));
+  std::vector<Elf64_Shdr> sections(ehdr.e_shnum);
+  std::memcpy(sections.data(), image.data() + ehdr.e_shoff, sections.size() * sizeof(Elf64_Shdr));
+  const auto symbols = std::ranges::find(sections, SHT_DYNSYM, &Elf64_Shdr::sh_type);
+  const auto text = std::ranges::find_if(
+      sections, [](const Elf64_Shdr &section) { return (section.sh_flags & SHF_EXECINSTR) != 0; });
+  ASSERT_NE(symbols, sections.end());
+  ASSERT_NE(text, sections.end());
+  ASSERT_GE(symbols->sh_size, 2 * sizeof(Elf64_Sym));
+
+  Elf64_Sym function{};
+  std::memcpy(&function, image.data() + symbols->sh_offset + sizeof(Elf64_Sym), sizeof(function));
+  function.st_info = elf_symbol_info(kElfSymbolBindGlobal, kElfSymbolTypeFunc);
+  function.st_shndx = static_cast<uint16_t>(text - sections.begin());
+  function.st_value = target_vaddr;
+  function.st_size = sizeof(uint32_t);
+  std::memcpy(image.data() + symbols->sh_offset + sizeof(Elf64_Sym), &function, sizeof(function));
+}
+
 // Mutate the first R_AMDGPU_RELATIVE64 relocation in the .rela section via a
 // caller-supplied editor, so negative tests can corrupt one table entry's slot
 // offset or addend and confirm discovery rejects just that entry.
@@ -344,6 +365,39 @@ void edit_first_relative64(std::vector<uint8_t> &image,
   FAIL() << "no R_AMDGPU_RELATIVE64 relocation found to edit";
 }
 
+void append_conflicting_duplicate_relocation_section(std::vector<uint8_t> &image) {
+  Elf64_Ehdr ehdr{};
+  std::memcpy(&ehdr, image.data(), sizeof(ehdr));
+  std::vector<Elf64_Shdr> sections(ehdr.e_shnum);
+  std::memcpy(sections.data(), image.data() + ehdr.e_shoff, sections.size() * sizeof(Elf64_Shdr));
+  const auto rela_section = std::ranges::find(sections, SHT_RELA, &Elf64_Shdr::sh_type);
+  ASSERT_NE(rela_section, sections.end());
+  ASSERT_EQ(rela_section->sh_size % sizeof(Elf64_Rela), 0u);
+
+  std::vector<Elf64_Rela> relas(rela_section->sh_size / sizeof(Elf64_Rela));
+  std::memcpy(relas.data(), image.data() + rela_section->sh_offset, rela_section->sh_size);
+  const auto relative = std::ranges::find_if(relas, [](const Elf64_Rela &rela) {
+    return elf_reloc_type(rela.r_info) == R_AMDGPU_RELATIVE64;
+  });
+  ASSERT_NE(relative, relas.end());
+  relative->r_addend += sizeof(uint32_t);
+
+  image.resize(ehdr.e_shoff);
+  const uint64_t duplicate_rela_offset = align_up(image.size(), alignof(Elf64_Rela));
+  image.resize(duplicate_rela_offset);
+  const auto *rela_bytes = reinterpret_cast<const uint8_t *>(relas.data());
+  image.insert(image.end(), rela_bytes, rela_bytes + relas.size() * sizeof(Elf64_Rela));
+
+  Elf64_Shdr duplicate = *rela_section;
+  duplicate.sh_offset = duplicate_rela_offset;
+  sections.push_back(duplicate);
+  ehdr.e_shoff = align_up(image.size(), alignof(Elf64_Shdr));
+  ehdr.e_shnum = static_cast<uint16_t>(sections.size());
+  image.resize(ehdr.e_shoff + sections.size() * sizeof(Elf64_Shdr));
+  std::memcpy(image.data(), &ehdr, sizeof(ehdr));
+  std::memcpy(image.data() + ehdr.e_shoff, sections.data(), sections.size() * sizeof(Elf64_Shdr));
+}
+
 TEST(RelocationFunctionTable, DiscoversGotReferencedRelativeTextPointers) {
   const auto image = make_relocation_function_table_elf();
   const AmdGpuCodeObject object(image.data(), image.size());
@@ -359,6 +413,24 @@ TEST(RelocationFunctionTable, DiscoversGotReferencedRelativeTextPointers) {
   EXPECT_EQ(tables[0].entries[0].target_text_offset, 4u);
   EXPECT_EQ(tables[0].entries[1].slot_vaddr, 0x2010u);
   EXPECT_EQ(tables[0].entries[1].target_text_offset, 12u);
+}
+
+TEST(RelocationFunctionTable, MergesConflictingDuplicateRelocationSectionsDeterministically) {
+  auto image = make_relocation_function_table_elf();
+  append_conflicting_duplicate_relocation_section(image);
+  const AmdGpuCodeObject object(image.data(), image.size());
+  ASSERT_TRUE(object.is_valid());
+
+  const auto tables = discover_relocation_function_tables(object);
+  ASSERT_EQ(tables.size(), 1u);
+  EXPECT_EQ(tables[0].got_slot_vaddrs, std::vector<uint64_t>{0x3000u});
+  ASSERT_EQ(tables[0].entries.size(), 3u);
+  EXPECT_EQ(tables[0].entries[0].slot_vaddr, 0x2000u);
+  EXPECT_EQ(tables[0].entries[0].target_text_offset, 4u);
+  EXPECT_EQ(tables[0].entries[1].slot_vaddr, 0x2000u);
+  EXPECT_EQ(tables[0].entries[1].target_text_offset, 8u);
+  EXPECT_EQ(tables[0].entries[2].slot_vaddr, 0x2010u);
+  EXPECT_EQ(tables[0].entries[2].target_text_offset, 12u);
 }
 
 TEST(RelocationFunctionTable, DiscoveryRejectsMisalignedTableSlot) {
@@ -537,6 +609,56 @@ TEST(RelocationFunctionTable, ResolvesRcclDirectIndexedTableDispatch) {
             analysis.address_builders[0].source_address_add_offset);
   EXPECT_EQ(table_free_analysis.address_builders[0].target_vaddr,
             analysis.address_builders[0].target_vaddr);
+}
+
+TEST(RelocationFunctionTable, ResolvesDirectFunctionPointerThroughGotLoad) {
+  constexpr uint64_t kTextVaddr = 0x1000;
+  constexpr uint64_t kGotVaddr = 0x3000;
+  constexpr uint64_t kCalleeOffset = 32;
+  const auto text_words =
+      make_direct_table_dispatch_text_with_addend(kGotVaddr - (kTextVaddr + sizeof(uint32_t)));
+  auto image = make_relocation_function_table_elf(text_words);
+  make_got_reference_target_function(image, kTextVaddr + kCalleeOffset);
+  const AmdGpuCodeObject object(image.data(), image.size());
+  ASSERT_TRUE(object.is_valid());
+
+  const auto tables = discover_relocation_function_tables(object);
+  ASSERT_EQ(tables.size(), 1u);
+  EXPECT_EQ(tables[0].table_vaddr, kGotVaddr);
+  EXPECT_EQ(tables[0].table_size, sizeof(uint64_t));
+  EXPECT_TRUE(tables[0].exact_base_only);
+  EXPECT_TRUE(tables[0].got_slot_vaddrs.empty());
+  ASSERT_EQ(tables[0].entries.size(), 1u);
+  EXPECT_EQ(tables[0].entries[0].slot_vaddr, kGotVaddr);
+  EXPECT_EQ(tables[0].entries[0].target_text_offset, kCalleeOffset);
+  EXPECT_TRUE(tables[0].entries[0].abi_function_symbol);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  constexpr std::array<uint64_t, 1> leaders{kCalleeOffset};
+  const auto blocks = BasicBlock::build(object, *decoder, ROCJITSU_CODE_ARCH_GFX1250, leaders);
+  const auto dispatches = analyze_relocation_pairs(blocks, tables, kTextVaddr).dispatches;
+  ASSERT_EQ(dispatches.size(), 1u);
+  EXPECT_EQ(dispatches[0].table_index, 0u);
+  EXPECT_EQ(dispatches[0].source_call_offset, 24u);
+  EXPECT_EQ(dispatches[0].return_sreg, 30u);
+  EXPECT_EQ(dispatches[0].source_getpc_offset, 0u);
+  EXPECT_EQ(dispatches[0].source_address_add_offset, 4u);
+  EXPECT_EQ(dispatches[0].source_table_address_vaddr, kGotVaddr);
+
+  const auto indexed_text = make_direct_table_dispatch_text_with_addend(
+      kGotVaddr + sizeof(uint32_t) - (kTextVaddr + sizeof(uint32_t)));
+  auto indexed_image = make_relocation_function_table_elf(indexed_text);
+  make_got_reference_target_function(indexed_image, kTextVaddr + kCalleeOffset);
+  const AmdGpuCodeObject indexed_object(indexed_image.data(), indexed_image.size());
+  ASSERT_TRUE(indexed_object.is_valid());
+  const auto indexed_tables = discover_relocation_function_tables(indexed_object);
+  ASSERT_EQ(indexed_tables.size(), 1u);
+  const auto indexed_blocks =
+      BasicBlock::build(indexed_object, *decoder, ROCJITSU_CODE_ARCH_GFX1250, leaders);
+  EXPECT_TRUE(
+      analyze_relocation_pairs(indexed_blocks, indexed_tables, kTextVaddr).dispatches.empty())
+      << "an indexed address must not widen a synthetic single-slot table";
 }
 
 TEST(RelocationFunctionTable, RejectsChainedAddressAddDispatch) {

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -705,7 +705,8 @@ bool has_error_containing(const TranslatedCodeObject &result, DiagnosticKind kin
 }
 
 std::vector<uint8_t> make_minimal_amdgpu_elf_with_two_kernel_descriptors(
-    const std::vector<uint32_t> &text_words = {0xBF810000u, 0xBF810000u}) {
+    const std::vector<uint32_t> &text_words = {0xBF810000u, 0xBF810000u},
+    size_t kernel1_entry_offset_words = 1) {
   constexpr uint64_t text_offset = 0x100;
   constexpr uint64_t text_vaddr = 0x1100;
   const uint64_t text_size = text_words.size() * sizeof(uint32_t);
@@ -785,7 +786,7 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_two_kernel_descriptors(
                                                                static_cast<int64_t>(rodata_vaddr));
   write_kernel_descriptor_entry_offset(
       descriptors.data() + kKernelDescriptorSize,
-      static_cast<int64_t>(text_vaddr + sizeof(uint32_t)) -
+      static_cast<int64_t>(text_vaddr + kernel1_entry_offset_words * sizeof(uint32_t)) -
           static_cast<int64_t>(rodata_vaddr + kKernelDescriptorSize));
   std::memcpy(image.data() + rodata_offset, descriptors.data(), descriptors.size());
   std::memcpy(image.data() + strtab_offset, strtab.data(), strtab.size());
@@ -12259,6 +12260,442 @@ TEST(BinaryTranslatorE2E, Gfx1250AdoptsDeviceFunctionBodyReachedByNoScope) {
   // The addend must land on the adopted body, not on whatever now occupies its original range.
   EXPECT_EQ(text_words_at_relative64_addend(result.elf_bytes, 2),
             (std::vector<uint32_t>{kGfx1250SNop, kGfx1250SEndpgm}));
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250AdoptsFunctionsForKernargLoadedIndirectCall) {
+  constexpr auto load_target =
+      gfx1250::build_smem(gfx1250::kSLoadB64Smem, {.sbase = 0, .sdata = 4, .soffset = 128});
+  constexpr auto call = gfx1250::build_sop1(gfx1250::kSSwapPcI64Sop1, {.ssrc0 = 4, .sdst = 30});
+  constexpr auto function_return = gfx1250::build_sop1(gfx1250::kSSetPcI64Sop1, {.ssrc0 = 30});
+  constexpr uint32_t kWaitKmcntZero = 0xBFC70000u;
+  constexpr uint32_t kSEndpgm = 0xBFB00000u;
+  constexpr uint32_t kSNop = 0xBF800000u;
+  const std::vector<uint32_t> words = {load_target[0], load_target[1], kWaitKmcntZero,    call[0],
+                                       kSEndpgm,       kSNop,          function_return[0]};
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      words, /*text_function_words=*/1, /*text_function_offset_words=*/6);
+  rocjitsu::enable_kernarg_segment_ptr_sgpr(image);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+  EXPECT_TRUE(result.dispatchable());
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250TracksWideKernargLoadsToExternalCalls) {
+  constexpr auto load_targets =
+      gfx1250::build_smem(gfx1250::kSLoadB256Smem, {.sbase = 0, .sdata = 4, .soffset = 128});
+  constexpr auto call = gfx1250::build_sop1(gfx1250::kSSwapPcI64Sop1, {.ssrc0 = 8, .sdst = 30});
+  constexpr auto function_return = gfx1250::build_sop1(gfx1250::kSSetPcI64Sop1, {.ssrc0 = 30});
+  constexpr uint32_t kWaitKmcntZero = 0xBFC70000u;
+  constexpr uint32_t kSEndpgm = 0xBFB00000u;
+  constexpr uint32_t kSNop = 0xBF800000u;
+  const std::vector<uint32_t> words = {load_targets[0], load_targets[1], kWaitKmcntZero,    call[0],
+                                       kSEndpgm,        kSNop,           function_return[0]};
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      words, /*text_function_words=*/1, /*text_function_offset_words=*/6);
+  rocjitsu::enable_kernarg_segment_ptr_sgpr(image, 32);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+  EXPECT_TRUE(result.dispatchable());
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250TracksFunctionPointerLoadedThroughKernargTable) {
+  constexpr auto load_table_and_index =
+      gfx1250::build_smem(gfx1250::kSLoadB96Smem, {.sbase = 0, .sdata = 12, .soffset = 128});
+  constexpr auto load_target =
+      gfx1250::build_smem(gfx1250::kSLoadB64Smem, {.sbase = 6, .sdata = 12, .soffset = 128});
+  constexpr auto call = gfx1250::build_sop1(gfx1250::kSSwapPcI64Sop1, {.ssrc0 = 12, .sdst = 30});
+  constexpr auto function_return = gfx1250::build_sop1(gfx1250::kSSetPcI64Sop1, {.ssrc0 = 30});
+  constexpr uint32_t kWaitKmcntZero = 0xBFC70000u;
+  constexpr uint32_t kSEndpgm = 0xBFB00000u;
+  constexpr uint32_t kSNop = 0xBF800000u;
+  const std::vector<uint32_t> words = {
+      load_table_and_index[0],
+      load_table_and_index[1],
+      kWaitKmcntZero,
+      load_target[0],
+      load_target[1],
+      kWaitKmcntZero,
+      call[0],
+      kSEndpgm,
+      kSNop,
+      function_return[0],
+  };
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      words, /*text_function_words=*/1, /*text_function_offset_words=*/9);
+  rocjitsu::enable_kernarg_segment_ptr_sgpr(image, 16);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+  EXPECT_TRUE(result.dispatchable());
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250RejectsExternalCallWhenFunctionEnumerationFails) {
+  constexpr auto load_target =
+      gfx1250::build_smem(gfx1250::kSLoadB64Smem, {.sbase = 0, .sdata = 4, .soffset = 128});
+  constexpr auto call = gfx1250::build_sop1(gfx1250::kSSwapPcI64Sop1, {.ssrc0 = 4, .sdst = 30});
+  constexpr auto function_return = gfx1250::build_sop1(gfx1250::kSSetPcI64Sop1, {.ssrc0 = 30});
+  constexpr uint32_t kWaitKmcntZero = 0xBFC70000u;
+  constexpr uint32_t kSEndpgm = 0xBFB00000u;
+  constexpr uint32_t kSNop = 0xBF800000u;
+  const std::vector<uint32_t> words = {load_target[0], load_target[1], kWaitKmcntZero,    call[0],
+                                       kSEndpgm,       kSNop,          function_return[0]};
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      words, /*text_function_words=*/1, /*text_function_offset_words=*/6);
+  rocjitsu::enable_kernarg_segment_ptr_sgpr(image);
+
+  rocjitsu::Elf64_Ehdr ehdr{};
+  std::memcpy(&ehdr, image.data(), sizeof(ehdr));
+  std::vector<rocjitsu::Elf64_Shdr> sections(ehdr.e_shnum);
+  std::memcpy(sections.data(), image.data() + ehdr.e_shoff,
+              sections.size() * sizeof(rocjitsu::Elf64_Shdr));
+  const auto text_section = std::ranges::find_if(sections, [](const rocjitsu::Elf64_Shdr &section) {
+    return (section.sh_flags & rocjitsu::SHF_EXECINSTR) != 0;
+  });
+  ASSERT_NE(text_section, sections.end());
+  ASSERT_EQ(image.size(), ehdr.e_shoff + sections.size() * sizeof(rocjitsu::Elf64_Shdr));
+  const rocjitsu::Elf64_Shdr duplicate_text = *text_section;
+  image.resize(image.size() + sizeof(duplicate_text));
+  std::memcpy(image.data() + ehdr.e_shoff + sections.size() * sizeof(rocjitsu::Elf64_Shdr),
+              &duplicate_text, sizeof(duplicate_text));
+  ++ehdr.e_shnum;
+  std::memcpy(image.data(), &ehdr, sizeof(ehdr));
+
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(rocjitsu::has_error_containing(result, rocjitsu::DiagnosticKind::Legalization,
+                                             "complete static device-function set could not be "
+                                             "enumerated"));
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250RejectsExternalCallWhenLocalFunctionSymbolsAreStripped) {
+  constexpr auto load_target =
+      gfx1250::build_smem(gfx1250::kSLoadB64Smem, {.sbase = 0, .sdata = 4, .soffset = 128});
+  constexpr auto call = gfx1250::build_sop1(gfx1250::kSSwapPcI64Sop1, {.ssrc0 = 4, .sdst = 30});
+  constexpr auto function_return = gfx1250::build_sop1(gfx1250::kSSetPcI64Sop1, {.ssrc0 = 30});
+  constexpr uint32_t kWaitKmcntZero = 0xBFC70000u;
+  constexpr uint32_t kSEndpgm = 0xBFB00000u;
+  constexpr uint32_t kSNop = 0xBF800000u;
+  const std::vector<uint32_t> words = {load_target[0], load_target[1], kWaitKmcntZero,    call[0],
+                                       kSEndpgm,       kSNop,          function_return[0]};
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      words, /*text_function_words=*/1, /*text_function_offset_words=*/6);
+  rocjitsu::enable_kernarg_segment_ptr_sgpr(image);
+
+  rocjitsu::Elf64_Ehdr ehdr{};
+  std::memcpy(&ehdr, image.data(), sizeof(ehdr));
+  std::vector<rocjitsu::Elf64_Shdr> sections(ehdr.e_shnum);
+  std::memcpy(sections.data(), image.data() + ehdr.e_shoff,
+              sections.size() * sizeof(rocjitsu::Elf64_Shdr));
+  const auto symbols =
+      std::ranges::find(sections, rocjitsu::SHT_SYMTAB, &rocjitsu::Elf64_Shdr::sh_type);
+  ASSERT_NE(symbols, sections.end());
+  for (size_t index = 0; index < symbols->sh_size / sizeof(rocjitsu::Elf64_Sym); ++index) {
+    const size_t offset = symbols->sh_offset + index * sizeof(rocjitsu::Elf64_Sym);
+    rocjitsu::Elf64_Sym symbol{};
+    std::memcpy(&symbol, image.data() + offset, sizeof(symbol));
+    if (rocjitsu::elf_symbol_type(symbol.st_info) != rocjitsu::kElfSymbolTypeFunc)
+      continue;
+    symbol.st_info =
+        rocjitsu::elf_symbol_info(rocjitsu::kElfSymbolBindLocal, rocjitsu::kElfSymbolTypeNone);
+    std::memcpy(image.data() + offset, &symbol, sizeof(symbol));
+  }
+
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(rocjitsu::has_error_containing(result, rocjitsu::DiagnosticKind::Legalization,
+                                             "complete static device-function set could not be "
+                                             "enumerated"));
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250RejectsExternalCallAcrossKernelScopes) {
+  constexpr auto trusted_load =
+      gfx1250::build_smem(gfx1250::kSLoadB64Smem, {.sbase = 0, .sdata = 4, .soffset = 128});
+  constexpr auto unknown_load =
+      gfx1250::build_smem(gfx1250::kSLoadB64Smem, {.sbase = 1, .sdata = 4, .soffset = 128});
+  constexpr auto call = gfx1250::build_sop1(gfx1250::kSSwapPcI64Sop1, {.ssrc0 = 4, .sdst = 30});
+  constexpr auto function_return = gfx1250::build_sop1(gfx1250::kSSetPcI64Sop1, {.ssrc0 = 30});
+  constexpr uint32_t kWaitKmcntZero = 0xBFC70000u;
+  constexpr uint32_t kSEndpgm = 0xBFB00000u;
+  constexpr uint32_t kSNop = 0xBF800000u;
+  constexpr size_t kSecondKernelWord = 5;
+  constexpr size_t kFunctionWord = 10;
+  const std::vector<uint32_t> words = {
+      trusted_load[0], trusted_load[1], kWaitKmcntZero, call[0],  kSEndpgm, unknown_load[0],
+      unknown_load[1], kWaitKmcntZero,  call[0],        kSEndpgm, kSNop,    function_return[0],
+  };
+  auto image =
+      rocjitsu::make_minimal_amdgpu_elf_with_two_kernel_descriptors(words, kSecondKernelWord);
+  rocjitsu::enable_kernarg_segment_ptr_sgpr(image);
+
+  rocjitsu::Elf64_Ehdr ehdr{};
+  std::memcpy(&ehdr, image.data(), sizeof(ehdr));
+  std::vector<rocjitsu::Elf64_Shdr> sections(ehdr.e_shnum);
+  std::memcpy(sections.data(), image.data() + ehdr.e_shoff,
+              sections.size() * sizeof(rocjitsu::Elf64_Shdr));
+  const auto text = std::ranges::find_if(sections, [](const auto &section) {
+    return (section.sh_flags & rocjitsu::SHF_EXECINSTR) != 0;
+  });
+  const auto symbols =
+      std::ranges::find(sections, rocjitsu::SHT_SYMTAB, &rocjitsu::Elf64_Shdr::sh_type);
+  ASSERT_NE(text, sections.end());
+  ASSERT_NE(symbols, sections.end());
+  std::vector<rocjitsu::Elf64_Sym> expanded_symbols(symbols->sh_size / sizeof(rocjitsu::Elf64_Sym) +
+                                                    1);
+  std::memcpy(expanded_symbols.data(), image.data() + symbols->sh_offset, symbols->sh_size);
+  auto &function = expanded_symbols.back();
+  function.st_info =
+      rocjitsu::elf_symbol_info(rocjitsu::kElfSymbolBindLocal, rocjitsu::kElfSymbolTypeFunc);
+  function.st_shndx = static_cast<uint16_t>(text - sections.begin());
+  function.st_value = text->sh_addr + kFunctionWord * sizeof(uint32_t);
+  function.st_size = 2 * sizeof(uint32_t);
+  const uint64_t new_symtab_offset = image.size();
+  image.resize(image.size() + expanded_symbols.size() * sizeof(rocjitsu::Elf64_Sym));
+  std::memcpy(image.data() + new_symtab_offset, expanded_symbols.data(),
+              expanded_symbols.size() * sizeof(rocjitsu::Elf64_Sym));
+  const size_t symbol_section_index = static_cast<size_t>(symbols - sections.begin());
+  sections[symbol_section_index].sh_offset = new_symtab_offset;
+  sections[symbol_section_index].sh_size = expanded_symbols.size() * sizeof(rocjitsu::Elf64_Sym);
+  std::memcpy(image.data() + ehdr.e_shoff, sections.data(),
+              sections.size() * sizeof(rocjitsu::Elf64_Shdr));
+
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(rocjitsu::has_error_containing(
+      result, rocjitsu::DiagnosticKind::Legalization,
+      "kernarg-loaded indirect calls require one compatible kernel translation scope"));
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250RejectsExternalCallWhenFunctionIsNotAnInstructionBoundary) {
+  constexpr auto load_target =
+      gfx1250::build_smem(gfx1250::kSLoadB64Smem, {.sbase = 0, .sdata = 4, .soffset = 128});
+  constexpr auto call = gfx1250::build_sop1(gfx1250::kSSwapPcI64Sop1, {.ssrc0 = 4, .sdst = 30});
+  constexpr auto function_return = gfx1250::build_sop1(gfx1250::kSSetPcI64Sop1, {.ssrc0 = 30});
+  constexpr uint32_t kWaitKmcntZero = 0xBFC70000u;
+  constexpr uint32_t kSEndpgm = 0xBFB00000u;
+  constexpr uint32_t kSNop = 0xBF800000u;
+  const std::vector<uint32_t> words = {load_target[0], load_target[1], kWaitKmcntZero,    call[0],
+                                       kSEndpgm,       kSNop,          function_return[0]};
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      words, /*text_function_words=*/1, /*text_function_offset_words=*/6);
+  rocjitsu::enable_kernarg_segment_ptr_sgpr(image);
+
+  rocjitsu::Elf64_Ehdr ehdr{};
+  std::memcpy(&ehdr, image.data(), sizeof(ehdr));
+  std::vector<rocjitsu::Elf64_Shdr> sections(ehdr.e_shnum);
+  std::memcpy(sections.data(), image.data() + ehdr.e_shoff,
+              sections.size() * sizeof(rocjitsu::Elf64_Shdr));
+  const auto text = std::ranges::find_if(sections, [](const rocjitsu::Elf64_Shdr &section) {
+    return (section.sh_flags & rocjitsu::SHF_EXECINSTR) != 0;
+  });
+  const auto symbols = std::ranges::find_if(sections, [](const rocjitsu::Elf64_Shdr &section) {
+    return section.sh_type == rocjitsu::SHT_SYMTAB;
+  });
+  ASSERT_NE(text, sections.end());
+  ASSERT_NE(symbols, sections.end());
+  const uint16_t text_index = static_cast<uint16_t>(text - sections.begin());
+  bool changed_function = false;
+  for (size_t index = 0; index < symbols->sh_size / sizeof(rocjitsu::Elf64_Sym); ++index) {
+    const size_t offset = symbols->sh_offset + index * sizeof(rocjitsu::Elf64_Sym);
+    rocjitsu::Elf64_Sym symbol{};
+    std::memcpy(&symbol, image.data() + offset, sizeof(symbol));
+    if (symbol.st_shndx != text_index ||
+        rocjitsu::elf_symbol_type(symbol.st_info) != rocjitsu::kElfSymbolTypeFunc ||
+        symbol.st_value != text->sh_addr + 6 * sizeof(uint32_t)) {
+      continue;
+    }
+    symbol.st_value += 2;
+    std::memcpy(image.data() + offset, &symbol, sizeof(symbol));
+    changed_function = true;
+  }
+  ASSERT_TRUE(changed_function);
+
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(
+      rocjitsu::has_error_containing(result, rocjitsu::DiagnosticKind::Legalization,
+                                     "defined device function is not an instruction boundary"));
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250IgnoresEmptySymbolSectionDuringFunctionEnumeration) {
+  constexpr auto load_target =
+      gfx1250::build_smem(gfx1250::kSLoadB64Smem, {.sbase = 0, .sdata = 4, .soffset = 128});
+  constexpr auto call = gfx1250::build_sop1(gfx1250::kSSwapPcI64Sop1, {.ssrc0 = 4, .sdst = 30});
+  constexpr auto function_return = gfx1250::build_sop1(gfx1250::kSSetPcI64Sop1, {.ssrc0 = 30});
+  constexpr uint32_t kWaitKmcntZero = 0xBFC70000u;
+  constexpr uint32_t kSEndpgm = 0xBFB00000u;
+  constexpr uint32_t kSNop = 0xBF800000u;
+  const std::vector<uint32_t> words = {load_target[0], load_target[1], kWaitKmcntZero,    call[0],
+                                       kSEndpgm,       kSNop,          function_return[0]};
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      words, /*text_function_words=*/1, /*text_function_offset_words=*/6);
+  rocjitsu::enable_kernarg_segment_ptr_sgpr(image);
+
+  rocjitsu::Elf64_Ehdr ehdr{};
+  std::memcpy(&ehdr, image.data(), sizeof(ehdr));
+  ASSERT_EQ(image.size(), ehdr.e_shoff + ehdr.e_shnum * sizeof(rocjitsu::Elf64_Shdr));
+  rocjitsu::Elf64_Shdr empty_symbols{};
+  empty_symbols.sh_type = rocjitsu::SHT_DYNSYM;
+  image.resize(image.size() + sizeof(empty_symbols));
+  std::memcpy(image.data() + ehdr.e_shoff + ehdr.e_shnum * sizeof(rocjitsu::Elf64_Shdr),
+              &empty_symbols, sizeof(empty_symbols));
+  ++ehdr.e_shnum;
+  std::memcpy(image.data(), &ehdr, sizeof(ehdr));
+
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+  EXPECT_TRUE(result.dispatchable());
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250RefusesCanonicalResourceGrowthAcrossDescriptors) {
+  constexpr uint32_t kSEndpgm = 0xBFB00000u;
+  constexpr uint32_t kSNop = 0xBF800000u;
+  constexpr uint32_t kGetPcS0 = 0xBE804700u;
+  constexpr uint32_t kAddNcU64S0 = 0xA980FE00u;
+  constexpr auto addtid =
+      gfx1250::build_vds(gfx1250::kDsStoreAddtidB32Vds, {.offset0 = 4, .data0 = 8});
+  constexpr auto function_return = gfx1250::build_sop1(gfx1250::kSSetPcI64Sop1, {.ssrc0 = 30});
+
+  for (const bool canonical_host_first : {false, true}) {
+    SCOPED_TRACE(canonical_host_first ? "canonical host first" : "canonical host second");
+    // In either order, one kernel ends immediately while the other takes the
+    // address of word 8 and calls it directly. The scratch floor makes the
+    // canonical body's semantic rewrite claim v200. The translator cannot
+    // attribute that requirement to the body independently of its host scope,
+    // so it must refuse instead of inflating the unrelated descriptor.
+    const std::vector<uint32_t> words = canonical_host_first
+                                            ? std::vector<uint32_t>{
+                                                  kGetPcS0,
+                                                  kAddNcU64S0,
+                                                  28u,
+                                                  0u,
+                                                  rocjitsu::build_s_call_b64(
+                                                      30, 3, ROCJITSU_CODE_ARCH_GFX1250),
+                                                  kSEndpgm,
+                                                  kSEndpgm,
+                                                  kSNop,
+                                                  addtid[0],
+                                                  addtid[1],
+                                                  function_return[0],
+                                              }
+                                            : std::vector<uint32_t>{
+                                                  kSEndpgm,
+                                                  kGetPcS0,
+                                                  kAddNcU64S0,
+                                                  24u,
+                                                  0u,
+                                                  rocjitsu::build_s_call_b64(
+                                                      30, 2, ROCJITSU_CODE_ARCH_GFX1250),
+                                                  kSEndpgm,
+                                                  kSNop,
+                                                  addtid[0],
+                                                  addtid[1],
+                                                  function_return[0],
+                                              };
+    const size_t kernel1_entry = canonical_host_first ? 6 : 1;
+    auto image =
+        rocjitsu::make_minimal_amdgpu_elf_with_two_kernel_descriptors(words, kernel1_entry);
+    rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+    ASSERT_TRUE(source.is_valid());
+
+    auto options = gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                                            rocjitsu::ProcessorRevision::Gfx1250A0);
+    options.debug_min_free_vgpr = 200;
+    rocjitsu::BinaryTranslator translator(ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+                                          options);
+    const auto result = translator.translate(source);
+    EXPECT_FALSE(result.ok());
+    EXPECT_EQ(result.elf_bytes, image);
+    EXPECT_TRUE(rocjitsu::has_error_containing(
+        result, rocjitsu::DiagnosticKind::KernelDescriptor,
+        "body reached through a code address needs resources beyond its hosting kernel"));
+  }
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250DoesNotTrustIndirectCallLoadedThroughUnknownBase) {
+  constexpr auto load_target =
+      gfx1250::build_smem(gfx1250::kSLoadB64Smem, {.sbase = 1, .sdata = 4, .soffset = 128});
+  constexpr auto call = gfx1250::build_sop1(gfx1250::kSSwapPcI64Sop1, {.ssrc0 = 4, .sdst = 30});
+  constexpr auto function_return = gfx1250::build_sop1(gfx1250::kSSetPcI64Sop1, {.ssrc0 = 30});
+  constexpr uint32_t kWaitKmcntZero = 0xBFC70000u;
+  constexpr uint32_t kSEndpgm = 0xBFB00000u;
+  constexpr uint32_t kSNop = 0xBF800000u;
+  const std::vector<uint32_t> words = {load_target[0], load_target[1], kWaitKmcntZero,    call[0],
+                                       kSEndpgm,       kSNop,          function_return[0]};
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      words, /*text_function_words=*/1, /*text_function_offset_words=*/6);
+  rocjitsu::enable_kernarg_segment_ptr_sgpr(image);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
 }
 // The same shape with the pointer array's own symbol stripped. Adoption is driven by the
 // discovered function tables, and discovery needs a qualifying `STT_OBJECT` around the slot, so a


### PR DESCRIPTION
Discover direct GOT slots that reference defined device functions, normalize relocation-backed tables, and treat their standard ABI returns as bounded adopted roots.

Track kernarg-derived function pointers across kernel CFGs, preserve every compatible defined function, and propagate canonical-body VGPR, SGPR, and private-memory requirements to all descriptors that can enter those bodies.
