### PR TITLE
clr: log options string and parser error when ParseAllOptions fails

### DIFF
--- a/projects/clr/rocclr/platform/program.cpp
+++ b/projects/clr/rocclr/platform/program.cpp
@@ -598,9 +598,10 @@ bool Program::ParseAllOptions(const std::string& options, option::Options& parse
         allOpts.append(" ");
         allOpts.append(AMD_OCL_BUILD_OPTIONS);
       }
-      if (!Device::appProfile()->GetBuildOptsAppend().empty()) {
+      const std::string& buildOptsAppend = Device::appProfile()->GetBuildOptsAppend();
+      if (!buildOptsAppend.empty()) {
         allOpts.append(" ");
-        allOpts.append(Device::appProfile()->GetBuildOptsAppend());
+        allOpts.append(buildOptsAppend);
       }
       if (AMD_OCL_BUILD_OPTIONS_APPEND != NULL) {
         allOpts.append(" ");
@@ -608,7 +609,21 @@ bool Program::ParseAllOptions(const std::string& options, option::Options& parse
       }
     }
   }
-  return amd::option::parseAllOptions(allOpts, parsedOptions, linkOptsOnly);
+
+  bool result = amd::option::parseAllOptions(allOpts, parsedOptions, linkOptsOnly);
+
+  if (!result) {
+    // Sanitize newlines in both strings to keep the log output on a single line.
+    auto sanitize = [](std::string s) {
+      for (char& c : s)
+        if (c == '\n' || c == '\r') c = ' ';
+      return s;
+    };
+    LogPrintfError("ParseAllOptions failed: options=\"%s\", optionsLog=\"%s\"",
+                   sanitize(allOpts).c_str(), sanitize(parsedOptions.optionsLog()).c_str());
+  }
+
+  return result;
 }
 
 bool Symbol::setDeviceKernel(const Device& device, const device::Kernel* func) {


### PR DESCRIPTION
## Motivation
Print more detailed error messages from the runtime when it fails to parse compile options, as invalid option error happens more than one may think according to compiler's request. 
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Print build options string and parser error when ParseAllOptions fails
<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking
ROCM-27806
<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan
Nuke15 test and ocltst with good and bad build options
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
The log is printed as expected when ParseAllOptions fails
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
