### PR TITLE
[rocjitsu] Permit VCC pseudo-scalar destinations

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -7475,22 +7475,22 @@ class CodeGenerator:
                     ctor_body_parts.extend(conditional_src_body)
                     ctor_body_parts.extend(conditional_dst_body)
 
-                    # Pseudo-scalar V_S_* instructions encode their SGPR
-                    # destination through VDST, but the ISA reserves the VCC
-                    # selectors for this instruction family. Keep this check
-                    # local to pseudo_scalar_unary: OPR_SREG legitimately
-                    # permits VCC destinations for other instructions.
+                    # LLVM models pseudo-scalar V_S_* destinations as
+                    # SReg_32_XEXEC: selectors 0..125 (SGPRs, TTMPs, VCC,
+                    # NULL, and M0) are legal, while EXEC and every larger
+                    # selector are excluded. The operand is represented as
+                    # OPR_SREG, whose enum stops at NULL, so compare against
+                    # the matching SDST_EXEC value for the first excluded
+                    # selector immediately above M0.
                     if (
                         inst_sem is not None
                         and inst_sem.semantic_class == 'pseudo_scalar_unary'
                     ):
                         ctor_body_parts.append(
-                            'if (reinterpret_cast<const OpEncoding*>(inst)->vdst == '
-                            'OpSelSreg::OPR_SREG_VCC_LO || '
-                            'reinterpret_cast<const OpEncoding*>(inst)->vdst == '
-                            'OpSelSreg::OPR_SREG_VCC_HI) '
-                            f'throw util::InvalidInst("{inst.name} may not use VCC as '
-                            'a destination", "");'
+                            'if (reinterpret_cast<const OpEncoding*>(inst)->vdst >= '
+                            'OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO) '
+                            f'throw util::InvalidInst("{inst.name} has an invalid '
+                            'SReg_32_XEXEC destination", "");'
                         )
 
                     # Flat segment-aware operands: adjust addr width and add

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
@@ -1882,14 +1882,17 @@ def test_generated_pseudo_scalar_vop3_paths_ignore_exec_and_f16_opsel(
         ]
         for class_name in pseudo_scalar_constructors:
             constructor = _generated_constructor_body(constructor_source, class_name)
-            assert 'OpSelSreg::OPR_SREG_VCC_LO' in constructor
-            assert 'OpSelSreg::OPR_SREG_VCC_HI' in constructor
-            assert 'may not use VCC as a destination' in constructor
+            assert '>= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO' in constructor
+            assert 'has an invalid SReg_32_XEXEC destination' in constructor
+            assert 'may not use VCC as a destination' not in constructor
+            assert constructor.index(
+                'has an invalid SReg_32_XEXEC destination'
+            ) < constructor.index('does not support DPP')
             assert '->opsel' not in constructor
             assert 'vop3_opsel' not in constructor
-        assert constructor_source.count('may not use VCC as a destination') == len(
-            pseudo_scalar_constructors
-        )
+        assert constructor_source.count(
+            'has an invalid SReg_32_XEXEC destination'
+        ) == len(pseudo_scalar_constructors)
 
         generic_true16_constructor = _generated_constructor_body(
             constructor_source, 'VAddF16Vop3'

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_alu.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_alu.cpp
@@ -5215,9 +5215,8 @@ VSExpF32Vop3::VSExpF32Vop3(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->vdst == OpSelSreg::OPR_SREG_VCC_LO ||
-      reinterpret_cast<const OpEncoding *>(inst)->vdst == OpSelSreg::OPR_SREG_VCC_HI)
-    throw util::InvalidInst("V_S_EXP_F32 may not use VCC as a destination", "");
+  if (reinterpret_cast<const OpEncoding *>(inst)->vdst >= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO)
+    throw util::InvalidInst("V_S_EXP_F32 has an invalid SReg_32_XEXEC destination", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -5242,9 +5241,8 @@ VSExpF16Vop3::VSExpF16Vop3(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->vdst == OpSelSreg::OPR_SREG_VCC_LO ||
-      reinterpret_cast<const OpEncoding *>(inst)->vdst == OpSelSreg::OPR_SREG_VCC_HI)
-    throw util::InvalidInst("V_S_EXP_F16 may not use VCC as a destination", "");
+  if (reinterpret_cast<const OpEncoding *>(inst)->vdst >= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO)
+    throw util::InvalidInst("V_S_EXP_F16 has an invalid SReg_32_XEXEC destination", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
     src0 =
         Operand(16, OperandType::OPR_SIMM32,
@@ -5270,9 +5268,8 @@ VSLogF32Vop3::VSLogF32Vop3(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->vdst == OpSelSreg::OPR_SREG_VCC_LO ||
-      reinterpret_cast<const OpEncoding *>(inst)->vdst == OpSelSreg::OPR_SREG_VCC_HI)
-    throw util::InvalidInst("V_S_LOG_F32 may not use VCC as a destination", "");
+  if (reinterpret_cast<const OpEncoding *>(inst)->vdst >= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO)
+    throw util::InvalidInst("V_S_LOG_F32 has an invalid SReg_32_XEXEC destination", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -5297,9 +5294,8 @@ VSLogF16Vop3::VSLogF16Vop3(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->vdst == OpSelSreg::OPR_SREG_VCC_LO ||
-      reinterpret_cast<const OpEncoding *>(inst)->vdst == OpSelSreg::OPR_SREG_VCC_HI)
-    throw util::InvalidInst("V_S_LOG_F16 may not use VCC as a destination", "");
+  if (reinterpret_cast<const OpEncoding *>(inst)->vdst >= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO)
+    throw util::InvalidInst("V_S_LOG_F16 has an invalid SReg_32_XEXEC destination", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
     src0 =
         Operand(16, OperandType::OPR_SIMM32,
@@ -5325,9 +5321,8 @@ VSRcpF32Vop3::VSRcpF32Vop3(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->vdst == OpSelSreg::OPR_SREG_VCC_LO ||
-      reinterpret_cast<const OpEncoding *>(inst)->vdst == OpSelSreg::OPR_SREG_VCC_HI)
-    throw util::InvalidInst("V_S_RCP_F32 may not use VCC as a destination", "");
+  if (reinterpret_cast<const OpEncoding *>(inst)->vdst >= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO)
+    throw util::InvalidInst("V_S_RCP_F32 has an invalid SReg_32_XEXEC destination", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -5352,9 +5347,8 @@ VSRcpF16Vop3::VSRcpF16Vop3(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->vdst == OpSelSreg::OPR_SREG_VCC_LO ||
-      reinterpret_cast<const OpEncoding *>(inst)->vdst == OpSelSreg::OPR_SREG_VCC_HI)
-    throw util::InvalidInst("V_S_RCP_F16 may not use VCC as a destination", "");
+  if (reinterpret_cast<const OpEncoding *>(inst)->vdst >= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO)
+    throw util::InvalidInst("V_S_RCP_F16 has an invalid SReg_32_XEXEC destination", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
     src0 =
         Operand(16, OperandType::OPR_SIMM32,
@@ -5380,9 +5374,8 @@ VSRsqF32Vop3::VSRsqF32Vop3(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->vdst == OpSelSreg::OPR_SREG_VCC_LO ||
-      reinterpret_cast<const OpEncoding *>(inst)->vdst == OpSelSreg::OPR_SREG_VCC_HI)
-    throw util::InvalidInst("V_S_RSQ_F32 may not use VCC as a destination", "");
+  if (reinterpret_cast<const OpEncoding *>(inst)->vdst >= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO)
+    throw util::InvalidInst("V_S_RSQ_F32 has an invalid SReg_32_XEXEC destination", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -5407,9 +5400,8 @@ VSRsqF16Vop3::VSRsqF16Vop3(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->vdst == OpSelSreg::OPR_SREG_VCC_LO ||
-      reinterpret_cast<const OpEncoding *>(inst)->vdst == OpSelSreg::OPR_SREG_VCC_HI)
-    throw util::InvalidInst("V_S_RSQ_F16 may not use VCC as a destination", "");
+  if (reinterpret_cast<const OpEncoding *>(inst)->vdst >= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO)
+    throw util::InvalidInst("V_S_RSQ_F16 has an invalid SReg_32_XEXEC destination", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
     src0 =
         Operand(16, OperandType::OPR_SIMM32,
@@ -5435,9 +5427,8 @@ VSSqrtF32Vop3::VSSqrtF32Vop3(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->vdst == OpSelSreg::OPR_SREG_VCC_LO ||
-      reinterpret_cast<const OpEncoding *>(inst)->vdst == OpSelSreg::OPR_SREG_VCC_HI)
-    throw util::InvalidInst("V_S_SQRT_F32 may not use VCC as a destination", "");
+  if (reinterpret_cast<const OpEncoding *>(inst)->vdst >= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO)
+    throw util::InvalidInst("V_S_SQRT_F32 has an invalid SReg_32_XEXEC destination", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -5462,9 +5453,8 @@ VSSqrtF16Vop3::VSSqrtF16Vop3(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->vdst == OpSelSreg::OPR_SREG_VCC_LO ||
-      reinterpret_cast<const OpEncoding *>(inst)->vdst == OpSelSreg::OPR_SREG_VCC_HI)
-    throw util::InvalidInst("V_S_SQRT_F16 may not use VCC as a destination", "");
+  if (reinterpret_cast<const OpEncoding *>(inst)->vdst >= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO)
+    throw util::InvalidInst("V_S_SQRT_F16 has an invalid SReg_32_XEXEC destination", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
     src0 =
         Operand(16, OperandType::OPR_SIMM32,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/vop3.cpp
@@ -12508,9 +12508,8 @@ VSExpF32Vop3::VSExpF32Vop3(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->vdst == OpSelSreg::OPR_SREG_VCC_LO ||
-      reinterpret_cast<const OpEncoding *>(inst)->vdst == OpSelSreg::OPR_SREG_VCC_HI)
-    throw util::InvalidInst("V_S_EXP_F32 may not use VCC as a destination", "");
+  if (reinterpret_cast<const OpEncoding *>(inst)->vdst >= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO)
+    throw util::InvalidInst("V_S_EXP_F32 has an invalid SReg_32_XEXEC destination", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -12532,9 +12531,8 @@ VSExpF16Vop3::VSExpF16Vop3(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->vdst == OpSelSreg::OPR_SREG_VCC_LO ||
-      reinterpret_cast<const OpEncoding *>(inst)->vdst == OpSelSreg::OPR_SREG_VCC_HI)
-    throw util::InvalidInst("V_S_EXP_F16 may not use VCC as a destination", "");
+  if (reinterpret_cast<const OpEncoding *>(inst)->vdst >= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO)
+    throw util::InvalidInst("V_S_EXP_F16 has an invalid SReg_32_XEXEC destination", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
     src0 =
         Operand(16, OperandType::OPR_SIMM32,
@@ -12563,9 +12561,8 @@ VSLogF32Vop3::VSLogF32Vop3(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->vdst == OpSelSreg::OPR_SREG_VCC_LO ||
-      reinterpret_cast<const OpEncoding *>(inst)->vdst == OpSelSreg::OPR_SREG_VCC_HI)
-    throw util::InvalidInst("V_S_LOG_F32 may not use VCC as a destination", "");
+  if (reinterpret_cast<const OpEncoding *>(inst)->vdst >= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO)
+    throw util::InvalidInst("V_S_LOG_F32 has an invalid SReg_32_XEXEC destination", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -12587,9 +12584,8 @@ VSLogF16Vop3::VSLogF16Vop3(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->vdst == OpSelSreg::OPR_SREG_VCC_LO ||
-      reinterpret_cast<const OpEncoding *>(inst)->vdst == OpSelSreg::OPR_SREG_VCC_HI)
-    throw util::InvalidInst("V_S_LOG_F16 may not use VCC as a destination", "");
+  if (reinterpret_cast<const OpEncoding *>(inst)->vdst >= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO)
+    throw util::InvalidInst("V_S_LOG_F16 has an invalid SReg_32_XEXEC destination", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
     src0 =
         Operand(16, OperandType::OPR_SIMM32,
@@ -12618,9 +12614,8 @@ VSRcpF32Vop3::VSRcpF32Vop3(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->vdst == OpSelSreg::OPR_SREG_VCC_LO ||
-      reinterpret_cast<const OpEncoding *>(inst)->vdst == OpSelSreg::OPR_SREG_VCC_HI)
-    throw util::InvalidInst("V_S_RCP_F32 may not use VCC as a destination", "");
+  if (reinterpret_cast<const OpEncoding *>(inst)->vdst >= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO)
+    throw util::InvalidInst("V_S_RCP_F32 has an invalid SReg_32_XEXEC destination", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -12642,9 +12637,8 @@ VSRcpF16Vop3::VSRcpF16Vop3(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->vdst == OpSelSreg::OPR_SREG_VCC_LO ||
-      reinterpret_cast<const OpEncoding *>(inst)->vdst == OpSelSreg::OPR_SREG_VCC_HI)
-    throw util::InvalidInst("V_S_RCP_F16 may not use VCC as a destination", "");
+  if (reinterpret_cast<const OpEncoding *>(inst)->vdst >= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO)
+    throw util::InvalidInst("V_S_RCP_F16 has an invalid SReg_32_XEXEC destination", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
     src0 =
         Operand(16, OperandType::OPR_SIMM32,
@@ -12673,9 +12667,8 @@ VSRsqF32Vop3::VSRsqF32Vop3(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->vdst == OpSelSreg::OPR_SREG_VCC_LO ||
-      reinterpret_cast<const OpEncoding *>(inst)->vdst == OpSelSreg::OPR_SREG_VCC_HI)
-    throw util::InvalidInst("V_S_RSQ_F32 may not use VCC as a destination", "");
+  if (reinterpret_cast<const OpEncoding *>(inst)->vdst >= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO)
+    throw util::InvalidInst("V_S_RSQ_F32 has an invalid SReg_32_XEXEC destination", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -12697,9 +12690,8 @@ VSRsqF16Vop3::VSRsqF16Vop3(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->vdst == OpSelSreg::OPR_SREG_VCC_LO ||
-      reinterpret_cast<const OpEncoding *>(inst)->vdst == OpSelSreg::OPR_SREG_VCC_HI)
-    throw util::InvalidInst("V_S_RSQ_F16 may not use VCC as a destination", "");
+  if (reinterpret_cast<const OpEncoding *>(inst)->vdst >= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO)
+    throw util::InvalidInst("V_S_RSQ_F16 has an invalid SReg_32_XEXEC destination", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
     src0 =
         Operand(16, OperandType::OPR_SIMM32,
@@ -12729,9 +12721,8 @@ VSSqrtF32Vop3::VSSqrtF32Vop3(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->vdst == OpSelSreg::OPR_SREG_VCC_LO ||
-      reinterpret_cast<const OpEncoding *>(inst)->vdst == OpSelSreg::OPR_SREG_VCC_HI)
-    throw util::InvalidInst("V_S_SQRT_F32 may not use VCC as a destination", "");
+  if (reinterpret_cast<const OpEncoding *>(inst)->vdst >= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO)
+    throw util::InvalidInst("V_S_SQRT_F32 has an invalid SReg_32_XEXEC destination", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
     src0 = Operand(
         32, OperandType::OPR_SIMM32,
@@ -12754,9 +12745,8 @@ VSSqrtF16Vop3::VSSqrtF16Vop3(const MachineInst *inst)
   src_operands_[0] = &src0;
   num_src_ = 1;
   num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->vdst == OpSelSreg::OPR_SREG_VCC_LO ||
-      reinterpret_cast<const OpEncoding *>(inst)->vdst == OpSelSreg::OPR_SREG_VCC_HI)
-    throw util::InvalidInst("V_S_SQRT_F16 may not use VCC as a destination", "");
+  if (reinterpret_cast<const OpEncoding *>(inst)->vdst >= OpSelSdstExec::OPR_SDST_EXEC_EXEC_LO)
+    throw util::InvalidInst("V_S_SQRT_F16 has an invalid SReg_32_XEXEC destination", "");
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
     src0 =
         Operand(16, OperandType::OPR_SIMM32,

--- a/emulation/rocjitsu/tests/pseudo_scalar_exec_test.cpp
+++ b/emulation/rocjitsu/tests/pseudo_scalar_exec_test.cpp
@@ -717,22 +717,51 @@ TEST_P(PseudoScalarExecTest, ExecutesAtExecZeroWithDestinationOpselZeroAndUsesLo
   EXPECT_EQ(fixture.wavefront->exec(), 0u);
 }
 
-TEST_P(PseudoScalarExecTest, RejectsVccDestinations) {
-  constexpr uint32_t kSourceSgpr = 0;
-  constexpr std::array<uint32_t, 2> kVccDestinationEncodings{{106u, 107u}};
+TEST_P(PseudoScalarExecTest, ExecutesWithVccAsSourceAndDestination) {
+  constexpr std::array<uint32_t, 2> kVccSelectors{{106u, 107u}};
+  constexpr uint32_t kOtherHalfSentinel = 0xDEADBEEFu;
 
   const PseudoScalarProfile &profile = *GetParam().profile;
   const PseudoScalarCase &test_case = *GetParam().test_case;
-  PseudoScalarFixture fixture(profile);
-  ASSERT_TRUE(fixture.ready()) << profile.name;
+  for (const uint32_t selector : kVccSelectors) {
+    SCOPED_TRACE(selector);
+    PseudoScalarFixture fixture(profile);
+    ASSERT_TRUE(fixture.ready()) << profile.name;
 
-  for (const uint32_t destination : kVccDestinationEncodings) {
-    const InstructionWords words =
-        encode_vop3(profile, test_case.mnemonic, destination, kSourceSgpr);
-    EXPECT_THROW(
-        { std::unique_ptr<Instruction> instruction(fixture.decoder->decode(words.data())); },
-        util::InvalidInst)
-        << profile.name << " " << test_case.mnemonic << " destination=" << destination;
+    const InstructionWords words = encode_vop3(profile, test_case.mnemonic, selector, selector,
+                                               {.source_opsel = test_case.set_source_opsel});
+    std::unique_ptr<Instruction> instruction(fixture.decoder->decode(words.data()));
+    ASSERT_NE(instruction, nullptr);
+
+    const uint64_t source = selector == kVccSelectors[0]
+                                ? (uint64_t{kOtherHalfSentinel} << 32) | test_case.source
+                                : (uint64_t{test_case.source} << 32) | kOtherHalfSentinel;
+    const uint64_t expected = selector == kVccSelectors[0]
+                                  ? (uint64_t{kOtherHalfSentinel} << 32) | test_case.expected
+                                  : (uint64_t{test_case.expected} << 32) | kOtherHalfSentinel;
+    fixture.wavefront->set_vcc(source);
+    fixture.compute_unit->execute_instruction(instruction.get(), *fixture.wavefront);
+    EXPECT_EQ(fixture.wavefront->vcc(), expected);
+  }
+}
+
+TEST(PseudoScalarDecodeTest, RejectsOutOfClassDestinations) {
+  constexpr std::array<uint32_t, 4> kInvalidSelectors{{126u, 127u, 128u, 255u}};
+  constexpr uint32_t kSourceSgpr = 0;
+
+  for (const PseudoScalarProfile &profile : kProfiles) {
+    SCOPED_TRACE(profile.name);
+    std::unique_ptr<Decoder> decoder = Decoder::create(profile.arch);
+    ASSERT_NE(decoder, nullptr);
+    for (const PseudoScalarCase &test_case : kCases) {
+      SCOPED_TRACE(test_case.mnemonic);
+      for (const uint32_t selector : kInvalidSelectors) {
+        SCOPED_TRACE(selector);
+        const InstructionWords words =
+            encode_vop3(profile, test_case.mnemonic, selector, kSourceSgpr);
+        EXPECT_THROW((void)decoder->decode(words.data()), util::InvalidInst);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Match the pseudo-scalar SReg_32_XEXEC destination class by accepting ordinary SGPRs and both VCC halves while continuing to reject EXEC_LO and EXEC_HI.

Regenerate gfx1250 and RDNA4 constructors and cover VCC execution plus fail-closed EXEC decoding in the focused pseudo-scalar tests.
