### PR TITLE
[rocjitsu] Stage flat-scratch inputs in VGPRs

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/liveness.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/liveness.cpp
@@ -393,6 +393,11 @@ std::optional<uint8_t> LivenessAnalysis::vgpr_msb_bank_before(const Instruction 
   return gfx1250_vgpr_msb_->bank_before(inst, role);
 }
 
+bool LivenessAnalysis::global_vgpr_usage_is_complete() const {
+  require_available();
+  return global_vgpr_usage_is_complete_;
+}
+
 std::optional<uint16_t>
 LivenessAnalysis::find_globally_unused_vgpr_run(const Instruction *inst, uint16_t count,
                                                 uint16_t search_start, uint16_t base_alignment,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/liveness.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/liveness.h
@@ -191,6 +191,13 @@ public:
   [[nodiscard]] std::optional<uint8_t> vgpr_msb_bank_before(const Instruction &inst,
                                                             amdgpu::VgprMsbRole role) const;
 
+  /// @brief Whether statically decoded operands cover every VGPR access in the scope.
+  ///
+  /// @details False when relative addressing or runtime GPR indexing can redirect
+  /// an encoded VGPR operand. Transformations that compare or reuse physical
+  /// VGPR ranges must fail closed when this query returns false.
+  [[nodiscard]] bool global_vgpr_usage_is_complete() const;
+
   /// @brief Find a VGPR tuple that no instruction in the kernel reads or writes.
   ///
   /// @details This query is cheaper and stronger than point liveness: the

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_flat_scratch_base.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_flat_scratch_base.cpp
@@ -7,6 +7,7 @@
 #include "rocjitsu/code/dbt/semantic/gfx1250_flat_scratch_base.h"
 
 #include "rocjitsu/analysis/liveness.h"
+#include "rocjitsu/code/dbt/hazard_tracker.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/gfx1250/builders.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/gfx1250/opcodes.h"
 #include "rocjitsu/isa/instruction.h"
@@ -41,6 +42,12 @@ constexpr int k64BitOperand = 64;
 /// the general-purpose file, so a borrowed pair must stay below it.
 constexpr uint16_t kMaxOrdinarySgpr = 105;
 
+/// @brief Complete any producer of the aliased s102:s103 state before reading
+/// the architectural flat-scratch selectors.
+[[nodiscard]] uint32_t flat_scratch_selector_wait() {
+  return gfx1250::build_sopp(gfx1250::kSWaitAluSopp, {.simm16 = 0})[0];
+}
+
 /// @brief Width of a vector source field wide enough to name a scalar value.
 /// @details The compact vector formats give their second source an eight-bit
 /// field that indexes the vector file directly, so it can hold the selector's
@@ -60,6 +67,8 @@ struct EncodingSourceFields {
   std::array<SourceField, 3> fields{};
   uint8_t count = 0;
   bool vector = false; ///< True when sources are read by the vector ALU.
+  /// True when this EXEC-masked encoding may stage through an overwritten destination.
+  bool destination_stageable = false;
 };
 
 /// @brief Identify the base encoding from its self-describing high bits.
@@ -81,21 +90,29 @@ struct EncodingSourceFields {
   if ((word0 >> 30) == 2) // SOP2
     return EncodingSourceFields{.fields = {{{0, 0, 8}, {0, 8, 8}}}, .count = 2, .vector = false};
   if ((word0 >> 26) == 53) // VOP3
-    return EncodingSourceFields{
-        .fields = {{{1, 0, 9}, {1, 9, 9}, {1, 18, 9}}}, .count = 3, .vector = true};
+    return EncodingSourceFields{.fields = {{{1, 0, 9}, {1, 9, 9}, {1, 18, 9}}},
+                                .count = 3,
+                                .vector = true,
+                                .destination_stageable = true};
   // VOP3P shares VOP3's second-word source layout but not its leading bits, and
   // its packed sources are 64 bits wide, so it reaches the selector the same way.
   if ((word0 >> 24) == 204) // VOP3P
-    return EncodingSourceFields{
-        .fields = {{{1, 0, 9}, {1, 9, 9}, {1, 18, 9}}}, .count = 3, .vector = true};
+    return EncodingSourceFields{.fields = {{{1, 0, 9}, {1, 9, 9}, {1, 18, 9}}},
+                                .count = 3,
+                                .vector = true,
+                                .destination_stageable = true};
   if ((word0 >> 25) == 63) // VOP1
-    return EncodingSourceFields{.fields = {{{0, 0, 9}}}, .count = 1, .vector = true};
+    return EncodingSourceFields{
+        .fields = {{{0, 0, 9}}}, .count = 1, .vector = true, .destination_stageable = true};
   if ((word0 >> 25) == 62) // VOPC
     return EncodingSourceFields{.fields = {{{0, 0, 9}, {0, 9, 8}}}, .count = 2, .vector = true};
   // VOP2 is the remaining format whose leading bit is clear; the compact
   // formats above are tested first, so reaching here identifies it.
   if ((word0 >> 31) == 0) // VOP2
-    return EncodingSourceFields{.fields = {{{0, 0, 9}, {0, 9, 8}}}, .count = 2, .vector = true};
+    return EncodingSourceFields{.fields = {{{0, 0, 9}, {0, 9, 8}}},
+                                .count = 2,
+                                .vector = true,
+                                .destination_stageable = true};
   return std::nullopt;
 }
 
@@ -238,6 +255,95 @@ instruction_words(const Instruction &inst, uint64_t offset, std::span<const uint
   return false;
 }
 
+[[nodiscard]] bool register_ranges_overlap(uint16_t lhs_base, uint16_t lhs_width, uint16_t rhs_base,
+                                           uint16_t rhs_width) {
+  return lhs_base < static_cast<uint32_t>(rhs_base) + rhs_width &&
+         rhs_base < static_cast<uint32_t>(lhs_base) + lhs_width;
+}
+
+/// @brief Reuse an overwritten destination pair to stage the flat-scratch base.
+///
+/// @details Two 32-bit vector moves can read the low and high special selectors
+/// on A0 even though a 64-bit vector source cannot. The gfx1250 A0 source-
+/// operand table assigns selectors 230 and 231 to the two 32-bit halves; the
+/// corresponding VOP1 encodings also round-trip through llvm-mc for gfx1250.
+/// The destination is safe
+/// scratch only when it is exactly one VGPR pair, no other source aliases it,
+/// and each rewritten source role selects the same physical VGPR bank as the
+/// destination role. Tied operands are rejected by the explicit-source scan;
+/// gfx1250 partial-write and read-modify-write destinations are rejected by the
+/// separate implicit-use scan. Unknown or mismatched banking fails closed.
+///
+/// The staging moves are EXEC-masked VALU operations. They are safe here because
+/// the instruction they precede is also an EXEC-masked VALU operation; an
+/// encoding with different lane-mask semantics must not use this fallback.
+[[nodiscard]] std::optional<uint16_t> reusable_destination_pair(const Instruction &inst,
+                                                                const EncodingSourceFields &layout,
+                                                                std::span<const uint32_t> words,
+                                                                const LivenessAnalysis &liveness) {
+  if (!layout.destination_stageable || inst.num_dst_operands() != 1 ||
+      !liveness.global_vgpr_usage_is_complete())
+    return std::nullopt;
+
+  const Operand *dst = inst.dst_operand(0);
+  if (dst == nullptr)
+    return std::nullopt;
+  const auto dst_ref = dst->to_register_ref();
+  if (!dst_ref || dst_ref->cls != RegClass::VGPR || dst_ref->width != 2 ||
+      static_cast<uint32_t>(dst_ref->index) + dst_ref->width > 256u)
+    return std::nullopt;
+  const auto dst_bank = liveness.vgpr_msb_bank_before(inst, dst->vgpr_msb_role());
+  if (!dst_bank)
+    return std::nullopt;
+  const uint16_t dst_phys =
+      static_cast<uint16_t>(dst_ref->index + static_cast<uint16_t>(*dst_bank) * 256u);
+
+  bool found_rewritable_source = false;
+  for (int index = 0; index < inst.num_src_operands(); ++index) {
+    const Operand *src = inst.src_operand(index);
+    if (src == nullptr)
+      continue;
+    const bool rewritable = index < static_cast<int>(layout.count) &&
+                            is_flat_scratch_base_64bit_source(inst, index, layout, words);
+    if (rewritable) {
+      found_rewritable_source = true;
+      const auto src_bank = liveness.vgpr_msb_bank_before(inst, src->vgpr_msb_role());
+      if (!src_bank || *src_bank != *dst_bank)
+        return std::nullopt;
+      continue;
+    }
+
+    const auto src_ref = src->to_register_ref();
+    if (!src_ref || src_ref->cls != RegClass::VGPR)
+      continue;
+    if (static_cast<uint32_t>(src_ref->index) + src_ref->width > 256u)
+      return std::nullopt;
+    const auto src_bank = liveness.vgpr_msb_bank_before(inst, src->vgpr_msb_role());
+    if (!src_bank) {
+      if (register_ranges_overlap(dst_ref->index, dst_ref->width, src_ref->index, src_ref->width))
+        return std::nullopt;
+      continue;
+    }
+    const uint16_t src_phys =
+        static_cast<uint16_t>(src_ref->index + static_cast<uint16_t>(*src_bank) * 256u);
+    if (register_ranges_overlap(dst_phys, dst_ref->width, src_phys, src_ref->width))
+      return std::nullopt;
+  }
+
+  RegisterSet implicit_uses;
+  inst.implicit_uses(implicit_uses);
+  bool implicit_alias = false;
+  implicit_uses.for_each([&](RegisterRef ref) {
+    if (ref.cls == RegClass::VGPR &&
+        register_ranges_overlap(dst_ref->index, dst_ref->width,
+                                static_cast<uint16_t>(ref.index & 0xffu), ref.width))
+      implicit_alias = true;
+  });
+  if (implicit_alias || !found_rewritable_source)
+    return std::nullopt;
+  return dst_ref->index;
+}
+
 } // namespace
 
 bool gfx1250_reads_flat_scratch_base_64bit(const Instruction &inst) {
@@ -290,6 +396,37 @@ ExpandResult gfx1250_lower_flat_scratch_base_source(const Instruction &inst, uin
   const int rewritable = std::min(inst.num_src_operands(), static_cast<int>(layout->count));
   std::vector<uint32_t> prologue;
   std::optional<uint16_t> borrowed_pair;
+  std::optional<uint16_t> staged_vgpr_pair;
+  if (layout->vector) {
+    borrowed_pair = liveness.find_free_sgpr_pair(&inst);
+    if (!borrowed_pair || *borrowed_pair + 1 > kMaxOrdinarySgpr) {
+      borrowed_pair.reset();
+      staged_vgpr_pair = reusable_destination_pair(inst, *layout, *words, liveness);
+      if (!staged_vgpr_pair) {
+        return ExpandResult::failed(
+            "gfx1250 flat-scratch-base rewrite could not allocate safe temporary storage",
+            {"Free an aligned SGPR pair or a non-aliasing destination VGPR pair around this "
+             "instruction."});
+      }
+    }
+    if (borrowed_pair) {
+      prologue.push_back(flat_scratch_selector_wait());
+      // No descriptor growth is involved. This target's scalar file is fixed
+      // rather than sized by the descriptor, and the translator does not write
+      // the legacy granulated field for it, so raising a requirement here would
+      // change nothing. The bound that matters is that the pair stays inside the
+      // architecturally addressable range, which the check above enforces.
+      const auto move = gfx1250::build_sop1(gfx1250::kSMovB64Sop1,
+                                            {.ssrc0 = static_cast<uint8_t>(kFlatScratchBaseLo),
+                                             .sdst = static_cast<uint8_t>(*borrowed_pair)});
+      // Appended one word at a time rather than as an iterator range: the
+      // range form of insert() reduces to a bulk copy whose bounds GCC cannot
+      // relate back to a single-element std::array, and it reports the
+      // one-past-the-end pointer as an out-of-bounds access.
+      for (const uint32_t word : move)
+        prologue.push_back(word);
+    }
+  }
   for (int i = 0; i < rewritable; ++i) {
     if (!is_flat_scratch_base_64bit_source(inst, i, *layout, *words))
       continue;
@@ -306,31 +443,30 @@ ExpandResult gfx1250_lower_flat_scratch_base_source(const Instruction &inst, uin
       continue;
     }
 
-    // A vector read takes the base from an ordinary SGPR pair. One scalar move
-    // serves every affected source position in this instruction.
-    if (!borrowed_pair) {
-      borrowed_pair = liveness.find_free_sgpr_pair(&inst);
-      if (!borrowed_pair || *borrowed_pair + 1 > kMaxOrdinarySgpr) {
-        return ExpandResult::failed(
-            "gfx1250 flat-scratch-base rewrite could not allocate a dead SGPR pair",
-            {"Free an aligned SGPR pair around this instruction."});
-      }
-      // No descriptor growth is involved. This target's scalar file is fixed
-      // rather than sized by the descriptor, and the translator does not write
-      // the legacy granulated field for it, so raising a requirement here would
-      // change nothing. The bound that matters is that the pair stays inside the
-      // architecturally addressable range, which the check above enforces.
-      const auto move = gfx1250::build_sop1(gfx1250::kSMovB64Sop1,
-                                            {.ssrc0 = static_cast<uint8_t>(kFlatScratchBaseLo),
-                                             .sdst = static_cast<uint8_t>(*borrowed_pair)});
-      // Appended one word at a time rather than as an iterator range: the
-      // range form of insert() reduces to a bulk copy whose bounds GCC cannot
-      // relate back to a single-element std::array, and it reports the
-      // one-past-the-end pointer as an out-of-bounds access.
-      for (const uint32_t word : move)
-        prologue.push_back(word);
+    // One temporary serves every affected source position in this instruction.
+    if (staged_vgpr_pair) {
+      set_word_field((*words)[field.word], 256u + *staged_vgpr_pair, field.shift, field.width);
+      continue;
     }
     set_word_field((*words)[field.word], *borrowed_pair, field.shift, field.width);
+  }
+
+  if (staged_vgpr_pair) {
+    std::vector<uint32_t> replacement;
+    using Pipeline = HazardTracker::Pipeline;
+    HazardTracker hazards;
+    const auto low = gfx1250::build_vop1(
+        gfx1250::kVMovB32Vop1,
+        {.src0 = kFlatScratchBaseLo, .vdst = static_cast<uint8_t>(*staged_vgpr_pair)});
+    const auto high = gfx1250::build_vop1(
+        gfx1250::kVMovB32Vop1,
+        {.src0 = kFlatScratchBaseHi, .vdst = static_cast<uint8_t>(*staged_vgpr_pair + 1)});
+    replacement.push_back(flat_scratch_selector_wait());
+    hazards.emit_raw(replacement, low[0]);
+    hazards.emit(replacement, high[0], Pipeline::VALU);
+    hazards.emit(replacement, (*words)[0], Pipeline::VALU);
+    replacement.insert(replacement.end(), words->begin() + 1, words->end());
+    return ExpandResult::success(std::move(replacement));
   }
 
   prologue.insert(prologue.end(), words->begin(), words->end());

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_flat_scratch_base.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_flat_scratch_base.h
@@ -36,10 +36,14 @@ class LivenessAnalysis;
 /// @brief Rewrite a 64-bit FLAT_SCRATCH_BASE source for the A0 profile.
 ///
 /// @details Scalar reads keep their instruction and change the selector to 230.
-/// Vector reads cannot name the selector at all, so the base is first moved
-/// into a dead SGPR pair with a 64-bit scalar read and the source position is
-/// repointed at that pair; one pair serves every affected position in the
-/// instruction.
+/// A 64-bit vector source cannot name the selector directly. The preferred
+/// replacement moves the base into a dead SGPR pair. When none is available,
+/// an explicitly opted-in EXEC-masked VALU encoding may instead use two 32-bit
+/// vector moves to stage the halves in the instruction's overwritten two-VGPR
+/// destination. Destination staging requires no explicit or implicit read of
+/// that pair and known, matching source/destination VGPR-MSB banks. One chosen
+/// temporary serves every affected source position. The replacement can grow
+/// by one scalar move, or by two vector moves plus dependency padding.
 ///
 /// @param inst        The decoded instruction.
 /// @param offset      Byte offset of @p inst in @p source_text.

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -15841,9 +15841,23 @@ TEST(KernelDescriptorTranslator, VirtualLdsRejectsMissingKernargSegmentPointerWi
 
 TEST(KernelDescriptorTranslator, IgnoresNonAllocExecutableSectionsForEntryRange) {
   auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text();
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+  const uint64_t descriptor_vaddr = source.kernel_descriptor_offset("kernel");
+  ASSERT_NE(descriptor_vaddr, 0u);
   const auto ehdr = rocjitsu::read_elf_struct_for_test<rocjitsu::Elf64_Ehdr>(image, 0);
   auto shdrs =
       rocjitsu::read_elf_array_for_test<rocjitsu::Elf64_Shdr>(image, ehdr.e_shoff, ehdr.e_shnum);
+
+  const auto descriptor_section = std::ranges::find_if(shdrs, [&](const auto &section) {
+    return (section.sh_flags & rocjitsu::SHF_ALLOC) != 0 &&
+           (section.sh_flags & rocjitsu::SHF_EXECINSTR) == 0 &&
+           descriptor_vaddr >= section.sh_addr &&
+           descriptor_vaddr - section.sh_addr < section.sh_size;
+  });
+  ASSERT_NE(descriptor_section, shdrs.end());
+  const uint64_t descriptor_file_offset =
+      descriptor_section->sh_offset + (descriptor_vaddr - descriptor_section->sh_addr);
 
   constexpr uint64_t fake_exec_vaddr = 0x9000;
   shdrs[5].sh_flags = rocjitsu::SHF_EXECINSTR;
@@ -15853,9 +15867,9 @@ TEST(KernelDescriptorTranslator, IgnoresNonAllocExecutableSectionsForEntryRange)
     rocjitsu::write_elf_struct_for_test(image, ehdr.e_shoff + i * sizeof(rocjitsu::Elf64_Shdr),
                                         shdrs[i]);
 
-  rocjitsu::write_kernel_descriptor_entry_offset(image.data() + shdrs[2].sh_offset,
+  rocjitsu::write_kernel_descriptor_entry_offset(image.data() + descriptor_file_offset,
                                                  static_cast<int64_t>(fake_exec_vaddr) -
-                                                     static_cast<int64_t>(shdrs[2].sh_addr));
+                                                     static_cast<int64_t>(descriptor_vaddr));
 
   rocjitsu::KernelDescriptorTranslator translator(ROCJITSU_CODE_ARCH_CDNA4,
                                                   ROCJITSU_CODE_ARCH_RDNA4);
@@ -15871,6 +15885,44 @@ namespace {
 constexpr uint16_t kFlatScratchBaseLoSelector = 230;
 /// @brief Scalar selector naming the high half of the flat-scratch base.
 constexpr uint16_t kFlatScratchBaseHiSelector = 231;
+/// @brief Dependency wait required before a generated flat-scratch selector read.
+constexpr auto kFlatScratchSelectorWait =
+    gfx1250::build_sopp(gfx1250::kSWaitAluSopp, {.simm16 = 0});
+
+/// @brief Translate a gfx1250 kernel that forces destination staging while GPR indexing is active.
+[[nodiscard]] rocjitsu::TranslatedCodeObject
+translate_gfx1250_indexed_flat_scratch_destination(uint32_t gpr_index_control) {
+  constexpr uint16_t kModeGprIdxEnableHwreg = 1u | (27u << 6);
+  constexpr uint16_t kLiteralSelector = 255;
+  constexpr uint16_t kM0Operand = 125;
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  const auto enable_gpr_indexing =
+      gfx1250::build_sopk(gfx1250::kSSetregImm32B32Sopk, {.simm16 = kModeGprIdxEnableHwreg});
+  const auto set_m0 =
+      gfx1250::build_sop1(gfx1250::kSMovB32Sop1, {.ssrc0 = kLiteralSelector, .sdst = kM0Operand});
+  const auto vector_read = gfx1250::build_vop3(
+      gfx1250::kVAddNcU64Vop3, {.vdst = 0, .src0 = kFlatScratchBaseHiSelector, .src1 = 256 + 2});
+
+  std::vector<uint32_t> words = {
+      enable_gpr_indexing[0], 1u, set_m0[0], gpr_index_control, vector_read[0], vector_read[1]};
+  // Reading every ordinary scalar register after the affected instruction
+  // leaves no SGPR pair to borrow, forcing the destination-staging decision.
+  for (uint16_t base = 0; base + 1 <= 101; base += 2) {
+    words.push_back(
+        gfx1250::build_sop2(gfx1250::kSAndB32Sop2, {.ssrc0 = static_cast<uint8_t>(base),
+                                                    .ssrc1 = static_cast<uint8_t>(base + 1),
+                                                    .sdst = 102})[0]);
+  }
+  words.push_back(kGfx1250SEndpgm);
+
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  return translator.translate(source);
+}
 
 /// @brief Translate a single-instruction gfx1250 kernel with the B0-to-A0 profile.
 [[nodiscard]] std::vector<uint32_t> translate_gfx1250_b0_to_a0_words(std::vector<uint32_t> words) {
@@ -15988,13 +16040,14 @@ TEST(BinaryTranslatorE2E, Gfx1250MovesFlatScratchBaseInSingleSourceVectorFormToS
   const auto source =
       gfx1250::build_vop1(gfx1250::kVMovB64Vop1, {.src0 = kFlatScratchBaseHiSelector, .vdst = 4});
   const auto out = translate_gfx1250_b0_to_a0_words({source[0]});
-  ASSERT_GE(out.size(), 3u) << "the rewrite prepends one scalar move";
+  ASSERT_GE(out.size(), 4u) << "the rewrite prepends a wait and one scalar move";
 
-  ASSERT_EQ((out[0] >> 23) & 0x1ffu, 381u) << "prologue must be a SOP1 instruction";
-  EXPECT_EQ(out[0] & 0xffu, kFlatScratchBaseLoSelector);
-  const uint32_t pair_base = (out[0] >> 16) & 0x7fu;
+  EXPECT_EQ(out[0], kFlatScratchSelectorWait[0]);
+  ASSERT_EQ((out[1] >> 23) & 0x1ffu, 381u) << "prologue must be a SOP1 instruction";
+  EXPECT_EQ(out[1] & 0xffu, kFlatScratchBaseLoSelector);
+  const uint32_t pair_base = (out[1] >> 16) & 0x7fu;
   EXPECT_EQ(pair_base % 2u, 0u) << "a 64-bit scalar operand must be even-aligned";
-  EXPECT_EQ(out[1] & 0x1ffu, pair_base) << "the vector source must name the borrowed pair";
+  EXPECT_EQ(out[2] & 0x1ffu, pair_base) << "the vector source must name the borrowed pair";
 }
 
 // Two affected positions in one instruction share a single borrowed pair. This
@@ -16005,15 +16058,16 @@ TEST(BinaryTranslatorE2E, Gfx1250SharesOneBorrowedPairAcrossTwoVectorSourcesForA
       gfx1250::kVAddNcU64Vop3,
       {.vdst = 0, .src0 = kFlatScratchBaseHiSelector, .src1 = kFlatScratchBaseHiSelector});
   const auto out = translate_gfx1250_b0_to_a0_words({source[0], source[1]});
-  ASSERT_GE(out.size(), 4u);
+  ASSERT_GE(out.size(), 5u);
 
-  ASSERT_EQ((out[0] >> 23) & 0x1ffu, 381u) << "prologue must be a SOP1 instruction";
-  EXPECT_EQ(out[0] & 0xffu, kFlatScratchBaseLoSelector);
-  const uint32_t pair_base = (out[0] >> 16) & 0x7fu;
+  EXPECT_EQ(out[0], kFlatScratchSelectorWait[0]);
+  ASSERT_EQ((out[1] >> 23) & 0x1ffu, 381u) << "prologue must be a SOP1 instruction";
+  EXPECT_EQ(out[1] & 0xffu, kFlatScratchBaseLoSelector);
+  const uint32_t pair_base = (out[1] >> 16) & 0x7fu;
 
-  EXPECT_EQ(out[2] & 0x1ffu, pair_base) << "src0 must name the borrowed pair";
-  EXPECT_EQ((out[2] >> 9) & 0x1ffu, pair_base) << "src1 must name the same pair";
-  EXPECT_EQ(out.size(), 4u) << "one move serves both positions, so only one is emitted";
+  EXPECT_EQ(out[3] & 0x1ffu, pair_base) << "src0 must name the borrowed pair";
+  EXPECT_EQ((out[3] >> 9) & 0x1ffu, pair_base) << "src1 must name the same pair";
+  EXPECT_EQ(out.size(), 5u) << "one move serves both positions, so only one is emitted";
 }
 
 // The third source is the last modelled field and the only one no other case
@@ -16024,16 +16078,17 @@ TEST(BinaryTranslatorE2E, Gfx1250MovesFlatScratchBaseInThirdVectorSourceToSgprPa
       gfx1250::kVFmaF64Vop3,
       {.vdst = 0, .src0 = 256 + 2, .src1 = 256 + 4, .src2 = kFlatScratchBaseHiSelector});
   const auto out = translate_gfx1250_b0_to_a0_words({source[0], source[1]});
-  ASSERT_GE(out.size(), 4u) << "the rewrite prepends one scalar move";
+  ASSERT_GE(out.size(), 5u) << "the rewrite prepends a wait and one scalar move";
 
-  ASSERT_EQ((out[0] >> 23) & 0x1ffu, 381u) << "prologue must be a SOP1 instruction";
-  EXPECT_EQ(out[0] & 0xffu, kFlatScratchBaseLoSelector);
-  const uint32_t pair_base = (out[0] >> 16) & 0x7fu;
+  EXPECT_EQ(out[0], kFlatScratchSelectorWait[0]);
+  ASSERT_EQ((out[1] >> 23) & 0x1ffu, 381u) << "prologue must be a SOP1 instruction";
+  EXPECT_EQ(out[1] & 0xffu, kFlatScratchBaseLoSelector);
+  const uint32_t pair_base = (out[1] >> 16) & 0x7fu;
   EXPECT_EQ(pair_base % 2u, 0u) << "a 64-bit scalar operand must be even-aligned";
 
-  EXPECT_EQ(out[2] & 0x1ffu, 256u + 2u) << "src0 is unchanged";
-  EXPECT_EQ((out[2] >> 9) & 0x1ffu, 256u + 4u) << "src1 is unchanged";
-  EXPECT_EQ((out[2] >> 18) & 0x1ffu, pair_base) << "src2 must name the borrowed pair";
+  EXPECT_EQ(out[3] & 0x1ffu, 256u + 2u) << "src0 is unchanged";
+  EXPECT_EQ((out[3] >> 9) & 0x1ffu, 256u + 4u) << "src1 is unchanged";
+  EXPECT_EQ((out[3] >> 18) & 0x1ffu, pair_base) << "src2 must name the borrowed pair";
 }
 
 // VOP3P carries packed 64-bit sources through nine-bit fields, so it reaches
@@ -16044,16 +16099,17 @@ TEST(BinaryTranslatorE2E, Gfx1250MovesVop3pFlatScratchBaseSourceToSgprPairForA0)
   const auto source = gfx1250::build_vop3p(
       gfx1250::kVPkMulF32Vop3p, {.vdst = 0, .src0 = kFlatScratchBaseHiSelector, .src1 = 258});
   const auto out = translate_gfx1250_b0_to_a0_words({source[0], source[1]});
-  ASSERT_GE(out.size(), 4u) << "the rewrite prepends one scalar move";
+  ASSERT_GE(out.size(), 5u) << "the rewrite prepends a wait and one scalar move";
 
-  ASSERT_EQ((out[0] >> 23) & 0x1ffu, 381u) << "prologue must be a SOP1 instruction";
-  EXPECT_EQ(out[0] & 0xffu, kFlatScratchBaseLoSelector);
-  const uint32_t pair_base = (out[0] >> 16) & 0x7fu;
+  EXPECT_EQ(out[0], kFlatScratchSelectorWait[0]);
+  ASSERT_EQ((out[1] >> 23) & 0x1ffu, 381u) << "prologue must be a SOP1 instruction";
+  EXPECT_EQ(out[1] & 0xffu, kFlatScratchBaseLoSelector);
+  const uint32_t pair_base = (out[1] >> 16) & 0x7fu;
   EXPECT_EQ(pair_base % 2u, 0u) << "a 64-bit scalar operand must be even-aligned";
 
-  EXPECT_EQ(out[1], source[0]) << "the first word is unchanged";
-  EXPECT_EQ(out[2] & 0x1ffu, pair_base) << "src0 must name the borrowed pair";
-  EXPECT_EQ((out[2] >> 9) & 0x1ffu, 258u) << "src1 is unchanged";
+  EXPECT_EQ(out[2], source[0]) << "the first word is unchanged";
+  EXPECT_EQ(out[3] & 0x1ffu, pair_base) << "src0 must name the borrowed pair";
+  EXPECT_EQ((out[3] >> 9) & 0x1ffu, 258u) << "src1 is unchanged";
 }
 
 // A decoder may report more sources than the encoding has source fields: an
@@ -16073,26 +16129,216 @@ TEST(BinaryTranslatorE2E, Gfx1250RewritesCompactFormsWithExtraDecodedOperandsFor
   for (const ExtraOperandCase &test_case : cases) {
     SCOPED_TRACE(test_case.name);
     const auto out = translate_gfx1250_b0_to_a0_words(test_case.words);
-    ASSERT_GE(out.size(), 3u) << "the rewrite prepends one scalar move";
+    ASSERT_GE(out.size(), 4u) << "the rewrite prepends a wait and one scalar move";
 
-    ASSERT_EQ((out[0] >> 23) & 0x1ffu, 381u) << "prologue must be a SOP1 instruction";
-    EXPECT_EQ(out[0] & 0xffu, kFlatScratchBaseLoSelector);
-    const uint32_t pair_base = (out[0] >> 16) & 0x7fu;
-    EXPECT_EQ(out[1] & 0x1ffu, pair_base) << "src0 must name the borrowed pair";
-    EXPECT_EQ((out[1] >> 9) & 0xffu, 2u) << "the VGPR source is unchanged";
+    EXPECT_EQ(out[0], kFlatScratchSelectorWait[0]);
+    ASSERT_EQ((out[1] >> 23) & 0x1ffu, 381u) << "prologue must be a SOP1 instruction";
+    EXPECT_EQ(out[1] & 0xffu, kFlatScratchBaseLoSelector);
+    const uint32_t pair_base = (out[1] >> 16) & 0x7fu;
+    EXPECT_EQ(out[2] & 0x1ffu, pair_base) << "src0 must name the borrowed pair";
+    EXPECT_EQ((out[2] >> 9) & 0xffu, 2u) << "the VGPR source is unchanged";
   }
 }
 
-// With every ordinary scalar register live there is no pair to borrow. The
-// rewrite must fail rather than clobber one, and the object must come back
-// unchanged.
-TEST(BinaryTranslatorE2E, Gfx1250FailsClosedWhenNoDeadSgprPairIsAvailableForA0) {
+// With every ordinary scalar register live there is no pair to borrow. A
+// non-aliasing two-register destination is overwritten by the guest
+// instruction anyway, so stage the two 32-bit halves there instead.
+TEST(BinaryTranslatorE2E, Gfx1250StagesFlatScratchBaseInDestinationWhenSgprsAreLive) {
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  const auto scratch_alias_producer =
+      gfx1250::build_sop1(gfx1250::kSMovB32Sop1, {.ssrc0 = 0, .sdst = 102});
   const auto vector_read = gfx1250::build_vop3(
       gfx1250::kVAddNcU64Vop3, {.vdst = 0, .src0 = kFlatScratchBaseHiSelector, .src1 = 256 + 2});
-  std::vector<uint32_t> words = {vector_read[0], vector_read[1]};
+  std::vector<uint32_t> words = {scratch_alias_producer[0], vector_read[0], vector_read[1]};
   // Reading every ordinary scalar register after the rewrite keeps them all
   // live across it, so the allocator has nothing to take.
+  for (uint16_t base = 0; base + 1 <= 101; base += 2) {
+    words.push_back(
+        gfx1250::build_sop2(gfx1250::kSAndB32Sop2, {.ssrc0 = static_cast<uint8_t>(base),
+                                                    .ssrc1 = static_cast<uint8_t>(base + 1),
+                                                    .sdst = 102})[0]);
+  }
+  words.push_back(kGfx1250SEndpgm);
+
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_FALSE(translated.text_sections().empty());
+  const auto *section = translated.text_sections()[0];
+  const auto *out = reinterpret_cast<const uint32_t *>(section->data());
+  const size_t out_words = section->size() / sizeof(uint32_t);
+  constexpr auto low =
+      gfx1250::build_vop1(gfx1250::kVMovB32Vop1, {.src0 = kFlatScratchBaseLoSelector, .vdst = 0});
+  constexpr auto high =
+      gfx1250::build_vop1(gfx1250::kVMovB32Vop1, {.src0 = kFlatScratchBaseHiSelector, .vdst = 1});
+  const auto low_move = std::ranges::find(out, out + out_words, low[0]);
+  ASSERT_NE(low_move, out + out_words);
+  ASSERT_NE(low_move, out);
+  EXPECT_EQ(*std::prev(low_move), kFlatScratchSelectorWait[0])
+      << "the selector read must wait for the preceding s102 producer";
+  EXPECT_NE(std::ranges::find(low_move + 1, out + out_words, high[0]), out + out_words);
+
+  auto decoder = rocjitsu::Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  bool found_rewritten_add = false;
+  for (size_t offset = 0; offset < out_words;) {
+    std::unique_ptr<rocjitsu::Instruction> inst(decoder->decode(out + offset));
+    ASSERT_NE(inst, nullptr) << "translated word " << offset << " failed to decode";
+    if (std::string_view(inst->mnemonic()) == "v_add_nc_u64") {
+      ASSERT_NE(inst->raw_encoding(), nullptr);
+      EXPECT_EQ(inst->raw_encoding()[1] & 0x1ffu, 256u)
+          << "the wide source must read staged v[0:1]";
+      found_rewritten_add = true;
+    }
+    offset += static_cast<size_t>(inst->size()) / sizeof(uint32_t);
+  }
+  EXPECT_TRUE(found_rewritten_add);
+}
+
+// The source and destination roles both select bank 1. Executing the translated
+// sequence proves that the two staging moves and the rewritten source all name
+// that physical bank, rather than merely agreeing in the encoded low byte.
+TEST(BinaryTranslatorE2E, Gfx1250DestinationStagingExecutesInMatchingNonzeroBank) {
+  constexpr uint8_t kMatchingBankOneMode = 0x41;
+  constexpr uint64_t kScratchBase = 0x1122334455667788ull;
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  const auto set_vgpr_msb =
+      gfx1250::build_sopp(gfx1250::kSSetVgprMsbSopp, {.simm16 = kMatchingBankOneMode});
+  const auto vector_read = gfx1250::build_vop3(
+      gfx1250::kVAddNcU64Vop3, {.vdst = 0, .src0 = kFlatScratchBaseHiSelector, .src1 = 256 + 2});
+  std::vector<uint32_t> words = {set_vgpr_msb[0], vector_read[0], vector_read[1]};
+  for (uint16_t base = 0; base + 1 <= 101; base += 2) {
+    words.push_back(
+        gfx1250::build_sop2(gfx1250::kSAndB32Sop2, {.ssrc0 = static_cast<uint8_t>(base),
+                                                    .ssrc1 = static_cast<uint8_t>(base + 1),
+                                                    .sdst = 102})[0]);
+  }
+  words.push_back(kGfx1250SEndpgm);
+
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_FALSE(translated.text_sections().empty());
+  const auto *translated_words =
+      reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+  const size_t translated_count = translated.text_sections()[0]->size() / sizeof(uint32_t);
+
+  rocjitsu::amdgpu::GpuMemory gpu_mem("gfx1250_flat_scratch_stage_mem");
+  rocjitsu::amdgpu::L2Cache l2("gfx1250_flat_scratch_stage_l2");
+  rocjitsu::amdgpu::ComputeUnitCore::Config cfg{};
+  cfg.arch = ROCJITSU_CODE_ARCH_GFX1250;
+  cfg.num_wf_slots = 1;
+  cfg.sgprs_per_wf = 106;
+  cfg.vgprs_per_wf = 1024;
+  cfg.lds_size_kb = 64;
+  auto cu =
+      rocjitsu::amdgpu::ComputeUnitCore::create("gfx1250_flat_scratch_stage", cfg, &gpu_mem, &l2);
+  ASSERT_NE(cu, nullptr);
+  auto *wf = cu->dispatch_wf(0, 0, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(1u);
+  wf->set_scratch_base(kScratchBase);
+  const uint32_t vb = wf->vgpr_alloc().base;
+  cu->write_vgpr(vb + 2, 0, 0u);
+  cu->write_vgpr(vb + 3, 0, 0u);
+
+  auto decoder = rocjitsu::Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  for (size_t offset = 0; offset < translated_count;) {
+    std::unique_ptr<rocjitsu::Instruction> inst(decoder->decode(translated_words + offset));
+    ASSERT_NE(inst, nullptr) << "translated word " << offset << " failed to decode";
+    if (std::string_view(inst->mnemonic()) == "s_endpgm")
+      break;
+    cu->execute_instruction(inst.get(), *wf);
+    offset += static_cast<size_t>(inst->size()) / sizeof(uint32_t);
+  }
+
+  EXPECT_EQ(cu->read_vgpr(vb + 256, 0), static_cast<uint32_t>(kScratchBase));
+  EXPECT_EQ(cu->read_vgpr(vb + 257, 0), static_cast<uint32_t>(kScratchBase >> 32));
+  EXPECT_EQ(wf->vgpr_msb_mode(), kMatchingBankOneMode);
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250DestinationStagingRejectsMismatchedBanks) {
+  constexpr uint8_t kSourceBankOneDestinationBankTwo = 0x81;
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  const auto set_vgpr_msb =
+      gfx1250::build_sopp(gfx1250::kSSetVgprMsbSopp, {.simm16 = kSourceBankOneDestinationBankTwo});
+  const auto vector_read = gfx1250::build_vop3(
+      gfx1250::kVAddNcU64Vop3, {.vdst = 0, .src0 = kFlatScratchBaseHiSelector, .src1 = 256 + 2});
+  std::vector<uint32_t> words = {set_vgpr_msb[0], vector_read[0], vector_read[1]};
+  for (uint16_t base = 0; base + 1 <= 101; base += 2) {
+    words.push_back(
+        gfx1250::build_sop2(gfx1250::kSAndB32Sop2, {.ssrc0 = static_cast<uint8_t>(base),
+                                                    .ssrc1 = static_cast<uint8_t>(base + 1),
+                                                    .sdst = 102})[0]);
+  }
+  words.push_back(kGfx1250SEndpgm);
+
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_FALSE(result.dispatchable());
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(rocjitsu::has_error_containing(
+      result, rocjitsu::DiagnosticKind::ExpandFailed,
+      "flat-scratch-base rewrite could not allocate safe temporary storage"));
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250DestinationStagingRejectsSourceGprIndexing) {
+  constexpr uint32_t kNonzeroOffset = 16;
+  constexpr uint32_t kIndexSource0 = 1u << 8;
+  const auto result =
+      translate_gfx1250_indexed_flat_scratch_destination(kIndexSource0 | kNonzeroOffset);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_FALSE(result.dispatchable());
+  EXPECT_TRUE(rocjitsu::has_error_containing(
+      result, rocjitsu::DiagnosticKind::ExpandFailed,
+      "flat-scratch-base rewrite could not allocate safe temporary storage"));
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250DestinationStagingRejectsDestinationGprIndexing) {
+  constexpr uint32_t kNonzeroOffset = 16;
+  constexpr uint32_t kIndexDestination = 1u << 11;
+  const auto result =
+      translate_gfx1250_indexed_flat_scratch_destination(kIndexDestination | kNonzeroOffset);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_FALSE(result.dispatchable());
+  EXPECT_TRUE(rocjitsu::has_error_containing(
+      result, rocjitsu::DiagnosticKind::ExpandFailed,
+      "flat-scratch-base rewrite could not allocate safe temporary storage"));
+}
+
+// Destination staging is not safe when another source reads that pair: the
+// moves would overwrite the guest input before the original instruction. With
+// all SGPRs live as well, the rewrite must fail closed.
+TEST(BinaryTranslatorE2E, Gfx1250FailsClosedWhenFlatScratchTemporariesAlias) {
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  const auto vector_read = gfx1250::build_vop3(
+      gfx1250::kVAddNcU64Vop3, {.vdst = 0, .src0 = kFlatScratchBaseHiSelector, .src1 = 256});
+  std::vector<uint32_t> words = {vector_read[0], vector_read[1]};
   for (uint16_t base = 0; base + 1 <= 101; base += 2) {
     words.push_back(
         gfx1250::build_sop2(gfx1250::kSAndB32Sop2, {.ssrc0 = static_cast<uint8_t>(base),
@@ -16114,7 +16360,7 @@ TEST(BinaryTranslatorE2E, Gfx1250FailsClosedWhenNoDeadSgprPairIsAvailableForA0) 
   EXPECT_EQ(result.elf_bytes, image) << "fail-closed must leave the object unchanged";
   EXPECT_TRUE(rocjitsu::has_error_containing(
       result, rocjitsu::DiagnosticKind::ExpandFailed,
-      "flat-scratch-base rewrite could not allocate a dead SGPR pair"));
+      "flat-scratch-base rewrite could not allocate safe temporary storage"));
 }
 
 // An unmodelled encoding carrying a wide vector register whose number equals
@@ -16150,16 +16396,17 @@ TEST(BinaryTranslatorE2E, Gfx1250BorrowsFlatScratchBasePairAboveLiveRegistersFor
         {.ssrc0 = base, .ssrc1 = static_cast<uint8_t>(base + 1), .sdst = 20})[0]);
   }
   const auto out = translate_gfx1250_b0_to_a0_words(words);
-  ASSERT_GE(out.size(), 3u);
+  ASSERT_GE(out.size(), 4u);
 
-  ASSERT_EQ((out[0] >> 23) & 0x1ffu, 381u) << "prologue must be a SOP1 instruction";
-  EXPECT_EQ(out[0] & 0xffu, kFlatScratchBaseLoSelector);
-  const uint32_t pair_base = (out[0] >> 16) & 0x7fu;
+  EXPECT_EQ(out[0], kFlatScratchSelectorWait[0]);
+  ASSERT_EQ((out[1] >> 23) & 0x1ffu, 381u) << "prologue must be a SOP1 instruction";
+  EXPECT_EQ(out[1] & 0xffu, kFlatScratchBaseLoSelector);
+  const uint32_t pair_base = (out[1] >> 16) & 0x7fu;
   EXPECT_GE(pair_base, 8u) << "s0..s7 are live, so the pair must sit above them";
   EXPECT_EQ(pair_base % 2u, 0u) << "a 64-bit scalar operand must be even-aligned";
   EXPECT_LE(pair_base + 1u, kHighestOrdinarySgpr)
       << "the borrowed pair must stay inside the ordinary scalar file";
-  EXPECT_EQ(out[2] & 0x1ffu, pair_base) << "the vector read must name the borrowed pair";
+  EXPECT_EQ(out[3] & 0x1ffu, pair_base) << "the vector read must name the borrowed pair";
 }
 
 // The compact vector formats reach the same rewrite as their VOP3 forms.
@@ -16179,15 +16426,16 @@ TEST(BinaryTranslatorE2E, Gfx1250MovesCompactVectorFlatScratchBaseSourceToSgprPa
   for (const CompactCase &test_case : cases) {
     SCOPED_TRACE(test_case.name);
     const auto out = translate_gfx1250_b0_to_a0_words(test_case.words);
-    ASSERT_GE(out.size(), 3u) << "the rewrite prepends one scalar move";
+    ASSERT_GE(out.size(), 4u) << "the rewrite prepends a wait and one scalar move";
 
-    EXPECT_EQ((out[0] >> 23) & 0x1ffu, 381u) << "prologue must be a SOP1 instruction";
-    EXPECT_EQ(out[0] & 0xffu, kFlatScratchBaseLoSelector);
-    const uint32_t pair_base = (out[0] >> 16) & 0x7fu;
+    EXPECT_EQ(out[0], kFlatScratchSelectorWait[0]);
+    EXPECT_EQ((out[1] >> 23) & 0x1ffu, 381u) << "prologue must be a SOP1 instruction";
+    EXPECT_EQ(out[1] & 0xffu, kFlatScratchBaseLoSelector);
+    const uint32_t pair_base = (out[1] >> 16) & 0x7fu;
     EXPECT_EQ(pair_base % 2u, 0u);
 
-    EXPECT_EQ(out[1] & 0x1ffu, pair_base) << "src0 must name the borrowed pair";
-    EXPECT_EQ((out[1] >> 9) & 0xffu, 2u) << "the VGPR source is unchanged";
+    EXPECT_EQ(out[2] & 0x1ffu, pair_base) << "src0 must name the borrowed pair";
+    EXPECT_EQ((out[2] >> 9) & 0xffu, 2u) << "the VGPR source is unchanged";
   }
 }
 
@@ -16277,19 +16525,20 @@ TEST(BinaryTranslatorE2E, Gfx1250RewritesVop3SelectorButKeepsCollidingLiteralFor
       {.vdst = 10, .src0 = kFlatScratchBaseHiSelector, .src1 = kLiteralSelector});
   const auto out =
       translate_gfx1250_b0_to_a0_words({source[0], source[1], kFlatScratchBaseHiSelector});
-  ASSERT_GE(out.size(), 5u) << "the rewrite prepends one scalar move and keeps four words";
+  ASSERT_GE(out.size(), 6u) << "the rewrite prepends a wait and scalar move and keeps four words";
 
-  ASSERT_EQ((out[0] >> 23) & 0x1ffu, 381u) << "prologue must be a SOP1 instruction";
-  EXPECT_EQ(out[0] & 0xffu, kFlatScratchBaseLoSelector);
-  const uint32_t pair_base = (out[0] >> 16) & 0x7fu;
+  EXPECT_EQ(out[0], kFlatScratchSelectorWait[0]);
+  ASSERT_EQ((out[1] >> 23) & 0x1ffu, 381u) << "prologue must be a SOP1 instruction";
+  EXPECT_EQ(out[1] & 0xffu, kFlatScratchBaseLoSelector);
+  const uint32_t pair_base = (out[1] >> 16) & 0x7fu;
   EXPECT_EQ(pair_base % 2u, 0u) << "a 64-bit scalar operand must be even-aligned";
 
-  EXPECT_EQ(out[1], source[0]) << "vdst, opcode, and modifiers are unchanged";
-  EXPECT_EQ(out[2] & 0x1ffu, pair_base) << "the real selector must name the borrowed pair";
-  EXPECT_EQ((out[2] >> 9) & 0x1ffu, kLiteralSelector)
+  EXPECT_EQ(out[2], source[0]) << "vdst, opcode, and modifiers are unchanged";
+  EXPECT_EQ(out[3] & 0x1ffu, pair_base) << "the real selector must name the borrowed pair";
+  EXPECT_EQ((out[3] >> 9) & 0x1ffu, kLiteralSelector)
       << "the literal marker must survive, or its dword becomes an instruction";
-  EXPECT_EQ(out[3], kFlatScratchBaseHiSelector) << "the literal dword itself is unchanged";
-  EXPECT_EQ(out.size(), 5u) << "only the prologue is added";
+  EXPECT_EQ(out[4], kFlatScratchBaseHiSelector) << "the literal dword itself is unchanged";
+  EXPECT_EQ(out.size(), 6u) << "only the wait and move prologue are added";
 }
 
 namespace {
@@ -16443,20 +16692,21 @@ TEST(BinaryTranslatorE2E, Gfx1250MovesVectorFlatScratchBase64BitSourceToSgprPair
   const auto source = gfx1250::build_vop3(
       gfx1250::kVAddNcU64Vop3, {.vdst = 0, .src0 = kFlatScratchBaseHiSelector, .src1 = 256 + 2});
   const auto out = translate_gfx1250_b0_to_a0_words({source[0], source[1]});
-  ASSERT_GE(out.size(), 4u) << "the rewrite prepends one scalar move";
+  ASSERT_GE(out.size(), 5u) << "the rewrite prepends a wait and one scalar move";
 
   // The prologue is a 64-bit scalar read of the base through the low selector.
   const auto expected_prologue_op = static_cast<uint32_t>(gfx1250::kSMovB64Sop1);
-  EXPECT_EQ((out[0] >> 23) & 0x1ffu, 381u) << "prologue must be a SOP1 instruction";
-  EXPECT_EQ((out[0] >> 8) & 0xffu, expected_prologue_op);
-  EXPECT_EQ(out[0] & 0xffu, kFlatScratchBaseLoSelector);
+  EXPECT_EQ(out[0], kFlatScratchSelectorWait[0]);
+  EXPECT_EQ((out[1] >> 23) & 0x1ffu, 381u) << "prologue must be a SOP1 instruction";
+  EXPECT_EQ((out[1] >> 8) & 0xffu, expected_prologue_op);
+  EXPECT_EQ(out[1] & 0xffu, kFlatScratchBaseLoSelector);
 
-  const uint32_t pair_base = (out[0] >> 16) & 0x7fu;
+  const uint32_t pair_base = (out[1] >> 16) & 0x7fu;
   EXPECT_EQ(pair_base % 2u, 0u) << "a 64-bit scalar operand must be even-aligned";
   EXPECT_LE(pair_base + 1u, 105u) << "the borrowed pair must be an ordinary SGPR pair";
 
   // The vector instruction now reads that pair; its other operands are intact.
-  EXPECT_EQ(out[1] & 0xffffu, source[0] & 0xffffu) << "vdst and modifiers are unchanged";
-  EXPECT_EQ(out[2] & 0x1ffu, pair_base) << "src0 must name the borrowed pair";
-  EXPECT_EQ((out[2] >> 9) & 0x1ffu, 256u + 2u) << "src1 is unchanged";
+  EXPECT_EQ(out[2] & 0xffffu, source[0] & 0xffffu) << "vdst and modifiers are unchanged";
+  EXPECT_EQ(out[3] & 0x1ffu, pair_base) << "src0 must name the borrowed pair";
+  EXPECT_EQ((out[3] >> 9) & 0x1ffu, 256u + 2u) << "src1 is unchanged";
 }


### PR DESCRIPTION
When every ordinary SGPR pair is live, reuse a non-aliasing two-register vector destination to stage the low and high flat-scratch selectors before the rewritten instruction.

Require matching known VGPR banks and EXEC-masked vector semantics, reject tied or aliased destinations, and emit the required VALU hazards. Preserve fail-closed behavior when no safe temporary exists.
