### PR TITLE
test(hip-tests): add shared-HW-queue any-order overlap stream tests f…

### DIFF
--- a/projects/hip-tests/catch/config/configs/performance.yaml
+++ b/projects/hip-tests/catch/config/configs/performance.yaml
@@ -258,3 +258,5 @@ performance:
   Performance_hipPerfHostNumaAlloc_test_preferred_host_numa_node_on_each_GPU: *level_2
   Performance_Graph_CollapseCorrectness: *level_2
   Performance_Graph_DisabledBoundarySynchronization: *level_2
+  Performance_hipPerfSharedQueueAnyOrderOverlap: *level_2
+  Performance_hipPerfSharedQueueAnyOrderOverlap_EventDependency: *level_2

--- a/projects/hip-tests/catch/config/configs/unit/stream.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/stream.yaml
@@ -490,3 +490,24 @@ stream:
   Unit_hipStreamWriteValue_Increment_MultiStream_MultiDevice:
     <<: *level_2
     tags: [synchronization, multigpu]
+  Unit_hipSharedQueueAnyOrderOverlap_Independence:
+    <<: *level_2
+    tags: [synchronization, overlap]
+  Unit_hipSharedQueueAnyOrderOverlap_EventDependencyHonored:
+    <<: *level_2
+    tags: [synchronization, overlap]
+  Unit_hipSharedQueueAnyOrderOverlap_IntraStreamOrderAcrossActivation:
+    <<: *level_2
+    tags: [synchronization, overlap]
+  Unit_hipSharedQueueAnyOrderOverlap_InternalPredecessorOrdering:
+    <<: *level_2
+    tags: [synchronization, overlap]
+  Unit_hipSharedQueueAnyOrderOverlap_NullStreamOrdering:
+    <<: *level_2
+    tags: [synchronization, overlap]
+  Unit_hipSharedQueueAnyOrderOverlap_GraphUnaffected:
+    <<: *level_2
+    tags: [synchronization, overlap]
+  Unit_hipSharedQueueAnyOrderOverlap_StreamWaitValueDependencyHonored:
+    <<: *level_2
+    tags: [synchronization, overlap]

--- a/projects/hip-tests/catch/config/configs/unit/stream.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/stream.yaml
@@ -511,3 +511,6 @@ stream:
   Unit_hipSharedQueueAnyOrderOverlap_StreamWaitValueDependencyHonored:
     <<: *level_2
     tags: [synchronization, overlap]
+    # Pre-existing PAL limitation (unrelated to the barrier-bit opt): spin-wait blit
+    # stream wait-value deadlocks on HW rings.
+    disabled: [amd_windows, amd_wsl]

--- a/projects/hip-tests/catch/performance/scenarios/stream/CMakeLists.txt
+++ b/projects/hip-tests/catch/performance/scenarios/stream/CMakeLists.txt
@@ -9,6 +9,7 @@ set(TEST_SRC
     hipPerfStreamCreateCopyDestroy.cc
     hipPerfIncreasingNumberOfStreams.cc
     hipPerfMultiStreamKernelLaunch.cc
+    hipPerfSharedQueueAnyOrderOverlap.cc
 )
 
 hip_add_exe_to_target(NAME StreamScenarioPerformance

--- a/projects/hip-tests/catch/performance/scenarios/stream/hipPerfSharedQueueAnyOrderOverlap.cc
+++ b/projects/hip-tests/catch/performance/scenarios/stream/hipPerfSharedQueueAnyOrderOverlap.cc
@@ -36,9 +36,8 @@ __global__ void BusyKernel(int* out, int slot, int busy_iters) {
   for (int i = 0; i < busy_iters; ++i) {
     acc += __sinf(static_cast<float>(i) * 0.001f);
   }
-  if (acc == 123456.789f) {  // never true; defeats dead-code elimination
-    out[slot] += 1;
-  }
+  if (acc == 123456.789f) acc += 1.0f;  // never true; keeps the spin loop
+  out[slot] += 1;                        // unconditional sink defeats dead-code elimination
 }
 
 __global__ void BusyRmwKernel(int* buf, int busy_iters) {
@@ -58,6 +57,8 @@ double TimeEventDependencyPairs(int num_pairs, int busy_iters, int iters) {
     HIP_CHECK(hipEventCreateWithFlags(&ev[p], hipEventDisableTiming));
     HIP_CHECK(hipMalloc(&bp[p], sizeof(int)));
     HIP_CHECK(hipMalloc(&bc[p], sizeof(int)));
+    HIP_CHECK(hipMemset(bp[p], 0, sizeof(int)));
+    HIP_CHECK(hipMemset(bc[p], 0, sizeof(int)));
   }
 
   auto launch_all = [&]() {
@@ -76,6 +77,7 @@ double TimeEventDependencyPairs(int num_pairs, int busy_iters, int iters) {
   HIP_CHECK(hipEventCreate(&beg));
   HIP_CHECK(hipEventCreate(&end));
   HIP_CHECK(hipEventRecord(beg));
+  HIP_CHECK(hipEventSynchronize(beg));  // ensure start timestamp is taken before timed work
   for (int it = 0; it < iters; ++it) launch_all();
   HIP_CHECK(hipEventRecord(end));
   HIP_CHECK(hipEventSynchronize(end));
@@ -115,6 +117,7 @@ double TimeStreamSweep(int num_streams, int busy_iters, int iters) {
   HIP_CHECK(hipEventCreate(&beg));
   HIP_CHECK(hipEventCreate(&end));
   HIP_CHECK(hipEventRecord(beg));
+  HIP_CHECK(hipEventSynchronize(beg));  // ensure start timestamp is taken before timed work
   for (int it = 0; it < iters; ++it) launch_all();
   HIP_CHECK(hipEventRecord(end));
   HIP_CHECK(hipEventSynchronize(end));

--- a/projects/hip-tests/catch/performance/scenarios/stream/hipPerfSharedQueueAnyOrderOverlap.cc
+++ b/projects/hip-tests/catch/performance/scenarios/stream/hipPerfSharedQueueAnyOrderOverlap.cc
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * @addtogroup hipPerfSharedQueueAnyOrderOverlap hipPerfSharedQueueAnyOrderOverlap
+ * @{
+ * @ingroup PerformanceTestStream
+ * Characterizes the any-order dispatch overlap optimization
+ * (DEBUG_CLR_AQL_BARRIER_OPT) for plain HIP streams.
+ *
+ * When more streams are created than the HW queue pool (GPU_MAX_HW_QUEUES,
+ * default 4), the extra streams share HW queues. With the flag OFF the first
+ * kernel of each oversubscribed stream carries a head barrier and serializes
+ * behind the prior tenant on the ring; with the flag ON that barrier is cleared
+ * so independent streams overlap.
+ *
+ * This test sweeps the stream count and reports per-iteration launch time. Run it
+ * twice to see the effect (the flag is read once at process init):
+ *   DEBUG_CLR_AQL_BARRIER_OPT=0 <exe> "Performance_hipPerfSharedQueueAnyOrderOverlap"
+ *   DEBUG_CLR_AQL_BARRIER_OPT=1 <exe> "Performance_hipPerfSharedQueueAnyOrderOverlap"
+ * At/below the pool size the two must match (no regression); above it the ON run
+ * should stay roughly flat while the OFF run grows with the stream count.
+ */
+
+#include <hip_test_common.hh>
+
+#include <vector>
+
+namespace {
+
+__global__ void BusyKernel(int* out, int slot, int busy_iters) {
+  volatile float acc = 0.0f;
+  for (int i = 0; i < busy_iters; ++i) {
+    acc += __sinf(static_cast<float>(i) * 0.001f);
+  }
+  if (acc == 123456.789f) {  // never true; defeats dead-code elimination
+    out[slot] += 1;
+  }
+}
+
+__global__ void BusyRmwKernel(int* buf, int busy_iters) {
+  volatile float acc = 0.0f;
+  for (int i = 0; i < busy_iters; ++i) acc += __sinf(static_cast<float>(i) * 0.001f);
+  if (acc == 123456.789f) buf[0] += 1;  // defeat DCE
+  buf[0] += 1;
+}
+
+double TimeEventDependencyPairs(int num_pairs, int busy_iters, int iters) {
+  std::vector<hipStream_t> prod(num_pairs), cons(num_pairs);
+  std::vector<hipEvent_t> ev(num_pairs);
+  std::vector<int*> bp(num_pairs), bc(num_pairs);
+  for (int p = 0; p < num_pairs; ++p) {
+    HIP_CHECK(hipStreamCreate(&prod[p]));
+    HIP_CHECK(hipStreamCreate(&cons[p]));
+    HIP_CHECK(hipEventCreateWithFlags(&ev[p], hipEventDisableTiming));
+    HIP_CHECK(hipMalloc(&bp[p], sizeof(int)));
+    HIP_CHECK(hipMalloc(&bc[p], sizeof(int)));
+  }
+
+  auto launch_all = [&]() {
+    for (int p = 0; p < num_pairs; ++p) {
+      BusyRmwKernel<<<dim3(1), dim3(1), 0, prod[p]>>>(bp[p], busy_iters);
+      HIP_CHECK(hipEventRecord(ev[p], prod[p]));
+      HIP_CHECK(hipStreamWaitEvent(cons[p], ev[p], 0));
+      BusyRmwKernel<<<dim3(1), dim3(1), 0, cons[p]>>>(bc[p], busy_iters);
+    }
+    HIP_CHECK(hipDeviceSynchronize());
+  };
+
+  for (int w = 0; w < 5; ++w) launch_all();  // warm-up + reach steady oversubscription
+
+  hipEvent_t beg, end;
+  HIP_CHECK(hipEventCreate(&beg));
+  HIP_CHECK(hipEventCreate(&end));
+  HIP_CHECK(hipEventRecord(beg));
+  for (int it = 0; it < iters; ++it) launch_all();
+  HIP_CHECK(hipEventRecord(end));
+  HIP_CHECK(hipEventSynchronize(end));
+  float ms = 0.0f;
+  HIP_CHECK(hipEventElapsedTime(&ms, beg, end));
+
+  HIP_CHECK(hipEventDestroy(beg));
+  HIP_CHECK(hipEventDestroy(end));
+  for (int p = 0; p < num_pairs; ++p) {
+    HIP_CHECK(hipFree(bp[p]));
+    HIP_CHECK(hipFree(bc[p]));
+    HIP_CHECK(hipEventDestroy(ev[p]));
+    HIP_CHECK(hipStreamDestroy(prod[p]));
+    HIP_CHECK(hipStreamDestroy(cons[p]));
+  }
+  return (static_cast<double>(ms) * 1000.0) / iters;  // microseconds per iteration
+}
+
+double TimeStreamSweep(int num_streams, int busy_iters, int iters) {
+  std::vector<hipStream_t> streams(num_streams);
+  for (auto& s : streams) HIP_CHECK(hipStreamCreate(&s));
+
+  int* d_out = nullptr;
+  HIP_CHECK(hipMalloc(&d_out, num_streams * sizeof(int)));
+  HIP_CHECK(hipMemset(d_out, 0, num_streams * sizeof(int)));
+
+  auto launch_all = [&]() {
+    for (int k = 0; k < num_streams; ++k) {
+      BusyKernel<<<dim3(1), dim3(1), 0, streams[k]>>>(d_out, k, busy_iters);
+    }
+    for (auto& s : streams) HIP_CHECK(hipStreamSynchronize(s));
+  };
+
+  for (int w = 0; w < 5; ++w) launch_all();  // warm-up + reach steady oversubscription
+
+  hipEvent_t beg, end;
+  HIP_CHECK(hipEventCreate(&beg));
+  HIP_CHECK(hipEventCreate(&end));
+  HIP_CHECK(hipEventRecord(beg));
+  for (int it = 0; it < iters; ++it) launch_all();
+  HIP_CHECK(hipEventRecord(end));
+  HIP_CHECK(hipEventSynchronize(end));
+  float ms = 0.0f;
+  HIP_CHECK(hipEventElapsedTime(&ms, beg, end));
+
+  HIP_CHECK(hipEventDestroy(beg));
+  HIP_CHECK(hipEventDestroy(end));
+  HIP_CHECK(hipFree(d_out));
+  for (auto& s : streams) HIP_CHECK(hipStreamDestroy(s));
+  return (static_cast<double>(ms) * 1000.0) / iters;  // microseconds per iteration
+}
+
+}  // namespace
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Sweep the stream count from below to well above the HW queue pool size and
+ *    report per-iteration multi-stream launch time, characterizing the overlap
+ *    optimization's effect under oversubscription.
+ * Test source
+ * ------------------------
+ *  - performance/scenarios/stream/hipPerfSharedQueueAnyOrderOverlap.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.6
+ */
+TEST_CASE("Performance_hipPerfSharedQueueAnyOrderOverlap") {
+  constexpr int kBusyIters = 20000;
+  constexpr int kIters = 100;
+  const int stream_counts[] = {2, 4, 8, 16, 32};
+
+  hipDeviceProp_t props{};
+  HIP_CHECK(hipGetDeviceProperties(&props, 0));
+  CONSOLE_PRINT("device=%s busy_iters=%d iters=%d", props.gcnArchName, kBusyIters, kIters);
+
+  for (int n : stream_counts) {
+    const double us_per_iter = TimeStreamSweep(n, kBusyIters, kIters);
+    CONSOLE_PRINT("streams=%d us_per_iter=%.3f", n, us_per_iter);
+    REQUIRE(us_per_iter > 0.0);
+  }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Characterizes overlap when streams carry explicit cross-stream dependencies.
+ *    Each pair is producer -> hipEventRecord -> hipStreamWaitEvent -> consumer, so a
+ *    consumer waits its own producer, but producers across pairs are independent and
+ *    can overlap on the shared ring. Sweeps the pair count and reports per-iteration
+ *    time. Run twice (flag OFF then ON): correctness of the waits is unchanged, and
+ *    the ON run should improve as independent producers overlap under oversubscription.
+ * Test source
+ * ------------------------
+ *  - performance/scenarios/stream/hipPerfSharedQueueAnyOrderOverlap.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.6
+ */
+TEST_CASE("Performance_hipPerfSharedQueueAnyOrderOverlap_EventDependency") {
+  constexpr int kBusyIters = 20000;
+  constexpr int kIters = 100;
+  const int pair_counts[] = {2, 4, 8, 16};
+
+  hipDeviceProp_t props{};
+  HIP_CHECK(hipGetDeviceProperties(&props, 0));
+  CONSOLE_PRINT("device=%s busy_iters=%d iters=%d", props.gcnArchName, kBusyIters, kIters);
+
+  for (int n : pair_counts) {
+    const double us_per_iter = TimeEventDependencyPairs(n, kBusyIters, kIters);
+    CONSOLE_PRINT("pairs=%d us_per_iter=%.3f", n, us_per_iter);
+    REQUIRE(us_per_iter > 0.0);
+  }
+}
+
+/**
+ * End doxygen group PerformanceTestStream.
+ * @}
+ */

--- a/projects/hip-tests/catch/performance/scenarios/stream/hipPerfSharedQueueAnyOrderOverlap.cc
+++ b/projects/hip-tests/catch/performance/scenarios/stream/hipPerfSharedQueueAnyOrderOverlap.cc
@@ -32,19 +32,17 @@
 namespace {
 
 __global__ void BusyKernel(int* out, int slot, int busy_iters) {
-  volatile float acc = 0.0f;
+  float acc = 0.0f;
   for (int i = 0; i < busy_iters; ++i) {
     acc += __sinf(static_cast<float>(i) * 0.001f);
   }
-  if (acc == 123456.789f) acc += 1.0f;  // never true; keeps the spin loop
-  out[slot] += 1;                        // unconditional sink defeats dead-code elimination
+  out[slot] += (acc > 3.0e38f) ? 2 : 1;  // branch never taken; keeps acc (and the loop) live
 }
 
 __global__ void BusyRmwKernel(int* buf, int busy_iters) {
-  volatile float acc = 0.0f;
+  float acc = 0.0f;
   for (int i = 0; i < busy_iters; ++i) acc += __sinf(static_cast<float>(i) * 0.001f);
-  if (acc == 123456.789f) buf[0] += 1;  // defeat DCE
-  buf[0] += 1;
+  buf[0] += (acc > 3.0e38f) ? 2 : 1;
 }
 
 double TimeEventDependencyPairs(int num_pairs, int busy_iters, int iters) {
@@ -148,7 +146,7 @@ double TimeStreamSweep(int num_streams, int busy_iters, int iters) {
  */
 TEST_CASE("Performance_hipPerfSharedQueueAnyOrderOverlap") {
   constexpr int kBusyIters = 20000;
-  constexpr int kIters = 100;
+  constexpr int kIters = 50;
   const int stream_counts[] = {2, 4, 8, 16, 32};
 
   hipDeviceProp_t props{};
@@ -180,8 +178,8 @@ TEST_CASE("Performance_hipPerfSharedQueueAnyOrderOverlap") {
  */
 TEST_CASE("Performance_hipPerfSharedQueueAnyOrderOverlap_EventDependency") {
   constexpr int kBusyIters = 20000;
-  constexpr int kIters = 100;
-  const int pair_counts[] = {2, 4, 8, 16};
+  constexpr int kIters = 50;
+  const int pair_counts[] = {2, 4, 8};
 
   hipDeviceProp_t props{};
   HIP_CHECK(hipGetDeviceProperties(&props, 0));

--- a/projects/hip-tests/catch/unit/stream/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/stream/CMakeLists.txt
@@ -24,6 +24,7 @@ set(TEST_SRC
     hipStreamLegacy_compiler_options.cc
     hipStreamGetId.cc
     hipStreamSetGetAttributes.cc
+    hipSharedQueueAnyOrderOverlap.cc
     hipStreamAttachMemAsync.cc
     # TODO renable it TheRock is not finding it
     hipStreamCopyAttributes.cc

--- a/projects/hip-tests/catch/unit/stream/hipSharedQueueAnyOrderOverlap.cc
+++ b/projects/hip-tests/catch/unit/stream/hipSharedQueueAnyOrderOverlap.cc
@@ -1,0 +1,445 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * @addtogroup hipSharedQueueAnyOrderOverlap hipSharedQueueAnyOrderOverlap
+ * @{
+ * @ingroup StreamTest
+ * Correctness tests for DEBUG_CLR_AQL_BARRIER_OPT. Each test asserts a property that
+ * must hold with the flag OFF and ON; run with the flag set (optionally
+ * GPU_MAX_HW_QUEUES=1 to force one shared ring) to exercise the ON path. Correctness is
+ * checked via observable ordering, not by inspecting packets.
+ */
+
+#include <hip_test_common.hh>
+
+#include <vector>
+
+namespace {
+
+// Spins to widen the execution window, then increments its own slot.
+__global__ void SlotIncrementKernel(int* out, int slot, int busy_iters) {
+  volatile float acc = 0.0f;
+  for (int i = 0; i < busy_iters; ++i) {
+    acc += __sinf(static_cast<float>(i) * 0.001f);
+  }
+  if (acc == 123456.789f) {  // never true; defeats dead-code elimination
+    out[slot] += 1;
+  }
+  out[slot] += 1;
+}
+
+// Producer writes 'val' after a spin (late write); consumer reads buf into seen (early read).
+__global__ void ProducerKernel(int* buf, int val, int busy_iters) {
+  volatile float acc = 0.0f;
+  for (int i = 0; i < busy_iters; ++i) acc += __sinf(static_cast<float>(i) * 0.001f);
+  if (acc == 123456.789f) buf[0] += 1;  // defeat DCE
+  buf[0] = val;
+}
+__global__ void ConsumerKernel(const int* buf, int* seen) { seen[0] = buf[0]; }
+
+// Long-running write then a dependent add on the same stream (intra-stream RAW hazard).
+__global__ void SpinSetKernel(int* buf, int val, long long spin) {
+  long long s = clock_function();
+  while (clock_function() - s < spin) {}
+  buf[0] = val;
+}
+__global__ void AddDeltaKernel(int* buf, int delta) { buf[0] += delta; }
+__global__ void TouchKernel(int* buf) { buf[0] += 1; }
+
+// Reads the last byte of a buffer (written last by a large memset/copy predecessor).
+__global__ void ReadLastByteKernel(const unsigned char* buf, size_t n, int* seen) {
+  *seen = static_cast<int>(buf[n - 1]);
+}
+
+}  // namespace
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Oversubscribe the HW queue pool with independent per-stream increment chains
+ *    (each on its own buffer slot); every slot must have the exact expected count.
+ * Test source
+ * ------------------------
+ *  - unit/stream/hipSharedQueueAnyOrderOverlap.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.6
+ */
+TEST_CASE("Unit_hipSharedQueueAnyOrderOverlap_Independence") {
+  constexpr int kStreams = 32;  // >> GPU_MAX_HW_QUEUES (default 4) -> forced oversubscription
+  constexpr int kChain = 4;
+  constexpr int kReps = 20;
+  constexpr int kBusyIters = 4000;
+
+  std::vector<hipStream_t> streams(kStreams);
+  for (auto& s : streams) HIP_CHECK(hipStreamCreate(&s));
+
+  int* d_out = nullptr;
+  HIP_CHECK(hipMalloc(&d_out, kStreams * sizeof(int)));
+  HIP_CHECK(hipMemset(d_out, 0, kStreams * sizeof(int)));
+
+  for (int r = 0; r < kReps; ++r) {
+    for (int k = 0; k < kStreams; ++k) {
+      for (int c = 0; c < kChain; ++c) {
+        SlotIncrementKernel<<<dim3(1), dim3(1), 0, streams[k]>>>(d_out, k, kBusyIters);
+      }
+    }
+  }
+  for (auto& s : streams) HIP_CHECK(hipStreamSynchronize(s));
+
+  std::vector<int> h(kStreams);
+  HIP_CHECK(hipMemcpy(h.data(), d_out, kStreams * sizeof(int), hipMemcpyDeviceToHost));
+
+  const int expected = kReps * kChain;
+  for (int k = 0; k < kStreams; ++k) {
+    INFO("stream slot " << k);
+    REQUIRE(h[k] == expected);
+  }
+
+  HIP_CHECK(hipFree(d_out));
+  for (auto& s : streams) HIP_CHECK(hipStreamDestroy(s));
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Oversubscribed producer/consumer pairs linked by hipEventRecord/
+ *    hipStreamWaitEvent (producer writes late, consumer reads early). The consumer
+ *    must never see a stale value.
+ * Test source
+ * ------------------------
+ *  - unit/stream/hipSharedQueueAnyOrderOverlap.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.6
+ */
+TEST_CASE("Unit_hipSharedQueueAnyOrderOverlap_EventDependencyHonored") {
+  constexpr int kPairs = 8;  // 16 streams -> oversubscribes the default pool
+  constexpr int kReps = 50;
+  constexpr int kBusyIters = 8000;
+
+  std::vector<hipStream_t> prod(kPairs), cons(kPairs);
+  std::vector<hipEvent_t> ev(kPairs);
+  std::vector<int*> buf(kPairs), seen(kPairs);
+  for (int p = 0; p < kPairs; ++p) {
+    HIP_CHECK(hipStreamCreate(&prod[p]));
+    HIP_CHECK(hipStreamCreate(&cons[p]));
+    HIP_CHECK(hipEventCreateWithFlags(&ev[p], hipEventDisableTiming));
+    HIP_CHECK(hipMalloc(&buf[p], sizeof(int)));
+    HIP_CHECK(hipMalloc(&seen[p], sizeof(int)));
+    HIP_CHECK(hipMemset(buf[p], 0, sizeof(int)));
+  }
+
+  std::vector<int> h_seen(kPairs);
+  for (int it = 1; it <= kReps; ++it) {
+    for (int p = 0; p < kPairs; ++p) {
+      ProducerKernel<<<dim3(1), dim3(1), 0, prod[p]>>>(buf[p], it, kBusyIters);
+      HIP_CHECK(hipEventRecord(ev[p], prod[p]));
+      HIP_CHECK(hipStreamWaitEvent(cons[p], ev[p], 0));
+      ConsumerKernel<<<dim3(1), dim3(1), 0, cons[p]>>>(buf[p], seen[p]);
+    }
+    for (int p = 0; p < kPairs; ++p) {
+      HIP_CHECK(hipStreamSynchronize(cons[p]));
+      HIP_CHECK(hipMemcpy(&h_seen[p], seen[p], sizeof(int), hipMemcpyDeviceToHost));
+      INFO("pair " << p << " iteration " << it);
+      REQUIRE(h_seen[p] == it);  // consumer must observe producer's write, never a stale value
+    }
+  }
+
+  for (int p = 0; p < kPairs; ++p) {
+    HIP_CHECK(hipFree(buf[p]));
+    HIP_CHECK(hipFree(seen[p]));
+    HIP_CHECK(hipEventDestroy(ev[p]));
+    HIP_CHECK(hipStreamDestroy(prod[p]));
+    HIP_CHECK(hipStreamDestroy(cons[p]));
+  }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Guards intra-stream order across the sole-tenant -> shared transition: stream A
+ *    writes BASE (long kernel), stream B joins the ring, then A adds DELTA to the same
+ *    buffer. If A's second dispatch were misread as a "first dispatch" and cleared it
+ *    would race A0, so the sum must equal BASE+DELTA. Fresh streams each iteration.
+ * Test source
+ * ------------------------
+ *  - unit/stream/hipSharedQueueAnyOrderOverlap.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.6
+ */
+TEST_CASE("Unit_hipSharedQueueAnyOrderOverlap_IntraStreamOrderAcrossActivation") {
+  constexpr int kIters = 200;
+  constexpr int kBase = 5, kDelta = 7, kExpect = kBase + kDelta;
+
+  int ticks_per_ms = 0;  // hipDeviceAttributeWallClockRate is in kHz, i.e. ticks per millisecond
+  HIP_CHECK(hipDeviceGetAttribute(&ticks_per_ms, hipDeviceAttributeWallClockRate, 0));
+  if (ticks_per_ms == 0) ticks_per_ms = 1000;
+  const long long kSpin = 2LL * ticks_per_ms;  // long first kernel so a racing second is observable
+
+  for (int it = 0; it < kIters; ++it) {
+    hipStream_t a, b;
+    int *bufA = nullptr, *bufB = nullptr;
+    HIP_CHECK(hipStreamCreate(&a));
+    HIP_CHECK(hipStreamCreate(&b));
+    HIP_CHECK(hipMalloc(&bufA, sizeof(int)));
+    HIP_CHECK(hipMalloc(&bufB, sizeof(int)));
+    HIP_CHECK(hipMemset(bufA, 0, sizeof(int)));
+    HIP_CHECK(hipMemset(bufB, 0, sizeof(int)));
+    HIP_CHECK(hipDeviceSynchronize());
+
+    SpinSetKernel<<<dim3(1), dim3(1), 0, a>>>(bufA, kBase, kSpin);  // A0: sole tenant, long
+    TouchKernel<<<dim3(1), dim3(1), 0, b>>>(bufB);                   // B0: joins the shared ring
+    AddDeltaKernel<<<dim3(1), dim3(1), 0, a>>>(bufA, kDelta);        // A1: depends on A0
+    HIP_CHECK(hipDeviceSynchronize());
+
+    int h = 0;
+    HIP_CHECK(hipMemcpy(&h, bufA, sizeof(int), hipMemcpyDeviceToHost));
+    INFO("iteration " << it);
+    REQUIRE(h == kExpect);
+
+    HIP_CHECK(hipFree(bufA));
+    HIP_CHECK(hipFree(bufB));
+    HIP_CHECK(hipStreamDestroy(a));
+    HIP_CHECK(hipStreamDestroy(b));
+  }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Guards ordering against an internal same-stream predecessor: on a shared ring, a
+ *    large hipMemsetAsync (its device fillBuffer is a compute dispatch) is followed by
+ *    a kernel reading the last byte written. A wrongly cleared barrier would race the
+ *    fill and read a stale byte.
+ * Test source
+ * ------------------------
+ *  - unit/stream/hipSharedQueueAnyOrderOverlap.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.6
+ */
+TEST_CASE("Unit_hipSharedQueueAnyOrderOverlap_InternalPredecessorOrdering") {
+  constexpr int kStreams = 16, kReps = 40;
+  const size_t n = 32u << 20;  // large fill to widen the race window
+  const unsigned char kVal = 0xAB;
+
+  std::vector<hipStream_t> s(kStreams);
+  std::vector<unsigned char*> buf(kStreams);
+  std::vector<int*> seen(kStreams), warm(kStreams);
+  for (int i = 0; i < kStreams; ++i) {
+    HIP_CHECK(hipStreamCreate(&s[i]));
+    HIP_CHECK(hipMalloc(&buf[i], n));
+    HIP_CHECK(hipMalloc(&seen[i], sizeof(int)));
+    HIP_CHECK(hipMalloc(&warm[i], sizeof(int)));
+  }
+
+  for (int r = 0; r < kReps; ++r) {
+    for (int i = 0; i < kStreams; ++i) TouchKernel<<<dim3(1), dim3(1), 0, s[i]>>>(warm[i]);
+    HIP_CHECK(hipDeviceSynchronize());  // all streams now co-reside -> ring is shared
+    for (int i = 0; i < kStreams; ++i) {
+      HIP_CHECK(hipMemsetAsync(buf[i], kVal, n, s[i]));                 // internal predecessor
+      ReadLastByteKernel<<<dim3(1), dim3(1), 0, s[i]>>>(buf[i], n, seen[i]);
+    }
+    for (int i = 0; i < kStreams; ++i) HIP_CHECK(hipStreamSynchronize(s[i]));
+    for (int i = 0; i < kStreams; ++i) {
+      int h = 0;
+      HIP_CHECK(hipMemcpy(&h, seen[i], sizeof(int), hipMemcpyDeviceToHost));
+      INFO("rep " << r << " stream " << i);
+      REQUIRE(h == static_cast<int>(kVal));
+    }
+  }
+
+  for (int i = 0; i < kStreams; ++i) {
+    HIP_CHECK(hipFree(buf[i]));
+    HIP_CHECK(hipFree(seen[i]));
+    HIP_CHECK(hipFree(warm[i]));
+    HIP_CHECK(hipStreamDestroy(s[i]));
+  }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - The null/blocking stream (dedicated queue, excluded from the opt) keeps its chain
+ *    ordered while many async streams hammer the shared ring; async streams stay correct.
+ * Test source
+ * ------------------------
+ *  - unit/stream/hipSharedQueueAnyOrderOverlap.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.6
+ */
+TEST_CASE("Unit_hipSharedQueueAnyOrderOverlap_NullStreamOrdering") {
+  constexpr int kAsync = 16, kChain = 12;
+  std::vector<hipStream_t> a(kAsync);
+  for (auto& x : a) HIP_CHECK(hipStreamCreate(&x));
+  std::vector<int*> abuf(kAsync);
+  int* nbuf = nullptr;
+  for (auto& p : abuf) {
+    HIP_CHECK(hipMalloc(&p, sizeof(int)));
+    HIP_CHECK(hipMemset(p, 0, sizeof(int)));
+  }
+  HIP_CHECK(hipMalloc(&nbuf, sizeof(int)));
+  HIP_CHECK(hipMemset(nbuf, 0, sizeof(int)));
+
+  for (int c = 0; c < kChain; ++c) {
+    TouchKernel<<<dim3(1), dim3(1), 0, 0>>>(nbuf);  // null (blocking) stream chain
+    for (int i = 0; i < kAsync; ++i) TouchKernel<<<dim3(1), dim3(1), 0, a[i]>>>(abuf[i]);
+  }
+  HIP_CHECK(hipDeviceSynchronize());
+
+  int hn = 0;
+  HIP_CHECK(hipMemcpy(&hn, nbuf, sizeof(int), hipMemcpyDeviceToHost));
+  REQUIRE(hn == kChain);
+  for (int i = 0; i < kAsync; ++i) {
+    int h = 0;
+    HIP_CHECK(hipMemcpy(&h, abuf[i], sizeof(int), hipMemcpyDeviceToHost));
+    INFO("async stream " << i);
+    REQUIRE(h == kChain);
+  }
+
+  HIP_CHECK(hipFree(nbuf));
+  for (auto& p : abuf) HIP_CHECK(hipFree(p));
+  for (auto& x : a) HIP_CHECK(hipStreamDestroy(x));
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - HIP graphs must be unaffected: independent same-buffer dependency chains
+ *    (oversubscribed), instantiated once and launched many times; the chained sum
+ *    proves every intra-graph edge survived.
+ * Test source
+ * ------------------------
+ *  - unit/stream/hipSharedQueueAnyOrderOverlap.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.6
+ */
+TEST_CASE("Unit_hipSharedQueueAnyOrderOverlap_GraphUnaffected") {
+  constexpr int kChains = 16, kDepth = 6, kLaunches = 50;
+  std::vector<int*> buf(kChains);
+  for (auto& b : buf) {
+    HIP_CHECK(hipMalloc(&b, sizeof(int)));
+    HIP_CHECK(hipMemset(b, 0, sizeof(int)));
+  }
+
+  hipGraph_t graph;
+  HIP_CHECK(hipGraphCreate(&graph, 0));
+  for (int c = 0; c < kChains; ++c) {
+    hipGraphNode_t prev = nullptr;
+    for (int d = 0; d < kDepth; ++d) {
+      int one = 1;
+      void* args[] = {&buf[c], &one};
+      hipKernelNodeParams np{};
+      np.func = reinterpret_cast<void*>(AddDeltaKernel);
+      np.gridDim = dim3(1);
+      np.blockDim = dim3(1);
+      np.sharedMemBytes = 0;
+      np.kernelParams = args;
+      np.extra = nullptr;
+      hipGraphNode_t node;
+      hipGraphNode_t* deps = prev ? &prev : nullptr;
+      HIP_CHECK(hipGraphAddKernelNode(&node, graph, deps, prev ? 1 : 0, &np));
+      prev = node;
+    }
+  }
+
+  hipGraphExec_t exec;
+  HIP_CHECK(hipGraphInstantiate(&exec, graph, nullptr, nullptr, 0));
+  hipStream_t s;
+  HIP_CHECK(hipStreamCreate(&s));
+  for (int i = 0; i < kLaunches; ++i) HIP_CHECK(hipGraphLaunch(exec, s));
+  HIP_CHECK(hipStreamSynchronize(s));
+
+  for (int c = 0; c < kChains; ++c) {
+    int h = 0;
+    HIP_CHECK(hipMemcpy(&h, buf[c], sizeof(int), hipMemcpyDeviceToHost));
+    INFO("graph chain " << c);
+    REQUIRE(h == kLaunches * kDepth);
+  }
+
+  HIP_CHECK(hipGraphExecDestroy(exec));
+  HIP_CHECK(hipGraphDestroy(graph));
+  HIP_CHECK(hipStreamDestroy(s));
+  for (auto& b : buf) HIP_CHECK(hipFree(b));
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Barrier-value fence on a shared ring: a hipStreamWaitValue32 consumer must
+ *    always observe its hipStreamWriteValue32 producer's payload. Must hold with
+ *    DEBUG_CLR_AQL_BARRIER_OPT OFF, ON, and ON with GPU_MAX_HW_QUEUES=1.
+ * Test source
+ * ------------------------
+ *  - unit/stream/hipSharedQueueAnyOrderOverlap.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.6
+ *  - Stream wait-value support (hipDeviceAttributeCanUseStreamWaitValue)
+ */
+TEST_CASE("Unit_hipSharedQueueAnyOrderOverlap_StreamWaitValueDependencyHonored") {
+  int waitValueSupported = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&waitValueSupported, hipDeviceAttributeCanUseStreamWaitValue, 0));
+  if (waitValueSupported == 0) {
+    HIP_SKIP_TEST("hipStreamWaitValue not supported on this device");
+    return;
+  }
+
+  // A few pairs oversubscribe the 4-queue pool so fences land on shared rings (functional, not stress).
+  constexpr int kPairs = 3;  // 6 streams > default pool (4) -> shared rings
+  constexpr int kReps = 5;
+  constexpr int kBusyIters = 1000;
+
+  std::vector<hipStream_t> prod(kPairs), cons(kPairs);
+  std::vector<uint32_t*> flag(kPairs);
+  std::vector<int*> payload(kPairs), seen(kPairs);
+  for (int p = 0; p < kPairs; ++p) {
+    HIP_CHECK(hipStreamCreate(&prod[p]));
+    HIP_CHECK(hipStreamCreate(&cons[p]));
+    HIP_CHECK(hipMalloc(&flag[p], sizeof(uint32_t)));
+    HIP_CHECK(hipMalloc(&payload[p], sizeof(int)));
+    HIP_CHECK(hipMalloc(&seen[p], sizeof(int)));
+    HIP_CHECK(hipMemset(flag[p], 0, sizeof(uint32_t)));
+  }
+
+  // Monotonic flag + Gte wait: a stale prior value can't fire early, so payload != it is a real ordering bug.
+  std::vector<int> hSeen(kPairs);
+  for (int it = 1; it <= kReps; ++it) {
+    for (int p = 0; p < kPairs; ++p) {
+      // Producer publishes the payload late (after a spin), then raises the flag to it.
+      ProducerKernel<<<dim3(1), dim3(1), 0, prod[p]>>>(payload[p], it, kBusyIters);
+      HIP_CHECK(hipStreamWriteValue32(prod[p], flag[p], static_cast<uint32_t>(it), 0));
+      // Consumer waits on the flag via a barrier-value fence, then reads the payload.
+      HIP_CHECK(hipStreamWaitValue32(cons[p], flag[p], static_cast<uint32_t>(it),
+                                     hipStreamWaitValueGte, 0xFFFFFFFF));
+      ConsumerKernel<<<dim3(1), dim3(1), 0, cons[p]>>>(payload[p], seen[p]);
+    }
+    for (int p = 0; p < kPairs; ++p) {
+      HIP_CHECK(hipStreamSynchronize(cons[p]));
+      HIP_CHECK(hipMemcpy(&hSeen[p], seen[p], sizeof(int), hipMemcpyDeviceToHost));
+      INFO("pair " << p << " iteration " << it);
+      REQUIRE(hSeen[p] == it);  // consumer must observe the producer's payload
+    }
+  }
+
+  for (int p = 0; p < kPairs; ++p) {
+    HIP_CHECK(hipFree(flag[p]));
+    HIP_CHECK(hipFree(payload[p]));
+    HIP_CHECK(hipFree(seen[p]));
+    HIP_CHECK(hipStreamDestroy(prod[p]));
+    HIP_CHECK(hipStreamDestroy(cons[p]));
+  }
+}
+
+/**
+ * End doxygen group StreamTest.
+ * @}
+ */

--- a/projects/hip-tests/catch/unit/stream/hipSharedQueueAnyOrderOverlap.cc
+++ b/projects/hip-tests/catch/unit/stream/hipSharedQueueAnyOrderOverlap.cc
@@ -69,7 +69,7 @@ __global__ void ReadLastByteKernel(const unsigned char* buf, size_t n, int* seen
  * ------------------------
  *  - HIP_VERSION >= 5.6
  */
-TEST_CASE("Unit_hipSharedQueueAnyOrderOverlap_Independence") {
+HIP_TEST_CASE(Unit_hipSharedQueueAnyOrderOverlap_Independence) {
   constexpr int kStreams = 32;  // >> GPU_MAX_HW_QUEUES (default 4) -> forced oversubscription
   constexpr int kChain = 4;
   constexpr int kReps = 20;
@@ -117,7 +117,7 @@ TEST_CASE("Unit_hipSharedQueueAnyOrderOverlap_Independence") {
  * ------------------------
  *  - HIP_VERSION >= 5.6
  */
-TEST_CASE("Unit_hipSharedQueueAnyOrderOverlap_EventDependencyHonored") {
+HIP_TEST_CASE(Unit_hipSharedQueueAnyOrderOverlap_EventDependencyHonored) {
   constexpr int kPairs = 8;  // 16 streams -> oversubscribes the default pool
   constexpr int kReps = 50;
   constexpr int kBusyIters = 8000;
@@ -173,7 +173,7 @@ TEST_CASE("Unit_hipSharedQueueAnyOrderOverlap_EventDependencyHonored") {
  * ------------------------
  *  - HIP_VERSION >= 5.6
  */
-TEST_CASE("Unit_hipSharedQueueAnyOrderOverlap_IntraStreamOrderAcrossActivation") {
+HIP_TEST_CASE(Unit_hipSharedQueueAnyOrderOverlap_IntraStreamOrderAcrossActivation) {
   constexpr int kIters = 200;
   constexpr int kBase = 5, kDelta = 7, kExpect = kBase + kDelta;
 
@@ -224,7 +224,7 @@ TEST_CASE("Unit_hipSharedQueueAnyOrderOverlap_IntraStreamOrderAcrossActivation")
  * ------------------------
  *  - HIP_VERSION >= 5.6
  */
-TEST_CASE("Unit_hipSharedQueueAnyOrderOverlap_InternalPredecessorOrdering") {
+HIP_TEST_CASE(Unit_hipSharedQueueAnyOrderOverlap_InternalPredecessorOrdering) {
   constexpr int kStreams = 16, kReps = 40;
   const size_t n = 32u << 20;  // large fill to widen the race window
   const unsigned char kVal = 0xAB;
@@ -276,7 +276,7 @@ TEST_CASE("Unit_hipSharedQueueAnyOrderOverlap_InternalPredecessorOrdering") {
  * ------------------------
  *  - HIP_VERSION >= 5.6
  */
-TEST_CASE("Unit_hipSharedQueueAnyOrderOverlap_NullStreamOrdering") {
+HIP_TEST_CASE(Unit_hipSharedQueueAnyOrderOverlap_NullStreamOrdering) {
   constexpr int kAsync = 16, kChain = 12;
   std::vector<hipStream_t> a(kAsync);
   for (auto& x : a) HIP_CHECK(hipStreamCreate(&x));
@@ -323,7 +323,7 @@ TEST_CASE("Unit_hipSharedQueueAnyOrderOverlap_NullStreamOrdering") {
  * ------------------------
  *  - HIP_VERSION >= 5.6
  */
-TEST_CASE("Unit_hipSharedQueueAnyOrderOverlap_GraphUnaffected") {
+HIP_TEST_CASE(Unit_hipSharedQueueAnyOrderOverlap_GraphUnaffected) {
   constexpr int kChains = 16, kDepth = 6, kLaunches = 50;
   std::vector<int*> buf(kChains);
   for (auto& b : buf) {
@@ -386,7 +386,7 @@ TEST_CASE("Unit_hipSharedQueueAnyOrderOverlap_GraphUnaffected") {
  *  - HIP_VERSION >= 5.6
  *  - Stream wait-value support (hipDeviceAttributeCanUseStreamWaitValue)
  */
-TEST_CASE("Unit_hipSharedQueueAnyOrderOverlap_StreamWaitValueDependencyHonored") {
+HIP_TEST_CASE(Unit_hipSharedQueueAnyOrderOverlap_StreamWaitValueDependencyHonored) {
   int waitValueSupported = 0;
   HIP_CHECK(hipDeviceGetAttribute(&waitValueSupported, hipDeviceAttributeCanUseStreamWaitValue, 0));
   if (waitValueSupported == 0) {

--- a/projects/hip-tests/catch/unit/stream/hipSharedQueueAnyOrderOverlap.cc
+++ b/projects/hip-tests/catch/unit/stream/hipSharedQueueAnyOrderOverlap.cc
@@ -237,6 +237,7 @@ TEST_CASE("Unit_hipSharedQueueAnyOrderOverlap_InternalPredecessorOrdering") {
     HIP_CHECK(hipMalloc(&buf[i], n));
     HIP_CHECK(hipMalloc(&seen[i], sizeof(int)));
     HIP_CHECK(hipMalloc(&warm[i], sizeof(int)));
+    HIP_CHECK(hipMemset(warm[i], 0, sizeof(int)));
   }
 
   for (int r = 0; r < kReps; ++r) {
@@ -332,10 +333,10 @@ TEST_CASE("Unit_hipSharedQueueAnyOrderOverlap_GraphUnaffected") {
 
   hipGraph_t graph;
   HIP_CHECK(hipGraphCreate(&graph, 0));
+  int one = 1;  // outlives graph instantiation/launch; args are captured at node add time
   for (int c = 0; c < kChains; ++c) {
     hipGraphNode_t prev = nullptr;
     for (int d = 0; d < kDepth; ++d) {
-      int one = 1;
       void* args[] = {&buf[c], &one};
       hipKernelNodeParams np{};
       np.func = reinterpret_cast<void*>(AddDeltaKernel);

--- a/projects/hip-tests/catch/unit/stream/hipSharedQueueAnyOrderOverlap.cc
+++ b/projects/hip-tests/catch/unit/stream/hipSharedQueueAnyOrderOverlap.cc
@@ -43,8 +43,13 @@ __global__ void ConsumerKernel(const int* buf, int* seen) { seen[0] = buf[0]; }
 
 // Long-running write then a dependent add on the same stream (intra-stream RAW hazard).
 __global__ void SpinSetKernel(int* buf, int val, long long spin) {
+#if HT_NVIDIA
+  long long s = clock64();
+  while ((clock64() - s) < spin) {}
+#else
   long long s = clock_function();
   while (clock_function() - s < spin) {}
+#endif
   buf[0] = val;
 }
 __global__ void AddDeltaKernel(int* buf, int delta) { buf[0] += delta; }
@@ -177,8 +182,12 @@ HIP_TEST_CASE(Unit_hipSharedQueueAnyOrderOverlap_IntraStreamOrderAcrossActivatio
   constexpr int kIters = 200;
   constexpr int kBase = 5, kDelta = 7, kExpect = kBase + kDelta;
 
-  int ticks_per_ms = 0;  // hipDeviceAttributeWallClockRate is in kHz, i.e. ticks per millisecond
+  int ticks_per_ms = 0;  // rate attribute is in kHz, i.e. ticks per millisecond
+#if HT_NVIDIA
+  HIP_CHECK(hipDeviceGetAttribute(&ticks_per_ms, hipDeviceAttributeClockRate, 0));
+#else
   HIP_CHECK(hipDeviceGetAttribute(&ticks_per_ms, hipDeviceAttributeWallClockRate, 0));
+#endif
   if (ticks_per_ms == 0) ticks_per_ms = 1000;
   const long long kSpin = 2LL * ticks_per_ms;  // long first kernel so a racing second is observable
 


### PR DESCRIPTION
…or #9895

Add correctness + performance coverage for the per-stream AQL barrier-bit optimization on shared HW queues implemented in #9895 (users/saleelk/AqlBarrierBitOpt).

Unit (unit/stream/hipSharedQueueAnyOrderOverlap.cc), 7 behavioral cases asserting observable ordering with the optimization ON and OFF (and forced single-ring): Independence, EventDependencyHonored, IntraStreamOrderAcrossActivation, InternalPredecessorOrdering, NullStreamOrdering, GraphUnaffected, StreamWaitValueDependencyHonored.

Perf (performance/scenarios/stream/hipPerfSharedQueueAnyOrderOverlap.cc): independent kernel overlap swept over 2/4/8/16/32 streams plus a producer->event->consumer dependency scenario, toggled via DEBUG_CLR_AQL_BARRIER_OPT.

Validated against the #9895 runtime: correctness passes ON/OFF/single-ring; perf shows overlap staying flat above the HW-queue pool (up to ~7x at 32 streams) and neutral at/below the pool and for dependency-bound work.

JIRA: AIRUNTIME-74

## Motivation

Add behavioral + performance test coverage for the per-stream AQL barrier-bit optimization on shared HW queues.

## Technical Details

Tests are runtime-behavioral (assert observable stream ordering, not packet internals) and toggle via DEBUG_CLR_AQL_BARRIER_OPT; no runtime code changes, only hip-tests sources + CMake/YAML wiring.

CLR changes from #9895 (users/saleelk/AqlBarrierBitOpt, per-stream AQL barrier-bit optimization).

## Issue Tracking
JIRA AIRUNTIME-74

## Test Plan

7 unit correctness cases (Independence, EventDependencyHonored, IntraStreamOrderAcrossActivation, InternalPredecessorOrdering, NullStreamOrdering, GraphUnaffected, StreamWaitValueDependencyHonored) run OFF/ON and forced single-ring; 2 perf scenarios (independent-kernel overlap sweep + event-dependency) run OFF vs ON.

## Test Result

 Correctness: 1320 assertions pass ON/OFF/single-ring. Perf: overlap stays flat above the HW-queue pool (1.7×@8, 3.7×@16, ~7.4×@32 streams) and is neutral at/below the pool and for dependency-bound work.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
