### PR TITLE
feat(rocprofiler-sdk): wire up KFD dispatch-log + docs + master gate [9/9]

### DIFF
--- a/projects/rocprofiler-sdk/source/docs/api-reference/tool_library_environment.rst
+++ b/projects/rocprofiler-sdk/source/docs/api-reference/tool_library_environment.rst
@@ -124,6 +124,103 @@ automatically based on the services your tool enables.
         path (counter collection, ATT, or PC sampling) is registered, the SDK
         logs a warning and falls back to the legacy path anyway.
 
+Kernel dispatch timestamp source
+--------------------------------
+
+.. list-table::
+    :header-rows: 1
+    :widths: 30 15 55
+
+    * - Variable
+      - Default
+      - Description
+    * - ``ROCPROFILER_KFD_DISPATCH_LOG_SIZE_KB``
+      - ``10240``
+      - Size in KiB of the firmware dispatch-log ring, as an integer from ``1`` to
+        ``4194303``. Defaults to 10 MiB. A non-integer, empty, zero, or
+        out-of-range value is ignored with a warning and the default is used. If
+        the firmware laps the reader the SDK logs an overrun warning and the
+        affected dispatches fall back to the HSA timestamps; raising this value
+        gives the reader more headroom.
+
+        The driver only accepts ring sizes of ``80 * 2^k`` bytes (80 KiB, 160 KiB,
+        320 KiB, ... up to the 640 MiB maximum), so the requested size is rounded
+        DOWN to the nearest accepted size, and a size below 80 KiB or above
+        640 MiB is clamped. The effective size is logged whenever it differs from
+        the requested one.
+    * - ``ROCPROFILER_KFD_DISPATCH_LOG_POLL_TIMEOUT_MS``
+      - ``10``
+      - Timeout in milliseconds, as an integer from ``1`` to ``2147483647``, that
+        the dispatch-log reader passes to ``poll()``. The reader wakes on a
+        firmware notification and drains; if none arrives it wakes on this timeout
+        and does a full scan anyway, so this value bounds how long a sparse or
+        lost-interrupt tail can sit undrained. It is the only timer -- there is no
+        separate watchdog thread. A non-integer, empty, zero, or out-of-range
+        value is ignored with a warning and the default is used. Lowering it
+        shortens sparse-tail latency at the cost of more idle wakeups; raising it
+        does the reverse.
+
+    * - ``ROCPROFILER_KFD_DISPATCH_LOG_CLOSE_DRAIN_MS``
+      - ``250``
+      - Internal/advanced. Per-queue close-drain budget in milliseconds: how long
+        ``destroy_queue`` waits for the hardware to finish a signal-less queue's
+        in-flight dispatches before it stops draining and closes the queue. A
+        negative value is clamped to ``0``. This is a per-queue budget only; there
+        is no aggregate teardown ceiling. Most tools should leave this at the
+        default.
+
+    * - ``ROCPROFILER_KFD_DISPATCH_LOG_SIGNAL_LESS``
+      - ``false``
+      - Boolean. The master switch for the entire KFD dispatch-log feature. When
+        unset (the default) the SDK does not probe the KFD dispatch-log interface
+        and every dispatch uses ``hsa_amd_profiling_get_dispatch_time``. When set,
+        the SDK probes the interface and, on GPUs that support it, both reports
+        kernel dispatch ``start_timestamp``/``end_timestamp`` from the firmware
+        dispatch log (taken at the true hardware dispatch boundaries, so tighter
+        than the HSA signal-based interval) and opts in to signal-less
+        completion.
+
+        Under signal-less completion, a dispatch batch that qualifies is published
+        with its AQL packet **untouched** -- the SDK allocates no completion signal
+        and does not modify the application's -- and the dispatch completes from the
+        firmware dispatch-log record instead of a signal. A batch that does not
+        qualify keeps the signal path, so the two coexist. Firmware timestamps
+        require inline queue interposition, so enabling a service that only the
+        legacy interception path supports (counter collection, advanced thread
+        trace, or PC sampling) puts every dispatch on the HSA timestamps.
+
+        A batch qualifies only when the dispatch log is live for that GPU, the
+        reader is healthy, and every packet's doorbell slot has exactly one live
+        owning queue; a doorbell collision (two live queues sharing a slot) retires
+        that slot to the signal path. A queue destroy does **not** retire the slot:
+        a later queue that reuses the doorbell opens a fresh owner window and its
+        records are attributed by dispatch time, so a queue-churning workload (for
+        example a HIP stream pool) keeps using signal-less. If the firmware ring
+        overruns, an end-of-pipe record observed under the overrun cannot be trusted
+        to belong to any specific dispatch, so it is not attributed: those
+        dispatches emit no firmware record, and a warning names the counts.
+        Signal-less is **not** disabled -- later, loss-free dispatches keep using
+        it. As a current limitation, such un-attributed dispatches keep their
+        correlation-id references until process teardown rather than being retired
+        eagerly.
+
+        One limitation is inherent to the doorbell-slot design: attribution
+        requires that no two live queues on the same GPU share a page-relative
+        doorbell slot at the same time. The doorbell allocator makes this rare, but
+        if it does occur the slot is treated as ambiguous and its dispatches fall
+        back to the signal path rather than risk a misattribution.
+
+        **Experimental, and gfx950-only today.** This feature and its
+        ``ROCPROFILER_KFD_DISPATCH_LOG_*`` variables are experimental and may change
+        or be replaced by context/service API options. Signal-less completion is
+        validated and enabled only on gfx950 (MI350), the one SKU whose GPU clock
+        domain has passed the per-SKU T-CLK screen; on every other GPU those
+        dispatches use the HSA signal path regardless of this setting.
+
+        Disabled by default. Enabling it changes when dispatch records are
+        delivered relative to the application observing its own completion
+        signal, so it is opt-in.
+
 Beta-feature opt-in
 -------------------
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/code_object/code_object.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/code_object/code_object.cpp
@@ -34,6 +34,7 @@
 #include "lib/rocprofiler-sdk/context/context.hpp"
 #include "lib/rocprofiler-sdk/hsa/hsa.hpp"
 #include "lib/rocprofiler-sdk/hsa/queue_interposition.hpp"
+#include "lib/rocprofiler-sdk/kfd/signal_less_gate.hpp"
 
 #include <rocprofiler-sdk/callback_tracing.h>
 #include <rocprofiler-sdk/fwd.h>
@@ -1272,6 +1273,12 @@ shutdown(hsa_executable_t executable)
     // Code-object unload callbacks often invalidate tool-side kernel symbol metadata. Drain inline
     // queue-interposition completion records first so pending dispatch records are delivered while
     // that metadata is still valid.
+    // Hub-aware sync: joining already-enqueued tasks is not enough once a
+    // firmware record can still be sitting in the ring or parked in the retry
+    // owner. This additionally fences registration/publication, the reader's
+    // drain, and the ready-task handoff, so no completion can run against symbol
+    // metadata this unload is about to invalidate. No-op with signal-less off.
+    ::rocprofiler::kfd::signal_less_fence_completions();
     ::rocprofiler::hsa::queue_interposition::interposition_sync();
 
     constexpr auto CODE_OBJECT_KIND = ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
@@ -29,6 +29,7 @@
 #include "lib/rocprofiler-sdk/buffer.hpp"
 #include "lib/rocprofiler-sdk/counters/core.hpp"
 #include "lib/rocprofiler-sdk/hsa/queue_interposition.hpp"
+#include "lib/rocprofiler-sdk/kfd/kfd_profiler.hpp"
 #include "lib/rocprofiler-sdk/pc_sampling/service.hpp"
 #include "lib/rocprofiler-sdk/thread_trace/core.hpp"
 
@@ -342,6 +343,13 @@ start_context(rocprofiler_context_id_t context_id)
     }
 
     auto status = ROCPROFILER_STATUS_SUCCESS;
+
+    // A context that traces kernel dispatch is the only reason to arm the KFD
+    // dispatch-log ring, so arm it here rather than at startup. Idempotent, and
+    // early enough that the firmware is recording before the first dispatch.
+    if(cfg->is_tracing_one_of(ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH,
+                              ROCPROFILER_CALLBACK_TRACING_KERNEL_DISPATCH))
+        rocprofiler::kfd::arm_dispatch_log_sessions();
 
     if(cfg->dispatch_counter_collection) rocprofiler::counters::start_context(cfg);
     if(cfg->dispatch_spm) status = rocprofiler::spm::start_context(cfg);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/correlation_id.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/correlation_id.cpp
@@ -26,6 +26,7 @@
 #include "lib/common/utility.hpp"
 #include "lib/rocprofiler-sdk/buffer.hpp"
 #include "lib/rocprofiler-sdk/context/context.hpp"
+#include "lib/rocprofiler-sdk/kfd/signal_less_gate.hpp"
 #include "lib/rocprofiler-sdk/registration.hpp"
 
 #include <rocprofiler-sdk/fwd.h>
@@ -237,6 +238,13 @@ correlation_id_finalize()
         {
             if(itr && itr->get_ref_count() > 0)
             {
+                // "Leaked" = a signal-less dispatch whose firmware completion record was
+                // lost (ring overrun, slot quarantine, or teardown), so no record is
+                // emitted and the id is intentionally not retired here: its kernel may
+                // still be running, and force-retiring would release state the GPU can
+                // still reach.
+                if(kfd::signal_less_id_is_leaked(itr->internal)) continue;
+
                 ++ndangling;
                 ROCP_WARNING << "retiring dangling correlation ID " << itr->internal
                              << " from thread " << itr->thread_idx

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_profiler.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_profiler.cpp
@@ -25,6 +25,7 @@
 #include "lib/common/logging.hpp"
 #include "lib/common/static_object.hpp"
 #include "lib/rocprofiler-sdk/kfd/kfd_reader.hpp"
+#include "lib/rocprofiler-sdk/kfd/signal_less_gate.hpp"
 
 // NOTE: this vendored header carries the *active* (profiler ABI v6, stream ABI
 // v3) dispatch-log UAPI: AMDKFD_IOC_PROFILER at 0x28 with the single OPEN_STREAM
@@ -35,11 +36,13 @@
 
 #include <fmt/core.h>
 
+#include <algorithm>
 #include <atomic>
 #include <cstdint>
 #include <cstdio>
 #include <string>
 #include <unordered_set>
+#include <vector>
 
 #include <dirent.h>
 #include <fcntl.h>
@@ -198,6 +201,14 @@ init_kfd_profiler()
                              st.abi_version,
                              st.supported_gpu_ids.size());
 
+    // a tool that starts its kernel-dispatch context in tool_init calls
+    // start_context BEFORE HSA loads, so the arm there is a guaranteed no-op and
+    // the ring is armed only lazily on the first dispatch -- losing the earliest
+    // ones. This runs at HSA-table install, gated by the feature and reached only
+    // because a kernel-dispatch context enabled interception, so arm now that
+    // probe_ok is set. Idempotent (establish_session early-outs).
+    if(signal_less_feature_enabled()) arm_dispatch_log_sessions();
+
     // Neither the reader thread nor the ring is created here: installing the HSA
     // table says nothing about whether anyone wants kernel traces, and the SDK
     // must create no internal thread when no tool consumes them. Both happen on
@@ -261,6 +272,45 @@ void
 note_kfd_reader_started()
 {
     state().available = true;
+}
+
+void
+arm_dispatch_log_sessions()
+{
+    // the fourth lock-first site (establish_session takes setup_mu with no
+    // child-stale test on the way). One choke point: gate the callee here so a
+    // forked child never arms an inherited reader.
+    if(signal_less_child_stale()) return;
+
+    // Non-constructing peek: a kernel-dispatch context can call this with the
+    // feature off (context.cpp), and flag-off must construct no state. When the
+    // feature is on, init_kfd_profiler() has already constructed this and set
+    // probe_ok, so a null state here means the feature was never initialized.
+    auto* st = state_or_null();
+    if(!st || !st->probe_ok) return;
+
+    // Arming a GPU the application never dispatches on is harmless -- its ring
+    // stays empty -- and is the only way to be ready for whichever it does use.
+    // Sessions are independent, so one GPU's failure never affects another.
+    //
+    // Arm in ascending gpu_id order, not the unordered_set's hash order: if the
+    // session cap is ever reached (many partitioned GPUs), the survivors are then a
+    // deterministic set (the lowest gpu_ids) instead of implementation-defined.
+    auto _ordered =
+        std::vector<uint32_t>(st->supported_gpu_ids.begin(), st->supported_gpu_ids.end());
+    std::sort(_ordered.begin(), _ordered.end());
+
+    size_t _armed = 0;
+    for(uint32_t _gpu_id : _ordered)
+    {
+        if(arm_reader_session_early(_gpu_id)) ++_armed;
+    }
+
+    ROCP_INFO << fmt::format(
+        "KFD dispatch-log: armed {} of {} supported GPU(s) at kernel-trace configuration, before "
+        "any dispatch",
+        _armed,
+        st->supported_gpu_ids.size());
 }
 
 bool

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_profiler.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_profiler.hpp
@@ -78,6 +78,12 @@ note_kfd_reader_started();
 bool
 gpu_supports_dispatch_log(uint32_t gpu_id);
 
+// Called when a context tracing kernel dispatch starts, not at startup: arming
+// opens a KFD-owned dispatch-log stream, and installing the HSA table says
+// nothing about whether anyone wants kernel traces. Idempotent.
+void
+arm_dispatch_log_sessions();
+
 // Non-constructing: true iff the profiler_state singleton has been constructed in
 // this process. Used to verify flag-off inertness (the feature must construct no
 // state). Never constructs it.

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/CMakeLists.txt
@@ -130,6 +130,7 @@ rocprofiler_add_unit_test(
     ENVIRONMENT
         "LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}:${CMAKE_LIBRARY_OUTPUT_DIRECTORY}:${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/llvm/lib:${ROCM_PATH}/lib:${ROCM_PATH}/llvm/lib:$ENV{LD_LIBRARY_PATH}"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")
+
 set(ROCPROFILER_LIB_KFD_DLOG_HUB_TEST_SOURCES dispatch_hub_test.cpp)
 
 add_executable(kfd-dlog-hub)
@@ -149,6 +150,28 @@ rocprofiler_add_unit_test(
     LABELS "unittests;kfd-dlog"
     ENVIRONMENT
         "LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}:${CMAKE_LIBRARY_OUTPUT_DIRECTORY}:${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/llvm/lib:${ROCM_PATH}/lib:${ROCM_PATH}/llvm/lib:$ENV{LD_LIBRARY_PATH}"
+    FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")
+
+set(ROCPROFILER_LIB_KFD_FEATURE_OFF_TEST_SOURCES feature_off_test.cpp)
+
+add_executable(kfd-dlog-feature-off)
+
+target_sources(kfd-dlog-feature-off
+               PRIVATE ${ROCPROFILER_LIB_KFD_FEATURE_OFF_TEST_SOURCES})
+
+target_link_libraries(
+    kfd-dlog-feature-off
+    PRIVATE rocprofiler-sdk::rocprofiler-sdk-common-library
+            rocprofiler-sdk::rocprofiler-sdk-static-library GTest::gtest
+            GTest::gtest_main)
+
+rocprofiler_add_unit_test(
+    TARGET kfd-dlog-feature-off
+    SOURCES ${ROCPROFILER_LIB_KFD_FEATURE_OFF_TEST_SOURCES}
+    TIMEOUT 45
+    LABELS "unittests;kfd-dlog"
+    ENVIRONMENT
+        "ROCPROFILER_KFD_DISPATCH_LOG_SIGNAL_LESS=0;LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}:${CMAKE_LIBRARY_OUTPUT_DIRECTORY}:${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/llvm/lib:${ROCM_PATH}/lib:${ROCM_PATH}/llvm/lib:$ENV{LD_LIBRARY_PATH}"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")
 
 set(ROCPROFILER_LIB_KFD_CSLD_TEST_SOURCES complete_signal_less_dispatch_test.cpp)

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/feature_off_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/feature_off_test.cpp
@@ -1,0 +1,63 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Flag-off inertness: with the feature off, the public KFD dispatch-log entry
+// points reached during normal SDK operation must construct NEITHER the
+// profiler_state NOR the reader_state singleton. The CTest layer pins
+// ROCPROFILER_KFD_DISPATCH_LOG_SIGNAL_LESS=0 and runs this in its own process, so
+// nothing else has constructed the singletons first.
+
+#include "lib/rocprofiler-sdk/kfd/kfd_profiler.hpp"
+#include "lib/rocprofiler-sdk/kfd/kfd_reader.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace rocprofiler::kfd;
+
+TEST(feature_off, static_objects_stay_unconstructed)
+{
+    // Clean start: nothing in this process has constructed either singleton yet.
+    ASSERT_FALSE(kfd_profiler_state_constructed()) << "profiler_state must start unconstructed";
+    ASSERT_FALSE(kfd_reader_state_constructed()) << "reader_state must start unconstructed";
+
+    // The arm path (reached from a kernel-dispatch context start) must peek, not
+    // construct, when the feature is off.
+    arm_dispatch_log_sessions();
+    EXPECT_FALSE(kfd_profiler_state_constructed()) << "arm must not construct profiler_state";
+    EXPECT_FALSE(kfd_reader_state_constructed()) << "arm must not start the reader";
+
+    // The atfork/disable path must peek, not construct.
+    disable_kfd_dispatch_log();
+    EXPECT_FALSE(kfd_profiler_state_constructed()) << "disable must not construct profiler_state";
+
+    // Shutdown (called unconditionally from finalize) must return before
+    // stop_kfd_reader()'s constructing accessor when nothing was ever constructed.
+    shutdown_kfd_profiler();
+    EXPECT_FALSE(kfd_profiler_state_constructed()) << "shutdown must not construct profiler_state";
+    EXPECT_FALSE(kfd_reader_state_constructed()) << "shutdown must not construct reader_state";
+
+    // The public availability/support queries are non-constructing and report off.
+    EXPECT_FALSE(kfd_dispatch_log_available());
+    EXPECT_FALSE(kfd_dispatch_log_supported());
+    EXPECT_FALSE(kfd_profiler_state_constructed());
+    EXPECT_FALSE(kfd_reader_state_constructed());
+}

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
@@ -50,6 +50,7 @@
 #include "lib/rocprofiler-sdk/intercept_table.hpp"
 #include "lib/rocprofiler-sdk/internal_threading.hpp"
 #include "lib/rocprofiler-sdk/kfd/kfd.hpp"
+#include "lib/rocprofiler-sdk/kfd/signal_less_gate.hpp"
 #include "lib/rocprofiler-sdk/marker/marker.hpp"
 #include "lib/rocprofiler-sdk/ompt.hpp"
 #include "lib/rocprofiler-sdk/pc_sampling/code_object.hpp"
@@ -1130,6 +1131,14 @@ finalize()
     std::call_once(_once, []() {
         auto num_clients = get_num_clients();
         set_fini_status(-1);
+
+        // Signal-less teardown steps 1-6, in the one order that strands no
+        // EOP-proven completion. Must precede the sequence below:
+        // queue_controller_fini joins the task group, and correlation_id_finalize
+        // consults the loss ledger this populates. No-op unless signal-less is
+        // active.
+        kfd::signal_less_teardown();
+
         hsa::async_copy_fini();
         counters::device_counting_service_finalize();
         hsa::queue_controller_fini();


### PR DESCRIPTION
The only PR that makes the feature reachable: interposition_init() calls
kfd::init_kfd_profiler() gated on signal_less_feature_enabled() (the master
opt-in, relocated here from inside the probe); start_context arms dispatch-log
sessions for kernel-dispatch tracing; finalize runs signal_less_teardown first;
correlation_id_finalize skips leaked ids; code-object shutdown quiesces;
docs updated (SIZE_KB 10 MiB default, CLOSE_DRAIN_MS, corrected overrun +
queue-churn/one-page limitations). Feature is OFF by default.


---

## This PR (9/9) — wire-up + master gate

The only PR that makes the feature reachable. `interposition_init()` calls
`init_kfd_profiler()` **only** when the master opt-in is set (relocated here from inside the
probe). Sessions arm on `start_context`, teardown/quiesce/leak-skip hook into the shutdown
paths, and the docs are updated. Feature is **OFF by default**.

```mermaid
flowchart TD
    GATE{{"signal_less_feature_enabled<br/>master opt-in, OFF by default"}}
    GATE --> INIT["interposition_init"]
    INIT -->|"if enabled"| PROBE["kfd::init_kfd_profiler"]
    START["start_context"] --> ARM["arm dispatch-log sessions"]
    FIN["finalize"] --> TDN["signal_less_teardown (first)"]
    CID["correlation_id_finalize"] --> SKIP["skip leaked ids"]
    CO["code-object shutdown"] --> QUI["signal_less_quiesce"]
    DOCS["docs: SIZE_KB 10 MiB default, CLOSE_DRAIN_MS,<br/>overrun + queue-churn / one-page limits"]
```



---

JIRA ID: AIPROFSDK-1012
