### PR TITLE
feat(ci): Re-enable MI455 test runner label

### DIFF
--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -203,8 +203,7 @@ jobs:
     with:
       projects_to_test: "hip-tests, rocrtst"
       amdgpu_families: gfx125X-dcgpu
-      # MI455 machine is down - disabled until back online (was: linux-mi455-gpu-rocm)
-      test_runs_on: ""
+      test_runs_on: linux-mi455-gpu-rocm
       platform: linux
       artifact_run_id: ${{ github.run_id }}
 


### PR DESCRIPTION
Bringing back mi455 machine

test running here: https://github.com/ROCm/rocm-systems/actions/runs/31521916125