### PR TITLE
rocprofiler-systems: Enable phase-1 clang-tidy readability checks

### DIFF
--- a/.github/workflows/rocprofiler-systems-formatting.yml
+++ b/.github/workflows/rocprofiler-systems-formatting.yml
@@ -178,3 +178,87 @@ jobs:
       working-directory: projects/rocprofiler-systems/
       run: |
         bash scripts/check-fixedwidth-types.sh
+
+  # clang-tidy needs a real compile_commands.json, so unlike the other
+  # formatting jobs it configures + builds the project (in the CI container
+  # that already ships ROCm and the build deps). clang-tidy runs as part of
+  # compilation via CMAKE_CXX_CLANG_TIDY (enabled by ROCPROFSYS_USE_CLANG_TIDY)
+  # and is configured with -warnings-as-errors=* in cmake/Formatting.cmake, so
+  # any finding for the enabled checks in .clang-tidy fails this job. Only the
+  # project's own source/ targets are analyzed; third-party deps, the Python
+  # bindings and examples are excluded.
+  clang-tidy:
+    runs-on: ubuntu-latest
+    container:
+      image: dgaliffiamd/rocprofiler-systems:ci-rocm-7.2-ubuntu-24.04
+      options: --shm-size=512m
+
+    env:
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CMAKE_C_COMPILER_LAUNCHER: ccache
+      CMAKE_CXX_COMPILER_LAUNCHER: ccache
+
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        sparse-checkout: |
+          projects/rocprofiler-systems
+          .gitmodules
+        submodules: recursive
+
+    - name: Install clang-tidy
+      shell: bash
+      run: |
+        apt-get update
+        apt-get install -y clang-tidy
+        clang-tidy --version
+
+    - name: Configure ROCm environment
+      shell: bash
+      run: |
+        echo "/opt/rocm/bin" >> $GITHUB_PATH
+        echo "ROCM_PATH=/opt/rocm" >> $GITHUB_ENV
+        echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
+
+    - name: Restore ccache
+      uses: actions/cache@v6
+      with:
+        path: ${{ github.workspace }}/.ccache
+        key: ccache-clang-tidy-${{ github.sha }}
+        restore-keys: |
+          ccache-clang-tidy-
+
+    - name: Configure ccache
+      shell: bash
+      run: |
+        mkdir -p "${CCACHE_DIR}"
+        ccache --max-size=1G
+        ccache -z
+
+    - name: Configure
+      timeout-minutes: 30
+      shell: bash
+      working-directory: projects/rocprofiler-systems/
+      run: |
+        git config --global --add safe.directory ${GITHUB_WORKSPACE}
+        git config --global --add safe.directory ${PWD}
+        cmake --version
+        clang-tidy --version
+        cmake -B build . \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DROCPROFSYS_USE_CLANG_TIDY=ON \
+          -DROCPROFSYS_BUILD_TESTING=OFF \
+          -DROCPROFSYS_BUILD_EXAMPLES=OFF \
+          -DROCPROFSYS_USE_PYTHON=ON \
+          -DROCPROFSYS_BUILD_DYNINST=ON \
+          -DROCPROFSYS_BUILD_TBB=ON \
+          -DROCPROFSYS_BUILD_ELFUTILS=ON \
+          -DROCPROFSYS_BUILD_LIBIBERTY=ON \
+          -DROCPROFSYS_PYTHON_PREFIX=/opt/conda/envs
+
+    - name: Build with clang-tidy
+      timeout-minutes: 90
+      shell: bash
+      working-directory: projects/rocprofiler-systems/
+      run: |
+        cmake --build build --parallel $(nproc)

--- a/projects/rocprofiler-systems/.clang-tidy
+++ b/projects/rocprofiler-systems/.clang-tidy
@@ -1,80 +1,33 @@
 ---
 Checks: "-*,\
-bugprone-*,\
--bugprone-easily-swappable-parameters,\
-cert-*,\
--cert-dcl37-c,\
--cert-dcl51-cpp,\
--cert-err58-cpp,\
-concurrency-*,\
-cppcoreguidelines-*,\
--cppcoreguidelines-avoid-do-while,\
--cppcoreguidelines-avoid-non-const-global-variables,\
--cppcoreguidelines-macro-usage,\
--cppcoreguidelines-non-private-member-variables-in-classes,\
--cppcoreguidelines-owning-memory,\
--cppcoreguidelines-pro-bounds-array-to-pointer-decay,\
--cppcoreguidelines-pro-bounds-constant-array-index,\
--cppcoreguidelines-pro-bounds-pointer-arithmetic,\
--cppcoreguidelines-pro-type-reinterpret-cast,\
--cppcoreguidelines-pro-type-union-access,\
--cppcoreguidelines-pro-type-vararg,\
-google-*,\
--google-objc-*,\
--google-readability-todo,\
-misc-*,\
--misc-no-recursion,\
--misc-non-private-member-variables-in-classes,\
-modernize-*,\
--modernize-use-trailing-return-type,\
-performance-*,\
 readability-*,\
 -readability-function-size,\
--readability-redundant-access-specifiers,\
+-readability-identifier-naming,\
+-readability-implicit-bool-conversion,\
+-readability-inconsistent-declaration-parameter-name,\
+-readability-named-parameter,\
+-readability-magic-numbers,\
+-readability-redundant-declaration,\
 -readability-redundant-member-init,\
+-readability-simplify-boolean-expr,\
+-readability-uppercase-literal-suffix,\
+-readability-braces-around-statements,\
+-readability-avoid-const-params-in-decls,\
+-readability-else-after-return,\
+-readability-isolate-declaration,\
+-readability-redundant-string-cstr,\
+-readability-static-accessed-through-instance,\
+-readability-const-return-type,\
+-readability-redundant-access-specifiers,\
+-readability-function-cognitive-complexity,\
+-readability-identifier-length,\
+-readability-use-anyofallof,\
+-readability-enum-initial-value,\
+-readability-math-missing-parentheses,\
+-readability-convert-member-functions-to-static,\
+-readability-non-const-parameter,\
+-readability-make-member-function-const,\
+-readability-avoid-nested-conditional-operator,\
+-readability-suspicious-call-argument,\
+-readability-avoid-unconditional-preprocessor-if,\
 "
-CheckOptions:
-  - key:             readability-braces-around-statements.ShortStatementLines
-    value:           '1'
-  - key:             readability-implicit-bool-conversion.AllowPointerConditions
-    value:           '1'
-  - key:             cppcoreguidelines-init-variables.IncludeStyle
-    value:           llvm
-  - key:             readability-identifier-naming.ClassCase
-    value:           lower_case
-  - key:             readability-identifier-naming.StructCase
-    value:           lower_case
-  - key:             readability-identifier-naming.UnionCase
-    value:           lower_case
-  - key:             readability-identifier-naming.EnumCase
-    value:           lower_case
-  - key:             readability-identifier-naming.EnumConstantCase
-    value:           UPPER_CASE
-  - key:             readability-identifier-naming.FunctionCase
-    value:           lower_case
-  - key:             readability-identifier-naming.MethodCase
-    value:           lower_case
-  - key:             readability-identifier-naming.VariableCase
-    value:           lower_case
-  - key:             readability-identifier-naming.ParameterCase
-    value:           lower_case
-  - key:             readability-identifier-naming.MemberCase
-    value:           lower_case
-  - key:             readability-identifier-naming.PrivateMemberPrefix
-    value:           m_
-  - key:             readability-identifier-naming.ProtectedMemberPrefix
-    value:           m_
-  - key:             readability-identifier-naming.PublicMemberPrefix
-    value:           m_
-  - key:             readability-identifier-naming.GlobalConstantCase
-    value:           UPPER_CASE
-  - key:             readability-identifier-naming.MacroDefinitionCase
-    value:           UPPER_CASE
-  - key:             readability-identifier-naming.TemplateParameterCase
-    value:           CamelCase
-  - key:             readability-identifier-naming.NamespaceCase
-    value:           lower_case
-  - key:             readability-identifier-naming.TypeAliasCase
-    value:           lower_case
-  - key:             readability-identifier-naming.TypedefCase
-    value:           lower_case

--- a/projects/rocprofiler-systems/cmake/Formatting.cmake
+++ b/projects/rocprofiler-systems/cmake/Formatting.cmake
@@ -20,7 +20,10 @@ macro(ROCPROFILER_SYSTEMS_ACTIVATE_CLANG_TIDY)
             )
             set(ROCPROFSYS_USE_CLANG_TIDY OFF)
         else()
-            set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_COMMAND})
+            # Treat every clang-tidy diagnostic as an error so the build (and CI)
+            # fails on any finding. Matches the enforcement used by sibling
+            # projects in this monorepo (e.g. hipFile).
+            set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_COMMAND} "-warnings-as-errors=*")
 
             # Create a preprocessor definition that depends on .clang-tidy content so the
             # compile command will change when .clang-tidy changes.  This ensures that a

--- a/projects/rocprofiler-systems/source/bin/common/common_utils.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/common_utils.cpp
@@ -806,7 +806,7 @@ print_help_for_topic(const std::string& captured, std::string_view topic,
     bool found = false;
     for(const auto& sec : sections)
     {
-        if(target_headers.count(sec.header) > 0)
+        if(target_headers.contains(sec.header))
         {
             found = true;
             for(size_t line_idx = sec.start; line_idx < sec.end; ++line_idx)

--- a/projects/rocprofiler-systems/source/bin/common/json_config.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/json_config.cpp
@@ -51,7 +51,7 @@ collect_enabled_entry_names(const nlohmann::json&             metrics_obj,
     std::vector<std::string> result;
     for(const auto& [name, metric] : metrics_obj.items())
     {
-        if(exclude.count(name) > 0) continue;
+        if(exclude.contains(name)) continue;
         if(metric.is_object() && metric.contains("enabled") &&
            metric["enabled"].get<bool>())
         {
@@ -506,8 +506,8 @@ expand_rocm_domain_shorthand(const std::string& shorthand)
         { "hipfile", "hipfile_api" },
     } };
 
-    auto it = std::find_if(shortcuts.begin(), shortcuts.end(),
-                           [&](const entry& e) { return e.first == shorthand; });
+    const auto* it = std::find_if(shortcuts.begin(), shortcuts.end(),
+                                  [&](const entry& e) { return e.first == shorthand; });
     if(it != shortcuts.end()) return std::string{ it->second };
     return shorthand;
 }
@@ -557,8 +557,8 @@ expand_parallel_runtimes(const std::string& runtimes_str)
 
     for(const auto& token : split_csv_lowercase(runtimes_str))
     {
-        auto it = std::find_if(shortcuts.begin(), shortcuts.end(),
-                               [&](const entry& e) { return e.first == token; });
+        const auto* it = std::find_if(shortcuts.begin(), shortcuts.end(),
+                                      [&](const entry& e) { return e.first == token; });
         if(it != shortcuts.end()) result[std::string{ it->second }] = "true";
     }
     return result;
@@ -580,8 +580,8 @@ expand_gpu_metrics(const std::string& metrics_str)
     std::string result;
     for(const auto& token : split_csv_lowercase(metrics_str))
     {
-        auto it = std::find_if(shortcuts.begin(), shortcuts.end(),
-                               [&](const entry& e) { return e.first == token; });
+        const auto* it = std::find_if(shortcuts.begin(), shortcuts.end(),
+                                      [&](const entry& e) { return e.first == token; });
         if(!result.empty()) result += ',';
         result += (it != shortcuts.end()) ? std::string{ it->second } : token;
     }

--- a/projects/rocprofiler-systems/source/bin/common/preset_registry.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/preset_registry.cpp
@@ -120,7 +120,7 @@ preset_registry::translate_legacy_flag(std::string_view arg) const
         return {};
 
     auto name = std::string{ arg.substr(2) };
-    if(m_presets.count(name) == 0) return {};
+    if(!m_presets.contains(name)) return {};
 
     std::cerr << "[rocprof-sys] WARNING: '" << arg
               << "' is deprecated. Use '--preset=" << name << "' instead.\n";
@@ -251,7 +251,7 @@ preset_registry::ensure_all_loaded()
             std::string{ filename.substr(0, filename.size() - json_ext.size()) };
 
         // Skip if preset is already cached (e.g. from embedded presets)
-        if(m_presets.count(preset_name) > 0) continue;
+        if(m_presets.contains(preset_name)) continue;
 
         const auto filepath = fmt::format("{}/{}", m_directory, filename);
         if(auto info = load_file(filepath)) m_presets[preset_name] = std::move(*info);

--- a/projects/rocprofiler-systems/source/bin/common/tests/test_help_system.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/tests/test_help_system.cpp
@@ -409,8 +409,8 @@ TEST_F(help_system_test, see_also_references_valid_topics_only)
     const auto& domain_map = get_domain_help_map();
 
     auto is_valid_topic = [&](std::string_view name) {
-        return group_map.count(std::string{ name }) > 0 ||
-               domain_map.count(std::string{ name }) > 0;
+        return group_map.contains(std::string{ name }) ||
+               domain_map.contains(std::string{ name });
     };
 
     for(const auto& [topic, related] : relations)

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.cpp
@@ -697,8 +697,7 @@ main(int argc, char** argv)
         category_regex_keys.emplace_back(_pos_regex);
     }
 
-    if(category_view.count("advanced") > 0 ||
-       category_view.count("settings::advanced") > 0)
+    if(category_view.contains("advanced") || category_view.contains("settings::advanced"))
         fmt_opts.print_advanced = true;
 
     if(category_view.empty()) category_view = _category_options;
@@ -1021,9 +1020,9 @@ write_settings_info(std::ostream& os, format_options& fmt_opts,
             bool _found = false;
             for(const auto& category : _categories)
             {
-                if(category_view.count(category) > 0) _found = true;
+                if(category_view.contains(category)) _found = true;
             }
-            if(!fmt_opts.print_advanced && _categories.count("settings::advanced") > 0)
+            if(!fmt_opts.print_advanced && _categories.contains("settings::advanced"))
             {
                 if(!sitr->second->get_config_updated() &&
                    !sitr->second->get_environ_updated())
@@ -1247,8 +1246,8 @@ write_hw_counter_info(std::ostream& os, format_options& fmt_opts,
     auto _valid_symbols = std::set<std::string>{};
     for(auto& fitr : fields)
     {
-        if(!category_view.empty() && category_view.count(fitr.first) == 0 &&
-           category_view.count(std::string{ "hw_counters::" } + fitr.first) == 0)
+        if(!category_view.empty() && !category_view.contains(fitr.first) &&
+           !category_view.contains(std::string{ "hw_counters::" } + fitr.first))
             fitr.second.clear();
 
         if(!is_category_selected(fitr.first) &&

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/generate_config.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/generate_config.cpp
@@ -69,12 +69,12 @@ ignore_setting(const Tp& _v, const format_options& fmt_opts)
         }
         if(!_found) return true;
     }
-    if(category_view.count("deprecated") == 0 &&
-       category_view.count("settings::deprecated") == 0 &&
+    if(!category_view.contains("deprecated") &&
+       !category_view.contains("settings::deprecated") &&
        _v->get_categories().count("deprecated") > 0)
         return true;
-    if(!fmt_opts.print_advanced && category_view.count("advanced") == 0 &&
-       category_view.count("settings::advanced") == 0 &&
+    if(!fmt_opts.print_advanced && !category_view.contains("advanced") &&
+       !category_view.contains("settings::advanced") &&
        _v->get_categories().count("advanced") > 0)
         return true;
     return false;
@@ -224,7 +224,7 @@ generate_config(std::string _config_file, const std::set<std::string>& _config_f
         _fmts = _config_fmts;
     else if(!_fmts.empty())
     {
-        for(auto& itr : _config_fmts)
+        for(const auto& itr : _config_fmts)
             _fmts.emplace(itr);
     }
 
@@ -286,7 +286,7 @@ generate_config(std::string _config_file, const std::set<std::string>& _config_f
         return _ofs;
     };
 
-    if(_fmts.count("json") > 0)
+    if(_fmts.contains("json"))
     {
         // JSON schema output includes all ROCPROFSYS_* settings regardless of
         // --filter, --categories, or --advanced flags. This is intentional: the
@@ -323,7 +323,7 @@ generate_config(std::string _config_file, const std::set<std::string>& _config_f
         _open(ofs, _fname, "JSON") << preset_json.dump(4) << "\n";
     }
 
-    if(_fmts.count("xml") > 0)
+    if(_fmts.contains("xml"))
     {
         std::stringstream _ss{};
         output_archive<cereal::XMLOutputArchive>::indent() = true;
@@ -334,7 +334,7 @@ generate_config(std::string _config_file, const std::set<std::string>& _config_f
         _open(ofs, _fname, "XML") << _ss.str() << "\n";
     }
 
-    if(_fmts.count("txt") > 0 || _fmts.count("cfg") > 0 || _nout == 0)
+    if(_fmts.contains("txt") || _fmts.contains("cfg") || _nout == 0)
     {
         std::stringstream _ss{};
         size_t            _w = fmt_opts.min_width;

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-causal/impl.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-causal/impl.cpp
@@ -13,13 +13,13 @@
 
 #include <spdlog/fmt/ranges.h>
 
+#include <algorithm>
 #include <timemory/environment.hpp>
 #include <timemory/log/color.hpp>
 #include <timemory/utility/argparse.hpp>
 #include <timemory/utility/console.hpp>
 #include <timemory/utility/filepath.hpp>
 
-#include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <cstdio>
@@ -651,7 +651,7 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
     else if(_cerr)
         throw std::runtime_error(_cerr.what());
 
-    if(_niterations < 1) _niterations = 1;
+    _niterations   = std::max<int64_t>(_niterations, 1);
     auto _get_size = [](const auto& _v) { return std::max<size_t>(_v.size(), 1); };
 
     auto _causal_envs_tmp = std::vector<std::map<std::string_view, std::string>>{};

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/details.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/details.cpp
@@ -6,6 +6,7 @@
 #include "log.hpp"
 #include "rocprof-sys-instrument.hpp"
 
+#include <algorithm>
 #include <timemory/components/rusage/components.hpp>
 #include <timemory/components/timing/wall_clock.hpp>
 
@@ -14,7 +15,6 @@
 
 #include <spdlog/fmt/ranges.h>
 
-#include <algorithm>
 #include <link.h>
 #include <linux/limits.h>
 #include <string>
@@ -301,7 +301,7 @@ get_loop_file_line_info(module_t* module, procedure_t* func, flow_graph_t*,
             _col2 = std::max(_col2, itr.lineOffset());
         }
 
-        if(_col1 < 0) _col1 = 0;
+        _col1 = std::max(_col1, 0);
 
         if(module->getSourceLines(_last_addr, _lines_end))
         {
@@ -310,8 +310,8 @@ get_loop_file_line_info(module_t* module, procedure_t* func, flow_graph_t*,
                 _row2 = std::max(_row2, itr.lineNumber());
                 _col2 = std::max(_col2, itr.lineOffset());
             }
-            if(_col2 < 0) _col2 = 0;
-            if(_row2 < _row1) _row1 = _row2;  // Fix for wrong line numbers
+            _col2 = std::max(_col2, 0);
+            _row1 = std::min(_row2, _row1);  // Fix for wrong line numbers
 
             return function_signature(_return_type, _func_name, _file_name, _param_types,
                                       { _row1, _row2 }, { _col1, _col2 }, true, true,
@@ -889,8 +889,6 @@ error_func_fake(error_level_t level, int num, const char* const* params)
 
 #include "internal_libs.hpp"
 
-#include <timemory/components/timing/wall_clock.hpp>
-
 //======================================================================================//
 //
 //  Filters app_objects (internal constraints are applied in module level filtering)
@@ -1257,7 +1255,7 @@ process_modules(const std::vector<module_t*>& _app_modules)
         auto _base_name = rocprofsys::path::filename(itr->fullName());
         auto _real_name = rocprofsys::path::realpath(itr->fullName());
 
-        if(_names.count(_base_name) == 0 && _names.count(_real_name) == 0)
+        if(!_names.contains(_base_name) && !_names.contains(_real_name))
         {
             verbprintf(2, "Processing symbol table for module '%s'...\n",
                        itr->fullName().c_str());

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/function_signature.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/function_signature.cpp
@@ -82,9 +82,9 @@ function_signature::get(bool _all, bool _save) const
             errprintf(3, "line info for %s is empty! [{%s}] [{%s}]\n", m_name.c_str(),
                       _rc1.c_str(), _rc2.c_str());
     }
-    if((_all || use_file_info) && m_file.length() > 0) ss << " [" << m_file;
+    if((_all || use_file_info) && !m_file.empty()) ss << " [" << m_file;
     if((_all || use_line_info) && m_row.first > 0) ss << ":" << m_row.first;
-    if((_all || use_file_info) && m_file.length() > 0) ss << "]";
+    if((_all || use_file_info) && !m_file.empty()) ss << "]";
 
     if(_save) m_signature = ss.str();
     return ss.str();
@@ -98,7 +98,7 @@ function_signature::get_coverage(bool _basic_block) const
     ss << m_name << m_params;
     if(_basic_block && m_loop && m_info_beg)
     {
-        if(m_file.length() > 0) ss << " [" << m_file << "]";
+        if(!m_file.empty()) ss << " [" << m_file << "]";
         auto _row_col_str = [](unsigned long _row, unsigned long _col) {
             std::stringstream _ss{};
             if(_row == 0 && _col == 0) return std::string{};
@@ -124,9 +124,9 @@ function_signature::get_coverage(bool _basic_block) const
     }
     else
     {
-        if(m_file.length() > 0) ss << " [" << m_file;
+        if(!m_file.empty()) ss << " [" << m_file;
         if(m_row.first > 0) ss << ":" << m_row.first;
-        if(m_file.length() > 0) ss << "]";
+        if(!m_file.empty()) ss << "]";
     }
 
     return ss.str();

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/internal_libs.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/internal_libs.cpp
@@ -331,7 +331,7 @@ get_internal_basic_libs_impl()
     {
         for(auto itr : gitr)
         {
-            if(!itr.empty() && _exclude.count(itr) == 0) _libs.emplace(itr);
+            if(!itr.empty() && !_exclude.contains(itr)) _libs.emplace(itr);
         }
     }
 

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/module_function.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/module_function.cpp
@@ -596,7 +596,7 @@ module_function::is_routine_constrained() const
     //    return _report("Excluding", "critical-printf", 3);
     //}
 
-    if(whole.count(function_name) > 0)
+    if(whole.contains(function_name))
     {
         return _report("Excluding", "critical-whole-match", 3);
     }

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
@@ -1873,7 +1873,7 @@ main(int argc, char** argv)
         string_t best_init_name = {};
         for(const auto& sitr : init_stub_names)
         {
-            if(sitr.find(_name) != npos_v && used_stub_names.count(sitr) == 0)
+            if(sitr.find(_name) != npos_v && !used_stub_names.contains(sitr))
             {
                 verbprintf(
                     3, "Found possible match for '%s' instrumentation init: '%s'...\n",
@@ -1886,7 +1886,7 @@ main(int argc, char** argv)
         string_t base_fini_name = {};
         for(const auto& sitr : fini_stub_names)
         {
-            if(sitr.find(_name) != npos_v && used_stub_names.count(sitr) == 0)
+            if(sitr.find(_name) != npos_v && !used_stub_names.contains(sitr))
             {
                 verbprintf(
                     3, "Found possible match for '%s' instrumentation fini: '%s'...\n",
@@ -2241,7 +2241,7 @@ main(int argc, char** argv)
                            const std::string& _extra = {}) {
         static std::map<std::string, strset_t> already_reported{};
         auto _key = fmt::format("{}_{}_{}_{}_{}", _type, _action, _reason, _name, _extra);
-        if(already_reported[_key].count(_name) == 0)
+        if(!already_reported[_key].contains(_name))
         {
             verbprintf(_lvl, "[%s][%s] %s :: '%s'", _type.c_str(), _action.c_str(),
                        _reason.c_str(), _name.c_str());
@@ -2560,7 +2560,7 @@ main(int argc, char** argv)
             else if(app_thread->terminationStatus() == ExitedViaSignal)
             {
                 auto sign = app_thread->getExitSignal();
-                fprintf(stderr, "\nApplication exited with signal: %i\n", int(sign));
+                fprintf(stderr, "\nApplication exited with signal: %i\n", sign);
             }
             code = app_thread->getExitCode();
         };

--- a/projects/rocprofiler-systems/source/lib/binary/dwarf_entry.cpp
+++ b/projects/rocprofiler-systems/source/lib/binary/dwarf_entry.cpp
@@ -10,6 +10,8 @@
 #include <dwarf.h>
 #include <elfutils/libdw.h>
 
+#include <algorithm>
+
 namespace rocprofsys
 {
 namespace binary
@@ -35,7 +37,7 @@ get_dwarf_address_ranges(Dwarf_Die* _die)
     {
         Dwarf_Addr _entry_pc;
         dwarf_entrypc(_die, &_entry_pc);
-        if(_entry_pc < _low_pc) _low_pc = _entry_pc;
+        _low_pc = std::min(_entry_pc, _low_pc);
     }
 
     if(_low_pc < _high_pc) _ranges.emplace_back(_low_pc, _high_pc);

--- a/projects/rocprofiler-systems/source/lib/binary/symbol.cpp
+++ b/projects/rocprofiler-systems/source/lib/binary/symbol.cpp
@@ -21,6 +21,7 @@ typedef Elf32_Word  Elf32_Relr;
 typedef Elf64_Xword Elf64_Relr;
 #endif
 
+#include <algorithm>
 #include <bfd.h>
 #include <coff/external.h>
 #include <coff/internal.h>
@@ -125,8 +126,8 @@ symbol::operator+=(const symbol& _rhs)
         address += _rhs.address;
         utility::combine(inlines, _rhs.inlines);
         utility::combine(dwarf_info, _rhs.dwarf_info);
-        if(_rhs.binding < binding) binding = _rhs.binding;
-        if(_rhs.visibility < visibility) visibility = _rhs.visibility;
+        binding    = std::min(_rhs.binding, binding);
+        visibility = std::min(_rhs.visibility, visibility);
         if(load_address == 0 && _rhs.load_address > load_address)
             load_address = _rhs.load_address;
     }
@@ -221,7 +222,7 @@ symbol::read_bfd_line_info(bfd_file& _bfd)
 
     if(_pc < _vma || _pc >= _vma + _size) return false;
     // add one to vma + size because address range is exclusive of last address
-    if(_pc_end > _vma + _size) _pc_end = (_vma + _size);
+    _pc_end = std::min(_pc_end, _vma + _size);
 
     auto* _inp  = static_cast<bfd*>(_bfd.data);
     auto* _syms = reinterpret_cast<asymbol**>(_bfd.syms);

--- a/projects/rocprofiler-systems/source/lib/common/tests/test_environment.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/tests/test_environment.cpp
@@ -20,7 +20,7 @@ struct fake_env
 
     static int setenv(const char* name, const char* value, int overwrite)
     {
-        if(!overwrite && store.count(name)) return 0;
+        if(!overwrite && store.contains(name)) return 0;
         store[name] = value;
         return 0;
     }

--- a/projects/rocprofiler-systems/source/lib/common/tests/test_remove_env.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/tests/test_remove_env.cpp
@@ -152,7 +152,7 @@ TEST_F(RemoveEnvTest, RealWorld_LD_PRELOAD)
     remove_env(m_env_vars, "LD_PRELOAD", m_original_envs);
 
     ASSERT_EQ(m_env_vars.size(), 2);
-    EXPECT_FALSE(find_env_var(m_env_vars, "LD_PRELOAD").length() > 0);
+    EXPECT_FALSE(!find_env_var(m_env_vars, "LD_PRELOAD").empty());
     EXPECT_EQ(find_env_var(m_env_vars, "LD_LIBRARY_PATH"), "LD_LIBRARY_PATH=/usr/lib");
     EXPECT_EQ(find_env_var(m_env_vars, "PATH"), "PATH=/usr/bin");
 }

--- a/projects/rocprofiler-systems/source/lib/core/argparse.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse.cpp
@@ -17,8 +17,6 @@
 
 #include <spdlog/fmt/ranges.h>
 
-#include <cstdint>
-
 namespace rocprofsys
 {
 namespace argparse
@@ -82,21 +80,21 @@ update_env(parser_data& _data, std::string_view _env_var, Tp&& _env_val,
 bool
 default_setting_filter(vsetting_t* _v, const parser_data& _data)
 {
-    return (_data.reg.processed_settings.count(_v) == 0 &&
-            _data.reg.processed_environs.count(_v->get_name()) == 0 &&
-            _data.reg.processed_environs.count(_v->get_env_name()) == 0);
+    return (!_data.reg.processed_settings.contains(_v) &&
+            !_data.reg.processed_environs.contains(_v->get_name()) &&
+            !_data.reg.processed_environs.contains(_v->get_env_name()));
 }
 
 bool
 default_environ_filter(std::string_view _v, const parser_data& _data)
 {
-    return (_data.reg.processed_environs.count(_v.data()) == 0);
+    return (!_data.reg.processed_environs.contains(_v.data()));
 }
 
 bool
 default_grouping_filter(std::string_view _v, const parser_data& _data)
 {
-    return (_data.reg.processed_groups.count(_v.data()) == 0);
+    return (!_data.reg.processed_groups.contains(_v.data()));
 }
 
 parser_data&
@@ -383,9 +381,9 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
                 if(!_modes.empty())
                 {
                     update_env(_data, env_vars::SAMPLING_CPUTIME,
-                               _modes.count("cputime") > 0, update_mode::WEAK);
+                               _modes.contains("cputime"), update_mode::WEAK);
                     update_env(_data, env_vars::SAMPLING_REALTIME,
-                               _modes.count("realtime") > 0, update_mode::WEAK);
+                               _modes.contains("realtime"), update_mode::WEAK);
                 }
             });
 
@@ -583,18 +581,18 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .action([&](parser_t& p) {
                 auto _v      = p.get<strset_t>("include");
                 auto _update = [&](const auto& _opt, bool _cond) {
-                    if(_cond || _v.count("all") > 0) update_env(_data, _opt, true);
+                    if(_cond || _v.contains("all")) update_env(_data, _opt, true);
                 };
-                _update(env_vars::USE_KOKKOSP, _v.count("kokkosp") > 0);
-                _update(env_vars::USE_MPIP, _v.count("mpip") > 0);
-                _update(env_vars::USE_OMPT, _v.count("ompt") > 0);
-                _update(env_vars::USE_RCCLP, _v.count("rcclp") > 0);
-                _update(env_vars::USE_AMD_SMI, _v.count("amd-smi") > 0);
-                _update(env_vars::TRACE_THREAD_LOCKS, _v.count("mutex-locks") > 0);
-                _update(env_vars::TRACE_THREAD_RW_LOCKS, _v.count("rw-locks") > 0);
-                _update(env_vars::TRACE_THREAD_SPIN_LOCKS, _v.count("spin-locks") > 0);
+                _update(env_vars::USE_KOKKOSP, _v.contains("kokkosp"));
+                _update(env_vars::USE_MPIP, _v.contains("mpip"));
+                _update(env_vars::USE_OMPT, _v.contains("ompt"));
+                _update(env_vars::USE_RCCLP, _v.contains("rcclp"));
+                _update(env_vars::USE_AMD_SMI, _v.contains("amd-smi"));
+                _update(env_vars::TRACE_THREAD_LOCKS, _v.contains("mutex-locks"));
+                _update(env_vars::TRACE_THREAD_RW_LOCKS, _v.contains("rw-locks"));
+                _update(env_vars::TRACE_THREAD_SPIN_LOCKS, _v.contains("spin-locks"));
 
-                if(_v.count("all") > 0 || _v.count("kokkosp") > 0)
+                if(_v.contains("all") || _v.contains("kokkosp"))
                     update_env(_data, "KOKKOS_TOOLS_LIBS", _data.env.omni_libpath,
                                update_mode::PREPEND);
             });
@@ -612,18 +610,18 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .action([&](parser_t& p) {
                 auto _v      = p.get<strset_t>("exclude");
                 auto _update = [&](const auto& _opt, bool _cond) {
-                    if(_cond || _v.count("all") > 0) update_env(_data, _opt, false);
+                    if(_cond || _v.contains("all")) update_env(_data, _opt, false);
                 };
-                _update(env_vars::USE_KOKKOSP, _v.count("kokkosp") > 0);
-                _update(env_vars::USE_MPIP, _v.count("mpip") > 0);
-                _update(env_vars::USE_OMPT, _v.count("ompt") > 0);
-                _update(env_vars::USE_RCCLP, _v.count("rcclp") > 0);
-                _update(env_vars::USE_AMD_SMI, _v.count("amd-smi") > 0);
-                _update(env_vars::TRACE_THREAD_LOCKS, _v.count("mutex-locks") > 0);
-                _update(env_vars::TRACE_THREAD_RW_LOCKS, _v.count("rw-locks") > 0);
-                _update(env_vars::TRACE_THREAD_SPIN_LOCKS, _v.count("spin-locks") > 0);
+                _update(env_vars::USE_KOKKOSP, _v.contains("kokkosp"));
+                _update(env_vars::USE_MPIP, _v.contains("mpip"));
+                _update(env_vars::USE_OMPT, _v.contains("ompt"));
+                _update(env_vars::USE_RCCLP, _v.contains("rcclp"));
+                _update(env_vars::USE_AMD_SMI, _v.contains("amd-smi"));
+                _update(env_vars::TRACE_THREAD_LOCKS, _v.contains("mutex-locks"));
+                _update(env_vars::TRACE_THREAD_RW_LOCKS, _v.contains("rw-locks"));
+                _update(env_vars::TRACE_THREAD_SPIN_LOCKS, _v.contains("spin-locks"));
 
-                if(_v.count("all") > 0 || _v.count("kokkosp") > 0)
+                if(_v.contains("all") || _v.contains("kokkosp"))
                     remove_env(_data.env.current, "KOKKOS_TOOLS_LIBS", _data.env.initial);
             });
 
@@ -862,9 +860,9 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
                 update_env(_data, env_vars::PROFILE, true);
                 if(!_v.empty())
                 {
-                    update_env(_data, env_vars::TEXT_OUTPUT, _v.count("text") != 0);
-                    update_env(_data, env_vars::JSON_OUTPUT, _v.count("json") != 0);
-                    update_env(_data, env_vars::COUT_OUTPUT, _v.count("console") != 0);
+                    update_env(_data, env_vars::TEXT_OUTPUT, _v.contains("text"));
+                    update_env(_data, env_vars::JSON_OUTPUT, _v.contains("json"));
+                    update_env(_data, env_vars::COUT_OUTPUT, _v.contains("console"));
                 }
             });
 
@@ -1317,12 +1315,12 @@ add_group_arguments(parser_t& _parser, const std::string& _group_name, parser_da
     auto _settings = std::vector<std::shared_ptr<tim::vsettings>>{};
     for(auto& itr : *rocprofsys::settings::instance())
     {
-        if(itr.second->get_categories().count("rocprofsys") == 0) continue;
-        if(itr.second->get_categories().count("deprecated") > 0) continue;
+        if(!itr.second->get_categories().contains("rocprofsys")) continue;
+        if(itr.second->get_categories().contains("deprecated")) continue;
         if(itr.second->get_hidden()) continue;
         if(!_data.reg.setting_filter(itr.second.get(), _data)) continue;
         if(!_data.reg.environ_filter(itr.second->get_name(), _data)) continue;
-        if(itr.second->get_categories().count(_group_name) == 0) continue;
+        if(!itr.second->get_categories().contains(_group_name)) continue;
 
         itr.second->set_enabled(true);
         _settings.emplace_back(itr.second);
@@ -1379,8 +1377,8 @@ add_extended_arguments(parser_t& _parser, parser_data& _data)
     auto _settings           = std::vector<std::shared_ptr<tim::vsettings>>{};
     for(auto& itr : *rocprofsys::settings::instance())
     {
-        if(itr.second->get_categories().count("rocprofsys") == 0) continue;
-        if(itr.second->get_categories().count("deprecated") > 0) continue;
+        if(!itr.second->get_categories().contains("rocprofsys")) continue;
+        if(itr.second->get_categories().contains("deprecated")) continue;
         if(itr.second->get_hidden()) continue;
         if(!_data.reg.setting_filter(itr.second.get(), _data)) continue;
         if(!_data.reg.environ_filter(itr.second->get_name(), _data)) continue;
@@ -1433,7 +1431,7 @@ add_extended_arguments(parser_t& _parser, parser_data& _data)
         _groups[citr] = {};
         for(const auto& itr : _settings)
         {
-            if(itr->get_categories().count(citr) > 0) _groups[citr].emplace_back(itr);
+            if(itr->get_categories().contains(citr)) _groups[citr].emplace_back(itr);
         }
         _settings.erase(std::remove_if(_settings.begin(), _settings.end(),
                                        [&citr](const auto& itr) {

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -251,7 +251,7 @@ get_setting_choices(const std::shared_ptr<settings>& _config, std::string_view n
 [[nodiscard]] const config_value_validation*
 find_config_value_validation(std::string_view name)
 {
-    auto itr = std::find_if(
+    const auto* itr = std::find_if(
         strict_config_value_validations.begin(), strict_config_value_validations.end(),
         [name](const auto& validation) { return validation.name == name; });
     return (itr != strict_config_value_validations.end()) ? &*itr : nullptr;
@@ -261,7 +261,7 @@ void
 validate_config_setting_value(std::string_view name, std::string_view raw_value,
                               const std::vector<std::string>* choices = nullptr)
 {
-    auto* validation = find_config_value_validation(name);
+    const auto* validation = find_config_value_validation(name);
     if(!validation) return;
 
     auto valid       = false;
@@ -1868,7 +1868,7 @@ configure_disabled_settings(const std::shared_ptr<settings>& _config)
     for(const auto& itr : *_config)
     {
         auto _v = itr.second->get_env_name();
-        if(_hidden_exact.count(_v) > 0 ||
+        if(_hidden_exact.contains(_v) ||
            std::regex_match(_v, std::regex{ _hidden_exact_re }) ||
            std::regex_match(_v, std::regex{ _hidden_begin_re }))
         {
@@ -2507,7 +2507,7 @@ get_category_config()
                     static_cast<tim::tsettings<std::string>&>(*_setting->second).get(),
                     " ,;:\n\t"))
             {
-                if(_avail.count(itr) > 0) _ret.emplace(itr);
+                if(_avail.contains(itr)) _ret.emplace(itr);
             }
             return _ret;
         };
@@ -2525,14 +2525,14 @@ get_category_config()
         {
             for(auto itr : _avail)
             {
-                if(_disabled.count(itr) == 0) _enabled.emplace(itr);
+                if(!_disabled.contains(itr)) _enabled.emplace(itr);
             }
         }
         else if(!_enabled.empty() && _disabled.empty())
         {
             for(auto itr : _avail)
             {
-                if(_enabled.count(itr) == 0) _disabled.emplace(itr);
+                if(!_enabled.contains(itr)) _disabled.emplace(itr);
             }
         }
         else
@@ -2856,7 +2856,7 @@ get_debug_tid()
         parse_numeric_range<std::int64_t, std::unordered_set<std::int64_t>>(
             rocprofsys::get_env<std::string>(env_vars::DEBUG_TIDS, ""), "debug tids", 1L);
     static thread_local bool _v =
-        _vlist.empty() || _vlist.count(tim::threading::get_id()) > 0;
+        _vlist.empty() || _vlist.contains(tim::threading::get_id());
     return _v;
 }
 
@@ -2866,8 +2866,8 @@ get_debug_pid()
     static auto _vlist =
         parse_numeric_range<std::int64_t, std::unordered_set<std::int64_t>>(
             rocprofsys::get_env<std::string>(env_vars::DEBUG_PIDS, ""), "debug pids", 1L);
-    static bool _v = _vlist.empty() || _vlist.count(tim::process::get_id()) > 0 ||
-                     _vlist.count(dmp::rank()) > 0;
+    static bool _v = _vlist.empty() || _vlist.contains(tim::process::get_id()) ||
+                     _vlist.contains(dmp::rank());
     return _v;
 }
 
@@ -3284,7 +3284,7 @@ rank_passes_filter(std::optional<std::uint64_t> current_rank,
     }
 
     const auto is_enabled =
-        enabled_ranks.count(static_cast<std::int64_t>(*current_rank)) != 0;
+        enabled_ranks.contains(static_cast<std::int64_t>(*current_rank));
     LOG_DEBUG("Output for MPI rank {} is {}", *current_rank,
               is_enabled ? "enabled" : "disabled");
     return is_enabled;

--- a/projects/rocprofiler-systems/source/lib/core/perf.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/perf.cpp
@@ -173,7 +173,7 @@ config_overflow_sampling(struct perf_event_attr& _pe, std::string_view _event,
         }
         case PERF_TYPE_HW_CACHE:
         {
-            _pe.config = static_cast<int>(perf::get_hw_cache_config(_event));
+            _pe.config = perf::get_hw_cache_config(_event);
             break;
         }
         case PERF_TYPE_BREAKPOINT:

--- a/projects/rocprofiler-systems/source/lib/core/progress/bar.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/progress/bar.cpp
@@ -222,9 +222,9 @@ bar::render_locked() noexcept
 
     const double frac =
         (total == 0) ? 0.0 : static_cast<double>(current) / static_cast<double>(total);
-    const auto width   = static_cast<std::size_t>(m_opts.width);
-    const auto bar_str = detail::format_bar(m_opts.style, width, frac);
-    const auto sep     = bar_str.empty() ? "" : " ";
+    const auto        width   = static_cast<std::size_t>(m_opts.width);
+    const auto        bar_str = detail::format_bar(m_opts.style, width, frac);
+    const auto* const sep     = bar_str.empty() ? "" : " ";
 
     std::fputs(ANSI_RESET_LINE, m_opts.stream);
     std::fprintf(m_opts.stream, "%s%s%s %3.0f%%", m_label.c_str(), sep, bar_str.c_str(),

--- a/projects/rocprofiler-systems/source/lib/core/rocprofiler-sdk.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/rocprofiler-sdk.cpp
@@ -250,7 +250,7 @@ config_settings(const std::shared_ptr<settings>& _config)
     auto _add_domain     = [&_domain_choices, &_skip_domains](std::string_view _domain) {
         auto _v = to_lower(_domain);
 
-        if(_skip_domains.count(_v) == 0)
+        if(!_skip_domains.contains(_v))
         {
             auto itr = std::find(_domain_choices.begin(), _domain_choices.end(), _v);
             if(itr == _domain_choices.end()) _domain_choices.emplace_back(_v);
@@ -263,7 +263,7 @@ config_settings(const std::shared_ptr<settings>& _config)
                                        auto& _operation_option_names) {
         auto _v = to_lower(_domain_name);
 
-        if(_skip_domains.count(_v) > 0) return;
+        if(_skip_domains.contains(_v)) return;
 
         auto _op_option_name = fmt::format("ROCPROFSYS_ROCM_{}_OPERATIONS", _domain_name);
         auto _eop_option_name =
@@ -491,7 +491,7 @@ get_callback_domains()
             {
                 auto ditr = callback_tracing_info[idx];
                 auto dval = static_cast<rocprofiler_callback_tracing_kind_t>(idx);
-                if(itr == to_lower(ditr.name) && supported.count(dval) > 0)
+                if(itr == to_lower(ditr.name) && supported.contains(dval))
                 {
                     _data.emplace(dval);
                     break;
@@ -634,7 +634,7 @@ get_buffered_domains()
             {
                 auto ditr = buffer_tracing_info[idx];
                 auto dval = static_cast<rocprofiler_buffer_tracing_kind_t>(idx);
-                if(itr == to_lower(ditr.name) && supported.count(dval) > 0)
+                if(itr == to_lower(ditr.name) && supported.contains(dval))
                 {
                     _data.emplace(dval);
                     break;
@@ -679,7 +679,7 @@ get_rocm_events()
 std::vector<std::int32_t>
 get_operations(rocprofiler_callback_tracing_kind_t kindv)
 {
-    if(callback_operation_option_names.count(kindv) == 0)
+    if(!callback_operation_option_names.contains(kindv))
     {
         LOG_CRITICAL("callback_operation_operation_names does not have value for {}",
                      static_cast<int>(kindv));
@@ -699,7 +699,7 @@ get_operations(rocprofiler_callback_tracing_kind_t kindv)
 std::vector<std::int32_t>
 get_operations(rocprofiler_buffer_tracing_kind_t kindv)
 {
-    if(buffered_operation_option_names.count(kindv) == 0)
+    if(!buffered_operation_option_names.contains(kindv))
     {
         LOG_CRITICAL("buffered_operation_option_names does not have value for {}",
                      static_cast<int>(kindv));
@@ -719,7 +719,7 @@ get_operations(rocprofiler_buffer_tracing_kind_t kindv)
 std::unordered_set<std::int32_t>
 get_backtrace_operations(rocprofiler_callback_tracing_kind_t kindv)
 {
-    if(callback_operation_option_names.count(kindv) == 0)
+    if(!callback_operation_option_names.contains(kindv))
     {
         LOG_CRITICAL("callback_operation_option_names does not have value for {}",
                      static_cast<int>(kindv));
@@ -739,7 +739,7 @@ get_backtrace_operations(rocprofiler_callback_tracing_kind_t kindv)
 std::unordered_set<std::int32_t>
 get_backtrace_operations(rocprofiler_buffer_tracing_kind_t kindv)
 {
-    if(buffered_operation_option_names.count(kindv) == 0)
+    if(!buffered_operation_option_names.contains(kindv))
     {
         LOG_CRITICAL("buffered_operation_option_names does not have value for {}",
                      static_cast<int>(kindv));

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.cpp
@@ -1540,7 +1540,7 @@ perfetto_processor_t::handle(const kfd_sample& sample)
               category::rocm_kfd_event_dropped_events> },
     } };
 
-    const auto entry =
+    const auto* const entry =
         std::find_if(dispatch.begin(), dispatch.end(),
                      [&](const auto& row) { return row.first == sample.category; });
     if(entry == dispatch.end())

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys-dl/dl.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys-dl/dl.cpp
@@ -907,15 +907,15 @@ extern "C"
 
     void rocprofsys_progress(const char* _name)
     {
-        return ROCPROFSYS_DL_INVOKE(get_indirect().rocprofsys_progress_f, _name);
+        ROCPROFSYS_DL_INVOKE(get_indirect().rocprofsys_progress_f, _name);
     }
 
     void rocprofsys_annotated_progress(const char*              _name,
                                        rocprofsys_annotation_t* _annotations,
                                        size_t                   _annotation_count)
     {
-        return ROCPROFSYS_DL_INVOKE(get_indirect().rocprofsys_annotated_progress_f, _name,
-                                    _annotations, _annotation_count);
+        ROCPROFSYS_DL_INVOKE(get_indirect().rocprofsys_annotated_progress_f, _name,
+                             _annotations, _annotation_count);
     }
 
     void rocprofsys_external_register_pause_callbacks(void (*pause_fn)(),
@@ -949,131 +949,127 @@ extern "C"
 
     void kokkosp_print_help(char* argv0)
     {
-        return ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_print_help_f, argv0);
+        ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_print_help_f, argv0);
     }
 
     void kokkosp_parse_args(int argc, char** argv)
     {
-        return ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_parse_args_f, argc, argv);
+        ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_parse_args_f, argc, argv);
     }
 
     void kokkosp_declare_metadata(const char* key, const char* value)
     {
-        return ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_declare_metadata_f, key,
-                                    value);
+        ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_declare_metadata_f, key, value);
     }
 
     void kokkosp_request_tool_settings(const std::uint32_t        version,
                                        Kokkos_Tools_ToolSettings* settings)
     {
-        return ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_request_tool_settings_f,
-                                    version, settings);
+        ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_request_tool_settings_f, version,
+                             settings);
     }
 
     void kokkosp_init_library(const int loadSeq, const std::uint64_t interfaceVer,
                               const std::uint32_t devInfoCount, void* deviceInfo)
     {
-        return ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_init_library_f, loadSeq,
-                                    interfaceVer, devInfoCount, deviceInfo);
+        ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_init_library_f, loadSeq, interfaceVer,
+                             devInfoCount, deviceInfo);
     }
 
     void kokkosp_finalize_library()
     {
-        return ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_finalize_library_f);
+        ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_finalize_library_f);
     }
 
     void kokkosp_begin_parallel_for(const char* name, std::uint32_t devid,
                                     std::uint64_t* kernid)
     {
-        return ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_begin_parallel_for_f, name,
-                                    devid, kernid);
+        ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_begin_parallel_for_f, name, devid,
+                             kernid);
     }
 
     void kokkosp_end_parallel_for(std::uint64_t kernid)
     {
-        return ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_end_parallel_for_f, kernid);
+        ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_end_parallel_for_f, kernid);
     }
 
     void kokkosp_begin_parallel_reduce(const char* name, std::uint32_t devid,
                                        std::uint64_t* kernid)
     {
-        return ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_begin_parallel_reduce_f, name,
-                                    devid, kernid);
+        ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_begin_parallel_reduce_f, name, devid,
+                             kernid);
     }
 
     void kokkosp_end_parallel_reduce(std::uint64_t kernid)
     {
-        return ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_end_parallel_reduce_f, kernid);
+        ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_end_parallel_reduce_f, kernid);
     }
 
     void kokkosp_begin_parallel_scan(const char* name, std::uint32_t devid,
                                      std::uint64_t* kernid)
     {
-        return ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_begin_parallel_scan_f, name,
-                                    devid, kernid);
+        ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_begin_parallel_scan_f, name, devid,
+                             kernid);
     }
 
     void kokkosp_end_parallel_scan(std::uint64_t kernid)
     {
-        return ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_end_parallel_scan_f, kernid);
+        ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_end_parallel_scan_f, kernid);
     }
 
     void kokkosp_begin_fence(const char* name, std::uint32_t devid, std::uint64_t* kernid)
     {
-        return ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_begin_fence_f, name, devid,
-                                    kernid);
+        ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_begin_fence_f, name, devid, kernid);
     }
 
     void kokkosp_end_fence(std::uint64_t kernid)
     {
-        return ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_end_fence_f, kernid);
+        ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_end_fence_f, kernid);
     }
 
     void kokkosp_push_profile_region(const char* name)
     {
-        return ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_push_profile_region_f, name);
+        ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_push_profile_region_f, name);
     }
 
     void kokkosp_pop_profile_region()
     {
-        return ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_pop_profile_region_f);
+        ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_pop_profile_region_f);
     }
 
     void kokkosp_create_profile_section(const char* name, std::uint32_t* secid)
     {
-        return ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_create_profile_section_f, name,
-                                    secid);
+        ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_create_profile_section_f, name,
+                             secid);
     }
 
     void kokkosp_destroy_profile_section(std::uint32_t secid)
     {
-        return ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_destroy_profile_section_f,
-                                    secid);
+        ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_destroy_profile_section_f, secid);
     }
 
     void kokkosp_start_profile_section(std::uint32_t secid)
     {
-        return ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_start_profile_section_f,
-                                    secid);
+        ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_start_profile_section_f, secid);
     }
 
     void kokkosp_stop_profile_section(std::uint32_t secid)
     {
-        return ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_stop_profile_section_f, secid);
+        ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_stop_profile_section_f, secid);
     }
 
     void kokkosp_allocate_data(const SpaceHandle space, const char* label,
                                const void* const ptr, const std::uint64_t size)
     {
-        return ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_allocate_data_f, space, label,
-                                    ptr, size);
+        ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_allocate_data_f, space, label, ptr,
+                             size);
     }
 
     void kokkosp_deallocate_data(const SpaceHandle space, const char* label,
                                  const void* const ptr, const std::uint64_t size)
     {
-        return ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_deallocate_data_f, space,
-                                    label, ptr, size);
+        ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_deallocate_data_f, space, label, ptr,
+                             size);
     }
 
     void kokkosp_begin_deep_copy(SpaceHandle dst_handle, const char* dst_name,
@@ -1081,32 +1077,31 @@ extern "C"
                                  const char* src_name, const void* src_ptr,
                                  std::uint64_t size)
     {
-        return ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_begin_deep_copy_f, dst_handle,
-                                    dst_name, dst_ptr, src_handle, src_name, src_ptr,
-                                    size);
+        ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_begin_deep_copy_f, dst_handle,
+                             dst_name, dst_ptr, src_handle, src_name, src_ptr, size);
     }
 
     void kokkosp_end_deep_copy()
     {
-        return ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_end_deep_copy_f);
+        ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_end_deep_copy_f);
     }
 
     void kokkosp_profile_event(const char* name)
     {
-        return ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_profile_event_f, name);
+        ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_profile_event_f, name);
     }
 
     void kokkosp_dual_view_sync(const char* label, const void* const data, bool is_device)
     {
-        return ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_dual_view_sync_f, label, data,
-                                    is_device);
+        ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_dual_view_sync_f, label, data,
+                             is_device);
     }
 
     void kokkosp_dual_view_modify(const char* label, const void* const data,
                                   bool is_device)
     {
-        return ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_dual_view_modify_f, label,
-                                    data, is_device);
+        ROCPROFSYS_DL_INVOKE(get_indirect().kokkosp_dual_view_modify_f, label, data,
+                             is_device);
     }
 
     //----------------------------------------------------------------------------------//

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys-rt/src/RTcommon.c
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys-rt/src/RTcommon.c
@@ -525,7 +525,6 @@ DYNINST_stopThread(void* pointAddr, void* callBackID, void* flags, void* calcula
     fflush(stOut);
     tc_lock_unlock(&DYNINST_trace_lock);
     reentrant = 0;
-    return;
 }
 
 // zeroes out the useCache flag if the call is interprocedural

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys-rt/src/RTlinux.c
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys-rt/src/RTlinux.c
@@ -48,7 +48,6 @@
 #    include <dlfcn.h>
 #endif
 
-#include <errno.h>
 #include <link.h>
 #include <signal.h>
 #include <string.h>
@@ -337,7 +336,7 @@ dyn_pthread_self(void)
         return (dyntid_t) DYNINST_SINGLETHREADED;
     }
     me = (*DYNINST_pthread_self)();
-    return (dyntid_t) me;
+    return me;
 }
 
 /*

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys-rt/src/RTposix.c
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys-rt/src/RTposix.c
@@ -59,9 +59,7 @@
 #if !(defined(arch_power) && defined(os_linux))
 void
 RTmutatedBinary_init(void)
-{
-    return;
-}
+{}
 #endif
 
 #if defined(__GNUC) || defined(__GNUC__)

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
@@ -280,7 +280,7 @@ struct fini_bundle
     std::string as_string(bool _print_prefix = true) const
     {
         std::stringstream _ss;
-        if(_print_prefix && m_label.length() > 0) _ss << m_label << " : ";
+        if(_print_prefix && !m_label.empty()) _ss << m_label << " : ";
         size_t _idx = 0;
         ((_ss << (_idx++ > 0 ? ", " : "") << std::get<Tp>(m_data)), ...);
         return _ss.str();

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/data.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/data.cpp
@@ -122,7 +122,7 @@ get_filters(const std::set<binary::scope_filter::filter_scope>& _scopes = {
     auto _filters = std::vector<binary::scope_filter>{};
 
     // exclude internal libraries used by rocprof-sys
-    if(_scopes.count(sf::BINARY_FILTER) > 0)
+    if(_scopes.contains(sf::BINARY_FILTER))
         _filters.emplace_back(sf{ sf::FILTER_EXCLUDE, sf::BINARY_FILTER,
                                   "lib(rocprof-sys[-\\.]|dyninst|"
                                   "tbbmalloc|gotcha\\.|unwind\\.so\\.99)" });
@@ -131,7 +131,7 @@ get_filters(const std::set<binary::scope_filter::filter_scope>& _scopes = {
     // telling the user to "make the main function" faster is literally useless since it
     // contains everything that could be made faster
     if(config::get_causal_mode() == state::process::CausalMode::Function &&
-       _scopes.count(sf::FUNCTION_FILTER) > 0)
+       _scopes.contains(sf::FUNCTION_FILTER))
         _filters.emplace_back(sf{ sf::FILTER_EXCLUDE, sf::FUNCTION_FILTER,
                                   "( main\\(|^main$|^main\\.cold$)" });
 
@@ -140,7 +140,7 @@ get_filters(const std::set<binary::scope_filter::filter_scope>& _scopes = {
             std::string{ env_vars::CAUSAL_FUNCTION_EXCLUDE_DEFAULTS })
             .value_or(true);
 
-    if(_use_default_excludes && _scopes.count(sf::FUNCTION_FILTER) > 0)
+    if(_use_default_excludes && _scopes.contains(sf::FUNCTION_FILTER))
     {
         // symbols starting with leading underscore are generally system functions
         _filters.emplace_back(sf{ sf::FILTER_EXCLUDE, sf::FUNCTION_FILTER, "^_" });
@@ -156,7 +156,7 @@ get_filters(const std::set<binary::scope_filter::filter_scope>& _scopes = {
     // "make main function" faster since it contains everything
     // that could be made faster
     if(config::get_causal_mode() == state::process::CausalMode::Function &&
-       _scopes.count(sf::FUNCTION_FILTER) > 0)
+       _scopes.contains(sf::FUNCTION_FILTER))
     {
         _filters.emplace_back(sf{ sf::FILTER_EXCLUDE, sf::FUNCTION_FILTER,
                                   "(^main$|^main.cold$|int main\\()" });
@@ -188,15 +188,15 @@ get_filters(const std::set<binary::scope_filter::filter_scope>& _scopes = {
             _former_include = _current_include;
         }
 
-        if(!_binary_include.empty() && _scopes.count(sf::BINARY_FILTER) > 0)
+        if(!_binary_include.empty() && _scopes.contains(sf::BINARY_FILTER))
             _filters.emplace_back(
                 sf{ sf::FILTER_INCLUDE, sf::BINARY_FILTER, _binary_include });
 
-        if(!_source_include.empty() && _scopes.count(sf::SOURCE_FILTER) > 0)
+        if(!_source_include.empty() && _scopes.contains(sf::SOURCE_FILTER))
             _filters.emplace_back(
                 sf{ sf::FILTER_INCLUDE, sf::SOURCE_FILTER, _source_include });
 
-        if(!_function_include.empty() && _scopes.count(sf::FUNCTION_FILTER) > 0)
+        if(!_function_include.empty() && _scopes.contains(sf::FUNCTION_FILTER))
             _filters.emplace_back(
                 sf{ sf::FILTER_INCLUDE, sf::FUNCTION_FILTER, _function_include });
     }
@@ -223,15 +223,15 @@ get_filters(const std::set<binary::scope_filter::filter_scope>& _scopes = {
             _former_exclude = _current_exclude;
         }
 
-        if(!_binary_exclude.empty() && _scopes.count(sf::BINARY_FILTER) > 0)
+        if(!_binary_exclude.empty() && _scopes.contains(sf::BINARY_FILTER))
             _filters.emplace_back(
                 sf{ sf::FILTER_EXCLUDE, sf::BINARY_FILTER, _binary_exclude });
 
-        if(!_source_exclude.empty() && _scopes.count(sf::SOURCE_FILTER) > 0)
+        if(!_source_exclude.empty() && _scopes.contains(sf::SOURCE_FILTER))
             _filters.emplace_back(
                 sf{ sf::FILTER_EXCLUDE, sf::SOURCE_FILTER, _source_exclude });
 
-        if(!_function_exclude.empty() && _scopes.count(sf::FUNCTION_FILTER) > 0)
+        if(!_function_exclude.empty() && _scopes.contains(sf::FUNCTION_FILTER))
             _filters.emplace_back(
                 sf{ sf::FILTER_EXCLUDE, sf::FUNCTION_FILTER, _function_exclude });
     }
@@ -414,7 +414,7 @@ save_line_info_impl(std::ostream&                           _ofs,
         {
             for(const auto& itr : _data.debug_info)
             {
-                if(_emitted_dwarf_addresses.count(itr.address.low) > 0) continue;
+                if(_emitted_dwarf_addresses.contains(itr.address.low)) continue;
                 _ofs << "    " << itr.address.as_hex() << " :: " << itr.file << ":"
                      << itr.line;
                 _ofs << "\n";

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_create_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_create_gotcha.cpp
@@ -418,7 +418,7 @@ pthread_create_gotcha::shutdown()
         for(auto itr : native_handles)
         {
             // skip sending signals to internal threads
-            if(internal_native_handles.count(itr) != 0) continue;
+            if(internal_native_handles.contains(itr)) continue;
 
             bool                         has_bundle = false;
             std::unique_lock<std::mutex> _bundle_lk{ *bundles_mutex };

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/tests/test_shmem_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/tests/test_shmem_gotcha.cpp
@@ -60,13 +60,13 @@ struct MockedSHMEMGotcha
     static bool is_permitted(const std::string& func_name)
     {
         auto& reject_fn = get_reject_list();
-        if(reject_fn && reject_fn().count(func_name) > 0) return false;
+        if(reject_fn && reject_fn().contains(func_name)) return false;
 
         auto& permit_fn = get_permit_list();
         if(permit_fn)
         {
             const auto& permit = permit_fn();
-            if(!permit.empty() && permit.count(func_name) == 0) return false;
+            if(!permit.empty() && !permit.contains(func_name)) return false;
         }
         return true;
     }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/kokkosp.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/kokkosp.cpp
@@ -378,8 +378,16 @@ extern "C"
     void kokkosp_begin_parallel_for(const char* name, std::uint32_t devid,
                                     std::uint64_t* kernid)
     {
-        if(rocprofsys::kokkosp::is_paused()) return set_invalid_id(kernid);
-        if(violates_name_rules(name)) return set_invalid_id(kernid);
+        if(rocprofsys::kokkosp::is_paused())
+        {
+            set_invalid_id(kernid);
+            return;
+        }
+        if(violates_name_rules(name))
+        {
+            set_invalid_id(kernid);
+            return;
+        }
 
         auto _thread_state_guard =
             rocprofsys::state::thread::scoped(rocprofsys::state::thread::Internal);
@@ -409,8 +417,16 @@ extern "C"
     void kokkosp_begin_parallel_reduce(const char* name, std::uint32_t devid,
                                        std::uint64_t* kernid)
     {
-        if(rocprofsys::kokkosp::is_paused()) return set_invalid_id(kernid);
-        if(violates_name_rules(name)) return set_invalid_id(kernid);
+        if(rocprofsys::kokkosp::is_paused())
+        {
+            set_invalid_id(kernid);
+            return;
+        }
+        if(violates_name_rules(name))
+        {
+            set_invalid_id(kernid);
+            return;
+        }
 
         auto _thread_state_guard =
             rocprofsys::state::thread::scoped(rocprofsys::state::thread::Internal);
@@ -440,8 +456,16 @@ extern "C"
     void kokkosp_begin_parallel_scan(const char* name, std::uint32_t devid,
                                      std::uint64_t* kernid)
     {
-        if(rocprofsys::kokkosp::is_paused()) return set_invalid_id(kernid);
-        if(violates_name_rules(name)) return set_invalid_id(kernid);
+        if(rocprofsys::kokkosp::is_paused())
+        {
+            set_invalid_id(kernid);
+            return;
+        }
+        if(violates_name_rules(name))
+        {
+            set_invalid_id(kernid);
+            return;
+        }
 
         auto _thread_state_guard =
             rocprofsys::state::thread::scoped(rocprofsys::state::thread::Internal);
@@ -470,8 +494,16 @@ extern "C"
 
     void kokkosp_begin_fence(const char* name, std::uint32_t devid, std::uint64_t* kernid)
     {
-        if(rocprofsys::kokkosp::is_paused()) return set_invalid_id(kernid);
-        if(violates_name_rules(name)) return set_invalid_id(kernid);
+        if(rocprofsys::kokkosp::is_paused())
+        {
+            set_invalid_id(kernid);
+            return;
+        }
+        if(violates_name_rules(name))
+        {
+            set_invalid_id(kernid);
+            return;
+        }
 
         auto _thread_state_guard =
             rocprofsys::state::thread::scoped(rocprofsys::state::thread::Internal);

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/gpu_perf_counter/gpu_perf_counter_traits.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/gpu_perf_counter/gpu_perf_counter_traits.hpp
@@ -92,8 +92,7 @@ struct gpu_perf_counter_traits
         {
             if(dev->is_supported())
             {
-                entries.push_back(
-                    device_entry{ std::move(dev), enabled_metrics_t{ {} } });
+                entries.push_back(device_entry{ std::move(dev), enabled_metrics_t{} });
             }
         }
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/sampler.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/sampler.cpp
@@ -53,7 +53,6 @@
 
 #include <atomic>
 #include <cassert>
-#include <cstdint>
 #include <memory>
 #include <mutex>
 #include <new>

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -1302,7 +1302,7 @@ tool_tracing_callback(rocprofiler_callback_tracing_record_t record,
         auto use_rocpd = config::get_use_rocpd();
 
         if((use_perfetto || use_rocpd) &&
-           tool_data->backtrace_operations.at(record.kind).count(record.operation) > 0)
+           tool_data->backtrace_operations.at(record.kind).contains(record.operation))
         {
             auto _backtrace =
                 tim::get_unw_stack<backtrace_stack_depth, backtrace_ignore_depth,
@@ -2252,7 +2252,7 @@ counter_record_callback(rocprofiler_dispatch_counting_service_data_t dispatch_da
     if(_agent_counter_storage->count(_agent_id) == 0)
         _agent_counter_storage->emplace(_agent_id, counter_storage_map_t{});
 
-    if(get_kernel_dispatch_timestamps().count(_dispatch_id) > 0)
+    if(get_kernel_dispatch_timestamps().contains(_dispatch_id))
     {
         _interval = get_kernel_dispatch_timestamps().at(_dispatch_id);
         get_kernel_dispatch_timestamps().erase(_dispatch_id);
@@ -2260,7 +2260,7 @@ counter_record_callback(rocprofiler_dispatch_counting_service_data_t dispatch_da
 
     for(const auto& itr : _aggregate)
     {
-        if(_agent_counter_storage->at(_agent_id).count(itr.first) == 0)
+        if(!_agent_counter_storage->at(_agent_id).contains(itr.first))
         {
             const auto* _agent = tool_data->get_gpu_tool_agent(_agent_id);
             const auto* _info  = tool_data->get_tool_counter_info(_agent_id, itr.first);
@@ -2536,7 +2536,7 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* user_data)
 #endif
         })
     {
-        if(_callback_domains.count(itr) > 0)
+        if(_callback_domains.contains(itr))
         {
             auto _ops = rocprofiler_sdk::get_operations(itr);
             _data->backtrace_operations.emplace(
@@ -2556,8 +2556,8 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* user_data)
         set_kernel_rename_and_stream_correlation_id, _data));
 
 #if(ROCPROFILER_VERSION >= 700)
-    if((_buffered_domain.count(ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH) > 0) ||
-       (_buffered_domain.count(ROCPROFILER_BUFFER_TRACING_MEMORY_COPY) > 0))
+    if((_buffered_domain.contains(ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH)) ||
+       (_buffered_domain.contains(ROCPROFILER_BUFFER_TRACING_MEMORY_COPY)))
     {
         ROCPROFILER_CALL(rocprofiler_configure_callback_tracing_service(
             _data->primary_ctx, ROCPROFILER_CALLBACK_TRACING_HIP_STREAM, nullptr, 0,
@@ -2565,12 +2565,12 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* user_data)
     }
 #endif
 
-    if(_callback_domains.count(ROCPROFILER_CALLBACK_TRACING_RCCL_API) > 0)
+    if(_callback_domains.contains(ROCPROFILER_CALLBACK_TRACING_RCCL_API))
     {
         rocprofiler_sdk::rccl_comm_data_initialize();
     }
 
-    if(_buffered_domain.count(ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH) > 0)
+    if(_buffered_domain.contains(ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH))
     {
         ROCPROFILER_CALL(rocprofiler_create_buffer(
             _data->primary_ctx, buffer_size, watermark,
@@ -2583,7 +2583,7 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* user_data)
     }
     // ROCPROFILER_BUFFER_TRACING_HSA_CORE_API,          ///< @see
     // ::rocprofiler_hsa_core_api_id_t ROCPROFILER_BUFFER_TRACING_HSA_AMD_EXT_API,
-    if(_buffered_domain.count(ROCPROFILER_BUFFER_TRACING_MEMORY_COPY) > 0)
+    if(_buffered_domain.contains(ROCPROFILER_BUFFER_TRACING_MEMORY_COPY))
     {
         ROCPROFILER_CALL(rocprofiler_create_buffer(
             _data->primary_ctx, buffer_size, watermark,
@@ -2594,7 +2594,7 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* user_data)
             _data->primary_ctx, ROCPROFILER_BUFFER_TRACING_MEMORY_COPY, nullptr, 0,
             _data->memory_copy_buffer));
     }
-    if(_buffered_domain.count(ROCPROFILER_BUFFER_TRACING_SCRATCH_MEMORY) > 0)
+    if(_buffered_domain.contains(ROCPROFILER_BUFFER_TRACING_SCRATCH_MEMORY))
     {
         ROCPROFILER_CALL(rocprofiler_create_buffer(
             _data->primary_ctx, buffer_size, watermark,
@@ -2607,7 +2607,7 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* user_data)
     }
 
 #if(ROCPROFILER_VERSION >= 600)
-    if(_buffered_domain.count(ROCPROFILER_BUFFER_TRACING_MEMORY_ALLOCATION) > 0)
+    if(_buffered_domain.contains(ROCPROFILER_BUFFER_TRACING_MEMORY_ALLOCATION))
     {
         ROCPROFILER_CALL(rocprofiler_create_buffer(
             _data->primary_ctx, buffer_size, watermark,
@@ -2630,17 +2630,17 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* user_data)
 
 #if(ROCPROFILER_VERSION >= 10000)
     // Initialize KFD event metadata
-    if(_buffered_domain.count(ROCPROFILER_BUFFER_TRACING_KFD_PAGE_FAULT) > 0 ||
-       _buffered_domain.count(ROCPROFILER_BUFFER_TRACING_KFD_PAGE_MIGRATE) > 0 ||
-       _buffered_domain.count(ROCPROFILER_BUFFER_TRACING_KFD_QUEUE) > 0 ||
-       _buffered_domain.count(ROCPROFILER_BUFFER_TRACING_KFD_EVENT_QUEUE) > 0 ||
-       _buffered_domain.count(ROCPROFILER_BUFFER_TRACING_KFD_EVENT_UNMAP_FROM_GPU) > 0 ||
-       _buffered_domain.count(ROCPROFILER_BUFFER_TRACING_KFD_EVENT_DROPPED_EVENTS) > 0)
+    if(_buffered_domain.contains(ROCPROFILER_BUFFER_TRACING_KFD_PAGE_FAULT) ||
+       _buffered_domain.contains(ROCPROFILER_BUFFER_TRACING_KFD_PAGE_MIGRATE) ||
+       _buffered_domain.contains(ROCPROFILER_BUFFER_TRACING_KFD_QUEUE) ||
+       _buffered_domain.contains(ROCPROFILER_BUFFER_TRACING_KFD_EVENT_QUEUE) ||
+       _buffered_domain.contains(ROCPROFILER_BUFFER_TRACING_KFD_EVENT_UNMAP_FROM_GPU) ||
+       _buffered_domain.contains(ROCPROFILER_BUFFER_TRACING_KFD_EVENT_DROPPED_EVENTS))
     {
         rocprofiler_sdk::kfd_event_metadata_initialize(tool_data);
     }
 
-    if(_buffered_domain.count(ROCPROFILER_BUFFER_TRACING_KFD_PAGE_FAULT) > 0)
+    if(_buffered_domain.contains(ROCPROFILER_BUFFER_TRACING_KFD_PAGE_FAULT))
     {
         ROCPROFILER_CALL(rocprofiler_create_buffer(
             _data->primary_ctx, buffer_size, watermark,
@@ -2652,7 +2652,7 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* user_data)
             _data->kfd_page_fault_buffer));
     }
 
-    if(_buffered_domain.count(ROCPROFILER_BUFFER_TRACING_KFD_PAGE_MIGRATE) > 0)
+    if(_buffered_domain.contains(ROCPROFILER_BUFFER_TRACING_KFD_PAGE_MIGRATE))
     {
         ROCPROFILER_CALL(rocprofiler_create_buffer(
             _data->primary_ctx, buffer_size, watermark,
@@ -2664,7 +2664,7 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* user_data)
             _data->kfd_page_migrate_buffer));
     }
 
-    if(_buffered_domain.count(ROCPROFILER_BUFFER_TRACING_KFD_QUEUE) > 0)
+    if(_buffered_domain.contains(ROCPROFILER_BUFFER_TRACING_KFD_QUEUE))
     {
         ROCPROFILER_CALL(rocprofiler_create_buffer(
             _data->primary_ctx, buffer_size, watermark,
@@ -2676,7 +2676,7 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* user_data)
             _data->kfd_queue_buffer));
     }
 
-    if(_buffered_domain.count(ROCPROFILER_BUFFER_TRACING_KFD_EVENT_QUEUE) > 0)
+    if(_buffered_domain.contains(ROCPROFILER_BUFFER_TRACING_KFD_EVENT_QUEUE))
     {
         ROCPROFILER_CALL(rocprofiler_create_buffer(
             _data->primary_ctx, buffer_size, watermark,
@@ -2695,7 +2695,7 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* user_data)
             _data->kfd_event_queue_buffer));
     }
 
-    if(_buffered_domain.count(ROCPROFILER_BUFFER_TRACING_KFD_EVENT_UNMAP_FROM_GPU) > 0)
+    if(_buffered_domain.contains(ROCPROFILER_BUFFER_TRACING_KFD_EVENT_UNMAP_FROM_GPU))
     {
         ROCPROFILER_CALL(rocprofiler_create_buffer(
             _data->primary_ctx, buffer_size, watermark,
@@ -2707,7 +2707,7 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* user_data)
             nullptr, 0, _data->kfd_event_unmap_buffer));
     }
 
-    if(_buffered_domain.count(ROCPROFILER_BUFFER_TRACING_KFD_EVENT_DROPPED_EVENTS) > 0)
+    if(_buffered_domain.contains(ROCPROFILER_BUFFER_TRACING_KFD_EVENT_DROPPED_EVENTS))
     {
         ROCPROFILER_CALL(rocprofiler_create_buffer(
             _data->primary_ctx, buffer_size, watermark,

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk/trace_control.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk/trace_control.cpp
@@ -51,7 +51,7 @@ trace_control::force_initial_pause()
 void
 trace_control::handle_range_start(std::uint64_t range_id, const char* message)
 {
-    if(message == nullptr || m_trace_regions.count(message) == 0)
+    if(message == nullptr || !m_trace_regions.contains(message))
     {
         return;
     }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/sampling.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/sampling.cpp
@@ -717,7 +717,7 @@ load_offload_buffer(std::int64_t _thread_idx)
         return _data;
     }
 
-    if(offload_seq_data.count(_thread_idx) == 0) return _data;
+    if(!offload_seq_data.contains(_thread_idx)) return _data;
 
     size_t _count = 0;
     for(auto itr : offload_seq_data.at(_thread_idx))

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/thread_info.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/thread_info.cpp
@@ -219,7 +219,7 @@ thread_info::get()
 const std::optional<thread_info>&
 thread_info::get(native_handle_t& _tid)
 {
-    return get(native_handle_t{ _tid });
+    return get(_tid);
 }
 
 const std::optional<thread_info>&


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

First phase of enabling clang-tidy in rocprofiler-systems, intentionally scoped
to a **low-risk, high-signal subset of the `readability-*` checks** so we can roll
enforcement in gradually. No user-visible behavior changes.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
- `ROCPROFSYS_USE_CLANG_TIDY` now runs clang-tidy with `-warnings-as-errors=*`. Only the project's own `source/` targets are analyzed - third-party deps, Python bindings and `examples/` are excluded (verified via `CMakeLists.txt` ordering).
- Added a `clang-tidy` job to `rocprofiler-systems-formatting.yml` that configures
  + builds with `ROCPROFSYS_USE_CLANG_TIDY=ON` inside the existing CI image.


## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
