### PR TITLE
hotswap: Implement caching and prepare for AOT compilation of the RCCL code objects

### DIFF
--- a/emulation/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/CMakeLists.txt
@@ -428,14 +428,31 @@ install(
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    # The translator ships alongside the hook: both must resolve to the SAME
+    # shared object, or the cache identity they derive from it would differ and
+    # neither could read what the other wrote.
     install(
-        TARGETS hsa_hotswap_rocjitsu
+        TARGETS hsa_hotswap_rocjitsu rocjitsu_gfx1250_b0_to_a0
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     )
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    install(TARGETS rocjitsu_bin RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+    # rj_pretranslate ships because the tier it fills is only worth having if an
+    # image build or a post-install step can fill it.
+    install(
+        TARGETS rocjitsu_bin rj_pretranslate
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
+    # And the wrapper ships with it. rj_pretranslate takes standalone code
+    # objects; the script is the only piece that knows how to find them inside
+    # fat binaries, offload bundles and KPACK archives, and the tool's own help
+    # text points at it. Installing one without the other leaves that pointer
+    # dangling and the deployed workflow with no entry point.
+    install(
+        PROGRAMS scripts/rocjitsu-pretranslate.py
+        DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
 endif()
 
 # Config files and schemas: share/rocjitsu/

--- a/emulation/rocjitsu/lib/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/CMakeLists.txt
@@ -29,12 +29,21 @@ set_target_properties(
 )
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    # Private fixed-profile archive for the gfx1250 B0-to-A0 hotswap hook. Its
-    # default registry contains only the gfx1250 model provider, excluding the
-    # full simulator aggregate and execution objects.
+    # Fixed-profile gfx1250 B0-to-A0 translator. Its default registry contains
+    # only the gfx1250 model provider, excluding the full simulator aggregate and
+    # execution objects.
+    #
+    # Shared rather than static because the translation cache keys entries on the
+    # build id of the module that produced them. A static archive is copied into
+    # every consumer, so each would carry a different build id and none could read
+    # another's entries -- which is exactly what a translation performed ahead of
+    # time needs to be able to do. One shared object gives every consumer the same
+    # identity, derived by the linker from emitted content, so a rebuild that
+    # changes translation output invalidates the cache with nobody maintaining a
+    # version number.
     add_library(
         rocjitsu_gfx1250_b0_to_a0
-        STATIC
+        SHARED
         src/rocjitsu/code/dbt/gfx1250_b0_to_a0_library.cpp
     )
     foreach(_object_lib IN LISTS ROCJITSU_DBT_BASE_OBJECT_LIBS)
@@ -48,6 +57,8 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         PROPERTIES
             OUTPUT_NAME rocjitsu_gfx1250_b0_to_a0
             POSITION_INDEPENDENT_CODE ON
+            VERSION ${PROJECT_VERSION}
+            SOVERSION ${PROJECT_VERSION_MAJOR}
     )
     target_link_libraries(
         rocjitsu_gfx1250_b0_to_a0
@@ -62,6 +73,25 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         PRIVATE_INCLUDES
         WARNINGS
         HIDDEN
+    )
+    # --build-id is load bearing: the translation cache keys every entry on this
+    # note. Without it the store finds no identity for the translator and turns
+    # itself off, which would look like a cache that simply never hits.
+    #
+    # The version script is what keeps the exported surface to the C API. HIDDEN
+    # above only governs this target's own sources; the object libraries linked in
+    # are not built that way, so unscripted this library exports 126 symbols.
+    set(_gfx1250_map ${CMAKE_CURRENT_SOURCE_DIR}/rocjitsu_gfx1250_b0_to_a0.map)
+    set_property(
+        TARGET rocjitsu_gfx1250_b0_to_a0
+        APPEND
+        PROPERTY LINK_DEPENDS ${_gfx1250_map}
+    )
+    target_link_options(
+        rocjitsu_gfx1250_b0_to_a0
+        PRIVATE
+            "LINKER:--build-id=sha1"
+            "LINKER:--version-script=${_gfx1250_map}"
     )
 endif()
 

--- a/emulation/rocjitsu/lib/rocjitsu/rocjitsu_gfx1250_b0_to_a0.map
+++ b/emulation/rocjitsu/lib/rocjitsu/rocjitsu_gfx1250_b0_to_a0.map
@@ -1,0 +1,24 @@
+# Exported ABI of the fixed-profile gfx1250 B0-to-A0 translator.
+#
+# Only the C API in rocjitsu/code/rj_gfx1250_b0_to_a0.h. The library is built
+# from object libraries that are not themselves compiled with hidden visibility,
+# so without this script it exports 126 symbols -- every rj_code_* entry point it
+# happens to link -- and those become an ABI nobody chose to promise.
+#
+# This matters more than tidiness now that the library is shared and installed:
+# its build id is the translation cache's identity, so it is a versioned artifact
+# whose surface has to be deliberate.
+{
+  global:
+    rj_gfx1250_b0_to_a0_translate;
+    rj_gfx1250_b0_to_a0_free;
+    # One deliberate C++ export beyond the C API: the in-tree library test drives
+    # the required-work fan-out directly, and the alternative -- a second target
+    # differing only in its version script, as the hook does -- costs more than a
+    # single named symbol is worth.
+    extern "C++" {
+      rocjitsu::emit_gfx1250_b0_to_a0_diagnostics*;
+    };
+  local:
+    *;
+};

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/gfx1250_b0_a0_cache.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/gfx1250_b0_a0_cache.h
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file dbt/gfx1250_b0_a0_cache.h
+/// @brief What every consumer of the fixed-profile B0-to-A0 translator must
+///        agree on to share cached translations.
+///
+/// @details Two programs share entries only if they derive the same key and look
+/// in the same tree. Nothing reports a disagreement: a tool writing under one
+/// domain and a runtime reading under another both work perfectly, produce no
+/// error, and never exchange a single entry. The pre-translation tool would
+/// appear to succeed while start-up kept paying full translation cost.
+///
+/// So these are stated once and included by both sides rather than declared
+/// alongside each use.
+
+#ifndef ROCJITSU_CODE_DBT_GFX1250_B0_A0_CACHE_H_
+#define ROCJITSU_CODE_DBT_GFX1250_B0_A0_CACHE_H_
+
+#include "rocjitsu/code/dbt/translation_store.h"
+#include "rocjitsu/code/rj_gfx1250_b0_to_a0.h"
+
+#include <string_view>
+
+namespace rocjitsu {
+
+/// @brief Tree holding this translator's entries, in either tier.
+constexpr std::string_view kGfx1250B0A0Domain = "gfx1250-b0-a0";
+
+/// @brief The single configuration this translator runs under.
+///
+/// @details Its entry point takes no options, so every request shares one
+/// identity. It is still recorded and re-checked, so an entry produced under a
+/// future profile can never satisfy a request made under this one.
+constexpr TranslationIdentity kGfx1250B0A0Identity{
+    .profile_id = 1,
+    .input_revision = 1,
+    .output_revision = 0,
+    .target_isa = "gfx1250",
+};
+
+/// @brief An address inside the translator, not inside the caller.
+///
+/// @details Passed to the store, whose keys name whatever produced an entry, and
+/// to shared_translation_root(), which locates the shared tree relative to that
+/// same object. Both callers resolve this to the one translator they are linked
+/// against, so they agree by construction rather than by convention.
+inline const void *gfx1250_b0_a0_translator_anchor() {
+  return reinterpret_cast<const void *>(&rj_gfx1250_b0_to_a0_translate);
+}
+
+} // namespace rocjitsu
+
+#endif // ROCJITSU_CODE_DBT_GFX1250_B0_A0_CACHE_H_

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/gfx1250_b0_a0_cache.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/gfx1250_b0_a0_cache.h
@@ -27,6 +27,13 @@ namespace rocjitsu {
 /// @brief Tree holding this translator's entries, in either tier.
 constexpr std::string_view kGfx1250B0A0Domain = "gfx1250-b0-a0";
 
+/// @brief Key contract shared by the packaged producer and runtime consumer.
+/// @details These entries are built and shipped as one deployment artifact, so
+/// their explicit profile and format revisions, rather than one producer ELF's
+/// build ID, define compatibility.
+constexpr TranslationStore::KeyMode kGfx1250B0A0KeyMode =
+    TranslationStore::KeyMode::kPortablePrebuilt;
+
 /// @brief The single configuration this translator runs under.
 ///
 /// @details Its entry point takes no options, so every request shares one

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/gfx1250_b0_to_a0_diagnostics.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/gfx1250_b0_to_a0_diagnostics.h
@@ -13,8 +13,15 @@
 
 namespace rocjitsu {
 
-void emit_gfx1250_b0_to_a0_diagnostics(
-    rj_gfx1250_b0_to_a0_diagnostic_callback_t callback, void *user_data,
-    const std::vector<TranslationDiagnostic> &diagnostics) noexcept;
+/// @details Given default visibility rather than left hidden because the
+/// translator is now a shared library whose other symbols are all hidden -- that
+/// is what makes its build id a meaningful cache identity. The in-tree library
+/// test drives this fan-out directly and would otherwise be unable to reach it.
+/// The version script names it explicitly, so the exported surface stays
+/// deliberate rather than incidental.
+RJ_API_EXPORT void
+emit_gfx1250_b0_to_a0_diagnostics(rj_gfx1250_b0_to_a0_diagnostic_callback_t callback,
+                                  void *user_data,
+                                  const std::vector<TranslationDiagnostic> &diagnostics) noexcept;
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/translation_store.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/translation_store.cpp
@@ -1,0 +1,1060 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file dbt/translation_store.cpp
+/// @brief On-disk store for translated code objects.
+
+#include "rocjitsu/code/dbt/translation_store.h"
+
+#include <algorithm>
+#include <atomic>
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+#include <ctime>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include <dirent.h>
+#include <dlfcn.h>
+#include <elf.h>
+#include <fcntl.h>
+#include <link.h>
+#include <sys/file.h>
+#include <sys/stat.h>
+#include <sys/statvfs.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+namespace rocjitsu {
+namespace {
+
+/// @brief Stable identity for caches distributed with their consumer.
+/// @details Changing the portable cache contract requires changing this nonce
+/// or the cache epoch. It is deliberately not a wildcard: manifests and keys
+/// still agree on one explicit producer identity.
+constexpr std::string_view kPortablePrebuiltNonce = "unversioned-prebuilt-v1";
+
+/// @brief Bumped by hand to invalidate every entry a deployment already holds.
+/// @details The build identity below already separates differently-built
+/// translators. This exists for the case where an operator needs to discard
+/// entries without a rebuild.
+constexpr uint32_t kCacheEpoch = 1;
+
+/// @brief Layout revision, carried in the path so a change starts a new tree.
+constexpr std::string_view kSchemaDir = "v1";
+
+/// @brief Prefix distinguishing this digest from a plain hash of the source.
+constexpr std::string_view kKeyDomain = "rjc1";
+
+constexpr std::string_view kManifestMagic = "rjcache1";
+
+/// @brief Largest store, before the proportional and headroom limits apply.
+constexpr uint64_t operator""_MiB(unsigned long long value) { return value << 20; }
+constexpr uint64_t operator""_GiB(unsigned long long value) { return value << 30; }
+
+/// @brief Below this much free space the store stops accepting writes.
+/// @details The runtime directory is shared with the daemon socket and config,
+/// and is memory-backed, so exhausting it breaks more than caching.
+constexpr uint64_t kHeadroomBytes = 64_MiB;
+
+/// @brief Largest object the store will read or write.
+///
+/// @details The store exists to hold exactly the objects too large to be worth
+/// translating repeatedly -- a device library of a few hundred megabytes takes
+/// minutes -- so this is not a capacity policy but a sanity bound, so a corrupt
+/// size never turns into an allocation of that size.
+constexpr uint64_t kMaxObjectBytes = 4_GiB;
+
+/// @brief Age at which an unrenamed temporary is treated as abandoned.
+/// @details A writer killed between creating its temporary and renaming it
+/// leaves bytes that no entry accounts for and nothing would ever reclaim. The
+/// threshold only has to exceed the time one write can take, which is a single
+/// buffered write and an fsync, so it is generous by orders of magnitude.
+constexpr time_t kAbandonedTempSeconds = 600;
+
+// ---------------------------------------------------------------------------
+// SHA-256. Self-contained: this library links no crypto dependency, and the
+// store needs a digest strong enough that two distinct code objects cannot be
+// made to collide by accident.
+// ---------------------------------------------------------------------------
+
+struct Sha256 {
+  uint32_t state[8] = {0x6a09e667u, 0xbb67ae85u, 0x3c6ef372u, 0xa54ff53au,
+                       0x510e527fu, 0x9b05688cu, 0x1f83d9abu, 0x5be0cd19u};
+  uint64_t bit_count = 0;
+  uint8_t buffer[64] = {};
+  size_t buffered = 0;
+
+  static uint32_t rotr(uint32_t v, uint32_t n) { return (v >> n) | (v << (32u - n)); }
+
+  void compress(const uint8_t *block) {
+    static constexpr uint32_t k[64] = {
+        0x428a2f98u, 0x71374491u, 0xb5c0fbcfu, 0xe9b5dba5u, 0x3956c25bu, 0x59f111f1u, 0x923f82a4u,
+        0xab1c5ed5u, 0xd807aa98u, 0x12835b01u, 0x243185beu, 0x550c7dc3u, 0x72be5d74u, 0x80deb1feu,
+        0x9bdc06a7u, 0xc19bf174u, 0xe49b69c1u, 0xefbe4786u, 0x0fc19dc6u, 0x240ca1ccu, 0x2de92c6fu,
+        0x4a7484aau, 0x5cb0a9dcu, 0x76f988dau, 0x983e5152u, 0xa831c66du, 0xb00327c8u, 0xbf597fc7u,
+        0xc6e00bf3u, 0xd5a79147u, 0x06ca6351u, 0x14292967u, 0x27b70a85u, 0x2e1b2138u, 0x4d2c6dfcu,
+        0x53380d13u, 0x650a7354u, 0x766a0abbu, 0x81c2c92eu, 0x92722c85u, 0xa2bfe8a1u, 0xa81a664bu,
+        0xc24b8b70u, 0xc76c51a3u, 0xd192e819u, 0xd6990624u, 0xf40e3585u, 0x106aa070u, 0x19a4c116u,
+        0x1e376c08u, 0x2748774cu, 0x34b0bcb5u, 0x391c0cb3u, 0x4ed8aa4au, 0x5b9cca4fu, 0x682e6ff3u,
+        0x748f82eeu, 0x78a5636fu, 0x84c87814u, 0x8cc70208u, 0x90befffau, 0xa4506cebu, 0xbef9a3f7u,
+        0xc67178f2u};
+    uint32_t w[64];
+    for (int i = 0; i < 16; ++i)
+      w[i] = (static_cast<uint32_t>(block[i * 4]) << 24) |
+             (static_cast<uint32_t>(block[i * 4 + 1]) << 16) |
+             (static_cast<uint32_t>(block[i * 4 + 2]) << 8) |
+             static_cast<uint32_t>(block[i * 4 + 3]);
+    for (int i = 16; i < 64; ++i) {
+      const uint32_t s0 = rotr(w[i - 15], 7) ^ rotr(w[i - 15], 18) ^ (w[i - 15] >> 3);
+      const uint32_t s1 = rotr(w[i - 2], 17) ^ rotr(w[i - 2], 19) ^ (w[i - 2] >> 10);
+      w[i] = w[i - 16] + s0 + w[i - 7] + s1;
+    }
+    uint32_t a = state[0], b = state[1], c = state[2], d = state[3];
+    uint32_t e = state[4], f = state[5], g = state[6], h = state[7];
+    for (int i = 0; i < 64; ++i) {
+      const uint32_t s1 = rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25);
+      const uint32_t ch = (e & f) ^ (~e & g);
+      const uint32_t t1 = h + s1 + ch + k[i] + w[i];
+      const uint32_t s0 = rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22);
+      const uint32_t maj = (a & b) ^ (a & c) ^ (b & c);
+      const uint32_t t2 = s0 + maj;
+      h = g;
+      g = f;
+      f = e;
+      e = d + t1;
+      d = c;
+      c = b;
+      b = a;
+      a = t1 + t2;
+    }
+    state[0] += a;
+    state[1] += b;
+    state[2] += c;
+    state[3] += d;
+    state[4] += e;
+    state[5] += f;
+    state[6] += g;
+    state[7] += h;
+  }
+
+  void update(const void *data, size_t size) {
+    const auto *p = static_cast<const uint8_t *>(data);
+    bit_count += static_cast<uint64_t>(size) * 8u;
+    while (size > 0) {
+      const size_t take = std::min(size, sizeof(buffer) - buffered);
+      std::memcpy(buffer + buffered, p, take);
+      buffered += take;
+      p += take;
+      size -= take;
+      if (buffered == sizeof(buffer)) {
+        compress(buffer);
+        buffered = 0;
+      }
+    }
+  }
+
+  void update(std::string_view text) { update(text.data(), text.size()); }
+
+  std::array<uint8_t, 32> finish() {
+    const uint64_t bits = bit_count;
+    const uint8_t pad = 0x80;
+    update(&pad, 1);
+    const uint8_t zero = 0;
+    while (buffered != 56)
+      update(&zero, 1);
+    uint8_t tail[8];
+    for (int i = 0; i < 8; ++i)
+      tail[i] = static_cast<uint8_t>(bits >> (56 - i * 8));
+    // Length is appended directly: routing it through update() would grow
+    // bit_count again and corrupt the padding invariant.
+    std::memcpy(buffer + buffered, tail, sizeof(tail));
+    compress(buffer);
+    std::array<uint8_t, 32> out{};
+    for (int i = 0; i < 8; ++i) {
+      out[i * 4] = static_cast<uint8_t>(state[i] >> 24);
+      out[i * 4 + 1] = static_cast<uint8_t>(state[i] >> 16);
+      out[i * 4 + 2] = static_cast<uint8_t>(state[i] >> 8);
+      out[i * 4 + 3] = static_cast<uint8_t>(state[i]);
+    }
+    return out;
+  }
+};
+
+[[nodiscard]] std::string to_hex(std::span<const uint8_t> bytes) {
+  static constexpr char kDigits[] = "0123456789abcdef";
+  std::string out;
+  out.reserve(bytes.size() * 2);
+  for (uint8_t b : bytes) {
+    out.push_back(kDigits[b >> 4]);
+    out.push_back(kDigits[b & 0xf]);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Build identity
+// ---------------------------------------------------------------------------
+
+/// @brief GNU build identity of the object holding this code.
+///
+/// @details The linker derives it from object content, so any rebuild that
+/// changes emitted bytes changes it without anyone having to remember. That is
+/// the property the store depends on to never serve an entry produced by a
+/// different translator. Returns empty when the note is absent, which disables
+/// the store rather than falling back to a weaker identity.
+///
+/// The object is identified by the loaded segment that contains @p address
+/// rather than by comparing load bases, because a load base only equals the
+/// iterator's reported address for a position-independent object. Whether a
+/// consumer is a shared library or a non-relocatable executable is not something
+/// this component should care about.
+///
+/// Probing by a caller-supplied address rather than by this function's own is
+/// what lets the key name the TRANSLATOR instead of whichever binary happens to
+/// embed the store. Two programs calling the same translator derive the same id
+/// and so agree on keys; one linking a different build of it derives a different
+/// id and simply misses.
+[[nodiscard]] std::string read_build_id_of(const void *address) {
+  struct Query {
+    const uint8_t *self;
+    std::string result;
+  } query{static_cast<const uint8_t *>(address), {}};
+
+  dl_iterate_phdr(
+      [](struct dl_phdr_info *phdr_info, size_t, void *data) -> int {
+        auto *q = static_cast<Query *>(data);
+        bool holds_self = false;
+        for (int i = 0; i < phdr_info->dlpi_phnum && !holds_self; ++i) {
+          const ElfW(Phdr) &segment = phdr_info->dlpi_phdr[i];
+          if (segment.p_type != PT_LOAD)
+            continue;
+          const auto *begin =
+              reinterpret_cast<const uint8_t *>(phdr_info->dlpi_addr + segment.p_vaddr);
+          holds_self = q->self >= begin && q->self < begin + segment.p_memsz;
+        }
+        if (!holds_self)
+          return 0;
+
+        for (int i = 0; i < phdr_info->dlpi_phnum; ++i) {
+          const ElfW(Phdr) &segment = phdr_info->dlpi_phdr[i];
+          if (segment.p_type != PT_NOTE)
+            continue;
+          const auto *cursor =
+              reinterpret_cast<const uint8_t *>(phdr_info->dlpi_addr + segment.p_vaddr);
+          const uint8_t *end = cursor + segment.p_memsz;
+          while (cursor + sizeof(ElfW(Nhdr)) <= end) {
+            ElfW(Nhdr) note{};
+            std::memcpy(&note, cursor, sizeof(note));
+            const size_t name_size = (note.n_namesz + 3u) & ~3u;
+            const size_t desc_size = (note.n_descsz + 3u) & ~3u;
+            const uint8_t *name = cursor + sizeof(note);
+            const uint8_t *desc = name + name_size;
+            if (desc + desc_size > end)
+              break;
+            if (note.n_type == NT_GNU_BUILD_ID && note.n_namesz == 4 &&
+                std::memcmp(name, "GNU", 4) == 0) {
+              q->result = to_hex({desc, note.n_descsz});
+              return 1;
+            }
+            cursor = desc + desc_size;
+          }
+        }
+        return 1;
+      },
+      &query);
+  return query.result;
+}
+
+} // namespace
+
+std::string shared_translation_root(const void *address) {
+  Dl_info info{};
+  if (dladdr(address, &info) == 0 || info.dli_fname == nullptr)
+    return {};
+  const std::string_view path(info.dli_fname);
+  const size_t file_at = path.rfind('/');
+  if (file_at == std::string_view::npos)
+    return {}; // A bare name means the loader resolved it by search; no prefix.
+  const std::string_view library_dir = path.substr(0, file_at);
+  const size_t prefix_at = library_dir.rfind('/');
+  if (prefix_at == std::string_view::npos)
+    return {};
+
+  // Only an install layout gets a root. Stripping two components unconditionally
+  // means a module loaded from anywhere at all names a sibling `share` -- a copy
+  // under /tmp would derive /tmp/share/rocjitsu/translations, inventing a cache
+  // location in a world-writable directory purely because that is where the
+  // library happened to sit. Requiring the containing directory to be a library
+  // directory keeps the derivation to the case it was designed for; anything
+  // else reports no root, and the caller treats that as "not pre-translated".
+  const std::string_view library_dir_name = library_dir.substr(prefix_at + 1);
+  const bool is_library_dir = library_dir_name == "lib" || library_dir_name == "lib64" ||
+                              // Debian/Ubuntu multiarch, e.g. lib/x86_64-linux-gnu, whose prefix is
+                              // one level further up than the two-component strip above assumes.
+                              library_dir_name.find('-') != std::string_view::npos;
+  if (!is_library_dir)
+    return {};
+  std::string_view prefix = library_dir.substr(0, prefix_at);
+  if (library_dir_name.find('-') != std::string_view::npos) {
+    const size_t multiarch_prefix_at = prefix.rfind('/');
+    if (multiarch_prefix_at == std::string_view::npos ||
+        prefix.substr(multiarch_prefix_at + 1) != "lib")
+      return {};
+    prefix = prefix.substr(0, multiarch_prefix_at);
+  }
+  return std::string(prefix) + "/share/rocjitsu/translations";
+}
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+/// @brief Create @p path and every missing parent with mode @p mode.
+///
+/// @details The mode is explicit because the two tiers need opposite things. The
+/// session tree is private to one user. The shared tree is typically written by
+/// root during an image build and read later by an unprivileged process, so a
+/// private mode would produce a tree nobody can use.
+///
+/// mkdir applies the umask, so a component this call creates has its mode set
+/// again afterwards. A component that already existed is left exactly as found:
+/// correcting one would quietly repair the very thing the directory checks below
+/// exist to notice, and repairing it is precisely what someone who planted it
+/// would want.
+[[nodiscard]] std::vector<std::string> path_components(std::string_view path) {
+  std::vector<std::string> components;
+  size_t at = 0;
+  while (at < path.size()) {
+    const size_t next = path.find('/', at);
+    const std::string_view component =
+        path.substr(at, next == std::string_view::npos ? std::string_view::npos : next - at);
+    if (!component.empty())
+      components.emplace_back(component);
+    if (next == std::string_view::npos)
+      break;
+    at = next + 1;
+  }
+  return components;
+}
+
+/// @brief Which owners a directory the store relies on may have.
+enum class DirectoryTrust {
+  /// Sole ownership by the caller. The session tier is writable by the process
+  /// that checks it, and exclusivity is what makes its own writes safe to trust.
+  kOwnedByCaller,
+  /// Owner root or the caller -- the standard trusted-system-directory test. The
+  /// shared tier is read at run time and written only by an installer, so the
+  /// question is not exclusivity but whether anyone outside the trust boundary
+  /// could have placed an entry.
+  kOwnedByRootOrCaller,
+};
+
+/// @brief Whether @p info names a directory an acceptable user owns.
+///
+/// @details Asked of the directories the store is handed rather than the ones it
+/// creates. The fallback root lives in a world-writable directory, so another
+/// user can pre-create it, and ownership is what rules that out. Their MODE is
+/// not the store's business: $XDG_RUNTIME_DIR/rocjitsu is made by the daemon and
+/// is group-writable, and demanding otherwise would disable the session tier
+/// wherever the daemon has run.
+[[nodiscard]] bool directory_owner_is_trusted(const struct stat &info, DirectoryTrust trust) {
+  if (!S_ISDIR(info.st_mode))
+    return false;
+  if (trust == DirectoryTrust::kOwnedByCaller)
+    return info.st_uid == geteuid();
+  return info.st_uid == 0 || info.st_uid == geteuid();
+}
+
+/// @brief Whether @p info names a directory only its owner can write.
+///
+/// @details Asked of the directories holding entries, which the store creates
+/// itself and whose contents it is about to believe. Group or other write there
+/// means someone outside the trust boundary could have placed an entry.
+[[nodiscard]] bool directory_is_trusted(const struct stat &info, DirectoryTrust trust) {
+  return directory_owner_is_trusted(info, trust) && (info.st_mode & (S_IWGRP | S_IWOTH)) == 0;
+}
+
+/// @brief Walk to @p path one component at a time, following no symlink.
+///
+/// @details Opening the assembled path in one call and checking only what it
+/// lands on proves nothing about how it got there: any component along the way
+/// can be a symlink, and the check then describes the target rather than the
+/// place the caller named. A domain pre-created as a symlink was enough to send
+/// the writer outside the root it was given and have the reader find the entry
+/// there, with every check passing.
+///
+/// So each component is opened relative to its already-verified parent with
+/// O_NOFOLLOW, and the checks apply to that descriptor. A symlink anywhere is
+/// refused instead of followed. The final descriptor is then held for the
+/// process lifetime, so nothing that happens to the path afterwards changes
+/// which directory is used.
+///
+/// @param create_mode Non-zero creates missing components with that mode. mkdir
+///        applies the umask, so a component this call creates has its mode set
+///        again through its own descriptor. A component that already existed is
+///        left exactly as found: correcting one would quietly repair the very
+///        thing these checks exist to notice.
+/// @param trusted_from Index of the first component the trust policy applies to.
+///        The directories above a store root are the system's -- /tmp is
+///        world-writable by design and would fail any ownership test -- so they
+///        are walked without following symlinks but are not otherwise judged.
+[[nodiscard]] int open_descended_directory(const std::string &path, mode_t create_mode,
+                                           DirectoryTrust trust, size_t owner_checked_from,
+                                           size_t trusted_from) {
+  const std::vector<std::string> components = path_components(path);
+  if (components.empty())
+    return -1;
+
+  int parent = open("/", O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+  if (parent < 0)
+    return -1;
+
+  for (size_t index = 0; index < components.size(); ++index) {
+    const std::string &component = components[index];
+    // "." and ".." would step outside the chain of descriptors this walk has
+    // verified, which is the whole point of walking it.
+    if (component == "." || component == "..") {
+      close(parent);
+      return -1;
+    }
+    const bool created = create_mode != 0 && mkdirat(parent, component.c_str(), create_mode) == 0;
+    if (!created && create_mode != 0 && errno != EEXIST) {
+      close(parent);
+      return -1;
+    }
+    const int child =
+        openat(parent, component.c_str(), O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+    close(parent);
+    if (child < 0)
+      return -1;
+    if (created)
+      (void)fchmod(child, create_mode);
+    if (index >= owner_checked_from) {
+      struct stat info {};
+      const bool ok = fstat(child, &info) == 0 &&
+                      (index >= trusted_from ? directory_is_trusted(info, trust)
+                                             : directory_owner_is_trusted(info, trust));
+      if (!ok) {
+        close(child);
+        return -1;
+      }
+    }
+    parent = child;
+  }
+  return parent;
+}
+
+/// @brief Holds the domain directory's lock for a write.
+///
+/// @details The in-process mutex covers one handle, which is the wrong scope for
+/// a capacity decision: separate processes each scan the same pre-write usage,
+/// each concludes there is room, and each writes. Forty-eight writers with
+/// distinct keys left 194592 bytes under a 65536-byte cap, and no same-key test
+/// can expose it because the collision is in the arithmetic rather than the
+/// bytes.
+///
+/// The scan, the eviction it drives and the publication that consumes the result
+/// therefore happen under one lock on the directory itself. Readers do not take
+/// it: publication is already atomic through rename, so a lookup either sees a
+/// complete entry or misses, and making hits wait behind a writer would trade a
+/// real cost for no benefit.
+///
+/// An advisory lock is enough because every writer is this code. It is released
+/// by the kernel if the holder dies, which matters more here than in a
+/// longer-lived design: a killed pre-translation run must not wedge the store
+/// for everyone after it.
+class DirectoryWriteLock {
+public:
+  explicit DirectoryWriteLock(int dir_fd) : dir_fd_(dir_fd) {
+    held_ = dir_fd_ >= 0 && flock(dir_fd_, LOCK_EX) == 0;
+  }
+  ~DirectoryWriteLock() {
+    if (held_)
+      (void)flock(dir_fd_, LOCK_UN);
+  }
+  DirectoryWriteLock(const DirectoryWriteLock &) = delete;
+  DirectoryWriteLock &operator=(const DirectoryWriteLock &) = delete;
+
+  /// @details A store that could not take the lock declines the write rather
+  /// than proceeding unsynchronised, which is the same best-effort outcome as
+  /// any other refusal.
+  [[nodiscard]] bool held() const { return held_; }
+
+private:
+  int dir_fd_;
+  bool held_ = false;
+};
+
+struct Entry {
+  /// Key without the .obj/.man suffix, so one entry covers the pair.
+  std::string name;
+  /// Object plus manifest, which is what the entry actually occupies.
+  uint64_t size = 0;
+  time_t used = 0;
+  bool has_object = false;
+};
+
+/// @brief True when @p domain names exactly one directory beneath the root.
+///
+/// @details The domain reaches a path, so a caller that passed a separator or a
+/// traversal component could place entries outside the verified directory. It is
+/// a compile-time constant at every call site today, which is why rejecting it
+/// outright is preferable to sanitising it.
+[[nodiscard]] bool is_single_path_component(std::string_view domain) {
+  // A NUL is as much a separator problem as a slash: the C path APIs stop at it,
+  // so "pair\0a" and "pair\0b" are distinct string_views that name one directory
+  // and silently share entries, which is exactly the isolation the domain exists
+  // to provide.
+  return !domain.empty() && domain != "." && domain != ".." &&
+         domain.find('/') == std::string_view::npos && domain.find('\0') == std::string_view::npos;
+}
+
+} // namespace
+
+struct TranslationStore::Impl {
+  Impl(std::string_view domain, const void *translator, std::string_view root, Access access,
+       KeyMode key_mode)
+      : domain_(domain), translator_(translator), root_(root), access_(access),
+        key_mode_(key_mode) {}
+
+  ~Impl() {
+    if (dir_fd_ >= 0)
+      close(dir_fd_);
+  }
+
+  [[nodiscard]] bool available() {
+    std::lock_guard lock(mutex_);
+    ensure_open_locked();
+    return dir_fd_ >= 0 && !build_nonce_.empty();
+  }
+
+  [[nodiscard]] std::string build_nonce() {
+    std::lock_guard lock(mutex_);
+    ensure_open_locked();
+    return build_nonce_;
+  }
+
+  [[nodiscard]] std::vector<uint8_t> lookup(const std::string &key,
+                                            const TranslationIdentity &identity);
+  void store(const std::string &key, std::span<const uint8_t> object,
+             const TranslationIdentity &identity);
+
+#if defined(RJ_TRANSLATION_STORE_TEST_HOOKS)
+  void set_root_for_test(const char *root) {
+    std::lock_guard lock(mutex_);
+    if (dir_fd_ >= 0)
+      close(dir_fd_);
+    dir_fd_ = -1;
+    opened_ = false;
+    hits_ = 0;
+    root_override_ = root == nullptr ? std::string{} : std::string(root);
+  }
+  void set_headroom_for_test(uint64_t bytes) {
+    std::lock_guard lock(mutex_);
+    headroom_override_ = bytes;
+  }
+  [[nodiscard]] uint64_t hits_for_test() {
+    std::lock_guard lock(mutex_);
+    return hits_;
+  }
+  [[nodiscard]] uint64_t size_for_test() {
+    std::lock_guard lock(mutex_);
+    ensure_open_locked();
+    if (dir_fd_ < 0)
+      return 0;
+    uint64_t total = 0;
+    for (const Entry &entry : scan_locked())
+      total += entry.size;
+    return total;
+  }
+#endif
+
+  [[nodiscard]] bool writable() const { return access_ == Access::kReadWrite; }
+
+  [[nodiscard]] uint64_t max_object_bytes() const { return kMaxObjectBytes; }
+
+  void ensure_open_locked() {
+    if (opened_)
+      return;
+    opened_ = true;
+    if (!is_single_path_component(domain_))
+      return;
+    if (key_mode_ == KeyMode::kPortablePrebuilt) {
+      build_nonce_ = kPortablePrebuiltNonce;
+    } else {
+      build_nonce_ = read_build_id_of(translator_);
+      if (build_nonce_.empty())
+        return; // No stable identity: refuse to key on anything weaker.
+    }
+
+    std::string base;
+#if defined(RJ_TRANSLATION_STORE_TEST_HOOKS)
+    base = root_override_;
+#endif
+    if (base.empty()) {
+      // An empty root disables the store rather than defaulting somewhere: a
+      // caller that could not locate its install has not told us where to look.
+      if (root_.empty())
+        return;
+      base = root_;
+    }
+    const std::string path = base + "/" + domain_ + "/" + std::string(kSchemaDir);
+    // The trust policy starts at the store's own root. Everything above it
+    // belongs to the system -- /tmp is world-writable by design, and judging it
+    // by the store's rules would refuse every fallback location -- so those are
+    // walked without following symlinks but are not otherwise judged. From the
+    // root down, every component must pass, because those are the directories
+    // whose contents this store is about to believe.
+    // Ownership is checked from the store root down, because a root someone else
+    // owns is a root someone else controls -- that is what protects the /tmp
+    // fallback. The stricter no-group-or-other-write rule starts one level
+    // lower, at the directories this store creates and reads entries from: the
+    // root itself may be the daemon's, and it is group-writable.
+    const size_t owner_checked_from = path_components(base).size() - 1;
+    const size_t trusted_from = path_components(base).size();
+    // A read-only store never creates its tree. An absent shared tier means
+    // nobody pre-translated, which is a miss and not something to repair -- and
+    // a directory this process created could not be trusted by the next one
+    // anyway, since it would fail its own ownership test under a different user.
+    const mode_t create_mode = writable() ? 0755 : 0;
+    dir_fd_ = open_descended_directory(path, create_mode, DirectoryTrust::kOwnedByRootOrCaller,
+                                       owner_checked_from, trusted_from);
+    if (writable()) {
+      // Once per process, and the only moment at which a temporary left by a
+      // process that died mid-write is unambiguously abandoned.
+      sweep_abandoned_locked();
+    }
+  }
+
+  [[nodiscard, maybe_unused]] std::vector<Entry> scan_locked() const;
+  [[nodiscard]] bool reserve_space_locked(uint64_t needed);
+  void sweep_abandoned_locked() const;
+
+  [[nodiscard]] uint64_t headroom_locked() const {
+#if defined(RJ_TRANSLATION_STORE_TEST_HOOKS)
+    if (headroom_override_ != 0)
+      return headroom_override_;
+#endif
+    return kHeadroomBytes;
+  }
+
+  const std::string domain_;
+  // An address inside the translator whose output these entries are. Exact mode
+  // resolves its module's build ID; portable mode deliberately does not.
+  const void *const translator_;
+  // Root of the tree, supplied by the caller from its own install location.
+  const std::string root_;
+  const Access access_;
+  const KeyMode key_mode_;
+  std::mutex mutex_;
+  bool opened_ = false;
+  int dir_fd_ = -1;
+  std::string build_nonce_;
+#if defined(RJ_TRANSLATION_STORE_TEST_HOOKS)
+  std::string root_override_;
+  uint64_t headroom_override_ = 0;
+  uint64_t hits_ = 0;
+#endif
+};
+
+std::vector<Entry> TranslationStore::Impl::scan_locked() const {
+  std::vector<Entry> entries;
+  if (dir_fd_ < 0)
+    return entries;
+  const int scan_fd = openat(dir_fd_, ".", O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+  if (scan_fd < 0)
+    return entries;
+  DIR *dir = fdopendir(scan_fd);
+  if (dir == nullptr) {
+    close(scan_fd);
+    return entries;
+  }
+  // An entry is the object AND its manifest. Counting only the object lets the
+  // manifests accumulate outside the cap entirely -- 400 one-byte objects under
+  // an 8192-byte cap left 100400 bytes on disk while the store reported 400 --
+  // and makes eviction give back less than it appears to.
+  //
+  // A manifest whose object is missing is counted too, under its own name. That
+  // is what a process killed between the two renames leaves behind: it belongs
+  // to no entry, is never a lookup hit, and nothing would otherwise reclaim it.
+  std::unordered_map<std::string, Entry> by_key;
+  while (const dirent *item = readdir(dir)) {
+    const std::string_view name(item->d_name);
+    const bool is_object = name.ends_with(".obj");
+    if (!is_object && !name.ends_with(".man"))
+      continue;
+    struct stat info {};
+    if (fstatat(dir_fd_, item->d_name, &info, AT_SYMLINK_NOFOLLOW) != 0 || !S_ISREG(info.st_mode))
+      continue;
+    std::string key(name.substr(0, name.size() - 4));
+    Entry &entry = by_key[key];
+    if (entry.name.empty())
+      entry.name = key;
+    entry.size += static_cast<uint64_t>(info.st_size);
+    // The object's timestamp is the one lookups refresh, so it decides eviction
+    // order whenever there is an object at all.
+    if (is_object || entry.used == 0) {
+      entry.used = info.st_mtime;
+      entry.has_object = entry.has_object || is_object;
+    }
+  }
+  closedir(dir);
+  entries.reserve(by_key.size());
+  for (auto &[key, entry] : by_key)
+    entries.push_back(std::move(entry));
+  return entries;
+}
+
+void TranslationStore::Impl::sweep_abandoned_locked() const {
+  if (dir_fd_ < 0)
+    return;
+  const int scan_fd = openat(dir_fd_, ".", O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+  if (scan_fd < 0)
+    return;
+  DIR *dir = fdopendir(scan_fd);
+  if (dir == nullptr) {
+    close(scan_fd);
+    return;
+  }
+  const time_t now = time(nullptr);
+  while (const dirent *item = readdir(dir)) {
+    const std::string_view name(item->d_name);
+    // A manifest published without its object is the other way a writer can die
+    // mid-entry: the manifest is renamed first, so a kill between the two leaves
+    // one that can never satisfy a lookup and that eviction only ever reaches
+    // under cap pressure. The same age threshold applies for the same reason --
+    // below it, the writer may simply still be working.
+    const bool orphan_manifest =
+        name.ends_with(".man") &&
+        faccessat(dir_fd_, (std::string(name.substr(0, name.size() - 4)) + ".obj").c_str(), F_OK,
+                  0) != 0;
+    if (!orphan_manifest && name.find(".tmp.") == std::string_view::npos)
+      continue;
+    struct stat info {};
+    if (fstatat(dir_fd_, item->d_name, &info, AT_SYMLINK_NOFOLLOW) != 0 || !S_ISREG(info.st_mode))
+      continue;
+    if (now - info.st_mtime > kAbandonedTempSeconds)
+      unlinkat(dir_fd_, item->d_name, 0);
+  }
+  closedir(dir);
+}
+
+bool TranslationStore::Impl::reserve_space_locked(uint64_t needed) {
+  // The store is curated rather than cached: someone decided which objects
+  // belong in it, so evicting one to fit another would silently undo that
+  // decision and leave a pre-translation pass with unpredictable output. It gets
+  // a per-entry ceiling and the free-space floor, and nothing else.
+  struct statvfs vfs {};
+  if (dir_fd_ < 0 || fstatvfs(dir_fd_, &vfs) != 0)
+    return false;
+  const uint64_t free_now = static_cast<uint64_t>(vfs.f_bavail) * vfs.f_frsize;
+  return needed <= kMaxObjectBytes && free_now >= needed + headroom_locked();
+}
+
+namespace {
+
+/// @brief Serialise the fields a reader re-checks before trusting an object.
+[[nodiscard]] std::string build_manifest(const std::string &key, std::span<const uint8_t> object,
+                                         const TranslationIdentity &identity,
+                                         const std::string &build_id) {
+  Sha256 hash;
+  hash.update(object.data(), object.size());
+  std::string text;
+  text += std::string(kManifestMagic) + "\n";
+  text += "key=" + key + "\n";
+  text += "build=" + build_id + "\n";
+  text += "epoch=" + std::to_string(kCacheEpoch) + "\n";
+  text += "profile=" + std::to_string(identity.profile_id) + "\n";
+  text += "in_rev=" + std::to_string(identity.input_revision) + "\n";
+  text += "out_rev=" + std::to_string(identity.output_revision) + "\n";
+  text += "isa=" + std::string(identity.target_isa) + "\n";
+  text += "size=" + std::to_string(object.size()) + "\n";
+  text += "sha=" + to_hex(hash.finish()) + "\n";
+  return text;
+}
+
+[[nodiscard]] std::optional<std::string> manifest_field(std::string_view text,
+                                                        std::string_view name) {
+  std::string needle = "\n" + std::string(name) + "=";
+  const size_t at = text.find(needle);
+  if (at == std::string_view::npos)
+    return std::nullopt;
+  const size_t begin = at + needle.size();
+  const size_t end = text.find('\n', begin);
+  if (end == std::string_view::npos)
+    return std::nullopt;
+  return std::string(text.substr(begin, end - begin));
+}
+
+[[nodiscard]] std::optional<std::string> read_whole(int dir_fd, const std::string &name,
+                                                    uint64_t limit) {
+  const int fd = openat(dir_fd, name.c_str(), O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
+  if (fd < 0)
+    return std::nullopt;
+  struct stat info {};
+  if (fstat(fd, &info) != 0 || !S_ISREG(info.st_mode) ||
+      static_cast<uint64_t>(info.st_size) > limit) {
+    close(fd);
+    return std::nullopt;
+  }
+  std::string data;
+  data.resize(static_cast<size_t>(info.st_size));
+  size_t done = 0;
+  while (done < data.size()) {
+    const ssize_t got = read(fd, data.data() + done, data.size() - done);
+    if (got <= 0) {
+      close(fd);
+      return std::nullopt;
+    }
+    done += static_cast<size_t>(got);
+  }
+  close(fd);
+  return data;
+}
+
+[[nodiscard]] bool write_atomically(int dir_fd, const std::string &name, const void *data,
+                                    size_t size, mode_t mode) {
+  static std::atomic<uint64_t> counter{0};
+  const std::string temp = name + ".tmp." +
+                           std::to_string(counter.fetch_add(1, std::memory_order_relaxed)) + "." +
+                           std::to_string(getpid());
+  const int fd =
+      openat(dir_fd, temp.c_str(), O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW | O_CLOEXEC, mode);
+  if (fd < 0)
+    return false;
+  // open() applies the umask, which for a shared entry written during an image
+  // build would leave a file the eventual reader cannot open. Set the mode on the
+  // descriptor instead, before the rename makes the name visible.
+  if (fchmod(fd, mode) != 0) {
+    close(fd);
+    unlinkat(dir_fd, temp.c_str(), 0);
+    return false;
+  }
+  const auto *cursor = static_cast<const uint8_t *>(data);
+  size_t left = size;
+  while (left > 0) {
+    const ssize_t put = write(fd, cursor, left);
+    if (put <= 0) {
+      close(fd);
+      unlinkat(dir_fd, temp.c_str(), 0);
+      return false;
+    }
+    cursor += put;
+    left -= static_cast<size_t>(put);
+  }
+  if (fsync(fd) != 0) {
+    close(fd);
+    unlinkat(dir_fd, temp.c_str(), 0);
+    return false;
+  }
+  close(fd);
+  if (renameat(dir_fd, temp.c_str(), dir_fd, name.c_str()) != 0) {
+    unlinkat(dir_fd, temp.c_str(), 0);
+    return false;
+  }
+  return true;
+}
+
+} // namespace
+
+std::vector<uint8_t> TranslationStore::Impl::lookup(const std::string &key,
+                                                    const TranslationIdentity &identity) {
+  // Only opening needs the lock. Holding it across the file reads and the
+  // digest made independent hits serialise against each other -- repeated
+  // lookups of one 8 MiB entry went from 320 ms on one thread to 2561 ms on
+  // eight -- and none of that work touches shared state. Once the descriptor
+  // and the build identity are settled they do not change again, and a
+  // concurrent publication is already invisible: rename is atomic, so a reader
+  // sees the previous entry or the new one, and anything else fails the
+  // manifest and digest checks and degrades to a miss.
+  int dir_fd = -1;
+  std::string build_nonce;
+  {
+    std::lock_guard lock(mutex_);
+    ensure_open_locked();
+    dir_fd = dir_fd_;
+    build_nonce = build_nonce_;
+  }
+  if (dir_fd < 0)
+    return {};
+
+  const std::string manifest_name = key + ".man";
+  const std::string object_name = key + ".obj";
+  constexpr uint64_t kManifestLimit = 4096;
+  const std::optional<std::string> manifest = read_whole(dir_fd, manifest_name, kManifestLimit);
+  if (!manifest || !manifest->starts_with(kManifestMagic))
+    return {};
+
+  // The key already covers these, so a mismatch means a digest collision or a
+  // file left behind by a defect. Either way the object is not ours to use.
+  const auto recorded_size = manifest_field(*manifest, "size");
+  const auto recorded_sha = manifest_field(*manifest, "sha");
+  if (!recorded_size || !recorded_sha)
+    return {};
+  const std::pair<std::string_view, std::string> expected[] = {
+      {"key", key},
+      {"build", build_nonce},
+      {"epoch", std::to_string(kCacheEpoch)},
+      {"profile", std::to_string(identity.profile_id)},
+      {"in_rev", std::to_string(identity.input_revision)},
+      {"out_rev", std::to_string(identity.output_revision)},
+      {"isa", std::string(identity.target_isa)},
+  };
+  for (const auto &[name, want] : expected) {
+    const auto got = manifest_field(*manifest, name);
+    if (!got || *got != want)
+      return {};
+  }
+
+  const std::optional<std::string> object = read_whole(dir_fd, object_name, max_object_bytes());
+  if (!object || std::to_string(object->size()) != *recorded_size)
+    return {};
+
+  Sha256 hash;
+  hash.update(object->data(), object->size());
+  if (to_hex(hash.finish()) != *recorded_sha)
+    return {};
+
+  // Refresh for the eviction order. Failure only costs ordering accuracy, and
+  // the shared tier never evicts, so it has no order to keep.
+  if (writable()) {
+    const timespec now[2] = {{0, UTIME_NOW}, {0, UTIME_NOW}};
+    (void)utimensat(dir_fd, object_name.c_str(), now, AT_SYMLINK_NOFOLLOW);
+  }
+
+#if defined(RJ_TRANSLATION_STORE_TEST_HOOKS)
+  {
+    std::lock_guard lock(mutex_);
+    ++hits_;
+  }
+#endif
+  return std::vector<uint8_t>(object->begin(), object->end());
+}
+
+void TranslationStore::Impl::store(const std::string &key, std::span<const uint8_t> object,
+                                   const TranslationIdentity &identity) {
+  std::lock_guard lock(mutex_);
+  if (!writable())
+    return;
+  ensure_open_locked();
+  if (dir_fd_ < 0 || object.empty())
+    return;
+
+  // Everything from here to publication is one critical section across
+  // processes, because the reservation below is only meaningful if nobody else
+  // writes between the scan and the rename that consumes its result.
+  const DirectoryWriteLock directory_lock(dir_fd_);
+  if (!directory_lock.held())
+    return;
+
+  // Refuse what cannot fit before hashing it. build_manifest() digests the whole
+  // object, so a refused 64 MiB entry spent 234 ms on a SHA-256 whose result was
+  // discarded -- with the directory locked and the mutex held, so every other
+  // writer and every opening reader waited behind it. The bound only has to be
+  // no smaller than the real manifest; the reservation below still uses the
+  // exact size.
+  // The object alone already exceeding the per-entry share is enough to refuse:
+  // the manifest only makes it larger, so this can never reject something the
+  // exact check below would have accepted. Anything subtler belongs to that
+  // check, which still runs with the real size.
+  if (object.size() > kMaxObjectBytes)
+    return;
+
+  const std::string manifest = build_manifest(key, object, identity, build_nonce_);
+  if (!reserve_space_locked(object.size() + manifest.size()))
+    return;
+
+  // Entries must be readable by whoever eventually runs; the directory's
+  // ownership, not the file's mode, is what keeps them trustworthy.
+  constexpr mode_t mode = 0644;
+  // Manifest first: a visible object must always have something to verify
+  // against. A manifest with no object simply reads as a miss.
+  if (!write_atomically(dir_fd_, key + ".man", manifest.data(), manifest.size(), mode))
+    return;
+  if (!write_atomically(dir_fd_, key + ".obj", object.data(), object.size(), mode))
+    unlinkat(dir_fd_, (key + ".man").c_str(), 0);
+}
+
+TranslationStore::TranslationStore(std::string_view domain, const void *translator,
+                                   std::string_view root, Access access, KeyMode key_mode)
+    : impl_(std::make_unique<Impl>(domain, translator, root, access, key_mode)) {}
+
+bool TranslationStore::available() { return impl_->available(); }
+
+TranslationStore::~TranslationStore() = default;
+
+// Every public operation is contained here rather than at each internal step.
+// The documented contract is best effort -- a caller translates instead -- but
+// these paths allocate strings, vectors and file buffers, and this component is
+// reached from an HSA load callback. A std::bad_alloc escaping key_for() fails
+// that load outright, turning a cache that could not answer into a program that
+// cannot run. Returning an invalid key, a miss, or a no-op keeps the promise.
+CacheKey TranslationStore::key_for(std::span<const uint8_t> source,
+                                   const TranslationIdentity &identity) try {
+  CacheKey key;
+  if (source.empty())
+    return key;
+  const std::string build_nonce = impl_->build_nonce();
+  if (build_nonce.empty() || !impl_->available())
+    return key;
+
+  // The manifest is line oriented, so a newline here forges an earlier size= or
+  // sha= field. The object still gets written, every later lookup rejects it,
+  // and the entry is retried forever: a write-only cache slot. The one identity
+  // this hook presents is safe, but the type accepts any string_view.
+  if (identity.target_isa.find('\n') != std::string_view::npos ||
+      identity.target_isa.find('\r') != std::string_view::npos)
+    return key;
+
+  Sha256 hash;
+  hash.update(kKeyDomain);
+  hash.update(build_nonce);
+  const uint32_t fields[] = {kCacheEpoch, identity.profile_id, identity.input_revision,
+                             identity.output_revision};
+  hash.update(fields, sizeof(fields));
+  hash.update(identity.target_isa);
+  const uint64_t source_size = source.size();
+  hash.update(&source_size, sizeof(source_size));
+  hash.update(source.data(), source.size());
+  key.digest = hash.finish();
+  key.valid = true;
+  return key;
+} catch (...) {
+  return CacheKey{};
+}
+
+std::vector<uint8_t> TranslationStore::lookup(const CacheKey &key,
+                                              const TranslationIdentity &identity) try {
+  if (!key.valid)
+    return {};
+  return impl_->lookup(to_hex(key.digest), identity);
+} catch (...) {
+  return {};
+}
+
+void TranslationStore::store(const CacheKey &key, std::span<const uint8_t> translated,
+                             const TranslationIdentity &identity) noexcept try {
+  if (!key.valid || translated.empty())
+    return;
+  impl_->store(to_hex(key.digest), translated, identity);
+} catch (...) {
+  // Declared never to throw, and now actually is.
+}
+
+#if defined(RJ_TRANSLATION_STORE_TEST_HOOKS)
+void TranslationStore::set_root_for_test(const char *root) { impl_->set_root_for_test(root); }
+uint64_t TranslationStore::size_for_test() { return impl_->size_for_test(); }
+uint64_t TranslationStore::hits_for_test() { return impl_->hits_for_test(); }
+void TranslationStore::set_headroom_for_test(uint64_t bytes) {
+  impl_->set_headroom_for_test(bytes);
+}
+#endif
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/translation_store.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/translation_store.cpp
@@ -10,6 +10,7 @@
 #include <atomic>
 #include <cerrno>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <ctime>
 #include <mutex>
@@ -276,7 +277,15 @@ std::string shared_translation_root(const void *address) {
   Dl_info info{};
   if (dladdr(address, &info) == 0 || info.dli_fname == nullptr)
     return {};
-  const std::string_view path(info.dli_fname);
+  // dladdr() preserves the spelling used by the loader, including relative
+  // components. The secure descriptor walk intentionally rejects those, so
+  // derive the installed root from the resolved module path instead.
+  char *resolved = realpath(info.dli_fname, nullptr);
+  if (resolved == nullptr)
+    return {};
+  const std::string resolved_path(resolved);
+  free(resolved);
+  const std::string_view path(resolved_path);
   const size_t file_at = path.rfind('/');
   if (file_at == std::string_view::npos)
     return {}; // A bare name means the loader resolved it by search; no prefix.
@@ -342,6 +351,20 @@ namespace {
     at = next + 1;
   }
   return components;
+}
+
+/// @brief Whether a store root is an absolute, descended path.
+/// @details The descriptor walk begins at `/`, so accepting a relative root
+/// would silently reinterpret it as absolute. Requiring at least one ordinary
+/// component also rejects `/` before trust-boundary index arithmetic.
+[[nodiscard]] bool is_descended_absolute_path(std::string_view path) {
+  if (path.size() < 2 || path.front() != '/' || path.find('\0') != std::string_view::npos)
+    return false;
+  const auto components = path_components(path);
+  return !components.empty() &&
+         std::none_of(components.begin(), components.end(), [](const std::string &component) {
+           return component == "." || component == "..";
+         });
 }
 
 /// @brief Which owners a directory the store relies on may have.
@@ -472,8 +495,11 @@ enum class DirectoryTrust {
 /// for everyone after it.
 class DirectoryWriteLock {
 public:
-  explicit DirectoryWriteLock(int dir_fd) : dir_fd_(dir_fd) {
-    held_ = dir_fd_ >= 0 && flock(dir_fd_, LOCK_EX) == 0;
+  enum class Mode { kBlocking, kNonBlocking };
+
+  explicit DirectoryWriteLock(int dir_fd, Mode mode = Mode::kBlocking) : dir_fd_(dir_fd) {
+    const int operation = LOCK_EX | (mode == Mode::kNonBlocking ? LOCK_NB : 0);
+    held_ = dir_fd_ >= 0 && flock(dir_fd_, operation) == 0;
   }
   ~DirectoryWriteLock() {
     if (held_)
@@ -605,6 +631,8 @@ struct TranslationStore::Impl {
         return;
       base = root_;
     }
+    if (!is_descended_absolute_path(base))
+      return;
     const std::string path = base + "/" + domain_ + "/" + std::string(kSchemaDir);
     // The trust policy starts at the store's own root. Everything above it
     // belongs to the system -- /tmp is world-writable by design, and judging it
@@ -626,10 +654,15 @@ struct TranslationStore::Impl {
     const mode_t create_mode = writable() ? 0755 : 0;
     dir_fd_ = open_descended_directory(path, create_mode, DirectoryTrust::kOwnedByRootOrCaller,
                                        owner_checked_from, trusted_from);
-    if (writable()) {
+    if (writable() && dir_fd_ >= 0) {
       // Once per process, and the only moment at which a temporary left by a
       // process that died mid-write is unambiguously abandoned.
-      sweep_abandoned_locked();
+      // Opening and lookup must never wait behind a publisher. The sweep is
+      // opportunistic; losing this race only leaves old files for the next
+      // process to reclaim.
+      const DirectoryWriteLock directory_lock(dir_fd_, DirectoryWriteLock::Mode::kNonBlocking);
+      if (directory_lock.held())
+        sweep_abandoned_locked();
     }
   }
 
@@ -793,8 +826,9 @@ namespace {
   return std::string(text.substr(begin, end - begin));
 }
 
-[[nodiscard]] std::optional<std::string> read_whole(int dir_fd, const std::string &name,
-                                                    uint64_t limit) {
+template <typename Buffer>
+[[nodiscard]] std::optional<Buffer> read_whole(int dir_fd, const std::string &name,
+                                               uint64_t limit) {
   const int fd = openat(dir_fd, name.c_str(), O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
   if (fd < 0)
     return std::nullopt;
@@ -804,7 +838,7 @@ namespace {
     close(fd);
     return std::nullopt;
   }
-  std::string data;
+  Buffer data;
   data.resize(static_cast<size_t>(info.st_size));
   size_t done = 0;
   while (done < data.size()) {
@@ -888,7 +922,8 @@ std::vector<uint8_t> TranslationStore::Impl::lookup(const std::string &key,
   const std::string manifest_name = key + ".man";
   const std::string object_name = key + ".obj";
   constexpr uint64_t kManifestLimit = 4096;
-  const std::optional<std::string> manifest = read_whole(dir_fd, manifest_name, kManifestLimit);
+  const std::optional<std::string> manifest =
+      read_whole<std::string>(dir_fd, manifest_name, kManifestLimit);
   if (!manifest || !manifest->starts_with(kManifestMagic))
     return {};
 
@@ -913,7 +948,8 @@ std::vector<uint8_t> TranslationStore::Impl::lookup(const std::string &key,
       return {};
   }
 
-  const std::optional<std::string> object = read_whole(dir_fd, object_name, max_object_bytes());
+  std::optional<std::vector<uint8_t>> object =
+      read_whole<std::vector<uint8_t>>(dir_fd, object_name, max_object_bytes());
   if (!object || std::to_string(object->size()) != *recorded_size)
     return {};
 
@@ -935,7 +971,7 @@ std::vector<uint8_t> TranslationStore::Impl::lookup(const std::string &key,
     ++hits_;
   }
 #endif
-  return std::vector<uint8_t>(object->begin(), object->end());
+  return std::move(*object);
 }
 
 void TranslationStore::Impl::store(const std::string &key, std::span<const uint8_t> object,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/translation_store.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/translation_store.h
@@ -1,0 +1,213 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file dbt/translation_store.h
+/// @brief On-disk store for translated code objects.
+///
+/// @details Translation is deterministic for a given input and configuration, so
+/// a process can reuse an object another process already produced.
+///
+/// The store lives at a caller-supplied root, is populated ahead of time by a
+/// separate tool, and is read-only to the processes that benefit from it. It is
+/// curated rather than cached: the tool decides what belongs in it, so nothing
+/// is ever evicted to make room, and the size ceiling is a sanity bound rather
+/// than a capacity policy. That is what lets it hold the objects worth caching
+/// at all -- a device library of a few hundred megabytes takes minutes to
+/// translate.
+///
+/// Every operation is best effort. A lookup that cannot be satisfied and a store
+/// that cannot be completed both leave the caller to translate normally, so an
+/// unusable store degrades throughput and never correctness.
+///
+/// Nothing here is specific to one translation pair. A consumer names its own
+/// domain, which selects an independent tree, and describes its configuration
+/// through TranslationIdentity. Two consumers in one process never observe each
+/// other's entries, because their domains differ. The key can name either the
+/// exact translator build or the portable-prebuilt compatibility contract. That
+/// is what lets a translation performed ahead of time, by a tool that is not the
+/// eventual reader, be found.
+
+#ifndef ROCJITSU_CODE_DBT_TRANSLATION_STORE_H_
+#define ROCJITSU_CODE_DBT_TRANSLATION_STORE_H_
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace rocjitsu {
+
+/// @brief Where the shared tier lives, relative to the module holding @p address.
+///
+/// @details Resolves `<prefix>/share/rocjitsu/translations` from the install
+/// location of whichever loaded object contains @p address, so an install can be
+/// moved or built into a container at any prefix and still be found with nothing
+/// configured.
+///
+/// Callers pass an address in the TRANSLATOR, the same one they pass to the
+/// store. That is the point: the object whose build id decides what an entry is
+/// keyed on also decides where entries live, so a tool and a runtime that agree
+/// on the translator cannot disagree about either. Deriving the root from the
+/// caller instead would let a tool in `bin` and a hook in `lib` compute
+/// different directories while computing identical keys.
+///
+/// @returns The root, or an empty string when the module cannot be located.
+///          Assumes a two-level layout (`<prefix>/lib`, `<prefix>/lib64`); a
+///          multiarch library directory would resolve elsewhere and simply miss.
+[[nodiscard]] std::string shared_translation_root(const void *address);
+
+/// @brief Everything besides the source object that determines the output.
+///
+/// @details These are folded into the key so an entry produced under one
+/// configuration can never satisfy a request made under another. The meaning of
+/// each numeric field is the consumer's to define; the store only requires that
+/// a given consumer assigns them consistently.
+struct TranslationIdentity {
+  uint32_t profile_id = 0;
+  uint32_t input_revision = 0;
+  uint32_t output_revision = 0;
+  std::string_view target_isa;
+};
+
+/// @brief Digest identifying one translation request.
+/// @details `valid` is false when the store is unavailable, in which case the
+/// lookup and store entry points do nothing.
+struct CacheKey {
+  std::array<uint8_t, 32> digest{};
+  bool valid = false;
+};
+
+/// @brief One domain's entries within one tier.
+///
+/// @details Construct one per translation pair per tier and keep it for the
+/// process lifetime; opening is deferred to first use and the verified directory
+/// descriptor is then held rather than the path re-resolved, which is what
+/// closes the path-swap window. Safe to use from several threads.
+class TranslationStore {
+public:
+  /// @brief What a store is allowed to do.
+  enum class Access {
+    /// Lookups only. store() does nothing and no directory is created, so a
+    /// runtime consulting an install-owned tree cannot alter it -- or create one
+    /// where the installer made none.
+    kReadOnly,
+    /// The ahead-of-time tool's mode: creates the tree and writes entries.
+    kReadWrite,
+  };
+
+  /// @brief What identifies the translator in keys and manifests.
+  enum class KeyMode {
+    /// Bind entries to the translator ELF's GNU build ID. This is the safe
+    /// default for caches whose producer and consumer can be upgraded apart.
+    kTranslatorBuild,
+    /// Use the cache-format compatibility contract instead of an ELF build ID.
+    /// Reserved for prebuilt entries shipped with the code that consumes them.
+    kPortablePrebuilt,
+  };
+
+  /// @brief Open the store rooted at @p root.
+  ///
+  /// @details The tree is curated rather than cached: the ahead-of-time tool
+  /// decides what belongs in it and a runtime only reads. An entry written here
+  /// by one program is found by another that never ran the translator itself.
+  ///
+  /// @param domain Selects an independent tree, so two consumers in one process
+  ///               never observe each other's entries. Must be a single
+  ///               non-empty path component; anything else disables the store.
+  /// @param translator Any address inside the translator that produces these
+  ///               entries -- the address of one of its functions will do. The
+  ///               build id of the module containing it becomes part of every
+  ///               key, so entries name what PRODUCED them rather than whichever
+  ///               binary was running. Two programs calling the same translator
+  ///               therefore agree on keys and can reuse each other's work, which
+  ///               is what lets a translation performed ahead of time be found at
+  ///               runtime. Passing an address in the caller instead would key on
+  ///               the caller, and two consumers of one translator would silently
+  ///               keep separate caches of identical results.
+  /// @param root Directory holding the tree, typically derived from the caller's
+  ///             own install location rather than configured. Never created when
+  ///             @p access is kReadOnly.
+  /// @param access Whether this instance may write. A runtime passes kReadOnly;
+  ///             only the ahead-of-time tool passes kReadWrite.
+  /// @param key_mode Whether entries bind to the exact translator build or to
+  ///             the portable-prebuilt cache contract. Use portable mode only
+  ///             when cache and consumer are distributed as one product.
+  TranslationStore(std::string_view domain, const void *translator, std::string_view root,
+                   Access access, KeyMode key_mode = KeyMode::kTranslatorBuild);
+
+  ~TranslationStore();
+
+  TranslationStore(const TranslationStore &) = delete;
+  TranslationStore &operator=(const TranslationStore &) = delete;
+
+  /// @brief Whether this store can serve requests at all.
+  ///
+  /// @details Opens the tree if it is not open yet. Callers that translate
+  /// anyway on failure have no reason to ask; it exists so a tool whose entire
+  /// purpose is to populate the store can report an unusable root instead of
+  /// appearing to succeed while writing nothing.
+  [[nodiscard]] bool available();
+
+  /// @brief Derive the key for @p source under @p identity.
+  ///
+  /// @details The digest covers the source bytes, identity fields, and the
+  /// translator identity selected at construction. Build-specific stores use
+  /// the translator's GNU build ID. Portable-prebuilt stores use a reserved
+  /// format nonce and rely on the cache epoch and translation identity as their
+  /// compatibility boundary. Returns an invalid key when the store is
+  /// unavailable, which lets callers skip both the lookup and the store.
+  [[nodiscard]] CacheKey key_for(std::span<const uint8_t> source,
+                                 const TranslationIdentity &identity);
+
+  /// @brief Fetch a stored translation.
+  ///
+  /// @details @p identity is re-checked against the record stored alongside the
+  /// object, so an entry can only satisfy a request made under the same
+  /// configuration even if the digest were somehow to match.
+  /// @returns The translated object, or an empty vector on a miss or any failure.
+  [[nodiscard]] std::vector<uint8_t> lookup(const CacheKey &key,
+                                            const TranslationIdentity &identity);
+
+  /// @brief Offer a translation for reuse. Never throws.
+  /// @details Does nothing on a read-only store, and nothing on any store whose
+  /// tier refuses an object this large.
+  void store(const CacheKey &key, std::span<const uint8_t> translated,
+             const TranslationIdentity &identity) noexcept;
+
+#if defined(RJ_TRANSLATION_STORE_TEST_HOOKS)
+  /// @brief Test-only: point the store at @p root and re-run its checks.
+  /// @details Passing nullptr restores the default location. Tests need this
+  /// because both tiers derive their location from the environment -- the
+  /// runtime directory for one, the install prefix for the other -- and neither
+  /// takes configuration. The tier's own trust policy still applies to @p root,
+  /// which is what lets a test show that a badly-owned directory is refused.
+  void set_root_for_test(const char *root);
+
+  /// @brief Test-only: bytes currently occupied by stored objects.
+  [[nodiscard]] uint64_t size_for_test();
+
+  /// @brief Test-only: lookups satisfied since the last root change.
+  /// @details Without this a test can only observe that two requests agree,
+  /// which is also true when both translated. This distinguishes reuse from
+  /// repetition.
+  [[nodiscard]] uint64_t hits_for_test();
+
+  /// @brief Test-only: override the byte cap so eviction can be exercised.
+
+  /// @brief Test-only: override the free-space floor below which writes stop.
+  /// @details Raising it above the real free space is the only way to reach the
+  /// low-space behaviour without filling the filesystem.
+  void set_headroom_for_test(uint64_t bytes);
+#endif // RJ_TRANSLATION_STORE_TEST_HOOKS
+
+private:
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+} // namespace rocjitsu
+
+#endif // ROCJITSU_CODE_DBT_TRANSLATION_STORE_H_

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/translation_store.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/translation_store.h
@@ -136,7 +136,7 @@ public:
   ///             the portable-prebuilt cache contract. Use portable mode only
   ///             when cache and consumer are distributed as one product.
   TranslationStore(std::string_view domain, const void *translator, std::string_view root,
-                   Access access, KeyMode key_mode = KeyMode::kTranslatorBuild);
+                   Access access, KeyMode key_mode);
 
   ~TranslationStore();
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/CMakeLists.txt
@@ -108,7 +108,17 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     # target stay identical except for those two axes -- the production target's ABI
     # and compile definitions must be invariant across BUILD_TESTING.
     function(rj_add_hotswap_hook _target _export_map _test_hooks)
-        add_library(${_target} SHARED gfx1250_b0_a0_hotswap.cpp)
+        # The translation store lives in the DBT layer and is compiled in rather
+        # than linked, because this DSO deliberately depends on nothing but the
+        # fixed-profile translator. Another consumer that wants reuse adds the
+        # same source to its own target; nothing about it is specific to this
+        # hook, and the two would keep separate trees.
+        add_library(
+            ${_target}
+            SHARED
+            gfx1250_b0_a0_hotswap.cpp
+            ${ROCJITSU_SRC_DIR}/rocjitsu/code/dbt/translation_store.cpp
+        )
         set_target_properties(${_target} PROPERTIES OUTPUT_NAME ${_target})
         target_link_libraries(
             ${_target}
@@ -125,13 +135,31 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
             PRIVATE -ffunction-sections -fdata-sections
         )
         if(_test_hooks)
-            target_compile_definitions(${_target} PRIVATE RJ_HOTSWAP_TEST_HOOKS)
+            target_compile_definitions(
+                ${_target}
+                PRIVATE RJ_HOTSWAP_TEST_HOOKS RJ_TRANSLATION_STORE_TEST_HOOKS
+            )
         endif()
         set(_map ${CMAKE_CURRENT_SOURCE_DIR}/${_export_map})
         set_property(TARGET ${_target} APPEND PROPERTY LINK_DEPENDS ${_map})
+        # --build-id is not decoration here: the translation store keys entries on
+        # the TRANSLATOR's note, and the same flag is what gives that shared
+        # object one. Without it the store finds no identity and disables itself.
         target_link_options(
             ${_target}
-            PRIVATE "LINKER:--gc-sections" "LINKER:--version-script=${_map}"
+            PRIVATE
+                "LINKER:--gc-sections"
+                "LINKER:--version-script=${_map}"
+                "LINKER:--build-id=sha1"
+        )
+        # The translator is a shared object installed beside this one. Resolving
+        # it relative to our own location keeps an install relocatable and, more
+        # importantly, keeps every consumer bound to the same copy: the cache
+        # identity IS that object's build id, so two consumers resolving to
+        # different copies would silently stop sharing entries.
+        set_target_properties(
+            ${_target}
+            PROPERTIES BUILD_RPATH "$ORIGIN" INSTALL_RPATH "$ORIGIN"
         )
     endfunction()
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/CMakeLists.txt
@@ -122,7 +122,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         set_target_properties(${_target} PROPERTIES OUTPUT_NAME ${_target})
         target_link_libraries(
             ${_target}
-            PRIVATE rocjitsu_gfx1250_b0_to_a0 Threads::Threads
+            PRIVATE rocjitsu_gfx1250_b0_to_a0 Threads::Threads ${CMAKE_DL_LIBS}
         )
         target_include_directories(
             ${_target}

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/gfx1250_b0_a0_hotswap.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/gfx1250_b0_a0_hotswap.cpp
@@ -89,7 +89,7 @@ TranslationStore &pretranslation_store() {
   static TranslationStore &store = *new TranslationStore(
       rocjitsu::kGfx1250B0A0Domain, rocjitsu::gfx1250_b0_a0_translator_anchor(),
       rocjitsu::shared_translation_root(rocjitsu::gfx1250_b0_a0_translator_anchor()),
-      TranslationStore::Access::kReadOnly, TranslationStore::KeyMode::kPortablePrebuilt);
+      TranslationStore::Access::kReadOnly, rocjitsu::kGfx1250B0A0KeyMode);
   return store;
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/gfx1250_b0_a0_hotswap.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/gfx1250_b0_a0_hotswap.cpp
@@ -26,6 +26,9 @@
 
 #include "hsa/hsa_api_trace_minimal.h"
 #include "rocjitsu/code/amdgpu_elf.h"
+#include "rocjitsu/code/code_object_identity.h"
+#include "rocjitsu/code/dbt/gfx1250_b0_a0_cache.h"
+#include "rocjitsu/code/dbt/translation_store.h"
 #include "rocjitsu/code/rj_gfx1250_b0_to_a0.h"
 
 #include <algorithm>
@@ -59,6 +62,36 @@ using Blob = std::shared_ptr<std::vector<uint8_t>>;
 using VendorReaderCreate = hsa_status_t (*)(hsa_file_t, size_t, size_t, hsa_code_object_reader_t *);
 
 constexpr uint32_t kAmdAgentInfoAsicRevision = 0xA012;
+
+using rocjitsu::CacheKey;
+using rocjitsu::TranslationIdentity;
+using rocjitsu::TranslationStore;
+
+/// @brief The single configuration this hook translates under.
+/// @details Shared with the ahead-of-time tool, which must derive the same keys.
+constexpr TranslationIdentity kTranslationIdentity = rocjitsu::kGfx1250B0A0Identity;
+
+/// @brief Entries produced ahead of time, which this process only reads.
+///
+/// @details The objects that most need caching are the large device libraries --
+/// a few hundred megabytes, minutes to translate -- which no in-process cache can
+/// hold across runs. This tier is what a container image or a post-install step
+/// populates, on ordinary storage, once.
+///
+/// Read-only is a property of the tier and not a precaution: a runtime that wrote
+/// here would be writing outside its own trust boundary, and the entry it left
+/// would be refused by the next reader for exactly that reason.
+///
+/// The *new is deliberate and never freed: a load can arrive after static
+/// destructors would have run, so the store has to outlive them. It stays
+/// reachable through this reference, so LeakSanitizer does not report it.
+TranslationStore &pretranslation_store() {
+  static TranslationStore &store = *new TranslationStore(
+      rocjitsu::kGfx1250B0A0Domain, rocjitsu::gfx1250_b0_a0_translator_anchor(),
+      rocjitsu::shared_translation_root(rocjitsu::gfx1250_b0_a0_translator_anchor()),
+      TranslationStore::Access::kReadOnly, TranslationStore::KeyMode::kPortablePrebuilt);
+  return store;
+}
 
 // Minimal mirror through the sole AMD loader entry intercepted by this hook.
 struct VendorLoaderTable {
@@ -1144,6 +1177,16 @@ void uninstall() {
   g_state.core = nullptr;
 }
 
+Blob adopt_bytes(std::vector<uint8_t> &&bytes) {
+  if (bytes.empty())
+    return nullptr;
+  try {
+    return std::make_shared<std::vector<uint8_t>>(std::move(bytes));
+  } catch (...) {
+    return nullptr;
+  }
+}
+
 Blob copy_bytes(const void *data, size_t size) {
   if (data == nullptr || size == 0)
     return nullptr;
@@ -1522,6 +1565,42 @@ hsa_status_t HSA_API load_agent_code_object(hsa_executable_t executable, hsa_age
       return reused_status;
     }
 
+    // Only a load this process has not already answered reaches the store, which
+    // is what keeps its cost off the repeat path: a digest over the whole source
+    // and a file read, once per distinct object rather than once per load.
+    //
+    // The key names the translator, the configuration and the source -- never
+    // where the entry lives -- so the tool that wrote it and this reader agree by
+    // construction, which is the whole reason a translation performed ahead of
+    // time can be found at all.
+    const CacheKey cache_key = pretranslation_store().key_for(*source, kTranslationIdentity);
+    std::vector<uint8_t> cached = pretranslation_store().lookup(cache_key, kTranslationIdentity);
+    // Adopting the store's buffer rather than copying it again keeps a hit to one
+    // allocation; the bytes have already been read once.
+    const size_t cached_size = cached.size();
+    if (Blob reused = adopt_bytes(std::move(cached)); reused != nullptr) {
+      // Remember what the store gave us. Without this, every later load of these
+      // bytes would read the file again -- the repetition the memo exists to
+      // remove, moved from the translator to the filesystem.
+      TranslationRecord stored;
+      stored.output = reused;
+      // Only when someone is listening. This walks the whole source -- about
+      // 237 ms for the 212 MiB device library -- and its only consumer is a field
+      // in a log line that log_translation() drops unless verbose output is on.
+      // Paying that on the path whose entire purpose is to be fast, for output
+      // almost nobody asks for, is the wrong trade.
+      if (verbose_logging())
+        stored.info.source_code_object_id =
+            rocjitsu::stable_code_object_id(source->data(), source->size());
+      remember(stored);
+
+      const hsa_status_t reused_status =
+          load_owned_bytes(executable, agent, reused, options, loaded, *api, original_load);
+      log("reused tier=aot input_bytes=%zu output_bytes=%zu status=%d", source->size(), cached_size,
+          static_cast<int>(reused_status));
+      return reused_status;
+    }
+
     uint8_t *translated_data = nullptr;
     size_t translated_size = 0;
     g_state.translations.fetch_add(1, std::memory_order_relaxed);
@@ -1810,4 +1889,16 @@ rj_test_log_translation_diagnostic(uint64_t source_id,
                                    const rj_gfx1250_b0_to_a0_diagnostic_t *diagnostic) {
   log_translation_diagnostic(source_id, diagnostic);
 }
+// Test-only seam onto the pre-translated tier. Its production root is derived
+// from the translator's install prefix, so a test can only reach it by naming
+// one -- and only by counting its hits can a test show that a pre-translated
+// entry is what served a load.
+extern "C" RJ_HOOK_EXPORT void rj_test_set_pretranslation_root(const char *root) {
+  pretranslation_store().set_root_for_test(root);
+}
+
+extern "C" RJ_HOOK_EXPORT uint64_t rj_test_pretranslation_hits() {
+  return pretranslation_store().hits_for_test();
+}
+
 #endif // RJ_HOTSWAP_TEST_HOOKS

--- a/emulation/rocjitsu/scripts/rocjitsu-pretranslate.py
+++ b/emulation/rocjitsu/scripts/rocjitsu-pretranslate.py
@@ -27,12 +27,14 @@ import hashlib
 import json
 import os
 import re
+import stat
 import struct
 import subprocess
 import sys
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Callable
 
 ELF_MAGIC = b"\x7fELF"
 ELFCLASS64 = 2
@@ -68,8 +70,8 @@ def is_amdgpu_elf(data: bytes) -> bool:
     )
 
 
-def elf_section(data: bytes, wanted: bytes) -> bytes | None:
-    """Return the contents of section `wanted`, or None.
+def read_elf_section(path: Path, wanted: bytes) -> bytes | None:
+    """Read one ELF section without materializing the host binary.
 
     Done here rather than by shelling out to llvm-objcopy so the script has no
     toolchain dependency: an image build that has ROCm installed does not
@@ -77,41 +79,68 @@ def elf_section(data: bytes, wanted: bytes) -> bytes | None:
     reason for pre-translation to be unavailable.
     """
     try:
-        if len(data) < 64 or not data.startswith(ELF_MAGIC) or data[4] != ELFCLASS64:
-            return None
-        table_offset = struct.unpack_from("<Q", data, 40)[0]
-        entry_size, count, name_index = struct.unpack_from("<HHH", data, 58)
-        if entry_size < 64 or table_offset + entry_size > len(data):
-            return None
-        if count == 0:
-            count = struct.unpack_from("<Q", data, table_offset + 32)[0]
-        if name_index == 0xFFFF:
-            name_index = struct.unpack_from("<I", data, table_offset + 40)[0]
-        if not count or name_index >= count:
-            return None
-        if table_offset + entry_size * count > len(data):
-            return None
-
-        names_header = table_offset + name_index * entry_size
-        names_offset, names_size = struct.unpack_from("<QQ", data, names_header + 24)
-        if names_offset + names_size > len(data):
-            return None
-
-        for index in range(count):
-            header = table_offset + index * entry_size
-            name_offset = struct.unpack_from("<I", data, header)[0]
-            start = names_offset + name_offset
-            if start >= names_offset + names_size:
-                continue
-            end = data.find(b"\0", start, names_offset + names_size)
-            if end < 0 or data[start:end] != wanted:
-                continue
-            section_type = struct.unpack_from("<I", data, header + 4)[0]
-            offset, size = struct.unpack_from("<QQ", data, header + 24)
-            if section_type == SHT_NOBITS or not size or offset + size > len(data):
+        file_size = path.stat().st_size
+        with path.open("rb") as handle:
+            elf_header = handle.read(64)
+            if (
+                len(elf_header) < 64
+                or not elf_header.startswith(ELF_MAGIC)
+                or elf_header[4] != ELFCLASS64
+                or elf_header[5] != ELFDATA2LSB
+            ):
                 return None
-            return data[offset : offset + size]
-    except (struct.error, ValueError):
+            table_offset = struct.unpack_from("<Q", elf_header, 40)[0]
+            entry_size, count, name_index = struct.unpack_from("<HHH", elf_header, 58)
+            if entry_size < 64 or table_offset + entry_size > file_size:
+                return None
+
+            handle.seek(table_offset)
+            first_header = handle.read(entry_size)
+            if len(first_header) != entry_size:
+                return None
+            if count == 0:
+                count = struct.unpack_from("<Q", first_header, 32)[0]
+            if name_index == 0xFFFF:
+                name_index = struct.unpack_from("<I", first_header, 40)[0]
+            table_size = entry_size * count
+            if (
+                not count
+                or name_index >= count
+                or table_offset + table_size > file_size
+            ):
+                return None
+
+            handle.seek(table_offset)
+            table = handle.read(table_size)
+            if len(table) != table_size:
+                return None
+            names_header = name_index * entry_size
+            names_offset, names_size = struct.unpack_from(
+                "<QQ", table, names_header + 24
+            )
+            if names_offset + names_size > file_size:
+                return None
+            handle.seek(names_offset)
+            names = handle.read(names_size)
+            if len(names) != names_size:
+                return None
+
+            for index in range(count):
+                header = index * entry_size
+                name_offset = struct.unpack_from("<I", table, header)[0]
+                if name_offset >= len(names):
+                    continue
+                name_end = names.find(b"\0", name_offset)
+                if name_end < 0 or names[name_offset:name_end] != wanted:
+                    continue
+                section_type = struct.unpack_from("<I", table, header + 4)[0]
+                offset, size = struct.unpack_from("<QQ", table, header + 24)
+                if section_type == SHT_NOBITS or not size or offset + size > file_size:
+                    return None
+                handle.seek(offset)
+                content = handle.read(size)
+                return content if len(content) == size else None
+    except (OSError, struct.error, ValueError):
         return None
     return None
 
@@ -178,8 +207,10 @@ def find_bundler(explicit: str | None) -> str | None:
     return which("clang-offload-bundler")
 
 
-def unbundle_compressed(bundler: str, blob: bytes, target: str) -> list[bytes]:
-    """Return the `target` payloads inside one compressed bundle.
+def unbundle_compressed(
+    bundler: str, blob: bytes, target: str
+) -> tuple[list[tuple[str, bytes]], list[tuple[str, str]]]:
+    """Return successful `target` payloads and per-entry failures.
 
     A compressed bundle cannot be walked with struct.unpack the way a plain one
     can, so this shells out. It does NOT need a GPU -- the container is just
@@ -192,13 +223,16 @@ def unbundle_compressed(bundler: str, blob: bytes, target: str) -> list[bytes]:
         listed = subprocess.run(
             [bundler, "--list", "--type=o", f"--input={source}"],
             stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
             text=True,
         )
         if listed.returncode:
-            return []
+            raise RuntimeError(
+                f"bundler list failed ({listed.returncode}): {listed.stderr.strip()}"
+            )
 
-        payloads = []
+        payloads: list[tuple[str, bytes]] = []
+        failures: list[tuple[str, str]] = []
         for index, entry_target in enumerate(listed.stdout.split()):
             if not bundle_target_matches(entry_target, target):
                 continue
@@ -212,14 +246,23 @@ def unbundle_compressed(bundler: str, blob: bytes, target: str) -> list[bytes]:
                     f"--input={source}",
                     f"--output={destination}",
                 ],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
             )
-            if extracted.returncode == 0 and destination.exists():
-                data = destination.read_bytes()
-                if data:
-                    payloads.append(data)
-        return payloads
+            if extracted.returncode != 0 or not destination.exists():
+                failures.append(
+                    (
+                        entry_target,
+                        f"bundler extraction failed ({extracted.returncode}): "
+                        f"{extracted.stderr.strip()}",
+                    )
+                )
+                continue
+            data = destination.read_bytes()
+            if data:
+                payloads.append((entry_target, data))
+        return payloads, failures
 
 
 # ---------------------------------------------------------------------------
@@ -326,34 +369,81 @@ class Kpack:
 class Found:
     """One extracted code object and where it came from."""
 
-    data: bytes
+    byte_count: int
     origin: dict[str, object]
 
 
 @dataclass
 class Discovery:
-    objects: list[Found] = field(default_factory=list)
+    objects: dict[str, Found] = field(default_factory=dict)
+    extracted_objects: int = 0
+    duplicate_objects: int = 0
     compressed_bundles: list[Path] = field(default_factory=list)
     compressed_unpacked: int = 0
     kpack_archives: list[Path] = field(default_factory=list)
     kpack_skipped: int = 0
     failures: list[dict[str, object]] = field(default_factory=list)
 
+    def add_object(
+        self,
+        data: bytes,
+        origin: dict[str, object],
+        on_unique: Callable[[str, bytes, Found], None] | None,
+    ) -> None:
+        """Deduplicate one object and hand unique bytes to the batch consumer."""
+        self.extracted_objects += 1
+        digest = hashlib.sha256(data).hexdigest()
+        if digest in self.objects:
+            self.duplicate_objects += 1
+            return
+        item = Found(len(data), origin)
+        self.objects[digest] = item
+        if on_unique is None:
+            return
+        try:
+            on_unique(digest, data, item)
+        except OSError as error:
+            self.failures.append({"category": "stage", **origin, "error": str(error)})
 
-def walk(roots: list[Path]):
+
+def walk(roots: list[Path], failures: list[dict[str, object]]):
     seen: set[tuple[int, int]] = set()
     for root in roots:
-        if root.is_file():
+        try:
+            root_info = root.stat()
+        except OSError as error:
+            failures.append(
+                {"category": "stat", "path": str(root), "error": str(error)}
+            )
+            continue
+        if stat.S_ISREG(root_info.st_mode):
             yield root
             continue
-        for directory, _, names in os.walk(root, followlinks=False):
+        if not stat.S_ISDIR(root_info.st_mode):
+            continue
+
+        def record_traversal_error(error: OSError) -> None:
+            failures.append(
+                {
+                    "category": "traversal",
+                    "path": str(error.filename or root),
+                    "error": str(error),
+                }
+            )
+
+        for directory, _, names in os.walk(
+            root, followlinks=False, onerror=record_traversal_error
+        ):
             for name in names:
                 path = Path(directory) / name
                 try:
                     info = path.stat()
-                except OSError:
+                except OSError as error:
+                    failures.append(
+                        {"category": "stat", "path": str(path), "error": str(error)}
+                    )
                     continue
-                if not os.path.isfile(path):
+                if not stat.S_ISREG(info.st_mode):
                     continue
                 # Hard links are common in an install tree; extracting the same
                 # bytes twice would translate them twice.
@@ -369,13 +459,49 @@ def discover(
     target: str,
     kpack: Kpack | None,
     bundler: str | None,
+    on_unique: Callable[[str, bytes, Found], None] | None = None,
     kpack_intentionally_skipped: bool = False,
 ) -> Discovery:
     found = Discovery()
-    # (path, container bytes) for every compressed bundle, resolved after the
-    # walk so one missing tool does not abort the scan.
-    compressed: list[tuple[Path, bytes]] = []
-    for path in walk(roots):
+
+    def unpack_compressed(path: Path, blob: bytes) -> None:
+        if bundler is None:
+            return
+        try:
+            payloads, entry_failures = unbundle_compressed(bundler, blob, target)
+        except (OSError, RuntimeError) as error:
+            found.failures.append(
+                {
+                    "category": "compressed-bundle",
+                    "path": str(path),
+                    "error": str(error),
+                }
+            )
+            return
+        for entry_target, error in entry_failures:
+            found.failures.append(
+                {
+                    "category": "compressed-bundle",
+                    "path": str(path),
+                    "target": entry_target,
+                    "error": error,
+                }
+            )
+        if payloads:
+            found.compressed_unpacked += 1
+        for index, (entry_target, payload) in enumerate(payloads):
+            found.add_object(
+                payload,
+                {
+                    "container": "compressed-bundle",
+                    "path": str(path),
+                    "entry": index,
+                    "target": entry_target,
+                },
+                on_unique,
+            )
+
+    for path in walk(roots, found.failures):
         try:
             with path.open("rb") as handle:
                 header = handle.read(64)
@@ -387,7 +513,13 @@ def discover(
                 is_compressed = header.startswith(COMPRESSED_BUNDLE_MAGIC)
                 if not is_compressed and not header.startswith(ELF_MAGIC):
                     continue
-                data = header + handle.read()
+                if is_compressed and bundler is None:
+                    found.compressed_bundles.append(path)
+                    continue
+                if is_compressed or is_amdgpu_elf(header):
+                    data = header + handle.read()
+                else:
+                    data = None
         except OSError as error:
             found.failures.append(
                 {"category": "read", "path": str(path), "error": str(error)}
@@ -396,65 +528,37 @@ def discover(
 
         if is_compressed:
             found.compressed_bundles.append(path)
-            compressed.append((path, data))
+            unpack_compressed(path, data)
             continue
 
-        if is_amdgpu_elf(data):
+        if data is not None and is_amdgpu_elf(data):
             # A standalone code object. Whether it is for this target is the
             # translator's verdict to give, not ours to guess from the name.
-            found.objects.append(Found(data, {"container": "elf", "path": str(path)}))
+            found.add_object(data, {"container": "elf", "path": str(path)}, on_unique)
             continue
 
-        fatbin = elf_section(data, b".hip_fatbin")
+        fatbin = read_elf_section(path, b".hip_fatbin")
         if fatbin is None:
             continue
         if fatbin.startswith(COMPRESSED_BUNDLE_MAGIC):
             found.compressed_bundles.append(path)
-            compressed.append((path, fatbin))
+            unpack_compressed(path, fatbin)
             continue
         for index, (entry_target, payload) in enumerate(
             parse_clang_offload_bundles(fatbin)
         ):
             if not bundle_target_matches(entry_target, target) or not payload:
                 continue
-            found.objects.append(
-                Found(
-                    payload,
-                    {
-                        "container": "hip-fatbin",
-                        "path": str(path),
-                        "entry": index,
-                        "target": entry_target,
-                    },
-                )
+            found.add_object(
+                payload,
+                {
+                    "container": "hip-fatbin",
+                    "path": str(path),
+                    "entry": index,
+                    "target": entry_target,
+                },
+                on_unique,
             )
-
-    if bundler is not None:
-        for path, blob in compressed:
-            try:
-                payloads = unbundle_compressed(bundler, blob, target)
-            except OSError as error:
-                found.failures.append(
-                    {
-                        "category": "compressed-bundle",
-                        "path": str(path),
-                        "error": str(error),
-                    }
-                )
-                continue
-            if payloads:
-                found.compressed_unpacked += 1
-            for index, payload in enumerate(payloads):
-                found.objects.append(
-                    Found(
-                        payload,
-                        {
-                            "container": "compressed-bundle",
-                            "path": str(path),
-                            "entry": index,
-                        },
-                    )
-                )
 
     for archive in found.kpack_archives:
         if kpack is None:
@@ -476,16 +580,15 @@ def discover(
             continue
         try:
             for member, architecture, data in kpack.objects(archive, target):
-                found.objects.append(
-                    Found(
-                        data,
-                        {
-                            "container": "kpack",
-                            "path": str(archive),
-                            "member": member,
-                            "architecture": architecture,
-                        },
-                    )
+                found.add_object(
+                    data,
+                    {
+                        "container": "kpack",
+                        "path": str(archive),
+                        "member": member,
+                        "architecture": architecture,
+                    },
+                    on_unique,
                 )
         except (OSError, RuntimeError) as error:
             found.failures.append(
@@ -519,7 +622,6 @@ def run_tool(
     store_root: str | None,
     paths: list[Path],
     force: bool,
-    portable: bool,
     fail_on_skipped: bool,
     verbose: bool,
 ) -> tuple[int, str]:
@@ -528,8 +630,6 @@ def run_tool(
         command += ["--store-root", store_root]
     if force:
         command.append("--force")
-    if portable:
-        command.append("--portable")
     if fail_on_skipped:
         command.append("--fail-on-skipped")
     command += [str(path) for path in paths]
@@ -559,7 +659,7 @@ def parse_tool_output(text: str) -> dict[str, int]:
 # ---------------------------------------------------------------------------
 
 
-def parse_arguments() -> argparse.Namespace:
+def parse_arguments(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
@@ -624,7 +724,8 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--portable",
         action="store_true",
-        help="write a prebuilt cache independent of the translator ELF build ID",
+        default=True,
+        help="accepted for packaging compatibility; the domain owns its key policy",
     )
     parser.add_argument(
         "--fail-on-skipped",
@@ -637,11 +738,14 @@ def parse_arguments() -> argparse.Namespace:
         help="report what would be translated and stop",
     )
     parser.add_argument("--verbose", action="store_true", help="echo the tool's output")
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 
-def main() -> int:
-    args = parse_arguments()
+def main(argv: list[str] | None = None) -> int:
+    args = parse_arguments(argv)
+    if args.batch < 1:
+        print("error: --batch must be at least 1", file=sys.stderr)
+        return 2
     roots = args.paths or [DEFAULT_ROOT]
     missing = [root for root in roots if not root.exists()]
     if missing:
@@ -665,6 +769,9 @@ def main() -> int:
     if not args.skip_compressed:
         bundler = find_bundler(args.bundler)
         if bundler is None:
+            if args.bundler is not None:
+                print(f"error: bundler not found: {args.bundler}", file=sys.stderr)
+                return 2
             print(
                 "warning: clang-offload-bundler not found; compressed bundles will be "
                 "reported as skipped. On this ROCm tree those hold the gfx1250 GEMM "
@@ -672,61 +779,31 @@ def main() -> int:
                 file=sys.stderr,
             )
 
-    found = discover(roots, args.target, kpack, bundler, args.skip_kpack)
-
-    # Content-address before translating. An install tree holds the same object
-    # under several names, and the whole point is not to do the work twice.
-    unique: dict[str, Found] = {}
-    duplicates = 0
-    for item in found.objects:
-        digest = hashlib.sha256(item.data).hexdigest()
-        if digest in unique:
-            duplicates += 1
-            continue
-        unique[digest] = item
-
-    print(
-        f"found {len(unique)} unique objects "
-        f"({len(found.objects)} extracted, {duplicates} duplicates), "
-        f"{len(found.kpack_archives)} kpack archives, "
-        f"{found.compressed_unpacked}/{len(found.compressed_bundles)} compressed "
-        "bundles unpacked"
-    )
-    if args.dry_run:
-        return 0 if not found.failures else 1
-
-    tool = locate_tool(args.tool)
-    if tool is None:
-        print("error: rj_pretranslate not found; pass --tool", file=sys.stderr)
-        return 2
-
     totals = {"written": 0, "held": 0, "skipped": 0, "failed": 0}
     tool_failures = 0
     provenance: list[dict[str, object]] = []
+    tool = None if args.dry_run else locate_tool(args.tool)
+    if not args.dry_run and tool is None:
+        print("error: rj_pretranslate not found; pass --tool", file=sys.stderr)
+        return 2
     if args.temporary_root is not None:
         args.temporary_root.mkdir(parents=True, exist_ok=True)
     with tempfile.TemporaryDirectory(
         prefix="rocjitsu-pretranslate-", dir=args.temporary_root
     ) as temporary:
         staged: list[Path] = []
-        order = sorted(unique.items())
-        for index, (digest, item) in enumerate(order, start=1):
-            path = Path(temporary) / f"{digest}.co"
-            path.write_bytes(item.data)
-            staged.append(path)
-            provenance.append(
-                {"digest": digest, "bytes": len(item.data), **item.origin}
-            )
+        processed = 0
 
-            at_end = index == len(order)
-            if len(staged) < args.batch and not at_end:
-                continue
+        def flush_batch() -> None:
+            nonlocal processed, staged, tool_failures
+            if not staged:
+                return
+            assert tool is not None
             code, output = run_tool(
                 tool,
                 args.store_root,
                 staged,
                 args.force,
-                args.portable,
                 args.fail_on_skipped,
                 args.verbose,
             )
@@ -736,25 +813,60 @@ def main() -> int:
                 sys.stderr.write(output)
             if code != 0:
                 tool_failures += 1
-            for path in staged:
-                path.unlink(missing_ok=True)
+            processed += len(staged)
+            for staged_path in staged:
+                staged_path.unlink(missing_ok=True)
             staged = []
-            if args.progress_every and (index % args.progress_every == 0 or at_end):
-                print(f"pretranslate: {index}/{len(order)} objects", flush=True)
+            if args.progress_every and processed % args.progress_every == 0:
+                print(f"pretranslate: {processed} objects", flush=True)
+
+        def stage_unique(digest: str, data: bytes, item: Found) -> None:
+            path = Path(temporary) / f"{digest}.co"
+            path.write_bytes(data)
+            staged.append(path)
+            provenance.append(
+                {"digest": digest, "bytes": item.byte_count, **item.origin}
+            )
+            if len(staged) == args.batch:
+                flush_batch()
+
+        found = discover(
+            roots,
+            args.target,
+            kpack,
+            bundler,
+            None if args.dry_run else stage_unique,
+            args.skip_kpack,
+        )
+        if not args.dry_run:
+            flush_batch()
+        unique = found.objects
+        print(
+            f"found {len(unique)} unique objects "
+            f"({found.extracted_objects} extracted, "
+            f"{found.duplicate_objects} duplicates), "
+            f"{len(found.kpack_archives)} kpack archives, "
+            f"{found.compressed_unpacked}/{len(found.compressed_bundles)} compressed "
+            "bundles unpacked"
+        )
+        if args.dry_run:
+            return 0 if not found.failures else 1
+        if args.progress_every and processed % args.progress_every != 0:
+            print(f"pretranslate: {processed}/{len(unique)} objects", flush=True)
 
     summary = {
         "target": args.target,
         "roots": [str(root) for root in roots],
         "store_root": args.store_root,
         "unique_objects": len(unique),
-        "duplicate_objects": duplicates,
+        "duplicate_objects": found.duplicate_objects,
         "kpack_archives": len(found.kpack_archives),
         "kpack_archives_skipped": found.kpack_skipped,
         "compressed_bundles": len(found.compressed_bundles),
         "compressed_bundles_unpacked": found.compressed_unpacked,
         "discovery_failures": len(found.failures),
         "fail_on_skipped": args.fail_on_skipped,
-        "portable": args.portable,
+        "portable": True,
         "tool_failures": tool_failures,
         **totals,
     }

--- a/emulation/rocjitsu/scripts/rocjitsu-pretranslate.py
+++ b/emulation/rocjitsu/scripts/rocjitsu-pretranslate.py
@@ -1,0 +1,788 @@
+#!/usr/bin/env python3
+"""Pre-translate the gfx1250 code objects in a ROCm install.
+
+Translating a large device library takes minutes. The hotswap hook does it at
+load time and remembers the result, which makes a long-running process pay once
+-- but a container that starts, runs a job and exits pays every time. This script
+moves the work to image-build or post-install time, where it is paid once for the
+life of the image.
+
+It finds gfx1250 code objects in the containers ROCm actually uses, extracts
+them, and hands them to rj_pretranslate, which records each translation where the
+hook looks first. Re-running is cheap: entries already held are reported and
+skipped.
+
+Extraction is entirely file based. Compressed Clang offload bundles are unpacked
+with clang-offload-bundler, which needs no GPU -- an important detail, because
+the ROCm install here keeps 224 gfx1250 containers in that form, all of them
+GEMM libraries. Without the bundler they are counted and reported as skipped
+rather than failing the run, so this still works where it is unavailable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import hashlib
+import json
+import os
+import re
+import struct
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+ELF_MAGIC = b"\x7fELF"
+ELFCLASS64 = 2
+ELFDATA2LSB = 1
+EM_AMDGPU = 224
+SHT_NOBITS = 8
+CLANG_OFFLOAD_BUNDLE_MAGIC = b"__CLANG_OFFLOAD_BUNDLE__"
+KPACK_MAGIC = b"KPAK"
+COMPRESSED_BUNDLE_MAGIC = b"CCOB"
+KPACK_ERROR_KERNEL_NOT_FOUND = 5
+
+DEFAULT_TARGET = "gfx1250"
+DEFAULT_ROOT = Path("/opt/rocm")
+DEFAULT_KPACK_LIBRARY = "librocm_kpack.so.0"
+
+# Anything this small cannot be a code object, and reading a header from every
+# file in an install tree is the bulk of the scan.
+MIN_CANDIDATE_BYTES = 64
+
+
+# ---------------------------------------------------------------------------
+# ELF
+# ---------------------------------------------------------------------------
+
+
+def is_amdgpu_elf(data: bytes) -> bool:
+    return (
+        len(data) >= 20
+        and data.startswith(ELF_MAGIC)
+        and data[4] == ELFCLASS64
+        and data[5] == ELFDATA2LSB
+        and struct.unpack_from("<H", data, 18)[0] == EM_AMDGPU
+    )
+
+
+def elf_section(data: bytes, wanted: bytes) -> bytes | None:
+    """Return the contents of section `wanted`, or None.
+
+    Done here rather than by shelling out to llvm-objcopy so the script has no
+    toolchain dependency: an image build that has ROCm installed does not
+    necessarily have the LLVM tools, and needing them would be a surprising
+    reason for pre-translation to be unavailable.
+    """
+    try:
+        if len(data) < 64 or not data.startswith(ELF_MAGIC) or data[4] != ELFCLASS64:
+            return None
+        table_offset = struct.unpack_from("<Q", data, 40)[0]
+        entry_size, count, name_index = struct.unpack_from("<HHH", data, 58)
+        if entry_size < 64 or table_offset + entry_size > len(data):
+            return None
+        if count == 0:
+            count = struct.unpack_from("<Q", data, table_offset + 32)[0]
+        if name_index == 0xFFFF:
+            name_index = struct.unpack_from("<I", data, table_offset + 40)[0]
+        if not count or name_index >= count:
+            return None
+        if table_offset + entry_size * count > len(data):
+            return None
+
+        names_header = table_offset + name_index * entry_size
+        names_offset, names_size = struct.unpack_from("<QQ", data, names_header + 24)
+        if names_offset + names_size > len(data):
+            return None
+
+        for index in range(count):
+            header = table_offset + index * entry_size
+            name_offset = struct.unpack_from("<I", data, header)[0]
+            start = names_offset + name_offset
+            if start >= names_offset + names_size:
+                continue
+            end = data.find(b"\0", start, names_offset + names_size)
+            if end < 0 or data[start:end] != wanted:
+                continue
+            section_type = struct.unpack_from("<I", data, header + 4)[0]
+            offset, size = struct.unpack_from("<QQ", data, header + 24)
+            if section_type == SHT_NOBITS or not size or offset + size > len(data):
+                return None
+            return data[offset : offset + size]
+    except (struct.error, ValueError):
+        return None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Clang offload bundles
+# ---------------------------------------------------------------------------
+
+
+def bundle_target_matches(entry_target: str, target: str) -> bool:
+    match = re.search(r"--(gfx[0-9a-z]+)(?::[^\s]+)?$", entry_target)
+    return match is not None and match.group(1) == target
+
+
+def parse_clang_offload_bundles(data: bytes):
+    """Yield (entry_target, payload) from concatenated Clang offload bundles."""
+    search_offset = 0
+    while True:
+        bundle_offset = data.find(CLANG_OFFLOAD_BUNDLE_MAGIC, search_offset)
+        if bundle_offset < 0:
+            return
+        cursor = bundle_offset + len(CLANG_OFFLOAD_BUNDLE_MAGIC)
+        if cursor + 8 > len(data):
+            return
+        entry_count = struct.unpack_from("<Q", data, cursor)[0]
+        cursor += 8
+        if entry_count > (len(data) - cursor) // 24:
+            return
+
+        bundle_end = cursor
+        for _ in range(entry_count):
+            offset, size, target_size = struct.unpack_from("<QQQ", data, cursor)
+            cursor += 24
+            target_end = cursor + target_size
+            if target_end > len(data):
+                return
+            entry_target = data[cursor:target_end].decode("utf-8", errors="replace")
+            cursor = target_end
+            payload_offset = bundle_offset + offset
+            payload_end = payload_offset + size
+            if payload_offset < bundle_offset or payload_end > len(data):
+                return
+            yield entry_target, data[payload_offset:payload_end]
+            bundle_end = max(bundle_end, payload_end)
+        search_offset = max(cursor, bundle_end)
+
+
+# ---------------------------------------------------------------------------
+# Compressed Clang offload bundles
+# ---------------------------------------------------------------------------
+
+
+def find_bundler(explicit: str | None) -> str | None:
+    if explicit:
+        return explicit if Path(explicit).exists() else None
+    for candidate in (
+        Path("/opt/rocm/lib/llvm/bin/clang-offload-bundler"),
+        Path("/opt/rocm/llvm/bin/clang-offload-bundler"),
+    ):
+        if candidate.exists():
+            return str(candidate)
+    from shutil import which
+
+    return which("clang-offload-bundler")
+
+
+def unbundle_compressed(bundler: str, blob: bytes, target: str) -> list[bytes]:
+    """Return the `target` payloads inside one compressed bundle.
+
+    A compressed bundle cannot be walked with struct.unpack the way a plain one
+    can, so this shells out. It does NOT need a GPU -- the container is just
+    compressed, not device-resident -- which is what makes pre-translation of
+    the Tensile GEMM libraries possible inside a Docker build.
+    """
+    with tempfile.TemporaryDirectory(prefix="rocjitsu-ccob-") as temporary:
+        source = Path(temporary) / "bundle"
+        source.write_bytes(blob)
+        listed = subprocess.run(
+            [bundler, "--list", "--type=o", f"--input={source}"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        if listed.returncode:
+            return []
+
+        payloads = []
+        for index, entry_target in enumerate(listed.stdout.split()):
+            if not bundle_target_matches(entry_target, target):
+                continue
+            destination = Path(temporary) / f"payload{index}"
+            extracted = subprocess.run(
+                [
+                    bundler,
+                    "--unbundle",
+                    "--type=o",
+                    f"--targets={entry_target}",
+                    f"--input={source}",
+                    f"--output={destination}",
+                ],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            if extracted.returncode == 0 and destination.exists():
+                data = destination.read_bytes()
+                if data:
+                    payloads.append(data)
+        return payloads
+
+
+# ---------------------------------------------------------------------------
+# KPACK
+#
+# Not optional: RCCL's gfx1250 device image -- the object that motivated all of
+# this -- ships inside a .kpack archive and is reachable no other way.
+# ---------------------------------------------------------------------------
+
+
+class Kpack:
+    """ctypes wrapper around the KPACK discovery API."""
+
+    def __init__(self, library: str):
+        self.lib = ctypes.CDLL(library)
+        void_p = ctypes.c_void_p
+        size_t = ctypes.c_size_t
+        char_p = ctypes.c_char_p
+
+        self.lib.kpack_open.argtypes = [char_p, ctypes.POINTER(void_p)]
+        self.lib.kpack_open.restype = ctypes.c_int
+        self.lib.kpack_close.argtypes = [void_p]
+        self.lib.kpack_close.restype = None
+        for name in ("architecture", "binary"):
+            count = getattr(self.lib, f"kpack_get_{name}_count")
+            count.argtypes = [void_p, ctypes.POINTER(size_t)]
+            count.restype = ctypes.c_int
+            value = getattr(self.lib, f"kpack_get_{name}")
+            value.argtypes = [void_p, size_t, ctypes.POINTER(char_p)]
+            value.restype = ctypes.c_int
+        self.lib.kpack_get_kernel.argtypes = [
+            void_p,
+            char_p,
+            char_p,
+            ctypes.POINTER(void_p),
+            ctypes.POINTER(size_t),
+        ]
+        self.lib.kpack_get_kernel.restype = ctypes.c_int
+        self.lib.kpack_free_kernel.argtypes = [void_p]
+        self.lib.kpack_free_kernel.restype = None
+
+    def _strings(self, handle, get_count, get_value) -> list[str]:
+        count = ctypes.c_size_t()
+        if get_count(handle, ctypes.byref(count)):
+            raise RuntimeError("KPACK count query failed")
+        values = []
+        for index in range(count.value):
+            value = ctypes.c_char_p()
+            if get_value(handle, index, ctypes.byref(value)) or value.value is None:
+                raise RuntimeError(f"KPACK query {index} failed")
+            values.append(value.value.decode())
+        return values
+
+    def objects(self, archive: Path, target: str):
+        """Yield (member, architecture, bytes) for every `target` object."""
+        handle = ctypes.c_void_p()
+        if self.lib.kpack_open(os.fsencode(archive), ctypes.byref(handle)):
+            raise RuntimeError(f"kpack_open failed: {archive}")
+        try:
+            architectures = self._strings(
+                handle,
+                self.lib.kpack_get_architecture_count,
+                self.lib.kpack_get_architecture,
+            )
+            binaries = self._strings(
+                handle, self.lib.kpack_get_binary_count, self.lib.kpack_get_binary
+            )
+            for architecture in sorted(architectures):
+                if architecture.partition(":")[0] != target:
+                    continue
+                for binary in sorted(binaries):
+                    pointer = ctypes.c_void_p()
+                    size = ctypes.c_size_t()
+                    result = self.lib.kpack_get_kernel(
+                        handle,
+                        binary.encode(),
+                        architecture.encode(),
+                        ctypes.byref(pointer),
+                        ctypes.byref(size),
+                    )
+                    if result == KPACK_ERROR_KERNEL_NOT_FOUND:
+                        continue
+                    if result:
+                        raise RuntimeError(
+                            f"kpack_get_kernel failed ({result}): "
+                            f"{archive}:{binary}:{architecture}"
+                        )
+                    try:
+                        yield binary, architecture, ctypes.string_at(
+                            pointer, size.value
+                        )
+                    finally:
+                        self.lib.kpack_free_kernel(pointer)
+        finally:
+            self.lib.kpack_close(handle)
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Found:
+    """One extracted code object and where it came from."""
+
+    data: bytes
+    origin: dict[str, object]
+
+
+@dataclass
+class Discovery:
+    objects: list[Found] = field(default_factory=list)
+    compressed_bundles: list[Path] = field(default_factory=list)
+    compressed_unpacked: int = 0
+    kpack_archives: list[Path] = field(default_factory=list)
+    kpack_skipped: int = 0
+    failures: list[dict[str, object]] = field(default_factory=list)
+
+
+def walk(roots: list[Path]):
+    seen: set[tuple[int, int]] = set()
+    for root in roots:
+        if root.is_file():
+            yield root
+            continue
+        for directory, _, names in os.walk(root, followlinks=False):
+            for name in names:
+                path = Path(directory) / name
+                try:
+                    info = path.stat()
+                except OSError:
+                    continue
+                if not os.path.isfile(path):
+                    continue
+                # Hard links are common in an install tree; extracting the same
+                # bytes twice would translate them twice.
+                key = (info.st_dev, info.st_ino)
+                if key in seen:
+                    continue
+                seen.add(key)
+                yield path
+
+
+def discover(
+    roots: list[Path],
+    target: str,
+    kpack: Kpack | None,
+    bundler: str | None,
+    kpack_intentionally_skipped: bool = False,
+) -> Discovery:
+    found = Discovery()
+    # (path, container bytes) for every compressed bundle, resolved after the
+    # walk so one missing tool does not abort the scan.
+    compressed: list[tuple[Path, bytes]] = []
+    for path in walk(roots):
+        try:
+            with path.open("rb") as handle:
+                header = handle.read(64)
+                if len(header) < MIN_CANDIDATE_BYTES:
+                    continue
+                if header.startswith(KPACK_MAGIC):
+                    found.kpack_archives.append(path)
+                    continue
+                is_compressed = header.startswith(COMPRESSED_BUNDLE_MAGIC)
+                if not is_compressed and not header.startswith(ELF_MAGIC):
+                    continue
+                data = header + handle.read()
+        except OSError as error:
+            found.failures.append(
+                {"category": "read", "path": str(path), "error": str(error)}
+            )
+            continue
+
+        if is_compressed:
+            found.compressed_bundles.append(path)
+            compressed.append((path, data))
+            continue
+
+        if is_amdgpu_elf(data):
+            # A standalone code object. Whether it is for this target is the
+            # translator's verdict to give, not ours to guess from the name.
+            found.objects.append(Found(data, {"container": "elf", "path": str(path)}))
+            continue
+
+        fatbin = elf_section(data, b".hip_fatbin")
+        if fatbin is None:
+            continue
+        if fatbin.startswith(COMPRESSED_BUNDLE_MAGIC):
+            found.compressed_bundles.append(path)
+            compressed.append((path, fatbin))
+            continue
+        for index, (entry_target, payload) in enumerate(
+            parse_clang_offload_bundles(fatbin)
+        ):
+            if not bundle_target_matches(entry_target, target) or not payload:
+                continue
+            found.objects.append(
+                Found(
+                    payload,
+                    {
+                        "container": "hip-fatbin",
+                        "path": str(path),
+                        "entry": index,
+                        "target": entry_target,
+                    },
+                )
+            )
+
+    if bundler is not None:
+        for path, blob in compressed:
+            try:
+                payloads = unbundle_compressed(bundler, blob, target)
+            except OSError as error:
+                found.failures.append(
+                    {
+                        "category": "compressed-bundle",
+                        "path": str(path),
+                        "error": str(error),
+                    }
+                )
+                continue
+            if payloads:
+                found.compressed_unpacked += 1
+            for index, payload in enumerate(payloads):
+                found.objects.append(
+                    Found(
+                        payload,
+                        {
+                            "container": "compressed-bundle",
+                            "path": str(path),
+                            "entry": index,
+                        },
+                    )
+                )
+
+    for archive in found.kpack_archives:
+        if kpack is None:
+            # An archive nobody meant to open is not a failure. --skip-kpack
+            # documents those as accepted skips, so reporting them as errors and
+            # exiting nonzero contradicts the option and breaks any build step
+            # that checks the exit status. An archive that WAS meant to be
+            # processed and could not be is still a failure.
+            if kpack_intentionally_skipped:
+                found.kpack_skipped += 1
+                continue
+            found.failures.append(
+                {
+                    "category": "kpack",
+                    "path": str(archive),
+                    "error": "no KPACK library; pass --kpack-library or --skip-kpack",
+                }
+            )
+            continue
+        try:
+            for member, architecture, data in kpack.objects(archive, target):
+                found.objects.append(
+                    Found(
+                        data,
+                        {
+                            "container": "kpack",
+                            "path": str(archive),
+                            "member": member,
+                            "architecture": architecture,
+                        },
+                    )
+                )
+        except (OSError, RuntimeError) as error:
+            found.failures.append(
+                {"category": "kpack", "path": str(archive), "error": str(error)}
+            )
+    return found
+
+
+# ---------------------------------------------------------------------------
+# Driving the tool
+# ---------------------------------------------------------------------------
+
+
+def locate_tool(explicit: str | None) -> str | None:
+    if explicit:
+        return explicit if Path(explicit).exists() else None
+    # Beside this script's install prefix first, then the path. A ROCm install
+    # ships both, and finding the one that belongs to this tree matters: the tool
+    # and the runtime hook share entries only when they resolve the same
+    # translator.
+    beside = Path(__file__).resolve().parent.parent / "bin" / "rj_pretranslate"
+    if beside.exists():
+        return str(beside)
+    from shutil import which
+
+    return which("rj_pretranslate")
+
+
+def run_tool(
+    tool: str,
+    store_root: str | None,
+    paths: list[Path],
+    force: bool,
+    portable: bool,
+    fail_on_skipped: bool,
+    verbose: bool,
+) -> tuple[int, str]:
+    command = [tool]
+    if store_root:
+        command += ["--store-root", store_root]
+    if force:
+        command.append("--force")
+    if portable:
+        command.append("--portable")
+    if fail_on_skipped:
+        command.append("--fail-on-skipped")
+    command += [str(path) for path in paths]
+    result = subprocess.run(
+        command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
+    )
+    if verbose:
+        sys.stdout.write(result.stdout)
+        sys.stdout.flush()
+    return result.returncode, result.stdout
+
+
+def parse_tool_output(text: str) -> dict[str, int]:
+    totals = {"written": 0, "held": 0, "skipped": 0, "failed": 0}
+    for line in text.splitlines():
+        if not line.startswith("summary "):
+            continue
+        for field_text in line.split()[1:]:
+            name, _, value = field_text.partition("=")
+            if name in totals and value.isdigit():
+                totals[name] += int(value)
+    return totals
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        help="files or directories to scan (default: %s)" % DEFAULT_ROOT,
+    )
+    parser.add_argument(
+        "--target", default=DEFAULT_TARGET, help="GPU target (default: %(default)s)"
+    )
+    parser.add_argument(
+        "--tool", help="path to rj_pretranslate (default: found beside this script)"
+    )
+    parser.add_argument(
+        "--store-root",
+        help="write here instead of the location derived from the translator",
+    )
+    parser.add_argument(
+        "--report-dir",
+        type=Path,
+        help="write provenance.jsonl and summary.json here",
+    )
+    parser.add_argument(
+        "--temporary-root",
+        type=Path,
+        help="create translation staging directories below this location",
+    )
+    parser.add_argument(
+        "--kpack-library",
+        default=DEFAULT_KPACK_LIBRARY,
+        help="KPACK library to load (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--skip-kpack",
+        action="store_true",
+        help="do not open KPACK archives; they are reported as skipped",
+    )
+    parser.add_argument(
+        "--bundler",
+        help="clang-offload-bundler to unpack compressed bundles "
+        "(default: found under /opt/rocm or on PATH)",
+    )
+    parser.add_argument(
+        "--skip-compressed",
+        action="store_true",
+        help="do not unpack compressed bundles; they are reported as skipped",
+    )
+    parser.add_argument(
+        "--batch", type=int, default=8, help="objects per tool invocation (default: 8)"
+    )
+    parser.add_argument(
+        "--progress-every",
+        type=int,
+        default=25,
+        help="objects between progress lines (default: %(default)s; 0 disables)",
+    )
+    parser.add_argument(
+        "--force", action="store_true", help="translate even objects already held"
+    )
+    parser.add_argument(
+        "--portable",
+        action="store_true",
+        help="write a prebuilt cache independent of the translator ELF build ID",
+    )
+    parser.add_argument(
+        "--fail-on-skipped",
+        action="store_true",
+        help="exit nonzero if the translator rejects any discovered object",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="report what would be translated and stop",
+    )
+    parser.add_argument("--verbose", action="store_true", help="echo the tool's output")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_arguments()
+    roots = args.paths or [DEFAULT_ROOT]
+    missing = [root for root in roots if not root.exists()]
+    if missing:
+        for root in missing:
+            print(f"error: {root} does not exist", file=sys.stderr)
+        return 2
+
+    kpack = None
+    if not args.skip_kpack:
+        try:
+            kpack = Kpack(args.kpack_library)
+        except OSError as error:
+            print(
+                f"warning: {args.kpack_library} unavailable ({error}); KPACK archives "
+                "will be reported as failures. Pass --skip-kpack to accept that, but "
+                "note that large device libraries such as RCCL's live only there.",
+                file=sys.stderr,
+            )
+
+    bundler = None
+    if not args.skip_compressed:
+        bundler = find_bundler(args.bundler)
+        if bundler is None:
+            print(
+                "warning: clang-offload-bundler not found; compressed bundles will be "
+                "reported as skipped. On this ROCm tree those hold the gfx1250 GEMM "
+                "libraries, so a cache built without it will be missing them.",
+                file=sys.stderr,
+            )
+
+    found = discover(roots, args.target, kpack, bundler, args.skip_kpack)
+
+    # Content-address before translating. An install tree holds the same object
+    # under several names, and the whole point is not to do the work twice.
+    unique: dict[str, Found] = {}
+    duplicates = 0
+    for item in found.objects:
+        digest = hashlib.sha256(item.data).hexdigest()
+        if digest in unique:
+            duplicates += 1
+            continue
+        unique[digest] = item
+
+    print(
+        f"found {len(unique)} unique objects "
+        f"({len(found.objects)} extracted, {duplicates} duplicates), "
+        f"{len(found.kpack_archives)} kpack archives, "
+        f"{found.compressed_unpacked}/{len(found.compressed_bundles)} compressed "
+        "bundles unpacked"
+    )
+    if args.dry_run:
+        return 0 if not found.failures else 1
+
+    tool = locate_tool(args.tool)
+    if tool is None:
+        print("error: rj_pretranslate not found; pass --tool", file=sys.stderr)
+        return 2
+
+    totals = {"written": 0, "held": 0, "skipped": 0, "failed": 0}
+    tool_failures = 0
+    provenance: list[dict[str, object]] = []
+    if args.temporary_root is not None:
+        args.temporary_root.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(
+        prefix="rocjitsu-pretranslate-", dir=args.temporary_root
+    ) as temporary:
+        staged: list[Path] = []
+        order = sorted(unique.items())
+        for index, (digest, item) in enumerate(order, start=1):
+            path = Path(temporary) / f"{digest}.co"
+            path.write_bytes(item.data)
+            staged.append(path)
+            provenance.append(
+                {"digest": digest, "bytes": len(item.data), **item.origin}
+            )
+
+            at_end = index == len(order)
+            if len(staged) < args.batch and not at_end:
+                continue
+            code, output = run_tool(
+                tool,
+                args.store_root,
+                staged,
+                args.force,
+                args.portable,
+                args.fail_on_skipped,
+                args.verbose,
+            )
+            for name, value in parse_tool_output(output).items():
+                totals[name] += value
+            if code != 0 and not args.verbose:
+                sys.stderr.write(output)
+            if code != 0:
+                tool_failures += 1
+            for path in staged:
+                path.unlink(missing_ok=True)
+            staged = []
+            if args.progress_every and (index % args.progress_every == 0 or at_end):
+                print(f"pretranslate: {index}/{len(order)} objects", flush=True)
+
+    summary = {
+        "target": args.target,
+        "roots": [str(root) for root in roots],
+        "store_root": args.store_root,
+        "unique_objects": len(unique),
+        "duplicate_objects": duplicates,
+        "kpack_archives": len(found.kpack_archives),
+        "kpack_archives_skipped": found.kpack_skipped,
+        "compressed_bundles": len(found.compressed_bundles),
+        "compressed_bundles_unpacked": found.compressed_unpacked,
+        "discovery_failures": len(found.failures),
+        "fail_on_skipped": args.fail_on_skipped,
+        "portable": args.portable,
+        "tool_failures": tool_failures,
+        **totals,
+    }
+    print(
+        "summary written={written} held={held} skipped={skipped} "
+        "failed={failed}".format(**totals)
+    )
+
+    if args.report_dir:
+        args.report_dir.mkdir(parents=True, exist_ok=True)
+        with (args.report_dir / "provenance.jsonl").open("w", encoding="utf-8") as out:
+            for record in provenance:
+                out.write(json.dumps(record, sort_keys=True) + "\n")
+        (args.report_dir / "summary.json").write_text(
+            json.dumps(
+                {**summary, "failures": found.failures}, indent=2, sort_keys=True
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+    for failure in found.failures:
+        print(f"error: {failure}", file=sys.stderr)
+    failed = totals["failed"] != 0 or tool_failures != 0 or bool(found.failures)
+    if args.fail_on_skipped and totals["skipped"] != 0:
+        failed = True
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -625,11 +625,17 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         WARNINGS
     )
     rj_add_gtest_tests(gfx1250_b0_to_a0_library_test)
+    # Checked on the translator rather than the hook. The hook used to link the
+    # translator as a static archive and so carried the model code itself; now it
+    # loads a shared object, and the boundary this guards -- model in, execution
+    # out -- belongs to whichever artifact holds that code. Pointed at the hook it
+    # would now pass vacuously, which is the failure mode the required-symbol
+    # check at the end of the script exists to catch.
     add_test(
         NAME Gfx1250B0ToA0Library.SymbolBoundary
         COMMAND
             ${CMAKE_COMMAND} -DNM=${CMAKE_NM}
-            -DMODEL_BINARY=$<TARGET_FILE:hsa_hotswap_rocjitsu> -P
+            -DMODEL_BINARY=$<TARGET_FILE:rocjitsu_gfx1250_b0_to_a0> -P
             ${CMAKE_CURRENT_SOURCE_DIR}/check_model_only_symbols.cmake
     )
 
@@ -1222,9 +1228,72 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
             hsa_hotswap_rocjitsu_unit_test
             probe_relocation_function_table_dispatch_gfx1250
         )
+        # The pre-translated tier is filled by a separate program and read by the
+        # hook. Running the real tool is the only way to test that the two agree
+        # on a key; writing entries through a test seam would exercise the hook's
+        # own derivation twice and prove nothing about the pair.
+        target_compile_definitions(
+            hsa_hotswap_rocjitsu_unit_test
+            PRIVATE RJ_PRETRANSLATE_TOOL="$<TARGET_FILE:rj_pretranslate>"
+        )
+        add_dependencies(hsa_hotswap_rocjitsu_unit_test rj_pretranslate)
     endif()
     rj_configure_target(hsa_hotswap_rocjitsu_unit_test TEST)
     gtest_discover_tests(hsa_hotswap_rocjitsu_unit_test)
+
+    # Compiles the translation store as a plain DBT component rather than
+    # reaching it through a hook, which is how a second consumer would use it.
+    add_executable(
+        translation_store_test
+        dbt/translation_store_test.cpp
+        ${CMAKE_SOURCE_DIR}/lib/rocjitsu/src/rocjitsu/code/dbt/translation_store.cpp
+    )
+    target_include_directories(
+        translation_store_test
+        PRIVATE
+            ${CMAKE_SOURCE_DIR}/lib/rocjitsu/include
+            ${CMAKE_SOURCE_DIR}/lib/rocjitsu/src
+    )
+    target_compile_definitions(
+        translation_store_test
+        PRIVATE RJ_TRANSLATION_STORE_TEST_HOOKS
+    )
+    # The store keys entries on this note and disables itself without it.
+    target_link_options(translation_store_test PRIVATE "LINKER:--build-id=sha1")
+    target_link_libraries(
+        translation_store_test
+        PRIVATE GTest::gtest_main ${CMAKE_DL_LIBS}
+    )
+    rj_configure_target(translation_store_test TEST)
+    gtest_discover_tests(translation_store_test)
+
+    # One source, two modules differing only in build id -- which is what a
+    # rebuilt translator is. Entries written against one must be invisible to the
+    # other, and no single binary can show that: the store derives identity from
+    # the module containing an address, so two identities need two modules.
+    #
+    # The ids are fixed rather than content-derived so this stays a test of the
+    # store rather than of the linker. Content-derived ids would also differ, but
+    # only incidentally, and would churn whenever either file was touched.
+    foreach(_probe_suffix a b)
+        set(_probe rj_translator_build_probe_${_probe_suffix})
+        add_library(${_probe} MODULE dbt/translator_build_probe.cpp)
+        rj_configure_target(${_probe} TEST)
+        target_compile_definitions(
+            translation_store_test
+            PRIVATE
+                RJ_TRANSLATOR_PROBE_${_probe_suffix}="$<TARGET_FILE:${_probe}>"
+        )
+        add_dependencies(translation_store_test ${_probe})
+    endforeach()
+    target_link_options(
+        rj_translator_build_probe_a
+        PRIVATE "LINKER:--build-id=0xaaaaaaaaaaaaaaaa"
+    )
+    target_link_options(
+        rj_translator_build_probe_b
+        PRIVATE "LINKER:--build-id=0xbbbbbbbbbbbbbbbb"
+    )
 endif()
 
 # A separate loadable module is the only way to observe the force-scalar gate's

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -348,6 +348,12 @@ add_test(
         ${Python3_EXECUTABLE}
         ${CMAKE_CURRENT_SOURCE_DIR}/fuzz/decode/test_decode_cli.py -v
 )
+add_test(
+    NAME PretranslateScriptUnitTest
+    COMMAND
+        ${Python3_EXECUTABLE}
+        ${CMAKE_CURRENT_SOURCE_DIR}/tools/test_pretranslate.py -v
+)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(PLUGIN_LOADER_FIXTURE_DIR

--- a/emulation/rocjitsu/tests/dbt/hsa_hotswap_rocjitsu_unit_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/hsa_hotswap_rocjitsu_unit_test.cpp
@@ -53,6 +53,8 @@ extern "C" uint64_t rj_test_dump_path_count();
 extern "C" uint64_t rj_test_sample_fingerprint(const void *bytes, size_t size);
 extern "C" void rj_test_retain_completed_claims(bool retain);
 extern "C" void rj_test_fail_next_memo_admission(int stage);
+extern "C" void rj_test_set_pretranslation_root(const char *root);
+extern "C" uint64_t rj_test_pretranslation_hits();
 
 namespace {
 
@@ -1776,6 +1778,126 @@ TEST_F(HsaHotswapMemoTest, ReuseIsReportedAgainstTheSameSourceObject) {
       ++reuse_records;
   }
   EXPECT_EQ(reuse_records, 1u);
+}
+#endif
+
+#if defined(GFX1250_B0_TO_A0_FIXTURE) && defined(RJ_PRETRANSLATE_TOOL)
+/// @brief A private pre-translated tier for one test.
+///
+/// @details A failed mkdtemp points the store at a path that cannot exist rather
+/// than passing nullptr, which would restore the REAL install tier: on a machine
+/// where someone had pre-translated, a test could then pass without ever touching
+/// its own directory.
+class ScopedPretranslationRoot {
+public:
+  static constexpr const char *kUnusableRoot = "/dev/null/rj-fixture-has-no-root";
+
+  ScopedPretranslationRoot() {
+    std::strcpy(path_, "/tmp/rj-hotswap-aot-XXXXXX");
+    if (mkdtemp(path_) == nullptr)
+      path_[0] = '\0';
+    rj_test_set_pretranslation_root(path_[0] == '\0' ? kUnusableRoot : path_);
+  }
+  ~ScopedPretranslationRoot() {
+    rj_test_set_pretranslation_root(nullptr);
+    if (path_[0] != '\0')
+      std::filesystem::remove_all(path_);
+  }
+  ScopedPretranslationRoot(const ScopedPretranslationRoot &) = delete;
+  ScopedPretranslationRoot &operator=(const ScopedPretranslationRoot &) = delete;
+
+  [[nodiscard]] bool has_root() const { return path_[0] != '\0'; }
+  [[nodiscard]] const char *path() const { return path_; }
+
+  /// @brief Re-run the tier's checks after filling its directory.
+  /// @details It opens once and holds the descriptor, so a tier populated after
+  /// the first lookup would otherwise stay closed.
+  void reopen() const { rj_test_set_pretranslation_root(path_); }
+
+private:
+  char path_[64] = {};
+};
+
+class HsaHotswapPretranslationTest : public HsaHotswapHookTest {
+protected:
+  void SetUp() override {
+    HsaHotswapHookTest::SetUp();
+    ASSERT_TRUE(store_root.has_root()) << "fixture could not create its private store root";
+    ASSERT_TRUE(OnLoad(&api.table, 0, 0, nullptr));
+    source = read_translation_fixture();
+    ASSERT_FALSE(source.empty()) << GFX1250_B0_TO_A0_FIXTURE;
+  }
+
+  /// @brief Run one A0 load of @p bytes and return what reached the loader.
+  std::vector<uint8_t> load(const std::vector<uint8_t> &bytes) {
+    hsa_code_object_reader_t reader{};
+    EXPECT_EQ(
+        api.core.hsa_code_object_reader_create_from_memory_fn(bytes.data(), bytes.size(), &reader),
+        HSA_STATUS_SUCCESS);
+    EXPECT_EQ(api.core.hsa_executable_load_agent_code_object_fn(kExecutable, kA0Agent, reader,
+                                                                nullptr, nullptr),
+              HSA_STATUS_SUCCESS);
+    const std::vector<uint8_t> loaded = g_loaded_bytes;
+    EXPECT_EQ(api.core.hsa_executable_destroy_fn(kExecutable), HSA_STATUS_SUCCESS);
+    return loaded;
+  }
+
+  /// @brief Fill the tier by running the real tool over @p bytes.
+  void pretranslate(const std::vector<uint8_t> &bytes) {
+    const std::filesystem::path input = std::filesystem::path(store_root.path()) / "source.co";
+    {
+      std::ofstream out(input, std::ios::binary);
+      out.write(reinterpret_cast<const char *>(bytes.data()),
+                static_cast<std::streamsize>(bytes.size()));
+      ASSERT_TRUE(out.good());
+    }
+    const std::string command = std::string(RJ_PRETRANSLATE_TOOL) + " --portable --store-root '" +
+                                store_root.path() + "' '" + input.string() + "' > /dev/null 2>&1";
+    ASSERT_EQ(std::system(command.c_str()), 0) << command;
+    std::filesystem::remove(input);
+    store_root.reopen();
+  }
+
+  ScopedPretranslationRoot store_root;
+  std::vector<uint8_t> source;
+};
+
+// The tier is only worth anything if a DIFFERENT program can fill it. Both sides
+// key entries on the portable-prebuilt contract and locate the tree relative to
+// the same shared object, so they agree by construction -- but nothing reports
+// a disagreement. A tool writing keys the hook never computes would produce no
+// error, no warning, and no reuse whatsoever.
+//
+// So this runs the real tool as a separate process rather than writing entries
+// through a test seam. A seam would exercise the hook's own key derivation twice
+// and prove nothing about the pair.
+TEST_F(HsaHotswapPretranslationTest, WhatTheToolWritesAheadOfTimeServesALoad) {
+  pretranslate(source);
+
+  const std::vector<uint8_t> loaded = load(source);
+  ASSERT_FALSE(loaded.empty());
+  EXPECT_EQ(rj_test_pretranslation_hits(), 1u);
+
+  // Nothing was added to the tier: it is read-only to this process, so a runtime
+  // never writes back what it was handed.
+  size_t objects = 0;
+  for (const auto &item : std::filesystem::recursive_directory_iterator(store_root.path()))
+    objects += item.path().extension() == ".obj" ? 1 : 0;
+  EXPECT_EQ(objects, 1u);
+}
+
+TEST_F(HsaHotswapPretranslationTest, APreTranslatedObjectIsWhatTranslatingWouldHaveProduced) {
+  // Reuse is only correct if it is indistinguishable from doing the work. The
+  // tool and the hook run the same translator, so this should hold trivially --
+  // which is exactly why it is worth an assertion rather than an assumption.
+  const std::vector<uint8_t> translated = load(source);
+  ASSERT_FALSE(translated.empty());
+  rj_test_clear_retained_storage();
+
+  pretranslate(source);
+
+  EXPECT_EQ(load(source), translated);
+  EXPECT_EQ(rj_test_pretranslation_hits(), 1u);
 }
 #endif
 

--- a/emulation/rocjitsu/tests/dbt/hsa_hotswap_rocjitsu_unit_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/hsa_hotswap_rocjitsu_unit_test.cpp
@@ -1851,7 +1851,7 @@ protected:
                 static_cast<std::streamsize>(bytes.size()));
       ASSERT_TRUE(out.good());
     }
-    const std::string command = std::string(RJ_PRETRANSLATE_TOOL) + " --portable --store-root '" +
+    const std::string command = std::string(RJ_PRETRANSLATE_TOOL) + " --store-root '" +
                                 store_root.path() + "' '" + input.string() + "' > /dev/null 2>&1";
     ASSERT_EQ(std::system(command.c_str()), 0) << command;
     std::filesystem::remove(input);

--- a/emulation/rocjitsu/tests/dbt/translation_store_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translation_store_test.cpp
@@ -18,6 +18,7 @@
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <future>
 #include <iterator>
 #include <memory>
 #include <span>
@@ -25,7 +26,9 @@
 #include <vector>
 
 #include <dlfcn.h>
+#include <fcntl.h>
 #include <sched.h>
+#include <sys/file.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -70,7 +73,7 @@ protected:
                                                               const char *path = nullptr) {
     return std::make_unique<TranslationStore>(
         domain, reinterpret_cast<const void *>(&translator_identity_anchor),
-        path == nullptr ? root_ : path, access);
+        path == nullptr ? root_ : path, access, TranslationStore::KeyMode::kTranslatorBuild);
   }
 
   /// @brief The common case: a writable store over this test's directory.
@@ -121,6 +124,19 @@ TEST_F(TranslationStoreTest, ADomainThatIsNotOneComponentDisablesTheStore) {
   // Nothing was created outside the domain directories.
   for (const auto &item : std::filesystem::recursive_directory_iterator(root_))
     EXPECT_TRUE(std::filesystem::is_directory(item)) << item.path();
+}
+
+TEST_F(TranslationStoreTest, AStoreRootMustBeAnAbsoluteDescendedPath) {
+  EXPECT_FALSE(open_shared("pair-a", TranslationStore::Access::kReadWrite, "/")->available());
+
+  // This spelling would reach the fixture directory if it were incorrectly
+  // interpreted relative to `/`, making the assertion independent of whether a
+  // coincidentally named top-level directory exists on the host.
+  const std::string relative = std::string(root_).substr(1);
+  auto store = open_shared("pair-a", TranslationStore::Access::kReadWrite, relative.c_str());
+  EXPECT_FALSE(store->available());
+  EXPECT_FALSE(store->key_for(kSource, kIdentity).valid);
+  EXPECT_TRUE(std::filesystem::is_empty(root_));
 }
 
 TEST_F(TranslationStoreTest, AnEmptyObjectIsNotStored) {
@@ -246,7 +262,8 @@ open_against_module(const char *module, std::string_view domain, const char *roo
   if (anchor == nullptr)
     return nullptr;
   return std::make_unique<TranslationStore>(domain, anchor, root,
-                                            TranslationStore::Access::kReadWrite);
+                                            TranslationStore::Access::kReadWrite,
+                                            TranslationStore::KeyMode::kTranslatorBuild);
 }
 
 [[nodiscard]] std::unique_ptr<TranslationStore>
@@ -262,6 +279,24 @@ open_portable_against_module(const char *module, std::string_view domain, const 
     return nullptr;
   return std::make_unique<TranslationStore>(domain, anchor, root, access,
                                             TranslationStore::KeyMode::kPortablePrebuilt);
+}
+
+TEST_F(TranslationStoreTest, SharedRootUsesTheResolvedTranslatorPath) {
+  const std::filesystem::path prefix(root_);
+  std::filesystem::create_directories(prefix / "bin");
+  std::filesystem::create_directories(prefix / "lib");
+  const std::filesystem::path copied = prefix / "lib" / "librj-probe.so";
+  std::filesystem::copy_file(RJ_TRANSLATOR_PROBE_a, copied);
+
+  const std::string loader_path = (prefix / "bin" / ".." / "lib" / "librj-probe.so").string();
+  void *handle = dlopen(loader_path.c_str(), RTLD_NOW | RTLD_LOCAL);
+  ASSERT_NE(handle, nullptr) << dlerror();
+  void *anchor = dlsym(handle, "rj_probe_translator_anchor");
+  ASSERT_NE(anchor, nullptr);
+
+  EXPECT_EQ(rocjitsu::shared_translation_root(anchor),
+            (prefix / "share" / "rocjitsu" / "translations").string());
+  dlclose(handle);
 }
 
 TEST_F(TranslationStoreTest, ARebuiltTranslatorDoesNotReadTheOldEntries) {
@@ -396,6 +431,59 @@ TEST_F(TranslationStoreTest, AManifestWithNoObjectIsReclaimed) {
     orphans += std::filesystem::exists(object) ? 0 : 1;
   }
   EXPECT_EQ(orphans, 0u) << "an orphan manifest must be reclaimed";
+}
+
+TEST_F(TranslationStoreTest, AbandonedFileSweepWaitsForTheDirectoryWriter) {
+  {
+    auto initial = open("pair-a");
+    ASSERT_TRUE(initial->available());
+  }
+  const std::filesystem::path entries = std::filesystem::path(root_) / "pair-a" / "v1";
+  const std::filesystem::path temporary = entries / "entry.tmp.writer";
+  std::ofstream(temporary) << "still publishing";
+  std::filesystem::last_write_time(temporary, std::filesystem::file_time_type::clock::now() -
+                                                  std::chrono::hours(1));
+
+  int ready[2];
+  int release[2];
+  ASSERT_EQ(pipe(ready), 0);
+  ASSERT_EQ(pipe(release), 0);
+  const pid_t child = fork();
+  ASSERT_GE(child, 0);
+  if (child == 0) {
+    close(ready[0]);
+    close(release[1]);
+    const int fd = ::open(entries.c_str(), O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    char token = 'x';
+    if (fd < 0 || flock(fd, LOCK_EX) != 0 || write(ready[1], &token, 1) != 1 ||
+        read(release[0], &token, 1) != 1)
+      _exit(1);
+    close(fd);
+    _exit(0);
+  }
+
+  close(ready[1]);
+  close(release[0]);
+  char token = 0;
+  ASSERT_EQ(read(ready[0], &token, 1), 1);
+  auto reopening = std::async(std::launch::async, [this] {
+    auto store = open("pair-a");
+    return store->available();
+  });
+  EXPECT_EQ(reopening.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+  EXPECT_TRUE(reopening.get());
+  EXPECT_TRUE(std::filesystem::exists(temporary));
+
+  ASSERT_EQ(write(release[1], &token, 1), 1);
+  int status = 0;
+  ASSERT_EQ(waitpid(child, &status, 0), child);
+  EXPECT_TRUE(WIFEXITED(status));
+  EXPECT_EQ(WEXITSTATUS(status), 0);
+  auto next = open("pair-a");
+  EXPECT_TRUE(next->available());
+  EXPECT_FALSE(std::filesystem::exists(temporary));
+  close(ready[0]);
+  close(release[1]);
 }
 
 TEST_F(TranslationStoreTest, AGroupWritableStoreRootIsStillUsable) {

--- a/emulation/rocjitsu/tests/dbt/translation_store_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translation_store_test.cpp
@@ -1,0 +1,504 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file translation_store_test.cpp
+/// @brief Covers TranslationStore away from any hook.
+///
+/// @details The store is meant to serve more than one translation pair, so this
+/// compiles it as an ordinary DBT component and drives it directly. That also
+/// keeps the header honest: anything it needed from a hook would fail to build
+/// here.
+
+#include <gtest/gtest.h>
+
+#include "rocjitsu/code/dbt/translation_store.h"
+
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <memory>
+#include <span>
+#include <string_view>
+#include <vector>
+
+#include <dlfcn.h>
+#include <sched.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+namespace {
+
+using rocjitsu::TranslationIdentity;
+using rocjitsu::TranslationStore;
+
+constexpr TranslationIdentity kIdentity{
+    .profile_id = 7,
+    .input_revision = 2,
+    .output_revision = 1,
+    .target_isa = "gfx-example",
+};
+
+constexpr auto kSafeDirPerms =
+    std::filesystem::perms::owner_all | std::filesystem::perms::group_read |
+    std::filesystem::perms::group_exec | std::filesystem::perms::others_read |
+    std::filesystem::perms::others_exec;
+
+const std::vector<uint8_t> kSource{'s', 'r', 'c'};
+const std::vector<uint8_t> kObject{'o', 'u', 't', 'p', 'u', 't'};
+
+/// Stands in for the translator: its address identifies this test binary, which
+/// is the module every store constructed here shares.
+void translator_identity_anchor() {}
+
+class TranslationStoreTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    std::strcpy(root_, "/tmp/rj-translation-store-XXXXXX");
+    ASSERT_NE(mkdtemp(root_), nullptr);
+  }
+  void TearDown() override { std::filesystem::remove_all(root_); }
+
+  /// @brief A writable store over @p path, or over this test's directory.
+  /// @details Any address inside the translator would do in production; a test
+  /// that is not translating anything only needs the stores it compares to agree.
+  [[nodiscard]] std::unique_ptr<TranslationStore> open_shared(std::string_view domain,
+                                                              TranslationStore::Access access,
+                                                              const char *path = nullptr) {
+    return std::make_unique<TranslationStore>(
+        domain, reinterpret_cast<const void *>(&translator_identity_anchor),
+        path == nullptr ? root_ : path, access);
+  }
+
+  /// @brief The common case: a writable store over this test's directory.
+  [[nodiscard]] std::unique_ptr<TranslationStore> open(std::string_view domain) {
+    return open_shared(domain, TranslationStore::Access::kReadWrite);
+  }
+
+  static void put(TranslationStore &store, std::span<const uint8_t> object) {
+    store.store(store.key_for(kSource, kIdentity), object, kIdentity);
+  }
+
+  [[nodiscard]] static std::vector<uint8_t> get(TranslationStore &store) {
+    return store.lookup(store.key_for(kSource, kIdentity), kIdentity);
+  }
+
+  char root_[64] = {};
+};
+
+TEST_F(TranslationStoreTest, StoredObjectComesBack) {
+  auto store = open("pair-a");
+  put(*store, kObject);
+  EXPECT_EQ(get(*store), kObject);
+  EXPECT_EQ(store->hits_for_test(), 1u);
+}
+
+TEST_F(TranslationStoreTest, DomainsDoNotShareEntries) {
+  auto first = open("pair-a");
+  auto second = open("pair-b");
+  put(*first, kObject);
+
+  EXPECT_EQ(get(*first), kObject);
+  EXPECT_TRUE(get(*second).empty());
+
+  // And the second domain can hold a different object under the same source.
+  const std::vector<uint8_t> other{'e', 'l', 's', 'e'};
+  put(*second, other);
+  EXPECT_EQ(get(*second), other);
+  EXPECT_EQ(get(*first), kObject);
+}
+
+TEST_F(TranslationStoreTest, ADomainThatIsNotOneComponentDisablesTheStore) {
+  for (const char *domain : {"", ".", "..", "a/b", "../escape"}) {
+    auto store = open(domain);
+    put(*store, kObject);
+    EXPECT_TRUE(get(*store).empty()) << "domain: " << domain;
+    EXPECT_FALSE(store->key_for(kSource, kIdentity).valid) << "domain: " << domain;
+  }
+  // Nothing was created outside the domain directories.
+  for (const auto &item : std::filesystem::recursive_directory_iterator(root_))
+    EXPECT_TRUE(std::filesystem::is_directory(item)) << item.path();
+}
+
+TEST_F(TranslationStoreTest, AnEmptyObjectIsNotStored) {
+  auto store = open("pair-a");
+  put(*store, {});
+  EXPECT_TRUE(get(*store).empty());
+  EXPECT_EQ(store->size_for_test(), 0u);
+}
+
+TEST_F(TranslationStoreTest, TwoHandlesOnOneDomainSeeEachOther) {
+  auto writer = open("pair-a");
+  put(*writer, kObject);
+
+  // Independent handles do not share in-process state, so this is the same
+  // path a second process would take.
+  auto reader = open("pair-a");
+  EXPECT_EQ(get(*reader), kObject);
+}
+
+TEST_F(TranslationStoreTest, WhatAToolWritesToTheSharedTierARuntimeReads) {
+  auto tool = open_shared("pair-a", TranslationStore::Access::kReadWrite);
+  put(*tool, kObject);
+
+  auto runtime = open_shared("pair-a", TranslationStore::Access::kReadOnly);
+  EXPECT_EQ(get(*runtime), kObject);
+}
+
+TEST_F(TranslationStoreTest, TheSharedTierIsReadableByWhoeverEventuallyRuns) {
+  // A shared tree is usually written by root during an image build and read by
+  // an unprivileged process afterwards. Modes only the writer can open would
+  // make every one of those reads a miss, and nothing would report it.
+  //
+  // The umask is what makes this a real risk, and the reason the store sets
+  // modes explicitly instead of trusting the ones it passes to open(). A build
+  // running under a restrictive umask is exactly where this goes wrong, so the
+  // test creates that condition rather than waiting to meet it.
+  const mode_t previous = umask(077);
+  auto tool = open_shared("pair-a", TranslationStore::Access::kReadWrite);
+  put(*tool, kObject);
+  umask(previous);
+
+  size_t files = 0;
+  for (const auto &item : std::filesystem::recursive_directory_iterator(root_)) {
+    const auto mode = std::filesystem::status(item).permissions();
+    EXPECT_NE(mode & std::filesystem::perms::others_read, std::filesystem::perms::none)
+        << item.path();
+    EXPECT_EQ(mode & (std::filesystem::perms::group_write | std::filesystem::perms::others_write),
+              std::filesystem::perms::none)
+        << item.path();
+    files += std::filesystem::is_regular_file(item) ? 1 : 0;
+  }
+  EXPECT_EQ(files, 2u) << "expected one object and one manifest";
+}
+
+TEST_F(TranslationStoreTest, AReadOnlySharedStoreDoesNotWriteAnExistingTree) {
+  // The tree has to already exist, or this would only be re-proving that a store
+  // with nowhere to write does not write.
+  auto tool = open_shared("pair-a", TranslationStore::Access::kReadWrite);
+  put(*tool, kObject);
+  const uint64_t before = tool->size_for_test();
+  ASSERT_GT(before, 0u);
+
+  const std::vector<uint8_t> replacement{'w', 'r', 'o', 'n', 'g'};
+  auto runtime = open_shared("pair-a", TranslationStore::Access::kReadOnly);
+  ASSERT_TRUE(runtime->available());
+  put(*runtime, replacement);
+
+  EXPECT_EQ(get(*runtime), kObject);
+  EXPECT_EQ(tool->size_for_test(), before);
+}
+
+TEST_F(TranslationStoreTest, AReadOnlySharedStoreCreatesNoTree) {
+  // An absent shared tier means nobody pre-translated. That is a miss, not
+  // something to repair: a directory this process created could not be trusted
+  // by the next one anyway, since it would fail its own ownership test under a
+  // different user.
+  auto runtime = open_shared("pair-a", TranslationStore::Access::kReadOnly);
+  put(*runtime, kObject);
+  EXPECT_TRUE(get(*runtime).empty());
+  EXPECT_TRUE(std::filesystem::is_empty(root_));
+}
+
+TEST_F(TranslationStoreTest, ASharedTreeAnyoneCanWriteIsRefused) {
+  // The question is whether someone outside the trust boundary could have
+  // placed an entry, and a directory writable by group or other says yes.
+  //
+  // The tree is planted rather than created and then loosened, because that is
+  // the shape of the real thing: an attacker who can write the parent makes the
+  // directory before the tool does. The tool must refuse it as found, not
+  // silently correct the mode and carry on.
+  int domain_index = 0;
+  for (const auto extra :
+       {std::filesystem::perms::group_write, std::filesystem::perms::others_write}) {
+    const std::string domain = "pair-" + std::to_string(domain_index++);
+    const std::filesystem::path leaf = std::filesystem::path(root_) / domain / "v1";
+    std::filesystem::create_directories(leaf);
+    std::filesystem::permissions(leaf, std::filesystem::perms::owner_all | extra);
+
+    auto tool = open_shared(domain, TranslationStore::Access::kReadWrite);
+    EXPECT_FALSE(tool->available()) << domain;
+    put(*tool, kObject);
+    EXPECT_TRUE(get(*tool).empty()) << domain;
+
+    auto runtime = open_shared(domain, TranslationStore::Access::kReadOnly);
+    EXPECT_FALSE(runtime->available()) << domain;
+  }
+}
+
+#if defined(RJ_TRANSLATOR_PROBE_a) && defined(RJ_TRANSLATOR_PROBE_b)
+/// @brief A store keyed on a translator loaded from @p module.
+///
+/// @details The module stays loaded for the process lifetime. Unloading it while
+/// a store still names an address inside it would leave that address pointing at
+/// nothing, and the store resolves it lazily.
+[[nodiscard]] std::unique_ptr<TranslationStore>
+open_against_module(const char *module, std::string_view domain, const char *root) {
+  void *handle = dlopen(module, RTLD_NOW | RTLD_LOCAL | RTLD_NODELETE);
+  EXPECT_NE(handle, nullptr) << dlerror();
+  if (handle == nullptr)
+    return nullptr;
+  void *anchor = dlsym(handle, "rj_probe_translator_anchor");
+  EXPECT_NE(anchor, nullptr) << module;
+  if (anchor == nullptr)
+    return nullptr;
+  return std::make_unique<TranslationStore>(domain, anchor, root,
+                                            TranslationStore::Access::kReadWrite);
+}
+
+[[nodiscard]] std::unique_ptr<TranslationStore>
+open_portable_against_module(const char *module, std::string_view domain, const char *root,
+                             TranslationStore::Access access) {
+  void *handle = dlopen(module, RTLD_NOW | RTLD_LOCAL | RTLD_NODELETE);
+  EXPECT_NE(handle, nullptr) << dlerror();
+  if (handle == nullptr)
+    return nullptr;
+  void *anchor = dlsym(handle, "rj_probe_translator_anchor");
+  EXPECT_NE(anchor, nullptr) << module;
+  if (anchor == nullptr)
+    return nullptr;
+  return std::make_unique<TranslationStore>(domain, anchor, root, access,
+                                            TranslationStore::KeyMode::kPortablePrebuilt);
+}
+
+TEST_F(TranslationStoreTest, ARebuiltTranslatorDoesNotReadTheOldEntries) {
+  // The anti-staleness guarantee. Translation output is a function of the
+  // translator, so an entry produced by one build must never satisfy a request
+  // made against another -- a miss costs a retranslation, whereas a stale hit
+  // silently runs code the current translator would not have emitted.
+  //
+  // The two modules differ in build id and nothing else, which is what a rebuild
+  // that changed emitted bytes looks like to the store.
+  auto first = open_against_module(RJ_TRANSLATOR_PROBE_a, "pair-a", root_);
+  ASSERT_NE(first, nullptr);
+  put(*first, kObject);
+  ASSERT_EQ(get(*first), kObject) << "the entry was never written";
+
+  auto second = open_against_module(RJ_TRANSLATOR_PROBE_b, "pair-a", root_);
+  ASSERT_NE(second, nullptr);
+  EXPECT_TRUE(get(*second).empty()) << "a differently-built translator read a stale entry";
+
+  // The keys must actually differ, rather than the miss coming from some
+  // unrelated refusal that would also hide a real collision.
+  EXPECT_NE(first->key_for(kSource, kIdentity).digest, second->key_for(kSource, kIdentity).digest);
+
+  // And the second build can hold its own entry for the same source alongside
+  // the first, so this is separation rather than the tier being unusable.
+  const std::vector<uint8_t> rebuilt{'n', 'e', 'w', 'e', 'r'};
+  put(*second, rebuilt);
+  EXPECT_EQ(get(*second), rebuilt);
+  EXPECT_EQ(get(*first), kObject);
+}
+
+TEST_F(TranslationStoreTest, APortablePrebuiltEntrySurvivesATranslatorRebuild) {
+  // A packaged cache and its consuming code are released as one product. Its
+  // compatibility boundary is the cache epoch plus translation identity, not
+  // an incidental ELF build ID that packaging may change without changing the
+  // translation contract.
+  auto tool = open_portable_against_module(RJ_TRANSLATOR_PROBE_a, "pair-a", root_,
+                                           TranslationStore::Access::kReadWrite);
+  ASSERT_NE(tool, nullptr);
+  put(*tool, kObject);
+  ASSERT_EQ(get(*tool), kObject) << "the portable entry was never written";
+
+  std::filesystem::path manifest;
+  for (const auto &item : std::filesystem::recursive_directory_iterator(root_)) {
+    if (item.path().extension() == ".man")
+      manifest = item.path();
+  }
+  ASSERT_FALSE(manifest.empty());
+  std::ifstream manifest_stream(manifest);
+  const std::string manifest_text((std::istreambuf_iterator<char>(manifest_stream)), {});
+  EXPECT_NE(manifest_text.find("\nbuild=unversioned-prebuilt-v1\n"), std::string::npos);
+
+  auto runtime = open_portable_against_module(RJ_TRANSLATOR_PROBE_b, "pair-a", root_,
+                                              TranslationStore::Access::kReadOnly);
+  ASSERT_NE(runtime, nullptr);
+  EXPECT_EQ(get(*runtime), kObject);
+  EXPECT_EQ(tool->key_for(kSource, kIdentity).digest, runtime->key_for(kSource, kIdentity).digest);
+
+  // Exact and portable stores remain separate policies. Opting a packaged tier
+  // into portability cannot weaken an ordinary build-specific cache.
+  auto exact = open_against_module(RJ_TRANSLATOR_PROBE_b, "pair-a", root_);
+  ASSERT_NE(exact, nullptr);
+  EXPECT_TRUE(get(*exact).empty());
+}
+#endif // RJ_TRANSLATOR_PROBE_a && RJ_TRANSLATOR_PROBE_b
+
+TEST_F(TranslationStoreTest, ADomainContainingNulDoesNotAliasAnother) {
+  // The C path APIs stop at a NUL, so these two distinct views name one
+  // directory. Without rejecting them the second domain reads back what the
+  // first wrote, which is precisely the isolation a domain is supposed to give.
+  const std::string_view first("pair\0a", 6);
+  const std::string_view second("pair\0b", 6);
+
+  auto writer = open(first);
+  EXPECT_FALSE(writer->key_for(kSource, kIdentity).valid);
+  put(*writer, kObject);
+
+  auto reader = open(second);
+  EXPECT_TRUE(get(*reader).empty()) << "a truncated domain must not alias another";
+  EXPECT_TRUE(get(*writer).empty());
+}
+
+TEST_F(TranslationStoreTest, ALineBreakingIdentityIsRefusedRatherThanStored) {
+  // The manifest is line oriented. A newline in the ISA forges an earlier size=
+  // or sha= field, so the object is written but every later lookup rejects it --
+  // a write-only entry that is retried for as long as the workload runs.
+  constexpr TranslationIdentity injected{
+      .profile_id = 7,
+      .input_revision = 2,
+      .output_revision = 1,
+      .target_isa = "gfx-example\nsize=0\nsha=0",
+  };
+
+  auto store = open("pair-a");
+  EXPECT_FALSE(store->key_for(kSource, injected).valid);
+  store->store(store->key_for(kSource, injected), kObject, injected);
+  EXPECT_TRUE(store->lookup(store->key_for(kSource, injected), injected).empty());
+  EXPECT_EQ(store->size_for_test(), 0u) << "nothing may be written for a refused identity";
+
+  // The ordinary identity still works, so this is refusal and not a dead store.
+  put(*store, kObject);
+  EXPECT_EQ(get(*store), kObject);
+}
+
+TEST_F(TranslationStoreTest, AManifestWithNoObjectIsReclaimed) {
+  // What a process killed between the two renames leaves behind. It can never
+  // satisfy a lookup, and if eviction does not remove it nothing ever will.
+  auto store = open("pair-a");
+  put(*store, kObject);
+  ASSERT_EQ(get(*store), kObject);
+
+  const std::filesystem::path entries = std::filesystem::path(root_) / "pair-a" / "v1";
+  for (const auto &item : std::filesystem::directory_iterator(entries))
+    if (item.path().extension() == ".obj")
+      std::filesystem::remove(item.path());
+  ASSERT_GT(store->size_for_test(), 0u) << "the orphan manifest must still be accounted";
+
+  // Age it past the threshold that separates an abandoned write from one still
+  // in progress, then re-open: the sweep runs once when the store opens.
+  for (const auto &item : std::filesystem::directory_iterator(entries))
+    std::filesystem::last_write_time(item.path(), std::filesystem::file_time_type::clock::now() -
+                                                      std::chrono::hours(1));
+  auto reopened = open("pair-a");
+  EXPECT_TRUE(get(*reopened).empty());
+
+  size_t orphans = 0;
+  for (const auto &item : std::filesystem::directory_iterator(entries)) {
+    if (item.path().extension() != ".man")
+      continue;
+    auto object = item.path();
+    object.replace_extension(".obj");
+    orphans += std::filesystem::exists(object) ? 0 : 1;
+  }
+  EXPECT_EQ(orphans, 0u) << "an orphan manifest must be reclaimed";
+}
+
+TEST_F(TranslationStoreTest, AGroupWritableStoreRootIsStillUsable) {
+  // A root the store is handed may legitimately be group-writable -- an install
+  // directory owned by a packaging group, for one -- and applying the store's own
+  // no-group-or-other-write rule to it would disable the store silently, because
+  // an unusable store is indistinguishable from a cold one. Ownership is what
+  // matters for a root the store did not create; the stricter rule belongs to the
+  // directories it creates and reads entries from.
+  const std::filesystem::path root = std::filesystem::path(root_) / "daemon-made";
+  std::filesystem::create_directories(root);
+  std::filesystem::permissions(root, kSafeDirPerms | std::filesystem::perms::group_write);
+
+  auto store = open_shared("pair-a", TranslationStore::Access::kReadWrite, root.string().c_str());
+  ASSERT_TRUE(store->available()) << "a group-writable root must not disable the store";
+  put(*store, kObject);
+  EXPECT_EQ(get(*store), kObject);
+
+  // The directories holding entries are still strict, whatever the root allows.
+  for (const auto &item : std::filesystem::recursive_directory_iterator(root)) {
+    if (!std::filesystem::is_directory(item))
+      continue;
+    EXPECT_EQ(std::filesystem::status(item).permissions() &
+                  (std::filesystem::perms::group_write | std::filesystem::perms::others_write),
+              std::filesystem::perms::none)
+        << item.path();
+  }
+}
+
+TEST_F(TranslationStoreTest, ASymlinkedDomainIsRefusedRatherThanFollowed) {
+  // Checking only where an assembled path lands proves nothing about how it got
+  // there. With the domain pre-created as a symlink, a writer walks out of the
+  // root it was given and a reader finds the entry at the target, with every
+  // check passing -- so a symlink at any component has to be refused rather than
+  // followed and then described.
+  //
+  // The ordinary domain below is the control, and it is the whole reason this
+  // test means anything: without it, a store refusing BOTH cases -- for any
+  // unrelated reason -- would read as a pass, and the assertion would be
+  // measuring nothing. Both halves run under identical ownership and modes, so
+  // the only difference between them is the symlink.
+  auto ordinary = open_shared("pair-ok", TranslationStore::Access::kReadWrite);
+  ASSERT_TRUE(ordinary->available()) << "control: a plain domain must be usable here";
+  put(*ordinary, kObject);
+  ASSERT_EQ(get(*ordinary), kObject) << "control: a plain domain must round-trip here";
+
+  const std::filesystem::path elsewhere = std::filesystem::path(root_) / "elsewhere";
+  std::filesystem::create_directories(elsewhere);
+  // Explicit, because the ambient umask decides otherwise: a group-writable
+  // directory is refused on its own merits, which would make the symlink
+  // assertion below pass without testing the symlink at all.
+  std::filesystem::permissions(elsewhere, kSafeDirPerms);
+  std::filesystem::create_directory_symlink(elsewhere, std::filesystem::path(root_) / "pair-a");
+
+  for (auto access : {TranslationStore::Access::kReadWrite, TranslationStore::Access::kReadOnly}) {
+    auto shared_store = open_shared("pair-a", access);
+    EXPECT_FALSE(shared_store->available()) << "a symlinked domain must not be followed";
+    put(*shared_store, kObject);
+    EXPECT_TRUE(get(*shared_store).empty());
+  }
+
+  // And nothing was written through the link into the directory it targets.
+  EXPECT_TRUE(std::filesystem::is_empty(elsewhere));
+}
+
+TEST_F(TranslationStoreTest, ASymlinkAboveTheDomainIsRefusedToo) {
+  // The parent of the domain is just as load-bearing: redirecting it relocates
+  // the whole tree, including entries a later reader would trust. Same structure
+  // as above -- a real directory first, so refusing everything cannot pass.
+  const std::filesystem::path real_root = std::filesystem::path(root_) / "real";
+  std::filesystem::create_directories(real_root);
+  std::filesystem::permissions(real_root, kSafeDirPerms);
+  auto ordinary =
+      open_shared("pair-a", TranslationStore::Access::kReadWrite, real_root.string().c_str());
+  ASSERT_TRUE(ordinary->available()) << "control: a plain root must be usable here";
+  put(*ordinary, kObject);
+  ASSERT_EQ(get(*ordinary), kObject);
+
+  const std::filesystem::path elsewhere = std::filesystem::path(root_) / "elsewhere";
+  std::filesystem::create_directories(elsewhere);
+  std::filesystem::permissions(elsewhere, kSafeDirPerms);
+  const std::filesystem::path linked_root = std::filesystem::path(root_) / "link";
+  std::filesystem::create_directory_symlink(elsewhere, linked_root);
+
+  auto tool =
+      open_shared("pair-a", TranslationStore::Access::kReadWrite, linked_root.string().c_str());
+  EXPECT_FALSE(tool->available()) << "a symlinked root must not be followed";
+  put(*tool, kObject);
+  EXPECT_TRUE(get(*tool).empty());
+  EXPECT_TRUE(std::filesystem::is_empty(elsewhere));
+}
+
+TEST_F(TranslationStoreTest, AnObjectFarLargerThanAnInMemoryCacheRoundTrips) {
+  // The reason the store exists. The objects whose translation dominates
+  // start-up are the large device libraries -- a few hundred megabytes -- and
+  // an in-process or memory-backed cache cannot hold them at any sensible size.
+  // Anything that caps entries in the low megabytes would refuse exactly the
+  // objects pre-translating is for, so the ceiling here is a sanity bound only.
+  const std::vector<uint8_t> oversized(17u << 20, 0xab);
+
+  auto tool = open_shared("pair-b", TranslationStore::Access::kReadWrite);
+  put(*tool, oversized);
+  EXPECT_EQ(get(*tool), oversized);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/dbt/translator_build_probe.cpp
+++ b/emulation/rocjitsu/tests/dbt/translator_build_probe.cpp
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file translator_build_probe.cpp
+/// @brief Loadable module standing in for a translator, built twice.
+///
+/// @details The translation store keys every entry on the GNU build id of the
+/// module that produced it, so a translator rebuilt with different output cannot
+/// serve entries written by the previous one. That is the property protecting
+/// every deployment from a stale hit, and it cannot be exercised from a single
+/// binary: it needs two modules that differ in nothing but identity.
+///
+/// This source is therefore linked into two targets whose only difference is an
+/// explicit --build-id. Same code, same exported symbol, different identity --
+/// exactly what a rebuild produces.
+
+extern "C" __attribute__((visibility("default"))) void rj_probe_translator_anchor() {}

--- a/emulation/rocjitsu/tests/tools/test_pretranslate.py
+++ b/emulation/rocjitsu/tests/tools/test_pretranslate.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Unit tests for the installed pretranslation wrapper."""
+
+from __future__ import annotations
+
+import errno
+import importlib.util
+import struct
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+SCRIPT = Path(__file__).parents[2] / "scripts" / "rocjitsu-pretranslate.py"
+SPEC = importlib.util.spec_from_file_location("rocjitsu_pretranslate", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+pretranslate = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = pretranslate
+SPEC.loader.exec_module(pretranslate)
+
+
+def amdgpu_object(marker: int) -> bytes:
+    data = bytearray(64)
+    data[:6] = b"\x7fELF\x02\x01"
+    struct.pack_into("<H", data, 18, pretranslate.EM_AMDGPU)
+    data[24] = marker
+    return bytes(data)
+
+
+class PretranslateTest(unittest.TestCase):
+    def test_traversal_error_is_reported_and_fails_main(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "input"
+            root.mkdir()
+            denied = root / "denied"
+
+            def failed_walk(_root, *, followlinks, onerror):
+                self.assertFalse(followlinks)
+                onerror(PermissionError(errno.EACCES, "permission denied", denied))
+                return []
+
+            with mock.patch.object(pretranslate.os, "walk", side_effect=failed_walk):
+                found = pretranslate.discover([root], "gfx1250", None, None, None, True)
+                code = pretranslate.main(
+                    ["--skip-kpack", "--skip-compressed", "--dry-run", str(root)]
+                )
+
+        self.assertEqual(code, 1)
+        self.assertEqual(len(found.failures), 1)
+        self.assertEqual(found.failures[0]["category"], "traversal")
+        self.assertEqual(found.failures[0]["path"], str(denied))
+
+    def test_stat_error_is_reported_and_fails_main(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "input"
+            root.mkdir()
+            denied = root / "denied.co"
+            denied.write_bytes(amdgpu_object(1))
+            original_stat = Path.stat
+
+            def failed_stat(path, *args, **kwargs):
+                if path == denied:
+                    raise PermissionError(errno.EACCES, "permission denied", path)
+                return original_stat(path, *args, **kwargs)
+
+            with mock.patch.object(Path, "stat", failed_stat):
+                found = pretranslate.discover([root], "gfx1250", None, None, None, True)
+                code = pretranslate.main(
+                    ["--skip-kpack", "--skip-compressed", "--dry-run", str(root)]
+                )
+
+        self.assertEqual(code, 1)
+        self.assertEqual(len(found.failures), 1)
+        self.assertEqual(found.failures[0]["category"], "stat")
+        self.assertEqual(found.failures[0]["path"], str(denied))
+
+    def test_discovery_streams_and_deduplicates_objects(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "install"
+            root.mkdir()
+            (root / "first.co").write_bytes(amdgpu_object(1))
+            (root / "duplicate.co").write_bytes(amdgpu_object(1))
+            (root / "second.co").write_bytes(amdgpu_object(2))
+
+            streamed = {}
+
+            def consume(digest, data, item):
+                streamed[digest] = (data, item)
+
+            found = pretranslate.discover([root], "gfx1250", None, None, consume, True)
+
+            self.assertEqual(found.extracted_objects, 3)
+            self.assertEqual(found.duplicate_objects, 1)
+            self.assertEqual(len(found.objects), 2)
+            self.assertEqual(len(streamed), 2)
+            for item in found.objects.values():
+                self.assertFalse(hasattr(item, "data"))
+                self.assertFalse(hasattr(item, "path"))
+
+    def test_host_elf_discovery_never_uses_an_unbounded_read(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            host = Path(temporary) / "host.so"
+            header = bytearray(64)
+            header[:6] = b"\x7fELF\x02\x01"
+            struct.pack_into("<H", header, 18, 62)  # EM_X86_64
+            host.write_bytes(header + bytes(1 << 20))
+            original_open = Path.open
+
+            class GuardedReader:
+                def __init__(self, wrapped):
+                    self.wrapped = wrapped
+
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, *args):
+                    return self.wrapped.__exit__(*args)
+
+                def read(self, size=-1):
+                    if size < 0:
+                        raise AssertionError("host ELF was read without a bound")
+                    return self.wrapped.read(size)
+
+                def seek(self, *args):
+                    return self.wrapped.seek(*args)
+
+            def guarded_open(path, *args, **kwargs):
+                opened = original_open(path, *args, **kwargs)
+                return GuardedReader(opened) if path == host else opened
+
+            with mock.patch.object(Path, "open", guarded_open):
+                found = pretranslate.discover([host], "gfx1250", None, None, None, True)
+            self.assertFalse(found.objects)
+
+    def test_bundler_failure_is_reported(self):
+        failed = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="bad compressed input"
+        )
+        with mock.patch.object(pretranslate.subprocess, "run", return_value=failed):
+            with self.assertRaisesRegex(RuntimeError, "bad compressed input"):
+                pretranslate.unbundle_compressed("bundler", b"CCOB", "gfx1250")
+
+    def test_bundler_keeps_successful_entries_when_another_entry_fails(self):
+        targets = "hip-amdgcn-amd-amdhsa--gfx1250 " "hipv4-amdgcn-amd-amdhsa--gfx1250\n"
+        extraction = 0
+
+        def run(command, **_kwargs):
+            nonlocal extraction
+            if "--list" in command:
+                return subprocess.CompletedProcess(command, 0, targets, "")
+            extraction += 1
+            if extraction == 1:
+                output = Path(
+                    next(
+                        arg.removeprefix("--output=")
+                        for arg in command
+                        if arg.startswith("--output=")
+                    )
+                )
+                output.write_bytes(amdgpu_object(1))
+                return subprocess.CompletedProcess(command, 0, "", "")
+            return subprocess.CompletedProcess(command, 1, "", "bad entry")
+
+        with mock.patch.object(pretranslate.subprocess, "run", side_effect=run):
+            payloads, failures = pretranslate.unbundle_compressed(
+                "bundler", b"CCOB", "gfx1250"
+            )
+        self.assertEqual(len(payloads), 1)
+        self.assertEqual(len(failures), 1)
+        self.assertIn("bad entry", failures[0][1])
+
+    def test_wrapper_does_not_override_the_domain_key_policy(self):
+        args = pretranslate.parse_arguments(["--portable"])
+        self.assertTrue(args.portable)
+
+        completed = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="summary written=0 held=1 skipped=0 failed=0\n",
+        )
+        with mock.patch.object(
+            pretranslate.subprocess, "run", return_value=completed
+        ) as run:
+            pretranslate.run_tool(
+                "rj_pretranslate", None, [Path("object.co")], False, False, False
+            )
+        self.assertNotIn("--portable", run.call_args.args[0])
+        self.assertNotIn("--translator-build", run.call_args.args[0])
+
+    def test_dry_run_does_not_stage_objects(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "input"
+            root.mkdir()
+            (root / "object.co").write_bytes(amdgpu_object(1))
+            with mock.patch.object(
+                pretranslate, "discover", wraps=pretranslate.discover
+            ) as discover:
+                code = pretranslate.main(
+                    ["--skip-kpack", "--skip-compressed", "--dry-run", str(root)]
+                )
+        self.assertEqual(code, 0)
+        self.assertIsNone(discover.call_args.args[4])
+
+    def test_staging_footprint_is_bounded_by_the_batch(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "input"
+            root.mkdir()
+            for marker in range(3):
+                (root / f"object{marker}.co").write_bytes(amdgpu_object(marker))
+            observed = []
+
+            def run_tool(_tool, _store_root, paths, *_args):
+                observed.append(len(list(paths[0].parent.glob("*.co"))))
+                return 0, (f"summary written=0 held={len(paths)} skipped=0 failed=0\n")
+
+            with mock.patch.object(pretranslate, "run_tool", side_effect=run_tool):
+                code = pretranslate.main(
+                    [
+                        "--skip-kpack",
+                        "--skip-compressed",
+                        "--batch",
+                        "2",
+                        "--tool",
+                        sys.executable,
+                        str(root),
+                    ]
+                )
+        self.assertEqual(code, 0)
+        self.assertEqual(observed, [2, 1])
+
+    def test_explicit_missing_bundler_is_an_error(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "input"
+            root.mkdir()
+            code = pretranslate.main(
+                [
+                    "--skip-kpack",
+                    "--dry-run",
+                    "--bundler",
+                    str(Path(temporary) / "missing-bundler"),
+                    str(root),
+                ]
+            )
+        self.assertEqual(code, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/emulation/rocjitsu/tools/CMakeLists.txt
+++ b/emulation/rocjitsu/tools/CMakeLists.txt
@@ -32,3 +32,35 @@ rj_configure_target(rocjitsu_translate_cli TOOL)
 add_executable(rj_dbt_translate rj_dbt_translate_main.cpp)
 target_link_libraries(rj_dbt_translate PRIVATE rocjitsu_translate_cli)
 rj_configure_target(rj_dbt_translate TOOL)
+
+# Ahead-of-time population of the shared translation tier.
+#
+# Deliberately narrow: the fixed-profile translator, the store, and nothing else
+# -- not rocjitsu_tooling, and not the hook, which contributes nothing to
+# translation. The tier is keyed on the TRANSLATOR's build id, so this tool and
+# the hook share entries only for as long as they resolve the same shared object;
+# keeping the dependency list this short is what makes that easy to see.
+#
+# The store is compiled in rather than linked, as the hook does: neither wants a
+# library dependency for one source file. TOOL is not used here because its
+# generated-header and schema dependencies would assert a relationship this tool
+# does not have.
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    add_executable(
+        rj_pretranslate
+        rj_pretranslate.cpp
+        ${ROCJITSU_SRC_DIR}/rocjitsu/code/dbt/translation_store.cpp
+    )
+    target_link_libraries(
+        rj_pretranslate
+        PRIVATE rocjitsu_gfx1250_b0_to_a0 Threads::Threads ${CMAKE_DL_LIBS}
+    )
+    rj_configure_target(rj_pretranslate PRIVATE_INCLUDES WARNINGS)
+    # Bind to the translator installed beside us. Two copies would carry two
+    # build ids, and entries written against one would be invisible to a runtime
+    # resolving the other -- a silent loss of every pre-translated object.
+    set_target_properties(
+        rj_pretranslate
+        PROPERTIES INSTALL_RPATH "$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
+    )
+endif()

--- a/emulation/rocjitsu/tools/rj_pretranslate.cpp
+++ b/emulation/rocjitsu/tools/rj_pretranslate.cpp
@@ -1,0 +1,250 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file rj_pretranslate.cpp
+/// @brief Populate the shared translation tier ahead of time.
+///
+/// @details Translating a large device library takes minutes. A process that
+/// does it at load time pays that once per process, and a container that starts,
+/// runs one job and exits pays it every single time. This tool moves the work to
+/// image-build or post-install time: it translates the objects it is given and
+/// writes them where the runtime hook looks first.
+///
+/// It links the translator and the store, and nothing else -- in particular not
+/// the hook, which contributes nothing to translation. Both sides derive their
+/// keys and their tree location from the translator itself, so agreement is a
+/// property of linking against the same shared object rather than of two
+/// programs being kept in step.
+
+#include "rocjitsu/code/dbt/gfx1250_b0_a0_cache.h"
+#include "rocjitsu/code/dbt/translation_store.h"
+#include "rocjitsu/code/rj_gfx1250_b0_to_a0.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+namespace {
+
+/// @brief Refuse anything too large to be a code object.
+/// @details Bounds the allocation from a path that turns out to be something
+/// else entirely; the store applies its own limit to what it will accept.
+constexpr uint64_t kMaxInputBytes = 4ull << 30;
+
+[[nodiscard]] bool read_file(const char *path, std::vector<uint8_t> &out) {
+  const int fd = open(path, O_RDONLY | O_CLOEXEC);
+  if (fd < 0)
+    return false;
+  struct stat info {};
+  if (fstat(fd, &info) != 0 || !S_ISREG(info.st_mode) ||
+      static_cast<uint64_t>(info.st_size) > kMaxInputBytes) {
+    close(fd);
+    return false;
+  }
+  out.resize(static_cast<size_t>(info.st_size));
+  size_t done = 0;
+  while (done < out.size()) {
+    const ssize_t got = read(fd, out.data() + done, out.size() - done);
+    if (got <= 0) {
+      close(fd);
+      return false;
+    }
+    done += static_cast<size_t>(got);
+  }
+  close(fd);
+  return true;
+}
+
+void usage(const char *program) {
+  std::fprintf(stderr,
+               "usage: %s [--store-root DIR] [--force] [--portable] "
+               "[--fail-on-skipped] FILE...\n"
+               "\n"
+               "Translate each gfx1250 code object and record the result in the\n"
+               "shared translation tier, where the runtime hook finds it without\n"
+               "translating again.\n"
+               "\n"
+               "  --store-root DIR  Write here instead of the location derived from\n"
+               "                    the translator's own install prefix.\n"
+               "  --force           Translate even objects already recorded.\n"
+               "  --portable        Write a prebuilt cache independent of the\n"
+               "                    translator ELF build ID.\n"
+               "  --fail-on-skipped Exit nonzero if any input is rejected.\n"
+               "\n"
+               "Each input must be a standalone AMDGPU code object. Extracting\n"
+               "those from fat binaries, bundles and archives is the caller's job;\n"
+               "see rocjitsu-pretranslate.py, installed alongside this tool.\n",
+               program);
+}
+
+/// @brief What became of one input.
+enum class Outcome {
+  kWritten,     ///< Translated and recorded.
+  kAlreadyHeld, ///< The tier already had it; nothing to do.
+  kRejected,    ///< Not something this translator handles. Expected in bulk runs.
+  kFailed,      ///< Should have worked and did not.
+};
+
+struct Totals {
+  size_t written = 0;
+  size_t already_held = 0;
+  size_t rejected = 0;
+  size_t failed = 0;
+};
+
+Outcome pretranslate_one(const char *path, rocjitsu::TranslationStore &store, bool force) {
+  std::vector<uint8_t> source;
+  if (!read_file(path, source) || source.empty()) {
+    std::fprintf(stderr, "%s: cannot read\n", path);
+    return Outcome::kFailed;
+  }
+
+  const rocjitsu::CacheKey key = store.key_for(source, rocjitsu::kGfx1250B0A0Identity);
+  if (!key.valid) {
+    std::fprintf(stderr, "%s: no cache key could be derived\n", path);
+    return Outcome::kFailed;
+  }
+
+  // Re-running over an unchanged tree is the normal case -- an image build that
+  // adds one library should not retranslate the rest -- so an entry that is
+  // already present is a success, not work to redo.
+  if (!force && !store.lookup(key, rocjitsu::kGfx1250B0A0Identity).empty()) {
+    std::printf("held    %s\n", path);
+    return Outcome::kAlreadyHeld;
+  }
+
+  uint8_t *translated = nullptr;
+  size_t translated_size = 0;
+  // The info block is required by the entry point rather than optional, and this
+  // tool has no use for what it reports: the store keys on the source bytes it
+  // already holds. Diagnostics are declined for the same reason -- a scan over an
+  // install tree meets many objects this translator will refuse, and the refusal
+  // itself is the answer.
+  rj_gfx1250_b0_to_a0_translation_info_t info{};
+  const rj_status_t status = rj_gfx1250_b0_to_a0_translate(
+      source.data(), source.size(), &translated, &translated_size, &info, nullptr, nullptr);
+  if (status != ROCJITSU_STATUS_SUCCESS || translated == nullptr || translated_size == 0) {
+    rj_gfx1250_b0_to_a0_free(translated);
+    // A verdict on the bytes, not a malfunction: a scan over an install tree
+    // will hand this tool plenty of objects for other targets.
+    if (status == ROCJITSU_STATUS_INVALID_CODE_OBJECT ||
+        status == ROCJITSU_STATUS_INVALID_ARGUMENT) {
+      std::printf("skip    %s (not a translatable gfx1250 object)\n", path);
+      return Outcome::kRejected;
+    }
+    std::fprintf(stderr, "%s: translation failed with status %d\n", path, static_cast<int>(status));
+    return Outcome::kFailed;
+  }
+
+  store.store(key, {translated, translated_size}, rocjitsu::kGfx1250B0A0Identity);
+  rj_gfx1250_b0_to_a0_free(translated);
+
+  // Read it back. The store is best effort by design: it declines quietly when
+  // an entry is too large or the filesystem is too full, which is right for a
+  // runtime that can translate instead but wrong for a tool whose only product
+  // is the entry. Without this check the tool's whole failure mode is to report
+  // success and leave start-up paying full cost.
+  if (store.lookup(key, rocjitsu::kGfx1250B0A0Identity).empty()) {
+    std::fprintf(stderr, "%s: translated but the store did not keep it\n", path);
+    return Outcome::kFailed;
+  }
+
+  std::printf("write   %s (%zu -> %zu bytes)\n", path, source.size(), translated_size);
+  return Outcome::kWritten;
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+  std::string root;
+  bool force = false;
+  bool portable = false;
+  bool fail_on_skipped = false;
+  std::vector<const char *> inputs;
+
+  for (int i = 1; i < argc; ++i) {
+    const std::string_view arg(argv[i]);
+    if (arg == "--help" || arg == "-h") {
+      usage(argv[0]);
+      return 0;
+    }
+    if (arg == "--force") {
+      force = true;
+    } else if (arg == "--portable") {
+      portable = true;
+    } else if (arg == "--fail-on-skipped") {
+      fail_on_skipped = true;
+    } else if (arg == "--store-root") {
+      if (++i == argc) {
+        std::fprintf(stderr, "--store-root needs a directory\n");
+        return 2;
+      }
+      root = argv[i];
+    } else if (arg.starts_with("--store-root=")) {
+      root = arg.substr(std::strlen("--store-root="));
+    } else if (arg.starts_with("-")) {
+      std::fprintf(stderr, "unknown option %s\n", argv[i]);
+      return 2;
+    } else {
+      inputs.push_back(argv[i]);
+    }
+  }
+
+  if (inputs.empty()) {
+    usage(argv[0]);
+    return 2;
+  }
+
+  if (root.empty())
+    root = rocjitsu::shared_translation_root(rocjitsu::gfx1250_b0_a0_translator_anchor());
+  if (root.empty()) {
+    std::fprintf(stderr, "cannot locate the translator's install prefix; pass --store-root\n");
+    return 1;
+  }
+
+  rocjitsu::TranslationStore store(
+      rocjitsu::kGfx1250B0A0Domain, rocjitsu::gfx1250_b0_a0_translator_anchor(), root,
+      rocjitsu::TranslationStore::Access::kReadWrite,
+      portable ? rocjitsu::TranslationStore::KeyMode::kPortablePrebuilt
+               : rocjitsu::TranslationStore::KeyMode::kTranslatorBuild);
+  // Establish this before translating anything. Discovering an unusable root
+  // after several minutes of work would be the same result reached expensively.
+  if (!store.available()) {
+    std::fprintf(stderr,
+                 "%s is not usable as a translation store: it must be owned by root or by "
+                 "this user, and writable by neither group nor other\n",
+                 root.c_str());
+    return 1;
+  }
+  std::printf("store   %s\n", root.c_str());
+
+  Totals totals;
+  for (const char *path : inputs) {
+    switch (pretranslate_one(path, store, force)) {
+    case Outcome::kWritten:
+      ++totals.written;
+      break;
+    case Outcome::kAlreadyHeld:
+      ++totals.already_held;
+      break;
+    case Outcome::kRejected:
+      ++totals.rejected;
+      break;
+    case Outcome::kFailed:
+      ++totals.failed;
+      break;
+    }
+    std::fflush(stdout);
+  }
+
+  std::printf("summary written=%zu held=%zu skipped=%zu failed=%zu\n", totals.written,
+              totals.already_held, totals.rejected, totals.failed);
+  return totals.failed == 0 && (!fail_on_skipped || totals.rejected == 0) ? 0 : 1;
+}

--- a/emulation/rocjitsu/tools/rj_pretranslate.cpp
+++ b/emulation/rocjitsu/tools/rj_pretranslate.cpp
@@ -74,8 +74,8 @@ void usage(const char *program) {
                "  --store-root DIR  Write here instead of the location derived from\n"
                "                    the translator's own install prefix.\n"
                "  --force           Translate even objects already recorded.\n"
-               "  --portable        Write a prebuilt cache independent of the\n"
-               "                    translator ELF build ID.\n"
+               "  --portable        Accepted for packaging compatibility; this\n"
+               "                    domain always uses its packaged-cache contract.\n"
                "  --fail-on-skipped Exit nonzero if any input is rejected.\n"
                "\n"
                "Each input must be a standalone AMDGPU code object. Extracting\n"
@@ -165,7 +165,6 @@ Outcome pretranslate_one(const char *path, rocjitsu::TranslationStore &store, bo
 int main(int argc, char **argv) {
   std::string root;
   bool force = false;
-  bool portable = false;
   bool fail_on_skipped = false;
   std::vector<const char *> inputs;
 
@@ -178,7 +177,9 @@ int main(int argc, char **argv) {
     if (arg == "--force") {
       force = true;
     } else if (arg == "--portable") {
-      portable = true;
+      // Compatibility with packaging recipes written before the domain owned
+      // its key policy. There is deliberately no mode override: an entry this
+      // product's runtime cannot read is not a useful output.
     } else if (arg == "--fail-on-skipped") {
       fail_on_skipped = true;
     } else if (arg == "--store-root") {
@@ -211,9 +212,7 @@ int main(int argc, char **argv) {
 
   rocjitsu::TranslationStore store(
       rocjitsu::kGfx1250B0A0Domain, rocjitsu::gfx1250_b0_a0_translator_anchor(), root,
-      rocjitsu::TranslationStore::Access::kReadWrite,
-      portable ? rocjitsu::TranslationStore::KeyMode::kPortablePrebuilt
-               : rocjitsu::TranslationStore::KeyMode::kTranslatorBuild);
+      rocjitsu::TranslationStore::Access::kReadWrite, rocjitsu::kGfx1250B0A0KeyMode);
   // Establish this before translating anything. Discovering an unusable root
   // after several minutes of work would be the same result reached expensively.
   if (!store.available()) {

--- a/shared/kpack/python/rocm_kpack/binutils.py
+++ b/shared/kpack/python/rocm_kpack/binutils.py
@@ -10,6 +10,7 @@ import msgpack
 
 from rocm_kpack.ccob_parser import ExtractedCodeObject, extract_code_objects_from_fatbin
 from rocm_kpack.coff.surgery import CoffSurgery
+from rocm_kpack.elf.surgery import ElfSurgery
 from rocm_kpack.format_detect import detect_binary_format, UnsupportedBinaryFormat
 
 
@@ -20,6 +21,14 @@ class BinaryType(Enum):
     BUNDLED = (
         "bundled"  # Executables/libraries with device code section (ELF or PE/COFF)
     )
+
+
+def _target_gfx_arch(target: str) -> str | None:
+    """Return the base gfx architecture from a Clang offload target triple."""
+    _, separator, architecture = target.rpartition("--")
+    if not separator:
+        return None
+    return architecture.partition(":")[0]
 
 
 class Toolchain:
@@ -212,18 +221,22 @@ class BundledBinary:
     """
 
     def __init__(self, file_path: Path, *, toolchain: Toolchain | None = None):
-        # Initialize _temp_dir first to ensure cleanup works even if init fails
-        self._temp_dir: Path | None = None  # For extracted .hip_fatbin sections
-
         self.toolchain = toolchain or Toolchain()
         self.file_path = file_path
         self.binary_type = self._detect_binary_type()
 
     def unbundle(
-        self, *, dest_dir: Path | None = None, delete_on_close: bool = True
+        self,
+        *,
+        dest_dir: Path | None = None,
+        delete_on_close: bool = True,
+        gfx_arch: str | None = None,
     ) -> UnbundledContents:
         """Unbundles the binary, returning a context manager which can be used
         to hold the unbundled files open for as long as needed.
+
+        If ``gfx_arch`` is provided, only code objects for that base architecture
+        are written. Target features such as ``:xnack+`` do not affect matching.
         """
         if dest_dir is None:
             dest_dir = Path(tempfile.mkdtemp())
@@ -231,6 +244,14 @@ class BundledBinary:
         # Extract code objects once, then derive both the target list and
         # write the files from the same extraction result.
         code_objects = self._extract_code_objects()
+        if gfx_arch is not None:
+            code_objects = [
+                obj for obj in code_objects if _target_gfx_arch(obj.target) == gfx_arch
+            ]
+            if not code_objects:
+                raise ValueError(
+                    f"No code objects for architecture {gfx_arch!r} in {self.file_path}"
+                )
         target_list = self._build_target_list(code_objects)
 
         contents = UnbundledContents(
@@ -248,7 +269,7 @@ class BundledBinary:
     def _detect_binary_type(self) -> BinaryType:
         """Detect if this is a standalone bundler file or a bundled binary.
 
-        For ELF, checks for .hip_fatbin section via readelf.
+        For ELF, checks for .hip_fatbin using the in-process ELF parser.
         For PE/COFF, checks for .hip_fat section via CoffSurgery.
         Files without device code sections are STANDALONE (.co files in bundler format).
 
@@ -265,18 +286,11 @@ class BundledBinary:
 
         if fmt == "elf":
             try:
-                result = subprocess.run(
-                    [str(self.toolchain.readelf), "-S", str(self.file_path.resolve())],
-                    capture_output=True,
-                    text=True,
-                    check=True,
+                return (
+                    BinaryType.BUNDLED
+                    if ElfSurgery.has_fatbin_section(self.file_path)
+                    else BinaryType.STANDALONE
                 )
-                if ".hip_fatbin" in result.stdout:
-                    return BinaryType.BUNDLED
-                else:
-                    return BinaryType.STANDALONE
-            except subprocess.CalledProcessError:
-                return BinaryType.STANDALONE
             except Exception as e:
                 raise RuntimeError(
                     f"Unexpected error detecting binary type for {self.file_path}: {e}"
@@ -294,23 +308,18 @@ class BundledBinary:
                     f"Unexpected error detecting binary type for {self.file_path}: {e}"
                 ) from e
 
-    def _get_bundler_input(self) -> Path:
-        """Get the file path to use as input to clang-offload-bundler.
+    def _get_bundler_data(self) -> bytes:
+        """Get the bytes containing the offload bundles.
 
-        For STANDALONE files, returns the file path directly.
-        For BUNDLED ELF binaries, extracts .hip_fatbin section via objcopy.
-        For BUNDLED PE/COFF binaries, extracts .hip_fat section via CoffSurgery.
+        For standalone files, this reads the file directly. For bundled ELF and
+        PE/COFF binaries, the in-process surgery classes extract the device-code
+        section. Unbundling therefore has no readelf or objcopy dependency.
 
         Returns:
-            Path to file in bundler format
+            Bytes in a supported fatbin format.
         """
         if self.binary_type == BinaryType.STANDALONE:
-            return self.file_path
-
-        if self._temp_dir is None:
-            self._temp_dir = Path(tempfile.mkdtemp())
-
-        fatbin_path = self._temp_dir / "fatbin.o"
+            return self.file_path.read_bytes()
 
         fmt = detect_binary_format(self.file_path)
         if fmt == "coff":
@@ -321,38 +330,22 @@ class BundledBinary:
                     f"PE binary {self.file_path} has no .hip_fat section"
                 )
             content = surgery.get_section_content(section)
-            content = content[: section.virtual_size]
-            fatbin_path.write_bytes(content)
+            return content[: section.virtual_size]
         else:
-            # ELF: extract .hip_fatbin section via objcopy
-            abs_file_path = self.file_path.resolve()
-            abs_fatbin_path = fatbin_path.resolve()
-            try:
-                self.toolchain.exec(
-                    [
-                        self.toolchain.objcopy,
-                        "--dump-section",
-                        f".hip_fatbin={abs_fatbin_path}",
-                        abs_file_path,
-                    ]
-                )
-            except subprocess.CalledProcessError as e:
-                error_output = e.output.decode() if e.output else "(no output)"
+            surgery = ElfSurgery.load(self.file_path)
+            section = surgery.find_section(".hip_fatbin")
+            if section is None:
                 raise RuntimeError(
-                    f"Failed to extract .hip_fatbin section from {self.file_path}. "
-                    f"objcopy exit code: {e.returncode}. Output: {error_output}"
-                ) from e
-
-        return fatbin_path
+                    f"ELF binary {self.file_path} has no .hip_fatbin section"
+                )
+            return surgery.get_section_content(section)
 
     def _extract_code_objects(self) -> list[ExtractedCodeObject]:
         """Extract code objects from the fatbin data.
 
         Reads the bundler input once and parses all code objects.
         """
-        bundler_input = self._get_bundler_input()
-        data = bundler_input.read_bytes()
-        return extract_code_objects_from_fatbin(data)
+        return extract_code_objects_from_fatbin(self._get_bundler_data())
 
     def _build_target_list(
         self, code_objects: list[ExtractedCodeObject]
@@ -447,14 +440,11 @@ class BundledBinary:
             )
 
     def cleanup(self) -> None:
-        """Clean up temporary files created during operations."""
-        if self._temp_dir and self._temp_dir.exists():
-            shutil.rmtree(self._temp_dir)
-            self._temp_dir = None
+        """Retained for callers written before unbundling became in-process.
 
-    def __del__(self):
-        """Cleanup on deletion."""
-        self.cleanup()
+        BundledBinary no longer creates temporary files, so there is no work to
+        do. Keeping the method avoids needlessly breaking existing callers.
+        """
 
 
 def get_section_vaddr(

--- a/shared/kpack/python/rocm_kpack/binutils.py
+++ b/shared/kpack/python/rocm_kpack/binutils.py
@@ -238,9 +238,6 @@ class BundledBinary:
         If ``gfx_arch`` is provided, only code objects for that base architecture
         are written. Target features such as ``:xnack+`` do not affect matching.
         """
-        if dest_dir is None:
-            dest_dir = Path(tempfile.mkdtemp())
-
         # Extract code objects once, then derive both the target list and
         # write the files from the same extraction result.
         code_objects = self._extract_code_objects()
@@ -253,6 +250,12 @@ class BundledBinary:
                     f"No code objects for architecture {gfx_arch!r} in {self.file_path}"
                 )
         target_list = self._build_target_list(code_objects)
+
+        # Do not create an owned temporary directory until extraction and
+        # filtering have succeeded. A no-match exception has no context manager
+        # to clean one created earlier.
+        if dest_dir is None:
+            dest_dir = Path(tempfile.mkdtemp())
 
         contents = UnbundledContents(
             self, dest_dir, delete_on_close=delete_on_close, target_list=target_list
@@ -332,13 +335,12 @@ class BundledBinary:
             content = surgery.get_section_content(section)
             return content[: section.virtual_size]
         else:
-            surgery = ElfSurgery.load(self.file_path)
-            section = surgery.find_section(".hip_fatbin")
-            if section is None:
+            content = ElfSurgery.read_section(self.file_path, ".hip_fatbin")
+            if content is None:
                 raise RuntimeError(
-                    f"ELF binary {self.file_path} has no .hip_fatbin section"
+                    f"ELF binary {self.file_path} has no readable .hip_fatbin section"
                 )
-            return surgery.get_section_content(section)
+            return content
 
     def _extract_code_objects(self) -> list[ExtractedCodeObject]:
         """Extract code objects from the fatbin data.

--- a/shared/kpack/python/rocm_kpack/database_handlers.py
+++ b/shared/kpack/python/rocm_kpack/database_handlers.py
@@ -324,6 +324,37 @@ class HipKernelProviderRockeHandler(DatabaseHandler):
         return None
 
 
+class HotswapCacheHandler(DatabaseHandler):
+    """Handler for packaged RocJitsu ahead-of-time translations.
+
+    RocJitsu owns the directory-domain spelling. Keep the mapping explicit so
+    a new translator profile cannot accidentally be assigned to an architecture
+    merely because its directory happens to contain a gfx-looking substring.
+    """
+
+    _DOMAIN_TO_BUNDLE = {
+        "gfx1250-b0-a0": "gfx1250",
+    }
+    _ENTRY_PATTERN = re.compile(r"^[0-9a-f]{64}\.(?:man|obj)$")
+
+    def name(self) -> str:
+        return "hotswap_cache"
+
+    def detect(self, path: Path, prefix_root: Path) -> Optional[str]:
+        parts = Path(self._relative_path(path, prefix_root)).parts
+        if len(parts) != 6 or parts[:3] != (
+            "share",
+            "rocjitsu",
+            "translations",
+        ):
+            return None
+
+        domain, schema, filename = parts[3:]
+        if schema != "v1" or not self._ENTRY_PATTERN.fullmatch(filename):
+            return None
+        return self._DOMAIN_TO_BUNDLE.get(domain)
+
+
 # Registry of available handlers
 AVAILABLE_HANDLERS = {
     "rocblas": RocBLASHandler,
@@ -332,6 +363,7 @@ AVAILABLE_HANDLERS = {
     "aotriton": AotritonHandler,
     "miopen": MIOpenHandler,
     "hipkernelprovider": HipKernelProviderRockeHandler,
+    "hotswap_cache": HotswapCacheHandler,
 }
 
 

--- a/shared/kpack/python/rocm_kpack/elf/surgery.py
+++ b/shared/kpack/python/rocm_kpack/elf/surgery.py
@@ -152,26 +152,26 @@ class ElfSurgery:
         return cls(data, path)
 
     @staticmethod
-    def has_fatbin_section(file_path: Path) -> bool:
-        """Fast check for .hip_fatbin section without loading the full binary.
+    def _section_location(file_path: Path, section_name: str) -> tuple[int, int] | None:
+        """Find a section's file range without loading the full binary.
 
         Reads only the ELF header, section header table, and section name
         string table — typically a few KB total even for multi-GB binaries.
-        Returns False for non-ELF files (wrong magic, too small, 32-bit).
+        Returns None for non-ELF files (wrong magic, too small, 32-bit).
         Raises on I/O errors or corrupt ELF headers.
         """
         file_size = os.path.getsize(file_path)
         if file_size < ELF64_EHDR_SIZE:
-            return False
+            return None
 
         with open(file_path, "rb") as f:
             ehdr = f.read(ELF64_EHDR_SIZE)
             if len(ehdr) < ELF64_EHDR_SIZE:
-                return False
+                return None
             if ehdr[:4] != b"\x7fELF":
-                return False
-            if ehdr[4] != 2:  # ELFCLASS64
-                return False
+                return None
+            if ehdr[4] != 2 or ehdr[5] != 1:  # ELFCLASS64, ELFDATA2LSB
+                return None
 
             # All offsets and sizes below follow the System V ABI for ELF64.
             # e_shoff:    offset 40 — file offset to section header table
@@ -183,8 +183,13 @@ class ElfSurgery:
             e_shnum = struct.unpack_from("<H", ehdr, 60)[0]
             e_shstrndx = struct.unpack_from("<H", ehdr, 62)[0]
 
-            if e_shoff == 0 or e_shnum == 0 or e_shstrndx >= e_shnum:
-                return False
+            if (
+                e_shoff == 0
+                or e_shentsize < ELF64_SHDR_SIZE
+                or e_shnum == 0
+                or e_shstrndx >= e_shnum
+            ):
+                return None
 
             # Bounds check section header table against file size
             total_sht_size = e_shentsize * e_shnum
@@ -193,13 +198,13 @@ class ElfSurgery:
                 or total_sht_size > file_size
                 or e_shoff + total_sht_size > file_size
             ):
-                return False
+                return None
 
             # Read section header table
             f.seek(e_shoff)
             shtab = f.read(total_sht_size)
             if len(shtab) < total_sht_size:
-                return False
+                return None
 
             # Read .shstrtab
             strtab_entry = e_shstrndx * e_shentsize
@@ -212,23 +217,53 @@ class ElfSurgery:
                 or sh_size > file_size
                 or sh_offset + sh_size > file_size
             ):
-                return False
+                return None
 
             f.seek(sh_offset)
             shstrtab = f.read(sh_size)
+            if len(shstrtab) < sh_size:
+                return None
 
-            # Search for ".hip_fatbin" in section names
-            target = b".hip_fatbin\x00"
-            if target not in shstrtab:
-                return False
-
-            target_offset = shstrtab.index(target)
+            target = section_name.encode()
             for i in range(e_shnum):
-                sh_name = struct.unpack_from("<I", shtab, i * e_shentsize)[0]
-                if sh_name == target_offset:
-                    return True
+                entry = i * e_shentsize
+                sh_name = struct.unpack_from("<I", shtab, entry)[0]
+                if sh_name >= len(shstrtab):
+                    continue
+                name_end = shstrtab.find(b"\x00", sh_name)
+                if name_end < 0 or shstrtab[sh_name:name_end] != target:
+                    continue
+                section_type = struct.unpack_from("<I", shtab, entry + 4)[0]
+                if section_type == SHT_NOBITS:
+                    return None
+                section_offset = struct.unpack_from("<Q", shtab, entry + 24)[0]
+                section_size = struct.unpack_from("<Q", shtab, entry + 32)[0]
+                if (
+                    section_offset > file_size
+                    or section_size > file_size
+                    or section_offset + section_size > file_size
+                ):
+                    return None
+                return section_offset, section_size
 
-            return False
+            return None
+
+    @staticmethod
+    def has_fatbin_section(file_path: Path) -> bool:
+        """Fast check for .hip_fatbin without loading the full binary."""
+        return ElfSurgery._section_location(file_path, ".hip_fatbin") is not None
+
+    @staticmethod
+    def read_section(file_path: Path, section_name: str) -> bytes | None:
+        """Read one ELF section without retaining the rest of the ELF image."""
+        location = ElfSurgery._section_location(file_path, section_name)
+        if location is None:
+            return None
+        offset, size = location
+        with open(file_path, "rb") as f:
+            f.seek(offset)
+            content = f.read(size)
+        return content if len(content) == size else None
 
     # =========================================================================
     # Properties

--- a/shared/kpack/python/rocm_kpack/tools/bulk_unbundle.py
+++ b/shared/kpack/python/rocm_kpack/tools/bulk_unbundle.py
@@ -45,7 +45,7 @@ def main(argv: list[str]):
         "--gfx-arch",
         help="write only code objects for this base architecture (for example, gfx1250)",
     )
-    args = p.parse_args()
+    args = p.parse_args(argv)
     if args.output_dir is not None and len(args.files) != 1:
         p.error("--output-dir requires exactly one input file")
     run(args)

--- a/shared/kpack/python/rocm_kpack/tools/bulk_unbundle.py
+++ b/shared/kpack/python/rocm_kpack/tools/bulk_unbundle.py
@@ -3,7 +3,8 @@
 This is presently mostly a debugging aid.
 
 Usage:
-  python -m rocm_kpack.tools.bulk_unbundle {fat binary files...}
+  python -m rocm_kpack.tools.bulk_unbundle [--output-dir DIR]
+      [--gfx-arch ARCH] {fat binary files...}
 
 This can also be used for decompressing compressed code object bundle files
 (i.e. CCOB), since decompressing is implicit in unpacking.
@@ -13,25 +14,41 @@ import argparse
 from pathlib import Path
 import sys
 
-from rocm_kpack.binutils import Toolchain, BundledBinary
+from rocm_kpack.binutils import BundledBinary
 
 
-def run(args: argparse.Namespace, *, toolchain: Toolchain):
+def run(args: argparse.Namespace):
     for raw_file in args.files:
         file: Path = raw_file
-        dest_dir = file.with_suffix(".unbundled")
-        binary = BundledBinary(file, toolchain=toolchain)
-        with binary.unbundle(dest_dir=dest_dir, delete_on_close=False) as ub:
+        dest_dir = args.output_dir or file.with_suffix(".unbundled")
+        binary = BundledBinary(file)
+        with binary.unbundle(
+            dest_dir=dest_dir,
+            delete_on_close=False,
+            gfx_arch=args.gfx_arch,
+        ) as ub:
             print(f"Unbundled {dest_dir}: {', '.join(ub.file_names)}")
 
 
 def main(argv: list[str]):
-    p = argparse.ArgumentParser()
+    p = argparse.ArgumentParser(
+        description="Extract device code objects from fat binaries"
+    )
     p.add_argument("files", nargs="+", type=Path)
-    Toolchain.configure_argparse(p)
+    p.add_argument(
+        "-o",
+        "--output-dir",
+        type=Path,
+        help="write the contents of one input to this directory",
+    )
+    p.add_argument(
+        "--gfx-arch",
+        help="write only code objects for this base architecture (for example, gfx1250)",
+    )
     args = p.parse_args()
-    toolchain = Toolchain.from_args(args)
-    run(args, toolchain=toolchain)
+    if args.output_dir is not None and len(args.files) != 1:
+        p.error("--output-dir requires exactly one input file")
+    run(args)
 
 
 if __name__ == "__main__":

--- a/shared/kpack/tests/test_artifact_splitter_integration.py
+++ b/shared/kpack/tests/test_artifact_splitter_integration.py
@@ -558,9 +558,7 @@ class TestArtifactSplitterIntegration:
         (prefix_dir / "share").mkdir(parents=True)
         (prefix_dir / "share/common.txt").write_text("generic")
         digest = "0123456789abcdef" * 4
-        cache_dir = (
-            prefix_dir / "share/rocjitsu/translations/gfx1250-b0-a0/v1"
-        )
+        cache_dir = prefix_dir / "share/rocjitsu/translations/gfx1250-b0-a0/v1"
         cache_dir.mkdir(parents=True)
         (cache_dir / f"{digest}.obj").write_text("translated object")
         (cache_dir / f"{digest}.man").write_text("manifest")
@@ -576,9 +574,7 @@ class TestArtifactSplitterIntegration:
         )
         batch_split(args, toolchain)
 
-        relative_cache = Path(
-            "share/rocjitsu/translations/gfx1250-b0-a0/v1"
-        )
+        relative_cache = Path("share/rocjitsu/translations/gfx1250-b0-a0/v1")
         gfx1250_prefix = output_dir / "rccl_lib_gfx1250" / prefix
         generic_prefix = output_dir / "rccl_lib_generic" / prefix
         assert (gfx1250_prefix / relative_cache / f"{digest}.obj").exists()

--- a/shared/kpack/tests/test_artifact_splitter_integration.py
+++ b/shared/kpack/tests/test_artifact_splitter_integration.py
@@ -547,6 +547,46 @@ class TestArtifactSplitterIntegration:
         assert (arch_db_path / "TensileLibrary_gfx1100.dat").exists()
         assert (arch_db_path / "TensileLibrary_gfx1100.co").exists()
 
+    def test_hotswap_cache_moves_only_to_gfx1250(self, toolchain, tmp_path):
+        parent_dir = tmp_path / "shard"
+        input_dir = parent_dir / "rccl_lib_gfx1250-gfx1100"
+        input_dir.mkdir(parents=True)
+        prefix = "comm-libs/rccl-translate/stage"
+        write_artifact_manifest(input_dir, [prefix])
+
+        prefix_dir = input_dir / prefix
+        (prefix_dir / "share").mkdir(parents=True)
+        (prefix_dir / "share/common.txt").write_text("generic")
+        digest = "0123456789abcdef" * 4
+        cache_dir = (
+            prefix_dir / "share/rocjitsu/translations/gfx1250-b0-a0/v1"
+        )
+        cache_dir.mkdir(parents=True)
+        (cache_dir / f"{digest}.obj").write_text("translated object")
+        (cache_dir / f"{digest}.man").write_text("manifest")
+
+        output_dir = tmp_path / "output"
+        args = Namespace(
+            input_dir=parent_dir,
+            output_dir=output_dir,
+            split_databases=["hotswap_cache"],
+            verbose=False,
+            tmp_dir=tmp_path / "tmp",
+            gpu_targets=["gfx1250", "gfx1100"],
+        )
+        batch_split(args, toolchain)
+
+        relative_cache = Path(
+            "share/rocjitsu/translations/gfx1250-b0-a0/v1"
+        )
+        gfx1250_prefix = output_dir / "rccl_lib_gfx1250" / prefix
+        generic_prefix = output_dir / "rccl_lib_generic" / prefix
+        assert (gfx1250_prefix / relative_cache / f"{digest}.obj").exists()
+        assert (gfx1250_prefix / relative_cache / f"{digest}.man").exists()
+        assert not (generic_prefix / relative_cache).exists()
+        assert (generic_prefix / "share/common.txt").exists()
+        assert not (output_dir / "rccl_lib_gfx1100").exists()
+
     def test_kpack_uses_original_prefix_not_synthetic(
         self, test_assets_dir, toolchain, tmp_path
     ):

--- a/shared/kpack/tests/test_binutils.py
+++ b/shared/kpack/tests/test_binutils.py
@@ -1,8 +1,12 @@
-"""Tests for binutils module."""
+"""Tests for binutils and the bulk-unbundle CLI."""
 
+from argparse import Namespace
 from pathlib import Path
 
+import pytest
+
 from rocm_kpack import binutils
+from rocm_kpack.tools import bulk_unbundle
 
 
 def test_toolchain(test_assets_dir: Path, toolchain: binutils.Toolchain):
@@ -18,3 +22,67 @@ def test_toolchain(test_assets_dir: Path, toolchain: binutils.Toolchain):
                 break
         else:
             raise AssertionError("No target hsaco file")
+
+
+def test_bundled_binary_unbundles_elf_without_external_tools(
+    test_assets_dir: Path, tmp_path: Path
+):
+    """ELF discovery and section extraction use the in-process parser."""
+    binary = test_assets_dir / "bundled_binaries/linux/cov5/test_kernel_single.exe"
+    unavailable = tmp_path / "not-a-tool"
+    toolchain = binutils.Toolchain(readelf=unavailable, objcopy=unavailable)
+
+    with binutils.BundledBinary(binary, toolchain=toolchain).unbundle() as contents:
+        assert contents.target_list
+        assert all((contents.dest_dir / name).is_file() for name in contents.file_names)
+
+
+def test_bulk_unbundle_output_dir(
+    test_assets_dir: Path, tmp_path: Path
+):
+    source = test_assets_dir / "ccob" / "ccob_gfx942_sample1.co"
+    output_dir = tmp_path / "explicit-output"
+
+    bulk_unbundle.run(
+        Namespace(files=[source], output_dir=output_dir, gfx_arch=None)
+    )
+
+    outputs = list(output_dir.iterdir())
+    assert outputs
+    assert all(output.is_file() for output in outputs)
+
+
+def test_bulk_unbundle_filters_gfx_arch(test_assets_dir: Path, tmp_path: Path):
+    source = test_assets_dir / "ccob" / "ccob_gfx942_sample1.co"
+    output_dir = tmp_path / "gfx942-only"
+
+    bulk_unbundle.run(
+        Namespace(files=[source], output_dir=output_dir, gfx_arch="gfx942")
+    )
+
+    outputs = list(output_dir.iterdir())
+    assert outputs
+    assert all("gfx942" in output.name for output in outputs)
+
+
+def test_unbundle_gfx_arch_filter_requires_a_match(
+    test_assets_dir: Path, tmp_path: Path
+):
+    source = test_assets_dir / "ccob" / "ccob_gfx942_sample1.co"
+    output_dir = tmp_path / "no-matches"
+
+    with pytest.raises(ValueError, match="No code objects for architecture 'gfx1250'"):
+        binutils.BundledBinary(source).unbundle(
+            dest_dir=output_dir, gfx_arch="gfx1250"
+        )
+
+    assert not output_dir.exists()
+
+
+def test_bulk_unbundle_output_dir_requires_one_input(tmp_path: Path):
+    with pytest.raises(SystemExit) as exc:
+        bulk_unbundle.main(
+            ["--output-dir", str(tmp_path / "output"), "first.co", "second.co"]
+        )
+
+    assert exc.value.code == 2

--- a/shared/kpack/tests/test_binutils.py
+++ b/shared/kpack/tests/test_binutils.py
@@ -2,11 +2,86 @@
 
 from argparse import Namespace
 from pathlib import Path
+import struct
 
 import pytest
 
 from rocm_kpack import binutils
 from rocm_kpack.tools import bulk_unbundle
+
+
+def _write_synthetic_elf(path: Path, sections: list[tuple[str, int, bytes]]) -> None:
+    """Write a minimal ELF64 with the requested named sections."""
+    names = bytearray(b"\0")
+    name_offsets = []
+    for name, _, _ in sections:
+        name_offsets.append(len(names))
+        names += name.encode() + b"\0"
+    shstrtab_name = len(names)
+    names += b".shstrtab\0"
+
+    section_count = len(sections) + 2
+    section_table_offset = 64
+    payload_offset = section_table_offset + section_count * 64
+    payload = bytearray()
+    headers = [bytes(64)]
+    for name_offset, (_, section_type, content) in zip(name_offsets, sections):
+        offset = payload_offset + len(payload)
+        headers.append(
+            struct.pack(
+                "<IIQQQQIIQQ",
+                name_offset,
+                section_type,
+                0,
+                0,
+                offset,
+                len(content),
+                0,
+                0,
+                1,
+                0,
+            )
+        )
+        if section_type != 8:  # SHT_NOBITS
+            payload += content
+
+    names_offset = payload_offset + len(payload)
+    headers.append(
+        struct.pack(
+            "<IIQQQQIIQQ",
+            shstrtab_name,
+            3,
+            0,
+            0,
+            names_offset,
+            len(names),
+            0,
+            0,
+            1,
+            0,
+        )
+    )
+    header = bytearray(64)
+    header[:6] = b"\x7fELF\x02\x01"
+    struct.pack_into(
+        "<HHIQQQIHHHHHH",
+        header,
+        16,
+        3,
+        62,
+        1,
+        0,
+        0,
+        section_table_offset,
+        0,
+        64,
+        0,
+        0,
+        64,
+        section_count,
+        section_count - 1,
+    )
+    path.write_bytes(header + b"".join(headers) + payload + names)
 
 
 def test_toolchain(test_assets_dir: Path, toolchain: binutils.Toolchain):
@@ -25,27 +100,48 @@ def test_toolchain(test_assets_dir: Path, toolchain: binutils.Toolchain):
 
 
 def test_bundled_binary_unbundles_elf_without_external_tools(
-    test_assets_dir: Path, tmp_path: Path
+    test_assets_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
-    """ELF discovery and section extraction use the in-process parser."""
+    """ELF extraction reads only the fatbin rather than loading the host ELF."""
     binary = test_assets_dir / "bundled_binaries/linux/cov5/test_kernel_single.exe"
     unavailable = tmp_path / "not-a-tool"
     toolchain = binutils.Toolchain(readelf=unavailable, objcopy=unavailable)
+    monkeypatch.setattr(
+        binutils.ElfSurgery,
+        "load",
+        lambda _path: pytest.fail("full ELF load is not allowed for extraction"),
+    )
 
     with binutils.BundledBinary(binary, toolchain=toolchain).unbundle() as contents:
         assert contents.target_list
         assert all((contents.dest_dir / name).is_file() for name in contents.file_names)
 
 
-def test_bulk_unbundle_output_dir(
-    test_assets_dir: Path, tmp_path: Path
-):
+def test_lazy_elf_reader_matches_each_section_name_exactly(tmp_path: Path):
+    binary = tmp_path / "substring-name.elf"
+    _write_synthetic_elf(
+        binary,
+        [
+            ("x.hip_fatbin", 1, b"wrong"),
+            (".hip_fatbin", 1, b"right"),
+        ],
+    )
+
+    assert binutils.ElfSurgery.read_section(binary, ".hip_fatbin") == b"right"
+
+
+def test_lazy_elf_reader_rejects_nobits_sections(tmp_path: Path):
+    binary = tmp_path / "nobits.elf"
+    _write_synthetic_elf(binary, [(".ghost", 8, b"not-file-content")])
+
+    assert binutils.ElfSurgery.read_section(binary, ".ghost") is None
+
+
+def test_bulk_unbundle_output_dir(test_assets_dir: Path, tmp_path: Path):
     source = test_assets_dir / "ccob" / "ccob_gfx942_sample1.co"
     output_dir = tmp_path / "explicit-output"
 
-    bulk_unbundle.run(
-        Namespace(files=[source], output_dir=output_dir, gfx_arch=None)
-    )
+    bulk_unbundle.run(Namespace(files=[source], output_dir=output_dir, gfx_arch=None))
 
     outputs = list(output_dir.iterdir())
     assert outputs
@@ -72,17 +168,32 @@ def test_unbundle_gfx_arch_filter_requires_a_match(
     output_dir = tmp_path / "no-matches"
 
     with pytest.raises(ValueError, match="No code objects for architecture 'gfx1250'"):
-        binutils.BundledBinary(source).unbundle(
-            dest_dir=output_dir, gfx_arch="gfx1250"
-        )
+        binutils.BundledBinary(source).unbundle(dest_dir=output_dir, gfx_arch="gfx1250")
 
     assert not output_dir.exists()
 
 
-def test_bulk_unbundle_output_dir_requires_one_input(tmp_path: Path):
+def test_unbundle_no_match_does_not_create_owned_temporary_directory(
+    test_assets_dir: Path, monkeypatch: pytest.MonkeyPatch
+):
+    source = test_assets_dir / "ccob" / "ccob_gfx942_sample1.co"
+    binary = binutils.BundledBinary(source)
+
+    def unexpected_mkdtemp():
+        pytest.fail("temporary directory was created before filtering")
+
+    monkeypatch.setattr(binutils.tempfile, "mkdtemp", unexpected_mkdtemp)
+    with pytest.raises(ValueError, match="No code objects for architecture 'gfx1250'"):
+        binary.unbundle(gfx_arch="gfx1250")
+
+
+def test_bulk_unbundle_output_dir_requires_one_input(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+):
     with pytest.raises(SystemExit) as exc:
         bulk_unbundle.main(
             ["--output-dir", str(tmp_path / "output"), "first.co", "second.co"]
         )
 
     assert exc.value.code == 2
+    assert "--output-dir requires exactly one input file" in capsys.readouterr().err

--- a/shared/kpack/tests/test_database_handlers.py
+++ b/shared/kpack/tests/test_database_handlers.py
@@ -11,10 +11,58 @@ from rocm_kpack.database_handlers import (
     AotritonHandler,
     MIOpenHandler,
     HipKernelProviderRockeHandler,
+    HotswapCacheHandler,
     WHEEL_TYPE_PRESETS,
     get_database_handlers,
     list_available_handlers,
 )
+
+
+class TestHotswapCacheHandler:
+    @pytest.fixture
+    def handler(self):
+        return HotswapCacheHandler()
+
+    @pytest.fixture
+    def prefix_root(self, tmp_path):
+        root = tmp_path / "prefix"
+        root.mkdir()
+        return root
+
+    def test_name(self, handler):
+        assert handler.name() == "hotswap_cache"
+
+    @pytest.mark.parametrize("extension", ["obj", "man"])
+    def test_detect_gfx1250_entry(self, handler, prefix_root, extension):
+        digest = "0123456789abcdef" * 4
+        file_path = (
+            prefix_root
+            / f"share/rocjitsu/translations/gfx1250-b0-a0/v1/{digest}.{extension}"
+        )
+        file_path.parent.mkdir(parents=True)
+        file_path.touch()
+        assert handler.detect(file_path, prefix_root) == "gfx1250"
+
+    @pytest.mark.parametrize(
+        "relative_path",
+        [
+            "share/rocjitsu/translations/gfx1250-b0-a0/v2/" + "a" * 64 + ".obj",
+            "share/rocjitsu/translations/gfx1250-b0-a1/v1/" + "a" * 64 + ".obj",
+            "share/rocjitsu/translations/gfx1250-b0-a0/v1/not-a-digest.obj",
+            "share/rocjitsu/translations/gfx1250-b0-a0/v1/" + "a" * 64 + ".txt",
+            "share/rocjitsu/translations/gfx1250-b0-a0/v1/nested/" + "a" * 64 + ".obj",
+            "share/other/translations/gfx1250-b0-a0/v1/" + "a" * 64 + ".obj",
+        ],
+    )
+    def test_reject_unowned_layout(self, handler, prefix_root, relative_path):
+        file_path = prefix_root / relative_path
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.touch()
+        assert handler.detect(file_path, prefix_root) is None
+
+    def test_reject_file_outside_prefix(self, handler, prefix_root):
+        with pytest.raises(ValueError, match="is not under prefix_root"):
+            handler.detect(Path("/tmp/outside.obj"), prefix_root)
 
 
 class TestRocBLASHandler:
@@ -906,7 +954,8 @@ class TestDatabaseHandlerRegistry:
         assert "aotriton" in handlers
         assert "miopen" in handlers
         assert "hipkernelprovider" in handlers
-        assert len(handlers) == 6
+        assert "hotswap_cache" in handlers
+        assert len(handlers) == 7
 
     def test_get_database_handlers_single(self):
         """Test getting a single handler by name."""
@@ -931,15 +980,17 @@ class TestDatabaseHandlerRegistry:
                 "aotriton",
                 "miopen",
                 "hipkernelprovider",
+                "hotswap_cache",
             ]
         )
-        assert len(handlers) == 6
+        assert len(handlers) == 7
         assert isinstance(handlers[0], RocBLASHandler)
         assert isinstance(handlers[1], HipBLASLtHandler)
         assert isinstance(handlers[2], HipSparseLtHandler)
         assert isinstance(handlers[3], AotritonHandler)
         assert isinstance(handlers[4], MIOpenHandler)
         assert isinstance(handlers[5], HipKernelProviderRockeHandler)
+        assert isinstance(handlers[6], HotswapCacheHandler)
 
     def test_wheel_type_preset(self):
         """Test that wheel type presets resolve to valid handlers."""

--- a/shared/kpack/tests/test_database_handlers.py
+++ b/shared/kpack/tests/test_database_handlers.py
@@ -835,9 +835,7 @@ class TestHipKernelProviderRockeHandler:
 
     def test_detect_deeply_nested_file(self, handler, prefix_root):
         """Any file nested below the arch dir routes to that arch."""
-        file_path = (
-            prefix_root / f"{self._ENGINE_DIR}/gfx942/sub/extra/blob.bin"
-        )
+        file_path = prefix_root / f"{self._ENGINE_DIR}/gfx942/sub/extra/blob.bin"
         file_path.parent.mkdir(parents=True)
         file_path.touch()
 


### PR DESCRIPTION
* Squashes rocjitsu draft changes for maintaining a cache
* Supports build-id hashing for external caching and pre-shared nonce for build time caching
* Extends the kpack unpacker debug tool into a real tool that can robustly unpack all code objects from a binary (since clang-offload-bundler has fatal issues with some more advanced/concatenated fat binaries like rccl and the kpack implementation is already battle tested and in use for all builds)
* Adds a kpack database handler that will recognize the hotswap build-time cache installation and categorize it as arch specific. When combined with project level changes to activate this handler, the cache files will be included in the same artifact as the un-translated kpack files for gfx1250 only.
* Will be paired with a corresponding change to TheRock to perform the translation as a new sub-project.

Corresponding TheRock PR: https://github.com/ROCm/TheRock/pull/7288