### PR TITLE
feat(rocprofiler-compute) - Per kernel csv dump in analysis mode

### DIFF
--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -9,6 +9,10 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 * Added GPU benchmarking and roofline profiling/analysis support for gfx1153 hardware.
 
+* Added per-kernel PC sampling analysis.
+  * `rocprof-compute analyze --output-format csv` writes each kernel's disassembly under `per_kernel_pc_sampling/`, with the sample and stall counts on every instruction and the source it was compiled from.
+  * The analysis database records the same per-instruction data, so `--output-format db` can be queried for it.
+
 * Added multi-process PC sampling across profile and analyze modes.
   * Profile mode writes one PID-prefixed `<pid>_ps_file_results.json` per process.
   * Analyze mode reports every process in a single run, with a `pid` column
@@ -21,6 +25,8 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
   XCD, L2 channel, and HBM channel counts from them.
 
 ### Changed
+
+* Renamed the PC sampling analysis output: `pc_sampling.csv` is now `pc_sampling_summary.csv`, and the `compute_pc_sampling_view` view is now `compute_pc_sampling_summary_view`.
 
 * ML API tracing options (--torch-trace/--triton-trace/--ml-api-trace) are no longer allowed with PC-sampling-only profiling; the run now fails with an error telling the user to drop the ML API tracing flag or add a counter block, since without counters there is nothing to correlate the markers against.
 

--- a/projects/rocprofiler-compute/docs/how-to/analyze/cli.rst
+++ b/projects/rocprofiler-compute/docs/how-to/analyze/cli.rst
@@ -601,6 +601,7 @@ format is ``stdout``.
 * ``csv`` format:
    * Generate a folder named ``rocprof_compute_<uuid>`` in the current working directory.
    * This folder contains one CSV file per view defined in the :ref:`analysis database schema <analysis-database>`.
+   * For a PC-sampled workload it also holds each kernel's disassembly and source; see :ref:`pc-sampling-per-kernel-csv`.
    * This is useful for further programmatic analysis of analysis reports.
    * NOTE: This option will disable output of analysis report to terminal.
 

--- a/projects/rocprofiler-compute/docs/how-to/pc_sampling.rst
+++ b/projects/rocprofiler-compute/docs/how-to/pc_sampling.rst
@@ -163,6 +163,71 @@ Sorting by ``count`` ranks on sample count alone, so rows from different
 processes can interleave. In both cases, ``--pc-sampling-rows 10`` selects ten
 rows from the workload as a whole, not ten rows per process.
 
+.. _pc-sampling-per-kernel-csv:
+
+Per-kernel ISA and source in CSV output
+=======================================
+
+``--output-format csv`` writes, alongside the analysis tables, one file per
+kernel per code object per process holding that kernel's instruction lines with
+the samples collected on them, and exports the source those instructions were
+compiled from beside it:
+
+.. code-block:: none
+
+   <output_name>/
+       kernel.csv, pc_sampling_summary.csv, ...
+       per_kernel_pc_sampling/
+           <workload_name>/<workload_sub_name>/
+               source/<source path with the leading separator dropped>
+               kernel_<kernel_uuid>/
+                   isa_code_object_id_<code_object_id>_pid_<pid>.csv
+
+A folder is named by ``kernel_uuid`` because a kernel name is a C++ signature,
+which cannot be a path. ``kernel.csv`` carries ``kernel_uuid`` alongside
+``kernel_name``, so it maps a folder back to the kernel it holds. One kernel has
+more than one file when it was compiled into several code objects, or when
+several processes ran it.
+
+Each file holds one row per instruction line, ordered by code object offset:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Column
+     - Description
+   * - ``Instruction line number``
+     - Position of the line within this file, counting from 1.
+   * - ``Code object offset``
+     - Offset of the instruction from the code object's load address.
+   * - ``Instruction line``
+     - Disassembled instruction.
+   * - ``Total count``
+     - Samples that landed on this instruction.
+   * - ``Active count``
+     - Samples where the wave issued. Empty for ``host_trap``.
+   * - ``Stall count``
+     - Samples where the wave was stalled. Empty for ``host_trap``.
+   * - ``Wave occupancy percent``
+     - Reserved; not yet collected, so empty on every row.
+   * - ``Active thread percent``
+     - Reserved; not yet collected, so empty on every row.
+   * - ``Stall <REASON>``
+     - Samples stalled at this instruction for that reason.
+   * - ``Source``
+     - Inline stack of ``path:line`` frames, innermost first.
+   * - ``Code object id``
+     - Code object the instruction belongs to, local to its process.
+   * - ``Pid``
+     - Process the code object was loaded in.
+
+The ``Stall <REASON>`` columns are the reasons the workload's samples actually
+carry, so they vary between runs, and a ``host_trap`` workload has none of them.
+Every file of one workload has the same columns. A cell is empty where that
+reason was not seen at that offset.
+
+An instruction that no sample landed on keeps its row, with empty counts.
+
 .. _pc-sampling-note:
 
 .. note::

--- a/projects/rocprofiler-compute/docs/how-to/pc_sampling.rst
+++ b/projects/rocprofiler-compute/docs/how-to/pc_sampling.rst
@@ -228,9 +228,12 @@ reason was not seen at that offset.
 
 An instruction that no sample landed on keeps its row, with empty counts.
 
+The ``Source`` column and the ``source/`` folder are populated only when the
+target app was built with debug info; see the :ref:`note <pc-sampling-note>`.
+
 .. _pc-sampling-note:
 
 .. note::
 
   * PC sampling now only shows assembly instructions collected in our record of pc samples and not all instructions of compiled code are represented.
-  * To associate PC sampling info back to HIP source code, you need to build the profiling target app with ``-g`` to keep the symbols. Otherwise, PC sampling info will be only associated with assembly lines.
+  * Source information requires the target app to be built with debug info (for example ``hipcc -g``). Without it, samples map to assembly only: profile mode captures no source files, the terminal table's ``source_line`` shows ``N/A``, and the ``Source`` column of the per-kernel CSV is empty.

--- a/projects/rocprofiler-compute/src/pc_sampling/per_kernel_isa_export.py
+++ b/projects/rocprofiler-compute/src/pc_sampling/per_kernel_isa_export.py
@@ -1,0 +1,161 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
+"""
+Per-kernel ISA export.
+
+A CSV analysis result carries the PC sampling counts of every kernel in one
+`pc_sampling_summary.csv`, which is hard to read against a kernel's own
+disassembly. This module writes one file per kernel per code object per
+process, holding that kernel's instruction lines in offset order with the
+counts collected on them.
+"""
+
+import csv
+from collections.abc import Iterable, Iterator
+from pathlib import Path
+from typing import Any, NamedTuple
+
+from utils.logger import console_debug, console_warning
+
+PER_KERNEL_DIRECTORY_NAME = "per_kernel_pc_sampling"
+STALL_COLUMN_PREFIX = "Stall "
+
+# The row columns naming the file, ahead of the columns written into it.
+FILE_KEY_COLUMN_COUNT = 5
+
+BASE_COLUMNS = (
+    "Instruction line number",
+    "Code object offset",
+    "Instruction line",
+    "Total count",
+    "Active count",
+    "Stall count",
+    "Wave occupancy percent",
+    "Active thread percent",
+)
+TRAILING_COLUMNS = (
+    "Source",
+    "Code object id",
+    "Pid",
+)
+
+# (workload name, workload sub-name, kernel uuid, code object id, pid)
+FileKey = tuple[str, str, int, int, int]
+
+
+class WorkloadIsaExport(NamedTuple):
+    """One workload's instruction rows and the stall columns they fill.
+
+    The rows carry the workload's own names, so the export folder cannot drift
+    from the database.
+    """
+
+    workload_id: int
+    stall_reasons: list[str]
+    isa_rows: Iterator[tuple[Any, ...]]
+
+
+def export_per_kernel_isa_files(
+    csv_result_directory: Path,
+    workload_isa_exports: Iterable[WorkloadIsaExport],
+) -> Path:
+    """Export every workload's per-kernel ISA beneath a CSV result folder.
+
+    Returns the folder the files were written to, which is also where the
+    source they point at is exported.
+    """
+    per_kernel_directory = csv_result_directory / PER_KERNEL_DIRECTORY_NAME
+
+    for workload_isa_export in workload_isa_exports:
+        file_count = _write_per_kernel_isa_files(
+            per_kernel_directory,
+            workload_isa_export.isa_rows,
+            workload_isa_export.stall_reasons,
+        )
+        console_debug(
+            f"Exported {file_count} per-kernel ISA files for workload "
+            f"{workload_isa_export.workload_id}."
+        )
+
+    if per_kernel_directory.is_dir():
+        console_warning(f"Created directory: {per_kernel_directory}")
+    return per_kernel_directory
+
+
+def _build_isa_header(stall_reasons: Iterable[str]) -> list[str]:
+    """Return the column names of one workload's ISA files.
+
+    A workload's stall reasons vary with how it was sampled, so the columns
+    are the ones its samples carry. The prefix keeps a reason such as NONE
+    from reading as an unrelated column next to the counts.
+    """
+    return [
+        *BASE_COLUMNS,
+        *(f"{STALL_COLUMN_PREFIX}{stall_reason}" for stall_reason in stall_reasons),
+        *TRAILING_COLUMNS,
+    ]
+
+
+def _resolve_isa_export_path(per_kernel_directory: Path, file_key: FileKey) -> Path:
+    """Return the file one kernel's ISA is written to.
+
+    The folder is named by kernel uuid because a kernel name is a C++
+    signature, which cannot be a path. ``kernel.csv`` maps the uuid back.
+    """
+    workload_name, workload_sub_name, kernel_uuid, code_object_id, pid = file_key
+    return (
+        per_kernel_directory
+        / workload_name
+        / workload_sub_name
+        / f"kernel_{kernel_uuid}"
+        / f"isa_code_object_id_{code_object_id}_pid_{pid}.csv"
+    )
+
+
+def _write_per_kernel_isa_files(
+    per_kernel_directory: Path,
+    isa_rows: Iterator[tuple[Any, ...]],
+    stall_reasons: list[str],
+) -> int:
+    """Write one workload's grouped ISA rows, returning the file count.
+
+    The rows arrive grouped and ordered, so a file is opened when the key
+    changes and closed when the next one starts.
+    """
+    header = _build_isa_header(stall_reasons)
+    file_count = 0
+    for file_key, file_rows in _group_rows_by_file(isa_rows):
+        export_path = _resolve_isa_export_path(per_kernel_directory, file_key)
+        export_path.parent.mkdir(parents=True, exist_ok=True)
+        with export_path.open("w", newline="", encoding="utf-8") as export_file:
+            writer = csv.writer(export_file)
+            writer.writerow(header)
+            writer.writerows(
+                [line_number, *row]
+                for line_number, row in enumerate(file_rows, start=1)
+            )
+        file_count += 1
+    return file_count
+
+
+def _group_rows_by_file(
+    isa_rows: Iterator[tuple[Any, ...]],
+) -> Iterator[tuple[FileKey, list[tuple[Any, ...]]]]:
+    """Split the ordered row stream into the rows of one file at a time.
+
+    Only the file being written is held, so the whole result set never is.
+    """
+    current_key = None
+    current_rows: list[tuple[Any, ...]] = []
+    for row in isa_rows:
+        file_key: FileKey = row[:FILE_KEY_COLUMN_COUNT]
+        if file_key != current_key:
+            if current_key is not None:
+                yield current_key, current_rows
+            current_key = file_key
+            current_rows = []
+        current_rows.append(row[FILE_KEY_COLUMN_COUNT:])
+
+    if current_key is not None:
+        yield current_key, current_rows

--- a/projects/rocprofiler-compute/src/pc_sampling/source_snapshot_analysis.py
+++ b/projects/rocprofiler-compute/src/pc_sampling/source_snapshot_analysis.py
@@ -108,15 +108,19 @@ def resolve_export_path(
 
 def export_source_snapshot_files(
     workload_source_snapshots: Iterable[WorkloadSourceSnapshot],
-    csv_result_directory: Path,
+    export_directory: Path,
 ) -> None:
-    """Copy the source files a CSV result references into the result folder."""
+    """Copy the source files a CSV result references into the result folder.
+
+    The source of one workload sits beside the ISA that points at it, under
+    that workload's folder.
+    """
     for workload_source_snapshot in workload_source_snapshots:
         workload_result_directory = (
-            csv_result_directory
-            / SOURCE_EXPORT_DIRECTORY_NAME
+            export_directory
             / workload_source_snapshot.workload_name
             / workload_source_snapshot.workload_sub_name
+            / SOURCE_EXPORT_DIRECTORY_NAME
         )
         for absolute_path in workload_source_snapshot.absolute_source_paths:
             export_path = resolve_export_path(workload_result_directory, absolute_path)

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
@@ -22,6 +22,10 @@ from pc_sampling.pc_sampling_analysis import (
     InstructionLineRecord,
     load_aggregated_pc_sampling,
 )
+from pc_sampling.per_kernel_isa_export import (
+    WorkloadIsaExport,
+    export_per_kernel_isa_files,
+)
 from pc_sampling.source_snapshot_analysis import (
     SourceFrame,
     WorkloadSourceSnapshot,
@@ -83,6 +87,49 @@ from utils.utils_counter_defs import (
 KernelKey = str
 CodeObjectKey = tuple[int, int]
 KernelSymbolKey = tuple[int, int, str]  # (pid, code_object_id, kernel_name)
+
+
+def filter_dispatch_frame(
+    dispatch_frame: pd.DataFrame,
+    filter_gpu_ids: Optional[list[str]],
+    filter_kernel_ids: Optional[list[int]],
+    filter_dispatch_ids: Optional[list[str]],
+) -> pd.DataFrame:
+    """Apply the analysis mode filters to one frame of dispatch rows.
+
+    The frame carries the profiler's column names, so both the counter frame
+    and the PC-sampling trace can be filtered by the same rules.
+    """
+    top_kernels = (
+        dispatch_frame
+        .assign(
+            duration=dispatch_frame["End_Timestamp"] - dispatch_frame["Start_Timestamp"]
+        )
+        .sort_values(by="duration", ascending=False)
+        .drop_duplicates("Kernel_Name")["Kernel_Name"]
+        .to_list()
+    )
+    if filter_gpu_ids:
+        dispatch_frame = dispatch_frame.loc[
+            dispatch_frame["GPU_ID"].astype(str).isin([filter_gpu_ids])
+        ]
+    if filter_kernel_ids:
+        dispatch_frame = dispatch_frame.loc[
+            dispatch_frame["Kernel_Name"].isin([
+                top_kernels[kernel_id] for kernel_id in filter_kernel_ids
+            ])
+        ]
+    if filter_dispatch_ids:
+        if ">" in filter_dispatch_ids[0]:
+            dispatch_bound = re.match(r"\> (\d+)", filter_dispatch_ids[0])
+            dispatch_frame = dispatch_frame[
+                dispatch_frame["Dispatch_ID"] > int(dispatch_bound.group(1))
+            ]
+        else:
+            dispatch_frame = dispatch_frame.loc[
+                dispatch_frame["Dispatch_ID"].astype(str).isin(filter_dispatch_ids)
+            ]
+    return dispatch_frame
 
 
 class MetricInfoRow(NamedTuple):
@@ -264,6 +311,7 @@ class db_analysis(OmniAnalyze_Base):
 
         # Iterate over all workloads
         workload_source_snapshots: list[WorkloadSourceSnapshot] = []
+        workload_objs: list[orm.Workload] = []
         for workload_path in self._runs.keys():
             # Add workload
             workload_obj = orm.Workload(
@@ -276,6 +324,7 @@ class db_analysis(OmniAnalyze_Base):
                 profiling_config_extdata=self._profiling_config,
             )
             Database.get_session().add(workload_obj)
+            workload_objs.append(workload_obj)
 
             # Add kernel
             kernel_objs: dict[KernelKey, orm.Kernel] = {}
@@ -384,15 +433,40 @@ class db_analysis(OmniAnalyze_Base):
         if self.get_args().output_format == "csv":
             Database.commit()
             csv_result_folder = Path(db_name).with_suffix("")
+            # Before write_csv_dir, which closes the session these rows stream from.
+            per_kernel_folder = export_per_kernel_isa_files(
+                csv_result_directory=csv_result_folder,
+                workload_isa_exports=self._build_workload_isa_exports(workload_objs),
+            )
             Database.write_csv_dir(csv_result_folder)
             export_source_snapshot_files(
                 workload_source_snapshots=workload_source_snapshots,
-                csv_result_directory=csv_result_folder,
+                export_directory=per_kernel_folder,
             )
         else:
             Database.create_views()
             Database.commit()
             Database.write()
+
+    @staticmethod
+    def _build_workload_isa_exports(
+        workload_objs: list[orm.Workload],
+    ) -> list[WorkloadIsaExport]:
+        """Pair each workload's stall reasons with its instruction rows."""
+        stall_reasons_by_workload = Database.get_stall_reasons_by_workload()
+        workload_isa_exports = []
+        for workload_obj in workload_objs:
+            stall_reasons = stall_reasons_by_workload.get(workload_obj.workload_id, [])
+            workload_isa_exports.append(
+                WorkloadIsaExport(
+                    workload_id=workload_obj.workload_id,
+                    stall_reasons=stall_reasons,
+                    isa_rows=Database.stream_per_kernel_isa_rows(
+                        workload_obj.workload_id, stall_reasons
+                    ),
+                )
+            )
+        return workload_isa_exports
 
     def run_analysis_metrics(
         self,
@@ -552,7 +626,12 @@ class db_analysis(OmniAnalyze_Base):
         kernel_symbols: dict[KernelSymbolKey, orm.KernelSymbol],
         source_frames: SourceFrameCollector,
     ) -> dict[CodeObjectKey, orm.CodeObjectStore]:
-        """Insert the normalized PC-sampling rows for one workload."""
+        """Insert the normalized PC-sampling rows for one workload.
+
+        A code object's store row is created by the first line that survives
+        the kernel filter, so one whose kernels were all filtered out leaves no
+        row with nothing under it.
+        """
         code_object_stores: dict[CodeObjectKey, orm.CodeObjectStore] = {}
         tool_data_records = self._pc_sampling_tool_data_per_workload.get(
             workload_path, []
@@ -562,28 +641,45 @@ class db_analysis(OmniAnalyze_Base):
             pid: int = tool_data["metadata"]["pid"]
 
             for code_object in load_aggregated_pc_sampling(tool_data):
-                code_object_key: CodeObjectKey = (pid, code_object.code_object_id)
-                code_object_store = code_object_stores.get(code_object_key)
-                if code_object_store is None:
-                    code_object_store = orm.CodeObjectStore(
-                        code_object_id=code_object.code_object_id,
-                        pid=pid,
-                        load_base=code_object.load_base,
-                        workload=workload_obj,
-                    )
-                    Database.get_session().add(code_object_store)
-                    code_object_stores[code_object_key] = code_object_store
-
                 for line in code_object.instruction_lines:
+                    kernel = kernel_objs.get(line.kernel_name)
+                    if kernel is None:
+                        # Drop lines whose kernel was filtered out or never mapped.
+                        continue
+
                     self._add_instruction_line(
                         line,
-                        code_object_store,
-                        kernel_objs,
+                        self._get_or_create_code_object_store(
+                            code_object_stores,
+                            (pid, code_object.code_object_id),
+                            code_object.load_base,
+                            workload_obj,
+                        ),
+                        kernel,
                         kernel_symbols,
                         source_frames,
                     )
 
         return code_object_stores
+
+    @staticmethod
+    def _get_or_create_code_object_store(
+        code_object_stores: dict[CodeObjectKey, orm.CodeObjectStore],
+        code_object_key: CodeObjectKey,
+        load_base: Optional[int],
+        workload_obj: orm.Workload,
+    ) -> orm.CodeObjectStore:
+        """Return the store for a (pid, code object) pair, creating it once."""
+        if code_object_key not in code_object_stores:
+            pid, code_object_id = code_object_key
+            code_object_stores[code_object_key] = orm.CodeObjectStore(
+                code_object_id=code_object_id,
+                pid=pid,
+                load_base=load_base,
+                workload=workload_obj,
+            )
+            Database.get_session().add(code_object_stores[code_object_key])
+        return code_object_stores[code_object_key]
 
     @staticmethod
     def _get_or_create_kernel_symbol(
@@ -609,16 +705,11 @@ class db_analysis(OmniAnalyze_Base):
     def _add_instruction_line(
         line: InstructionLineRecord,
         code_object_store: orm.CodeObjectStore,
-        kernel_objs: dict[KernelKey, orm.Kernel],
+        kernel: orm.Kernel,
         kernel_symbols: dict[KernelSymbolKey, orm.KernelSymbol],
         source_frames: SourceFrameCollector,
     ) -> None:
         """Insert one instruction line, its sample state, and child counts."""
-        kernel = kernel_objs.get(line.kernel_name)
-        if kernel is None:
-            # Drop lines whose kernel was filtered out or never mapped.
-            return
-
         instruction_line = orm.InstructionLine(
             code_object_offset=line.code_object_offset,
             instruction=line.instruction,
@@ -694,20 +785,12 @@ class db_analysis(OmniAnalyze_Base):
                 if disassembly.code_object_id not in invoked_code_object_ids:
                     continue
 
-                code_object_key: CodeObjectKey = (
-                    pid,
-                    disassembly.code_object_id,
+                code_object_store = self._get_or_create_code_object_store(
+                    code_object_stores,
+                    (pid, disassembly.code_object_id),
+                    load_base_by_id.get(disassembly.code_object_id),
+                    workload_obj,
                 )
-                code_object_store = code_object_stores.get(code_object_key)
-                if code_object_store is None:
-                    code_object_store = orm.CodeObjectStore(
-                        code_object_id=disassembly.code_object_id,
-                        pid=pid,
-                        load_base=load_base_by_id.get(disassembly.code_object_id),
-                        workload=workload_obj,
-                    )
-                    Database.get_session().add(code_object_store)
-                    code_object_stores[code_object_key] = code_object_store
 
                 # The disassembly's own offset is into the ELF file, not the
                 # offset the PC-sampling rows use (measured from the code
@@ -1185,7 +1268,8 @@ class db_analysis(OmniAnalyze_Base):
             if self.pc_sampling_only():
                 dispatch_data_per_workload[workload_path] = (
                     self._build_pc_sampling_dispatch_data(
-                        tool_data_per_workload.get(workload_path, [])
+                        tool_data_per_workload.get(workload_path, []),
+                        self._runs[workload_path],
                     )
                 )
             else:
@@ -1233,8 +1317,13 @@ class db_analysis(OmniAnalyze_Base):
     @staticmethod
     def _build_pc_sampling_dispatch_data(
         tool_data_records: list[dict[str, Any]],
+        workload: schema.Workload,
     ) -> pd.DataFrame:
-        """Convert combined sampling traces to the database dispatch schema."""
+        """Convert combined sampling traces to the database dispatch schema.
+
+        The filters run here because a sampling-only workload has no counter
+        frame for them to reach the database through.
+        """
         columns = [
             "dispatch_id",
             "kernel_name",
@@ -1246,8 +1335,15 @@ class db_analysis(OmniAnalyze_Base):
         if trace_df.empty:
             return pd.DataFrame(columns=columns)
 
+        # The trace names the column Dispatch_Id, the filters read Dispatch_ID.
+        trace_df = filter_dispatch_frame(
+            trace_df.rename(columns={"Dispatch_Id": "Dispatch_ID"}),
+            workload.filter_gpu_ids,
+            workload.filter_kernel_ids,
+            workload.filter_dispatch_ids,
+        )
         dispatch_df = pd.DataFrame({
-            "dispatch_id": trace_df["Dispatch_Id"],
+            "dispatch_id": trace_df["Dispatch_ID"],
             "kernel_name": trace_df["Kernel_Name"],
             "gpu_id": trace_df["GPU_ID"],
             "start_timestamp": trace_df["Start_Timestamp"],
@@ -1259,42 +1355,12 @@ class db_analysis(OmniAnalyze_Base):
         pmc_df_per_workload = self._pmc_df_per_workload.copy()
 
         for workload_path, pmc_df in pmc_df_per_workload.items():
-            top_kernels = (
-                pmc_df
-                .assign(duration=pmc_df["End_Timestamp"] - pmc_df["Start_Timestamp"])
-                .sort_values(by="duration", ascending=False)
-                .drop_duplicates("Kernel_Name")["Kernel_Name"]
-                .to_list()
+            pmc_df_per_workload[workload_path] = filter_dispatch_frame(
+                pmc_df,
+                self._runs[workload_path].filter_gpu_ids,
+                self._runs[workload_path].filter_kernel_ids,
+                self._runs[workload_path].filter_dispatch_ids,
             )
-            # Filter gpu_ids
-            if self._runs[workload_path].filter_gpu_ids:
-                pmc_df = pmc_df.loc[
-                    pmc_df["GPU_ID"]
-                    .astype(str)
-                    .isin([self._runs[workload_path].filter_gpu_ids])
-                ]
-            # Filter kernel_ids
-            if self._runs[workload_path].filter_kernel_ids:
-                pmc_df = pmc_df.loc[
-                    pmc_df["Kernel_Name"].isin([
-                        top_kernels[id]
-                        for id in self._runs[workload_path].filter_kernel_ids
-                    ])
-                ]
-            # Filter dispatch_ids
-            if self._runs[workload_path].filter_dispatch_ids:
-                if ">" in self._runs[workload_path].filter_dispatch_ids[0]:
-                    m = re.match(
-                        r"\> (\d+)", self._runs[workload_path].filter_dispatch_ids[0]
-                    )
-                    pmc_df = pmc_df[pmc_df["Dispatch_ID"] > int(m.group(1))]
-                else:
-                    pmc_df = pmc_df.loc[
-                        pmc_df["Dispatch_ID"]
-                        .astype(str)
-                        .isin(self._runs[workload_path].filter_dispatch_ids)
-                    ]
-            pmc_df_per_workload[workload_path] = pmc_df
 
         if pmc_df_per_workload:
             console_debug("Applied analysis mode filters")

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
@@ -78,7 +78,7 @@ from utils.utils_analysis import (
     PEAK_COL_PREFERENCE,
     VALUE_COL_PREFERENCE,
 )
-from utils.utils_common import get_uuid, get_version
+from utils.utils_common import get_uuid, get_version, normalize_filter_to_str_list
 from utils.utils_counter_defs import (
     extract_counters_and_variables,
     get_build_in_vars,
@@ -111,7 +111,9 @@ def filter_dispatch_frame(
     )
     if filter_gpu_ids:
         dispatch_frame = dispatch_frame.loc[
-            dispatch_frame["GPU_ID"].astype(str).isin([filter_gpu_ids])
+            dispatch_frame["GPU_ID"]
+            .astype(str)
+            .isin(normalize_filter_to_str_list(filter_gpu_ids))
         ]
     if filter_kernel_ids:
         dispatch_frame = dispatch_frame.loc[
@@ -121,7 +123,7 @@ def filter_dispatch_frame(
         ]
     if filter_dispatch_ids:
         if ">" in filter_dispatch_ids[0]:
-            dispatch_bound = re.match(r"\> (\d+)", filter_dispatch_ids[0])
+            dispatch_bound = re.match(r"\>\s*(\d+)", filter_dispatch_ids[0])
             dispatch_frame = dispatch_frame[
                 dispatch_frame["Dispatch_ID"] > int(dispatch_bound.group(1))
             ]

--- a/projects/rocprofiler-compute/src/utils/analysis_orm.py
+++ b/projects/rocprofiler-compute/src/utils/analysis_orm.py
@@ -11,6 +11,7 @@ import csv
 import json
 import math
 import sqlite3
+from collections.abc import Iterator
 from contextlib import closing
 from pathlib import Path
 from typing import Any, Optional
@@ -24,6 +25,7 @@ from sqlalchemy import (
     String,
     Text,
     UniqueConstraint,
+    case,
     cast,
     create_engine,
     func,
@@ -641,6 +643,45 @@ class Database:
             cls._session = None
 
     @classmethod
+    def get_stall_reasons_by_workload(cls) -> dict[int, list[str]]:
+        """Return the stall reasons each workload's samples actually carry.
+
+        A host_trap workload records none, so it maps to an empty list and its
+        exports carry no stall columns.
+        """
+        stall_reasons_by_workload: dict[int, list[str]] = {}
+        for workload_id, reason in cls._session.execute(
+            cls._stall_reasons_by_workload_statement()
+        ):
+            stall_reasons_by_workload.setdefault(workload_id, []).append(reason)
+        return {
+            workload_id: sorted(reasons)
+            for workload_id, reasons in stall_reasons_by_workload.items()
+        }
+
+    @classmethod
+    def stream_per_kernel_isa_rows(
+        cls,
+        workload_id: int,
+        stall_reasons: list[str],
+    ) -> Iterator[tuple[Any, ...]]:
+        """Yield one workload's instruction lines, grouped file by file.
+
+        Rows arrive in the order the exporter writes them, through the raw
+        sqlite3 cursor so the full result set is never held in memory.
+        """
+        statement = cls._per_kernel_isa_statement(workload_id, stall_reasons)
+        raw_conn = cls._session.connection().connection
+        yield from raw_conn.execute(
+            str(
+                statement.compile(
+                    dialect=sqlite.dialect(),
+                    compile_kwargs={"literal_binds": True},
+                )
+            )
+        )
+
+    @classmethod
     def create_views(cls) -> None:
         """Materialize CREATE VIEW statements in the in-memory DB."""
         for name, sql in cls.get_view_sql().items():
@@ -728,6 +769,124 @@ class Database:
                 .exists()
             )
         ).subquery("source_chain")
+
+    @staticmethod
+    def _stall_reasons_by_workload_statement() -> Select[Any]:
+        """Select the distinct (workload, stall reason) pairs that were stored."""
+        return (
+            select(
+                CodeObjectStore.workload_id,
+                PCSampleStallReasonLookup.text,
+            )
+            .select_from(PCSampleStallReason)
+            .join(
+                PCSampleStallReasonLookup,
+                PCSampleStallReason.pc_sample_stall_reason_lookup_uuid
+                == PCSampleStallReasonLookup.pc_sample_stall_reason_lookup_uuid,
+            )
+            .join(
+                PCSampleState,
+                PCSampleStallReason.pc_sample_state_uuid
+                == PCSampleState.pc_sample_state_uuid,
+            )
+            .join(
+                InstructionLine,
+                PCSampleState.instruction_uuid == InstructionLine.instruction_uuid,
+            )
+            .join(
+                KernelSymbol,
+                InstructionLine.kernel_symbol_uuid == KernelSymbol.kernel_symbol_uuid,
+            )
+            .join(
+                CodeObjectStore,
+                KernelSymbol.code_object_uuid == CodeObjectStore.code_object_uuid,
+            )
+            .distinct()
+        )
+
+    @staticmethod
+    def _per_kernel_isa_statement(
+        workload_id: int,
+        stall_reasons: list[str],
+    ) -> Select[Any]:
+        """Select one workload's instruction lines with their sample counts.
+
+        The first columns name the file each row belongs in; the rest are the
+        row as it is written, in CSV column order. Every disassembled line is
+        returned, so an unsampled line arrives with empty counts.
+        """
+        source_chain_subquery = Database._source_chain_subquery()
+        # The CASE is non-null on one row of each group; MAX skips the nulls.
+        stall_reason_columns = [
+            func.max(
+                case((
+                    PCSampleStallReasonLookup.text == stall_reason,
+                    PCSampleStallReason.count,
+                ))
+            ).label(stall_reason)
+            for stall_reason in stall_reasons
+        ]
+
+        return (
+            select(
+                Workload.name.label("workload_name"),
+                Workload.sub_name.label("workload_sub_name"),
+                Kernel.kernel_uuid.label("kernel_uuid"),
+                CodeObjectStore.code_object_id.label("code_object_id"),
+                CodeObjectStore.pid.label("pid"),
+                InstructionLine.code_object_offset.label("offset"),
+                InstructionLine.instruction,
+                PCSampleState.total_count.label("count"),
+                PCSampleState.issue_count.label("count_issue"),
+                PCSampleState.stall_count.label("count_stall"),
+                PCSampleState.wave_occupancy_percent,
+                PCSampleState.active_thread_percent,
+                *stall_reason_columns,
+                source_chain_subquery.c.source.label("source"),
+                CodeObjectStore.code_object_id.label("code_object_id_cell"),
+                CodeObjectStore.pid.label("pid_cell"),
+            )
+            .select_from(InstructionLine)
+            .join(
+                KernelSymbol,
+                InstructionLine.kernel_symbol_uuid == KernelSymbol.kernel_symbol_uuid,
+            )
+            .join(
+                CodeObjectStore,
+                KernelSymbol.code_object_uuid == CodeObjectStore.code_object_uuid,
+            )
+            .join(Kernel, KernelSymbol.kernel_uuid == Kernel.kernel_uuid)
+            .join(Workload, CodeObjectStore.workload_id == Workload.workload_id)
+            # A line the disassembly holds but no sample landed on has no state.
+            .outerjoin(
+                PCSampleState,
+                InstructionLine.instruction_uuid == PCSampleState.instruction_uuid,
+            )
+            .outerjoin(
+                PCSampleStallReason,
+                PCSampleState.pc_sample_state_uuid
+                == PCSampleStallReason.pc_sample_state_uuid,
+            )
+            .outerjoin(
+                PCSampleStallReasonLookup,
+                PCSampleStallReason.pc_sample_stall_reason_lookup_uuid
+                == PCSampleStallReasonLookup.pc_sample_stall_reason_lookup_uuid,
+            )
+            .outerjoin(
+                source_chain_subquery,
+                InstructionLine.instruction_uuid
+                == source_chain_subquery.c.instruction_uuid,
+            )
+            .where(CodeObjectStore.workload_id == workload_id)
+            # One row per line: the stall-reason join multiplies them otherwise.
+            .group_by(InstructionLine.instruction_uuid)
+            .order_by(
+                Kernel.kernel_uuid,
+                CodeObjectStore.code_object_id,
+                CodeObjectStore.pid,
+                InstructionLine.code_object_offset,
+            )
+        )
 
     @staticmethod
     def _compile_view_sql() -> dict[str, str]:

--- a/projects/rocprofiler-compute/tests/test_analysis_db.py
+++ b/projects/rocprofiler-compute/tests/test_analysis_db.py
@@ -4,6 +4,7 @@
 """Unit tests for analysis_db.py static methods."""
 
 import copy
+import csv
 import json
 from contextlib import ExitStack
 from functools import partial
@@ -18,7 +19,7 @@ import pandas as pd
 import pytest
 from sqlalchemy import text
 
-from pc_sampling import source_snapshot_analysis
+from pc_sampling import per_kernel_isa_export, source_snapshot_analysis
 from rocprof_compute_analyze.analysis_db import SourceFrameCollector, db_analysis
 from utils import analysis_orm as orm
 from utils import schema
@@ -26,6 +27,9 @@ from utils.metrics.noise_clamper import (
     clear_noise_clamp_warnings,
     get_noise_clamp_warnings,
 )
+
+ISA_WORKLOAD_NAME = "vector_copy"
+ISA_WORKLOAD_SUB_NAME = "run"
 
 VIEW_CSV_FILENAMES = frozenset({
     "kernel.csv",
@@ -103,7 +107,11 @@ def make_source_frame_collector(workload, workload_path="/fake/workload"):
     return SourceFrameCollector(Path(workload_path), workload)
 
 
-def make_pc_sampling_database_analyzer(tool_data_per_workload):
+def make_pc_sampling_database_analyzer(
+    tool_data_per_workload,
+    filter_kernel_ids=(),
+    filter_dispatch_ids=(),
+):
     """Build a database analyzer configured for sampling-only workloads."""
     analyzer = db_analysis(
         SimpleNamespace(output_name=None, output_format="database"),
@@ -112,6 +120,8 @@ def make_pc_sampling_database_analyzer(tool_data_per_workload):
     analyzer._runs = {
         workload_path: schema.Workload(
             sys_info=pd.DataFrame([{"gpu_arch": "gfx942"}]),
+            filter_kernel_ids=list(filter_kernel_ids),
+            filter_dispatch_ids=list(filter_dispatch_ids),
         )
         for workload_path in tool_data_per_workload
     }
@@ -119,7 +129,9 @@ def make_pc_sampling_database_analyzer(tool_data_per_workload):
     analyzer._profiling_config = {"filter_blocks": ["pc_sampling"]}
     analyzer._pc_sampling_tool_data_per_workload = tool_data_per_workload
     analyzer._dispatch_data_per_workload = {
-        workload_path: analyzer._build_pc_sampling_dispatch_data(tool_data_records)
+        workload_path: analyzer._build_pc_sampling_dispatch_data(
+            tool_data_records, analyzer._runs[workload_path]
+        )
         for workload_path, tool_data_records in tool_data_per_workload.items()
     }
     analyzer._roofline_data_per_kernel = {}
@@ -127,9 +139,18 @@ def make_pc_sampling_database_analyzer(tool_data_per_workload):
     return analyzer
 
 
-def make_pc_sampling_only_database_analyzer(workload_path, tool_data_records):
+def make_pc_sampling_only_database_analyzer(
+    workload_path,
+    tool_data_records,
+    filter_kernel_ids=(),
+    filter_dispatch_ids=(),
+):
     """Build a database analyzer configured for one sampling-only workload."""
-    return make_pc_sampling_database_analyzer({workload_path: tool_data_records})
+    return make_pc_sampling_database_analyzer(
+        {workload_path: tool_data_records},
+        filter_kernel_ids=filter_kernel_ids,
+        filter_dispatch_ids=filter_dispatch_ids,
+    )
 
 
 def make_counter_backed_database_analyzer(
@@ -1168,7 +1189,9 @@ def test_run_analysis_scopes_pc_sampling_uuids_by_process(db_session):
     analyzer._profiling_config = {"filter_blocks": ["pc_sampling"]}
     analyzer._pc_sampling_tool_data_per_workload = {workload_path: tool_data_records}
     analyzer._dispatch_data_per_workload = {
-        workload_path: analyzer._build_pc_sampling_dispatch_data(tool_data_records)
+        workload_path: analyzer._build_pc_sampling_dispatch_data(
+            tool_data_records, workload
+        )
     }
     analyzer._roofline_data_per_kernel = {}
     analyzer._roofline_data_per_workload = {}
@@ -1772,7 +1795,10 @@ def make_source_export_analyzer(tmp_path, output_format):
             )
         )
         expected_exported_files[
-            Path(workload_name) / "run" / Path(referenced_source_path).relative_to("/")
+            Path(workload_name)
+            / "run"
+            / "source"
+            / Path(referenced_source_path).relative_to("/")
         ] = contents.encode()
 
     analyzer = make_pc_sampling_database_analyzer(tool_data_per_workload)
@@ -1798,6 +1824,18 @@ def run_source_export_analysis(analyzer):
         cleanup_database()
 
 
+def read_exported_source_files(result_path):
+    """Return the exported source files under a CSV result folder."""
+    exported_files = common.read_binary_file_tree(
+        result_path / per_kernel_isa_export.PER_KERNEL_DIRECTORY_NAME
+    )
+    return {
+        exported_path: contents
+        for exported_path, contents in exported_files.items()
+        if source_snapshot_analysis.SOURCE_EXPORT_DIRECTORY_NAME in exported_path.parts
+    }
+
+
 def read_view_csv_files(result_path):
     """Return view CSV contents keyed by filename."""
     return {
@@ -1815,8 +1853,8 @@ def write_view_csv_files_and_capture(
     captured_view_csv_files.update(read_view_csv_files(csv_directory))
 
 
-def test_run_analysis_source_export_is_not_created_for_db_output(tmp_path):
-    """Do not export source snapshots for database output."""
+def test_run_analysis_per_kernel_export_is_not_created_for_db_output(tmp_path):
+    """Do not export per-kernel ISA or source snapshots for database output."""
     analyzer, result_path, _expected_exported_files = make_source_export_analyzer(
         tmp_path,
         "db",
@@ -1829,7 +1867,7 @@ def test_run_analysis_source_export_is_not_created_for_db_output(tmp_path):
 
     export_source_snapshot_files.assert_not_called()
     assert Path(f"{result_path}.db").is_file()
-    assert not (result_path / "source").exists()
+    assert not (result_path / per_kernel_isa_export.PER_KERNEL_DIRECTORY_NAME).exists()
 
 
 def test_run_analysis_source_export_scopes_workloads_and_preserves_view_csvs(
@@ -1866,7 +1904,9 @@ def test_run_analysis_source_export_scopes_workloads_and_preserves_view_csvs(
     # The analyzer names each export folder, rather than the export rederiving
     # it, so a folder cannot drift from the workload row it belongs to.
     export_arguments = export_source_snapshot_files.call_args.kwargs
-    assert export_arguments["csv_result_directory"] == result_path
+    assert (
+        export_arguments["export_directory"] == result_path / "per_kernel_pc_sampling"
+    )
     assert [
         (snapshot.workload_name, snapshot.workload_sub_name)
         for snapshot in export_arguments["workload_source_snapshots"]
@@ -1877,20 +1917,18 @@ def test_run_analysis_source_export_scopes_workloads_and_preserves_view_csvs(
     assert set(view_csvs_after_analysis) == VIEW_CSV_FILENAMES
     assert view_csvs_after_analysis == view_csvs_before_source_export
 
-    source_directory = result_path / "source"
-    assert source_directory.is_dir()
-    assert common.read_binary_file_tree(source_directory) == expected_exported_files
+    exported_source_files = read_exported_source_files(result_path)
+    assert exported_source_files == expected_exported_files
 
     # Every path the CSV records locates its copy by dropping the leading "/".
-    exported_paths = common.read_binary_file_tree(source_directory)
     source_lines_frame = pd.read_csv(result_path / "source_lines.csv")
     assert {
         Path(file_path).relative_to("/")
         for file_path in source_lines_frame["file_path"]
     } == {
-        # The first two components name the workload, not the source file.
-        Path(*exported_path.parts[2:])
-        for exported_path in exported_paths
+        # The first three components name the workload and the source folder.
+        Path(*exported_path.parts[3:])
+        for exported_path in exported_source_files
     }
 
 
@@ -2591,3 +2629,257 @@ def test_run_analysis_keeps_sampled_row_without_a_comment(db_session, tmp_path):
         )
     }
     assert rebuilt_sources == {0x10: "/home/u/app/vcopy.cpp:1", 0x20: None}
+
+
+def make_csv_run_analyzer(tmp_path, tool_data_per_workload, **filters):
+    """Build a CSV-output analyzer over sampling-only workloads."""
+    analyzer = make_pc_sampling_database_analyzer(tool_data_per_workload, **filters)
+    result_path = tmp_path / "csv_analysis"
+    analyzer.get_args().output_name = str(result_path)
+    analyzer.get_args().output_format = "csv"
+    return analyzer, result_path
+
+
+def read_per_kernel_isa_file(result_path, kernel_uuid, code_object_id=5, pid=42):
+    """Return one exported ISA file as its header and its rows."""
+    export_path = (
+        result_path
+        / per_kernel_isa_export.PER_KERNEL_DIRECTORY_NAME
+        / ISA_WORKLOAD_NAME
+        / ISA_WORKLOAD_SUB_NAME
+        / f"kernel_{kernel_uuid}"
+        / f"isa_code_object_id_{code_object_id}_pid_{pid}.csv"
+    )
+    with export_path.open(newline="", encoding="utf-8") as export_file:
+        header, *rows = list(csv.reader(export_file))
+    return header, rows
+
+
+def stall_reason_columns(header):
+    """Return the pivoted stall-reason columns of one ISA header."""
+    return header[header.index("Active thread percent") + 1 : header.index("Source")]
+
+
+def per_kernel_isa_paths(result_path):
+    """Return the exported ISA files, relative to the per-kernel folder."""
+    per_kernel_directory = result_path / per_kernel_isa_export.PER_KERNEL_DIRECTORY_NAME
+    return sorted(
+        str(export_path.relative_to(per_kernel_directory))
+        for export_path in per_kernel_directory.rglob("isa_*.csv")
+    )
+
+
+def test_run_analysis_writes_one_isa_file_per_kernel_code_object_and_process(
+    tmp_path,
+):
+    """A kernel compiled twice, and a code object in two processes, split up."""
+    workload_path = tmp_path / "workloads" / ISA_WORKLOAD_NAME / ISA_WORKLOAD_SUB_NAME
+    first_process_tool_data = make_pc_sampling_tool_data()
+    second_process_tool_data = make_pc_sampling_tool_data()
+    second_process_tool_data["metadata"]["pid"] = 43
+    # The same kernel, sampled a second time out of another code object.
+    other_code_object_tool_data = make_pc_sampling_tool_data()
+    other_code_object_tool_data["metadata"]["pid"] = 44
+    other_code_object_tool_data["code_objects"] = [
+        {"code_object_id": 6, "load_base": 0x2000}
+    ]
+    for sample in other_code_object_tool_data["buffer_records"]["pc_sample_stochastic"]:
+        sample["record"]["pc"]["code_object_id"] = 6
+    for kernel_symbol in other_code_object_tool_data["kernel_symbols"]:
+        kernel_symbol["code_object_id"] = 6
+
+    analyzer, result_path = make_csv_run_analyzer(
+        tmp_path,
+        {
+            str(workload_path): [
+                first_process_tool_data,
+                second_process_tool_data,
+                other_code_object_tool_data,
+            ]
+        },
+    )
+    run_source_export_analysis(analyzer)
+
+    kernel_frame = pd.read_csv(result_path / "kernel.csv")
+    kernel_uuids = dict(
+        zip(kernel_frame["kernel_name"], kernel_frame["kernel_uuid"], strict=True)
+    )
+    assert per_kernel_isa_paths(result_path) == sorted(
+        f"vector_copy/run/kernel_{kernel_uuid}"
+        f"/isa_code_object_id_{code_object_id}_pid_{pid}.csv"
+        for kernel_uuid in kernel_uuids.values()
+        for code_object_id, pid in ((5, 42), (5, 43), (6, 44))
+    )
+
+
+def test_run_analysis_isa_file_carries_the_kernels_sampled_lines(tmp_path):
+    """One kernel's file holds its own offsets, counts and source."""
+    workload_path = tmp_path / "workloads" / ISA_WORKLOAD_NAME / ISA_WORKLOAD_SUB_NAME
+    analyzer, result_path = make_csv_run_analyzer(
+        tmp_path,
+        {str(workload_path): [make_pc_sampling_tool_data()]},
+    )
+    run_source_export_analysis(analyzer)
+
+    kernel_frame = pd.read_csv(result_path / "kernel.csv")
+    kernel_uuids = dict(
+        zip(kernel_frame["kernel_name"], kernel_frame["kernel_uuid"], strict=True)
+    )
+    header, rows = read_per_kernel_isa_file(result_path, kernel_uuids["vecCopy"])
+
+    assert header == [
+        "Instruction line number",
+        "Code object offset",
+        "Instruction line",
+        "Total count",
+        "Active count",
+        "Stall count",
+        "Wave occupancy percent",
+        "Active thread percent",
+        "Stall WAITCNT",
+        "Source",
+        "Code object id",
+        "Pid",
+    ]
+    assert rows == [
+        [
+            "1",
+            str(0x10),
+            "v_mov",
+            "1",
+            "0",
+            "1",
+            "",
+            "",
+            "1",
+            "/s/a.cpp:1",
+            "5",
+            "42",
+        ]
+    ]
+
+
+def test_run_analysis_isa_stall_columns_follow_the_workloads_reasons(tmp_path):
+    """Each observed reason gets a column, empty where it was not seen."""
+    workload_path = tmp_path / "workloads" / ISA_WORKLOAD_NAME / ISA_WORKLOAD_SUB_NAME
+    tool_data = make_pc_sampling_tool_data()
+    tool_data["buffer_records"]["pc_sample_stochastic"][1]["record"]["snapshot"] = {
+        "stall_reason": (
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_SLEEP_WAIT"
+        )
+    }
+    tool_data["buffer_records"]["pc_sample_stochastic"][1]["record"]["wave_issued"] = (
+        False
+    )
+    # Both offsets belong to one kernel, so one file holds both reasons.
+    tool_data["kernel_symbols"][1]["kernel_id"] = 100
+    tool_data["buffer_records"]["kernel_dispatch"][1]["dispatch_info"]["kernel_id"] = (
+        100
+    )
+
+    analyzer, result_path = make_csv_run_analyzer(
+        tmp_path,
+        {str(workload_path): [tool_data]},
+    )
+    run_source_export_analysis(analyzer)
+
+    kernel_uuid = pd.read_csv(result_path / "kernel.csv")["kernel_uuid"].iloc[0]
+    header, rows = read_per_kernel_isa_file(result_path, kernel_uuid)
+
+    assert stall_reason_columns(header) == ["Stall SLEEP_WAIT", "Stall WAITCNT"]
+    sleep_index, waitcnt_index = (
+        header.index("Stall SLEEP_WAIT"),
+        header.index("Stall WAITCNT"),
+    )
+    assert [(row[sleep_index], row[waitcnt_index]) for row in rows] == [
+        ("", "1"),
+        ("1", ""),
+    ]
+
+
+def test_run_analysis_isa_carries_no_stall_columns_for_host_trap(tmp_path):
+    """host_trap records no stall reason, so its files carry no stall column."""
+    workload_path = tmp_path / "workloads" / ISA_WORKLOAD_NAME / ISA_WORKLOAD_SUB_NAME
+    tool_data = make_pc_sampling_tool_data()
+    tool_data["buffer_records"]["pc_sample_host_trap"] = [
+        {
+            "inst_index": 0,
+            "record": {
+                "pc": {"code_object_id": 5, "code_object_offset": 0x10},
+                "dispatch_id": 0,
+            },
+        }
+    ]
+    tool_data["buffer_records"]["pc_sample_stochastic"] = []
+
+    analyzer, result_path = make_csv_run_analyzer(
+        tmp_path,
+        {str(workload_path): [tool_data]},
+    )
+    run_source_export_analysis(analyzer)
+
+    kernel_uuid = pd.read_csv(result_path / "kernel.csv")["kernel_uuid"].iloc[0]
+    header, rows = read_per_kernel_isa_file(result_path, kernel_uuid)
+
+    assert stall_reason_columns(header) == []
+    # host_trap knows the sample landed, but not whether the wave issued.
+    assert rows[0][3:6] == ["1", "", ""]
+
+
+def test_run_analysis_kernel_filter_reaches_a_sampling_only_workload(tmp_path):
+    """-k keeps one kernel's rows, and no code object left with nothing in it."""
+    workload_path = tmp_path / "workloads" / ISA_WORKLOAD_NAME / ISA_WORKLOAD_SUB_NAME
+    tool_data = make_pc_sampling_tool_data()
+    # The filter indexes kernels by descending dispatch duration.
+    tool_data["buffer_records"]["kernel_dispatch"][0]["end_timestamp"] = 10
+    other_code_object_tool_data = make_pc_sampling_tool_data()
+    other_code_object_tool_data["metadata"]["pid"] = 43
+    other_code_object_tool_data["code_objects"] = [
+        {"code_object_id": 6, "load_base": 0x2000}
+    ]
+    # Only the kernel the filter drops was sampled out of this code object.
+    other_code_object_tool_data["buffer_records"]["pc_sample_stochastic"] = [
+        other_code_object_tool_data["buffer_records"]["pc_sample_stochastic"][1]
+    ]
+    other_code_object_tool_data["buffer_records"]["pc_sample_stochastic"][0]["record"][
+        "pc"
+    ]["code_object_id"] = 6
+    for kernel_symbol in other_code_object_tool_data["kernel_symbols"]:
+        kernel_symbol["code_object_id"] = 6
+
+    analyzer, result_path = make_csv_run_analyzer(
+        tmp_path,
+        {str(workload_path): [tool_data, other_code_object_tool_data]},
+        filter_kernel_ids=[0],
+    )
+    run_source_export_analysis(analyzer)
+
+    kernel_frame = pd.read_csv(result_path / "kernel.csv")
+    assert list(kernel_frame["kernel_name"]) == ["vecCopy"]
+    summary_frame = pd.read_csv(result_path / "pc_sampling_summary.csv")
+    assert list(summary_frame["offset"]) == [0x10]
+    # The second code object held only the kernel the filter dropped.
+    assert set(summary_frame["code_object_id"]) == {5}
+    assert per_kernel_isa_paths(result_path) == [
+        f"vector_copy/run/kernel_{kernel_frame['kernel_uuid'].iloc[0]}"
+        "/isa_code_object_id_5_pid_42.csv"
+    ]
+
+
+def test_run_analysis_dispatch_filter_reaches_a_sampling_only_workload(tmp_path):
+    """-d drops a dispatch, and the kernel that keeps none of its own."""
+    workload_path = tmp_path / "workloads" / ISA_WORKLOAD_NAME / ISA_WORKLOAD_SUB_NAME
+    analyzer, result_path = make_csv_run_analyzer(
+        tmp_path,
+        {str(workload_path): [make_pc_sampling_tool_data()]},
+        filter_dispatch_ids=["1"],
+    )
+
+    run_source_export_analysis(analyzer)
+
+    kernel_frame = pd.read_csv(result_path / "kernel.csv")
+    assert list(kernel_frame["kernel_name"]) == ["vecAdd"]
+    assert per_kernel_isa_paths(result_path) == [
+        f"vector_copy/run/kernel_{kernel_frame['kernel_uuid'].iloc[0]}"
+        "/isa_code_object_id_5_pid_42.csv"
+    ]

--- a/projects/rocprofiler-compute/tests/test_analysis_db.py
+++ b/projects/rocprofiler-compute/tests/test_analysis_db.py
@@ -109,6 +109,7 @@ def make_source_frame_collector(workload, workload_path="/fake/workload"):
 
 def make_pc_sampling_database_analyzer(
     tool_data_per_workload,
+    filter_gpu_ids=(),
     filter_kernel_ids=(),
     filter_dispatch_ids=(),
 ):
@@ -120,6 +121,7 @@ def make_pc_sampling_database_analyzer(
     analyzer._runs = {
         workload_path: schema.Workload(
             sys_info=pd.DataFrame([{"gpu_arch": "gfx942"}]),
+            filter_gpu_ids=list(filter_gpu_ids),
             filter_kernel_ids=list(filter_kernel_ids),
             filter_dispatch_ids=list(filter_dispatch_ids),
         )
@@ -2712,12 +2714,19 @@ def test_run_analysis_writes_one_isa_file_per_kernel_code_object_and_process(
     )
 
 
-def test_run_analysis_isa_file_carries_the_kernels_sampled_lines(tmp_path):
-    """One kernel's file holds its own offsets, counts and source."""
+@pytest.mark.parametrize("filter_gpu_ids", [(), ["0"]])
+def test_run_analysis_isa_file_carries_the_kernels_sampled_lines(
+    tmp_path, filter_gpu_ids
+):
+    """One kernel's file holds its own offsets, counts and source.
+
+    Filtering on the workload's own GPU keeps every row it already had.
+    """
     workload_path = tmp_path / "workloads" / ISA_WORKLOAD_NAME / ISA_WORKLOAD_SUB_NAME
     analyzer, result_path = make_csv_run_analyzer(
         tmp_path,
         {str(workload_path): [make_pc_sampling_tool_data()]},
+        filter_gpu_ids=filter_gpu_ids,
     )
     run_source_export_analysis(analyzer)
 
@@ -2866,13 +2875,16 @@ def test_run_analysis_kernel_filter_reaches_a_sampling_only_workload(tmp_path):
     ]
 
 
-def test_run_analysis_dispatch_filter_reaches_a_sampling_only_workload(tmp_path):
+@pytest.mark.parametrize("filter_dispatch_ids", [["1"], [">0"], ["> 0"]])
+def test_run_analysis_dispatch_filter_reaches_a_sampling_only_workload(
+    tmp_path, filter_dispatch_ids
+):
     """-d drops a dispatch, and the kernel that keeps none of its own."""
     workload_path = tmp_path / "workloads" / ISA_WORKLOAD_NAME / ISA_WORKLOAD_SUB_NAME
     analyzer, result_path = make_csv_run_analyzer(
         tmp_path,
         {str(workload_path): [make_pc_sampling_tool_data()]},
-        filter_dispatch_ids=["1"],
+        filter_dispatch_ids=filter_dispatch_ids,
     )
 
     run_source_export_analysis(analyzer)

--- a/projects/rocprofiler-compute/tests/test_analyze_commands.py
+++ b/projects/rocprofiler-compute/tests/test_analyze_commands.py
@@ -1,13 +1,17 @@
 # Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier:  MIT
 
+import csv
 import os
 import shutil
 import tempfile
 from pathlib import Path
 
 import common
+import pandas as pd
 import pytest
+
+from pc_sampling.per_kernel_isa_export import PER_KERNEL_DIRECTORY_NAME
 
 config = {}
 config["cleanup"] = True
@@ -1039,31 +1043,31 @@ def test_list_torch_operators_no_trace_data(
 
 @pytest.mark.misc
 @pytest.mark.parametrize(
-    ("output_format", "output_name", "exports_source_snapshot"),
+    ("output_format", "output_name", "exports_per_kernel_files"),
     [
         pytest.param(
             "csv",
             "pc_sampling_source_csv",
             True,
-            id="csv-exports-source-snapshot",
+            id="csv-exports-isa-and-source",
         ),
         pytest.param(
             "db",
             "pc_sampling_source_db",
             False,
-            id="db-does-not-export-source-snapshot",
+            id="db-exports-neither",
         ),
     ],
 )
-def test_analyze_source_snapshot_output_format(
+def test_analyze_per_kernel_export_output_format(
     binary_handler_analyze_rocprof_compute,
     monkeypatch,
     tmp_path,
     output_format,
     output_name,
-    exports_source_snapshot,
+    exports_per_kernel_files,
 ):
-    """Export source snapshots for CSV output but not database output."""
+    """Export each kernel's ISA and its source for CSV output only."""
     workload_path = setup_pc_sampling_source_workload(tmp_path).resolve()
     output_path = (tmp_path / output_name).resolve()
     monkeypatch.chdir(tmp_path)
@@ -1081,20 +1085,43 @@ def test_analyze_source_snapshot_output_format(
     ])
 
     assert code == 0
-    workload_source_path = (
-        output_path / "source" / SOURCE_WORKLOAD_NAME / SOURCE_WORKLOAD_SUB_NAME
+    workload_export_path = (
+        output_path
+        / PER_KERNEL_DIRECTORY_NAME
+        / SOURCE_WORKLOAD_NAME
+        / SOURCE_WORKLOAD_SUB_NAME
     )
-    if exports_source_snapshot:
-        assert workload_source_path.is_dir()
-        # Every exported file sits under the absolute path the CSV records for
-        # it, so the paths below are the fixture's own capture-host paths.
-        assert set(common.read_binary_file_tree(workload_source_path)) == {
-            Path("app/projects/rocprofiler-compute/sample/vcopy.cpp"),
-            Path(
-                "rocm-venv/lib/python3.12/site-packages/_rocm_sdk_devel"
-                "/include/hip/amd_detail/amd_hip_runtime.h"
-            ),
-        }
-    else:
+    if not exports_per_kernel_files:
         assert output_path.with_suffix(".db").is_file()
-        assert not (output_path / "source").exists()
+        assert not (output_path / PER_KERNEL_DIRECTORY_NAME).exists()
+        return
+
+    # Every exported file sits under the absolute path the CSV records for
+    # it, so the paths below are the fixture's own capture-host paths.
+    assert set(common.read_binary_file_tree(workload_export_path / "source")) == {
+        Path("app/projects/rocprofiler-compute/sample/vcopy.cpp"),
+        Path(
+            "rocm-venv/lib/python3.12/site-packages/_rocm_sdk_devel"
+            "/include/hip/amd_detail/amd_hip_runtime.h"
+        ),
+    }
+
+    # Each ISA folder is one kernel of kernel.csv, named by its recorded uuid.
+    isa_paths = sorted(workload_export_path.rglob("isa_*.csv"))
+    assert isa_paths
+    kernel_frame = pd.read_csv(output_path / "kernel.csv")
+    assert {isa_path.parent.name for isa_path in isa_paths} <= {
+        f"kernel_{kernel_uuid}" for kernel_uuid in kernel_frame["kernel_uuid"]
+    }
+
+    with isa_paths[0].open(newline="", encoding="utf-8") as isa_file:
+        header, *rows = list(csv.reader(isa_file))
+    assert header[:3] == [
+        "Instruction line number",
+        "Code object offset",
+        "Instruction line",
+    ]
+    assert header[-3:] == ["Source", "Code object id", "Pid"]
+    assert [row[0] for row in rows] == [
+        str(line_number) for line_number in range(1, len(rows) + 1)
+    ]

--- a/projects/rocprofiler-compute/tests/test_categories.yaml
+++ b/projects/rocprofiler-compute/tests/test_categories.yaml
@@ -18,6 +18,7 @@ test_categories:
       - test_analysis_orm
       - test_code_object_analysis
       - test_source_snapshot_analysis
+      - test_per_kernel_isa_export
       - test_torch_trace_analysis
       - test_torch_trace_coverage
       - test_L1_cache_counters
@@ -98,6 +99,7 @@ test_categories:
       - test_analysis_orm
       - test_code_object_analysis
       - test_source_snapshot_analysis
+      - test_per_kernel_isa_export
       - test_pc_sampling_analysis
       - test_utils_profile_csv
       - test_csv_compression
@@ -171,6 +173,7 @@ test_categories:
       - test_analysis_orm
       - test_code_object_analysis
       - test_source_snapshot_analysis
+      - test_per_kernel_isa_export
       - test_pc_sampling_analysis
       - test_utils_profile_csv
       - test_csv_compression
@@ -244,6 +247,7 @@ test_categories:
       - test_analysis_orm
       - test_code_object_analysis
       - test_source_snapshot_analysis
+      - test_per_kernel_isa_export
       - test_pc_sampling_analysis
       - test_utils_profile_csv
       - test_csv_compression

--- a/projects/rocprofiler-compute/tests/test_pc_sampling_analysis.py
+++ b/projects/rocprofiler-compute/tests/test_pc_sampling_analysis.py
@@ -1657,7 +1657,7 @@ def test_build_agent_to_gpu_map_empty() -> None:
 def make_db_analysis(workload_path: str) -> db_analysis:
     """Construct a db_analysis whose only populated state is _runs."""
     instance = db_analysis.__new__(db_analysis)
-    instance._runs = {workload_path: None}
+    instance._runs = {workload_path: schema.Workload()}
     return instance
 
 

--- a/projects/rocprofiler-compute/tests/test_per_kernel_isa_export.py
+++ b/projects/rocprofiler-compute/tests/test_per_kernel_isa_export.py
@@ -1,0 +1,199 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
+"""Unit tests for per_kernel_isa_export.py."""
+
+import csv
+from pathlib import Path
+
+from pc_sampling.per_kernel_isa_export import (
+    _build_isa_header,
+    _resolve_isa_export_path,
+    _write_per_kernel_isa_files,
+    export_per_kernel_isa_files,
+)
+
+
+def make_isa_row(
+    kernel_uuid=1,
+    code_object_id=5,
+    pid=42,
+    offset=0x10,
+    instruction="v_mov",
+    total_count=3,
+    issue_count=2,
+    stall_count=1,
+    stall_reason_counts=(),
+    source="/s/a.cpp:1",
+    workload_name="vector_copy",
+    workload_sub_name="MI300X_A1",
+):
+    """Build one row as the per-kernel ISA select returns it."""
+    return (
+        workload_name,
+        workload_sub_name,
+        kernel_uuid,
+        code_object_id,
+        pid,
+        offset,
+        instruction,
+        total_count,
+        issue_count,
+        stall_count,
+        None,
+        None,
+        *stall_reason_counts,
+        source,
+        code_object_id,
+        pid,
+    )
+
+
+def read_exported_rows(export_path):
+    """Return one exported file as a list of string rows."""
+    with export_path.open(newline="", encoding="utf-8") as export_file:
+        return list(csv.reader(export_file))
+
+
+def test_resolve_isa_export_path_names_kernel_code_object_and_process():
+    """One kernel's ISA is filed by uuid, then by the code object and process."""
+    export_path = _resolve_isa_export_path(
+        Path("/results/per_kernel_pc_sampling"),
+        ("vector_copy", "MI300X_A1", 7, 5, 42),
+    )
+
+    assert export_path == Path(
+        "/results/per_kernel_pc_sampling/vector_copy/MI300X_A1"
+        "/kernel_7/isa_code_object_id_5_pid_42.csv"
+    )
+
+
+def test_build_isa_header_places_stall_reasons_between_counts_and_source():
+    """The reasons a workload observed become columns of their own."""
+    header = _build_isa_header(["NONE", "WAITCNT"])
+
+    assert header == [
+        "Instruction line number",
+        "Code object offset",
+        "Instruction line",
+        "Total count",
+        "Active count",
+        "Stall count",
+        "Wave occupancy percent",
+        "Active thread percent",
+        "Stall NONE",
+        "Stall WAITCNT",
+        "Source",
+        "Code object id",
+        "Pid",
+    ]
+
+
+def test_build_isa_header_carries_no_stall_columns_without_reasons():
+    """A host_trap workload records no stall reason, so it gets no column."""
+    header = _build_isa_header([])
+
+    assert "Stall NONE" not in header
+    assert header[-3:] == ["Source", "Code object id", "Pid"]
+
+
+def test_write_per_kernel_isa_files_opens_one_file_per_grouping_key(tmp_path):
+    """A kernel spanning code objects and processes lands in separate files."""
+    isa_rows = [
+        make_isa_row(kernel_uuid=1, code_object_id=5, pid=42),
+        make_isa_row(kernel_uuid=1, code_object_id=6, pid=42),
+        make_isa_row(kernel_uuid=1, code_object_id=6, pid=43),
+        make_isa_row(kernel_uuid=2, code_object_id=6, pid=43),
+    ]
+
+    file_count = _write_per_kernel_isa_files(tmp_path, iter(isa_rows), [])
+
+    assert file_count == 4
+    assert sorted(
+        str(export_path.relative_to(tmp_path))
+        for export_path in tmp_path.rglob("*.csv")
+    ) == [
+        "vector_copy/MI300X_A1/kernel_1/isa_code_object_id_5_pid_42.csv",
+        "vector_copy/MI300X_A1/kernel_1/isa_code_object_id_6_pid_42.csv",
+        "vector_copy/MI300X_A1/kernel_1/isa_code_object_id_6_pid_43.csv",
+        "vector_copy/MI300X_A1/kernel_2/isa_code_object_id_6_pid_43.csv",
+    ]
+
+
+def test_write_per_kernel_isa_files_numbers_instruction_lines_per_file(tmp_path):
+    """Line numbers count the file's own lines, not the kernel's."""
+    isa_rows = [
+        make_isa_row(code_object_id=5, offset=0x10),
+        make_isa_row(code_object_id=5, offset=0x14),
+        make_isa_row(code_object_id=6, offset=0x20),
+    ]
+
+    _write_per_kernel_isa_files(tmp_path, iter(isa_rows), [])
+
+    workload_directory = tmp_path / "vector_copy" / "MI300X_A1" / "kernel_1"
+    first_rows = read_exported_rows(
+        workload_directory / "isa_code_object_id_5_pid_42.csv"
+    )
+    second_rows = read_exported_rows(
+        workload_directory / "isa_code_object_id_6_pid_42.csv"
+    )
+
+    assert [row[0] for row in first_rows[1:]] == ["1", "2"]
+    assert [row[0] for row in second_rows[1:]] == ["1"]
+
+
+def test_write_per_kernel_isa_files_leaves_unsampled_counts_empty(tmp_path):
+    """A disassembled line no sample landed on carries no counts."""
+    isa_rows = [
+        make_isa_row(
+            offset=0x10,
+            total_count=None,
+            issue_count=None,
+            stall_count=None,
+            stall_reason_counts=(None,),
+            source=None,
+        ),
+        make_isa_row(offset=0x14, stall_reason_counts=(4,)),
+    ]
+
+    _write_per_kernel_isa_files(tmp_path, iter(isa_rows), ["WAITCNT"])
+
+    exported_rows = read_exported_rows(
+        tmp_path
+        / "vector_copy"
+        / "MI300X_A1"
+        / "kernel_1"
+        / "isa_code_object_id_5_pid_42.csv"
+    )
+    assert exported_rows[1] == [
+        "1",
+        "16",
+        "v_mov",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "5",
+        "42",
+    ]
+    assert exported_rows[2][3:6] == ["3", "2", "1"]
+    assert exported_rows[2][8] == "4"
+
+
+def test_write_per_kernel_isa_files_writes_nothing_without_rows(tmp_path):
+    """A workload with no instruction lines leaves no folder behind."""
+    file_count = _write_per_kernel_isa_files(tmp_path / "per_kernel", iter([]), [])
+
+    assert file_count == 0
+    assert not (tmp_path / "per_kernel").exists()
+
+
+def test_export_per_kernel_isa_files_returns_the_folder_it_wrote(tmp_path):
+    """The export folder is returned so the source lands beside the ISA."""
+    per_kernel_directory = export_per_kernel_isa_files(tmp_path, [])
+
+    assert per_kernel_directory == tmp_path / "per_kernel_pc_sampling"
+    assert not per_kernel_directory.exists()

--- a/projects/rocprofiler-compute/tests/test_source_snapshot_analysis.py
+++ b/projects/rocprofiler-compute/tests/test_source_snapshot_analysis.py
@@ -182,15 +182,15 @@ def test_export_source_snapshot_files_mirrors_absolute_paths(
         tmp_path / "vector_copy" / "MI300X_A1",
         snapshot_contents_by_absolute_path,
     )
-    csv_result_directory = tmp_path / "csv_result"
+    export_directory = tmp_path / "per_kernel_pc_sampling"
 
     source_snapshot_analysis.export_source_snapshot_files(
         workload_source_snapshots=[workload_source_snapshot],
-        csv_result_directory=csv_result_directory,
+        export_directory=export_directory,
     )
 
     workload_export_directory = (
-        csv_result_directory / "source" / "vector_copy" / "MI300X_A1"
+        export_directory / "vector_copy" / "MI300X_A1" / "source"
     )
     assert (
         common.read_binary_file_tree(workload_export_directory)
@@ -208,15 +208,15 @@ def test_export_source_snapshot_files_copies_only_referenced_paths(tmp_path):
         },
         exported_absolute_paths=("/home/u/app/kernel.cpp",),
     )
-    csv_result_directory = tmp_path / "csv_result"
+    export_directory = tmp_path / "per_kernel_pc_sampling"
 
     source_snapshot_analysis.export_source_snapshot_files(
         workload_source_snapshots=[workload_source_snapshot],
-        csv_result_directory=csv_result_directory,
+        export_directory=export_directory,
     )
 
     workload_export_directory = (
-        csv_result_directory / "source" / "vector_copy" / "MI300X_A1"
+        export_directory / "vector_copy" / "MI300X_A1" / "source"
     )
     assert common.read_binary_file_tree(workload_export_directory) == {
         Path("home/u/app/kernel.cpp"): b"kernel source\n"
@@ -235,16 +235,20 @@ def test_export_source_snapshot_files_keeps_workloads_apart(tmp_path):
             ("second_workload", b"second source\n"),
         )
     ]
-    csv_result_directory = tmp_path / "csv_result"
+    export_directory = tmp_path / "per_kernel_pc_sampling"
 
     source_snapshot_analysis.export_source_snapshot_files(
         workload_source_snapshots=workload_source_snapshots,
-        csv_result_directory=csv_result_directory,
+        export_directory=export_directory,
     )
 
-    assert common.read_binary_file_tree(csv_result_directory / "source") == {
-        Path("first_workload/MI300X_A1/home/u/app/kernel.cpp"): b"first source\n",
-        Path("second_workload/MI300X_A1/home/u/app/kernel.cpp"): b"second source\n",
+    assert common.read_binary_file_tree(export_directory) == {
+        Path(
+            "first_workload/MI300X_A1/source/home/u/app/kernel.cpp"
+        ): b"first source\n",
+        Path(
+            "second_workload/MI300X_A1/source/home/u/app/kernel.cpp"
+        ): b"second source\n",
     }
 
 
@@ -268,15 +272,15 @@ def test_export_source_snapshot_files_is_quiet_for_workload_without_sources(
         tmp_path / "vector_copy" / "MI300X_A1",
         {},
     )
-    csv_result_directory = tmp_path / "csv_result"
+    export_directory = tmp_path / "per_kernel_pc_sampling"
 
     source_snapshot_analysis.export_source_snapshot_files(
         workload_source_snapshots=[workload_source_snapshot],
-        csv_result_directory=csv_result_directory,
+        export_directory=export_directory,
     )
 
     assert warning_messages == []
-    assert not (csv_result_directory / "source").exists()
+    assert not export_directory.exists()
 
 
 def test_export_source_snapshot_files_leaves_exports_writable(tmp_path):
@@ -292,15 +296,15 @@ def test_export_source_snapshot_files_leaves_exports_writable(tmp_path):
     )
     snapshot_path = resolve_snapshot_path(workload_path, "/home/u/app/kernel.cpp")
     snapshot_path.chmod(0o444)
-    csv_result_directory = tmp_path / "csv_result"
+    export_directory = tmp_path / "per_kernel_pc_sampling"
 
     source_snapshot_analysis.export_source_snapshot_files(
         workload_source_snapshots=[workload_source_snapshot],
-        csv_result_directory=csv_result_directory,
+        export_directory=export_directory,
     )
 
     exported_path = resolve_export_path(
-        csv_result_directory / "source" / "vector_copy" / "MI300X_A1",
+        export_directory / "vector_copy" / "MI300X_A1" / "source",
         "/home/u/app/kernel.cpp",
     )
     assert exported_path.read_bytes() == b"kernel source\n"


### PR DESCRIPTION
## Motivation

Write each kernel's disassembly, the samples collected on it, and the source it
was compiled from into the CSV analysis result, completing the stack of #9835,
#9905 and #9978.

Bugfix: `-k` now reaches the database for a PC-sampling-only workload.

Here is an example output of csv analyze format for a sample vcopy workload:  [vcopy_pc_sampling_csv_analyze.tar.gz](https://github.com/user-attachments/files/31036220/vcopy_pc_sampling_csv_analyze.tar.gz)

## Technical Details

- One file per kernel per code object per process under
  `per_kernel_pc_sampling/<workload>/<sub>/kernel_<kernel_uuid>/`, with the
  exported source beside it. `kernel.csv` maps a uuid back to its kernel name.
- Every disassembled line appears, sampled or not; the `Stall <REASON>` columns
  are the reasons that workload's samples carry, so a `host_trap` workload has
  none of them.
- The pivot is compiled per workload and streamed through the raw sqlite3
  cursor; it is not registered as a view, so no schema diagram changes.
- The analysis mode filters move into one frame-level function used by both the
  counter frame and the PC-sampling trace.
- A code object row is created by the first instruction line that survives the
  kernel filter, so a filtered-out code object leaves no row behind.
- Documents the export layout, the columns, and the debug-info requirement for
  source in `docs/how-to/pc_sampling.rst`, linked from the csv bullet in
  `analyze/cli.rst`.
- Restores the changelog entry for the `pc_sampling.csv` and
  `compute_pc_sampling_view` renames made earlier in the stack, which was lost
  when the base branch was rewritten.

## Issue Tracking

JIRA ID: AIPROFCOMP-536

## Test Plan

- `pytest tests/test_per_kernel_isa_export.py tests/test_analysis_db.py
  tests/test_analysis_orm.py tests/test_source_snapshot_analysis.py
  tests/test_pc_sampling_analysis.py tests/test_code_object_analysis.py`
- `rocprof-compute analyze -p <pc-sampled workload> --output-format csv` and
  inspect the exported tree and one ISA file.

## Test Result

Unit tests pass locally, along with the analyze-tier export test in
`test_analyze_commands.py`. Hand-checked the export for the
`vcopy_pc_sampling_only/MI350` fixture: the ISA file carries the sampled
instruction lines with their counts and stall columns, and the source sits
beside it.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.

