### PR TITLE
refactor(rocprofiler-sdk): remove non-user-actionable gfx1250 counters

### DIFF
--- a/projects/rocprofiler-sdk/source/share/rocprofiler-sdk/config.yaml
+++ b/projects/rocprofiler-sdk/source/share/rocprofiler-sdk/config.yaml
@@ -280,7 +280,6 @@ rocprofiler-sdk:
             - gfx1150
             - gfx1151
             - gfx1152
-            - gfx1250
           block: CPC
           event: 24
     - name: CPC_ALWAYS_COUNT
@@ -1678,7 +1677,6 @@ rocprofiler-sdk:
             - gfx1150
             - gfx1151
             - gfx1152
-            - gfx1250
           block: GRBM
           event: 31
     - name: GRBM_CP_BUSY
@@ -1722,7 +1720,6 @@ rocprofiler-sdk:
             - gfx1150
             - gfx1151
             - gfx1152
-            - gfx1250
           block: GRBM
           event: 35
     - name: GRBM_GDS_BUSY
@@ -1827,7 +1824,6 @@ rocprofiler-sdk:
             - gfx1150
             - gfx1151
             - gfx1152
-            - gfx1250
           block: GRBM
           event: 13
     - name: GRBM_TC_BUSY
@@ -1841,7 +1837,6 @@ rocprofiler-sdk:
             - gfx941
             - gfx942
             - gfx950
-            - gfx1250
           block: GRBM
           event: 28
     - name: GRBM_UTCL2_BUSY
@@ -14093,14 +14088,6 @@ rocprofiler-sdk:
             - gfx1250
           block: GL2C
           event: 180
-    - name: GL2C_BUBBLE
-      description: Total number of bubble requests sent to the GL2A
-      properties: []
-      definitions:
-        - architectures:
-            - gfx1250
-          block: GL2C
-          event: 46
     - name: GL2C_BYPASS_REQ
       description: total number of client bypass requests. This is measured at tag block.
       properties: []


### PR DESCRIPTION
## Motivation
Remove gfx1250 counters that are not user-actionable 
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
