### PR TITLE
fix(clr) : Fix segfault during coop launch due to queue release

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -5072,6 +5072,13 @@ bool VirtualGPU::submitKernelInternal(const amd::NDRangeContainer& sizes, const 
 // ================================================================================================
 void VirtualGPU::submitKernel(amd::NDRangeKernelCommand& vcmd) {
   if (vcmd.cooperativeGroups()) {
+    // Under dynamic queues an idle stream may have released its HW queue back to the pool
+    // (gpu_queue_ == nullptr). Reacquire before flushing the fence, since releaseGpuMemoryFence()
+    // dereferences gpu_queue_ in dispatchBarrierPacket().
+    if (!dedicated_queue_ && gpu_queue_ == nullptr) {
+      SetGpuQueue(roc_device_.AcquireActiveQueue(priority_, last_hwq_));
+      last_hwq_ = nullptr;
+    }
     // Wait for the execution on the current queue, since the coop groups will use the device queue
     releaseGpuMemoryFence(kSkipCpuWait);
 

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1262,11 +1262,22 @@ void VirtualGPU::SetGpuQueue(hsa_queue_t* queue) {
 }
 
 // ================================================================================================
-void VirtualGPU::AcquireQueueWithPreference() {
-  std::scoped_lock lock(execution());
-  if (!dedicated_queue_ && gpu_queue_ == nullptr && last_hwq_ != nullptr) {
+void VirtualGPU::ensureHwQueueLocked() {
+  if (!dedicated_queue_ && gpu_queue_ == nullptr) {
     SetGpuQueue(roc_device_.AcquireActiveQueue(priority_, last_hwq_));
     last_hwq_ = nullptr;
+    if (gpu_queue_ == nullptr) {
+      LogError("Runtime failed to acquire a HW queue!");
+    }
+  }
+}
+
+// ================================================================================================
+void VirtualGPU::AcquireQueueWithPreference() {
+  std::scoped_lock lock(execution());
+  // Graph launch: only reattach when a preferred queue was actually saved by SetPreferredQueue().
+  if (last_hwq_ != nullptr) {
+    ensureHwQueueLocked();
   }
 }
 
@@ -1288,10 +1299,7 @@ bool VirtualGPU::ReacquireQueueExcluding(const std::unordered_set<uint64_t>& exc
 // ================================================================================================
 uint64_t VirtualGPU::getQueueID() {
   std::scoped_lock lock(execution());
-  // Dedicated queues keep their HW queue, never acquire from pool
-  if (!dedicated_queue_ && gpu_queue_ == nullptr) {
-    SetGpuQueue(roc_device_.AcquireActiveQueue(priority_));
-  }
+  ensureHwQueueLocked();
   return gpu_queue_->id;
 }
 
@@ -2361,10 +2369,7 @@ VirtualGPU::~VirtualGPU() {
 
   if (tracking_created_) {
     std::scoped_lock l(execution());
-    // Dedicated queues keep their HW queue, never acquire from pool
-    if (!dedicated_queue_ && gpu_queue_ == nullptr) {
-      SetGpuQueue(roc_device_.AcquireActiveQueue(priority_));
-    }
+    ensureHwQueueLocked();
     // Windows requires an interrupt in more cases than Linux for OS fence updates
     force_irq_ = IS_WINDOWS;
     // Force extra barrier to make sure OS gets an interrupt,
@@ -5078,15 +5083,10 @@ void VirtualGPU::submitKernel(amd::NDRangeKernelCommand& vcmd) {
       std::scoped_lock lock(execution());
 
       // Dynamic queues may have reclaimed an idle stream's HW queue; reacquire before the fence.
-      if (!dedicated_queue_ && gpu_queue_ == nullptr) {
-        hsa_queue_t* hwq = roc_device_.AcquireActiveQueue(priority_, last_hwq_);
-        if (hwq == nullptr) {
-          LogError("Runtime failed to acquire a HW queue for cooperative launch!");
-          vcmd.setStatus(CL_INVALID_OPERATION);
-          return;
-        }
-        SetGpuQueue(hwq);
-        last_hwq_ = nullptr;
+      ensureHwQueueLocked();
+      if (gpu_queue_ == nullptr) {
+        vcmd.setStatus(CL_INVALID_OPERATION);
+        return;
       }
       // Wait for the execution on the current queue, since the coop groups will use the device queue
       releaseGpuMemoryFence(kSkipCpuWait);
@@ -5167,9 +5167,7 @@ void VirtualGPU::submitMarker(amd::Marker& vcmd) {
     force_irq_ = IS_WINDOWS;
     // It should be safe to call flush directly if there are not pending dispatches without
     // HSA signal callback
-    if (!dedicated_queue_ && gpu_queue_ == nullptr) {
-      SetGpuQueue(roc_device_.AcquireActiveQueue(priority_));
-    }
+    ensureHwQueueLocked();
     flush(vcmd.GetBatchHead());
     SetCoalesceWindow(0, nullptr);
   } else {

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1262,7 +1262,7 @@ void VirtualGPU::SetGpuQueue(hsa_queue_t* queue) {
 }
 
 // ================================================================================================
-void VirtualGPU::ensureHwQueueLocked() {
+void VirtualGPU::AcquireHwQueueIfNeeded() {
   if (!dedicated_queue_ && gpu_queue_ == nullptr) {
     SetGpuQueue(roc_device_.AcquireActiveQueue(priority_, last_hwq_));
     last_hwq_ = nullptr;
@@ -1277,7 +1277,7 @@ void VirtualGPU::AcquireQueueWithPreference() {
   std::scoped_lock lock(execution());
   // Graph launch: only reattach when a preferred queue was actually saved by SetPreferredQueue().
   if (last_hwq_ != nullptr) {
-    ensureHwQueueLocked();
+    AcquireHwQueueIfNeeded();
   }
 }
 
@@ -1299,7 +1299,7 @@ bool VirtualGPU::ReacquireQueueExcluding(const std::unordered_set<uint64_t>& exc
 // ================================================================================================
 uint64_t VirtualGPU::getQueueID() {
   std::scoped_lock lock(execution());
-  ensureHwQueueLocked();
+  AcquireHwQueueIfNeeded();
   return gpu_queue_->id;
 }
 
@@ -2369,7 +2369,7 @@ VirtualGPU::~VirtualGPU() {
 
   if (tracking_created_) {
     std::scoped_lock l(execution());
-    ensureHwQueueLocked();
+    AcquireHwQueueIfNeeded();
     // Windows requires an interrupt in more cases than Linux for OS fence updates
     force_irq_ = IS_WINDOWS;
     // Force extra barrier to make sure OS gets an interrupt,
@@ -5083,7 +5083,7 @@ void VirtualGPU::submitKernel(amd::NDRangeKernelCommand& vcmd) {
       std::scoped_lock lock(execution());
 
       // Dynamic queues may have reclaimed an idle stream's HW queue; reacquire before the fence.
-      ensureHwQueueLocked();
+      AcquireHwQueueIfNeeded();
       if (gpu_queue_ == nullptr) {
         vcmd.setStatus(CL_INVALID_OPERATION);
         return;
@@ -5167,7 +5167,7 @@ void VirtualGPU::submitMarker(amd::Marker& vcmd) {
     force_irq_ = IS_WINDOWS;
     // It should be safe to call flush directly if there are not pending dispatches without
     // HSA signal callback
-    ensureHwQueueLocked();
+    AcquireHwQueueIfNeeded();
     flush(vcmd.GetBatchHead());
     SetCoalesceWindow(0, nullptr);
   } else {

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -5072,15 +5072,25 @@ bool VirtualGPU::submitKernelInternal(const amd::NDRangeContainer& sizes, const 
 // ================================================================================================
 void VirtualGPU::submitKernel(amd::NDRangeKernelCommand& vcmd) {
   if (vcmd.cooperativeGroups()) {
-    // Under dynamic queues an idle stream may have released its HW queue back to the pool
-    // (gpu_queue_ == nullptr). Reacquire before flushing the fence, since releaseGpuMemoryFence()
-    // dereferences gpu_queue_ in dispatchBarrierPacket().
-    if (!dedicated_queue_ && gpu_queue_ == nullptr) {
-      SetGpuQueue(roc_device_.AcquireActiveQueue(priority_, last_hwq_));
-      last_hwq_ = nullptr;
+    {
+      // Hold execution() across reacquire + fence: ReleaseHwQueue() nulls gpu_queue_ under the
+      // same mutex, so an unlocked window could leave it null before dispatchBarrierPacket() derefs.
+      std::scoped_lock lock(execution());
+
+      // Dynamic queues may have reclaimed an idle stream's HW queue; reacquire before the fence.
+      if (!dedicated_queue_ && gpu_queue_ == nullptr) {
+        hsa_queue_t* hwq = roc_device_.AcquireActiveQueue(priority_, last_hwq_);
+        if (hwq == nullptr) {
+          LogError("Runtime failed to acquire a HW queue for cooperative launch!");
+          vcmd.setStatus(CL_INVALID_OPERATION);
+          return;
+        }
+        SetGpuQueue(hwq);
+        last_hwq_ = nullptr;
+      }
+      // Wait for the execution on the current queue, since the coop groups will use the device queue
+      releaseGpuMemoryFence(kSkipCpuWait);
     }
-    // Wait for the execution on the current queue, since the coop groups will use the device queue
-    releaseGpuMemoryFence(kSkipCpuWait);
 
     // Get device queue for exclusive GPU access
     VirtualGPU* queue = dev().xferQueue();

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -602,6 +602,11 @@ class VirtualGPU : public device::VirtualDevice {
   //! Set the active HW queue and keep the metadata preloader in sync.
   void SetGpuQueue(hsa_queue_t* queue);
 
+  //! Ensure a HW queue is held, acquiring one (with the last_hwq_ affinity hint) if a
+  //! dynamic-queue reclaim released it. No-op for dedicated queues or when one is already held.
+  //! Caller must hold the execution() lock.
+  void ensureHwQueueLocked();
+
   //! Snapshot the current HW queue as preferred for future re-acquisition (used by graph launch).
   //! Only updates if the queue is still valid — avoids clobbering a hint saved by ReleaseHwQueue.
   void SetPreferredQueue() override {

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -605,7 +605,7 @@ class VirtualGPU : public device::VirtualDevice {
   //! Ensure a HW queue is held, acquiring one (with the last_hwq_ affinity hint) if a
   //! dynamic-queue reclaim released it. No-op for dedicated queues or when one is already held.
   //! Caller must hold the execution() lock.
-  void ensureHwQueueLocked();
+  void AcquireHwQueueIfNeeded();
 
   //! Snapshot the current HW queue as preferred for future re-acquisition (used by graph launch).
   //! Only updates if the queue is still valid — avoids clobbering a hint saved by ReleaseHwQueue.

--- a/projects/hip-tests/catch/config/configs/unit/cooperativeGrps.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/cooperativeGrps.yaml
@@ -103,6 +103,9 @@ cooperativeGrps:
   Unit_hipLaunchCooperativeKernel_Basic:
     <<: *level_2
     tags: [cooperative, launch]
+  Unit_hipLaunchCooperativeKernel_QueueReclaim:
+    <<: *level_2
+    tags: [cooperative, launch]
   Unit_hipLaunchCooperativeKernelMultiDevice_Basic:
     <<: *level_2
     # Kernel uses runtime sized shared memory which is not adjusted to handle ASAN extra memory requirements

--- a/projects/hip-tests/catch/unit/cooperativeGrps/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/CMakeLists.txt
@@ -13,6 +13,7 @@ set(TEST_SRC
   hipCGThreadBlockTileTypeShfl_old.cc
   hipCGCoalescedGroups_old.cc
   hipLaunchCooperativeKernel_old.cc
+  coop_launch_queue_reclaim.cc
   coalesced_groups_shfl_down_old.cc
   coalesced_groups_shfl_up_old.cc
   coalesced_group.cc

--- a/projects/hip-tests/catch/unit/cooperativeGrps/coop_launch_queue_reclaim.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/coop_launch_queue_reclaim.cc
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+// Regression test for a NULL gpu_queue_ dereference in the cooperative-launch path.
+//
+// Under dynamic HW queues, an idle stream releases its HW queue back to the shared pool and sets
+// gpu_queue_ = nullptr (VirtualGPU::ReleaseHwQueue). The cooperative branch of
+// VirtualGPU::submitKernel used to flush the fence (releaseGpuMemoryFence ->
+// dispatchBarrierPacket) before reacquiring a queue, dereferencing the null pointer and crashing
+// inside libamdhip64.
+//
+// The reclaim only happens under queue pressure, so the test creates more streams than the default
+// HW queue cap, lets their work drain (so the queues go idle and get reclaimed), then issues two
+// back-to-back cooperative launches per stream. Without the fix this segfaults, usually on the
+// first iteration; with the fix it runs to completion. A segfault takes the whole test process
+// down, so this case fails loudly when the fix is absent.
+
+#include <hip/hip_cooperative_groups.h>
+#include <hip_test_common.hh>
+
+#include <chrono>
+#include <thread>
+#include <vector>
+
+static __global__ void bump(int* out) {
+  if (threadIdx.x == 0) {
+    atomicAdd(out, 1);
+  }
+}
+
+HIP_TEST_CASE(Unit_hipLaunchCooperativeKernel_QueueReclaim) {
+  hipDeviceProp_t props;
+  HIP_CHECK(hipGetDeviceProperties(&props, 0));
+  if (!props.cooperativeLaunch) {
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+  }
+
+  // More streams than the default HW queue cap so the pool is under pressure and idle streams get
+  // their queues reclaimed.
+  constexpr int kNumStreams = 8;
+  constexpr int kLaunchesPerStream = 2;
+  constexpr int kIterations = 20;
+
+  int* out = nullptr;
+  HIP_CHECK(hipMalloc(&out, sizeof(int)));
+  HIP_CHECK(hipMemset(out, 0, sizeof(int)));
+
+  std::vector<hipStream_t> streams(kNumStreams);
+  for (auto& s : streams) {
+    HIP_CHECK(hipStreamCreate(&s));
+  }
+
+  void* args[] = {&out};
+  int expected = 0;
+  for (int it = 0; it < kIterations; ++it) {
+    // Give every stream some work so each holds a HW queue.
+    for (int i = 0; i < kNumStreams; ++i) {
+      hipLaunchKernelGGL(bump, dim3(1), dim3(64), 0, streams[i], out);
+      HIP_CHECK(hipGetLastError());
+      ++expected;
+    }
+
+    // Let the work drain while the host issues no synchronization, so the idle streams release
+    // their HW queues back to the pool (gpu_queue_ -> nullptr).
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    // Synchronize one stream, matching the original reproducer.
+    HIP_CHECK(hipStreamSynchronize(streams[0]));
+
+    // Back-to-back cooperative launches with no intervening op. The first launch leaves a pending
+    // dispatch + retained external signal, guaranteeing the second launch's fence flush hits the
+    // reclaimed (null) queue on the pre-fix runtime.
+    for (int i = 0; i < kNumStreams; ++i) {
+      for (int n = 0; n < kLaunchesPerStream; ++n) {
+        HIP_CHECK(hipLaunchCooperativeKernel(reinterpret_cast<const void*>(&bump), dim3(1),
+                                             dim3(64), args, 0, streams[i]));
+        ++expected;
+      }
+    }
+    HIP_CHECK(hipDeviceSynchronize());
+  }
+
+  int host_out = 0;
+  HIP_CHECK(hipMemcpy(&host_out, out, sizeof(int), hipMemcpyDeviceToHost));
+  REQUIRE(host_out == expected);
+
+  for (auto& s : streams) {
+    HIP_CHECK(hipStreamDestroy(s));
+  }
+  HIP_CHECK(hipFree(out));
+}


### PR DESCRIPTION
## Motivation
VirtualGPU::submitKernel's cooperative-groups branch called releaseGpuMemoryFence() before ensuring it held a HW queue. Under dynamic queues, an idle stream releases its queue back to the pool and sets gpu_queue_ = nullptr (rocvirtual.cpp:2565). The fence flush then dereferenced the null pointer in dispatchBarrierPacket (gpu_queue_->size, line 1997) → SIGSEGV.

## Technical Details
- reacquire the queue before the fence flush

## Issue Tracking

JIRA ID : ROCM-29369

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
