### PR TITLE
Make the fmt char array static to avoid propagating stack usage

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/hip_assert.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/hip_assert.h
@@ -25,7 +25,7 @@ extern "C" __device__ __attribute__((noinline)) __attribute__((weak)) void _wass
 #else /* defined(_WIN32) || defined(_WIN64) */
 extern "C" __device__ __attribute__((noinline)) __attribute__((weak)) void __assert_fail(
     const char* assertion, const char* file, unsigned int line, const char* function) {
-  const char fmt[] = "%s:%u: %s: Device-side assertion `%s' failed.\n";
+  static const char fmt[] = "%s:%u: %s: Device-side assertion `%s' failed.\n";
 
   // strlen is not available as a built-in yet, so we create our own
   // loop in a macro. With a string literal argument, the compiler


### PR DESCRIPTION
## Motivation

Avoids propagating stack usage when using asserts and elides a memcpy of the fmt string from constant to private addrspace. The introduction of fmt char array in https://github.com/ROCm/rocm-systems/commit/c2268df3917d9aad4459cd04c934b9bc161434fc also introduced unnecessary stack usage for the fmt char array that did not happen with the inline literal string variant.

## Technical Details

Change the C++ semantics to use static storage duration

## Issue Tracking

JIRA ID: LCOMPILER-2464

## Test Plan

Compile against kernel assert microbenchmark from ticket and see if stack usage has decreased

## Test Result

Removed the scratch use

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.