### PR TITLE
[hipFile] Implement execution of submitted batch operations.

### DIFF
--- a/projects/hipfile/include/hipfile.h
+++ b/projects/hipfile/include/hipfile.h
@@ -720,7 +720,9 @@ typedef struct hipFileIOParams {
 typedef struct hipFileIOEvents {
     void *cookie; //!< Optionally used to track IO operations (e.g. pointer to corresponding hipFileIOParams)
     hipFileStatus_t status; //!< Status of the batch IO operation
-    size_t          ret;    //!< Number of bytes transferred or POSIX error code if negative
+    size_t          ret;    //!< Number of bytes transferred or error code. Cast to ssize_t to inspect.
+                            //!< If non-negative, number of bytes transferred
+                            //!< If negative, POSIX or hipFileOpError_t error
 } hipFileIOEvents_t;
 
 /*!

--- a/projects/hipfile/src/amd_detail/batch/batch.cpp
+++ b/projects/hipfile/src/amd_detail/batch/batch.cpp
@@ -100,13 +100,13 @@ BatchContext::BatchContext(unsigned _capacity) : capacity{_capacity}
 }
 
 unsigned
-BatchContext::get_capacity() const noexcept
+BatchContext::getCapacity() const noexcept
 {
     return capacity;
 }
 
 void
-BatchContext::submit_operations(const hipFileIOParams_t *params, unsigned num_params)
+BatchContext::submitOperations(const hipFileIOParams_t *params, unsigned num_params)
 {
     std::unique_lock<std::shared_mutex> _ulock{context_mutex};
 

--- a/projects/hipfile/src/amd_detail/batch/batch.cpp
+++ b/projects/hipfile/src/amd_detail/batch/batch.cpp
@@ -5,10 +5,8 @@
 
 #include "batch.h"
 #include "buffer.h"
-#include "context.h"
 #include "file.h"
 #include "hipfile.h"
-#include "state.h"
 
 #include <bit>
 #include <cstddef>
@@ -254,36 +252,18 @@ BatchContext::getCapacity() const noexcept
 }
 
 void
-BatchContext::submitOperations(const hipFileIOParams_t *params, unsigned num_params)
+BatchContext::submitOperations(BatchOperations pending_ops)
 {
     std::unique_lock<std::shared_mutex> _ulock{context_mutex};
 
-    // Check num_params first before doing anything else
-    if (num_params > capacity - outstanding_ops.size()) {
+    if (pending_ops.size() > capacity - outstanding_ops.size()) {
         std::stringstream msg;
         msg << "Submission exceeds the capacity of this context. Number of ops submitted: ";
-        msg << num_params << ". Context capacity: " << capacity << ". Current outstanding ops: ";
+        msg << pending_ops.size() << ". Context capacity: " << capacity << ". Current outstanding ops: ";
         msg << outstanding_ops.size();
         throw std::invalid_argument(msg.str());
     }
 
-    std::vector<std::shared_ptr<BatchOperation>> pending_ops{};
-
-    // It would be more performant to be able to perform multiple lookups
-    // rather than waiting to lock the DriverState lock for each lookup.
-    for (unsigned i = 0; i < num_params; i++) {
-        // Make a copy of the params so another thread cannot modify the operation.
-        auto param_copy = std::make_unique<const hipFileIOParams_t>(params[i]);
-        // flags currently unused. Ambiguous if flags in hipFileBatchIOSubmit is for buffer or
-        // file flags.
-        auto [_file, _buffer] =
-            Context<DriverState>::get()->getFileAndBuffer(param_copy->fh, param_copy->u.batch.devPtr_base);
-        auto op = std::make_shared<BatchOperation>(std::move(param_copy), _buffer, _file);
-
-        pending_ops.push_back(std::move(op));
-    }
-
-    // All submitted operations look valid at this point. Accept them.
     outstanding_ops.insert(pending_ops.begin(), pending_ops.end());
 }
 

--- a/projects/hipfile/src/amd_detail/batch/batch.cpp
+++ b/projects/hipfile/src/amd_detail/batch/batch.cpp
@@ -261,11 +261,7 @@ BatchContext::submitOperations(BatchOperations pending_ops)
     std::unique_lock<std::shared_mutex> _ulock{context_mutex};
 
     if (pending_ops.size() > capacity - outstanding_ops.size()) {
-        std::stringstream msg;
-        msg << "Submission exceeds the capacity of this context. Number of ops submitted: ";
-        msg << pending_ops.size() << ". Context capacity: " << capacity << ". Current outstanding ops: ";
-        msg << outstanding_ops.size();
-        throw std::invalid_argument(msg.str());
+        throw BatchFull();
     }
 
     outstanding_ops.insert(pending_ops.begin(), pending_ops.end());

--- a/projects/hipfile/src/amd_detail/batch/batch.cpp
+++ b/projects/hipfile/src/amd_detail/batch/batch.cpp
@@ -14,6 +14,7 @@
 #include <mutex>
 #include <shared_mutex>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <type_traits>
 #include <unordered_map>
@@ -254,6 +255,9 @@ BatchContext::getCapacity() const noexcept
 void
 BatchContext::submitOperations(BatchOperations pending_ops)
 {
+    if (pending_ops.empty()) {
+        throw std::invalid_argument("ops must not be empty");
+    }
     std::unique_lock<std::shared_mutex> _ulock{context_mutex};
 
     if (pending_ops.size() > capacity - outstanding_ops.size()) {

--- a/projects/hipfile/src/amd_detail/batch/batch.cpp
+++ b/projects/hipfile/src/amd_detail/batch/batch.cpp
@@ -5,8 +5,12 @@
 
 #include "batch.h"
 #include "buffer.h"
+#include "context.h"
 #include "file.h"
 #include "hipfile.h"
+#include "hipfile-private.h"
+#include "state.h"
+#include "thread-pool.h"
 
 #include <bit>
 #include <cstddef>
@@ -229,6 +233,50 @@ BatchOperation::event() const
 }
 
 void
+BatchOperation::run() noexcept
+try {
+    {
+        std::lock_guard<std::mutex> lock{state_mutex};
+        if (std::holds_alternative<Canceled>(state)) {
+            return;
+        }
+        transitionTo(Running{});
+    }
+
+    ssize_t result   = 0;
+    auto    backends = Context<DriverState>::get()->getBackends();
+    try {
+        if (io_params->opcode == hipFileBatchRead) {
+            result = hipFileIo(IoType::Read, file, buffer, io_params->u.batch.size,
+                               io_params->u.batch.file_offset, io_params->u.batch.devPtr_offset, backends);
+        }
+        else {
+            result = hipFileIo(IoType::Write, file, buffer, io_params->u.batch.size,
+                               io_params->u.batch.file_offset, io_params->u.batch.devPtr_offset, backends);
+        }
+        if (result == -1) {
+            result = -errno;
+        }
+    }
+    catch (const Hip::RuntimeError &) {
+        // Return hipFileHipDriverError for HIP runtime errors to avoid
+        // collision with POSIX errors.
+        result = -hipFileHipDriverError;
+    }
+
+    std::lock_guard<std::mutex> lock{state_mutex};
+    if (result >= 0) {
+        transitionTo(Complete{result});
+    }
+    else {
+        transitionTo(Failed{result});
+    }
+}
+catch (...) {
+    recordInternalError();
+}
+
+void
 BatchOperation::recordInternalError()
 {
     std::lock_guard<std::mutex> lock{state_mutex};
@@ -244,7 +292,11 @@ BatchContext::BatchContext(unsigned _capacity) : capacity{_capacity}
     if (_capacity > MAX_SIZE) {
         throw std::invalid_argument("Batch capacity is limited to " + std::to_string(MAX_SIZE));
     }
+
+    task_group = Context<IThreadPool>::get()->makeTaskGroup();
 }
+
+BatchContext::~BatchContext() = default;
 
 unsigned
 BatchContext::getCapacity() const noexcept
@@ -258,13 +310,22 @@ BatchContext::submitOperations(BatchOperations pending_ops)
     if (pending_ops.empty()) {
         throw std::invalid_argument("ops must not be empty");
     }
-    std::unique_lock<std::shared_mutex> _ulock{context_mutex};
+    {
+        std::unique_lock<std::shared_mutex> _ulock{context_mutex};
 
-    if (pending_ops.size() > capacity - outstanding_ops.size()) {
-        throw BatchFull();
+        if (pending_ops.size() > capacity - outstanding_ops.size()) {
+            throw BatchFull();
+        }
+
+        for (const auto &op : pending_ops) {
+            op->markPending();
+        }
+        outstanding_ops.insert(pending_ops.begin(), pending_ops.end());
     }
 
-    outstanding_ops.insert(pending_ops.begin(), pending_ops.end());
+    for (const auto &op : pending_ops) {
+        task_group->run([op]() { op->run(); });
+    }
 }
 
 void

--- a/projects/hipfile/src/amd_detail/batch/batch.cpp
+++ b/projects/hipfile/src/amd_detail/batch/batch.cpp
@@ -24,6 +24,100 @@
 
 namespace hipFile {
 
+using batchOperationState::Canceled;
+using batchOperationState::Complete;
+using batchOperationState::Failed;
+using batchOperationState::Invalid;
+using batchOperationState::OperationState;
+using batchOperationState::Pending;
+using batchOperationState::Running;
+using batchOperationState::Timeout;
+using batchOperationState::Waiting;
+
+InvalidStateTransition::InvalidStateTransition(const char *from, const char *to)
+    : std::logic_error{std::string{"Invalid batch operation state transition: "} + from + " -> " + to}
+{
+}
+
+namespace batchOperationState {
+
+    Pending Waiting::transitionTo(const Pending &next) const
+    {
+        return next;
+    }
+
+    Invalid Waiting::transitionTo(const Invalid &next) const
+    {
+        return next;
+    }
+
+    Failed Waiting::transitionTo(const Failed &next) const
+    {
+        return next;
+    }
+
+    Running Pending::transitionTo(const Running &next) const
+    {
+        return next;
+    }
+
+    Canceled Pending::transitionTo(const Canceled &next) const
+    {
+        return next;
+    }
+
+    Failed Pending::transitionTo(const Failed &next) const
+    {
+        return next;
+    }
+
+    Complete Running::transitionTo(const Complete &next) const
+    {
+        return next;
+    }
+
+    Failed Running::transitionTo(const Failed &next) const
+    {
+        return next;
+    }
+
+    Timeout Running::transitionTo(const Timeout &next) const
+    {
+        return next;
+    }
+
+    Failed Complete::transitionTo(const Failed &next) const
+    {
+        return next;
+    }
+
+    Canceled Canceled::transitionTo(const Canceled &) const
+    {
+        return *this;
+    }
+
+    Failed Canceled::transitionTo(const Failed &next) const
+    {
+        return next;
+    }
+
+    Failed Invalid::transitionTo(const Failed &next) const
+    {
+        return next;
+    }
+
+    Failed Timeout::transitionTo(const Failed &next) const
+    {
+        return next;
+    }
+
+    Failed Failed::transitionTo(const Failed &next) const
+    {
+        return next;
+    }
+
+}
+
 BatchOperation::BatchOperation(std::unique_ptr<const hipFileIOParams_t> params,
                                std::shared_ptr<IBuffer> _buffer, std::shared_ptr<IFile> _file)
     : io_params{std::move(params)}, buffer{std::move(_buffer)}, file{std::move(_file)}
@@ -87,6 +181,60 @@ BatchOperation::BatchOperation(std::unique_ptr<const hipFileIOParams_t> params,
         msg << ". Cookie: " << io_params->cookie;
         throw std::invalid_argument(msg.str());
     }
+}
+
+template <class Next>
+void
+BatchOperation::transitionTo(Next next)
+{
+    state = std::visit([&next](const auto &current) -> OperationState { return current.transitionTo(next); },
+                       state);
+    // Drop references when they're no longer needed
+    if constexpr (Next::isTerminal()) {
+        buffer.reset();
+        file.reset();
+    }
+}
+
+void
+BatchOperation::markPending()
+{
+    std::lock_guard<std::mutex> lock{state_mutex};
+
+    transitionTo(Pending{});
+}
+
+bool
+BatchOperation::tryCancel()
+{
+    std::lock_guard<std::mutex> lock{state_mutex};
+
+    try {
+        transitionTo(Canceled{});
+        return true;
+    }
+    catch (const InvalidStateTransition &) {
+        return false;
+    }
+}
+
+hipFileIOEvents_t
+BatchOperation::event() const
+{
+    std::lock_guard<std::mutex> lock{state_mutex};
+    return std::visit(
+        [this](const auto &current) -> hipFileIOEvents_t {
+            return {io_params->cookie, current.toPublic(), static_cast<size_t>(current.ret())};
+        },
+        state);
+}
+
+void
+BatchOperation::recordInternalError()
+{
+    std::lock_guard<std::mutex> lock{state_mutex};
+
+    transitionTo(Failed{-hipFileInternalError});
 }
 
 BatchContext::BatchContext(unsigned _capacity) : capacity{_capacity}

--- a/projects/hipfile/src/amd_detail/batch/batch.cpp
+++ b/projects/hipfile/src/amd_detail/batch/batch.cpp
@@ -5,8 +5,12 @@
 
 #include "batch.h"
 #include "buffer.h"
+#include "context.h"
 #include "file.h"
 #include "hipfile.h"
+#include "hipfile-private.h"
+#include "state.h"
+#include "thread-pool.h"
 
 #include <bit>
 #include <cstddef>
@@ -229,6 +233,50 @@ BatchOperation::event() const
 }
 
 void
+BatchOperation::run() noexcept
+try {
+    {
+        std::lock_guard<std::mutex> lock{state_mutex};
+        if (std::holds_alternative<Canceled>(state)) {
+            return;
+        }
+        transitionTo(Running{});
+    }
+
+    ssize_t result   = 0;
+    auto    backends = Context<DriverState>::get()->getBackends();
+    try {
+        if (io_params->opcode == hipFileBatchRead) {
+            result = hipFileIo(IoType::Read, file, buffer, io_params->u.batch.size,
+                               io_params->u.batch.file_offset, io_params->u.batch.devPtr_offset, backends);
+        }
+        else {
+            result = hipFileIo(IoType::Write, file, buffer, io_params->u.batch.size,
+                               io_params->u.batch.file_offset, io_params->u.batch.devPtr_offset, backends);
+        }
+        if (result == -1) {
+            result = -errno;
+        }
+    }
+    catch (const Hip::RuntimeError &) {
+        // Return hipFileHipDriverError for HIP runtime errors to avoid
+        // collision with POSIX errors.
+        result = -hipFileHipDriverError;
+    }
+
+    std::lock_guard<std::mutex> lock{state_mutex};
+    if (result >= 0) {
+        transitionTo(Complete{result});
+    }
+    else {
+        transitionTo(Failed{result});
+    }
+}
+catch (...) {
+    recordInternalError();
+}
+
+void
 BatchOperation::recordInternalError()
 {
     std::lock_guard<std::mutex> lock{state_mutex};
@@ -244,7 +292,11 @@ BatchContext::BatchContext(unsigned _capacity) : capacity{_capacity}
     if (_capacity > MAX_SIZE) {
         throw std::invalid_argument("Batch capacity is limited to " + std::to_string(MAX_SIZE));
     }
+
+    task_group = Context<IThreadPool>::get()->makeTaskGroup();
 }
+
+BatchContext::~BatchContext() = default;
 
 unsigned
 BatchContext::getCapacity() const noexcept
@@ -258,13 +310,22 @@ BatchContext::submitOperations(BatchOperations pending_ops)
     if (pending_ops.empty()) {
         throw std::invalid_argument("ops must not be empty");
     }
-    std::unique_lock<std::shared_mutex> _ulock{context_mutex};
+    {
+        std::unique_lock<std::shared_mutex> context_lock{context_mutex};
 
-    if (pending_ops.size() > capacity - outstanding_ops.size()) {
-        throw BatchFull();
+        if (pending_ops.size() > capacity - outstanding_ops.size()) {
+            throw BatchFull();
+        }
+
+        for (const auto &op : pending_ops) {
+            op->markPending();
+        }
+        outstanding_ops.insert(pending_ops.begin(), pending_ops.end());
+
+        for (const auto &op : pending_ops) {
+            task_group->run([op]() { op->run(); });
+        }
     }
-
-    outstanding_ops.insert(pending_ops.begin(), pending_ops.end());
 }
 
 void

--- a/projects/hipfile/src/amd_detail/batch/batch.h
+++ b/projects/hipfile/src/amd_detail/batch/batch.h
@@ -31,6 +31,14 @@ struct InvalidBatchHandle : public std::invalid_argument {
 /// @brief Represents a single IO Request
 class BatchOperation {
 public:
+    // Don't allow copying
+    BatchOperation(const BatchOperation &)            = delete;
+    BatchOperation &operator=(const BatchOperation &) = delete;
+
+    // Don't allow moving
+    BatchOperation(BatchOperation &&)            = delete;
+    BatchOperation &operator=(BatchOperation &&) = delete;
+
     /// @brief Create an operation to handle and track an IO request.
     /// @param [in] params IO parameters
     /// @param [in] buffer Buffer corresponding to params->u.batch.devPtr_base
@@ -61,6 +69,14 @@ public:
 
 class BatchContext : public IBatchContext {
 public:
+    // Don't allow copying
+    BatchContext(const BatchContext &)            = delete;
+    BatchContext &operator=(const BatchContext &) = delete;
+
+    // Don't allow moving
+    BatchContext(BatchContext &&)            = delete;
+    BatchContext &operator=(BatchContext &&) = delete;
+
     ///
     /// @brief Return the max number of concurrent operations supported by this BatchContext.
     ///

--- a/projects/hipfile/src/amd_detail/batch/batch.h
+++ b/projects/hipfile/src/amd_detail/batch/batch.h
@@ -54,9 +54,9 @@ class IBatchContext {
 public:
     static constexpr unsigned MAX_SIZE = 128;
 
-    virtual ~IBatchContext()                                                                 = default;
-    virtual unsigned get_capacity() const noexcept                                           = 0;
-    virtual void     submit_operations(const hipFileIOParams_t *params, unsigned num_params) = 0;
+    virtual ~IBatchContext()                                                                = default;
+    virtual unsigned getCapacity() const noexcept                                           = 0;
+    virtual void     submitOperations(const hipFileIOParams_t *params, unsigned num_params) = 0;
 };
 
 class BatchContext : public IBatchContext {
@@ -66,7 +66,7 @@ public:
     ///
     /// @return The max number of concurrent operations that can be processed by this BatchContext.
     /// @note This may not exceed the value returned by `MAX_SIZE`.
-    unsigned get_capacity() const noexcept override;
+    unsigned getCapacity() const noexcept override;
 
     ///
     /// @brief Submit one or more operations to this Context.
@@ -76,7 +76,7 @@ public:
     /// @note This is an All or None operation. If one submitted operation is not valid, no operations
     ///       will be submitted.
     ///
-    void submit_operations(const hipFileIOParams_t *params, const unsigned num_params) override;
+    void submitOperations(const hipFileIOParams_t *params, const unsigned num_params) override;
 
 private:
     const unsigned capacity;

--- a/projects/hipfile/src/amd_detail/batch/batch.h
+++ b/projects/hipfile/src/amd_detail/batch/batch.h
@@ -309,10 +309,10 @@ private:
     const std::unique_ptr<const hipFileIOParams_t> io_params;
 
     /// @brief A reference to the specified Buffer.
-    std::shared_ptr<const IBuffer> buffer;
+    std::shared_ptr<IBuffer> buffer;
 
     /// @brief A reference to the specified registered File.
-    std::shared_ptr<const IFile> file;
+    std::shared_ptr<IFile> file;
 
     /// @brief Protects operation state.
     mutable std::mutex state_mutex;

--- a/projects/hipfile/src/amd_detail/batch/batch.h
+++ b/projects/hipfile/src/amd_detail/batch/batch.h
@@ -32,6 +32,12 @@ struct InvalidBatchHandle : public std::invalid_argument {
     }
 };
 
+struct BatchFull : public std::invalid_argument {
+    BatchFull() : std::invalid_argument{"Not enough room in batch"}
+    {
+    }
+};
+
 struct InvalidStateTransition : public std::logic_error {
     InvalidStateTransition(const char *from, const char *to);
 };

--- a/projects/hipfile/src/amd_detail/batch/batch.h
+++ b/projects/hipfile/src/amd_detail/batch/batch.h
@@ -15,6 +15,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <variant>
+#include <vector>
 
 namespace hipFile {
 class IBuffer;
@@ -323,13 +324,15 @@ private:
     template <class Next> void transitionTo(Next next);
 };
 
+using BatchOperations = std::vector<std::shared_ptr<BatchOperation>>;
+
 class IBatchContext {
 public:
     static constexpr unsigned MAX_SIZE = 128;
 
-    virtual ~IBatchContext()                                                                = default;
-    virtual unsigned getCapacity() const noexcept                                           = 0;
-    virtual void     submitOperations(const hipFileIOParams_t *params, unsigned num_params) = 0;
+    virtual ~IBatchContext()                               = default;
+    virtual unsigned getCapacity() const noexcept          = 0;
+    virtual void     submitOperations(BatchOperations ops) = 0;
 };
 
 class BatchContext : public IBatchContext {
@@ -351,13 +354,11 @@ public:
 
     ///
     /// @brief Submit one or more operations to this Context.
-    /// @param [in] params     Pointer to the operations to enqueue.
-    /// @param [in] num_params Number of operations to enqueue.
+    /// @param [in] ops Operations to enqueue.
     ///
-    /// @note This is an All or None operation. If one submitted operation is not valid, no operations
-    ///       will be submitted.
+    /// @note This is an All or None operation.
     ///
-    void submitOperations(const hipFileIOParams_t *params, const unsigned num_params) override;
+    void submitOperations(BatchOperations ops) override;
 
 private:
     const unsigned capacity;

--- a/projects/hipfile/src/amd_detail/batch/batch.h
+++ b/projects/hipfile/src/amd_detail/batch/batch.h
@@ -23,6 +23,9 @@ class IBuffer;
 namespace hipFile {
 class IFile;
 }
+namespace hipFile {
+class ITaskGroup;
+}
 
 namespace hipFile {
 
@@ -303,6 +306,9 @@ public:
     /// @return True if the operation now has Canceled state, false otherwise.
     bool tryCancel();
 
+    /// @brief Execute the operation.
+    void run() noexcept;
+
     /// @brief Record an internal execution failure on the operation.
     void recordInternalError();
 
@@ -351,6 +357,8 @@ public:
     BatchContext(BatchContext &&)            = delete;
     BatchContext &operator=(BatchContext &&) = delete;
 
+    ~BatchContext() override;
+
     ///
     /// @brief Return the max number of concurrent operations supported by this BatchContext.
     ///
@@ -378,6 +386,9 @@ private:
     /// application.
     /// shared_ptr as it may need to be passed to a backend.
     std::unordered_set<std::shared_ptr<BatchOperation>> outstanding_ops;
+
+    /// Task group used for all submitted operations owned by this context.
+    std::unique_ptr<ITaskGroup> task_group;
 
     BatchContext(unsigned capacity);
 

--- a/projects/hipfile/src/amd_detail/batch/batch.h
+++ b/projects/hipfile/src/amd_detail/batch/batch.h
@@ -7,11 +7,14 @@
 
 #include "hipfile.h"
 
+#include <cstddef>
 #include <memory>
+#include <mutex>
 #include <shared_mutex>
 #include <stdexcept>
 #include <unordered_map>
 #include <unordered_set>
+#include <variant>
 
 namespace hipFile {
 class IBuffer;
@@ -27,6 +30,246 @@ struct InvalidBatchHandle : public std::invalid_argument {
     {
     }
 };
+
+struct InvalidStateTransition : public std::logic_error {
+    InvalidStateTransition(const char *from, const char *to);
+};
+
+namespace batchOperationState {
+
+    struct Waiting;
+    struct Pending;
+    struct Running;
+    struct Complete;
+    struct Canceled;
+    struct Invalid;
+    struct Timeout;
+    struct Failed;
+
+    template <class Derived> struct StateBase {
+        // Every state must also define:
+        //     static constexpr bool isTerminal() noexcept;
+        // which is true when the operation has reached a final state and will
+        // never run again. It is static so that it can be queried on a state
+        // type that is not default constructible.
+
+        ssize_t ret() const noexcept
+        {
+            return 0;
+        }
+
+        template <class To> [[noreturn]] To transitionTo(const To &to) const
+        {
+            throw InvalidStateTransition{self().name(), to.name()};
+        }
+
+    private:
+        const Derived &self() const noexcept
+        {
+            return static_cast<const Derived &>(*this);
+        }
+    };
+
+    struct Waiting : StateBase<Waiting> {
+        using StateBase<Waiting>::transitionTo;
+
+        const char *name() const noexcept
+        {
+            return "hipFileWaiting";
+        }
+
+        hipFileStatus_t toPublic() const noexcept
+        {
+            return hipFileWaiting;
+        }
+
+        static constexpr bool isTerminal() noexcept
+        {
+            return false;
+        }
+
+        Pending transitionTo(const Pending &next) const;
+        Invalid transitionTo(const Invalid &next) const;
+        Failed  transitionTo(const Failed &next) const;
+    };
+
+    struct Pending : StateBase<Pending> {
+        using StateBase<Pending>::transitionTo;
+
+        const char *name() const noexcept
+        {
+            return "hipFilePending";
+        }
+
+        hipFileStatus_t toPublic() const noexcept
+        {
+            return hipFilePending;
+        }
+
+        static constexpr bool isTerminal() noexcept
+        {
+            return false;
+        }
+
+        Running  transitionTo(const Running &next) const;
+        Canceled transitionTo(const Canceled &next) const;
+        Failed   transitionTo(const Failed &next) const;
+    };
+
+    struct Running : StateBase<Running> {
+        using StateBase<Running>::transitionTo;
+
+        const char *name() const noexcept
+        {
+            return "hipFileRunning";
+        }
+
+        hipFileStatus_t toPublic() const noexcept
+        {
+            return hipFilePending;
+        }
+
+        static constexpr bool isTerminal() noexcept
+        {
+            return false;
+        }
+
+        Complete transitionTo(const Complete &next) const;
+        Failed   transitionTo(const Failed &next) const;
+        Timeout  transitionTo(const Timeout &next) const;
+    };
+
+    struct Complete : StateBase<Complete> {
+        using StateBase<Complete>::transitionTo;
+
+        explicit Complete(ssize_t _num_bytes) : num_bytes{_num_bytes}
+        {
+        }
+
+        const char *name() const noexcept
+        {
+            return "hipFileComplete";
+        }
+
+        hipFileStatus_t toPublic() const noexcept
+        {
+            return hipFileComplete;
+        }
+
+        static constexpr bool isTerminal() noexcept
+        {
+            return true;
+        }
+
+        ssize_t ret() const noexcept
+        {
+            return num_bytes;
+        }
+
+        Failed transitionTo(const Failed &next) const;
+
+        ssize_t num_bytes;
+    };
+
+    struct Canceled : StateBase<Canceled> {
+        using StateBase<Canceled>::transitionTo;
+
+        const char *name() const noexcept
+        {
+            return "hipFileCanceled";
+        }
+
+        hipFileStatus_t toPublic() const noexcept
+        {
+            return hipFileCanceled;
+        }
+
+        static constexpr bool isTerminal() noexcept
+        {
+            return true;
+        }
+
+        Canceled transitionTo(const Canceled &) const;
+        Failed   transitionTo(const Failed &next) const;
+    };
+
+    struct Invalid : StateBase<Invalid> {
+        using StateBase<Invalid>::transitionTo;
+
+        const char *name() const noexcept
+        {
+            return "hipFileInvalid";
+        }
+
+        hipFileStatus_t toPublic() const noexcept
+        {
+            return hipFileInvalid;
+        }
+
+        static constexpr bool isTerminal() noexcept
+        {
+            return true;
+        }
+
+        Failed transitionTo(const Failed &next) const;
+    };
+
+    struct Timeout : StateBase<Timeout> {
+        using StateBase<Timeout>::transitionTo;
+
+        const char *name() const noexcept
+        {
+            return "hipFileTimeout";
+        }
+
+        hipFileStatus_t toPublic() const noexcept
+        {
+            return hipFileTimeout;
+        }
+
+        static constexpr bool isTerminal() noexcept
+        {
+            return true;
+        }
+
+        Failed transitionTo(const Failed &next) const;
+    };
+
+    struct Failed : StateBase<Failed> {
+        using StateBase<Failed>::transitionTo;
+
+        explicit Failed(ssize_t _error) : error{_error}
+        {
+        }
+
+        const char *name() const noexcept
+        {
+            return "hipFileFailed";
+        }
+
+        hipFileStatus_t toPublic() const noexcept
+        {
+            return hipFileFailed;
+        }
+
+        static constexpr bool isTerminal() noexcept
+        {
+            return true;
+        }
+
+        ssize_t ret() const noexcept
+        {
+            return error;
+        }
+
+        Failed transitionTo(const Failed &next) const;
+
+        ssize_t error;
+    };
+
+    using OperationState =
+        std::variant<Waiting, Pending, Running, Complete, Canceled, Invalid, Timeout, Failed>;
+}
 
 /// @brief Represents a single IO Request
 class BatchOperation {
@@ -46,16 +289,38 @@ public:
     BatchOperation(std::unique_ptr<const hipFileIOParams_t> params, std::shared_ptr<IBuffer> buffer,
                    std::shared_ptr<IFile> file);
 
+    /// @brief Mark the operation as accepted and ready to run.
+    void markPending();
+
+    /// @brief Cancel the operation if it can be transitioned to Canceled; otherwise no-op.
+    /// @return True if the operation now has Canceled state, false otherwise.
+    bool tryCancel();
+
+    /// @brief Record an internal execution failure on the operation.
+    void recordInternalError();
+
+    /// @brief Return a snapshot of the operation event state.
+    hipFileIOEvents_t event() const;
+
 private:
     /// @brief A copy of the params provided by the application.
     /// @internal Keep this listed at the top of BatchOperation.
     const std::unique_ptr<const hipFileIOParams_t> io_params;
 
     /// @brief A reference to the specified Buffer.
-    const std::shared_ptr<const IBuffer> buffer;
+    std::shared_ptr<const IBuffer> buffer;
 
     /// @brief A reference to the specified registered File.
-    const std::shared_ptr<const IFile> file;
+    std::shared_ptr<const IFile> file;
+
+    /// @brief Protects operation state.
+    mutable std::mutex state_mutex;
+
+    /// @brief Current operation state.
+    batchOperationState::OperationState state{batchOperationState::Waiting{}};
+
+    /// @brief Move to the next operation state. Caller must hold state_mutex.
+    template <class Next> void transitionTo(Next next);
 };
 
 class IBatchContext {

--- a/projects/hipfile/src/amd_detail/hipfile-private.h
+++ b/projects/hipfile/src/amd_detail/hipfile-private.h
@@ -13,7 +13,13 @@
 
 namespace hipFile {
 enum class IoType;
+class IBuffer;
+class IFile;
 struct Backend;
+
+ssize_t hipFileIo(hipFile::IoType type, std::shared_ptr<hipFile::IFile> file,
+                  std::shared_ptr<hipFile::IBuffer> buffer, size_t size, hoff_t file_offset,
+                  hoff_t buffer_offset, const std::vector<std::shared_ptr<hipFile::Backend>> &backends);
 
 ssize_t hipFileIo(hipFile::IoType type, hipFileHandle_t fh, const void *buffer_base, size_t size,
                   hoff_t file_offset, hoff_t buffer_offset,

--- a/projects/hipfile/src/amd_detail/hipfile.cpp
+++ b/projects/hipfile/src/amd_detail/hipfile.cpp
@@ -430,9 +430,30 @@ try {
     }
 
     std::shared_ptr<IBatchContext> batch_context = Context<DriverState>::get()->getBatchContext(batch_idp);
-    batch_context->submitOperations(iocbp, nr);
+    BatchOperations                pending_ops{};
+    pending_ops.reserve(nr);
+
+    for (unsigned i = 0; i < nr; i++) {
+        // Make a copy so another thread cannot modify an accepted operation.
+        auto param_copy = std::make_unique<const hipFileIOParams_t>(iocbp[i]);
+        auto [file, buffer] =
+            Context<DriverState>::get()->getFileAndBuffer(param_copy->fh, param_copy->u.batch.devPtr_base);
+        pending_ops.push_back(
+            std::make_shared<BatchOperation>(std::move(param_copy), std::move(buffer), std::move(file)));
+    }
+
+    batch_context->submitOperations(std::move(pending_ops));
 
     return {hipFileSuccess, hipSuccess};
+}
+catch (const DriverNotInitialized &) {
+    return {hipFileDriverNotInitialized, hipSuccess};
+}
+catch (const InvalidMemoryType &) {
+    return {hipFileHipMemoryTypeInvalid, hipSuccess};
+}
+catch (const FileNotRegistered &) {
+    return {hipFileHandleNotRegistered, hipSuccess};
 }
 catch (const std::invalid_argument &) {
     return {hipFileInvalidValue, hipSuccess};

--- a/projects/hipfile/src/amd_detail/hipfile.cpp
+++ b/projects/hipfile/src/amd_detail/hipfile.cpp
@@ -446,6 +446,9 @@ try {
 
     return {hipFileSuccess, hipSuccess};
 }
+catch (const BatchFull &) {
+    return {hipFileBatchFull, hipSuccess};
+}
 catch (const DriverNotInitialized &) {
     return {hipFileDriverNotInitialized, hipSuccess};
 }

--- a/projects/hipfile/src/amd_detail/hipfile.cpp
+++ b/projects/hipfile/src/amd_detail/hipfile.cpp
@@ -425,7 +425,7 @@ try {
     hipFileInit();
     (void)flags; // Unused at this time.
 
-    if (iocbp == nullptr && nr > 0) {
+    if (nr == 0 || iocbp == nullptr) {
         return {hipFileInvalidValue, hipSuccess};
     }
 

--- a/projects/hipfile/src/amd_detail/hipfile.cpp
+++ b/projects/hipfile/src/amd_detail/hipfile.cpp
@@ -208,11 +208,9 @@ selectBackend(const vector<shared_ptr<Backend>> &backends, const shared_ptr<IFil
 }
 
 ssize_t
-hipFileIo(IoType type, hipFileHandle_t fh, const void *buffer_base, size_t size, hoff_t file_offset,
-          hoff_t buffer_offset, const vector<shared_ptr<Backend>> &backends)
+hipFileIo(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,
+          hoff_t file_offset, hoff_t buffer_offset, const vector<shared_ptr<Backend>> &backends)
 try {
-    auto [file, buffer] = Context<DriverState>::get()->getFileAndBuffer(fh, buffer_base);
-
     if (file_offset < 0 || buffer_offset < 0) {
         throw std::system_error(EINVAL, std::generic_category());
     }
@@ -221,11 +219,32 @@ try {
 
     return backend->io(type, std::move(file), std::move(buffer), size, file_offset, buffer_offset);
 }
-catch (const DriverNotInitialized &) {
-    return -hipFileDriverNotInitialized;
-}
 catch (hipFileError_t e) {
     return -e.err;
+}
+catch (const Hip::RuntimeError &) {
+    throw;
+}
+catch (const std::system_error &e) {
+    errno = e.code().value();
+    return -1;
+}
+catch (const std::invalid_argument &) {
+    return -hipFileInvalidValue;
+}
+catch (...) {
+    return -hipFileInternalError;
+}
+
+ssize_t
+hipFileIo(IoType type, hipFileHandle_t fh, const void *buffer_base, size_t size, hoff_t file_offset,
+          hoff_t buffer_offset, const vector<shared_ptr<Backend>> &backends)
+try {
+    auto [file, buffer] = Context<DriverState>::get()->getFileAndBuffer(fh, buffer_base);
+    return hipFileIo(type, std::move(file), std::move(buffer), size, file_offset, buffer_offset, backends);
+}
+catch (const DriverNotInitialized &) {
+    return -hipFileDriverNotInitialized;
 }
 catch (const InvalidMemoryType &) {
     return -hipFileHipMemoryTypeInvalid;
@@ -238,10 +257,6 @@ catch (const FileNotRegistered &) {
 }
 catch (const Hip::RuntimeError &e) {
     return -e.error;
-}
-catch (const std::system_error &e) {
-    errno = e.code().value();
-    return -1;
 }
 catch (...) {
     return -hipFileInternalError;

--- a/projects/hipfile/src/amd_detail/hipfile.cpp
+++ b/projects/hipfile/src/amd_detail/hipfile.cpp
@@ -415,7 +415,7 @@ try {
     }
 
     std::shared_ptr<IBatchContext> batch_context = Context<DriverState>::get()->getBatchContext(batch_idp);
-    batch_context->submit_operations(iocbp, nr);
+    batch_context->submitOperations(iocbp, nr);
 
     return {hipFileSuccess, hipSuccess};
 }

--- a/projects/hipfile/test/amd_detail/batch/batch.cpp
+++ b/projects/hipfile/test/amd_detail/batch/batch.cpp
@@ -12,7 +12,11 @@
 #include "invalid-enum.h"
 #include "mbuffer.h"
 #include "mfile.h"
+#include "mstate.h"
+#include "mthread-pool.h"
+#include "state.h"
 
+#include <functional>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <limits>
@@ -21,23 +25,29 @@
 #include <utility>
 #include <vector>
 
+using ::testing::_;
+using ::testing::ByMove;
 using ::testing::Return;
 using ::testing::StrictMock;
+using ::testing::Throw;
 
 using namespace hipFile;
 
 HIPFILE_WARN_NO_GLOBAL_CTOR_OFF
 
 struct HipFileBatch : public HipFileUnopened {
-    BatchContextMap                      batch_map = BatchContextMap{};
-    std::unique_ptr<hipFileIOParams_t>   io_params;
-    std::shared_ptr<StrictMock<MBuffer>> default_mock_buffer;
-    std::shared_ptr<StrictMock<MFile>>   default_mock_file;
-    const hipFileHandle_t                file_handle{reinterpret_cast<void *>(0xDEADBEEF)};
-    void *const                          buffer_pointer{reinterpret_cast<void *>(0x0BADF00D)};
+    BatchContextMap                           batch_map = BatchContextMap{};
+    std::unique_ptr<hipFileIOParams_t>        io_params;
+    std::unique_ptr<StrictMock<MDriverState>> mock_driver_state;
+    std::shared_ptr<StrictMock<MBuffer>>      default_mock_buffer;
+    std::shared_ptr<StrictMock<MFile>>        default_mock_file;
+    const hipFileHandle_t                     file_handle{reinterpret_cast<void *>(0xDEADBEEF)};
+    void *const                               buffer_pointer{reinterpret_cast<void *>(0x0BADF00D)};
+    int                                       cookie{};
 
     void SetUp() override
     {
+        mock_driver_state   = std::make_unique<StrictMock<MDriverState>>();
         default_mock_buffer = std::make_shared<StrictMock<MBuffer>>();
         EXPECT_CALL(*default_mock_buffer, getBuffer).WillRepeatedly(Return(buffer_pointer));
         EXPECT_CALL(*default_mock_buffer, getLength).WillRepeatedly(Return(1));
@@ -51,6 +61,7 @@ struct HipFileBatch : public HipFileUnopened {
         io_params->fh                  = file_handle;
         io_params->mode                = hipFileBatch;
         io_params->opcode              = hipFileBatchRead;
+        io_params->cookie              = &cookie;
     }
 };
 
@@ -146,6 +157,32 @@ TEST_F(HipFileBatch, MarkPendingCanceledOperationThrowsInvalidStateTransition)
     ASSERT_THROW(op.markPending(), InvalidStateTransition);
 
     ASSERT_EQ(op.event().status, hipFileCanceled);
+}
+
+TEST_F(HipFileBatch, RunCanceledOperationReturnsImmediately)
+{
+    BatchOperation op = BatchOperation{std::move(io_params), default_mock_buffer, default_mock_file};
+
+    op.markPending();
+    op.tryCancel();
+    EXPECT_CALL(*mock_driver_state, getBackends).Times(0);
+    op.run();
+
+    hipFileIOEvents_t event = op.event();
+    ASSERT_EQ(event.status, hipFileCanceled);
+}
+
+TEST_F(HipFileBatch, RunInternalStateErrorRecordsFailedEvent)
+{
+    BatchOperation op = BatchOperation{std::move(io_params), default_mock_buffer, default_mock_file};
+
+    // Running waiting op results in invalid transition
+    op.run();
+
+    hipFileIOEvents_t event = op.event();
+    ASSERT_EQ(event.status, hipFileFailed);
+    ASSERT_EQ(event.ret, static_cast<size_t>(-hipFileInternalError));
+    ASSERT_EQ(event.cookie, &cookie);
 }
 
 TEST_F(HipFileBatch, CreateOperationBadBuffer)
@@ -295,9 +332,12 @@ TEST_F(HipFileBatch, GetDestroyedContext)
 }
 
 struct HipFileBatchContext : public HipFileUnopened {
-    BatchContextMap                batch_map = BatchContextMap{};
-    std::shared_ptr<IBatchContext> _context;
-    unsigned                       _context_capacity = 2;
+    BatchContextMap                           batch_map = BatchContextMap{};
+    std::shared_ptr<IBatchContext>            _context;
+    unsigned                                  _context_capacity = 2;
+    std::unique_ptr<StrictMock<MDriverState>> mock_driver_state;
+    std::unique_ptr<StrictMock<MThreadPool>>  mock_thread_pool;
+    StrictMock<MTaskGroup>                   *mock_task_group = nullptr;
 
     hipFileIOParams_t                    io_params{};
     std::shared_ptr<StrictMock<MBuffer>> default_mock_buffer;
@@ -318,7 +358,18 @@ struct HipFileBatchContext : public HipFileUnopened {
         io_params.mode                = hipFileBatch;
         io_params.opcode              = hipFileBatchRead;
 
-        _context = batch_map.get(batch_map.createContext(_context_capacity));
+        mock_driver_state = std::make_unique<StrictMock<MDriverState>>();
+        mock_thread_pool  = std::make_unique<StrictMock<MThreadPool>>();
+        mock_task_group   = expectTaskGroupCreated();
+        _context          = batch_map.get(batch_map.createContext(_context_capacity));
+    }
+
+    StrictMock<MTaskGroup> *expectTaskGroupCreated()
+    {
+        auto task_group = std::make_unique<StrictMock<MTaskGroup>>();
+        auto raw        = task_group.get();
+        EXPECT_CALL(*mock_thread_pool, makeTaskGroup()).WillOnce(Return(ByMove(std::move(task_group))));
+        return raw;
     }
 
     std::shared_ptr<BatchOperation> makeOperation()
@@ -330,12 +381,41 @@ struct HipFileBatchContext : public HipFileUnopened {
 
 TEST_F(HipFileBatchContext, SubmitSingleGoodOp)
 {
-    _context->submitOperations(BatchOperations{makeOperation()});
+    EXPECT_CALL(*mock_task_group, run(_)).Times(1);
+
+    ASSERT_NO_THROW(_context->submitOperations(BatchOperations{makeOperation()}));
+}
+
+TEST_F(HipFileBatchContext, SubmitMultipleGoodOps)
+{
+    EXPECT_CALL(*mock_task_group, run(_)).Times(2);
+
+    ASSERT_NO_THROW(_context->submitOperations(BatchOperations{makeOperation(), makeOperation()}));
 }
 
 TEST_F(HipFileBatchContext, EmptyOperationsThrows)
 {
     ASSERT_THROW(_context->submitOperations({}), std::invalid_argument);
+}
+
+TEST_F(HipFileBatchContext, SubmittedOperationRunsFromQueuedWork)
+{
+    std::function<void()> enqueued_work;
+    auto                  op = makeOperation();
+
+    EXPECT_CALL(*mock_task_group, run(_)).WillOnce([&enqueued_work](std::function<void()> work) {
+        enqueued_work = std::move(work);
+    });
+
+    _context->submitOperations(BatchOperations{op});
+    ASSERT_TRUE(enqueued_work);
+    ASSERT_EQ(op->event().status, hipFilePending);
+
+    // Op will have state set to failed when run and IO has no backends
+    EXPECT_CALL(*mock_driver_state, getBackends).WillOnce(Return(std::vector<std::shared_ptr<Backend>>{}));
+    enqueued_work();
+
+    ASSERT_EQ(op->event().status, hipFileFailed);
 }
 
 TEST_F(HipFileBatchContext, SubmitOverCapacity)
@@ -350,6 +430,8 @@ TEST_F(HipFileBatchContext, SubmitOverCapacity)
 
 TEST_F(HipFileBatchContext, SubmitOverCapacityOverMultipleSubmissions)
 {
+    EXPECT_CALL(*mock_task_group, run(_)).Times(static_cast<int>(_context_capacity));
+
     for (unsigned i = 0; i < _context_capacity; i++) {
         _context->submitOperations(BatchOperations{makeOperation()});
     }

--- a/projects/hipfile/test/amd_detail/batch/batch.cpp
+++ b/projects/hipfile/test/amd_detail/batch/batch.cpp
@@ -333,9 +333,9 @@ TEST_F(HipFileBatchContext, SubmitSingleGoodOp)
     _context->submitOperations(BatchOperations{makeOperation()});
 }
 
-TEST_F(HipFileBatchContext, SubmitZeroOperations)
+TEST_F(HipFileBatchContext, EmptyOperationsThrows)
 {
-    _context->submitOperations({});
+    ASSERT_THROW(_context->submitOperations({}), std::invalid_argument);
 }
 
 TEST_F(HipFileBatchContext, SubmitOverCapacity)

--- a/projects/hipfile/test/amd_detail/batch/batch.cpp
+++ b/projects/hipfile/test/amd_detail/batch/batch.cpp
@@ -12,22 +12,17 @@
 #include "invalid-enum.h"
 #include "mbuffer.h"
 #include "mfile.h"
-#include "mstate.h"
-#include "state.h"
 
-#include <cstdio>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <limits>
 #include <memory>
 #include <stdexcept>
 #include <utility>
+#include <vector>
 
-using ::testing::_;
-using ::testing::DoDefault;
 using ::testing::Return;
 using ::testing::StrictMock;
-using ::testing::Throw;
 
 using namespace hipFile;
 
@@ -300,26 +295,22 @@ TEST_F(HipFileBatch, GetDestroyedContext)
 }
 
 struct HipFileBatchContext : public HipFileUnopened {
-    BatchContextMap                           batch_map = BatchContextMap{};
-    std::shared_ptr<IBatchContext>            _context;
-    unsigned                                  _context_capacity = 2;
-    std::unique_ptr<StrictMock<MDriverState>> mock_driver_state;
+    BatchContextMap                batch_map = BatchContextMap{};
+    std::shared_ptr<IBatchContext> _context;
+    unsigned                       _context_capacity = 2;
 
     hipFileIOParams_t                    io_params{};
     std::shared_ptr<StrictMock<MBuffer>> default_mock_buffer;
-    int                                  default_mock_buffer_length = 1;
     std::shared_ptr<StrictMock<MFile>>   default_mock_file;
 
     void SetUp() override
     {
         default_mock_buffer = std::make_shared<StrictMock<MBuffer>>();
         EXPECT_CALL(*default_mock_buffer, getBuffer).WillRepeatedly(Return(reinterpret_cast<void *>(0x123)));
-        EXPECT_CALL(*default_mock_buffer, getLength).WillRepeatedly(Return(default_mock_buffer_length));
+        EXPECT_CALL(*default_mock_buffer, getLength).WillRepeatedly(Return(1));
 
         default_mock_file = std::make_shared<StrictMock<MFile>>();
         EXPECT_CALL(*default_mock_file, handle).WillRepeatedly(Return(default_mock_file.get()));
-
-        file_buffer_pair default_fb_pair = {default_mock_file, default_mock_buffer};
 
         io_params.u.batch.devPtr_base = default_mock_buffer->getBuffer();
         io_params.u.batch.size        = 1;
@@ -327,94 +318,43 @@ struct HipFileBatchContext : public HipFileUnopened {
         io_params.mode                = hipFileBatch;
         io_params.opcode              = hipFileBatchRead;
 
-        mock_driver_state = std::make_unique<StrictMock<MDriverState>>();
-        _context          = batch_map.get(batch_map.createContext(_context_capacity));
-        // May be overridden with EXPECT_CALL in the test.
-        EXPECT_CALL(*mock_driver_state, getFileAndBuffer).WillRepeatedly(Return(std::move(default_fb_pair)));
+        _context = batch_map.get(batch_map.createContext(_context_capacity));
+    }
+
+    std::shared_ptr<BatchOperation> makeOperation()
+    {
+        return std::make_shared<BatchOperation>(std::make_unique<const hipFileIOParams_t>(io_params),
+                                                default_mock_buffer, default_mock_file);
     }
 };
 
 TEST_F(HipFileBatchContext, SubmitSingleGoodOp)
 {
-    _context->submitOperations(&io_params, 1);
+    _context->submitOperations(BatchOperations{makeOperation()});
 }
 
 TEST_F(HipFileBatchContext, SubmitZeroOperations)
 {
-    _context->submitOperations(nullptr, 0);
+    _context->submitOperations({});
 }
 
 TEST_F(HipFileBatchContext, SubmitOverCapacity)
 {
-    // We should fail before we ever try touching the nullptr.
-    ASSERT_THROW(_context->submitOperations(nullptr, _context_capacity + 1), std::invalid_argument);
+    BatchOperations ops;
+    for (unsigned i = 0; i <= _context_capacity; i++) {
+        ops.push_back(makeOperation());
+    }
+
+    ASSERT_THROW(_context->submitOperations(std::move(ops)), std::invalid_argument);
 }
 
 TEST_F(HipFileBatchContext, SubmitOverCapacityOverMultipleSubmissions)
 {
-    // Submit one at a time up to the capacity.
-    // In the future we might care that we are submitting the same operation.
     for (unsigned i = 0; i < _context_capacity; i++) {
-        printf("i: %u\n", i);
-        _context->submitOperations(&io_params, 1);
+        _context->submitOperations(BatchOperations{makeOperation()});
     }
 
-    ASSERT_THROW(_context->submitOperations(nullptr, 1), std::invalid_argument);
-}
-
-TEST_F(HipFileBatchContext, SubmitSingleBadBuffer)
-{
-    EXPECT_CALL(*mock_driver_state, getFileAndBuffer).WillOnce(Throw(BufferNotRegistered()));
-    ASSERT_THROW(_context->submitOperations(&io_params, 1), BufferNotRegistered);
-}
-
-TEST_F(HipFileBatchContext, SubmitSingleBadFileHandle)
-{
-    EXPECT_CALL(*mock_driver_state, getFileAndBuffer).WillOnce(Throw(FileNotRegistered()));
-    ASSERT_THROW(_context->submitOperations(&io_params, 1), FileNotRegistered);
-}
-
-// BatchOperation is not mocked.
-TEST_F(HipFileBatchContext, SubmitSingleBadParamBufferOffsetNegative)
-{
-    hipFileIOParams_t bad_io_params     = io_params;
-    bad_io_params.u.batch.devPtr_offset = -1;
-    ASSERT_THROW(_context->submitOperations(&bad_io_params, 1), std::invalid_argument);
-}
-
-TEST_F(HipFileBatchContext, SubmitSingleBadParamBufferOffsetTooLarge)
-{
-    hipFileIOParams_t bad_io_params     = io_params;
-    bad_io_params.u.batch.devPtr_offset = default_mock_buffer_length;
-    ASSERT_THROW(_context->submitOperations(&bad_io_params, 1), std::invalid_argument);
-}
-
-TEST_F(HipFileBatchContext, SubmitSingleBadParamIOSizeTooLarge)
-{
-    hipFileIOParams_t bad_io_params = io_params;
-    bad_io_params.u.batch.size      = static_cast<size_t>(default_mock_buffer_length + 1);
-    ASSERT_THROW(_context->submitOperations(&bad_io_params, 1), std::invalid_argument);
-}
-
-TEST_F(HipFileBatchContext, SubmitSingleBadParamFileOffsetNegative)
-{
-    hipFileIOParams_t bad_io_params   = io_params;
-    bad_io_params.u.batch.file_offset = -1;
-    ASSERT_THROW(_context->submitOperations(&bad_io_params, 1), std::invalid_argument);
-}
-
-TEST_F(HipFileBatchContext, SubmitSingleBadParamOpcodeInvalid)
-{
-    hipFileIOParams_t bad_io_params = io_params;
-    bad_io_params.opcode            = invalidEnum<hipFileOpcode_t>(maxEnum<hipFileOpcode_t>());
-    ASSERT_THROW(_context->submitOperations(&bad_io_params, 1), std::invalid_argument);
-}
-
-TEST_F(HipFileBatchContext, SubmitSingleBadParamModeInvalid)
-{
-    hipFileIOParams_t bad_io_params = io_params;
-    bad_io_params.mode              = invalidEnum<hipFileBatchMode_t>(maxEnum<hipFileBatchMode_t>());
-    ASSERT_THROW(_context->submitOperations(&bad_io_params, 1), std::invalid_argument);
+    ASSERT_THROW(_context->submitOperations(BatchOperations{makeOperation()}), std::invalid_argument);
 }
 
 HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/projects/hipfile/test/amd_detail/batch/batch.cpp
+++ b/projects/hipfile/test/amd_detail/batch/batch.cpp
@@ -57,11 +57,6 @@ struct HipFileBatch : public HipFileUnopened {
         io_params->mode                = hipFileBatch;
         io_params->opcode              = hipFileBatchRead;
     }
-
-    HipFileBatch()
-    {
-        batch_map.clear();
-    }
 };
 
 TEST_F(HipFileBatch, CreateOperationRead)
@@ -336,12 +331,6 @@ struct HipFileBatchContext : public HipFileUnopened {
         _context          = batch_map.get(batch_map.createContext(_context_capacity));
         // May be overridden with EXPECT_CALL in the test.
         EXPECT_CALL(*mock_driver_state, getFileAndBuffer).WillRepeatedly(Return(std::move(default_fb_pair)));
-    }
-
-    void TearDown() override
-    {
-        batch_map.destroyContext(_context.get());
-        mock_driver_state.reset();
     }
 };
 

--- a/projects/hipfile/test/amd_detail/batch/batch.cpp
+++ b/projects/hipfile/test/amd_detail/batch/batch.cpp
@@ -345,7 +345,7 @@ TEST_F(HipFileBatchContext, SubmitOverCapacity)
         ops.push_back(makeOperation());
     }
 
-    ASSERT_THROW(_context->submitOperations(std::move(ops)), std::invalid_argument);
+    ASSERT_THROW(_context->submitOperations(std::move(ops)), BatchFull);
 }
 
 TEST_F(HipFileBatchContext, SubmitOverCapacityOverMultipleSubmissions)
@@ -354,7 +354,7 @@ TEST_F(HipFileBatchContext, SubmitOverCapacityOverMultipleSubmissions)
         _context->submitOperations(BatchOperations{makeOperation()});
     }
 
-    ASSERT_THROW(_context->submitOperations(BatchOperations{makeOperation()}), std::invalid_argument);
+    ASSERT_THROW(_context->submitOperations(BatchOperations{makeOperation()}), BatchFull);
 }
 
 HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/projects/hipfile/test/amd_detail/batch/batch.cpp
+++ b/projects/hipfile/test/amd_detail/batch/batch.cpp
@@ -69,6 +69,8 @@ TEST_F(HipFileBatch, CreateOperationRead)
     io_params->opcode = hipFileBatchRead;
 
     BatchOperation op = BatchOperation{std::move(io_params), default_mock_buffer, default_mock_file};
+
+    ASSERT_EQ(op.event().status, hipFileWaiting);
 }
 
 TEST_F(HipFileBatch, CreateOperationWrite)
@@ -76,6 +78,84 @@ TEST_F(HipFileBatch, CreateOperationWrite)
     io_params->opcode = hipFileBatchWrite;
 
     BatchOperation op = BatchOperation{std::move(io_params), default_mock_buffer, default_mock_file};
+
+    ASSERT_EQ(op.event().status, hipFileWaiting);
+}
+
+TEST_F(HipFileBatch, OnlyFinalStatesAreTerminal)
+{
+    using namespace batchOperationState;
+
+    static_assert(!Waiting::isTerminal());
+    static_assert(!Pending::isTerminal());
+    static_assert(!Running::isTerminal());
+
+    static_assert(Complete::isTerminal());
+    static_assert(Canceled::isTerminal());
+    static_assert(Invalid::isTerminal());
+    static_assert(Timeout::isTerminal());
+    static_assert(Failed::isTerminal());
+}
+
+TEST_F(HipFileBatch, MarkOperationPending)
+{
+    BatchOperation op = BatchOperation{std::move(io_params), default_mock_buffer, default_mock_file};
+
+    op.markPending();
+
+    ASSERT_EQ(op.event().status, hipFilePending);
+}
+
+TEST_F(HipFileBatch, TryCancelWaitingOperationIsNoOp)
+{
+    BatchOperation op = BatchOperation{std::move(io_params), default_mock_buffer, default_mock_file};
+
+    op.tryCancel();
+
+    ASSERT_EQ(op.event().status, hipFileWaiting);
+}
+
+TEST_F(HipFileBatch, MarkPendingPendingOperationThrowsInvalidStateTransition)
+{
+    BatchOperation op = BatchOperation{std::move(io_params), default_mock_buffer, default_mock_file};
+
+    op.markPending();
+
+    ASSERT_THROW(op.markPending(), InvalidStateTransition);
+    ASSERT_EQ(op.event().status, hipFilePending);
+}
+
+TEST_F(HipFileBatch, CancelPendingOperation)
+{
+    BatchOperation op = BatchOperation{std::move(io_params), default_mock_buffer, default_mock_file};
+
+    op.markPending();
+    op.tryCancel();
+
+    ASSERT_EQ(op.event().status, hipFileCanceled);
+}
+
+TEST_F(HipFileBatch, CancelPendingOperationIsIdempotent)
+{
+    BatchOperation op = BatchOperation{std::move(io_params), default_mock_buffer, default_mock_file};
+
+    op.markPending();
+    op.tryCancel();
+    op.tryCancel();
+
+    ASSERT_EQ(op.event().status, hipFileCanceled);
+}
+
+TEST_F(HipFileBatch, MarkPendingCanceledOperationThrowsInvalidStateTransition)
+{
+    BatchOperation op = BatchOperation{std::move(io_params), default_mock_buffer, default_mock_file};
+
+    op.markPending();
+    op.tryCancel();
+
+    ASSERT_THROW(op.markPending(), InvalidStateTransition);
+
+    ASSERT_EQ(op.event().status, hipFileCanceled);
 }
 
 TEST_F(HipFileBatch, CreateOperationBadBuffer)

--- a/projects/hipfile/test/amd_detail/batch/batch.cpp
+++ b/projects/hipfile/test/amd_detail/batch/batch.cpp
@@ -267,18 +267,18 @@ struct HipFileBatchContext : public HipFileUnopened {
 
 TEST_F(HipFileBatchContext, SubmitSingleGoodOp)
 {
-    _context->submit_operations(&io_params, 1);
+    _context->submitOperations(&io_params, 1);
 }
 
 TEST_F(HipFileBatchContext, SubmitZeroOperations)
 {
-    _context->submit_operations(nullptr, 0);
+    _context->submitOperations(nullptr, 0);
 }
 
 TEST_F(HipFileBatchContext, SubmitOverCapacity)
 {
     // We should fail before we ever try touching the nullptr.
-    ASSERT_THROW(_context->submit_operations(nullptr, _context_capacity + 1), std::invalid_argument);
+    ASSERT_THROW(_context->submitOperations(nullptr, _context_capacity + 1), std::invalid_argument);
 }
 
 TEST_F(HipFileBatchContext, SubmitOverCapacityOverMultipleSubmissions)
@@ -287,22 +287,22 @@ TEST_F(HipFileBatchContext, SubmitOverCapacityOverMultipleSubmissions)
     // In the future we might care that we are submitting the same operation.
     for (unsigned i = 0; i < _context_capacity; i++) {
         printf("i: %u\n", i);
-        _context->submit_operations(&io_params, 1);
+        _context->submitOperations(&io_params, 1);
     }
 
-    ASSERT_THROW(_context->submit_operations(nullptr, 1), std::invalid_argument);
+    ASSERT_THROW(_context->submitOperations(nullptr, 1), std::invalid_argument);
 }
 
 TEST_F(HipFileBatchContext, SubmitSingleBadBuffer)
 {
     EXPECT_CALL(*mock_driver_state, getFileAndBuffer).WillOnce(Throw(BufferNotRegistered()));
-    ASSERT_THROW(_context->submit_operations(&io_params, 1), BufferNotRegistered);
+    ASSERT_THROW(_context->submitOperations(&io_params, 1), BufferNotRegistered);
 }
 
 TEST_F(HipFileBatchContext, SubmitSingleBadFileHandle)
 {
     EXPECT_CALL(*mock_driver_state, getFileAndBuffer).WillOnce(Throw(FileNotRegistered()));
-    ASSERT_THROW(_context->submit_operations(&io_params, 1), FileNotRegistered);
+    ASSERT_THROW(_context->submitOperations(&io_params, 1), FileNotRegistered);
 }
 
 // BatchOperation is not mocked.
@@ -310,42 +310,42 @@ TEST_F(HipFileBatchContext, SubmitSingleBadParamBufferOffsetNegative)
 {
     hipFileIOParams_t bad_io_params     = io_params;
     bad_io_params.u.batch.devPtr_offset = -1;
-    ASSERT_THROW(_context->submit_operations(&bad_io_params, 1), std::invalid_argument);
+    ASSERT_THROW(_context->submitOperations(&bad_io_params, 1), std::invalid_argument);
 }
 
 TEST_F(HipFileBatchContext, SubmitSingleBadParamBufferOffsetTooLarge)
 {
     hipFileIOParams_t bad_io_params     = io_params;
     bad_io_params.u.batch.devPtr_offset = default_mock_buffer_length;
-    ASSERT_THROW(_context->submit_operations(&bad_io_params, 1), std::invalid_argument);
+    ASSERT_THROW(_context->submitOperations(&bad_io_params, 1), std::invalid_argument);
 }
 
 TEST_F(HipFileBatchContext, SubmitSingleBadParamIOSizeTooLarge)
 {
     hipFileIOParams_t bad_io_params = io_params;
     bad_io_params.u.batch.size      = static_cast<size_t>(default_mock_buffer_length + 1);
-    ASSERT_THROW(_context->submit_operations(&bad_io_params, 1), std::invalid_argument);
+    ASSERT_THROW(_context->submitOperations(&bad_io_params, 1), std::invalid_argument);
 }
 
 TEST_F(HipFileBatchContext, SubmitSingleBadParamFileOffsetNegative)
 {
     hipFileIOParams_t bad_io_params   = io_params;
     bad_io_params.u.batch.file_offset = -1;
-    ASSERT_THROW(_context->submit_operations(&bad_io_params, 1), std::invalid_argument);
+    ASSERT_THROW(_context->submitOperations(&bad_io_params, 1), std::invalid_argument);
 }
 
 TEST_F(HipFileBatchContext, SubmitSingleBadParamOpcodeInvalid)
 {
     hipFileIOParams_t bad_io_params = io_params;
     bad_io_params.opcode            = invalidEnum<hipFileOpcode_t>(maxEnum<hipFileOpcode_t>());
-    ASSERT_THROW(_context->submit_operations(&bad_io_params, 1), std::invalid_argument);
+    ASSERT_THROW(_context->submitOperations(&bad_io_params, 1), std::invalid_argument);
 }
 
 TEST_F(HipFileBatchContext, SubmitSingleBadParamModeInvalid)
 {
     hipFileIOParams_t bad_io_params = io_params;
     bad_io_params.mode              = invalidEnum<hipFileBatchMode_t>(maxEnum<hipFileBatchMode_t>());
-    ASSERT_THROW(_context->submit_operations(&bad_io_params, 1), std::invalid_argument);
+    ASSERT_THROW(_context->submitOperations(&bad_io_params, 1), std::invalid_argument);
 }
 
 HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/projects/hipfile/test/amd_detail/hipfile-api.cpp
+++ b/projects/hipfile/test/amd_detail/hipfile-api.cpp
@@ -96,7 +96,7 @@ TEST_F(HipFileUnit, TestHipFileBatchIOSubmitSuccess)
     std::shared_ptr<MBatchContext> mock_b_context = std::make_shared<MBatchContext>();
 
     EXPECT_CALL(mock_state, getBatchContext).WillOnce(Return(mock_b_context));
-    EXPECT_CALL(*mock_b_context, submit_operations);
+    EXPECT_CALL(*mock_b_context, submitOperations);
 
     auto result = hipFileBatchIOSubmit(b_handle, 1, &io_param, 0);
     ASSERT_EQ(result, HIPFILE_SUCCESS);
@@ -109,7 +109,7 @@ TEST_F(HipFileUnit, TestHipFileBatchIOSubmitBadHandle)
     std::shared_ptr<MBatchContext> mock_b_context = std::make_shared<MBatchContext>();
 
     EXPECT_CALL(mock_state, getBatchContext).WillOnce(Throw(InvalidBatchHandle()));
-    EXPECT_CALL(*mock_b_context, submit_operations).Times(0);
+    EXPECT_CALL(*mock_b_context, submitOperations).Times(0);
 
     auto           result          = hipFileBatchIOSubmit(b_handle, 1, &io_param, 0);
     hipFileError_t expected_result = {hipFileInvalidValue, hipSuccess};
@@ -123,7 +123,7 @@ TEST_F(HipFileUnit, TestHipFileBatchIOSubmitBadArgument)
     std::shared_ptr<MBatchContext> mock_b_context = std::make_shared<MBatchContext>();
 
     EXPECT_CALL(mock_state, getBatchContext).WillOnce(Return(mock_b_context));
-    EXPECT_CALL(*mock_b_context, submit_operations).WillOnce(Throw(std::invalid_argument("")));
+    EXPECT_CALL(*mock_b_context, submitOperations).WillOnce(Throw(std::invalid_argument("")));
 
     auto result = hipFileBatchIOSubmit(b_handle, 1, &io_param, 0);
     ASSERT_EQ(result, HIPFILE_INVALID_VALUE);
@@ -137,7 +137,7 @@ TEST_F(HipFileUnit, TestHipFileBatchIOSubmitNullptrParams)
     // With nr > 0 and a nullptr iocbp, the API must reject the call before
     // ever reaching the batch context (avoids dereferencing the nullptr).
     EXPECT_CALL(mock_state, getBatchContext).Times(0);
-    EXPECT_CALL(*mock_b_context, submit_operations).Times(0);
+    EXPECT_CALL(*mock_b_context, submitOperations).Times(0);
 
     auto           result          = hipFileBatchIOSubmit(b_handle, 1, nullptr, 0);
     hipFileError_t expected_result = {hipFileInvalidValue, hipSuccess};

--- a/projects/hipfile/test/amd_detail/hipfile-api.cpp
+++ b/projects/hipfile/test/amd_detail/hipfile-api.cpp
@@ -91,9 +91,9 @@ TEST_F(HipFileUnit, TestHipFileBatchIOSetupNullptrHandle)
 
 TEST_F(HipFileUnit, TestHipFileBatchIOSubmitSuccess)
 {
-    hipFileBatchHandle_t           b_handle = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
-    hipFileIOParams_t              io_param;
-    std::shared_ptr<MBatchContext> mock_b_context = std::make_shared<MBatchContext>();
+    hipFileBatchHandle_t                       b_handle = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
+    hipFileIOParams_t                          io_param;
+    std::shared_ptr<StrictMock<MBatchContext>> mock_b_context = std::make_shared<StrictMock<MBatchContext>>();
 
     EXPECT_CALL(mock_state, getBatchContext).WillOnce(Return(mock_b_context));
     EXPECT_CALL(*mock_b_context, submitOperations);
@@ -104,9 +104,9 @@ TEST_F(HipFileUnit, TestHipFileBatchIOSubmitSuccess)
 
 TEST_F(HipFileUnit, TestHipFileBatchIOSubmitBadHandle)
 {
-    hipFileBatchHandle_t           b_handle = nullptr;
-    hipFileIOParams_t              io_param;
-    std::shared_ptr<MBatchContext> mock_b_context = std::make_shared<MBatchContext>();
+    hipFileBatchHandle_t                       b_handle = nullptr;
+    hipFileIOParams_t                          io_param;
+    std::shared_ptr<StrictMock<MBatchContext>> mock_b_context = std::make_shared<StrictMock<MBatchContext>>();
 
     EXPECT_CALL(mock_state, getBatchContext).WillOnce(Throw(InvalidBatchHandle()));
     EXPECT_CALL(*mock_b_context, submitOperations).Times(0);
@@ -118,9 +118,9 @@ TEST_F(HipFileUnit, TestHipFileBatchIOSubmitBadHandle)
 
 TEST_F(HipFileUnit, TestHipFileBatchIOSubmitBadArgument)
 {
-    hipFileBatchHandle_t           b_handle = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
-    hipFileIOParams_t              io_param;
-    std::shared_ptr<MBatchContext> mock_b_context = std::make_shared<MBatchContext>();
+    hipFileBatchHandle_t                       b_handle = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
+    hipFileIOParams_t                          io_param;
+    std::shared_ptr<StrictMock<MBatchContext>> mock_b_context = std::make_shared<StrictMock<MBatchContext>>();
 
     EXPECT_CALL(mock_state, getBatchContext).WillOnce(Return(mock_b_context));
     EXPECT_CALL(*mock_b_context, submitOperations).WillOnce(Throw(std::invalid_argument("")));
@@ -131,8 +131,8 @@ TEST_F(HipFileUnit, TestHipFileBatchIOSubmitBadArgument)
 
 TEST_F(HipFileUnit, TestHipFileBatchIOSubmitNullptrParams)
 {
-    hipFileBatchHandle_t           b_handle       = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
-    std::shared_ptr<MBatchContext> mock_b_context = std::make_shared<MBatchContext>();
+    hipFileBatchHandle_t                       b_handle = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
+    std::shared_ptr<StrictMock<MBatchContext>> mock_b_context = std::make_shared<StrictMock<MBatchContext>>();
 
     // With nr > 0 and a nullptr iocbp, the API must reject the call before
     // ever reaching the batch context (avoids dereferencing the nullptr).

--- a/projects/hipfile/test/amd_detail/hipfile-api.cpp
+++ b/projects/hipfile/test/amd_detail/hipfile-api.cpp
@@ -334,7 +334,7 @@ TEST_F(HipFileUnit, TestHipFileBatchIOSubmitNullptrParams)
     hipFileBatchHandle_t                       b_handle = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
     std::shared_ptr<StrictMock<MBatchContext>> mock_b_context = std::make_shared<StrictMock<MBatchContext>>();
 
-    // With nr > 0 and a nullptr iocbp, the API must reject the call before
+    // With a nullptr iocbp, the API must reject the call before
     // ever reaching the batch context (avoids dereferencing the nullptr).
     EXPECT_CALL(mock_state, getBatchContext).Times(0);
     EXPECT_CALL(*mock_b_context, submitOperations).Times(0);
@@ -342,6 +342,17 @@ TEST_F(HipFileUnit, TestHipFileBatchIOSubmitNullptrParams)
     auto           result          = hipFileBatchIOSubmit(b_handle, 1, nullptr, 0);
     hipFileError_t expected_result = {hipFileInvalidValue, hipSuccess};
     ASSERT_EQ(result, expected_result);
+}
+
+TEST_F(HipFileUnit, TestHipFileBatchIOSubmitZeroRequests)
+{
+    hipFileBatchHandle_t b_handle = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
+    hipFileIOParams_t    io_param;
+
+    EXPECT_CALL(mock_state, getBatchContext).Times(0);
+
+    auto result = hipFileBatchIOSubmit(b_handle, 0, &io_param, 0);
+    ASSERT_EQ(result, HIPFILE_INVALID_VALUE);
 }
 
 /// @brief Test hipFileIO function

--- a/projects/hipfile/test/amd_detail/hipfile-api.cpp
+++ b/projects/hipfile/test/amd_detail/hipfile-api.cpp
@@ -19,6 +19,7 @@
 #include "hipfile-private.h"
 #include "hipfile-test.h"
 #include "hipfile-warnings.h"
+#include "invalid-enum.h"
 #include "io.h"
 #include "mbackend.h"
 #include "mbatch.h"
@@ -54,9 +55,47 @@ using namespace testing;
 HIPFILE_WARN_NO_GLOBAL_CTOR_OFF
 
 struct HipFileUnit : public HipFileUnopened {
-    StrictMock<MDriverState> mock_state;
-    void                     SetUp() override
+    StrictMock<MDriverState>             mock_state;
+    std::shared_ptr<StrictMock<MBuffer>> batch_buffer;
+    std::shared_ptr<StrictMock<MFile>>   batch_file;
+    int                                  batch_cookie{};
+
+    void SetUp() override
     {
+        setUpBatchMocks();
+    }
+
+    /// @brief Create the registered buffer and file that batch parameters refer to.
+    ///
+    /// The buffer is one byte long, so any non-zero offset or size greater
+    /// than one is out of range.
+    void setUpBatchMocks()
+    {
+        batch_buffer = std::make_shared<StrictMock<MBuffer>>();
+        EXPECT_CALL(*batch_buffer, getBuffer).WillRepeatedly(Return(reinterpret_cast<void *>(0x123)));
+        EXPECT_CALL(*batch_buffer, getLength).WillRepeatedly(Return(1));
+
+        batch_file = std::make_shared<StrictMock<MFile>>();
+        EXPECT_CALL(*batch_file, handle).WillRepeatedly(Return(batch_file.get()));
+    }
+
+    /// @brief Build a valid batch parameter referring to the fixture mocks.
+    hipFileIOParams_t makeBatchParam()
+    {
+        hipFileIOParams_t param{};
+        param.u.batch.devPtr_base = batch_buffer->getBuffer();
+        param.u.batch.size        = 1;
+        param.fh                  = batch_file->handle();
+        param.mode                = hipFileBatch;
+        param.opcode              = hipFileBatchRead;
+        param.cookie              = &batch_cookie;
+        return param;
+    }
+
+    void expectBatchLookup(const hipFileIOParams_t &param)
+    {
+        EXPECT_CALL(mock_state, getFileAndBuffer(param.fh, param.u.batch.devPtr_base))
+            .WillOnce(Return(file_buffer_pair{batch_file, batch_buffer}));
     }
 };
 
@@ -92,11 +131,16 @@ TEST_F(HipFileUnit, TestHipFileBatchIOSetupNullptrHandle)
 TEST_F(HipFileUnit, TestHipFileBatchIOSubmitSuccess)
 {
     hipFileBatchHandle_t                       b_handle = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
-    hipFileIOParams_t                          io_param;
+    hipFileIOParams_t                          io_param = makeBatchParam();
     std::shared_ptr<StrictMock<MBatchContext>> mock_b_context = std::make_shared<StrictMock<MBatchContext>>();
 
-    EXPECT_CALL(mock_state, getBatchContext).WillOnce(Return(mock_b_context));
-    EXPECT_CALL(*mock_b_context, submitOperations);
+    EXPECT_CALL(mock_state, getBatchContext(b_handle)).WillOnce(Return(mock_b_context));
+    expectBatchLookup(io_param);
+    EXPECT_CALL(*mock_b_context, submitOperations(_)).WillOnce([this](BatchOperations ops) {
+        ASSERT_EQ(ops.size(), 1);
+        EXPECT_EQ(ops[0]->event().cookie, &batch_cookie);
+        EXPECT_EQ(ops[0]->event().status, hipFileWaiting);
+    });
 
     auto result = hipFileBatchIOSubmit(b_handle, 1, &io_param, 0);
     ASSERT_EQ(result, HIPFILE_SUCCESS);
@@ -108,8 +152,8 @@ TEST_F(HipFileUnit, TestHipFileBatchIOSubmitBadHandle)
     hipFileIOParams_t                          io_param;
     std::shared_ptr<StrictMock<MBatchContext>> mock_b_context = std::make_shared<StrictMock<MBatchContext>>();
 
-    EXPECT_CALL(mock_state, getBatchContext).WillOnce(Throw(InvalidBatchHandle()));
-    EXPECT_CALL(*mock_b_context, submitOperations).Times(0);
+    EXPECT_CALL(mock_state, getBatchContext(b_handle)).WillOnce(Throw(InvalidBatchHandle()));
+    EXPECT_CALL(*mock_b_context, submitOperations(_)).Times(0);
 
     auto           result          = hipFileBatchIOSubmit(b_handle, 1, &io_param, 0);
     hipFileError_t expected_result = {hipFileInvalidValue, hipSuccess};
@@ -119,14 +163,170 @@ TEST_F(HipFileUnit, TestHipFileBatchIOSubmitBadHandle)
 TEST_F(HipFileUnit, TestHipFileBatchIOSubmitBadArgument)
 {
     hipFileBatchHandle_t                       b_handle = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
-    hipFileIOParams_t                          io_param;
+    hipFileIOParams_t                          io_param = makeBatchParam();
     std::shared_ptr<StrictMock<MBatchContext>> mock_b_context = std::make_shared<StrictMock<MBatchContext>>();
 
-    EXPECT_CALL(mock_state, getBatchContext).WillOnce(Return(mock_b_context));
-    EXPECT_CALL(*mock_b_context, submitOperations).WillOnce(Throw(std::invalid_argument("")));
+    EXPECT_CALL(mock_state, getBatchContext(b_handle)).WillOnce(Return(mock_b_context));
+    expectBatchLookup(io_param);
+    EXPECT_CALL(*mock_b_context, submitOperations(_)).WillOnce(Throw(std::invalid_argument("")));
 
     auto result = hipFileBatchIOSubmit(b_handle, 1, &io_param, 0);
     ASSERT_EQ(result, HIPFILE_INVALID_VALUE);
+}
+
+TEST_F(HipFileUnit, TestHipFileBatchIOSubmitInvalidOperation)
+{
+    hipFileBatchHandle_t                       b_handle = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
+    hipFileIOParams_t                          io_param = makeBatchParam();
+    std::shared_ptr<StrictMock<MBatchContext>> mock_b_context = std::make_shared<StrictMock<MBatchContext>>();
+    io_param.u.batch.file_offset                              = -1;
+
+    EXPECT_CALL(mock_state, getBatchContext(b_handle)).WillOnce(Return(mock_b_context));
+    expectBatchLookup(io_param);
+    EXPECT_CALL(*mock_b_context, submitOperations(_)).Times(0);
+
+    auto result = hipFileBatchIOSubmit(b_handle, 1, &io_param, 0);
+    ASSERT_EQ(result, HIPFILE_INVALID_VALUE);
+}
+
+TEST_F(HipFileUnit, TestHipFileBatchIOSubmitNegativeBufferOffset)
+{
+    hipFileBatchHandle_t                       b_handle = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
+    hipFileIOParams_t                          io_param = makeBatchParam();
+    std::shared_ptr<StrictMock<MBatchContext>> mock_b_context = std::make_shared<StrictMock<MBatchContext>>();
+    io_param.u.batch.devPtr_offset                            = -1;
+
+    EXPECT_CALL(mock_state, getBatchContext(b_handle)).WillOnce(Return(mock_b_context));
+    expectBatchLookup(io_param);
+    EXPECT_CALL(*mock_b_context, submitOperations(_)).Times(0);
+
+    auto result = hipFileBatchIOSubmit(b_handle, 1, &io_param, 0);
+    ASSERT_EQ(result, HIPFILE_INVALID_VALUE);
+}
+
+TEST_F(HipFileUnit, TestHipFileBatchIOSubmitBufferOffsetTooLarge)
+{
+    hipFileBatchHandle_t                       b_handle = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
+    hipFileIOParams_t                          io_param = makeBatchParam();
+    std::shared_ptr<StrictMock<MBatchContext>> mock_b_context = std::make_shared<StrictMock<MBatchContext>>();
+    // The mocked buffer is one byte long, so any offset is past its end.
+    io_param.u.batch.devPtr_offset = 1;
+
+    EXPECT_CALL(mock_state, getBatchContext(b_handle)).WillOnce(Return(mock_b_context));
+    expectBatchLookup(io_param);
+    EXPECT_CALL(*mock_b_context, submitOperations(_)).Times(0);
+
+    auto result = hipFileBatchIOSubmit(b_handle, 1, &io_param, 0);
+    ASSERT_EQ(result, HIPFILE_INVALID_VALUE);
+}
+
+TEST_F(HipFileUnit, TestHipFileBatchIOSubmitIOSizeTooLarge)
+{
+    hipFileBatchHandle_t                       b_handle = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
+    hipFileIOParams_t                          io_param = makeBatchParam();
+    std::shared_ptr<StrictMock<MBatchContext>> mock_b_context = std::make_shared<StrictMock<MBatchContext>>();
+    // The mocked buffer is one byte long.
+    io_param.u.batch.size = 2;
+
+    EXPECT_CALL(mock_state, getBatchContext(b_handle)).WillOnce(Return(mock_b_context));
+    expectBatchLookup(io_param);
+    EXPECT_CALL(*mock_b_context, submitOperations(_)).Times(0);
+
+    auto result = hipFileBatchIOSubmit(b_handle, 1, &io_param, 0);
+    ASSERT_EQ(result, HIPFILE_INVALID_VALUE);
+}
+
+TEST_F(HipFileUnit, TestHipFileBatchIOSubmitInvalidOpcode)
+{
+    hipFileBatchHandle_t                       b_handle = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
+    hipFileIOParams_t                          io_param = makeBatchParam();
+    std::shared_ptr<StrictMock<MBatchContext>> mock_b_context = std::make_shared<StrictMock<MBatchContext>>();
+    io_param.opcode = invalidEnum<hipFileOpcode_t>(maxEnum<hipFileOpcode_t>());
+
+    EXPECT_CALL(mock_state, getBatchContext(b_handle)).WillOnce(Return(mock_b_context));
+    expectBatchLookup(io_param);
+    EXPECT_CALL(*mock_b_context, submitOperations(_)).Times(0);
+
+    auto result = hipFileBatchIOSubmit(b_handle, 1, &io_param, 0);
+    ASSERT_EQ(result, HIPFILE_INVALID_VALUE);
+}
+
+TEST_F(HipFileUnit, TestHipFileBatchIOSubmitInvalidMode)
+{
+    hipFileBatchHandle_t                       b_handle = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
+    hipFileIOParams_t                          io_param = makeBatchParam();
+    std::shared_ptr<StrictMock<MBatchContext>> mock_b_context = std::make_shared<StrictMock<MBatchContext>>();
+    io_param.mode = invalidEnum<hipFileBatchMode_t>(maxEnum<hipFileBatchMode_t>());
+
+    EXPECT_CALL(mock_state, getBatchContext(b_handle)).WillOnce(Return(mock_b_context));
+    expectBatchLookup(io_param);
+    EXPECT_CALL(*mock_b_context, submitOperations(_)).Times(0);
+
+    auto result = hipFileBatchIOSubmit(b_handle, 1, &io_param, 0);
+    ASSERT_EQ(result, HIPFILE_INVALID_VALUE);
+}
+
+TEST_F(HipFileUnit, TestHipFileBatchIOSubmitInvalidSecondOperationDoesNotSubmit)
+{
+    hipFileBatchHandle_t                       b_handle = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
+    hipFileIOParams_t                          io_param = makeBatchParam();
+    std::array<hipFileIOParams_t, 2>           io_params{io_param, io_param};
+    std::shared_ptr<StrictMock<MBatchContext>> mock_b_context = std::make_shared<StrictMock<MBatchContext>>();
+    io_params[1].u.batch.file_offset                          = -1;
+
+    EXPECT_CALL(mock_state, getBatchContext(b_handle)).WillOnce(Return(mock_b_context));
+    EXPECT_CALL(mock_state, getFileAndBuffer(io_param.fh, io_param.u.batch.devPtr_base))
+        .Times(2)
+        .WillRepeatedly(Return(file_buffer_pair{batch_file, batch_buffer}));
+    EXPECT_CALL(*mock_b_context, submitOperations(_)).Times(0);
+
+    auto result = hipFileBatchIOSubmit(b_handle, io_params.size(), io_params.data(), 0);
+    ASSERT_EQ(result, HIPFILE_INVALID_VALUE);
+}
+
+TEST_F(HipFileUnit, TestHipFileBatchIOSubmitFileNotRegistered)
+{
+    hipFileBatchHandle_t                       b_handle = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
+    hipFileIOParams_t                          io_param = makeBatchParam();
+    std::shared_ptr<StrictMock<MBatchContext>> mock_b_context = std::make_shared<StrictMock<MBatchContext>>();
+
+    EXPECT_CALL(mock_state, getBatchContext(b_handle)).WillOnce(Return(mock_b_context));
+    EXPECT_CALL(mock_state, getFileAndBuffer(io_param.fh, io_param.u.batch.devPtr_base))
+        .WillOnce(Throw(FileNotRegistered()));
+    EXPECT_CALL(*mock_b_context, submitOperations(_)).Times(0);
+
+    auto result = hipFileBatchIOSubmit(b_handle, 1, &io_param, 0);
+    ASSERT_EQ(result, HipFileOpError(hipFileHandleNotRegistered));
+}
+
+TEST_F(HipFileUnit, TestHipFileBatchIOSubmitDriverNotInitialized)
+{
+    hipFileBatchHandle_t                       b_handle = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
+    hipFileIOParams_t                          io_param = makeBatchParam();
+    std::shared_ptr<StrictMock<MBatchContext>> mock_b_context = std::make_shared<StrictMock<MBatchContext>>();
+
+    EXPECT_CALL(mock_state, getBatchContext(b_handle)).WillOnce(Return(mock_b_context));
+    EXPECT_CALL(mock_state, getFileAndBuffer(io_param.fh, io_param.u.batch.devPtr_base))
+        .WillOnce(Throw(DriverNotInitialized()));
+    EXPECT_CALL(*mock_b_context, submitOperations(_)).Times(0);
+
+    auto result = hipFileBatchIOSubmit(b_handle, 1, &io_param, 0);
+    ASSERT_EQ(result, HipFileOpError(hipFileDriverNotInitialized));
+}
+
+TEST_F(HipFileUnit, TestHipFileBatchIOSubmitInvalidMemoryType)
+{
+    hipFileBatchHandle_t                       b_handle = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
+    hipFileIOParams_t                          io_param = makeBatchParam();
+    std::shared_ptr<StrictMock<MBatchContext>> mock_b_context = std::make_shared<StrictMock<MBatchContext>>();
+
+    EXPECT_CALL(mock_state, getBatchContext(b_handle)).WillOnce(Return(mock_b_context));
+    EXPECT_CALL(mock_state, getFileAndBuffer(io_param.fh, io_param.u.batch.devPtr_base))
+        .WillOnce(Throw(InvalidMemoryType()));
+    EXPECT_CALL(*mock_b_context, submitOperations(_)).Times(0);
+
+    auto result = hipFileBatchIOSubmit(b_handle, 1, &io_param, 0);
+    ASSERT_EQ(result, HipFileOpError(hipFileHipMemoryTypeInvalid));
 }
 
 TEST_F(HipFileUnit, TestHipFileBatchIOSubmitNullptrParams)

--- a/projects/hipfile/test/amd_detail/hipfile-api.cpp
+++ b/projects/hipfile/test/amd_detail/hipfile-api.cpp
@@ -174,6 +174,20 @@ TEST_F(HipFileUnit, TestHipFileBatchIOSubmitBadArgument)
     ASSERT_EQ(result, HIPFILE_INVALID_VALUE);
 }
 
+TEST_F(HipFileUnit, TestHipFileBatchIOSubmitBatchFull)
+{
+    hipFileBatchHandle_t                       b_handle = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
+    hipFileIOParams_t                          io_param = makeBatchParam();
+    std::shared_ptr<StrictMock<MBatchContext>> mock_b_context = std::make_shared<StrictMock<MBatchContext>>();
+
+    EXPECT_CALL(mock_state, getBatchContext(b_handle)).WillOnce(Return(mock_b_context));
+    expectBatchLookup(io_param);
+    EXPECT_CALL(*mock_b_context, submitOperations(_)).WillOnce(Throw(BatchFull()));
+
+    auto result = hipFileBatchIOSubmit(b_handle, 1, &io_param, 0);
+    ASSERT_EQ(result, HipFileOpError(hipFileBatchFull));
+}
+
 TEST_F(HipFileUnit, TestHipFileBatchIOSubmitInvalidOperation)
 {
     hipFileBatchHandle_t                       b_handle = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);

--- a/projects/hipfile/test/amd_detail/mbatch.h
+++ b/projects/hipfile/test/amd_detail/mbatch.h
@@ -18,8 +18,7 @@ namespace hipFile {
 class MBatchContext : public IBatchContext {
 public:
     MOCK_METHOD(unsigned, getCapacity, (), (const, noexcept, override));
-    MOCK_METHOD(void, submitOperations, (const hipFileIOParams_t *params, const unsigned num_params),
-                (override));
+    MOCK_METHOD(void, submitOperations, (BatchOperations ops), (override));
 };
 
 }

--- a/projects/hipfile/test/amd_detail/mbatch.h
+++ b/projects/hipfile/test/amd_detail/mbatch.h
@@ -17,8 +17,8 @@ namespace hipFile {
 
 class MBatchContext : public IBatchContext {
 public:
-    MOCK_METHOD(unsigned, get_capacity, (), (const, noexcept, override));
-    MOCK_METHOD(void, submit_operations, (const hipFileIOParams_t *params, const unsigned num_params),
+    MOCK_METHOD(unsigned, getCapacity, (), (const, noexcept, override));
+    MOCK_METHOD(void, submitOperations, (const hipFileIOParams_t *params, const unsigned num_params),
                 (override));
 };
 


### PR DESCRIPTION
## Motivation

This PR implements execution of the submitted batch operations on the thread pool, with some prior cleanup.

Depends on: https://github.com/ROCm/rocm-systems/pull/9659
Starts at commit: Use camel case for BatchContext methods.

## Technical Details

- Add a state machine to for the state of each operation.  Encodes valid transitions.  Invalid transitions throw an error.
- Moves creation of BatchOperations to the hipFile API layer so that batch code doesn't grab DriverState lock.  Avoids possible deadlock issue with future cleanup code called from DriverState.
- Submits run function to thread pool to execute batch operations.  Uses the existing synchronous IO calls.

## Issue Tracking

Part of:

JIRA ID: AIHIPFILE-65

## Test Plan

Unit tests added for new functionality.

## Test Result

Tests pass.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
