### PR TITLE
fix(clr): Report all kernel timestamps in graph profiling trace (#8735)

### DIFF
--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -564,13 +564,13 @@ void GraphExec::BuildSyncPlan() {
 
       sync_plan_.patch_list.push_back(
           {completion_barrier, nullptr, hw_slot,
-           amd::Device::HwEventPatch::kCompletionSignal});
+           amd::Device::HwEventPatch::kCompletionSignal, segment.id});
     } else if (!lastBatch.dispatchPackets.empty() && completion_signal_needed) {
       // Safe to patch the last kernel dispatch directly
       uint8_t* last_pkt = lastBatch.dispatchPackets.back();
       sync_plan_.patch_list.push_back(
           {last_pkt, nullptr, hw_slot,
-           amd::Device::HwEventPatch::kCompletionSignal});
+           amd::Device::HwEventPatch::kCompletionSignal, segment.id});
     }
 
     if (segment.segment_ids_edges.empty()) {
@@ -1889,12 +1889,6 @@ amd::Command* GraphExec::EnqueueSegmentedGraph(hip::Stream* launch_stream,
     }
   }
 
-  // Apply pre-computed patches -- writes HW events directly into flatPacketData
-  // via the flat_packet pointers resolved at instantiate time, so no rebuild needed.
-  if (!sync_plan_.patch_list.empty()) {
-    device->ApplyHwEventPatches(sync_plan_.patch_list, segment_hw_events);
-  }
-
   // Resolve a segment's assigned hip::Stream* from its pre-computed stream_id.
   // streams is the collision-handled streams_ vector built by UpdateStreams.
   auto resolveSegmentStream = [&](const Segment& seg) -> hip::Stream* {
@@ -1903,6 +1897,21 @@ amd::Command* GraphExec::EnqueueSegmentedGraph(hip::Stream* launch_stream,
     }
     return launch_stream;
   };
+
+  // Apply pre-computed patches -- writes HW events directly into flatPacketData
+  // via the flat_packet pointers resolved at instantiate time, so no rebuild needed.
+  // Resolve each completion-signal patch's segment_id (set at BuildSyncPlan time) to
+  // the actual stream's queue index now that streams are available.
+  if (!sync_plan_.patch_list.empty()) {
+    for (auto& patch : sync_plan_.patch_list) {
+      if (patch.dep_slot == amd::Device::HwEventPatch::kCompletionSignal &&
+          patch.segment_id >= 0 &&
+          patch.segment_id < static_cast<int>(segments_.size())) {
+        patch.queue_index = resolveSegmentStream(segments_[patch.segment_id])->vdev()->index();
+      }
+    }
+    device->ApplyHwEventPatches(sync_plan_.patch_list, segment_hw_events);
+  }
 
   // Single AccumulateCommand on launch_stream manages all HW event lifetimes
   // and serves as the dispatch anchor for all segments across all streams.

--- a/projects/clr/hipamd/src/profiler/hip_clr_profiler.cpp
+++ b/projects/clr/hipamd/src/profiler/hip_clr_profiler.cpp
@@ -573,16 +573,21 @@ void WriteJsonTraceImpl(const char* filepath) {
   // Track only the (device_id, gpu_tid) pairs that actually received events.
   // Key = device_id, Value = set of gpu tids (lane*2+sdma) with events.
   std::unordered_map<int, std::unordered_set<uint64_t>> device_gpu_tids;
-  // Map (device_id, gpu_tid) -> last seen hipStream_t for lane labeling.
-  std::map<std::pair<int,uint64_t>, hipStream_t> gpu_tid_stream;
+  // Map (device_id, gpu_tid) -> (stream, queue_id) for lane labeling.
+  struct StreamLaneInfo { hipStream_t stream; uint64_t queue_id; };
+  std::map<std::pair<int,uint64_t>, StreamLaneInfo> gpu_tid_stream;
   std::unordered_set<uint64_t> tid_set;  // unique CPU thread ids seen
   uint64_t flow_id  = 0;  // unique id for each CPU→GPU flow arrow pair
   bool first = true;
-  // Compact lane index per unique stream (same scheme as pftrace writer).
-  std::unordered_map<uintptr_t, uint64_t> stream_lane_idx;
-  uint64_t next_stream_lane = 0;
+  // Compact lane index per unique (stream, queue_id) pair. Graph kernels share
+  // the launch stream pointer but run on different internal queues; keying on
+  // queue_id as well gives each queue its own visual lane in the trace.
+  // Start at 1 so the first lane produces tid=2 (tid=0 is treated as "main
+  // thread" by Chrome trace viewer and merges with the process header row).
+  std::map<std::pair<uintptr_t, uint64_t>, uint64_t> stream_lane_idx;
+  uint64_t next_stream_lane = 1;
   auto compact_stream_lane = [&](hipStream_t stream, uint64_t queue_id) -> uint64_t {
-    uintptr_t key = stream ? reinterpret_cast<uintptr_t>(stream) : (0x8000ULL | queue_id);
+    auto key = std::make_pair(reinterpret_cast<uintptr_t>(stream), queue_id);
     auto [it, ins] = stream_lane_idx.emplace(key, next_stream_lane);
     if (ins) ++next_stream_lane;
     return it->second;
@@ -739,7 +744,7 @@ void WriteJsonTraceImpl(const char* filepath) {
         }
 
         // Track stream→lane mapping for metadata labels.
-        if (stream) gpu_tid_stream[{static_cast<int>(gop.device_id), gpu_tid}] = stream;
+        if (stream) gpu_tid_stream[{static_cast<int>(gop.device_id), gpu_tid}] = {stream, gop.queue_id};
 
         // Only draw flow arrow when GPU timestamps are valid (begin_ns == 0
         // means ReportActivity never populated the record — no arrow to draw).
@@ -1003,13 +1008,14 @@ void WriteJsonTraceImpl(const char* filepath) {
       uint64_t q   = gpu_tid / 2;
       std::string lane_name;
       auto sit = gpu_tid_stream.find({dev_id, gpu_tid});
-      if (sit != gpu_tid_stream.end() && sit->second) {
+      if (sit != gpu_tid_stream.end() && sit->second.stream) {
         char buf[32];
         snprintf(buf, sizeof(buf), "0x%llx",
                  static_cast<unsigned long long>(
-                   reinterpret_cast<uintptr_t>(sit->second)));
-        // SDMA lane shares the stream prefix so it sorts next to its compute lane.
-        lane_name = std::string("Stream ") + buf + (is_sdma ? " [DMA]" : "");
+                   reinterpret_cast<uintptr_t>(sit->second.stream)));
+        lane_name = std::string("Stream ") + buf;
+        lane_name += " [" + std::to_string(sit->second.queue_id) + "]";
+        if (is_sdma) lane_name += " [DMA]";
       } else if (!is_sdma && q == 0) {
         lane_name = "Default Stream";
       } else if (is_sdma && q == 0) {
@@ -1359,7 +1365,7 @@ static uint64_t                                   g_pf_next_iid{1};
 static std::unordered_set<uint64_t> g_pf_emitted_tracks;
 
 // Compact stream-lane index (same scheme as batch writer).
-static std::unordered_map<uintptr_t, uint64_t> g_pf_stream_lane;
+static std::unordered_map<uint64_t, uint64_t> g_pf_stream_lane;
 static uint64_t                                 g_pf_next_lane{0};
 
 // Compact CPU thread index.
@@ -1411,7 +1417,8 @@ static void PfEnsureTrack(uint64_t uuid, uint64_t parent, const std::string& nam
 
 // ── Lane helpers (same logic as batch writer) ─────────────────────────────────
 static uint64_t PfCompactLane(hipStream_t stream, uint64_t queue_id) {
-  uintptr_t key = stream ? reinterpret_cast<uintptr_t>(stream) : (0x8000ULL | queue_id);
+  uint64_t key = stream ? (reinterpret_cast<uintptr_t>(stream) ^ (queue_id * 0x9E3779B97F4A7C15ULL))
+                        : (0x8000ULL | queue_id);
   auto [it, ins] = g_pf_stream_lane.emplace(key, g_pf_next_lane);
   if (ins) ++g_pf_next_lane;
   return it->second;
@@ -1452,7 +1459,8 @@ static void PfEnsureCpuThread(uint32_t ctid) {
   PfEnsureTrack(uuid, CpuProcessUuid(), "HIP Thread " + std::to_string(ctid),
                 1024, int(ctid), false);
 }
-static void PfEnsureGpuThread(int dev_id, uint64_t gtid, hipStream_t stream) {
+static void PfEnsureGpuThread(int dev_id, uint64_t gtid, hipStream_t stream,
+                              uint64_t queue_id = 0) {
   uint64_t proc_uuid = GpuProcessUuid(dev_id);
   if (!g_pf_emitted_tracks.count(proc_uuid)) {
     auto [gfxip, hip_idx] = PfGetGfxip(dev_id);
@@ -1467,7 +1475,9 @@ static void PfEnsureGpuThread(int dev_id, uint64_t gtid, hipStream_t stream) {
     if (stream) {
       char buf[32]; snprintf(buf, sizeof(buf), "0x%llx",
         static_cast<unsigned long long>(reinterpret_cast<uintptr_t>(stream)));
-      lane = std::string("Stream ") + buf + (is_sdma ? " [DMA]" : "");
+      lane = std::string("Stream ") + buf;
+      lane += " [" + std::to_string(queue_id) + "]";
+      if (is_sdma) lane += " [DMA]";
     } else {
       lane = std::string(is_sdma ? "SDMA " : "Compute ") + std::to_string(gtid / 2);
     }
@@ -1658,7 +1668,7 @@ static void PfChunkCallback(const hipApiRecordExt* records, uint32_t count, uint
       uint64_t lane     = PfCompactLane(rec.stream, gop.queue_id);
       uint64_t gtid     = lane * 2 + sdma;
       uint64_t gpu_uuid = GpuThreadUuid(static_cast<int>(gop.device_id), gtid);
-      PfEnsureGpuThread(static_cast<int>(gop.device_id), gtid, rec.stream);
+      PfEnsureGpuThread(static_cast<int>(gop.device_id), gtid, rec.stream, gop.queue_id);
 
       uint64_t g_ts  = gop.begin_ns;
       uint64_t g_dur = (gop.end_ns > gop.begin_ns) ? (gop.end_ns - gop.begin_ns) : 1;
@@ -1879,11 +1889,12 @@ void WriteProtoTraceImpl(const char* filepath) {
     return it->second;
   };
   std::unordered_map<int, std::unordered_set<uint64_t>> device_gpu_tids;
-  std::map<std::pair<int,uint64_t>, hipStream_t> gpu_tid_stream;
-  std::unordered_map<uintptr_t, uint64_t> stream_lane_idx;
-  uint64_t next_stream_lane = 0;
+  struct StreamLaneInfo { hipStream_t stream; uint64_t queue_id; };
+  std::map<std::pair<int,uint64_t>, StreamLaneInfo> gpu_tid_stream;
+  std::map<std::pair<uintptr_t, uint64_t>, uint64_t> stream_lane_idx;
+  uint64_t next_stream_lane = 1;
   auto compact_stream_lane = [&](hipStream_t stream, uint64_t queue_id) -> uint64_t {
-    uintptr_t key = stream ? reinterpret_cast<uintptr_t>(stream) : (0x8000ULL | queue_id);
+    auto key = std::make_pair(reinterpret_cast<uintptr_t>(stream), queue_id);
     auto [it, ins] = stream_lane_idx.emplace(key, next_stream_lane);
     if (ins) ++next_stream_lane;
     return it->second;
@@ -1921,7 +1932,7 @@ void WriteProtoTraceImpl(const char* filepath) {
         uint64_t lane = compact_stream_lane(rec.stream, gop.queue_id);
         uint64_t gtid = lane * 2 + sdma;
         device_gpu_tids[static_cast<int>(gop.device_id)].insert(gtid);
-        if (rec.stream) gpu_tid_stream[{static_cast<int>(gop.device_id), gtid}] = rec.stream;
+        if (rec.stream) gpu_tid_stream[{static_cast<int>(gop.device_id), gtid}] = {rec.stream, gop.queue_id};
       };
       scan(rec.gpu);
       for (const hipGpuActivityExt* n = rec.gpu.next; n; n = n->next) scan(*n);
@@ -2085,10 +2096,12 @@ void WriteProtoTraceImpl(const char* filepath) {
       bool is_sdma = (gtid & 1) != 0;
       std::string lane;
       auto sit = gpu_tid_stream.find({dev_id, gtid});
-      if (sit != gpu_tid_stream.end() && sit->second) {
+      if (sit != gpu_tid_stream.end() && sit->second.stream) {
         char buf[32]; snprintf(buf, sizeof(buf), "0x%llx",
-          static_cast<unsigned long long>(reinterpret_cast<uintptr_t>(sit->second)));
-        lane = std::string("Stream ") + buf + (is_sdma ? " [DMA]" : "");
+          static_cast<unsigned long long>(reinterpret_cast<uintptr_t>(sit->second.stream)));
+        lane = std::string("Stream ") + buf;
+        lane += " [" + std::to_string(sit->second.queue_id) + "]";
+        if (is_sdma) lane += " [DMA]";
       } else {
         lane = std::string(is_sdma ? "SDMA " : "Compute ") + std::to_string(gtid / 2);
       }

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -2233,6 +2233,12 @@ class Device : public RuntimeObject {
     uint8_t* flat_packet; // pointer into flatPacketData (patched directly at launch)
     int hw_event_index;
     int dep_slot;  // kCompletionSignal, kExtDispatchDepSignal, or 0-4 for barrier dep_signal[slot]
+    // Segment that owns this patch (set at BuildSyncPlan time). At launch the
+    // graph layer resolves it to the actual stream's vGPU index into queue_index.
+    int segment_id = -1;
+    // vGPU (queue) index resolved at launch from segment_id. Read by
+    // ApplyHwEventPatches to attribute the signal to its execution stream.
+    uint32_t queue_index = std::numeric_limits<uint32_t>::max();
   };
 
   virtual uint8_t* CreateBarrierPacket() const { return nullptr; }

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -3854,6 +3854,10 @@ void Device::ApplyHwEventPatches(const std::vector<HwEventPatch>& patches,
       // the packet type so checkGpuTime → addTimestamps only fires for
       // kernel dispatches (not synthetic barriers).
       ps->flags_.done_ = false;
+      // Record the queue this patched dispatch signal runs on (resolved from the
+      // owning segment's stream at launch) so profiling attributes it to the
+      // right stream rather than the graph launch stream.
+      ps->queue_index_ = patch.queue_index;
       uint16_t hdr;
       memcpy(&hdr, patch.packet, sizeof(hdr));
       uint8_t pktType = hdr & ((1 << HSA_PACKET_HEADER_WIDTH_TYPE) - 1);

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -58,9 +58,16 @@ class PrintfDbg;
 
 class ProfilingSignal : public amd::ReferenceCountedObject {
  public:
+  //! Sentinel for queue_index_ when the owning stream is unknown.
+  static constexpr uint32_t kInvalidQueueIndex = std::numeric_limits<uint32_t>::max();
+
   hsa_signal_t signal_;   //!< HSA signal to track profiling information
   Timestamp* ts_;         //!< Timestamp object associated with the signal
   HwQueueEngine engine_;  //!< Engine used with this signal
+  //! vGPU (queue) index of the stream this signal was dispatched on. Graphs span
+  //! multiple streams under one command, so profiling reads this per-signal to
+  //! attribute each kernel to the queue it actually ran on.
+  uint32_t queue_index_ = kInvalidQueueIndex;
   std::recursive_mutex lock_;  //!< Signal lock for update
 
   typedef union {
@@ -87,6 +94,7 @@ class ProfilingSignal : public amd::ReferenceCountedObject {
     signal_.handle = 0;
     flags_.data_ = 0;
     flags_.done_ = true;
+    queue_index_ = kInvalidQueueIndex;
   }
 
   virtual ~ProfilingSignal();
@@ -101,6 +109,7 @@ class ProfilingSignal : public amd::ReferenceCountedObject {
     cached_timing_.start_ = 0;
     cached_timing_.end_ = 0;
     cached_timing_.valid_ = false;
+    queue_index_ = kInvalidQueueIndex;
   }
 
   //! Check if timing is already cached

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -368,7 +368,8 @@ void Timestamp::ExtractSignalTiming(ProfilingSignal* signal,
   if ((command().type() == CL_COMMAND_TASK) && (signal->flags_.isPacketDispatch_ == true)) {
     static_cast<amd::AccumulateCommand&>(command()).addTimestamps(
         static_cast<uint64_t>(sig_start * ticksToTime_),
-        static_cast<uint64_t>(sig_end * ticksToTime_));
+        static_cast<uint64_t>(sig_end * ticksToTime_),
+        signal->queue_index_);
   }
 
   signal->flags_.done_ = true;
@@ -675,6 +676,7 @@ hsa_signal_t VirtualGPU::HwQueueTracker::ActiveSignal(hsa_signal_value_t init_va
   prof_signal->engine_ = engine_;
   prof_signal->flags_.isPacketDispatch_ = false;
   prof_signal->ResetCachedTiming();
+  prof_signal->queue_index_ = gpu_.index();
 
   // Release any existing HwEvent before setting new one for the same command
   VirtualGPU::AttachHwEvent(cmd, prof_signal);
@@ -1462,8 +1464,8 @@ bool VirtualGPU::dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPack
   profilingBegin(*vcmd);
   dispatchBlockingWait(nullptr);
 
-  if (kernelNames != nullptr) {
-    vcmd->setKernelNamesRef(kernelNames);
+  if (kernelNames != nullptr && vcmd->profilingInfo().enabled_) {
+    vcmd->addKernelNames(*kernelNames);
   }
 
   const uint32_t queueSize = gpu_queue_->size;

--- a/projects/clr/rocclr/platform/activity.cpp
+++ b/projects/clr/rocclr/platform/activity.cpp
@@ -122,12 +122,19 @@ void ReportActivity(const amd::Command& command) {
     // kernel_names has one entry per AQL packet slot (nullptr for barriers and SDMA/copy nodes
     // that don't generate timestamps). Walk kernel_names; for each non-null entry consume
     // the next timestamp.
+    // Queue id to fall back on when a timestamp did not record its stream.
+    const uint64_t fallback_queue_id = queue->vdev()->index();
     uint32_t ti = 0;
     for (uint32_t ki = 0; ki < kernel_names.size() && ti < timestamps.size(); ki++) {
       if (kernel_names[ki] == nullptr) continue;
-      auto it = timestamps[ti++];
-      record.begin_ns = it.first;
-      record.end_ns = it.second;
+      const auto& it = timestamps[ti++];
+      record.begin_ns = it.start;
+      record.end_ns = it.end;
+      // Graph kernels can run on different streams under one command; attribute
+      // each to the queue it actually ran on when known.
+      record.queue_id = (it.queue_index != amd::AccumulateCommand::kInvalidQueueIndex)
+          ? static_cast<uint64_t>(it.queue_index)
+          : fallback_queue_id;
       record.kernel_name = kernel_names[ki]->c_str();
       function(ACTIVITY_DOMAIN_HIP_OPS, operation_id, &record);
     }

--- a/projects/clr/rocclr/platform/command.hpp
+++ b/projects/clr/rocclr/platform/command.hpp
@@ -1547,7 +1547,22 @@ class AccumulateCommand : public Command {
   //! ties the strings' lifetime to the consumer (this command) rather than to
   //! the graph launch, with no string copies. Set via the constructor.
   ReferenceCountedObject* kernelNamesOwner_ = nullptr;
-  std::vector<std::pair<uint64_t, uint64_t>> tsList_;
+
+ public:
+  //! Sentinel queue index meaning "unknown; fall back to the command's queue".
+  static constexpr uint32_t kInvalidQueueIndex = 0xFFFFFFFFu;
+
+  //! One kernel dispatch's GPU timing plus the queue (vGPU index) it ran on.
+  //! Graphs span multiple streams under one command, so the queue is tracked
+  //! per timestamp rather than taken from the command's queue.
+  struct KernelTimestamp {
+    uint64_t start;
+    uint64_t end;
+    uint32_t queue_index;
+  };
+
+ private:
+  std::vector<KernelTimestamp> tsList_;
   //! HW events that need to be released when this command is destroyed
   std::unordered_map<Device*, std::vector<void*>> hw_events_;
   //! When false, the destructor does not destroy hw_events_ (an external owner,
@@ -1612,9 +1627,11 @@ class AccumulateCommand : public Command {
     kernelNamesRef_ = kernelNames;
   }
 
-  //! Add kernel timestamp to the list if available
-  void addTimestamps(uint64_t startTs, uint64_t endTs) {
-    tsList_.push_back(std::make_pair(startTs, endTs));
+  //! Add kernel timestamp to the list if available. queue_index is the vGPU
+  //! index of the stream the kernel ran on (kInvalidQueueIndex when unknown).
+  void addTimestamps(uint64_t startTs, uint64_t endTs,
+                     uint32_t queue_index = kInvalidQueueIndex) {
+    tsList_.push_back(KernelTimestamp{startTs, endTs, queue_index});
   }
 
   //! Return the kernel names (pointers to stable strings, no copies)
@@ -1623,7 +1640,7 @@ class AccumulateCommand : public Command {
   }
 
   //! Return the kernel timestamps
-  const std::vector<std::pair<uint64_t, uint64_t>>& getTimestamps() const { return tsList_; }
+  const std::vector<KernelTimestamp>& getTimestamps() const { return tsList_; }
 
   //! The command implementation
   virtual void submit(device::VirtualDevice& device) { device.submitAccumulate(*this); }


### PR DESCRIPTION
Cherry-picks commit a585ccb into the ROCm 7.14 release branch.

JIRA ID: AIRDEL-30

---

The per-segment kernel names were set via setKernelNamesRef() which overwrites on each segment dispatch, leaving only the last segment's names for ReportActivity. Switch to addKernelNames() (guarded by profilingInfo().enabled_) so all segments' kernel names accumulate and every kernel dispatch gets its timestamp reported in the trace.

Also propagate per-signal queue_index through ProfilingSignal and AccumulateCommand so graph kernels land on correct profiling lanes.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
JIRA ID: AIRUNTIM-0

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.