### PR TITLE
ci: refresh apt metadata for KPACK Python tests

### DIFF
--- a/.github/workflows/kpack-ci.yml
+++ b/.github/workflows/kpack-ci.yml
@@ -40,7 +40,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install gdb (Linux)
         if: runner.os == 'Linux'
-        run: sudo apt-get install -y gdb
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gdb
       - name: Install
         run: |
           pip install python/rocm-bootstrap


### PR DESCRIPTION
Fixes a CI flake noticed in https://github.com/ROCm/rocm-systems/pull/10037