### PR TITLE
chore: add CODEOWNERS entry for ci-precheckin.json

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,7 @@
 /projects/hip-tests/                                                  @ROCm/hip-tests-reviewers
 /projects/rccl/                                                       @ROCm/rccl-reviewers
 /projects/rccl/src/include/api_trace.h                                @ROCm/rccl-reviewers @ROCm/ROCM-DevTools-Team
+/projects/rccl/tools/scripts/test_runner/configs/ci-precheckin.json   @ROCm/rccl-ci
 /projects/rccl-tests/                                                 @ROCm/rccl-reviewers
 /projects/rdc/                                                        @ROCm/rdc-reviewers
 /projects/rocm-core/                                                  @nunnikri @frepaul @raramakr @ashutom @amd-isparry @arvindcheru


### PR DESCRIPTION
## Motivation

Our precheckin has expanded to well over 50 minutes as a result of tests being added to incorrect configs. 
Making sure people only adjust the precheckin job with approval. 

## Technical Details

Adds a CODEOWNERS rule so `@ROCm/rccl-ci` owns
`projects/rccl/tools/scripts/test_runner/configs/ci-precheckin.json`,
ensuring changes to the RCCL precheckin test config get rccl-ci review.

## Issue Tracking

JIRA ID : AICOMRCCL-1877

## Test Plan

NA

## Test Result

NA

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
