### PR TITLE
refactor(rocjitsu): make instruction register access wave-owned

### DIFF
--- a/emulation/rocjitsu/docs/plugins.md
+++ b/emulation/rocjitsu/docs/plugins.md
@@ -259,7 +259,22 @@ additional architectural callbacks.
 Asynchronous memory operations are modeled separately. The race detector
 records their register dependencies when they are issued. A later completion
 updates storage without emitting the same instruction-level write again.
-Synchronization retires the corresponding outstanding operations.
+Synchronization retires the corresponding outstanding operations using the
+counter family captured at issue. This distinguishes legacy combined
+`vmcnt`/`lgkmcnt` waits from split `loadcnt`, `storecnt`, `dscnt`, and `kmcnt`
+waits on newer targets.
+
+### Scalar register identity
+
+`onAmdgpuReadScalarRegister` and `onAmdgpuWriteScalarRegister` carry a
+`RegisterRef` whose class and index identify the architectural register. This
+keeps plugins independent of encoded selector values and of the simulator's
+physical storage layout. In particular, ordinary SGPRs and wave-private TTMPs
+have distinct identities even though both can appear in scalar operand fields.
+
+The older `onAmdgpuReadSgpr` hook continues to expose physical SGPR indices for
+compatibility. New consumers that need architectural identity should use the
+typed scalar-register hooks. Scalar writes have only the typed callback.
 
 ### Dispatch threading
 
@@ -285,8 +300,9 @@ every high-frequency callback, serializing it with the infrequent callbacks
 without a per-instruction scan of the plugin list. Plugins that protect their
 own shared state should retain the parallel default.
 
-SGPR owner resolution is skipped when no contained plugin observes SGPR reads.
-Plugins that do not consume `onAmdgpuReadSgpr` should override
+SGPR owner resolution is skipped when no contained plugin observes scalar
+register reads. Plugins that consume neither `onAmdgpuReadScalarRegister` nor
+`onAmdgpuReadSgpr` should override
 `observes_sgpr_reads()` to return `false`. The group samples this policy when
 each plugin is added. Its conservative default is `true`, so existing plugins
 continue receiving SGPR read callbacks unless they explicitly opt out.

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -7392,9 +7392,12 @@ class CodeGenerator:
         L = []
         elem_size = sem.elem_size or 4
         nd = sem.num_elems if elem_size == 4 else 1
+        L.append(
+            f'  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, {nd}u);'
+        )
+        L.append('  if (!dst_register) return;')
         L.append('  auto d = std::make_unique<amdgpu::ScalarMemState>();')
-        L.append(f'  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;')
-        L.append(f'  d->dst_selector = inst_.sdata;')
+        L.append('  d->dst_register = *dst_register;')
         L.append(f'  d->num_dwords = {nd};')
         L.append(f'  d->elem_size = {elem_size};')
         L.append(f'  d->sign_extend = {str(sem.sign_extend).lower()};')
@@ -7405,7 +7408,9 @@ class CodeGenerator:
             addr_args = 'inst_, wf, d->elem_size * d->num_dwords'
         else:
             addr_args = 'inst_, wf'
-        L.append(f'  d->addr = smem_calculate_address({addr_args});')
+        L.append(f'  auto address = smem_calculate_address({addr_args});')
+        L.append('  if (!address) return;')
+        L.append('  d->addr = *address;')
         # Counter increment handled by MemoryPipeline::issue().
         L.append('  set_data(std::move(d));')
         return '\n'.join(L)
@@ -7423,15 +7428,21 @@ class CodeGenerator:
         self._append_wait_counter_type(L, 'smem_store')
         L.append(f'  d->mtype = {self._mtype_expr(is_smem=True)};')
         L.append('  const uint32_t sdata_sel = inst_.sdata;')
+        L.append(
+            f'  auto src_register = amdgpu::resolve_scalar_register_range(wf, sdata_sel, {nd}u);'
+        )
+        L.append('  if (!src_register) return;')
         L.append(f'  for (uint32_t i = 0; i < {nd}; ++i)')
         L.append(
-            '    d->store_data[i] = amdgpu::read_scalar_selector(wf, sdata_sel + i);'
+            '    d->store_data[i] = amdgpu::read_scalar_register(wf, *src_register, i);'
         )
         if self.isa_spec.profile.smem_address_uses_access_size:
             addr_args = 'inst_, wf, d->elem_size * d->num_dwords'
         else:
             addr_args = 'inst_, wf'
-        L.append(f'  d->addr = smem_calculate_address({addr_args});')
+        L.append(f'  auto address = smem_calculate_address({addr_args});')
+        L.append('  if (!address) return;')
+        L.append('  d->addr = *address;')
         # Counter increment handled by MemoryPipeline::issue().
         L.append('  set_data(std::move(d));')
         return '\n'.join(L)
@@ -9311,6 +9322,19 @@ class CodeGenerator:
         require('OPR_SSRC_VCC_HI', 107)
         require('OPR_SSRC_EXEC_LO', 126)
         require('OPR_SSRC_EXEC_HI', 127)
+
+        # The shared runtime decoder supports the three layouts present in the
+        # MRISA corpus: CDNA1-4 have M0 at 124 and no NULL selector, RDNA1/2
+        # have M0 at 124 and NULL at 125, and GFX11+ have the two reversed.
+        m0_and_null = (
+            enum_values.get('OPR_SSRC_M0'),
+            enum_values.get('OPR_SSRC_NULL'),
+        )
+        if m0_and_null not in ((124, None), (124, 125), (125, 124)):
+            raise ValueError(
+                f'{arch}: unsupported shared M0/NULL selector layout '
+                f'{m0_and_null!r}'
+            )
 
         sgpr_max = enum_values.get('OPR_SSRC_SGPR_MAX')
         if sgpr_max not in (101, 105):
@@ -12009,6 +12033,10 @@ class CodeGenerator:
                                 ),
                                 False,
                             ),
+                            (
+                                'rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h',
+                                False,
+                            ),
                         ]
                     )
                     for cf_inc in self._cache_flags_includes():
@@ -13507,13 +13535,20 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
                 return 'RegClass::VGPR'
             case 'acc':
                 return 'RegClass::ACC_VGPR'
+            case 'ttmp':
+                return 'RegClass::TTMP'
             case _:
                 return None
 
     @staticmethod
     def _named_reg_ref(operand_name: str) -> tuple[str, int] | None:
         """Map a named special register to (RegClass, index) for to_register_ref."""
-        match operand_name.upper():
+        name = operand_name.upper()
+        if name.startswith('TTMP') and name[4:].isdigit():
+            index = int(name[4:])
+            if 0 <= index < 16:
+                return ('RegClass::TTMP', index)
+        match name:
             case 'EXEC' | 'EXEC_LO':
                 return ('RegClass::EXEC', 0)
             case 'EXEC_HI':
@@ -14415,7 +14450,7 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
                     '    uint32_t off = packed->reg + (wf.vgpr_msb_for_role(vgpr_msb_role()) << 8);',
                     '    uint32_t voff = amdgpu::apply_gpr_idx(wf, off, vgpr_msb_role());',
                     '    uint8_t byte_mask = packed->shift ? rocjitsu::ExecutionPlugin::kHighHalfByteMask : rocjitsu::ExecutionPlugin::kLowHalfByteMask;',
-                    '    uint32_t raw = amdgpu::RegisterAccess(wf.cu()).read_vgpr(wf.vgpr_alloc().base + voff, lane, byte_mask);',
+                    '    uint32_t raw = amdgpu::RegisterAccess(wf).read_vgpr(wf.vgpr_alloc().base + voff, lane, byte_mask);',
                     '    return (raw >> packed->shift) & 0xffffu;',
                     '  }',
                 ]
@@ -14424,7 +14459,7 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
             [
                 f'  if (auto off = {_resolved_vgpr_read_call}) {{',
                 '    uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, vgpr_msb_role());',
-                '    return amdgpu::RegisterAccess(wf.cu()).read_vgpr(wf.vgpr_alloc().base + voff, lane);',
+                '    return amdgpu::RegisterAccess(wf).read_vgpr(wf.vgpr_alloc().base + voff, lane);',
                 '  }',
                 '  if (is_immediate_type(opr_type_))',
                 '    return static_cast<uint32_t>(ev);',
@@ -14444,7 +14479,7 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
             f'  if (auto off = {_resolved_vgpr_read_call}) {{\n'
             '    uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, vgpr_msb_role());\n'
             '    uint32_t idx = wf.vgpr_alloc().base + voff;\n'
-            '    return amdgpu::RegisterAccess(wf.cu()).read_vgpr64(idx, lane);\n'
+            '    return amdgpu::RegisterAccess(wf).read_vgpr64(idx, lane);\n'
             '  }\n'
             '  if (literal32_widening_)\n'
             '    return widened_literal32_value();\n'
@@ -14534,7 +14569,7 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
                       if (auto off = detail::resolved_vgpr_offset_for_operand<Isa>(wf, *this)) {
                         uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, vgpr_msb_role());
                         uint64_t lane_mask = count == 0 ? 0 : util::mask<uint64_t>(static_cast<int>(count)) << lane_base;
-                        auto region = amdgpu::RegisterAccess(wf.cu()).read_vgpr_region(
+                        auto region = amdgpu::RegisterAccess(wf).read_vgpr_region(
                             wf.vgpr_alloc().base + voff, 1, lane_mask);
                         std::copy_n(region.lanes().begin() + lane_base, count, out);
                         return;
@@ -14570,6 +14605,8 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
                               : vgpr_msb_role();
                       uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, role);
                       uint32_t reg = wf.vgpr_alloc().base + voff;
+                      if (!raw_compute_unit(wf.cu()).owns_vgpr_range(wf, reg, 1))
+                        return;
                       uint64_t full_mask = util::mask<uint64_t>(static_cast<int>(count));
                       uint8_t *dst = raw_compute_unit(wf.cu()).raw_vgpr_data(reg);
                       if ((mask & full_mask) == full_mask) {
@@ -14611,7 +14648,7 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
                     uint64_t lane_mask =
                         count == 0 ? 0
                                    : util::mask<uint64_t>(static_cast<int>(count)) << lane_base;
-                    auto region = amdgpu::RegisterAccess(wf.cu()).read_vgpr_region(
+                    auto region = amdgpu::RegisterAccess(wf).read_vgpr_region(
                         wf.vgpr_alloc().base + voff, 1, lane_mask);
                     std::copy_n(region.lanes().begin() + lane_base, count, out);
                     return;
@@ -14640,6 +14677,8 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
                           : vgpr_msb_role();
                   uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, role);
                   uint32_t reg = wf.vgpr_alloc().base + voff;
+                  if (!raw_compute_unit(wf.cu()).owns_vgpr_range(wf, reg, 1))
+                    return;
                   uint64_t full_mask = util::mask<uint64_t>(static_cast<int>(count));
                   uint8_t *dst = raw_compute_unit(wf.cu()).raw_vgpr_data(reg);
                   if ((mask & full_mask) == full_mask) {
@@ -14668,7 +14707,7 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
                     uint32_t idx = wf.vgpr_alloc().base + voff;
                     uint8_t write_byte_mask = packed->shift ? rocjitsu::ExecutionPlugin::kHighHalfByteMask : rocjitsu::ExecutionPlugin::kLowHalfByteMask;
                     uint32_t placed = (val & 0xffffu) << packed->shift;
-                    amdgpu::RegisterAccess(wf.cu()).write_vgpr(idx, lane, placed, write_byte_mask);
+                    amdgpu::RegisterAccess(wf).write_vgpr(idx, lane, placed, write_byte_mask);
                     return;
                   }
                 ''')
@@ -14728,7 +14767,7 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
             '                                    ? amdgpu::VgprMsbRole::Dst\n'
             '                                    : vgpr_msb_role();\n'
             '    uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, role);\n'
-            '    amdgpu::RegisterAccess(wf.cu()).write_vgpr(wf.vgpr_alloc().base + voff, lane, val);\n'
+            '    amdgpu::RegisterAccess(wf).write_vgpr(wf.vgpr_alloc().base + voff, lane, val);\n'
             '    return;\n'
             '  }\n'
             '  throw std::logic_error("write_lane called on non-VGPR operand type");\n'
@@ -14742,7 +14781,7 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
             '                                    : vgpr_msb_role();\n'
             '    uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, role);\n'
             '    uint32_t idx = wf.vgpr_alloc().base + voff;\n'
-            '    amdgpu::RegisterAccess(wf.cu()).write_vgpr64(idx, lane, val);\n'
+            '    amdgpu::RegisterAccess(wf).write_vgpr64(idx, lane, val);\n'
             '    return;\n'
             '  }\n'
             '  throw std::logic_error("write_lane64 called on non-VGPR operand type");\n'

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/vector_alu.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/vector_alu.py
@@ -234,7 +234,7 @@ def gen_vector_unary(
             f'    amdgpu::RegisterAccess(wf).write_lane({dst[0]}, lane, std::bit_cast<uint32_t>(lo));'
         )
         L.append(
-            f'    amdgpu::RegisterAccess(wf.cu()).write_vgpr(wf.vgpr_alloc().base + {dst[0]}.encoding_value_ + 1, lane, std::bit_cast<uint32_t>(hi));'
+            f'    amdgpu::RegisterAccess(wf).write_vgpr(wf.vgpr_alloc().base + {dst[0]}.encoding_value_ + 1, lane, std::bit_cast<uint32_t>(hi));'
         )
     elif op == 'cvt_pk_f32_bf8':
         conv = fp8_helper_name(arch_name, 'util::bf8_e5m2_to_f32')
@@ -247,7 +247,7 @@ def gen_vector_unary(
             f'    amdgpu::RegisterAccess(wf).write_lane({dst[0]}, lane, std::bit_cast<uint32_t>(lo));'
         )
         L.append(
-            f'    amdgpu::RegisterAccess(wf.cu()).write_vgpr(wf.vgpr_alloc().base + {dst[0]}.encoding_value_ + 1, lane, std::bit_cast<uint32_t>(hi));'
+            f'    amdgpu::RegisterAccess(wf).write_vgpr(wf.vgpr_alloc().base + {dst[0]}.encoding_value_ + 1, lane, std::bit_cast<uint32_t>(hi));'
         )
     elif op in (
         'not',

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/vector_special.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/vector_special.py
@@ -2025,11 +2025,37 @@ def gen_vector_cvt_scale(
 
     direction, pack_width, out_fmt, in_fmt = parts
     count = int(pack_width[2:])
+    if direction == 'unpack':
+        bits = _scale_lowp_bits(in_fmt)
+        src_word_count = (count * bits + 31) // 32
+        if out_fmt == 'f32':
+            dst_word_count = count
+        elif out_fmt in ('f16', 'bf16'):
+            dst_word_count = count // 2
+        else:
+            raise ValueError(f'unsupported scaled unpack output format: {out_fmt}')
+    elif direction == 'pack':
+        bits = _scale_lowp_bits(out_fmt)
+        src_word_count = count if in_fmt == 'f32' else count // 2
+        dst_word_count = (count * bits + 31) // 32
+    else:
+        raise ValueError(f'unsupported vector_cvt_scale direction: {direction}')
+
     L: list[str] = []
     L.append('  uint64_t exec = wf.exec();')
     L.append('  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {')
     L.append('    if (!(exec & (1ULL << lane))) continue;')
     _scale_read_vgpr_base(L, 'dst_base', dst[0])
+    _scale_read_vgpr_base(L, 'src_base', src[0])
+    L.append('    amdgpu::RegisterAccess regs(wf);')
+    # TODO(newling): Apply this check-before-observe pattern to other
+    # multi-region instruction helpers, then make region acquisition require
+    # successful preflight instead of returning validity-bearing views.
+    L.append(
+        f'    if (!regs.owns_vgpr_range(src_base, {src_word_count}u) || '
+        f'!regs.owns_vgpr_range(dst_base, {dst_word_count}u))'
+    )
+    L.append('      continue;')
     scale_src = src[2] if stochastic else src[1]
     if direction == 'unpack':
         L.extend(_scale_e8m0_unpack_scale(scale_src))
@@ -2043,31 +2069,31 @@ def gen_vector_cvt_scale(
         )
 
     if direction == 'unpack':
-        bits = _scale_lowp_bits(in_fmt)
+        L.append(
+            f'    auto src_region = regs.read_vgpr_region('
+            f'src_base, {src_word_count}u, 1ULL << lane);'
+        )
         if count == 8 and bits == 4:
-            L.append(
-                f'    uint32_t src_payload = amdgpu::RegisterAccess(wf).read_lane({src[0]}, lane);'
-            )
+            L.append('    uint32_t src_payload = src_region.lane(0, lane);')
         elif count == 8 and bits == 8:
-            L.append(
-                f'    uint64_t src_payload = amdgpu::RegisterAccess(wf).read_lane64({src[0]}, lane);'
-            )
+            L.append('    uint64_t src_payload = src_region.lane64(0, lane);')
         elif count == 16 and bits == 6:
-            _scale_read_vgpr_base(L, 'src_base', src[0])
             L.append('    uint32_t src_words[4] = {};')
             L.append('    for (uint32_t word = 0; word < 3u; ++word)')
-            L.append(
-                '      src_words[word] = amdgpu::RegisterAccess(wf.cu()).read_vgpr(src_base + word, lane);'
-            )
+            L.append('      src_words[word] = src_region.lane(word, lane);')
         else:
             raise ValueError(f'unsupported scaled unpack operation: {op}')
 
         L.extend(_scale_unpack_element_raw(in_fmt, arch_name))
         if out_fmt == 'f32':
+            L.append(
+                f'    auto dst_region = regs.write_vgpr_region('
+                f'dst_base, {dst_word_count}u, 1ULL << lane);'
+            )
             L.append(f'    for (uint32_t index = 0; index < {count}u; ++index) {{')
             L.append('      float value = read_scaled_src(index) * scale;')
             L.append(
-                '      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + index, lane, std::bit_cast<uint32_t>(value));'
+                '      dst_region.set_lane(index, lane, std::bit_cast<uint32_t>(value));'
             )
             L.append('    }')
         elif out_fmt in ('f16', 'bf16'):
@@ -2076,32 +2102,33 @@ def gen_vector_cvt_scale(
                 if out_fmt == 'f16'
                 else 'util::f32_to_bf16_rne_mode'
             )
-            words = count // 2
-            L.append(f'    uint32_t dst_words[{words}] = {{}};')
+            L.append(
+                f'    auto dst_region = regs.write_vgpr_region('
+                f'dst_base, {dst_word_count}u, 1ULL << lane);'
+            )
+            L.append(f'    uint32_t dst_words[{dst_word_count}] = {{}};')
             L.append(f'    for (uint32_t index = 0; index < {count}u; ++index) {{')
             L.append(
                 f'      uint32_t bits = {conv}(read_scaled_src(index) * scale, wf.fp16_ovfl());'
             )
             L.append('      dst_words[index / 2u] |= bits << ((index & 1u) * 16u);')
             L.append('    }')
-            L.append(f'    for (uint32_t word = 0; word < {words}u; ++word)')
-            L.append(
-                '      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);'
-            )
-        else:
-            raise ValueError(f'unsupported scaled unpack output format: {out_fmt}')
+            L.append(f'    for (uint32_t word = 0; word < {dst_word_count}u; ++word)')
+            L.append('      dst_region.set_lane(word, lane, dst_words[word]);')
     elif direction == 'pack':
-        bits = _scale_lowp_bits(out_fmt)
-        src_words = count if in_fmt == 'f32' else count // 2
-        out_words = (count * bits + 31) // 32
-        _scale_read_vgpr_base(L, 'src_base', src[0])
-        L.append(f'    uint32_t src_words[{src_words}] = {{}};')
-        L.append(f'    for (uint32_t word = 0; word < {src_words}u; ++word)')
         L.append(
-            '      src_words[word] = amdgpu::RegisterAccess(wf.cu()).read_vgpr(src_base + word, lane);'
+            f'    auto src_region = regs.read_vgpr_region('
+            f'src_base, {src_word_count}u, 1ULL << lane);'
         )
+        L.append(
+            f'    auto dst_region = regs.write_vgpr_region('
+            f'dst_base, {dst_word_count}u, 1ULL << lane);'
+        )
+        L.append(f'    uint32_t src_words[{src_word_count}] = {{}};')
+        L.append(f'    for (uint32_t word = 0; word < {src_word_count}u; ++word)')
+        L.append('      src_words[word] = src_region.lane(word, lane);')
         L.extend(_scale_source_reader(in_fmt))
-        L.append(f'    uint32_t dst_words[{out_words}] = {{}};')
+        L.append(f'    uint32_t dst_words[{dst_word_count}] = {{}};')
         L.append('    auto pack_scaled_dst = [&](uint32_t index, uint32_t code) {')
         L.append(f'      code &= 0x{((1 << bits) - 1):x}u;')
         L.append(f'      uint32_t bit = index * {bits}u;')
@@ -2123,12 +2150,8 @@ def gen_vector_cvt_scale(
                 f"      pack_scaled_dst(index, {_scale_encode_call(out_fmt, 'value', arch_name)});"
             )
         L.append('    }')
-        L.append(f'    for (uint32_t word = 0; word < {out_words}u; ++word)')
-        L.append(
-            '      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);'
-        )
-    else:
-        raise ValueError(f'unsupported vector_cvt_scale direction: {direction}')
+        L.append(f'    for (uint32_t word = 0; word < {dst_word_count}u; ++word)')
+        L.append('      dst_region.set_lane(word, lane, dst_words[word]);')
 
     L.append('  }')
     return '\n'.join(L)

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
@@ -4552,6 +4552,19 @@ def test_cdna3_generated_disassembly_preserves_ds_and_flat_offsets(
     assert 'void Flat::build_modifiers' not in encodings_cpp
 
 
+def test_generated_sdwa_scalar_destination_uses_explicit_lane_mask_write(
+    cdna4_generated_root: Path,
+) -> None:
+    vopc = (cdna4_generated_root / 'vopc_exec.cpp').read_text()
+
+    lane_mask_write = (
+        'amdgpu::write_explicit_lane_mask(sb + sdwa_sdst_, wf, cmp_result);'
+    )
+    assert lane_mask_write in vopc
+    assert 'write_sgpr(sb + sdwa_sdst_' not in vopc
+    assert 'write_sgpr(sb + sdwa_sdst_ + 1' not in vopc
+
+
 def test_generated_sdwa_uses_source_specific_modifier_formats(
     cdna4_generated_root: Path,
 ) -> None:
@@ -5931,6 +5944,7 @@ def test_gfx1250_generated_fp8_vop3_byte_select_uses_local_inst_member(
     assert 'inline void execute_v_cvt_f32_fp8_vop3' not in execute_shared
 
     gfx1250_vop3_cvt = (gfx1250_generated_root / 'vop3_exec_cvt.cpp').read_text()
+    assert 'RegisterAccess(wf.cu())' not in gfx1250_vop3_cvt
 
     body = _generated_method_body(gfx1250_vop3_cvt, 'VCvtF32Fp8Vop3', 'VCvtF32Bf8Vop3')
 
@@ -6976,7 +6990,12 @@ def test_ev124_125_arch_gating_in_generated_operand(
     # there: encoding value 124 is the NULL slot when M0 is 125, and the operand
     # matching the arch's M0 encoding reads M0.
     shared_resolve = (amdgpu_root / 'shared' / 'scalar_operand_resolve.h').read_text()
-    assert 'if (m0_ev == 125 && ev == 124)\n    return 0u; // NULL' in shared_resolve
+    assert re.search(
+        r'if \(m0_ev == static_cast<int>\(kModernM0Selector\) &&\s*'
+        r'ev == static_cast<int>\(kModernNullSelector\)\)\s*'
+        r'return 0u; // NULL',
+        shared_resolve,
+    )
     assert 'if (ev == m0_ev)\n    return wf.m0();' in shared_resolve
 
 
@@ -7328,6 +7347,43 @@ def test_only_gfx1250_generates_implicit_use_operands_overrides(
             f'{arch} has no VGPR-MSB banking, so implicit_use_operands() overrides '
             f'are dead weight: {offenders}'
         )
+
+
+def test_generated_smem_rejects_invalid_complete_scalar_selector_ranges(
+    amdgpu_generated_root: Path,
+):
+    """SMEM must issue only after complete address and data ranges validate."""
+    for arch in (
+        'cdna1',
+        'cdna2',
+        'cdna3',
+        'cdna4',
+        'gfx1250',
+        'rdna1',
+        'rdna2',
+        'rdna3',
+        'rdna3_5',
+        'rdna4',
+    ):
+        smem_exec = (
+            _execution_source_path(
+                amdgpu_generated_root / _generated_dir_name(arch) / 'smem.cpp',
+                _profile_for_arch(arch),
+            )
+        ).read_text()
+        assert (
+            'auto dst_register = amdgpu::resolve_scalar_register_range(wf,' in smem_exec
+        )
+        assert 'd->dst_register = *dst_register;' in smem_exec
+        assert 'auto address = smem_calculate_address(' in smem_exec
+        assert 'if (!address)' in smem_exec
+        if 'd->is_load = false;' in smem_exec:
+            assert 'const uint32_t sdata_sel = inst_.sdata;' in smem_exec
+            assert (
+                'auto src_register = amdgpu::resolve_scalar_register_range(wf,'
+                in smem_exec
+            )
+            assert 'read_scalar_register(wf, *src_register, i)' in smem_exec
 
 
 @pytest.mark.parametrize(

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_profile_properties.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_profile_properties.py
@@ -652,6 +652,9 @@ def test_gfx1250_operand_execution_backend_uses_separate_source(tmp_path):
     assert 'apply_gpr_idx(wf, *off, amdgpu::VgprMsbRole::Dst)' not in operand_exec_cpp
     assert 'execution_backend_registered_' not in operand_exec_cpp
     assert 'rocjitsu/vm/amdgpu/compute_unit.h' in operand_exec_cpp
+    assert 'RegisterAccess(wf.cu())' not in operand_exec_cpp
+    assert 'RegisterAccess(wf)' in operand_exec_cpp
+    assert 'owns_vgpr_range(wf, reg, 1)' in operand_exec_cpp
 
 
 def test_gfx1250_instruction_execution_backend_is_dense_and_scoped(tmp_path):

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_derive.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_derive.py
@@ -1281,7 +1281,8 @@ class TestDeriveVectorUnary:
         )
         assert 'read_scaled_src(index) * scale' in cpp
         assert 'Isa::resolved_vgpr_offset' in cpp
-        assert 'amdgpu::RegisterAccess(wf.cu()).write_vgpr' in cpp
+        assert 'write_vgpr_region' in cpp
+        assert 'dst_region.set_lane' in cpp
 
     @pytest.mark.parametrize(
         ('name', 'op', 'read_helper', 'encode_helper'),
@@ -1336,6 +1337,8 @@ class TestDeriveVectorUnary:
         assert 'pack_scaled_dst(index' in cpp
         assert 'read_scaled_input(index) / scale' in cpp
         assert 'Isa::resolved_vgpr_offset' in cpp
+        assert 'read_vgpr_region' in cpp
+        assert 'write_vgpr_region' in cpp
 
     @pytest.mark.parametrize(
         ('name', 'op', 'read_helper', 'encode_helper'),

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_semantic_operand_codegen.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_semantic_operand_codegen.py
@@ -6,6 +6,13 @@
 from amdisa.codegen._generator import CodeGenerator, _OperandCtx
 
 
+def test_ttmp_prefix_maps_to_architectural_register_class():
+    assert CodeGenerator._reg_class_for_prefix('ttmp') == 'RegClass::TTMP'
+    assert CodeGenerator._named_reg_ref('TTMP0') == ('RegClass::TTMP', 0)
+    assert CodeGenerator._named_reg_ref('ttmp15') == ('RegClass::TTMP', 15)
+    assert CodeGenerator._named_reg_ref('ttmp16') is None
+
+
 def test_legacy_buffer_vaddr_width_follows_address_mode():
     for enc_name in ('ENC_MUBUF', 'ENC_MTBUF'):
         assert CodeGenerator._buffer_vaddr_operand_size_expr(enc_name, 'vaddr') == (

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna1/addr_calc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna1/addr_calc.cpp
@@ -14,7 +14,7 @@
 namespace rocjitsu {
 namespace cdna1 {
 
-uint64_t smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf) {
+std::optional<uint64_t> smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf) {
   return amdgpu::addr_calc::smem_calculate_address(inst, wf);
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna1/addr_calc.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna1/addr_calc.h
@@ -8,6 +8,7 @@
 #include "rocjitsu/vm/amdgpu/mtype.h"
 
 #include <cstdint>
+#include <optional>
 
 namespace rocjitsu {
 namespace amdgpu {
@@ -17,7 +18,7 @@ struct VectorMemState;
 
 namespace cdna1 {
 
-uint64_t smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf);
+std::optional<uint64_t> smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf);
 
 void flat_calculate_addresses(const FlatMachineInst &inst, amdgpu::Wavefront &wf,
                               amdgpu::VectorMemState &d);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna2/addr_calc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna2/addr_calc.cpp
@@ -14,7 +14,7 @@
 namespace rocjitsu {
 namespace cdna2 {
 
-uint64_t smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf) {
+std::optional<uint64_t> smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf) {
   return amdgpu::addr_calc::smem_calculate_address(inst, wf);
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna2/addr_calc.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna2/addr_calc.h
@@ -8,6 +8,7 @@
 #include "rocjitsu/vm/amdgpu/mtype.h"
 
 #include <cstdint>
+#include <optional>
 
 namespace rocjitsu {
 namespace amdgpu {
@@ -17,7 +18,7 @@ struct VectorMemState;
 
 namespace cdna2 {
 
-uint64_t smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf);
+std::optional<uint64_t> smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf);
 
 void flat_calculate_addresses(const FlatMachineInst &inst, amdgpu::Wavefront &wf,
                               amdgpu::VectorMemState &d);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/addr_calc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/addr_calc.cpp
@@ -14,7 +14,7 @@
 namespace rocjitsu {
 namespace cdna3 {
 
-uint64_t smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf) {
+std::optional<uint64_t> smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf) {
   return amdgpu::addr_calc::smem_calculate_address(inst, wf);
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/addr_calc.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/addr_calc.h
@@ -8,6 +8,7 @@
 #include "rocjitsu/vm/amdgpu/mtype.h"
 
 #include <cstdint>
+#include <optional>
 
 namespace rocjitsu {
 namespace amdgpu {
@@ -17,7 +18,7 @@ struct VectorMemState;
 
 namespace cdna3 {
 
-uint64_t smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf);
+std::optional<uint64_t> smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf);
 
 void flat_calculate_addresses(const FlatMachineInst &inst, amdgpu::Wavefront &wf,
                               amdgpu::VectorMemState &d);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/addr_calc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/addr_calc.cpp
@@ -14,7 +14,7 @@
 namespace rocjitsu {
 namespace cdna4 {
 
-uint64_t smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf) {
+std::optional<uint64_t> smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf) {
   return amdgpu::addr_calc::smem_calculate_address(inst, wf);
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/addr_calc.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/addr_calc.h
@@ -14,6 +14,7 @@
 #include "rocjitsu/vm/amdgpu/mtype.h"
 
 #include <cstdint>
+#include <optional>
 
 namespace rocjitsu {
 namespace amdgpu {
@@ -24,7 +25,7 @@ struct VectorMemState;
 namespace cdna4 {
 
 /// @brief Compute scalar address for SMEM encoding.
-uint64_t smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf);
+std::optional<uint64_t> smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf);
 
 /// @brief Compute per-lane addresses for FLAT/GLOBAL/SCRATCH encoding.
 void flat_calculate_addresses(const FlatMachineInst &inst, amdgpu::Wavefront &wf,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna5/addr_calc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna5/addr_calc.cpp
@@ -36,30 +36,20 @@ bool has_saddr(uint32_t saddr) { return saddr != OPR_SREG_NULL; }
 
 bool has_smem_offset(uint32_t soffset) { return soffset != OPR_SMEM_OFFSET_NULL; }
 
-uint32_t read_sreg_m0_operand(amdgpu::Wavefront &wf, uint32_t operand) {
-  auto &cu = wf.cu();
-  uint32_t base = wf.sgpr_alloc().base;
-  if (operand <= 105)
-    return amdgpu::RegisterAccess(cu).read_sgpr(base + operand);
-  if (operand == 106)
-    return static_cast<uint32_t>(wf.vcc());
-  if (operand == 107)
-    return static_cast<uint32_t>(wf.vcc() >> 32);
-  if (operand >= 108 && operand <= 123) {
-    // CommandProcessor aliases TTMP selectors into the wavefront SGPR slice.
-    assert(operand < cu.sgprs_per_wf());
-    return amdgpu::RegisterAccess(cu).read_sgpr(base + operand);
-  }
-  if (operand == 124)
-    return 0;
-  if (operand == 125)
-    return wf.m0();
+std::optional<uint32_t> read_sreg_m0_operand(amdgpu::Wavefront &wf, uint32_t operand) {
+  if (operand <= amdgpu::kModernM0Selector)
+    return amdgpu::try_read_scalar_selector(wf, operand);
   throw util::UnimplementedInst("unsupported gfx1250 scalar memory offset operand");
 }
 
-uint64_t read_sreg64_operand(amdgpu::Wavefront &wf, uint32_t operand) {
-  return (static_cast<uint64_t>(read_sreg_m0_operand(wf, operand + 1)) << 32) |
-         read_sreg_m0_operand(wf, operand);
+std::optional<uint64_t> read_sreg64_operand(amdgpu::Wavefront &wf, uint32_t operand) {
+  if (operand <= amdgpu::kModernNullSelector)
+    return amdgpu::try_read_scalar_selector64(wf, operand);
+  auto lo = read_sreg_m0_operand(wf, operand);
+  auto hi = read_sreg_m0_operand(wf, operand + 1);
+  if (!lo || !hi)
+    return std::nullopt;
+  return static_cast<uint64_t>(*lo) | (static_cast<uint64_t>(*hi) << 32);
 }
 
 uint32_t resolved_vgpr_base(const amdgpu::Wavefront &wf, uint32_t operand,
@@ -143,7 +133,12 @@ void flat_global_calculate_addresses(const Inst &inst, amdgpu::Wavefront &wf,
   uint64_t exec = d.exec_mask;
   int64_t offset = static_cast<int64_t>(signed_ioffset(inst.ioffset));
   bool saddr_present = has_saddr(inst.saddr);
-  uint64_t saddr_val = saddr_present ? read_sreg64_operand(wf, inst.saddr) : 0;
+  auto saddr = saddr_present ? read_sreg64_operand(wf, inst.saddr) : std::optional<uint64_t>{0};
+  if (!saddr) {
+    amdgpu::reject_vector_memory_access(d);
+    return;
+  }
+  uint64_t saddr_val = *saddr;
   uint32_t scale = saddr_present && inst.scale_offset ? scaled_vaddr_factor(d) : 1;
   uint32_t vbase = resolved_vgpr_base(wf, inst.vaddr, amdgpu::VgprMsbRole::Src0);
   amdgpu::RegisterAccess regs(cu);
@@ -191,16 +186,22 @@ BufferResource decode_buffer_resource(uint32_t srd0, uint32_t srd1, uint32_t srd
   return resource;
 }
 
-uint64_t smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf,
-                                uint32_t access_size_bytes) {
+std::optional<uint64_t> smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf,
+                                               uint32_t access_size_bytes) {
   assert(access_size_bytes != 0);
   const uint32_t sbase_sel = inst.sbase * 2;
-  uint64_t base = amdgpu::read_scalar_selector64(wf, sbase_sel);
+  auto base = amdgpu::try_read_scalar_selector64(wf, sbase_sel);
+  if (!base)
+    return std::nullopt;
   int64_t off = static_cast<int64_t>(signed_ioffset(inst.ioffset));
   uint32_t scale = inst.scale_offset ? access_size_bytes : 1;
-  if (has_smem_offset(inst.soffset))
-    off += static_cast<int64_t>(read_sreg_m0_operand(wf, inst.soffset)) * scale;
-  uint64_t addr = base + off;
+  if (has_smem_offset(inst.soffset)) {
+    auto soffset = read_sreg_m0_operand(wf, inst.soffset);
+    if (!soffset)
+      return std::nullopt;
+    off += static_cast<int64_t>(*soffset) * scale;
+  }
+  uint64_t addr = *base + off;
   assert(util::is_aligned(addr, std::min<uint64_t>(access_size_bytes, 4u)) &&
          "gfx1250 scalar memory address must satisfy access alignment");
   return addr;
@@ -238,8 +239,14 @@ void flat_calculate_addresses(const VscratchMachineInst &inst, amdgpu::Wavefront
   int64_t offset = static_cast<int64_t>(signed_ioffset(inst.ioffset));
   uint64_t scratch_base = wf.scratch_base();
   uint32_t saddr_val = 0;
-  if (has_saddr(inst.saddr))
-    saddr_val = read_sreg_m0_operand(wf, inst.saddr);
+  if (has_saddr(inst.saddr)) {
+    auto saddr = read_sreg_m0_operand(wf, inst.saddr);
+    if (!saddr) {
+      amdgpu::reject_vector_memory_access(d);
+      return;
+    }
+    saddr_val = *saddr;
+  }
   uint32_t vbase = 0;
   uint32_t scale = 1;
   if (inst.sve) {
@@ -281,6 +288,10 @@ void mubuf_calculate_addresses(const VbufferMachineInst &inst, amdgpu::Wavefront
   // descriptor sourced from TTMPs lives in the trap-temporary file, and
   // read_sgpr() would fetch whatever the allocation holds at that index.
   const uint32_t sb_sel = inst.rsrc;
+  if (!amdgpu::scalar_selector_range_is_backed(wf, sb_sel, 4)) {
+    amdgpu::reject_vector_memory_access(d);
+    return;
+  }
   uint32_t srd0 = amdgpu::read_scalar_selector(wf, sb_sel);
   uint32_t srd1 = amdgpu::read_scalar_selector(wf, sb_sel + 1);
   uint32_t srd2 = amdgpu::read_scalar_selector(wf, sb_sel + 2);
@@ -295,12 +306,20 @@ void mubuf_calculate_addresses(const VbufferMachineInst &inst, amdgpu::Wavefront
     d.element_lane_masks.clear();
     return;
   }
-  uint32_t soffset_val = has_smem_offset(inst.soffset) ? read_sreg_m0_operand(wf, inst.soffset) : 0;
+  amdgpu::RegisterAccess regs(cu);
+  uint32_t soffset_val = 0;
+  if (has_smem_offset(inst.soffset)) {
+    auto soffset = read_sreg_m0_operand(wf, inst.soffset);
+    if (!soffset) {
+      amdgpu::reject_vector_memory_access(d);
+      return;
+    }
+    soffset_val = *soffset;
+  }
   int32_t ioff = signed_ioffset(inst.ioffset);
   uint32_t vbase = 0;
   if (inst.idxen || inst.offen)
     vbase = resolved_vgpr_base(wf, inst.vaddr, amdgpu::VgprMsbRole::Src0);
-  amdgpu::RegisterAccess regs(cu);
   std::optional<amdgpu::RegisterAccess::VgprReadRegion> vaddr_region;
   if (inst.idxen || inst.offen) {
     uint32_t reg_count = (inst.idxen && inst.offen) ? 2 : 1;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna5/addr_calc.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna5/addr_calc.h
@@ -10,6 +10,7 @@
 #include "rocjitsu/isa/arch/amdgpu/shared/mtype.h"
 
 #include <cstdint>
+#include <optional>
 
 namespace rocjitsu::amdgpu {
 class Wavefront;
@@ -35,8 +36,8 @@ BufferResource decode_buffer_resource(uint32_t srd0, uint32_t srd1, uint32_t srd
 /// @brief Sign-extend a CDNA5 24-bit IOFFSET field.
 inline int32_t signed_ioffset(uint32_t ioffset) { return static_cast<int32_t>(ioffset << 8) >> 8; }
 
-uint64_t smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf,
-                                uint32_t access_size_bytes);
+std::optional<uint64_t> smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf,
+                                               uint32_t access_size_bytes);
 
 void flat_calculate_addresses(const VflatMachineInst &inst, amdgpu::Wavefront &wf,
                               amdgpu::VectorMemState &d);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/ds_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/ds_exec.cpp
@@ -8,6 +8,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/ds.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx9_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/flat_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/flat_exec.cpp
@@ -7,6 +7,7 @@
 #include "rocjitsu/isa/arch/amdgpu/cdna1/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/flat.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx9_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/mtbuf_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/mtbuf_exec.cpp
@@ -7,6 +7,7 @@
 #include "rocjitsu/isa/arch/amdgpu/cdna1/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/mtbuf.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx9_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/mubuf_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/mubuf_exec.cpp
@@ -7,6 +7,7 @@
 #include "rocjitsu/isa/arch/amdgpu/cdna1/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/mubuf.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx9_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/operand.cpp
@@ -1134,6 +1134,11 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSdst::OPR_SDST_SGPR_MIN),
                          reg_width};
+    if (encoding_value_ >= OpSelSdst::OPR_SDST_TTMP_MIN &&
+        encoding_value_ <= OpSelSdst::OPR_SDST_TTMP_MAX)
+      return RegisterRef{RegClass::TTMP,
+                         static_cast<uint16_t>(encoding_value_ - OpSelSdst::OPR_SDST_TTMP_MIN),
+                         reg_width};
     if (encoding_value_ == OpSelSdst::OPR_SDST_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
     if (encoding_value_ == OpSelSdst::OPR_SDST_EXEC_HI)
@@ -1157,6 +1162,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSmemOffset::OPR_SMEM_OFFSET_SGPR_MIN),
           reg_width};
+    if (encoding_value_ >= OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP_MIN &&
+        encoding_value_ <= OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP_MIN),
+          reg_width};
     break;
   }
   case OperandType::OPR_SRC: {
@@ -1164,6 +1175,11 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
         encoding_value_ <= OpSelSrc::OPR_SRC_SGPR_MAX)
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSrc::OPR_SRC_SGPR_MIN),
+                         reg_width};
+    if (encoding_value_ >= OpSelSrc::OPR_SRC_TTMP_MIN &&
+        encoding_value_ <= OpSelSrc::OPR_SRC_TTMP_MAX)
+      return RegisterRef{RegClass::TTMP,
+                         static_cast<uint16_t>(encoding_value_ - OpSelSrc::OPR_SRC_TTMP_MIN),
                          reg_width};
     if (encoding_value_ == OpSelSrc::OPR_SRC_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
@@ -1202,6 +1218,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSrcNolds::OPR_SRC_NOLDS_SGPR_MIN),
           reg_width};
+    if (encoding_value_ >= OpSelSrcNolds::OPR_SRC_NOLDS_TTMP_MIN &&
+        encoding_value_ <= OpSelSrcNolds::OPR_SRC_NOLDS_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSrcNolds::OPR_SRC_NOLDS_TTMP_MIN),
+          reg_width};
     if (encoding_value_ == OpSelSrcNolds::OPR_SRC_NOLDS_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
     if (encoding_value_ == OpSelSrcNolds::OPR_SRC_NOLDS_EXEC_HI)
@@ -1221,6 +1243,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSrcNolit::OPR_SRC_NOLIT_SGPR_MIN),
           reg_width};
+    if (encoding_value_ >= OpSelSrcNolit::OPR_SRC_NOLIT_TTMP_MIN &&
+        encoding_value_ <= OpSelSrcNolit::OPR_SRC_NOLIT_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSrcNolit::OPR_SRC_NOLIT_TTMP_MIN),
+          reg_width};
     if (encoding_value_ == OpSelSrcNolit::OPR_SRC_NOLIT_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
     if (encoding_value_ == OpSelSrcNolit::OPR_SRC_NOLIT_EXEC_HI)
@@ -1239,6 +1267,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSrcSimple::OPR_SRC_SIMPLE_SGPR_MIN),
+          reg_width};
+    if (encoding_value_ >= OpSelSrcSimple::OPR_SRC_SIMPLE_TTMP_MIN &&
+        encoding_value_ <= OpSelSrcSimple::OPR_SRC_SIMPLE_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSrcSimple::OPR_SRC_SIMPLE_TTMP_MIN),
           reg_width};
     if (encoding_value_ == OpSelSrcSimple::OPR_SRC_SIMPLE_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
@@ -1283,6 +1317,11 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSreg::OPR_SREG_SGPR_MIN),
                          reg_width};
+    if (encoding_value_ >= OpSelSreg::OPR_SREG_TTMP_MIN &&
+        encoding_value_ <= OpSelSreg::OPR_SREG_TTMP_MAX)
+      return RegisterRef{RegClass::TTMP,
+                         static_cast<uint16_t>(encoding_value_ - OpSelSreg::OPR_SREG_TTMP_MIN),
+                         reg_width};
     break;
   }
   case OperandType::OPR_SREG_NOVCC: {
@@ -1292,6 +1331,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSregNovcc::OPR_SREG_NOVCC_SGPR_MIN),
           reg_width};
+    if (encoding_value_ >= OpSelSregNovcc::OPR_SREG_NOVCC_TTMP_MIN &&
+        encoding_value_ <= OpSelSregNovcc::OPR_SREG_NOVCC_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSregNovcc::OPR_SREG_NOVCC_TTMP_MIN),
+          reg_width};
     break;
   }
   case OperandType::OPR_SSRC: {
@@ -1299,6 +1344,11 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
         encoding_value_ <= OpSelSsrc::OPR_SSRC_SGPR_MAX)
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSsrc::OPR_SSRC_SGPR_MIN),
+                         reg_width};
+    if (encoding_value_ >= OpSelSsrc::OPR_SSRC_TTMP_MIN &&
+        encoding_value_ <= OpSelSsrc::OPR_SSRC_TTMP_MAX)
+      return RegisterRef{RegClass::TTMP,
+                         static_cast<uint16_t>(encoding_value_ - OpSelSsrc::OPR_SSRC_TTMP_MIN),
                          reg_width};
     if (encoding_value_ == OpSelSsrc::OPR_SSRC_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
@@ -1313,6 +1363,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSsrcLanesel::OPR_SSRC_LANESEL_SGPR_MIN),
           reg_width};
+    if (encoding_value_ >= OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP_MIN &&
+        encoding_value_ <= OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP_MIN),
+          reg_width};
     break;
   }
   case OperandType::OPR_SSRC_NOLIT: {
@@ -1321,6 +1377,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSsrcNolit::OPR_SSRC_NOLIT_SGPR_MIN),
+          reg_width};
+    if (encoding_value_ >= OpSelSsrcNolit::OPR_SSRC_NOLIT_TTMP_MIN &&
+        encoding_value_ <= OpSelSsrcNolit::OPR_SSRC_NOLIT_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSsrcNolit::OPR_SSRC_NOLIT_TTMP_MIN),
           reg_width};
     if (encoding_value_ == OpSelSsrcNolit::OPR_SSRC_NOLIT_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/operand_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/operand_exec.cpp
@@ -112,7 +112,7 @@ void Operand::read_lane_chunk_exec(const amdgpu::Wavefront &wf, uint32_t lane_ba
     uint64_t lane_mask =
         count == 0 ? 0 : util::mask<uint64_t>(static_cast<int>(count)) << lane_base;
     auto region =
-        amdgpu::RegisterAccess(wf.cu()).read_vgpr_region(wf.vgpr_alloc().base + voff, 1, lane_mask);
+        amdgpu::RegisterAccess(wf).read_vgpr_region(wf.vgpr_alloc().base + voff, 1, lane_mask);
     std::copy_n(region.lanes().begin() + lane_base, count, out);
     return;
   }
@@ -136,6 +136,8 @@ void Operand::write_lane_chunk_exec(amdgpu::Wavefront &wf, uint32_t lane_base, u
       vgpr_msb_role() == amdgpu::VgprMsbRole::None ? amdgpu::VgprMsbRole::Dst : vgpr_msb_role();
   uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, role);
   uint32_t reg = wf.vgpr_alloc().base + voff;
+  if (!amdgpu::OperandExecutionAccess::raw_compute_unit(wf.cu()).owns_vgpr_range(wf, reg, 1))
+    return;
   uint64_t full_mask = util::mask<uint64_t>(static_cast<int>(count));
   uint8_t *dst = amdgpu::OperandExecutionAccess::raw_compute_unit(wf.cu()).raw_vgpr_data(reg);
   if ((mask & full_mask) == full_mask) {
@@ -175,7 +177,7 @@ uint32_t Operand::read_lane_exec(const amdgpu::Wavefront &wf, uint32_t lane) con
   int ev = encoding_value_;
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev)) {
     uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, vgpr_msb_role());
-    return amdgpu::RegisterAccess(wf.cu()).read_vgpr(wf.vgpr_alloc().base + voff, lane);
+    return amdgpu::RegisterAccess(wf).read_vgpr(wf.vgpr_alloc().base + voff, lane);
   }
   if (is_immediate_type(opr_type_))
     return static_cast<uint32_t>(ev);
@@ -205,7 +207,7 @@ void Operand::write_lane_exec(amdgpu::Wavefront &wf, uint32_t lane, uint32_t val
     amdgpu::VgprMsbRole role =
         vgpr_msb_role() == amdgpu::VgprMsbRole::None ? amdgpu::VgprMsbRole::Dst : vgpr_msb_role();
     uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, role);
-    amdgpu::RegisterAccess(wf.cu()).write_vgpr(wf.vgpr_alloc().base + voff, lane, val);
+    amdgpu::RegisterAccess(wf).write_vgpr(wf.vgpr_alloc().base + voff, lane, val);
     return;
   }
   throw std::logic_error("write_lane called on non-VGPR operand type");
@@ -224,7 +226,7 @@ uint64_t Operand::read_lane64_exec(const amdgpu::Wavefront &wf, uint32_t lane) c
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev)) {
     uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, vgpr_msb_role());
     uint32_t idx = wf.vgpr_alloc().base + voff;
-    return amdgpu::RegisterAccess(wf.cu()).read_vgpr64(idx, lane);
+    return amdgpu::RegisterAccess(wf).read_vgpr64(idx, lane);
   }
   if (literal32_widening_)
     return widened_literal32_value();
@@ -247,7 +249,7 @@ void Operand::write_lane64_exec(amdgpu::Wavefront &wf, uint32_t lane, uint64_t v
         vgpr_msb_role() == amdgpu::VgprMsbRole::None ? amdgpu::VgprMsbRole::Dst : vgpr_msb_role();
     uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, role);
     uint32_t idx = wf.vgpr_alloc().base + voff;
-    amdgpu::RegisterAccess(wf.cu()).write_vgpr64(idx, lane, val);
+    amdgpu::RegisterAccess(wf).write_vgpr64(idx, lane, val);
     return;
   }
   throw std::logic_error("write_lane64 called on non-VGPR operand type");

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/smem_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/smem_exec.cpp
@@ -8,6 +8,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna1/smem.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx9_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"
@@ -25,184 +26,249 @@ namespace rocjitsu {
 namespace cdna1 {
 
 void SLoadDwordSmem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadDwordx2Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 2u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 2;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadDwordx4Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 4u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 4;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadDwordx8Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 8u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 8;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadDwordx16Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 16u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 16;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SScratchLoadDwordSmem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SScratchLoadDwordx2Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 2u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 2;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SScratchLoadDwordx4Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 4u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 4;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadDwordSmem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadDwordx2Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 2u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 2;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadDwordx4Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 4u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 4;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadDwordx8Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 8u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 8;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadDwordx16Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 16u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 16;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
@@ -213,9 +279,15 @@ void SStoreDwordSmem::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
   const uint32_t sdata_sel = inst_.sdata;
+  auto src_register = amdgpu::resolve_scalar_register_range(wf, sdata_sel, 1u);
+  if (!src_register)
+    return;
   for (uint32_t i = 0; i < 1; ++i)
-    d->store_data[i] = amdgpu::read_scalar_selector(wf, sdata_sel + i);
-  d->addr = smem_calculate_address(inst_, wf);
+    d->store_data[i] = amdgpu::read_scalar_register(wf, *src_register, i);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
@@ -226,9 +298,15 @@ void SStoreDwordx2Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
   const uint32_t sdata_sel = inst_.sdata;
+  auto src_register = amdgpu::resolve_scalar_register_range(wf, sdata_sel, 2u);
+  if (!src_register)
+    return;
   for (uint32_t i = 0; i < 2; ++i)
-    d->store_data[i] = amdgpu::read_scalar_selector(wf, sdata_sel + i);
-  d->addr = smem_calculate_address(inst_, wf);
+    d->store_data[i] = amdgpu::read_scalar_register(wf, *src_register, i);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
@@ -239,9 +317,15 @@ void SStoreDwordx4Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
   const uint32_t sdata_sel = inst_.sdata;
+  auto src_register = amdgpu::resolve_scalar_register_range(wf, sdata_sel, 4u);
+  if (!src_register)
+    return;
   for (uint32_t i = 0; i < 4; ++i)
-    d->store_data[i] = amdgpu::read_scalar_selector(wf, sdata_sel + i);
-  d->addr = smem_calculate_address(inst_, wf);
+    d->store_data[i] = amdgpu::read_scalar_register(wf, *src_register, i);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
@@ -252,9 +336,15 @@ void SScratchStoreDwordSmem::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
   const uint32_t sdata_sel = inst_.sdata;
+  auto src_register = amdgpu::resolve_scalar_register_range(wf, sdata_sel, 1u);
+  if (!src_register)
+    return;
   for (uint32_t i = 0; i < 1; ++i)
-    d->store_data[i] = amdgpu::read_scalar_selector(wf, sdata_sel + i);
-  d->addr = smem_calculate_address(inst_, wf);
+    d->store_data[i] = amdgpu::read_scalar_register(wf, *src_register, i);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
@@ -265,9 +355,15 @@ void SScratchStoreDwordx2Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
   const uint32_t sdata_sel = inst_.sdata;
+  auto src_register = amdgpu::resolve_scalar_register_range(wf, sdata_sel, 2u);
+  if (!src_register)
+    return;
   for (uint32_t i = 0; i < 2; ++i)
-    d->store_data[i] = amdgpu::read_scalar_selector(wf, sdata_sel + i);
-  d->addr = smem_calculate_address(inst_, wf);
+    d->store_data[i] = amdgpu::read_scalar_register(wf, *src_register, i);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
@@ -278,9 +374,15 @@ void SScratchStoreDwordx4Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
   const uint32_t sdata_sel = inst_.sdata;
+  auto src_register = amdgpu::resolve_scalar_register_range(wf, sdata_sel, 4u);
+  if (!src_register)
+    return;
   for (uint32_t i = 0; i < 4; ++i)
-    d->store_data[i] = amdgpu::read_scalar_selector(wf, sdata_sel + i);
-  d->addr = smem_calculate_address(inst_, wf);
+    d->store_data[i] = amdgpu::read_scalar_register(wf, *src_register, i);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
@@ -291,9 +393,15 @@ void SBufferStoreDwordSmem::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
   const uint32_t sdata_sel = inst_.sdata;
+  auto src_register = amdgpu::resolve_scalar_register_range(wf, sdata_sel, 1u);
+  if (!src_register)
+    return;
   for (uint32_t i = 0; i < 1; ++i)
-    d->store_data[i] = amdgpu::read_scalar_selector(wf, sdata_sel + i);
-  d->addr = smem_calculate_address(inst_, wf);
+    d->store_data[i] = amdgpu::read_scalar_register(wf, *src_register, i);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
@@ -304,9 +412,15 @@ void SBufferStoreDwordx2Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
   const uint32_t sdata_sel = inst_.sdata;
+  auto src_register = amdgpu::resolve_scalar_register_range(wf, sdata_sel, 2u);
+  if (!src_register)
+    return;
   for (uint32_t i = 0; i < 2; ++i)
-    d->store_data[i] = amdgpu::read_scalar_selector(wf, sdata_sel + i);
-  d->addr = smem_calculate_address(inst_, wf);
+    d->store_data[i] = amdgpu::read_scalar_register(wf, *src_register, i);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
@@ -317,9 +431,15 @@ void SBufferStoreDwordx4Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
   const uint32_t sdata_sel = inst_.sdata;
+  auto src_register = amdgpu::resolve_scalar_register_range(wf, sdata_sel, 4u);
+  if (!src_register)
+    return;
   for (uint32_t i = 0; i < 4; ++i)
-    d->store_data[i] = amdgpu::read_scalar_selector(wf, sdata_sel + i);
-  d->addr = smem_calculate_address(inst_, wf);
+    d->store_data[i] = amdgpu::read_scalar_register(wf, *src_register, i);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/ds_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/ds_exec.cpp
@@ -8,6 +8,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/ds.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx9_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/flat_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/flat_exec.cpp
@@ -7,6 +7,7 @@
 #include "rocjitsu/isa/arch/amdgpu/cdna2/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/flat.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx9_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/mtbuf_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/mtbuf_exec.cpp
@@ -7,6 +7,7 @@
 #include "rocjitsu/isa/arch/amdgpu/cdna2/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/mtbuf.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx9_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/mubuf_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/mubuf_exec.cpp
@@ -7,6 +7,7 @@
 #include "rocjitsu/isa/arch/amdgpu/cdna2/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/mubuf.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx9_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/operand.cpp
@@ -967,6 +967,11 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSdst::OPR_SDST_SGPR_MIN),
                          reg_width};
+    if (encoding_value_ >= OpSelSdst::OPR_SDST_TTMP_MIN &&
+        encoding_value_ <= OpSelSdst::OPR_SDST_TTMP_MAX)
+      return RegisterRef{RegClass::TTMP,
+                         static_cast<uint16_t>(encoding_value_ - OpSelSdst::OPR_SDST_TTMP_MIN),
+                         reg_width};
     if (encoding_value_ == OpSelSdst::OPR_SDST_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
     if (encoding_value_ == OpSelSdst::OPR_SDST_EXEC_HI)
@@ -990,6 +995,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSmemOffset::OPR_SMEM_OFFSET_SGPR_MIN),
           reg_width};
+    if (encoding_value_ >= OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP_MIN &&
+        encoding_value_ <= OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP_MIN),
+          reg_width};
     break;
   }
   case OperandType::OPR_SRC: {
@@ -997,6 +1008,11 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
         encoding_value_ <= OpSelSrc::OPR_SRC_SGPR_MAX)
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSrc::OPR_SRC_SGPR_MIN),
+                         reg_width};
+    if (encoding_value_ >= OpSelSrc::OPR_SRC_TTMP_MIN &&
+        encoding_value_ <= OpSelSrc::OPR_SRC_TTMP_MAX)
+      return RegisterRef{RegClass::TTMP,
+                         static_cast<uint16_t>(encoding_value_ - OpSelSrc::OPR_SRC_TTMP_MIN),
                          reg_width};
     if (encoding_value_ == OpSelSrc::OPR_SRC_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
@@ -1025,6 +1041,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSrcNolds::OPR_SRC_NOLDS_SGPR_MIN),
           reg_width};
+    if (encoding_value_ >= OpSelSrcNolds::OPR_SRC_NOLDS_TTMP_MIN &&
+        encoding_value_ <= OpSelSrcNolds::OPR_SRC_NOLDS_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSrcNolds::OPR_SRC_NOLDS_TTMP_MIN),
+          reg_width};
     if (encoding_value_ == OpSelSrcNolds::OPR_SRC_NOLDS_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
     if (encoding_value_ == OpSelSrcNolds::OPR_SRC_NOLDS_EXEC_HI)
@@ -1044,6 +1066,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSrcNolit::OPR_SRC_NOLIT_SGPR_MIN),
           reg_width};
+    if (encoding_value_ >= OpSelSrcNolit::OPR_SRC_NOLIT_TTMP_MIN &&
+        encoding_value_ <= OpSelSrcNolit::OPR_SRC_NOLIT_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSrcNolit::OPR_SRC_NOLIT_TTMP_MIN),
+          reg_width};
     if (encoding_value_ == OpSelSrcNolit::OPR_SRC_NOLIT_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
     if (encoding_value_ == OpSelSrcNolit::OPR_SRC_NOLIT_EXEC_HI)
@@ -1062,6 +1090,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSrcSimple::OPR_SRC_SIMPLE_SGPR_MIN),
+          reg_width};
+    if (encoding_value_ >= OpSelSrcSimple::OPR_SRC_SIMPLE_TTMP_MIN &&
+        encoding_value_ <= OpSelSrcSimple::OPR_SRC_SIMPLE_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSrcSimple::OPR_SRC_SIMPLE_TTMP_MIN),
           reg_width};
     if (encoding_value_ == OpSelSrcSimple::OPR_SRC_SIMPLE_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
@@ -1126,6 +1160,11 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSreg::OPR_SREG_SGPR_MIN),
                          reg_width};
+    if (encoding_value_ >= OpSelSreg::OPR_SREG_TTMP_MIN &&
+        encoding_value_ <= OpSelSreg::OPR_SREG_TTMP_MAX)
+      return RegisterRef{RegClass::TTMP,
+                         static_cast<uint16_t>(encoding_value_ - OpSelSreg::OPR_SREG_TTMP_MIN),
+                         reg_width};
     break;
   }
   case OperandType::OPR_SREG_NOVCC: {
@@ -1135,6 +1174,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSregNovcc::OPR_SREG_NOVCC_SGPR_MIN),
           reg_width};
+    if (encoding_value_ >= OpSelSregNovcc::OPR_SREG_NOVCC_TTMP_MIN &&
+        encoding_value_ <= OpSelSregNovcc::OPR_SREG_NOVCC_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSregNovcc::OPR_SREG_NOVCC_TTMP_MIN),
+          reg_width};
     break;
   }
   case OperandType::OPR_SSRC: {
@@ -1142,6 +1187,11 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
         encoding_value_ <= OpSelSsrc::OPR_SSRC_SGPR_MAX)
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSsrc::OPR_SSRC_SGPR_MIN),
+                         reg_width};
+    if (encoding_value_ >= OpSelSsrc::OPR_SSRC_TTMP_MIN &&
+        encoding_value_ <= OpSelSsrc::OPR_SSRC_TTMP_MAX)
+      return RegisterRef{RegClass::TTMP,
+                         static_cast<uint16_t>(encoding_value_ - OpSelSsrc::OPR_SSRC_TTMP_MIN),
                          reg_width};
     if (encoding_value_ == OpSelSsrc::OPR_SSRC_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
@@ -1156,6 +1206,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSsrcLanesel::OPR_SSRC_LANESEL_SGPR_MIN),
           reg_width};
+    if (encoding_value_ >= OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP_MIN &&
+        encoding_value_ <= OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP_MIN),
+          reg_width};
     break;
   }
   case OperandType::OPR_SSRC_NOLIT: {
@@ -1164,6 +1220,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSsrcNolit::OPR_SSRC_NOLIT_SGPR_MIN),
+          reg_width};
+    if (encoding_value_ >= OpSelSsrcNolit::OPR_SSRC_NOLIT_TTMP_MIN &&
+        encoding_value_ <= OpSelSsrcNolit::OPR_SSRC_NOLIT_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSsrcNolit::OPR_SSRC_NOLIT_TTMP_MIN),
           reg_width};
     if (encoding_value_ == OpSelSsrcNolit::OPR_SSRC_NOLIT_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/operand_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/operand_exec.cpp
@@ -122,7 +122,7 @@ void Operand::read_lane_chunk_exec(const amdgpu::Wavefront &wf, uint32_t lane_ba
     uint64_t lane_mask =
         count == 0 ? 0 : util::mask<uint64_t>(static_cast<int>(count)) << lane_base;
     auto region =
-        amdgpu::RegisterAccess(wf.cu()).read_vgpr_region(wf.vgpr_alloc().base + voff, 1, lane_mask);
+        amdgpu::RegisterAccess(wf).read_vgpr_region(wf.vgpr_alloc().base + voff, 1, lane_mask);
     std::copy_n(region.lanes().begin() + lane_base, count, out);
     return;
   }
@@ -146,6 +146,8 @@ void Operand::write_lane_chunk_exec(amdgpu::Wavefront &wf, uint32_t lane_base, u
       vgpr_msb_role() == amdgpu::VgprMsbRole::None ? amdgpu::VgprMsbRole::Dst : vgpr_msb_role();
   uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, role);
   uint32_t reg = wf.vgpr_alloc().base + voff;
+  if (!amdgpu::OperandExecutionAccess::raw_compute_unit(wf.cu()).owns_vgpr_range(wf, reg, 1))
+    return;
   uint64_t full_mask = util::mask<uint64_t>(static_cast<int>(count));
   uint8_t *dst = amdgpu::OperandExecutionAccess::raw_compute_unit(wf.cu()).raw_vgpr_data(reg);
   if ((mask & full_mask) == full_mask) {
@@ -185,7 +187,7 @@ uint32_t Operand::read_lane_exec(const amdgpu::Wavefront &wf, uint32_t lane) con
   int ev = encoding_value_;
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev)) {
     uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, vgpr_msb_role());
-    return amdgpu::RegisterAccess(wf.cu()).read_vgpr(wf.vgpr_alloc().base + voff, lane);
+    return amdgpu::RegisterAccess(wf).read_vgpr(wf.vgpr_alloc().base + voff, lane);
   }
   if (is_immediate_type(opr_type_))
     return static_cast<uint32_t>(ev);
@@ -215,7 +217,7 @@ void Operand::write_lane_exec(amdgpu::Wavefront &wf, uint32_t lane, uint32_t val
     amdgpu::VgprMsbRole role =
         vgpr_msb_role() == amdgpu::VgprMsbRole::None ? amdgpu::VgprMsbRole::Dst : vgpr_msb_role();
     uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, role);
-    amdgpu::RegisterAccess(wf.cu()).write_vgpr(wf.vgpr_alloc().base + voff, lane, val);
+    amdgpu::RegisterAccess(wf).write_vgpr(wf.vgpr_alloc().base + voff, lane, val);
     return;
   }
   throw std::logic_error("write_lane called on non-VGPR operand type");
@@ -234,7 +236,7 @@ uint64_t Operand::read_lane64_exec(const amdgpu::Wavefront &wf, uint32_t lane) c
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev)) {
     uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, vgpr_msb_role());
     uint32_t idx = wf.vgpr_alloc().base + voff;
-    return amdgpu::RegisterAccess(wf.cu()).read_vgpr64(idx, lane);
+    return amdgpu::RegisterAccess(wf).read_vgpr64(idx, lane);
   }
   if (literal32_widening_)
     return widened_literal32_value();
@@ -257,7 +259,7 @@ void Operand::write_lane64_exec(amdgpu::Wavefront &wf, uint32_t lane, uint64_t v
         vgpr_msb_role() == amdgpu::VgprMsbRole::None ? amdgpu::VgprMsbRole::Dst : vgpr_msb_role();
     uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, role);
     uint32_t idx = wf.vgpr_alloc().base + voff;
-    amdgpu::RegisterAccess(wf.cu()).write_vgpr64(idx, lane, val);
+    amdgpu::RegisterAccess(wf).write_vgpr64(idx, lane, val);
     return;
   }
   throw std::logic_error("write_lane64 called on non-VGPR operand type");

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/smem_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/smem_exec.cpp
@@ -8,6 +8,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna2/smem.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx9_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"
@@ -25,184 +26,249 @@ namespace rocjitsu {
 namespace cdna2 {
 
 void SLoadDwordSmem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadDwordx2Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 2u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 2;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadDwordx4Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 4u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 4;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadDwordx8Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 8u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 8;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadDwordx16Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 16u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 16;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SScratchLoadDwordSmem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SScratchLoadDwordx2Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 2u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 2;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SScratchLoadDwordx4Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 4u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 4;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadDwordSmem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadDwordx2Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 2u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 2;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadDwordx4Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 4u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 4;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadDwordx8Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 8u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 8;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadDwordx16Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 16u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 16;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
@@ -213,9 +279,15 @@ void SStoreDwordSmem::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
   const uint32_t sdata_sel = inst_.sdata;
+  auto src_register = amdgpu::resolve_scalar_register_range(wf, sdata_sel, 1u);
+  if (!src_register)
+    return;
   for (uint32_t i = 0; i < 1; ++i)
-    d->store_data[i] = amdgpu::read_scalar_selector(wf, sdata_sel + i);
-  d->addr = smem_calculate_address(inst_, wf);
+    d->store_data[i] = amdgpu::read_scalar_register(wf, *src_register, i);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
@@ -226,9 +298,15 @@ void SStoreDwordx2Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
   const uint32_t sdata_sel = inst_.sdata;
+  auto src_register = amdgpu::resolve_scalar_register_range(wf, sdata_sel, 2u);
+  if (!src_register)
+    return;
   for (uint32_t i = 0; i < 2; ++i)
-    d->store_data[i] = amdgpu::read_scalar_selector(wf, sdata_sel + i);
-  d->addr = smem_calculate_address(inst_, wf);
+    d->store_data[i] = amdgpu::read_scalar_register(wf, *src_register, i);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
@@ -239,9 +317,15 @@ void SStoreDwordx4Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
   const uint32_t sdata_sel = inst_.sdata;
+  auto src_register = amdgpu::resolve_scalar_register_range(wf, sdata_sel, 4u);
+  if (!src_register)
+    return;
   for (uint32_t i = 0; i < 4; ++i)
-    d->store_data[i] = amdgpu::read_scalar_selector(wf, sdata_sel + i);
-  d->addr = smem_calculate_address(inst_, wf);
+    d->store_data[i] = amdgpu::read_scalar_register(wf, *src_register, i);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
@@ -252,9 +336,15 @@ void SScratchStoreDwordSmem::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
   const uint32_t sdata_sel = inst_.sdata;
+  auto src_register = amdgpu::resolve_scalar_register_range(wf, sdata_sel, 1u);
+  if (!src_register)
+    return;
   for (uint32_t i = 0; i < 1; ++i)
-    d->store_data[i] = amdgpu::read_scalar_selector(wf, sdata_sel + i);
-  d->addr = smem_calculate_address(inst_, wf);
+    d->store_data[i] = amdgpu::read_scalar_register(wf, *src_register, i);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
@@ -265,9 +355,15 @@ void SScratchStoreDwordx2Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
   const uint32_t sdata_sel = inst_.sdata;
+  auto src_register = amdgpu::resolve_scalar_register_range(wf, sdata_sel, 2u);
+  if (!src_register)
+    return;
   for (uint32_t i = 0; i < 2; ++i)
-    d->store_data[i] = amdgpu::read_scalar_selector(wf, sdata_sel + i);
-  d->addr = smem_calculate_address(inst_, wf);
+    d->store_data[i] = amdgpu::read_scalar_register(wf, *src_register, i);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
@@ -278,9 +374,15 @@ void SScratchStoreDwordx4Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
   const uint32_t sdata_sel = inst_.sdata;
+  auto src_register = amdgpu::resolve_scalar_register_range(wf, sdata_sel, 4u);
+  if (!src_register)
+    return;
   for (uint32_t i = 0; i < 4; ++i)
-    d->store_data[i] = amdgpu::read_scalar_selector(wf, sdata_sel + i);
-  d->addr = smem_calculate_address(inst_, wf);
+    d->store_data[i] = amdgpu::read_scalar_register(wf, *src_register, i);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
@@ -291,9 +393,15 @@ void SBufferStoreDwordSmem::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
   const uint32_t sdata_sel = inst_.sdata;
+  auto src_register = amdgpu::resolve_scalar_register_range(wf, sdata_sel, 1u);
+  if (!src_register)
+    return;
   for (uint32_t i = 0; i < 1; ++i)
-    d->store_data[i] = amdgpu::read_scalar_selector(wf, sdata_sel + i);
-  d->addr = smem_calculate_address(inst_, wf);
+    d->store_data[i] = amdgpu::read_scalar_register(wf, *src_register, i);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
@@ -304,9 +412,15 @@ void SBufferStoreDwordx2Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
   const uint32_t sdata_sel = inst_.sdata;
+  auto src_register = amdgpu::resolve_scalar_register_range(wf, sdata_sel, 2u);
+  if (!src_register)
+    return;
   for (uint32_t i = 0; i < 2; ++i)
-    d->store_data[i] = amdgpu::read_scalar_selector(wf, sdata_sel + i);
-  d->addr = smem_calculate_address(inst_, wf);
+    d->store_data[i] = amdgpu::read_scalar_register(wf, *src_register, i);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
@@ -317,9 +431,15 @@ void SBufferStoreDwordx4Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
   const uint32_t sdata_sel = inst_.sdata;
+  auto src_register = amdgpu::resolve_scalar_register_range(wf, sdata_sel, 4u);
+  if (!src_register)
+    return;
   for (uint32_t i = 0; i < 4; ++i)
-    d->store_data[i] = amdgpu::read_scalar_selector(wf, sdata_sel + i);
-  d->addr = smem_calculate_address(inst_, wf);
+    d->store_data[i] = amdgpu::read_scalar_register(wf, *src_register, i);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/ds_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/ds_exec.cpp
@@ -9,6 +9,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx940_cache_flags.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx9_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/flat_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/flat_exec.cpp
@@ -8,6 +8,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna3/flat.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx940_cache_flags.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx9_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/mtbuf_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/mtbuf_exec.cpp
@@ -9,6 +9,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx940_cache_flags.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx9_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/mubuf_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/mubuf_exec.cpp
@@ -9,6 +9,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx940_cache_flags.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx9_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/operand.cpp
@@ -967,6 +967,11 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSdst::OPR_SDST_SGPR_MIN),
                          reg_width};
+    if (encoding_value_ >= OpSelSdst::OPR_SDST_TTMP_MIN &&
+        encoding_value_ <= OpSelSdst::OPR_SDST_TTMP_MAX)
+      return RegisterRef{RegClass::TTMP,
+                         static_cast<uint16_t>(encoding_value_ - OpSelSdst::OPR_SDST_TTMP_MIN),
+                         reg_width};
     if (encoding_value_ == OpSelSdst::OPR_SDST_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
     if (encoding_value_ == OpSelSdst::OPR_SDST_EXEC_HI)
@@ -990,6 +995,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSmemOffset::OPR_SMEM_OFFSET_SGPR_MIN),
           reg_width};
+    if (encoding_value_ >= OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP_MIN &&
+        encoding_value_ <= OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP_MIN),
+          reg_width};
     break;
   }
   case OperandType::OPR_SRC: {
@@ -997,6 +1008,11 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
         encoding_value_ <= OpSelSrc::OPR_SRC_SGPR_MAX)
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSrc::OPR_SRC_SGPR_MIN),
+                         reg_width};
+    if (encoding_value_ >= OpSelSrc::OPR_SRC_TTMP_MIN &&
+        encoding_value_ <= OpSelSrc::OPR_SRC_TTMP_MAX)
+      return RegisterRef{RegClass::TTMP,
+                         static_cast<uint16_t>(encoding_value_ - OpSelSrc::OPR_SRC_TTMP_MIN),
                          reg_width};
     if (encoding_value_ == OpSelSrc::OPR_SRC_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
@@ -1025,6 +1041,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSrcNolds::OPR_SRC_NOLDS_SGPR_MIN),
           reg_width};
+    if (encoding_value_ >= OpSelSrcNolds::OPR_SRC_NOLDS_TTMP_MIN &&
+        encoding_value_ <= OpSelSrcNolds::OPR_SRC_NOLDS_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSrcNolds::OPR_SRC_NOLDS_TTMP_MIN),
+          reg_width};
     if (encoding_value_ == OpSelSrcNolds::OPR_SRC_NOLDS_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
     if (encoding_value_ == OpSelSrcNolds::OPR_SRC_NOLDS_EXEC_HI)
@@ -1044,6 +1066,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSrcNolit::OPR_SRC_NOLIT_SGPR_MIN),
           reg_width};
+    if (encoding_value_ >= OpSelSrcNolit::OPR_SRC_NOLIT_TTMP_MIN &&
+        encoding_value_ <= OpSelSrcNolit::OPR_SRC_NOLIT_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSrcNolit::OPR_SRC_NOLIT_TTMP_MIN),
+          reg_width};
     if (encoding_value_ == OpSelSrcNolit::OPR_SRC_NOLIT_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
     if (encoding_value_ == OpSelSrcNolit::OPR_SRC_NOLIT_EXEC_HI)
@@ -1062,6 +1090,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSrcSimple::OPR_SRC_SIMPLE_SGPR_MIN),
+          reg_width};
+    if (encoding_value_ >= OpSelSrcSimple::OPR_SRC_SIMPLE_TTMP_MIN &&
+        encoding_value_ <= OpSelSrcSimple::OPR_SRC_SIMPLE_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSrcSimple::OPR_SRC_SIMPLE_TTMP_MIN),
           reg_width};
     if (encoding_value_ == OpSelSrcSimple::OPR_SRC_SIMPLE_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
@@ -1126,6 +1160,11 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSreg::OPR_SREG_SGPR_MIN),
                          reg_width};
+    if (encoding_value_ >= OpSelSreg::OPR_SREG_TTMP_MIN &&
+        encoding_value_ <= OpSelSreg::OPR_SREG_TTMP_MAX)
+      return RegisterRef{RegClass::TTMP,
+                         static_cast<uint16_t>(encoding_value_ - OpSelSreg::OPR_SREG_TTMP_MIN),
+                         reg_width};
     break;
   }
   case OperandType::OPR_SREG_NOVCC: {
@@ -1135,6 +1174,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSregNovcc::OPR_SREG_NOVCC_SGPR_MIN),
           reg_width};
+    if (encoding_value_ >= OpSelSregNovcc::OPR_SREG_NOVCC_TTMP_MIN &&
+        encoding_value_ <= OpSelSregNovcc::OPR_SREG_NOVCC_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSregNovcc::OPR_SREG_NOVCC_TTMP_MIN),
+          reg_width};
     break;
   }
   case OperandType::OPR_SSRC: {
@@ -1142,6 +1187,11 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
         encoding_value_ <= OpSelSsrc::OPR_SSRC_SGPR_MAX)
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSsrc::OPR_SSRC_SGPR_MIN),
+                         reg_width};
+    if (encoding_value_ >= OpSelSsrc::OPR_SSRC_TTMP_MIN &&
+        encoding_value_ <= OpSelSsrc::OPR_SSRC_TTMP_MAX)
+      return RegisterRef{RegClass::TTMP,
+                         static_cast<uint16_t>(encoding_value_ - OpSelSsrc::OPR_SSRC_TTMP_MIN),
                          reg_width};
     if (encoding_value_ == OpSelSsrc::OPR_SSRC_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
@@ -1156,6 +1206,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSsrcLanesel::OPR_SSRC_LANESEL_SGPR_MIN),
           reg_width};
+    if (encoding_value_ >= OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP_MIN &&
+        encoding_value_ <= OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP_MIN),
+          reg_width};
     break;
   }
   case OperandType::OPR_SSRC_NOLIT: {
@@ -1164,6 +1220,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSsrcNolit::OPR_SSRC_NOLIT_SGPR_MIN),
+          reg_width};
+    if (encoding_value_ >= OpSelSsrcNolit::OPR_SSRC_NOLIT_TTMP_MIN &&
+        encoding_value_ <= OpSelSsrcNolit::OPR_SSRC_NOLIT_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSsrcNolit::OPR_SSRC_NOLIT_TTMP_MIN),
           reg_width};
     if (encoding_value_ == OpSelSsrcNolit::OPR_SSRC_NOLIT_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/operand_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/operand_exec.cpp
@@ -122,7 +122,7 @@ void Operand::read_lane_chunk_exec(const amdgpu::Wavefront &wf, uint32_t lane_ba
     uint64_t lane_mask =
         count == 0 ? 0 : util::mask<uint64_t>(static_cast<int>(count)) << lane_base;
     auto region =
-        amdgpu::RegisterAccess(wf.cu()).read_vgpr_region(wf.vgpr_alloc().base + voff, 1, lane_mask);
+        amdgpu::RegisterAccess(wf).read_vgpr_region(wf.vgpr_alloc().base + voff, 1, lane_mask);
     std::copy_n(region.lanes().begin() + lane_base, count, out);
     return;
   }
@@ -146,6 +146,8 @@ void Operand::write_lane_chunk_exec(amdgpu::Wavefront &wf, uint32_t lane_base, u
       vgpr_msb_role() == amdgpu::VgprMsbRole::None ? amdgpu::VgprMsbRole::Dst : vgpr_msb_role();
   uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, role);
   uint32_t reg = wf.vgpr_alloc().base + voff;
+  if (!amdgpu::OperandExecutionAccess::raw_compute_unit(wf.cu()).owns_vgpr_range(wf, reg, 1))
+    return;
   uint64_t full_mask = util::mask<uint64_t>(static_cast<int>(count));
   uint8_t *dst = amdgpu::OperandExecutionAccess::raw_compute_unit(wf.cu()).raw_vgpr_data(reg);
   if ((mask & full_mask) == full_mask) {
@@ -185,7 +187,7 @@ uint32_t Operand::read_lane_exec(const amdgpu::Wavefront &wf, uint32_t lane) con
   int ev = encoding_value_;
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev)) {
     uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, vgpr_msb_role());
-    return amdgpu::RegisterAccess(wf.cu()).read_vgpr(wf.vgpr_alloc().base + voff, lane);
+    return amdgpu::RegisterAccess(wf).read_vgpr(wf.vgpr_alloc().base + voff, lane);
   }
   if (is_immediate_type(opr_type_))
     return static_cast<uint32_t>(ev);
@@ -215,7 +217,7 @@ void Operand::write_lane_exec(amdgpu::Wavefront &wf, uint32_t lane, uint32_t val
     amdgpu::VgprMsbRole role =
         vgpr_msb_role() == amdgpu::VgprMsbRole::None ? amdgpu::VgprMsbRole::Dst : vgpr_msb_role();
     uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, role);
-    amdgpu::RegisterAccess(wf.cu()).write_vgpr(wf.vgpr_alloc().base + voff, lane, val);
+    amdgpu::RegisterAccess(wf).write_vgpr(wf.vgpr_alloc().base + voff, lane, val);
     return;
   }
   throw std::logic_error("write_lane called on non-VGPR operand type");
@@ -234,7 +236,7 @@ uint64_t Operand::read_lane64_exec(const amdgpu::Wavefront &wf, uint32_t lane) c
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev)) {
     uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, vgpr_msb_role());
     uint32_t idx = wf.vgpr_alloc().base + voff;
-    return amdgpu::RegisterAccess(wf.cu()).read_vgpr64(idx, lane);
+    return amdgpu::RegisterAccess(wf).read_vgpr64(idx, lane);
   }
   if (literal32_widening_)
     return widened_literal32_value();
@@ -257,7 +259,7 @@ void Operand::write_lane64_exec(amdgpu::Wavefront &wf, uint32_t lane, uint64_t v
         vgpr_msb_role() == amdgpu::VgprMsbRole::None ? amdgpu::VgprMsbRole::Dst : vgpr_msb_role();
     uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, role);
     uint32_t idx = wf.vgpr_alloc().base + voff;
-    amdgpu::RegisterAccess(wf.cu()).write_vgpr64(idx, lane, val);
+    amdgpu::RegisterAccess(wf).write_vgpr64(idx, lane, val);
     return;
   }
   throw std::logic_error("write_lane64 called on non-VGPR operand type");

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/smem_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/smem_exec.cpp
@@ -9,6 +9,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx940_cache_flags.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx9_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"
@@ -26,184 +27,249 @@ namespace rocjitsu {
 namespace cdna3 {
 
 void SLoadDwordSmem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadDwordx2Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 2u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 2;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadDwordx4Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 4u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 4;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadDwordx8Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 8u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 8;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadDwordx16Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 16u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 16;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SScratchLoadDwordSmem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SScratchLoadDwordx2Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 2u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 2;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SScratchLoadDwordx4Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 4u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 4;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadDwordSmem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadDwordx2Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 2u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 2;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadDwordx4Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 4u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 4;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadDwordx8Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 8u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 8;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadDwordx16Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 16u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 16;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
@@ -214,9 +280,15 @@ void SStoreDwordSmem::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
   const uint32_t sdata_sel = inst_.sdata;
+  auto src_register = amdgpu::resolve_scalar_register_range(wf, sdata_sel, 1u);
+  if (!src_register)
+    return;
   for (uint32_t i = 0; i < 1; ++i)
-    d->store_data[i] = amdgpu::read_scalar_selector(wf, sdata_sel + i);
-  d->addr = smem_calculate_address(inst_, wf);
+    d->store_data[i] = amdgpu::read_scalar_register(wf, *src_register, i);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
@@ -227,9 +299,15 @@ void SStoreDwordx2Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
   const uint32_t sdata_sel = inst_.sdata;
+  auto src_register = amdgpu::resolve_scalar_register_range(wf, sdata_sel, 2u);
+  if (!src_register)
+    return;
   for (uint32_t i = 0; i < 2; ++i)
-    d->store_data[i] = amdgpu::read_scalar_selector(wf, sdata_sel + i);
-  d->addr = smem_calculate_address(inst_, wf);
+    d->store_data[i] = amdgpu::read_scalar_register(wf, *src_register, i);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
@@ -240,9 +318,15 @@ void SStoreDwordx4Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
   const uint32_t sdata_sel = inst_.sdata;
+  auto src_register = amdgpu::resolve_scalar_register_range(wf, sdata_sel, 4u);
+  if (!src_register)
+    return;
   for (uint32_t i = 0; i < 4; ++i)
-    d->store_data[i] = amdgpu::read_scalar_selector(wf, sdata_sel + i);
-  d->addr = smem_calculate_address(inst_, wf);
+    d->store_data[i] = amdgpu::read_scalar_register(wf, *src_register, i);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
@@ -253,9 +337,15 @@ void SScratchStoreDwordSmem::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
   const uint32_t sdata_sel = inst_.sdata;
+  auto src_register = amdgpu::resolve_scalar_register_range(wf, sdata_sel, 1u);
+  if (!src_register)
+    return;
   for (uint32_t i = 0; i < 1; ++i)
-    d->store_data[i] = amdgpu::read_scalar_selector(wf, sdata_sel + i);
-  d->addr = smem_calculate_address(inst_, wf);
+    d->store_data[i] = amdgpu::read_scalar_register(wf, *src_register, i);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
@@ -266,9 +356,15 @@ void SScratchStoreDwordx2Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
   const uint32_t sdata_sel = inst_.sdata;
+  auto src_register = amdgpu::resolve_scalar_register_range(wf, sdata_sel, 2u);
+  if (!src_register)
+    return;
   for (uint32_t i = 0; i < 2; ++i)
-    d->store_data[i] = amdgpu::read_scalar_selector(wf, sdata_sel + i);
-  d->addr = smem_calculate_address(inst_, wf);
+    d->store_data[i] = amdgpu::read_scalar_register(wf, *src_register, i);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
@@ -279,9 +375,15 @@ void SScratchStoreDwordx4Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
   const uint32_t sdata_sel = inst_.sdata;
+  auto src_register = amdgpu::resolve_scalar_register_range(wf, sdata_sel, 4u);
+  if (!src_register)
+    return;
   for (uint32_t i = 0; i < 4; ++i)
-    d->store_data[i] = amdgpu::read_scalar_selector(wf, sdata_sel + i);
-  d->addr = smem_calculate_address(inst_, wf);
+    d->store_data[i] = amdgpu::read_scalar_register(wf, *src_register, i);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
@@ -292,9 +394,15 @@ void SBufferStoreDwordSmem::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
   const uint32_t sdata_sel = inst_.sdata;
+  auto src_register = amdgpu::resolve_scalar_register_range(wf, sdata_sel, 1u);
+  if (!src_register)
+    return;
   for (uint32_t i = 0; i < 1; ++i)
-    d->store_data[i] = amdgpu::read_scalar_selector(wf, sdata_sel + i);
-  d->addr = smem_calculate_address(inst_, wf);
+    d->store_data[i] = amdgpu::read_scalar_register(wf, *src_register, i);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
@@ -305,9 +413,15 @@ void SBufferStoreDwordx2Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
   const uint32_t sdata_sel = inst_.sdata;
+  auto src_register = amdgpu::resolve_scalar_register_range(wf, sdata_sel, 2u);
+  if (!src_register)
+    return;
   for (uint32_t i = 0; i < 2; ++i)
-    d->store_data[i] = amdgpu::read_scalar_selector(wf, sdata_sel + i);
-  d->addr = smem_calculate_address(inst_, wf);
+    d->store_data[i] = amdgpu::read_scalar_register(wf, *src_register, i);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
@@ -318,9 +432,15 @@ void SBufferStoreDwordx4Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
   const uint32_t sdata_sel = inst_.sdata;
+  auto src_register = amdgpu::resolve_scalar_register_range(wf, sdata_sel, 4u);
+  if (!src_register)
+    return;
   for (uint32_t i = 0; i < 4; ++i)
-    d->store_data[i] = amdgpu::read_scalar_selector(wf, sdata_sel + i);
-  d->addr = smem_calculate_address(inst_, wf);
+    d->store_data[i] = amdgpu::read_scalar_register(wf, *src_register, i);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/ds_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/ds_exec.cpp
@@ -9,6 +9,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx940_cache_flags.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx9_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/flat_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/flat_exec.cpp
@@ -8,6 +8,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna4/flat.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx940_cache_flags.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx9_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/mtbuf_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/mtbuf_exec.cpp
@@ -9,6 +9,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx940_cache_flags.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx9_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/mubuf_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/mubuf_exec.cpp
@@ -9,6 +9,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx940_cache_flags.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx9_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/operand.cpp
@@ -967,6 +967,11 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSdst::OPR_SDST_SGPR_MIN),
                          reg_width};
+    if (encoding_value_ >= OpSelSdst::OPR_SDST_TTMP_MIN &&
+        encoding_value_ <= OpSelSdst::OPR_SDST_TTMP_MAX)
+      return RegisterRef{RegClass::TTMP,
+                         static_cast<uint16_t>(encoding_value_ - OpSelSdst::OPR_SDST_TTMP_MIN),
+                         reg_width};
     if (encoding_value_ == OpSelSdst::OPR_SDST_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
     if (encoding_value_ == OpSelSdst::OPR_SDST_EXEC_HI)
@@ -990,6 +995,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSmemOffset::OPR_SMEM_OFFSET_SGPR_MIN),
           reg_width};
+    if (encoding_value_ >= OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP_MIN &&
+        encoding_value_ <= OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP_MIN),
+          reg_width};
     break;
   }
   case OperandType::OPR_SRC: {
@@ -997,6 +1008,11 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
         encoding_value_ <= OpSelSrc::OPR_SRC_SGPR_MAX)
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSrc::OPR_SRC_SGPR_MIN),
+                         reg_width};
+    if (encoding_value_ >= OpSelSrc::OPR_SRC_TTMP_MIN &&
+        encoding_value_ <= OpSelSrc::OPR_SRC_TTMP_MAX)
+      return RegisterRef{RegClass::TTMP,
+                         static_cast<uint16_t>(encoding_value_ - OpSelSrc::OPR_SRC_TTMP_MIN),
                          reg_width};
     if (encoding_value_ == OpSelSrc::OPR_SRC_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
@@ -1025,6 +1041,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSrcNolds::OPR_SRC_NOLDS_SGPR_MIN),
           reg_width};
+    if (encoding_value_ >= OpSelSrcNolds::OPR_SRC_NOLDS_TTMP_MIN &&
+        encoding_value_ <= OpSelSrcNolds::OPR_SRC_NOLDS_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSrcNolds::OPR_SRC_NOLDS_TTMP_MIN),
+          reg_width};
     if (encoding_value_ == OpSelSrcNolds::OPR_SRC_NOLDS_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
     if (encoding_value_ == OpSelSrcNolds::OPR_SRC_NOLDS_EXEC_HI)
@@ -1044,6 +1066,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSrcNolit::OPR_SRC_NOLIT_SGPR_MIN),
           reg_width};
+    if (encoding_value_ >= OpSelSrcNolit::OPR_SRC_NOLIT_TTMP_MIN &&
+        encoding_value_ <= OpSelSrcNolit::OPR_SRC_NOLIT_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSrcNolit::OPR_SRC_NOLIT_TTMP_MIN),
+          reg_width};
     if (encoding_value_ == OpSelSrcNolit::OPR_SRC_NOLIT_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
     if (encoding_value_ == OpSelSrcNolit::OPR_SRC_NOLIT_EXEC_HI)
@@ -1062,6 +1090,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSrcSimple::OPR_SRC_SIMPLE_SGPR_MIN),
+          reg_width};
+    if (encoding_value_ >= OpSelSrcSimple::OPR_SRC_SIMPLE_TTMP_MIN &&
+        encoding_value_ <= OpSelSrcSimple::OPR_SRC_SIMPLE_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSrcSimple::OPR_SRC_SIMPLE_TTMP_MIN),
           reg_width};
     if (encoding_value_ == OpSelSrcSimple::OPR_SRC_SIMPLE_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
@@ -1126,6 +1160,11 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSreg::OPR_SREG_SGPR_MIN),
                          reg_width};
+    if (encoding_value_ >= OpSelSreg::OPR_SREG_TTMP_MIN &&
+        encoding_value_ <= OpSelSreg::OPR_SREG_TTMP_MAX)
+      return RegisterRef{RegClass::TTMP,
+                         static_cast<uint16_t>(encoding_value_ - OpSelSreg::OPR_SREG_TTMP_MIN),
+                         reg_width};
     break;
   }
   case OperandType::OPR_SREG_NOVCC: {
@@ -1135,6 +1174,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSregNovcc::OPR_SREG_NOVCC_SGPR_MIN),
           reg_width};
+    if (encoding_value_ >= OpSelSregNovcc::OPR_SREG_NOVCC_TTMP_MIN &&
+        encoding_value_ <= OpSelSregNovcc::OPR_SREG_NOVCC_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSregNovcc::OPR_SREG_NOVCC_TTMP_MIN),
+          reg_width};
     break;
   }
   case OperandType::OPR_SSRC: {
@@ -1142,6 +1187,11 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
         encoding_value_ <= OpSelSsrc::OPR_SSRC_SGPR_MAX)
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSsrc::OPR_SSRC_SGPR_MIN),
+                         reg_width};
+    if (encoding_value_ >= OpSelSsrc::OPR_SSRC_TTMP_MIN &&
+        encoding_value_ <= OpSelSsrc::OPR_SSRC_TTMP_MAX)
+      return RegisterRef{RegClass::TTMP,
+                         static_cast<uint16_t>(encoding_value_ - OpSelSsrc::OPR_SSRC_TTMP_MIN),
                          reg_width};
     if (encoding_value_ == OpSelSsrc::OPR_SSRC_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
@@ -1156,6 +1206,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSsrcLanesel::OPR_SSRC_LANESEL_SGPR_MIN),
           reg_width};
+    if (encoding_value_ >= OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP_MIN &&
+        encoding_value_ <= OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP_MIN),
+          reg_width};
     break;
   }
   case OperandType::OPR_SSRC_NOLIT: {
@@ -1164,6 +1220,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSsrcNolit::OPR_SSRC_NOLIT_SGPR_MIN),
+          reg_width};
+    if (encoding_value_ >= OpSelSsrcNolit::OPR_SSRC_NOLIT_TTMP_MIN &&
+        encoding_value_ <= OpSelSsrcNolit::OPR_SSRC_NOLIT_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSsrcNolit::OPR_SSRC_NOLIT_TTMP_MIN),
           reg_width};
     if (encoding_value_ == OpSelSsrcNolit::OPR_SSRC_NOLIT_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/operand_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/operand_exec.cpp
@@ -122,7 +122,7 @@ void Operand::read_lane_chunk_exec(const amdgpu::Wavefront &wf, uint32_t lane_ba
     uint64_t lane_mask =
         count == 0 ? 0 : util::mask<uint64_t>(static_cast<int>(count)) << lane_base;
     auto region =
-        amdgpu::RegisterAccess(wf.cu()).read_vgpr_region(wf.vgpr_alloc().base + voff, 1, lane_mask);
+        amdgpu::RegisterAccess(wf).read_vgpr_region(wf.vgpr_alloc().base + voff, 1, lane_mask);
     std::copy_n(region.lanes().begin() + lane_base, count, out);
     return;
   }
@@ -146,6 +146,8 @@ void Operand::write_lane_chunk_exec(amdgpu::Wavefront &wf, uint32_t lane_base, u
       vgpr_msb_role() == amdgpu::VgprMsbRole::None ? amdgpu::VgprMsbRole::Dst : vgpr_msb_role();
   uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, role);
   uint32_t reg = wf.vgpr_alloc().base + voff;
+  if (!amdgpu::OperandExecutionAccess::raw_compute_unit(wf.cu()).owns_vgpr_range(wf, reg, 1))
+    return;
   uint64_t full_mask = util::mask<uint64_t>(static_cast<int>(count));
   uint8_t *dst = amdgpu::OperandExecutionAccess::raw_compute_unit(wf.cu()).raw_vgpr_data(reg);
   if ((mask & full_mask) == full_mask) {
@@ -185,7 +187,7 @@ uint32_t Operand::read_lane_exec(const amdgpu::Wavefront &wf, uint32_t lane) con
   int ev = encoding_value_;
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev)) {
     uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, vgpr_msb_role());
-    return amdgpu::RegisterAccess(wf.cu()).read_vgpr(wf.vgpr_alloc().base + voff, lane);
+    return amdgpu::RegisterAccess(wf).read_vgpr(wf.vgpr_alloc().base + voff, lane);
   }
   if (is_immediate_type(opr_type_))
     return static_cast<uint32_t>(ev);
@@ -215,7 +217,7 @@ void Operand::write_lane_exec(amdgpu::Wavefront &wf, uint32_t lane, uint32_t val
     amdgpu::VgprMsbRole role =
         vgpr_msb_role() == amdgpu::VgprMsbRole::None ? amdgpu::VgprMsbRole::Dst : vgpr_msb_role();
     uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, role);
-    amdgpu::RegisterAccess(wf.cu()).write_vgpr(wf.vgpr_alloc().base + voff, lane, val);
+    amdgpu::RegisterAccess(wf).write_vgpr(wf.vgpr_alloc().base + voff, lane, val);
     return;
   }
   throw std::logic_error("write_lane called on non-VGPR operand type");
@@ -234,7 +236,7 @@ uint64_t Operand::read_lane64_exec(const amdgpu::Wavefront &wf, uint32_t lane) c
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev)) {
     uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, vgpr_msb_role());
     uint32_t idx = wf.vgpr_alloc().base + voff;
-    return amdgpu::RegisterAccess(wf.cu()).read_vgpr64(idx, lane);
+    return amdgpu::RegisterAccess(wf).read_vgpr64(idx, lane);
   }
   if (literal32_widening_)
     return widened_literal32_value();
@@ -257,7 +259,7 @@ void Operand::write_lane64_exec(amdgpu::Wavefront &wf, uint32_t lane, uint64_t v
         vgpr_msb_role() == amdgpu::VgprMsbRole::None ? amdgpu::VgprMsbRole::Dst : vgpr_msb_role();
     uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, role);
     uint32_t idx = wf.vgpr_alloc().base + voff;
-    amdgpu::RegisterAccess(wf.cu()).write_vgpr64(idx, lane, val);
+    amdgpu::RegisterAccess(wf).write_vgpr64(idx, lane, val);
     return;
   }
   throw std::logic_error("write_lane64 called on non-VGPR operand type");

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/smem_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/smem_exec.cpp
@@ -9,6 +9,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx940_cache_flags.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx9_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"
@@ -26,184 +27,249 @@ namespace rocjitsu {
 namespace cdna4 {
 
 void SLoadDwordSmem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadDwordx2Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 2u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 2;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadDwordx4Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 4u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 4;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadDwordx8Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 8u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 8;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadDwordx16Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 16u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 16;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SScratchLoadDwordSmem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SScratchLoadDwordx2Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 2u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 2;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SScratchLoadDwordx4Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 4u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 4;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadDwordSmem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadDwordx2Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 2u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 2;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadDwordx4Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 4u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 4;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadDwordx8Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 8u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 8;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadDwordx16Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 16u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 16;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
@@ -214,9 +280,15 @@ void SStoreDwordSmem::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
   const uint32_t sdata_sel = inst_.sdata;
+  auto src_register = amdgpu::resolve_scalar_register_range(wf, sdata_sel, 1u);
+  if (!src_register)
+    return;
   for (uint32_t i = 0; i < 1; ++i)
-    d->store_data[i] = amdgpu::read_scalar_selector(wf, sdata_sel + i);
-  d->addr = smem_calculate_address(inst_, wf);
+    d->store_data[i] = amdgpu::read_scalar_register(wf, *src_register, i);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
@@ -227,9 +299,15 @@ void SStoreDwordx2Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
   const uint32_t sdata_sel = inst_.sdata;
+  auto src_register = amdgpu::resolve_scalar_register_range(wf, sdata_sel, 2u);
+  if (!src_register)
+    return;
   for (uint32_t i = 0; i < 2; ++i)
-    d->store_data[i] = amdgpu::read_scalar_selector(wf, sdata_sel + i);
-  d->addr = smem_calculate_address(inst_, wf);
+    d->store_data[i] = amdgpu::read_scalar_register(wf, *src_register, i);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
@@ -240,9 +318,15 @@ void SStoreDwordx4Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
   const uint32_t sdata_sel = inst_.sdata;
+  auto src_register = amdgpu::resolve_scalar_register_range(wf, sdata_sel, 4u);
+  if (!src_register)
+    return;
   for (uint32_t i = 0; i < 4; ++i)
-    d->store_data[i] = amdgpu::read_scalar_selector(wf, sdata_sel + i);
-  d->addr = smem_calculate_address(inst_, wf);
+    d->store_data[i] = amdgpu::read_scalar_register(wf, *src_register, i);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
@@ -253,9 +337,15 @@ void SScratchStoreDwordSmem::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
   const uint32_t sdata_sel = inst_.sdata;
+  auto src_register = amdgpu::resolve_scalar_register_range(wf, sdata_sel, 1u);
+  if (!src_register)
+    return;
   for (uint32_t i = 0; i < 1; ++i)
-    d->store_data[i] = amdgpu::read_scalar_selector(wf, sdata_sel + i);
-  d->addr = smem_calculate_address(inst_, wf);
+    d->store_data[i] = amdgpu::read_scalar_register(wf, *src_register, i);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
@@ -266,9 +356,15 @@ void SScratchStoreDwordx2Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
   const uint32_t sdata_sel = inst_.sdata;
+  auto src_register = amdgpu::resolve_scalar_register_range(wf, sdata_sel, 2u);
+  if (!src_register)
+    return;
   for (uint32_t i = 0; i < 2; ++i)
-    d->store_data[i] = amdgpu::read_scalar_selector(wf, sdata_sel + i);
-  d->addr = smem_calculate_address(inst_, wf);
+    d->store_data[i] = amdgpu::read_scalar_register(wf, *src_register, i);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
@@ -279,9 +375,15 @@ void SScratchStoreDwordx4Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
   const uint32_t sdata_sel = inst_.sdata;
+  auto src_register = amdgpu::resolve_scalar_register_range(wf, sdata_sel, 4u);
+  if (!src_register)
+    return;
   for (uint32_t i = 0; i < 4; ++i)
-    d->store_data[i] = amdgpu::read_scalar_selector(wf, sdata_sel + i);
-  d->addr = smem_calculate_address(inst_, wf);
+    d->store_data[i] = amdgpu::read_scalar_register(wf, *src_register, i);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
@@ -292,9 +394,15 @@ void SBufferStoreDwordSmem::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
   const uint32_t sdata_sel = inst_.sdata;
+  auto src_register = amdgpu::resolve_scalar_register_range(wf, sdata_sel, 1u);
+  if (!src_register)
+    return;
   for (uint32_t i = 0; i < 1; ++i)
-    d->store_data[i] = amdgpu::read_scalar_selector(wf, sdata_sel + i);
-  d->addr = smem_calculate_address(inst_, wf);
+    d->store_data[i] = amdgpu::read_scalar_register(wf, *src_register, i);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
@@ -305,9 +413,15 @@ void SBufferStoreDwordx2Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
   const uint32_t sdata_sel = inst_.sdata;
+  auto src_register = amdgpu::resolve_scalar_register_range(wf, sdata_sel, 2u);
+  if (!src_register)
+    return;
   for (uint32_t i = 0; i < 2; ++i)
-    d->store_data[i] = amdgpu::read_scalar_selector(wf, sdata_sel + i);
-  d->addr = smem_calculate_address(inst_, wf);
+    d->store_data[i] = amdgpu::read_scalar_register(wf, *src_register, i);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
@@ -318,9 +432,15 @@ void SBufferStoreDwordx4Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
   const uint32_t sdata_sel = inst_.sdata;
+  auto src_register = amdgpu::resolve_scalar_register_range(wf, sdata_sel, 4u);
+  if (!src_register)
+    return;
   for (uint32_t i = 0; i < 4; ++i)
-    d->store_data[i] = amdgpu::read_scalar_selector(wf, sdata_sel + i);
-  d->addr = smem_calculate_address(inst_, wf);
+    d->store_data[i] = amdgpu::read_scalar_register(wf, *src_register, i);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/operand.cpp
@@ -1045,6 +1045,38 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSdst::OPR_SDST_SGPR_MIN),
                          reg_width};
+    if (encoding_value_ == OpSelSdst::OPR_SDST_TTMP0)
+      return RegisterRef{RegClass::TTMP, 0, reg_width};
+    if (encoding_value_ == OpSelSdst::OPR_SDST_TTMP1)
+      return RegisterRef{RegClass::TTMP, 1, reg_width};
+    if (encoding_value_ == OpSelSdst::OPR_SDST_TTMP2)
+      return RegisterRef{RegClass::TTMP, 2, reg_width};
+    if (encoding_value_ == OpSelSdst::OPR_SDST_TTMP3)
+      return RegisterRef{RegClass::TTMP, 3, reg_width};
+    if (encoding_value_ == OpSelSdst::OPR_SDST_TTMP4)
+      return RegisterRef{RegClass::TTMP, 4, reg_width};
+    if (encoding_value_ == OpSelSdst::OPR_SDST_TTMP5)
+      return RegisterRef{RegClass::TTMP, 5, reg_width};
+    if (encoding_value_ == OpSelSdst::OPR_SDST_TTMP6)
+      return RegisterRef{RegClass::TTMP, 6, reg_width};
+    if (encoding_value_ == OpSelSdst::OPR_SDST_TTMP7)
+      return RegisterRef{RegClass::TTMP, 7, reg_width};
+    if (encoding_value_ == OpSelSdst::OPR_SDST_TTMP8)
+      return RegisterRef{RegClass::TTMP, 8, reg_width};
+    if (encoding_value_ == OpSelSdst::OPR_SDST_TTMP9)
+      return RegisterRef{RegClass::TTMP, 9, reg_width};
+    if (encoding_value_ == OpSelSdst::OPR_SDST_TTMP10)
+      return RegisterRef{RegClass::TTMP, 10, reg_width};
+    if (encoding_value_ == OpSelSdst::OPR_SDST_TTMP11)
+      return RegisterRef{RegClass::TTMP, 11, reg_width};
+    if (encoding_value_ == OpSelSdst::OPR_SDST_TTMP12)
+      return RegisterRef{RegClass::TTMP, 12, reg_width};
+    if (encoding_value_ == OpSelSdst::OPR_SDST_TTMP13)
+      return RegisterRef{RegClass::TTMP, 13, reg_width};
+    if (encoding_value_ == OpSelSdst::OPR_SDST_TTMP14)
+      return RegisterRef{RegClass::TTMP, 14, reg_width};
+    if (encoding_value_ == OpSelSdst::OPR_SDST_TTMP15)
+      return RegisterRef{RegClass::TTMP, 15, reg_width};
     if (encoding_value_ == OpSelSdst::OPR_SDST_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
     if (encoding_value_ == OpSelSdst::OPR_SDST_EXEC_HI)
@@ -1076,6 +1108,38 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSmemOffset::OPR_SMEM_OFFSET_SGPR_MIN),
           reg_width};
+    if (encoding_value_ == OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP0)
+      return RegisterRef{RegClass::TTMP, 0, reg_width};
+    if (encoding_value_ == OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP1)
+      return RegisterRef{RegClass::TTMP, 1, reg_width};
+    if (encoding_value_ == OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP2)
+      return RegisterRef{RegClass::TTMP, 2, reg_width};
+    if (encoding_value_ == OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP3)
+      return RegisterRef{RegClass::TTMP, 3, reg_width};
+    if (encoding_value_ == OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP4)
+      return RegisterRef{RegClass::TTMP, 4, reg_width};
+    if (encoding_value_ == OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP5)
+      return RegisterRef{RegClass::TTMP, 5, reg_width};
+    if (encoding_value_ == OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP6)
+      return RegisterRef{RegClass::TTMP, 6, reg_width};
+    if (encoding_value_ == OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP7)
+      return RegisterRef{RegClass::TTMP, 7, reg_width};
+    if (encoding_value_ == OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP8)
+      return RegisterRef{RegClass::TTMP, 8, reg_width};
+    if (encoding_value_ == OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP9)
+      return RegisterRef{RegClass::TTMP, 9, reg_width};
+    if (encoding_value_ == OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP10)
+      return RegisterRef{RegClass::TTMP, 10, reg_width};
+    if (encoding_value_ == OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP11)
+      return RegisterRef{RegClass::TTMP, 11, reg_width};
+    if (encoding_value_ == OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP12)
+      return RegisterRef{RegClass::TTMP, 12, reg_width};
+    if (encoding_value_ == OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP13)
+      return RegisterRef{RegClass::TTMP, 13, reg_width};
+    if (encoding_value_ == OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP14)
+      return RegisterRef{RegClass::TTMP, 14, reg_width};
+    if (encoding_value_ == OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP15)
+      return RegisterRef{RegClass::TTMP, 15, reg_width};
     break;
   }
   case OperandType::OPR_SMEM_OFFSET_NOK: {
@@ -1085,6 +1149,38 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSmemOffsetNok::OPR_SMEM_OFFSET_NOK_SGPR_MIN),
           reg_width};
+    if (encoding_value_ == OpSelSmemOffsetNok::OPR_SMEM_OFFSET_NOK_TTMP0)
+      return RegisterRef{RegClass::TTMP, 0, reg_width};
+    if (encoding_value_ == OpSelSmemOffsetNok::OPR_SMEM_OFFSET_NOK_TTMP1)
+      return RegisterRef{RegClass::TTMP, 1, reg_width};
+    if (encoding_value_ == OpSelSmemOffsetNok::OPR_SMEM_OFFSET_NOK_TTMP2)
+      return RegisterRef{RegClass::TTMP, 2, reg_width};
+    if (encoding_value_ == OpSelSmemOffsetNok::OPR_SMEM_OFFSET_NOK_TTMP3)
+      return RegisterRef{RegClass::TTMP, 3, reg_width};
+    if (encoding_value_ == OpSelSmemOffsetNok::OPR_SMEM_OFFSET_NOK_TTMP4)
+      return RegisterRef{RegClass::TTMP, 4, reg_width};
+    if (encoding_value_ == OpSelSmemOffsetNok::OPR_SMEM_OFFSET_NOK_TTMP5)
+      return RegisterRef{RegClass::TTMP, 5, reg_width};
+    if (encoding_value_ == OpSelSmemOffsetNok::OPR_SMEM_OFFSET_NOK_TTMP6)
+      return RegisterRef{RegClass::TTMP, 6, reg_width};
+    if (encoding_value_ == OpSelSmemOffsetNok::OPR_SMEM_OFFSET_NOK_TTMP7)
+      return RegisterRef{RegClass::TTMP, 7, reg_width};
+    if (encoding_value_ == OpSelSmemOffsetNok::OPR_SMEM_OFFSET_NOK_TTMP8)
+      return RegisterRef{RegClass::TTMP, 8, reg_width};
+    if (encoding_value_ == OpSelSmemOffsetNok::OPR_SMEM_OFFSET_NOK_TTMP9)
+      return RegisterRef{RegClass::TTMP, 9, reg_width};
+    if (encoding_value_ == OpSelSmemOffsetNok::OPR_SMEM_OFFSET_NOK_TTMP10)
+      return RegisterRef{RegClass::TTMP, 10, reg_width};
+    if (encoding_value_ == OpSelSmemOffsetNok::OPR_SMEM_OFFSET_NOK_TTMP11)
+      return RegisterRef{RegClass::TTMP, 11, reg_width};
+    if (encoding_value_ == OpSelSmemOffsetNok::OPR_SMEM_OFFSET_NOK_TTMP12)
+      return RegisterRef{RegClass::TTMP, 12, reg_width};
+    if (encoding_value_ == OpSelSmemOffsetNok::OPR_SMEM_OFFSET_NOK_TTMP13)
+      return RegisterRef{RegClass::TTMP, 13, reg_width};
+    if (encoding_value_ == OpSelSmemOffsetNok::OPR_SMEM_OFFSET_NOK_TTMP14)
+      return RegisterRef{RegClass::TTMP, 14, reg_width};
+    if (encoding_value_ == OpSelSmemOffsetNok::OPR_SMEM_OFFSET_NOK_TTMP15)
+      return RegisterRef{RegClass::TTMP, 15, reg_width};
     break;
   }
   case OperandType::OPR_SRC: {
@@ -1093,6 +1189,38 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSrc::OPR_SRC_SGPR_MIN),
                          reg_width};
+    if (encoding_value_ == OpSelSrc::OPR_SRC_TTMP0)
+      return RegisterRef{RegClass::TTMP, 0, reg_width};
+    if (encoding_value_ == OpSelSrc::OPR_SRC_TTMP1)
+      return RegisterRef{RegClass::TTMP, 1, reg_width};
+    if (encoding_value_ == OpSelSrc::OPR_SRC_TTMP2)
+      return RegisterRef{RegClass::TTMP, 2, reg_width};
+    if (encoding_value_ == OpSelSrc::OPR_SRC_TTMP3)
+      return RegisterRef{RegClass::TTMP, 3, reg_width};
+    if (encoding_value_ == OpSelSrc::OPR_SRC_TTMP4)
+      return RegisterRef{RegClass::TTMP, 4, reg_width};
+    if (encoding_value_ == OpSelSrc::OPR_SRC_TTMP5)
+      return RegisterRef{RegClass::TTMP, 5, reg_width};
+    if (encoding_value_ == OpSelSrc::OPR_SRC_TTMP6)
+      return RegisterRef{RegClass::TTMP, 6, reg_width};
+    if (encoding_value_ == OpSelSrc::OPR_SRC_TTMP7)
+      return RegisterRef{RegClass::TTMP, 7, reg_width};
+    if (encoding_value_ == OpSelSrc::OPR_SRC_TTMP8)
+      return RegisterRef{RegClass::TTMP, 8, reg_width};
+    if (encoding_value_ == OpSelSrc::OPR_SRC_TTMP9)
+      return RegisterRef{RegClass::TTMP, 9, reg_width};
+    if (encoding_value_ == OpSelSrc::OPR_SRC_TTMP10)
+      return RegisterRef{RegClass::TTMP, 10, reg_width};
+    if (encoding_value_ == OpSelSrc::OPR_SRC_TTMP11)
+      return RegisterRef{RegClass::TTMP, 11, reg_width};
+    if (encoding_value_ == OpSelSrc::OPR_SRC_TTMP12)
+      return RegisterRef{RegClass::TTMP, 12, reg_width};
+    if (encoding_value_ == OpSelSrc::OPR_SRC_TTMP13)
+      return RegisterRef{RegClass::TTMP, 13, reg_width};
+    if (encoding_value_ == OpSelSrc::OPR_SRC_TTMP14)
+      return RegisterRef{RegClass::TTMP, 14, reg_width};
+    if (encoding_value_ == OpSelSrc::OPR_SRC_TTMP15)
+      return RegisterRef{RegClass::TTMP, 15, reg_width};
     if (encoding_value_ == OpSelSrc::OPR_SRC_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
     if (encoding_value_ == OpSelSrc::OPR_SRC_EXEC_HI)
@@ -1111,6 +1239,38 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSrcNoinline::OPR_SRC_NOINLINE_SGPR_MIN),
           reg_width};
+    if (encoding_value_ == OpSelSrcNoinline::OPR_SRC_NOINLINE_TTMP0)
+      return RegisterRef{RegClass::TTMP, 0, reg_width};
+    if (encoding_value_ == OpSelSrcNoinline::OPR_SRC_NOINLINE_TTMP1)
+      return RegisterRef{RegClass::TTMP, 1, reg_width};
+    if (encoding_value_ == OpSelSrcNoinline::OPR_SRC_NOINLINE_TTMP2)
+      return RegisterRef{RegClass::TTMP, 2, reg_width};
+    if (encoding_value_ == OpSelSrcNoinline::OPR_SRC_NOINLINE_TTMP3)
+      return RegisterRef{RegClass::TTMP, 3, reg_width};
+    if (encoding_value_ == OpSelSrcNoinline::OPR_SRC_NOINLINE_TTMP4)
+      return RegisterRef{RegClass::TTMP, 4, reg_width};
+    if (encoding_value_ == OpSelSrcNoinline::OPR_SRC_NOINLINE_TTMP5)
+      return RegisterRef{RegClass::TTMP, 5, reg_width};
+    if (encoding_value_ == OpSelSrcNoinline::OPR_SRC_NOINLINE_TTMP6)
+      return RegisterRef{RegClass::TTMP, 6, reg_width};
+    if (encoding_value_ == OpSelSrcNoinline::OPR_SRC_NOINLINE_TTMP7)
+      return RegisterRef{RegClass::TTMP, 7, reg_width};
+    if (encoding_value_ == OpSelSrcNoinline::OPR_SRC_NOINLINE_TTMP8)
+      return RegisterRef{RegClass::TTMP, 8, reg_width};
+    if (encoding_value_ == OpSelSrcNoinline::OPR_SRC_NOINLINE_TTMP9)
+      return RegisterRef{RegClass::TTMP, 9, reg_width};
+    if (encoding_value_ == OpSelSrcNoinline::OPR_SRC_NOINLINE_TTMP10)
+      return RegisterRef{RegClass::TTMP, 10, reg_width};
+    if (encoding_value_ == OpSelSrcNoinline::OPR_SRC_NOINLINE_TTMP11)
+      return RegisterRef{RegClass::TTMP, 11, reg_width};
+    if (encoding_value_ == OpSelSrcNoinline::OPR_SRC_NOINLINE_TTMP12)
+      return RegisterRef{RegClass::TTMP, 12, reg_width};
+    if (encoding_value_ == OpSelSrcNoinline::OPR_SRC_NOINLINE_TTMP13)
+      return RegisterRef{RegClass::TTMP, 13, reg_width};
+    if (encoding_value_ == OpSelSrcNoinline::OPR_SRC_NOINLINE_TTMP14)
+      return RegisterRef{RegClass::TTMP, 14, reg_width};
+    if (encoding_value_ == OpSelSrcNoinline::OPR_SRC_NOINLINE_TTMP15)
+      return RegisterRef{RegClass::TTMP, 15, reg_width};
     if (encoding_value_ == OpSelSrcNoinline::OPR_SRC_NOINLINE_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
     if (encoding_value_ == OpSelSrcNoinline::OPR_SRC_NOINLINE_EXEC_HI)
@@ -1130,6 +1290,38 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSrcSimple::OPR_SRC_SIMPLE_SGPR_MIN),
           reg_width};
+    if (encoding_value_ == OpSelSrcSimple::OPR_SRC_SIMPLE_TTMP0)
+      return RegisterRef{RegClass::TTMP, 0, reg_width};
+    if (encoding_value_ == OpSelSrcSimple::OPR_SRC_SIMPLE_TTMP1)
+      return RegisterRef{RegClass::TTMP, 1, reg_width};
+    if (encoding_value_ == OpSelSrcSimple::OPR_SRC_SIMPLE_TTMP2)
+      return RegisterRef{RegClass::TTMP, 2, reg_width};
+    if (encoding_value_ == OpSelSrcSimple::OPR_SRC_SIMPLE_TTMP3)
+      return RegisterRef{RegClass::TTMP, 3, reg_width};
+    if (encoding_value_ == OpSelSrcSimple::OPR_SRC_SIMPLE_TTMP4)
+      return RegisterRef{RegClass::TTMP, 4, reg_width};
+    if (encoding_value_ == OpSelSrcSimple::OPR_SRC_SIMPLE_TTMP5)
+      return RegisterRef{RegClass::TTMP, 5, reg_width};
+    if (encoding_value_ == OpSelSrcSimple::OPR_SRC_SIMPLE_TTMP6)
+      return RegisterRef{RegClass::TTMP, 6, reg_width};
+    if (encoding_value_ == OpSelSrcSimple::OPR_SRC_SIMPLE_TTMP7)
+      return RegisterRef{RegClass::TTMP, 7, reg_width};
+    if (encoding_value_ == OpSelSrcSimple::OPR_SRC_SIMPLE_TTMP8)
+      return RegisterRef{RegClass::TTMP, 8, reg_width};
+    if (encoding_value_ == OpSelSrcSimple::OPR_SRC_SIMPLE_TTMP9)
+      return RegisterRef{RegClass::TTMP, 9, reg_width};
+    if (encoding_value_ == OpSelSrcSimple::OPR_SRC_SIMPLE_TTMP10)
+      return RegisterRef{RegClass::TTMP, 10, reg_width};
+    if (encoding_value_ == OpSelSrcSimple::OPR_SRC_SIMPLE_TTMP11)
+      return RegisterRef{RegClass::TTMP, 11, reg_width};
+    if (encoding_value_ == OpSelSrcSimple::OPR_SRC_SIMPLE_TTMP12)
+      return RegisterRef{RegClass::TTMP, 12, reg_width};
+    if (encoding_value_ == OpSelSrcSimple::OPR_SRC_SIMPLE_TTMP13)
+      return RegisterRef{RegClass::TTMP, 13, reg_width};
+    if (encoding_value_ == OpSelSrcSimple::OPR_SRC_SIMPLE_TTMP14)
+      return RegisterRef{RegClass::TTMP, 14, reg_width};
+    if (encoding_value_ == OpSelSrcSimple::OPR_SRC_SIMPLE_TTMP15)
+      return RegisterRef{RegClass::TTMP, 15, reg_width};
     if (encoding_value_ == OpSelSrcSimple::OPR_SRC_SIMPLE_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
     if (encoding_value_ == OpSelSrcSimple::OPR_SRC_SIMPLE_EXEC_HI)
@@ -1166,6 +1358,38 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSreg::OPR_SREG_SGPR_MIN),
                          reg_width};
+    if (encoding_value_ == OpSelSreg::OPR_SREG_TTMP0)
+      return RegisterRef{RegClass::TTMP, 0, reg_width};
+    if (encoding_value_ == OpSelSreg::OPR_SREG_TTMP1)
+      return RegisterRef{RegClass::TTMP, 1, reg_width};
+    if (encoding_value_ == OpSelSreg::OPR_SREG_TTMP2)
+      return RegisterRef{RegClass::TTMP, 2, reg_width};
+    if (encoding_value_ == OpSelSreg::OPR_SREG_TTMP3)
+      return RegisterRef{RegClass::TTMP, 3, reg_width};
+    if (encoding_value_ == OpSelSreg::OPR_SREG_TTMP4)
+      return RegisterRef{RegClass::TTMP, 4, reg_width};
+    if (encoding_value_ == OpSelSreg::OPR_SREG_TTMP5)
+      return RegisterRef{RegClass::TTMP, 5, reg_width};
+    if (encoding_value_ == OpSelSreg::OPR_SREG_TTMP6)
+      return RegisterRef{RegClass::TTMP, 6, reg_width};
+    if (encoding_value_ == OpSelSreg::OPR_SREG_TTMP7)
+      return RegisterRef{RegClass::TTMP, 7, reg_width};
+    if (encoding_value_ == OpSelSreg::OPR_SREG_TTMP8)
+      return RegisterRef{RegClass::TTMP, 8, reg_width};
+    if (encoding_value_ == OpSelSreg::OPR_SREG_TTMP9)
+      return RegisterRef{RegClass::TTMP, 9, reg_width};
+    if (encoding_value_ == OpSelSreg::OPR_SREG_TTMP10)
+      return RegisterRef{RegClass::TTMP, 10, reg_width};
+    if (encoding_value_ == OpSelSreg::OPR_SREG_TTMP11)
+      return RegisterRef{RegClass::TTMP, 11, reg_width};
+    if (encoding_value_ == OpSelSreg::OPR_SREG_TTMP12)
+      return RegisterRef{RegClass::TTMP, 12, reg_width};
+    if (encoding_value_ == OpSelSreg::OPR_SREG_TTMP13)
+      return RegisterRef{RegClass::TTMP, 13, reg_width};
+    if (encoding_value_ == OpSelSreg::OPR_SREG_TTMP14)
+      return RegisterRef{RegClass::TTMP, 14, reg_width};
+    if (encoding_value_ == OpSelSreg::OPR_SREG_TTMP15)
+      return RegisterRef{RegClass::TTMP, 15, reg_width};
     break;
   }
   case OperandType::OPR_SREG_M0: {
@@ -1174,6 +1398,38 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSregM0::OPR_SREG_M0_SGPR_MIN),
                          reg_width};
+    if (encoding_value_ == OpSelSregM0::OPR_SREG_M0_TTMP0)
+      return RegisterRef{RegClass::TTMP, 0, reg_width};
+    if (encoding_value_ == OpSelSregM0::OPR_SREG_M0_TTMP1)
+      return RegisterRef{RegClass::TTMP, 1, reg_width};
+    if (encoding_value_ == OpSelSregM0::OPR_SREG_M0_TTMP2)
+      return RegisterRef{RegClass::TTMP, 2, reg_width};
+    if (encoding_value_ == OpSelSregM0::OPR_SREG_M0_TTMP3)
+      return RegisterRef{RegClass::TTMP, 3, reg_width};
+    if (encoding_value_ == OpSelSregM0::OPR_SREG_M0_TTMP4)
+      return RegisterRef{RegClass::TTMP, 4, reg_width};
+    if (encoding_value_ == OpSelSregM0::OPR_SREG_M0_TTMP5)
+      return RegisterRef{RegClass::TTMP, 5, reg_width};
+    if (encoding_value_ == OpSelSregM0::OPR_SREG_M0_TTMP6)
+      return RegisterRef{RegClass::TTMP, 6, reg_width};
+    if (encoding_value_ == OpSelSregM0::OPR_SREG_M0_TTMP7)
+      return RegisterRef{RegClass::TTMP, 7, reg_width};
+    if (encoding_value_ == OpSelSregM0::OPR_SREG_M0_TTMP8)
+      return RegisterRef{RegClass::TTMP, 8, reg_width};
+    if (encoding_value_ == OpSelSregM0::OPR_SREG_M0_TTMP9)
+      return RegisterRef{RegClass::TTMP, 9, reg_width};
+    if (encoding_value_ == OpSelSregM0::OPR_SREG_M0_TTMP10)
+      return RegisterRef{RegClass::TTMP, 10, reg_width};
+    if (encoding_value_ == OpSelSregM0::OPR_SREG_M0_TTMP11)
+      return RegisterRef{RegClass::TTMP, 11, reg_width};
+    if (encoding_value_ == OpSelSregM0::OPR_SREG_M0_TTMP12)
+      return RegisterRef{RegClass::TTMP, 12, reg_width};
+    if (encoding_value_ == OpSelSregM0::OPR_SREG_M0_TTMP13)
+      return RegisterRef{RegClass::TTMP, 13, reg_width};
+    if (encoding_value_ == OpSelSregM0::OPR_SREG_M0_TTMP14)
+      return RegisterRef{RegClass::TTMP, 14, reg_width};
+    if (encoding_value_ == OpSelSregM0::OPR_SREG_M0_TTMP15)
+      return RegisterRef{RegClass::TTMP, 15, reg_width};
     break;
   }
   case OperandType::OPR_SSRC: {
@@ -1182,6 +1438,38 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSsrc::OPR_SSRC_SGPR_MIN),
                          reg_width};
+    if (encoding_value_ == OpSelSsrc::OPR_SSRC_TTMP0)
+      return RegisterRef{RegClass::TTMP, 0, reg_width};
+    if (encoding_value_ == OpSelSsrc::OPR_SSRC_TTMP1)
+      return RegisterRef{RegClass::TTMP, 1, reg_width};
+    if (encoding_value_ == OpSelSsrc::OPR_SSRC_TTMP2)
+      return RegisterRef{RegClass::TTMP, 2, reg_width};
+    if (encoding_value_ == OpSelSsrc::OPR_SSRC_TTMP3)
+      return RegisterRef{RegClass::TTMP, 3, reg_width};
+    if (encoding_value_ == OpSelSsrc::OPR_SSRC_TTMP4)
+      return RegisterRef{RegClass::TTMP, 4, reg_width};
+    if (encoding_value_ == OpSelSsrc::OPR_SSRC_TTMP5)
+      return RegisterRef{RegClass::TTMP, 5, reg_width};
+    if (encoding_value_ == OpSelSsrc::OPR_SSRC_TTMP6)
+      return RegisterRef{RegClass::TTMP, 6, reg_width};
+    if (encoding_value_ == OpSelSsrc::OPR_SSRC_TTMP7)
+      return RegisterRef{RegClass::TTMP, 7, reg_width};
+    if (encoding_value_ == OpSelSsrc::OPR_SSRC_TTMP8)
+      return RegisterRef{RegClass::TTMP, 8, reg_width};
+    if (encoding_value_ == OpSelSsrc::OPR_SSRC_TTMP9)
+      return RegisterRef{RegClass::TTMP, 9, reg_width};
+    if (encoding_value_ == OpSelSsrc::OPR_SSRC_TTMP10)
+      return RegisterRef{RegClass::TTMP, 10, reg_width};
+    if (encoding_value_ == OpSelSsrc::OPR_SSRC_TTMP11)
+      return RegisterRef{RegClass::TTMP, 11, reg_width};
+    if (encoding_value_ == OpSelSsrc::OPR_SSRC_TTMP12)
+      return RegisterRef{RegClass::TTMP, 12, reg_width};
+    if (encoding_value_ == OpSelSsrc::OPR_SSRC_TTMP13)
+      return RegisterRef{RegClass::TTMP, 13, reg_width};
+    if (encoding_value_ == OpSelSsrc::OPR_SSRC_TTMP14)
+      return RegisterRef{RegClass::TTMP, 14, reg_width};
+    if (encoding_value_ == OpSelSsrc::OPR_SSRC_TTMP15)
+      return RegisterRef{RegClass::TTMP, 15, reg_width};
     if (encoding_value_ == OpSelSsrc::OPR_SSRC_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
     if (encoding_value_ == OpSelSsrc::OPR_SSRC_EXEC_HI)
@@ -1198,6 +1486,38 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSsrcLanesel::OPR_SSRC_LANESEL_SGPR_MIN),
           reg_width};
+    if (encoding_value_ == OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP0)
+      return RegisterRef{RegClass::TTMP, 0, reg_width};
+    if (encoding_value_ == OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP1)
+      return RegisterRef{RegClass::TTMP, 1, reg_width};
+    if (encoding_value_ == OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP2)
+      return RegisterRef{RegClass::TTMP, 2, reg_width};
+    if (encoding_value_ == OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP3)
+      return RegisterRef{RegClass::TTMP, 3, reg_width};
+    if (encoding_value_ == OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP4)
+      return RegisterRef{RegClass::TTMP, 4, reg_width};
+    if (encoding_value_ == OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP5)
+      return RegisterRef{RegClass::TTMP, 5, reg_width};
+    if (encoding_value_ == OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP6)
+      return RegisterRef{RegClass::TTMP, 6, reg_width};
+    if (encoding_value_ == OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP7)
+      return RegisterRef{RegClass::TTMP, 7, reg_width};
+    if (encoding_value_ == OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP8)
+      return RegisterRef{RegClass::TTMP, 8, reg_width};
+    if (encoding_value_ == OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP9)
+      return RegisterRef{RegClass::TTMP, 9, reg_width};
+    if (encoding_value_ == OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP10)
+      return RegisterRef{RegClass::TTMP, 10, reg_width};
+    if (encoding_value_ == OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP11)
+      return RegisterRef{RegClass::TTMP, 11, reg_width};
+    if (encoding_value_ == OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP12)
+      return RegisterRef{RegClass::TTMP, 12, reg_width};
+    if (encoding_value_ == OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP13)
+      return RegisterRef{RegClass::TTMP, 13, reg_width};
+    if (encoding_value_ == OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP14)
+      return RegisterRef{RegClass::TTMP, 14, reg_width};
+    if (encoding_value_ == OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP15)
+      return RegisterRef{RegClass::TTMP, 15, reg_width};
     break;
   }
   case OperandType::OPR_SSRC_SPECIAL_SCC: {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/operand_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/operand_exec.cpp
@@ -144,7 +144,7 @@ void Operand::read_lane_chunk_exec(const amdgpu::Wavefront &wf, uint32_t lane_ba
     uint64_t lane_mask =
         count == 0 ? 0 : util::mask<uint64_t>(static_cast<int>(count)) << lane_base;
     auto region =
-        amdgpu::RegisterAccess(wf.cu()).read_vgpr_region(wf.vgpr_alloc().base + voff, 1, lane_mask);
+        amdgpu::RegisterAccess(wf).read_vgpr_region(wf.vgpr_alloc().base + voff, 1, lane_mask);
     std::copy_n(region.lanes().begin() + lane_base, count, out);
     return;
   }
@@ -174,6 +174,8 @@ void Operand::write_lane_chunk_exec(amdgpu::Wavefront &wf, uint32_t lane_base, u
       vgpr_msb_role() == amdgpu::VgprMsbRole::None ? amdgpu::VgprMsbRole::Dst : vgpr_msb_role();
   uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, role);
   uint32_t reg = wf.vgpr_alloc().base + voff;
+  if (!amdgpu::OperandExecutionAccess::raw_compute_unit(wf.cu()).owns_vgpr_range(wf, reg, 1))
+    return;
   uint64_t full_mask = util::mask<uint64_t>(static_cast<int>(count));
   uint8_t *dst = amdgpu::OperandExecutionAccess::raw_compute_unit(wf.cu()).raw_vgpr_data(reg);
   if ((mask & full_mask) == full_mask) {
@@ -217,12 +219,12 @@ uint32_t Operand::read_lane_exec(const amdgpu::Wavefront &wf, uint32_t lane) con
     uint8_t byte_mask = packed->shift ? rocjitsu::ExecutionPlugin::kHighHalfByteMask
                                       : rocjitsu::ExecutionPlugin::kLowHalfByteMask;
     uint32_t raw =
-        amdgpu::RegisterAccess(wf.cu()).read_vgpr(wf.vgpr_alloc().base + voff, lane, byte_mask);
+        amdgpu::RegisterAccess(wf).read_vgpr(wf.vgpr_alloc().base + voff, lane, byte_mask);
     return (raw >> packed->shift) & 0xffffu;
   }
   if (auto off = Isa::resolved_vgpr_offset(wf, opr_type_, ev, vgpr_msb_role())) {
     uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, vgpr_msb_role());
-    return amdgpu::RegisterAccess(wf.cu()).read_vgpr(wf.vgpr_alloc().base + voff, lane);
+    return amdgpu::RegisterAccess(wf).read_vgpr(wf.vgpr_alloc().base + voff, lane);
   }
   if (is_immediate_type(opr_type_))
     return static_cast<uint32_t>(ev);
@@ -258,14 +260,14 @@ void Operand::write_lane_exec(amdgpu::Wavefront &wf, uint32_t lane, uint32_t val
     uint8_t write_byte_mask = packed->shift ? rocjitsu::ExecutionPlugin::kHighHalfByteMask
                                             : rocjitsu::ExecutionPlugin::kLowHalfByteMask;
     uint32_t placed = (val & 0xffffu) << packed->shift;
-    amdgpu::RegisterAccess(wf.cu()).write_vgpr(idx, lane, placed, write_byte_mask);
+    amdgpu::RegisterAccess(wf).write_vgpr(idx, lane, placed, write_byte_mask);
     return;
   }
   if (auto off = Isa::resolved_vgpr_offset(wf, opr_type_, encoding_value_, vgpr_msb_role())) {
     amdgpu::VgprMsbRole role =
         vgpr_msb_role() == amdgpu::VgprMsbRole::None ? amdgpu::VgprMsbRole::Dst : vgpr_msb_role();
     uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, role);
-    amdgpu::RegisterAccess(wf.cu()).write_vgpr(wf.vgpr_alloc().base + voff, lane, val);
+    amdgpu::RegisterAccess(wf).write_vgpr(wf.vgpr_alloc().base + voff, lane, val);
     return;
   }
   throw std::logic_error("write_lane called on non-VGPR operand type");
@@ -284,7 +286,7 @@ uint64_t Operand::read_lane64_exec(const amdgpu::Wavefront &wf, uint32_t lane) c
   if (auto off = Isa::resolved_vgpr_offset(wf, opr_type_, ev, vgpr_msb_role())) {
     uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, vgpr_msb_role());
     uint32_t idx = wf.vgpr_alloc().base + voff;
-    return amdgpu::RegisterAccess(wf.cu()).read_vgpr64(idx, lane);
+    return amdgpu::RegisterAccess(wf).read_vgpr64(idx, lane);
   }
   if (literal32_widening_)
     return widened_literal32_value();
@@ -307,7 +309,7 @@ void Operand::write_lane64_exec(amdgpu::Wavefront &wf, uint32_t lane, uint64_t v
         vgpr_msb_role() == amdgpu::VgprMsbRole::None ? amdgpu::VgprMsbRole::Dst : vgpr_msb_role();
     uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, role);
     uint32_t idx = wf.vgpr_alloc().base + voff;
-    amdgpu::RegisterAccess(wf.cu()).write_vgpr64(idx, lane, val);
+    amdgpu::RegisterAccess(wf).write_vgpr64(idx, lane, val);
     return;
   }
   throw std::logic_error("write_lane64 called on non-VGPR operand type");

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/smem_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/smem_exec.cpp
@@ -7,6 +7,7 @@
 #include "rocjitsu/isa/arch/amdgpu/cdna5/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/smem.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx12_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"
@@ -24,282 +25,382 @@ namespace rocjitsu {
 namespace cdna5 {
 
 void SLoadB32Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
+  auto address = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadB64Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 2u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 2;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
+  auto address = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadB128Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 4u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 4;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
+  auto address = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadB256Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 8u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 8;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
+  auto address = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadB512Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 16u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 16;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
+  auto address = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadB96Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 3u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 3;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
+  auto address = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadI8Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 1;
   d->sign_extend = true;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
+  auto address = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadU8Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 1;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
+  auto address = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadI16Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 2;
   d->sign_extend = true;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
+  auto address = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadU16Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 2;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
+  auto address = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadB32Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
+  auto address = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadB64Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 2u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 2;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
+  auto address = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadB128Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 4u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 4;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
+  auto address = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadB256Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 8u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 8;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
+  auto address = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadB512Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 16u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 16;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
+  auto address = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadB96Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 3u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 3;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
+  auto address = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadI8Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 1;
   d->sign_extend = true;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
+  auto address = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadU8Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 1;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
+  auto address = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadI16Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 2;
   d->sign_extend = true;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
+  auto address = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadU16Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 2;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
+  auto address = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vbuffer_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vbuffer_exec.cpp
@@ -7,6 +7,7 @@
 #include "rocjitsu/isa/arch/amdgpu/cdna5/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/vbuffer.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx12_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vds_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vds_exec.cpp
@@ -8,6 +8,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/vds.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx12_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vflat_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vflat_exec.cpp
@@ -7,6 +7,7 @@
 #include "rocjitsu/isa/arch/amdgpu/cdna5/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/vflat.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx12_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vglobal_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vglobal_exec.cpp
@@ -7,6 +7,7 @@
 #include "rocjitsu/isa/arch/amdgpu/cdna5/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/vglobal.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx12_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3_exec_cvt.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3_exec_cvt.cpp
@@ -1852,14 +1852,19 @@ void VCvtScalef32SrPk8Fp4F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
-    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src2, lane));
-    uint32_t seed = static_cast<uint32_t>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
     uint32_t src_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 8u) || !regs.owns_vgpr_range(dst_base, 1u))
+      continue;
+    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src2, lane));
+    uint32_t seed = static_cast<uint32_t>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
+    auto src_region = regs.read_vgpr_region(src_base, 8u, 1ULL << lane);
+    auto dst_region = regs.write_vgpr_region(dst_base, 1u, 1ULL << lane);
     uint32_t src_words[8] = {};
     for (uint32_t word = 0; word < 8u; ++word)
-      src_words[word] = amdgpu::RegisterAccess(wf.cu()).read_vgpr(src_base + word, lane);
+      src_words[word] = src_region.lane(word, lane);
     auto read_scaled_input = [&](uint32_t index) -> float {
       return std::bit_cast<float>(src_words[index]);
     };
@@ -1879,7 +1884,7 @@ void VCvtScalef32SrPk8Fp4F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
       seed = util::prng_advance(seed);
     }
     for (uint32_t word = 0; word < 1u; ++word)
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);
+      dst_region.set_lane(word, lane, dst_words[word]);
   }
 }
 
@@ -1891,14 +1896,19 @@ void VCvtScalef32SrPk8Fp8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
-    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src2, lane));
-    uint32_t seed = static_cast<uint32_t>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
     uint32_t src_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 8u) || !regs.owns_vgpr_range(dst_base, 2u))
+      continue;
+    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src2, lane));
+    uint32_t seed = static_cast<uint32_t>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
+    auto src_region = regs.read_vgpr_region(src_base, 8u, 1ULL << lane);
+    auto dst_region = regs.write_vgpr_region(dst_base, 2u, 1ULL << lane);
     uint32_t src_words[8] = {};
     for (uint32_t word = 0; word < 8u; ++word)
-      src_words[word] = amdgpu::RegisterAccess(wf.cu()).read_vgpr(src_base + word, lane);
+      src_words[word] = src_region.lane(word, lane);
     auto read_scaled_input = [&](uint32_t index) -> float {
       return std::bit_cast<float>(src_words[index]);
     };
@@ -1918,7 +1928,7 @@ void VCvtScalef32SrPk8Fp8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
       seed = util::prng_advance(seed);
     }
     for (uint32_t word = 0; word < 2u; ++word)
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);
+      dst_region.set_lane(word, lane, dst_words[word]);
   }
 }
 
@@ -1930,14 +1940,19 @@ void VCvtScalef32SrPk8Bf8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
-    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src2, lane));
-    uint32_t seed = static_cast<uint32_t>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
     uint32_t src_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 8u) || !regs.owns_vgpr_range(dst_base, 2u))
+      continue;
+    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src2, lane));
+    uint32_t seed = static_cast<uint32_t>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
+    auto src_region = regs.read_vgpr_region(src_base, 8u, 1ULL << lane);
+    auto dst_region = regs.write_vgpr_region(dst_base, 2u, 1ULL << lane);
     uint32_t src_words[8] = {};
     for (uint32_t word = 0; word < 8u; ++word)
-      src_words[word] = amdgpu::RegisterAccess(wf.cu()).read_vgpr(src_base + word, lane);
+      src_words[word] = src_region.lane(word, lane);
     auto read_scaled_input = [&](uint32_t index) -> float {
       return std::bit_cast<float>(src_words[index]);
     };
@@ -1957,7 +1972,7 @@ void VCvtScalef32SrPk8Bf8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
       seed = util::prng_advance(seed);
     }
     for (uint32_t word = 0; word < 2u; ++word)
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);
+      dst_region.set_lane(word, lane, dst_words[word]);
   }
 }
 
@@ -1969,21 +1984,29 @@ void VCvtScalePk8F16Fp4Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
+    uint32_t src_base =
+        wf.vgpr_alloc().base +
+        *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 1u) || !regs.owns_vgpr_range(dst_base, 4u))
+      continue;
     uint32_t scale_payload = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
     uint32_t scale_byte = (scale_payload >> ((inst_.opsel & 0x3u) * 8u)) & 0xffu;
     float scale = util::e8m0_to_f32(static_cast<uint8_t>(scale_byte));
-    uint32_t src_payload = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
+    auto src_region = regs.read_vgpr_region(src_base, 1u, 1ULL << lane);
+    uint32_t src_payload = src_region.lane(0, lane);
     auto read_scaled_src = [&](uint32_t index) -> float {
       uint32_t raw = (src_payload >> (index * 4u)) & 0xfu;
       return util::fp4_e2m1_to_f32(static_cast<uint8_t>(raw));
     };
+    auto dst_region = regs.write_vgpr_region(dst_base, 4u, 1ULL << lane);
     uint32_t dst_words[4] = {};
     for (uint32_t index = 0; index < 8u; ++index) {
       uint32_t bits = util::f32_to_f16_mode(read_scaled_src(index) * scale, wf.fp16_ovfl());
       dst_words[index / 2u] |= bits << ((index & 1u) * 16u);
     }
     for (uint32_t word = 0; word < 4u; ++word)
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);
+      dst_region.set_lane(word, lane, dst_words[word]);
   }
 }
 
@@ -1995,21 +2018,29 @@ void VCvtScalePk8Bf16Fp4Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
+    uint32_t src_base =
+        wf.vgpr_alloc().base +
+        *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 1u) || !regs.owns_vgpr_range(dst_base, 4u))
+      continue;
     uint32_t scale_payload = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
     uint32_t scale_byte = (scale_payload >> ((inst_.opsel & 0x3u) * 8u)) & 0xffu;
     float scale = util::e8m0_to_f32(static_cast<uint8_t>(scale_byte));
-    uint32_t src_payload = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
+    auto src_region = regs.read_vgpr_region(src_base, 1u, 1ULL << lane);
+    uint32_t src_payload = src_region.lane(0, lane);
     auto read_scaled_src = [&](uint32_t index) -> float {
       uint32_t raw = (src_payload >> (index * 4u)) & 0xfu;
       return util::fp4_e2m1_to_f32(static_cast<uint8_t>(raw));
     };
+    auto dst_region = regs.write_vgpr_region(dst_base, 4u, 1ULL << lane);
     uint32_t dst_words[4] = {};
     for (uint32_t index = 0; index < 8u; ++index) {
       uint32_t bits = util::f32_to_bf16_rne_mode(read_scaled_src(index) * scale, wf.fp16_ovfl());
       dst_words[index / 2u] |= bits << ((index & 1u) * 16u);
     }
     for (uint32_t word = 0; word < 4u; ++word)
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);
+      dst_region.set_lane(word, lane, dst_words[word]);
   }
 }
 
@@ -2021,18 +2052,25 @@ void VCvtScalePk8F32Fp4Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
+    uint32_t src_base =
+        wf.vgpr_alloc().base +
+        *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 1u) || !regs.owns_vgpr_range(dst_base, 8u))
+      continue;
     uint32_t scale_payload = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
     uint32_t scale_byte = (scale_payload >> ((inst_.opsel & 0x3u) * 8u)) & 0xffu;
     float scale = util::e8m0_to_f32(static_cast<uint8_t>(scale_byte));
-    uint32_t src_payload = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
+    auto src_region = regs.read_vgpr_region(src_base, 1u, 1ULL << lane);
+    uint32_t src_payload = src_region.lane(0, lane);
     auto read_scaled_src = [&](uint32_t index) -> float {
       uint32_t raw = (src_payload >> (index * 4u)) & 0xfu;
       return util::fp4_e2m1_to_f32(static_cast<uint8_t>(raw));
     };
+    auto dst_region = regs.write_vgpr_region(dst_base, 8u, 1ULL << lane);
     for (uint32_t index = 0; index < 8u; ++index) {
       float value = read_scaled_src(index) * scale;
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + index, lane,
-                                                 std::bit_cast<uint32_t>(value));
+      dst_region.set_lane(index, lane, std::bit_cast<uint32_t>(value));
     }
   }
 }
@@ -2045,21 +2083,29 @@ void VCvtScalePk8F16Fp8Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
+    uint32_t src_base =
+        wf.vgpr_alloc().base +
+        *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 2u) || !regs.owns_vgpr_range(dst_base, 4u))
+      continue;
     uint32_t scale_payload = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
     uint32_t scale_byte = (scale_payload >> ((inst_.opsel & 0x3u) * 8u)) & 0xffu;
     float scale = util::e8m0_to_f32(static_cast<uint8_t>(scale_byte));
-    uint64_t src_payload = amdgpu::RegisterAccess(wf).read_lane64(src0, lane);
+    auto src_region = regs.read_vgpr_region(src_base, 2u, 1ULL << lane);
+    uint64_t src_payload = src_region.lane64(0, lane);
     auto read_scaled_src = [&](uint32_t index) -> float {
       uint32_t raw = static_cast<uint32_t>((src_payload >> (index * 8u)) & 0xffu);
       return util::fp8_e4m3_to_f32(static_cast<uint8_t>(raw));
     };
+    auto dst_region = regs.write_vgpr_region(dst_base, 4u, 1ULL << lane);
     uint32_t dst_words[4] = {};
     for (uint32_t index = 0; index < 8u; ++index) {
       uint32_t bits = util::f32_to_f16_mode(read_scaled_src(index) * scale, wf.fp16_ovfl());
       dst_words[index / 2u] |= bits << ((index & 1u) * 16u);
     }
     for (uint32_t word = 0; word < 4u; ++word)
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);
+      dst_region.set_lane(word, lane, dst_words[word]);
   }
 }
 
@@ -2071,21 +2117,29 @@ void VCvtScalePk8Bf16Fp8Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
+    uint32_t src_base =
+        wf.vgpr_alloc().base +
+        *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 2u) || !regs.owns_vgpr_range(dst_base, 4u))
+      continue;
     uint32_t scale_payload = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
     uint32_t scale_byte = (scale_payload >> ((inst_.opsel & 0x3u) * 8u)) & 0xffu;
     float scale = util::e8m0_to_f32(static_cast<uint8_t>(scale_byte));
-    uint64_t src_payload = amdgpu::RegisterAccess(wf).read_lane64(src0, lane);
+    auto src_region = regs.read_vgpr_region(src_base, 2u, 1ULL << lane);
+    uint64_t src_payload = src_region.lane64(0, lane);
     auto read_scaled_src = [&](uint32_t index) -> float {
       uint32_t raw = static_cast<uint32_t>((src_payload >> (index * 8u)) & 0xffu);
       return util::fp8_e4m3_to_f32(static_cast<uint8_t>(raw));
     };
+    auto dst_region = regs.write_vgpr_region(dst_base, 4u, 1ULL << lane);
     uint32_t dst_words[4] = {};
     for (uint32_t index = 0; index < 8u; ++index) {
       uint32_t bits = util::f32_to_bf16_rne_mode(read_scaled_src(index) * scale, wf.fp16_ovfl());
       dst_words[index / 2u] |= bits << ((index & 1u) * 16u);
     }
     for (uint32_t word = 0; word < 4u; ++word)
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);
+      dst_region.set_lane(word, lane, dst_words[word]);
   }
 }
 
@@ -2097,18 +2151,25 @@ void VCvtScalePk8F32Fp8Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
+    uint32_t src_base =
+        wf.vgpr_alloc().base +
+        *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 2u) || !regs.owns_vgpr_range(dst_base, 8u))
+      continue;
     uint32_t scale_payload = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
     uint32_t scale_byte = (scale_payload >> ((inst_.opsel & 0x3u) * 8u)) & 0xffu;
     float scale = util::e8m0_to_f32(static_cast<uint8_t>(scale_byte));
-    uint64_t src_payload = amdgpu::RegisterAccess(wf).read_lane64(src0, lane);
+    auto src_region = regs.read_vgpr_region(src_base, 2u, 1ULL << lane);
+    uint64_t src_payload = src_region.lane64(0, lane);
     auto read_scaled_src = [&](uint32_t index) -> float {
       uint32_t raw = static_cast<uint32_t>((src_payload >> (index * 8u)) & 0xffu);
       return util::fp8_e4m3_to_f32(static_cast<uint8_t>(raw));
     };
+    auto dst_region = regs.write_vgpr_region(dst_base, 8u, 1ULL << lane);
     for (uint32_t index = 0; index < 8u; ++index) {
       float value = read_scaled_src(index) * scale;
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + index, lane,
-                                                 std::bit_cast<uint32_t>(value));
+      dst_region.set_lane(index, lane, std::bit_cast<uint32_t>(value));
     }
   }
 }
@@ -2121,21 +2182,29 @@ void VCvtScalePk8F16Bf8Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
+    uint32_t src_base =
+        wf.vgpr_alloc().base +
+        *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 2u) || !regs.owns_vgpr_range(dst_base, 4u))
+      continue;
     uint32_t scale_payload = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
     uint32_t scale_byte = (scale_payload >> ((inst_.opsel & 0x3u) * 8u)) & 0xffu;
     float scale = util::e8m0_to_f32(static_cast<uint8_t>(scale_byte));
-    uint64_t src_payload = amdgpu::RegisterAccess(wf).read_lane64(src0, lane);
+    auto src_region = regs.read_vgpr_region(src_base, 2u, 1ULL << lane);
+    uint64_t src_payload = src_region.lane64(0, lane);
     auto read_scaled_src = [&](uint32_t index) -> float {
       uint32_t raw = static_cast<uint32_t>((src_payload >> (index * 8u)) & 0xffu);
       return util::bf8_e5m2_to_f32(static_cast<uint8_t>(raw));
     };
+    auto dst_region = regs.write_vgpr_region(dst_base, 4u, 1ULL << lane);
     uint32_t dst_words[4] = {};
     for (uint32_t index = 0; index < 8u; ++index) {
       uint32_t bits = util::f32_to_f16_mode(read_scaled_src(index) * scale, wf.fp16_ovfl());
       dst_words[index / 2u] |= bits << ((index & 1u) * 16u);
     }
     for (uint32_t word = 0; word < 4u; ++word)
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);
+      dst_region.set_lane(word, lane, dst_words[word]);
   }
 }
 
@@ -2147,21 +2216,29 @@ void VCvtScalePk8Bf16Bf8Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
+    uint32_t src_base =
+        wf.vgpr_alloc().base +
+        *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 2u) || !regs.owns_vgpr_range(dst_base, 4u))
+      continue;
     uint32_t scale_payload = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
     uint32_t scale_byte = (scale_payload >> ((inst_.opsel & 0x3u) * 8u)) & 0xffu;
     float scale = util::e8m0_to_f32(static_cast<uint8_t>(scale_byte));
-    uint64_t src_payload = amdgpu::RegisterAccess(wf).read_lane64(src0, lane);
+    auto src_region = regs.read_vgpr_region(src_base, 2u, 1ULL << lane);
+    uint64_t src_payload = src_region.lane64(0, lane);
     auto read_scaled_src = [&](uint32_t index) -> float {
       uint32_t raw = static_cast<uint32_t>((src_payload >> (index * 8u)) & 0xffu);
       return util::bf8_e5m2_to_f32(static_cast<uint8_t>(raw));
     };
+    auto dst_region = regs.write_vgpr_region(dst_base, 4u, 1ULL << lane);
     uint32_t dst_words[4] = {};
     for (uint32_t index = 0; index < 8u; ++index) {
       uint32_t bits = util::f32_to_bf16_rne_mode(read_scaled_src(index) * scale, wf.fp16_ovfl());
       dst_words[index / 2u] |= bits << ((index & 1u) * 16u);
     }
     for (uint32_t word = 0; word < 4u; ++word)
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);
+      dst_region.set_lane(word, lane, dst_words[word]);
   }
 }
 
@@ -2173,18 +2250,25 @@ void VCvtScalePk8F32Bf8Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
+    uint32_t src_base =
+        wf.vgpr_alloc().base +
+        *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 2u) || !regs.owns_vgpr_range(dst_base, 8u))
+      continue;
     uint32_t scale_payload = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
     uint32_t scale_byte = (scale_payload >> ((inst_.opsel & 0x3u) * 8u)) & 0xffu;
     float scale = util::e8m0_to_f32(static_cast<uint8_t>(scale_byte));
-    uint64_t src_payload = amdgpu::RegisterAccess(wf).read_lane64(src0, lane);
+    auto src_region = regs.read_vgpr_region(src_base, 2u, 1ULL << lane);
+    uint64_t src_payload = src_region.lane64(0, lane);
     auto read_scaled_src = [&](uint32_t index) -> float {
       uint32_t raw = static_cast<uint32_t>((src_payload >> (index * 8u)) & 0xffu);
       return util::bf8_e5m2_to_f32(static_cast<uint8_t>(raw));
     };
+    auto dst_region = regs.write_vgpr_region(dst_base, 8u, 1ULL << lane);
     for (uint32_t index = 0; index < 8u; ++index) {
       float value = read_scaled_src(index) * scale;
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + index, lane,
-                                                 std::bit_cast<uint32_t>(value));
+      dst_region.set_lane(index, lane, std::bit_cast<uint32_t>(value));
     }
   }
 }
@@ -2197,13 +2281,18 @@ void VCvtScalef32Pk8Fp4F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
-    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
     uint32_t src_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 8u) || !regs.owns_vgpr_range(dst_base, 1u))
+      continue;
+    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
+    auto src_region = regs.read_vgpr_region(src_base, 8u, 1ULL << lane);
+    auto dst_region = regs.write_vgpr_region(dst_base, 1u, 1ULL << lane);
     uint32_t src_words[8] = {};
     for (uint32_t word = 0; word < 8u; ++word)
-      src_words[word] = amdgpu::RegisterAccess(wf.cu()).read_vgpr(src_base + word, lane);
+      src_words[word] = src_region.lane(word, lane);
     auto read_scaled_input = [&](uint32_t index) -> float {
       return std::bit_cast<float>(src_words[index]);
     };
@@ -2222,7 +2311,7 @@ void VCvtScalef32Pk8Fp4F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
       pack_scaled_dst(index, util::f32_to_fp4_e2m1_rne(value));
     }
     for (uint32_t word = 0; word < 1u; ++word)
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);
+      dst_region.set_lane(word, lane, dst_words[word]);
   }
 }
 
@@ -2234,13 +2323,18 @@ void VCvtScalef32Pk8Fp4F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
-    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
     uint32_t src_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 4u) || !regs.owns_vgpr_range(dst_base, 1u))
+      continue;
+    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
+    auto src_region = regs.read_vgpr_region(src_base, 4u, 1ULL << lane);
+    auto dst_region = regs.write_vgpr_region(dst_base, 1u, 1ULL << lane);
     uint32_t src_words[4] = {};
     for (uint32_t word = 0; word < 4u; ++word)
-      src_words[word] = amdgpu::RegisterAccess(wf.cu()).read_vgpr(src_base + word, lane);
+      src_words[word] = src_region.lane(word, lane);
     auto read_scaled_input = [&](uint32_t index) -> float {
       uint32_t raw = src_words[index / 2u];
       return util::f16_to_f32(static_cast<uint16_t>(raw >> ((index & 1u) * 16u)));
@@ -2260,7 +2354,7 @@ void VCvtScalef32Pk8Fp4F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
       pack_scaled_dst(index, util::f32_to_fp4_e2m1_rne(value));
     }
     for (uint32_t word = 0; word < 1u; ++word)
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);
+      dst_region.set_lane(word, lane, dst_words[word]);
   }
 }
 
@@ -2272,13 +2366,18 @@ void VCvtScalef32Pk8Fp8Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
-    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
     uint32_t src_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 4u) || !regs.owns_vgpr_range(dst_base, 2u))
+      continue;
+    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
+    auto src_region = regs.read_vgpr_region(src_base, 4u, 1ULL << lane);
+    auto dst_region = regs.write_vgpr_region(dst_base, 2u, 1ULL << lane);
     uint32_t src_words[4] = {};
     for (uint32_t word = 0; word < 4u; ++word)
-      src_words[word] = amdgpu::RegisterAccess(wf.cu()).read_vgpr(src_base + word, lane);
+      src_words[word] = src_region.lane(word, lane);
     auto read_scaled_input = [&](uint32_t index) -> float {
       uint32_t raw = src_words[index / 2u];
       return util::bf16_to_f32(static_cast<uint16_t>(raw >> ((index & 1u) * 16u)));
@@ -2298,7 +2397,7 @@ void VCvtScalef32Pk8Fp8Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
       pack_scaled_dst(index, util::f32_to_fp8_e4m3_rne_mode(value, wf.fp16_ovfl()));
     }
     for (uint32_t word = 0; word < 2u; ++word)
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);
+      dst_region.set_lane(word, lane, dst_words[word]);
   }
 }
 
@@ -2310,13 +2409,18 @@ void VCvtScalef32Pk8Bf8Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
-    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
     uint32_t src_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 4u) || !regs.owns_vgpr_range(dst_base, 2u))
+      continue;
+    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
+    auto src_region = regs.read_vgpr_region(src_base, 4u, 1ULL << lane);
+    auto dst_region = regs.write_vgpr_region(dst_base, 2u, 1ULL << lane);
     uint32_t src_words[4] = {};
     for (uint32_t word = 0; word < 4u; ++word)
-      src_words[word] = amdgpu::RegisterAccess(wf.cu()).read_vgpr(src_base + word, lane);
+      src_words[word] = src_region.lane(word, lane);
     auto read_scaled_input = [&](uint32_t index) -> float {
       uint32_t raw = src_words[index / 2u];
       return util::bf16_to_f32(static_cast<uint16_t>(raw >> ((index & 1u) * 16u)));
@@ -2336,7 +2440,7 @@ void VCvtScalef32Pk8Bf8Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
       pack_scaled_dst(index, util::f32_to_bf8_e5m2_rne_mode(value, wf.fp16_ovfl()));
     }
     for (uint32_t word = 0; word < 2u; ++word)
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);
+      dst_region.set_lane(word, lane, dst_words[word]);
   }
 }
 
@@ -2348,13 +2452,18 @@ void VCvtScalef32Pk8Fp4Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
-    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
     uint32_t src_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 4u) || !regs.owns_vgpr_range(dst_base, 1u))
+      continue;
+    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
+    auto src_region = regs.read_vgpr_region(src_base, 4u, 1ULL << lane);
+    auto dst_region = regs.write_vgpr_region(dst_base, 1u, 1ULL << lane);
     uint32_t src_words[4] = {};
     for (uint32_t word = 0; word < 4u; ++word)
-      src_words[word] = amdgpu::RegisterAccess(wf.cu()).read_vgpr(src_base + word, lane);
+      src_words[word] = src_region.lane(word, lane);
     auto read_scaled_input = [&](uint32_t index) -> float {
       uint32_t raw = src_words[index / 2u];
       return util::bf16_to_f32(static_cast<uint16_t>(raw >> ((index & 1u) * 16u)));
@@ -2374,7 +2483,7 @@ void VCvtScalef32Pk8Fp4Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
       pack_scaled_dst(index, util::f32_to_fp4_e2m1_rne(value));
     }
     for (uint32_t word = 0; word < 1u; ++word)
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);
+      dst_region.set_lane(word, lane, dst_words[word]);
   }
 }
 
@@ -2386,14 +2495,19 @@ void VCvtScalef32SrPk8Fp4F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
-    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src2, lane));
-    uint32_t seed = static_cast<uint32_t>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
     uint32_t src_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 4u) || !regs.owns_vgpr_range(dst_base, 1u))
+      continue;
+    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src2, lane));
+    uint32_t seed = static_cast<uint32_t>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
+    auto src_region = regs.read_vgpr_region(src_base, 4u, 1ULL << lane);
+    auto dst_region = regs.write_vgpr_region(dst_base, 1u, 1ULL << lane);
     uint32_t src_words[4] = {};
     for (uint32_t word = 0; word < 4u; ++word)
-      src_words[word] = amdgpu::RegisterAccess(wf.cu()).read_vgpr(src_base + word, lane);
+      src_words[word] = src_region.lane(word, lane);
     auto read_scaled_input = [&](uint32_t index) -> float {
       uint32_t raw = src_words[index / 2u];
       return util::f16_to_f32(static_cast<uint16_t>(raw >> ((index & 1u) * 16u)));
@@ -2414,7 +2528,7 @@ void VCvtScalef32SrPk8Fp4F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
       seed = util::prng_advance(seed);
     }
     for (uint32_t word = 0; word < 1u; ++word)
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);
+      dst_region.set_lane(word, lane, dst_words[word]);
   }
 }
 
@@ -2426,14 +2540,19 @@ void VCvtScalef32SrPk8Fp4Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
-    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src2, lane));
-    uint32_t seed = static_cast<uint32_t>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
     uint32_t src_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 4u) || !regs.owns_vgpr_range(dst_base, 1u))
+      continue;
+    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src2, lane));
+    uint32_t seed = static_cast<uint32_t>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
+    auto src_region = regs.read_vgpr_region(src_base, 4u, 1ULL << lane);
+    auto dst_region = regs.write_vgpr_region(dst_base, 1u, 1ULL << lane);
     uint32_t src_words[4] = {};
     for (uint32_t word = 0; word < 4u; ++word)
-      src_words[word] = amdgpu::RegisterAccess(wf.cu()).read_vgpr(src_base + word, lane);
+      src_words[word] = src_region.lane(word, lane);
     auto read_scaled_input = [&](uint32_t index) -> float {
       uint32_t raw = src_words[index / 2u];
       return util::bf16_to_f32(static_cast<uint16_t>(raw >> ((index & 1u) * 16u)));
@@ -2454,7 +2573,7 @@ void VCvtScalef32SrPk8Fp4Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
       seed = util::prng_advance(seed);
     }
     for (uint32_t word = 0; word < 1u; ++word)
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);
+      dst_region.set_lane(word, lane, dst_words[word]);
   }
 }
 
@@ -2466,14 +2585,19 @@ void VCvtScalef32SrPk8Fp8F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
-    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src2, lane));
-    uint32_t seed = static_cast<uint32_t>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
     uint32_t src_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 4u) || !regs.owns_vgpr_range(dst_base, 2u))
+      continue;
+    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src2, lane));
+    uint32_t seed = static_cast<uint32_t>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
+    auto src_region = regs.read_vgpr_region(src_base, 4u, 1ULL << lane);
+    auto dst_region = regs.write_vgpr_region(dst_base, 2u, 1ULL << lane);
     uint32_t src_words[4] = {};
     for (uint32_t word = 0; word < 4u; ++word)
-      src_words[word] = amdgpu::RegisterAccess(wf.cu()).read_vgpr(src_base + word, lane);
+      src_words[word] = src_region.lane(word, lane);
     auto read_scaled_input = [&](uint32_t index) -> float {
       uint32_t raw = src_words[index / 2u];
       return util::f16_to_f32(static_cast<uint16_t>(raw >> ((index & 1u) * 16u)));
@@ -2494,7 +2618,7 @@ void VCvtScalef32SrPk8Fp8F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
       seed = util::prng_advance(seed);
     }
     for (uint32_t word = 0; word < 2u; ++word)
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);
+      dst_region.set_lane(word, lane, dst_words[word]);
   }
 }
 
@@ -2506,14 +2630,19 @@ void VCvtScalef32SrPk8Fp8Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
-    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src2, lane));
-    uint32_t seed = static_cast<uint32_t>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
     uint32_t src_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 4u) || !regs.owns_vgpr_range(dst_base, 2u))
+      continue;
+    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src2, lane));
+    uint32_t seed = static_cast<uint32_t>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
+    auto src_region = regs.read_vgpr_region(src_base, 4u, 1ULL << lane);
+    auto dst_region = regs.write_vgpr_region(dst_base, 2u, 1ULL << lane);
     uint32_t src_words[4] = {};
     for (uint32_t word = 0; word < 4u; ++word)
-      src_words[word] = amdgpu::RegisterAccess(wf.cu()).read_vgpr(src_base + word, lane);
+      src_words[word] = src_region.lane(word, lane);
     auto read_scaled_input = [&](uint32_t index) -> float {
       uint32_t raw = src_words[index / 2u];
       return util::bf16_to_f32(static_cast<uint16_t>(raw >> ((index & 1u) * 16u)));
@@ -2534,7 +2663,7 @@ void VCvtScalef32SrPk8Fp8Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
       seed = util::prng_advance(seed);
     }
     for (uint32_t word = 0; word < 2u; ++word)
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);
+      dst_region.set_lane(word, lane, dst_words[word]);
   }
 }
 
@@ -2546,14 +2675,19 @@ void VCvtScalef32SrPk8Bf8F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
-    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src2, lane));
-    uint32_t seed = static_cast<uint32_t>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
     uint32_t src_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 4u) || !regs.owns_vgpr_range(dst_base, 2u))
+      continue;
+    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src2, lane));
+    uint32_t seed = static_cast<uint32_t>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
+    auto src_region = regs.read_vgpr_region(src_base, 4u, 1ULL << lane);
+    auto dst_region = regs.write_vgpr_region(dst_base, 2u, 1ULL << lane);
     uint32_t src_words[4] = {};
     for (uint32_t word = 0; word < 4u; ++word)
-      src_words[word] = amdgpu::RegisterAccess(wf.cu()).read_vgpr(src_base + word, lane);
+      src_words[word] = src_region.lane(word, lane);
     auto read_scaled_input = [&](uint32_t index) -> float {
       uint32_t raw = src_words[index / 2u];
       return util::f16_to_f32(static_cast<uint16_t>(raw >> ((index & 1u) * 16u)));
@@ -2574,7 +2708,7 @@ void VCvtScalef32SrPk8Bf8F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
       seed = util::prng_advance(seed);
     }
     for (uint32_t word = 0; word < 2u; ++word)
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);
+      dst_region.set_lane(word, lane, dst_words[word]);
   }
 }
 
@@ -2586,14 +2720,19 @@ void VCvtScalef32SrPk8Bf8Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
-    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src2, lane));
-    uint32_t seed = static_cast<uint32_t>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
     uint32_t src_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 4u) || !regs.owns_vgpr_range(dst_base, 2u))
+      continue;
+    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src2, lane));
+    uint32_t seed = static_cast<uint32_t>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
+    auto src_region = regs.read_vgpr_region(src_base, 4u, 1ULL << lane);
+    auto dst_region = regs.write_vgpr_region(dst_base, 2u, 1ULL << lane);
     uint32_t src_words[4] = {};
     for (uint32_t word = 0; word < 4u; ++word)
-      src_words[word] = amdgpu::RegisterAccess(wf.cu()).read_vgpr(src_base + word, lane);
+      src_words[word] = src_region.lane(word, lane);
     auto read_scaled_input = [&](uint32_t index) -> float {
       uint32_t raw = src_words[index / 2u];
       return util::bf16_to_f32(static_cast<uint16_t>(raw >> ((index & 1u) * 16u)));
@@ -2614,7 +2753,7 @@ void VCvtScalef32SrPk8Bf8Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
       seed = util::prng_advance(seed);
     }
     for (uint32_t word = 0; word < 2u; ++word)
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);
+      dst_region.set_lane(word, lane, dst_words[word]);
   }
 }
 
@@ -2626,13 +2765,18 @@ void VCvtScalef32Pk8Fp8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
-    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
     uint32_t src_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 8u) || !regs.owns_vgpr_range(dst_base, 2u))
+      continue;
+    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
+    auto src_region = regs.read_vgpr_region(src_base, 8u, 1ULL << lane);
+    auto dst_region = regs.write_vgpr_region(dst_base, 2u, 1ULL << lane);
     uint32_t src_words[8] = {};
     for (uint32_t word = 0; word < 8u; ++word)
-      src_words[word] = amdgpu::RegisterAccess(wf.cu()).read_vgpr(src_base + word, lane);
+      src_words[word] = src_region.lane(word, lane);
     auto read_scaled_input = [&](uint32_t index) -> float {
       return std::bit_cast<float>(src_words[index]);
     };
@@ -2651,7 +2795,7 @@ void VCvtScalef32Pk8Fp8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
       pack_scaled_dst(index, util::f32_to_fp8_e4m3_rne_mode(value, wf.fp16_ovfl()));
     }
     for (uint32_t word = 0; word < 2u; ++word)
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);
+      dst_region.set_lane(word, lane, dst_words[word]);
   }
 }
 
@@ -2663,13 +2807,18 @@ void VCvtScalef32Pk8Fp8F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
-    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
     uint32_t src_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 4u) || !regs.owns_vgpr_range(dst_base, 2u))
+      continue;
+    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
+    auto src_region = regs.read_vgpr_region(src_base, 4u, 1ULL << lane);
+    auto dst_region = regs.write_vgpr_region(dst_base, 2u, 1ULL << lane);
     uint32_t src_words[4] = {};
     for (uint32_t word = 0; word < 4u; ++word)
-      src_words[word] = amdgpu::RegisterAccess(wf.cu()).read_vgpr(src_base + word, lane);
+      src_words[word] = src_region.lane(word, lane);
     auto read_scaled_input = [&](uint32_t index) -> float {
       uint32_t raw = src_words[index / 2u];
       return util::f16_to_f32(static_cast<uint16_t>(raw >> ((index & 1u) * 16u)));
@@ -2689,7 +2838,7 @@ void VCvtScalef32Pk8Fp8F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
       pack_scaled_dst(index, util::f32_to_fp8_e4m3_rne_mode(value, wf.fp16_ovfl()));
     }
     for (uint32_t word = 0; word < 2u; ++word)
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);
+      dst_region.set_lane(word, lane, dst_words[word]);
   }
 }
 
@@ -2701,13 +2850,18 @@ void VCvtScalef32Pk8Bf8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
-    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
     uint32_t src_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 8u) || !regs.owns_vgpr_range(dst_base, 2u))
+      continue;
+    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
+    auto src_region = regs.read_vgpr_region(src_base, 8u, 1ULL << lane);
+    auto dst_region = regs.write_vgpr_region(dst_base, 2u, 1ULL << lane);
     uint32_t src_words[8] = {};
     for (uint32_t word = 0; word < 8u; ++word)
-      src_words[word] = amdgpu::RegisterAccess(wf.cu()).read_vgpr(src_base + word, lane);
+      src_words[word] = src_region.lane(word, lane);
     auto read_scaled_input = [&](uint32_t index) -> float {
       return std::bit_cast<float>(src_words[index]);
     };
@@ -2726,7 +2880,7 @@ void VCvtScalef32Pk8Bf8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
       pack_scaled_dst(index, util::f32_to_bf8_e5m2_rne_mode(value, wf.fp16_ovfl()));
     }
     for (uint32_t word = 0; word < 2u; ++word)
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);
+      dst_region.set_lane(word, lane, dst_words[word]);
   }
 }
 
@@ -2738,13 +2892,18 @@ void VCvtScalef32Pk8Bf8F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
-    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
     uint32_t src_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 4u) || !regs.owns_vgpr_range(dst_base, 2u))
+      continue;
+    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
+    auto src_region = regs.read_vgpr_region(src_base, 4u, 1ULL << lane);
+    auto dst_region = regs.write_vgpr_region(dst_base, 2u, 1ULL << lane);
     uint32_t src_words[4] = {};
     for (uint32_t word = 0; word < 4u; ++word)
-      src_words[word] = amdgpu::RegisterAccess(wf.cu()).read_vgpr(src_base + word, lane);
+      src_words[word] = src_region.lane(word, lane);
     auto read_scaled_input = [&](uint32_t index) -> float {
       uint32_t raw = src_words[index / 2u];
       return util::f16_to_f32(static_cast<uint16_t>(raw >> ((index & 1u) * 16u)));
@@ -2764,7 +2923,7 @@ void VCvtScalef32Pk8Bf8F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
       pack_scaled_dst(index, util::f32_to_bf8_e5m2_rne_mode(value, wf.fp16_ovfl()));
     }
     for (uint32_t word = 0; word < 2u; ++word)
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);
+      dst_region.set_lane(word, lane, dst_words[word]);
   }
 }
 
@@ -2776,15 +2935,19 @@ void VCvtScalePk16F16Fp6Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
-    uint32_t scale_payload = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
-    uint32_t scale_byte = (scale_payload >> ((inst_.opsel & 0x3u) * 8u)) & 0xffu;
-    float scale = util::e8m0_to_f32(static_cast<uint8_t>(scale_byte));
     uint32_t src_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 3u) || !regs.owns_vgpr_range(dst_base, 8u))
+      continue;
+    uint32_t scale_payload = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
+    uint32_t scale_byte = (scale_payload >> ((inst_.opsel & 0x3u) * 8u)) & 0xffu;
+    float scale = util::e8m0_to_f32(static_cast<uint8_t>(scale_byte));
+    auto src_region = regs.read_vgpr_region(src_base, 3u, 1ULL << lane);
     uint32_t src_words[4] = {};
     for (uint32_t word = 0; word < 3u; ++word)
-      src_words[word] = amdgpu::RegisterAccess(wf.cu()).read_vgpr(src_base + word, lane);
+      src_words[word] = src_region.lane(word, lane);
     auto read_scaled_src = [&](uint32_t index) -> float {
       uint32_t bit = index * 6u;
       uint32_t word = bit / 32u;
@@ -2795,13 +2958,14 @@ void VCvtScalePk16F16Fp6Vop3::execute_impl(amdgpu::Wavefront &wf) {
       raw &= 0x3fu;
       return util::fp6_e2m3_to_f32(static_cast<uint8_t>(raw));
     };
+    auto dst_region = regs.write_vgpr_region(dst_base, 8u, 1ULL << lane);
     uint32_t dst_words[8] = {};
     for (uint32_t index = 0; index < 16u; ++index) {
       uint32_t bits = util::f32_to_f16_mode(read_scaled_src(index) * scale, wf.fp16_ovfl());
       dst_words[index / 2u] |= bits << ((index & 1u) * 16u);
     }
     for (uint32_t word = 0; word < 8u; ++word)
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);
+      dst_region.set_lane(word, lane, dst_words[word]);
   }
 }
 
@@ -2813,15 +2977,19 @@ void VCvtScalePk16Bf16Fp6Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
-    uint32_t scale_payload = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
-    uint32_t scale_byte = (scale_payload >> ((inst_.opsel & 0x3u) * 8u)) & 0xffu;
-    float scale = util::e8m0_to_f32(static_cast<uint8_t>(scale_byte));
     uint32_t src_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 3u) || !regs.owns_vgpr_range(dst_base, 8u))
+      continue;
+    uint32_t scale_payload = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
+    uint32_t scale_byte = (scale_payload >> ((inst_.opsel & 0x3u) * 8u)) & 0xffu;
+    float scale = util::e8m0_to_f32(static_cast<uint8_t>(scale_byte));
+    auto src_region = regs.read_vgpr_region(src_base, 3u, 1ULL << lane);
     uint32_t src_words[4] = {};
     for (uint32_t word = 0; word < 3u; ++word)
-      src_words[word] = amdgpu::RegisterAccess(wf.cu()).read_vgpr(src_base + word, lane);
+      src_words[word] = src_region.lane(word, lane);
     auto read_scaled_src = [&](uint32_t index) -> float {
       uint32_t bit = index * 6u;
       uint32_t word = bit / 32u;
@@ -2832,13 +3000,14 @@ void VCvtScalePk16Bf16Fp6Vop3::execute_impl(amdgpu::Wavefront &wf) {
       raw &= 0x3fu;
       return util::fp6_e2m3_to_f32(static_cast<uint8_t>(raw));
     };
+    auto dst_region = regs.write_vgpr_region(dst_base, 8u, 1ULL << lane);
     uint32_t dst_words[8] = {};
     for (uint32_t index = 0; index < 16u; ++index) {
       uint32_t bits = util::f32_to_bf16_rne_mode(read_scaled_src(index) * scale, wf.fp16_ovfl());
       dst_words[index / 2u] |= bits << ((index & 1u) * 16u);
     }
     for (uint32_t word = 0; word < 8u; ++word)
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);
+      dst_region.set_lane(word, lane, dst_words[word]);
   }
 }
 
@@ -2850,15 +3019,19 @@ void VCvtScalePk16F32Fp6Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
-    uint32_t scale_payload = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
-    uint32_t scale_byte = (scale_payload >> ((inst_.opsel & 0x3u) * 8u)) & 0xffu;
-    float scale = util::e8m0_to_f32(static_cast<uint8_t>(scale_byte));
     uint32_t src_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 3u) || !regs.owns_vgpr_range(dst_base, 16u))
+      continue;
+    uint32_t scale_payload = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
+    uint32_t scale_byte = (scale_payload >> ((inst_.opsel & 0x3u) * 8u)) & 0xffu;
+    float scale = util::e8m0_to_f32(static_cast<uint8_t>(scale_byte));
+    auto src_region = regs.read_vgpr_region(src_base, 3u, 1ULL << lane);
     uint32_t src_words[4] = {};
     for (uint32_t word = 0; word < 3u; ++word)
-      src_words[word] = amdgpu::RegisterAccess(wf.cu()).read_vgpr(src_base + word, lane);
+      src_words[word] = src_region.lane(word, lane);
     auto read_scaled_src = [&](uint32_t index) -> float {
       uint32_t bit = index * 6u;
       uint32_t word = bit / 32u;
@@ -2869,10 +3042,10 @@ void VCvtScalePk16F32Fp6Vop3::execute_impl(amdgpu::Wavefront &wf) {
       raw &= 0x3fu;
       return util::fp6_e2m3_to_f32(static_cast<uint8_t>(raw));
     };
+    auto dst_region = regs.write_vgpr_region(dst_base, 16u, 1ULL << lane);
     for (uint32_t index = 0; index < 16u; ++index) {
       float value = read_scaled_src(index) * scale;
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + index, lane,
-                                                 std::bit_cast<uint32_t>(value));
+      dst_region.set_lane(index, lane, std::bit_cast<uint32_t>(value));
     }
   }
 }
@@ -2885,15 +3058,19 @@ void VCvtScalePk16F16Bf6Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
-    uint32_t scale_payload = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
-    uint32_t scale_byte = (scale_payload >> ((inst_.opsel & 0x3u) * 8u)) & 0xffu;
-    float scale = util::e8m0_to_f32(static_cast<uint8_t>(scale_byte));
     uint32_t src_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 3u) || !regs.owns_vgpr_range(dst_base, 8u))
+      continue;
+    uint32_t scale_payload = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
+    uint32_t scale_byte = (scale_payload >> ((inst_.opsel & 0x3u) * 8u)) & 0xffu;
+    float scale = util::e8m0_to_f32(static_cast<uint8_t>(scale_byte));
+    auto src_region = regs.read_vgpr_region(src_base, 3u, 1ULL << lane);
     uint32_t src_words[4] = {};
     for (uint32_t word = 0; word < 3u; ++word)
-      src_words[word] = amdgpu::RegisterAccess(wf.cu()).read_vgpr(src_base + word, lane);
+      src_words[word] = src_region.lane(word, lane);
     auto read_scaled_src = [&](uint32_t index) -> float {
       uint32_t bit = index * 6u;
       uint32_t word = bit / 32u;
@@ -2904,13 +3081,14 @@ void VCvtScalePk16F16Bf6Vop3::execute_impl(amdgpu::Wavefront &wf) {
       raw &= 0x3fu;
       return util::bf6_e3m2_to_f32(static_cast<uint8_t>(raw));
     };
+    auto dst_region = regs.write_vgpr_region(dst_base, 8u, 1ULL << lane);
     uint32_t dst_words[8] = {};
     for (uint32_t index = 0; index < 16u; ++index) {
       uint32_t bits = util::f32_to_f16_mode(read_scaled_src(index) * scale, wf.fp16_ovfl());
       dst_words[index / 2u] |= bits << ((index & 1u) * 16u);
     }
     for (uint32_t word = 0; word < 8u; ++word)
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);
+      dst_region.set_lane(word, lane, dst_words[word]);
   }
 }
 
@@ -2922,15 +3100,19 @@ void VCvtScalePk16Bf16Bf6Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
-    uint32_t scale_payload = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
-    uint32_t scale_byte = (scale_payload >> ((inst_.opsel & 0x3u) * 8u)) & 0xffu;
-    float scale = util::e8m0_to_f32(static_cast<uint8_t>(scale_byte));
     uint32_t src_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 3u) || !regs.owns_vgpr_range(dst_base, 8u))
+      continue;
+    uint32_t scale_payload = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
+    uint32_t scale_byte = (scale_payload >> ((inst_.opsel & 0x3u) * 8u)) & 0xffu;
+    float scale = util::e8m0_to_f32(static_cast<uint8_t>(scale_byte));
+    auto src_region = regs.read_vgpr_region(src_base, 3u, 1ULL << lane);
     uint32_t src_words[4] = {};
     for (uint32_t word = 0; word < 3u; ++word)
-      src_words[word] = amdgpu::RegisterAccess(wf.cu()).read_vgpr(src_base + word, lane);
+      src_words[word] = src_region.lane(word, lane);
     auto read_scaled_src = [&](uint32_t index) -> float {
       uint32_t bit = index * 6u;
       uint32_t word = bit / 32u;
@@ -2941,13 +3123,14 @@ void VCvtScalePk16Bf16Bf6Vop3::execute_impl(amdgpu::Wavefront &wf) {
       raw &= 0x3fu;
       return util::bf6_e3m2_to_f32(static_cast<uint8_t>(raw));
     };
+    auto dst_region = regs.write_vgpr_region(dst_base, 8u, 1ULL << lane);
     uint32_t dst_words[8] = {};
     for (uint32_t index = 0; index < 16u; ++index) {
       uint32_t bits = util::f32_to_bf16_rne_mode(read_scaled_src(index) * scale, wf.fp16_ovfl());
       dst_words[index / 2u] |= bits << ((index & 1u) * 16u);
     }
     for (uint32_t word = 0; word < 8u; ++word)
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);
+      dst_region.set_lane(word, lane, dst_words[word]);
   }
 }
 
@@ -2959,15 +3142,19 @@ void VCvtScalePk16F32Bf6Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
-    uint32_t scale_payload = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
-    uint32_t scale_byte = (scale_payload >> ((inst_.opsel & 0x3u) * 8u)) & 0xffu;
-    float scale = util::e8m0_to_f32(static_cast<uint8_t>(scale_byte));
     uint32_t src_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 3u) || !regs.owns_vgpr_range(dst_base, 16u))
+      continue;
+    uint32_t scale_payload = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
+    uint32_t scale_byte = (scale_payload >> ((inst_.opsel & 0x3u) * 8u)) & 0xffu;
+    float scale = util::e8m0_to_f32(static_cast<uint8_t>(scale_byte));
+    auto src_region = regs.read_vgpr_region(src_base, 3u, 1ULL << lane);
     uint32_t src_words[4] = {};
     for (uint32_t word = 0; word < 3u; ++word)
-      src_words[word] = amdgpu::RegisterAccess(wf.cu()).read_vgpr(src_base + word, lane);
+      src_words[word] = src_region.lane(word, lane);
     auto read_scaled_src = [&](uint32_t index) -> float {
       uint32_t bit = index * 6u;
       uint32_t word = bit / 32u;
@@ -2978,10 +3165,10 @@ void VCvtScalePk16F32Bf6Vop3::execute_impl(amdgpu::Wavefront &wf) {
       raw &= 0x3fu;
       return util::bf6_e3m2_to_f32(static_cast<uint8_t>(raw));
     };
+    auto dst_region = regs.write_vgpr_region(dst_base, 16u, 1ULL << lane);
     for (uint32_t index = 0; index < 16u; ++index) {
       float value = read_scaled_src(index) * scale;
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + index, lane,
-                                                 std::bit_cast<uint32_t>(value));
+      dst_region.set_lane(index, lane, std::bit_cast<uint32_t>(value));
     }
   }
 }
@@ -2994,13 +3181,18 @@ void VCvtScalef32Pk16Fp6F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
-    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
     uint32_t src_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 16u) || !regs.owns_vgpr_range(dst_base, 3u))
+      continue;
+    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
+    auto src_region = regs.read_vgpr_region(src_base, 16u, 1ULL << lane);
+    auto dst_region = regs.write_vgpr_region(dst_base, 3u, 1ULL << lane);
     uint32_t src_words[16] = {};
     for (uint32_t word = 0; word < 16u; ++word)
-      src_words[word] = amdgpu::RegisterAccess(wf.cu()).read_vgpr(src_base + word, lane);
+      src_words[word] = src_region.lane(word, lane);
     auto read_scaled_input = [&](uint32_t index) -> float {
       return std::bit_cast<float>(src_words[index]);
     };
@@ -3019,7 +3211,7 @@ void VCvtScalef32Pk16Fp6F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
       pack_scaled_dst(index, util::f32_to_fp6_e2m3_rne(value));
     }
     for (uint32_t word = 0; word < 3u; ++word)
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);
+      dst_region.set_lane(word, lane, dst_words[word]);
   }
 }
 
@@ -3031,13 +3223,18 @@ void VCvtScalef32Pk16Bf6F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
-    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
     uint32_t src_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 16u) || !regs.owns_vgpr_range(dst_base, 3u))
+      continue;
+    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
+    auto src_region = regs.read_vgpr_region(src_base, 16u, 1ULL << lane);
+    auto dst_region = regs.write_vgpr_region(dst_base, 3u, 1ULL << lane);
     uint32_t src_words[16] = {};
     for (uint32_t word = 0; word < 16u; ++word)
-      src_words[word] = amdgpu::RegisterAccess(wf.cu()).read_vgpr(src_base + word, lane);
+      src_words[word] = src_region.lane(word, lane);
     auto read_scaled_input = [&](uint32_t index) -> float {
       return std::bit_cast<float>(src_words[index]);
     };
@@ -3056,7 +3253,7 @@ void VCvtScalef32Pk16Bf6F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
       pack_scaled_dst(index, util::f32_to_bf6_e3m2_rne(value));
     }
     for (uint32_t word = 0; word < 3u; ++word)
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);
+      dst_region.set_lane(word, lane, dst_words[word]);
   }
 }
 
@@ -3068,13 +3265,18 @@ void VCvtScalef32Pk16Fp6F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
-    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
     uint32_t src_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 8u) || !regs.owns_vgpr_range(dst_base, 3u))
+      continue;
+    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
+    auto src_region = regs.read_vgpr_region(src_base, 8u, 1ULL << lane);
+    auto dst_region = regs.write_vgpr_region(dst_base, 3u, 1ULL << lane);
     uint32_t src_words[8] = {};
     for (uint32_t word = 0; word < 8u; ++word)
-      src_words[word] = amdgpu::RegisterAccess(wf.cu()).read_vgpr(src_base + word, lane);
+      src_words[word] = src_region.lane(word, lane);
     auto read_scaled_input = [&](uint32_t index) -> float {
       uint32_t raw = src_words[index / 2u];
       return util::f16_to_f32(static_cast<uint16_t>(raw >> ((index & 1u) * 16u)));
@@ -3094,7 +3296,7 @@ void VCvtScalef32Pk16Fp6F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
       pack_scaled_dst(index, util::f32_to_fp6_e2m3_rne(value));
     }
     for (uint32_t word = 0; word < 3u; ++word)
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);
+      dst_region.set_lane(word, lane, dst_words[word]);
   }
 }
 
@@ -3106,13 +3308,18 @@ void VCvtScalef32Pk16Bf6F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
-    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
     uint32_t src_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 8u) || !regs.owns_vgpr_range(dst_base, 3u))
+      continue;
+    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
+    auto src_region = regs.read_vgpr_region(src_base, 8u, 1ULL << lane);
+    auto dst_region = regs.write_vgpr_region(dst_base, 3u, 1ULL << lane);
     uint32_t src_words[8] = {};
     for (uint32_t word = 0; word < 8u; ++word)
-      src_words[word] = amdgpu::RegisterAccess(wf.cu()).read_vgpr(src_base + word, lane);
+      src_words[word] = src_region.lane(word, lane);
     auto read_scaled_input = [&](uint32_t index) -> float {
       uint32_t raw = src_words[index / 2u];
       return util::f16_to_f32(static_cast<uint16_t>(raw >> ((index & 1u) * 16u)));
@@ -3132,7 +3339,7 @@ void VCvtScalef32Pk16Bf6F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
       pack_scaled_dst(index, util::f32_to_bf6_e3m2_rne(value));
     }
     for (uint32_t word = 0; word < 3u; ++word)
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);
+      dst_region.set_lane(word, lane, dst_words[word]);
   }
 }
 
@@ -3144,13 +3351,18 @@ void VCvtScalef32Pk16Fp6Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
-    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
     uint32_t src_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 8u) || !regs.owns_vgpr_range(dst_base, 3u))
+      continue;
+    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
+    auto src_region = regs.read_vgpr_region(src_base, 8u, 1ULL << lane);
+    auto dst_region = regs.write_vgpr_region(dst_base, 3u, 1ULL << lane);
     uint32_t src_words[8] = {};
     for (uint32_t word = 0; word < 8u; ++word)
-      src_words[word] = amdgpu::RegisterAccess(wf.cu()).read_vgpr(src_base + word, lane);
+      src_words[word] = src_region.lane(word, lane);
     auto read_scaled_input = [&](uint32_t index) -> float {
       uint32_t raw = src_words[index / 2u];
       return util::bf16_to_f32(static_cast<uint16_t>(raw >> ((index & 1u) * 16u)));
@@ -3170,7 +3382,7 @@ void VCvtScalef32Pk16Fp6Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
       pack_scaled_dst(index, util::f32_to_fp6_e2m3_rne(value));
     }
     for (uint32_t word = 0; word < 3u; ++word)
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);
+      dst_region.set_lane(word, lane, dst_words[word]);
   }
 }
 
@@ -3182,13 +3394,18 @@ void VCvtScalef32Pk16Bf6Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
-    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
     uint32_t src_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 8u) || !regs.owns_vgpr_range(dst_base, 3u))
+      continue;
+    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
+    auto src_region = regs.read_vgpr_region(src_base, 8u, 1ULL << lane);
+    auto dst_region = regs.write_vgpr_region(dst_base, 3u, 1ULL << lane);
     uint32_t src_words[8] = {};
     for (uint32_t word = 0; word < 8u; ++word)
-      src_words[word] = amdgpu::RegisterAccess(wf.cu()).read_vgpr(src_base + word, lane);
+      src_words[word] = src_region.lane(word, lane);
     auto read_scaled_input = [&](uint32_t index) -> float {
       uint32_t raw = src_words[index / 2u];
       return util::bf16_to_f32(static_cast<uint16_t>(raw >> ((index & 1u) * 16u)));
@@ -3208,7 +3425,7 @@ void VCvtScalef32Pk16Bf6Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
       pack_scaled_dst(index, util::f32_to_bf6_e3m2_rne(value));
     }
     for (uint32_t word = 0; word < 3u; ++word)
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);
+      dst_region.set_lane(word, lane, dst_words[word]);
   }
 }
 
@@ -3220,14 +3437,19 @@ void VCvtScalef32SrPk16Fp6F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
-    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src2, lane));
-    uint32_t seed = static_cast<uint32_t>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
     uint32_t src_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 16u) || !regs.owns_vgpr_range(dst_base, 3u))
+      continue;
+    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src2, lane));
+    uint32_t seed = static_cast<uint32_t>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
+    auto src_region = regs.read_vgpr_region(src_base, 16u, 1ULL << lane);
+    auto dst_region = regs.write_vgpr_region(dst_base, 3u, 1ULL << lane);
     uint32_t src_words[16] = {};
     for (uint32_t word = 0; word < 16u; ++word)
-      src_words[word] = amdgpu::RegisterAccess(wf.cu()).read_vgpr(src_base + word, lane);
+      src_words[word] = src_region.lane(word, lane);
     auto read_scaled_input = [&](uint32_t index) -> float {
       return std::bit_cast<float>(src_words[index]);
     };
@@ -3247,7 +3469,7 @@ void VCvtScalef32SrPk16Fp6F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
       seed = util::prng_advance(seed);
     }
     for (uint32_t word = 0; word < 3u; ++word)
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);
+      dst_region.set_lane(word, lane, dst_words[word]);
   }
 }
 
@@ -3259,14 +3481,19 @@ void VCvtScalef32SrPk16Bf6F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
-    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src2, lane));
-    uint32_t seed = static_cast<uint32_t>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
     uint32_t src_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 16u) || !regs.owns_vgpr_range(dst_base, 3u))
+      continue;
+    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src2, lane));
+    uint32_t seed = static_cast<uint32_t>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
+    auto src_region = regs.read_vgpr_region(src_base, 16u, 1ULL << lane);
+    auto dst_region = regs.write_vgpr_region(dst_base, 3u, 1ULL << lane);
     uint32_t src_words[16] = {};
     for (uint32_t word = 0; word < 16u; ++word)
-      src_words[word] = amdgpu::RegisterAccess(wf.cu()).read_vgpr(src_base + word, lane);
+      src_words[word] = src_region.lane(word, lane);
     auto read_scaled_input = [&](uint32_t index) -> float {
       return std::bit_cast<float>(src_words[index]);
     };
@@ -3286,7 +3513,7 @@ void VCvtScalef32SrPk16Bf6F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
       seed = util::prng_advance(seed);
     }
     for (uint32_t word = 0; word < 3u; ++word)
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);
+      dst_region.set_lane(word, lane, dst_words[word]);
   }
 }
 
@@ -3298,14 +3525,19 @@ void VCvtScalef32SrPk16Fp6F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
-    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src2, lane));
-    uint32_t seed = static_cast<uint32_t>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
     uint32_t src_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 8u) || !regs.owns_vgpr_range(dst_base, 3u))
+      continue;
+    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src2, lane));
+    uint32_t seed = static_cast<uint32_t>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
+    auto src_region = regs.read_vgpr_region(src_base, 8u, 1ULL << lane);
+    auto dst_region = regs.write_vgpr_region(dst_base, 3u, 1ULL << lane);
     uint32_t src_words[8] = {};
     for (uint32_t word = 0; word < 8u; ++word)
-      src_words[word] = amdgpu::RegisterAccess(wf.cu()).read_vgpr(src_base + word, lane);
+      src_words[word] = src_region.lane(word, lane);
     auto read_scaled_input = [&](uint32_t index) -> float {
       uint32_t raw = src_words[index / 2u];
       return util::f16_to_f32(static_cast<uint16_t>(raw >> ((index & 1u) * 16u)));
@@ -3326,7 +3558,7 @@ void VCvtScalef32SrPk16Fp6F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
       seed = util::prng_advance(seed);
     }
     for (uint32_t word = 0; word < 3u; ++word)
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);
+      dst_region.set_lane(word, lane, dst_words[word]);
   }
 }
 
@@ -3338,14 +3570,19 @@ void VCvtScalef32SrPk16Bf6F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
-    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src2, lane));
-    uint32_t seed = static_cast<uint32_t>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
     uint32_t src_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 8u) || !regs.owns_vgpr_range(dst_base, 3u))
+      continue;
+    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src2, lane));
+    uint32_t seed = static_cast<uint32_t>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
+    auto src_region = regs.read_vgpr_region(src_base, 8u, 1ULL << lane);
+    auto dst_region = regs.write_vgpr_region(dst_base, 3u, 1ULL << lane);
     uint32_t src_words[8] = {};
     for (uint32_t word = 0; word < 8u; ++word)
-      src_words[word] = amdgpu::RegisterAccess(wf.cu()).read_vgpr(src_base + word, lane);
+      src_words[word] = src_region.lane(word, lane);
     auto read_scaled_input = [&](uint32_t index) -> float {
       uint32_t raw = src_words[index / 2u];
       return util::f16_to_f32(static_cast<uint16_t>(raw >> ((index & 1u) * 16u)));
@@ -3366,7 +3603,7 @@ void VCvtScalef32SrPk16Bf6F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
       seed = util::prng_advance(seed);
     }
     for (uint32_t word = 0; word < 3u; ++word)
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);
+      dst_region.set_lane(word, lane, dst_words[word]);
   }
 }
 
@@ -3378,14 +3615,19 @@ void VCvtScalef32SrPk16Fp6Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
-    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src2, lane));
-    uint32_t seed = static_cast<uint32_t>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
     uint32_t src_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 8u) || !regs.owns_vgpr_range(dst_base, 3u))
+      continue;
+    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src2, lane));
+    uint32_t seed = static_cast<uint32_t>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
+    auto src_region = regs.read_vgpr_region(src_base, 8u, 1ULL << lane);
+    auto dst_region = regs.write_vgpr_region(dst_base, 3u, 1ULL << lane);
     uint32_t src_words[8] = {};
     for (uint32_t word = 0; word < 8u; ++word)
-      src_words[word] = amdgpu::RegisterAccess(wf.cu()).read_vgpr(src_base + word, lane);
+      src_words[word] = src_region.lane(word, lane);
     auto read_scaled_input = [&](uint32_t index) -> float {
       uint32_t raw = src_words[index / 2u];
       return util::bf16_to_f32(static_cast<uint16_t>(raw >> ((index & 1u) * 16u)));
@@ -3406,7 +3648,7 @@ void VCvtScalef32SrPk16Fp6Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
       seed = util::prng_advance(seed);
     }
     for (uint32_t word = 0; word < 3u; ++word)
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);
+      dst_region.set_lane(word, lane, dst_words[word]);
   }
 }
 
@@ -3418,14 +3660,19 @@ void VCvtScalef32SrPk16Bf6Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t dst_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
-    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src2, lane));
-    uint32_t seed = static_cast<uint32_t>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
     uint32_t src_base =
         wf.vgpr_alloc().base +
         *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    amdgpu::RegisterAccess regs(wf);
+    if (!regs.owns_vgpr_range(src_base, 8u) || !regs.owns_vgpr_range(dst_base, 3u))
+      continue;
+    float scale = std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(src2, lane));
+    uint32_t seed = static_cast<uint32_t>(amdgpu::RegisterAccess(wf).read_lane(src1, lane));
+    auto src_region = regs.read_vgpr_region(src_base, 8u, 1ULL << lane);
+    auto dst_region = regs.write_vgpr_region(dst_base, 3u, 1ULL << lane);
     uint32_t src_words[8] = {};
     for (uint32_t word = 0; word < 8u; ++word)
-      src_words[word] = amdgpu::RegisterAccess(wf.cu()).read_vgpr(src_base + word, lane);
+      src_words[word] = src_region.lane(word, lane);
     auto read_scaled_input = [&](uint32_t index) -> float {
       uint32_t raw = src_words[index / 2u];
       return util::bf16_to_f32(static_cast<uint16_t>(raw >> ((index & 1u) * 16u)));
@@ -3446,7 +3693,7 @@ void VCvtScalef32SrPk16Bf6Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
       seed = util::prng_advance(seed);
     }
     for (uint32_t word = 0; word < 3u; ++word)
-      amdgpu::RegisterAccess(wf.cu()).write_vgpr(dst_base + word, lane, dst_words[word]);
+      dst_region.set_lane(word, lane, dst_words[word]);
   }
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vscratch_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vscratch_exec.cpp
@@ -7,6 +7,7 @@
 #include "rocjitsu/isa/arch/amdgpu/cdna5/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/vscratch.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx12_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/ds_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/ds_exec.cpp
@@ -8,6 +8,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h"
 #include "rocjitsu/isa/arch/amdgpu/rdna1/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx10_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/flat_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/flat_exec.cpp
@@ -7,6 +7,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna1/flat.h"
 #include "rocjitsu/isa/arch/amdgpu/rdna1/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx10_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/mtbuf_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/mtbuf_exec.cpp
@@ -8,6 +8,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h"
 #include "rocjitsu/isa/arch/amdgpu/rdna1/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx10_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/mubuf_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/mubuf_exec.cpp
@@ -8,6 +8,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h"
 #include "rocjitsu/isa/arch/amdgpu/rdna1/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx10_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/operand.cpp
@@ -1019,6 +1019,11 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSdst::OPR_SDST_SGPR_MIN),
                          reg_width};
+    if (encoding_value_ >= OpSelSdst::OPR_SDST_TTMP_MIN &&
+        encoding_value_ <= OpSelSdst::OPR_SDST_TTMP_MAX)
+      return RegisterRef{RegClass::TTMP,
+                         static_cast<uint16_t>(encoding_value_ - OpSelSdst::OPR_SDST_TTMP_MIN),
+                         reg_width};
     if (encoding_value_ == OpSelSdst::OPR_SDST_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
     if (encoding_value_ == OpSelSdst::OPR_SDST_EXEC_HI)
@@ -1045,6 +1050,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSmemOffset::OPR_SMEM_OFFSET_SGPR_MIN),
           reg_width};
+    if (encoding_value_ >= OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP_MIN &&
+        encoding_value_ <= OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP_MIN),
+          reg_width};
     break;
   }
   case OperandType::OPR_SRC: {
@@ -1052,6 +1063,11 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
         encoding_value_ <= OpSelSrc::OPR_SRC_SGPR_MAX)
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSrc::OPR_SRC_SGPR_MIN),
+                         reg_width};
+    if (encoding_value_ >= OpSelSrc::OPR_SRC_TTMP_MIN &&
+        encoding_value_ <= OpSelSrc::OPR_SRC_TTMP_MAX)
+      return RegisterRef{RegClass::TTMP,
+                         static_cast<uint16_t>(encoding_value_ - OpSelSrc::OPR_SRC_TTMP_MIN),
                          reg_width};
     if (encoding_value_ == OpSelSrc::OPR_SRC_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
@@ -1071,6 +1087,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSrcNolds::OPR_SRC_NOLDS_SGPR_MIN),
           reg_width};
+    if (encoding_value_ >= OpSelSrcNolds::OPR_SRC_NOLDS_TTMP_MIN &&
+        encoding_value_ <= OpSelSrcNolds::OPR_SRC_NOLDS_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSrcNolds::OPR_SRC_NOLDS_TTMP_MIN),
+          reg_width};
     if (encoding_value_ == OpSelSrcNolds::OPR_SRC_NOLDS_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
     if (encoding_value_ == OpSelSrcNolds::OPR_SRC_NOLDS_EXEC_HI)
@@ -1089,6 +1111,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSrcSimple::OPR_SRC_SIMPLE_SGPR_MIN),
+          reg_width};
+    if (encoding_value_ >= OpSelSrcSimple::OPR_SRC_SIMPLE_TTMP_MIN &&
+        encoding_value_ <= OpSelSrcSimple::OPR_SRC_SIMPLE_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSrcSimple::OPR_SRC_SIMPLE_TTMP_MIN),
           reg_width};
     if (encoding_value_ == OpSelSrcSimple::OPR_SRC_SIMPLE_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
@@ -1116,6 +1144,11 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSreg::OPR_SREG_SGPR_MIN),
                          reg_width};
+    if (encoding_value_ >= OpSelSreg::OPR_SREG_TTMP_MIN &&
+        encoding_value_ <= OpSelSreg::OPR_SREG_TTMP_MAX)
+      return RegisterRef{RegClass::TTMP,
+                         static_cast<uint16_t>(encoding_value_ - OpSelSreg::OPR_SREG_TTMP_MIN),
+                         reg_width};
     break;
   }
   case OperandType::OPR_SREG_M0_INL: {
@@ -1124,6 +1157,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSregM0Inl::OPR_SREG_M0_INL_SGPR_MIN),
+          reg_width};
+    if (encoding_value_ >= OpSelSregM0Inl::OPR_SREG_M0_INL_TTMP_MIN &&
+        encoding_value_ <= OpSelSregM0Inl::OPR_SREG_M0_INL_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSregM0Inl::OPR_SREG_M0_INL_TTMP_MIN),
           reg_width};
     break;
   }
@@ -1134,6 +1173,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSregNonull::OPR_SREG_NONULL_SGPR_MIN),
           reg_width};
+    if (encoding_value_ >= OpSelSregNonull::OPR_SREG_NONULL_TTMP_MIN &&
+        encoding_value_ <= OpSelSregNonull::OPR_SREG_NONULL_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSregNonull::OPR_SREG_NONULL_TTMP_MIN),
+          reg_width};
     break;
   }
   case OperandType::OPR_SSRC: {
@@ -1141,6 +1186,11 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
         encoding_value_ <= OpSelSsrc::OPR_SSRC_SGPR_MAX)
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSsrc::OPR_SSRC_SGPR_MIN),
+                         reg_width};
+    if (encoding_value_ >= OpSelSsrc::OPR_SSRC_TTMP_MIN &&
+        encoding_value_ <= OpSelSsrc::OPR_SSRC_TTMP_MAX)
+      return RegisterRef{RegClass::TTMP,
+                         static_cast<uint16_t>(encoding_value_ - OpSelSsrc::OPR_SSRC_TTMP_MIN),
                          reg_width};
     if (encoding_value_ == OpSelSsrc::OPR_SSRC_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
@@ -1155,6 +1205,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSsrcLanesel::OPR_SSRC_LANESEL_SGPR_MIN),
           reg_width};
+    if (encoding_value_ >= OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP_MIN &&
+        encoding_value_ <= OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP_MIN),
+          reg_width};
     break;
   }
   case OperandType::OPR_SSRC_NOLDS: {
@@ -1163,6 +1219,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSsrcNolds::OPR_SSRC_NOLDS_SGPR_MIN),
+          reg_width};
+    if (encoding_value_ >= OpSelSsrcNolds::OPR_SSRC_NOLDS_TTMP_MIN &&
+        encoding_value_ <= OpSelSsrcNolds::OPR_SSRC_NOLDS_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSsrcNolds::OPR_SSRC_NOLDS_TTMP_MIN),
           reg_width};
     if (encoding_value_ == OpSelSsrcNolds::OPR_SSRC_NOLDS_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/operand_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/operand_exec.cpp
@@ -91,7 +91,7 @@ void Operand::read_lane_chunk_exec(const amdgpu::Wavefront &wf, uint32_t lane_ba
     uint64_t lane_mask =
         count == 0 ? 0 : util::mask<uint64_t>(static_cast<int>(count)) << lane_base;
     auto region =
-        amdgpu::RegisterAccess(wf.cu()).read_vgpr_region(wf.vgpr_alloc().base + voff, 1, lane_mask);
+        amdgpu::RegisterAccess(wf).read_vgpr_region(wf.vgpr_alloc().base + voff, 1, lane_mask);
     std::copy_n(region.lanes().begin() + lane_base, count, out);
     return;
   }
@@ -115,6 +115,8 @@ void Operand::write_lane_chunk_exec(amdgpu::Wavefront &wf, uint32_t lane_base, u
       vgpr_msb_role() == amdgpu::VgprMsbRole::None ? amdgpu::VgprMsbRole::Dst : vgpr_msb_role();
   uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, role);
   uint32_t reg = wf.vgpr_alloc().base + voff;
+  if (!amdgpu::OperandExecutionAccess::raw_compute_unit(wf.cu()).owns_vgpr_range(wf, reg, 1))
+    return;
   uint64_t full_mask = util::mask<uint64_t>(static_cast<int>(count));
   uint8_t *dst = amdgpu::OperandExecutionAccess::raw_compute_unit(wf.cu()).raw_vgpr_data(reg);
   if ((mask & full_mask) == full_mask) {
@@ -154,7 +156,7 @@ uint32_t Operand::read_lane_exec(const amdgpu::Wavefront &wf, uint32_t lane) con
   int ev = encoding_value_;
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev)) {
     uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, vgpr_msb_role());
-    return amdgpu::RegisterAccess(wf.cu()).read_vgpr(wf.vgpr_alloc().base + voff, lane);
+    return amdgpu::RegisterAccess(wf).read_vgpr(wf.vgpr_alloc().base + voff, lane);
   }
   if (is_immediate_type(opr_type_))
     return static_cast<uint32_t>(ev);
@@ -184,7 +186,7 @@ void Operand::write_lane_exec(amdgpu::Wavefront &wf, uint32_t lane, uint32_t val
     amdgpu::VgprMsbRole role =
         vgpr_msb_role() == amdgpu::VgprMsbRole::None ? amdgpu::VgprMsbRole::Dst : vgpr_msb_role();
     uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, role);
-    amdgpu::RegisterAccess(wf.cu()).write_vgpr(wf.vgpr_alloc().base + voff, lane, val);
+    amdgpu::RegisterAccess(wf).write_vgpr(wf.vgpr_alloc().base + voff, lane, val);
     return;
   }
   throw std::logic_error("write_lane called on non-VGPR operand type");
@@ -203,7 +205,7 @@ uint64_t Operand::read_lane64_exec(const amdgpu::Wavefront &wf, uint32_t lane) c
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev)) {
     uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, vgpr_msb_role());
     uint32_t idx = wf.vgpr_alloc().base + voff;
-    return amdgpu::RegisterAccess(wf.cu()).read_vgpr64(idx, lane);
+    return amdgpu::RegisterAccess(wf).read_vgpr64(idx, lane);
   }
   if (literal32_widening_)
     return widened_literal32_value();
@@ -226,7 +228,7 @@ void Operand::write_lane64_exec(amdgpu::Wavefront &wf, uint32_t lane, uint64_t v
         vgpr_msb_role() == amdgpu::VgprMsbRole::None ? amdgpu::VgprMsbRole::Dst : vgpr_msb_role();
     uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, role);
     uint32_t idx = wf.vgpr_alloc().base + voff;
-    amdgpu::RegisterAccess(wf.cu()).write_vgpr64(idx, lane, val);
+    amdgpu::RegisterAccess(wf).write_vgpr64(idx, lane, val);
     return;
   }
   throw std::logic_error("write_lane64 called on non-VGPR operand type");

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/smem_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/smem_exec.cpp
@@ -8,6 +8,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h"
 #include "rocjitsu/isa/arch/amdgpu/rdna1/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx10_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"
@@ -25,184 +26,249 @@ namespace rocjitsu {
 namespace rdna1 {
 
 void SLoadDwordSmem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadDwordx2Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 2u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 2;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadDwordx4Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 4u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 4;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadDwordx8Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 8u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 8;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadDwordx16Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 16u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 16;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SScratchLoadDwordSmem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SScratchLoadDwordx2Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 2u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 2;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SScratchLoadDwordx4Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 4u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 4;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadDwordSmem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadDwordx2Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 2u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 2;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadDwordx4Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 4u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 4;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadDwordx8Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 8u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 8;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadDwordx16Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 16u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 16;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/ds_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/ds_exec.cpp
@@ -8,6 +8,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h"
 #include "rocjitsu/isa/arch/amdgpu/rdna2/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx10_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/flat_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/flat_exec.cpp
@@ -7,6 +7,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna2/flat.h"
 #include "rocjitsu/isa/arch/amdgpu/rdna2/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx10_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/mtbuf_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/mtbuf_exec.cpp
@@ -8,6 +8,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h"
 #include "rocjitsu/isa/arch/amdgpu/rdna2/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx10_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/mubuf_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/mubuf_exec.cpp
@@ -8,6 +8,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h"
 #include "rocjitsu/isa/arch/amdgpu/rdna2/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx10_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/operand.cpp
@@ -993,6 +993,11 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSdst::OPR_SDST_SGPR_MIN),
                          reg_width};
+    if (encoding_value_ >= OpSelSdst::OPR_SDST_TTMP_MIN &&
+        encoding_value_ <= OpSelSdst::OPR_SDST_TTMP_MAX)
+      return RegisterRef{RegClass::TTMP,
+                         static_cast<uint16_t>(encoding_value_ - OpSelSdst::OPR_SDST_TTMP_MIN),
+                         reg_width};
     if (encoding_value_ == OpSelSdst::OPR_SDST_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
     if (encoding_value_ == OpSelSdst::OPR_SDST_EXEC_HI)
@@ -1016,6 +1021,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSmemOffset::OPR_SMEM_OFFSET_SGPR_MIN),
           reg_width};
+    if (encoding_value_ >= OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP_MIN &&
+        encoding_value_ <= OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP_MIN),
+          reg_width};
     break;
   }
   case OperandType::OPR_SRC: {
@@ -1023,6 +1034,11 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
         encoding_value_ <= OpSelSrc::OPR_SRC_SGPR_MAX)
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSrc::OPR_SRC_SGPR_MIN),
+                         reg_width};
+    if (encoding_value_ >= OpSelSrc::OPR_SRC_TTMP_MIN &&
+        encoding_value_ <= OpSelSrc::OPR_SRC_TTMP_MAX)
+      return RegisterRef{RegClass::TTMP,
+                         static_cast<uint16_t>(encoding_value_ - OpSelSrc::OPR_SRC_TTMP_MIN),
                          reg_width};
     if (encoding_value_ == OpSelSrc::OPR_SRC_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
@@ -1042,6 +1058,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSrcNolds::OPR_SRC_NOLDS_SGPR_MIN),
           reg_width};
+    if (encoding_value_ >= OpSelSrcNolds::OPR_SRC_NOLDS_TTMP_MIN &&
+        encoding_value_ <= OpSelSrcNolds::OPR_SRC_NOLDS_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSrcNolds::OPR_SRC_NOLDS_TTMP_MIN),
+          reg_width};
     if (encoding_value_ == OpSelSrcNolds::OPR_SRC_NOLDS_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
     if (encoding_value_ == OpSelSrcNolds::OPR_SRC_NOLDS_EXEC_HI)
@@ -1060,6 +1082,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSrcSimple::OPR_SRC_SIMPLE_SGPR_MIN),
+          reg_width};
+    if (encoding_value_ >= OpSelSrcSimple::OPR_SRC_SIMPLE_TTMP_MIN &&
+        encoding_value_ <= OpSelSrcSimple::OPR_SRC_SIMPLE_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSrcSimple::OPR_SRC_SIMPLE_TTMP_MIN),
           reg_width};
     if (encoding_value_ == OpSelSrcSimple::OPR_SRC_SIMPLE_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
@@ -1087,6 +1115,11 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSreg::OPR_SREG_SGPR_MIN),
                          reg_width};
+    if (encoding_value_ >= OpSelSreg::OPR_SREG_TTMP_MIN &&
+        encoding_value_ <= OpSelSreg::OPR_SREG_TTMP_MAX)
+      return RegisterRef{RegClass::TTMP,
+                         static_cast<uint16_t>(encoding_value_ - OpSelSreg::OPR_SREG_TTMP_MIN),
+                         reg_width};
     break;
   }
   case OperandType::OPR_SREG_M0_INL: {
@@ -1095,6 +1128,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSregM0Inl::OPR_SREG_M0_INL_SGPR_MIN),
+          reg_width};
+    if (encoding_value_ >= OpSelSregM0Inl::OPR_SREG_M0_INL_TTMP_MIN &&
+        encoding_value_ <= OpSelSregM0Inl::OPR_SREG_M0_INL_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSregM0Inl::OPR_SREG_M0_INL_TTMP_MIN),
           reg_width};
     break;
   }
@@ -1105,6 +1144,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSregNonull::OPR_SREG_NONULL_SGPR_MIN),
           reg_width};
+    if (encoding_value_ >= OpSelSregNonull::OPR_SREG_NONULL_TTMP_MIN &&
+        encoding_value_ <= OpSelSregNonull::OPR_SREG_NONULL_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSregNonull::OPR_SREG_NONULL_TTMP_MIN),
+          reg_width};
     break;
   }
   case OperandType::OPR_SSRC: {
@@ -1112,6 +1157,11 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
         encoding_value_ <= OpSelSsrc::OPR_SSRC_SGPR_MAX)
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSsrc::OPR_SSRC_SGPR_MIN),
+                         reg_width};
+    if (encoding_value_ >= OpSelSsrc::OPR_SSRC_TTMP_MIN &&
+        encoding_value_ <= OpSelSsrc::OPR_SSRC_TTMP_MAX)
+      return RegisterRef{RegClass::TTMP,
+                         static_cast<uint16_t>(encoding_value_ - OpSelSsrc::OPR_SSRC_TTMP_MIN),
                          reg_width};
     if (encoding_value_ == OpSelSsrc::OPR_SSRC_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
@@ -1126,6 +1176,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSsrcLanesel::OPR_SSRC_LANESEL_SGPR_MIN),
           reg_width};
+    if (encoding_value_ >= OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP_MIN &&
+        encoding_value_ <= OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP_MIN),
+          reg_width};
     break;
   }
   case OperandType::OPR_SSRC_NOLDS: {
@@ -1134,6 +1190,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSsrcNolds::OPR_SSRC_NOLDS_SGPR_MIN),
+          reg_width};
+    if (encoding_value_ >= OpSelSsrcNolds::OPR_SSRC_NOLDS_TTMP_MIN &&
+        encoding_value_ <= OpSelSsrcNolds::OPR_SSRC_NOLDS_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSsrcNolds::OPR_SSRC_NOLDS_TTMP_MIN),
           reg_width};
     if (encoding_value_ == OpSelSsrcNolds::OPR_SSRC_NOLDS_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/operand_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/operand_exec.cpp
@@ -91,7 +91,7 @@ void Operand::read_lane_chunk_exec(const amdgpu::Wavefront &wf, uint32_t lane_ba
     uint64_t lane_mask =
         count == 0 ? 0 : util::mask<uint64_t>(static_cast<int>(count)) << lane_base;
     auto region =
-        amdgpu::RegisterAccess(wf.cu()).read_vgpr_region(wf.vgpr_alloc().base + voff, 1, lane_mask);
+        amdgpu::RegisterAccess(wf).read_vgpr_region(wf.vgpr_alloc().base + voff, 1, lane_mask);
     std::copy_n(region.lanes().begin() + lane_base, count, out);
     return;
   }
@@ -115,6 +115,8 @@ void Operand::write_lane_chunk_exec(amdgpu::Wavefront &wf, uint32_t lane_base, u
       vgpr_msb_role() == amdgpu::VgprMsbRole::None ? amdgpu::VgprMsbRole::Dst : vgpr_msb_role();
   uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, role);
   uint32_t reg = wf.vgpr_alloc().base + voff;
+  if (!amdgpu::OperandExecutionAccess::raw_compute_unit(wf.cu()).owns_vgpr_range(wf, reg, 1))
+    return;
   uint64_t full_mask = util::mask<uint64_t>(static_cast<int>(count));
   uint8_t *dst = amdgpu::OperandExecutionAccess::raw_compute_unit(wf.cu()).raw_vgpr_data(reg);
   if ((mask & full_mask) == full_mask) {
@@ -154,7 +156,7 @@ uint32_t Operand::read_lane_exec(const amdgpu::Wavefront &wf, uint32_t lane) con
   int ev = encoding_value_;
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev)) {
     uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, vgpr_msb_role());
-    return amdgpu::RegisterAccess(wf.cu()).read_vgpr(wf.vgpr_alloc().base + voff, lane);
+    return amdgpu::RegisterAccess(wf).read_vgpr(wf.vgpr_alloc().base + voff, lane);
   }
   if (is_immediate_type(opr_type_))
     return static_cast<uint32_t>(ev);
@@ -184,7 +186,7 @@ void Operand::write_lane_exec(amdgpu::Wavefront &wf, uint32_t lane, uint32_t val
     amdgpu::VgprMsbRole role =
         vgpr_msb_role() == amdgpu::VgprMsbRole::None ? amdgpu::VgprMsbRole::Dst : vgpr_msb_role();
     uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, role);
-    amdgpu::RegisterAccess(wf.cu()).write_vgpr(wf.vgpr_alloc().base + voff, lane, val);
+    amdgpu::RegisterAccess(wf).write_vgpr(wf.vgpr_alloc().base + voff, lane, val);
     return;
   }
   throw std::logic_error("write_lane called on non-VGPR operand type");
@@ -203,7 +205,7 @@ uint64_t Operand::read_lane64_exec(const amdgpu::Wavefront &wf, uint32_t lane) c
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev)) {
     uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, vgpr_msb_role());
     uint32_t idx = wf.vgpr_alloc().base + voff;
-    return amdgpu::RegisterAccess(wf.cu()).read_vgpr64(idx, lane);
+    return amdgpu::RegisterAccess(wf).read_vgpr64(idx, lane);
   }
   if (literal32_widening_)
     return widened_literal32_value();
@@ -226,7 +228,7 @@ void Operand::write_lane64_exec(amdgpu::Wavefront &wf, uint32_t lane, uint64_t v
         vgpr_msb_role() == amdgpu::VgprMsbRole::None ? amdgpu::VgprMsbRole::Dst : vgpr_msb_role();
     uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, role);
     uint32_t idx = wf.vgpr_alloc().base + voff;
-    amdgpu::RegisterAccess(wf.cu()).write_vgpr64(idx, lane, val);
+    amdgpu::RegisterAccess(wf).write_vgpr64(idx, lane, val);
     return;
   }
   throw std::logic_error("write_lane64 called on non-VGPR operand type");

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/smem_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/smem_exec.cpp
@@ -8,6 +8,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h"
 #include "rocjitsu/isa/arch/amdgpu/rdna2/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx10_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"
@@ -25,142 +26,192 @@ namespace rocjitsu {
 namespace rdna2 {
 
 void SLoadDwordSmem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadDwordx2Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 2u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 2;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadDwordx4Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 4u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 4;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadDwordx8Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 8u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 8;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadDwordx16Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 16u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 16;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadDwordSmem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadDwordx2Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 2u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 2;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadDwordx4Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 4u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 4;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadDwordx8Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 8u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 8;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadDwordx16Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 16u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 16;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::LGKMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/ds_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/ds_exec.cpp
@@ -8,6 +8,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h"
 #include "rocjitsu/isa/arch/amdgpu/rdna3/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx11_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/flat_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/flat_exec.cpp
@@ -7,6 +7,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/flat.h"
 #include "rocjitsu/isa/arch/amdgpu/rdna3/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx11_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/mtbuf_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/mtbuf_exec.cpp
@@ -8,6 +8,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h"
 #include "rocjitsu/isa/arch/amdgpu/rdna3/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx11_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/mubuf_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/mubuf_exec.cpp
@@ -8,6 +8,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h"
 #include "rocjitsu/isa/arch/amdgpu/rdna3/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx11_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/operand.cpp
@@ -756,6 +756,11 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSdst::OPR_SDST_SGPR_MIN),
                          reg_width};
+    if (encoding_value_ >= OpSelSdst::OPR_SDST_TTMP_MIN &&
+        encoding_value_ <= OpSelSdst::OPR_SDST_TTMP_MAX)
+      return RegisterRef{RegClass::TTMP,
+                         static_cast<uint16_t>(encoding_value_ - OpSelSdst::OPR_SDST_TTMP_MIN),
+                         reg_width};
     if (encoding_value_ == OpSelSdst::OPR_SDST_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
     if (encoding_value_ == OpSelSdst::OPR_SDST_EXEC_HI)
@@ -782,6 +787,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSmemOffset::OPR_SMEM_OFFSET_SGPR_MIN),
           reg_width};
+    if (encoding_value_ >= OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP_MIN &&
+        encoding_value_ <= OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP_MIN),
+          reg_width};
     break;
   }
   case OperandType::OPR_SRC: {
@@ -789,6 +800,11 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
         encoding_value_ <= OpSelSrc::OPR_SRC_SGPR_MAX)
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSrc::OPR_SRC_SGPR_MIN),
+                         reg_width};
+    if (encoding_value_ >= OpSelSrc::OPR_SRC_TTMP_MIN &&
+        encoding_value_ <= OpSelSrc::OPR_SRC_TTMP_MAX)
+      return RegisterRef{RegClass::TTMP,
+                         static_cast<uint16_t>(encoding_value_ - OpSelSrc::OPR_SRC_TTMP_MIN),
                          reg_width};
     if (encoding_value_ == OpSelSrc::OPR_SRC_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
@@ -825,6 +841,11 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSreg::OPR_SREG_SGPR_MIN),
                          reg_width};
+    if (encoding_value_ >= OpSelSreg::OPR_SREG_TTMP_MIN &&
+        encoding_value_ <= OpSelSreg::OPR_SREG_TTMP_MAX)
+      return RegisterRef{RegClass::TTMP,
+                         static_cast<uint16_t>(encoding_value_ - OpSelSreg::OPR_SREG_TTMP_MIN),
+                         reg_width};
     break;
   }
   case OperandType::OPR_SREG_M0_INL: {
@@ -834,6 +855,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSregM0Inl::OPR_SREG_M0_INL_SGPR_MIN),
           reg_width};
+    if (encoding_value_ >= OpSelSregM0Inl::OPR_SREG_M0_INL_TTMP_MIN &&
+        encoding_value_ <= OpSelSregM0Inl::OPR_SREG_M0_INL_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSregM0Inl::OPR_SREG_M0_INL_TTMP_MIN),
+          reg_width};
     break;
   }
   case OperandType::OPR_SSRC: {
@@ -841,6 +868,11 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
         encoding_value_ <= OpSelSsrc::OPR_SSRC_SGPR_MAX)
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSsrc::OPR_SSRC_SGPR_MIN),
+                         reg_width};
+    if (encoding_value_ >= OpSelSsrc::OPR_SSRC_TTMP_MIN &&
+        encoding_value_ <= OpSelSsrc::OPR_SSRC_TTMP_MAX)
+      return RegisterRef{RegClass::TTMP,
+                         static_cast<uint16_t>(encoding_value_ - OpSelSsrc::OPR_SSRC_TTMP_MIN),
                          reg_width};
     if (encoding_value_ == OpSelSsrc::OPR_SSRC_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
@@ -854,6 +886,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSsrcLanesel::OPR_SSRC_LANESEL_SGPR_MIN),
+          reg_width};
+    if (encoding_value_ >= OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP_MIN &&
+        encoding_value_ <= OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP_MIN),
           reg_width};
     break;
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/operand_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/operand_exec.cpp
@@ -136,7 +136,7 @@ void Operand::read_lane_chunk_exec(const amdgpu::Wavefront &wf, uint32_t lane_ba
     uint64_t lane_mask =
         count == 0 ? 0 : util::mask<uint64_t>(static_cast<int>(count)) << lane_base;
     auto region =
-        amdgpu::RegisterAccess(wf.cu()).read_vgpr_region(wf.vgpr_alloc().base + voff, 1, lane_mask);
+        amdgpu::RegisterAccess(wf).read_vgpr_region(wf.vgpr_alloc().base + voff, 1, lane_mask);
     std::copy_n(region.lanes().begin() + lane_base, count, out);
     return;
   }
@@ -166,6 +166,8 @@ void Operand::write_lane_chunk_exec(amdgpu::Wavefront &wf, uint32_t lane_base, u
       vgpr_msb_role() == amdgpu::VgprMsbRole::None ? amdgpu::VgprMsbRole::Dst : vgpr_msb_role();
   uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, role);
   uint32_t reg = wf.vgpr_alloc().base + voff;
+  if (!amdgpu::OperandExecutionAccess::raw_compute_unit(wf.cu()).owns_vgpr_range(wf, reg, 1))
+    return;
   uint64_t full_mask = util::mask<uint64_t>(static_cast<int>(count));
   uint8_t *dst = amdgpu::OperandExecutionAccess::raw_compute_unit(wf.cu()).raw_vgpr_data(reg);
   if ((mask & full_mask) == full_mask) {
@@ -209,12 +211,12 @@ uint32_t Operand::read_lane_exec(const amdgpu::Wavefront &wf, uint32_t lane) con
     uint8_t byte_mask = packed->shift ? rocjitsu::ExecutionPlugin::kHighHalfByteMask
                                       : rocjitsu::ExecutionPlugin::kLowHalfByteMask;
     uint32_t raw =
-        amdgpu::RegisterAccess(wf.cu()).read_vgpr(wf.vgpr_alloc().base + voff, lane, byte_mask);
+        amdgpu::RegisterAccess(wf).read_vgpr(wf.vgpr_alloc().base + voff, lane, byte_mask);
     return (raw >> packed->shift) & 0xffffu;
   }
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev)) {
     uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, vgpr_msb_role());
-    return amdgpu::RegisterAccess(wf.cu()).read_vgpr(wf.vgpr_alloc().base + voff, lane);
+    return amdgpu::RegisterAccess(wf).read_vgpr(wf.vgpr_alloc().base + voff, lane);
   }
   if (is_immediate_type(opr_type_))
     return static_cast<uint32_t>(ev);
@@ -250,14 +252,14 @@ void Operand::write_lane_exec(amdgpu::Wavefront &wf, uint32_t lane, uint32_t val
     uint8_t write_byte_mask = packed->shift ? rocjitsu::ExecutionPlugin::kHighHalfByteMask
                                             : rocjitsu::ExecutionPlugin::kLowHalfByteMask;
     uint32_t placed = (val & 0xffffu) << packed->shift;
-    amdgpu::RegisterAccess(wf.cu()).write_vgpr(idx, lane, placed, write_byte_mask);
+    amdgpu::RegisterAccess(wf).write_vgpr(idx, lane, placed, write_byte_mask);
     return;
   }
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, encoding_value_)) {
     amdgpu::VgprMsbRole role =
         vgpr_msb_role() == amdgpu::VgprMsbRole::None ? amdgpu::VgprMsbRole::Dst : vgpr_msb_role();
     uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, role);
-    amdgpu::RegisterAccess(wf.cu()).write_vgpr(wf.vgpr_alloc().base + voff, lane, val);
+    amdgpu::RegisterAccess(wf).write_vgpr(wf.vgpr_alloc().base + voff, lane, val);
     return;
   }
   throw std::logic_error("write_lane called on non-VGPR operand type");
@@ -276,7 +278,7 @@ uint64_t Operand::read_lane64_exec(const amdgpu::Wavefront &wf, uint32_t lane) c
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev)) {
     uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, vgpr_msb_role());
     uint32_t idx = wf.vgpr_alloc().base + voff;
-    return amdgpu::RegisterAccess(wf.cu()).read_vgpr64(idx, lane);
+    return amdgpu::RegisterAccess(wf).read_vgpr64(idx, lane);
   }
   if (literal32_widening_)
     return widened_literal32_value();
@@ -299,7 +301,7 @@ void Operand::write_lane64_exec(amdgpu::Wavefront &wf, uint32_t lane, uint64_t v
         vgpr_msb_role() == amdgpu::VgprMsbRole::None ? amdgpu::VgprMsbRole::Dst : vgpr_msb_role();
     uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, role);
     uint32_t idx = wf.vgpr_alloc().base + voff;
-    amdgpu::RegisterAccess(wf.cu()).write_vgpr64(idx, lane, val);
+    amdgpu::RegisterAccess(wf).write_vgpr64(idx, lane, val);
     return;
   }
   throw std::logic_error("write_lane64 called on non-VGPR operand type");

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/smem_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/smem_exec.cpp
@@ -8,6 +8,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h"
 #include "rocjitsu/isa/arch/amdgpu/rdna3/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx11_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"
@@ -25,142 +26,192 @@ namespace rocjitsu {
 namespace rdna3 {
 
 void SLoadB32Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx11(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadB64Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 2u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 2;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx11(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadB128Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 4u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 4;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx11(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadB256Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 8u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 8;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx11(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadB512Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 16u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 16;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx11(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadB32Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx11(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadB64Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 2u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 2;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx11(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadB128Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 4u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 4;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx11(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadB256Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 8u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 8;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx11(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadB512Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 16u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 16;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx11(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/ds_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/ds_exec.cpp
@@ -8,6 +8,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h"
 #include "rocjitsu/isa/arch/amdgpu/rdna3_5/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx11_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/flat_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/flat_exec.cpp
@@ -7,6 +7,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/flat.h"
 #include "rocjitsu/isa/arch/amdgpu/rdna3_5/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx11_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/mtbuf_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/mtbuf_exec.cpp
@@ -8,6 +8,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h"
 #include "rocjitsu/isa/arch/amdgpu/rdna3_5/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx11_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/mubuf_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/mubuf_exec.cpp
@@ -8,6 +8,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h"
 #include "rocjitsu/isa/arch/amdgpu/rdna3_5/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx11_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/operand.cpp
@@ -784,6 +784,11 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSdst::OPR_SDST_SGPR_MIN),
                          reg_width};
+    if (encoding_value_ >= OpSelSdst::OPR_SDST_TTMP_MIN &&
+        encoding_value_ <= OpSelSdst::OPR_SDST_TTMP_MAX)
+      return RegisterRef{RegClass::TTMP,
+                         static_cast<uint16_t>(encoding_value_ - OpSelSdst::OPR_SDST_TTMP_MIN),
+                         reg_width};
     if (encoding_value_ == OpSelSdst::OPR_SDST_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
     if (encoding_value_ == OpSelSdst::OPR_SDST_EXEC_HI)
@@ -810,6 +815,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSmemOffset::OPR_SMEM_OFFSET_SGPR_MIN),
           reg_width};
+    if (encoding_value_ >= OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP_MIN &&
+        encoding_value_ <= OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP_MIN),
+          reg_width};
     break;
   }
   case OperandType::OPR_SRC: {
@@ -817,6 +828,11 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
         encoding_value_ <= OpSelSrc::OPR_SRC_SGPR_MAX)
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSrc::OPR_SRC_SGPR_MIN),
+                         reg_width};
+    if (encoding_value_ >= OpSelSrc::OPR_SRC_TTMP_MIN &&
+        encoding_value_ <= OpSelSrc::OPR_SRC_TTMP_MAX)
+      return RegisterRef{RegClass::TTMP,
+                         static_cast<uint16_t>(encoding_value_ - OpSelSrc::OPR_SRC_TTMP_MIN),
                          reg_width};
     if (encoding_value_ == OpSelSrc::OPR_SRC_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
@@ -853,6 +869,11 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSreg::OPR_SREG_SGPR_MIN),
                          reg_width};
+    if (encoding_value_ >= OpSelSreg::OPR_SREG_TTMP_MIN &&
+        encoding_value_ <= OpSelSreg::OPR_SREG_TTMP_MAX)
+      return RegisterRef{RegClass::TTMP,
+                         static_cast<uint16_t>(encoding_value_ - OpSelSreg::OPR_SREG_TTMP_MIN),
+                         reg_width};
     break;
   }
   case OperandType::OPR_SREG_M0_INL: {
@@ -862,6 +883,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSregM0Inl::OPR_SREG_M0_INL_SGPR_MIN),
           reg_width};
+    if (encoding_value_ >= OpSelSregM0Inl::OPR_SREG_M0_INL_TTMP_MIN &&
+        encoding_value_ <= OpSelSregM0Inl::OPR_SREG_M0_INL_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSregM0Inl::OPR_SREG_M0_INL_TTMP_MIN),
+          reg_width};
     break;
   }
   case OperandType::OPR_SSRC: {
@@ -869,6 +896,11 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
         encoding_value_ <= OpSelSsrc::OPR_SSRC_SGPR_MAX)
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSsrc::OPR_SSRC_SGPR_MIN),
+                         reg_width};
+    if (encoding_value_ >= OpSelSsrc::OPR_SSRC_TTMP_MIN &&
+        encoding_value_ <= OpSelSsrc::OPR_SSRC_TTMP_MAX)
+      return RegisterRef{RegClass::TTMP,
+                         static_cast<uint16_t>(encoding_value_ - OpSelSsrc::OPR_SSRC_TTMP_MIN),
                          reg_width};
     if (encoding_value_ == OpSelSsrc::OPR_SSRC_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
@@ -882,6 +914,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSsrcLanesel::OPR_SSRC_LANESEL_SGPR_MIN),
+          reg_width};
+    if (encoding_value_ >= OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP_MIN &&
+        encoding_value_ <= OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP_MIN),
           reg_width};
     break;
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/operand_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/operand_exec.cpp
@@ -136,7 +136,7 @@ void Operand::read_lane_chunk_exec(const amdgpu::Wavefront &wf, uint32_t lane_ba
     uint64_t lane_mask =
         count == 0 ? 0 : util::mask<uint64_t>(static_cast<int>(count)) << lane_base;
     auto region =
-        amdgpu::RegisterAccess(wf.cu()).read_vgpr_region(wf.vgpr_alloc().base + voff, 1, lane_mask);
+        amdgpu::RegisterAccess(wf).read_vgpr_region(wf.vgpr_alloc().base + voff, 1, lane_mask);
     std::copy_n(region.lanes().begin() + lane_base, count, out);
     return;
   }
@@ -166,6 +166,8 @@ void Operand::write_lane_chunk_exec(amdgpu::Wavefront &wf, uint32_t lane_base, u
       vgpr_msb_role() == amdgpu::VgprMsbRole::None ? amdgpu::VgprMsbRole::Dst : vgpr_msb_role();
   uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, role);
   uint32_t reg = wf.vgpr_alloc().base + voff;
+  if (!amdgpu::OperandExecutionAccess::raw_compute_unit(wf.cu()).owns_vgpr_range(wf, reg, 1))
+    return;
   uint64_t full_mask = util::mask<uint64_t>(static_cast<int>(count));
   uint8_t *dst = amdgpu::OperandExecutionAccess::raw_compute_unit(wf.cu()).raw_vgpr_data(reg);
   if ((mask & full_mask) == full_mask) {
@@ -209,12 +211,12 @@ uint32_t Operand::read_lane_exec(const amdgpu::Wavefront &wf, uint32_t lane) con
     uint8_t byte_mask = packed->shift ? rocjitsu::ExecutionPlugin::kHighHalfByteMask
                                       : rocjitsu::ExecutionPlugin::kLowHalfByteMask;
     uint32_t raw =
-        amdgpu::RegisterAccess(wf.cu()).read_vgpr(wf.vgpr_alloc().base + voff, lane, byte_mask);
+        amdgpu::RegisterAccess(wf).read_vgpr(wf.vgpr_alloc().base + voff, lane, byte_mask);
     return (raw >> packed->shift) & 0xffffu;
   }
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev)) {
     uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, vgpr_msb_role());
-    return amdgpu::RegisterAccess(wf.cu()).read_vgpr(wf.vgpr_alloc().base + voff, lane);
+    return amdgpu::RegisterAccess(wf).read_vgpr(wf.vgpr_alloc().base + voff, lane);
   }
   if (is_immediate_type(opr_type_))
     return static_cast<uint32_t>(ev);
@@ -250,14 +252,14 @@ void Operand::write_lane_exec(amdgpu::Wavefront &wf, uint32_t lane, uint32_t val
     uint8_t write_byte_mask = packed->shift ? rocjitsu::ExecutionPlugin::kHighHalfByteMask
                                             : rocjitsu::ExecutionPlugin::kLowHalfByteMask;
     uint32_t placed = (val & 0xffffu) << packed->shift;
-    amdgpu::RegisterAccess(wf.cu()).write_vgpr(idx, lane, placed, write_byte_mask);
+    amdgpu::RegisterAccess(wf).write_vgpr(idx, lane, placed, write_byte_mask);
     return;
   }
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, encoding_value_)) {
     amdgpu::VgprMsbRole role =
         vgpr_msb_role() == amdgpu::VgprMsbRole::None ? amdgpu::VgprMsbRole::Dst : vgpr_msb_role();
     uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, role);
-    amdgpu::RegisterAccess(wf.cu()).write_vgpr(wf.vgpr_alloc().base + voff, lane, val);
+    amdgpu::RegisterAccess(wf).write_vgpr(wf.vgpr_alloc().base + voff, lane, val);
     return;
   }
   throw std::logic_error("write_lane called on non-VGPR operand type");
@@ -276,7 +278,7 @@ uint64_t Operand::read_lane64_exec(const amdgpu::Wavefront &wf, uint32_t lane) c
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev)) {
     uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, vgpr_msb_role());
     uint32_t idx = wf.vgpr_alloc().base + voff;
-    return amdgpu::RegisterAccess(wf.cu()).read_vgpr64(idx, lane);
+    return amdgpu::RegisterAccess(wf).read_vgpr64(idx, lane);
   }
   if (literal32_widening_)
     return widened_literal32_value();
@@ -299,7 +301,7 @@ void Operand::write_lane64_exec(amdgpu::Wavefront &wf, uint32_t lane, uint64_t v
         vgpr_msb_role() == amdgpu::VgprMsbRole::None ? amdgpu::VgprMsbRole::Dst : vgpr_msb_role();
     uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, role);
     uint32_t idx = wf.vgpr_alloc().base + voff;
-    amdgpu::RegisterAccess(wf.cu()).write_vgpr64(idx, lane, val);
+    amdgpu::RegisterAccess(wf).write_vgpr64(idx, lane, val);
     return;
   }
   throw std::logic_error("write_lane64 called on non-VGPR operand type");

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/smem_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/smem_exec.cpp
@@ -8,6 +8,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h"
 #include "rocjitsu/isa/arch/amdgpu/rdna3_5/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx11_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"
@@ -25,142 +26,192 @@ namespace rocjitsu {
 namespace rdna3_5 {
 
 void SLoadB32Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx11(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadB64Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 2u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 2;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx11(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadB128Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 4u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 4;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx11(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadB256Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 8u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 8;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx11(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadB512Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 16u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 16;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx11(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadB32Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx11(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadB64Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 2u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 2;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx11(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadB128Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 4u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 4;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx11(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadB256Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 8u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 8;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx11(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadB512Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 16u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 16;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx11(inst_.glc, inst_.dlc, false);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/operand.cpp
@@ -789,6 +789,11 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSdst::OPR_SDST_SGPR_MIN),
                          reg_width};
+    if (encoding_value_ >= OpSelSdst::OPR_SDST_TTMP_MIN &&
+        encoding_value_ <= OpSelSdst::OPR_SDST_TTMP_MAX)
+      return RegisterRef{RegClass::TTMP,
+                         static_cast<uint16_t>(encoding_value_ - OpSelSdst::OPR_SDST_TTMP_MIN),
+                         reg_width};
     if (encoding_value_ == OpSelSdst::OPR_SDST_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
     if (encoding_value_ == OpSelSdst::OPR_SDST_EXEC_HI)
@@ -812,6 +817,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSmemOffset::OPR_SMEM_OFFSET_SGPR_MIN),
           reg_width};
+    if (encoding_value_ >= OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP_MIN &&
+        encoding_value_ <= OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSmemOffset::OPR_SMEM_OFFSET_TTMP_MIN),
+          reg_width};
     break;
   }
   case OperandType::OPR_SMEM_OFFSET_NOK: {
@@ -821,6 +832,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSmemOffsetNok::OPR_SMEM_OFFSET_NOK_SGPR_MIN),
           reg_width};
+    if (encoding_value_ >= OpSelSmemOffsetNok::OPR_SMEM_OFFSET_NOK_TTMP_MIN &&
+        encoding_value_ <= OpSelSmemOffsetNok::OPR_SMEM_OFFSET_NOK_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSmemOffsetNok::OPR_SMEM_OFFSET_NOK_TTMP_MIN),
+          reg_width};
     break;
   }
   case OperandType::OPR_SRC: {
@@ -828,6 +845,11 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
         encoding_value_ <= OpSelSrc::OPR_SRC_SGPR_MAX)
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSrc::OPR_SRC_SGPR_MIN),
+                         reg_width};
+    if (encoding_value_ >= OpSelSrc::OPR_SRC_TTMP_MIN &&
+        encoding_value_ <= OpSelSrc::OPR_SRC_TTMP_MAX)
+      return RegisterRef{RegClass::TTMP,
+                         static_cast<uint16_t>(encoding_value_ - OpSelSrc::OPR_SRC_TTMP_MIN),
                          reg_width};
     if (encoding_value_ == OpSelSrc::OPR_SRC_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
@@ -864,6 +886,11 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSreg::OPR_SREG_SGPR_MIN),
                          reg_width};
+    if (encoding_value_ >= OpSelSreg::OPR_SREG_TTMP_MIN &&
+        encoding_value_ <= OpSelSreg::OPR_SREG_TTMP_MAX)
+      return RegisterRef{RegClass::TTMP,
+                         static_cast<uint16_t>(encoding_value_ - OpSelSreg::OPR_SREG_TTMP_MIN),
+                         reg_width};
     break;
   }
   case OperandType::OPR_SREG_LITERAL: {
@@ -873,6 +900,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSregLiteral::OPR_SREG_LITERAL_SGPR_MIN),
           reg_width};
+    if (encoding_value_ >= OpSelSregLiteral::OPR_SREG_LITERAL_TTMP_MIN &&
+        encoding_value_ <= OpSelSregLiteral::OPR_SREG_LITERAL_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSregLiteral::OPR_SREG_LITERAL_TTMP_MIN),
+          reg_width};
     break;
   }
   case OperandType::OPR_SREG_M0: {
@@ -881,6 +914,11 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSregM0::OPR_SREG_M0_SGPR_MIN),
                          reg_width};
+    if (encoding_value_ >= OpSelSregM0::OPR_SREG_M0_TTMP_MIN &&
+        encoding_value_ <= OpSelSregM0::OPR_SREG_M0_TTMP_MAX)
+      return RegisterRef{RegClass::TTMP,
+                         static_cast<uint16_t>(encoding_value_ - OpSelSregM0::OPR_SREG_M0_TTMP_MIN),
+                         reg_width};
     break;
   }
   case OperandType::OPR_SSRC: {
@@ -888,6 +926,11 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
         encoding_value_ <= OpSelSsrc::OPR_SSRC_SGPR_MAX)
       return RegisterRef{RegClass::SGPR,
                          static_cast<uint16_t>(encoding_value_ - OpSelSsrc::OPR_SSRC_SGPR_MIN),
+                         reg_width};
+    if (encoding_value_ >= OpSelSsrc::OPR_SSRC_TTMP_MIN &&
+        encoding_value_ <= OpSelSsrc::OPR_SSRC_TTMP_MAX)
+      return RegisterRef{RegClass::TTMP,
+                         static_cast<uint16_t>(encoding_value_ - OpSelSsrc::OPR_SSRC_TTMP_MIN),
                          reg_width};
     if (encoding_value_ == OpSelSsrc::OPR_SSRC_EXEC_LO)
       return RegisterRef{RegClass::EXEC, 0, reg_width};
@@ -904,6 +947,12 @@ std::optional<RegisterRef> Operand::to_register_ref() const {
       return RegisterRef{
           RegClass::SGPR,
           static_cast<uint16_t>(encoding_value_ - OpSelSsrcLanesel::OPR_SSRC_LANESEL_SGPR_MIN),
+          reg_width};
+    if (encoding_value_ >= OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP_MIN &&
+        encoding_value_ <= OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP_MAX)
+      return RegisterRef{
+          RegClass::TTMP,
+          static_cast<uint16_t>(encoding_value_ - OpSelSsrcLanesel::OPR_SSRC_LANESEL_TTMP_MIN),
           reg_width};
     break;
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/operand_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/operand_exec.cpp
@@ -136,7 +136,7 @@ void Operand::read_lane_chunk_exec(const amdgpu::Wavefront &wf, uint32_t lane_ba
     uint64_t lane_mask =
         count == 0 ? 0 : util::mask<uint64_t>(static_cast<int>(count)) << lane_base;
     auto region =
-        amdgpu::RegisterAccess(wf.cu()).read_vgpr_region(wf.vgpr_alloc().base + voff, 1, lane_mask);
+        amdgpu::RegisterAccess(wf).read_vgpr_region(wf.vgpr_alloc().base + voff, 1, lane_mask);
     std::copy_n(region.lanes().begin() + lane_base, count, out);
     return;
   }
@@ -166,6 +166,8 @@ void Operand::write_lane_chunk_exec(amdgpu::Wavefront &wf, uint32_t lane_base, u
       vgpr_msb_role() == amdgpu::VgprMsbRole::None ? amdgpu::VgprMsbRole::Dst : vgpr_msb_role();
   uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, role);
   uint32_t reg = wf.vgpr_alloc().base + voff;
+  if (!amdgpu::OperandExecutionAccess::raw_compute_unit(wf.cu()).owns_vgpr_range(wf, reg, 1))
+    return;
   uint64_t full_mask = util::mask<uint64_t>(static_cast<int>(count));
   uint8_t *dst = amdgpu::OperandExecutionAccess::raw_compute_unit(wf.cu()).raw_vgpr_data(reg);
   if ((mask & full_mask) == full_mask) {
@@ -209,12 +211,12 @@ uint32_t Operand::read_lane_exec(const amdgpu::Wavefront &wf, uint32_t lane) con
     uint8_t byte_mask = packed->shift ? rocjitsu::ExecutionPlugin::kHighHalfByteMask
                                       : rocjitsu::ExecutionPlugin::kLowHalfByteMask;
     uint32_t raw =
-        amdgpu::RegisterAccess(wf.cu()).read_vgpr(wf.vgpr_alloc().base + voff, lane, byte_mask);
+        amdgpu::RegisterAccess(wf).read_vgpr(wf.vgpr_alloc().base + voff, lane, byte_mask);
     return (raw >> packed->shift) & 0xffffu;
   }
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev)) {
     uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, vgpr_msb_role());
-    return amdgpu::RegisterAccess(wf.cu()).read_vgpr(wf.vgpr_alloc().base + voff, lane);
+    return amdgpu::RegisterAccess(wf).read_vgpr(wf.vgpr_alloc().base + voff, lane);
   }
   if (is_immediate_type(opr_type_))
     return static_cast<uint32_t>(ev);
@@ -250,14 +252,14 @@ void Operand::write_lane_exec(amdgpu::Wavefront &wf, uint32_t lane, uint32_t val
     uint8_t write_byte_mask = packed->shift ? rocjitsu::ExecutionPlugin::kHighHalfByteMask
                                             : rocjitsu::ExecutionPlugin::kLowHalfByteMask;
     uint32_t placed = (val & 0xffffu) << packed->shift;
-    amdgpu::RegisterAccess(wf.cu()).write_vgpr(idx, lane, placed, write_byte_mask);
+    amdgpu::RegisterAccess(wf).write_vgpr(idx, lane, placed, write_byte_mask);
     return;
   }
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, encoding_value_)) {
     amdgpu::VgprMsbRole role =
         vgpr_msb_role() == amdgpu::VgprMsbRole::None ? amdgpu::VgprMsbRole::Dst : vgpr_msb_role();
     uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, role);
-    amdgpu::RegisterAccess(wf.cu()).write_vgpr(wf.vgpr_alloc().base + voff, lane, val);
+    amdgpu::RegisterAccess(wf).write_vgpr(wf.vgpr_alloc().base + voff, lane, val);
     return;
   }
   throw std::logic_error("write_lane called on non-VGPR operand type");
@@ -276,7 +278,7 @@ uint64_t Operand::read_lane64_exec(const amdgpu::Wavefront &wf, uint32_t lane) c
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev)) {
     uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, vgpr_msb_role());
     uint32_t idx = wf.vgpr_alloc().base + voff;
-    return amdgpu::RegisterAccess(wf.cu()).read_vgpr64(idx, lane);
+    return amdgpu::RegisterAccess(wf).read_vgpr64(idx, lane);
   }
   if (literal32_widening_)
     return widened_literal32_value();
@@ -299,7 +301,7 @@ void Operand::write_lane64_exec(amdgpu::Wavefront &wf, uint32_t lane, uint64_t v
         vgpr_msb_role() == amdgpu::VgprMsbRole::None ? amdgpu::VgprMsbRole::Dst : vgpr_msb_role();
     uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, role);
     uint32_t idx = wf.vgpr_alloc().base + voff;
-    amdgpu::RegisterAccess(wf.cu()).write_vgpr64(idx, lane, val);
+    amdgpu::RegisterAccess(wf).write_vgpr64(idx, lane, val);
     return;
   }
   throw std::logic_error("write_lane64 called on non-VGPR operand type");

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/smem_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/smem_exec.cpp
@@ -7,6 +7,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/smem.h"
 #include "rocjitsu/isa/arch/amdgpu/rdna4/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx12_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"
@@ -24,282 +25,382 @@ namespace rocjitsu {
 namespace rdna4 {
 
 void SLoadB32Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadB64Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 2u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 2;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadB128Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 4u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 4;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadB256Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 8u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 8;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadB512Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 16u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 16;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadB96Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 3u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 3;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadI8Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 1;
   d->sign_extend = true;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadU8Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 1;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadI16Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 2;
   d->sign_extend = true;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SLoadU16Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 2;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadB32Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadB64Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 2u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 2;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadB128Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 4u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 4;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadB256Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 8u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 8;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadB512Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 16u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 16;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadB96Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 3u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 3;
   d->elem_size = 4;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadI8Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 1;
   d->sign_extend = true;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadU8Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 1;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadI16Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 2;
   d->sign_extend = true;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 
 void SBufferLoadU16Smem::execute_impl(amdgpu::Wavefront &wf) {
+  auto dst_register = amdgpu::resolve_scalar_register_range(wf, inst_.sdata, 1u);
+  if (!dst_register)
+    return;
   auto d = std::make_unique<amdgpu::ScalarMemState>();
-  d->dst_reg_base = wf.sgpr_alloc().base + inst_.sdata;
-  d->dst_selector = inst_.sdata;
+  d->dst_register = *dst_register;
   d->num_dwords = 1;
   d->elem_size = 2;
   d->sign_extend = false;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf);
+  auto address = smem_calculate_address(inst_, wf);
+  if (!address)
+    return;
+  d->addr = *address;
   set_data(std::move(d));
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vbuffer_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vbuffer_exec.cpp
@@ -7,6 +7,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/vbuffer.h"
 #include "rocjitsu/isa/arch/amdgpu/rdna4/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx12_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vds_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vds_exec.cpp
@@ -8,6 +8,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h"
 #include "rocjitsu/isa/arch/amdgpu/rdna4/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx12_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vflat_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vflat_exec.cpp
@@ -7,6 +7,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/vflat.h"
 #include "rocjitsu/isa/arch/amdgpu/rdna4/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx12_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vglobal_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vglobal_exec.cpp
@@ -7,6 +7,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/vglobal.h"
 #include "rocjitsu/isa/arch/amdgpu/rdna4/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx12_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vscratch_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vscratch_exec.cpp
@@ -7,6 +7,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/vscratch.h"
 #include "rocjitsu/isa/arch/amdgpu/rdna4/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx12_cache_flags.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna1/addr_calc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna1/addr_calc.cpp
@@ -19,22 +19,27 @@ namespace rdna1 {
 
 namespace {
 
-uint32_t read_smem_offset(uint32_t soffset, amdgpu::Wavefront &wf) {
+std::optional<uint32_t> read_smem_offset(uint32_t soffset, amdgpu::Wavefront &wf) {
   if (soffset == OPR_SMEM_OFFSET_NULL || soffset == 0x7F)
     return 0;
   if (soffset == OPR_SMEM_OFFSET_M0)
     return wf.m0();
-  return amdgpu::read_scalar_selector(wf, soffset);
+  return amdgpu::try_read_scalar_selector(wf, soffset);
 }
 
 } // namespace
 
-uint64_t smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf) {
+std::optional<uint64_t> smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf) {
   const uint32_t sbase_sel = inst.sbase * 2;
-  uint64_t base = amdgpu::read_scalar_selector64(wf, sbase_sel);
+  auto base = amdgpu::try_read_scalar_selector64(wf, sbase_sel);
+  if (!base)
+    return std::nullopt;
   int64_t off = static_cast<int64_t>(static_cast<int32_t>(inst.offset << 11) >> 11);
-  off += read_smem_offset(inst.soffset, wf);
-  return (base + off) & ~0x3ULL;
+  auto soffset = read_smem_offset(inst.soffset, wf);
+  if (!soffset)
+    return std::nullopt;
+  off += *soffset;
+  return (*base + off) & ~0x3ULL;
 }
 
 void flat_calculate_addresses(const FlatMachineInst &inst, amdgpu::Wavefront &wf,
@@ -44,13 +49,18 @@ void flat_calculate_addresses(const FlatMachineInst &inst, amdgpu::Wavefront &wf
   d.lane_mask = exec;
   d.exec_mask = exec;
   int64_t offset = static_cast<int64_t>(static_cast<int32_t>(inst.offset << 20) >> 20);
+  amdgpu::RegisterAccess regs(cu);
   uint64_t saddr_val = 0;
   if (inst.saddr != 0x7F) {
     const uint32_t sb_sel = inst.saddr;
-    saddr_val = amdgpu::read_scalar_selector64(wf, sb_sel);
+    auto saddr = amdgpu::try_read_scalar_selector64(wf, sb_sel);
+    if (!saddr) {
+      amdgpu::reject_vector_memory_access(d);
+      return;
+    }
+    saddr_val = *saddr;
   }
   uint32_t vbase = wf.vgpr_alloc().base + inst.addr;
-  amdgpu::RegisterAccess regs(cu);
   auto vaddr_region = regs.read_vgpr_region(vbase, inst.saddr != 0x7F ? 1 : 2, exec);
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna1/addr_calc.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna1/addr_calc.h
@@ -8,6 +8,7 @@
 #include "rocjitsu/vm/amdgpu/mtype.h"
 
 #include <cstdint>
+#include <optional>
 
 namespace rocjitsu {
 namespace amdgpu {
@@ -17,7 +18,7 @@ struct VectorMemState;
 
 namespace rdna1 {
 
-uint64_t smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf);
+std::optional<uint64_t> smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf);
 
 void flat_calculate_addresses(const FlatMachineInst &inst, amdgpu::Wavefront &wf,
                               amdgpu::VectorMemState &d);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna2/addr_calc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna2/addr_calc.cpp
@@ -19,22 +19,27 @@ namespace rdna2 {
 
 namespace {
 
-uint32_t read_smem_offset(uint32_t soffset, amdgpu::Wavefront &wf) {
+std::optional<uint32_t> read_smem_offset(uint32_t soffset, amdgpu::Wavefront &wf) {
   if (soffset == OPR_SMEM_OFFSET_NULL || soffset == 0x7F)
     return 0;
   if (soffset == OPR_SMEM_OFFSET_M0)
     return wf.m0();
-  return amdgpu::read_scalar_selector(wf, soffset);
+  return amdgpu::try_read_scalar_selector(wf, soffset);
 }
 
 } // namespace
 
-uint64_t smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf) {
+std::optional<uint64_t> smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf) {
   const uint32_t sbase_sel = inst.sbase * 2;
-  uint64_t base = amdgpu::read_scalar_selector64(wf, sbase_sel);
+  auto base = amdgpu::try_read_scalar_selector64(wf, sbase_sel);
+  if (!base)
+    return std::nullopt;
   int64_t off = static_cast<int64_t>(static_cast<int32_t>(inst.offset << 11) >> 11);
-  off += read_smem_offset(inst.soffset, wf);
-  return (base + off) & ~0x3ULL;
+  auto soffset = read_smem_offset(inst.soffset, wf);
+  if (!soffset)
+    return std::nullopt;
+  off += *soffset;
+  return (*base + off) & ~0x3ULL;
 }
 
 void flat_calculate_addresses(const FlatMachineInst &inst, amdgpu::Wavefront &wf,
@@ -44,13 +49,18 @@ void flat_calculate_addresses(const FlatMachineInst &inst, amdgpu::Wavefront &wf
   d.lane_mask = exec;
   d.exec_mask = exec;
   int64_t offset = static_cast<int64_t>(static_cast<int32_t>(inst.offset << 20) >> 20);
+  amdgpu::RegisterAccess regs(cu);
   uint64_t saddr_val = 0;
   if (inst.saddr != 0x7F) {
     const uint32_t sb_sel = inst.saddr;
-    saddr_val = amdgpu::read_scalar_selector64(wf, sb_sel);
+    auto saddr = amdgpu::try_read_scalar_selector64(wf, sb_sel);
+    if (!saddr) {
+      amdgpu::reject_vector_memory_access(d);
+      return;
+    }
+    saddr_val = *saddr;
   }
   uint32_t vbase = wf.vgpr_alloc().base + inst.addr;
-  amdgpu::RegisterAccess regs(cu);
   auto vaddr_region = regs.read_vgpr_region(vbase, inst.saddr != 0x7F ? 1 : 2, exec);
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna2/addr_calc.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna2/addr_calc.h
@@ -8,6 +8,7 @@
 #include "rocjitsu/vm/amdgpu/mtype.h"
 
 #include <cstdint>
+#include <optional>
 
 namespace rocjitsu {
 namespace amdgpu {
@@ -17,7 +18,7 @@ struct VectorMemState;
 
 namespace rdna2 {
 
-uint64_t smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf);
+std::optional<uint64_t> smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf);
 
 void flat_calculate_addresses(const FlatMachineInst &inst, amdgpu::Wavefront &wf,
                               amdgpu::VectorMemState &d);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/addr_calc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/addr_calc.cpp
@@ -31,22 +31,27 @@ int64_t sign_extend(uint32_t value, uint32_t bits) {
   return static_cast<int64_t>(static_cast<int32_t>(value << shift) >> shift);
 }
 
-uint32_t read_smem_offset(uint32_t soffset, amdgpu::Wavefront &wf) {
+std::optional<uint32_t> read_smem_offset(uint32_t soffset, amdgpu::Wavefront &wf) {
   if (soffset == OPR_SMEM_OFFSET_NULL || soffset == 0x7F)
     return 0;
   if (soffset == OPR_SMEM_OFFSET_M0)
     return wf.m0();
-  return amdgpu::read_scalar_selector(wf, soffset);
+  return amdgpu::try_read_scalar_selector(wf, soffset);
 }
 
 } // namespace
 
-uint64_t smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf) {
+std::optional<uint64_t> smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf) {
   const uint32_t sbase_sel = inst.sbase * 2;
-  uint64_t base = amdgpu::read_scalar_selector64(wf, sbase_sel);
+  auto base = amdgpu::try_read_scalar_selector64(wf, sbase_sel);
+  if (!base)
+    return std::nullopt;
   int64_t off = static_cast<int64_t>(static_cast<int32_t>(inst.offset << 11) >> 11);
-  off += read_smem_offset(inst.soffset, wf);
-  return (base + off) & ~0x3ULL;
+  auto soffset = read_smem_offset(inst.soffset, wf);
+  if (!soffset)
+    return std::nullopt;
+  off += *soffset;
+  return (*base + off) & ~0x3ULL;
 }
 
 void flat_calculate_addresses(const FlatMachineInst &inst, amdgpu::Wavefront &wf,
@@ -59,14 +64,19 @@ void flat_calculate_addresses(const FlatMachineInst &inst, amdgpu::Wavefront &wf
   int64_t offset = sign_extend(inst.offset, 13);
 
   if (inst.seg == 1) {
+    amdgpu::RegisterAccess regs(cu);
     uint32_t saddr_val = 0;
     if (has_saddr(inst.saddr)) {
       const uint32_t sb_sel = inst.saddr;
-      saddr_val = amdgpu::read_scalar_selector(wf, sb_sel);
+      auto saddr = amdgpu::try_read_scalar_selector(wf, sb_sel);
+      if (!saddr) {
+        amdgpu::reject_vector_memory_access(d);
+        return;
+      }
+      saddr_val = *saddr;
     }
     uint64_t scratch_base = wf.scratch_base();
     uint32_t lane_stride = wf.scratch_lane_size();
-    amdgpu::RegisterAccess regs(cu);
     std::optional<amdgpu::RegisterAccess::VgprReadRegion> vaddr_region;
     if (inst.sve) {
       uint32_t vbase = wf.vgpr_alloc().base + inst.addr;
@@ -86,15 +96,20 @@ void flat_calculate_addresses(const FlatMachineInst &inst, amdgpu::Wavefront &wf
   }
 
   uint64_t saddr_val = 0;
+  amdgpu::RegisterAccess regs(cu);
   if (has_saddr(inst.saddr)) {
     const uint32_t sb_sel = inst.saddr;
-    saddr_val = amdgpu::read_scalar_selector64(wf, sb_sel);
+    auto saddr = amdgpu::try_read_scalar_selector64(wf, sb_sel);
+    if (!saddr) {
+      amdgpu::reject_vector_memory_access(d);
+      return;
+    }
+    saddr_val = *saddr;
   }
   uint32_t priv_hi = static_cast<uint32_t>(wf.private_aperture_base() >> 32);
   uint64_t scratch_base = wf.scratch_base();
   uint32_t lane_stride = wf.scratch_lane_size();
   uint32_t vbase = wf.vgpr_alloc().base + inst.addr;
-  amdgpu::RegisterAccess regs(cu);
   auto vaddr_region = regs.read_vgpr_region(vbase, has_saddr(inst.saddr) ? 1 : 2, exec);
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/addr_calc.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/addr_calc.h
@@ -8,6 +8,7 @@
 #include "rocjitsu/vm/amdgpu/mtype.h"
 
 #include <cstdint>
+#include <optional>
 
 namespace rocjitsu {
 namespace amdgpu {
@@ -17,7 +18,7 @@ struct VectorMemState;
 
 namespace rdna3 {
 
-uint64_t smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf);
+std::optional<uint64_t> smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf);
 
 void flat_calculate_addresses(const FlatMachineInst &inst, amdgpu::Wavefront &wf,
                               amdgpu::VectorMemState &d);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/addr_calc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/addr_calc.cpp
@@ -31,22 +31,27 @@ int64_t sign_extend(uint32_t value, uint32_t bits) {
   return static_cast<int64_t>(static_cast<int32_t>(value << shift) >> shift);
 }
 
-uint32_t read_smem_offset(uint32_t soffset, amdgpu::Wavefront &wf) {
+std::optional<uint32_t> read_smem_offset(uint32_t soffset, amdgpu::Wavefront &wf) {
   if (soffset == OPR_SMEM_OFFSET_NULL || soffset == 0x7F)
     return 0;
   if (soffset == OPR_SMEM_OFFSET_M0)
     return wf.m0();
-  return amdgpu::read_scalar_selector(wf, soffset);
+  return amdgpu::try_read_scalar_selector(wf, soffset);
 }
 
 } // namespace
 
-uint64_t smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf) {
+std::optional<uint64_t> smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf) {
   const uint32_t sbase_sel = inst.sbase * 2;
-  uint64_t base = amdgpu::read_scalar_selector64(wf, sbase_sel);
+  auto base = amdgpu::try_read_scalar_selector64(wf, sbase_sel);
+  if (!base)
+    return std::nullopt;
   int64_t off = static_cast<int64_t>(static_cast<int32_t>(inst.offset << 11) >> 11);
-  off += read_smem_offset(inst.soffset, wf);
-  return (base + off) & ~0x3ULL;
+  auto soffset = read_smem_offset(inst.soffset, wf);
+  if (!soffset)
+    return std::nullopt;
+  off += *soffset;
+  return (*base + off) & ~0x3ULL;
 }
 
 void flat_calculate_addresses(const FlatMachineInst &inst, amdgpu::Wavefront &wf,
@@ -59,14 +64,19 @@ void flat_calculate_addresses(const FlatMachineInst &inst, amdgpu::Wavefront &wf
   int64_t offset = sign_extend(inst.offset, 13);
 
   if (inst.seg == 1) {
+    amdgpu::RegisterAccess regs(cu);
     uint32_t saddr_val = 0;
     if (has_saddr(inst.saddr)) {
       const uint32_t sb_sel = inst.saddr;
-      saddr_val = amdgpu::read_scalar_selector(wf, sb_sel);
+      auto saddr = amdgpu::try_read_scalar_selector(wf, sb_sel);
+      if (!saddr) {
+        amdgpu::reject_vector_memory_access(d);
+        return;
+      }
+      saddr_val = *saddr;
     }
     uint64_t scratch_base = wf.scratch_base();
     uint32_t lane_stride = wf.scratch_lane_size();
-    amdgpu::RegisterAccess regs(cu);
     std::optional<amdgpu::RegisterAccess::VgprReadRegion> vaddr_region;
     if (inst.sve) {
       uint32_t vbase = wf.vgpr_alloc().base + inst.addr;
@@ -86,15 +96,20 @@ void flat_calculate_addresses(const FlatMachineInst &inst, amdgpu::Wavefront &wf
   }
 
   uint64_t saddr_val = 0;
+  amdgpu::RegisterAccess regs(cu);
   if (has_saddr(inst.saddr)) {
     const uint32_t sb_sel = inst.saddr;
-    saddr_val = amdgpu::read_scalar_selector64(wf, sb_sel);
+    auto saddr = amdgpu::try_read_scalar_selector64(wf, sb_sel);
+    if (!saddr) {
+      amdgpu::reject_vector_memory_access(d);
+      return;
+    }
+    saddr_val = *saddr;
   }
   uint32_t priv_hi = static_cast<uint32_t>(wf.private_aperture_base() >> 32);
   uint64_t scratch_base = wf.scratch_base();
   uint32_t lane_stride = wf.scratch_lane_size();
   uint32_t vbase = wf.vgpr_alloc().base + inst.addr;
-  amdgpu::RegisterAccess regs(cu);
   auto vaddr_region = regs.read_vgpr_region(vbase, has_saddr(inst.saddr) ? 1 : 2, exec);
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/addr_calc.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/addr_calc.h
@@ -8,6 +8,7 @@
 #include "rocjitsu/vm/amdgpu/mtype.h"
 
 #include <cstdint>
+#include <optional>
 
 namespace rocjitsu {
 namespace amdgpu {
@@ -17,7 +18,7 @@ struct VectorMemState;
 
 namespace rdna3_5 {
 
-uint64_t smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf);
+std::optional<uint64_t> smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf);
 
 void flat_calculate_addresses(const FlatMachineInst &inst, amdgpu::Wavefront &wf,
                               amdgpu::VectorMemState &d);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/addr_calc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/addr_calc.cpp
@@ -26,20 +26,20 @@ bool has_saddr(uint32_t saddr) {
   return saddr != 0x7C && saddr != 0x7F;
 }
 
-uint32_t read_optional_sreg_m0(uint32_t reg, amdgpu::Wavefront &wf) {
+std::optional<uint32_t> read_optional_sreg_m0(uint32_t reg, amdgpu::Wavefront &wf) {
   if (reg == OPR_SREG_M0_NULL)
     return 0;
   if (reg == OPR_SREG_M0_M0)
     return wf.m0();
-  return amdgpu::read_scalar_selector(wf, reg);
+  return amdgpu::try_read_scalar_selector(wf, reg);
 }
 
-uint32_t read_smem_offset(uint32_t soffset, amdgpu::Wavefront &wf) {
+std::optional<uint32_t> read_smem_offset(uint32_t soffset, amdgpu::Wavefront &wf) {
   if (soffset == OPR_SMEM_OFFSET_NULL || soffset == 0x7F)
     return 0;
   if (soffset == OPR_SMEM_OFFSET_M0)
     return wf.m0();
-  return amdgpu::read_scalar_selector(wf, soffset);
+  return amdgpu::try_read_scalar_selector(wf, soffset);
 }
 
 void init_vector_mem_state(amdgpu::Wavefront &wf, amdgpu::VectorMemState &d) {
@@ -53,14 +53,19 @@ void init_vector_mem_state(amdgpu::Wavefront &wf, amdgpu::VectorMemState &d) {
 
 } // namespace
 
-uint64_t smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf) {
+std::optional<uint64_t> smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf) {
   // GFX12 SMEM: sbase is an aligned SGPR pair, ioffset is a 24-bit signed immediate,
   // soffset is an SGPR/M0/null selector from rdna4/operand_types.h.
   const uint32_t sbase_sel = inst.sbase * 2;
-  uint64_t base = amdgpu::read_scalar_selector64(wf, sbase_sel);
+  auto base = amdgpu::try_read_scalar_selector64(wf, sbase_sel);
+  if (!base)
+    return std::nullopt;
   int64_t off = static_cast<int64_t>(static_cast<int32_t>(inst.ioffset << 8) >> 8);
-  off += read_smem_offset(inst.soffset, wf);
-  return (base + off) & ~0x3ULL;
+  auto soffset = read_smem_offset(inst.soffset, wf);
+  if (!soffset)
+    return std::nullopt;
+  off += *soffset;
+  return (*base + off) & ~0x3ULL;
 }
 
 void flat_calculate_addresses(const VflatMachineInst &inst, amdgpu::Wavefront &wf,
@@ -70,16 +75,21 @@ void flat_calculate_addresses(const VflatMachineInst &inst, amdgpu::Wavefront &w
   init_vector_mem_state(wf, d);
   uint64_t exec = d.exec_mask;
   int64_t offset = static_cast<int64_t>(static_cast<int32_t>(inst.ioffset << 8) >> 8);
+  amdgpu::RegisterAccess regs(cu);
   uint64_t saddr_val = 0;
   if (has_saddr(inst.saddr)) {
     const uint32_t sb_sel = inst.saddr;
-    saddr_val = amdgpu::read_scalar_selector64(wf, sb_sel);
+    auto saddr = amdgpu::try_read_scalar_selector64(wf, sb_sel);
+    if (!saddr) {
+      amdgpu::reject_vector_memory_access(d);
+      return;
+    }
+    saddr_val = *saddr;
   }
   uint32_t priv_hi = static_cast<uint32_t>(wf.private_aperture_base() >> 32);
   uint64_t scratch_base = wf.scratch_base();
   uint32_t lane_stride = wf.scratch_lane_size();
   uint32_t vbase = wf.vgpr_alloc().base + inst.vaddr;
-  amdgpu::RegisterAccess regs(cu);
   auto vaddr_region = regs.read_vgpr_region(vbase, has_saddr(inst.saddr) ? 1 : 2, exec);
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -104,13 +114,18 @@ void flat_calculate_addresses(const VglobalMachineInst &inst, amdgpu::Wavefront 
   init_vector_mem_state(wf, d);
   uint64_t exec = d.exec_mask;
   int64_t offset = static_cast<int64_t>(static_cast<int32_t>(inst.ioffset << 8) >> 8);
+  amdgpu::RegisterAccess regs(cu);
   uint64_t saddr_val = 0;
   if (has_saddr(inst.saddr)) {
     const uint32_t sb_sel = inst.saddr;
-    saddr_val = amdgpu::read_scalar_selector64(wf, sb_sel);
+    auto saddr = amdgpu::try_read_scalar_selector64(wf, sb_sel);
+    if (!saddr) {
+      amdgpu::reject_vector_memory_access(d);
+      return;
+    }
+    saddr_val = *saddr;
   }
   uint32_t vbase = wf.vgpr_alloc().base + inst.vaddr;
-  amdgpu::RegisterAccess regs(cu);
   auto vaddr_region = regs.read_vgpr_region(vbase, has_saddr(inst.saddr) ? 1 : 2, exec);
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -136,12 +151,17 @@ void flat_calculate_addresses(const VscratchMachineInst &inst, amdgpu::Wavefront
   uint64_t scratch_base = wf.scratch_base();
   uint32_t lane_stride = wf.scratch_lane_size();
   uint32_t saddr_val = 0;
+  amdgpu::RegisterAccess regs(cu);
   if (has_saddr(inst.saddr)) {
     const uint32_t sb_sel = inst.saddr;
-    saddr_val = amdgpu::read_scalar_selector(wf, sb_sel);
+    auto saddr = amdgpu::try_read_scalar_selector(wf, sb_sel);
+    if (!saddr) {
+      amdgpu::reject_vector_memory_access(d);
+      return;
+    }
+    saddr_val = *saddr;
   }
   uint32_t vbase = wf.vgpr_alloc().base + inst.vaddr;
-  amdgpu::RegisterAccess regs(cu);
   std::optional<amdgpu::RegisterAccess::VgprReadRegion> vaddr_region;
   if (inst.sve)
     vaddr_region.emplace(regs.read_vgpr_region(vbase, 1, exec));
@@ -163,13 +183,22 @@ void mubuf_calculate_addresses(const VbufferMachineInst &inst, amdgpu::Wavefront
   d.lane_mask = exec;
   d.exec_mask = exec;
   const uint32_t sb_sel = inst.rsrc;
+  if (!amdgpu::scalar_selector_range_is_backed(wf, sb_sel, 4)) {
+    amdgpu::reject_vector_memory_access(d);
+    return;
+  }
   uint64_t base_addr =
       (static_cast<uint64_t>(amdgpu::read_scalar_selector(wf, sb_sel + 1) & 0xFFFF) << 32) |
       amdgpu::read_scalar_selector(wf, sb_sel);
-  uint32_t soffset_val = read_optional_sreg_m0(inst.soffset, wf);
+  amdgpu::RegisterAccess regs(cu);
+  auto soffset = read_optional_sreg_m0(inst.soffset, wf);
+  if (!soffset) {
+    amdgpu::reject_vector_memory_access(d);
+    return;
+  }
+  uint32_t soffset_val = *soffset;
   int64_t ioff = static_cast<int64_t>(static_cast<int32_t>(inst.ioffset << 8) >> 8);
   assert(!inst.idxen && "Vbuffer idxen not yet supported");
-  amdgpu::RegisterAccess regs(cu);
   std::optional<amdgpu::RegisterAccess::VgprReadRegion> voffset_region;
   if (inst.offen)
     voffset_region.emplace(regs.read_vgpr_region(wf.vgpr_alloc().base + inst.vaddr, 1, exec));

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/addr_calc.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/addr_calc.h
@@ -21,6 +21,7 @@
 #include "rocjitsu/vm/amdgpu/mtype.h"
 
 #include <cstdint>
+#include <optional>
 
 namespace rocjitsu {
 namespace amdgpu {
@@ -30,7 +31,7 @@ struct VectorMemState;
 
 namespace rdna4 {
 
-uint64_t smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf);
+std::optional<uint64_t> smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf);
 
 void flat_calculate_addresses(const VflatMachineInst &inst, amdgpu::Wavefront &wf,
                               amdgpu::VectorMemState &d);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/addr_calc_buffer.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/addr_calc_buffer.h
@@ -47,7 +47,7 @@ constexpr uint64_t buffer_total_offset(uint32_t index, uint32_t stride, uint32_t
 ///           inst.offset.
 template <typename MubufInst>
 void mubuf_calculate_addresses(const MubufInst &inst, amdgpu::Wavefront &wf, VectorMemState &d) {
-  auto &cu = wf.cu();
+  RegisterAccess regs(wf);
   uint64_t exec = wf.exec();
   d.lane_mask = exec;
   d.exec_mask = exec;
@@ -55,14 +55,25 @@ void mubuf_calculate_addresses(const MubufInst &inst, amdgpu::Wavefront &wf, Vec
   d.wg_id = wf.wg_id();
   d.wf_id = wf.wf_id();
   const uint32_t sb_sel = inst.srsrc * 4;
+  if (!amdgpu::scalar_selector_range_is_backed(wf, sb_sel, 4)) {
+    reject_vector_memory_access(d);
+    return;
+  }
   uint32_t srd0 = amdgpu::read_scalar_selector(wf, sb_sel);
   uint32_t srd1 = amdgpu::read_scalar_selector(wf, sb_sel + 1);
   uint32_t srd2 = amdgpu::read_scalar_selector(wf, sb_sel + 2);
   uint32_t srd3 = amdgpu::read_scalar_selector(wf, sb_sel + 3);
   uint64_t base_addr = (static_cast<uint64_t>(srd1 & 0xFFFF) << 32) | srd0;
   // soffset field: 0-105 = SGPR index, 128 (0x80) = inline constant 0.
-  uint32_t soffset_val =
-      (inst.soffset == 0x80) ? 0u : amdgpu::read_scalar_selector(wf, inst.soffset);
+  uint32_t soffset_val = 0;
+  if (inst.soffset != 0x80) {
+    auto soffset = amdgpu::try_read_scalar_selector(wf, inst.soffset);
+    if (!soffset) {
+      reject_vector_memory_access(d);
+      return;
+    }
+    soffset_val = *soffset;
+  }
   // GFX9 buffer bounds checking: OOB loads return 0, OOB stores are dropped.
   // Per ISA spec (structured mode, stride=0): num_records is the buffer size
   // in bytes. The OOB check uses voffset + inst_offset only — soffset is NOT
@@ -94,7 +105,6 @@ void mubuf_calculate_addresses(const MubufInst &inst, amdgpu::Wavefront &wf, Vec
   uint32_t stride = (srd1 >> 16) & 0x3FFF;
   bool oob_raw = (srd3 >> 31) & 1;
   uint32_t vgpr_base = wf.vgpr_alloc().base + inst.vaddr;
-  RegisterAccess regs(cu);
   std::optional<RegisterAccess::VgprReadRegion> vaddr_region;
   if (inst.idxen || inst.offen) {
     uint32_t reg_count = (inst.idxen && inst.offen) ? 2 : 1;
@@ -156,7 +166,7 @@ void mubuf_calculate_addresses(const MubufInst &inst, amdgpu::Wavefront &wf, Vec
 ///           inst.offset.
 template <typename MtbufInst>
 void mtbuf_calculate_addresses(const MtbufInst &inst, amdgpu::Wavefront &wf, VectorMemState &d) {
-  auto &cu = wf.cu();
+  RegisterAccess regs(wf);
   uint64_t exec = wf.exec();
   d.lane_mask = exec;
   d.exec_mask = exec;
@@ -164,18 +174,28 @@ void mtbuf_calculate_addresses(const MtbufInst &inst, amdgpu::Wavefront &wf, Vec
   d.wg_id = wf.wg_id();
   d.wf_id = wf.wf_id();
   const uint32_t sb_sel = inst.srsrc * 4;
+  if (!amdgpu::scalar_selector_range_is_backed(wf, sb_sel, 4)) {
+    reject_vector_memory_access(d);
+    return;
+  }
   uint32_t srd0 = amdgpu::read_scalar_selector(wf, sb_sel);
   uint32_t srd1 = amdgpu::read_scalar_selector(wf, sb_sel + 1);
   uint32_t srd2 = amdgpu::read_scalar_selector(wf, sb_sel + 2);
   uint32_t srd3 = amdgpu::read_scalar_selector(wf, sb_sel + 3);
   uint64_t base_addr = (static_cast<uint64_t>(srd1 & 0xFFFF) << 32) | srd0;
-  uint32_t soffset_val =
-      (inst.soffset == 0x80) ? 0u : amdgpu::read_scalar_selector(wf, inst.soffset);
+  uint32_t soffset_val = 0;
+  if (inst.soffset != 0x80) {
+    auto soffset = amdgpu::try_read_scalar_selector(wf, inst.soffset);
+    if (!soffset) {
+      reject_vector_memory_access(d);
+      return;
+    }
+    soffset_val = *soffset;
+  }
   uint32_t num_records = srd2;
   uint32_t stride = (srd1 >> 16) & 0x3FFF;
   bool oob_raw = (srd3 >> 31) & 1;
   uint32_t vgpr_base = wf.vgpr_alloc().base + inst.vaddr;
-  RegisterAccess regs(cu);
   std::optional<RegisterAccess::VgprReadRegion> vaddr_region;
   if (inst.idxen || inst.offen) {
     uint32_t reg_count = (inst.idxen && inst.offen) ? 2 : 1;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/addr_calc_flat.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/addr_calc_flat.h
@@ -75,7 +75,12 @@ void flat_calculate_addresses(const FlatInst &inst, amdgpu::Wavefront &wf, Vecto
     int64_t saddr_val = 0;
     if (inst.saddr != 0x7F) {
       const uint32_t sb_sel = inst.saddr;
-      saddr_val = static_cast<int32_t>(amdgpu::read_scalar_selector(wf, sb_sel));
+      auto saddr = amdgpu::try_read_scalar_selector(wf, sb_sel);
+      if (!saddr) {
+        reject_vector_memory_access(d);
+        return;
+      }
+      saddr_val = static_cast<int32_t>(*saddr);
     }
     bool has_vaddr = true;
     if constexpr (requires { inst.sve; })
@@ -106,7 +111,12 @@ void flat_calculate_addresses(const FlatInst &inst, amdgpu::Wavefront &wf, Vecto
     uint64_t saddr_val = 0;
     if (inst.saddr != 0x7F) {
       const uint32_t sb_sel = inst.saddr;
-      saddr_val = amdgpu::read_scalar_selector64(wf, sb_sel);
+      auto saddr = amdgpu::try_read_scalar_selector64(wf, sb_sel);
+      if (!saddr) {
+        reject_vector_memory_access(d);
+        return;
+      }
+      saddr_val = *saddr;
     }
     uint32_t vbase = wf.vgpr_alloc().base + inst.addr;
     auto vaddr_region = regs.read_vgpr_region(vbase, inst.saddr != 0x7F ? 1 : 2, exec);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/addr_calc_scalar.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/addr_calc_scalar.h
@@ -13,7 +13,6 @@
 /// with any ISA family whose encoding struct exposes the required field names.
 
 #include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
-#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_resolve.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"
 #include "rocjitsu/vm/amdgpu/register_access.h"
@@ -22,6 +21,7 @@
 
 #include <array>
 #include <cstdint>
+#include <optional>
 
 namespace rocjitsu {
 namespace amdgpu {
@@ -41,26 +41,33 @@ constexpr bool smem_is_scratch_op(uint32_t op) {
 ///
 /// Requires: inst.op, inst.sbase, inst.soffset_en, inst.soffset, inst.imm, inst.offset.
 template <typename SmemInst>
-uint64_t smem_calculate_address(const SmemInst &inst, amdgpu::Wavefront &wf) {
+std::optional<uint64_t> smem_calculate_address(const SmemInst &inst, amdgpu::Wavefront &wf) {
   constexpr uint64_t kDwordMask = ~0x3ULL;
-  constexpr int kM0Selector = 124;
-  const uint64_t base = amdgpu::resolve_src_scalar64(wf, inst.sbase * 2, kM0Selector) & kDwordMask;
+  auto base = amdgpu::try_read_scalar_selector64(wf, inst.sbase * 2);
+  if (!base)
+    return std::nullopt;
+  *base &= kDwordMask;
+
   int64_t inst_offset = 0;
   if (inst.imm)
     inst_offset = static_cast<int64_t>(static_cast<int32_t>(inst.offset << 11) >> 11) & ~0x3LL;
+
   uint64_t reg_offset = 0;
-  if (inst.soffset_en)
-    reg_offset = amdgpu::resolve_src_scalar(wf, inst.soffset, kM0Selector);
-  else if (!inst.imm)
-    reg_offset = amdgpu::resolve_src_scalar(wf, inst.offset & 0x7F, kM0Selector);
+  if (inst.soffset_en || !inst.imm) {
+    const uint32_t selector = inst.soffset_en ? inst.soffset : inst.offset & 0x7F;
+    auto value = amdgpu::try_read_scalar_selector(wf, selector);
+    if (!value)
+      return std::nullopt;
+    reg_offset = *value;
+  }
   reg_offset = smem_is_scratch_op(inst.op) ? reg_offset * 64 : reg_offset & kDwordMask;
-  const uint64_t addr = base + inst_offset + reg_offset;
+  const uint64_t addr = *base + inst_offset + reg_offset;
   util::Logger::vm([&](auto &os) {
     static thread_local uint64_t smem_count = 0;
     if (++smem_count <= 12 || (smem_count % 240) == 0)
       os << std::format("SMEM #{} op={} base={:#x} inst_off={:#x} reg_off={:#x} imm={} soff_en={} "
                         "addr={:#x} raw_off={}",
-                        smem_count, inst.op, base, inst_offset, reg_offset, inst.imm,
+                        smem_count, inst.op, *base, inst_offset, reg_offset, inst.imm,
                         inst.soffset_en, addr, inst.offset);
   });
   return addr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h
@@ -7,18 +7,139 @@
 #ifndef ROCJITSU_ISA_ARCH_AMDGPU_SHARED_SCALAR_OPERAND_READ_H_
 #define ROCJITSU_ISA_ARCH_AMDGPU_SHARED_SCALAR_OPERAND_READ_H_
 
+#include "rocjitsu/isa/isa_traits.h"
 #include "rocjitsu/vm/amdgpu/register_access.h"
 #include "rocjitsu/vm/amdgpu/wavefront.h"
 
 #include <cstdint>
+#include <limits>
+#include <optional>
 
 namespace rocjitsu {
 namespace amdgpu {
 
-/// @brief First scalar selector that addresses a trap-temporary register.
-inline constexpr uint32_t kTtmpSelectorFirst = 108;
-/// @brief Last scalar selector that addresses a trap-temporary register.
-inline constexpr uint32_t kTtmpSelectorLast = 123;
+[[nodiscard]] inline bool scalar_selector_is_null(rj_code_arch_t arch, uint32_t selector) {
+  switch (arch) {
+  case ROCJITSU_CODE_ARCH_RDNA1:
+  case ROCJITSU_CODE_ARCH_RDNA2:
+    return selector == kGfx10NullSelector;
+  case ROCJITSU_CODE_ARCH_RDNA3:
+  case ROCJITSU_CODE_ARCH_RDNA3_5:
+  case ROCJITSU_CODE_ARCH_RDNA4:
+  case ROCJITSU_CODE_ARCH_CDNA5:
+    return selector == kModernNullSelector;
+  case ROCJITSU_CODE_ARCH_CDNA1:
+  case ROCJITSU_CODE_ARCH_CDNA2:
+  case ROCJITSU_CODE_ARCH_CDNA3:
+  case ROCJITSU_CODE_ARCH_CDNA4:
+  default:
+    return false;
+  }
+}
+
+[[nodiscard]] inline uint32_t scalar_m0_selector(rj_code_arch_t arch) {
+  return scalar_selector_is_null(arch, kModernNullSelector) ? kModernM0Selector : kLegacyM0Selector;
+}
+
+[[nodiscard]] inline std::optional<ScalarRegisterRange>
+scalar_register_for_selector(const Wavefront &wf, uint32_t selector) {
+  const rj_code_arch_t arch = wf.cu().arch();
+  if (arch_uses_legacy_flat_scratch_sgprs(arch) && selector >= kFlatScratchSelectorFirst &&
+      selector <= kFlatScratchSelectorLast)
+    return ScalarRegisterRange{ScalarRegisterStorage::FLAT_SCRATCH,
+                               static_cast<uint16_t>(selector - kFlatScratchSelectorFirst), 1};
+  if (selector <= kScalarSgprSelectorLast)
+    return ScalarRegisterRange{ScalarRegisterStorage::SGPR, static_cast<uint16_t>(selector), 1};
+  if (selector <= kVccSelectorLast)
+    return ScalarRegisterRange{ScalarRegisterStorage::VCC,
+                               static_cast<uint16_t>(selector - kVccSelectorFirst), 1};
+  if (selector <= kTtmpSelectorLast)
+    return ScalarRegisterRange{ScalarRegisterStorage::TTMP,
+                               static_cast<uint16_t>(selector - kTtmpSelectorFirst), 1};
+  if (scalar_selector_is_null(arch, selector))
+    return ScalarRegisterRange{ScalarRegisterStorage::DISCARD, 0, 1};
+  if (selector == scalar_m0_selector(arch))
+    return ScalarRegisterRange{ScalarRegisterStorage::M0, 0, 1};
+  if (selector >= kExecSelectorFirst && selector <= kExecSelectorLast)
+    return ScalarRegisterRange{ScalarRegisterStorage::EXEC,
+                               static_cast<uint16_t>(selector - kExecSelectorFirst), 1};
+  return std::nullopt;
+}
+
+/// @brief Resolve and validate one complete scalar-register range.
+/// @details Every dword must name consecutive storage in one architectural
+/// register file. NULL is a single selector that discards or supplies the
+/// complete operand independently of its width.
+[[nodiscard]] inline std::optional<ScalarRegisterRange>
+resolve_scalar_register_range(const Wavefront &wf, uint32_t selector, uint32_t count) {
+  if (count == 0 || count > std::numeric_limits<uint8_t>::max() ||
+      selector > UINT32_MAX - (count - 1))
+    return std::nullopt;
+
+  auto first = scalar_register_for_selector(wf, selector);
+  if (!first)
+    return std::nullopt;
+  first->width = static_cast<uint8_t>(count);
+  if (first->storage == ScalarRegisterStorage::DISCARD)
+    return first;
+
+  for (uint32_t offset = 1; offset < count; ++offset) {
+    auto current = scalar_register_for_selector(wf, selector + offset);
+    if (!current || current->storage != first->storage || current->index != first->index + offset)
+      return std::nullopt;
+  }
+
+  if (first->storage == ScalarRegisterStorage::SGPR &&
+      !RegisterAccess(wf).owns_sgpr_range(wf.sgpr_alloc().base + first->index, count))
+    return std::nullopt;
+  return first;
+}
+
+/// @brief Check that a complete selector range has backing owned by this wave.
+[[nodiscard]] inline bool scalar_selector_range_is_backed(const Wavefront &wf, uint32_t selector,
+                                                          uint32_t count) {
+  return resolve_scalar_register_range(wf, selector, count).has_value();
+}
+
+/// @brief Read one dword from a previously validated scalar-register range.
+[[nodiscard]] inline uint32_t
+read_scalar_register(const Wavefront &wf, const ScalarRegisterRange &range, uint32_t offset = 0) {
+  if (offset >= range.width)
+    return 0;
+  const uint32_t index = range.index + offset;
+  switch (range.storage) {
+  case ScalarRegisterStorage::SGPR:
+    return RegisterAccess(wf).read_sgpr(wf.sgpr_alloc().base + index);
+  case ScalarRegisterStorage::FLAT_SCRATCH:
+    return index == 0 ? static_cast<uint32_t>(wf.scratch_base())
+                      : static_cast<uint32_t>(wf.scratch_base() >> 32);
+  case ScalarRegisterStorage::VCC:
+    return index == 0 ? static_cast<uint32_t>(wf.vcc()) : static_cast<uint32_t>(wf.vcc() >> 32);
+  case ScalarRegisterStorage::TTMP:
+    return RegisterAccess(wf).read_ttmp(index);
+  case ScalarRegisterStorage::M0:
+    return wf.m0();
+  case ScalarRegisterStorage::EXEC:
+    return index == 0 ? static_cast<uint32_t>(wf.exec())
+                      : static_cast<uint32_t>(wf.exec_raw() >> 32);
+  case ScalarRegisterStorage::DISCARD:
+    return 0;
+  }
+  return 0;
+}
+
+/// @brief Read the first two dwords of a validated scalar-register range.
+[[nodiscard]] inline uint64_t read_scalar_register64(const Wavefront &wf,
+                                                     const ScalarRegisterRange &range) {
+  if (range.width < 2)
+    return 0;
+  if (range.storage == ScalarRegisterStorage::SGPR)
+    return RegisterAccess(wf).read_sgpr64(wf.sgpr_alloc().base + range.index);
+  if (range.storage == ScalarRegisterStorage::TTMP)
+    return RegisterAccess(wf).read_ttmp64(range.index);
+  return static_cast<uint64_t>(read_scalar_register(wf, range)) |
+         (static_cast<uint64_t>(read_scalar_register(wf, range, 1)) << 32);
+}
 
 /// @brief Read the scalar register named by an encoded operand selector.
 ///
@@ -30,30 +151,51 @@ inline constexpr uint32_t kTtmpSelectorLast = 123;
 /// which the ROCr handler does -- must read the TTMP, not whatever SGPR happens
 /// to sit at that offset in the allocation.
 [[nodiscard]] inline uint32_t read_scalar_selector(Wavefront &wf, uint32_t selector) {
-  if (selector >= kTtmpSelectorFirst && selector <= kTtmpSelectorLast)
-    return wf.ttmp(selector - kTtmpSelectorFirst);
-  return RegisterAccess(wf.cu()).read_sgpr(wf.sgpr_alloc().base + selector);
+  auto range = resolve_scalar_register_range(wf, selector, 1);
+  return range ? read_scalar_register(wf, *range) : 0;
 }
 
 /// @brief Read a 64-bit scalar pair named by an encoded operand selector.
-/// @details The two halves are resolved independently so a pair that straddles
-/// the TTMP boundary still reads each half from the file that owns it.
+/// @details The complete pair must resolve to one architectural register file.
 [[nodiscard]] inline uint64_t read_scalar_selector64(Wavefront &wf, uint32_t selector) {
-  return (static_cast<uint64_t>(read_scalar_selector(wf, selector + 1)) << 32) |
-         read_scalar_selector(wf, selector);
+  auto range = resolve_scalar_register_range(wf, selector, 2);
+  if (!range)
+    return 0;
+  return read_scalar_register64(wf, *range);
 }
 
-/// @brief Write the scalar register named by an encoded operand selector.
-/// @details Counterpart to read_scalar_selector(): a destination in 108..123
-/// must land in the trap-temporary file. Writing it through the SGPR
-/// allocation would both lose the value (every read comes from the TTMP file)
-/// and scribble past the end of this wave's allocation into a neighbour's.
+[[nodiscard]] inline std::optional<uint32_t> try_read_scalar_selector(Wavefront &wf,
+                                                                      uint32_t selector) {
+  auto range = resolve_scalar_register_range(wf, selector, 1);
+  if (!range)
+    return std::nullopt;
+  return read_scalar_register(wf, *range);
+}
+
+[[nodiscard]] inline std::optional<uint64_t> try_read_scalar_selector64(Wavefront &wf,
+                                                                        uint32_t selector) {
+  auto range = resolve_scalar_register_range(wf, selector, 2);
+  if (!range)
+    return std::nullopt;
+  return read_scalar_register64(wf, *range);
+}
+
+/// @brief Write one scalar register selected by an encoded operand.
+/// @details This is an instruction-visible write. Deferred memory completion
+/// deliberately uses its separate, unobserved storage path.
 inline void write_scalar_selector(Wavefront &wf, uint32_t selector, uint32_t value) {
-  if (selector >= kTtmpSelectorFirst && selector <= kTtmpSelectorLast) {
-    wf.set_ttmp(selector - kTtmpSelectorFirst, value);
+  auto range = resolve_scalar_register_range(wf, selector, 1);
+  if (!range)
+    return;
+  if (range->storage == ScalarRegisterStorage::SGPR) {
+    RegisterAccess(wf).write_sgpr(wf.sgpr_alloc().base + range->index, value);
     return;
   }
-  RegisterAccess(wf.cu()).write_sgpr(wf.sgpr_alloc().base + selector, value);
+  if (range->storage == ScalarRegisterStorage::TTMP) {
+    RegisterAccess(wf).write_ttmp(range->index, value);
+    return;
+  }
+  RegisterAccess(wf).write_scalar_unobserved(*range, 0, value);
 }
 
 } // namespace amdgpu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/scalar_operand_resolve.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/scalar_operand_resolve.h
@@ -27,38 +27,40 @@ namespace amdgpu {
 // value for this arch (124 on most arches; 125 on RDNA 3 / RDNA 3.5 / RDNA4
 // / GFX1250, where 124 is the NULL slot).
 inline uint32_t resolve_src_scalar(const Wavefront &wf, int ev, int m0_ev) {
-  if (arch_uses_legacy_flat_scratch_sgprs(wf.cu().arch()) && ev == 102)
+  if (arch_uses_legacy_flat_scratch_sgprs(wf.cu().arch()) &&
+      ev == static_cast<int>(kFlatScratchSelectorFirst))
     return static_cast<uint32_t>(wf.scratch_base());
-  if (arch_uses_legacy_flat_scratch_sgprs(wf.cu().arch()) && ev == 103)
+  if (arch_uses_legacy_flat_scratch_sgprs(wf.cu().arch()) &&
+      ev == static_cast<int>(kFlatScratchSelectorLast))
     return static_cast<uint32_t>(wf.scratch_base() >> 32);
-  if (ev <= 105)
+  if (ev <= static_cast<int>(kScalarSgprSelectorLast))
     return RegisterAccess(wf).read_sgpr(wf.sgpr_alloc().base + static_cast<uint32_t>(ev));
-  if (ev == 106)
+  if (ev == static_cast<int>(kVccSelectorFirst))
     return static_cast<uint32_t>(wf.vcc());
-  if (ev == 107)
+  if (ev == static_cast<int>(kVccSelectorLast))
     return static_cast<uint32_t>(wf.vcc() >> 32);
   // TTMP0-15 are the trap handler's private scratch registers. They are NOT
   // part of the wave's SGPR allocation: hardware banks them separately, the CP
   // seeds them with the dispatch/queue identity that rocm-dbgapi reads back out
   // of the CWSR area, and a shader that never enters a trap must not be able to
   // clobber them through an SGPR write.
-  if (ev >= 108 && ev <= 123)
-    return wf.ttmp(static_cast<uint32_t>(ev - 108));
-  if (m0_ev == 125 && ev == 124)
+  if (ev >= static_cast<int>(kTtmpSelectorFirst) && ev <= static_cast<int>(kTtmpSelectorLast))
+    return RegisterAccess(wf).read_ttmp(static_cast<uint32_t>(ev) - kTtmpSelectorFirst);
+  if (m0_ev == static_cast<int>(kModernM0Selector) && ev == static_cast<int>(kModernNullSelector))
     return 0u; // NULL
   if (ev == m0_ev)
     return wf.m0();
-  if (ev == 126)
+  if (ev == static_cast<int>(kExecSelectorFirst))
     return static_cast<uint32_t>(wf.exec());
-  if (ev == 127)
+  if (ev == static_cast<int>(kExecSelectorLast))
     return static_cast<uint32_t>(wf.exec_raw() >> 32);
   if (ev >= 128 && ev <= 192)
     return static_cast<uint32_t>(ev - 128);
   if (ev >= 193 && ev <= 208)
     return static_cast<uint32_t>(static_cast<int32_t>(-(ev - 192)));
-  if (ev == 230)
+  if (ev == static_cast<int>(kFlatScratchBaseSelectorFirst))
     return static_cast<uint32_t>(wf.scratch_base()); // SRC_FLAT_SCRATCH_BASE_LO
-  if (ev == 231)
+  if (ev == static_cast<int>(kFlatScratchBaseSelectorLast))
     return static_cast<uint32_t>(wf.scratch_base() >> 32); // SRC_FLAT_SCRATCH_BASE_HI
   if (ev == 240)
     return 0x3F000000u; // 0.5f
@@ -132,38 +134,39 @@ inline uint32_t resolve_src_scalar16(const Wavefront &wf, int ev, int m0_ev) {
 // Isa::simd_capable_value() to keep the SIMD fast path off operands whose
 // scalar broadcast would throw at runtime.
 inline bool can_resolve_src_scalar(int ev, int m0_ev) {
-  bool ok = (ev >= 0 && ev <= 107) || (ev >= 108 && ev <= 123) || ev == 124 || ev == 126 ||
-            ev == 127 || (ev >= 128 && ev <= 208) || (ev >= 235 && ev <= 238) ||
-            (ev >= 240 && ev <= 253);
-  if (m0_ev == 125)
-    ok = ok || ev == 125 || ev == 230 || ev == 231;
+  bool ok =
+      (ev >= 0 && ev <= static_cast<int>(kVccSelectorLast)) ||
+      (ev >= static_cast<int>(kTtmpSelectorFirst) && ev <= static_cast<int>(kTtmpSelectorLast)) ||
+      ev == static_cast<int>(kLegacyM0Selector) ||
+      (ev >= static_cast<int>(kExecSelectorFirst) && ev <= static_cast<int>(kExecSelectorLast)) ||
+      (ev >= 128 && ev <= 208) || (ev >= 235 && ev <= 238) || (ev >= 240 && ev <= 253);
+  if (m0_ev == static_cast<int>(kModernM0Selector))
+    ok = ok || ev == static_cast<int>(kModernM0Selector) ||
+         ev == static_cast<int>(kFlatScratchBaseSelectorFirst) ||
+         ev == static_cast<int>(kFlatScratchBaseSelectorLast);
   return ok;
 }
 
 inline uint64_t resolve_src_scalar64(const Wavefront &wf, int ev, int m0_ev) {
   if (is_src_scalar_register_pair(ev)) {
-    if (arch_uses_legacy_flat_scratch_sgprs(wf.cu().arch()) && ev == 102)
+    if (arch_uses_legacy_flat_scratch_sgprs(wf.cu().arch()) &&
+        ev == static_cast<int>(kFlatScratchSelectorFirst))
       return wf.scratch_base();
-    if (ev <= 105) {
-      uint32_t lo = RegisterAccess(wf).read_sgpr(wf.sgpr_alloc().base + static_cast<uint32_t>(ev));
-      uint32_t hi =
-          RegisterAccess(wf).read_sgpr(wf.sgpr_alloc().base + static_cast<uint32_t>(ev + 1));
-      return static_cast<uint64_t>(hi) << 32 | lo;
-    }
-    if (ev == 106)
+    if (ev <= static_cast<int>(kScalarSgprSelectorLast))
+      return RegisterAccess(wf).read_sgpr64(wf.sgpr_alloc().base + static_cast<uint32_t>(ev));
+    if (ev == static_cast<int>(kVccSelectorFirst))
       return wf.vcc();
-    if (ev >= 108 && ev <= 122) { // TTMP pair; see resolve_src_scalar()
-      uint32_t lo = wf.ttmp(static_cast<uint32_t>(ev - 108));
-      uint32_t hi = wf.ttmp(static_cast<uint32_t>(ev - 107));
-      return static_cast<uint64_t>(hi) << 32 | lo;
+    if (ev >= static_cast<int>(kTtmpSelectorFirst) &&
+        ev < static_cast<int>(kTtmpSelectorLast)) { // TTMP pair; see resolve_src_scalar()
+      return RegisterAccess(wf).read_ttmp64(static_cast<uint32_t>(ev) - kTtmpSelectorFirst);
     }
-    if (ev == 126)
+    if (ev == static_cast<int>(kExecSelectorFirst))
       return wf.exec_raw();
-    if (ev == 230)
+    if (ev == static_cast<int>(kFlatScratchBaseSelectorFirst))
       return wf.scratch_base(); // SRC_FLAT_SCRATCH_BASE
     throw std::logic_error("Scalar register-pair selector is not resolved: " + std::to_string(ev));
   }
-  if (m0_ev == 125 && ev == 124)
+  if (m0_ev == static_cast<int>(kModernM0Selector) && ev == static_cast<int>(kModernNullSelector))
     return 0u; // NULL
   if (ev == m0_ev)
     return wf.m0();
@@ -201,43 +204,46 @@ inline uint64_t resolve_src_scalar64(const Wavefront &wf, int ev, int m0_ev) {
 }
 
 inline void resolve_dst_write(Wavefront &wf, int ev, uint32_t val, int m0_ev) {
-  if (arch_uses_legacy_flat_scratch_sgprs(wf.cu().arch()) && ev == 102) {
+  if (arch_uses_legacy_flat_scratch_sgprs(wf.cu().arch()) &&
+      ev == static_cast<int>(kFlatScratchSelectorFirst)) {
     uint64_t sb = wf.scratch_base();
     wf.set_scratch_base((sb & 0xFFFFFFFF00000000ULL) | val);
     return;
   }
-  if (arch_uses_legacy_flat_scratch_sgprs(wf.cu().arch()) && ev == 103) {
+  if (arch_uses_legacy_flat_scratch_sgprs(wf.cu().arch()) &&
+      ev == static_cast<int>(kFlatScratchSelectorLast)) {
     uint64_t sb = wf.scratch_base();
     wf.set_scratch_base((sb & 0x00000000FFFFFFFFULL) | (static_cast<uint64_t>(val) << 32));
     return;
   }
-  if (ev <= 105) {
+  if (ev <= static_cast<int>(kScalarSgprSelectorLast)) {
     RegisterAccess(wf).write_sgpr(wf.sgpr_alloc().base + static_cast<uint32_t>(ev), val);
     return;
   }
-  if (ev == 106) {
+  if (ev == static_cast<int>(kVccSelectorFirst)) {
     wf.set_vcc_raw((wf.vcc() & 0xFFFFFFFF00000000ULL) | val);
     return;
   }
-  if (ev == 107) {
+  if (ev == static_cast<int>(kVccSelectorLast)) {
     wf.set_vcc_raw((wf.vcc() & 0x00000000FFFFFFFFULL) | (static_cast<uint64_t>(val) << 32));
     return;
   }
-  if (ev >= 108 && ev <= 123) { // see resolve_src_scalar()
-    wf.set_ttmp(static_cast<uint32_t>(ev - 108), val);
+  if (ev >= static_cast<int>(kTtmpSelectorFirst) &&
+      ev <= static_cast<int>(kTtmpSelectorLast)) { // see resolve_src_scalar()
+    RegisterAccess(wf).write_ttmp(static_cast<uint32_t>(ev) - kTtmpSelectorFirst, val);
     return;
   }
-  if (m0_ev == 125 && ev == 124)
+  if (m0_ev == static_cast<int>(kModernM0Selector) && ev == static_cast<int>(kModernNullSelector))
     return; // NULL
   if (ev == m0_ev) {
     wf.set_m0(val);
     return;
   }
-  if (ev == 126) {
+  if (ev == static_cast<int>(kExecSelectorFirst)) {
     wf.set_exec((wf.exec() & 0xFFFFFFFF00000000ULL) | val);
     return;
   }
-  if (ev == 127) {
+  if (ev == static_cast<int>(kExecSelectorLast)) {
     wf.set_exec_raw((wf.exec_raw() & 0x00000000FFFFFFFFULL) | (static_cast<uint64_t>(val) << 32));
     return;
   }
@@ -245,29 +251,27 @@ inline void resolve_dst_write(Wavefront &wf, int ev, uint32_t val, int m0_ev) {
 }
 
 inline void resolve_dst_write64(Wavefront &wf, int ev, uint64_t val) {
-  if (arch_uses_legacy_flat_scratch_sgprs(wf.cu().arch()) && ev == 102) {
+  if (arch_uses_legacy_flat_scratch_sgprs(wf.cu().arch()) &&
+      ev == static_cast<int>(kFlatScratchSelectorFirst)) {
     wf.set_scratch_base(val);
     return;
   }
-  if (ev <= 105) {
-    RegisterAccess(wf).write_sgpr(wf.sgpr_alloc().base + static_cast<uint32_t>(ev),
-                                  static_cast<uint32_t>(val));
-    RegisterAccess(wf).write_sgpr(wf.sgpr_alloc().base + static_cast<uint32_t>(ev + 1),
-                                  static_cast<uint32_t>(val >> 32));
+  if (ev <= static_cast<int>(kScalarSgprSelectorLast)) {
+    RegisterAccess(wf).write_sgpr64(wf.sgpr_alloc().base + static_cast<uint32_t>(ev), val);
     return;
   }
-  if (ev == 106) {
+  if (ev == static_cast<int>(kVccSelectorFirst)) {
     wf.set_vcc_raw(val);
     return;
   }
-  if (ev >= 108 && ev <= 122) { // TTMP pair; see resolve_src_scalar()
-    wf.set_ttmp(static_cast<uint32_t>(ev - 108), static_cast<uint32_t>(val));
-    wf.set_ttmp(static_cast<uint32_t>(ev - 107), static_cast<uint32_t>(val >> 32));
+  if (ev >= static_cast<int>(kTtmpSelectorFirst) &&
+      ev < static_cast<int>(kTtmpSelectorLast)) { // TTMP pair; see resolve_src_scalar()
+    RegisterAccess(wf).write_ttmp64(static_cast<uint32_t>(ev) - kTtmpSelectorFirst, val);
     return;
   }
-  if (ev == 124)
+  if (ev == static_cast<int>(kModernNullSelector))
     return;
-  if (ev == 126) {
+  if (ev == static_cast<int>(kExecSelectorFirst)) {
     wf.set_exec_raw(val);
     return;
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/scalar_operand_selectors.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/scalar_operand_selectors.h
@@ -4,7 +4,74 @@
 #ifndef ROCJITSU_ISA_AMDGPU_SHARED_SCALAR_OPERAND_SELECTORS_H_
 #define ROCJITSU_ISA_AMDGPU_SHARED_SCALAR_OPERAND_SELECTORS_H_
 
+#include "rocjitsu/isa/register_set.h"
+
+#include <cstdint>
+#include <optional>
+
 namespace rocjitsu::amdgpu {
+
+/// Shared scalar-selector landmarks used by every supported AMDGPU ISA.
+/// The generator validates these values against each ISA's OPR_SSRC table.
+inline constexpr uint32_t kScalarSgprSelectorLast = 105;
+inline constexpr uint32_t kFlatScratchSelectorFirst = 102;
+inline constexpr uint32_t kFlatScratchSelectorLast = 103;
+inline constexpr uint32_t kVccSelectorFirst = 106;
+inline constexpr uint32_t kVccSelectorLast = 107;
+inline constexpr uint32_t kTtmpSelectorFirst = 108;
+inline constexpr uint32_t kTtmpSelectorLast = 123;
+inline constexpr uint32_t kTtmpRegisterCount = kTtmpSelectorLast - kTtmpSelectorFirst + 1;
+inline constexpr uint32_t kLegacyM0Selector = 124;
+inline constexpr uint32_t kModernNullSelector = 124;
+inline constexpr uint32_t kModernM0Selector = 125;
+inline constexpr uint32_t kGfx10NullSelector = 125;
+inline constexpr uint32_t kExecSelectorFirst = 126;
+inline constexpr uint32_t kExecSelectorLast = 127;
+inline constexpr uint32_t kFlatScratchBaseSelectorFirst = 230;
+inline constexpr uint32_t kFlatScratchBaseSelectorLast = 231;
+
+/// Backing selected by a decoded scalar-register operand.
+enum class ScalarRegisterStorage : uint8_t {
+  SGPR,
+  FLAT_SCRATCH,
+  VCC,
+  TTMP,
+  M0,
+  EXEC,
+  DISCARD,
+};
+
+/// A complete, homogeneous scalar-register range.
+///
+/// This is resolved once while an instruction is issued and can then be
+/// carried through deferred memory completion. `index` is relative to the
+/// selected storage class; `width` is measured in dwords. DISCARD represents
+/// the architectural NULL destination and ignores index.
+struct ScalarRegisterRange {
+  ScalarRegisterStorage storage = ScalarRegisterStorage::DISCARD;
+  uint16_t index = 0;
+  uint8_t width = 0;
+
+  [[nodiscard]] std::optional<RegisterRef> register_ref() const {
+    switch (storage) {
+    case ScalarRegisterStorage::SGPR:
+      return RegisterRef{RegClass::SGPR, index, width};
+    case ScalarRegisterStorage::FLAT_SCRATCH:
+      return RegisterRef{RegClass::FLAT_SCRATCH, index, width};
+    case ScalarRegisterStorage::VCC:
+      return RegisterRef{RegClass::VCC, index, width};
+    case ScalarRegisterStorage::TTMP:
+      return RegisterRef{RegClass::TTMP, index, width};
+    case ScalarRegisterStorage::M0:
+      return RegisterRef{RegClass::M0, index, width};
+    case ScalarRegisterStorage::EXEC:
+      return RegisterRef{RegClass::EXEC, index, width};
+    case ScalarRegisterStorage::DISCARD:
+      return std::nullopt;
+    }
+    return std::nullopt;
+  }
+};
 
 /// @brief Return whether a scalar source selector names the low word of a
 /// 64-bit register pair.
@@ -16,7 +83,10 @@ namespace rocjitsu::amdgpu {
 /// excluded. The amdisa generator validates these shared values against every
 /// ISA's OPR_SSRC table.
 [[nodiscard]] inline constexpr bool is_src_scalar_register_pair(int ev) {
-  return (ev >= 0 && ev <= 106) || (ev >= 108 && ev <= 122) || ev == 126 || ev == 230;
+  return (ev >= 0 && ev <= static_cast<int>(kVccSelectorFirst)) ||
+         (ev >= static_cast<int>(kTtmpSelectorFirst) && ev < static_cast<int>(kTtmpSelectorLast)) ||
+         ev == static_cast<int>(kExecSelectorFirst) ||
+         ev == static_cast<int>(kFlatScratchBaseSelectorFirst);
 }
 
 } // namespace rocjitsu::amdgpu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
@@ -168,9 +168,10 @@ inline void write_explicit_lane_mask(const Operand &dst, Wavefront &wf, uint64_t
 
 inline void write_explicit_lane_mask(uint32_t physical_dst, Wavefront &wf, uint64_t mask) {
   amdgpu::RegisterAccess regs(wf);
-  regs.write_sgpr(physical_dst, static_cast<uint32_t>(mask));
-  if (wf.wf_size() > 32)
-    regs.write_sgpr(physical_dst + 1, static_cast<uint32_t>(mask >> 32));
+  if (wf.wf_size() <= 32)
+    regs.write_sgpr(physical_dst, static_cast<uint32_t>(mask));
+  else
+    regs.write_sgpr64(physical_dst, mask);
 }
 
 inline util::native<uint32_t> simd_sign_extend_u32(util::native<uint32_t> v, unsigned bits) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/tensor_dma.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/tensor_dma.h
@@ -58,8 +58,11 @@ std::array<uint32_t, N> read_sgpr_group(const Wavefront &wf, int reg, bool allow
   if (reg < 0 || reg > 105 || static_cast<size_t>(reg) + N > 106)
     throw util::UnimplementedInst("tensor DMA non-SGPR descriptor operand");
   const uint32_t base = wf.sgpr_alloc().base + static_cast<uint32_t>(reg);
+  auto group = amdgpu::RegisterAccess(wf).read_sgpr_region(base, static_cast<uint32_t>(N));
+  if (!group.valid())
+    throw util::UnimplementedInst("tensor DMA descriptor outside wavefront SGPR block");
   for (size_t i = 0; i < N; ++i)
-    words[i] = amdgpu::RegisterAccess(wf).read_sgpr(base + static_cast<uint32_t>(i));
+    words[i] = group.dword(static_cast<uint32_t>(i));
   return words;
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/isa_operand_simd_inl.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/isa_operand_simd_inl.h
@@ -75,7 +75,7 @@ void AmdgpuIsaOperand<Isa>::read_lane_chunk(const amdgpu::Wavefront &wf, uint32_
     uint64_t lane_mask =
         count == 0 ? 0 : util::mask<uint64_t>(static_cast<int>(count)) << lane_base;
     auto region =
-        amdgpu::RegisterAccess(wf.cu()).read_vgpr_region(wf.vgpr_alloc().base + voff, 1, lane_mask);
+        amdgpu::RegisterAccess(wf).read_vgpr_region(wf.vgpr_alloc().base + voff, 1, lane_mask);
     std::copy_n(region.lanes().begin() + lane_base, count, out);
     return;
   }
@@ -96,6 +96,8 @@ void AmdgpuIsaOperand<Isa>::write_lane_chunk(amdgpu::Wavefront &wf, uint32_t lan
   }
   uint32_t voff = amdgpu::apply_gpr_idx(wf, *off, detail::write_vgpr_role(*this));
   uint32_t reg = wf.vgpr_alloc().base + voff;
+  if (!wf.cu().raw_cu().owns_vgpr_range(wf, reg, 1))
+    return;
   uint64_t full_mask = util::mask<uint64_t>(static_cast<int>(count));
   uint8_t *dst = amdgpu::OperandExecutionAccess::raw_compute_unit(wf.cu()).raw_vgpr_data(reg);
   if ((mask & full_mask) == full_mask) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/register_set.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/register_set.h
@@ -31,6 +31,7 @@ inline constexpr size_t REGISTER_SET_MAX_SGPRS =
     std::max<size_t>(amdgpu::CdnaIsaBase::MAX_SGPRS_PER_WF, amdgpu::RdnaIsaBase::MAX_SGPRS_PER_WF);
 inline constexpr size_t REGISTER_SET_MAX_VGPRS = MAX_SUPPORTED_ADDRESSABLE_VGPRS_PER_WF;
 inline constexpr size_t REGISTER_SET_MAX_ACC_VGPRS = REGISTER_SET_MAX_VGPRS;
+inline constexpr size_t REGISTER_SET_MAX_TTMPS = 16;
 
 /// @brief Normal SGPRs safe for scratch allocation across supported families.
 ///

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -1583,9 +1583,9 @@ uint32_t CommandProcessor::dispatch_workgroups(DispatchEntry &entry) {
                         entry.num_named_barriers);
     register_cluster_workgroup(entry, local_wg_id, global_wg_id, cu, lds_base);
 
-    plugin_group_->onAmdgpuWorkgroupDispatched(entry.dispatch_id, global_wg_id,
-                                               cu->vgpr_allocation_block_size(), entry.sgprs_per_wf,
-                                               std::span<Wavefront *>(wg_wavefronts));
+    plugin_group_->onAmdgpuWorkgroupDispatched(
+        entry.dispatch_id, global_wg_id, cu->vgpr_allocation_block_size(),
+        cu->sgpr_allocation_block_size(), std::span<Wavefront *>(wg_wavefronts));
     for (auto *wf : wg_wavefronts)
       plugin_group_->onAmdgpuWavefrontDispatched(*wf);
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
@@ -20,6 +20,7 @@
 #include "rocjitsu/isa/instruction.h"
 #include "rocjitsu/vm/amdgpu/hwreg.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"
+#include "rocjitsu/vm/amdgpu/register_access.h"
 #include "util/except.h"
 #include "util/log.h"
 
@@ -226,7 +227,7 @@ Wavefront *ComputeUnitCore::dispatch_wf_at(uint32_t wf_id, uint32_t wg_id, uint6
   wf->trace_inst_count_ = 0;
 
   sgpr_block_owners_[static_cast<uint32_t>(sgpr_base) / config_.sgprs_per_wf] = {
-      wf, static_cast<uint32_t>(sgpr_base) + num_sgprs};
+      wf, static_cast<uint32_t>(sgpr_base) + config_.sgprs_per_wf};
   set_vgpr_block_owner(static_cast<uint32_t>(vgpr_base), wf);
 
   util::Logger::cp([&](auto &os) {
@@ -848,10 +849,9 @@ void ComputeUnitCore::issue_instruction(Wavefront *active) {
     auto mn = std::string_view(inst->mnemonic());
     if (mn.find("s_setpc") != std::string_view::npos ||
         mn.find("s_swappc") != std::string_view::npos) {
-      uint32_t ssrc0_idx = words[0] & 0x7F;
-      uint32_t sb = active->sgpr_alloc().base;
-      uint64_t target = static_cast<uint64_t>(read_sgpr(sb + ssrc0_idx)) |
-                        (static_cast<uint64_t>(read_sgpr(sb + ssrc0_idx + 1)) << 32);
+      const Operand *target_operand = inst->src_operand(0);
+      assert(target_operand && "indirect PC instruction must have a target operand");
+      uint64_t target = RegisterAccess(*active).read_scalar64(*target_operand);
       if (target == 0) {
         active->halt();
         delete inst;
@@ -1000,11 +1000,19 @@ void ComputeUnitCore::issue_instruction(Wavefront *active) {
     return;
   }
   if (inst->is_memory_op()) {
-    if (inst->data() && inst->data()->tag() == GLOBAL_MEM) {
-      auto *d = inst->data_as<VectorMemState>();
-      d->issue_pc = active->pc;
+    if (!inst->data()) {
+      // A memory execute path can intentionally reject an invalid complete
+      // register operand before constructing pipeline state. Treat that as a
+      // fully suppressed instruction: no route callback, wait-counter update,
+      // or memory transaction is permitted.
+      delete inst;
+    } else {
+      if (inst->data()->tag() == GLOBAL_MEM) {
+        auto *d = inst->data_as<VectorMemState>();
+        d->issue_pc = active->pc;
+      }
+      route_memory_inst(inst, *active);
     }
-    route_memory_inst(inst, *active);
   } else
     delete inst;
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -544,31 +544,126 @@ public:
   /// @returns Index of the next wavefront slot to schedule.
   uint64_t cycle_count() const { return cycle_counter_; }
 
+  /// @brief Return the physical SGPR allocation block size per wavefront.
+  uint32_t sgpr_allocation_block_size() const { return config_.sgprs_per_wf; }
+
+  /// @brief Test whether a physical SGPR range is contained in a wavefront's
+  /// fixed simulator storage block.
+  /// @details This is an isolation boundary, not the descriptor-derived
+  /// architectural allocation extent recorded in `wf.sgpr_alloc().count`.
+  [[nodiscard]] bool owns_sgpr_range(const Wavefront &wf, uint32_t physical_base,
+                                     uint32_t physical_count) const {
+    return &wf.raw_cu() == this && wf.sgpr_alloc().count != 0 &&
+           RegAllocation{wf.sgpr_alloc().base, sgpr_allocation_block_size()}.contains(
+               physical_base, physical_count);
+  }
+
+  /// @brief Test whether a physical VGPR range is contained in a wavefront's
+  /// fixed simulator storage block.
+  /// @details This is an isolation boundary, not the descriptor-derived
+  /// architectural allocation extent recorded in `wf.vgpr_alloc().count`.
+  [[nodiscard]] bool owns_vgpr_range(const Wavefront &wf, uint32_t physical_base,
+                                     uint32_t physical_count) const {
+    return &wf.raw_cu() == this && wf.vgpr_alloc().count != 0 &&
+           RegAllocation{wf.vgpr_alloc().base, vgpr_allocation_block_size()}.contains(
+               physical_base, physical_count);
+  }
+
+private:
+  // RegisterAccess is the instruction-facing register boundary. These
+  // ownership and SGPR access helpers validate the complete operation, fire
+  // callbacks, and only then expose or modify storage.
+  friend class RegisterAccess;
+
+  /// @brief Resolve one owner for a complete physical SGPR range.
+  /// @details Returns null for empty, unallocated, out-of-file, or mixed-owner
+  /// ranges. CU-bound RegisterAccess uses this compatibility path; wave-bound
+  /// access keeps its explicit owner instead.
+  [[nodiscard]] const Wavefront *sgpr_owner_for_range(uint32_t physical_base,
+                                                      uint32_t physical_count) const {
+    if (physical_count == 0 || physical_base >= sgpr_file_.total_regs() ||
+        physical_count > sgpr_file_.total_regs() - physical_base)
+      return nullptr;
+    const Wavefront *owner = sgpr_owner(physical_base);
+    if (!owner || !owns_sgpr_range(*owner, physical_base, physical_count))
+      return nullptr;
+    return owner;
+  }
+
+  /// @brief Resolve one owner for a complete physical VGPR range.
+  /// @details Returns null for empty, unallocated, out-of-file, or mixed-owner
+  /// ranges. Implemented by the concrete CU that owns the typed VGPR file.
+  [[nodiscard]] virtual const Wavefront *vgpr_owner_for_range(uint32_t physical_base,
+                                                              uint32_t physical_count) const = 0;
+
+  [[nodiscard]] uint32_t read_sgpr(const Wavefront &wf, uint32_t reg_idx) const {
+    if (!owns_sgpr_range(wf, reg_idx, 1))
+      return 0;
+    notify_scalar_register_read(
+        wf, RegisterRef{RegClass::SGPR, static_cast<uint16_t>(reg_idx - wf.sgpr_alloc().base), 1});
+    return sgpr_file_[reg_idx];
+  }
+
+  void write_sgpr(const Wavefront &wf, uint32_t reg_idx, uint32_t val) {
+    if (!owns_sgpr_range(wf, reg_idx, 1))
+      return;
+    plugin_group_->onAmdgpuWriteScalarRegister(
+        &wf, RegisterRef{RegClass::SGPR, static_cast<uint16_t>(reg_idx - wf.sgpr_alloc().base), 1});
+    sgpr_file_[reg_idx] = val;
+  }
+
+  void write_sgpr64(const Wavefront &wf, uint32_t reg_idx, uint64_t val) {
+    if (!owns_sgpr_range(wf, reg_idx, 2))
+      return;
+    plugin_group_->onAmdgpuWriteScalarRegister(
+        &wf, RegisterRef{RegClass::SGPR, static_cast<uint16_t>(reg_idx - wf.sgpr_alloc().base), 2});
+    sgpr_file_[reg_idx] = static_cast<uint32_t>(val);
+    sgpr_file_[reg_idx + 1] = static_cast<uint32_t>(val >> 32);
+  }
+
+  void notify_scalar_register_read(const Wavefront &wf, RegisterRef reg) const {
+    if (observes_sgpr_reads_)
+      plugin_group_->onAmdgpuReadScalarRegister(&wf, reg);
+  }
+
+  void notify_scalar_register_write(const Wavefront &wf, RegisterRef reg) const {
+    plugin_group_->onAmdgpuWriteScalarRegister(&wf, reg);
+  }
+
+public:
   /// @brief Read a scalar register from the physical SGPR file.
-  /// @details This is the VM-level scalar register accessor. It notifies the
-  /// plugin group of an SGPR read when the physical register is currently owned
-  /// by a wavefront. Instruction operand implementations use this to implement
-  /// scalar operand semantics. VGPR reads from instruction emulators should not
-  /// use the analogous CU physical VGPR accessors directly; use Operand or
-  /// RegisterAccess APIs instead.
+  /// @details VM/diagnostic compatibility accessor. It notifies the plugin
+  /// group when the physical register is currently owned by a wavefront.
+  /// Instruction code should use Operand or RegisterAccess so complete-range
+  /// ownership and the explicit executing wave are preserved.
   /// @param reg_idx Physical register index.
   /// @returns Register value.
   // TODO(newling) consider cmake flag to build without plugins, this call
   // overhead might be non-negligible.
   uint32_t read_sgpr(uint32_t reg_idx) const {
+    if (reg_idx >= sgpr_file_.total_regs())
+      return 0;
     if (observes_sgpr_reads_)
       if (auto *wf = sgpr_owner(reg_idx))
-        plugin_group_->onAmdgpuReadSgpr(wf, reg_idx);
+        return read_sgpr(*wf, reg_idx);
     return sgpr_file_[reg_idx];
   }
 
+  /// @brief Read raw SGPR storage without producing an observation callback.
+  uint32_t read_sgpr_storage(uint32_t reg_idx) const {
+    return reg_idx < sgpr_file_.total_regs() ? sgpr_file_[reg_idx] : 0;
+  }
+
   /// @brief Write a scalar register in the physical SGPR file.
-  /// @details VM-level scalar register write used for scalar operand
-  /// destinations and dispatch/runtime state setup. This does not imply a VGPR
-  /// read and does not participate in VGPR read observation.
+  /// @details Raw VM-level write used for memory completion and dispatch/runtime
+  /// state setup. It deliberately does not fire an instruction callback.
+  /// Instruction code must use wave-bound RegisterAccess.
   /// @param reg_idx Physical register index.
   /// @param val Value to write.
-  void write_sgpr(uint32_t reg_idx, uint32_t val) { sgpr_file_[reg_idx] = val; }
+  void write_sgpr(uint32_t reg_idx, uint32_t val) {
+    if (reg_idx < sgpr_file_.total_regs())
+      sgpr_file_[reg_idx] = val;
+  }
 
   /// @brief Notify plugins that a wavefront read lanes of a physical VGPR.
   /// @details Low-level notification primitive used by RegisterAccess and the
@@ -577,7 +672,7 @@ public:
   /// storage access with this hook.
   void notify_vgpr_read(const Wavefront *wf, uint32_t reg_idx, uint64_t lane_mask,
                         uint8_t byte_mask = rocjitsu::ExecutionPlugin::kFullByteMask) const {
-    if (wf && lane_mask != 0)
+    if (wf && lane_mask != 0 && owns_vgpr_range(*wf, reg_idx, 1))
       plugin_group_->onAmdgpuReadVgprLanes(wf, reg_idx, lane_mask, byte_mask);
   }
 
@@ -588,7 +683,7 @@ public:
                          uint8_t byte_mask = rocjitsu::ExecutionPlugin::kFullByteMask) const {
     if (wf)
       lane_mask &= wf->vgpr_write_mask();
-    if (wf && lane_mask != 0 && byte_mask != 0)
+    if (wf && lane_mask != 0 && byte_mask != 0 && owns_vgpr_range(*wf, reg_idx, 1))
       plugin_group_->onAmdgpuWriteVgprLanes(wf, reg_idx, lane_mask, byte_mask);
   }
 
@@ -598,22 +693,22 @@ public:
   void notify_scalar_lane_vgpr_write(
       const Wavefront *wf, uint32_t reg_idx, uint64_t lane_mask,
       uint8_t byte_mask = rocjitsu::ExecutionPlugin::kFullByteMask) const {
-    if (wf && lane_mask != 0 && byte_mask != 0)
+    if (wf && lane_mask != 0 && byte_mask != 0 && owns_vgpr_range(*wf, reg_idx, 1))
       plugin_group_->onAmdgpuWriteVgprLanes(wf, reg_idx, lane_mask, byte_mask);
   }
 
   /// @brief Notify plugins that lanes of a physical VGPR were read.
   /// @details Resolves the owning wavefront from the physical register index.
-  /// Intended for RegisterAccess and CU internals, not as a direct instruction
-  /// emulator API.
+  /// Transitional single-register compatibility path for CU internals.
+  /// Instruction helpers should retain their explicit wave in RegisterAccess.
   virtual void
   notify_vgpr_read_by_reg(uint32_t reg_idx, uint64_t lane_mask,
                           uint8_t byte_mask = rocjitsu::ExecutionPlugin::kFullByteMask) const = 0;
 
   /// @brief Notify plugins that lanes of a physical VGPR were written.
   /// @details Resolves the owning wavefront from the physical register index.
-  /// Intended for RegisterAccess and CU internals, not as a direct instruction
-  /// emulator API.
+  /// Transitional single-register compatibility path for CU internals.
+  /// Instruction helpers should retain their explicit wave in RegisterAccess.
   virtual void
   notify_vgpr_write_by_reg(uint32_t reg_idx, uint64_t lane_mask,
                            uint8_t byte_mask = rocjitsu::ExecutionPlugin::kFullByteMask) const = 0;
@@ -935,9 +1030,9 @@ protected:
     Wavefront *owner = nullptr;
     uint32_t end = 0;
   };
-  /// Reverse lookup: SGPR allocation block -> owning wavefront (for race detection).
-  /// One entry per hardware wave slot replaces one pointer per physical SGPR,
-  /// while end preserves the requested-register boundary for plugin observation.
+  /// Reverse lookup: SGPR allocation block -> owning wavefront for instruction
+  /// observation. One entry per hardware wave slot replaces one pointer per
+  /// physical SGPR, while end preserves the physical allocation-block boundary.
   std::vector<SgprBlockOwner> sgpr_block_owners_;
   uint32_t sgpr_block_shift_ = kVariableSgprBlockShift;
   /// Record or clear the owner of one VGPR allocation block.
@@ -982,12 +1077,6 @@ inline bool InstructionComputeUnitView::handle_sendmsg(Wavefront &wf, uint32_t m
 }
 inline void InstructionComputeUnitView::notify_trap_complete(Wavefront &wf) {
   raw_cu().notify_trap_complete(wf);
-}
-inline uint32_t InstructionComputeUnitView::read_sgpr(uint32_t reg_idx) const {
-  return raw_cu().read_sgpr(reg_idx);
-}
-inline void InstructionComputeUnitView::write_sgpr(uint32_t reg_idx, uint32_t value) {
-  raw_cu().write_sgpr(reg_idx, value);
 }
 
 /// @brief Execution-mode-aware compute unit shell.
@@ -1127,6 +1216,8 @@ public:
 
   /// @returns Lane value from the VGPR file.
   uint32_t read_vgpr(uint32_t reg_idx, uint32_t lane) const override {
+    if (reg_idx >= vgpr_file_.total_regs() || lane >= Isa::WF_SIZE_MAX)
+      return 0;
     notify_vgpr_read_by_reg(reg_idx, uint64_t{1} << lane);
     return vgpr_file_[reg_idx][lane];
   }
@@ -1152,6 +1243,17 @@ public:
     return block < this->config_.num_wf_slots ? vgpr_block_owners_[block] : nullptr;
   }
 
+private:
+  const Wavefront *vgpr_owner_for_range(uint32_t physical_base,
+                                        uint32_t physical_count) const override {
+    if (physical_count == 0 || physical_base >= vgpr_file_.total_regs() ||
+        physical_count > vgpr_file_.total_regs() - physical_base)
+      return nullptr;
+    const Wavefront *owner = vgpr_owner(physical_base);
+    return owner && this->owns_vgpr_range(*owner, physical_base, physical_count) ? owner : nullptr;
+  }
+
+public:
   void set_vgpr_block_owner(uint32_t base, Wavefront *wf) override {
     assert(vgprs_per_block_ != 0 && base % vgprs_per_block_ == 0);
     const size_t block = base / vgprs_per_block_;
@@ -1161,7 +1263,8 @@ public:
 
   /// @brief Write a value to the VGPR file.
   void write_vgpr(uint32_t reg_idx, uint32_t lane, uint32_t val) override {
-    vgpr_file_[reg_idx][lane] = val;
+    if (reg_idx < vgpr_file_.total_regs() && lane < Isa::WF_SIZE_MAX)
+      vgpr_file_[reg_idx][lane] = val;
   }
 
   /// @returns Const pointer to one VGPR's raw lane data.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/instruction_compute_unit_view.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/instruction_compute_unit_view.h
@@ -38,7 +38,7 @@ class Wavefront;
 /// should reach registers through Operand or RegisterAccess.
 class InstructionComputeUnitView {
 public:
-  explicit InstructionComputeUnitView(ComputeUnitCore &cu) : cu_(&cu) {}
+  InstructionComputeUnitView(ComputeUnitCore &cu, Wavefront &wf) : cu_(&cu), wf_(&wf) {}
 
   InstructionCache &instruction_cache();
   L1ScalarCache &l1_scalar();
@@ -59,17 +59,18 @@ public:
   bool signal_queue_exception(uint32_t queue_id, uint32_t process_id, uint64_t status);
 
 private:
-  uint32_t read_sgpr(uint32_t reg_idx) const;
-  void write_sgpr(uint32_t reg_idx, uint32_t value);
-
   ComputeUnitCore &raw_cu() { return *cu_; }
   const ComputeUnitCore &raw_cu() const { return *cu_; }
+  Wavefront &raw_wavefront() { return *wf_; }
+  const Wavefront &raw_wavefront() const { return *wf_; }
 
   ComputeUnitCore *cu_ = nullptr;
+  Wavefront *wf_ = nullptr;
 
-  // RegisterAccess unwraps the view so instruction helpers can use the same
-  // observed physical-register facade whether they were passed a full CU or an
-  // instruction-facing CU view.
+  // RegisterAccess unwraps both the CU and the owning wave. This keeps legacy
+  // instruction helpers that accept a CU-shaped service view wave-bound:
+  // physical register indices are validated against the executing wave rather
+  // than re-attributed through the CU's reverse ownership maps.
   friend class RegisterAccess;
 
   // The non-split ISA operand fallback and the execution-only access key are

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/mem_state.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/mem_state.h
@@ -11,6 +11,7 @@
 /// pipeline subclasses own the initiate/complete logic that operates
 /// on this state.
 
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_selectors.h"
 #include "rocjitsu/isa/instruction.h"
 #include "rocjitsu/vm/amdgpu/mtype.h"
 #include "rocjitsu/vm/amdgpu/wait_counters.h"
@@ -72,16 +73,8 @@ enum class AtomicOp : uint8_t {
 struct ScalarMemState : DynamicInstState {
   ScalarMemState() { tag_ = SCALAR_MEM; }
   uint64_t addr = 0;
-  uint32_t dst_reg_base = 0;
-  /// @brief The SDATA operand selector, before it was resolved to a physical
-  /// register.
-  /// @details Selectors 108..123 name the trap-temporary file rather than a
-  /// slot in the wave's SGPR allocation, so the load write-back has to dispatch
-  /// on the selector; dst_reg_base is meaningless for those. The ROCr trap
-  /// handler loads straight into TTMPs (`s_load_dwordx2 ttmp[2:3], ...`), so
-  /// this is a live path, and writing dst_reg_base for one would land outside
-  /// the wave's own allocation.
-  uint32_t dst_selector = 0;
+  /// Architectural destination resolved and range-checked at issue time.
+  ScalarRegisterRange dst_register;
   uint32_t num_dwords = 0;
   uint32_t elem_size = 4;
   bool sign_extend = false;
@@ -226,6 +219,15 @@ struct VectorMemState : DynamicInstState {
   std::vector<uint8_t> ds2_store_data;
   std::vector<uint8_t> ds2_response_data;
 };
+
+/// @brief Reject a vector-memory instruction before it reaches a memory pipeline.
+/// @details Preserve exec_mask so normal load completion semantics treat every
+/// denied lane as inactive/OOB, while clearing lane addresses and lane_mask so
+/// no transaction or store reaches memory.
+inline void reject_vector_memory_access(VectorMemState &state) {
+  state.lane_mask = 0;
+  state.per_lane_addr.fill(0);
+}
 
 } // namespace amdgpu
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.cpp
@@ -143,6 +143,8 @@ MemoryAccessCompletion vector_complete(VectorMemState &d, Wavefront &wf, Compute
   uint32_t total_bytes = d.num_elems * d.elem_size;
   uint32_t vgpr_count =
       is_atomic ? std::max(1u, (d.elem_size + 3u) / 4u) : std::max(1u, (total_bytes + 3u) / 4u);
+  if (!cu.owns_vgpr_range(wf, d.dst_reg_base, vgpr_count))
+    return MemoryAccessCompletion::Complete;
 
   // Zero destination VGPRs for OOB lanes. Per AMD ISA spec, out-of-bounds
   // buffer loads return 0. exec_mask is the effective issue mask; ordinary OOB
@@ -230,18 +232,18 @@ ScalarMemPipeline::complete_access(Instruction &inst, Wavefront &wf,
   auto &d = *inst.data_as<ScalarMemState>();
   if (!d.is_load)
     return MemoryAccessCompletion::Complete;
-  for (uint32_t i = 0; i < d.num_dwords; ++i) {
-    // Dispatch on the selector, not the resolved base: an SDATA of 108..123
-    // names the trap-temporary file, and the ROCr handler loads into TTMPs.
-    amdgpu::write_scalar_selector(wf, d.dst_selector + i, d.response_data[i]);
-  }
+  if (d.dst_register.width != d.num_dwords)
+    return MemoryAccessCompletion::Complete;
+  RegisterAccess registers(wf);
+  for (uint32_t i = 0; i < d.num_dwords; ++i)
+    registers.write_scalar_unobserved(d.dst_register, i, d.response_data[i]);
   // Trace: log SMEM load values for debugging.
   util::Logger::vm([&](auto &os) {
     if (wf.wg_id() == 0) {
       static thread_local uint32_t slw_count = 0;
       if (++slw_count <= 100) {
-        os << std::format("SMEM complete: addr={:#x} dst_s={} ndw={} data=[{:#x}", d.addr,
-                          d.dst_reg_base, d.num_dwords, d.response_data[0]);
+        os << std::format("SMEM complete: addr={:#x} dst={} ndw={} data=[{:#x}", d.addr,
+                          d.dst_register.index, d.num_dwords, d.response_data[0]);
         for (uint32_t i = 1; i < d.num_dwords && i < 4; ++i)
           os << std::format(",{:#x}", d.response_data[i]);
         os << std::format("] wg={}", wf.wg_id());

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/register_access.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/register_access.h
@@ -32,6 +32,7 @@
 #include "util/simd.h"
 
 #include <algorithm>
+#include <array>
 #include <bit>
 #include <cassert>
 #include <cstddef>
@@ -82,12 +83,12 @@ struct OperandPair32 {
 ///   indices, such as address calculation or generated SGPR-relative forms.
 ///
 /// Read and read-write acquisition fires the plugin read hook before any lane
-/// storage is exposed. Region reads notify once per physical register in the
-/// requested range with the caller-provided lane and byte masks. Write and
-/// read-write acquisition similarly fires the plugin write hook before mutable
-/// storage is exposed. A write view remembers the observed lane mask and rejects
-/// caller stores outside its acquisition window. Write-only views deliberately
-/// do not report reads.
+/// storage is exposed. VGPR region reads notify once per physical register with
+/// the caller-provided lane and byte masks; SGPR region reads carry one typed
+/// architectural range. Write and read-write acquisition similarly fires the
+/// plugin write hook before mutable storage is exposed. A write view remembers
+/// the observed lane mask and rejects caller stores outside its acquisition
+/// window. Write-only views deliberately do not report reads.
 ///
 /// Operand read views may be VGPR-backed or scalar-backed. Scalar-backed views
 /// represent SGPR, inline literal, immediate, and special-register operands as
@@ -100,9 +101,11 @@ struct OperandPair32 {
 /// here. They should be acquired during a single instruction's emulation and
 /// not cached across instructions.
 ///
-/// Logical operand APIs require construction from a Wavefront. Physical register
-/// APIs may be constructed from a ComputeUnitCore; write access requires
-/// a mutable ComputeUnitCore.
+/// Logical operand APIs require construction from a Wavefront. Physical VGPR
+/// APIs may use a CU-bound compatibility path, but a complete region must map
+/// to one live wave before any callback or storage view is produced. Physical
+/// SGPR writes require a mutable Wavefront; raw VM/runtime writes belong on
+/// ComputeUnitCore and deliberately bypass this instruction-facing facade.
 class RegisterAccess {
   static uint32_t byte_bit_mask(uint8_t byte_mask) {
     uint32_t bit_mask = 0;
@@ -180,10 +183,10 @@ public:
     friend class RegisterAccess;
 
     OperandReadView(const Operand &op, const Wavefront &wf, ConstVgprStorage storage,
-                    uint8_t byte_mask)
+                    uint8_t byte_mask, bool denied)
         : storage_(storage), byte_mask_(byte_mask) {
       if (!storage_)
-        scalar_fallback_.emplace(op.read_lane(wf, 0));
+        scalar_fallback_.emplace(denied ? 0u : op.read_lane(wf, 0));
     }
 
     uint32_t scalar_fallback() const {
@@ -226,6 +229,8 @@ public:
         }
         return;
       }
+      if (denied_)
+        return;
       if (byte_mask_ != rocjitsu::ExecutionPlugin::kFullByteMask)
         throw std::logic_error("partial-byte OperandWriteView requires VGPR storage");
       alignas(util::native<T>) uint32_t buf[W];
@@ -259,6 +264,8 @@ public:
         }
         return;
       }
+      if (denied_)
+        return;
       if (byte_mask_ != rocjitsu::ExecutionPlugin::kFullByteMask)
         throw std::logic_error("partial-byte OperandWriteView requires VGPR storage");
       alignas(util::narrow32<T>) T vals[W];
@@ -273,15 +280,17 @@ public:
     friend class RegisterAccess;
 
     OperandWriteView(const Operand &op, Wavefront &wf, VgprStorage storage,
-                     uint64_t permitted_write_lane_mask, uint8_t byte_mask)
+                     uint64_t permitted_write_lane_mask, uint8_t byte_mask, bool denied)
         : op_(&op), wf_(&wf), storage_(storage),
-          permitted_write_lane_mask_(permitted_write_lane_mask), byte_mask_(byte_mask) {}
+          permitted_write_lane_mask_(permitted_write_lane_mask), byte_mask_(byte_mask),
+          denied_(denied) {}
 
     const Operand *op_ = nullptr;
     Wavefront *wf_ = nullptr;
     VgprStorage storage_{};
     uint64_t permitted_write_lane_mask_ = 0;
     uint8_t byte_mask_ = rocjitsu::ExecutionPlugin::kFullByteMask;
+    bool denied_ = false;
   };
 
   class OperandWrite64View {
@@ -303,6 +312,8 @@ public:
         storage_.lo.template simd_store64<T>(storage_.hi, lane_base, value, lane_mask);
         return;
       }
+      if (denied_)
+        return;
       alignas(util::native<T>) uint64_t buf[W];
       util::stdx::native_simd<uint64_t> bits = [&] {
         if constexpr (std::is_same_v<T, uint64_t>)
@@ -320,14 +331,15 @@ public:
     friend class RegisterAccess;
 
     OperandWrite64View(const Operand &op, Wavefront &wf, VgprStoragePair64 storage,
-                       uint64_t permitted_write_lane_mask)
+                       uint64_t permitted_write_lane_mask, bool denied)
         : op_(&op), wf_(&wf), storage_(storage),
-          permitted_write_lane_mask_(permitted_write_lane_mask) {}
+          permitted_write_lane_mask_(permitted_write_lane_mask), denied_(denied) {}
 
     const Operand *op_ = nullptr;
     Wavefront *wf_ = nullptr;
     VgprStoragePair64 storage_{};
     uint64_t permitted_write_lane_mask_ = 0;
+    bool denied_ = false;
   };
 
   class OperandReadWriteView {
@@ -387,6 +399,8 @@ public:
         }
         return;
       }
+      if (denied_)
+        return;
       if (byte_mask_ != rocjitsu::ExecutionPlugin::kFullByteMask)
         throw std::logic_error("partial-byte OperandReadWriteView requires VGPR storage");
       alignas(util::native<T>) uint32_t buf[W];
@@ -420,6 +434,8 @@ public:
         }
         return;
       }
+      if (denied_)
+        return;
       if (byte_mask_ != rocjitsu::ExecutionPlugin::kFullByteMask)
         throw std::logic_error("partial-byte OperandReadWriteView requires VGPR storage");
       alignas(util::narrow32<T>) T vals[W];
@@ -435,12 +451,12 @@ public:
 
     OperandReadWriteView(const Operand &op, Wavefront &wf, VgprStorage storage,
                          uint64_t permitted_write_lane_mask, uint8_t read_byte_mask,
-                         uint8_t write_byte_mask)
+                         uint8_t write_byte_mask, bool denied)
         : op_(&op), wf_(&wf), storage_(storage),
           permitted_write_lane_mask_(permitted_write_lane_mask), read_byte_mask_(read_byte_mask),
-          byte_mask_(write_byte_mask) {
+          byte_mask_(write_byte_mask), denied_(denied) {
       if (!storage_)
-        scalar_fallback_.emplace(op.read_lane(wf, 0));
+        scalar_fallback_.emplace(denied ? 0u : op.read_lane(wf, 0));
     }
 
     uint32_t scalar_fallback() const {
@@ -454,6 +470,7 @@ public:
     uint64_t permitted_write_lane_mask_ = 0;
     uint8_t read_byte_mask_ = rocjitsu::ExecutionPlugin::kFullByteMask;
     uint8_t byte_mask_ = rocjitsu::ExecutionPlugin::kFullByteMask;
+    bool denied_ = false;
   };
 
   class OperandReadWrite64View {
@@ -488,6 +505,8 @@ public:
         storage_.lo.template simd_store64<T>(storage_.hi, lane_base, value, lane_mask);
         return;
       }
+      if (denied_)
+        return;
       alignas(util::native<T>) uint64_t buf[W];
       util::stdx::native_simd<uint64_t> bits = [&] {
         if constexpr (std::is_same_v<T, uint64_t>)
@@ -505,11 +524,12 @@ public:
     friend class RegisterAccess;
 
     OperandReadWrite64View(const Operand &op, Wavefront &wf, VgprStoragePair64 storage,
-                           uint64_t permitted_write_lane_mask, uint8_t read_byte_mask)
+                           uint64_t permitted_write_lane_mask, uint8_t read_byte_mask, bool denied)
         : op_(&op), wf_(&wf), storage_(storage),
-          permitted_write_lane_mask_(permitted_write_lane_mask), read_byte_mask_(read_byte_mask) {
+          permitted_write_lane_mask_(permitted_write_lane_mask), read_byte_mask_(read_byte_mask),
+          denied_(denied) {
       if (!storage_.lo)
-        scalar_fallback_.emplace(op.read_lane64(wf, 0));
+        scalar_fallback_.emplace(denied ? 0u : op.read_lane64(wf, 0));
     }
 
     uint64_t scalar_fallback() const {
@@ -522,6 +542,7 @@ public:
     std::optional<uint64_t> scalar_fallback_;
     uint64_t permitted_write_lane_mask_ = 0;
     uint8_t read_byte_mask_ = rocjitsu::ExecutionPlugin::kFullByteMask;
+    bool denied_ = false;
   };
 
   class OperandRead64View {
@@ -558,10 +579,10 @@ public:
     friend class RegisterAccess;
 
     OperandRead64View(const Operand &op, const Wavefront &wf, ConstVgprStoragePair64 storage,
-                      uint8_t byte_mask)
+                      uint8_t byte_mask, bool denied)
         : storage_(storage), byte_mask_(byte_mask) {
       if (!storage_.lo)
-        scalar_fallback_.emplace(op.read_lane64(wf, 0));
+        scalar_fallback_.emplace(denied ? 0u : op.read_lane64(wf, 0));
     }
 
     uint64_t scalar_fallback() const {
@@ -607,10 +628,11 @@ public:
     friend class RegisterAccess;
 
     OperandReadPair32View(const Operand &op, const Wavefront &wf, ConstVgprStoragePair64 storage,
-                          uint8_t byte_mask)
+                          uint8_t byte_mask, bool denied)
         : storage_(storage), byte_mask_(byte_mask) {
       if (!storage_.lo)
-        scalar_fallback_.emplace(RegisterAccess(wf).read_lane_pair32(op, 0));
+        scalar_fallback_.emplace(denied ? OperandPair32{}
+                                        : RegisterAccess(wf).read_lane_pair32(op, 0));
     }
 
     uint32_t scalar_fallback(bool high) const {
@@ -645,6 +667,8 @@ public:
         storage_.hi.template simd_store<T>(lane_base, hi, lane_mask);
         return;
       }
+      if (denied_)
+        return;
       alignas(util::native<T>) uint32_t lo_buf[W];
       alignas(util::native<T>) uint32_t hi_buf[W];
       util::blit_to_buffer<T>(lo_buf, lo);
@@ -662,14 +686,15 @@ public:
     friend class RegisterAccess;
 
     OperandWritePair32View(const Operand &op, Wavefront &wf, VgprStoragePair64 storage,
-                           uint64_t permitted_write_lane_mask)
+                           uint64_t permitted_write_lane_mask, bool denied)
         : op_(&op), wf_(&wf), storage_(storage),
-          permitted_write_lane_mask_(permitted_write_lane_mask) {}
+          permitted_write_lane_mask_(permitted_write_lane_mask), denied_(denied) {}
 
     const Operand *op_ = nullptr;
     Wavefront *wf_ = nullptr;
     VgprStoragePair64 storage_{};
     uint64_t permitted_write_lane_mask_ = 0;
+    bool denied_ = false;
   };
 
   class VgprReadRegion {
@@ -679,13 +704,18 @@ public:
     [[nodiscard]] uint32_t base() const { return base_; }
     [[nodiscard]] uint32_t reg_count() const { return reg_count_; }
     [[nodiscard]] uint32_t wf_size() const { return wf_size_; }
-    [[nodiscard]] bool empty() const { return cu_ == nullptr || reg_count_ == 0; }
+    [[nodiscard]] bool valid() const { return valid_; }
+    [[nodiscard]] bool empty() const { return reg_count_ == 0 || !observed_; }
 
     /// @brief Visit each logical VGPR as one lane span, in register order.
     template <typename Function> void for_each(Function &&function) const {
-      assert(cu_ && "VgprReadRegion is empty");
       if (byte_mask_ != rocjitsu::ExecutionPlugin::kFullByteMask)
         throw std::logic_error("partial-byte VgprReadRegion does not expose raw lane spans");
+      if (!valid_ || !observed_) {
+        for (uint32_t reg = 0; reg < reg_count_; ++reg)
+          function(std::span<const uint32_t>(zero_lanes_.data(), wf_size_));
+        return;
+      }
       cu_->for_each_raw_vgpr(base_, reg_count_, [&](std::span<const uint32_t> physical_lanes) {
         assert(physical_lanes.size() >= wf_size_ && "physical VGPR is narrower than wave");
         function(physical_lanes.first(wf_size_));
@@ -694,11 +724,14 @@ public:
 
     /// @brief Gather wave-width lane words from this logical VGPR range.
     void copy_to(std::span<uint32_t> destination) const {
-      assert(cu_ && "VgprReadRegion is empty");
       assert(destination.size() <= static_cast<size_t>(reg_count_) * wf_size_ &&
              "destination exceeds read region");
       if (byte_mask_ != rocjitsu::ExecutionPlugin::kFullByteMask)
         throw std::logic_error("partial-byte VgprReadRegion cannot copy raw words");
+      if (!valid_ || !observed_) {
+        std::fill(destination.begin(), destination.end(), 0);
+        return;
+      }
       size_t copied = 0;
       for_each([&](std::span<const uint32_t> lanes) {
         const size_t count = std::min(lanes.size(), destination.size() - copied);
@@ -708,16 +741,19 @@ public:
     }
 
     [[nodiscard]] std::span<const uint32_t> lanes(uint32_t relative_reg = 0) const {
-      assert(cu_ && "VgprReadRegion is empty");
       assert(relative_reg < reg_count_ && "relative VGPR outside read region");
       if (byte_mask_ != rocjitsu::ExecutionPlugin::kFullByteMask)
         throw std::logic_error("partial-byte VgprReadRegion does not expose raw lane spans");
+      if (!valid_ || !observed_)
+        return {zero_lanes_.data(), wf_size_};
       return {reg_data(relative_reg), wf_size_};
     }
 
     [[nodiscard]] uint32_t lane(uint32_t relative_reg, uint32_t lane) const {
       assert(lane < wf_size_ && "lane outside wavefront");
       assert(relative_reg < reg_count_ && "relative VGPR outside read region");
+      if (!valid_ || !observed_)
+        return 0;
       const auto *data =
           reinterpret_cast<const uint32_t *>(cu_->raw_vgpr_data(base_ + relative_reg));
       return data[lane] & RegisterAccess::byte_bit_mask(byte_mask_);
@@ -742,23 +778,27 @@ public:
     /// through another handle. Pointers must not be retained after the owning
     /// wavefront retires.
     [[nodiscard]] const uint32_t *reg_data(uint32_t relative_reg) const {
-      assert(cu_ && "VgprReadRegion is empty");
       assert(relative_reg < reg_count_ && "relative VGPR outside read region");
       if (byte_mask_ != rocjitsu::ExecutionPlugin::kFullByteMask)
         throw std::logic_error("partial-byte VgprReadRegion does not expose raw register data");
+      if (!valid_ || !observed_)
+        return zero_lanes_.data();
       return reinterpret_cast<const uint32_t *>(cu_->raw_vgpr_data(base_ + relative_reg));
     }
 
     VgprReadRegion(const ComputeUnitCore &cu, uint32_t base, uint32_t reg_count, uint32_t wave_size,
-                   uint8_t byte_mask)
-        : cu_(&cu), base_(base), reg_count_(reg_count), wf_size_(wave_size), byte_mask_(byte_mask) {
-    }
+                   uint8_t byte_mask, bool valid = true, bool observed = true)
+        : cu_(&cu), base_(base), reg_count_(reg_count), wf_size_(wave_size), byte_mask_(byte_mask),
+          valid_(valid), observed_(observed) {}
 
     const ComputeUnitCore *cu_ = nullptr;
     uint32_t base_ = 0;
     uint32_t reg_count_ = 0;
     uint32_t wf_size_ = 0;
     uint8_t byte_mask_ = rocjitsu::ExecutionPlugin::kFullByteMask;
+    bool valid_ = false;
+    bool observed_ = false;
+    inline static constexpr std::array<uint32_t, 64> zero_lanes_{};
   };
 
   class VgprWriteRegion {
@@ -769,11 +809,12 @@ public:
     [[nodiscard]] uint32_t reg_count() const { return reg_count_; }
     [[nodiscard]] uint32_t wf_size() const { return wf_size_; }
     [[nodiscard]] uint64_t lane_mask() const { return lane_mask_; }
+    [[nodiscard]] bool valid() const { return cu_ != nullptr; }
     [[nodiscard]] bool empty() const { return cu_ == nullptr || reg_count_ == 0; }
 
     void set_lane(uint32_t relative_reg, uint32_t lane, uint32_t value) const {
       assert(lane < wf_size_ && "lane outside wavefront");
-      if ((lane_mask_ & (uint64_t{1} << lane)) == 0)
+      if (!cu_ || (lane_mask_ & (uint64_t{1} << lane)) == 0)
         return;
       uint32_t &destination = reg_data(relative_reg)[lane];
       const uint32_t bit_mask = RegisterAccess::byte_bit_mask(byte_mask_);
@@ -795,9 +836,9 @@ public:
     friend class RegisterAccess;
 
     VgprWriteRegion(ComputeUnitCore &cu, uint32_t base, uint32_t reg_count, uint32_t wave_size,
-                    uint64_t lane_mask, uint8_t byte_mask)
-        : cu_(&cu), base_(base), reg_count_(reg_count), wf_size_(wave_size), lane_mask_(lane_mask),
-          byte_mask_(byte_mask) {}
+                    uint64_t lane_mask, uint8_t byte_mask, bool valid = true)
+        : cu_(valid ? &cu : nullptr), base_(base), reg_count_(reg_count), wf_size_(wave_size),
+          lane_mask_(lane_mask), byte_mask_(byte_mask) {}
 
     uint32_t *reg_data(uint32_t relative_reg = 0) const {
       assert(cu_ && "VgprWriteRegion is empty");
@@ -842,11 +883,51 @@ public:
     VgprWriteRegion write_;
   };
 
+  /// @brief Read-only observed range of physical SGPRs.
+  ///
+  /// The region is valid only when its complete range belongs to one live
+  /// wavefront. Acquisition validates the complete range and reports every
+  /// dword before this object exposes a value. A denied region returns zero
+  /// values for defensive callers, but callers that need to distinguish denial
+  /// from architectural zero must check valid().
+  class SgprReadRegion {
+  public:
+    SgprReadRegion() = delete;
+
+    [[nodiscard]] uint32_t base() const { return base_; }
+    [[nodiscard]] uint32_t reg_count() const { return reg_count_; }
+    [[nodiscard]] bool valid() const { return valid_; }
+
+    [[nodiscard]] uint32_t dword(uint32_t relative_reg = 0) const {
+      assert(relative_reg < reg_count_ && "relative SGPR outside read region");
+      return valid_ ? cu_->read_sgpr_storage(base_ + relative_reg) : 0;
+    }
+
+    [[nodiscard]] uint64_t qword(uint32_t relative_reg = 0) const {
+      assert(relative_reg + 1 < reg_count_ && "SGPR pair outside read region");
+      return static_cast<uint64_t>(dword(relative_reg)) |
+             (static_cast<uint64_t>(dword(relative_reg + 1)) << 32);
+    }
+
+  private:
+    friend class RegisterAccess;
+
+    SgprReadRegion(const ComputeUnitCore &cu, uint32_t base, uint32_t reg_count, bool valid)
+        : cu_(&cu), base_(base), reg_count_(reg_count), valid_(valid) {}
+
+    const ComputeUnitCore *cu_ = nullptr;
+    uint32_t base_ = 0;
+    uint32_t reg_count_ = 0;
+    bool valid_ = false;
+  };
+
   explicit RegisterAccess(ComputeUnitCore &cu) : cu_(&cu), mutable_cu_(&cu) {}
   explicit RegisterAccess(const ComputeUnitCore &cu) : cu_(&cu) {}
   explicit RegisterAccess(InstructionComputeUnitView &cu)
-      : cu_(&cu.raw_cu()), mutable_cu_(&cu.raw_cu()) {}
-  explicit RegisterAccess(const InstructionComputeUnitView &cu) : cu_(&cu.raw_cu()) {}
+      : cu_(&cu.raw_cu()), mutable_cu_(&cu.raw_cu()), wf_(&cu.raw_wavefront()),
+        mutable_wf_(&cu.raw_wavefront()) {}
+  explicit RegisterAccess(const InstructionComputeUnitView &cu)
+      : cu_(&cu.raw_cu()), wf_(&cu.raw_wavefront()) {}
   explicit RegisterAccess(Wavefront &wf) : RegisterAccess(wf.cu()) {
     wf_ = &wf;
     mutable_wf_ = &wf;
@@ -857,13 +938,22 @@ public:
   // for value-semantic operand reads and writes; Operand remains the
   // ISA-specific resolver/backend.
   [[nodiscard]] uint32_t read_scalar(const Operand &op) const {
-    return op.read_scalar(wavefront());
+    const Wavefront &wf = wavefront();
+    if (auto base = op.simd_vgpr_base(wf); base && !cu_->owns_vgpr_range(wf, *base, 1))
+      return 0;
+    return op.read_scalar(wf);
   }
   [[nodiscard]] uint64_t read_scalar64(const Operand &op) const {
-    return op.read_scalar64(wavefront());
+    const Wavefront &wf = wavefront();
+    if (auto base = op.simd_vgpr_base(wf); base && !cu_->owns_vgpr_range(wf, *base, 2))
+      return 0;
+    return op.read_scalar64(wf);
   }
   [[nodiscard]] uint32_t read_lane(const Operand &op, uint32_t lane) const {
-    return op.read_lane(wavefront(), lane);
+    const Wavefront &wf = wavefront();
+    if (auto base = op.simd_vgpr_base(wf); base && !cu_->owns_vgpr_range(wf, *base, 1))
+      return 0;
+    return op.read_lane(wf, lane);
   }
 
   /// @brief Read the lane selected by a scalar-lane instruction.
@@ -872,15 +962,18 @@ public:
     assert((wf.wf_size() == 32 || wf.wf_size() == 64) &&
            "scalar lane selection requires Wave32 or Wave64");
     lane &= wf.wf_size() - 1;
-    ConstVgprStorage storage = op.simd_vgpr_storage(wf);
     auto physical_reg = op.simd_vgpr_base(wf);
-    if (!storage || !physical_reg)
+    if (!physical_reg)
       throw std::logic_error("scalar lane read requires a VGPR source");
-    cu_->notify_vgpr_read(&wf, *physical_reg, uint64_t{1} << lane);
-    return storage[lane];
+    if (!cu_->owns_vgpr_range(wf, *physical_reg, 1))
+      return 0;
+    return read_vgpr(*physical_reg, lane);
   }
   [[nodiscard]] uint64_t read_lane64(const Operand &op, uint32_t lane) const {
-    return op.read_lane64(wavefront(), lane);
+    const Wavefront &wf = wavefront();
+    if (auto base = op.simd_vgpr_base(wf); base && !cu_->owns_vgpr_range(wf, *base, 2))
+      return 0;
+    return op.read_lane64(wf, lane);
   }
 
   /// @brief Read a packed pair of 32-bit words from one logical source.
@@ -912,13 +1005,21 @@ public:
     return {value, value};
   }
   void write_scalar(const Operand &op, uint32_t value) const {
-    op.write_scalar(mutable_wavefront(), value);
+    Wavefront &wf = mutable_wavefront();
+    if (auto base = op.simd_vgpr_base_mut(wf); base && !mutable_cu().owns_vgpr_range(wf, *base, 1))
+      return;
+    op.write_scalar(wf, value);
   }
   void write_scalar64(const Operand &op, uint64_t value) const {
-    op.write_scalar64(mutable_wavefront(), value);
+    Wavefront &wf = mutable_wavefront();
+    if (auto base = op.simd_vgpr_base_mut(wf); base && !mutable_cu().owns_vgpr_range(wf, *base, 2))
+      return;
+    op.write_scalar64(wf, value);
   }
   void write_lane(const Operand &op, uint32_t lane, uint32_t value) const {
     Wavefront &wf = mutable_wavefront();
+    if (auto base = op.simd_vgpr_base_mut(wf); base && !mutable_cu().owns_vgpr_range(wf, *base, 1))
+      return;
     if (op.simd_vgpr_storage_mut(wf) && !(wf.vgpr_write_mask() & (uint64_t{1} << lane)))
       return;
     op.write_lane(wf, lane, value);
@@ -933,10 +1034,14 @@ public:
     assert((wf.wf_size() == 32 || wf.wf_size() == 64) &&
            "scalar lane selection requires Wave32 or Wave64");
     lane &= wf.wf_size() - 1;
-    VgprStorage storage = op.simd_vgpr_storage_mut(wf);
     auto physical_reg = op.simd_vgpr_base_mut(wf);
-    if (!storage || !physical_reg)
+    if (!physical_reg)
       throw std::logic_error("scalar lane write requires a VGPR destination");
+    if (!mutable_cu().owns_vgpr_range(wf, *physical_reg, 1))
+      return;
+    VgprStorage storage = op.simd_vgpr_storage_mut(wf);
+    if (!storage)
+      throw std::logic_error("scalar lane write requires VGPR storage");
     mutable_cu().notify_scalar_lane_vgpr_write(&wf, *physical_reg, uint64_t{1} << lane);
     storage[lane] = value;
   }
@@ -948,10 +1053,14 @@ public:
   void write_lane_masked(const Operand &op, uint32_t lane, uint32_t value, uint8_t update_byte_mask,
                          uint8_t observed_byte_mask, PostWriteTransform post_transform) const {
     Wavefront &wf = mutable_wavefront();
-    VgprStorage storage = op.simd_vgpr_storage_mut(wf);
     auto physical_reg = op.simd_vgpr_base_mut(wf);
-    if (!storage || !physical_reg)
+    if (!physical_reg)
       throw std::logic_error("partial-byte operand write requires a VGPR destination");
+    if (!mutable_cu().owns_vgpr_range(wf, *physical_reg, 1))
+      return;
+    VgprStorage storage = op.simd_vgpr_storage_mut(wf);
+    if (!storage)
+      throw std::logic_error("partial-byte operand write requires VGPR storage");
     if (!(wf.vgpr_write_mask() & (uint64_t{1} << lane)))
       return;
     mutable_cu().notify_vgpr_write(&wf, *physical_reg, uint64_t{1} << lane, observed_byte_mask);
@@ -964,23 +1073,34 @@ public:
 
   void write_lane64(const Operand &op, uint32_t lane, uint64_t value) const {
     Wavefront &wf = mutable_wavefront();
+    if (auto base = op.simd_vgpr_base_mut(wf); base && !mutable_cu().owns_vgpr_range(wf, *base, 2))
+      return;
     if (op.simd_vgpr_storage64_mut(wf).lo && !(wf.vgpr_write_mask() & (uint64_t{1} << lane)))
       return;
     op.write_lane64(wf, lane, value);
   }
 
   void read_chunk(const Operand &op, uint32_t lane_base, uint32_t count, uint32_t *out) const {
-    op.read_lane_chunk(wavefront(), lane_base, count, out);
+    const Wavefront &wf = wavefront();
+    if (auto base = op.simd_vgpr_base(wf); base && !cu_->owns_vgpr_range(wf, *base, 1)) {
+      std::fill_n(out, count, 0u);
+      return;
+    }
+    op.read_lane_chunk(wf, lane_base, count, out);
   }
   void write_chunk(const Operand &op, uint32_t lane_base, uint32_t count, const uint32_t *values,
                    uint64_t lane_mask) const {
     Wavefront &wf = mutable_wavefront();
     uint64_t full_mask = util::mask<uint64_t>(static_cast<int>(count));
-    if (op.simd_vgpr_storage_mut(wf))
-      lane_mask &= wf.vgpr_write_mask() >> lane_base;
-    if (op.simd_capable())
+    if (op.simd_capable()) {
+      auto base = op.simd_vgpr_base_mut(wf);
+      if (base && !mutable_cu().owns_vgpr_range(wf, *base, 1))
+        return;
+      if (op.simd_vgpr_storage_mut(wf))
+        lane_mask &= wf.vgpr_write_mask() >> lane_base;
       op.simd_notify_write_mut(wf, (lane_mask & full_mask) << lane_base,
                                rocjitsu::ExecutionPlugin::kFullByteMask);
+    }
     op.write_lane_chunk(wf, lane_base, count, values, lane_mask);
   }
 
@@ -993,70 +1113,84 @@ public:
   [[nodiscard]] OperandReadView read_operand(const Operand &op, uint64_t lane_mask,
                                              uint8_t byte_mask = 0xF) const {
     const Wavefront &wf = wavefront();
-    ConstVgprStorage storage = op.simd_vgpr_storage(wf);
+    auto base = op.simd_vgpr_base(wf);
+    const bool valid = !base || cu_->owns_vgpr_range(wf, *base, 1);
+    ConstVgprStorage storage = valid ? op.simd_vgpr_storage(wf) : ConstVgprStorage{};
     if (storage)
       op.simd_notify_read(wf, lane_mask, byte_mask);
-    return OperandReadView(op, wf, storage, byte_mask);
+    return OperandReadView(op, wf, storage, byte_mask, base && !valid);
   }
 
   [[nodiscard]] OperandRead64View read_operand64(const Operand &op, uint64_t lane_mask,
                                                  uint8_t byte_mask = 0xF) const {
     const Wavefront &wf = wavefront();
-    ConstVgprStoragePair64 storage = op.simd_vgpr_storage64(wf);
+    auto base = op.simd_vgpr_base(wf);
+    const bool valid = !base || cu_->owns_vgpr_range(wf, *base, 2);
+    ConstVgprStoragePair64 storage = valid ? op.simd_vgpr_storage64(wf) : ConstVgprStoragePair64{};
     if (storage.lo)
       op.simd_notify_read64(wf, lane_mask, byte_mask);
-    return OperandRead64View(op, wf, storage, byte_mask);
+    return OperandRead64View(op, wf, storage, byte_mask, base && !valid);
   }
 
   [[nodiscard]] OperandReadPair32View read_operand_pair32(const Operand &op, uint64_t lane_mask,
                                                           uint8_t byte_mask = 0xF) const {
     const Wavefront &wf = wavefront();
-    ConstVgprStoragePair64 storage = op.simd_vgpr_storage64(wf);
+    auto base = op.simd_vgpr_base(wf);
+    const bool valid = !base || cu_->owns_vgpr_range(wf, *base, 2);
+    ConstVgprStoragePair64 storage = valid ? op.simd_vgpr_storage64(wf) : ConstVgprStoragePair64{};
     if (storage.lo)
       op.simd_notify_read64(wf, lane_mask, byte_mask);
-    return OperandReadPair32View(op, wf, storage, byte_mask);
+    return OperandReadPair32View(op, wf, storage, byte_mask, base && !valid);
   }
 
   [[nodiscard]] OperandWriteView
   write_operand(const Operand &op, uint64_t lane_mask,
                 uint8_t byte_mask = rocjitsu::ExecutionPlugin::kFullByteMask) const {
     Wavefront &wf = mutable_wavefront();
-    VgprStorage storage = op.simd_vgpr_storage_mut(wf);
+    auto base = op.simd_vgpr_base_mut(wf);
+    const bool valid = !base || mutable_cu().owns_vgpr_range(wf, *base, 1);
+    VgprStorage storage = valid ? op.simd_vgpr_storage_mut(wf) : VgprStorage{};
     const uint64_t permitted_write_lane_mask =
         storage ? lane_mask & wf.vgpr_write_mask() : lane_mask;
     if (storage)
       op.simd_notify_write_mut(wf, permitted_write_lane_mask, byte_mask);
-    return OperandWriteView(op, wf, storage, permitted_write_lane_mask, byte_mask);
+    return OperandWriteView(op, wf, storage, permitted_write_lane_mask, byte_mask, base && !valid);
   }
 
   [[nodiscard]] OperandWrite64View write_operand64(const Operand &op, uint64_t lane_mask) const {
     Wavefront &wf = mutable_wavefront();
-    VgprStoragePair64 storage = op.simd_vgpr_storage64_mut(wf);
+    auto base = op.simd_vgpr_base_mut(wf);
+    const bool valid = !base || mutable_cu().owns_vgpr_range(wf, *base, 2);
+    VgprStoragePair64 storage = valid ? op.simd_vgpr_storage64_mut(wf) : VgprStoragePair64{};
     const uint64_t permitted_write_lane_mask =
         storage.lo ? lane_mask & wf.vgpr_write_mask() : lane_mask;
     if (storage.lo)
       op.simd_notify_write64_mut(wf, permitted_write_lane_mask,
                                  rocjitsu::ExecutionPlugin::kFullByteMask);
-    return OperandWrite64View(op, wf, storage, permitted_write_lane_mask);
+    return OperandWrite64View(op, wf, storage, permitted_write_lane_mask, base && !valid);
   }
 
   [[nodiscard]] OperandWritePair32View write_operand_pair32(const Operand &op,
                                                             uint64_t lane_mask) const {
     Wavefront &wf = mutable_wavefront();
-    VgprStoragePair64 storage = op.simd_vgpr_storage64_mut(wf);
+    auto base = op.simd_vgpr_base_mut(wf);
+    const bool valid = !base || mutable_cu().owns_vgpr_range(wf, *base, 2);
+    VgprStoragePair64 storage = valid ? op.simd_vgpr_storage64_mut(wf) : VgprStoragePair64{};
     const uint64_t permitted_write_lane_mask =
         storage.lo ? lane_mask & wf.vgpr_write_mask() : lane_mask;
     if (storage.lo)
       op.simd_notify_write64_mut(wf, permitted_write_lane_mask,
                                  rocjitsu::ExecutionPlugin::kFullByteMask);
-    return OperandWritePair32View(op, wf, storage, permitted_write_lane_mask);
+    return OperandWritePair32View(op, wf, storage, permitted_write_lane_mask, base && !valid);
   }
 
   [[nodiscard]] OperandReadWriteView
   readwrite_operand(const Operand &op, uint64_t lane_mask, uint8_t byte_mask = 0xF,
                     uint8_t write_byte_mask = rocjitsu::ExecutionPlugin::kFullByteMask) const {
     Wavefront &wf = mutable_wavefront();
-    VgprStorage storage = op.simd_vgpr_storage_mut(wf);
+    auto base = op.simd_vgpr_base_mut(wf);
+    const bool valid = !base || mutable_cu().owns_vgpr_range(wf, *base, 1);
+    VgprStorage storage = valid ? op.simd_vgpr_storage_mut(wf) : VgprStorage{};
     const uint64_t permitted_write_lane_mask =
         storage ? lane_mask & wf.vgpr_write_mask() : lane_mask;
     if (storage) {
@@ -1064,13 +1198,15 @@ public:
       op.simd_notify_write_mut(wf, permitted_write_lane_mask, write_byte_mask);
     }
     return OperandReadWriteView(op, wf, storage, permitted_write_lane_mask, byte_mask,
-                                write_byte_mask);
+                                write_byte_mask, base && !valid);
   }
 
   [[nodiscard]] OperandReadWrite64View readwrite_operand64(const Operand &op, uint64_t lane_mask,
                                                            uint8_t byte_mask = 0xF) const {
     Wavefront &wf = mutable_wavefront();
-    VgprStoragePair64 storage = op.simd_vgpr_storage64_mut(wf);
+    auto base = op.simd_vgpr_base_mut(wf);
+    const bool valid = !base || mutable_cu().owns_vgpr_range(wf, *base, 2);
+    VgprStoragePair64 storage = valid ? op.simd_vgpr_storage64_mut(wf) : VgprStoragePair64{};
     const uint64_t permitted_write_lane_mask =
         storage.lo ? lane_mask & wf.vgpr_write_mask() : lane_mask;
     if (storage.lo) {
@@ -1078,29 +1214,134 @@ public:
       op.simd_notify_write64_mut(wf, permitted_write_lane_mask,
                                  rocjitsu::ExecutionPlugin::kFullByteMask);
     }
-    return OperandReadWrite64View(op, wf, storage, permitted_write_lane_mask, byte_mask);
+    return OperandReadWrite64View(op, wf, storage, permitted_write_lane_mask, byte_mask,
+                                  base && !valid);
+  }
+
+  // Logical TTMP access. TTMPs are wave-private scalar registers and do not
+  // occupy slots in the CU's physical SGPR file.
+  [[nodiscard]] uint32_t read_ttmp(uint32_t index) const {
+    const Wavefront &wf = wavefront();
+    if (index >= kTtmpRegisterCount)
+      return 0;
+    cu_->notify_scalar_register_read(wf,
+                                     RegisterRef{RegClass::TTMP, static_cast<uint16_t>(index), 1});
+    return wf.ttmp(index);
+  }
+
+  [[nodiscard]] uint64_t read_ttmp64(uint32_t index) const {
+    const Wavefront &wf = wavefront();
+    if (index >= kTtmpRegisterCount || kTtmpRegisterCount - index < 2)
+      return 0;
+    cu_->notify_scalar_register_read(wf,
+                                     RegisterRef{RegClass::TTMP, static_cast<uint16_t>(index), 2});
+    return static_cast<uint64_t>(wf.ttmp(index)) |
+           (static_cast<uint64_t>(wf.ttmp(index + 1)) << 32);
+  }
+
+  void write_ttmp(uint32_t index, uint32_t value) const {
+    Wavefront &wf = mutable_wavefront();
+    if (index >= kTtmpRegisterCount)
+      return;
+    mutable_cu().notify_scalar_register_write(
+        wf, RegisterRef{RegClass::TTMP, static_cast<uint16_t>(index), 1});
+    wf.set_ttmp(index, value);
+  }
+
+  void write_ttmp64(uint32_t index, uint64_t value) const {
+    Wavefront &wf = mutable_wavefront();
+    if (index >= kTtmpRegisterCount || kTtmpRegisterCount - index < 2)
+      return;
+    mutable_cu().notify_scalar_register_write(
+        wf, RegisterRef{RegClass::TTMP, static_cast<uint16_t>(index), 2});
+    wf.set_ttmp(index, static_cast<uint32_t>(value));
+    wf.set_ttmp(index + 1, static_cast<uint32_t>(value >> 32));
+  }
+
+  /// @brief Write one dword to validated scalar storage without reporting an
+  /// instruction-visible register write.
+  /// @details Memory completion and runtime initialization use this path
+  /// because they are state transitions, not instruction destination writes.
+  void write_scalar_unobserved(const ScalarRegisterRange &range, uint32_t offset,
+                               uint32_t value) const {
+    Wavefront &wf = mutable_wavefront();
+    if (offset >= range.width)
+      return;
+    const uint32_t index = range.index + offset;
+    switch (range.storage) {
+    case ScalarRegisterStorage::SGPR:
+      if (mutable_cu().owns_sgpr_range(wf, wf.sgpr_alloc().base + range.index, range.width))
+        mutable_cu().write_sgpr(wf.sgpr_alloc().base + index, value);
+      break;
+    case ScalarRegisterStorage::FLAT_SCRATCH: {
+      const uint64_t old = wf.scratch_base();
+      wf.set_scratch_base(index == 0 ? (old & 0xffffffff00000000ULL) | value
+                                     : (old & 0x00000000ffffffffULL) |
+                                           (static_cast<uint64_t>(value) << 32));
+      break;
+    }
+    case ScalarRegisterStorage::VCC: {
+      const uint64_t old = wf.vcc();
+      wf.set_vcc_raw(index == 0
+                         ? (old & 0xffffffff00000000ULL) | value
+                         : (old & 0x00000000ffffffffULL) | (static_cast<uint64_t>(value) << 32));
+      break;
+    }
+    case ScalarRegisterStorage::TTMP:
+      wf.set_ttmp(index, value);
+      break;
+    case ScalarRegisterStorage::M0:
+      wf.set_m0(value);
+      break;
+    case ScalarRegisterStorage::EXEC: {
+      const uint64_t old = wf.exec_raw();
+      wf.set_exec_raw(index == 0
+                          ? (old & 0xffffffff00000000ULL) | value
+                          : (old & 0x00000000ffffffffULL) | (static_cast<uint64_t>(value) << 32));
+      break;
+    }
+    case ScalarRegisterStorage::DISCARD:
+      break;
+    }
   }
 
   // Physical SGPR access. These APIs are for helpers that already know the
-  // physical scalar register index. ComputeUnitCore owns SGPR read observation,
-  // so reads delegate to the CU accessor rather than exposing raw SGPR storage.
+  // physical scalar register index. Reads may use a CU-bound compatibility path
+  // that resolves one owner for the complete range. Writes require an explicit
+  // mutable wavefront so instruction code cannot silently reach raw SGPR
+  // storage; VM/runtime code uses ComputeUnitCore's raw write API directly.
+  [[nodiscard]] bool owns_sgpr_range(uint32_t physical_base, uint32_t physical_count) const {
+    if (wf_)
+      return cu_->owns_sgpr_range(*wf_, physical_base, physical_count);
+    return cu_->sgpr_owner_for_range(physical_base, physical_count) != nullptr;
+  }
+
+  [[nodiscard]] bool owns_vgpr_range(uint32_t physical_base, uint32_t physical_count) const {
+    return vgpr_owner_for_range(physical_base, physical_count) != nullptr;
+  }
+
+  [[nodiscard]] SgprReadRegion read_sgpr_region(uint32_t physical_base, uint32_t reg_count) const {
+    const Wavefront *owner = sgpr_owner_for_range(physical_base, reg_count);
+    if (!owner)
+      return SgprReadRegion(*cu_, physical_base, reg_count, false);
+    observe_sgpr_region(*owner, physical_base, reg_count);
+    return SgprReadRegion(*cu_, physical_base, reg_count, true);
+  }
+
   [[nodiscard]] uint32_t read_sgpr(uint32_t physical_reg) const {
-    return cu_->read_sgpr(physical_reg);
+    return read_sgpr_region(physical_reg, 1).dword();
   }
 
   [[nodiscard]] uint64_t read_sgpr64(uint32_t physical_reg) const {
-    uint64_t lo = read_sgpr(physical_reg);
-    uint64_t hi = read_sgpr(physical_reg + 1);
-    return lo | (hi << 32);
+    return read_sgpr_region(physical_reg, 2).qword();
   }
 
   void write_sgpr(uint32_t physical_reg, uint32_t value) const {
-    mutable_cu().write_sgpr(physical_reg, value);
+    mutable_cu().write_sgpr(mutable_wavefront(), physical_reg, value);
   }
 
   void write_sgpr64(uint32_t physical_reg, uint64_t value) const {
-    write_sgpr(physical_reg, static_cast<uint32_t>(value));
-    write_sgpr(physical_reg + 1, static_cast<uint32_t>(value >> 32));
+    mutable_cu().write_sgpr64(mutable_wavefront(), physical_reg, value);
   }
 
   // Physical VGPR access. These APIs are for helpers that already know the
@@ -1128,9 +1369,14 @@ public:
 
   [[nodiscard]] VgprReadRegion read_vgpr_region(uint32_t physical_base, uint32_t reg_count,
                                                 uint64_t lane_mask, uint8_t byte_mask = 0xF) const {
-    observe_vgpr_region(physical_base, reg_count, lane_mask, byte_mask);
-    return VgprReadRegion(*cu_, physical_base, reg_count,
-                          vgpr_region_wave_size(physical_base, reg_count), byte_mask);
+    const uint32_t wave_size = vgpr_region_wave_size(physical_base, reg_count);
+    const Wavefront *owner = vgpr_owner_for_range(physical_base, reg_count);
+    if (!owner)
+      return VgprReadRegion(*cu_, physical_base, reg_count, wave_size, byte_mask, false, false);
+    if (lane_mask == 0)
+      return VgprReadRegion(*cu_, physical_base, reg_count, wave_size, byte_mask, true, false);
+    observe_vgpr_region(*owner, physical_base, reg_count, lane_mask, byte_mask);
+    return VgprReadRegion(*cu_, physical_base, reg_count, wave_size, byte_mask);
   }
 
   [[nodiscard]] VgprWriteRegion write_vgpr_region(uint32_t physical_base, uint32_t reg_count,
@@ -1138,9 +1384,13 @@ public:
                                                   uint8_t byte_mask = 0xF) const {
     if (mutable_wf_)
       lane_mask &= mutable_wf_->vgpr_write_mask();
-    observe_vgpr_write_region(physical_base, reg_count, lane_mask, byte_mask);
-    return VgprWriteRegion(mutable_cu(), physical_base, reg_count,
-                           vgpr_region_wave_size(physical_base, reg_count), lane_mask, byte_mask);
+    const uint32_t wave_size = vgpr_region_wave_size(physical_base, reg_count);
+    const Wavefront *owner = vgpr_owner_for_range(physical_base, reg_count);
+    if (!owner || lane_mask == 0 || byte_mask == 0)
+      return VgprWriteRegion(mutable_cu(), physical_base, reg_count, wave_size, lane_mask,
+                             byte_mask, false);
+    observe_vgpr_write_region(*owner, physical_base, reg_count, lane_mask, byte_mask);
+    return VgprWriteRegion(mutable_cu(), physical_base, reg_count, wave_size, lane_mask, byte_mask);
   }
 
   [[nodiscard]] VgprReadWriteRegion readwrite_vgpr_region(uint32_t physical_base,
@@ -1162,13 +1412,9 @@ private:
   [[nodiscard]] uint32_t vgpr_region_wave_size(uint32_t physical_base, uint32_t reg_count) const {
     if (wf_)
       return wf_->wf_size();
-    const Wavefront *owner = cu_->vgpr_owner(physical_base);
-    if (!owner)
-      return cu_->vgpr_storage_lane_count();
-    for (uint32_t reg = 1; reg < reg_count; ++reg)
-      if (cu_->vgpr_owner(physical_base + reg) != owner)
-        throw std::logic_error("physical VGPR region crosses wavefront ownership");
-    return owner->wf_size();
+    if (const Wavefront *owner = cu_->vgpr_owner_for_range(physical_base, reg_count))
+      return owner->wf_size();
+    return cu_->vgpr_storage_lane_count();
   }
 
   const Wavefront &wavefront() const {
@@ -1190,20 +1436,39 @@ private:
     return *mutable_cu_;
   }
 
-  void observe_vgpr_region(uint32_t physical_base, uint32_t reg_count, uint64_t lane_mask,
-                           uint8_t byte_mask) const {
-    if (lane_mask == 0)
-      return;
-    for (uint32_t reg = 0; reg < reg_count; ++reg)
-      cu_->notify_vgpr_read_by_reg(physical_base + reg, lane_mask, byte_mask);
+  [[nodiscard]] const Wavefront *vgpr_owner_for_range(uint32_t physical_base,
+                                                      uint32_t reg_count) const {
+    if (wf_)
+      return cu_->owns_vgpr_range(*wf_, physical_base, reg_count) ? wf_ : nullptr;
+    return cu_->vgpr_owner_for_range(physical_base, reg_count);
   }
 
-  void observe_vgpr_write_region(uint32_t physical_base, uint32_t reg_count, uint64_t lane_mask,
-                                 uint8_t byte_mask) const {
-    if (lane_mask == 0)
-      return;
+  [[nodiscard]] const Wavefront *sgpr_owner_for_range(uint32_t physical_base,
+                                                      uint32_t reg_count) const {
+    if (wf_)
+      return cu_->owns_sgpr_range(*wf_, physical_base, reg_count) ? wf_ : nullptr;
+    return cu_->sgpr_owner_for_range(physical_base, reg_count);
+  }
+
+  void observe_sgpr_region(const Wavefront &owner, uint32_t physical_base,
+                           uint32_t reg_count) const {
+    assert(reg_count <= std::numeric_limits<uint8_t>::max());
+    cu_->notify_scalar_register_read(
+        owner,
+        RegisterRef{RegClass::SGPR, static_cast<uint16_t>(physical_base - owner.sgpr_alloc().base),
+                    static_cast<uint8_t>(reg_count)});
+  }
+
+  void observe_vgpr_region(const Wavefront &owner, uint32_t physical_base, uint32_t reg_count,
+                           uint64_t lane_mask, uint8_t byte_mask) const {
     for (uint32_t reg = 0; reg < reg_count; ++reg)
-      cu_->notify_vgpr_write_by_reg(physical_base + reg, lane_mask, byte_mask);
+      cu_->notify_vgpr_read(&owner, physical_base + reg, lane_mask, byte_mask);
+  }
+
+  void observe_vgpr_write_region(const Wavefront &owner, uint32_t physical_base, uint32_t reg_count,
+                                 uint64_t lane_mask, uint8_t byte_mask) const {
+    for (uint32_t reg = 0; reg < reg_count; ++reg)
+      cu_->notify_vgpr_write(&owner, physical_base + reg, lane_mask, byte_mask);
   }
 
   const ComputeUnitCore *cu_ = nullptr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/wait_counters.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/wait_counters.h
@@ -33,6 +33,34 @@ enum class WaitCounterType : uint8_t {
   ASYNCCNT,  ///< Async global/cluster LDS transfer count (GFX12.5).
 };
 
+/// @brief Return whether waiting on @p wait_type also constrains an event
+/// tracked by @p event_type.
+///
+/// Monolithic counters cover the corresponding split-counter families. Split
+/// waits constrain only their exact counter. Keeping this relationship next to
+/// WaitCounterType avoids reimplementing it in each consumer.
+[[nodiscard]] constexpr bool wait_counter_covers(WaitCounterType wait_type,
+                                                 WaitCounterType event_type) {
+  switch (wait_type) {
+  case WaitCounterType::VMCNT:
+    return event_type == WaitCounterType::VMCNT || event_type == WaitCounterType::LOADCNT;
+  case WaitCounterType::LGKMCNT:
+    return event_type == WaitCounterType::LGKMCNT || event_type == WaitCounterType::DSCNT ||
+           event_type == WaitCounterType::KMCNT;
+  case WaitCounterType::VSCNT:
+    return event_type == WaitCounterType::VSCNT || event_type == WaitCounterType::STORECNT;
+  case WaitCounterType::EXPCNT:
+  case WaitCounterType::LOADCNT:
+  case WaitCounterType::STORECNT:
+  case WaitCounterType::DSCNT:
+  case WaitCounterType::KMCNT:
+  case WaitCounterType::TENSORCNT:
+  case WaitCounterType::ASYNCCNT:
+    return event_type == wait_type;
+  }
+  return false;
+}
+
 /// @brief Outstanding memory operation counters for a wavefront.
 ///
 /// Unified counter set that covers all ISA families.  CDNA1-4 use only

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/wavefront.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/wavefront.h
@@ -43,6 +43,13 @@ enum class WfState : uint8_t {
 struct RegAllocation {
   uint32_t base = 0;  ///< First register index in the physical file.
   uint32_t count = 0; ///< Number of registers allocated.
+
+  [[nodiscard]] constexpr bool contains(uint32_t physical_base, uint32_t physical_count = 1) const {
+    if (physical_count == 0 || physical_base < base)
+      return false;
+    const uint32_t offset = physical_base - base;
+    return offset < count && physical_count <= count - offset;
+  }
 };
 
 /// @brief AMDGPU wavefront execution state.
@@ -891,7 +898,7 @@ protected:
   /// @param mode_has_gpr_idx_en Whether MODE bit 27 enables GPR indexing.
   Wavefront(ComputeUnitCore &cu, uint32_t wf_id, uint32_t default_wf_size, uint32_t max_wf_size,
             uint32_t max_sgprs, uint32_t max_vgprs, bool mode_has_gpr_idx_en)
-      : cu_(cu), cu_view_(cu), wf_id_(wf_id), wf_size_(default_wf_size),
+      : cu_(cu), cu_view_(cu, *this), wf_id_(wf_id), wf_size_(default_wf_size),
         default_wf_size_(default_wf_size), max_wf_size_(max_wf_size), max_sgprs_(max_sgprs),
         max_vgprs_(max_vgprs), mode_has_gpr_idx_en_(mode_has_gpr_idx_en) {}
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/execution_plugin.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/execution_plugin.h
@@ -13,6 +13,7 @@
 #pragma once
 
 #include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/isa/register_set.h"
 #include "rocjitsu/vm/amdgpu/wavefront.h"
 #include "rocjitsu/vm/plugins/kernel_dispatch_info.h"
 #include "rocjitsu/vm/plugins/plugin_sink.h"
@@ -119,10 +120,11 @@ public:
 
   /// Called after a workgroup's wavefronts have been dispatched to a CU.
   /// @param physical_vgpr_count Physical VGPR allocation block size per wavefront.
+  /// @param physical_sgpr_count Physical SGPR allocation block size per wavefront.
   /// Infrequent hook; see the concurrency contract on requires_serial_hot_hooks().
   virtual void onAmdgpuWorkgroupDispatched(uint32_t /*dispatch_id*/, uint32_t /*wg_id*/,
                                            uint32_t /*physical_vgpr_count*/,
-                                           uint32_t /*sgpr_count*/,
+                                           uint32_t /*physical_sgpr_count*/,
                                            std::span<amdgpu::Wavefront *> /*wavefronts*/) {}
 
   /// Called when the last wavefront of a workgroup has halted.
@@ -171,14 +173,32 @@ public:
   /// requires_serial_hot_hooks() returns true.
   virtual void onAmdgpuReadSgpr(const amdgpu::Wavefront * /*wf*/, uint32_t /*physical_reg*/) {}
 
+  /// Called when an architectural scalar register is read during instruction execution.
+  /// @param wf Owning wavefront.
+  /// @param reg Logical register identity. The class distinguishes ordinary
+  ///        SGPRs from TTMPs without exposing their encoded selector values or
+  ///        physical storage layout.
+  /// May run concurrently across simulation partitions unless
+  /// requires_serial_hot_hooks() returns true.
+  virtual void onAmdgpuReadScalarRegister(const amdgpu::Wavefront *wf, RegisterRef reg) {
+    if (!wf || reg.cls != RegClass::SGPR)
+      return;
+    for (uint32_t offset = 0; offset < reg.width; ++offset)
+      onAmdgpuReadSgpr(wf, wf->sgpr_alloc().base + reg.index + offset);
+  }
+
+  /// Called when an architectural scalar register is written during instruction execution.
+  /// Memory completion and runtime initialization remain unobserved storage operations.
+  virtual void onAmdgpuWriteScalarRegister(const amdgpu::Wavefront * /*wf*/, RegisterRef /*reg*/) {}
+
   /// Called with the waves synchronized by a completed barrier domain.
   /// Infrequent hook; see the concurrency contract on requires_serial_hot_hooks().
   virtual void onAmdgpuBarrierResolved(std::span<amdgpu::Wavefront *> /*wavefronts*/) {}
 
-  /// Whether this plugin needs SGPR read callbacks. The group samples this
-  /// policy once when the plugin is added. The conservative default preserves
-  /// existing plugin behavior: callbacks continue unless a plugin explicitly
-  /// opts out.
+  /// Whether this plugin needs typed scalar-register reads or legacy SGPR reads.
+  /// The group samples this policy once when the plugin is added. The
+  /// conservative default preserves existing plugin behavior: callbacks
+  /// continue unless a plugin explicitly opts out.
   virtual bool observes_sgpr_reads() const { return true; }
 
 private:

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/execution_plugin_group.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/execution_plugin_group.h
@@ -190,12 +190,12 @@ public:
   }
 
   void onAmdgpuWorkgroupDispatched(uint32_t dispatch_id, uint32_t wg_id,
-                                   uint32_t physical_vgpr_count, uint32_t sgpr_count,
+                                   uint32_t physical_vgpr_count, uint32_t physical_sgpr_count,
                                    std::span<amdgpu::Wavefront *> wavefronts) {
     dispatch_with_plugin_lock([&]() {
       for (auto &entry : plugins_)
         entry.plugin->onAmdgpuWorkgroupDispatched(dispatch_id, wg_id, physical_vgpr_count,
-                                                  sgpr_count, wavefronts);
+                                                  physical_sgpr_count, wavefronts);
     });
   }
 
@@ -241,6 +241,20 @@ public:
     dispatch_with_optional_plugin_lock([&]() {
       for (auto &entry : plugins_)
         entry.plugin->onAmdgpuReadSgpr(wf, physical_reg);
+    });
+  }
+
+  void onAmdgpuReadScalarRegister(const amdgpu::Wavefront *wf, RegisterRef reg) {
+    dispatch_with_optional_plugin_lock([&]() {
+      for (auto &entry : plugins_)
+        entry.plugin->onAmdgpuReadScalarRegister(wf, reg);
+    });
+  }
+
+  void onAmdgpuWriteScalarRegister(const amdgpu::Wavefront *wf, RegisterRef reg) {
+    dispatch_with_optional_plugin_lock([&]() {
+      for (auto &entry : plugins_)
+        entry.plugin->onAmdgpuWriteScalarRegister(wf, reg);
     });
   }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/core/common_register.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/core/common_register.h
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 #pragma once
+#include "rocjitsu/vm/amdgpu/wait_counters.h"
+
 #include <ostream>
 #include <sstream>
 #include <string>
@@ -20,13 +22,15 @@ enum class MemoryEventType {
   /// registers), GLOBAL_TO_LDS events have no VGPR registers -- only LDS
   /// intervals.
   ///
-  /// Wait counter: DTL is a MUBUF instruction, so it uses vmcnt (not lgkmcnt).
-  /// s_waitcnt vmcnt(0) must complete before the owning wave can read the LDS
-  /// bytes. Cross-wave access requires s_barrier after vmcnt, same as ds_write
-  /// followed by s_barrier.
+  /// The event records the target-specific VMEM/async counter family separately.
+  /// The corresponding zero wait must complete before the owning wave can read
+  /// the LDS bytes. Cross-wave access additionally requires a barrier, like a
+  /// DS write followed by a barrier.
   GLOBAL_TO_LDS,
 
-  GLOBAL_TO_SGPR, ///< s_load_dword: scalar load to SGPR (counted by lgkmcnt).
+  GLOBAL_TO_SGPR,   ///< Scalar load to an SGPR; the event stores its counter family separately.
+  GLOBAL_TO_TTMP,   ///< Scalar load to a TTMP; the event stores its counter family separately.
+  SCALAR_TO_GLOBAL, ///< Scalar store; retained to preserve partial-wait ordering.
 
   N
 };
@@ -43,6 +47,10 @@ inline bool isToLds(MemoryEventType t) {
 
 inline bool isToSgpr(MemoryEventType t) { return t == MemoryEventType::GLOBAL_TO_SGPR; }
 
+inline bool isToTtmp(MemoryEventType t) { return t == MemoryEventType::GLOBAL_TO_TTMP; }
+
+inline bool isToScalar(MemoryEventType t) { return isToSgpr(t) || isToTtmp(t); }
+
 /// True if the event touches LDS (read or write).
 inline bool isLdsInvolved(MemoryEventType t) {
   return isToLds(t) || t == MemoryEventType::LDS_TO_VGPR;
@@ -54,6 +62,15 @@ inline bool isFromVgpr(MemoryEventType t) {
 
 /// True if the event doesn't touch LDS — safe to trim at WAVE_COMPLETE.
 inline bool isWaveLocal(MemoryEventType t) { return !isLdsInvolved(t); }
+
+/// Legacy wait-counter assignment for core callers without dynamic
+/// instruction state. Runtime integration passes the exact counter explicitly.
+inline amdgpu::WaitCounterType defaultWaitCounterType(MemoryEventType t) {
+  if (t == MemoryEventType::GLOBAL_TO_VGPR || t == MemoryEventType::VGPR_TO_GLOBAL ||
+      t == MemoryEventType::GLOBAL_TO_LDS)
+    return amdgpu::WaitCounterType::VMCNT;
+  return amdgpu::WaitCounterType::LGKMCNT;
+}
 
 /// A register reference (type + index).
 class CommonRegister {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/core/event_registry.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/core/event_registry.h
@@ -35,6 +35,7 @@ class EventRegistry {
     WaveId waveId;
     uint64_t pc;
     MemoryEventType type;
+    amdgpu::WaitCounterType waitCounterType;
     EventStatus status;
     uint8_t byteMask;
     uint64_t execMask;
@@ -45,9 +46,10 @@ class EventRegistry {
 public:
   /// Allocate a new event. Returns a unique EventId.
   EventId add(WaveId waveId, uint64_t pc, MemoryEventType type, std::vector<uint32_t> registers,
-              uint64_t execMask, uint8_t byteMask, IntervalSet ldsIntervals) {
+              uint64_t execMask, uint8_t byteMask, IntervalSet ldsIntervals,
+              amdgpu::WaitCounterType waitCounterType) {
     int id = base_offset_ + static_cast<int>(entries_.size());
-    entries_.push_back({waveId, pc, type, EventStatus::ACTIVE, byteMask, execMask,
+    entries_.push_back({waveId, pc, type, waitCounterType, EventStatus::ACTIVE, byteMask, execMask,
                         std::move(registers), std::move(ldsIntervals)});
 
     // To prevent the number of events recorded growing indefinitely, we try to
@@ -69,6 +71,9 @@ public:
   // -- Typed accessors (all inline) --
 
   MemoryEventType type(EventId id) const { return entries_[index(id)].type; }
+  amdgpu::WaitCounterType waitCounterType(EventId id) const {
+    return entries_[index(id)].waitCounterType;
+  }
   EventStatus status(EventId id) const { return entries_[index(id)].status; }
   bool isTrimmable(EventId id) const { return isEntryTrimmable(entries_[index(id)]); }
   uint64_t pc(EventId id) const { return entries_[index(id)].pc; }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/core/race_detector.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/core/race_detector.cpp
@@ -30,10 +30,11 @@ void RaceDetector::setProfiler(ProfilerInterface &p) {
 
 EventId RaceDetector::allocateEventId(WaveId waveId, uint64_t pc, MemoryEventType type,
                                       std::vector<uint32_t> registers, uint64_t execMask,
-                                      uint8_t byteMask, IntervalSet ldsIntervals) {
+                                      uint8_t byteMask, IntervalSet ldsIntervals,
+                                      amdgpu::WaitCounterType waitCounterType) {
   bool hasLds = !ldsIntervals.empty();
   EventId eid = events_.add(waveId, pc, type, std::move(registers), execMask, byteMask,
-                            std::move(ldsIntervals));
+                            std::move(ldsIntervals), waitCounterType);
   if (hasLds) {
     const auto &ivs = events_.ldsIntervals(eid);
     if (isToLds(type)) {
@@ -198,6 +199,17 @@ RaceDetector::decorateException(const RaceViolation &e, uint64_t wavePc, int num
   if (e.space == RaceViolation::Space::SGPR) {
     std::ostringstream oss;
     oss << "\nSGPR race detected on line " << wavePc << " (wave " << e.wave << ") in workgroup ("
+        << workgroupId.x << "," << workgroupId.y << "," << workgroupId.z
+        << "). Conflicting events:\n\n";
+
+    std::vector<uint64_t> eventPcs{wavePc, events_.pc(e.conflictingEvent)};
+    printCodeBlocks(oss, std::move(eventPcs));
+    return oss.str();
+  }
+
+  if (e.space == RaceViolation::Space::TTMP) {
+    std::ostringstream oss;
+    oss << "\nTTMP race detected on line " << wavePc << " (wave " << e.wave << ") in workgroup ("
         << workgroupId.x << "," << workgroupId.y << "," << workgroupId.z
         << "). Conflicting events:\n\n";
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/core/race_detector.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/core/race_detector.h
@@ -38,7 +38,8 @@ public:
 
   /// Allocate a workgroup-global event ID and record its metadata.
   EventId allocateEventId(WaveId, uint64_t pc, MemoryEventType, std::vector<uint32_t> registers,
-                          uint64_t execMask, uint8_t byteMask = 0xF, IntervalSet ldsIntervals = {});
+                          uint64_t execMask, uint8_t byteMask = 0xF, IntervalSet ldsIntervals = {},
+                          amdgpu::WaitCounterType waitCounterType = amdgpu::WaitCounterType::VMCNT);
 
   /// Transition an event from ACTIVE to WAVE_COMPLETE.
   void markEventWaveComplete(EventId);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/core/types.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/core/types.h
@@ -64,7 +64,7 @@ enum class EventStatus {
 /// Describes a detected race condition. Used by the race detection layer
 /// to report violations without depending on any exception type.
 struct RaceViolation {
-  enum class Space { VGPR, SGPR, LDS };
+  enum class Space { VGPR, SGPR, TTMP, LDS };
   Space space;
   int index;    ///< Register index (VGPR/SGPR) or byte address (LDS).
   int wave;     ///< Wave that triggered the violation.
@@ -79,28 +79,22 @@ struct RaceViolation {
         workgroupId(workgroupId), conflictingEvent(conflictingEvent) {}
 };
 
-/// Pending memory event data dispatched to WaveRaceState by the plugin adapter.
-struct PendingMemoryEvent {
-  uint64_t pc;
-  MemoryEventType type;
-  std::vector<uint32_t> registers;
-  uint64_t execMask;
-  int waveSize;
-  uint8_t byteMask = 0xF;
-  // LDS events:
-  std::vector<uint32_t> laneBaseAddresses;
-  int bytesPerLane = 0;
-  // Dual-offset LDS events:
-  bool isDualOffset = false;
-  int32_t offset0 = 0;
-  int32_t offset1 = 0;
+struct WaitCounterUpdate {
+  amdgpu::WaitCounterType type;
+  int threshold;
 };
 
-/// Pending wait count data written by the s_waitcnt executor. Dispatched to
-/// WaveRaceState by Workgroup::run after tryExecute returns.
+/// Counter thresholds changed by one wait instruction. A wait can update one
+/// or more counters; counters absent from this list retain their prior state.
 struct PendingWaitCount {
-  int vmcnt = -1;
-  int lgkmcnt = -1;
+  void add(amdgpu::WaitCounterType type, int threshold) {
+    if (threshold >= 0)
+      updates.push_back({type, threshold});
+  }
+
+  [[nodiscard]] bool empty() const { return updates.empty(); }
+
+  std::vector<WaitCounterUpdate> updates;
 };
 
 } // namespace rocjitsu::plugins::race_detector

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/core/wave_race_state.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/core/wave_race_state.cpp
@@ -4,6 +4,7 @@
 #include "rocjitsu/vm/plugins/race_detector/core/wave_race_state.h"
 #include "rocjitsu/vm/plugins/race_detector/core/interval_set.h"
 #include "rocjitsu/vm/plugins/race_detector/core/race_detector.h"
+#include <algorithm>
 #include <bit>
 #include <span>
 
@@ -22,55 +23,80 @@ WaveRaceState::WaveRaceState(int vgprCount, int sgprCount, WaveId waveId, RaceDe
   vgprMemoryEvents.resize(vgprCount);
   sgprMemoryEvents.resize(sgprCount);
   sgprEventCount.resize(sgprCount, 0);
+  ttmpMemoryEvents.resize(REGISTER_SET_MAX_TTMPS);
+  ttmpEventCount.resize(REGISTER_SET_MAX_TTMPS, 0);
   for (auto &counts : regEventCount) {
     counts.resize(vgprCount, 0);
   }
 }
 
-void WaveRaceState::dispatch(PendingMemoryEvent event) {
-  if (event.isDualOffset) {
-    registerDualOffsetLdsEvent(event.pc, event.type, std::move(event.registers), event.execMask,
-                               event.waveSize, event.laneBaseAddresses, event.offset0,
-                               event.offset1);
-  } else if (!event.laneBaseAddresses.empty()) {
-    registerLdsEvent(event.pc, event.type, std::move(event.registers), event.execMask,
-                     event.waveSize, event.laneBaseAddresses, event.bytesPerLane, event.byteMask);
-  } else {
-    registerEvent(event.pc, event.type, std::move(event.registers), event.execMask, event.byteMask);
-  }
-}
-
-void WaveRaceState::dispatch(PendingWaitCount waitCount) {
-  if (waitCount.vmcnt >= 0) {
-    sWaitCntVmcnt(waitCount.vmcnt);
-  }
-  if (waitCount.lgkmcnt >= 0) {
-    sWaitCntLgkmcnt(waitCount.lgkmcnt);
-  }
+void WaveRaceState::dispatch(const PendingWaitCount &wait_count) {
+  for (const auto &update : wait_count.updates)
+    applyWaitCounter(update.type, update.threshold);
 }
 
 void WaveRaceState::registerEvent(uint64_t pc, MemoryEventType type, std::vector<uint32_t> regIds,
                                   uint64_t execMask, uint8_t byteMask) {
-  registerEventWithIntervals(pc, type, std::move(regIds), execMask, byteMask, {});
+  registerEvent(pc, type, std::move(regIds), execMask, byteMask, defaultWaitCounterType(type));
+}
+
+void WaveRaceState::registerEvent(uint64_t pc, MemoryEventType type, std::vector<uint32_t> regIds,
+                                  uint64_t execMask, uint8_t byteMask,
+                                  amdgpu::WaitCounterType waitCounterType) {
+  registerEventWithIntervals(pc, type, std::move(regIds), execMask, byteMask, {}, waitCounterType);
+}
+
+void WaveRaceState::registerScalarLoad(uint64_t pc, RegisterRef destination, uint64_t execMask,
+                                       amdgpu::WaitCounterType waitCounterType) {
+  const size_t limit = destination.cls == RegClass::SGPR   ? sgprMemoryEvents.size()
+                       : destination.cls == RegClass::TTMP ? ttmpMemoryEvents.size()
+                                                           : 0;
+  if (destination.width == 0)
+    return;
+  if (limit == 0) {
+    registerEvent(pc, MemoryEventType::GLOBAL_TO_SGPR, {}, execMask, 0xF, waitCounterType);
+    return;
+  }
+  if (destination.index >= limit || destination.width > limit - destination.index)
+    return;
+
+  std::vector<uint32_t> registers(destination.width);
+  for (uint32_t i = 0; i < destination.width; ++i)
+    registers[i] = destination.index + i;
+  registerEvent(pc,
+                destination.cls == RegClass::SGPR ? MemoryEventType::GLOBAL_TO_SGPR
+                                                  : MemoryEventType::GLOBAL_TO_TTMP,
+                std::move(registers), execMask, 0xF, waitCounterType);
 }
 
 void WaveRaceState::registerEventWithIntervals(uint64_t pc, MemoryEventType type,
                                                std::vector<uint32_t> regIds, uint64_t execMask,
-                                               uint8_t byteMask, IntervalSet ldsIntervals) {
+                                               uint8_t byteMask, IntervalSet ldsIntervals,
+                                               amdgpu::WaitCounterType waitCounterType) {
   ProfileScope ps(*profiler_, "registerEvent");
   bool toSgpr = isToSgpr(type);
-  if (!toSgpr) {
+  bool toTtmp = isToTtmp(type);
+  const size_t register_limit = toSgpr   ? sgprMemoryEvents.size()
+                                : toTtmp ? ttmpMemoryEvents.size()
+                                         : vgprMemoryEvents.size();
+  if (std::any_of(regIds.begin(), regIds.end(),
+                  [register_limit](uint32_t reg) { return reg >= register_limit; }))
+    return;
+  if (!toSgpr && !toTtmp) {
     for (auto reg : regIds) {
       regEventCountInc(type, reg);
     }
   }
 
   auto eventId = detector->allocateEventId(waveId, pc, type, std::move(regIds), execMask, byteMask,
-                                           std::move(ldsIntervals));
+                                           std::move(ldsIntervals), waitCounterType);
   for (uint32_t reg : detector->events().registers(eventId)) {
     if (toSgpr) {
       sgprMemoryEvents[reg].push_back(eventId);
       sgprEventCount[reg]++;
+    } else if (toTtmp) {
+      ttmpMemoryEvents[reg].push_back(eventId);
+      ttmpEventCount[reg]++;
     } else {
       vgprMemoryEvents[reg].push_back(eventId);
     }
@@ -82,6 +108,15 @@ void WaveRaceState::registerLdsEvent(uint64_t pc, MemoryEventType type,
                                      std::vector<uint32_t> registers, uint64_t execMask,
                                      int waveSize, std::span<const uint32_t> laneBaseAddresses,
                                      int bytesPerLane, uint8_t byteMask) {
+  registerLdsEvent(pc, type, std::move(registers), execMask, waveSize, laneBaseAddresses,
+                   bytesPerLane, byteMask, defaultWaitCounterType(type));
+}
+
+void WaveRaceState::registerLdsEvent(uint64_t pc, MemoryEventType type,
+                                     std::vector<uint32_t> registers, uint64_t execMask,
+                                     int waveSize, std::span<const uint32_t> laneBaseAddresses,
+                                     int bytesPerLane, uint8_t byteMask,
+                                     amdgpu::WaitCounterType waitCounterType) {
   IntervalSet intervals;
   forEachActiveLane(execMask, waveSize, [&](int lane) {
     int addr = static_cast<int>(laneBaseAddresses[lane]);
@@ -89,7 +124,7 @@ void WaveRaceState::registerLdsEvent(uint64_t pc, MemoryEventType type,
   });
   intervals.finalize();
   registerEventWithIntervals(pc, type, std::move(registers), execMask, byteMask,
-                             std::move(intervals));
+                             std::move(intervals), waitCounterType);
 }
 
 void WaveRaceState::registerDualOffsetLdsEvent(uint64_t pc, MemoryEventType type,
@@ -97,6 +132,16 @@ void WaveRaceState::registerDualOffsetLdsEvent(uint64_t pc, MemoryEventType type
                                                int waveSize,
                                                std::span<const uint32_t> laneBaseAddresses,
                                                int32_t offset0, int32_t offset1) {
+  registerDualOffsetLdsEvent(pc, type, std::move(registers), execMask, waveSize, laneBaseAddresses,
+                             offset0, offset1, defaultWaitCounterType(type));
+}
+
+void WaveRaceState::registerDualOffsetLdsEvent(uint64_t pc, MemoryEventType type,
+                                               std::vector<uint32_t> registers, uint64_t execMask,
+                                               int waveSize,
+                                               std::span<const uint32_t> laneBaseAddresses,
+                                               int32_t offset0, int32_t offset1,
+                                               amdgpu::WaitCounterType waitCounterType) {
   IntervalSet intervals;
   forEachActiveLane(execMask, waveSize, [&](int lane) {
     uint32_t vAddr = laneBaseAddresses[lane];
@@ -106,17 +151,22 @@ void WaveRaceState::registerDualOffsetLdsEvent(uint64_t pc, MemoryEventType type
     intervals.append(intAddr1, intAddr1 + 8);
   });
   intervals.finalize();
-  registerEventWithIntervals(pc, type, std::move(registers), execMask, 0xF, std::move(intervals));
+  registerEventWithIntervals(pc, type, std::move(registers), execMask, 0xF, std::move(intervals),
+                             waitCounterType);
 }
 
 void WaveRaceState::retireEventRegisters(EventId eventId) {
   ProfileScope ps(*profiler_, "retireEventRegisters");
   auto eventType = detector->events().type(eventId);
   bool toSgpr = isToSgpr(eventType);
+  bool toTtmp = isToTtmp(eventType);
   for (uint32_t regId : detector->events().registers(eventId)) {
     if (toSgpr) {
       removeFromUnorderedList(sgprMemoryEvents[regId], eventId);
       sgprEventCount[regId]--;
+    } else if (toTtmp) {
+      removeFromUnorderedList(ttmpMemoryEvents[regId], eventId);
+      ttmpEventCount[regId]--;
     } else {
       removeFromUnorderedList(getVgprMemoryEvents(regId), eventId);
       regEventCountDec(eventType, regId);
@@ -124,10 +174,10 @@ void WaveRaceState::retireEventRegisters(EventId eventId) {
   }
 }
 
-template <typename Pred> void WaveRaceState::resolveWaitCnt(int limit, Pred isTargetType) {
+template <typename Pred> void WaveRaceState::resolveWaitCnt(int limit, Pred isTargetEvent) {
   int total = 0;
   for (auto eid : waveMemoryEvents)
-    if (isTargetType(detector->events().type(eid)))
+    if (isTargetEvent(eid))
       total++;
   int toRetire = total - limit;
   if (toRetire <= 0)
@@ -137,7 +187,7 @@ template <typename Pred> void WaveRaceState::resolveWaitCnt(int limit, Pred isTa
   size_t write = 0;
   for (size_t read = 0; read < waveMemoryEvents.size(); ++read) {
     EventId eid = waveMemoryEvents[read];
-    if (isTargetType(detector->events().type(eid)) && retired < toRetire) {
+    if (isTargetEvent(eid) && retired < toRetire) {
       retired++;
       retireEventRegisters(eid);
       detector->markEventWaveComplete(eid);
@@ -153,17 +203,28 @@ template <typename Pred> void WaveRaceState::resolveWaitCnt(int limit, Pred isTa
   waveMemoryEvents.resize(write);
 }
 
-void WaveRaceState::sWaitCntVmcnt(int vmcnt) {
-  resolveWaitCnt(vmcnt, [](MemoryEventType type) {
-    return type == MemoryEventType::GLOBAL_TO_VGPR || type == MemoryEventType::VGPR_TO_GLOBAL ||
-           type == MemoryEventType::GLOBAL_TO_LDS;
-  });
-}
+void WaveRaceState::applyWaitCounter(amdgpu::WaitCounterType type, int threshold) {
+  if (threshold < 0)
+    return;
 
-void WaveRaceState::sWaitCntLgkmcnt(int lgkmcnt) {
-  resolveWaitCnt(lgkmcnt, [](MemoryEventType type) {
-    return type == MemoryEventType::LDS_TO_VGPR || type == MemoryEventType::VGPR_TO_LDS ||
-           type == MemoryEventType::GLOBAL_TO_SGPR;
+  // Scalar-memory operations are not guaranteed to complete in issue order.
+  // A nonzero scalar or combined wait therefore cannot identify a particular
+  // scalar destination as complete. DS operations are ordered only within an
+  // operation class, so a combined LGKM wait can retire events older than its
+  // remaining-operation bound independently for DS reads and DS writes.
+  if (threshold != 0 &&
+      (type == amdgpu::WaitCounterType::LGKMCNT || type == amdgpu::WaitCounterType::KMCNT)) {
+    if (type == amdgpu::WaitCounterType::LGKMCNT)
+      for (MemoryEventType ds_type : {MemoryEventType::LDS_TO_VGPR, MemoryEventType::VGPR_TO_LDS})
+        resolveWaitCnt(threshold, [this, type, ds_type](EventId event_id) {
+          return amdgpu::wait_counter_covers(type, detector->events().waitCounterType(event_id)) &&
+                 detector->events().type(event_id) == ds_type;
+        });
+    return;
+  }
+
+  resolveWaitCnt(threshold, [this, type](EventId event_id) {
+    return amdgpu::wait_counter_covers(type, detector->events().waitCounterType(event_id));
   });
 }
 
@@ -236,14 +297,35 @@ bool WaveRaceState::isOutstandingFromVgpr(int lane, int reg) const {
   return false;
 }
 
-void WaveRaceState::checkSgprRead(int reg) const {
-  if (sgprEventCount[reg] == 0) {
+void WaveRaceState::checkScalarRead(RegisterRef ref) const {
+  const std::vector<std::vector<EventId>> *events = nullptr;
+  const std::vector<int> *counts = nullptr;
+  RaceViolation::Space space;
+  MemoryEventType type;
+  if (ref.cls == RegClass::SGPR) {
+    events = &sgprMemoryEvents;
+    counts = &sgprEventCount;
+    space = RaceViolation::Space::SGPR;
+    type = MemoryEventType::GLOBAL_TO_SGPR;
+  } else if (ref.cls == RegClass::TTMP) {
+    events = &ttmpMemoryEvents;
+    counts = &ttmpEventCount;
+    space = RaceViolation::Space::TTMP;
+    type = MemoryEventType::GLOBAL_TO_TTMP;
+  } else {
     return;
   }
-  for (EventId eid : sgprMemoryEvents[reg]) {
-    if (isToSgpr(detector->events().type(eid))) {
-      detector->getRaceHandler()({RaceViolation::Space::SGPR, reg, waveId.value, -1, false,
-                                  detector->getWorkgroupId(), eid});
+
+  if (ref.width == 0 || ref.index >= events->size() || ref.width > events->size() - ref.index)
+    return;
+  for (uint32_t offset = 0; offset < ref.width; ++offset) {
+    const uint32_t index = ref.index + offset;
+    if ((*counts)[index] == 0)
+      continue;
+    for (EventId eid : (*events)[index]) {
+      if (detector->events().type(eid) == type)
+        detector->getRaceHandler()({space, static_cast<int>(index), waveId.value, -1, false,
+                                    detector->getWorkgroupId(), eid});
     }
   }
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/core/wave_race_state.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/core/wave_race_state.h
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #pragma once
+#include "rocjitsu/isa/register_set.h"
 #include "rocjitsu/vm/plugins/race_detector/core/common_register.h"
 #include "rocjitsu/vm/plugins/race_detector/core/profiler_interface.h"
 #include "rocjitsu/vm/plugins/race_detector/core/types.h"
@@ -33,6 +34,15 @@ public:
   void registerEvent(uint64_t pc, MemoryEventType type, std::vector<uint32_t> registers,
                      uint64_t execMask, uint8_t byteMask = 0xF);
 
+  /// Register an event with the exact hardware counter that orders it.
+  void registerEvent(uint64_t pc, MemoryEventType type, std::vector<uint32_t> registers,
+                     uint64_t execMask, uint8_t byteMask, amdgpu::WaitCounterType waitCounterType);
+
+  /// Register an in-flight scalar load using its architectural destination.
+  void
+  registerScalarLoad(uint64_t pc, RegisterRef destination, uint64_t execMask,
+                     amdgpu::WaitCounterType waitCounterType = amdgpu::WaitCounterType::LGKMCNT);
+
   /// Register an in-flight memory event that involves LDS.
   /// The LDS memory involved is defined by `laneBaseAddresses` and `bytesPerLane`. Each active lane
   /// contributes one interval of size `bytesPerLane`.
@@ -40,6 +50,10 @@ public:
                         uint64_t execMask, int waveSize,
                         std::span<const uint32_t> laneBaseAddresses, int bytesPerLane,
                         uint8_t byteMask = 0xF);
+  void registerLdsEvent(uint64_t pc, MemoryEventType type, std::vector<uint32_t> registers,
+                        uint64_t execMask, int waveSize,
+                        std::span<const uint32_t> laneBaseAddresses, int bytesPerLane,
+                        uint8_t byteMask, amdgpu::WaitCounterType waitCounterType);
 
   /// Register an LDS event with dual-offset intervals. Each active lane
   /// contributes two 8-byte intervals at laneBaseAddresses[lane] + offset0*8
@@ -49,19 +63,13 @@ public:
                                   std::vector<uint32_t> registers, uint64_t execMask, int waveSize,
                                   std::span<const uint32_t> laneBaseAddresses, int32_t offset0,
                                   int32_t offset1);
+  void registerDualOffsetLdsEvent(uint64_t pc, MemoryEventType type,
+                                  std::vector<uint32_t> registers, uint64_t execMask, int waveSize,
+                                  std::span<const uint32_t> laneBaseAddresses, int32_t offset0,
+                                  int32_t offset1, amdgpu::WaitCounterType waitCounterType);
 
-  /// Retire global memory events until `vmcnt` or fewer remain outstanding. 'Retire' here means
-  /// marking the event as wave-complete.
-  void sWaitCntVmcnt(int vmcnt);
-
-  /// Retire LDS events until at `lgkmcnt` or fewer remain outstanding.
-  void sWaitCntLgkmcnt(int lgkmcnt);
-
-  /// Dispatch a pending memory event produced by an instruction executor.
-  void dispatch(PendingMemoryEvent);
-
-  /// Dispatch a pending wait count produced by an s_waitcnt executor.
-  void dispatch(PendingWaitCount);
+  /// Dispatch the counter thresholds changed by one wait instruction.
+  void dispatch(const PendingWaitCount &);
 
   /// Retire non-trimmable events whose owning wave completed them before a workgroup barrier.
   void flushBarrierPendingEvents();
@@ -83,8 +91,8 @@ public:
   void checkVgprReadAllLanes(int reg) const;
 
   /// Check a scalar register read for races. Calls the RaceHandler on
-  /// violation (outstanding s_load targeting this SGPR).
-  void checkSgprRead(int reg) const;
+  /// violation (outstanding scalar load targeting the same register).
+  void checkScalarRead(RegisterRef reg) const;
 
   /// True if any outstanding global/LDS store reads from the given VGPR lane.
   bool isOutstandingFromVgpr(int lane, int reg) const;
@@ -109,10 +117,12 @@ public:
 
 private:
   void registerEventWithIntervals(uint64_t pc, MemoryEventType, std::vector<uint32_t> registers,
-                                  uint64_t execMask, uint8_t byteMask, IntervalSet ldsIntervals);
+                                  uint64_t execMask, uint8_t byteMask, IntervalSet ldsIntervals,
+                                  amdgpu::WaitCounterType waitCounterType);
   void retireEventRegisters(EventId);
 
   template <typename Pred> void resolveWaitCnt(int limit, Pred isTargetType);
+  void applyWaitCounter(amdgpu::WaitCounterType type, int threshold);
 
   void regEventCountInc(MemoryEventType type, int reg) {
     regEventCount[static_cast<int>(type)][reg]++;
@@ -124,6 +134,8 @@ private:
   std::vector<std::vector<EventId>> vgprMemoryEvents;
   std::vector<std::vector<EventId>> sgprMemoryEvents;
   std::vector<int> sgprEventCount;
+  std::vector<std::vector<EventId>> ttmpMemoryEvents;
+  std::vector<int> ttmpEventCount;
 
   static constexpr int kNumEventTypes = static_cast<int>(MemoryEventType::N);
   std::array<std::vector<int>, kNumEventTypes> regEventCount;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/plugin.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/plugin.cpp
@@ -18,6 +18,7 @@
 #include <mutex>
 #include <sstream>
 #include <stdexcept>
+#include <string_view>
 
 namespace rocjitsu::plugins::race_detector {
 
@@ -174,7 +175,7 @@ void RaceDetectorPlugin::onAmdgpuDispatchPacketProcessed(const KernelDispatchInf
 
 void RaceDetectorPlugin::onAmdgpuWorkgroupDispatched(uint32_t dispatch_id, uint32_t wg_id,
                                                      uint32_t physical_vgpr_count,
-                                                     uint32_t sgpr_count,
+                                                     uint32_t physical_sgpr_count,
                                                      std::span<amdgpu::Wavefront *> wavefronts) {
   uint32_t num_waves = static_cast<uint32_t>(wavefronts.size());
   WorkgroupKey key{dispatch_id, wg_id};
@@ -202,11 +203,13 @@ void RaceDetectorPlugin::onAmdgpuWorkgroupDispatched(uint32_t dispatch_id, uint3
       oss << "Race on VGPR v" << v.index;
     else if (v.space == RaceViolation::Space::SGPR)
       oss << "Race on SGPR s" << v.index;
+    else if (v.space == RaceViolation::Space::TTMP)
+      oss << "Race on TTMP ttmp" << v.index;
     else
       oss << "Race on LDS byte " << v.index;
     oss << " [workgroup (" << v.workgroupId.x << ", " << v.workgroupId.y << ", " << v.workgroupId.z
         << "), wave " << v.wave;
-    if (v.space != RaceViolation::Space::SGPR)
+    if (v.space != RaceViolation::Space::SGPR && v.space != RaceViolation::Space::TTMP)
       oss << ", lane " << v.lane;
     oss << "]\n";
 
@@ -222,6 +225,7 @@ void RaceDetectorPlugin::onAmdgpuWorkgroupDispatched(uint32_t dispatch_id, uint3
         observed_races_.emplace(dispatch_id, conflict.pc);
         const char *space = v.space == RaceViolation::Space::VGPR   ? "VGPR"
                             : v.space == RaceViolation::Space::SGPR ? "SGPR"
+                            : v.space == RaceViolation::Space::TTMP ? "TTMP"
                                                                     : "LDS";
         auto kernel_name_iter = dispatch_kernel_names_.find(dispatch_id);
         const KernelNames kernel_names =
@@ -245,7 +249,7 @@ void RaceDetectorPlugin::onAmdgpuWorkgroupDispatched(uint32_t dispatch_id, uint3
   std::lock_guard<std::mutex> lock(dispatch_mutex_);
   detectors_[key] = std::make_unique<RaceDetector>(
       static_cast<int>(num_waves), static_cast<int>(physical_vgpr_count),
-      static_cast<int>(sgpr_count), Dim3d(static_cast<int>(wg_id)), std::move(handler));
+      static_cast<int>(physical_sgpr_count), Dim3d(static_cast<int>(wg_id)), std::move(handler));
 
   auto &det = *detectors_[key];
   auto &dc = dispatch_disasm_[dispatch_id];
@@ -293,8 +297,8 @@ void RaceDetectorPlugin::onAmdgpuRouteMemoryInstruction(const Instruction &inst,
     }
     uint8_t byte_mask = vector_memory_byte_mask(d, wf);
     rs->registerLdsEvent(wf.pc, type, std::move(registers), wf.exec(), wf.wf_size(),
-                         std::span<const uint32_t>(laneAddrs, wf.wf_size()), d.elem_size,
-                         byte_mask);
+                         std::span<const uint32_t>(laneAddrs, wf.wf_size()), d.elem_size, byte_mask,
+                         d.wait_counter_type);
   }
 
   if (inst.data()->tag() == amdgpu::GLOBAL_MEM) {
@@ -320,7 +324,8 @@ void RaceDetectorPlugin::onAmdgpuRouteMemoryInstruction(const Instruction &inst,
           validLaneMask &= ~(1ULL << lane);
       }
       rs->registerLdsEvent(wf.pc, MemoryEventType::GLOBAL_TO_LDS, {}, validLaneMask, wf.wf_size(),
-                           std::span<const uint32_t>(ldsAddrs, wf.wf_size()), perLaneBytes);
+                           std::span<const uint32_t>(ldsAddrs, wf.wf_size()), perLaneBytes, 0xF,
+                           d.wait_counter_type);
     } else if (d.is_load && d.dst_reg_base >= wf.vgpr_alloc().base) {
       uint32_t logicalBase = d.dst_reg_base - wf.vgpr_alloc().base;
       std::vector<uint32_t> registers(d.num_elems);
@@ -328,20 +333,25 @@ void RaceDetectorPlugin::onAmdgpuRouteMemoryInstruction(const Instruction &inst,
         registers[i] = logicalBase + i;
       uint8_t byte_mask = vector_memory_byte_mask(d, wf);
       rs->registerEvent(wf.pc, MemoryEventType::GLOBAL_TO_VGPR, std::move(registers), d.exec_mask,
-                        byte_mask);
+                        byte_mask, d.wait_counter_type);
     } else if (!d.is_load) {
-      rs->registerEvent(wf.pc, MemoryEventType::VGPR_TO_GLOBAL, {}, d.exec_mask);
+      rs->registerEvent(wf.pc, MemoryEventType::VGPR_TO_GLOBAL, {}, d.exec_mask, 0xF,
+                        d.wait_counter_type);
     }
   }
 
   if (inst.data()->tag() == amdgpu::SCALAR_MEM) {
     auto &d = *inst.data_as<amdgpu::ScalarMemState>();
     if (d.is_load) {
-      uint32_t logicalBase = d.dst_reg_base - wf.sgpr_alloc().base;
-      std::vector<uint32_t> registers(d.num_dwords);
-      for (uint32_t i = 0; i < d.num_dwords; ++i)
-        registers[i] = logicalBase + i;
-      rs->registerEvent(wf.pc, MemoryEventType::GLOBAL_TO_SGPR, std::move(registers), wf.exec());
+      if (const auto reg = d.dst_register.register_ref()) {
+        rs->registerScalarLoad(wf.pc, *reg, wf.exec(), d.wait_counter_type);
+      } else {
+        rs->registerEvent(wf.pc, MemoryEventType::GLOBAL_TO_SGPR, {}, wf.exec(), 0xF,
+                          d.wait_counter_type);
+      }
+    } else {
+      rs->registerEvent(wf.pc, MemoryEventType::SCALAR_TO_GLOBAL, {}, wf.exec(), 0xF,
+                        d.wait_counter_type);
     }
   }
 }
@@ -362,11 +372,10 @@ void RaceDetectorPlugin::onAmdgpuWriteVgprLanes(const amdgpu::Wavefront *wf, uin
   s->race_state->checkVgprWriteLanes(static_cast<int>(logical_reg), lane_mask, byte_mask);
 }
 
-void RaceDetectorPlugin::onAmdgpuReadSgpr(const amdgpu::Wavefront *wf, uint32_t physical_reg) {
+void RaceDetectorPlugin::onAmdgpuReadScalarRegister(const amdgpu::Wavefront *wf, RegisterRef reg) {
   auto *s = get_state(wf);
   assert(s && s->race_state);
-  uint32_t logical_reg = physical_reg - wf->sgpr_alloc().base;
-  s->race_state->checkSgprRead(static_cast<int>(logical_reg));
+  s->race_state->checkScalarRead(reg);
 }
 
 void RaceDetectorPlugin::onAmdgpuBeforeExecuteInstruction(uint64_t pc, const Instruction &inst,
@@ -382,11 +391,42 @@ void RaceDetectorPlugin::onAmdgpuAfterExecuteInstruction(uint64_t /*pc*/, const 
   auto *s = get_state(wf);
   assert(s && s->race_state);
 
-  if (inst.mnemonic().starts_with("s_waitcnt")) {
-    auto &tgt = wf.wait_target();
-    s->race_state->dispatch(
-        PendingWaitCount{static_cast<int>(tgt.vmcnt), static_cast<int>(tgt.lgkmcnt)});
+  const std::string_view mnemonic = inst.mnemonic();
+  const auto &target = wf.wait_target();
+  PendingWaitCount wait;
+  if (mnemonic == "s_waitcnt") {
+    wait.add(amdgpu::WaitCounterType::VMCNT, target.vmcnt);
+    wait.add(amdgpu::WaitCounterType::LGKMCNT, target.lgkmcnt);
+    wait.add(amdgpu::WaitCounterType::EXPCNT, target.expcnt);
+  } else if (mnemonic == "s_waitcnt_vmcnt") {
+    wait.add(amdgpu::WaitCounterType::VMCNT, target.vmcnt);
+  } else if (mnemonic == "s_waitcnt_vscnt") {
+    wait.add(amdgpu::WaitCounterType::VSCNT, target.vscnt);
+  } else if (mnemonic == "s_waitcnt_lgkmcnt") {
+    wait.add(amdgpu::WaitCounterType::LGKMCNT, target.lgkmcnt);
+  } else if (mnemonic == "s_waitcnt_expcnt" || mnemonic == "s_wait_expcnt") {
+    wait.add(amdgpu::WaitCounterType::EXPCNT, target.expcnt);
+  } else if (mnemonic == "s_wait_loadcnt") {
+    wait.add(amdgpu::WaitCounterType::LOADCNT, target.vmcnt);
+  } else if (mnemonic == "s_wait_storecnt") {
+    wait.add(amdgpu::WaitCounterType::STORECNT, target.vscnt);
+  } else if (mnemonic == "s_wait_dscnt") {
+    wait.add(amdgpu::WaitCounterType::DSCNT, target.dscnt);
+  } else if (mnemonic == "s_wait_kmcnt") {
+    wait.add(amdgpu::WaitCounterType::KMCNT, target.kmcnt);
+  } else if (mnemonic == "s_wait_loadcnt_dscnt") {
+    wait.add(amdgpu::WaitCounterType::LOADCNT, target.vmcnt);
+    wait.add(amdgpu::WaitCounterType::DSCNT, target.dscnt);
+  } else if (mnemonic == "s_wait_storecnt_dscnt") {
+    wait.add(amdgpu::WaitCounterType::STORECNT, target.vscnt);
+    wait.add(amdgpu::WaitCounterType::DSCNT, target.dscnt);
+  } else if (mnemonic == "s_wait_asynccnt") {
+    wait.add(amdgpu::WaitCounterType::ASYNCCNT, target.asynccnt);
+  } else if (mnemonic == "s_wait_tensorcnt") {
+    wait.add(amdgpu::WaitCounterType::TENSORCNT, target.tensorcnt);
   }
+  if (!wait.empty())
+    s->race_state->dispatch(wait);
 }
 
 void RaceDetectorPlugin::onAmdgpuBarrierResolved(std::span<amdgpu::Wavefront *> wavefronts) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/plugin.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/plugin.h
@@ -99,7 +99,7 @@ public:
   void onAmdgpuDispatchPacketProcessed(const KernelDispatchInfo &info) override;
 
   void onAmdgpuWorkgroupDispatched(uint32_t dispatch_id, uint32_t wg_id,
-                                   uint32_t physical_vgpr_count, uint32_t sgpr_count,
+                                   uint32_t physical_vgpr_count, uint32_t physical_sgpr_count,
                                    std::span<amdgpu::Wavefront *> wavefronts) override;
 
   void onAmdgpuRouteMemoryInstruction(const Instruction &inst, amdgpu::Wavefront &wf) override;
@@ -111,7 +111,7 @@ public:
                               uint64_t lane_mask,
                               uint8_t byte_mask = ExecutionPlugin::kFullByteMask) override;
 
-  void onAmdgpuReadSgpr(const amdgpu::Wavefront *wf, uint32_t physical_reg) override;
+  void onAmdgpuReadScalarRegister(const amdgpu::Wavefront *wf, RegisterRef reg) override;
 
   void onAmdgpuBeforeExecuteInstruction(uint64_t pc, const Instruction &inst,
                                         amdgpu::Wavefront &wf) override;

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -844,7 +844,11 @@ if(HAS_DEVICE_KERNELS AND HAS_PROBE_FIXTURES)
         probe_fixture_test
         PRIVATE KERNEL_DIR="${KERNEL_OUTPUT_DIR}"
     )
-    add_dependencies(probe_fixture_test probe_rj_nop_probe_gfx90a)
+    add_dependencies(
+        probe_fixture_test
+        probe_rj_nop_probe_gfx90a
+        probe_callable_sgpr_probe_gfx950
+    )
     rj_configure_target(probe_fixture_test TEST)
     if(RJ_INSTALL_TESTS)
         rj_install_test_target(probe_fixture_test)
@@ -854,6 +858,16 @@ if(HAS_DEVICE_KERNELS AND HAS_PROBE_FIXTURES)
         COMMAND probe_fixture_test
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         INSTALL_COMMAND "bin/probe_fixture_test"
+    )
+    rj_add_test(
+        NAME "ProbeFixture.CallableSgprUseExceedsKernelDescriptor"
+        COMMAND
+            probe_fixture_test
+            --gtest_filter=ProbeFixture.CallableSgprUseExceedsKernelDescriptor
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        INSTALL_COMMAND
+            "bin/probe_fixture_test"
+            "--gtest_filter=ProbeFixture.CallableSgprUseExceedsKernelDescriptor"
     )
 endif()
 

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -6,6 +6,7 @@
 
 #include "embedded_schema.h"
 #include "rocjitsu/code/amdgpu_elf.h"
+#include "rocjitsu/code/builders/instruction_builder.h"
 #include "rocjitsu/code/kernel_descriptor_scan.h"
 #include "rocjitsu/code/kernel_symbol.h"
 #include "rocjitsu/config/config_loader.h"
@@ -2189,6 +2190,46 @@ TEST_P(IsaTest, DispatchWfReturnsNullWhenSlotsExhausted) {
   EXPECT_EQ(cu->num_wfs(), kSlots);
   // All slots are occupied by resident (non-halted) waves — the next dispatch fails.
   EXPECT_EQ(cu->dispatch_wf(0, 0x1040, 104, 256), nullptr);
+}
+
+TEST(TrapRegisterPcTest, SetpcPrecheckReadsDecodedTtmpPair) {
+  amdgpu::GpuMemory mem("cdna4_setpc_ttmp_mem");
+  amdgpu::L2Cache l2("cdna4_setpc_ttmp_l2");
+  amdgpu::ComputeUnitCore::Config cfg{};
+  cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+  cfg.num_wf_slots = 2;
+  cfg.sgprs_per_wf = 104;
+  cfg.vgprs_per_wf = 16;
+  cfg.lds_size_kb = 64;
+  auto cu = amdgpu::ComputeUnitCore::create("cdna4_setpc_ttmp_cu", cfg, &mem, &l2);
+  ASSERT_NE(cu, nullptr);
+
+  test::HaltSnapshotPlugin *snapshot = nullptr;
+  cu->set_plugin_group(test::make_halt_snapshot_group(&snapshot));
+  ASSERT_NE(snapshot, nullptr);
+
+  constexpr uint64_t kStartPc = 0x1000;
+  constexpr uint64_t kTargetPc = kStartPc + 2 * sizeof(uint32_t);
+  constexpr uint32_t kTtmp0Selector = 108;
+  const std::array<uint32_t, 4> code = {
+      build_s_setpc_b64(kTtmp0Selector, ROCJITSU_CODE_ARCH_CDNA4),
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),
+      build_s_mov_b32(/*sdst=*/0, scalar_positive_inline_u32(1), ROCJITSU_CODE_ARCH_CDNA4),
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4),
+  };
+  mem.load_image(reinterpret_cast<const uint8_t *>(code.data()), sizeof(code), kStartPc);
+
+  auto *wavefront = cu->dispatch_wf(/*wg_id=*/0, kStartPc, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
+  ASSERT_NE(wavefront, nullptr);
+  wavefront->set_ttmp(/*TTMP0=*/0, static_cast<uint32_t>(kTargetPc));
+  wavefront->set_ttmp(/*TTMP1=*/1, static_cast<uint32_t>(kTargetPc >> 32));
+
+  for (uint32_t step = 0; step < code.size() && cu->has_active_wfs(); ++step)
+    static_cast<void>(cu->step());
+
+  ASSERT_FALSE(cu->has_active_wfs());
+  ASSERT_EQ(snapshot->snapshots().size(), 1u);
+  EXPECT_EQ(snapshot->snapshots()[0].sgpr(0), 1u);
 }
 
 TEST(CommandProcessorTest, DispatchToQuiescedDebugHaltedCuReactivatesEventLoop) {

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -477,6 +477,7 @@ TEST(RegisterSetAnalysis, GeneratedCdna4OperandsMapTrackedRegisterRefs) {
   cdna4::Operand vgpr(32, cdna4::OperandType::OPR_SRC, cdna4::OpSelSrc::OPR_SRC_VGPR_MIN + 7);
   cdna4::Operand acc(32, cdna4::OperandType::OPR_SRC_ACCVGPR,
                      cdna4::OpSelSrcAccvgpr::OPR_SRC_ACCVGPR_ACC_MIN + 7);
+  cdna4::Operand ttmp(64, cdna4::OperandType::OPR_SRC, cdna4::OpSelSrc::OPR_SRC_TTMP_MIN + 2);
   cdna4::Operand imm32(32, cdna4::OperandType::OPR_SIMM32, 123);
 
   ASSERT_TRUE(sgpr.to_register_ref().has_value());
@@ -485,6 +486,8 @@ TEST(RegisterSetAnalysis, GeneratedCdna4OperandsMapTrackedRegisterRefs) {
   EXPECT_EQ(*vgpr.to_register_ref(), (RegisterRef{RegClass::VGPR, 7, 1}));
   ASSERT_TRUE(acc.to_register_ref().has_value());
   EXPECT_EQ(*acc.to_register_ref(), (RegisterRef{RegClass::ACC_VGPR, 7, 1}));
+  ASSERT_TRUE(ttmp.to_register_ref().has_value());
+  EXPECT_EQ(*ttmp.to_register_ref(), (RegisterRef{RegClass::TTMP, 2, 2}));
   EXPECT_FALSE(imm32.to_register_ref().has_value());
 }
 

--- a/emulation/rocjitsu/tests/dbi/probe_fixture_test.cpp
+++ b/emulation/rocjitsu/tests/dbi/probe_fixture_test.cpp
@@ -26,6 +26,7 @@
 #include <cstring>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace rocjitsu {
@@ -115,6 +116,53 @@ TEST(ProbeFixture, NopProbeClobberSummaryIsEmpty) {
   EXPECT_FALSE(summary->touches_m0);
   EXPECT_FALSE(summary->touches_flat_scratch);
   EXPECT_FALSE(summary->uses_private_segment);
+}
+
+TEST(ProbeFixture, CallableSgprUseExceedsKernelDescriptor) {
+  Executable exec(kernel_hsaco_path("callable_sgpr_probe_gfx950"));
+  ASSERT_TRUE(exec.is_valid()) << "failed to load callable_sgpr_probe_gfx950.hsaco";
+  ASSERT_GT(exec.num_code_objects(ROCJITSU_CODE_TARGET_GFX950), 0u);
+  const AmdGpuCodeObject *co = exec.code_object(ROCJITSU_CODE_TARGET_GFX950, 0);
+  ASSERT_NE(co, nullptr);
+  EXPECT_EQ(co->target_id(), ROCJITSU_CODE_TARGET_GFX950);
+
+  const auto descriptor_sgprs = co->min_kernel_sgpr_count(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_TRUE(descriptor_sgprs.has_value());
+  EXPECT_EQ(*descriptor_sgprs, 40u);
+
+  std::string err;
+  const auto resolved = resolve_probe_symbol(*co, "callable_sgpr_probe", &err);
+  ASSERT_TRUE(resolved.has_value()) << err;
+  EXPECT_GT(resolved->body_size, 0u);
+  EXPECT_EQ(resolved->body_size % sizeof(uint32_t), 0u);
+
+  const auto *image = reinterpret_cast<const uint8_t *>(co->image_data());
+  const size_t num_words = resolved->body_size / sizeof(uint32_t);
+  std::vector<uint32_t> body(num_words + 1, 0);
+  std::memcpy(body.data(), image + resolved->body_file_offset, resolved->body_size);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+
+  constexpr uint32_t kMovS40One = 0xBEA80081u;
+  bool saw_s40_write = false;
+  size_t word = 0;
+  while (word < num_words) {
+    auto decoded = decoder->decode(&body[word]);
+    ASSERT_TRUE(decoded.succeeded());
+    std::unique_ptr<Instruction> inst = std::move(decoded).value();
+    ASSERT_NE(inst, nullptr);
+    const int size = inst->size();
+    ASSERT_TRUE(size == 4 || size == 8) << "unexpected instruction size in callable body";
+    if (body[word] == kMovS40One) {
+      EXPECT_EQ(std::string_view(inst->mnemonic()), "s_mov_b32");
+      saw_s40_write = true;
+    }
+    word += static_cast<size_t>(size) / sizeof(uint32_t);
+  }
+
+  EXPECT_TRUE(saw_s40_write);
+  EXPECT_LT(*descriptor_sgprs, 41u) << "the entry descriptor unexpectedly includes callable s40";
 }
 
 } // namespace

--- a/emulation/rocjitsu/tests/execution_plugin_test.cpp
+++ b/emulation/rocjitsu/tests/execution_plugin_test.cpp
@@ -20,6 +20,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna3/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna3/machine_insts.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna3/vop1.h"
+#include "rocjitsu/isa/arch/amdgpu/generated/cdna4/builders.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna4/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna4/machine_insts.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna4/opcodes.h"
@@ -34,6 +35,7 @@
 #include "rocjitsu/isa/arch/amdgpu/shared/dpp_sdwa_ops.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/mma_exec.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_selectors.h"
 #include "rocjitsu/isa/decoder.h"
 #include "rocjitsu/isa/instruction.h"
 #include "rocjitsu/kmd/linux/kfd_process.h"
@@ -180,9 +182,15 @@ public:
   using LocalMemPipeline::initiate_access;
 };
 
+class TestScalarMemPipeline : public ScalarMemPipeline {
+public:
+  using ScalarMemPipeline::ScalarMemPipeline;
+};
+
 class TestWaitcntInstruction : public Instruction {
 public:
-  TestWaitcntInstruction() : Instruction("s_waitcnt", nullptr) {}
+  explicit TestWaitcntInstruction(std::string_view mnemonic = "s_waitcnt")
+      : Instruction(mnemonic, nullptr) {}
 };
 
 struct ForceScalarOverride {
@@ -209,6 +217,7 @@ struct HookEvent {
     READ_VGPR,
     WRITE_VGPR,
     READ_SGPR,
+    WRITE_SGPR,
     BARRIER_RESOLVED,
     INIT,
     SHUTDOWN,
@@ -222,7 +231,7 @@ struct HookEvent {
   uint32_t wg_id = 0;
   uint32_t wf_id = 0;
   uint32_t physical_vgpr_count = 0;
-  uint32_t sgpr_count = 0;
+  uint32_t physical_sgpr_count = 0;
   uint32_t physical_reg = 0;
   uint64_t lane_mask = 0;
   uint8_t byte_mask = 0;
@@ -263,13 +272,13 @@ public:
   }
 
   void onAmdgpuWorkgroupDispatched(uint32_t dispatch_id, uint32_t wg_id,
-                                   uint32_t physical_vgpr_count, uint32_t sgpr_count,
+                                   uint32_t physical_vgpr_count, uint32_t physical_sgpr_count,
                                    std::span<amdgpu::Wavefront *>) override {
     HookEvent e{HookEvent::WORKGROUP_DISPATCHED};
     e.dispatch_id = dispatch_id;
     e.wg_id = wg_id;
     e.physical_vgpr_count = physical_vgpr_count;
-    e.sgpr_count = sgpr_count;
+    e.physical_sgpr_count = physical_sgpr_count;
     events.push_back(e);
   }
 
@@ -366,6 +375,19 @@ public:
     events.push_back(e);
   }
 
+  void onAmdgpuWriteScalarRegister(const amdgpu::Wavefront *wf, RegisterRef reg) override {
+    if (!wf || reg.cls != RegClass::SGPR)
+      return;
+    for (uint32_t offset = 0; offset < reg.width; ++offset) {
+      HookEvent e{HookEvent::WRITE_SGPR};
+      e.dispatch_id = wf->dispatch_id();
+      e.wg_id = wf->wg_id();
+      e.wf_id = wf->wf_id();
+      e.physical_reg = wf->sgpr_alloc().base + reg.index + offset;
+      events.push_back(e);
+    }
+  }
+
   void onAmdgpuBarrierResolved(std::span<amdgpu::Wavefront *> wfs) override {
     HookEvent e{HookEvent::BARRIER_RESOLVED};
     if (!wfs.empty()) {
@@ -418,6 +440,7 @@ public:
   NoSgprReadPlugin() : ExecutionPlugin("no_sgpr_read") {}
   bool observes_sgpr_reads() const override { return false; }
   void onAmdgpuReadSgpr(const amdgpu::Wavefront *, uint32_t) override { ++callbacks; }
+  void onAmdgpuReadScalarRegister(const amdgpu::Wavefront *, RegisterRef) override { ++callbacks; }
 
   uint32_t callbacks = 0;
 };
@@ -560,11 +583,11 @@ public:
   MfmaRacePlugin() : ExecutionPlugin("mfma_race_probe") {}
 
   void onAmdgpuWorkgroupDispatched(uint32_t, uint32_t wg_id, uint32_t physical_vgpr_count,
-                                   uint32_t sgpr_count,
+                                   uint32_t physical_sgpr_count,
                                    std::span<amdgpu::Wavefront *> wavefronts) override {
     detector_ = std::make_unique<RaceDetector>(
         static_cast<int>(wavefronts.size()), static_cast<int>(physical_vgpr_count),
-        static_cast<int>(sgpr_count), Dim3d(static_cast<int>(wg_id)),
+        static_cast<int>(physical_sgpr_count), Dim3d(static_cast<int>(wg_id)),
         [this](RaceViolation v) { violations.push_back(v); });
     wf_ = wavefronts.front();
     state_ = &detector_->getWaveRaceState(0);
@@ -640,6 +663,7 @@ const char *kindName(HookEvent::Kind k) {
       "READ_VGPR",
       "WRITE_VGPR",
       "READ_SGPR",
+      "WRITE_SGPR",
       "BARRIER_RESOLVED",
       "INIT",
       "SHUTDOWN",
@@ -810,7 +834,8 @@ struct PluginFixture {
   amdgpu::GpuMemory *mem = nullptr;
 
   explicit PluginFixture(uint32_t num_wf_slots = 10, std::string_view arch = "cdna4",
-                         uint32_t wavefront_size = 64, uint32_t sgprs_per_wf = 104) {
+                         uint32_t wavefront_size = 64, uint32_t sgprs_per_wf = 104,
+                         uint32_t vgprs_per_wf = 256) {
     std::string json = std::format(R"({{
       "max_ticks":10000,"num_threads":1,"exec_mode":"functional",
       "vm":{{"arch":"{}","gpu":{{"device":{{"wave_front_size":{},
@@ -824,7 +849,7 @@ struct PluginFixture {
             {{"name":"cu[0:1]","type":"compute_unit","config":[
               {{"key":"num_wf_slots","value":"{}"}},
               {{"key":"sgprs_per_wf","value":"{}"}},
-              {{"key":"vgprs_per_wf","value":"256"}},
+              {{"key":"vgprs_per_wf","value":"{}"}},
               {{"key":"lds_size_kb","value":"64"}}
             ]}}
           ]}}
@@ -834,7 +859,7 @@ struct PluginFixture {
         {{"src":"xcd0.se0.cu0.req","dst":"xcd0.l2.cpl_0","latency":1,"weight":10}}
       ]}}}}
     )",
-                                   arch, wavefront_size, num_wf_slots, sgprs_per_wf);
+                                   arch, wavefront_size, num_wf_slots, sgprs_per_wf, vgprs_per_wf);
     auto loaded = config::load_config_from_string(json, rocjitsu::kEmbeddedSchema);
     soc = loaded.soc();
     mem = loaded.memory();
@@ -847,12 +872,14 @@ struct PluginFixture {
   amdgpu::ComputeUnitCore *cu() { return soc->xcd(0)->shader_engine(0)->compute_unit(0); }
   amdgpu::CommandProcessor *cp() { return soc->xcd(0)->command_processor(); }
 
-  uint64_t write_kernel(uint64_t addr, const uint32_t *code, size_t num_words) {
+  uint64_t write_kernel(uint64_t addr, const uint32_t *code, size_t num_words,
+                        uint32_t granulated_sgpr_count = 12) {
     using namespace rocr::llvm::amdhsa;
     kernel_descriptor_t kd{};
     kd.kernel_code_entry_byte_offset = sizeof(kernel_descriptor_t);
     AMDHSA_BITS_SET(kd.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT, 31);
-    AMDHSA_BITS_SET(kd.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT, 12);
+    AMDHSA_BITS_SET(kd.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT,
+                    granulated_sgpr_count);
     AMDHSA_BITS_SET(kd.compute_pgm_rsrc2, COMPUTE_PGM_RSRC2_USER_SGPR_COUNT, 2);
     mem->load_image(reinterpret_cast<const uint8_t *>(&kd), sizeof(kd), addr);
     mem->load_image(reinterpret_cast<const uint8_t *>(code), num_words * 4,
@@ -884,15 +911,15 @@ struct PluginFixture {
   }
 
   void run_kernel(const uint32_t *code, size_t num_words, uint32_t grid = 64,
-                  uint32_t workgroup = 64) {
-    uint64_t ko = write_kernel(0x1000, code, num_words);
+                  uint32_t workgroup = 64, uint32_t granulated_sgpr_count = 12) {
+    uint64_t ko = write_kernel(0x1000, code, num_words, granulated_sgpr_count);
     test::AqlQueue queue(mem, cp());
     queue.dispatch(ko, grid, workgroup);
     run_until_idle();
   }
 };
 
-TEST(ExecutionPluginTest, SgprBlockOwnersTrackDispatchAndSlotReuseAcrossTargets) {
+TEST(ExecutionPluginTest, SgprBlockOwnersTrackPhysicalAllocationAndSlotReuseAcrossTargets) {
   struct TargetCase {
     std::string_view arch;
     uint32_t wave_size;
@@ -925,9 +952,7 @@ TEST(ExecutionPluginTest, SgprBlockOwnersTrackDispatchAndSlotReuseAcrossTargets)
 
     expect_owner(*first, first->sgpr_alloc().base + first_sgpr_count - 1);
     expect_owner(*second, second->sgpr_alloc().base);
-    plugin->events.clear();
-    EXPECT_EQ(f.cu()->read_sgpr(first->sgpr_alloc().base + first_sgpr_count), 0u);
-    EXPECT_TRUE(plugin->events.empty());
+    expect_owner(*first, first->sgpr_alloc().base + first_sgpr_count);
 
     const uint32_t reused_base = first->sgpr_alloc().base;
     const uint32_t reused_slot = first->wf_id();
@@ -1427,6 +1452,8 @@ TEST(ExecutionPluginTest, SgprReadOptOutSkipsComputeUnitCallback) {
   ASSERT_NE(wf, nullptr);
   f.cu()->write_sgpr(wf->sgpr_alloc().base, 0x12345678u);
   EXPECT_EQ(f.cu()->read_sgpr(wf->sgpr_alloc().base), 0x12345678u);
+  EXPECT_EQ(RegisterAccess(*wf).read_sgpr(wf->sgpr_alloc().base), 0x12345678u);
+  static_cast<void>(RegisterAccess(*wf).read_ttmp(0));
   EXPECT_EQ(plugin_ptr->callbacks, 0u);
 }
 
@@ -2370,6 +2397,37 @@ TEST(ExecutionPluginTest, SdwaVop2ScalarSelectorsUseSgprs) {
   run(true);
 }
 
+TEST(ExecutionPluginTest, SgprWriteObservationUsesExplicitWavePhysicalBlock) {
+  PluginFixture f(/*num_wf_slots=*/1);
+  auto *plugin = f.attach_ordering_plugin();
+  auto *cu = f.cu();
+  constexpr uint32_t kRequestedSgprs = 40;
+  constexpr uint32_t kCompilerTemporary = 40;
+  auto *wf = cu->dispatch_wf(0, 0, kRequestedSgprs, /*vgprs=*/256);
+  ASSERT_NE(wf, nullptr);
+
+  // s_mov_b32 s40, 1. The descriptor requests s0..s39, but the physical
+  // 104-register wave block includes compiler/ABI temporary s40.
+  constexpr uint32_t kMovTemporary = 0xBEA80081u;
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  auto decoded = decoder->decode(&kMovTemporary);
+  ASSERT_TRUE(decoded.succeeded());
+  std::unique_ptr<Instruction> inst = std::move(decoded).value();
+  ASSERT_NE(inst, nullptr);
+
+  plugin->events.clear();
+  cu->execute_instruction(inst.get(), *wf);
+
+  std::vector<HookEvent> writes;
+  for (const HookEvent &event : plugin->events)
+    if (event.kind == HookEvent::WRITE_SGPR)
+      writes.push_back(event);
+  ASSERT_EQ(writes.size(), 1u);
+  EXPECT_EQ(writes[0].physical_reg, wf->sgpr_alloc().base + kCompilerTemporary);
+  EXPECT_EQ(writes[0].wf_id, wf->wf_id());
+  EXPECT_EQ(cu->read_sgpr_storage(writes[0].physical_reg), 1u);
+}
+
 // SDWA observation tests cover byte, word, and dword source selectors plus
 // preserve, pad, sign-extension, and clamp behavior.
 // Selected source bytes must be the only bytes read. Preserved destination
@@ -2619,6 +2677,127 @@ TEST(ExecutionPluginTest, MemoryPipelineCompletionDoesNotObserveInstructionWrite
   EXPECT_EQ(cu->read_vgpr_storage(wf->vgpr_alloc().base + kDst, 0), kLoadedValue);
 }
 
+TEST(ExecutionPluginTest, MemoryPipelineCompletionDoesNotCrossWaveVgprBlock) {
+  constexpr uint32_t kVgprsPerWave = 16;
+  PluginFixture f(/*num_wf_slots=*/2, /*arch=*/"rdna4", /*wavefront_size=*/32,
+                  /*sgprs_per_wf=*/128, kVgprsPerWave);
+  auto *cu = f.cu();
+  auto *wf = cu->dispatch_wf(0, 0, /*sgprs=*/128, kVgprsPerWave, 32);
+  auto *adjacent = cu->dispatch_wf(1, 0, /*sgprs=*/128, kVgprsPerWave, 32);
+  ASSERT_NE(wf, nullptr);
+  ASSERT_NE(adjacent, nullptr);
+  ASSERT_EQ(adjacent->vgpr_alloc().base, wf->vgpr_alloc().base + kVgprsPerWave);
+
+  constexpr uint64_t kAddress = 0x8100;
+  constexpr std::array<uint32_t, 2> kLoaded = {0x11112222u, 0x33334444u};
+  constexpr uint32_t kLastSentinel = 0xA5A5A5A5u;
+  constexpr uint32_t kAdjacentSentinel = 0x5A5A5A5Au;
+  f.mem->load_image(reinterpret_cast<const uint8_t *>(kLoaded.data()), sizeof(kLoaded), kAddress);
+  cu->write_vgpr(wf->vgpr_alloc().base + kVgprsPerWave - 1, 0, kLastSentinel);
+  cu->write_vgpr(adjacent->vgpr_alloc().base, 0, kAdjacentSentinel);
+
+  auto state = std::make_unique<VectorMemState>(GLOBAL_MEM);
+  state->elem_size = sizeof(uint32_t);
+  state->num_elems = 2;
+  state->is_load = true;
+  state->wf_size = wf->wf_size();
+  state->exec_mask = 1;
+  state->lane_mask = 1;
+  state->dst_reg_base = wf->vgpr_alloc().base + kVgprsPerWave - 1;
+  state->per_lane_addr[0] = kAddress;
+
+  GlobalMemPipeline pipeline(&cu->l1_vector(), cu->l2());
+  pipeline.issue(new TestMemoryInstruction(std::move(state)), *wf);
+
+  EXPECT_EQ(cu->read_vgpr_storage(wf->vgpr_alloc().base + kVgprsPerWave - 1, 0), kLastSentinel);
+  EXPECT_EQ(cu->read_vgpr_storage(adjacent->vgpr_alloc().base, 0), kAdjacentSentinel);
+}
+
+TEST(ExecutionPluginTest, ScalarMemoryCompletionDoesNotObserveInstructionWrite) {
+  PluginFixture f(/*num_wf_slots=*/1);
+  auto *plugin = f.attach_ordering_plugin();
+  auto *cu = f.cu();
+  auto *wf = cu->dispatch_wf(0, 0, /*sgprs=*/104, /*vgprs=*/256);
+  ASSERT_NE(wf, nullptr);
+
+  constexpr uint64_t kAddress = 0x8200;
+  constexpr uint32_t kLoadedValue = 0x12345678u;
+  constexpr uint32_t kDst = 3;
+  f.mem->load_image(reinterpret_cast<const uint8_t *>(&kLoadedValue), sizeof(kLoadedValue),
+                    kAddress);
+
+  auto state = std::make_unique<ScalarMemState>();
+  state->addr = kAddress;
+  state->dst_register = {ScalarRegisterStorage::SGPR, kDst, 1};
+  state->num_dwords = 1;
+  state->is_load = true;
+
+  plugin->events.clear();
+  TestScalarMemPipeline pipeline(&cu->l1_scalar());
+  pipeline.issue(new TestMemoryInstruction(std::move(state)), *wf);
+
+  EXPECT_EQ(cu->read_sgpr_storage(wf->sgpr_alloc().base + kDst), kLoadedValue);
+  EXPECT_TRUE(
+      std::none_of(plugin->events.begin(), plugin->events.end(),
+                   [](const HookEvent &event) { return event.kind == HookEvent::WRITE_SGPR; }));
+
+  constexpr uint64_t kTtmpAddress = 0x8300;
+  constexpr uint32_t kTtmpValue = 0xAABBCCDDu;
+  f.mem->load_image(reinterpret_cast<const uint8_t *>(&kTtmpValue), sizeof(kTtmpValue),
+                    kTtmpAddress);
+  auto ttmp_state = std::make_unique<ScalarMemState>();
+  ttmp_state->addr = kTtmpAddress;
+  ttmp_state->dst_register = {ScalarRegisterStorage::TTMP, 0, 1};
+  ttmp_state->num_dwords = 1;
+  ttmp_state->is_load = true;
+  pipeline.issue(new TestMemoryInstruction(std::move(ttmp_state)), *wf);
+
+  EXPECT_EQ(wf->ttmp(0), kTtmpValue);
+
+  constexpr uint64_t kVccAddress = 0x8400;
+  constexpr uint32_t kVccValue = 0x55667788u;
+  f.mem->load_image(reinterpret_cast<const uint8_t *>(&kVccValue), sizeof(kVccValue), kVccAddress);
+  wf->set_vcc_raw(0xAABBCCDD00000000ull);
+  auto vcc_state = std::make_unique<ScalarMemState>();
+  vcc_state->addr = kVccAddress;
+  vcc_state->dst_register = {ScalarRegisterStorage::VCC, 0, 1};
+  vcc_state->num_dwords = 1;
+  vcc_state->is_load = true;
+  pipeline.issue(new TestMemoryInstruction(std::move(vcc_state)), *wf);
+
+  EXPECT_EQ(wf->vcc(), 0xAABBCCDD55667788ull);
+  EXPECT_TRUE(
+      std::none_of(plugin->events.begin(), plugin->events.end(),
+                   [](const HookEvent &event) { return event.kind == HookEvent::WRITE_SGPR; }));
+}
+
+TEST(ExecutionPluginTest, ScalarMemoryRejectsDestinationThatCrossesTtmpFile) {
+  PluginFixture f(/*num_wf_slots=*/2);
+  auto *cu = f.cu();
+  auto *wf = cu->dispatch_wf(0, 0, /*sgprs=*/104, /*vgprs=*/256);
+  auto *adjacent = cu->dispatch_wf(1, 0, /*sgprs=*/104, /*vgprs=*/256);
+  ASSERT_NE(wf, nullptr);
+  ASSERT_NE(adjacent, nullptr);
+
+  constexpr uint32_t kAdjacentOffset = 20;
+  constexpr uint32_t kSentinel = 0xA5A5A5A5u;
+  cu->write_sgpr(adjacent->sgpr_alloc().base + kAdjacentOffset, kSentinel);
+  cu->write_sgpr(wf->sgpr_alloc().base, 0x8000u);
+  cu->write_sgpr(wf->sgpr_alloc().base + 1, 0u);
+
+  const auto words = cdna4::build_smem(cdna4::kSLoadDwordx2Smem,
+                                       {.sbase = 0, .sdata = amdgpu::kTtmpSelectorLast, .imm = 1});
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> load(decode_valid(*decoder, words.data()));
+  ASSERT_NE(load, nullptr);
+
+  cu->execute_instruction(load.get(), *wf);
+
+  EXPECT_EQ(load->data(), nullptr);
+  EXPECT_EQ(cu->read_sgpr_storage(adjacent->sgpr_alloc().base + kAdjacentOffset), kSentinel);
+}
+
 TEST(ExecutionPluginTest, MemoryPipelinesSnapshotDispatchIdentityAtIssue) {
   PluginFixture f(/*num_wf_slots=*/4);
   auto *cu = f.cu();
@@ -2732,6 +2911,153 @@ TEST(RaceDetectorPluginTest, D16LoadTracksFullDwordWhenSramEccEnabled) {
   EXPECT_TRUE(opposite_half_read_reports_race("cdna4", /*wavefront_size=*/64));
   EXPECT_TRUE(opposite_half_read_reports_race("cdna5", /*wavefront_size=*/32));
   EXPECT_FALSE(opposite_half_read_reports_race("rdna4", /*wavefront_size=*/32));
+}
+
+TEST(RaceDetectorPluginTest, ScalarLoadToTtmpReportsReadBeforeWait) {
+  PluginFixture f(/*num_wf_slots=*/1);
+  PluginSinkConfig sink_config;
+  StringSink &sink = sink_config.emplace<StringSink>();
+  f.plugin_group_ = std::make_shared<ExecutionPluginGroup>(std::move(sink_config));
+  ASSERT_TRUE(f.plugin_group_->add(std::make_unique<RaceDetectorPlugin>()));
+  f.soc->set_plugin_group(f.plugin_group_);
+  f.plugin_group_->onInit();
+
+  auto *cu = f.cu();
+  auto *wf = cu->dispatch_wf(/*wg_id=*/0, /*pc=*/0, /*sgprs=*/104, /*vgprs=*/256);
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(1u);
+  std::array<amdgpu::Wavefront *, 1> waves{wf};
+  f.plugin_group_->onAmdgpuWorkgroupDispatched(
+      /*dispatch_id=*/1, /*wg_id=*/0, /*physical_vgpr_count=*/256,
+      /*physical_sgpr_count=*/104, waves);
+
+  constexpr uint32_t kTtmp0Selector = amdgpu::kTtmpSelectorFirst;
+  const auto words =
+      cdna4::build_smem(cdna4::kSLoadDwordSmem, {.sbase = 0, .sdata = kTtmp0Selector, .imm = 1});
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> load(decode_valid(*decoder, words.data()));
+  ASSERT_NE(load, nullptr);
+  ASSERT_NE(load->dst_operand(0), nullptr);
+  EXPECT_EQ(load->dst_operand(0)->to_register_ref(), (RegisterRef{RegClass::TTMP, 0, 1}));
+
+  cu->write_sgpr(wf->sgpr_alloc().base, 0x1000u);
+  cu->write_sgpr(wf->sgpr_alloc().base + 1, 0u);
+  cu->execute_instruction(load.get(), *wf);
+  ASSERT_NE(load->data(), nullptr);
+  f.plugin_group_->onAmdgpuRouteMemoryInstruction(*load, *wf);
+
+  static_cast<void>(RegisterAccess(*wf).read_scalar(*load->dst_operand(0)));
+  EXPECT_NE(sink.str().find("type=TTMP"), std::string::npos);
+}
+
+TEST(RaceDetectorPluginTest, ScalarLoadToTtmpHonorsSplitKmcntWait) {
+  PluginFixture f(/*num_wf_slots=*/1, /*arch=*/"rdna4", /*wavefront_size=*/32,
+                  /*sgprs_per_wf=*/128);
+  PluginSinkConfig sink_config;
+  StringSink &sink = sink_config.emplace<StringSink>();
+  f.plugin_group_ = std::make_shared<ExecutionPluginGroup>(std::move(sink_config));
+  ASSERT_TRUE(f.plugin_group_->add(std::make_unique<RaceDetectorPlugin>()));
+  f.soc->set_plugin_group(f.plugin_group_);
+  f.plugin_group_->onInit();
+
+  auto *cu = f.cu();
+  auto *wf = cu->dispatch_wf(/*wg_id=*/0, /*pc=*/0, /*sgprs=*/128, /*vgprs=*/256, 32);
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(1u);
+  std::array<amdgpu::Wavefront *, 1> waves{wf};
+  f.plugin_group_->onAmdgpuWorkgroupDispatched(
+      /*dispatch_id=*/1, /*wg_id=*/0, /*physical_vgpr_count=*/256,
+      /*physical_sgpr_count=*/128, waves);
+
+  auto state = std::make_unique<ScalarMemState>();
+  state->dst_register = {ScalarRegisterStorage::TTMP, 0, 1};
+  state->is_load = true;
+  state->wait_counter_type = WaitCounterType::KMCNT;
+  TestMemoryInstruction load(std::move(state));
+  f.plugin_group_->onAmdgpuRouteMemoryInstruction(load, *wf);
+
+  wf->set_wait_target_kmcnt(0);
+  TestWaitcntInstruction wait("s_wait_kmcnt");
+  f.plugin_group_->onAmdgpuAfterExecuteInstruction(/*pc=*/4, wait, *wf);
+  static_cast<void>(RegisterAccess(*wf).read_ttmp(0));
+  EXPECT_EQ(sink.str().find("RACE "), std::string::npos);
+}
+
+TEST(RaceDetectorPluginTest, NamedVmcntWaitRetiresMonolithicAndSplitLoadEvents) {
+  auto run = [](WaitCounterType event_counter) {
+    PluginFixture f(/*num_wf_slots=*/1, /*arch=*/"rdna3", /*wavefront_size=*/32,
+                    /*sgprs_per_wf=*/128);
+    PluginSinkConfig sink_config;
+    StringSink &sink = sink_config.emplace<StringSink>();
+    f.plugin_group_ = std::make_shared<ExecutionPluginGroup>(std::move(sink_config));
+    EXPECT_TRUE(f.plugin_group_->add(std::make_unique<RaceDetectorPlugin>()));
+    f.soc->set_plugin_group(f.plugin_group_);
+    f.plugin_group_->onInit();
+
+    auto *cu = f.cu();
+    auto *wf = cu->dispatch_wf(/*wg_id=*/0, /*pc=*/0, /*sgprs=*/128, /*vgprs=*/256, 32);
+    EXPECT_NE(wf, nullptr);
+    if (!wf)
+      return false;
+    wf->set_exec(1u);
+    std::array<amdgpu::Wavefront *, 1> waves{wf};
+    f.plugin_group_->onAmdgpuWorkgroupDispatched(
+        /*dispatch_id=*/1, /*wg_id=*/0, /*physical_vgpr_count=*/256,
+        /*physical_sgpr_count=*/128, waves);
+
+    auto state = std::make_unique<VectorMemState>(GLOBAL_MEM);
+    state->is_load = true;
+    state->num_elems = 1;
+    state->dst_reg_base = wf->vgpr_alloc().base;
+    state->exec_mask = 1;
+    state->wait_counter_type = event_counter;
+    TestMemoryInstruction load(std::move(state));
+    f.plugin_group_->onAmdgpuRouteMemoryInstruction(load, *wf);
+
+    wf->set_wait_target_loadcnt(0);
+    TestWaitcntInstruction wait("s_waitcnt_vmcnt");
+    f.plugin_group_->onAmdgpuAfterExecuteInstruction(/*pc=*/4, wait, *wf);
+    f.plugin_group_->onAmdgpuReadVgprLanes(wf, wf->vgpr_alloc().base, /*lane_mask=*/1);
+    return sink.str().find("RACE ") == std::string::npos;
+  };
+
+  EXPECT_TRUE(run(WaitCounterType::VMCNT));
+  EXPECT_TRUE(run(WaitCounterType::LOADCNT));
+}
+
+TEST(RaceDetectorPluginTest, NamedLgkmcntWaitRetiresSplitScalarEvent) {
+  PluginFixture f(/*num_wf_slots=*/1, /*arch=*/"rdna3", /*wavefront_size=*/32,
+                  /*sgprs_per_wf=*/128);
+  PluginSinkConfig sink_config;
+  StringSink &sink = sink_config.emplace<StringSink>();
+  f.plugin_group_ = std::make_shared<ExecutionPluginGroup>(std::move(sink_config));
+  ASSERT_TRUE(f.plugin_group_->add(std::make_unique<RaceDetectorPlugin>()));
+  f.soc->set_plugin_group(f.plugin_group_);
+  f.plugin_group_->onInit();
+
+  auto *cu = f.cu();
+  auto *wf = cu->dispatch_wf(/*wg_id=*/0, /*pc=*/0, /*sgprs=*/128, /*vgprs=*/256, 32);
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(1u);
+  std::array<amdgpu::Wavefront *, 1> waves{wf};
+  f.plugin_group_->onAmdgpuWorkgroupDispatched(
+      /*dispatch_id=*/1, /*wg_id=*/0, /*physical_vgpr_count=*/256,
+      /*physical_sgpr_count=*/128, waves);
+
+  auto state = std::make_unique<ScalarMemState>();
+  state->dst_register = {ScalarRegisterStorage::TTMP, 0, 1};
+  state->is_load = true;
+  state->wait_counter_type = WaitCounterType::KMCNT;
+  TestMemoryInstruction load(std::move(state));
+  f.plugin_group_->onAmdgpuRouteMemoryInstruction(load, *wf);
+
+  const auto current_wait = wf->wait_target();
+  wf->set_wait_target(current_wait.vmcnt, 0, current_wait.expcnt);
+  TestWaitcntInstruction wait("s_waitcnt_lgkmcnt");
+  f.plugin_group_->onAmdgpuAfterExecuteInstruction(/*pc=*/4, wait, *wf);
+  static_cast<void>(RegisterAccess(*wf).read_ttmp(0));
+  EXPECT_EQ(sink.str().find("RACE "), std::string::npos);
 }
 
 TEST(ExecutionPluginTest, F64SourceReadObservationReportsBothHalves) {
@@ -3075,8 +3401,8 @@ TEST(ExecutionPluginTest, MfmaReadObservationReportsRace) {
   ASSERT_EQ(wf->wf_size(), 64u);
   std::array<amdgpu::Wavefront *, 1> waves{wf};
   f.plugin_group_->onAmdgpuWorkgroupDispatched(/*dispatch_id=*/1, /*wg_id=*/0,
-                                               /*physical_vgpr_count=*/256, /*sgpr_count=*/104,
-                                               waves);
+                                               /*physical_vgpr_count=*/256,
+                                               /*physical_sgpr_count=*/104, waves);
 
   const uint32_t vb = wf->vgpr_alloc().base;
   constexpr uint32_t S0 = 0;
@@ -3151,8 +3477,8 @@ TEST(ExecutionPluginTest, MfmaFastPathReadHookReportsRace) {
     ASSERT_EQ(wf->wf_size(), 64u);
     std::array<amdgpu::Wavefront *, 1> waves{wf};
     f.plugin_group_->onAmdgpuWorkgroupDispatched(/*dispatch_id=*/1, /*wg_id=*/0,
-                                                 /*physical_vgpr_count=*/256, /*sgpr_count=*/104,
-                                                 waves);
+                                                 /*physical_vgpr_count=*/256,
+                                                 /*physical_sgpr_count=*/104, waves);
 
     const uint32_t vb = wf->vgpr_alloc().base;
     constexpr uint32_t S0 = 0, S1 = 16, ACC = 32, DST = 48;
@@ -3269,11 +3595,12 @@ TEST(HookOrderingTest, BarrierTwoWaves) {
   ASSERT_EQ(p->events.back().kind, HookEvent::SHUTDOWN);
 }
 
-TEST(HookOrderingTest, WorkgroupDispatchedReportsPhysicalVgprBlockSize) {
+TEST(HookOrderingTest, WorkgroupDispatchedReportsPhysicalRegisterBlockSizes) {
   PluginFixture f;
   auto *p = f.attach_ordering_plugin();
   const uint32_t code[] = {S_ENDPGM};
-  f.run_kernel(code, 1);
+  constexpr uint32_t kGranulatedSgprCount = 3; // Requests 32 SGPRs on CDNA4.
+  f.run_kernel(code, 1, /*grid=*/64, /*workgroup=*/64, kGranulatedSgprCount);
   f.shutdown();
 
   auto it = std::find_if(p->events.begin(), p->events.end(), [](const HookEvent &e) {
@@ -3282,7 +3609,8 @@ TEST(HookOrderingTest, WorkgroupDispatchedReportsPhysicalVgprBlockSize) {
   ASSERT_NE(it, p->events.end());
   EXPECT_EQ(it->physical_vgpr_count, f.cu()->vgpr_allocation_block_size());
   EXPECT_GT(it->physical_vgpr_count, f.cu()->config().vgprs_per_wf);
-  EXPECT_EQ(it->sgpr_count, f.cu()->config().sgprs_per_wf);
+  EXPECT_EQ(it->physical_sgpr_count, f.cu()->sgpr_allocation_block_size());
+  EXPECT_GT(it->physical_sgpr_count, 32u);
 }
 
 // The immediate-halt branch frees a wave's registers the instant s_endpgm

--- a/emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
+++ b/emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
@@ -327,7 +327,13 @@ public:
     read_registers.push_back(physical_reg);
   }
 
+  void onAmdgpuWriteVgprLanes(const amdgpu::Wavefront *, uint32_t physical_reg, uint64_t,
+                              uint8_t) override {
+    write_registers.push_back(physical_reg);
+  }
+
   std::vector<uint32_t> read_registers;
+  std::vector<uint32_t> write_registers;
 };
 
 /// @brief Check if a mnemonic should be skipped in the execution harness.
@@ -6853,6 +6859,150 @@ TEST(Gfx1250CvtScaleTest, UnpackUsesSelectedE8M0ScaleByte) {
   cu->execute_instruction(pk16_inst.get(), *wf);
   for (uint32_t i = 18; i <= 33; ++i)
     EXPECT_EQ(cu->read_vgpr(vb + i, 0), std::bit_cast<uint32_t>(2.0f)) << "vgpr=" << i;
+
+  if (!wf->is_halted())
+    wf->halt();
+}
+
+TEST(Gfx1250CvtScaleTest, WideUnpackRejectsDestinationRangeBeforeWriting) {
+  amdgpu::GpuMemory gpu_mem("gfx1250_cvt_scale_boundary_mem");
+  amdgpu::L2Cache l2("gfx1250_cvt_scale_boundary_l2");
+
+  amdgpu::ComputeUnitCore::Config cfg{};
+  cfg.arch = ROCJITSU_CODE_ARCH_CDNA5;
+  cfg.num_wf_slots = 1;
+  cfg.sgprs_per_wf = 106;
+  cfg.vgprs_per_wf = 1024;
+  cfg.lds_size_kb = 64;
+
+  auto cu = amdgpu::ComputeUnitCore::create("gfx1250", cfg, &gpu_mem, &l2);
+  ASSERT_NE(cu, nullptr);
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA5);
+  ASSERT_NE(decoder, nullptr);
+  auto *wf = cu->dispatch_wf(0, 0, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(1);
+  wf->set_vgpr_msb_mode(0xC0u); // Destination bank 3.
+
+  const uint32_t vb = wf->vgpr_alloc().base;
+  cu->write_vgpr(vb + 0, 0, 0x08208208u);
+  cu->write_vgpr(vb + 1, 0, 0x82082082u);
+  cu->write_vgpr(vb + 2, 0, 0x20820820u);
+  cu->write_vgpr(vb + 10, 0, std::bit_cast<uint32_t>(1.0f));
+
+  constexpr uint32_t kDestinationBase = 3 * 256 + 250;
+  constexpr uint32_t kSentinel = 0xA5A5A5A5u;
+  for (uint32_t reg = kDestinationBase; reg < cfg.vgprs_per_wf; ++reg)
+    cu->write_vgpr(vb + reg, 0, kSentinel);
+
+  // v_cvt_scale_pk16_f32_fp6 v[1018:1033], v[0:2], v10 scale_sel:1.
+  // The complete 16-register destination does not fit in this wave.
+  const uint32_t words[] = {0xD6C908FAU, 0x02021500U};
+  auto decoded = decoder->decode(words);
+  ASSERT_TRUE(decoded.succeeded());
+  std::unique_ptr<Instruction> inst = std::move(decoded).value();
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(std::string_view(inst->mnemonic()), "v_cvt_scale_pk16_f32_fp6");
+  cu->execute_instruction(inst.get(), *wf);
+
+  for (uint32_t reg = kDestinationBase; reg < cfg.vgprs_per_wf; ++reg)
+    EXPECT_EQ(cu->read_vgpr(vb + reg, 0), kSentinel) << "vgpr=" << reg;
+
+  if (!wf->is_halted())
+    wf->halt();
+}
+
+TEST(Gfx1250CvtScaleTest, WideRegionsRejectBoundariesBeforeCallbacksOrWrites) {
+  amdgpu::GpuMemory gpu_mem("gfx1250_cvt_scale_region_boundary_mem");
+  amdgpu::L2Cache l2("gfx1250_cvt_scale_region_boundary_l2");
+
+  amdgpu::ComputeUnitCore::Config cfg{};
+  cfg.arch = ROCJITSU_CODE_ARCH_CDNA5;
+  cfg.num_wf_slots = 1;
+  cfg.sgprs_per_wf = 106;
+  cfg.vgprs_per_wf = 1024;
+  cfg.lds_size_kb = 64;
+
+  auto cu = amdgpu::ComputeUnitCore::create("gfx1250", cfg, &gpu_mem, &l2);
+  ASSERT_NE(cu, nullptr);
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA5);
+  ASSERT_NE(decoder, nullptr);
+  auto *wf = cu->dispatch_wf(0, 0, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(1);
+
+  auto plugin_group = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
+  auto recorder = std::make_unique<Gfx1250VgprReadRecorder>();
+  auto *recorder_ptr = recorder.get();
+  plugin_group->add(std::move(recorder));
+  cu->set_plugin_group(plugin_group);
+
+  const uint32_t vb = wf->vgpr_alloc().base;
+  constexpr uint32_t kSentinel = 0xA5A5A5A5u;
+  cu->write_vgpr(vb + 10, 0, std::bit_cast<uint32_t>(1.0f));
+
+  // Unpack source v[1022:1024] does not fit. The valid destination must remain
+  // untouched instead of consuming zero/foreign source words.
+  wf->set_vgpr_msb_mode(0x03u); // Source 0 bank 3.
+  for (uint32_t reg = 20; reg < 36; ++reg)
+    cu->write_vgpr(vb + reg, 0, kSentinel);
+  const auto unpack_words = cdna5::build_vop3(
+      cdna5::kVCvtScalePk16F32Fp6Vop3, {.vdst = 20, .src0 = vgpr_src(254), .src1 = vgpr_src(10)});
+  auto decoded_unpack = decoder->decode(unpack_words.data());
+  ASSERT_TRUE(decoded_unpack.succeeded());
+  std::unique_ptr<Instruction> unpack = std::move(decoded_unpack).value();
+  ASSERT_NE(unpack, nullptr);
+  ASSERT_EQ(std::string_view(unpack->mnemonic()), "v_cvt_scale_pk16_f32_fp6");
+  recorder_ptr->read_registers.clear();
+  recorder_ptr->write_registers.clear();
+  cu->execute_instruction(unpack.get(), *wf);
+  for (uint32_t reg = 20; reg < 36; ++reg)
+    EXPECT_EQ(cu->read_vgpr_storage(vb + reg, 0), kSentinel) << "unpack dst vgpr=" << reg;
+  EXPECT_TRUE(recorder_ptr->read_registers.empty());
+  EXPECT_TRUE(recorder_ptr->write_registers.empty());
+
+  // Pack source v[1018:1033] does not fit. Its valid three-register
+  // destination must remain untouched.
+  wf->set_vgpr_msb_mode(0x03u); // Source 0 bank 3.
+  for (uint32_t reg = 40; reg < 43; ++reg)
+    cu->write_vgpr(vb + reg, 0, kSentinel);
+  const auto pack_source_words =
+      cdna5::build_vop3(cdna5::kVCvtScalef32Pk16Fp6F32Vop3,
+                        {.vdst = 40, .src0 = vgpr_src(250), .src1 = vgpr_src(10)});
+  auto decoded_pack_source = decoder->decode(pack_source_words.data());
+  ASSERT_TRUE(decoded_pack_source.succeeded());
+  std::unique_ptr<Instruction> pack_source = std::move(decoded_pack_source).value();
+  ASSERT_NE(pack_source, nullptr);
+  ASSERT_EQ(std::string_view(pack_source->mnemonic()), "v_cvt_scalef32_pk16_fp6_f32");
+  recorder_ptr->read_registers.clear();
+  recorder_ptr->write_registers.clear();
+  cu->execute_instruction(pack_source.get(), *wf);
+  for (uint32_t reg = 40; reg < 43; ++reg)
+    EXPECT_EQ(cu->read_vgpr_storage(vb + reg, 0), kSentinel) << "pack source dst vgpr=" << reg;
+  EXPECT_TRUE(recorder_ptr->read_registers.empty());
+  EXPECT_TRUE(recorder_ptr->write_registers.empty());
+
+  // Pack destination v[1022:1024] does not fit. The in-range portion must not
+  // be modified.
+  wf->set_vgpr_msb_mode(0xC0u); // Destination bank 3.
+  for (uint32_t reg = 0; reg < 16; ++reg)
+    cu->write_vgpr(vb + reg, 0, std::bit_cast<uint32_t>(1.0f));
+  cu->write_vgpr(vb + 1022, 0, kSentinel);
+  cu->write_vgpr(vb + 1023, 0, kSentinel);
+  const auto pack_destination_words = cdna5::build_vop3(
+      cdna5::kVCvtScalef32Pk16Fp6F32Vop3, {.vdst = 254, .src0 = vgpr_src(0), .src1 = vgpr_src(10)});
+  auto decoded_pack_destination = decoder->decode(pack_destination_words.data());
+  ASSERT_TRUE(decoded_pack_destination.succeeded());
+  std::unique_ptr<Instruction> pack_destination = std::move(decoded_pack_destination).value();
+  ASSERT_NE(pack_destination, nullptr);
+  ASSERT_EQ(std::string_view(pack_destination->mnemonic()), "v_cvt_scalef32_pk16_fp6_f32");
+  recorder_ptr->read_registers.clear();
+  recorder_ptr->write_registers.clear();
+  cu->execute_instruction(pack_destination.get(), *wf);
+  EXPECT_EQ(cu->read_vgpr_storage(vb + 1022, 0), kSentinel);
+  EXPECT_EQ(cu->read_vgpr_storage(vb + 1023, 0), kSentinel);
+  EXPECT_TRUE(recorder_ptr->read_registers.empty());
+  EXPECT_TRUE(recorder_ptr->write_registers.empty());
 
   if (!wf->is_halted())
     wf->halt();

--- a/emulation/rocjitsu/tests/kernels/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/kernels/CMakeLists.txt
@@ -183,6 +183,11 @@ set(HAS_GFX1250_DBT_FIXTURE FALSE)
 set(RJ_GFX1250_DBT_FIXTURE_TARGET)
 if(CLANG_OFFLOAD_BUNDLER)
     rj_add_probe_object(rj_nop_probe gfx90a OUTPUT_NAME rj_nop_probe_gfx90a)
+    rj_add_probe_object(
+        callable_sgpr_probe
+        gfx950
+        OUTPUT_NAME callable_sgpr_probe_gfx950
+    )
     set(HAS_PROBE_FIXTURES TRUE)
 
     # The narrow gfx1250 DBT library accepts a raw AMDGPU code object rather
@@ -205,7 +210,9 @@ if(CLANG_OFFLOAD_BUNDLER)
     # only when the offload bundler is available.
     if(RJ_INSTALL_TESTS)
         install(
-            FILES ${KERNEL_OUTPUT_DIR}/rj_nop_probe_gfx90a.hsaco
+            FILES
+                ${KERNEL_OUTPUT_DIR}/rj_nop_probe_gfx90a.hsaco
+                ${KERNEL_OUTPUT_DIR}/callable_sgpr_probe_gfx950.hsaco
             DESTINATION ${CMAKE_INSTALL_DATADIR}/rocjitsu/tests/kernels
         )
         if(HAS_GFX1250_DBT_FIXTURE)

--- a/emulation/rocjitsu/tests/kernels/callable_sgpr_probe.hip
+++ b/emulation/rocjitsu/tests/kernels/callable_sgpr_probe.hip
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+// Compiler-backed evidence for wave-owned SGPR observation.
+//
+// The kernel descriptor describes the entry kernel's register use, while the
+// separately callable device function deliberately uses s40. On gfx950, the
+// resulting kernel descriptor grants s0..s39, but the callee contains
+// `s_mov_b32 s40, 1`. This pins the instrumentation scenario in which a
+// callable can name a register beyond the entry descriptor. It motivates
+// keeping observation attribution inside the wave's simulator storage block;
+// it does not claim that the out-of-descriptor access is valid on hardware.
+
+extern "C" __device__ __attribute__((noinline, used, visibility("default"))) void
+callable_sgpr_probe() {
+  asm volatile("s_mov_b32 s40, 1" ::: "memory");
+}
+
+extern "C" __global__ void kernel_calls_s40() { callable_sgpr_probe(); }

--- a/emulation/rocjitsu/tests/race-detector/race_detector_event_registry_test.cpp
+++ b/emulation/rocjitsu/tests/race-detector/race_detector_event_registry_test.cpp
@@ -37,7 +37,9 @@ TEST(RaceDetector, EventRegistry_TrimmedWaveLocalEventsAreNotBarrierQueued) {
   for (int i = 0; i < N; ++i) {
     wave.registerEvent(/*pc=*/static_cast<uint64_t>(i), MemoryEventType::GLOBAL_TO_VGPR,
                        std::vector<uint32_t>{0}, /*execMask=*/1);
-    wave.dispatch(PendingWaitCount{/*vmcnt=*/0, /*lgkmcnt=*/-1});
+    PendingWaitCount wait;
+    wait.add(rocjitsu::amdgpu::WaitCounterType::VMCNT, 0);
+    wave.dispatch(wait);
   }
 
   EXPECT_GT(detector.events().trimmedCount(), 0);

--- a/emulation/rocjitsu/tests/race-detector/race_detector_tests.cpp
+++ b/emulation/rocjitsu/tests/race-detector/race_detector_tests.cpp
@@ -77,13 +77,153 @@ TEST(RaceDetector, Sgpr_WithWaitcnt) {
 
 TEST(RaceDetector, Sgpr_PartialWaitcnt) {
   RaceTestBuilder b(/*numWaves=*/1, /*vgprs=*/8, /*sgprs=*/8);
-  b.scalarLoad(/*wave=*/0, /*sgprBase=*/4, /*numRegs=*/1); // oldest
-  b.scalarLoad(/*wave=*/0, /*sgprBase=*/5, /*numRegs=*/1); // newest
-  b.waitcnt(/*wave=*/0, /*vmcnt=*/-1, /*lgkmcnt=*/1);      // drain oldest (s4)
-  b.checkSgprRead(/*wave=*/0, /*reg=*/4);                  // safe
-  EXPECT_FALSE(b.hasSgprRace(4));
-  b.checkSgprRead(/*wave=*/0, /*reg=*/5); // RACE
+  b.scalarLoad(/*wave=*/0, /*sgprBase=*/4, /*numRegs=*/1);
+  b.scalarLoad(/*wave=*/0, /*sgprBase=*/5, /*numRegs=*/1);
+  b.waitcnt(/*wave=*/0, /*vmcnt=*/-1, /*lgkmcnt=*/1);
+
+  // Scalar-memory loads can complete out of order, so a nonzero wait does not
+  // identify either destination as complete.
+  b.checkSgprRead(/*wave=*/0, /*reg=*/4);
+  EXPECT_TRUE(b.hasSgprRace(4));
+  b.clearViolations();
+  b.checkSgprRead(/*wave=*/0, /*reg=*/5);
   EXPECT_TRUE(b.hasSgprRace(5));
+}
+
+TEST(RaceDetector, SgprAndLds_PartialCombinedWaitRetiresOnlyProvablyCompletedDs) {
+  RaceTestBuilder b(/*numWaves=*/1, /*vgprs=*/8, /*sgprs=*/8);
+  b.scalarLoad(/*wave=*/0, /*sgprBase=*/4, /*numRegs=*/1);
+  b.ldsRead(/*wave=*/0, /*lane=*/0, /*addr=*/0, /*bytes=*/4, /*vgprDst=*/2);
+  b.ldsRead(/*wave=*/0, /*lane=*/0, /*addr=*/4, /*bytes=*/4, /*vgprDst=*/3);
+  b.waitcnt(/*wave=*/0, /*vmcnt=*/-1, /*lgkmcnt=*/1);
+
+  b.checkVgprRead(/*wave=*/0, /*reg=*/2, /*lane=*/0);
+  EXPECT_FALSE(b.hasVgprRace(2));
+  b.checkVgprRead(/*wave=*/0, /*reg=*/3, /*lane=*/0);
+  EXPECT_TRUE(b.hasVgprRace(3));
+  b.clearViolations();
+  b.checkSgprRead(/*wave=*/0, /*reg=*/4);
+  EXPECT_TRUE(b.hasSgprRace(4));
+}
+
+TEST(RaceDetector, SgprAndLds_PartialCombinedWaitDoesNotOverRetireDsAtBoundary) {
+  // lgkmcnt(2) permits both DS reads to remain after the scalar load completes,
+  // so neither ordered DS destination is provably safe yet.
+  RaceTestBuilder b(/*numWaves=*/1, /*vgprs=*/8, /*sgprs=*/8);
+  b.scalarLoad(/*wave=*/0, /*sgprBase=*/4, /*numRegs=*/1);
+  b.ldsRead(/*wave=*/0, /*lane=*/0, /*addr=*/0, /*bytes=*/4, /*vgprDst=*/2);
+  b.ldsRead(/*wave=*/0, /*lane=*/0, /*addr=*/4, /*bytes=*/4, /*vgprDst=*/3);
+  b.waitcnt(/*wave=*/0, /*vmcnt=*/-1, /*lgkmcnt=*/2);
+
+  b.checkVgprRead(/*wave=*/0, /*reg=*/2, /*lane=*/0);
+  EXPECT_TRUE(b.hasVgprRace(2));
+  b.clearViolations();
+  b.checkVgprRead(/*wave=*/0, /*reg=*/3, /*lane=*/0);
+  EXPECT_TRUE(b.hasVgprRace(3));
+  b.clearViolations();
+  b.checkSgprRead(/*wave=*/0, /*reg=*/4);
+  EXPECT_TRUE(b.hasSgprRace(4));
+}
+
+TEST(RaceDetector, SgprAndLds_PartialCombinedWaitUsesDsOrderAcrossInterleaving) {
+  RaceTestBuilder b(/*numWaves=*/1, /*vgprs=*/8, /*sgprs=*/8);
+  b.ldsRead(/*wave=*/0, /*lane=*/0, /*addr=*/0, /*bytes=*/4, /*vgprDst=*/2);
+  b.scalarLoad(/*wave=*/0, /*sgprBase=*/4, /*numRegs=*/1);
+  b.ldsRead(/*wave=*/0, /*lane=*/0, /*addr=*/4, /*bytes=*/4, /*vgprDst=*/3);
+  b.waitcnt(/*wave=*/0, /*vmcnt=*/-1, /*lgkmcnt=*/1);
+
+  b.checkVgprRead(/*wave=*/0, /*reg=*/2, /*lane=*/0);
+  EXPECT_FALSE(b.hasVgprRace(2));
+  b.checkVgprRead(/*wave=*/0, /*reg=*/3, /*lane=*/0);
+  EXPECT_TRUE(b.hasVgprRace(3));
+  b.clearViolations();
+  b.checkSgprRead(/*wave=*/0, /*reg=*/4);
+  EXPECT_TRUE(b.hasSgprRace(4));
+}
+
+TEST(RaceDetector, SgprAndLds_PartialCombinedWaitDoesNotOrderDifferentDsClasses) {
+  RaceTestBuilder b(/*numWaves=*/2, /*vgprs=*/8, /*sgprs=*/8);
+  b.scalarLoad(/*wave=*/0, /*sgprBase=*/4, /*numRegs=*/1);
+  b.ldsRead(/*wave=*/0, /*lane=*/0, /*addr=*/0, /*bytes=*/4, /*vgprDst=*/2);
+  b.ldsWrite(/*wave=*/0, /*lane=*/0, /*addr=*/4, /*bytes=*/4);
+  b.waitcnt(/*wave=*/0, /*vmcnt=*/-1, /*lgkmcnt=*/1);
+
+  // The read and write may complete in either order, so neither operation is
+  // individually known to be complete even though at most one remains.
+  b.checkVgprRead(/*wave=*/0, /*reg=*/2, /*lane=*/0);
+  EXPECT_TRUE(b.hasVgprRace(2));
+  b.clearViolations();
+  b.barrier();
+  b.checkLdsRead(/*wave=*/1, /*lane=*/0, /*addr=*/4, /*bytes=*/4);
+  EXPECT_TRUE(b.hasLdsRace(4));
+}
+
+TEST(RaceDetector, SgprAndLds_PartialCombinedWaitMakesOldestDsWriteBarrierEligible) {
+  RaceTestBuilder b(/*numWaves=*/2, /*vgprs=*/8, /*sgprs=*/8);
+  b.scalarLoad(/*wave=*/0, /*sgprBase=*/4, /*numRegs=*/1);
+  b.ldsWrite(/*wave=*/0, /*lane=*/0, /*addr=*/0, /*bytes=*/4);
+  b.ldsWrite(/*wave=*/0, /*lane=*/0, /*addr=*/4, /*bytes=*/4);
+  b.waitcnt(/*wave=*/0, /*vmcnt=*/-1, /*lgkmcnt=*/1);
+  b.barrier();
+
+  b.checkLdsRead(/*wave=*/1, /*lane=*/0, /*addr=*/0, /*bytes=*/4);
+  EXPECT_FALSE(b.hasLdsRace(0));
+  b.checkLdsRead(/*wave=*/1, /*lane=*/0, /*addr=*/4, /*bytes=*/4);
+  EXPECT_TRUE(b.hasLdsRace(4));
+  b.clearViolations();
+  b.checkSgprRead(/*wave=*/0, /*reg=*/4);
+  EXPECT_TRUE(b.hasSgprRace(4));
+}
+
+TEST(RaceDetector, Ttmp_MissingWaitcnt) {
+  RaceTestBuilder b(/*numWaves=*/1, /*vgprs=*/8, /*sgprs=*/8);
+  b.ttmpLoad(/*wave=*/0, /*ttmpBase=*/2, /*numRegs=*/2);
+  b.checkTtmpRead(/*wave=*/0, /*reg=*/3);
+  EXPECT_TRUE(b.hasTtmpRace(3));
+}
+
+TEST(RaceDetector, Ttmp_WithWaitcnt) {
+  RaceTestBuilder b(/*numWaves=*/1, /*vgprs=*/8, /*sgprs=*/8);
+  b.ttmpLoad(/*wave=*/0, /*ttmpBase=*/2, /*numRegs=*/2);
+  b.waitcnt(/*wave=*/0, /*vmcnt=*/-1, /*lgkmcnt=*/0);
+  b.checkTtmpRead(/*wave=*/0, /*reg=*/3);
+  EXPECT_FALSE(b.hasRace());
+}
+
+TEST(RaceDetector, Ttmp_KmcntRetiresOnlyScalarCounterDomain) {
+  RaceTestBuilder b(/*numWaves=*/1, /*vgprs=*/8, /*sgprs=*/8);
+  b.ttmpLoad(/*wave=*/0, /*ttmpBase=*/2, /*numRegs=*/1, rocjitsu::amdgpu::WaitCounterType::KMCNT);
+  b.ldsRead(/*wave=*/0, /*lane=*/0, /*addr=*/0, /*bytes=*/4, /*vgprDst=*/3,
+            /*byteMask=*/0xF, rocjitsu::amdgpu::WaitCounterType::DSCNT);
+
+  b.waitKmcnt(/*wave=*/0, /*kmcnt=*/0);
+  b.checkTtmpRead(/*wave=*/0, /*reg=*/2);
+  EXPECT_FALSE(b.hasRace());
+
+  b.checkVgprRead(/*wave=*/0, /*reg=*/3, /*lane=*/0);
+  EXPECT_TRUE(b.hasVgprRace(3));
+}
+
+TEST(RaceDetector, Ttmp_PartialKmcntKeepsUnorderedScalarLoad) {
+  RaceTestBuilder b(/*numWaves=*/1, /*vgprs=*/8, /*sgprs=*/8);
+  b.ttmpLoad(/*wave=*/0, /*ttmpBase=*/2, /*numRegs=*/1, rocjitsu::amdgpu::WaitCounterType::KMCNT);
+  b.scalarStore(/*wave=*/0, rocjitsu::amdgpu::WaitCounterType::KMCNT);
+
+  b.waitKmcnt(/*wave=*/0, /*kmcnt=*/1);
+  b.checkTtmpRead(/*wave=*/0, /*reg=*/2);
+  EXPECT_TRUE(b.hasTtmpRace(2));
+
+  b.clearViolations();
+  b.waitKmcnt(/*wave=*/0, /*kmcnt=*/0);
+  b.checkTtmpRead(/*wave=*/0, /*reg=*/2);
+  EXPECT_FALSE(b.hasRace());
+}
+
+TEST(RaceDetector, RejectsOutOfRangeScalarLoadDestination) {
+  RaceTestBuilder b(/*numWaves=*/1, /*vgprs=*/8, /*sgprs=*/8);
+  b.ttmpLoad(/*wave=*/0, /*ttmpBase=*/15, /*numRegs=*/2);
+  b.scalarLoad(/*wave=*/0, /*sgprBase=*/7, /*numRegs=*/2);
+  EXPECT_EQ(b.events().totalAllocated(), 0);
 }
 
 // ---- LDS cross-wave races ----

--- a/emulation/rocjitsu/tests/race-detector/race_test_builder.h
+++ b/emulation/rocjitsu/tests/race-detector/race_test_builder.h
@@ -64,14 +64,29 @@ public:
                                 /*registers=*/{}, exec);
   }
 
-  /// Register a scalar load into SGPRs (tracked by lgkmcnt).
-  void scalarLoad(int wave, int sgprBase, int numRegs) {
-    std::vector<uint32_t> regs(numRegs);
-    for (int i = 0; i < numRegs; ++i) {
-      regs[i] = sgprBase + i;
-    }
-    waves_[wave]->registerEvent(pc_++, MemoryEventType::GLOBAL_TO_SGPR, std::move(regs),
-                                defaultExec_);
+  /// Register a scalar load into SGPRs with its architecture-specific counter.
+  void scalarLoad(int wave, int sgprBase, int numRegs,
+                  amdgpu::WaitCounterType waitCounterType = amdgpu::WaitCounterType::LGKMCNT) {
+    waves_[wave]->registerScalarLoad(
+        pc_++,
+        RegisterRef{RegClass::SGPR, static_cast<uint16_t>(sgprBase), static_cast<uint8_t>(numRegs)},
+        defaultExec_, waitCounterType);
+  }
+
+  /// Register a scalar load into TTMPs with its architecture-specific counter.
+  void ttmpLoad(int wave, int ttmpBase, int numRegs,
+                amdgpu::WaitCounterType waitCounterType = amdgpu::WaitCounterType::LGKMCNT) {
+    waves_[wave]->registerScalarLoad(
+        pc_++,
+        RegisterRef{RegClass::TTMP, static_cast<uint16_t>(ttmpBase), static_cast<uint8_t>(numRegs)},
+        defaultExec_, waitCounterType);
+  }
+
+  /// Register a scalar store so partial waits retain counter ordering.
+  void scalarStore(int wave,
+                   amdgpu::WaitCounterType waitCounterType = amdgpu::WaitCounterType::LGKMCNT) {
+    waves_[wave]->registerEvent(pc_++, MemoryEventType::SCALAR_TO_GLOBAL, {}, defaultExec_, 0xF,
+                                waitCounterType);
   }
 
   /// Register an LDS write and validate against outstanding reads.
@@ -87,21 +102,31 @@ public:
   /// Register an LDS read and validate against outstanding writes.
   /// byteMask: which bytes of the destination VGPR are written by this load
   /// (0xF=full, 0x3=lo D16, 0xC=hi D16). Used for byte-level race tracking.
-  void ldsRead(int wave, int lane, int addr, int bytes, int vgprDst, uint8_t byteMask = 0xF) {
+  void ldsRead(int wave, int lane, int addr, int bytes, int vgprDst, uint8_t byteMask = 0xF,
+               amdgpu::WaitCounterType waitCounterType = amdgpu::WaitCounterType::LGKMCNT) {
     detector_->validateRead(addr, WaveId{wave}, lane, bytes);
     std::vector<uint32_t> ldsAddrs(waveSize_, 0);
     ldsAddrs[lane] = addr;
     uint64_t laneMask = 1ULL << lane;
     std::vector<uint32_t> regs = {static_cast<uint32_t>(vgprDst)};
     waves_[wave]->registerLdsEvent(pc_++, MemoryEventType::LDS_TO_VGPR, std::move(regs), laneMask,
-                                   waveSize_, ldsAddrs, bytes, byteMask);
+                                   waveSize_, ldsAddrs, bytes, byteMask, waitCounterType);
   }
 
   // -- Sync --
 
   /// Dispatch s_waitcnt. -1 means "don't change this counter".
   void waitcnt(int wave, int vmcnt = -1, int lgkmcnt = -1) {
-    waves_[wave]->dispatch(PendingWaitCount{vmcnt, lgkmcnt});
+    PendingWaitCount wait;
+    wait.add(amdgpu::WaitCounterType::VMCNT, vmcnt);
+    wait.add(amdgpu::WaitCounterType::LGKMCNT, lgkmcnt);
+    waves_[wave]->dispatch(wait);
+  }
+
+  void waitKmcnt(int wave, int kmcnt) {
+    PendingWaitCount wait;
+    wait.add(amdgpu::WaitCounterType::KMCNT, kmcnt);
+    waves_[wave]->dispatch(wait);
   }
 
   /// Barrier: flush all waves' barrier-pending events (simulates s_barrier).
@@ -135,7 +160,13 @@ public:
     waves_[wave]->checkVgprWriteLanes(reg, laneMask, byteMask);
   }
 
-  void checkSgprRead(int wave, int reg) { waves_[wave]->checkSgprRead(reg); }
+  void checkSgprRead(int wave, int reg) {
+    waves_[wave]->checkScalarRead(RegisterRef{RegClass::SGPR, static_cast<uint16_t>(reg), 1});
+  }
+
+  void checkTtmpRead(int wave, int reg) {
+    waves_[wave]->checkScalarRead(RegisterRef{RegClass::TTMP, static_cast<uint16_t>(reg), 1});
+  }
 
   void checkLdsRead(int wave, int lane, int addr, int bytes) {
     detector_->validateRead(addr, WaveId{wave}, lane, bytes);
@@ -165,6 +196,14 @@ public:
       if (v.space == RaceViolation::Space::SGPR && v.index == reg) {
         return true;
       }
+    }
+    return false;
+  }
+
+  bool hasTtmpRace(int reg) const {
+    for (const auto &v : violations_) {
+      if (v.space == RaceViolation::Space::TTMP && v.index == reg)
+        return true;
     }
     return false;
   }

--- a/emulation/rocjitsu/tests/register_access_test.cpp
+++ b/emulation/rocjitsu/tests/register_access_test.cpp
@@ -17,7 +17,10 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/execution_backend.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/operand.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/dpp_sdwa_ops.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_resolve.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_selectors.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/gpu_memory.h"
 #include "rocjitsu/vm/amdgpu/instruction_compute_unit_view.h"
@@ -29,6 +32,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <bit>
 #include <cstdint>
 #include <memory>
@@ -57,10 +61,14 @@ static_assert(!ExposesReadRegionRegData<RegisterAccess::VgprReadRegion>);
 template <typename T>
 concept ExposesUnobservedVgprWrite = requires(T &value) { value.write_vgpr_storage(0, 0, 0); };
 
+template <typename T>
+concept ExposesUnobservedSgprWrite = requires(T &value) { value.write_sgpr(0, 0); };
+
 static_assert(!ExposesRawComputeUnit<InstructionComputeUnitView>);
 static_assert(!ExposesRawComputeUnit<Wavefront>);
 static_assert(!ExposesRawVgprData<InstructionComputeUnitView>);
 static_assert(!ExposesUnobservedVgprWrite<InstructionComputeUnitView>);
+static_assert(!ExposesUnobservedSgprWrite<InstructionComputeUnitView>);
 static_assert(!std::is_move_constructible_v<ScopedOperandDelegate>);
 static_assert(!std::is_move_assignable_v<ScopedOperandDelegate>);
 
@@ -68,12 +76,14 @@ constexpr uint32_t kSgprsPerWave = 104;
 constexpr uint32_t kVgprsPerWave = 256;
 
 struct ReadEvent {
+  const Wavefront *wavefront = nullptr;
   uint32_t physical_reg = 0;
   uint64_t lane_mask = 0;
   uint8_t byte_mask = 0;
 };
 
 struct WriteEvent {
+  const Wavefront *wavefront = nullptr;
   uint32_t physical_reg = 0;
   uint64_t lane_mask = 0;
   uint8_t byte_mask = 0;
@@ -83,23 +93,48 @@ class RecordingPlugin : public ExecutionPlugin {
 public:
   RecordingPlugin() : ExecutionPlugin("register_access_recorder") {}
 
-  void onAmdgpuReadVgprLanes(const Wavefront *, uint32_t physical_reg, uint64_t lane_mask,
+  void onAmdgpuReadVgprLanes(const Wavefront *wf, uint32_t physical_reg, uint64_t lane_mask,
                              uint8_t byte_mask) override {
-    reads.push_back({physical_reg, lane_mask, byte_mask});
+    reads.push_back({wf, physical_reg, lane_mask, byte_mask});
   }
 
-  void onAmdgpuReadSgpr(const Wavefront *, uint32_t physical_reg) override {
+  void onAmdgpuReadSgpr(const Wavefront *wf, uint32_t physical_reg) override {
     sgpr_reads.push_back(physical_reg);
+    sgpr_read_wavefronts.push_back(wf);
   }
 
-  void onAmdgpuWriteVgprLanes(const Wavefront *, uint32_t physical_reg, uint64_t lane_mask,
+  void onAmdgpuReadScalarRegister(const Wavefront *wf, RegisterRef reg) override {
+    ExecutionPlugin::onAmdgpuReadScalarRegister(wf, reg);
+    scalar_reads.push_back(reg);
+    scalar_read_wavefronts.push_back(wf);
+  }
+
+  void onAmdgpuWriteScalarRegister(const Wavefront *wf, RegisterRef reg) override {
+    scalar_writes.push_back(reg);
+    scalar_write_wavefronts.push_back(wf);
+    if (wf && reg.cls == RegClass::SGPR) {
+      for (uint32_t offset = 0; offset < reg.width; ++offset) {
+        sgpr_writes.push_back(wf->sgpr_alloc().base + reg.index + offset);
+        sgpr_write_wavefronts.push_back(wf);
+      }
+    }
+  }
+
+  void onAmdgpuWriteVgprLanes(const Wavefront *wf, uint32_t physical_reg, uint64_t lane_mask,
                               uint8_t byte_mask) override {
-    writes.push_back({physical_reg, lane_mask, byte_mask});
+    writes.push_back({wf, physical_reg, lane_mask, byte_mask});
   }
 
   std::vector<ReadEvent> reads;
   std::vector<WriteEvent> writes;
   std::vector<uint32_t> sgpr_reads;
+  std::vector<const Wavefront *> sgpr_read_wavefronts;
+  std::vector<uint32_t> sgpr_writes;
+  std::vector<const Wavefront *> sgpr_write_wavefronts;
+  std::vector<RegisterRef> scalar_reads;
+  std::vector<const Wavefront *> scalar_read_wavefronts;
+  std::vector<RegisterRef> scalar_writes;
+  std::vector<const Wavefront *> scalar_write_wavefronts;
 };
 
 struct Fixture {
@@ -111,15 +146,17 @@ struct Fixture {
   RecordingPlugin *plugin = nullptr;
   Wavefront *wf = nullptr;
 
-  explicit Fixture(rj_code_arch_t arch = ROCJITSU_CODE_ARCH_CDNA4, uint32_t wave_size = 0)
+  explicit Fixture(rj_code_arch_t arch = ROCJITSU_CODE_ARCH_CDNA4,
+                   uint32_t requested_sgprs = kSgprsPerWave, uint32_t wavefront_slots = 1,
+                   uint32_t vgprs_per_wave = kVgprsPerWave, uint32_t wave_size = 0)
       : execution_backend_scope(arch == ROCJITSU_CODE_ARCH_CDNA5   ? &cdna5::execution_backend()
                                 : arch == ROCJITSU_CODE_ARCH_RDNA4 ? &rdna4::execution_backend()
                                                                    : &cdna4::execution_backend()) {
     ComputeUnitCore::Config cfg{};
     cfg.arch = arch;
-    cfg.num_wf_slots = 1;
+    cfg.num_wf_slots = wavefront_slots;
     cfg.sgprs_per_wf = kSgprsPerWave;
-    cfg.vgprs_per_wf = kVgprsPerWave;
+    cfg.vgprs_per_wf = vgprs_per_wave;
     cfg.lds_size_kb = 64;
     cu = ComputeUnitCore::create("register_access_cu", cfg, &gpu_mem, &l2);
 
@@ -129,7 +166,7 @@ struct Fixture {
     plugin_group->add(std::move(recorder));
     cu->set_plugin_group(plugin_group);
 
-    wf = cu->dispatch_wf(/*wg_id=*/0, /*pc=*/0, kSgprsPerWave, kVgprsPerWave, wave_size);
+    wf = cu->dispatch_wf(/*wg_id=*/0, /*pc=*/0, requested_sgprs, vgprs_per_wave, wave_size);
   }
 
   uint32_t sgpr_base() const { return wf->sgpr_alloc().base; }
@@ -446,8 +483,10 @@ TEST(RegisterAccessTest, Scalar64ReadObservesBothRegisters) {
   EXPECT_EQ(regs.read_vgpr64(base + 11, 6), 0x0123456789ABCDEFull);
 
   ASSERT_EQ(fx.plugin->reads.size(), 2u);
+  EXPECT_EQ(fx.plugin->reads[0].wavefront, fx.wf);
   EXPECT_EQ(fx.plugin->reads[0].physical_reg, base + 11);
   EXPECT_EQ(fx.plugin->reads[0].lane_mask, 1ULL << 6);
+  EXPECT_EQ(fx.plugin->reads[1].wavefront, fx.wf);
   EXPECT_EQ(fx.plugin->reads[1].physical_reg, base + 12);
   EXPECT_EQ(fx.plugin->reads[1].lane_mask, 1ULL << 6);
 }
@@ -465,8 +504,13 @@ TEST(RegisterAccessTest, Sgpr64ReadObservesBothRegisters) {
   ASSERT_EQ(fx.plugin->sgpr_reads.size(), 2u);
   EXPECT_EQ(fx.plugin->sgpr_reads[0], base + 17);
   EXPECT_EQ(fx.plugin->sgpr_reads[1], base + 18);
+  EXPECT_EQ(fx.plugin->scalar_reads, (std::vector<RegisterRef>{{RegClass::SGPR, 17, 2}}));
 
   regs.write_sgpr64(base + 19, 0xABCDEF0123456789ull);
+  ASSERT_EQ(fx.plugin->sgpr_writes.size(), 2u);
+  EXPECT_EQ(fx.plugin->sgpr_writes[0], base + 19);
+  EXPECT_EQ(fx.plugin->sgpr_writes[1], base + 20);
+  EXPECT_EQ(fx.plugin->scalar_writes, (std::vector<RegisterRef>{{RegClass::SGPR, 19, 2}}));
   fx.plugin->sgpr_reads.clear();
   EXPECT_EQ(fx.cu->read_sgpr(base + 19), 0x23456789u);
   EXPECT_EQ(fx.cu->read_sgpr(base + 20), 0xABCDEF01u);
@@ -474,16 +518,94 @@ TEST(RegisterAccessTest, Sgpr64ReadObservesBothRegisters) {
 
 TEST(ScalarOperandSelectorsTest, ClassifiesRegisterPairLowWords) {
   EXPECT_TRUE(is_src_scalar_register_pair(0));
-  EXPECT_TRUE(is_src_scalar_register_pair(106));
-  EXPECT_TRUE(is_src_scalar_register_pair(108));
-  EXPECT_TRUE(is_src_scalar_register_pair(126));
-  EXPECT_TRUE(is_src_scalar_register_pair(230));
+  EXPECT_TRUE(is_src_scalar_register_pair(kVccSelectorFirst));
+  EXPECT_TRUE(is_src_scalar_register_pair(kTtmpSelectorFirst));
+  EXPECT_TRUE(is_src_scalar_register_pair(kExecSelectorFirst));
+  EXPECT_TRUE(is_src_scalar_register_pair(kFlatScratchBaseSelectorFirst));
 
-  EXPECT_FALSE(is_src_scalar_register_pair(107));
-  EXPECT_FALSE(is_src_scalar_register_pair(124));
+  EXPECT_FALSE(is_src_scalar_register_pair(kVccSelectorLast));
+  EXPECT_FALSE(is_src_scalar_register_pair(kLegacyM0Selector));
   EXPECT_FALSE(is_src_scalar_register_pair(128));
-  EXPECT_FALSE(is_src_scalar_register_pair(231));
+  EXPECT_FALSE(is_src_scalar_register_pair(kFlatScratchBaseSelectorLast));
   EXPECT_FALSE(is_src_scalar_register_pair(242));
+}
+
+TEST(ScalarOperandSelectorsTest, SelectsM0AndNullLayoutByArchitecture) {
+  for (rj_code_arch_t arch : {ROCJITSU_CODE_ARCH_CDNA3, ROCJITSU_CODE_ARCH_CDNA4}) {
+    EXPECT_EQ(scalar_m0_selector(arch), kLegacyM0Selector);
+    EXPECT_FALSE(scalar_selector_is_null(arch, kLegacyM0Selector));
+    EXPECT_FALSE(scalar_selector_is_null(arch, kGfx10NullSelector));
+  }
+
+  for (rj_code_arch_t arch : {ROCJITSU_CODE_ARCH_RDNA1, ROCJITSU_CODE_ARCH_RDNA2}) {
+    EXPECT_EQ(scalar_m0_selector(arch), kLegacyM0Selector);
+    EXPECT_TRUE(scalar_selector_is_null(arch, kGfx10NullSelector));
+  }
+
+  for (rj_code_arch_t arch : {ROCJITSU_CODE_ARCH_RDNA3, ROCJITSU_CODE_ARCH_RDNA3_5,
+                              ROCJITSU_CODE_ARCH_RDNA4, ROCJITSU_CODE_ARCH_CDNA5}) {
+    EXPECT_EQ(scalar_m0_selector(arch), kModernM0Selector);
+    EXPECT_TRUE(scalar_selector_is_null(arch, kModernNullSelector));
+  }
+}
+
+TEST(ScalarOperandSelectorsTest, RejectsRangesThatCrossArchitecturalRegisterFiles) {
+  Fixture fx(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(fx.wf, nullptr);
+
+  auto ttmps = resolve_scalar_register_range(*fx.wf, kTtmpSelectorFirst, kTtmpRegisterCount);
+  ASSERT_TRUE(ttmps.has_value());
+  EXPECT_EQ(ttmps->storage, ScalarRegisterStorage::TTMP);
+  EXPECT_EQ(ttmps->index, 0u);
+  EXPECT_EQ(ttmps->width, kTtmpRegisterCount);
+
+  EXPECT_FALSE(resolve_scalar_register_range(*fx.wf, kTtmpSelectorLast, 2).has_value());
+  EXPECT_FALSE(resolve_scalar_register_range(*fx.wf, kScalarSgprSelectorLast, 2).has_value());
+
+  auto vcc = resolve_scalar_register_range(*fx.wf, kVccSelectorFirst, 2);
+  ASSERT_TRUE(vcc.has_value());
+  EXPECT_EQ(vcc->storage, ScalarRegisterStorage::VCC);
+  EXPECT_EQ(vcc->index, 0u);
+  EXPECT_EQ(vcc->width, 2u);
+}
+
+TEST(ScalarOperandSelectorsTest, ResolvesSpecialScalarStorageByArchitecture) {
+  Fixture cdna4_fx(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(cdna4_fx.wf, nullptr);
+  cdna4_fx.wf->set_scratch_base(0x2222222211111111ull);
+  cdna4_fx.wf->set_vcc_raw(0x4444444433333333ull);
+  cdna4_fx.wf->set_m0(0x55555555u);
+
+  EXPECT_EQ(read_scalar_selector64(*cdna4_fx.wf, kFlatScratchSelectorFirst), 0x2222222211111111ull);
+  EXPECT_EQ(read_scalar_selector64(*cdna4_fx.wf, kVccSelectorFirst), 0x4444444433333333ull);
+  EXPECT_EQ(read_scalar_selector(*cdna4_fx.wf, kLegacyM0Selector), 0x55555555u);
+
+  Fixture rdna4_fx(ROCJITSU_CODE_ARCH_RDNA4, kSgprsPerWave, 1, kVgprsPerWave, 32);
+  ASSERT_NE(rdna4_fx.wf, nullptr);
+  auto null_range =
+      resolve_scalar_register_range(*rdna4_fx.wf, kModernNullSelector, kTtmpRegisterCount);
+  ASSERT_TRUE(null_range.has_value());
+  EXPECT_EQ(null_range->storage, ScalarRegisterStorage::DISCARD);
+  EXPECT_EQ(read_scalar_register(*rdna4_fx.wf, *null_range, 15), 0u);
+}
+
+TEST(RegisterAccessTest, ScalarSelectedLaneReadRejectsAnotherWaveBlock) {
+  constexpr uint32_t kSmallVgprBlock = 16;
+  Fixture fx(ROCJITSU_CODE_ARCH_RDNA4, kSgprsPerWave, /*wavefront_slots=*/2, kSmallVgprBlock,
+             /*wave_size=*/32);
+  ASSERT_NE(fx.wf, nullptr);
+  auto *adjacent_wave =
+      fx.cu->dispatch_wf(/*wg_id=*/1, /*pc=*/0, kSgprsPerWave, kSmallVgprBlock, 32);
+  ASSERT_NE(adjacent_wave, nullptr);
+  ASSERT_EQ(adjacent_wave->vgpr_alloc().base, fx.vgpr_base() + kSmallVgprBlock);
+
+  constexpr uint32_t kSentinel = 0x12345678u;
+  fx.cu->write_vgpr(adjacent_wave->vgpr_alloc().base, 3, kSentinel);
+  rdna4::Operand adjacent_vgpr(32, rdna4::OperandType::OPR_VGPR, kSmallVgprBlock);
+
+  EXPECT_EQ(RegisterAccess(*fx.wf).read_scalar_selected_lane(adjacent_vgpr, 3), 0u);
+  EXPECT_TRUE(fx.plugin->reads.empty());
+  EXPECT_EQ(fx.cu->read_vgpr_storage(adjacent_wave->vgpr_alloc().base, 3), kSentinel);
 }
 
 TEST(RegisterAccessTest, LanePair32PreservesRegisterPairsAndSplatsSingleWords) {
@@ -542,6 +664,272 @@ TEST(RegisterAccessTest, LanePair32ReadsGfx1250FlatScratchBase) {
   const OperandPair32 pair = RegisterAccess(*fx.wf).read_lane_pair32(flat_scratch_base, 0);
   EXPECT_EQ(pair.lo, 0x66666666u);
   EXPECT_EQ(pair.hi, 0x77777777u);
+}
+
+TEST(RegisterAccessTest, CuBoundSgprWritesCannotBypassObservation) {
+  Fixture fx;
+  ASSERT_NE(fx.wf, nullptr);
+  const uint32_t reg = fx.sgpr_base() + 7;
+  fx.cu->write_sgpr(reg, 0x11112222u);
+
+  RegisterAccess registers(*fx.cu);
+  EXPECT_THROW(registers.write_sgpr(reg, 0x33334444u), std::logic_error);
+  EXPECT_THROW(registers.write_sgpr64(reg, 0x5555666677778888ull), std::logic_error);
+
+  EXPECT_EQ(fx.cu->read_sgpr_storage(reg), 0x11112222u);
+  EXPECT_TRUE(fx.plugin->sgpr_writes.empty());
+}
+
+TEST(RegisterAccessTest, Sgpr64AccessDoesNotCrossPhysicalBlockBoundary) {
+  Fixture fx(ROCJITSU_CODE_ARCH_CDNA4, kSgprsPerWave, /*wavefront_slots=*/2);
+  ASSERT_NE(fx.wf, nullptr);
+  auto *adjacent_wave = fx.cu->dispatch_wf(/*wg_id=*/1, /*pc=*/0, kSgprsPerWave, kVgprsPerWave);
+  ASSERT_NE(adjacent_wave, nullptr);
+  ASSERT_EQ(adjacent_wave->sgpr_alloc().base, fx.sgpr_base() + fx.cu->sgpr_allocation_block_size());
+
+  const uint32_t boundary = adjacent_wave->sgpr_alloc().base - 1;
+  constexpr uint32_t kLowSentinel = 0xA5A5A5A5u;
+  constexpr uint32_t kAdjacentSentinel = 0x11112222u;
+  fx.cu->write_sgpr(boundary, kLowSentinel);
+  fx.cu->write_sgpr(adjacent_wave->sgpr_alloc().base, kAdjacentSentinel);
+
+  RegisterAccess registers(*fx.wf);
+  registers.write_sgpr64(boundary, 0x3333444455556666ull);
+
+  EXPECT_EQ(fx.cu->read_sgpr_storage(boundary), kLowSentinel);
+  EXPECT_EQ(fx.cu->read_sgpr_storage(adjacent_wave->sgpr_alloc().base), kAdjacentSentinel);
+  EXPECT_TRUE(fx.plugin->sgpr_writes.empty());
+
+  EXPECT_EQ(registers.read_sgpr64(boundary), 0u);
+  EXPECT_TRUE(fx.plugin->sgpr_reads.empty());
+}
+
+TEST(RegisterAccessTest, SgprReadRegionRejectsWholeRangeBeforeCallbacks) {
+  Fixture fx(ROCJITSU_CODE_ARCH_CDNA4, kSgprsPerWave, /*wavefront_slots=*/2);
+  ASSERT_NE(fx.wf, nullptr);
+  auto *adjacent_wave = fx.cu->dispatch_wf(/*wg_id=*/1, /*pc=*/0, kSgprsPerWave, kVgprsPerWave);
+  ASSERT_NE(adjacent_wave, nullptr);
+
+  const uint32_t first = adjacent_wave->sgpr_alloc().base - 2;
+  fx.cu->write_sgpr(first, 0x11223344u);
+  fx.cu->write_sgpr(first + 1, 0x55667788u);
+  fx.cu->write_sgpr(adjacent_wave->sgpr_alloc().base, 0xA5A5A5A5u);
+  fx.cu->write_sgpr(adjacent_wave->sgpr_alloc().base + 1, 0x5A5A5A5Au);
+
+  RegisterAccess registers(*fx.wf);
+  auto denied = registers.read_sgpr_region(first, 4);
+  EXPECT_FALSE(denied.valid());
+  EXPECT_EQ(denied.qword(0), 0u);
+  EXPECT_TRUE(fx.plugin->sgpr_reads.empty());
+
+  auto owned = registers.read_sgpr_region(first, 2);
+  ASSERT_TRUE(owned.valid());
+  EXPECT_EQ(owned.qword(), 0x5566778811223344ull);
+  ASSERT_EQ(fx.plugin->sgpr_reads.size(), 2u);
+  EXPECT_EQ(fx.plugin->sgpr_reads[0], first);
+  EXPECT_EQ(fx.plugin->sgpr_reads[1], first + 1);
+  EXPECT_EQ(fx.plugin->sgpr_read_wavefronts[0], fx.wf);
+  EXPECT_EQ(fx.plugin->sgpr_read_wavefronts[1], fx.wf);
+  EXPECT_EQ(fx.plugin->scalar_reads,
+            (std::vector<RegisterRef>{{RegClass::SGPR, kSgprsPerWave - 2, 2}}));
+}
+
+TEST(RegisterAccessTest, Scalar64OperandAndExplicitMaskWritesAreAtomic) {
+  Fixture fx;
+  ASSERT_NE(fx.wf, nullptr);
+  constexpr int kLastSgprSelector = static_cast<int>(kSgprsPerWave - 1);
+  const uint32_t last_sgpr = fx.sgpr_base() + kSgprsPerWave - 1;
+  constexpr uint32_t kSentinel = 0xA5A5A5A5u;
+  fx.cu->write_sgpr(last_sgpr, kSentinel);
+
+  resolve_dst_write64(*fx.wf, kLastSgprSelector, 0x1122334455667788ull);
+
+  EXPECT_EQ(fx.cu->read_sgpr_storage(last_sgpr), kSentinel);
+  EXPECT_TRUE(fx.plugin->sgpr_writes.empty());
+  EXPECT_EQ(resolve_src_scalar64(*fx.wf, kLastSgprSelector, /*m0_ev=*/124), 0u);
+  EXPECT_TRUE(fx.plugin->sgpr_reads.empty());
+
+  write_explicit_lane_mask(last_sgpr, *fx.wf, 0xFFEEDDCCBBAA9988ull);
+  EXPECT_EQ(fx.cu->read_sgpr_storage(last_sgpr), kSentinel);
+  EXPECT_TRUE(fx.plugin->sgpr_writes.empty());
+}
+
+TEST(RegisterAccessTest, TrapSelectorsUseDedicatedWaveStorage) {
+  Fixture fx;
+  ASSERT_NE(fx.wf, nullptr);
+
+  constexpr int kTtmp0 = 108;
+  fx.wf->set_ttmp(0, 0x11223344u);
+  fx.wf->set_ttmp(1, 0x55667788u);
+
+  EXPECT_EQ(resolve_src_scalar(*fx.wf, kTtmp0, /*m0_ev=*/124), 0x11223344u);
+  EXPECT_EQ(resolve_src_scalar64(*fx.wf, kTtmp0, /*m0_ev=*/124), 0x5566778811223344ull);
+
+  resolve_dst_write(*fx.wf, kTtmp0, 0xAABBCCDDu, /*m0_ev=*/124);
+  EXPECT_EQ(fx.wf->ttmp(0), 0xAABBCCDDu);
+  resolve_dst_write64(*fx.wf, kTtmp0, 0x0123456789ABCDEFull);
+  EXPECT_EQ(fx.wf->ttmp(0), 0x89ABCDEFu);
+  EXPECT_EQ(fx.wf->ttmp(1), 0x01234567u);
+
+  EXPECT_TRUE(fx.plugin->sgpr_reads.empty());
+  EXPECT_TRUE(fx.plugin->sgpr_writes.empty());
+  EXPECT_EQ(fx.plugin->scalar_reads,
+            (std::vector<RegisterRef>{{RegClass::TTMP, 0, 1}, {RegClass::TTMP, 0, 2}}));
+  EXPECT_EQ(fx.plugin->scalar_writes,
+            (std::vector<RegisterRef>{{RegClass::TTMP, 0, 1}, {RegClass::TTMP, 0, 2}}));
+  EXPECT_TRUE(std::ranges::all_of(fx.plugin->scalar_read_wavefronts,
+                                  [&](const Wavefront *wf) { return wf == fx.wf; }));
+  EXPECT_TRUE(std::ranges::all_of(fx.plugin->scalar_write_wavefronts,
+                                  [&](const Wavefront *wf) { return wf == fx.wf; }));
+}
+
+TEST(RegisterAccessTest, Vgpr64AccessRequiresOneOwnerForCompleteRange) {
+  Fixture fx(ROCJITSU_CODE_ARCH_CDNA4, kSgprsPerWave, /*wavefront_slots=*/2);
+  ASSERT_NE(fx.wf, nullptr);
+  auto *adjacent_wave = fx.cu->dispatch_wf(/*wg_id=*/1, /*pc=*/0, kSgprsPerWave, kVgprsPerWave);
+  ASSERT_NE(adjacent_wave, nullptr);
+  ASSERT_EQ(adjacent_wave->vgpr_alloc().base, fx.vgpr_base() + fx.cu->vgpr_allocation_block_size());
+
+  const uint32_t boundary = adjacent_wave->vgpr_alloc().base - 1;
+  constexpr uint32_t kLane = 0;
+  constexpr uint32_t kLowSentinel = 0xA5A5A5A5u;
+  constexpr uint32_t kAdjacentSentinel = 0x11112222u;
+  fx.cu->write_vgpr(boundary, kLane, kLowSentinel);
+  fx.cu->write_vgpr(adjacent_wave->vgpr_alloc().base, kLane, kAdjacentSentinel);
+
+  RegisterAccess wave_registers(*fx.wf);
+  wave_registers.write_vgpr64(boundary, kLane, 0x3333444455556666ull);
+  EXPECT_EQ(wave_registers.read_vgpr64(boundary, kLane), 0u);
+
+  RegisterAccess inferred_registers(*fx.cu);
+  inferred_registers.write_vgpr64(boundary, kLane, 0x777788889999AAAAll);
+  EXPECT_EQ(inferred_registers.read_vgpr64(boundary, kLane), 0u);
+
+  EXPECT_EQ(fx.cu->read_vgpr_storage(boundary, kLane), kLowSentinel);
+  EXPECT_EQ(fx.cu->read_vgpr_storage(adjacent_wave->vgpr_alloc().base, kLane), kAdjacentSentinel);
+  EXPECT_TRUE(fx.plugin->writes.empty());
+  EXPECT_TRUE(fx.plugin->reads.empty());
+}
+
+TEST(RegisterAccessTest, DeniedMultiRegisterReadRegionReturnsBoundedZeros) {
+  Fixture fx(ROCJITSU_CODE_ARCH_CDNA4, kSgprsPerWave, /*wavefront_slots=*/2);
+  ASSERT_NE(fx.wf, nullptr);
+  auto *adjacent_wave = fx.cu->dispatch_wf(/*wg_id=*/1, /*pc=*/0, kSgprsPerWave, kVgprsPerWave);
+  ASSERT_NE(adjacent_wave, nullptr);
+
+  const uint32_t boundary = adjacent_wave->vgpr_alloc().base - 1;
+  auto region = RegisterAccess(*fx.wf).read_vgpr_region(boundary, /*reg_count=*/2, /*lane_mask=*/1);
+  EXPECT_FALSE(region.valid());
+
+  std::vector<uint32_t> copied(2 * fx.wf->wf_size(), 0xA5A5A5A5u);
+  region.copy_to(copied);
+  for (uint32_t value : copied)
+    EXPECT_EQ(value, 0u);
+
+  uint32_t visited = 0;
+  region.for_each([&](std::span<const uint32_t> lanes) {
+    ++visited;
+    ASSERT_EQ(lanes.size(), fx.wf->wf_size());
+    for (uint32_t value : lanes)
+      EXPECT_EQ(value, 0u);
+  });
+  EXPECT_EQ(visited, 2u);
+}
+
+TEST(RegisterAccessTest, ZeroLaneMaskDoesNotMeanOwnershipDenial) {
+  Fixture fx;
+  ASSERT_NE(fx.wf, nullptr);
+
+  auto region =
+      RegisterAccess(*fx.wf).read_vgpr_region(fx.vgpr_base(), /*reg_count=*/1, /*lane_mask=*/0);
+  EXPECT_TRUE(region.valid());
+  EXPECT_TRUE(region.empty());
+  EXPECT_EQ(region.lane(/*relative_reg=*/0, /*lane=*/0), 0u);
+  EXPECT_TRUE(fx.plugin->reads.empty());
+}
+
+TEST(RegisterAccessTest, ExplicitWaveSgprAccessUsesReservedPhysicalBlock) {
+  constexpr uint32_t kRequestedSgprs = 40;
+  Fixture fx(ROCJITSU_CODE_ARCH_CDNA4, kRequestedSgprs);
+  ASSERT_NE(fx.wf, nullptr);
+
+  const uint32_t compiler_temporary = fx.sgpr_base() + kRequestedSgprs;
+  ASSERT_LT(compiler_temporary, fx.sgpr_base() + fx.cu->sgpr_allocation_block_size());
+  fx.cu->write_sgpr(compiler_temporary, 0x11223344u);
+  EXPECT_TRUE(fx.plugin->sgpr_writes.empty());
+
+  RegisterAccess regs(*fx.wf);
+  EXPECT_EQ(regs.read_sgpr(compiler_temporary), 0x11223344u);
+  ASSERT_EQ(fx.plugin->sgpr_reads.size(), 1u);
+  EXPECT_EQ(fx.plugin->sgpr_reads[0], compiler_temporary);
+  EXPECT_EQ(fx.plugin->sgpr_read_wavefronts[0], fx.wf);
+
+  regs.write_sgpr(compiler_temporary, 0x55667788u);
+  ASSERT_EQ(fx.plugin->sgpr_writes.size(), 1u);
+  EXPECT_EQ(fx.plugin->sgpr_writes[0], compiler_temporary);
+  EXPECT_EQ(fx.plugin->sgpr_write_wavefronts[0], fx.wf);
+  EXPECT_EQ(fx.cu->read_sgpr_storage(compiler_temporary), 0x55667788u);
+
+  fx.plugin->sgpr_reads.clear();
+  fx.plugin->sgpr_read_wavefronts.clear();
+  EXPECT_EQ(RegisterAccess(*fx.cu).read_sgpr(compiler_temporary), 0x55667788u);
+  ASSERT_EQ(fx.plugin->sgpr_reads.size(), 1u);
+  EXPECT_EQ(fx.plugin->sgpr_reads[0], compiler_temporary);
+  EXPECT_EQ(fx.plugin->sgpr_read_wavefronts[0], fx.wf);
+}
+
+TEST(RegisterAccessTest, ReleasedWaveCannotOwnReallocatedRegisterBlock) {
+  Fixture fx(ROCJITSU_CODE_ARCH_CDNA4, kSgprsPerWave, /*wavefront_slots=*/2);
+  ASSERT_NE(fx.wf, nullptr);
+  auto *released_wave = fx.cu->dispatch_wf(/*wg_id=*/1, /*pc=*/0, kSgprsPerWave, kVgprsPerWave);
+  ASSERT_NE(released_wave, nullptr);
+
+  constexpr uint32_t kLane = 0;
+  constexpr uint32_t kSgprSentinel = 0x11223344u;
+  constexpr uint32_t kVgprSentinel = 0x55667788u;
+  const uint32_t live_sgpr = fx.wf->sgpr_alloc().base;
+  const uint32_t live_vgpr = fx.wf->vgpr_alloc().base;
+  fx.cu->write_sgpr(live_sgpr, kSgprSentinel);
+  fx.cu->write_vgpr(live_vgpr, kLane, kVgprSentinel);
+
+  released_wave->reset();
+  ASSERT_EQ(released_wave->sgpr_alloc().count, 0u);
+  ASSERT_EQ(released_wave->vgpr_alloc().count, 0u);
+
+  RegisterAccess released_access(*released_wave);
+  released_access.write_sgpr(live_sgpr, 0xAABBCCDDu);
+  released_access.write_vgpr(live_vgpr, kLane, 0xDDEEFF00u);
+
+  EXPECT_EQ(fx.cu->read_sgpr_storage(live_sgpr), kSgprSentinel);
+  EXPECT_EQ(fx.cu->read_vgpr_storage(live_vgpr, kLane), kVgprSentinel);
+  EXPECT_TRUE(fx.plugin->sgpr_writes.empty());
+  EXPECT_TRUE(fx.plugin->writes.empty());
+}
+
+TEST(RegisterAccessTest, FreeWavefrontClearsPhysicalOwnerMaps) {
+  constexpr uint32_t kRequestedSgprs = 40;
+  Fixture fx(ROCJITSU_CODE_ARCH_CDNA4, kRequestedSgprs);
+  ASSERT_NE(fx.wf, nullptr);
+
+  const uint32_t sgpr = fx.sgpr_base() + kRequestedSgprs;
+  const uint32_t vgpr = fx.vgpr_base() + 3;
+  fx.cu->write_sgpr(sgpr, 0x12345678u);
+  fx.cu->write_vgpr(vgpr, /*lane=*/0, 0x87654321u);
+
+  EXPECT_EQ(RegisterAccess(*fx.cu).read_sgpr(sgpr), 0x12345678u);
+  EXPECT_EQ(RegisterAccess(*fx.cu).read_vgpr(vgpr, /*lane=*/0), 0x87654321u);
+  ASSERT_EQ(fx.plugin->sgpr_reads.size(), 1u);
+  ASSERT_EQ(fx.plugin->reads.size(), 1u);
+
+  fx.cu->free_wavefront_resources(*fx.wf);
+  fx.plugin->sgpr_reads.clear();
+  fx.plugin->sgpr_read_wavefronts.clear();
+  fx.plugin->reads.clear();
+
+  (void)RegisterAccess(*fx.cu).read_sgpr(sgpr);
+  (void)RegisterAccess(*fx.cu).read_vgpr(vgpr, /*lane=*/0);
+  EXPECT_TRUE(fx.plugin->sgpr_reads.empty());
+  EXPECT_TRUE(fx.plugin->reads.empty());
 }
 
 TEST(RegisterAccessTest, PublicOperandChunkReadObservesReadWindow) {
@@ -676,7 +1064,8 @@ TEST(RegisterAccessTest, Wave32VgprWriteMaskRejectsNonExecutionLanes) {
 }
 
 TEST(RegisterAccessTest, Wave64DispatchExpandsVgprWriteMaskToArchitecturalWidth) {
-  Fixture fx(ROCJITSU_CODE_ARCH_RDNA4, /*wave_size=*/64);
+  Fixture fx(ROCJITSU_CODE_ARCH_RDNA4, kSgprsPerWave, /*wavefront_slots=*/1, kVgprsPerWave,
+             /*wave_size=*/64);
   ASSERT_NE(fx.wf, nullptr);
   ASSERT_EQ(fx.wf->wf_size(), 64u);
   EXPECT_EQ(fx.wf->vgpr_write_mask(), ~uint64_t{0});

--- a/emulation/rocjitsu/tests/shared_infra_test.cpp
+++ b/emulation/rocjitsu/tests/shared_infra_test.cpp
@@ -74,6 +74,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/machine_insts.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/opcodes.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/operand_types.h"
+#include "rocjitsu/isa/arch/amdgpu/generated/rdna4/smem.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/vop1.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/vop2.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/vop3.h"
@@ -6527,6 +6528,80 @@ TEST(Gfx1250AddrCalcTest, VbufferZeroNumRecordsMasksAllLanes) {
   EXPECT_EQ(null_range_state.lane_mask, 0ULL);
   EXPECT_EQ(null_range_state.per_lane_addr[0], 0ULL);
   EXPECT_EQ(null_range_state.per_lane_addr[1], 0ULL);
+}
+
+TEST(Gfx1250AddrCalcTest, DescriptorCannotMixAdjacentWaveSgprs) {
+  amdgpu::GpuMemory mem("gfx1250_vbuffer_cross_wave_sgpr_mem");
+  amdgpu::L2Cache l2("gfx1250_vbuffer_cross_wave_sgpr_l2");
+  amdgpu::ComputeUnitCore::Config cfg{};
+  cfg.arch = ROCJITSU_CODE_ARCH_CDNA5;
+  cfg.num_wf_slots = 2;
+  cfg.sgprs_per_wf = 106;
+  cfg.vgprs_per_wf = 16;
+  cfg.lds_size_kb = 64;
+  auto cu = amdgpu::ComputeUnitCore::create("gfx1250_vbuffer_cross_wave_sgpr_cu", cfg, &mem, &l2);
+  ASSERT_NE(cu, nullptr);
+
+  auto *executing_wave = cu->dispatch_wf(0, 0, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
+  auto *adjacent_wave = cu->dispatch_wf(1, 0, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
+  ASSERT_NE(executing_wave, nullptr);
+  ASSERT_NE(adjacent_wave, nullptr);
+  executing_wave->set_exec(1ULL);
+  ASSERT_EQ(adjacent_wave->sgpr_alloc().base, executing_wave->sgpr_alloc().base + cfg.sgprs_per_wf);
+
+  constexpr uint64_t kBase = 0x2'0000'1000ULL;
+  const uint32_t descriptor = executing_wave->sgpr_alloc().base + cfg.sgprs_per_wf - 2;
+  cu->write_sgpr(descriptor, static_cast<uint32_t>(kBase));
+  // Keep the base address unchanged while making the in-range descriptor
+  // words describe one record. The complete descriptor still must be denied.
+  cu->write_sgpr(descriptor + 1, static_cast<uint32_t>(kBase >> 32) | (1u << 25));
+  cu->write_sgpr(adjacent_wave->sgpr_alloc().base, 1u);
+  cu->write_sgpr(adjacent_wave->sgpr_alloc().base + 1, 0u);
+
+  cdna5::VbufferMachineInst inst{};
+  inst.rsrc = cfg.sgprs_per_wf - 2;
+  inst.soffset = cdna5::OPR_SREG_NULL;
+
+  amdgpu::VectorMemState d(amdgpu::GLOBAL_MEM);
+  d.elem_size = 4;
+  d.num_elems = 1;
+  cdna5::mubuf_calculate_addresses(inst, *executing_wave, d);
+  EXPECT_EQ(d.lane_mask, 0ULL);
+  EXPECT_EQ(d.per_lane_addr[0], 0ULL);
+}
+
+TEST(RdnaAddrCalcTest, SmemBasePairCannotCrossWaveSgprBoundary) {
+  amdgpu::GpuMemory mem("rdna4_smem_cross_wave_sgpr_mem");
+  amdgpu::L2Cache l2("rdna4_smem_cross_wave_sgpr_l2");
+  amdgpu::ComputeUnitCore::Config cfg{};
+  cfg.arch = ROCJITSU_CODE_ARCH_RDNA4;
+  cfg.num_wf_slots = 2;
+  cfg.sgprs_per_wf = 105;
+  cfg.vgprs_per_wf = 16;
+  cfg.lds_size_kb = 64;
+  auto cu = amdgpu::ComputeUnitCore::create("rdna4_smem_cross_wave_sgpr_cu", cfg, &mem, &l2);
+  ASSERT_NE(cu, nullptr);
+
+  auto *executing_wave = cu->dispatch_wf(0, 0, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
+  auto *adjacent_wave = cu->dispatch_wf(1, 0, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
+  ASSERT_NE(executing_wave, nullptr);
+  ASSERT_NE(adjacent_wave, nullptr);
+  ASSERT_EQ(adjacent_wave->sgpr_alloc().base, executing_wave->sgpr_alloc().base + cfg.sgprs_per_wf);
+
+  const uint32_t base = adjacent_wave->sgpr_alloc().base - 1;
+  cu->write_sgpr(base, 0x12345678u);
+  cu->write_sgpr(adjacent_wave->sgpr_alloc().base, 0x00000002u);
+
+  rdna4::SmemMachineInst inst{};
+  inst.sbase = 52; // logical s[104:105], which straddles this 105-register block.
+  inst.sdata = 4;
+  inst.soffset = rdna4::OPR_SMEM_OFFSET_NULL;
+
+  EXPECT_FALSE(rdna4::smem_calculate_address(inst, *executing_wave).has_value());
+
+  rdna4::SLoadB32Smem load(reinterpret_cast<const rdna4::MachineInst *>(&inst));
+  load.execute_impl(*executing_wave);
+  EXPECT_EQ(load.data(), nullptr);
 }
 
 TEST(Gfx1250AddrCalcTest, VbufferStructuredStrideChecksIndexBounds) {

--- a/emulation/rocjitsu/tests/waitcnt_counter_test.cpp
+++ b/emulation/rocjitsu/tests/waitcnt_counter_test.cpp
@@ -117,6 +117,39 @@ TEST(WaitCounterTest, SaturationAtMax) {
 }
 
 // ---------------------------------------------------------------------------
+// Wait-counter families
+// ---------------------------------------------------------------------------
+
+TEST(WaitCounterCoverageTest, MonolithicCountersCoverTheirSplitFamilies) {
+  EXPECT_TRUE(wait_counter_covers(WaitCounterType::VMCNT, WaitCounterType::VMCNT));
+  EXPECT_TRUE(wait_counter_covers(WaitCounterType::VMCNT, WaitCounterType::LOADCNT));
+  EXPECT_FALSE(wait_counter_covers(WaitCounterType::VMCNT, WaitCounterType::STORECNT));
+
+  EXPECT_TRUE(wait_counter_covers(WaitCounterType::LGKMCNT, WaitCounterType::LGKMCNT));
+  EXPECT_TRUE(wait_counter_covers(WaitCounterType::LGKMCNT, WaitCounterType::DSCNT));
+  EXPECT_TRUE(wait_counter_covers(WaitCounterType::LGKMCNT, WaitCounterType::KMCNT));
+  EXPECT_FALSE(wait_counter_covers(WaitCounterType::LGKMCNT, WaitCounterType::VMCNT));
+
+  EXPECT_TRUE(wait_counter_covers(WaitCounterType::VSCNT, WaitCounterType::VSCNT));
+  EXPECT_TRUE(wait_counter_covers(WaitCounterType::VSCNT, WaitCounterType::STORECNT));
+  EXPECT_FALSE(wait_counter_covers(WaitCounterType::VSCNT, WaitCounterType::LOADCNT));
+}
+
+TEST(WaitCounterCoverageTest, SplitCountersCoverOnlyThemselves) {
+  EXPECT_TRUE(wait_counter_covers(WaitCounterType::LOADCNT, WaitCounterType::LOADCNT));
+  EXPECT_FALSE(wait_counter_covers(WaitCounterType::LOADCNT, WaitCounterType::VMCNT));
+  EXPECT_TRUE(wait_counter_covers(WaitCounterType::STORECNT, WaitCounterType::STORECNT));
+  EXPECT_FALSE(wait_counter_covers(WaitCounterType::STORECNT, WaitCounterType::VSCNT));
+  EXPECT_TRUE(wait_counter_covers(WaitCounterType::DSCNT, WaitCounterType::DSCNT));
+  EXPECT_FALSE(wait_counter_covers(WaitCounterType::DSCNT, WaitCounterType::LGKMCNT));
+  EXPECT_TRUE(wait_counter_covers(WaitCounterType::KMCNT, WaitCounterType::KMCNT));
+  EXPECT_FALSE(wait_counter_covers(WaitCounterType::KMCNT, WaitCounterType::LGKMCNT));
+  EXPECT_TRUE(wait_counter_covers(WaitCounterType::EXPCNT, WaitCounterType::EXPCNT));
+  EXPECT_TRUE(wait_counter_covers(WaitCounterType::TENSORCNT, WaitCounterType::TENSORCNT));
+  EXPECT_TRUE(wait_counter_covers(WaitCounterType::ASYNCCNT, WaitCounterType::ASYNCCNT));
+}
+
+// ---------------------------------------------------------------------------
 // WaitTarget — satisfaction checks
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Overview

rocJITsu executes decoded GPU instructions against simulated GPU state and lets execution plugins observe their architectural effects. The race detector, for example, learns that an instruction read or wrote a register through these callbacks.

Before this change, instruction implementations reached SGPRs, TTMPs, and VGPRs through several different paths. Some paths retained the executing wave, while others reconstructed ownership from a physical register number. That made multi-register operations particularly fragile: an access could be checked one word at a time, cross the allocation boundary of a wave, or be attributed to the wrong wave by a plugin.

This PR gives instruction-visible register access one wave-owned contract. An instruction asks its wave for a typed register reference or region, and the complete range is checked before storage or a mutable view is exposed. Plugin callbacks are emitted at that boundary, before the underlying read or write occurs.

## How this matches the GPU model

The hardware allocates contiguous physical SGPR and VGPR blocks to each wave. Those allocation blocks—not the entry kernel's declared register count—are the correct access boundary. A callable function may legitimately use compiler temporaries beyond the entry function's reported count while still remaining inside the wave's allocation.

Scalar references also retain their architectural namespace. An ordinary SGPR and a wave-private TTMP no longer become indistinguishable merely because both eventually map to scalar storage. Generated operand code identifies TTMPs on every supported ISA and routes instruction-visible TTMP reads and writes through the same wave-owned boundary.

Internal simulator operations remain deliberately separate. Dispatch initialization, checkpoint restore, and deferred memory completion can update raw storage without pretending that a second instruction-level register effect occurred. Plugins therefore see the architectural instruction once, rather than simulator bookkeeping performed on its behalf.

This builds on the compact allocation-block ownership model from #10602 and the single-ISA generation model from #10477.

## Race-detector integration

The race detector now consumes typed SGPR/TTMP identities instead of interpreting encoded selectors or physical storage layout. Scalar memory events also retain the wait-counter family that actually governs them. Legacy and split wait instructions are handled through one counter model, and partial KMCNT/LGKMCNT waits retire only operations that are provably complete; they do not prematurely clear unordered scalar destinations or ordered DS operations.

As a result, a scalar load into a TTMP followed by an early read is reported against the TTMP itself and remains live until the required wait completes. This PR does not add SGPR write-after-write policy; that remains separate race-detector work.

The same typed operand path fixes `s_setpc_b64` and `s_swappc_b64` zero-target handling: the pre-check now reads the decoded source operand, so a valid target stored in a TTMP pair is not mistaken for zero.

## Review structure

The history is intentionally split into three commits:

1. the wave-owned register-access model, generator changes, documentation, and focused tests;
2. race-detector integration and wait-counter correctness; and
3. generated ISA output only.

After the latest rebase, `git diff --check` passes and the Release builds of the rocJITsu CLI, shared interposer, and race-detector plugin complete successfully.

## Issue tracking

Related: #9577
