### PR TITLE
[rocjitsu] Add checkout-relative ISA regeneration helper

### DIFF
--- a/emulation/rocjitsu/CONTRIBUTING.md
+++ b/emulation/rocjitsu/CONTRIBUTING.md
@@ -105,9 +105,10 @@ When modifying instruction semantics or adding instruction support:
 
 1. Edit `lib/python/amdisa/codegen/_generator.py` (never the generated
    C++ files)
-2. Regenerate with `--multi` mode (see [docs/codegen.md](docs/codegen.md))
-3. Format the generated files with `clang-format`
-4. Stage ALL generated files before committing
+2. Regenerate with `scripts/generate-amdisa.sh` (see
+   [docs/codegen.md](docs/codegen.md)); the helper formats changed generated
+   files through pre-commit
+3. Stage ALL generated files before committing
 
 ## Testing
 

--- a/emulation/rocjitsu/docs/codegen.md
+++ b/emulation/rocjitsu/docs/codegen.md
@@ -21,14 +21,17 @@ XML specification via the `amdisa` Python library in `lib/python/amdisa/`.
 
 ## Installation
 
-Install in editable mode from the rocjitsu project root:
+Create or activate a virtual environment, then install in editable mode from
+the rocjitsu project root together with pre-commit:
 
 ```bash
-pip install -e lib/python/
+python -m pip install -e lib/python/ pre-commit
 ```
 
-This installs `amdisa` and its dependency (`cgen`) into your active
-virtualenv.
+The helper deliberately takes both Python and pre-commit from the same active
+virtual environment. It prepends this checkout's `lib/python/` to `PYTHONPATH`,
+so the generator implementation comes from the same checkout as the helper
+while its installed dependencies come from the environment.
 
 ## MR ISA location
 
@@ -73,13 +76,29 @@ When neither `--gen-isas` nor `--gen-dbt` is specified, both are
 generated.
 
 <!-- \NPI new ISA family: add a `<isa>:$MRISA/amdgpu_isa_<isa>.xml` entry to \
-     each `--multi` invocation in the commands below. -->
+     each manual `--multi` invocation below and to the supported-ISA list in \
+     scripts/generate-amdisa.sh. -->
 
 ## Regenerating everything
 
-All commands are run from the rocjitsu project root. Set `MRISA` to the
-shared MR ISA directory and `GFX1250_MRISA` to the out-of-tree gfx1250
-XML directory:
+The repository helper derives the repository, shared MR ISA, and generated
+output directories from its own location. Activate a Python virtual environment
+containing the generator dependencies and `pre-commit`, then run this command
+from the `rocm-systems` repository root:
+
+```bash
+./emulation/rocjitsu/scripts/generate-amdisa.sh \
+  /path/to/amdgpu_isa_gfx1250.xml
+```
+
+The helper can be invoked from any working directory when given by an
+appropriate relative or absolute path. It discovers the active environment
+through `VIRTUAL_ENV` or the active Python interpreter, then formats changed
+generated files through the repository's pre-commit configuration.
+
+The manual commands below are useful for focused generator development and are
+run from the rocjitsu project root. Set `MRISA` to the shared MR ISA directory
+and `GFX1250_MRISA` to the out-of-tree gfx1250 XML directory:
 
 ```bash
 MRISA=../../shared/machine-readable-isa/isa
@@ -154,6 +173,7 @@ When modifying ISA semantics or adding instruction support:
 
 1. Edit `lib/python/amdisa/codegen/_generator.py` (never the generated
    C++ files)
-2. Regenerate with `--multi` as shown above
-3. Format the generated files with `clang-format`
+2. Regenerate with `scripts/generate-amdisa.sh` or `--multi` as shown above
+3. If you regenerated manually, format the generated files with `clang-format`
+   (the helper formats changed generated files for you)
 4. Stage ALL generated files before committing

--- a/emulation/rocjitsu/scripts/generate-amdisa.sh
+++ b/emulation/rocjitsu/scripts/generate-amdisa.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# Regenerate ISA and DBT sources for every supported AMDGPU ISA, then format
+# changed generated sources through the active virtual environment.
+#
+# Usage:
+#   ./scripts/generate-amdisa.sh /path/to/amdgpu_isa_gfx1250.xml
+
+set -Eeuo pipefail
+
+usage() {
+  printf 'usage: %s GFX1250_ISA_XML\n' "$(basename "$0")"
+}
+
+log() {
+  printf '\n==> %s\n' "$*"
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+if (($# == 1)) && [[ "$1" == "-h" || "$1" == "--help" ]]; then
+  usage
+  exit 0
+fi
+if (($# != 1)); then
+  usage >&2
+  exit 2
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+rocjitsu="$(cd "$script_dir/.." && pwd -P)"
+repo="$(git -C "$script_dir" rev-parse --show-toplevel)" \
+  || die "could not find repository root from $script_dir"
+repo="$(cd "$repo" && pwd -P)"
+isa_xml="$repo/shared/machine-readable-isa/isa"
+gfx1250_xml="$1"
+isa_out="$rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated"
+dbt_out="$rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/generated"
+
+discover_virtualenv() {
+  # Keep the generator and pre-commit installation coupled to one active
+  # virtual environment. PYTHONPATH below selects amdisa from this checkout.
+  if [[ -n "${VIRTUAL_ENV:-}" ]]; then
+    printf '%s\n' "$VIRTUAL_ENV"
+    return
+  fi
+
+  local active_python active_prefix
+  active_python="$(command -v python || true)"
+  if [[ -n "$active_python" ]]; then
+    active_prefix="$(
+      "$active_python" -c \
+        'import sys; print(sys.prefix if sys.prefix != sys.base_prefix else "")'
+    )"
+  fi
+  [[ -n "${active_prefix:-}" ]] \
+    || die "no active Python virtual environment; activate one before running"
+  printf '%s\n' "$active_prefix"
+}
+
+venv="$(discover_virtualenv)"
+python="$venv/bin/python"
+pre_commit="$venv/bin/pre-commit"
+
+# \NPI new ISA family: add its in-tree MR ISA XML to this supported-ISA list.
+isa_entries=(
+  "cdna1:$isa_xml/amdgpu_isa_cdna1.xml"
+  "cdna2:$isa_xml/amdgpu_isa_cdna2.xml"
+  "cdna3:$isa_xml/amdgpu_isa_cdna3.xml"
+  "cdna4:$isa_xml/amdgpu_isa_cdna4.xml"
+  "rdna1:$isa_xml/amdgpu_isa_rdna1.xml"
+  "rdna2:$isa_xml/amdgpu_isa_rdna2.xml"
+  "rdna3:$isa_xml/amdgpu_isa_rdna3.xml"
+  "rdna3_5:$isa_xml/amdgpu_isa_rdna3_5.xml"
+  "rdna4:$isa_xml/amdgpu_isa_rdna4.xml"
+  "gfx1250:$gfx1250_xml"
+)
+
+for dir in "$repo" "$rocjitsu" "$isa_out" "$dbt_out" "$venv"; do
+  [[ -d "$dir" ]] || die "directory not found: $dir"
+done
+for exe in "$python" "$pre_commit"; do
+  [[ -x "$exe" ]] || die "executable not found: $exe"
+done
+for entry in "${isa_entries[@]}"; do
+  [[ -f "${entry#*:}" ]] || die "ISA XML not found: ${entry#*:}"
+done
+
+export PATH="$venv/bin:$PATH"
+export PYTHONPATH="$rocjitsu/lib/python${PYTHONPATH:+:$PYTHONPATH}"
+
+log "Running amdisa generator"
+"$python" -m amdisa \
+  --multi "${isa_entries[@]}" \
+  --isa-output "$isa_out" \
+  --dbt-output "$dbt_out"
+
+isa_rel="${isa_out#"$repo/"}"
+dbt_rel="${dbt_out#"$repo/"}"
+
+log "Formatting generated files"
+generated_files="$(
+  git -C "$repo" ls-files -mo --exclude-standard -- "$isa_rel" "$dbt_rel"
+)"
+format_files=()
+if [[ -n "$generated_files" ]]; then
+  mapfile -t format_files <<<"$generated_files"
+fi
+if ((${#format_files[@]} > 0)); then
+  (
+    cd "$repo"
+    # pre-commit exits nonzero when clang-format rewrites files. Run it again
+    # to distinguish that expected first result from a persistent hook failure.
+    if ! "$pre_commit" run clang-format --files "${format_files[@]}"; then
+      log "Verifying files updated by clang-format"
+      "$pre_commit" run clang-format --files "${format_files[@]}"
+    fi
+  )
+else
+  printf '  no changed generated files to format\n'
+fi


### PR DESCRIPTION
Regeneration callers currently have to provide paths for the shared MR ISA inputs and both generated output trees. This duplicates checkout-specific layout knowledge and allowed output to be written into obsolete target directories after generated sources moved.

Add generate-amdisa.sh as the full-regeneration entry point. Resolve the repository, MR ISA inputs, and generated directories relative to the helper. Use Python and pre-commit from the active virtual environment, and format modified or untracked generated files.

Document the virtual-environment contract and helper-based workflow in the codegen and contributor guidance.