### PR TITLE
fix(rocprofiler-systems): Stop excluding binaries stored under "dyninst" path

### DIFF
--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/module_function.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/module_function.cpp
@@ -421,14 +421,20 @@ module_function::get_visibility() const
 // whereas an object path names a file the user may keep in any directory, so
 // only its filename is searched. E.g. "/home/me/dyninst-tests/app" is
 // not part of dyninst.
-bool
-module_function::is_object_module() const
+//
+// Returns whichever of the two the caller should search, so the result refers
+// to module_base and is valid for as long as it is.
+const string_t&
+module_function::get_module_identity(const string_t& module_base) const
 {
     auto* _object = (module) ? module->getObject() : nullptr;
-    if(_object == nullptr) return false;
 
-    return rocprofsys::path::filename(module_name) ==
-           rocprofsys::path::filename(_object->pathName());
+    // module_name is the object's own path when the code had no debug info
+    const bool _is_object_module =
+        _object != nullptr &&
+        module_base == rocprofsys::path::filename(_object->pathName());
+
+    return _is_object_module ? module_base : module_name;
 }
 
 bool
@@ -444,7 +450,7 @@ module_function::is_internal_constrained() const
 
     auto        _module_base = rocprofsys::path::filename(module_name);
     auto        _module_real = rocprofsys::path::realpath(module_name);
-    const auto& _module_id   = is_object_module() ? _module_base : module_name;
+    const auto& _module_id   = get_module_identity(_module_base);
 
     if(std::regex_search(_module_id,
                          std::regex{ "lib(rocprof-sys|rocprofsys|timemory|perfetto)" }))
@@ -507,7 +513,7 @@ module_function::is_module_constrained() const
         return false;
 
     auto        _module_base = rocprofsys::path::filename(module_name);
-    const auto& _module_id   = is_object_module() ? _module_base : module_name;
+    const auto& _module_id   = get_module_identity(_module_base);
 
     static std::regex ext_regex{ "\\.(s|S)$", regex_opts };
     static std::regex sys_regex{ "^(s|k|e|w)_[A-Za-z_0-9\\-]+\\.(c|C)$", regex_opts };

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/module_function.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/module_function.cpp
@@ -411,6 +411,26 @@ module_function::get_visibility() const
     return _v;
 }
 
+// Dyninst names a module either after the source file its code was compiled
+// from, taken from the debug info, e.g. "/home/me/src/app.cpp", or, when that
+// code has no debug info, after the object holding it, i.e. the binary or
+// library file itself, e.g. "/home/me/bin/app".
+//
+// Constraints that search a module name for the name of a known component must
+// tell the two apart: a source path names the code, so it is searched whole,
+// whereas an object path names a file the user may keep in any directory, so
+// only its filename is searched. E.g. "/home/me/dyninst-tests/app" is
+// not part of dyninst.
+bool
+module_function::is_object_module() const
+{
+    auto* _object = (module) ? module->getObject() : nullptr;
+    if(_object == nullptr) return false;
+
+    return rocprofsys::path::filename(module_name) ==
+           rocprofsys::path::filename(_object->pathName());
+}
+
 bool
 module_function::is_internal_constrained() const
 {
@@ -422,10 +442,11 @@ module_function::is_internal_constrained() const
 
     const auto& _gnu_libs = get_internal_libs_data();
 
-    auto _module_base = rocprofsys::path::filename(module_name);
-    auto _module_real = rocprofsys::path::realpath(module_name);
+    auto        _module_base = rocprofsys::path::filename(module_name);
+    auto        _module_real = rocprofsys::path::realpath(module_name);
+    const auto& _module_id   = is_object_module() ? _module_base : module_name;
 
-    if(std::regex_search(module_name,
+    if(std::regex_search(_module_id,
                          std::regex{ "lib(rocprof-sys|rocprofsys|timemory|perfetto)" }))
         return _report("Excluding", "module", "rocprofsys", 3);
     else if(std::regex_match(module_name,
@@ -485,6 +506,9 @@ module_function::is_module_constrained() const
         // return _report("Skipping", "default module", 2);
         return false;
 
+    auto        _module_base = rocprofsys::path::filename(module_name);
+    const auto& _module_id   = is_object_module() ? _module_base : module_name;
+
     static std::regex ext_regex{ "\\.(s|S)$", regex_opts };
     static std::regex sys_regex{ "^(s|k|e|w)_[A-Za-z_0-9\\-]+\\.(c|C)$", regex_opts };
     static std::regex sys_build_regex{ "^(\\.\\./sysdeps/|/build/)", regex_opts };
@@ -510,11 +534,11 @@ module_function::is_module_constrained() const
         return _report("Excluding", "system module", 3);
 
     // dyninst modules that must not be instrumented
-    if(std::regex_search(module_name, dyninst_regex))
+    if(std::regex_search(_module_id, dyninst_regex))
         return _report("Excluding", "dyninst module", 3);
 
     // modules used by rocprof-sys and dependent libraries
-    if(std::regex_search(module_name, core_lib_regex) ||
+    if(std::regex_search(_module_id, core_lib_regex) ||
        std::regex_search(module_name, core_cmod_regex))
         return _report("Excluding", "core module", 3);
 

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/module_function.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/module_function.hpp
@@ -104,6 +104,7 @@ struct module_function
     bool is_overlapping() const;  // checks if func overlaps
 
 private:
+    bool                is_object_module() const;  // named after its own object
     symbol_linkage_t    get_linkage() const;
     symbol_visibility_t get_visibility() const;
     bool is_loop_num_instructions_constrained() const;  // checks loop instr constraint

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/module_function.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/module_function.hpp
@@ -104,7 +104,7 @@ struct module_function
     bool is_overlapping() const;  // checks if func overlaps
 
 private:
-    bool                is_object_module() const;  // named after its own object
+    const string_t&     get_module_identity(const string_t& module_base) const;
     symbol_linkage_t    get_linkage() const;
     symbol_visibility_t get_visibility() const;
     bool is_loop_num_instructions_constrained() const;  // checks loop instr constraint


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

A binary stored under any directory whose name contains "dyninst" (e.g. `~/dyninst-tests/app`) had every one of its functions excluded from instrumentation, silently.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Dyninst names a module after the source file its code came from, or, when that code has no debug info, after the object holding it... in which case the module name is the binary's own path, directory components included. The exclusion patterns searched that whole name, so a directory the user happened to store their binary under was searched for the name of a known component.

- Added `module_function::get_module_identity()`, which tells the two naming cases apart by comparing the module name's filename against the filename of `module->getObject()->pathName()`, and returns the name to search: the filename alone for an object-named module, the whole name for a source-named one.
- The three unanchored searches now run over `_module_id`: the filename alone for object-named modules, the whole name for source-named ones — `dyninst_regex` and `core_lib_regex` in `is_module_constrained()`, and the `lib(rocprof-sys|rocprofsys|timemory|perfetto)` search in `is_internal_constrained()`.
- Source-tree exclusions are unchanged: a module compiled from Dyninst's own sources still matches on its full path.
- Verified with identical binaries in `plain/` and `dyninst-build/`, which now instrument identically (previously 4 vs 0), plus 119 existing regression tests.


## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

Resolves: #9999 

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

I don't think a new test is needed here. It will fail with existing tests, and I believe that when workflows are up on `ROCM/dyninst`, this will test this path quite fine.

Happy to add one though using `minimal-recursion` binary if needed.

## Test Result

<!-- Briefly summarize test outcomes. -->

No regressions locally, and tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
