### PR TITLE
docs(hip): enable GitHub source icon link

### DIFF
--- a/projects/hip/docs/conf.py
+++ b/projects/hip/docs/conf.py
@@ -45,7 +45,13 @@ for sphinx_var in ROCmDocs.SPHINX_VARS:
     globals()[sphinx_var] = getattr(docs_core, sphinx_var)
 
 # Enable the per-page Markdown download button.
-html_theme_options["use_download_button"] = True
+html_theme_options.update({
+    "repository_url": "https://github.com/ROCm/rocm-systems",
+    "path_to_docs": "projects/hip/docs",
+    "use_repository_button": True,
+    "use_issues_button": True,
+    "use_download_button": True,
+})
 
 # Add the _extensions directory to Python's search path
 sys.path.append(str(Path(__file__).parent / 'extension'))


### PR DESCRIPTION
## Motivation

Update web documentation to display a GitHub icon link so users can more easily navigate to the GitHub repository and source files.

<img width="1478" height="307" alt="image" src="https://github.com/user-attachments/assets/1f30e733-66f0-46e2-b767-d89fd639842a" />

The GitHub link was previously removed from the global header in https://github.com/ROCm/rocm-docs-core/pull/1575.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Add the following to `html_theme_options` in `docs/conf.py`:
```
    "repository_url": "https://github.com/ROCm/rocm-systems",
    "path_to_docs": "projects/<project>/docs",
    "use_repository_button": True,
    "use_issues_button": True,
```

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

ISSUE ID: AIROCDOC-4235

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Look at https://rocm.docs.amd.com/projects/HIP/en/users-peterjunpark-hip-docs-gh-link/

## Test Result

<!-- Briefly summarize test outcomes. -->

Looks ok

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
