### PR TITLE
fix(rocr): wake the async event monitor when a waiter takes its notification

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
@@ -393,6 +393,11 @@ class Runtime {
                                      hsa_signal_value_t value, hsa_amd_signal_handler handler,
                                      void* arg);
 
+  /// @brief Asks the asynchronous event monitor to rescan its signals.
+  /// Uses the monitor's own wake signal, which nothing else waits on, so the
+  /// request cannot be consumed by another thread.
+  void WakeAsyncSignalMonitor();
+
   hsa_status_t InteropMap(uint32_t num_agents, Agent** agents, hsa_handle_t handle,
                           hsa_interop_map_flag_t flags, size_t size_hint, size_t* size, void** ptr,
                           size_t* metadata_size, const void** metadata);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/interrupt_signal.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/interrupt_signal.cpp
@@ -195,6 +195,12 @@ hsa_signal_value_t InterruptSignal::WaitRelaxed(hsa_signal_condition_t condition
     );
 
     HSAKMT_CALL(hsaKmtWaitOnEvent_Ext(event_, wait_ms, &event_age));
+
+    // Without event age tracking one notification releases one parked thread,
+    // possibly this one. The async event monitor never passes through waiting_
+    // and so never demotes itself on prior != 0, so ask it to rescan.
+    if (!event_age && waiting_ > 1)
+      core::Runtime::runtime_singleton_->WakeAsyncSignalMonitor();
   }
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/interrupt_signal.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/interrupt_signal.cpp
@@ -196,9 +196,9 @@ hsa_signal_value_t InterruptSignal::WaitRelaxed(hsa_signal_condition_t condition
 
     HSAKMT_CALL(hsaKmtWaitOnEvent_Ext(event_, wait_ms, &event_age));
 
-    // Without event age tracking one notification releases one parked thread,
-    // possibly this one. The async event monitor never passes through waiting_
-    // and so never demotes itself on prior != 0, so ask it to rescan.
+    // Without event age tracking, one notification releases one parked thread and may be
+    // consumed by another waiter. The async event monitor's interrupt-wait path doesn't
+    // apply the `prior != 0` demotion logic, so ask it to rescan.
     if (!event_age && waiting_ > 1)
       core::Runtime::runtime_singleton_->WakeAsyncSignalMonitor();
   }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -984,6 +984,10 @@ hsa_status_t Runtime::SetAsyncSignalHandler(hsa_signal_t signal, hsa_signal_cond
   return HSA_STATUS_SUCCESS;
 }
 
+void Runtime::WakeAsyncSignalMonitor() {
+  if (!asyncSignals_.empty()) hsa_signal_handle((*asyncSignals_)->control.wake)->StoreRelease(1);
+}
+
 hsa_status_t Runtime::InteropMap(uint32_t num_agents, Agent** agents, hsa_handle_t handle,
                                  hsa_interop_map_flag_t flags, size_t size_hint, size_t* size,
                                  void** ptr, size_t* metadata_size, const void** metadata) {


### PR DESCRIPTION
## Motivation

On Windows/DXG an `HsaEvent` is an auto-reset Win32 event, so one notification releases one
parked thread. ROCclr registers an async handler on the same signal the application blocks
on, so when the application thread wins the wake, the async event monitor sleeps until the
thunk's 6000 ms wait chunk expires and the command's completion is never published.

## Technical Details

The `Signal::waiting_` guard can't demote the monitor, since `AsyncEventsLoop` calls
`hsaKmtWaitOnMultipleEvents_Ext` directly. A thread leaving a blocking wait with another
waiter registered now stores to the monitor's wake signal — the same store
`SetAsyncSignalHandler` already uses. `supports_event_age` stays false; Linux is unaffected.

## Issue Tracking

AIRUNTIME-2074

## Test Plan

Navi48, Windows. Quiescent-burst reproducer plus DaVinci Resolve / PugetBench, control and
fixed `amdocl64.dll` from the same commit.

## Test Result

3,040 waits: 1,227 ≥ 5.5 s → 0, worst 6,031 ms → 36.81 ms. Retained coverage 107,490 waits,
nothing over 100 ms. Idle CPU unchanged. Resolve passes. A kernel-mode fix is also required
for the full application symptom; this is the user-mode half.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.