### PR TITLE
fix(rocprofiler-sdk): Remove internal aqlprofile table load

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/util/hsa_rsrc_factory.cpp
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/util/hsa_rsrc_factory.cpp
@@ -200,8 +200,6 @@ FindGlobalPool(hsa_amd_memory_pool_t pool, void* data, bool kern_arg)
     return HSA_STATUS_INFO_BREAK;
 }
 
-#define ROCP_LD_AQLPROFILE
-
 // This is the call-back function for hsa_amd_agent_iterate_memory_pools() that
 // finds a pool with the properties of HSA_AMD_SEGMENT_GLOBAL and that is NOT
 // HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_KERNARG_INIT

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/util/hsa_rsrc_factory.cpp
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/util/hsa_rsrc_factory.cpp
@@ -828,5 +828,5 @@ HsaRsrcFactory::Submit(hsa_queue_t* queue, const void* packet, size_t size_bytes
     return write_idx;
 }
 
-HsaRsrcFactory*             HsaRsrcFactory::instance_ = nullptr;
-HsaRsrcFactory::mutex_t     HsaRsrcFactory::mutex_;
+HsaRsrcFactory*         HsaRsrcFactory::instance_ = nullptr;
+HsaRsrcFactory::mutex_t HsaRsrcFactory::mutex_;

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/util/hsa_rsrc_factory.cpp
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/util/hsa_rsrc_factory.cpp
@@ -608,7 +608,7 @@ HsaRsrcFactory::SignalWait(const hsa_signal_t& signal) const
     {
         const hsa_signal_value_t signal_value =
             rocprofiler::aqlprofile::get_core_table()->hsa_signal_wait_scacquire_fn(
-                signal, HSA_SIGNAL_CONDITION_LT, 1, 1<<30, HSA_WAIT_STATE_BLOCKED);
+                signal, HSA_SIGNAL_CONDITION_LT, 1, UINT64_MAX, HSA_WAIT_STATE_BLOCKED);
         if(signal_value == 0)
         {
             break;

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/util/hsa_rsrc_factory.cpp
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/util/hsa_rsrc_factory.cpp
@@ -200,6 +200,8 @@ FindGlobalPool(hsa_amd_memory_pool_t pool, void* data, bool kern_arg)
     return HSA_STATUS_INFO_BREAK;
 }
 
+#define ROCP_LD_AQLPROFILE
+
 // This is the call-back function for hsa_amd_agent_iterate_memory_pools() that
 // finds a pool with the properties of HSA_AMD_SEGMENT_GLOBAL and that is NOT
 // HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_KERNARG_INIT
@@ -241,40 +243,11 @@ HsaRsrcFactory::HsaRsrcFactory(bool initialize_hsa)
     if(cpu_pool_ == nullptr) CHECK_STATUS("CPU memory pool is not found", HSA_STATUS_ERROR);
     if(kern_arg_pool_ == nullptr)
         CHECK_STATUS("Kern-arg memory pool is not found", HSA_STATUS_ERROR);
-
-    // Get AqlProfile API table
-    aqlprofile_api_ = {0};
-#ifdef ROCP_LD_AQLPROFILE
-    status = LoadAqlProfileLib(&aqlprofile_api_);
-#else
-    status = rocprofiler::aqlprofile::get_core_table()->hsa_system_get_major_extension_table_fn(
-        HSA_EXTENSION_AMD_AQLPROFILE,
-        hsa_ven_amd_aqlprofile_VERSION_MAJOR,
-        sizeof(aqlprofile_api_),
-        &aqlprofile_api_);
-#endif
-    CHECK_STATUS("aqlprofile API table load failed", status);
-
-    // Get Loader API table
-    loader_api_ = {0};
-    status = rocprofiler::aqlprofile::get_core_table()->hsa_system_get_major_extension_table_fn(
-        HSA_EXTENSION_AMD_LOADER, 1, sizeof(loader_api_), &loader_api_);
-    CHECK_STATUS("loader API table query failed", status);
-
-    // Instantiate HSA timer
-    timer_ = new HsaTimer;
-    CHECK_STATUS("HSA timer allocation failed",
-                 (timer_ == nullptr) ? HSA_STATUS_ERROR : HSA_STATUS_SUCCESS);
-
-    // System timeout
-    timeout_ = (timeout_ns_ == HsaTimer::TIMESTAMP_MAX) ? timeout_ns_
-                                                        : timer_->ns_to_sysclock(timeout_ns_);
 }
 
 // Destructor of the class
 HsaRsrcFactory::~HsaRsrcFactory()
 {
-    delete timer_;
     for(auto p : cpu_list_)
         delete p;
     for(auto p : gpu_list_)
@@ -284,48 +257,6 @@ HsaRsrcFactory::~HsaRsrcFactory()
         hsa_status_t status = rocprofiler::aqlprofile::get_core_table()->hsa_shut_down_fn();
         CHECK_STATUS("Error in hsa_shut_down", status);
     }
-}
-
-hsa_status_t
-HsaRsrcFactory::LoadAqlProfileLib(aqlprofile_pfn_t* api)
-{
-#ifdef _WIN32
-    (void) api;
-    return HSA_STATUS_ERROR;
-#else
-    void* handle = dlopen(kAqlProfileLib, RTLD_NOW);
-    if(handle == nullptr)
-    {
-        fprintf(stderr, "Loading '%s' failed, %s\n", kAqlProfileLib, dlerror());
-        return HSA_STATUS_ERROR;
-    }
-    dlerror(); /* Clear any existing error */
-
-    api->hsa_ven_amd_aqlprofile_error_string =
-        (decltype(::hsa_ven_amd_aqlprofile_error_string)*) dlsym(
-            handle, "hsa_ven_amd_aqlprofile_error_string");
-    api->hsa_ven_amd_aqlprofile_validate_event =
-        (decltype(::hsa_ven_amd_aqlprofile_validate_event)*) dlsym(
-            handle, "hsa_ven_amd_aqlprofile_validate_event");
-    api->hsa_ven_amd_aqlprofile_start =
-        (decltype(::hsa_ven_amd_aqlprofile_start)*) dlsym(handle, "hsa_ven_amd_aqlprofile_start");
-    api->hsa_ven_amd_aqlprofile_stop =
-        (decltype(::hsa_ven_amd_aqlprofile_stop)*) dlsym(handle, "hsa_ven_amd_aqlprofile_stop");
-#    ifdef AQLPROF_NEW_API
-    api->hsa_ven_amd_aqlprofile_read =
-        (decltype(::hsa_ven_amd_aqlprofile_read)*) dlsym(handle, "hsa_ven_amd_aqlprofile_read");
-#    endif
-    api->hsa_ven_amd_aqlprofile_legacy_get_pm4 =
-        (decltype(::hsa_ven_amd_aqlprofile_legacy_get_pm4)*) dlsym(
-            handle, "hsa_ven_amd_aqlprofile_legacy_get_pm4");
-    api->hsa_ven_amd_aqlprofile_get_info = (decltype(::hsa_ven_amd_aqlprofile_get_info)*) dlsym(
-        handle, "hsa_ven_amd_aqlprofile_get_info");
-    api->hsa_ven_amd_aqlprofile_iterate_data =
-        (decltype(::hsa_ven_amd_aqlprofile_iterate_data)*) dlsym(
-            handle, "hsa_ven_amd_aqlprofile_iterate_data");
-
-    return HSA_STATUS_SUCCESS;
-#endif
 }
 
 // Add system agent info
@@ -679,7 +610,7 @@ HsaRsrcFactory::SignalWait(const hsa_signal_t& signal) const
     {
         const hsa_signal_value_t signal_value =
             rocprofiler::aqlprofile::get_core_table()->hsa_signal_wait_scacquire_fn(
-                signal, HSA_SIGNAL_CONDITION_LT, 1, timeout_, HSA_WAIT_STATE_BLOCKED);
+                signal, HSA_SIGNAL_CONDITION_LT, 1, 1<<30, HSA_WAIT_STATE_BLOCKED);
         if(signal_value == 0)
         {
             break;
@@ -901,4 +832,3 @@ HsaRsrcFactory::Submit(hsa_queue_t* queue, const void* packet, size_t size_bytes
 
 HsaRsrcFactory*             HsaRsrcFactory::instance_ = nullptr;
 HsaRsrcFactory::mutex_t     HsaRsrcFactory::mutex_;
-HsaRsrcFactory::timestamp_t HsaRsrcFactory::timeout_ns_ = HsaTimer::TIMESTAMP_MAX;

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/util/hsa_rsrc_factory.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/util/hsa_rsrc_factory.h
@@ -341,39 +341,12 @@ public:
     static uint64_t Submit(hsa_queue_t* queue, const void* packet);
     static uint64_t Submit(hsa_queue_t* queue, const void* packet, size_t size_bytes);
 
-    // Return AqlProfile API table
-    typedef hsa_ven_amd_aqlprofile_pfn_t aqlprofile_pfn_t;
-    const aqlprofile_pfn_t*              AqlProfileApi() const { return &aqlprofile_api_; }
-
-    // Return Loader API table
-    const hsa_ven_amd_loader_1_00_pfn_t* LoaderApi() const { return &loader_api_; }
-
-    // Methods for system-clock/ns conversion and timestamp in 'ns'
-    timestamp_t SysclockToNs(const timestamp_t& sysclock) const
-    {
-        return timer_->sysclock_to_ns(sysclock);
-    }
-    timestamp_t NsToSysclock(const timestamp_t& time) const { return timer_->ns_to_sysclock(time); }
-    timestamp_t TimestampNs() const { return timer_->timestamp_ns(); }
-
-    timestamp_t        GetSysTimeout() const { return timeout_; }
-    static timestamp_t GetTimeoutNs() { return timeout_ns_; }
-    static void        SetTimeoutNs(const timestamp_t& time)
-    {
-        std::lock_guard<mutex_t> lck(mutex_);
-        timeout_ns_ = time;
-        if(instance_ != nullptr) instance_->timeout_ = instance_->timer_->ns_to_sysclock(time);
-    }
-
 private:
     // System agents iterating callback
     static hsa_status_t GetHsaAgentsCallback(hsa_agent_t agent, void* data);
 
     // Callback function to find and bind kernarg region of an agent
     static hsa_status_t FindMemRegionsCallback(hsa_region_t region, void* data);
-
-    // Load AQL profile HSA extension library directly
-    static hsa_status_t LoadAqlProfileLib(aqlprofile_pfn_t* api);
 
     // Constructor of the class. Will initialize the Hsa Runtime and
     // query the system topology to get the list of Cpu and Gpu devices
@@ -389,8 +362,6 @@ private:
     static constexpr bool  CMD_MEMORY_MMAP = false;
     static HsaRsrcFactory* instance_;
     static mutex_t         mutex_;
-    // System timeout, ns
-    static timestamp_t timeout_ns_;
 
     // HSA was initialized
     const bool initialize_hsa_ = false;
@@ -405,18 +376,6 @@ private:
 
     // System agents map
     std::map<hsa_agent_handle_t, const AgentInfo*> agent_map_ = {};
-
-    // AqlProfile API table
-    aqlprofile_pfn_t aqlprofile_api_ = {};
-
-    // Loader API table
-    hsa_ven_amd_loader_1_00_pfn_t loader_api_ = {};
-
-    // System timeout, sysclock
-    timestamp_t timeout_ = HsaTimer::TIMESTAMP_MAX;
-
-    // HSA timer
-    HsaTimer* timer_ = nullptr;
 
     // CPU/kern-arg memory pools
     hsa_amd_memory_pool_t* cpu_pool_      = nullptr;


### PR DESCRIPTION
## Motivation

rocprofiler-sdk loads external aqlprofile to populate the API table, which is never used.
This can cause issues where the profiler fails to run ATT/PMC/SPM if the external aqlprofile cannot be properly loaded by HSA.

JIRA ID : ROCM-29395

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
