### PR TITLE
rocclr/hipGraph: fail cleanly when graph kernarg allocation fails under device-memory exhaustion

### DIFF
--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -290,13 +290,26 @@ class GraphNode : public hipGraphNodeDOTAttribute {
     gpuPackets_.clear();
     gpuMetadataPackets_.clear();
 
+    hipError_t submit_status = hipSuccess;
     for (auto& command : commands_) {
       command->setPktCapturingState(true, &gpuPackets_, kernArgMgr, &capturedKernelName_,
                                     &gpuMetadataPackets_);
       // Enqueue command to capture GPU Packet. The packet is not submitted to the device.
       // The packet is stored in gpuPacket_ and submitted during graph launch.
       command->submit(*(command->queue())->vdev());
+      // A kernarg allocation failure inside submit marks the command with a
+      // negative status (see VirtualGPU::submitKernelInternal) rather than
+      // forming a packet; surface it instead of reporting a successful update
+      // that would launch with a stale packet. Mirrors the status check the
+      // non-graph module-launch path performs in hip_module.cpp.
+      if (submit_status == hipSuccess && command->status() < 0) {
+        submit_status = hipErrorOutOfMemory;
+      }
       command->release();
+    }
+    if (submit_status != hipSuccess) {
+      commands_.clear();
+      return submit_status;
     }
 
     // The metadata capture path appends one metadata packet per AQL packet, but

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -2469,6 +2469,10 @@ bool KernelBlitManager::fillBuffer1D(device::Memory& memory, const void* pattern
       isGraphPktCapturing
           ? (unsigned char*)gpu().command()->getGraphKernArg(kCBSize, kCBAlignment, dev().index())
           : (unsigned char*)gpu().allocKernArg(kCBSize, kCBAlignment);
+  if (kernArgBase == nullptr) {
+    LogError("Failed to allocate fill constant buffer (out of memory)");
+    return false;
+  }
 
   assert((patternSize == 1 || patternSize == 2 || patternSize == 4 || patternSize == 8 ||
           patternSize == 16) &&
@@ -2649,6 +2653,10 @@ bool KernelBlitManager::fillBuffer2D(device::Memory& memory, const void* pattern
     auto constBuf = isGraphPktCapturing
                         ? gpu().command()->getGraphKernArg(kCBSize, kCBAlignment, dev().index())
                         : gpu().allocKernArg(kCBSize, kCBAlignment);
+    if (constBuf == nullptr) {
+      LogError("Failed to allocate fill constant buffer (out of memory)");
+      return false;
+    }
     memcpy(constBuf, pattern, patternSize);
 
     constexpr bool kDirectVa = true;

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -4754,6 +4754,10 @@ bool VirtualGPU::submitKernelInternal(const amd::NDRangeContainer& sizes, const 
     if (isGraphCapture) {
       argBuffer = command_->getGraphKernArg(gpuKernel.KernargSegmentByteSize(),
                                             gpuKernel.KernargSegmentAlignment(), dev().index());
+      if (argBuffer == nullptr) {
+        LogError("Failed to allocate graph kernel argument buffer (out of memory)");
+        return false;
+      }
       command_->SetKernelName(gpuKernel.getDemangledName());
     } else {
       argBuffer = reinterpret_cast<address>(

--- a/projects/hip-tests/catch/unit/graph/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/graph/CMakeLists.txt
@@ -8,6 +8,7 @@
 # But this exposes several problems with hipcc and build system on windows.
 # While those are fixed, this hack should allow us to pass windows CI.
 set(TEST_SRC
+  hipGraphExecUpdate_oom_test.cc
   hipGraphAddEmptyNode.cc
   hipGraphAddDependencies.cc
   hipGraphAddEventRecordNode.cc

--- a/projects/hip-tests/catch/unit/graph/hipGraphExecUpdate_oom_test.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphExecUpdate_oom_test.cc
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * @addtogroup hipGraphExecUpdate hipGraphExecUpdate
+ * @{
+ * @ingroup GraphTest
+ * Regression test for kernel-argument pool growth under device-memory
+ * exhaustion (https://github.com/ROCm/rocm-systems/issues/10021).
+ */
+
+#include <hip_test_common.hh>
+
+#include <vector>
+
+namespace {
+__global__ void WriteValue(int* out, int value) { *out = value; }
+}  // namespace
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Repeatedly updates and launches an executable graph while device memory
+ *    is exhausted. Graph exec updates re-capture kernel packets and allocate
+ *    fresh kernel-argument space on every update; once the pre-sized kernarg
+ *    pool is consumed, pool growth allocates device memory and fails when the
+ *    device is out of memory. That failure must surface as an error from the
+ *    API (and the previously-launched packet must never be silently reused):
+ *    prior to the fix for issue #10021 this path either crashed with SIGSEGV
+ *    inside libamdhip64 (NULL-destination nontemporalMemcpy) or, with the
+ *    null check alone, reported success while launching a stale kernel-arg
+ *    packet (silent output corruption). The probe kernel writes its argument
+ *    to device memory so stale-packet corruption is detected as a value
+ *    mismatch.
+ * Test source
+ * ------------------------
+ *  - unit/graph/hipGraphExecUpdate_oom_test.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 6.0
+ */
+HIP_TEST_CASE(Unit_hipGraphExecUpdate_KernargPoolExhaustion) {
+  int* d_out{nullptr};
+  HIP_CHECK(hipMalloc(&d_out, sizeof(int)));
+
+  // One-kernel graph: kernel writes its integer argument to d_out.
+  hipGraph_t graph{};
+  HIP_CHECK(hipGraphCreate(&graph, 0));
+  int value = 0;
+  void* kernelArgs[] = {&d_out, &value};
+  hipKernelNodeParams nodeParams{};
+  nodeParams.func = reinterpret_cast<void*>(WriteValue);
+  nodeParams.gridDim = dim3(1);
+  nodeParams.blockDim = dim3(1);
+  nodeParams.sharedMemBytes = 0;
+  nodeParams.kernelParams = kernelArgs;
+  nodeParams.extra = nullptr;
+  hipGraphNode_t kNode{};
+  HIP_CHECK(hipGraphAddKernelNode(&kNode, graph, nullptr, 0, &nodeParams));
+
+  hipGraphExec_t graphExec{};
+  HIP_CHECK(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+
+  // Prime one launch while memory is still available.
+  value = 1;
+  HIP_CHECK(hipGraphLaunch(graphExec, nullptr));
+  HIP_CHECK(hipStreamSynchronize(nullptr));
+
+  // Exhaust device memory: greedy halving-probe allocation, keeping every block.
+  std::vector<void*> hogs;
+  size_t chunk = size_t{1} << 30;
+  while (chunk >= (size_t{4} << 10)) {
+    void* p{nullptr};
+    if (hipMalloc(&p, chunk) == hipSuccess) {
+      hogs.push_back(p);
+    } else {
+      chunk >>= 1;
+    }
+  }
+  static_cast<void>(hipGetLastError());  // clear the expected final OOM
+
+  // Update + launch until either the iteration budget is reached or the
+  // runtime reports a clean out-of-memory failure. Each update captures a
+  // fresh kernel-argument slot; the budget is sized so the loop consumes the
+  // pre-sized kernarg pool plus any residual device memory through pool
+  // growth (observed trigger on a 24 GB gfx1100: ~135k iterations, ~2 min).
+  constexpr int kIters = 262144;
+  hipError_t status = hipSuccess;
+  for (int i = 2; i <= kIters; ++i) {
+    value = i;
+    HIP_CHECK(hipGraphKernelNodeSetParams(kNode, &nodeParams));
+    hipGraphNode_t errorNode{};
+    hipGraphExecUpdateResult updateResult{};
+    status = hipGraphExecUpdate(graphExec, graph, &errorNode, &updateResult);
+    if (status != hipSuccess) break;
+    status = hipGraphLaunch(graphExec, nullptr);
+    if (status != hipSuccess) break;
+    status = hipStreamSynchronize(nullptr);
+    if (status != hipSuccess) break;
+    int seen = -1;
+    status = hipMemcpy(&seen, d_out, sizeof(int), hipMemcpyDeviceToHost);
+    if (status != hipSuccess) break;
+    // A stale kernel-argument packet (issue #10021, propagation half) shows up
+    // as the previous iteration's value here.
+    REQUIRE(seen == i);
+  }
+
+  // Pass condition: reaching this point (no SIGSEGV) with no stale-packet
+  // value mismatch on any iteration whose calls all reported success. Under
+  // full exhaustion the runtime is permitted to fail any of the calls above
+  // with a clean error code — the regression under test is the process crash
+  // (issue #10021) and the silent stale-packet corruption, not which error
+  // class eventually surfaces.
+  static_cast<void>(status);
+
+  for (void* p : hogs) {
+    static_cast<void>(hipFree(p));
+  }
+  static_cast<void>(hipGraphExecDestroy(graphExec));
+  static_cast<void>(hipGraphDestroy(graph));
+  static_cast<void>(hipFree(d_out));
+}
+
+/**
+ * End doxygen group GraphTest.
+ * @}
+ */


### PR DESCRIPTION
## Motivation

Fixes the host-side SIGSEGV described in https://github.com/ROCm/rocm-systems/issues/10021: under near-exhausted device memory, the HIP-graph kernarg staging path writes through a null allocation result (`nontemporalMemcpy` in `VirtualGPU::submitKernelInternal`), crashing the process inside `libamdhip64` instead of surfacing an error. Reproduced deterministically on gfx1100 (2× RX 7900 XTX, ROCm 7.2.3) after 40–130 min of sustained inference at the VRAM floor.

## Technical Details

Two commits, both required (see issue for the full root-cause chain and symbolized backtraces):

1. **Null-check the three unchecked consumers of `getGraphKernArg`** (`submitKernelInternal` graph branch, `fillBuffer1D`, `fillBuffer2D`), failing through each function's established `LogError` + `return false` idiom. `GraphKernelArgManager::AllocKernArg` deliberately returns nullptr when its pool cannot grow (`Device::deviceLocalAlloc` failure on large-BAR devices); the producer honors the contract, the consumers didn't.
2. **Propagate the failed submit out of `GraphNode::CaptureAndFormPacket`** by checking the command status after `submit()` (mirroring the check the non-graph module-launch path performs in `hip_module.cpp`). Without this, the null-check alone converts the crash into something worse: `hipGraphExecUpdate` reports success, the graph launches with a stale kernarg packet, and we observed silent output corruption followed by delayed, misattributed application crashes.

## Issue Tracking

GitHub issue: https://github.com/ROCm/rocm-systems/issues/10021

## Test Plan

Validated on the `rocm-7.2.3` tag of clr (built standalone against installed ROCm 7.2.3, gfx1100 ×2), under a soak harness that reproduces the crash in 40–130 min (sustained deep-context llama.cpp inference holding ≤ 60 MiB free VRAM, gdb attached). Three configurations: unpatched control, commit-1-only, both commits. This branch is the same logic rebased onto `develop` (context drift: `gpuMetadataPackets_`, renamed local in `fillBuffer1D`); it has not been rebuilt against `develop` — happy to rerun validation if maintainers want it on a newer base.

## Test Result

| runtime | outcome |
|---|---|
| unpatched (shipped 7.2.70203 **and** self-built tag) | SIGSEGV at `libamdhip64+0x4632ef`, 40–130 min, six occurrences across three app builds |
| commit 1 only | no runtime crash; null-checks fired 23×/run — but silent stale-packet corruption → delayed app crash (why commit 2 is required) |
| both commits | immediate, correctly attributed failure: pool-grow logs its existing error, `hipGraphExecUpdate` returns the error, application (llama.cpp) reports it naming the failing function/device and aborts cleanly; no corruption; validated at two memory configurations |

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
