### PR TITLE
fix(rocshmem): Fix reduce wg and wave to enable more than 2 pes

### DIFF
--- a/projects/rocshmem/scripts/functional_tests/driver.sh
+++ b/projects/rocshmem/scripts/functional_tests/driver.sh
@@ -838,6 +838,8 @@ TestColl() {
   # check in the ring all-reduce path; this is a pre-existing bug unrelated to
   # work/sync pool alignment, so it is only run at 2 ranks here.
   ExecTest  "teamreduction"    2       1            64        32768
+  ExecTest  "teamreduction"    4       1            64        32768
+  ExecTest  "teamreduction"    8       1            64        32768
 
   ExecTest  "teamreducescatter" 2      1            64        32768
   ExecTest  "teamreducescatter" 4      1            64        32768
@@ -849,6 +851,8 @@ TestColl() {
     ExecTest  "alltoall_wave"       2       1            $WAVE_SIZE   512
     ExecTest  "fcollect_wave"       2       1            $WAVE_SIZE   32768
     ExecTest  "reduce_wave"         2       1            $WAVE_SIZE   32768
+    ExecTest  "reduce_wave"         4       1            $WAVE_SIZE   32768
+    ExecTest  "reduce_wave"         8       1            $WAVE_SIZE   32768
     ExecTest  "reducescatter_wave"  2       1            $WAVE_SIZE   32768
     ExecTest  "reducescatter_wave"  4       1            $WAVE_SIZE   32768
     ExecTest  "reducescatter_wave"  8       1            $WAVE_SIZE   32768

--- a/projects/rocshmem/scripts/functional_tests/driver.sh
+++ b/projects/rocshmem/scripts/functional_tests/driver.sh
@@ -834,9 +834,6 @@ TestColl() {
   ExecTest  "fcollect"         3       1            64        32768
   ExecTest  "fcollect"         5       1            64        32768
 
-  # NOTE: teamreduction at rank counts > 2 currently fails a data validation
-  # check in the ring all-reduce path; this is a pre-existing bug unrelated to
-  # work/sync pool alignment, so it is only run at 2 ranks here.
   ExecTest  "teamreduction"    2       1            64        32768
   ExecTest  "teamreduction"    3       1            64        32768
   ExecTest  "teamreduction"    4       1            64        32768

--- a/projects/rocshmem/scripts/functional_tests/driver.sh
+++ b/projects/rocshmem/scripts/functional_tests/driver.sh
@@ -838,6 +838,7 @@ TestColl() {
   # check in the ring all-reduce path; this is a pre-existing bug unrelated to
   # work/sync pool alignment, so it is only run at 2 ranks here.
   ExecTest  "teamreduction"    2       1            64        32768
+  ExecTest  "teamreduction"    3       1            64        32768
   ExecTest  "teamreduction"    4       1            64        32768
   ExecTest  "teamreduction"    8       1            64        32768
 

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -601,7 +601,7 @@ __device__ void GDAContext::internal_ring_allreduce_wg(T *dst, const T *src,
         chunk_size * sizeof(T), send_pe, send_pe, wf_info);
       fence();
       if (is_thread_zero_in_block()) {
-        wait_val = seg + 100;
+        wait_val = seg + 10;
         internal_putmem(&pSync[iter], &wait_val, sizeof(*pSync), send_pe,
           send_pe, wf_info);
 #if defined(__gfx90a__)

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -452,7 +452,6 @@ __device__ int GDAContext::reduce_wave(rocshmem_team_t team, T *dest,
 
       int n_seg = nreduce / seg_size;
       int n_seg_up = (nreduce - 1) / seg_size + 1;
-      chunk_size = seg_size / PE_size;
 
       if (n_seg > 0) {
         internal_ring_allreduce_wave<T, Op>(dest, source, nreduce, team_obj,
@@ -726,8 +725,6 @@ __device__ int GDAContext::reduce_wg(rocshmem_team_t team, T *dest,
       int n_seg = nreduce / seg_size;
       // integer division rounding up
       int n_seg_up = (nreduce - 1) / seg_size + 1;
-      // recalculate chunk_size
-      // chunk_size = seg_size / PE_size;
 
       if (n_seg > 0) {
         internal_ring_allreduce_wg<T, Op>(dest, source, nreduce, team_obj, n_seg,

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -568,47 +568,35 @@ __device__ void GDAContext::internal_ring_allreduce_wg(T *dst, const T *src,
 
   for (int seg = 0; seg < n_seg; seg++) {
     off_seg = seg * seg_size;
-    // Loop 2 in the algorithm above
-    for (int iter = 0; iter < PE_size - 1; iter++) {
+    for (int iter = 0; iter < 2* PE_size - 2; iter++) {
       off_send = (((my_pe_in_team + 1 - iter + 2 * PE_size) % PE_size) * chunk_size);
       off_recv = (((my_pe_in_team - iter + 2 * PE_size) % PE_size) * chunk_size);
 
       internal_putmem_wg(reinterpret_cast<void *>(&pWrk[off_send]),
-        reinterpret_cast<void *>(&dst[off_send + off_seg]),
-        chunk_size * sizeof(T), send_pe, send_pe, wf_info);
+                reinterpret_cast<void *>(&dst[off_send + off_seg]),
+                chunk_size * sizeof(T), send_pe, send_pe, wf_info);
+
+      fence();
 
       if (is_thread_zero_in_block()) {
-        fence();
-
-        wait_val = seg + 100;
+      wait_val = (seg + 1) * 1000 + iter + 1;
         internal_putmem(&pSync[iter], &wait_val, sizeof(*pSync), send_pe,
           send_pe, wf_info);
-#if defined(__gfx90a__)
-        __threadfence_system();
-#endif /* __gfx90a__ */
-        wait_until(&pSync[iter], ROCSHMEM_CMP_EQ, wait_val);
+    #if defined(__gfx90a__)
+      __threadfence_system();
+    #endif /* __gfx90a__ */
+      wait_until(&pSync[iter], ROCSHMEM_CMP_EQ, wait_val);
       }
+      fence();
       __syncthreads();
+      
+      if (iter < PE_size - 1) {
       gda_compute_reduce<T, Op>(&pWrk[off_recv], &dst[off_seg + off_recv],
                                 chunk_size, wg_id, wg_size);
-    }
-
-    // Loop 2 in the example above
-    for (int iter = PE_size - 1; iter < 2 * PE_size - 2; iter++) {
-      off_send = (((my_pe_in_team + 1 - iter + 2 * PE_size) % PE_size) * chunk_size);
-      internal_putmem_nbi_wg(reinterpret_cast<void *>(&dst[off_send + off_seg]),
-        reinterpret_cast<void *>(&dst[off_send + off_seg]),
-        chunk_size * sizeof(T), send_pe, send_pe, wf_info);
-
-      if (is_thread_zero_in_block()) {
-        fence();
-        wait_val = seg + 100;
-        internal_putmem(&pSync[iter], &wait_val, sizeof(*pSync), send_pe,
-          send_pe, wf_info);
-#if defined(__gfx90a__)
-        __threadfence_system();
-#endif /* __gfx90a__ */
-        wait_until(&pSync[iter], ROCSHMEM_CMP_EQ, wait_val);
+      } else {
+        for (int i = wg_id; i < chunk_size; i += wg_size) {
+          dst[off_recv + off_seg + i] = pWrk[off_recv + i];
+        }
       }
       __syncthreads();
     }
@@ -626,73 +614,62 @@ __device__ void GDAContext::internal_ring_allreduce_wave(T *dst, const T *src,
     int nelems, GDATeam *team_obj,  // NOLINT(runtime/int)
     int n_seg, int seg_size, int chunk_size, ActiveWFInfo &wf_info) {
 
-  int PE_size = team_obj->tinfo_wrt_world->size;
-  long *pSync = team_obj->reduce_pSync;
-  T *pWrk = reinterpret_cast<T *>(team_obj->pWrk);
-  int my_pe_in_team = team_obj->my_pe;
+    int PE_size = team_obj->tinfo_wrt_world->size;
+    long *pSync = team_obj->reduce_pSync;
+    T *pWrk = reinterpret_cast<T *>(team_obj->pWrk);
+    int my_pe_in_team = team_obj->my_pe;
 
-  int off_seg, off_send, off_recv;
-  int send_pe = (my_pe_in_team + 1) % PE_size;
-  send_pe = team_obj->get_pe_in_world(send_pe);
-  long wait_val;  // NOLINT(runtime/int)
+    int off_seg, off_send, off_recv;
+    int send_pe = (my_pe_in_team + 1) % PE_size;
+    send_pe = team_obj->get_pe_in_world(send_pe);
+    long wait_val;  // NOLINT(runtime/int)
 
-  int wf_tid = get_flat_block_id() % WF_SIZE;
+    int wf_tid = get_flat_block_id() % WF_SIZE;
 
-  for (int i = wf_tid; i < nelems; i += WF_SIZE) {
-    dst[i] = src[i];
-  }
+    for (int i = wf_tid; i < nelems; i += WF_SIZE) {
+      dst[i] = src[i];
+    }
 
-  for (int seg = 0; seg < n_seg; seg++) {
-    off_seg = seg * seg_size;
-    // Loop 1: reduce-scatter
-    for (int iter = 0; iter < PE_size - 1; iter++) {
-      off_send = (((my_pe_in_team + 1 - iter + 2 * PE_size) % PE_size) * chunk_size);
-      off_recv = (((my_pe_in_team - iter + 2 * PE_size) % PE_size) * chunk_size);
+    for (int seg = 0; seg < n_seg; seg++) {
+      off_seg = seg * seg_size;
+      // Loop 1: reduce-scatter
+      for (int iter = 0; iter < PE_size - 1; iter++) {
+        off_send = (((my_pe_in_team + 1 - iter + 2 * PE_size) % PE_size) * chunk_size);
+        off_recv = (((my_pe_in_team - iter + 2 * PE_size) % PE_size) * chunk_size);
 
-      internal_putmem_wave(reinterpret_cast<void *>(&pWrk[off_send]),
-        reinterpret_cast<void *>(&dst[off_send + off_seg]),
-        chunk_size * sizeof(T), send_pe, send_pe, wf_info);
+        internal_putmem_wave(reinterpret_cast<void *>(&pWrk[off_send]),
+          reinterpret_cast<void *>(&dst[off_send + off_seg]),
+          chunk_size * sizeof(T), send_pe, send_pe, wf_info);
 
-      if (is_thread_zero_in_wave()) {
-        qps[send_pe].quiet(wf_info);
-        wait_val = seg + 100;
-        internal_putmem_wave(&pSync[iter], &wait_val, sizeof(*pSync), send_pe,
-          send_pe, wf_info);
-#if defined(__gfx90a__)
+        if (is_thread_zero_in_wave()) {
+          qps[send_pe].quiet(wf_info);
+          wait_val = seg + 100;
+          internal_putmem_wave(&pSync[iter], &wait_val, sizeof(*pSync), send_pe,
+            send_pe, wf_info);
+      #if defined(__gfx90a__)
         __threadfence_system();
-#endif /* __gfx90a__ */
-        wait_until(&pSync[iter], ROCSHMEM_CMP_EQ, wait_val);
-      }
-      for (int j = wf_tid; j < chunk_size; j += WF_SIZE) {
-        OpWrap<Op>::Calc(&pWrk[off_recv], &dst[off_seg + off_recv], j);
-      }
-    }
+      #endif /* __gfx90a__ */
+          wait_until(&pSync[iter], ROCSHMEM_CMP_EQ, wait_val);
+        }
 
-    // Loop 2: all-gather
-    for (int iter = PE_size - 1; iter < 2 * PE_size - 2; iter++) {
-      off_send = (((my_pe_in_team + 1 - iter + 2 * PE_size) % PE_size) * chunk_size);
-      internal_putmem_nbi_wave(reinterpret_cast<void *>(&dst[off_send + off_seg]),
-        reinterpret_cast<void *>(&dst[off_send + off_seg]),
-        chunk_size * sizeof(T), send_pe, send_pe, wf_info);
-
-      if (is_thread_zero_in_wave()) {
-        qps[send_pe].quiet(wf_info);
-        wait_val = seg + 10;
-        internal_putmem_wave(&pSync[iter], &wait_val, sizeof(*pSync), send_pe,
-          send_pe, wf_info);
-#if defined(__gfx90a__)
-        __threadfence_system();
-#endif /* __gfx90a__ */
-        wait_until(&pSync[iter], ROCSHMEM_CMP_EQ, wait_val);
+        if (iter < PE_size - 1) {
+          for (int j = wf_tid; j < chunk_size; j += WF_SIZE) {
+            OpWrap<Op>::Calc(&pWrk[off_recv], &dst[off_seg + off_recv], j);
+          }
+        } else {
+          for (int i = wf_tid; i < chunk_size; i += WF_SIZE) {
+            dst[off_recv + off_seg + i] = pWrk[off_recv + i];
+          }
+        }
+        
       }
-    }
-  }
 
-  if (is_thread_zero_in_wave()) {
-    for (int i = 0; i < 2 * constmem.num_pes - 2; i++) {
-      pSync[i] = ROCSHMEM_SYNC_VALUE;
+    if (is_thread_zero_in_wave()) {
+      for (int i = 0; i < 2 * constmem.num_pes - 2; i++) {
+        pSync[i] = ROCSHMEM_SYNC_VALUE;
+      }
+      __threadfence_system();
     }
-    __threadfence_system();
   }
 }
 

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -568,36 +568,49 @@ __device__ void GDAContext::internal_ring_allreduce_wg(T *dst, const T *src,
 
   for (int seg = 0; seg < n_seg; seg++) {
     off_seg = seg * seg_size;
-    for (int iter = 0; iter < 2* PE_size - 2; iter++) {
+    // Loop 2 in the algorithm above
+    for (int iter = 0; iter < PE_size - 1; iter++) {
       off_send = (((my_pe_in_team + 1 - iter + 2 * PE_size) % PE_size) * chunk_size);
       off_recv = (((my_pe_in_team - iter + 2 * PE_size) % PE_size) * chunk_size);
 
       internal_putmem_wg(reinterpret_cast<void *>(&pWrk[off_send]),
-                reinterpret_cast<void *>(&dst[off_send + off_seg]),
-                chunk_size * sizeof(T), send_pe, send_pe, wf_info);
-
+        reinterpret_cast<void *>(&dst[off_send + off_seg]),
+        chunk_size * sizeof(T), send_pe, send_pe, wf_info);
+      
       fence();
 
       if (is_thread_zero_in_block()) {
-      wait_val = (seg + 1) * 1000 + iter + 1;
+        wait_val = seg + 100;
         internal_putmem(&pSync[iter], &wait_val, sizeof(*pSync), send_pe,
           send_pe, wf_info);
-    #if defined(__gfx90a__)
-      __threadfence_system();
-    #endif /* __gfx90a__ */
-      wait_until(&pSync[iter], ROCSHMEM_CMP_EQ, wait_val);
+#if defined(__gfx90a__)
+        __threadfence_system();
+#endif /* __gfx90a__ */
+        wait_until(&pSync[iter], ROCSHMEM_CMP_EQ, wait_val);
       }
       fence();
       __syncthreads();
-      
-      if (iter < PE_size - 1) {
       gda_compute_reduce<T, Op>(&pWrk[off_recv], &dst[off_seg + off_recv],
                                 chunk_size, wg_id, wg_size);
-      } else {
-        for (int i = wg_id; i < chunk_size; i += wg_size) {
-          dst[off_recv + off_seg + i] = pWrk[off_recv + i];
-        }
+    }
+
+    // Loop 2 in the example above
+    for (int iter = PE_size - 1; iter < 2 * PE_size - 2; iter++) {
+      off_send = (((my_pe_in_team + 1 - iter + 2 * PE_size) % PE_size) * chunk_size);
+      internal_putmem_nbi_wg(reinterpret_cast<void *>(&dst[off_send + off_seg]),
+        reinterpret_cast<void *>(&dst[off_send + off_seg]),
+        chunk_size * sizeof(T), send_pe, send_pe, wf_info);
+      fence();
+      if (is_thread_zero_in_block()) {
+        wait_val = seg + 100;
+        internal_putmem(&pSync[iter], &wait_val, sizeof(*pSync), send_pe,
+          send_pe, wf_info);
+#if defined(__gfx90a__)
+        __threadfence_system();
+#endif /* __gfx90a__ */
+        wait_until(&pSync[iter], ROCSHMEM_CMP_EQ, wait_val);
       }
+      fence();
       __syncthreads();
     }
   }
@@ -614,64 +627,74 @@ __device__ void GDAContext::internal_ring_allreduce_wave(T *dst, const T *src,
     int nelems, GDATeam *team_obj,  // NOLINT(runtime/int)
     int n_seg, int seg_size, int chunk_size, ActiveWFInfo &wf_info) {
 
-    int PE_size = team_obj->tinfo_wrt_world->size;
-    long *pSync = team_obj->reduce_pSync;
-    T *pWrk = reinterpret_cast<T *>(team_obj->pWrk);
-    int my_pe_in_team = team_obj->my_pe;
+  int PE_size = team_obj->tinfo_wrt_world->size;
+  long *pSync = team_obj->reduce_pSync;
+  T *pWrk = reinterpret_cast<T *>(team_obj->pWrk);
+  int my_pe_in_team = team_obj->my_pe;
 
-    int off_seg, off_send, off_recv;
-    int send_pe = (my_pe_in_team + 1) % PE_size;
-    send_pe = team_obj->get_pe_in_world(send_pe);
-    long wait_val;  // NOLINT(runtime/int)
+  int off_seg, off_send, off_recv;
+  int send_pe = (my_pe_in_team + 1) % PE_size;
+  send_pe = team_obj->get_pe_in_world(send_pe);
+  long wait_val;  // NOLINT(runtime/int)
 
-    int wf_tid = get_flat_block_id() % WF_SIZE;
+  int wf_tid = get_flat_block_id() % WF_SIZE;
 
-    for (int i = wf_tid; i < nelems; i += WF_SIZE) {
-      dst[i] = src[i];
-    }
+  for (int i = wf_tid; i < nelems; i += WF_SIZE) {
+    dst[i] = src[i];
+  }
 
-    for (int seg = 0; seg < n_seg; seg++) {
-      off_seg = seg * seg_size;
-      // Loop 1: reduce-scatter
-      for (int iter = 0; iter < PE_size - 1; iter++) {
-        off_send = (((my_pe_in_team + 1 - iter + 2 * PE_size) % PE_size) * chunk_size);
-        off_recv = (((my_pe_in_team - iter + 2 * PE_size) % PE_size) * chunk_size);
+  for (int seg = 0; seg < n_seg; seg++) {
+    off_seg = seg * seg_size;
+    // Loop 1: reduce-scatter
+    for (int iter = 0; iter < PE_size - 1; iter++) {
+      off_send = (((my_pe_in_team + 1 - iter + 2 * PE_size) % PE_size) * chunk_size);
+      off_recv = (((my_pe_in_team - iter + 2 * PE_size) % PE_size) * chunk_size);
 
-        internal_putmem_wave(reinterpret_cast<void *>(&pWrk[off_send]),
-          reinterpret_cast<void *>(&dst[off_send + off_seg]),
-          chunk_size * sizeof(T), send_pe, send_pe, wf_info);
-      
-        fence();
-        if (is_thread_zero_in_wave()) {
-          qps[send_pe].quiet(wf_info);
-          wait_val = seg + 100;
-          internal_putmem_wave(&pSync[iter], &wait_val, sizeof(*pSync), send_pe,
-            send_pe, wf_info);
-      #if defined(__gfx90a__)
+      internal_putmem_wave(reinterpret_cast<void *>(&pWrk[off_send]),
+        reinterpret_cast<void *>(&dst[off_send + off_seg]),
+        chunk_size * sizeof(T), send_pe, send_pe, wf_info);
+      fence();
+      if (is_thread_zero_in_wave()) {
+        qps[send_pe].quiet(wf_info);
+        wait_val = seg + 100;
+        internal_putmem_wave(&pSync[iter], &wait_val, sizeof(*pSync), send_pe,
+          send_pe, wf_info);
+#if defined(__gfx90a__)
         __threadfence_system();
-      #endif /* __gfx90a__ */
-          wait_until(&pSync[iter], ROCSHMEM_CMP_EQ, wait_val);
-        }
-        fence();
-
-        if (iter < PE_size - 1) {
-          for (int j = wf_tid; j < chunk_size; j += WF_SIZE) {
-            OpWrap<Op>::Calc(&pWrk[off_recv], &dst[off_seg + off_recv], j);
-          }
-        } else {
-          for (int i = wf_tid; i < chunk_size; i += WF_SIZE) {
-            dst[off_recv + off_seg + i] = pWrk[off_recv + i];
-          }
-        }
-        
+#endif /* __gfx90a__ */
+        wait_until(&pSync[iter], ROCSHMEM_CMP_EQ, wait_val);
       }
-
-    if (is_thread_zero_in_wave()) {
-      for (int i = 0; i < 2 * constmem.num_pes - 2; i++) {
-        pSync[i] = ROCSHMEM_SYNC_VALUE;
+      fence();
+      for (int j = wf_tid; j < chunk_size; j += WF_SIZE) {
+        OpWrap<Op>::Calc(&pWrk[off_recv], &dst[off_seg + off_recv], j);
       }
-      __threadfence_system();
     }
+
+    // Loop 2: all-gather
+    for (int iter = PE_size - 1; iter < 2 * PE_size - 2; iter++) {
+      off_send = (((my_pe_in_team + 1 - iter + 2 * PE_size) % PE_size) * chunk_size);
+      internal_putmem_nbi_wave(reinterpret_cast<void *>(&dst[off_send + off_seg]),
+        reinterpret_cast<void *>(&dst[off_send + off_seg]),
+        chunk_size * sizeof(T), send_pe, send_pe, wf_info);
+      fence();
+      if (is_thread_zero_in_wave()) {
+        qps[send_pe].quiet(wf_info);
+        wait_val = seg + 10;
+        internal_putmem_wave(&pSync[iter], &wait_val, sizeof(*pSync), send_pe,
+          send_pe, wf_info);
+#if defined(__gfx90a__)
+        __threadfence_system();
+#endif /* __gfx90a__ */
+        wait_until(&pSync[iter], ROCSHMEM_CMP_EQ, wait_val);
+      }
+    }
+  }
+
+  if (is_thread_zero_in_wave()) {
+    for (int i = 0; i < 2 * constmem.num_pes - 2; i++) {
+      pSync[i] = ROCSHMEM_SYNC_VALUE;
+    }
+    __threadfence_system();
   }
 }
 

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -640,7 +640,8 @@ __device__ void GDAContext::internal_ring_allreduce_wave(T *dst, const T *src,
         internal_putmem_wave(reinterpret_cast<void *>(&pWrk[off_send]),
           reinterpret_cast<void *>(&dst[off_send + off_seg]),
           chunk_size * sizeof(T), send_pe, send_pe, wf_info);
-
+      
+        fence();
         if (is_thread_zero_in_wave()) {
           qps[send_pe].quiet(wf_info);
           wait_val = seg + 100;
@@ -651,6 +652,7 @@ __device__ void GDAContext::internal_ring_allreduce_wave(T *dst, const T *src,
       #endif /* __gfx90a__ */
           wait_until(&pSync[iter], ROCSHMEM_CMP_EQ, wait_val);
         }
+        fence();
 
         if (iter < PE_size - 1) {
           for (int j = wf_tid; j < chunk_size; j += WF_SIZE) {

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -727,7 +727,7 @@ __device__ int GDAContext::reduce_wg(rocshmem_team_t team, T *dest,
       // integer division rounding up
       int n_seg_up = (nreduce - 1) / seg_size + 1;
       // recalculate chunk_size
-      chunk_size = seg_size / PE_size;
+      // chunk_size = seg_size / PE_size;
 
       if (n_seg > 0) {
         internal_ring_allreduce_wg<T, Op>(dest, source, nreduce, team_obj, n_seg,

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -288,7 +288,7 @@ __device__ int IPCContext::reduce_wave(rocshmem_team_t team, T *dest,
 
       int n_seg = nreduce / seg_size;
       int n_seg_up = (nreduce - 1) / seg_size + 1;
-      chunk_size = seg_size / PE_size;
+      // chunk_size = seg_size / PE_size;
 
       if (n_seg > 0) {
         internal_ring_allreduce_wave<T, Op>(dest, source, nreduce, team_obj,
@@ -465,12 +465,13 @@ __device__ void IPCContext::internal_ring_allreduce_wave(
   int send_pe = (my_pe_in_team + 1) % PE_size;
   send_pe = team_obj->get_pe_in_world(send_pe);
   long wait_val;  // NOLINT(runtime/int)
+  int wave_size = wave_SZ();
+  int wf_tid = get_flat_block_id() % wave_size;
 
-  int wf_tid = get_flat_block_id() % WF_SIZE;
-
-  for (int i = wf_tid; i < nelems; i += WF_SIZE) {
+  for (int i = wf_tid; i < nelems; i += wave_size) {
     dst[i] = src[i];
   }
+  __builtin_amdgcn_wave_barrier();
 
   for (int seg = 0; seg < n_seg; seg++) {
     off_seg = seg * seg_size;
@@ -482,20 +483,22 @@ __device__ void IPCContext::internal_ring_allreduce_wave(
       internal_putmem_wave(reinterpret_cast<void *>(&pWrk[off_send]),
                            reinterpret_cast<void *>(&dst[off_send + off_seg]),
                            chunk_size * sizeof(T), send_pe);
+      __builtin_amdgcn_wave_barrier();
+      fence(send_pe);
 
+      wait_val = seg + 100;
       if (is_thread_zero_in_wave()) {
-        wait_val = seg + 100;
-        fence(send_pe);
         internal_putmem(&pSync[iter], &wait_val, sizeof(*pSync), send_pe);
-        wait_until(&pSync[iter], ROCSHMEM_CMP_EQ, wait_val);
       }
-      
+      wait_until(&pSync[iter], ROCSHMEM_CMP_EQ, wait_val);
       detail::atomic::threadfence<detail::atomic::memory_scope_system,
                              detail::atomic::memory_order_acquire>();
+      __builtin_amdgcn_wave_barrier();
 
-      for (int j = wf_tid; j < chunk_size; j += WF_SIZE) {
+      for (int j = wf_tid; j < chunk_size; j += wave_size) {
         OpWrap<Op>::Calc(&pWrk[off_recv], &dst[off_seg + off_recv], j);
       }
+      __builtin_amdgcn_wave_barrier();
     }
 
     // Loop 2: all-gather
@@ -504,15 +507,17 @@ __device__ void IPCContext::internal_ring_allreduce_wave(
       putmem_nbi_wave(reinterpret_cast<void *>(&dst[off_send + off_seg]),
                       reinterpret_cast<void *>(&dst[off_send + off_seg]),
                       chunk_size * sizeof(T), send_pe);
-
+      __builtin_amdgcn_wave_barrier();
+      fence(send_pe);
+      
+      wait_val = seg + 100;
       if (is_thread_zero_in_wave()) {
-        wait_val = seg + 10;
-        fence(send_pe);
         internal_putmem(&pSync[iter], &wait_val, sizeof(*pSync), send_pe);
-        wait_until(&pSync[iter], ROCSHMEM_CMP_EQ, wait_val);
       }
+      wait_until(&pSync[iter], ROCSHMEM_CMP_EQ, wait_val);
       detail::atomic::threadfence<detail::atomic::memory_scope_system,
                              detail::atomic::memory_order_acquire>();
+      __builtin_amdgcn_wave_barrier();
     }
   }
 
@@ -562,6 +567,7 @@ __device__ int IPCContext::reduce_wg(rocshmem_team_t team, T *dest,
         int p_count = nreduce - (n_seg * seg_size);
         int p_chunk = p_count / PE_size;
         if (p_chunk > 0) {
+          barrier_wg(team);
           internal_ring_allreduce_wg<T, Op>(p_dst, p_src,
                                          (p_chunk * PE_size), team_obj, 1,
                                          (p_chunk * PE_size), p_chunk);
@@ -572,7 +578,7 @@ __device__ int IPCContext::reduce_wg(rocshmem_team_t team, T *dest,
           p_count -= (p_chunk * PE_size);
           p_dst += (p_chunk * PE_size);
           const T *p_src2 = p_src + (p_chunk * PE_size);
-
+          barrier_wg(team);
           internal_direct_allreduce_wg<T, Op>(p_dst, p_src2, p_count, team_obj);
         }
       }

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -472,7 +472,8 @@ __device__ void IPCContext::internal_ring_allreduce_wave(
         internal_putmem(&pSync[iter], &wait_val, sizeof(wait_val), send_pe);
       }
       wait_until(&pSync[iter], ROCSHMEM_CMP_EQ, wait_val);
-      detail::atomic::threadfence<detail::atomic::memory_scope_system, 
+      
+      detail::atomic::threadfence<detail::atomic::memory_scope_system,
                              detail::atomic::memory_order_acquire>();
 
       if (iter < PE_size - 1) {

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -435,7 +435,7 @@ __device__ void IPCContext::internal_ring_allreduce_wg(
       __syncthreads();
       fence(send_pe);
       if (is_thread_zero_in_block()) {
-        wait_val = seg + 100;
+        wait_val = seg + 10;
         internal_putmem(&pSync[iter], &wait_val, sizeof(*pSync), send_pe);
         wait_until(&pSync[iter], ROCSHMEM_CMP_EQ, wait_val);
       }
@@ -511,7 +511,7 @@ __device__ void IPCContext::internal_ring_allreduce_wave(
       __builtin_amdgcn_wave_barrier();
       fence(send_pe);
       
-      wait_val = seg + 100;
+      wait_val = seg + 10;
       if (is_thread_zero_in_wave()) {
         internal_putmem(&pSync[iter], &wait_val, sizeof(*pSync), send_pe);
       }

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -300,6 +300,7 @@ __device__ int IPCContext::reduce_wave(rocshmem_team_t team, T *dest,
         int p_count = nreduce - (n_seg * seg_size);
         int p_chunk = p_count / PE_size;
         if (p_chunk > 0) {
+          barrier_wave(team);
           internal_ring_allreduce_wave<T, Op>(p_dst, p_src,
                                               (p_chunk * PE_size), team_obj, 1,
                                               (p_chunk * PE_size), p_chunk);
@@ -309,6 +310,7 @@ __device__ int IPCContext::reduce_wave(rocshmem_team_t team, T *dest,
           p_count -= (p_chunk * PE_size);
           p_dst += (p_chunk * PE_size);
           const T *p_src2 = p_src + (p_chunk * PE_size);
+          barrier_wave(team);
           internal_direct_allreduce_wave<T, Op>(p_dst, p_src2, p_count, team_obj);
         }
       }

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -411,14 +411,13 @@ __device__ void IPCContext::internal_ring_allreduce_wg(
       internal_putmem_wg(reinterpret_cast<void *>(&pWrk[off_send]),
                     reinterpret_cast<void *>(&dst[off_send + off_seg]),
                     chunk_size * sizeof(T), send_pe);
-
+      fence(send_pe);
       if (is_thread_zero_in_block()) {
         wait_val = seg + 100;
-        fence(send_pe);
         internal_putmem(&pSync[iter], &wait_val, sizeof(*pSync), send_pe);
         wait_until(&pSync[iter], ROCSHMEM_CMP_EQ, wait_val);
       }
-      detail::atomic::threadfence<detail::atomic::memory_scope_system, 
+      detail::atomic::threadfence<detail::atomic::memory_scope_system,
                              detail::atomic::memory_order_acquire>();
       __syncthreads();
 
@@ -432,13 +431,15 @@ __device__ void IPCContext::internal_ring_allreduce_wg(
       putmem_nbi_wg(reinterpret_cast<void *>(&dst[off_send + off_seg]),
                     reinterpret_cast<void *>(&dst[off_send + off_seg]),
                     chunk_size * sizeof(T), send_pe);
-
+      __syncthreads();
+      fence(send_pe);
       if (is_thread_zero_in_block()) {
-        wait_val = seg + 10;
-        fence(send_pe);
+        wait_val = seg + 100;
         internal_putmem(&pSync[iter], &wait_val, sizeof(*pSync), send_pe);
         wait_until(&pSync[iter], ROCSHMEM_CMP_EQ, wait_val);
       }
+      detail::atomic::threadfence<detail::atomic::memory_scope_system,
+                             detail::atomic::memory_order_acquire>();
 
       __syncthreads();
     }
@@ -489,7 +490,7 @@ __device__ void IPCContext::internal_ring_allreduce_wave(
         wait_until(&pSync[iter], ROCSHMEM_CMP_EQ, wait_val);
       }
       
-      detail::atomic::threadfence<detail::atomic::memory_scope_system, 
+      detail::atomic::threadfence<detail::atomic::memory_scope_system,
                              detail::atomic::memory_order_acquire>();
 
       for (int j = wf_tid; j < chunk_size; j += WF_SIZE) {
@@ -510,6 +511,8 @@ __device__ void IPCContext::internal_ring_allreduce_wave(
         internal_putmem(&pSync[iter], &wait_val, sizeof(*pSync), send_pe);
         wait_until(&pSync[iter], ROCSHMEM_CMP_EQ, wait_val);
       }
+      detail::atomic::threadfence<detail::atomic::memory_scope_system,
+                             detail::atomic::memory_order_acquire>();
     }
   }
 
@@ -547,7 +550,7 @@ __device__ int IPCContext::reduce_wg(rocshmem_team_t team, T *dest,
       // integer division rounding up
       int n_seg_up = (nreduce - 1) / seg_size + 1;
       // recalculate chunk_size
-      chunk_size = seg_size / PE_size;
+      // chunk_size = seg_size / PE_size;
 
       if (n_seg > 0) {
         internal_ring_allreduce_wg<T, Op>(dest, source, nreduce, team_obj, n_seg,

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -386,11 +386,13 @@ __device__ void IPCContext::internal_ring_allreduce_wg(
   long *pSync = team_obj->reduce_pSync;
   T *pWrk = reinterpret_cast<T *>(team_obj->pWrk);
   int my_pe_in_team = team_obj->my_pe;
+
   int off_seg, off_send, off_recv;
   int send_pe = (my_pe_in_team + 1) % PE_size;
   // send_pe is relative to team, convert it relative to team world
   send_pe = team_obj->get_pe_in_world(send_pe);
   long wait_val;  // NOLINT(runtime/int)
+
   int wg_size = get_flat_block_size();
   int wg_id = get_flat_block_id();
 
@@ -401,31 +403,43 @@ __device__ void IPCContext::internal_ring_allreduce_wg(
 
   for (int seg = 0; seg < n_seg; seg++) {
     off_seg = seg * seg_size;
-    for (int iter = 0; iter < 2 * PE_size - 2; iter++) {
+    // Loop 1 in the algorithm above
+    for (int iter = 0; iter < PE_size - 1; iter++) {
       off_send = (((my_pe_in_team + 1 - iter + 2 * PE_size) % PE_size) * chunk_size);
       off_recv = (((my_pe_in_team - iter + 2 * PE_size) % PE_size) * chunk_size);
 
       internal_putmem_wg(reinterpret_cast<void *>(&pWrk[off_send]),
                     reinterpret_cast<void *>(&dst[off_send + off_seg]),
                     chunk_size * sizeof(T), send_pe);
-      fence();
 
-      wait_val = (seg + 1) * 1000 + iter + 1;
       if (is_thread_zero_in_block()) {
-        internal_putmem(&pSync[iter], &wait_val, sizeof(wait_val), send_pe);
+        wait_val = seg + 100;
+        fence(send_pe);
+        internal_putmem(&pSync[iter], &wait_val, sizeof(*pSync), send_pe);
+        wait_until(&pSync[iter], ROCSHMEM_CMP_EQ, wait_val);
       }
-      wait_until(&pSync[iter], ROCSHMEM_CMP_EQ, wait_val);
       detail::atomic::threadfence<detail::atomic::memory_scope_system, 
                              detail::atomic::memory_order_acquire>();
+      __syncthreads();
 
-      if (iter < PE_size - 1) {
-        ipc_compute_reduce<T, Op>(&pWrk[off_recv], &dst[off_seg + off_recv],
-                              chunk_size, wg_id, wg_size);
-      } else {
-        for (int i = wg_id; i < chunk_size; i += wg_size) {
-          dst[off_recv + off_seg + i] = pWrk[off_recv + i];
-        }
+      ipc_compute_reduce<T, Op>(&pWrk[off_recv], &dst[off_seg + off_recv],
+                            chunk_size, wg_id, wg_size);
+    }
+
+    // Loop 2 in the example above
+    for (int iter = PE_size - 1; iter < 2 * PE_size - 2; iter++) {
+      off_send = (((my_pe_in_team + 1 - iter + 2 * PE_size) % PE_size) * chunk_size);
+      putmem_nbi_wg(reinterpret_cast<void *>(&dst[off_send + off_seg]),
+                    reinterpret_cast<void *>(&dst[off_send + off_seg]),
+                    chunk_size * sizeof(T), send_pe);
+
+      if (is_thread_zero_in_block()) {
+        wait_val = seg + 10;
+        fence(send_pe);
+        internal_putmem(&pSync[iter], &wait_val, sizeof(*pSync), send_pe);
+        wait_until(&pSync[iter], ROCSHMEM_CMP_EQ, wait_val);
       }
+
       __syncthreads();
     }
   }
@@ -445,11 +459,12 @@ __device__ void IPCContext::internal_ring_allreduce_wave(
   long *pSync = team_obj->reduce_pSync;
   T *pWrk = reinterpret_cast<T *>(team_obj->pWrk);
   int my_pe_in_team = team_obj->my_pe;
+
   int off_seg, off_send, off_recv;
   int send_pe = (my_pe_in_team + 1) % PE_size;
-  // send_pe is relative to team, convert it relative to team world
   send_pe = team_obj->get_pe_in_world(send_pe);
   long wait_val;  // NOLINT(runtime/int)
+
   int wf_tid = get_flat_block_id() % WF_SIZE;
 
   for (int i = wf_tid; i < nelems; i += WF_SIZE) {
@@ -458,35 +473,46 @@ __device__ void IPCContext::internal_ring_allreduce_wave(
 
   for (int seg = 0; seg < n_seg; seg++) {
     off_seg = seg * seg_size;
-    for (int iter = 0; iter < 2 * PE_size - 2; iter++) {
+    // Loop 1: reduce-scatter
+    for (int iter = 0; iter < PE_size - 1; iter++) {
       off_send = (((my_pe_in_team + 1 - iter + 2 * PE_size) % PE_size) * chunk_size);
       off_recv = (((my_pe_in_team - iter + 2 * PE_size) % PE_size) * chunk_size);
 
       internal_putmem_wave(reinterpret_cast<void *>(&pWrk[off_send]),
-                    reinterpret_cast<void *>(&dst[off_send + off_seg]),
-                    chunk_size * sizeof(T), send_pe);
-      fence();
+                           reinterpret_cast<void *>(&dst[off_send + off_seg]),
+                           chunk_size * sizeof(T), send_pe);
 
-      wait_val = (seg + 1) * 1000 + iter + 1;
       if (is_thread_zero_in_wave()) {
-        internal_putmem(&pSync[iter], &wait_val, sizeof(wait_val), send_pe);
+        wait_val = seg + 100;
+        fence(send_pe);
+        internal_putmem(&pSync[iter], &wait_val, sizeof(*pSync), send_pe);
+        wait_until(&pSync[iter], ROCSHMEM_CMP_EQ, wait_val);
       }
-      wait_until(&pSync[iter], ROCSHMEM_CMP_EQ, wait_val);
       
-      detail::atomic::threadfence<detail::atomic::memory_scope_system,
+      detail::atomic::threadfence<detail::atomic::memory_scope_system, 
                              detail::atomic::memory_order_acquire>();
 
-      if (iter < PE_size - 1) {
-        for (int j = wf_tid; j < chunk_size; j += WF_SIZE) {
-          OpWrap<Op>::Calc(&pWrk[off_recv], &dst[off_seg + off_recv], j);
-        }
-      } else {
-        for (int i = wf_tid; i < chunk_size; i += WF_SIZE) {
-          dst[off_recv + off_seg + i] = pWrk[off_recv + i];
-        }
+      for (int j = wf_tid; j < chunk_size; j += WF_SIZE) {
+        OpWrap<Op>::Calc(&pWrk[off_recv], &dst[off_seg + off_recv], j);
+      }
+    }
+
+    // Loop 2: all-gather
+    for (int iter = PE_size - 1; iter < 2 * PE_size - 2; iter++) {
+      off_send = (((my_pe_in_team + 1 - iter + 2 * PE_size) % PE_size) * chunk_size);
+      putmem_nbi_wave(reinterpret_cast<void *>(&dst[off_send + off_seg]),
+                      reinterpret_cast<void *>(&dst[off_send + off_seg]),
+                      chunk_size * sizeof(T), send_pe);
+
+      if (is_thread_zero_in_wave()) {
+        wait_val = seg + 10;
+        fence(send_pe);
+        internal_putmem(&pSync[iter], &wait_val, sizeof(*pSync), send_pe);
+        wait_until(&pSync[iter], ROCSHMEM_CMP_EQ, wait_val);
       }
     }
   }
+
   if (is_thread_zero_in_wave()) {
     for (int i = 0; i < 2 * constmem.num_pes - 2; i++) {
       pSync[i] = ROCSHMEM_SYNC_VALUE;

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -386,13 +386,11 @@ __device__ void IPCContext::internal_ring_allreduce_wg(
   long *pSync = team_obj->reduce_pSync;
   T *pWrk = reinterpret_cast<T *>(team_obj->pWrk);
   int my_pe_in_team = team_obj->my_pe;
-
   int off_seg, off_send, off_recv;
   int send_pe = (my_pe_in_team + 1) % PE_size;
   // send_pe is relative to team, convert it relative to team world
   send_pe = team_obj->get_pe_in_world(send_pe);
   long wait_val;  // NOLINT(runtime/int)
-
   int wg_size = get_flat_block_size();
   int wg_id = get_flat_block_id();
 
@@ -403,38 +401,30 @@ __device__ void IPCContext::internal_ring_allreduce_wg(
 
   for (int seg = 0; seg < n_seg; seg++) {
     off_seg = seg * seg_size;
-    // Loop 1 in the algorithm above
-    for (int iter = 0; iter < PE_size - 1; iter++) {
+    for (int iter = 0; iter < 2 * PE_size - 2; iter++) {
       off_send = (((my_pe_in_team + 1 - iter + 2 * PE_size) % PE_size) * chunk_size);
       off_recv = (((my_pe_in_team - iter + 2 * PE_size) % PE_size) * chunk_size);
 
       internal_putmem_wg(reinterpret_cast<void *>(&pWrk[off_send]),
                     reinterpret_cast<void *>(&dst[off_send + off_seg]),
                     chunk_size * sizeof(T), send_pe);
+      fence();
 
+      wait_val = (seg + 1) * 1000 + iter + 1;
       if (is_thread_zero_in_block()) {
-        wait_val = seg + 100;
-        fence(send_pe);
-        internal_putmem(&pSync[iter], &wait_val, sizeof(*pSync), send_pe);
-        wait_until(&pSync[iter], ROCSHMEM_CMP_EQ, wait_val);
+        internal_putmem(&pSync[iter], &wait_val, sizeof(wait_val), send_pe);
       }
-      __syncthreads();
-      ipc_compute_reduce<T, Op>(&pWrk[off_recv], &dst[off_seg + off_recv],
-                            chunk_size, wg_id, wg_size);
-    }
+      wait_until(&pSync[iter], ROCSHMEM_CMP_EQ, wait_val);
+      detail::atomic::threadfence<detail::atomic::memory_scope_system, 
+                             detail::atomic::memory_order_acquire>();
 
-    // Loop 2 in the example above
-    for (int iter = PE_size - 1; iter < 2 * PE_size - 2; iter++) {
-      off_send = (((my_pe_in_team + 1 - iter + 2 * PE_size) % PE_size) * chunk_size);
-      putmem_nbi_wg(reinterpret_cast<void *>(&dst[off_send + off_seg]),
-                    reinterpret_cast<void *>(&dst[off_send + off_seg]),
-                    chunk_size * sizeof(T), send_pe);
-
-      if (is_thread_zero_in_block()) {
-        wait_val = seg + 10;
-        fence(send_pe);
-        internal_putmem(&pSync[iter], &wait_val, sizeof(*pSync), send_pe);
-        wait_until(&pSync[iter], ROCSHMEM_CMP_EQ, wait_val);
+      if (iter < PE_size - 1) {
+        ipc_compute_reduce<T, Op>(&pWrk[off_recv], &dst[off_seg + off_recv],
+                              chunk_size, wg_id, wg_size);
+      } else {
+        for (int i = wg_id; i < chunk_size; i += wg_size) {
+          dst[off_recv + off_seg + i] = pWrk[off_recv + i];
+        }
       }
       __syncthreads();
     }
@@ -455,12 +445,11 @@ __device__ void IPCContext::internal_ring_allreduce_wave(
   long *pSync = team_obj->reduce_pSync;
   T *pWrk = reinterpret_cast<T *>(team_obj->pWrk);
   int my_pe_in_team = team_obj->my_pe;
-
   int off_seg, off_send, off_recv;
   int send_pe = (my_pe_in_team + 1) % PE_size;
+  // send_pe is relative to team, convert it relative to team world
   send_pe = team_obj->get_pe_in_world(send_pe);
   long wait_val;  // NOLINT(runtime/int)
-
   int wf_tid = get_flat_block_id() % WF_SIZE;
 
   for (int i = wf_tid; i < nelems; i += WF_SIZE) {
@@ -469,42 +458,34 @@ __device__ void IPCContext::internal_ring_allreduce_wave(
 
   for (int seg = 0; seg < n_seg; seg++) {
     off_seg = seg * seg_size;
-    // Loop 1: reduce-scatter
-    for (int iter = 0; iter < PE_size - 1; iter++) {
+    for (int iter = 0; iter < 2 * PE_size - 2; iter++) {
       off_send = (((my_pe_in_team + 1 - iter + 2 * PE_size) % PE_size) * chunk_size);
       off_recv = (((my_pe_in_team - iter + 2 * PE_size) % PE_size) * chunk_size);
 
       internal_putmem_wave(reinterpret_cast<void *>(&pWrk[off_send]),
-                           reinterpret_cast<void *>(&dst[off_send + off_seg]),
-                           chunk_size * sizeof(T), send_pe);
+                    reinterpret_cast<void *>(&dst[off_send + off_seg]),
+                    chunk_size * sizeof(T), send_pe);
+      fence();
 
+      wait_val = (seg + 1) * 1000 + iter + 1;
       if (is_thread_zero_in_wave()) {
-        wait_val = seg + 100;
-        fence(send_pe);
-        internal_putmem(&pSync[iter], &wait_val, sizeof(*pSync), send_pe);
-        wait_until(&pSync[iter], ROCSHMEM_CMP_EQ, wait_val);
+        internal_putmem(&pSync[iter], &wait_val, sizeof(wait_val), send_pe);
       }
-      for (int j = wf_tid; j < chunk_size; j += WF_SIZE) {
-        OpWrap<Op>::Calc(&pWrk[off_recv], &dst[off_seg + off_recv], j);
-      }
-    }
+      wait_until(&pSync[iter], ROCSHMEM_CMP_EQ, wait_val);
+      detail::atomic::threadfence<detail::atomic::memory_scope_system, 
+                             detail::atomic::memory_order_acquire>();
 
-    // Loop 2: all-gather
-    for (int iter = PE_size - 1; iter < 2 * PE_size - 2; iter++) {
-      off_send = (((my_pe_in_team + 1 - iter + 2 * PE_size) % PE_size) * chunk_size);
-      putmem_nbi_wave(reinterpret_cast<void *>(&dst[off_send + off_seg]),
-                      reinterpret_cast<void *>(&dst[off_send + off_seg]),
-                      chunk_size * sizeof(T), send_pe);
-
-      if (is_thread_zero_in_wave()) {
-        wait_val = seg + 10;
-        fence(send_pe);
-        internal_putmem(&pSync[iter], &wait_val, sizeof(*pSync), send_pe);
-        wait_until(&pSync[iter], ROCSHMEM_CMP_EQ, wait_val);
+      if (iter < PE_size - 1) {
+        for (int j = wf_tid; j < chunk_size; j += WF_SIZE) {
+          OpWrap<Op>::Calc(&pWrk[off_recv], &dst[off_seg + off_recv], j);
+        }
+      } else {
+        for (int i = wf_tid; i < chunk_size; i += WF_SIZE) {
+          dst[off_recv + off_seg + i] = pWrk[off_recv + i];
+        }
       }
     }
   }
-
   if (is_thread_zero_in_wave()) {
     for (int i = 0; i < 2 * constmem.num_pes - 2; i++) {
       pSync[i] = ROCSHMEM_SYNC_VALUE;
@@ -533,13 +514,14 @@ __device__ int IPCContext::reduce_wg(rocshmem_team_t team, T *dest,
       // integer division truncating value
       int chunk_size = ring_pWrk / PE_size;
       int seg_size = chunk_size * PE_size;
+      // seg_size = seg_size > nreduce ? nreduce : seg_size;
 
       // integer division truncating value
       int n_seg = nreduce / seg_size;
       // integer division rounding up
       int n_seg_up = (nreduce - 1) / seg_size + 1;
       // recalculate chunk_size
-      chunk_size = seg_size / PE_size;
+      // chunk_size = seg_size / PE_size;
 
       if (n_seg > 0) {
         internal_ring_allreduce_wg<T, Op>(dest, source, nreduce, team_obj, n_seg,

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -541,14 +541,13 @@ __device__ int IPCContext::reduce_wg(rocshmem_team_t team, T *dest,
       // integer division truncating value
       int chunk_size = ring_pWrk / PE_size;
       int seg_size = chunk_size * PE_size;
-      // seg_size = seg_size > nreduce ? nreduce : seg_size;
 
       // integer division truncating value
       int n_seg = nreduce / seg_size;
       // integer division rounding up
       int n_seg_up = (nreduce - 1) / seg_size + 1;
       // recalculate chunk_size
-      // chunk_size = seg_size / PE_size;
+      chunk_size = seg_size / PE_size;
 
       if (n_seg > 0) {
         internal_ring_allreduce_wg<T, Op>(dest, source, nreduce, team_obj, n_seg,

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -288,7 +288,6 @@ __device__ int IPCContext::reduce_wave(rocshmem_team_t team, T *dest,
 
       int n_seg = nreduce / seg_size;
       int n_seg_up = (nreduce - 1) / seg_size + 1;
-      // chunk_size = seg_size / PE_size;
 
       if (n_seg > 0) {
         internal_ring_allreduce_wave<T, Op>(dest, source, nreduce, team_obj,
@@ -556,8 +555,6 @@ __device__ int IPCContext::reduce_wg(rocshmem_team_t team, T *dest,
       int n_seg = nreduce / seg_size;
       // integer division rounding up
       int n_seg_up = (nreduce - 1) / seg_size + 1;
-      // recalculate chunk_size
-      // chunk_size = seg_size / PE_size;
 
       if (n_seg > 0) {
         internal_ring_allreduce_wg<T, Op>(dest, source, nreduce, team_obj, n_seg,


### PR DESCRIPTION
## Motivation

Fix `reduce_wave` and `reduce_wg` operations that produce incorrect results when running with more than 2 PEs and message sizes ≥512B. Data validation errors indicate partial reductions, suggesting not all PEs are contributing to the reduction.

## Technical Details

Needs additional fencing to ensure that all threads have access to the correct data in order to proceed with the reduction. Added appropriate fencing, on IPC and GDA.

## Issue Tracking

JIRA ID: AIROCSHMEM-485

## Test Plan

Verified using the rocshmem functional test suite with the team-based reduction test (test ID 33) across multiple PE counts and message sizes:

`mpirun -n 4 -mca pml ucx -mca osc ucx -x ROCSHMEM_MAX_NUM_CONTEXTS=1 -x UCX_ROCM_IPC_SIGPOOL_MAX_ELEMS=16384 -x ROCSHMEM_HEAP_SIZE=6442450944 --timeout 300 --map-by numa ./tests/functional_tests/rocshmem_functional_tests -a 33 -w 1 -z 64 -localbuftype heap -s 32768`

## Test Result

 - Tests with power of 2 PEs (2,4,8) Pass on IPC and GDA.
 - Tests with non-power of 2 PEs pass on GDA

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
