### PR TITLE
feat(rocprofiler-compute): export PC sampling source snapshots

### DIFF
--- a/projects/rocprofiler-compute/src/pc_sampling/source_snapshot_analysis.py
+++ b/projects/rocprofiler-compute/src/pc_sampling/source_snapshot_analysis.py
@@ -14,14 +14,28 @@ import hashlib
 import shutil
 from collections.abc import Iterable
 from pathlib import Path
-from typing import Optional
+from typing import NamedTuple, Optional
 
-from utils.logger import console_debug, console_warning
+from utils.logger import console_debug
 
 SOURCE_FRAME_SEPARATOR = " -> "
 UNKNOWN_SOURCE_LINE_TOKEN = "?"
+SOURCE_EXPORT_DIRECTORY_NAME = "source"
 
 SourceFrame = tuple[str, Optional[int]]
+
+
+class WorkloadSourceSnapshot(NamedTuple):
+    """One workload's captured source files and the names it is filed under.
+
+    The names are the ones stored on the workload row, so the export folder
+    cannot drift from the database.
+    """
+
+    workload_path: Path
+    workload_name: str
+    workload_sub_name: str
+    absolute_source_paths: tuple[str, ...]
 
 
 def parse_source_frames(source: Optional[str]) -> list[SourceFrame]:
@@ -80,98 +94,41 @@ def read_source_file_digest_and_lines(
     )
 
 
+def resolve_export_path(
+    workload_result_directory: Path,
+    absolute_path: str,
+) -> Path:
+    """Return where one source file is exported under a workload's folder.
+
+    The export mirrors the absolute path the database records for the file, so
+    a source row locates its copy by dropping the leading separator.
+    """
+    return workload_result_directory / Path(absolute_path).relative_to("/")
+
+
 def export_source_snapshot_files(
-    workload_paths: Iterable[str],
+    workload_source_snapshots: Iterable[WorkloadSourceSnapshot],
     csv_result_directory: Path,
 ) -> None:
-    """Export workload source snapshots beneath a CSV result folder."""
-    source_result_directory = csv_result_directory / "source"
-
-    for workload_path in workload_paths:
-        workload_directory = Path(workload_path)
-        source_snapshot_directory = workload_directory / "src"
-        source_snapshot_file_pairs = [
-            (
-                source_snapshot_file,
-                Path("/") / source_snapshot_file.relative_to(source_snapshot_directory),
-            )
-            for source_snapshot_file in _find_source_snapshot_files(
-                source_snapshot_directory
-            )
-        ]
-
-        if not source_snapshot_file_pairs:
-            _log_skipped_source_snapshot_export(workload_path)
-            continue
-
-        source_files_common_ancestor = _find_common_parent([
-            original_source_file
-            for _source_snapshot_file, original_source_file in (
-                source_snapshot_file_pairs
-            )
-        ])
-
-        workload_name = workload_directory.parent.name
-        workload_sub_name = workload_directory.name
+    """Copy the source files a CSV result references into the result folder."""
+    for workload_source_snapshot in workload_source_snapshots:
         workload_result_directory = (
-            source_result_directory / workload_name / workload_sub_name
+            csv_result_directory
+            / SOURCE_EXPORT_DIRECTORY_NAME
+            / workload_source_snapshot.workload_name
+            / workload_source_snapshot.workload_sub_name
         )
-        source_snapshot_destinations = [
-            (
-                source_snapshot_file,
-                _make_source_snapshot_destination(
-                    original_source_file,
-                    source_files_common_ancestor,
-                    workload_result_directory,
+        for absolute_path in workload_source_snapshot.absolute_source_paths:
+            export_path = resolve_export_path(workload_result_directory, absolute_path)
+            export_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(
+                resolve_snapshot_path(
+                    workload_source_snapshot.workload_path, absolute_path
                 ),
+                export_path,
             )
-            for source_snapshot_file, original_source_file in (
-                source_snapshot_file_pairs
-            )
-        ]
-        for source_snapshot_file, destination_file in source_snapshot_destinations:
-            destination_file.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(source_snapshot_file, destination_file)
 
         console_debug(
-            f"Exported {len(source_snapshot_file_pairs)} source snapshot files "
-            f"for workload {workload_path}."
+            f"Exported {len(workload_source_snapshot.absolute_source_paths)} "
+            f"source files for workload {workload_source_snapshot.workload_path}."
         )
-
-
-def _find_source_snapshot_files(
-    source_snapshot_directory: Path,
-) -> list[Path]:
-    """Return regular files in a source snapshot."""
-    return sorted(
-        snapshot_path
-        for snapshot_path in source_snapshot_directory.rglob("*")
-        if snapshot_path.is_file()
-    )
-
-
-def _make_source_snapshot_destination(
-    original_source_file: Path,
-    source_files_common_ancestor: Path,
-    workload_result_directory: Path,
-) -> Path:
-    """Return the ancestor-relative destination for a snapshot file."""
-    return workload_result_directory / original_source_file.relative_to(
-        source_files_common_ancestor
-    )
-
-
-def _log_skipped_source_snapshot_export(workload_path: str) -> None:
-    """Log that no source snapshot files were exported for a workload."""
-    console_warning(f"Source snapshot export skipped for workload {workload_path}.")
-    console_debug(f"Exported 0 source snapshot files for workload {workload_path}.")
-
-
-def _find_common_parent(source_files: list[Path]) -> Path:
-    """Return the deepest directory containing every source file."""
-    first_parent = source_files[0].parent
-    return next(
-        ancestor
-        for ancestor in (first_parent, *first_parent.parents)
-        if all(source_file.is_relative_to(ancestor) for source_file in source_files)
-    )

--- a/projects/rocprofiler-compute/src/pc_sampling/source_snapshot_analysis.py
+++ b/projects/rocprofiler-compute/src/pc_sampling/source_snapshot_analysis.py
@@ -6,13 +6,17 @@ Source-snapshot analysis utilities.
 
 Each disassembled instruction carries a comment naming the source lines it came
 from, as an inline stack of "path:line" frames joined by " -> ", innermost
-first. This module parses those comments and reads the lines they name out of
-the source snapshot the profiler copied into the workload directory.
+first. This module parses those comments, reads the lines they name from the
+source snapshot, and exports captured source files with CSV analysis results.
 """
 
 import hashlib
+import shutil
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Optional
+
+from utils.logger import console_debug, console_warning
 
 SOURCE_FRAME_SEPARATOR = " -> "
 UNKNOWN_SOURCE_LINE_TOKEN = "?"
@@ -73,4 +77,101 @@ def read_source_file_digest_and_lines(
     return (
         hashlib.md5(file_bytes).hexdigest(),
         dict(enumerate(file_lines, start=1)),
+    )
+
+
+def export_source_snapshot_files(
+    workload_paths: Iterable[str],
+    csv_result_directory: Path,
+) -> None:
+    """Export workload source snapshots beneath a CSV result folder."""
+    source_result_directory = csv_result_directory / "source"
+
+    for workload_path in workload_paths:
+        workload_directory = Path(workload_path)
+        source_snapshot_directory = workload_directory / "src"
+        source_snapshot_file_pairs = [
+            (
+                source_snapshot_file,
+                Path("/") / source_snapshot_file.relative_to(source_snapshot_directory),
+            )
+            for source_snapshot_file in _find_source_snapshot_files(
+                source_snapshot_directory
+            )
+        ]
+
+        if not source_snapshot_file_pairs:
+            _log_skipped_source_snapshot_export(workload_path)
+            continue
+
+        source_files_common_ancestor = _find_common_parent([
+            original_source_file
+            for _source_snapshot_file, original_source_file in (
+                source_snapshot_file_pairs
+            )
+        ])
+
+        workload_name = workload_directory.parent.name
+        workload_sub_name = workload_directory.name
+        workload_result_directory = (
+            source_result_directory / workload_name / workload_sub_name
+        )
+        source_snapshot_destinations = [
+            (
+                source_snapshot_file,
+                _make_source_snapshot_destination(
+                    original_source_file,
+                    source_files_common_ancestor,
+                    workload_result_directory,
+                ),
+            )
+            for source_snapshot_file, original_source_file in (
+                source_snapshot_file_pairs
+            )
+        ]
+        for source_snapshot_file, destination_file in source_snapshot_destinations:
+            destination_file.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source_snapshot_file, destination_file)
+
+        console_debug(
+            f"Exported {len(source_snapshot_file_pairs)} source snapshot files "
+            f"for workload {workload_path}."
+        )
+
+
+def _find_source_snapshot_files(
+    source_snapshot_directory: Path,
+) -> list[Path]:
+    """Return regular files in a source snapshot."""
+    return sorted(
+        snapshot_path
+        for snapshot_path in source_snapshot_directory.rglob("*")
+        if snapshot_path.is_file()
+    )
+
+
+def _make_source_snapshot_destination(
+    original_source_file: Path,
+    source_files_common_ancestor: Path,
+    workload_result_directory: Path,
+) -> Path:
+    """Return the ancestor-relative destination for a snapshot file."""
+    return workload_result_directory / original_source_file.relative_to(
+        source_files_common_ancestor
+    )
+
+
+def _log_skipped_source_snapshot_export(workload_path: str) -> None:
+    """Log that no source snapshot files were exported for a workload."""
+    console_warning(f"Source snapshot export skipped for workload {workload_path}.")
+    console_debug(f"Exported 0 source snapshot files for workload {workload_path}.")
+
+
+def _find_common_parent(source_files: list[Path]) -> Path:
+    """Return the deepest directory containing every source file."""
+    first_parent = source_files[0].parent
+    return next(
+        ancestor
+        for ancestor in (first_parent, *first_parent.parents)
+        if all(source_file.is_relative_to(ancestor) for source_file in source_files)
     )

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
@@ -291,6 +291,7 @@ class OmniAnalyze_Base:
 
         # ensure absolute path
         seen_paths: set[str] = set()
+        seen_workload_names: set[tuple[str, ...]] = set()
         for dir_info in args.path:
             full_path = Path(dir_info[0]).absolute().resolve()
             dir_info[0] = str(full_path)
@@ -304,6 +305,17 @@ class OmniAnalyze_Base:
             if dir_info[0] in seen_paths:
                 console_error("analysis", "You cannot provide the same path twice.")
             seen_paths.add(dir_info[0])
+
+            # The pair names the workload's row and its source export folder.
+            workload_name = full_path.parts[-2:]
+            if workload_name in seen_workload_names:
+                console_error(
+                    "analysis",
+                    f"{full_path} reuses the workload name "
+                    f"{'/'.join(workload_name)}. Paths must differ in their "
+                    "last two components.",
+                )
+            seen_workload_names.add(workload_name)
 
         self._profiling_config: dict[str, Any] = file_io.load_profiling_config(
             args.path[0][0]

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
@@ -24,6 +24,7 @@ from pc_sampling.pc_sampling_analysis import (
 )
 from pc_sampling.source_snapshot_analysis import (
     SourceFrame,
+    export_source_snapshot_files,
     parse_source_frames,
     read_source_file_digest_and_lines,
     resolve_snapshot_path,
@@ -360,7 +361,12 @@ class db_analysis(OmniAnalyze_Base):
 
         if self.get_args().output_format == "csv":
             Database.commit()
-            Database.write_csv_dir(Path(db_name).with_suffix(""))
+            csv_result_folder = Path(db_name).with_suffix("")
+            Database.write_csv_dir(csv_result_folder)
+            export_source_snapshot_files(
+                workload_paths=self._runs.keys(),
+                csv_result_directory=csv_result_folder,
+            )
         else:
             Database.create_views()
             Database.commit()

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
@@ -24,6 +24,7 @@ from pc_sampling.pc_sampling_analysis import (
 )
 from pc_sampling.source_snapshot_analysis import (
     SourceFrame,
+    WorkloadSourceSnapshot,
     export_source_snapshot_files,
     parse_source_frames,
     read_source_file_digest_and_lines,
@@ -138,6 +139,18 @@ class SourceFrameCollector:
                 )
             )
 
+    def captured_source_paths(self) -> tuple[str, ...]:
+        """Return the absolute paths whose snapshot copy this workload holds.
+
+        A path the snapshot does not hold, and a frame naming a relative path,
+        carries no digest and has no copy to export.
+        """
+        return tuple(
+            absolute_path
+            for absolute_path, source_file in self._source_files.items()
+            if source_file.md5_checksum is not None
+        )
+
     def _get_or_create_source_line(self, frame: SourceFrame) -> orm.SourceLine:
         """Return the row for one frame's line, creating it if absent.
 
@@ -250,6 +263,7 @@ class db_analysis(OmniAnalyze_Base):
         console_debug(f"Initialized database: {db_name}")
 
         # Iterate over all workloads
+        workload_source_snapshots: list[WorkloadSourceSnapshot] = []
         for workload_path in self._runs.keys():
             # Add workload
             workload_obj = orm.Workload(
@@ -346,6 +360,14 @@ class db_analysis(OmniAnalyze_Base):
                 kernel_symbols,
                 source_frames,
             )
+            workload_source_snapshots.append(
+                WorkloadSourceSnapshot(
+                    workload_path=Path(workload_path),
+                    workload_name=workload_obj.name,
+                    workload_sub_name=workload_obj.sub_name,
+                    absolute_source_paths=source_frames.captured_source_paths(),
+                )
+            )
 
             # Add metrics and values - iterate on values, create metrics as needed
             self.run_analysis_metrics(workload_path, workload_obj, kernel_objs)
@@ -364,7 +386,7 @@ class db_analysis(OmniAnalyze_Base):
             csv_result_folder = Path(db_name).with_suffix("")
             Database.write_csv_dir(csv_result_folder)
             export_source_snapshot_files(
-                workload_paths=self._runs.keys(),
+                workload_source_snapshots=workload_source_snapshots,
                 csv_result_directory=csv_result_folder,
             )
         else:

--- a/projects/rocprofiler-compute/src/utils/analysis_orm.py
+++ b/projects/rocprofiler-compute/src/utils/analysis_orm.py
@@ -52,6 +52,8 @@ Base = declarative_base()
 
 class Workload(Base):
     __tablename__ = f"{PREFIX}workload"
+    # The pair names the workload's source export folder, so it must be unique.
+    __table_args__ = (UniqueConstraint("name", "sub_name"),)
 
     workload_id = Column(Integer, primary_key=True)
     name = Column(String)

--- a/projects/rocprofiler-compute/tests/common.py
+++ b/projects/rocprofiler-compute/tests/common.py
@@ -246,6 +246,15 @@ def get_num_pmc_file(output_dir):
     ])
 
 
+def read_binary_file_tree(root: Path) -> dict[Path, bytes]:
+    """Return binary contents keyed by each file's path relative to root."""
+    return {
+        file_path.relative_to(root): file_path.read_bytes()
+        for file_path in root.rglob("*")
+        if file_path.is_file()
+    }
+
+
 def strip_ansi(s: str) -> str:
     ansi_escape = re.compile(r"\x1B[@-_][0-?]*[ -/]*[@-~]")
     return ansi_escape.sub("", s)

--- a/projects/rocprofiler-compute/tests/test_analysis_base.py
+++ b/projects/rocprofiler-compute/tests/test_analysis_base.py
@@ -3,7 +3,9 @@
 
 """Unit tests for src/rocprof_compute_analyze/analysis_base.py."""
 
+import argparse
 import gzip
+from pathlib import Path
 
 import common
 import pandas as pd
@@ -173,3 +175,17 @@ def test_concat_result_csvs_rejects_wide_legacy_results(tmp_path, monkeypatch) -
         )
 
     assert not (tmp_path / "pmc_perf.csv").exists()
+
+
+def test_sanitize_rejects_paths_sharing_a_workload_name(tmp_path, monkeypatch) -> None:
+    """Reject two paths whose last two components match."""
+    mock_error = common.patch_console(monkeypatch, MODULE, "error")["error"]
+    paths = [[str(tmp_path / parent / "vcopy" / "MI300")] for parent in ("a", "b")]
+    for path in paths:
+        Path(path[0]).mkdir(parents=True)
+
+    # The mock records instead of exiting, so sanitize runs on to a later error.
+    with pytest.raises(SystemExit):
+        OmniAnalyze_Base(argparse.Namespace(tui=False, path=paths), {}).sanitize()
+
+    assert "last two components" in mock_error.call_args.args[1]

--- a/projects/rocprofiler-compute/tests/test_analysis_db.py
+++ b/projects/rocprofiler-compute/tests/test_analysis_db.py
@@ -1748,29 +1748,32 @@ def fetch_source_lines_by_workload(session):
 
 
 def make_source_export_analyzer(tmp_path, output_format):
-    """Build an analyzer and expected source exports for one output format."""
-    snapshot_files_per_workload = {
-        Path("first/run"): {
-            Path("workspace/src/shared.cpp"): b"first source\n",
-            Path("workspace/include/shared.hpp"): b"first header\n",
-        },
-        Path("second/run"): {
-            Path("workspace/src/shared.cpp"): b"second source\n",
-            Path("workspace/include/shared.hpp"): b"second header\n",
-        },
-    }
+    """Build an analyzer and the source export its result folder should hold.
+
+    Each workload holds one file its samples name and one it does not, so the
+    export is pinned to the files the database records.
+    """
+    unreferenced_source_path = "/workspace/include/unreferenced.hpp"
     tool_data_per_workload = {}
     expected_exported_files = {}
-    for workload_relative_path, snapshot_files in snapshot_files_per_workload.items():
-        workload_path = tmp_path / "workloads" / workload_relative_path
-        tool_data_per_workload[str(workload_path)] = []
-        for snapshot_relative_path, contents in snapshot_files.items():
-            snapshot_path = workload_path / "src" / snapshot_relative_path
-            snapshot_path.parent.mkdir(parents=True, exist_ok=True)
-            snapshot_path.write_bytes(contents)
-            expected_exported_files[
-                workload_relative_path / snapshot_relative_path.relative_to("workspace")
-            ] = contents
+    for workload_name, referenced_source_path, contents in (
+        ("first", "/workspace/src/first.cpp", "int first;\n"),
+        ("second", "/workspace/src/second.cpp", "int second;\n"),
+    ):
+        workload_path = tmp_path / "workloads" / workload_name / "run"
+        tool_data_per_workload[str(workload_path)] = (
+            make_source_workload_tool_data_records(
+                workload_path,
+                {
+                    referenced_source_path: contents,
+                    unreferenced_source_path: "int unreferenced;\n",
+                },
+                [f"{referenced_source_path}:1"],
+            )
+        )
+        expected_exported_files[
+            Path(workload_name) / "run" / Path(referenced_source_path).relative_to("/")
+        ] = contents.encode()
 
     analyzer = make_pc_sampling_database_analyzer(tool_data_per_workload)
     result_path = tmp_path / f"{output_format}_analysis"
@@ -1860,10 +1863,15 @@ def test_run_analysis_source_export_scopes_workloads_and_preserves_view_csvs(
         )
         run_source_export_analysis(analyzer)
 
-    export_source_snapshot_files.assert_called_once_with(
-        workload_paths=analyzer._runs.keys(),
-        csv_result_directory=result_path,
-    )
+    # The analyzer names each export folder, rather than the export rederiving
+    # it, so a folder cannot drift from the workload row it belongs to.
+    export_arguments = export_source_snapshot_files.call_args.kwargs
+    assert export_arguments["csv_result_directory"] == result_path
+    assert [
+        (snapshot.workload_name, snapshot.workload_sub_name)
+        for snapshot in export_arguments["workload_source_snapshots"]
+    ] == [("first", "run"), ("second", "run")]
+
     view_csvs_after_analysis = read_view_csv_files(result_path)
     assert set(view_csvs_before_source_export) == VIEW_CSV_FILENAMES
     assert set(view_csvs_after_analysis) == VIEW_CSV_FILENAMES
@@ -1872,6 +1880,18 @@ def test_run_analysis_source_export_scopes_workloads_and_preserves_view_csvs(
     source_directory = result_path / "source"
     assert source_directory.is_dir()
     assert common.read_binary_file_tree(source_directory) == expected_exported_files
+
+    # Every path the CSV records locates its copy by dropping the leading "/".
+    exported_paths = common.read_binary_file_tree(source_directory)
+    source_lines_frame = pd.read_csv(result_path / "source_lines.csv")
+    assert {
+        Path(file_path).relative_to("/")
+        for file_path in source_lines_frame["file_path"]
+    } == {
+        # The first two components name the workload, not the source file.
+        Path(*exported_path.parts[2:])
+        for exported_path in exported_paths
+    }
 
 
 def test_run_analysis_keeps_each_workloads_source_files_apart(db_session, tmp_path):

--- a/projects/rocprofiler-compute/tests/test_analysis_db.py
+++ b/projects/rocprofiler-compute/tests/test_analysis_db.py
@@ -6,6 +6,7 @@
 import copy
 import json
 from contextlib import ExitStack
+from functools import partial
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Optional
@@ -17,6 +18,7 @@ import pandas as pd
 import pytest
 from sqlalchemy import text
 
+from pc_sampling import source_snapshot_analysis
 from rocprof_compute_analyze.analysis_db import SourceFrameCollector, db_analysis
 from utils import analysis_orm as orm
 from utils import schema
@@ -24,6 +26,14 @@ from utils.metrics.noise_clamper import (
     clear_noise_clamp_warnings,
     get_noise_clamp_warnings,
 )
+
+VIEW_CSV_FILENAMES = frozenset({
+    "kernel.csv",
+    "kernel_metric.csv",
+    "pc_sampling_summary.csv",
+    "source_lines.csv",
+    "workload_metric.csv",
+})
 
 
 def make_dual_issue_arch_config(metric_name: str, peak_col: str = "Peak"):
@@ -187,6 +197,18 @@ def run_analysis_with_materialized_views(analyzer):
             )
         )
         analyzer.run_analysis()
+
+
+def cleanup_database() -> None:
+    """Close and clear the process-wide test database state."""
+    current_session = orm.Database._session
+    if current_session is not None:
+        current_session.close()
+    current_engine = orm.Database._engine
+    if current_engine is not None:
+        current_engine.dispose()
+    orm.Database._session = None
+    orm.Database._engine = None
 
 
 # =============================================================================
@@ -1448,13 +1470,7 @@ def test_run_analysis_exports_process_scoped_pc_sampling_csv(
         orm.Database.write_csv_dir(csv_directory)
 
         output_filenames = {path.name for path in csv_directory.iterdir()}
-        assert output_filenames == {
-            "kernel.csv",
-            "kernel_metric.csv",
-            "workload_metric.csv",
-            "pc_sampling_summary.csv",
-            "source_lines.csv",
-        }
+        assert output_filenames == VIEW_CSV_FILENAMES
         assert "dispatch.csv" not in output_filenames
 
         pc_sampling_frame = pd.read_csv(csv_directory / "pc_sampling_summary.csv")
@@ -1481,14 +1497,7 @@ def test_run_analysis_exports_process_scoped_pc_sampling_csv(
         # T1 regression guard: every sampling row must resolve in kernel.csv.
         assert set(pc_sampling_frame["kernel_uuid"]) <= set(kernel_frame["kernel_uuid"])
     finally:
-        current_session = orm.Database._session
-        if current_session is not None:
-            current_session.close()
-        current_engine = orm.Database._engine
-        if current_engine is not None:
-            current_engine.dispose()
-        orm.Database._session = None
-        orm.Database._engine = None
+        cleanup_database()
 
 
 def test_run_analysis_keeps_mixed_counter_and_pc_sampling_ownership(
@@ -1736,6 +1745,133 @@ def fetch_source_lines_by_workload(session):
         )
         for workload_name, rows in source_lines_by_workload.items()
     }
+
+
+def make_source_export_analyzer(tmp_path, output_format):
+    """Build an analyzer and expected source exports for one output format."""
+    snapshot_files_per_workload = {
+        Path("first/run"): {
+            Path("workspace/src/shared.cpp"): b"first source\n",
+            Path("workspace/include/shared.hpp"): b"first header\n",
+        },
+        Path("second/run"): {
+            Path("workspace/src/shared.cpp"): b"second source\n",
+            Path("workspace/include/shared.hpp"): b"second header\n",
+        },
+    }
+    tool_data_per_workload = {}
+    expected_exported_files = {}
+    for workload_relative_path, snapshot_files in snapshot_files_per_workload.items():
+        workload_path = tmp_path / "workloads" / workload_relative_path
+        tool_data_per_workload[str(workload_path)] = []
+        for snapshot_relative_path, contents in snapshot_files.items():
+            snapshot_path = workload_path / "src" / snapshot_relative_path
+            snapshot_path.parent.mkdir(parents=True, exist_ok=True)
+            snapshot_path.write_bytes(contents)
+            expected_exported_files[
+                workload_relative_path / snapshot_relative_path.relative_to("workspace")
+            ] = contents
+
+    analyzer = make_pc_sampling_database_analyzer(tool_data_per_workload)
+    result_path = tmp_path / f"{output_format}_analysis"
+    analyzer.get_args().output_name = str(result_path)
+    analyzer.get_args().output_format = output_format
+    return analyzer, result_path, expected_exported_files
+
+
+def run_source_export_analysis(analyzer):
+    """Run source-export analysis and always clear the test database state."""
+    try:
+        with ExitStack() as patch_stack:
+            patch_stack.enter_context(patch.object(analyzer, "run_analysis_metrics"))
+            patch_stack.enter_context(
+                patch(
+                    "rocprof_compute_analyze.analysis_db.get_version",
+                    return_value={"version": "test", "sha": "test"},
+                )
+            )
+            analyzer.run_analysis()
+    finally:
+        cleanup_database()
+
+
+def read_view_csv_files(result_path):
+    """Return view CSV contents keyed by filename."""
+    return {
+        csv_path.name: csv_path.read_bytes() for csv_path in result_path.glob("*.csv")
+    }
+
+
+def write_view_csv_files_and_capture(
+    original_write_csv_dir,
+    captured_view_csv_files,
+    csv_directory,
+):
+    """Write view CSVs and capture their contents before source export."""
+    original_write_csv_dir(csv_directory)
+    captured_view_csv_files.update(read_view_csv_files(csv_directory))
+
+
+def test_run_analysis_source_export_is_not_created_for_db_output(tmp_path):
+    """Do not export source snapshots for database output."""
+    analyzer, result_path, _expected_exported_files = make_source_export_analyzer(
+        tmp_path,
+        "db",
+    )
+
+    with patch(
+        "rocprof_compute_analyze.analysis_db.export_source_snapshot_files"
+    ) as export_source_snapshot_files:
+        run_source_export_analysis(analyzer)
+
+    export_source_snapshot_files.assert_not_called()
+    assert Path(f"{result_path}.db").is_file()
+    assert not (result_path / "source").exists()
+
+
+def test_run_analysis_source_export_scopes_workloads_and_preserves_view_csvs(
+    tmp_path,
+):
+    """Isolate workload exports without changing the generated view CSVs."""
+    analyzer, result_path, expected_exported_files = make_source_export_analyzer(
+        tmp_path,
+        "csv",
+    )
+    view_csvs_before_source_export = {}
+    original_write_csv_dir = orm.Database.write_csv_dir
+
+    with ExitStack() as patch_stack:
+        patch_stack.enter_context(
+            patch.object(
+                orm.Database,
+                "write_csv_dir",
+                side_effect=partial(
+                    write_view_csv_files_and_capture,
+                    original_write_csv_dir,
+                    view_csvs_before_source_export,
+                ),
+            )
+        )
+        export_source_snapshot_files = patch_stack.enter_context(
+            patch(
+                "rocprof_compute_analyze.analysis_db.export_source_snapshot_files",
+                wraps=source_snapshot_analysis.export_source_snapshot_files,
+            )
+        )
+        run_source_export_analysis(analyzer)
+
+    export_source_snapshot_files.assert_called_once_with(
+        workload_paths=analyzer._runs.keys(),
+        csv_result_directory=result_path,
+    )
+    view_csvs_after_analysis = read_view_csv_files(result_path)
+    assert set(view_csvs_before_source_export) == VIEW_CSV_FILENAMES
+    assert set(view_csvs_after_analysis) == VIEW_CSV_FILENAMES
+    assert view_csvs_after_analysis == view_csvs_before_source_export
+
+    source_directory = result_path / "source"
+    assert source_directory.is_dir()
+    assert common.read_binary_file_tree(source_directory) == expected_exported_files
 
 
 def test_run_analysis_keeps_each_workloads_source_files_apart(db_session, tmp_path):

--- a/projects/rocprofiler-compute/tests/test_analyze_commands.py
+++ b/projects/rocprofiler-compute/tests/test_analyze_commands.py
@@ -21,6 +21,19 @@ indirs = [
     "tests/workloads/vcopy/RDNA35_HALO",
 ]
 
+PC_SAMPLING_SOURCE_WORKLOAD = (
+    Path(__file__).resolve().parent / "workloads" / "vcopy_pc_sampling_only" / "MI350"
+)
+SOURCE_WORKLOAD_NAME = "pc_sampling_source_workload"
+SOURCE_WORKLOAD_SUB_NAME = "run_001"
+
+
+def setup_pc_sampling_source_workload(tmp_path):
+    """Copy the PC-sampling source fixture into a temporary workload."""
+    workload_path = tmp_path / SOURCE_WORKLOAD_NAME / SOURCE_WORKLOAD_SUB_NAME
+    shutil.copytree(PC_SAMPLING_SOURCE_WORKLOAD, workload_path)
+    return workload_path
+
 
 @pytest.mark.misc
 def test_valid_path(binary_handler_analyze_rocprof_compute):
@@ -1022,3 +1035,64 @@ def test_list_torch_operators_no_trace_data(
     assert "Total: 0 operators" in output
 
     common.clean_output_dir(config["cleanup"], workload_dir)
+
+
+@pytest.mark.misc
+@pytest.mark.parametrize(
+    ("output_format", "output_name", "exports_source_snapshot"),
+    [
+        pytest.param(
+            "csv",
+            "pc_sampling_source_csv",
+            True,
+            id="csv-exports-source-snapshot",
+        ),
+        pytest.param(
+            "db",
+            "pc_sampling_source_db",
+            False,
+            id="db-does-not-export-source-snapshot",
+        ),
+    ],
+)
+def test_analyze_source_snapshot_output_format(
+    binary_handler_analyze_rocprof_compute,
+    monkeypatch,
+    tmp_path,
+    output_format,
+    output_name,
+    exports_source_snapshot,
+):
+    """Export source snapshots for CSV output but not database output."""
+    expected_source_file_tree = common.read_binary_file_tree(
+        PC_SAMPLING_SOURCE_WORKLOAD / "src"
+    )
+    workload_path = setup_pc_sampling_source_workload(tmp_path).resolve()
+    output_path = (tmp_path / output_name).resolve()
+    monkeypatch.chdir(tmp_path)
+
+    code = binary_handler_analyze_rocprof_compute([
+        "analyze",
+        "--path",
+        str(workload_path),
+        "--block",
+        "21",
+        "--output-format",
+        output_format,
+        "--output-name",
+        output_name,
+    ])
+
+    assert code == 0
+    workload_source_path = (
+        output_path / "source" / SOURCE_WORKLOAD_NAME / SOURCE_WORKLOAD_SUB_NAME
+    )
+    if exports_source_snapshot:
+        assert workload_source_path.is_dir()
+        assert (
+            common.read_binary_file_tree(workload_source_path)
+            == expected_source_file_tree
+        )
+    else:
+        assert output_path.with_suffix(".db").is_file()
+        assert not (output_path / "source").exists()

--- a/projects/rocprofiler-compute/tests/test_analyze_commands.py
+++ b/projects/rocprofiler-compute/tests/test_analyze_commands.py
@@ -1064,9 +1064,6 @@ def test_analyze_source_snapshot_output_format(
     exports_source_snapshot,
 ):
     """Export source snapshots for CSV output but not database output."""
-    expected_source_file_tree = common.read_binary_file_tree(
-        PC_SAMPLING_SOURCE_WORKLOAD / "src"
-    )
     workload_path = setup_pc_sampling_source_workload(tmp_path).resolve()
     output_path = (tmp_path / output_name).resolve()
     monkeypatch.chdir(tmp_path)
@@ -1089,10 +1086,15 @@ def test_analyze_source_snapshot_output_format(
     )
     if exports_source_snapshot:
         assert workload_source_path.is_dir()
-        assert (
-            common.read_binary_file_tree(workload_source_path)
-            == expected_source_file_tree
-        )
+        # Every exported file sits under the absolute path the CSV records for
+        # it, so the paths below are the fixture's own capture-host paths.
+        assert set(common.read_binary_file_tree(workload_source_path)) == {
+            Path("app/projects/rocprofiler-compute/sample/vcopy.cpp"),
+            Path(
+                "rocm-venv/lib/python3.12/site-packages/_rocm_sdk_devel"
+                "/include/hip/amd_detail/amd_hip_runtime.h"
+            ),
+        }
     else:
         assert output_path.with_suffix(".db").is_file()
         assert not (output_path / "source").exists()

--- a/projects/rocprofiler-compute/tests/test_source_snapshot_analysis.py
+++ b/projects/rocprofiler-compute/tests/test_source_snapshot_analysis.py
@@ -4,18 +4,19 @@
 """Unit tests for pc_sampling.source_snapshot_analysis."""
 
 import hashlib
-import logging
 import os
-import stat
 from pathlib import Path
+from typing import Optional
 
 import common
 import pytest
 
 from pc_sampling import source_snapshot_analysis
 from pc_sampling.source_snapshot_analysis import (
+    WorkloadSourceSnapshot,
     parse_source_frames,
     read_source_file_digest_and_lines,
+    resolve_export_path,
     resolve_snapshot_path,
 )
 
@@ -109,73 +110,82 @@ def test_read_source_file_digest_and_lines_replaces_undecodable_bytes(tmp_path):
     assert lines == {1: "caf\ufffd"}
 
 
+def make_workload_source_snapshot(
+    workload_path: Path,
+    snapshot_contents_by_absolute_path: dict[str, bytes],
+    exported_absolute_paths: Optional[tuple[str, ...]] = None,
+) -> WorkloadSourceSnapshot:
+    """Populate a workload's snapshot and describe what to export from it."""
+    for absolute_path, contents in snapshot_contents_by_absolute_path.items():
+        create_source_snapshot(workload_path / "src", Path(absolute_path), contents)
+
+    if exported_absolute_paths is None:
+        exported_absolute_paths = tuple(snapshot_contents_by_absolute_path)
+    return WorkloadSourceSnapshot(
+        workload_path=workload_path,
+        workload_name=workload_path.parent.name,
+        workload_sub_name=workload_path.name,
+        absolute_source_paths=exported_absolute_paths,
+    )
+
+
+def test_resolve_export_path_mirrors_absolute_path(tmp_path):
+    """An exported file keeps the absolute path the database records for it."""
+    assert resolve_export_path(tmp_path, "/home/u/app/vcopy.cpp") == (
+        tmp_path / "home" / "u" / "app" / "vcopy.cpp"
+    )
+
+
 @pytest.mark.parametrize(
-    (
-        "snapshot_contents_by_original_path",
-        "empty_directory_paths",
-        "expected_exported_files",
-    ),
+    ("snapshot_contents_by_absolute_path", "expected_exported_files"),
     [
         pytest.param(
-            {Path("/home/u/app/kernel.cpp"): b"kernel source\n"},
-            (),
-            {Path("kernel.cpp"): b"kernel source\n"},
+            {"/home/u/app/kernel.cpp": b"kernel source\n"},
+            {Path("home/u/app/kernel.cpp"): b"kernel source\n"},
             id="single_file",
         ),
         pytest.param(
             {
-                Path("/home/u/app/src/kernel.cpp"): b"kernel source\n",
-                Path("/home/u/app/include/kernel.hpp"): b"header source\n",
+                "/home/u/app/src/kernel.cpp": b"kernel source\n",
+                "/home/u/app/include/kernel.hpp": b"header source\n",
             },
-            (),
             {
-                Path("src/kernel.cpp"): b"kernel source\n",
-                Path("include/kernel.hpp"): b"header source\n",
+                Path("home/u/app/src/kernel.cpp"): b"kernel source\n",
+                Path("home/u/app/include/kernel.hpp"): b"header source\n",
             },
-            id="deepest_parent",
+            id="shared_ancestor_is_not_stripped",
         ),
         pytest.param(
             {
-                Path("/home/u/app/kernel.cpp"): b"kernel source\n",
-                Path("/opt/rocm/include/runtime.hpp"): b"runtime header\n",
+                "/home/u/app/kernel.cpp": b"kernel source\n",
+                "/opt/rocm/include/runtime.hpp": b"runtime header\n",
             },
-            (),
             {
                 Path("home/u/app/kernel.cpp"): b"kernel source\n",
                 Path("opt/rocm/include/runtime.hpp"): b"runtime header\n",
             },
-            id="root_ancestor",
-        ),
-        pytest.param(
-            {Path("/home/u/app/kernel.cpp"): b"kernel source\n"},
-            (Path("opt/empty"),),
-            {Path("kernel.cpp"): b"kernel source\n"},
-            id="ignores_empty_directories",
+            id="unrelated_roots",
         ),
     ],
 )
-def test_export_source_snapshot_files_uses_deepest_parent_layout(
+def test_export_source_snapshot_files_mirrors_absolute_paths(
     tmp_path,
-    snapshot_contents_by_original_path,
-    empty_directory_paths,
+    snapshot_contents_by_absolute_path,
     expected_exported_files,
 ):
-    """Lay out exports relative to the snapshot's deepest common parent."""
-    workload_path = tmp_path / "vector_copy" / "MI300X_A1"
-    source_snapshot_directory = workload_path / "src"
-    for original_source_path, contents in snapshot_contents_by_original_path.items():
-        create_source_snapshot(
-            source_snapshot_directory,
-            original_source_path,
-            contents,
-        )
+    """Lay every export out under the absolute path recorded for the file.
 
-    for empty_directory_path in empty_directory_paths:
-        (source_snapshot_directory / empty_directory_path).mkdir(parents=True)
-
+    Adding a file must not move the others, so the layout cannot depend on
+    what the workload as a whole happens to reference.
+    """
+    workload_source_snapshot = make_workload_source_snapshot(
+        tmp_path / "vector_copy" / "MI300X_A1",
+        snapshot_contents_by_absolute_path,
+    )
     csv_result_directory = tmp_path / "csv_result"
+
     source_snapshot_analysis.export_source_snapshot_files(
-        workload_paths=[str(workload_path)],
+        workload_source_snapshots=[workload_source_snapshot],
         csv_result_directory=csv_result_directory,
     )
 
@@ -188,132 +198,110 @@ def test_export_source_snapshot_files_uses_deepest_parent_layout(
     )
 
 
-def test_export_source_snapshot_files_overwrites_and_preserves_file_metadata(
-    tmp_path,
-):
-    """Overwrite an existing export while preserving snapshot metadata."""
-    workload_path = tmp_path / "vector_copy" / "MI300X_A1"
-    original_source_path = Path("/home/u/app/src/kernel.cpp")
-    snapshot_path = create_source_snapshot(
-        workload_path / "src",
-        original_source_path,
-        b"\x00new source contents\xff",
+def test_export_source_snapshot_files_copies_only_referenced_paths(tmp_path):
+    """Leave a snapshot file no source row names out of the export."""
+    workload_source_snapshot = make_workload_source_snapshot(
+        tmp_path / "vector_copy" / "MI300X_A1",
+        {
+            "/home/u/app/kernel.cpp": b"kernel source\n",
+            "/home/u/app/unreferenced.cpp": b"unreferenced source\n",
+        },
+        exported_absolute_paths=("/home/u/app/kernel.cpp",),
     )
-    snapshot_path.chmod(0o640)
-    snapshot_timestamp_ns = 1_700_000_000_123_456_789
-    os.utime(
-        snapshot_path,
-        ns=(snapshot_timestamp_ns, snapshot_timestamp_ns),
-    )
-
     csv_result_directory = tmp_path / "csv_result"
-    exported_path = (
-        csv_result_directory / "source" / "vector_copy" / "MI300X_A1" / "kernel.cpp"
-    )
-    exported_path.parent.mkdir(parents=True)
-    exported_path.write_bytes(b"stale source contents")
-    exported_path.chmod(0o600)
-    os.utime(exported_path, ns=(1_600_000_000, 1_600_000_000))
 
     source_snapshot_analysis.export_source_snapshot_files(
-        workload_paths=[str(workload_path)],
+        workload_source_snapshots=[workload_source_snapshot],
         csv_result_directory=csv_result_directory,
     )
 
-    snapshot_metadata = snapshot_path.stat()
-    exported_metadata = exported_path.stat()
-    assert exported_path.read_bytes() == snapshot_path.read_bytes()
-    assert exported_metadata.st_mtime_ns == snapshot_metadata.st_mtime_ns
-    assert stat.S_IMODE(exported_metadata.st_mode) == stat.S_IMODE(
-        snapshot_metadata.st_mode
+    workload_export_directory = (
+        csv_result_directory / "source" / "vector_copy" / "MI300X_A1"
     )
+    assert common.read_binary_file_tree(workload_export_directory) == {
+        Path("home/u/app/kernel.cpp"): b"kernel source\n"
+    }
 
 
-def test_export_source_snapshot_files_scans_each_workload_once(tmp_path, monkeypatch):
-    """Discover each workload's source snapshot exactly once."""
-    workload_paths = [
-        tmp_path / "first_workload" / "MI300X_A1",
-        tmp_path / "second_workload" / "MI300X_A1",
-    ]
-    for workload_path in workload_paths:
-        create_source_snapshot(
-            workload_path / "src",
-            Path("/home/u/app/kernel.cpp"),
-            b"kernel source\n",
+def test_export_source_snapshot_files_keeps_workloads_apart(tmp_path):
+    """Two workloads holding the same absolute path each keep their own copy."""
+    workload_source_snapshots = [
+        make_workload_source_snapshot(
+            tmp_path / workload_name / "MI300X_A1",
+            {"/home/u/app/kernel.cpp": contents},
         )
-
-    discovered_snapshot_directories = []
-    original_snapshot_finder = source_snapshot_analysis._find_source_snapshot_files
-
-    def record_snapshot_discovery(source_snapshot_directory):
-        """Record a snapshot directory before delegating to the real finder."""
-        discovered_snapshot_directories.append(source_snapshot_directory)
-        return original_snapshot_finder(source_snapshot_directory)
-
-    monkeypatch.setattr(
-        source_snapshot_analysis,
-        "_find_source_snapshot_files",
-        record_snapshot_discovery,
-    )
-
-    source_snapshot_analysis.export_source_snapshot_files(
-        workload_paths=[str(workload_path) for workload_path in workload_paths],
-        csv_result_directory=tmp_path / "csv_result",
-    )
-
-    assert discovered_snapshot_directories == [
-        workload_path / "src" for workload_path in workload_paths
+        for workload_name, contents in (
+            ("first_workload", b"first source\n"),
+            ("second_workload", b"second source\n"),
+        )
     ]
-
-
-@pytest.mark.parametrize(
-    "create_empty_snapshot_directory",
-    (
-        pytest.param(False, id="missing_directory"),
-        pytest.param(True, id="empty_directory"),
-    ),
-)
-def test_export_source_snapshot_files_warns_and_continues_for_missing_or_empty_workload(
-    tmp_path,
-    caplog,
-    create_empty_snapshot_directory,
-):
-    """Warn for an empty snapshot and continue exporting later workloads."""
-    skipped_workload_path = tmp_path / "skipped_workload" / "MI300X_A1"
-    if create_empty_snapshot_directory:
-        (skipped_workload_path / "src").mkdir(parents=True)
-
-    populated_workload_path = tmp_path / "populated_workload" / "MI300X_A1"
-    create_source_snapshot(
-        populated_workload_path / "src",
-        Path("/home/u/app/kernel.cpp"),
-        b"kernel source\n",
-    )
-    workload_paths = [str(skipped_workload_path), str(populated_workload_path)]
     csv_result_directory = tmp_path / "csv_result"
 
-    with caplog.at_level(logging.WARNING):
-        source_snapshot_analysis.export_source_snapshot_files(
-            workload_paths=workload_paths,
-            csv_result_directory=csv_result_directory,
-        )
+    source_snapshot_analysis.export_source_snapshot_files(
+        workload_source_snapshots=workload_source_snapshots,
+        csv_result_directory=csv_result_directory,
+    )
 
-    skipped_export_directory = (
-        csv_result_directory / "source" / "skipped_workload" / "MI300X_A1"
+    assert common.read_binary_file_tree(csv_result_directory / "source") == {
+        Path("first_workload/MI300X_A1/home/u/app/kernel.cpp"): b"first source\n",
+        Path("second_workload/MI300X_A1/home/u/app/kernel.cpp"): b"second source\n",
+    }
+
+
+def test_export_source_snapshot_files_is_quiet_for_workload_without_sources(
+    tmp_path,
+    monkeypatch,
+):
+    """A workload with no source rows exports nothing and warns about nothing.
+
+    Every workload profiled without PC sampling lands here, so it is the
+    ordinary case rather than one worth reporting.
+    """
+    warning_messages = []
+    monkeypatch.setattr(
+        source_snapshot_analysis,
+        "console_warning",
+        warning_messages.append,
+        raising=False,
     )
-    populated_export_path = (
-        csv_result_directory
-        / "source"
-        / "populated_workload"
-        / "MI300X_A1"
-        / "kernel.cpp"
+    workload_source_snapshot = make_workload_source_snapshot(
+        tmp_path / "vector_copy" / "MI300X_A1",
+        {},
     )
-    warning_messages = [
-        record.getMessage()
-        for record in caplog.records
-        if record.levelno == logging.WARNING
-    ]
-    assert not skipped_export_directory.exists()
-    assert populated_export_path.read_bytes() == b"kernel source\n"
-    assert len(warning_messages) == 1
-    assert str(skipped_workload_path) in warning_messages[0]
+    csv_result_directory = tmp_path / "csv_result"
+
+    source_snapshot_analysis.export_source_snapshot_files(
+        workload_source_snapshots=[workload_source_snapshot],
+        csv_result_directory=csv_result_directory,
+    )
+
+    assert warning_messages == []
+    assert not (csv_result_directory / "source").exists()
+
+
+def test_export_source_snapshot_files_leaves_exports_writable(tmp_path):
+    """A read-only snapshot file must not export a read-only copy.
+
+    Preserving the mode would make a rerun into the same folder fail for a
+    user who cannot overwrite their own export.
+    """
+    workload_path = tmp_path / "vector_copy" / "MI300X_A1"
+    workload_source_snapshot = make_workload_source_snapshot(
+        workload_path,
+        {"/home/u/app/kernel.cpp": b"kernel source\n"},
+    )
+    snapshot_path = resolve_snapshot_path(workload_path, "/home/u/app/kernel.cpp")
+    snapshot_path.chmod(0o444)
+    csv_result_directory = tmp_path / "csv_result"
+
+    source_snapshot_analysis.export_source_snapshot_files(
+        workload_source_snapshots=[workload_source_snapshot],
+        csv_result_directory=csv_result_directory,
+    )
+
+    exported_path = resolve_export_path(
+        csv_result_directory / "source" / "vector_copy" / "MI300X_A1",
+        "/home/u/app/kernel.cpp",
+    )
+    assert exported_path.read_bytes() == b"kernel source\n"
+    assert os.access(exported_path, os.W_OK)

--- a/projects/rocprofiler-compute/tests/test_source_snapshot_analysis.py
+++ b/projects/rocprofiler-compute/tests/test_source_snapshot_analysis.py
@@ -4,14 +4,32 @@
 """Unit tests for pc_sampling.source_snapshot_analysis."""
 
 import hashlib
+import logging
+import os
+import stat
+from pathlib import Path
 
+import common
 import pytest
 
+from pc_sampling import source_snapshot_analysis
 from pc_sampling.source_snapshot_analysis import (
     parse_source_frames,
     read_source_file_digest_and_lines,
     resolve_snapshot_path,
 )
+
+
+def create_source_snapshot(
+    source_snapshot_directory: Path,
+    original_source_path: Path,
+    contents: bytes = b"",
+) -> Path:
+    """Create and return a snapshot file for an absolute source path."""
+    snapshot_path = source_snapshot_directory / original_source_path.relative_to("/")
+    snapshot_path.parent.mkdir(parents=True, exist_ok=True)
+    snapshot_path.write_bytes(contents)
+    return snapshot_path
 
 
 @pytest.mark.parametrize(
@@ -89,3 +107,213 @@ def test_read_source_file_digest_and_lines_replaces_undecodable_bytes(tmp_path):
     # The digest covers the raw bytes, so it still identifies the file version.
     assert digest == hashlib.md5(b"caf\xe9\n").hexdigest()
     assert lines == {1: "caf\ufffd"}
+
+
+@pytest.mark.parametrize(
+    (
+        "snapshot_contents_by_original_path",
+        "empty_directory_paths",
+        "expected_exported_files",
+    ),
+    [
+        pytest.param(
+            {Path("/home/u/app/kernel.cpp"): b"kernel source\n"},
+            (),
+            {Path("kernel.cpp"): b"kernel source\n"},
+            id="single_file",
+        ),
+        pytest.param(
+            {
+                Path("/home/u/app/src/kernel.cpp"): b"kernel source\n",
+                Path("/home/u/app/include/kernel.hpp"): b"header source\n",
+            },
+            (),
+            {
+                Path("src/kernel.cpp"): b"kernel source\n",
+                Path("include/kernel.hpp"): b"header source\n",
+            },
+            id="deepest_parent",
+        ),
+        pytest.param(
+            {
+                Path("/home/u/app/kernel.cpp"): b"kernel source\n",
+                Path("/opt/rocm/include/runtime.hpp"): b"runtime header\n",
+            },
+            (),
+            {
+                Path("home/u/app/kernel.cpp"): b"kernel source\n",
+                Path("opt/rocm/include/runtime.hpp"): b"runtime header\n",
+            },
+            id="root_ancestor",
+        ),
+        pytest.param(
+            {Path("/home/u/app/kernel.cpp"): b"kernel source\n"},
+            (Path("opt/empty"),),
+            {Path("kernel.cpp"): b"kernel source\n"},
+            id="ignores_empty_directories",
+        ),
+    ],
+)
+def test_export_source_snapshot_files_uses_deepest_parent_layout(
+    tmp_path,
+    snapshot_contents_by_original_path,
+    empty_directory_paths,
+    expected_exported_files,
+):
+    """Lay out exports relative to the snapshot's deepest common parent."""
+    workload_path = tmp_path / "vector_copy" / "MI300X_A1"
+    source_snapshot_directory = workload_path / "src"
+    for original_source_path, contents in snapshot_contents_by_original_path.items():
+        create_source_snapshot(
+            source_snapshot_directory,
+            original_source_path,
+            contents,
+        )
+
+    for empty_directory_path in empty_directory_paths:
+        (source_snapshot_directory / empty_directory_path).mkdir(parents=True)
+
+    csv_result_directory = tmp_path / "csv_result"
+    source_snapshot_analysis.export_source_snapshot_files(
+        workload_paths=[str(workload_path)],
+        csv_result_directory=csv_result_directory,
+    )
+
+    workload_export_directory = (
+        csv_result_directory / "source" / "vector_copy" / "MI300X_A1"
+    )
+    assert (
+        common.read_binary_file_tree(workload_export_directory)
+        == expected_exported_files
+    )
+
+
+def test_export_source_snapshot_files_overwrites_and_preserves_file_metadata(
+    tmp_path,
+):
+    """Overwrite an existing export while preserving snapshot metadata."""
+    workload_path = tmp_path / "vector_copy" / "MI300X_A1"
+    original_source_path = Path("/home/u/app/src/kernel.cpp")
+    snapshot_path = create_source_snapshot(
+        workload_path / "src",
+        original_source_path,
+        b"\x00new source contents\xff",
+    )
+    snapshot_path.chmod(0o640)
+    snapshot_timestamp_ns = 1_700_000_000_123_456_789
+    os.utime(
+        snapshot_path,
+        ns=(snapshot_timestamp_ns, snapshot_timestamp_ns),
+    )
+
+    csv_result_directory = tmp_path / "csv_result"
+    exported_path = (
+        csv_result_directory / "source" / "vector_copy" / "MI300X_A1" / "kernel.cpp"
+    )
+    exported_path.parent.mkdir(parents=True)
+    exported_path.write_bytes(b"stale source contents")
+    exported_path.chmod(0o600)
+    os.utime(exported_path, ns=(1_600_000_000, 1_600_000_000))
+
+    source_snapshot_analysis.export_source_snapshot_files(
+        workload_paths=[str(workload_path)],
+        csv_result_directory=csv_result_directory,
+    )
+
+    snapshot_metadata = snapshot_path.stat()
+    exported_metadata = exported_path.stat()
+    assert exported_path.read_bytes() == snapshot_path.read_bytes()
+    assert exported_metadata.st_mtime_ns == snapshot_metadata.st_mtime_ns
+    assert stat.S_IMODE(exported_metadata.st_mode) == stat.S_IMODE(
+        snapshot_metadata.st_mode
+    )
+
+
+def test_export_source_snapshot_files_scans_each_workload_once(tmp_path, monkeypatch):
+    """Discover each workload's source snapshot exactly once."""
+    workload_paths = [
+        tmp_path / "first_workload" / "MI300X_A1",
+        tmp_path / "second_workload" / "MI300X_A1",
+    ]
+    for workload_path in workload_paths:
+        create_source_snapshot(
+            workload_path / "src",
+            Path("/home/u/app/kernel.cpp"),
+            b"kernel source\n",
+        )
+
+    discovered_snapshot_directories = []
+    original_snapshot_finder = source_snapshot_analysis._find_source_snapshot_files
+
+    def record_snapshot_discovery(source_snapshot_directory):
+        """Record a snapshot directory before delegating to the real finder."""
+        discovered_snapshot_directories.append(source_snapshot_directory)
+        return original_snapshot_finder(source_snapshot_directory)
+
+    monkeypatch.setattr(
+        source_snapshot_analysis,
+        "_find_source_snapshot_files",
+        record_snapshot_discovery,
+    )
+
+    source_snapshot_analysis.export_source_snapshot_files(
+        workload_paths=[str(workload_path) for workload_path in workload_paths],
+        csv_result_directory=tmp_path / "csv_result",
+    )
+
+    assert discovered_snapshot_directories == [
+        workload_path / "src" for workload_path in workload_paths
+    ]
+
+
+@pytest.mark.parametrize(
+    "create_empty_snapshot_directory",
+    (
+        pytest.param(False, id="missing_directory"),
+        pytest.param(True, id="empty_directory"),
+    ),
+)
+def test_export_source_snapshot_files_warns_and_continues_for_missing_or_empty_workload(
+    tmp_path,
+    caplog,
+    create_empty_snapshot_directory,
+):
+    """Warn for an empty snapshot and continue exporting later workloads."""
+    skipped_workload_path = tmp_path / "skipped_workload" / "MI300X_A1"
+    if create_empty_snapshot_directory:
+        (skipped_workload_path / "src").mkdir(parents=True)
+
+    populated_workload_path = tmp_path / "populated_workload" / "MI300X_A1"
+    create_source_snapshot(
+        populated_workload_path / "src",
+        Path("/home/u/app/kernel.cpp"),
+        b"kernel source\n",
+    )
+    workload_paths = [str(skipped_workload_path), str(populated_workload_path)]
+    csv_result_directory = tmp_path / "csv_result"
+
+    with caplog.at_level(logging.WARNING):
+        source_snapshot_analysis.export_source_snapshot_files(
+            workload_paths=workload_paths,
+            csv_result_directory=csv_result_directory,
+        )
+
+    skipped_export_directory = (
+        csv_result_directory / "source" / "skipped_workload" / "MI300X_A1"
+    )
+    populated_export_path = (
+        csv_result_directory
+        / "source"
+        / "populated_workload"
+        / "MI300X_A1"
+        / "kernel.cpp"
+    )
+    warning_messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno == logging.WARNING
+    ]
+    assert not skipped_export_directory.exists()
+    assert populated_export_path.read_bytes() == b"kernel source\n"
+    assert len(warning_messages) == 1
+    assert str(skipped_workload_path) in warning_messages[0]


### PR DESCRIPTION
## Motivation

Make CSV analysis results self-contained by exporting captured source files beside their source references. This preserves workload context for portable offline inspection.

## Technical Details

- Export each captured source file under the absolute path recorded for it, so a CSV source row locates its copy by dropping the leading separator
- Copy the files the source rows were built from, leaving unreferenced snapshot files out
- Name each export folder from the workload row, and constrain workload name and sub-name to be unique
- Leave database output and existing CSV views unchanged

## Issue Tracking

JIRA ID: AIPROFCOMP-800

## Test Plan

- [x] Run pytest -q tests/test_source_snapshot_analysis.py
- [x] Run pytest -q tests/test_analysis_db.py
- [ ] Run pytest -q tests/test_analyze_commands.py -k source_snapshot

## Test Result

- [x] pytest -q tests/test_source_snapshot_analysis.py passes locally
- [x] pytest -q tests/test_analysis_db.py passes locally
- [ ] tests/test_analyze_commands.py -k source_snapshot left to CI

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
