### PR TITLE
ci(rocprofiler-systems): Install `clang-tidy` 18.1.8 in Docker images

### DIFF
--- a/projects/rocprofiler-systems/docker/Dockerfile.opensuse
+++ b/projects/rocprofiler-systems/docker/Dockerfile.opensuse
@@ -28,7 +28,7 @@ RUN zypper --non-interactive update -y && \
         ninja nlohmann_json-devel openmpi3-devel python3-pip rpm-build \
         sqlite3-devel wget libucp-devel libuct-devel && \
     python3 -m pip install --upgrade pip && \
-    python3 -m pip install 'cmake==3.25'
+    python3 -m pip install 'cmake==3.25' 'clang-tidy==18.1.8'
 
 ARG ROCM_VERSION=0.0
 ARG ROCM_MAJOR=0

--- a/projects/rocprofiler-systems/docker/Dockerfile.opensuse.ci
+++ b/projects/rocprofiler-systems/docker/Dockerfile.opensuse.ci
@@ -32,7 +32,7 @@ RUN zypper --non-interactive update -y && \
         sqlite3-devel vim wget libucp-devel libuct-devel && \
     zypper --non-interactive clean --all && \
     python3 -m pip install --upgrade pip && \
-    python3 -m pip install 'cmake==3.25' perfetto
+    python3 -m pip install 'cmake==3.25' perfetto 'clang-tidy==18.1.8'
 
 ARG PYTHON_VERSIONS="8 9 10 11 12 13"
 

--- a/projects/rocprofiler-systems/docker/Dockerfile.rhel
+++ b/projects/rocprofiler-systems/docker/Dockerfile.rhel
@@ -38,7 +38,8 @@ RUN OS_VERSION_MAJOR=$(grep '^VERSION_ID=' /etc/os-release | cut -d'=' -f2 | tr 
     yum clean all && \
     python3 -m pip install --upgrade pip && \
     python3 -m pip install 'cmake==3.25' && \
-    python3 -m pip install 'perfetto'
+    python3 -m pip install 'perfetto' && \
+    python3 -m pip install 'clang-tidy==18.1.8'
 
 ARG ROCM_VERSION=0.0
 ARG ROCM_MAJOR=0

--- a/projects/rocprofiler-systems/docker/Dockerfile.rhel.ci
+++ b/projects/rocprofiler-systems/docker/Dockerfile.rhel.ci
@@ -43,7 +43,7 @@ RUN OS_VERSION_MAJOR=$(grep '^VERSION_ID=' /etc/os-release | cut -d'=' -f2 | tr 
     fi && \
     yum clean all && \
     python3 -m pip install --upgrade pip && \
-    python3 -m pip install 'cmake==3.25' perfetto
+    python3 -m pip install 'cmake==3.25' perfetto 'clang-tidy==18.1.8'
 
 ARG PYTHON_VERSIONS="8 9 10 11 12 13"
 

--- a/projects/rocprofiler-systems/docker/Dockerfile.ubuntu
+++ b/projects/rocprofiler-systems/docker/Dockerfile.ubuntu
@@ -34,9 +34,9 @@ RUN apt-get update && \
     OS_VERSION=$(grep '^VERSION_ID=' /etc/os-release | cut -d'=' -f2 | tr -d '"') && \
     OS_ID=$(grep '^ID=' /etc/os-release | cut -d'=' -f2 | tr -d '"') && \
     if [ "${OS_ID}" == "ubuntu" ] && [ "${OS_VERSION}" == "22.04" ]; then \
-        python3 -m pip install 'cmake==3.25'; \
+        python3 -m pip install 'cmake==3.25' 'clang-tidy==18.1.8'; \
     else \
-        python3 -m pip install --break-system-packages 'cmake==3.25' perfetto; \
+        python3 -m pip install --break-system-packages 'cmake==3.25' perfetto 'clang-tidy==18.1.8'; \
     fi
 
 RUN if [ "${ROCM_MAJOR}" != "0" ] || [ "${ROCM_MINOR}" != "0" ]; then \

--- a/projects/rocprofiler-systems/docker/Dockerfile.ubuntu.ci
+++ b/projects/rocprofiler-systems/docker/Dockerfile.ubuntu.ci
@@ -34,9 +34,9 @@ RUN apt-get update && \
 RUN OS_VERSION=$(grep '^VERSION_ID=' /etc/os-release | cut -d'=' -f2 | tr -d '"') && \
     OS_ID=$(grep '^ID=' /etc/os-release | cut -d'=' -f2 | tr -d '"') && \
     if [ "${OS_ID}" == "ubuntu" ] && [ "${OS_VERSION}" == "22.04" ]; then \
-        python3 -m pip install 'cmake==3.25' perfetto; \
+        python3 -m pip install 'cmake==3.25' perfetto 'clang-tidy==18.1.8'; \
     else \
-        python3 -m pip install --break-system-packages 'cmake==3.25' perfetto; \
+        python3 -m pip install --break-system-packages 'cmake==3.25' perfetto 'clang-tidy==18.1.8'; \
     fi
 
 RUN if ! pip show perfetto 2>&1 | tee pip_output.log | grep -q "WARNING"; then \


### PR DESCRIPTION
## Motivation

Install `clang-tidy` to CI dockers. This can be used with https://github.com/ROCm/rocm-systems/pull/9944.

## Technical Details

- `pip install clang-tidy==18.1.8`. Using a `pip` to install because it was easier to ensure a constant version between supported distros.

## Issue Tracking

JIRA ID - AIPROFSYST-496
JIRA ID - AIPROFSYST-494

## Test Plan

- Test containers build in CI
- Test script with branch from https://github.com/ROCm/rocm-systems/pull/9945

## Test Result

- CIs pass
- Script runs successfully with clang-tidy from docker container.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
