### PR TITLE
feat(rocprofiler-sdk): KFD dispatch-log UAPI v6 / stream ABI v3, drain, 10 MiB default [1/9]

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/CMakeLists.txt
@@ -1,7 +1,8 @@
 #
 #
-set(ROCPROFILER_LIB_KFD_EVENT_SOURCES abi.cpp kfd.cpp)
-set(ROCPROFILER_LIB_KFD_EVENT_HEADERS defines.hpp kfd.hpp utils.hpp)
+set(ROCPROFILER_LIB_KFD_EVENT_SOURCES abi.cpp dlog_abi.cpp kfd.cpp)
+set(ROCPROFILER_LIB_KFD_EVENT_HEADERS defines.hpp kfd.hpp utils.hpp kfd_dlog_uapi.h
+                                      dlog_drain.hpp record_pipe.hpp stream_geometry.hpp)
 
 target_sources(
     rocprofiler-sdk-object-library PRIVATE ${ROCPROFILER_LIB_KFD_EVENT_SOURCES}

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/dlog_abi.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/dlog_abi.cpp
@@ -1,0 +1,101 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Owning translation unit for the dispatch-log UAPI ABI. It includes ONLY
+// kfd_dlog_uapi.h (never details/kfd_ioctl.h, which is TU-exclusive with it), so
+// the request layout the kernel reads and the firmware record stride are pinned
+// here at compile time. Adding a field to kfd_ioctl_dlog_args, growing the union
+// past its reserved 32 bytes, or reordering op/pad silently changes the _IOWR
+// size baked into AMDKFD_IOC_PROFILER and breaks the handshake; these asserts
+// turn that into a build failure instead. This is also the only place the drain's
+// kFwRecBytes and the UAPI's KFD_DISPATCH_LOG_FW_RECORD_BYTES are simultaneously
+// visible, so their agreement is checked here.
+
+#include "lib/rocprofiler-sdk/kfd/dlog_drain.hpp"  // kFwRecBytes
+#include "lib/rocprofiler-sdk/kfd/kfd_dlog_uapi.h"
+
+#include <cstddef>
+
+namespace rocprofiler
+{
+namespace kfd
+{
+// op (offset 0) and pad (offset 4) precede the union the kernel reads before
+// dispatching; the union is 32 bytes (reserved[8]) and 8-aligned (_align), so the
+// whole request is 8 + 32 = 40 bytes. 40 is the _IOWR size in AMDKFD_IOC_PROFILER.
+static_assert(sizeof(kfd_ioctl_profiler_args) == 40, "profiler request ABI size changed");
+static_assert(alignof(kfd_ioctl_profiler_args) == 8, "profiler request alignment changed");
+static_assert(offsetof(kfd_ioctl_profiler_args, op) == 0, "profiler request op moved");
+static_assert(offsetof(kfd_ioctl_profiler_args, pad) == 4, "profiler request pad moved");
+static_assert(offsetof(kfd_ioctl_profiler_args, version) == 8, "profiler request union moved");
+
+// The whole dlog request must fit the union's reserved 32 bytes; every field is
+// pinned by offset so reordering two equal-sized (u32) fields fails the build.
+static_assert(sizeof(kfd_ioctl_dlog_args) == 24, "dlog request ABI size changed");
+static_assert(sizeof(kfd_ioctl_dlog_args) <= 32, "dlog request no longer fits the union");
+static_assert(offsetof(kfd_ioctl_dlog_args, dlog_op) == 0, "dlog request dlog_op moved");
+static_assert(offsetof(kfd_ioctl_dlog_args, gpu_id) == 4, "dlog request gpu_id moved");
+static_assert(offsetof(kfd_ioctl_dlog_args, target_pid) == 8, "dlog request target_pid moved");
+static_assert(offsetof(kfd_ioctl_dlog_args, flags) == 12, "dlog request flags moved");
+static_assert(offsetof(kfd_ioctl_dlog_args, buffer_size) == 16, "dlog request buffer_size moved");
+static_assert(offsetof(kfd_ioctl_dlog_args, stream_fd) == 20, "dlog request stream_fd moved");
+
+// The stream-info OUT struct read via KFD_DLOG_STREAM_OP_INFO: the reader indexes
+// wptr[]/rptr[] and derives geometry from these offsets, so their layout is ABI.
+static_assert(sizeof(kfd_dlog_stream_info) == 72, "stream_info ABI size changed");
+static_assert(alignof(kfd_dlog_stream_info) == 8, "stream_info alignment changed");
+static_assert(offsetof(kfd_dlog_stream_info, abi_version) == 0, "stream_info abi_version moved");
+static_assert(offsetof(kfd_dlog_stream_info, fw_record_size) == 4,
+              "stream_info fw_record_size moved");
+static_assert(offsetof(kfd_dlog_stream_info, num_regions) == 8, "stream_info num_regions moved");
+static_assert(offsetof(kfd_dlog_stream_info, region_record_count) == 12,
+              "stream_info region_record_count moved");
+static_assert(offsetof(kfd_dlog_stream_info, buffer_size) == 16, "stream_info buffer_size moved");
+static_assert(offsetof(kfd_dlog_stream_info, mmap_size) == 24, "stream_info mmap_size moved");
+static_assert(offsetof(kfd_dlog_stream_info, records_offset) == 32,
+              "stream_info records_offset moved");
+static_assert(offsetof(kfd_dlog_stream_info, wptr_offset) == 40, "stream_info wptr_offset moved");
+static_assert(offsetof(kfd_dlog_stream_info, rptr_offset) == 48, "stream_info rptr_offset moved");
+static_assert(offsetof(kfd_dlog_stream_info, gpu_id) == 56, "stream_info gpu_id moved");
+static_assert(offsetof(kfd_dlog_stream_info, target_pid) == 60, "stream_info target_pid moved");
+static_assert(offsetof(kfd_dlog_stream_info, pasid) == 64, "stream_info pasid moved");
+static_assert(offsetof(kfd_dlog_stream_info, flags) == 68, "stream_info flags moved");
+
+// The stream-status OUT struct read via KFD_DLOG_STREAM_OP_STATUS.
+static_assert(sizeof(kfd_dlog_stream_status) == 16, "stream_status ABI size changed");
+static_assert(offsetof(kfd_dlog_stream_status, status) == 0, "stream_status status moved");
+static_assert(offsetof(kfd_dlog_stream_status, target_exit_count) == 8,
+              "stream_status target_exit_count moved");
+
+// The firmware record the drain parses out of the ring: 20-byte stride, and each
+// field at the byte offset copy_pipes()/pair_records() read. kFwRecBytes and the
+// UAPI constant are only simultaneously visible in this TU.
+static_assert(sizeof(fw_record) == kFwRecBytes, "fw_record is not the 20-byte stride");
+static_assert(kFwRecBytes == KFD_DISPATCH_LOG_FW_RECORD_BYTES,
+              "firmware record stride disagrees with the UAPI");
+static_assert(offsetof(fw_record, ts_lo) == 0, "fw_record ts_lo moved");
+static_assert(offsetof(fw_record, ts_hi) == 4, "fw_record ts_hi moved");
+static_assert(offsetof(fw_record, record_type) == 8, "fw_record record_type moved");
+static_assert(offsetof(fw_record, dispatch_id) == 12, "fw_record dispatch_id moved");
+static_assert(offsetof(fw_record, doorbell_off) == 16, "fw_record doorbell_off moved");
+}  // namespace kfd
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/dlog_drain.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/dlog_drain.hpp
@@ -1,0 +1,430 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#pragma once
+
+// Pure dispatch-log ring drain logic, factored out of kfd_reader.cpp so it can be
+// unit-tested against an in-memory buffer without a GPU or the reader's
+// singletons.
+//
+// Ring geometry: `num_regions` regions, each with its own wptr[i]/rptr[i] and
+// `region_record_count` slots (a power of two). Multiple queues can multiplex
+// into one region; records carry their own (doorbell_off, dispatch_id).
+
+#include <cstdint>
+#include <cstring>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+namespace rocprofiler
+{
+namespace kfd
+{
+// Firmware wire record: 20 bytes, little-endian, fixed layout (dispatch_log_format).
+constexpr uint32_t kFwRecBytes = 20;
+
+// Maximum regions the drain supports (bounds ring_cursors::rptr[]). Geometry with
+// more regions than this is rejected rather than partially drained.
+constexpr uint32_t kMaxRegions = 8;
+
+// Dispatch-log ring size, overridable via ROCPROFILER_KFD_DISPATCH_LOG_SIZE_KB.
+//
+// OPEN_STREAM only accepts buffer_size == num_regions * 20 * region_record_count
+// with region_record_count a power of two <= 2^24, and num_regions is ASIC-fixed
+// but not reported until STREAM_OP_INFO, i.e. AFTER the size must be chosen.
+// 80 * 2^k satisfies the rule at both 2 and 4 regions, so it needs no advance
+// knowledge. k is capped at 23, making 640 MiB the largest accepted size.
+// Requests are snapped DOWN onto this lattice so a reasonable-looking value can
+// never become an EINVAL that disables the feature.
+constexpr uint64_t kDlogMinRingBytes     = 80ull << 10;           // 80 KiB floor
+constexpr uint64_t kDlogDefaultRingBytes = 80ull << 17;           // 10 MiB (on the 80*2^k lattice)
+constexpr uint64_t kDlogMaxRingBytes     = 80ull << 23;           // 640 MiB
+constexpr uint64_t kDlogMaxRingKb        = 0xFFFFFFFFull / 1024;  // parse domain (uint32 field)
+
+// Snap `want` down onto the 80 * 2^k lattice, clamped to
+// [kDlogMinRingBytes, kDlogMaxRingBytes]. Every result is a buffer_size the
+// kernel accepts whether the ASIC reports 2 or 4 regions.
+inline uint64_t
+dlog_snap_ring_bytes(uint64_t want)
+{
+    if(want >= kDlogMaxRingBytes) return kDlogMaxRingBytes;
+    uint64_t sz = kDlogMinRingBytes;
+    while((sz << 1) <= want)
+        sz <<= 1;
+    return sz;
+}
+
+// Returns the requested byte count, or 0 to mean "use the default".
+inline uint64_t
+dlog_ring_bytes_from_kb_str(std::string_view v)
+{
+    if(v.empty()) return 0;
+    uint64_t kb = 0;
+    for(char c : v)
+    {
+        if(c < '0' || c > '9') return 0;
+        kb = kb * 10 + static_cast<uint64_t>(c - '0');
+        if(kb > kDlogMaxRingKb) return 0;
+    }
+    return kb * 1024;
+}
+
+constexpr uint32_t kRecPadding = 0;
+constexpr uint32_t kRecStart   = 1;  // dispatch_start
+constexpr uint32_t kRecEop     = 2;  // end-of-pipe (completion)
+
+struct fw_record
+{
+    uint32_t ts_lo;         // bytes 0-3:   low 32 bits of GPU timestamp
+    uint32_t ts_hi;         // bytes 4-7:   high 32 bits
+    uint32_t record_type;   // bytes 8-11:  0 padding, 1 dispatch_start, 2 eop
+    uint32_t dispatch_id;   // bytes 12-15: low 32 bits of HSA queue write index
+    uint32_t doorbell_off;  // bytes 16-19: queue identity (demux key)
+};
+static_assert(sizeof(fw_record) == kFwRecBytes,
+              "fw_record must match the 20-byte firmware record layout");
+
+// `start_known` distinguishes the two EOP shapes: a matched START+EOP pair, and
+// an EOP whose START was lost to a ring overwrite -- which still proves the
+// kernel completed but carries no interval.
+//
+// `loss_free` false means the producer lapped the reader before or during the
+// scan, so records around the collision may be torn and nothing may be
+// published from them.
+struct drained_record
+{
+    uint32_t doorbell_off = 0;
+    uint32_t dispatch_id  = 0;
+    uint64_t start_ticks  = 0;
+    uint64_t end_ticks    = 0;
+    bool     start_known  = false;
+    bool     loss_free    = true;
+};
+
+// Carries the copier's loss verdict, since pairing happens on another thread.
+struct copied_record
+{
+    fw_record rec       = {};
+    uint32_t  region    = 0;
+    bool      loss_free = true;
+};
+
+// Reader-side state: ring cursors and loss counters. Touched ONLY by the
+// ring-copier thread, so it needs no lock.
+struct ring_cursors
+{
+    uint64_t rptr[kMaxRegions] = {};     // consumer read pos per region
+    bool     rptr_init         = false;  // sync rptr to wptr on first drain
+
+    // Overrun telemetry. Exclusive-end contract: the producer has LAPPED us only
+    // once `w - rptr` EXCEEDS region_slots (== region_slots is merely exactly full).
+    // overruns/lost_records are written ONLY by note_overrun.
+    uint64_t overruns     = 0;  // laps observed
+    uint64_t lost_records = 0;  // records the producer advanced past
+
+    // Records copied while an aliasing producer write may have been in progress,
+    // distinct from `lost` -- at exactly-full there is no overrun and no
+    // loss, yet the oldest copied index may be torn. These are dropped downstream,
+    // so they are real coverage loss even when nothing was lapped.
+    uint64_t untrusted_records = 0;
+
+    // wptr regressions observed (w < rptr): a stream reset that zeroed wptr[]
+    // without zeroing our rptr[]. rptr is forced back to wptr so readiness
+    // (wptr != rptr) converges instead of reporting ready forever with the drain
+    // (w > rptr) refusing to advance.
+    uint64_t wptr_regressions = 0;
+
+    bool note_overrun(uint64_t dist, uint32_t region_slots)
+    {
+        if(dist <= region_slots) return false;  // == is exactly-full, not an overrun
+        ++overruns;
+        lost_records += dist - region_slots;
+        return true;
+    }
+};
+
+// Processor-side state: start/eop pairing. Touched ONLY by the processor thread,
+// so it needs no lock either. Deliberately separate from ring_cursors: the whole
+// point of the split is that the copier never touches this.
+struct pair_state
+{
+    struct pending_start
+    {
+        uint64_t start_ticks = 0;  // GPU ticks from the dispatch_start record
+        uint64_t seen_at_ns  = 0;  // host clock when recorded, for aging
+        // Number of outstanding STARTs sharing this raw key (>1 once a duplicate
+        // arrives). `ambiguous` latches when a second outstanding START appears:
+        // the raw key (doorbell_off, dispatch_id) carries no window, so a
+        // recycled doorbell or a low-32 wrap makes it impossible to say which
+        // dispatch an EOP belongs to. Once ambiguous, every EOP on the key is
+        // dropped at this layer until `outstanding` drains to 0 or the key ages
+        // out -- never forwarded as start-unknown (the hub cannot refuse it).
+        uint32_t outstanding = 0;
+        bool     ambiguous   = false;
+    };
+    // dispatch_start records awaiting their matching eop, keyed by
+    // (doorbell_off << 32 | dispatch_id).
+    std::unordered_map<uint64_t, pending_start> pending_starts = {};
+
+    uint64_t unmatched_eops = 0;  // EOPs whose START was lost (shape ii)
+
+    // Pairing census: starts_seen far below eops_seen means the firmware is not
+    // emitting STARTs, which is a different bug from a pairing mismatch.
+    uint64_t starts_seen        = 0;
+    uint64_t eops_seen          = 0;
+    uint64_t starts_overwritten = 0;  // a second START arrived on a retained key
+    uint64_t ambiguous_pairs    = 0;  // EOPs dropped because their raw key was ambiguous
+    uint64_t starts_evicted     = 0;  // retained STARTs aged out by the watermark
+
+    // Stream-driven eviction watermark: the copy timestamp of the last batch that
+    // triggered an evict for this GPU. Compared against batch.now_ns,
+    // never the wall clock, so a backlogged processor ages nothing prematurely.
+    uint64_t last_evict_ns = 0;
+
+    // Age out unmatched starts (queue died mid-dispatch, ring overwrite) so the
+    // map cannot grow unbounded. now_ns/max_age_ns passed in for testability.
+    size_t evict_stale(uint64_t now_ns, uint64_t max_age_ns)
+    {
+        size_t removed = 0;
+        for(auto it = pending_starts.begin(); it != pending_starts.end();)
+        {
+            if(now_ns > it->second.seen_at_ns && now_ns - it->second.seen_at_ns > max_age_ns)
+            {
+                it = pending_starts.erase(it);
+                ++removed;
+            }
+            else
+            {
+                ++it;
+            }
+        }
+        return removed;
+    }
+};
+
+// STAGE 1 (reader thread): copy raw records out of the shared ring, as fast as
+// possible and touching nothing else. This is the only code reading the volatile
+// mapping, and the time spent there is the window in which the producer can lap
+// us -- so NO lock, no map, no pairing or timestamp math. Returns the number
+// copied, or 0 on invalid geometry.
+//
+// ORDERING: a region's slots are copied BEFORE the release-store publishing the
+// new rptr, so the kernel cannot see the slots as free while we are reading.
+template <typename OutT>
+uint64_t
+copy_pipes(const uint8_t*           records_base,
+           uint32_t                 num_regions,
+           uint32_t                 region_record_count,
+           const volatile uint64_t* wptr_arr,
+           // rptr_arr is written via __atomic_store_n, which the const check does not model.
+           // NOLINTNEXTLINE(readability-non-const-parameter)
+           volatile uint64_t* rptr_arr,
+           ring_cursors&      cursors,
+           OutT&              out)
+{
+    if(num_regions == 0 || num_regions > kMaxRegions) return 0;
+
+    const uint32_t region_slots = region_record_count;
+    if(region_slots == 0 || (region_slots & (region_slots - 1)) != 0) return 0;
+
+    if(!cursors.rptr_init)
+    {
+        for(uint32_t p = 0; p < num_regions; ++p)
+        {
+            cursors.rptr[p] = 0;
+            __atomic_store_n(&rptr_arr[p], 0, __ATOMIC_RELEASE);
+        }
+        cursors.rptr_init = true;
+    }
+
+    uint64_t copied = 0;
+    for(uint32_t p = 0; p < num_regions; ++p)
+    {
+        const uint64_t w    = __atomic_load_n(&wptr_arr[p], __ATOMIC_ACQUIRE);
+        uint64_t       scan = cursors.rptr[p];
+        if(w < scan)
+        {
+            // wptr moved backwards: the stream was reset underneath us. Readiness
+            // uses wptr != rptr, so leaving rptr ahead would report ready forever
+            // while the w > scan drain below never runs. Snap rptr back to wptr in
+            // both the local cursor and the shared rptr[] so the predicates agree.
+            ++cursors.wptr_regressions;
+            cursors.rptr[p] = w;
+            __atomic_store_n(&rptr_arr[p], w, __ATOMIC_RELEASE);
+            continue;
+        }
+        if(w == scan) continue;
+
+        // The producer lapped us once dist EXCEEDS region_slots; note_overrun
+        // records overruns/lost. Skip the overwritten prefix: scan = w - slots
+        // (NOT w - slots + 1, which skipped one valid record).
+        cursors.note_overrun(w - scan, region_slots);
+        if(w - scan > region_slots) scan = w - region_slots;
+
+        // Every copied record starts loss_free = true; the region-wide
+        // verdict is gone. The untrusted back-patch below is per-record.
+        const size_t region_begin = out.size();
+        for(uint64_t idx = scan; idx != w; ++idx)
+        {
+            const uint64_t slot =
+                static_cast<uint64_t>(p) * region_slots + (idx & (region_slots - 1));
+            auto _out = copied_record{};
+            std::memcpy(&_out.rec, records_base + slot * kFwRecBytes, sizeof(_out.rec));
+            _out.region = p;
+            out.emplace_back(_out);
+            ++copied;
+        }
+
+        // reload wptr AFTER the copy. The producer may have advanced while
+        // we memcpy'd, so any copied index the producer's next write target now
+        // aliases is untrusted. w is exclusive, so index w2 aliases w2 - slots
+        // (power-of-two mask); the boundary the drain sits on when it just keeps up
+        // is exactly the one an acquire load of w2 cannot certify -- hence `<=`.
+        const uint64_t w2 = __atomic_load_n(&wptr_arr[p], __ATOMIC_ACQUIRE);
+        if(w2 >= region_slots)
+        {
+            const uint64_t untrusted_upto = w2 - region_slots;
+            size_t         k              = region_begin;
+            for(uint64_t idx = scan; idx != w; ++idx, ++k)
+            {
+                if(idx <= untrusted_upto)
+                {
+                    out[k].loss_free = false;
+                    ++cursors.untrusted_records;
+                }
+            }
+        }
+
+        // Release: every memcpy above is ordered before the kernel can see these
+        // slots as consumed.
+        cursors.rptr[p] = w;
+        __atomic_store_n(&rptr_arr[p], w, __ATOMIC_RELEASE);
+    }
+    return copied;
+}
+
+// STAGE 2 (processor thread): pair start/eop out of an already-copied batch.
+// No ring access, so it may take locks and do timestamp work.
+template <typename OnRecord>
+uint64_t
+pair_records(const copied_record* records,
+             size_t               count,
+             pair_state&          state,
+             uint64_t             now_ns,
+             OnRecord&&           on_record)
+{
+    uint64_t seen = 0;
+    // Two passes over the batch: bind every START first, then match every EOP. A
+    // batch is one drain sweep of all regions in index order, and the HWS can
+    // remap a queue onto a lower-numbered MEC pipe between its START and its EOP,
+    // which puts the EOP in an earlier region than the START -- so in copy order
+    // the EOP can precede its own START within this one batch. Firmware always
+    // writes START before EOP and the sweep reads region k before region k+1, so
+    // a copied EOP's START is either in an earlier batch (already consumed) or
+    // later in THIS batch; binding all of this batch's STARTs before any EOP is
+    // therefore exact, not a heuristic, and removes the spurious start-unknown
+    // that the old single pass produced for a same-batch region reorder.
+    for(int pass = 0; pass < 2; ++pass)
+        for(size_t i = 0; i < count; ++i)
+        {
+            const auto& rec = records[i].rec;
+            if(rec.record_type == kRecPadding || rec.doorbell_off == 0) continue;
+            // a torn record's doorbell_off/dispatch_id are as suspect as
+            // its tick, so it must never bind a START or claim an EOP. A torn START
+            // is thus never retained; its later intact EOP arrives start-unknown.
+            if(!records[i].loss_free) continue;
+            if(pass == 0 && rec.record_type != kRecStart) continue;
+            if(pass == 1 && rec.record_type == kRecStart) continue;
+
+            const uint64_t ts =
+                static_cast<uint64_t>(rec.ts_lo) | (static_cast<uint64_t>(rec.ts_hi) << 32);
+            const uint64_t key = (static_cast<uint64_t>(rec.doorbell_off) << 32) |
+                                 static_cast<uint64_t>(rec.dispatch_id);
+
+            if(rec.record_type == kRecStart)
+            {
+                ++state.starts_seen;
+                // dispatch_id is only low-32, so a raw key can recur. A second
+                // outstanding START on one key makes it AMBIGUOUS: keep the first
+                // START's ticks and age unchanged (so an unpairable key still
+                // ages out -- refreshing seen_at_ns would make it permanent) and
+                // count another outstanding. try_emplace, not [], so the first
+                // START's fields survive the duplicate.
+                auto [it, ins] = state.pending_starts.try_emplace(
+                    key, pair_state::pending_start{ts, now_ns, 1, false});
+                if(!ins)
+                {
+                    ++state.starts_overwritten;
+                    it->second.ambiguous = true;
+                    ++it->second.outstanding;
+                }
+                continue;
+            }
+            if(rec.record_type != kRecEop) continue;
+            ++state.eops_seen;
+
+            auto it = state.pending_starts.find(key);
+            if(it == state.pending_starts.end())
+            {
+                // The START was lost (shape ii): the EOP still proves the kernel
+                // finished, it just carries no interval.
+                ++state.unmatched_eops;
+                auto out         = drained_record{};
+                out.doorbell_off = rec.doorbell_off;
+                out.dispatch_id  = rec.dispatch_id;
+                out.end_ticks    = ts;
+                out.loss_free    = records[i].loss_free;
+                out.start_known  = false;
+                on_record(out);
+            }
+            else if(it->second.ambiguous)
+            {
+                // Cannot say which dispatch this EOP belongs to. Drop it HERE --
+                // forwarding it start-unknown would let the hub complete the
+                // wrong dispatch (the same-window low-32-wrap shape). The key
+                // stays unpairable until every outstanding START is consumed.
+                ++state.ambiguous_pairs;
+                if(--it->second.outstanding == 0) state.pending_starts.erase(it);
+            }
+            else
+            {
+                auto out         = drained_record{};
+                out.doorbell_off = rec.doorbell_off;
+                out.dispatch_id  = rec.dispatch_id;
+                out.end_ticks    = ts;
+                // Only the EOP's loss_free is needed, not eop.loss_free &&
+                // start.loss_free: a START is retained above only after clearing the
+                // same !loss_free guard, so the paired START is always loss_free. A
+                // lossy START is instead dropped, and its EOP arrives start-unknown.
+                out.loss_free   = records[i].loss_free;
+                out.start_ticks = it->second.start_ticks;
+                out.start_known = true;
+                state.pending_starts.erase(it);
+                ++seen;
+                on_record(out);
+            }
+        }
+    return seen;
+}
+}  // namespace kfd
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_dlog_uapi.h
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_dlog_uapi.h
@@ -1,0 +1,152 @@
+/* SPDX-License-Identifier: MIT */
+/* KFD dispatch-log stream UAPI (profiler ABI v6, stream ABI v3). Vendored subset
+ * of include/uapi/linux/kfd_ioctl.h needed by the SDK's dispatch-log reader; keep
+ * byte-accurate with the kernel header. The backing is always KFD-owned GTT
+ * consumed zero-copy via RAW_MMAP, so this carries only the OPEN_STREAM request
+ * and the stream-fd ioctl -- no ALLOC/MAP/REGISTER/UNREGISTER variants.
+ *
+ * INCOMPATIBLE WITH lib/rocprofiler-sdk/details/kfd_ioctl.h. This header carries
+ * the active dispatch-log UAPI: AMDKFD_IOC_PROFILER at NR 0x28, profiler version
+ * 6, with the single DLOG/OPEN_STREAM op. It deliberately conflicts with the
+ * older details/kfd_ioctl.h (profiler version 1, AMDKFD_IOC_PROFILER at NR 0x86,
+ * no dlog ops) -- both define the same macros and structs with different values.
+ * The two must never be included in the same translation unit. Any TU that needs
+ * to see both constants at once (e.g. to static_assert their agreement) belongs
+ * in a file that includes ONLY this header; see kfd/dlog_abi.cpp. */
+#ifndef KFD_DLOG_UAPI_H
+#define KFD_DLOG_UAPI_H
+
+#include <linux/ioctl.h>
+#include <linux/types.h>
+
+#define AMDKFD_IOCTL_BASE     'K'
+#define AMDKFD_IOWR(nr, type) _IOWR(AMDKFD_IOCTL_BASE, nr, type)
+
+#define KFD_DISPATCH_LOG_FW_RECORD_BYTES 20U
+#define KFD_IOC_PROFILER_VERSION_NUM     6
+
+enum kfd_profiler_ops
+{
+    KFD_IOC_PROFILER_PMC         = 0,
+    KFD_IOC_PROFILER_PC_SAMPLE   = 1,
+    KFD_IOC_PROFILER_VERSION     = 2,
+    KFD_IOC_PROFILER_PTL_CONTROL = 3,
+    KFD_IOC_PROFILER_DLOG        = 4,
+};
+
+/* Sub-operation for KFD_IOC_PROFILER_DLOG. */
+enum kfd_profiler_dlog_op
+{
+    KFD_IOC_PROFILER_DLOG_OPEN_STREAM = 0,
+};
+
+/* RAW_MMAP zero-copy consumption is the only supported mode; every other flag
+ * bit is reserved and must be zero. */
+#define KFD_DLOG_OPEN_F_RAW_MMAP (1u << 0)
+
+/*
+ * Args for the KFD_IOC_PROFILER_DLOG op. @dlog_op selects the action (only
+ * OPEN_STREAM) and @gpu_id is the KFD user gpu_id; both stay at fixed offsets
+ * (0 and 4) so the kernel reads them before dispatching. @buffer_size is the
+ * requested records-region size in bytes; the kernel allocates the backing and
+ * never silently alters the requested geometry.
+ */
+struct kfd_ioctl_dlog_args
+{
+    __u32 dlog_op;     /* IN: enum kfd_profiler_dlog_op */
+    __u32 gpu_id;      /* IN: KFD user gpu_id */
+    __u32 target_pid;  /* IN: target tgid */
+    __u32 flags;       /* IN: KFD_DLOG_OPEN_F_* (reserved bits 0) */
+    __u32 buffer_size; /* IN: requested records-region bytes */
+    __s32 stream_fd;   /* OUT: anon_inode stream fd */
+};
+
+/*
+ * Mirror of the kernel's AMDKFD_IOC_PROFILER (0x28) args. @op + @pad precede a
+ * union capped at exactly 32 bytes (reserved[8]); the _IOWR-encoded size baked
+ * into AMDKFD_IOC_PROFILER matches the kernel. Do not grow the union past 32
+ * bytes.
+ */
+struct kfd_ioctl_profiler_args
+{
+    __u32 op;  /* enum kfd_profiler_ops */
+    __u32 pad; /* IN: must be 0 (reserved) */
+    union
+    {
+        __u32                      version; /* KFD_IOC_PROFILER_VERSION_NUM */
+        struct kfd_ioctl_dlog_args dlog;
+        __u32                      reserved[8];
+        /* The kernel union carries a __u64-aligned member, so it is 8-aligned.
+         * Every member above is only 4-aligned; this mirror keeps the struct
+         * 8-aligned to match the kernel exactly. Size stays 32 bytes (union is
+         * already 32), only alignment changes. */
+        __u64 _align;
+    };
+};
+
+/* Dispatch-log profiler stream (anon_inode fd; KFD-owned GTT BO, RAW mmap) */
+#define KFD_DLOG_STREAM_ABI_VERSION 3
+
+#define KFD_DLOG_STATUS_TARGET_EXITED (1ULL << 2)
+#define KFD_DLOG_STATUS_FATAL         (1ULL << 5)
+
+/*
+ * RAW_MMAP layout in the mmap'd BO: an array of 20-byte firmware records,
+ * followed by u64 wptr[num_regions] (firmware producer) then u64
+ * rptr[num_regions] (consumer); byte offsets come from kfd_dlog_stream_info.
+ * Firmware publishes payload before wptr[]; consumers read wptr[], issue a read
+ * barrier, then read payload. The consumer barrier cannot repair missing
+ * firmware ordering. Treat record_type==0 or doorbell_off==0 as
+ * padding/not-yet-written and skip it.
+ */
+struct kfd_dlog_stream_info
+{
+    __u32 abi_version;
+    /* raw per-record stride from firmware */
+    __u32 fw_record_size;
+    __u32 num_regions;
+    __u32 region_record_count;
+    __u64 buffer_size;
+    __u64 mmap_size;
+    __u64 records_offset;
+    __u64 wptr_offset;
+    __u64 rptr_offset;
+    __u32 gpu_id;
+    __u32 target_pid;
+    __u32 pasid;
+    __u32 flags;
+};
+
+struct kfd_dlog_stream_status
+{
+    __u64 status;
+    __u64 target_exit_count;
+};
+
+/* Sub-operation selector for the dispatch-log stream fd ioctl. */
+enum kfd_dlog_stream_op
+{
+    KFD_DLOG_STREAM_OP_INFO = 0,
+    KFD_DLOG_STREAM_OP_STATUS,
+};
+
+struct kfd_dlog_stream_args
+{
+    __u32 op;  /* IN: enum kfd_dlog_stream_op */
+    __u32 pad; /* IN: must be 0 */
+    union
+    {
+        struct kfd_dlog_stream_info   info;   /* OUT for OP_INFO */
+        struct kfd_dlog_stream_status status; /* OUT for OP_STATUS */
+    };
+};
+
+/*
+ * Stream-fd ioctl. Dispatched only on the anon_inode dispatch-log stream fd,
+ * never through /dev/kfd. Reuses amdkfd's 'K' magic with NR 0x88.
+ */
+#define KFD_DLOG_STREAM_IOC _IOWR('K', 0x88, struct kfd_dlog_stream_args)
+
+#define AMDKFD_IOC_PROFILER AMDKFD_IOWR(0x28, struct kfd_ioctl_profiler_args)
+
+#endif /* KFD_DLOG_UAPI_H */

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/record_pipe.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/record_pipe.hpp
@@ -1,0 +1,156 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#pragma once
+
+#include "lib/rocprofiler-sdk/kfd/dlog_drain.hpp"
+
+#include <array>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <utility>
+#include <vector>
+
+// Bounded SPSC handoff of copied record batches, from the ring-copier to the
+// record processor. The split is load-bearing: a single thread doing both the
+// copy and the pairing fell behind and overran the firmware ring.
+//
+// The slots ARE the buffer pool: each holds a vector whose capacity is reused,
+// so steady state allocates nothing.
+//
+// The producer NEVER blocks. With no free slot acquire() returns nullptr and the
+// caller queues the batch in its own overflow: blocking would stall the ring
+// read and cause the very overrun this split avoids.
+//
+// MEMORY ORDERING: the release/acquire pair on m_tail publishes the filled bytes
+// to the consumer; the pair on m_head publishes the slot's availability, so the
+// producer cannot overwrite a batch the consumer is still reading. Each index
+// has exactly one writer, so neither is a read-modify-write.
+
+namespace rocprofiler
+{
+namespace kfd
+{
+// One batch of records copied out of the ring in a single drain.
+struct record_batch
+{
+    std::vector<copied_record> records = {};
+    uint64_t                   now_ns  = 0;  // host clock sampled once for the batch
+    // Which GPU's ring these came from. Pairing and correlation are keyed by it,
+    // so records from different GPUs can never be matched to each other.
+    uint32_t gpu_id = 0;
+
+    void clear()
+    {
+        records.clear();  // keeps capacity: steady state does not allocate
+        now_ns = 0;
+        gpu_id = 0;
+    }
+};
+
+template <size_t Capacity>
+class record_pipe
+{
+    static_assert(Capacity >= 2, "a pipe needs at least one in-flight and one free slot");
+
+public:
+    record_pipe()  = default;
+    ~record_pipe() = default;
+
+    record_pipe(const record_pipe&) = delete;
+    record_pipe& operator=(const record_pipe&) = delete;
+
+    // PRODUCER. A cleared batch to fill, or nullptr when the consumer has not
+    // kept up. Never blocks.
+    record_batch* acquire()
+    {
+        const auto _tail = m_tail.load(std::memory_order_relaxed);
+        if(_tail - m_head.load(std::memory_order_acquire) >= Capacity) return nullptr;
+        auto& _slot = m_slots[_tail % Capacity];
+        _slot.clear();
+        return &_slot;
+    }
+
+    // PRODUCER. Publish the batch returned by acquire(). The release store is what
+    // makes the copied bytes visible to the consumer.
+    void publish()
+    {
+        m_tail.store(m_tail.load(std::memory_order_relaxed) + 1, std::memory_order_release);
+    }
+
+    // CONSUMER. The oldest unread batch, or nullptr when empty.
+    record_batch* peek()
+    {
+        const auto _head = m_head.load(std::memory_order_relaxed);
+        if(m_tail.load(std::memory_order_acquire) == _head) return nullptr;
+        return &m_slots[_head % Capacity];
+    }
+
+    // CONSUMER. Return the batch from peek() to the pool.
+    void pop()
+    {
+        m_head.store(m_head.load(std::memory_order_relaxed) + 1, std::memory_order_release);
+    }
+
+    bool empty() const
+    {
+        return m_tail.load(std::memory_order_acquire) == m_head.load(std::memory_order_acquire);
+    }
+
+    size_t size() const
+    {
+        return m_tail.load(std::memory_order_acquire) - m_head.load(std::memory_order_acquire);
+    }
+
+    static constexpr size_t capacity() { return Capacity; }
+
+private:
+    std::array<record_batch, Capacity> m_slots = {};
+    // Written only by the consumer / only by the producer respectively.
+    std::atomic<size_t> m_head = {0};
+    std::atomic<size_t> m_tail = {0};
+};
+
+// PRODUCER-side helper: move as many FIFO batches from `overflow` into `pipe` as
+// there are free slots, publishing each. Returns true once `overflow` is empty.
+// This is the same handoff the copier performs when a slot frees; factoring it
+// out lets the shutdown path pump the remaining overflow to the processor before
+// declaring the reader finished, so a batch already taken from the ring is never
+// dropped when the pipe was full at stop.
+template <size_t Capacity>
+bool
+spill_overflow_to_pipe(record_pipe<Capacity>& pipe, std::deque<record_batch>& overflow)
+{
+    while(!overflow.empty())
+    {
+        auto* _slot = pipe.acquire();
+        if(_slot == nullptr) return false;
+        *_slot = std::move(overflow.front());
+        overflow.pop_front();
+        pipe.publish();
+    }
+    return true;
+}
+}  // namespace kfd
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/stream_geometry.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/stream_geometry.hpp
@@ -1,0 +1,133 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#pragma once
+
+// Pure exact-geometry validation for a KFD dispatch-log stream, factored out of
+// kfd_reader.cpp so it can be unit-tested without the vendored UAPI header (which
+// is translation-unit-exclusive) or a live stream. The validator takes plain
+// scalars pulled from kfd_dlog_stream_info and the requested ring size, and checks
+// them against the kernel's canonical BO layout:
+//   records[buffer_size] | wptr[num_regions] | rptr[num_regions] | page-pad
+// Every offset, the derived per-region record count, and the page-aligned mmap
+// size are fixed by the ABI, so anything else is a contract violation.
+
+#include "lib/rocprofiler-sdk/kfd/dlog_drain.hpp"  // kFwRecBytes, kMaxRegions
+
+#include <cstddef>
+#include <cstdint>
+
+namespace rocprofiler
+{
+namespace kfd
+{
+// Round `x` up to a multiple of `page` (page must be a power of two, > 0).
+inline uint64_t
+round_up_to_page(uint64_t x, uint64_t page)
+{
+    return (x + page - 1) & ~(page - 1);
+}
+
+// The geometry fields the validator checks, all straight from kfd_dlog_stream_info.
+struct stream_geometry
+{
+    uint32_t num_regions         = 0;
+    uint32_t region_record_count = 0;
+    uint64_t buffer_size         = 0;
+    uint64_t mmap_size           = 0;
+    uint64_t records_offset      = 0;
+    uint64_t wptr_offset         = 0;
+    uint64_t rptr_offset         = 0;
+};
+
+// Which validation check rejected the geometry. Kept as a returned value rather
+// than a log line so the validator stays pure and unit-testable; the caller
+// (which has the singletons) turns it into a warning.
+enum class geometry_reason
+{
+    ok,                    // accepted
+    buffer_size_mismatch,  // kernel buffer_size != the size we requested
+    bad_region_layout,     // num_regions out of range, or region_record_count not a power of two
+    layout_mismatch,       // an offset, the record count, the mmap size, or region disjointness
+};
+
+inline const char*
+geometry_reason_name(geometry_reason r)
+{
+    switch(r)
+    {
+        case geometry_reason::buffer_size_mismatch: return "buffer-size-mismatch";
+        case geometry_reason::bad_region_layout: return "bad-region-layout";
+        case geometry_reason::layout_mismatch: return "layout-mismatch";
+        case geometry_reason::ok: break;
+    }
+    return "ok";
+}
+
+// Result of validation: on success, `mmap_len` is the exact page-aligned mapping
+// length the caller must mmap. On failure, `ok` is false, `mmap_len` is 0, and
+// `reason` says which check rejected it.
+struct stream_geometry_result
+{
+    bool            ok       = false;
+    uint64_t        mmap_len = 0;
+    geometry_reason reason   = geometry_reason::ok;
+};
+
+// Validate `g` (the kernel-returned geometry) against `requested_buffer_size` and
+// `page_size`. Rejects an unsupported region layout copy_pipes() could not drain,
+// then requires every offset / count / mmap size to match the canonical layout
+// exactly, and requires the three regions to be disjoint. All arithmetic is in
+// u64; num_regions is bounded by kMaxRegions and buffer_size is a bounded u32, so
+// nothing wraps.
+inline stream_geometry_result
+validate_stream_geometry(const stream_geometry& g,
+                         uint64_t               requested_buffer_size,
+                         uint64_t               page_size)
+{
+    if(g.buffer_size != requested_buffer_size)
+        return {false, 0, geometry_reason::buffer_size_mismatch};
+
+    const uint32_t rrc = g.region_record_count;
+    if(g.num_regions == 0 || g.num_regions > kMaxRegions || rrc == 0 || (rrc & (rrc - 1)) != 0)
+        return {false, 0, geometry_reason::bad_region_layout};
+
+    const uint64_t nr        = g.num_regions;
+    const uint64_t ptr_bytes = nr * sizeof(uint64_t);
+    const uint64_t exp_wptr  = g.buffer_size;
+    const uint64_t exp_rptr  = g.buffer_size + ptr_bytes;
+    const uint64_t exp_mmap  = round_up_to_page(exp_rptr + ptr_bytes, page_size);
+    const uint64_t exp_rrc   = g.buffer_size / (nr * kFwRecBytes);
+
+    // Disjoint by construction once the offsets are exact, but asserted directly:
+    // records ends at wptr start, wptr ends at rptr start, rptr ends within mmap.
+    const bool disjoint =
+        g.records_offset < exp_wptr && exp_wptr < exp_rptr && exp_rptr + ptr_bytes <= exp_mmap;
+
+    if(g.records_offset != 0 || g.wptr_offset != exp_wptr || g.rptr_offset != exp_rptr ||
+       g.mmap_size != exp_mmap || rrc != exp_rrc || !disjoint)
+        return {false, 0, geometry_reason::layout_mismatch};
+
+    return stream_geometry_result{true, exp_mmap, geometry_reason::ok};
+}
+}  // namespace kfd
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/CMakeLists.txt
@@ -44,3 +44,24 @@ rocprofiler_add_unit_test(
     ENVIRONMENT
         "LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}:${CMAKE_LIBRARY_OUTPUT_DIRECTORY}:${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/llvm/lib:${ROCM_PATH}/lib:${ROCM_PATH}/llvm/lib:$ENV{LD_LIBRARY_PATH}"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")
+
+set(ROCPROFILER_LIB_KFD_DLOG_DRAIN_TEST_SOURCES dlog_drain_test.cpp)
+
+add_executable(kfd-dlog-drain)
+
+target_sources(kfd-dlog-drain PRIVATE ${ROCPROFILER_LIB_KFD_DLOG_DRAIN_TEST_SOURCES})
+
+target_link_libraries(
+    kfd-dlog-drain
+    PRIVATE rocprofiler-sdk::rocprofiler-sdk-common-library
+            rocprofiler-sdk::rocprofiler-sdk-static-library GTest::gtest
+            GTest::gtest_main)
+
+rocprofiler_add_unit_test(
+    TARGET kfd-dlog-drain
+    SOURCES ${ROCPROFILER_LIB_KFD_DLOG_DRAIN_TEST_SOURCES}
+    TIMEOUT 45
+    LABELS "unittests;kfd-dlog"
+    ENVIRONMENT
+        "LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}:${CMAKE_LIBRARY_OUTPUT_DIRECTORY}:${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/llvm/lib:${ROCM_PATH}/lib:${ROCM_PATH}/llvm/lib:$ENV{LD_LIBRARY_PATH}"
+    FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/dlog_drain_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/dlog_drain_test.cpp
@@ -1,0 +1,1111 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Unit tests for the dispatch-log ring drain against a hand-built in-memory ring.
+// Geometry mirrors GFX12: num_regions=2, region_record_count=2048.
+
+#include "lib/rocprofiler-sdk/kfd/dlog_drain.hpp"
+#include "lib/rocprofiler-sdk/kfd/record_pipe.hpp"
+#include "lib/rocprofiler-sdk/kfd/stream_geometry.hpp"
+
+#include <gtest/gtest.h>
+
+#include <deque>
+
+#include <atomic>
+#include <cstdint>
+#include <cstring>
+#include <map>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace
+{
+using namespace rocprofiler::kfd;
+// A hand-built ring: num_regions*rrc record slots plus per-pipe wptr/rptr arrays.
+struct fake_ring
+{
+    uint32_t              num_regions;
+    uint32_t              rrc;  // region_record_count (per-region slot count)
+    std::vector<uint8_t>  records;
+    std::vector<uint64_t> wptr;
+    std::vector<uint64_t> rptr;
+    fake_ring(uint32_t nreg, uint32_t region_record_count)
+    : num_regions(nreg)
+    , rrc(region_record_count)
+    , records(static_cast<size_t>(nreg) * region_record_count * kFwRecBytes, 0)
+    , wptr(nreg, 0)
+    , rptr(nreg, 0)
+    {}
+    // Region r's slots are [r*rrc, (r+1)*rrc); idx masks into that region.
+    void put(uint32_t region,
+             uint64_t idx,
+             uint32_t rtype,
+             uint32_t dispatch_id,
+             uint32_t doorbell_off,
+             uint64_t ts)
+    {
+        uint64_t  slot = static_cast<uint64_t>(region) * rrc + (idx & (rrc - 1));
+        fw_record rec{};
+        rec.ts_lo        = static_cast<uint32_t>(ts & 0xFFFFFFFFu);
+        rec.ts_hi        = static_cast<uint32_t>(ts >> 32);
+        rec.record_type  = rtype;
+        rec.dispatch_id  = dispatch_id;
+        rec.doorbell_off = doorbell_off;
+        std::memcpy(records.data() + slot * kFwRecBytes, &rec, sizeof(rec));
+    }
+};
+// Recording sink: matched pairs and START-less EOPs (shape ii) kept apart, plus the
+// per-record loss-free verdict.
+struct recorder
+{
+    std::map<std::pair<uint32_t, uint32_t>, std::pair<uint64_t, uint64_t>> pairs;  // -> (start,end)
+    std::vector<std::pair<uint32_t, uint32_t>>                             eops_without_start;
+    size_t                                                                 records = 0;
+    auto                                                                   on_record()
+    {
+        return [this](const drained_record& r) {
+            ++records;
+            if(r.start_known)
+                pairs[{r.doorbell_off, r.dispatch_id}] = {r.start_ticks, r.end_ticks};
+            else
+                eops_without_start.emplace_back(r.doorbell_off, r.dispatch_id);
+        };
+    }
+};
+// The two production stages back to back: reader copies the ring, processor pairs it.
+struct drain_state
+{
+    ring_cursors cursors = {};
+    pair_state   pairing = {};
+};
+// Copy one ring into `batch` (clearing it first) and return the copied count.
+uint64_t
+copy_ring(fake_ring& ring, ring_cursors& cur, std::vector<copied_record>& batch)
+{
+    batch.clear();
+    return copy_pipes(ring.records.data(),
+                      ring.num_regions,
+                      ring.rrc,
+                      ring.wptr.data(),
+                      ring.rptr.data(),
+                      cur,
+                      batch);
+}
+uint64_t
+run_drain(fake_ring& ring, drain_state& st, recorder& rec, uint64_t now_ns = 1000)
+{
+    auto batch = std::vector<copied_record>{};
+    copy_ring(ring, st.cursors, batch);
+    return pair_records(batch.data(), batch.size(), st.pairing, now_ns, rec.on_record());
+}
+// Prime a fresh ring: first drain syncs each pipe cursor to the origin.
+void
+prime(fake_ring& ring, drain_state& st)
+{
+    recorder rec0;
+    run_drain(ring, st, rec0);
+}
+
+// A fresh, already-primed drain environment: ring at [nreg,rrc], synced cursors.
+struct env
+{
+    fake_ring   ring;
+    drain_state st;
+    recorder    rec;
+    env(uint32_t nreg = 2, uint32_t rrc = 2048)
+    : ring(nreg, rrc)
+    {
+        prime(ring, st);
+    }
+    uint64_t drain() { return run_drain(ring, st, rec); }
+};
+
+// An OutT that advances the shared volatile wptr[region] once a chosen number of
+// records have been emplaced -- modelling a producer that laps the reader DURING
+// the copy loop, so the post-copy w2 reload exceeds the w that was
+// loaded once at the top. Supports the size()/operator[] the back-patch needs.
+struct advancing_out
+{
+    std::vector<copied_record> recs;
+    volatile uint64_t*         wptr          = nullptr;
+    uint32_t                   region        = 0;
+    size_t                     advance_after = SIZE_MAX;  // bump wptr after this many emplaces
+    uint64_t                   advance_to    = 0;
+    void                       emplace_back(const copied_record& r)
+    {
+        recs.emplace_back(r);
+        if(recs.size() == advance_after && wptr != nullptr)
+            __atomic_store_n(&wptr[region], advance_to, __ATOMIC_RELEASE);
+    }
+    size_t         size() const { return recs.size(); }
+    copied_record& operator[](size_t i) { return recs[i]; }
+};
+
+// One GPU's ring + cursors + copied batch, primed to origin; copy() refills the batch.
+struct gpu_ring
+{
+    fake_ring                  ring;
+    ring_cursors               cur;
+    std::vector<copied_record> batch;
+    gpu_ring(uint32_t rrc, uint32_t nreg = 1)
+    : ring(nreg, rrc)
+    {
+        copy_ring(ring, cur, batch);  // prime cursor to origin
+    }
+    uint64_t copy() { return copy_ring(ring, cur, batch); }
+};
+}  // namespace
+
+// Core start/eop pairing scenarios driven through the two-stage drain.
+TEST(dlog_drain, pairing_core)
+{
+    const uint32_t db = 4100;
+    // First drain consumes from the origin: records already present are this session's.
+    {
+        fake_ring   ring(2, 2048);
+        drain_state st;
+        recorder    rec;
+        ring.put(0, 0, kRecStart, 7, db, 111);
+        ring.put(0, 1, kRecEop, 7, db, 222);
+        ring.wptr[0] = 2;
+        EXPECT_EQ(run_drain(ring, st, rec), 1u);
+        ASSERT_EQ(rec.pairs.count(std::make_pair(db, 7u)), 1u);
+        EXPECT_EQ(rec.pairs[std::make_pair(db, 7u)].first, 111u);
+        EXPECT_EQ(ring.rptr[0], 2u);
+        EXPECT_TRUE(st.cursors.rptr_init);
+    }
+    // A single pipe with N pairs: all pair, correct ticks, rptr advances.
+    {
+        env e;
+        for(uint32_t i = 0; i < 40; ++i)
+        {
+            e.ring.put(0, 2 * i, kRecStart, i, db, 1000 + i);
+            e.ring.put(0, 2 * i + 1, kRecEop, i, db, 2000 + i);
+        }
+        e.ring.wptr[0] = 80;
+        EXPECT_EQ(e.drain(), 40u);
+        EXPECT_EQ(e.rec.pairs.size(), 40u);
+        EXPECT_EQ(e.ring.rptr[0], 80u);
+        for(uint32_t i = 0; i < 40; ++i)
+        {
+            auto it = e.rec.pairs.find({db, i});
+            ASSERT_NE(it, e.rec.pairs.end());
+            EXPECT_EQ(it->second.first, 1000u + i);
+            EXPECT_EQ(it->second.second, 2000u + i);
+        }
+    }
+    // Two pipes with DIFFERENT counts prove per-pipe indexing (each wptr[i] one doorbell).
+    {
+        env            e;
+        const uint32_t dbA = 4100, dbB = 4102;
+        for(uint32_t i = 0; i < 20; ++i)
+        {
+            e.ring.put(0, 2 * i, kRecStart, i, dbA, 100 + i);
+            e.ring.put(0, 2 * i + 1, kRecEop, i, dbA, 500 + i);
+        }
+        e.ring.wptr[0] = 40;
+        for(uint32_t i = 0; i < 40; ++i)
+        {
+            e.ring.put(1, 2 * i, kRecStart, i, dbB, 700 + i);
+            e.ring.put(1, 2 * i + 1, kRecEop, i, dbB, 900 + i);
+        }
+        e.ring.wptr[1] = 80;
+        EXPECT_EQ(e.drain(), 60u);
+        uint32_t a = 0, b = 0;
+        for(auto& kv : e.rec.pairs)
+        {
+            if(kv.first.first == dbA) ++a;
+            if(kv.first.first == dbB) ++b;
+        }
+        EXPECT_EQ(a, 20u);
+        EXPECT_EQ(b, 40u);
+        EXPECT_EQ(e.ring.rptr[0], 40u);
+        EXPECT_EQ(e.ring.rptr[1], 80u);
+    }
+    // Padding slots (type==0 or doorbell==0) are skipped, not scan-stopping.
+    {
+        env e;
+        e.ring.put(0, 0, kRecStart, 5, db, 10);
+        e.ring.put(0, 2, kRecEop, 5, db, 20);  // slot 1 left as padding
+        e.ring.wptr[0] = 3;
+        EXPECT_EQ(e.drain(), 1u);
+        auto key = std::make_pair(db, 5u);
+        ASSERT_EQ(e.rec.pairs.count(key), 1u);
+        EXPECT_EQ(e.rec.pairs[key].first, 10u);
+        EXPECT_EQ(e.rec.pairs[key].second, 20u);
+    }
+    // A start-less EOP is reported (start_known=false) but is not counted as a pair.
+    {
+        env e;
+        e.ring.put(0, 0, kRecEop, 9, 4100, 42);
+        e.ring.wptr[0] = 1;
+        EXPECT_EQ(e.drain(), 0u);
+        EXPECT_TRUE(e.rec.pairs.empty());
+        ASSERT_EQ(e.rec.eops_without_start.size(), 1u);
+        EXPECT_EQ(e.rec.eops_without_start[0].first, 4100u);
+        EXPECT_EQ(e.rec.eops_without_start[0].second, 9u);
+        EXPECT_EQ(e.st.pairing.unmatched_eops, 1u);
+    }
+    // A start in one drain pairs with its eop in a LATER drain (state persists).
+    {
+        env e;
+        e.ring.put(0, 0, kRecStart, 3, db, 111);
+        e.ring.wptr[0] = 1;
+        EXPECT_EQ(e.drain(), 0u);  // start seen, not yet paired
+        e.rec = recorder{};
+        e.ring.put(0, 1, kRecEop, 3, db, 222);
+        e.ring.wptr[0] = 2;
+        EXPECT_EQ(e.drain(), 1u);
+        auto key = std::make_pair(db, 3u);
+        ASSERT_EQ(e.rec.pairs.count(key), 1u);
+        EXPECT_EQ(e.rec.pairs[key].first, 111u);
+        EXPECT_EQ(e.rec.pairs[key].second, 222u);
+    }
+    // Ring wrap: a pair straddling the power-of-two boundary maps to the right slots.
+    {
+        env e;
+        e.st.cursors.rptr[0] = 2047;                 // drain [2047, 2049)
+        e.ring.put(0, 2047, kRecStart, 7, db, 500);  // physical slot 2047
+        e.ring.put(0, 2048, kRecEop, 7, db, 600);    // 2048 & 2047 = physical slot 0
+        e.ring.wptr[0] = 2049;
+        EXPECT_EQ(e.drain(), 1u);
+        ASSERT_EQ(e.rec.pairs.count(std::make_pair(db, 7u)), 1u);
+        EXPECT_EQ(e.rec.pairs[std::make_pair(db, 7u)].first, 500u);
+        EXPECT_EQ(e.rec.pairs[std::make_pair(db, 7u)].second, 600u);
+    }
+}
+
+// evict_stale drops unmatched starts older than max_age, keeps fresh ones.
+TEST(dlog_drain, evict_stale_starts)
+{
+    drain_state st;
+    st.pairing.pending_starts[1] = pair_state::pending_start{100, 1000};  // old
+    st.pairing.pending_starts[2] = pair_state::pending_start{200, 5000};  // fresh
+    EXPECT_EQ(st.pairing.evict_stale(/*now_ns=*/6000, /*max_age_ns=*/2000), 1u);
+    EXPECT_EQ(st.pairing.pending_starts.count(1), 0u);
+    EXPECT_EQ(st.pairing.pending_starts.count(2), 1u);
+}
+
+// Invalid geometry (0 regions, too many, or non-power-of-two rrc) is rejected.
+TEST(dlog_drain, invalid_geometry_rejected)
+{
+    drain_state st;
+    recorder    rec;
+    auto        batch = std::vector<copied_record>{};
+    EXPECT_EQ(copy_pipes(nullptr, 0, 2048, nullptr, nullptr, st.cursors, batch), 0u);
+    EXPECT_EQ(copy_pipes(nullptr, kMaxRegions + 1, 2048, nullptr, nullptr, st.cursors, batch), 0u);
+    fake_ring ring(2, 3000);  // region_record_count not a power of two
+    EXPECT_EQ(run_drain(ring, st, rec), 0u);
+    EXPECT_TRUE(rec.pairs.empty());
+}
+
+// Deep overrun: drain resumes at w-region_slots (not +1), drains the
+// live tail, syncs rptr.
+TEST(dlog_drain, overrun_recovery)
+{
+    const uint32_t db = 4100;
+    env            e;
+    // Recovery point = w - region_slots = 10000 - 2048 = 7952; place a valid pair
+    // in the still-live tail window (well past the untrusted boundary at 7952).
+    e.ring.put(0, 9990, kRecStart, 42, db, 111);
+    e.ring.put(0, 9991, kRecEop, 42, db, 222);
+    e.ring.wptr[0] = 10000;
+    EXPECT_EQ(e.drain(), 1u);
+    EXPECT_EQ(e.ring.rptr[0], 10000u);
+    ASSERT_EQ(e.rec.pairs.count(std::make_pair(db, 42u)), 1u);
+    EXPECT_EQ(e.rec.pairs[std::make_pair(db, 42u)].first, 111u);
+}
+
+// Overrun detection: a lap is w-rptr > region_slots, STRICTLY -- exactly
+// full is not an overrun. At/over full the oldest copied index aliases
+// the producer's next write target, so it is untrusted and its START is dropped.
+TEST(dlog_drain, overrun_detection_boundaries)
+{
+    struct row
+    {
+        const char* label;
+        uint32_t    rrc;
+        uint64_t    wptr;
+        uint64_t    exp_pairs;
+        uint64_t    exp_overruns;
+        uint64_t    exp_lost;
+        uint64_t    exp_untrusted;
+        uint64_t    exp_rptr;
+    };
+    // A live start/eop pair sits at slots 0,1 of a single region.
+    const row rows[] = {
+        {"one_below_full_is_safe", 8, 7, 1, 0, 0, 0, 7},
+        // exactly-full: not an overrun (dist == slots), but idx 0 (the START) is
+        // untrusted and dropped -> its EOP is unmatched, so no pair.
+        {"exactly_full_not_overrun_boundary_untrusted", 8, 8, 0, 0, 0, 1, 8},
+        // deep lap: overrun at dist > slots; lost = dist - slots (no +1). The pair
+        // at physical slots 0,1 is re-read via wrapped indices 8192,8193 (both past
+        // the untrusted boundary 7952, so trusted) and still pairs; only the oldest
+        // copied index (w-slots = 7952) is untrusted.
+        {"deep_lap_detected", 2048, 10000, 1, 1, 10000u - 2048u, 1, 10000},
+    };
+    const uint32_t db = 4100;
+    for(const auto& tc : rows)
+    {
+        env e(1, tc.rrc);
+        e.ring.put(0, 0, kRecStart, 1, db, 10);
+        e.ring.put(0, 1, kRecEop, 1, db, 20);
+        e.ring.wptr[0] = tc.wptr;
+        EXPECT_EQ(e.drain(), tc.exp_pairs) << tc.label;
+        EXPECT_EQ(e.st.cursors.overruns, tc.exp_overruns) << tc.label;
+        EXPECT_EQ(e.st.cursors.lost_records, tc.exp_lost) << tc.label;
+        EXPECT_EQ(e.st.cursors.untrusted_records, tc.exp_untrusted) << tc.label;
+        EXPECT_EQ(e.ring.rptr[0], tc.exp_rptr) << tc.label;
+    }
+}
+
+// A lap during a copy is caught on the NEXT pass: the copier reads wptr once (w),
+// so the following drain observes the overrun.
+TEST(dlog_drain, lap_after_the_copy_is_caught_on_the_following_drain)
+{
+    const uint32_t db = 4100;
+    env            e(1, 8);
+    e.ring.put(0, 0, kRecStart, 1, db, 10);
+    e.ring.put(0, 1, kRecEop, 1, db, 20);
+    e.ring.wptr[0] = 4;
+    EXPECT_EQ(e.drain(), 1u);
+    EXPECT_EQ(e.st.cursors.overruns, 0u);
+    EXPECT_EQ(e.st.cursors.untrusted_records, 0u);
+    e.ring.wptr[0] = 4 + 9;  // producer now laps past the ring
+    e.rec          = recorder{};
+    e.drain();
+    EXPECT_EQ(e.st.cursors.overruns, 1u);
+    EXPECT_GT(e.st.cursors.untrusted_records, 0u);
+}
+
+// a producer advancing DURING the copy makes the post-copy w2 reload
+// mark the aliased records untrusted -- the mid-copy verdict race a single w load
+// missed. Here w is captured at 4 (dist 4, no lap), but the producer laps to 11
+// mid-copy, so every copied index aliases its write frontier and is untrusted.
+TEST(dlog_drain, mid_copy_advance_marks_records_untrusted)
+{
+    fake_ring    ring(1, 8);
+    ring_cursors cur;
+    {
+        std::vector<copied_record> prime;
+        copy_pipes(ring.records.data(), 1, 8, ring.wptr.data(), ring.rptr.data(), cur, prime);
+    }
+    ring.put(0, 0, kRecStart, 1, 4100, 10);
+    ring.put(0, 1, kRecEop, 1, 4100, 20);
+    ring.wptr[0] = 4;  // w captured = 4 -> copy [0,4), dist 4 <= slots -> no overrun
+    advancing_out out;
+    out.wptr          = ring.wptr.data();
+    out.region        = 0;
+    out.advance_after = 2;   // after 2 emplaces, the producer laps
+    out.advance_to    = 11;  // w2 = 11 -> untrusted_upto = 3 -> idx 0..3 untrusted
+    const uint64_t copied =
+        copy_pipes(ring.records.data(), 1, 8, ring.wptr.data(), ring.rptr.data(), cur, out);
+    EXPECT_EQ(copied, 4u);
+    EXPECT_EQ(cur.overruns, 0u) << "the single w load saw no lap";
+    EXPECT_EQ(cur.untrusted_records, 4u) << "but the reload caught all four as torn";
+    for(size_t i = 0; i < out.recs.size(); ++i)
+        EXPECT_FALSE(out.recs[i].loss_free);
+    // the torn START(id1) is dropped, so no pair emerges.
+    pair_state pairing;
+    recorder   rec;
+    EXPECT_EQ(pair_records(out.recs.data(), out.recs.size(), pairing, 1000, rec.on_record()), 0u);
+    EXPECT_TRUE(rec.pairs.empty());
+}
+
+// Stream reset zeroes firmware wptr[] but not rptr[]: copy_pipes() must snap rptr
+// back to wptr, count the regression, copy nothing (no busy spin).
+TEST(dlog_drain, wptr_regression_snaps_rptr_and_converges)
+{
+    fake_ring   ring(2, 8);
+    drain_state st;
+    recorder    rec0;
+    ring.wptr[0] = 5;  // consume so rptr advances past origin on both regions
+    ring.wptr[1] = 3;
+    run_drain(ring, st, rec0);
+    ASSERT_EQ(st.cursors.rptr[0], 5u);
+    ASSERT_EQ(st.cursors.rptr[1], 3u);
+    ring.wptr[0] = 0;  // the reset: firmware wptr[] zeroed underneath us
+    ring.wptr[1] = 0;
+    recorder rec;
+    EXPECT_EQ(run_drain(ring, st, rec), 0u);  // nothing to copy from a reset ring
+    EXPECT_EQ(rec.records, 0u);
+    EXPECT_EQ(st.cursors.wptr_regressions, 2u);  // one per regressed region
+    EXPECT_EQ(st.cursors.rptr[0], 0u);
+    EXPECT_EQ(st.cursors.rptr[1], 0u);
+    EXPECT_EQ(ring.rptr[0], 0u);
+    EXPECT_EQ(ring.rptr[1], 0u);
+    EXPECT_EQ(st.cursors.overruns, 0u);  // no spurious overrun accounting
+    EXPECT_EQ(st.cursors.lost_records, 0u);
+    ring.put(0, 0, kRecStart, 9, 4100, 111);  // post-reset advance drains normally
+    ring.put(0, 1, kRecEop, 9, 4100, 222);
+    ring.wptr[0] = 2;
+    recorder rec2;
+    EXPECT_EQ(run_drain(ring, st, rec2), 1u);
+    EXPECT_EQ(st.cursors.rptr[0], 2u);
+}
+
+// Only a plain decimal in [1, kDlogMaxRingKb] (KiB) is accepted; else 0.
+TEST(dlog_ring_size, env_value_parsing)
+{
+    constexpr uint64_t kb = 1024;
+    struct row
+    {
+        const char* label;
+        std::string in;
+        uint64_t    expect;
+    };
+    const row rows[] = {
+        {"empty", "", 0},
+        {"zero", "0", 0},
+        {"double_zero", "00", 0},
+        {"neg1", "-1", 0},
+        {"neg80", "-80", 0},
+        {"alpha", "abc", 0},
+        {"leading_ws", " 80", 0},
+        {"trailing_ws", "80 ", 0},
+        {"trailing_junk", "80K", 0},
+        {"plus", "+80", 0},
+        {"hex", "0x80", 0},
+        {"min_1kb", "1", 1u * kb},
+        {"default_80kb", "80", 80u * kb},
+        {"default_is_floor", "80", kDlogMinRingBytes},
+        {"1024kb", "1024", 1024u * kb},
+        {"max_u32_field", "4194303", kDlogMaxRingKb * kb},
+        {"over_u32_field", "4194304", 0},
+        {"u32_max_plus", "4294967296", 0},
+        {"u64_max", "18446744073709551615", 0},
+        {"u64_max_plus_1", "18446744073709551616", 0},
+        {"64_nines", std::string(64, '9'), 0},
+    };
+    for(const auto& tc : rows)
+        EXPECT_EQ(dlog_ring_bytes_from_kb_str(tc.in), tc.expect) << tc.label;
+}
+
+// snap lands any request on the 80*2^k lattice: legal for both 2- and 4-region ASICs.
+TEST(dlog_ring_size, snap_yields_a_driver_legal_size)
+{
+    for(uint64_t want : {uint64_t{0},
+                         uint64_t{1},
+                         kDlogMinRingBytes - 1,
+                         kDlogMinRingBytes,
+                         uint64_t{100000},
+                         uint64_t{131072},
+                         uint64_t{1048576},
+                         uint64_t{5242880},
+                         kDlogMaxRingBytes - 1,
+                         kDlogMaxRingBytes,
+                         kDlogMaxRingBytes + 1,
+                         uint64_t{0xFFFFFFFF}})
+    {
+        uint64_t sz = dlog_snap_ring_bytes(want);
+        EXPECT_GE(sz, kDlogMinRingBytes);
+        EXPECT_LE(sz, kDlogMaxRingBytes);
+        EXPECT_LE(sz, 0xFFFFFFFFull);  // uint32 buffer_size field
+        if(want >= kDlogMinRingBytes)
+        {
+            EXPECT_LE(sz, want);  // never rounds up
+        }
+        EXPECT_EQ(sz % 80u, 0u);
+        for(uint64_t num_regions : {uint64_t{2}, uint64_t{4}})
+        {
+            ASSERT_EQ(sz % (num_regions * 20), 0u);
+            uint64_t rrc = sz / (num_regions * 20);
+            EXPECT_EQ(rrc & (rrc - 1), 0u);  // power of two
+            EXPECT_LE(rrc, 1u << 24);
+            EXPECT_GT(rrc, 0u);
+        }
+    }
+}
+
+// Specific snap cases: on-lattice unchanged, off-lattice snaps down, clamp at bounds.
+TEST(dlog_ring_size, snap_boundaries)
+{
+    struct row
+    {
+        const char* label;
+        uint64_t    want;
+        uint64_t    expect;
+    };
+    const row rows[] = {
+        {"default_snaps_to_self", kDlogMinRingBytes, 81920u},
+        {"128kb_snaps_down_to_80kb", 131072u, 81920u},
+        {"zero_clamps_up_to_floor", 0u, kDlogMinRingBytes},
+        {"one_clamps_up_to_floor", 1u, kDlogMinRingBytes},
+        {"640kb_on_lattice", 655360u, 655360u},
+        {"5mb_on_lattice", 5242880u, 5242880u},
+        {"40mb_on_lattice", 41943040u, 41943040u},
+        {"640mb_on_lattice", 671088640u, 671088640u},
+        {"above_ceiling_clamps", 671088641u, kDlogMaxRingBytes},
+        {"max_kb_clamps", kDlogMaxRingKb * 1024, kDlogMaxRingBytes},
+        {"just_below_ceiling_snaps_down", kDlogMaxRingBytes - 1, 335544320u},
+    };
+    for(const auto& tc : rows)
+        EXPECT_EQ(dlog_snap_ring_bytes(tc.want), tc.expect) << tc.label;
+}
+
+// The loss-free verdict lets a signal-less consumer trust an EOP as a completion.
+TEST(dlog_drain, loss_free_verdict)
+{
+    const uint32_t db = 4100;
+    // A normal drain, well below full, reports every record trusted.
+    {
+        env e(1, 8);
+        e.ring.put(0, 0, kRecStart, 1, db, 10);
+        e.ring.put(0, 1, kRecEop, 1, db, 20);
+        e.ring.put(0, 2, kRecEop, 2, db, 30);  // shape ii: no start
+        e.ring.wptr[0] = 3;                    // w2 = 3 < slots -> nothing untrusted
+        EXPECT_EQ(e.drain(), 1u);
+        EXPECT_EQ(e.rec.records, 2u);
+        EXPECT_EQ(e.rec.pairs.size(), 1u);
+        EXPECT_EQ(e.rec.eops_without_start.size(), 1u);
+        EXPECT_EQ(e.st.cursors.overruns, 0u);
+        EXPECT_EQ(e.st.cursors.untrusted_records, 0u) << "loss verdict lives on the copy side";
+    }
+    // Exactly-full: NOT an overrun, but the oldest copied index aliases
+    // the producer's next write target, so it is untrusted and dropped.
+    {
+        env e(1, 8);
+        e.ring.put(0, 0, kRecStart, 1, 4100, 10);
+        e.ring.put(0, 1, kRecEop, 1, 4100, 20);
+        e.ring.wptr[0] = 8;  // == region_slots
+        e.drain();
+        EXPECT_EQ(e.st.cursors.overruns, 0u) << "exactly-full is not an overrun";
+        EXPECT_EQ(e.st.cursors.lost_records, 0u);
+        EXPECT_EQ(e.st.cursors.untrusted_records, 1u);
+        EXPECT_TRUE(e.rec.pairs.empty()) << "the torn START is dropped";
+        EXPECT_EQ(e.rec.eops_without_start.size(), 1u) << "its EOP arrives start-unknown";
+    }
+}
+
+// Reverse-region: an EOP is copied BEFORE its own START when the START lands in a
+// LATER region of the same batch (copy_pipes sweeps region 0 then region 1).
+// pair_records binds every START in the batch before matching any EOP, so the pair
+// still forms rather than the EOP arriving start-unknown.
+TEST(dlog_drain, reverse_region_eop_before_start_in_one_batch)
+{
+    env            e(2, 8);
+    const uint32_t db = 4100;
+    e.ring.put(0, 0, kRecEop, 1, db, 200);    // region 0: copied first
+    e.ring.put(1, 0, kRecStart, 1, db, 100);  // region 1: its START, copied second
+    e.ring.wptr[0] = 1;
+    e.ring.wptr[1] = 1;
+    EXPECT_EQ(e.drain(), 1u) << "the EOP pairs with a START copied after it";
+    ASSERT_EQ(e.rec.pairs.count(std::make_pair(db, 1u)), 1u);
+    EXPECT_EQ(e.rec.pairs[std::make_pair(db, 1u)].first, 100u) << "start from region 1";
+    EXPECT_EQ(e.rec.pairs[std::make_pair(db, 1u)].second, 200u) << "end from region 0";
+    EXPECT_TRUE(e.rec.eops_without_start.empty()) << "not forwarded start-unknown";
+}
+
+// the loss verdict is PER RECORD (the w2 back-patch), not region-wide --
+// only the indices the producer's next write target aliases are untrusted.
+TEST(dlog_drain, untrusted_verdict_is_per_record_not_region_wide)
+{
+    gpu_ring g(8);
+    for(uint32_t i = 0; i < 8; ++i)
+        g.ring.put(0, i, kRecStart, i + 1, 4100, 10 + i);
+    g.ring.wptr[0] = 8;  // exactly full: only idx 0 aliases the next write target
+    EXPECT_EQ(g.copy(), 8u);
+    EXPECT_EQ(g.cur.overruns, 0u) << "exactly-full is not a lap";
+    EXPECT_EQ(g.cur.untrusted_records, 1u);
+    EXPECT_FALSE(g.batch[0].loss_free) << "boundary record untrusted";
+    for(size_t i = 1; i < g.batch.size(); ++i)
+        EXPECT_TRUE(g.batch[i].loss_free) << "non-boundary records trusted (not region-wide)";
+}
+
+// The copier advances rptr for every region copied, freeing space before pairing runs.
+TEST(dlog_drain, copier_advances_rptr_without_pairing)
+{
+    gpu_ring g(2048, 2);
+    g.ring.put(0, 0, kRecStart, 1, 4100, 10);
+    g.ring.put(0, 1, kRecEop, 1, 4100, 20);
+    g.ring.wptr[0] = 2;
+    g.ring.put(1, 0, kRecEop, 9, 4200, 30);
+    g.ring.wptr[1] = 1;
+    EXPECT_EQ(g.copy(), 3u);
+    EXPECT_EQ(g.ring.rptr[0], 2u);  // freed before anything was paired
+    EXPECT_EQ(g.ring.rptr[1], 1u);
+    EXPECT_EQ(g.batch.size(), 3u);
+    pair_state pairing;
+    recorder   rec;
+    EXPECT_EQ(pair_records(g.batch.data(), g.batch.size(), pairing, 1000, rec.on_record()), 1u);
+    EXPECT_EQ(rec.pairs.size(), 1u);
+    EXPECT_EQ(rec.eops_without_start.size(), 1u);
+}
+
+// The record's region is preserved; region 0 copies first so cross-region pairs match.
+TEST(dlog_drain, copied_records_carry_their_region)
+{
+    gpu_ring g(2048, 2);
+    g.ring.put(0, 0, kRecStart, 1, 4100, 10);
+    g.ring.wptr[0] = 1;
+    g.ring.put(1, 0, kRecEop, 1, 4100, 20);
+    g.ring.wptr[1] = 1;
+    ASSERT_EQ(g.copy(), 2u);
+    ASSERT_EQ(g.batch.size(), 2u);
+    EXPECT_EQ(g.batch[0].region, 0u);
+    EXPECT_EQ(g.batch[1].region, 1u);
+    pair_state pairing;
+    recorder   rec;
+    EXPECT_EQ(pair_records(g.batch.data(), g.batch.size(), pairing, 1000, rec.on_record()), 1u);
+}
+
+// The pairing census counts starts/eops/unmatched/overwrites.
+TEST(dlog_drain, pairing_census_counts_starts_eops_and_overwrites)
+{
+    const uint32_t db = 4100;
+    env            e(1, 2048);
+    e.ring.put(0, 0, kRecStart, 1, db, 10);
+    e.ring.put(0, 1, kRecEop, 1, db, 20);
+    e.ring.put(0, 2, kRecStart, 2, db, 30);
+    e.ring.put(0, 3, kRecEop, 2, db, 40);
+    e.ring.put(0, 4, kRecEop, 9, db, 50);    // orphan: no START ever
+    e.ring.put(0, 5, kRecStart, 7, db, 60);  // retained
+    e.ring.put(0, 6, kRecStart, 7, db, 70);  // overwrites the live key
+    e.ring.wptr[0] = 7;
+    EXPECT_EQ(e.drain(), 2u);
+    EXPECT_EQ(e.st.pairing.starts_seen, 4u);
+    EXPECT_EQ(e.st.pairing.eops_seen, 3u);
+    EXPECT_EQ(e.st.pairing.unmatched_eops, 1u);
+    EXPECT_EQ(e.st.pairing.starts_overwritten, 1u);
+    EXPECT_EQ(e.st.pairing.pending_starts.size(), 1u);  // id 7 still waiting
+}
+
+// Tier A (the headline): a second outstanding START on one raw key
+// makes it AMBIGUOUS; every EOP on the key is then dropped AT THIS LAYER, never
+// paired and never forwarded start-unknown. Falsifies the old unconditional
+// overwrite, which paired E(300) with S(250) -- a wrong-dispatch emission with
+// no overrun and no torn record.
+TEST(dlog_drain, same_key_ambiguity_drops_both_eops)
+{
+    const uint32_t db = 4100;
+    env            e(1, 2048);
+    e.ring.put(0, 0, kRecStart, 7, db, 100);
+    e.ring.put(0, 1, kRecStart, 7, db, 250);  // duplicate raw key -> ambiguous
+    e.ring.put(0, 2, kRecEop, 7, db, 300);
+    e.ring.put(0, 3, kRecEop, 7, db, 400);
+    e.ring.wptr[0] = 4;
+    EXPECT_EQ(e.drain(), 0u);
+    EXPECT_TRUE(e.rec.pairs.empty());               // neither EOP paired
+    EXPECT_TRUE(e.rec.eops_without_start.empty());  // neither forwarded start-unknown
+    EXPECT_EQ(e.st.pairing.starts_overwritten, 1u);
+    EXPECT_EQ(e.st.pairing.ambiguous_pairs, 2u);
+    EXPECT_TRUE(e.st.pairing.pending_starts.empty());  // outstanding drained to 0
+}
+
+// Tier A: ambiguity is sticky for the whole burst -- three STARTs
+// on one key and two EOPs must emit nothing; the key stays unpairable until
+// outstanding drains.
+TEST(dlog_drain, same_key_ambiguity_is_sticky)
+{
+    const uint32_t db = 4100;
+    env            e(1, 2048);
+    e.ring.put(0, 0, kRecStart, 7, db, 100);
+    e.ring.put(0, 1, kRecStart, 7, db, 250);
+    e.ring.put(0, 2, kRecEop, 7, db, 300);
+    e.ring.put(0, 3, kRecStart, 7, db, 500);
+    e.ring.put(0, 4, kRecEop, 7, db, 600);
+    e.ring.wptr[0] = 5;
+    EXPECT_EQ(e.drain(), 0u);
+    EXPECT_TRUE(e.rec.pairs.empty());
+    EXPECT_TRUE(e.rec.eops_without_start.empty());
+    EXPECT_EQ(e.st.pairing.starts_overwritten, 2u);
+    EXPECT_EQ(e.st.pairing.ambiguous_pairs, 2u);
+    EXPECT_EQ(e.st.pairing.pending_starts.size(), 1u);  // outstanding still 1
+}
+
+// Tier A: a recycle whose new START arrives while the old START is
+// still retained (across batches) marks the key ambiguous BEFORE any EOP binds,
+// so E_old cannot steal S_new. Both EOPs dropped, never forwarded.
+TEST(dlog_drain, retained_start_recycle_is_ambiguous_across_batches)
+{
+    const uint32_t db = 4100;
+    env            e(1, 2048);
+    e.ring.put(0, 0, kRecStart, 7, db, 100);
+    e.ring.wptr[0] = 1;
+    EXPECT_EQ(e.drain(), 0u);
+    ASSERT_EQ(e.st.pairing.pending_starts.size(), 1u);
+    e.rec = recorder{};
+    e.ring.put(0, 1, kRecStart, 7, db, 250);
+    e.ring.put(0, 2, kRecEop, 7, db, 300);
+    e.ring.put(0, 3, kRecEop, 7, db, 400);
+    e.ring.wptr[0] = 4;
+    EXPECT_EQ(e.drain(), 0u);
+    EXPECT_TRUE(e.rec.pairs.empty());
+    EXPECT_TRUE(e.rec.eops_without_start.empty());
+    EXPECT_EQ(e.st.pairing.ambiguous_pairs, 2u);
+    EXPECT_TRUE(e.st.pairing.pending_starts.empty());
+}
+
+// Tier A: a duplicate START must NOT refresh the key's
+// seen_at_ns, or an unpairable ambiguous key would never age out. It ages from
+// the FIRST START.
+TEST(dlog_drain, ambiguous_key_ages_from_first_start)
+{
+    pair_state st;
+    auto       make_start = [](uint32_t db, uint32_t id, uint64_t ts) {
+        copied_record cr{};
+        cr.rec.ts_lo        = static_cast<uint32_t>(ts & 0xFFFFFFFFu);
+        cr.rec.ts_hi        = static_cast<uint32_t>(ts >> 32);
+        cr.rec.record_type  = kRecStart;
+        cr.rec.dispatch_id  = id;
+        cr.rec.doorbell_off = db;
+        cr.loss_free        = true;
+        return cr;
+    };
+    auto           nop = [](const drained_record&) {};
+    const uint32_t db  = 4100;
+    // first START at now=0; two duplicates at 1000 and 2000 make the key
+    // ambiguous. seen_at_ns must remain 0.
+    std::vector<copied_record> b0{make_start(db, 7, 100)};
+    pair_records(b0.data(), b0.size(), st, /*now_ns=*/0, nop);
+    std::vector<copied_record> b1{make_start(db, 7, 200)};
+    pair_records(b1.data(), b1.size(), st, /*now_ns=*/1000, nop);
+    std::vector<copied_record> b2{make_start(db, 7, 300)};
+    pair_records(b2.data(), b2.size(), st, /*now_ns=*/2000, nop);
+    ASSERT_EQ(st.pending_starts.size(), 1u);
+    EXPECT_TRUE(st.pending_starts.begin()->second.ambiguous);
+    EXPECT_EQ(st.evict_stale(/*now_ns=*/2500, /*max_age_ns=*/2000), 1u);
+    EXPECT_TRUE(st.pending_starts.empty());
+}
+
+// Per-GPU isolation: shared doorbell+id, and an overrun on one.
+TEST(dlog_drain, per_gpu_isolation)
+{
+    const uint32_t db = 4100;
+    // Two rings, SAME doorbell+id: each keeps its own state and timestamps.
+    {
+        gpu_ring a(2048), b(2048);
+        a.ring.put(0, 0, kRecStart, 5, db, 100);
+        a.ring.put(0, 1, kRecEop, 5, db, 200);
+        a.ring.wptr[0] = 2;
+        b.ring.put(0, 0, kRecStart, 5, db, 300);
+        b.ring.put(0, 1, kRecEop, 5, db, 400);
+        b.ring.wptr[0] = 2;
+        a.copy();
+        b.copy();
+        pair_state pair_a;
+        pair_state pair_b;
+        recorder   rec_a;
+        recorder   rec_b;
+        EXPECT_EQ(pair_records(a.batch.data(), a.batch.size(), pair_a, 1000, rec_a.on_record()),
+                  1u);
+        EXPECT_EQ(pair_records(b.batch.data(), b.batch.size(), pair_b, 1000, rec_b.on_record()),
+                  1u);
+        ASSERT_EQ(rec_a.pairs.count(std::make_pair(db, 5u)), 1u);
+        ASSERT_EQ(rec_b.pairs.count(std::make_pair(db, 5u)), 1u);
+        EXPECT_EQ(rec_a.pairs[std::make_pair(db, 5u)].first, 100u);
+        EXPECT_EQ(rec_b.pairs[std::make_pair(db, 5u)].first, 300u);
+        EXPECT_EQ(pair_a.unmatched_eops, 0u);
+        EXPECT_EQ(pair_b.unmatched_eops, 0u);
+    }
+    // An overrun on A's ring must not touch B's cursors or verdicts.
+    {
+        gpu_ring a(8), b(8);
+        a.ring.put(0, 0, kRecStart, 1, 4100, 10);
+        a.ring.put(0, 1, kRecEop, 1, 4100, 20);
+        a.ring.wptr[0] = 40;  // A laps
+        b.ring.put(0, 0, kRecStart, 1, 4100, 30);
+        b.ring.put(0, 1, kRecEop, 1, 4100, 40);
+        b.ring.wptr[0] = 2;  // B clean
+        a.copy();
+        b.copy();
+        EXPECT_EQ(a.cur.overruns, 1u);
+        EXPECT_EQ(b.cur.overruns, 0u) << "one ring lapping must not mark another";
+        EXPECT_GT(a.cur.lost_records, 0u);
+        EXPECT_EQ(b.cur.lost_records, 0u);
+        for(const auto& r : b.batch)
+            EXPECT_TRUE(r.loss_free) << "the clean ring's records stay usable";
+    }
+}
+
+// --- Bounded SPSC handoff between the ring-copier and the record processor ---
+
+// Batches come out in the order they went in, with their contents intact.
+TEST(record_pipe, preserves_batch_order_and_contents)
+{
+    auto pipe = record_pipe<4>{};
+    EXPECT_TRUE(pipe.empty());
+    EXPECT_EQ(pipe.peek(), nullptr);
+    for(uint32_t b = 0; b < 3; ++b)
+    {
+        auto* slot = pipe.acquire();
+        ASSERT_NE(slot, nullptr);
+        slot->now_ns = 1000 + b;
+        for(uint32_t i = 0; i < 4; ++i)
+        {
+            auto r            = copied_record{};
+            r.rec.dispatch_id = b * 10 + i;
+            slot->records.emplace_back(r);
+        }
+        pipe.publish();
+    }
+    EXPECT_EQ(pipe.size(), 3u);
+    for(uint32_t b = 0; b < 3; ++b)
+    {
+        auto* got = pipe.peek();
+        ASSERT_NE(got, nullptr);
+        EXPECT_EQ(got->now_ns, 1000u + b);
+        ASSERT_EQ(got->records.size(), 4u);
+        for(uint32_t i = 0; i < 4; ++i)
+            EXPECT_EQ(got->records[i].rec.dispatch_id, b * 10 + i);
+        pipe.pop();
+    }
+    EXPECT_TRUE(pipe.empty());
+}
+
+// The producer NEVER blocks: when full, acquire() returns null so the caller drops.
+TEST(record_pipe, producer_never_blocks_when_the_consumer_stalls)
+{
+    auto pipe = record_pipe<4>{};
+    for(size_t i = 0; i < pipe.capacity(); ++i)  // fill completely; consumer never runs
+    {
+        auto* slot = pipe.acquire();
+        ASSERT_NE(slot, nullptr);
+        pipe.publish();
+    }
+    EXPECT_EQ(pipe.size(), pipe.capacity());
+    uint64_t dropped = 0;
+    for(int i = 0; i < 100; ++i)
+        if(pipe.acquire() == nullptr) ++dropped;
+    EXPECT_EQ(dropped, 100u);
+    EXPECT_EQ(pipe.size(), pipe.capacity());
+    pipe.pop();  // one pop frees exactly one slot
+    EXPECT_NE(pipe.acquire(), nullptr);
+}
+
+// Recycled slots arrive cleared, so a stale record is never processed twice.
+TEST(record_pipe, recycled_slots_are_cleared)
+{
+    auto  pipe = record_pipe<2>{};
+    auto* a    = pipe.acquire();
+    ASSERT_NE(a, nullptr);
+    a->records.emplace_back(copied_record{});
+    a->records.emplace_back(copied_record{});
+    pipe.publish();
+    ASSERT_NE(pipe.peek(), nullptr);
+    pipe.pop();
+    auto* reused = pipe.acquire();
+    ASSERT_NE(reused, nullptr);
+    EXPECT_TRUE(reused->records.empty());
+    EXPECT_EQ(reused->now_ns, 0u);
+}
+
+// Real threads: SPSC nothing lost/duplicated, order kept. Run under TSan.
+TEST(record_pipe, spsc_threads_lose_and_duplicate_nothing)
+{
+    constexpr uint32_t kBatches = 2000;
+    auto               pipe     = record_pipe<8>{};
+    auto               produced = std::atomic<uint32_t>{0};
+    auto               dropped  = std::atomic<uint32_t>{0};
+    auto               stop     = std::atomic<bool>{false};
+    auto               consumer = std::thread{[&pipe, &stop]() {
+        uint32_t expect = 0;
+        while(!stop.load(std::memory_order_acquire) || !pipe.empty())
+        {
+            auto* b = pipe.peek();
+            if(!b) continue;
+            if(!b->records.empty())  // contents must be exactly what was written
+            {
+                EXPECT_EQ(b->records[0].rec.dispatch_id, b->records.size() - 1);
+            }
+            EXPECT_EQ(b->now_ns, expect);
+            ++expect;
+            pipe.pop();
+        }
+    }};
+    for(uint32_t i = 0; i < kBatches; ++i)
+    {
+        record_batch* slot = nullptr;
+        while((slot = pipe.acquire()) == nullptr)  // retry rather than block
+            ++dropped;
+        slot->now_ns      = produced.load(std::memory_order_relaxed);
+        auto r            = copied_record{};
+        r.rec.dispatch_id = 0;
+        slot->records.emplace_back(r);
+        slot->records[0].rec.dispatch_id = static_cast<uint32_t>(slot->records.size() - 1);
+        produced.fetch_add(1, std::memory_order_relaxed);
+        pipe.publish();
+    }
+    stop.store(true, std::memory_order_release);
+    consumer.join();
+    EXPECT_EQ(produced.load(), kBatches);
+    EXPECT_TRUE(pipe.empty());
+}
+
+// spill_overflow_to_pipe() moves as many FIFO batches as fit and reports empty-ness.
+TEST(record_pipe, spill_overflow_hands_off_fifo_and_reports_remaining)
+{
+    auto pipe     = record_pipe<4>{};
+    auto overflow = std::deque<record_batch>{};
+    for(uint32_t i = 0; i < 10; ++i)
+        overflow.emplace_back().gpu_id = i;
+    EXPECT_FALSE(spill_overflow_to_pipe(pipe, overflow));  // fills 4, 6 remain
+    EXPECT_EQ(pipe.size(), pipe.capacity());
+    EXPECT_EQ(overflow.size(), 6u);
+    uint32_t expected = 0;
+    while(!overflow.empty() || !pipe.empty())
+    {
+        auto* got = pipe.peek();
+        ASSERT_NE(got, nullptr);
+        EXPECT_EQ(got->gpu_id, expected++);
+        pipe.pop();
+        spill_overflow_to_pipe(pipe, overflow);
+    }
+    EXPECT_EQ(expected, 10u);
+    EXPECT_TRUE(overflow.empty());
+    EXPECT_TRUE(spill_overflow_to_pipe(pipe, overflow));  // nothing queued -> no-op
+}
+
+// Shutdown data-loss regression: the processor reads ONLY the pipe, so overflow must
+// be pumped through before reader_done or copied batches are silently lost.
+TEST(record_pipe, shutdown_drains_overflow_before_declaring_done)
+{
+    constexpr uint32_t kTotal      = 500;
+    auto               pipe        = record_pipe<8>{};
+    auto               overflow    = std::deque<record_batch>{};
+    auto               reader_done = std::atomic<bool>{false};
+    auto               consumed    = std::atomic<uint32_t>{0};
+    // Processor: exits only after reader_done AND empty pipe; never touches overflow.
+    auto processor = std::thread{[&]() {
+        while(true)
+        {
+            auto* b = pipe.peek();
+            if(b == nullptr)
+            {
+                if(reader_done.load(std::memory_order_acquire))
+                {
+                    if(pipe.peek() == nullptr) break;
+                    continue;
+                }
+                std::this_thread::sleep_for(std::chrono::microseconds{50});
+                continue;
+            }
+            consumed.fetch_add(1, std::memory_order_relaxed);
+            pipe.pop();
+        }
+    }};
+    // Reader: copy every batch out; anything that does not fit queues in overflow.
+    for(uint32_t i = 0; i < kTotal; ++i)
+    {
+        record_batch* dst = overflow.empty() ? pipe.acquire() : nullptr;
+        if(dst != nullptr)
+        {
+            dst->gpu_id = i;
+            pipe.publish();
+        }
+        else
+        {
+            overflow.emplace_back().gpu_id = i;
+            spill_overflow_to_pipe(pipe, overflow);
+        }
+    }
+    // The fix: pump remaining overflow into the pipe, THEN declare done.
+    while(!spill_overflow_to_pipe(pipe, overflow))
+        std::this_thread::sleep_for(std::chrono::microseconds{50});
+    ASSERT_TRUE(overflow.empty()) << "overflow must be empty before reader_done";
+    reader_done.store(true, std::memory_order_release);
+    processor.join();
+    EXPECT_EQ(consumed.load(), kTotal)
+        << "a batch copied from the ring never reached the processor";
+}
+
+// Exact stream-geometry validation (validate_stream_geometry). Canonical layout:
+//   records[buffer_size] | wptr[num_regions*8] | rptr[num_regions*8] | pad-to-page
+
+namespace
+{
+constexpr uint64_t kPage = 4096;  // GFX12 default: 80 KiB, 2 regions, 4 KiB page
+stream_geometry
+canonical_geometry(uint64_t buffer_size, uint32_t num_regions)
+{
+    const uint64_t  ptr_bytes = static_cast<uint64_t>(num_regions) * 8;
+    stream_geometry g;
+    g.num_regions         = num_regions;
+    g.region_record_count = static_cast<uint32_t>(buffer_size / (num_regions * kFwRecBytes));
+    g.buffer_size         = buffer_size;
+    g.records_offset      = 0;
+    g.wptr_offset         = buffer_size;
+    g.rptr_offset         = buffer_size + ptr_bytes;
+    g.mmap_size           = round_up_to_page(g.rptr_offset + ptr_bytes, kPage);
+    return g;
+}
+}  // namespace
+
+TEST(stream_geometry, canonical_layouts_are_accepted)
+{
+    const uint64_t buf = kDlogMinRingBytes;  // 80 KiB, 2 regions
+    auto           g   = canonical_geometry(buf, 2);
+    auto           r   = validate_stream_geometry(g, buf, kPage);
+    ASSERT_TRUE(r.ok);
+    EXPECT_EQ(r.mmap_len, g.mmap_size);
+    EXPECT_EQ(g.region_record_count, 2048u);
+    EXPECT_EQ(r.mmap_len, round_up_to_page(buf + 4 * 8, kPage));  // single page span
+    // 640 KiB, 4 regions is also legal.
+    auto g4 = canonical_geometry(655360, 4);
+    EXPECT_TRUE(validate_stream_geometry(g4, 655360, kPage).ok);
+}
+
+// Every rejected mutation of the canonical layout: one row per corruption.
+TEST(stream_geometry, invalid_layouts_are_rejected)
+{
+    const uint64_t buf    = kDlogMinRingBytes;
+    auto           mutate = [&](const char* label, auto fn, uint64_t req = kDlogMinRingBytes) {
+        auto g = canonical_geometry(buf, 2);
+        fn(g);
+        EXPECT_FALSE(validate_stream_geometry(g, req, kPage).ok) << label;
+    };
+    mutate(
+        "buffer_size_differs_from_request", [](stream_geometry&) {}, buf * 2);
+    mutate("mis_routed_records_offset", [](stream_geometry& g) { g.records_offset = 64; });
+    mutate("wptr_offset_off_lattice", [](stream_geometry& g) { g.wptr_offset = buf + 8; });
+    mutate("wptr_rptr_not_disjoint", [](stream_geometry& g) { g.rptr_offset = buf + 4; });
+    mutate("mmap_too_small", [](stream_geometry& g) { g.mmap_size -= kPage; });
+    mutate("mmap_too_big", [](stream_geometry& g) { g.mmap_size += kPage; });
+    mutate("wrong_region_record_count", [](stream_geometry& g) { g.region_record_count = 1024; });
+    mutate("zero_regions", [](stream_geometry& g) { g.num_regions = 0; });
+    mutate("too_many_regions", [](stream_geometry& g) { g.num_regions = kMaxRegions + 1; });
+    mutate("non_power_of_two_rrc", [](stream_geometry& g) { g.region_record_count = 2047; });
+}
+
+// The rejection reason is reported so the caller can log which check tripped.
+TEST(stream_geometry, rejection_reason_is_reported)
+{
+    const uint64_t buf = kDlogMinRingBytes;
+    auto           ok  = validate_stream_geometry(canonical_geometry(buf, 2), buf, kPage);
+    EXPECT_TRUE(ok.ok);
+    EXPECT_EQ(ok.reason, geometry_reason::ok);
+
+    EXPECT_EQ(validate_stream_geometry(canonical_geometry(buf, 2), buf * 2, kPage).reason,
+              geometry_reason::buffer_size_mismatch);
+
+    auto bad_regions        = canonical_geometry(buf, 2);
+    bad_regions.num_regions = 0;
+    EXPECT_EQ(validate_stream_geometry(bad_regions, buf, kPage).reason,
+              geometry_reason::bad_region_layout);
+
+    auto bad_offset           = canonical_geometry(buf, 2);
+    bad_offset.records_offset = 64;
+    EXPECT_EQ(validate_stream_geometry(bad_offset, buf, kPage).reason,
+              geometry_reason::layout_mismatch);
+}


### PR DESCRIPTION
Pure ring layer: byte-exact KFD dispatch-log UAPI mirror (profiler ABI v6,
stream ABI v3), ring drain/pairing with the wptr-regression reconcile and
10 MiB default (kDlogDefaultRingBytes), stream-geometry validation, the SPSC
record pipe with spill_overflow_to_pipe, and the hardware-free drain tests.
No threads, no HSA, nothing wired.


---

## Architecture — full KFD dispatch-log / signal-less feature

The feature captures kernel-dispatch completion timing from **KFD firmware records** (a
`/dev/kfd` dispatch-log ring) instead of allocating an HSA completion signal per dispatch.
The whole path is inert until the master opt-in is set (PR 9); with it off, behavior is
byte-identical to develop. PR numbers below show where each component lands in the stack.

```mermaid
flowchart TD
    App["Application: enqueues kernel dispatch packets"]

    subgraph ENQ["Enqueue-side interception (PR8)"]
      WI["write_interceptor: batch eligibility,<br/>skip completion signal"]
      CAP["capture_doorbell_key:<br/>page-relative doorbell slot (PR3)"]
      REG["register batch with hub: PENDING (PR7)"]
      WI --> CAP --> REG
    end

    subgraph KFD["KFD / firmware (kernel)"]
      HW["GPU executes dispatch"]
      RING[("dispatch-log ring<br/>UAPI v6 / stream ABI v3<br/>mmap from /dev/kfd (PR1)")]
      HW --> RING
    end

    subgraph RDR["Reader / processor threads (PR5)"]
      POLL["poll loop: scheduling helpers (PR4)"]
      DRAIN["drain + pair records:<br/>wptr-regression reconcile (PR1)"]
      PIPE[("SPSC record pipe (PR1)")]
      PROC["processor: match record to dispatch<br/>via DoorbellMap / correlation_key (PR3)"]
      POLL --> DRAIN --> PIPE --> PROC
    end

    subgraph HUBG["Hub / completion (PR6 + PR7)"]
      HUB["DispatchHub:<br/>PENDING to EOP_PROVEN or LEAKED"]
      OWN["OwnerRegistry:<br/>doorbell-slot injectivity"]
      CSLD["complete_signal_less_dispatch:<br/>convert/clamp + exactly-once retire"]
      HUB --> OWN
      HUB --> CSLD
    end

    EMIT["emit_kernel_dispatch_record:<br/>shared emission seam (PR2)"]
    OUT["rocprofiler kernel-dispatch<br/>callback / buffer records"]
    GATE{{"signal_less_feature_enabled:<br/>master opt-in, OFF by default (PR9)"}}

    App --> WI
    REG -.->|"no signal allocated"| HW
    RING --> POLL
    PROC --> HUB
    REG --> HUB
    CSLD --> EMIT --> OUT
    GATE -.->|"off: whole path inert"| WI
```

## This PR (1/9) — pure ring layer

No threads, no HSA, nothing wired: just the byte-exact UAPI mirror, the ring drain/pair
math, geometry validation, and the SPSC pipe, all covered by hardware-free tests.

```mermaid
flowchart LR
    UAPI["KFD dispatch-log UAPI mirror<br/>profiler ABI v6, stream ABI v3"]
    GEO["stream-geometry validation"]
    DRAIN["ring drain + pairing<br/>wptr-regression reconcile<br/>default 10 MiB (kDlogDefaultRingBytes)"]
    PIPE[("SPSC record pipe<br/>spill_overflow_to_pipe")]
    TESTS["hardware-free drain tests"]
    UAPI --> DRAIN
    GEO --> DRAIN
    DRAIN --> PIPE
    TESTS -.->|"cover"| DRAIN
```



---

JIRA ID: AIPROFSDK-1012
