### PR TITLE
fix(rocr): use system scope for the fused SDMA wait

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_sdma.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_sdma.cpp
@@ -2315,6 +2315,7 @@ void BlitSdma<useGCR, scopeFields>::BuildMulticastWaitSignalCopyCommand(
 
     if (do_wait) {
       pkt.WAIT_FUNCTION_UNION.wait_function = 0x3;  // Equal
+      pkt.WAIT_FUNCTION_UNION.wait_scope = SDMA_MEMORY_SCOPE_SYS;
       void* wait_addr = const_cast<core::Signal*>(wait_signal)->ValueLocation();
       pkt.WAIT_ADDR_LO_UNION.wait_addr_31_3 = ptrlow32(wait_addr) >> 3;
       pkt.WAIT_ADDR_HI_UNION.wait_addr_63_32 = ptrhigh32(wait_addr);
@@ -2746,6 +2747,7 @@ void BlitSdma<useGCR, scopeFields>::BuildWaitSignalCopyCommand(
 
     if (do_wait) {
       pkt.WAIT_FUNCTION_UNION.wait_function = 0x3;  // Equal
+      pkt.WAIT_FUNCTION_UNION.wait_scope = SDMA_MEMORY_SCOPE_SYS;
       void* wait_addr = const_cast<core::Signal*>(wait_signal)->ValueLocation();
       pkt.WAIT_ADDR_LO_UNION.wait_addr_31_3 = ptrlow32(wait_addr) >> 3;
       pkt.WAIT_ADDR_HI_UNION.wait_addr_63_32 = ptrhigh32(wait_addr);
@@ -2817,6 +2819,7 @@ void BlitSdma<useGCR, scopeFields>::BuildWaitSignalIndirectCopyCommand(
 
   if (do_wait) {
     pkt.WAIT_FUNCTION_UNION.wait_function = 0x3;  // Equal
+    pkt.WAIT_FUNCTION_UNION.wait_scope = SDMA_MEMORY_SCOPE_SYS;
     void* wait_addr = const_cast<core::Signal*>(wait_signal)->ValueLocation();
     pkt.WAIT_ADDR_LO_UNION.wait_addr_31_3 = ptrlow32(wait_addr) >> 3;
     pkt.WAIT_ADDR_HI_UNION.wait_addr_63_32 = ptrhigh32(wait_addr);
@@ -2894,6 +2897,7 @@ void BlitSdma<useGCR, scopeFields>::BuildWaitSignalSwapCommand(
 
     if (do_wait) {
       pkt.WAIT_FUNCTION_UNION.wait_function  = 0x3;  // Equal
+      pkt.WAIT_FUNCTION_UNION.wait_scope     = SDMA_MEMORY_SCOPE_SYS;
       void* wa = const_cast<core::Signal*>(wait_signal)->ValueLocation();
       pkt.WAIT_ADDR_LO_UNION.wait_addr_31_3  = ptrlow32(wa) >> 3;
       pkt.WAIT_ADDR_HI_UNION.wait_addr_63_32 = ptrhigh32(wa);


### PR DESCRIPTION
The gfx1250 fused wait/signal copy packets left `wait_scope` at 0 (CU scope), so the inline poll can miss a host write to the signal value. This sets it to system scope in all four builders.

## Motivation

The fused wait/signal packets fold a dependency poll into the copy packet itself, and the value they poll is a signal that the host writes. With `wait_scope` at CU scope the poll is not guaranteed to observe that write, so the copy can stall on a dependency that has already been satisfied.

Every other scope field in these packets is already system scope — `dst_scope`/`src_scope` on linear and multicast, `scope_a`/`scope_b` on swap, `copy_dst_scope`/`copy_src_scope`/`indirect_addr_scope` on indirect, and `signal_scope` on all four. `wait_scope` was the one left at the default.

## Technical Details

Add `pkt.WAIT_FUNCTION_UNION.wait_scope = SDMA_MEMORY_SCOPE_SYS;` alongside the existing `wait_function` assignment in:

- `BuildWaitSignalCopyCommand` (linear)
- `BuildWaitSignalIndirectCopyCommand` (indirect)
- `BuildWaitSignalSwapCommand` (swap)
- `BuildMulticastWaitSignalCopyCommand` (multicast)

No packet layout, ring reservation or path selection changes: the fused packets keep their compacted variable-length encoding, and gfx125+ copies keep taking the fused path.

An earlier revision of this PR added an `HSA_FUSED_SWAP` toggle to route swap copies off the fused path while `Unit_hipMemcpyBatchAsync_Swap` was hanging on gfx1250. That hang turned out to be a hardware issue, so all of that has been dropped and the branch is rebased on develop with only the scope fix.

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->

## Test Plan

`Unit_hipMemcpyBatchAsync_Swap` and the linear, indirect and multicast batch copy tests on gfx1250, exercising the fused wait/signal path with host-signalled dependencies.

## Test Result

Pending on gfx1250 hardware.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
