### PR TITLE
[rocjitsu] Translate device-linked objects that call through function pointers

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/gfx1250_vgpr_msb.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/gfx1250_vgpr_msb.cpp
@@ -37,6 +37,13 @@ struct VgprMsbState {
   bool operator==(const VgprMsbState &) const = default;
 };
 
+/// @brief Architectural VGPR_MSB state at a function entry: all four banks zero.
+///
+/// @details This is an ABI guarantee rather than an assumption. LLVM documents it in
+/// AMDGPULowerVGPREncoding ("the ABI is set to expect all 4 MSBs to be zero on entry") and
+/// enforces it by resetting the mode before every call and every terminator, so a callee is
+/// always entered with the banks cleared. The same state therefore seeds a kernel entry and any
+/// address-taken device function adopted as an additional root.
 [[nodiscard]] VgprMsbState entry_state() {
   VgprMsbState state;
   state.reachable = true;
@@ -137,9 +144,9 @@ void transfer_instruction(VgprMsbState &state, const Instruction &inst,
 class Gfx1250VgprMsbAnalysis::Impl {
 public:
   Impl(KernelBlockScope blocks, BasicBlock *entry, std::span<const ScopedCfgEdge> extra_edges,
-       std::span<const uint8_t> text)
+       std::span<const uint8_t> text, std::span<BasicBlock *const> additional_entries)
       : text_(text) {
-    analyze(blocks, entry, extra_edges);
+    analyze(blocks, entry, extra_edges, additional_entries);
   }
 
   [[nodiscard]] std::optional<uint8_t> bank_before(const Instruction &inst,
@@ -157,7 +164,8 @@ public:
 
 private:
   void analyze(KernelBlockScope blocks, BasicBlock *entry,
-               std::span<const ScopedCfgEdge> extra_edges) {
+               std::span<const ScopedCfgEdge> extra_edges,
+               std::span<BasicBlock *const> additional_entries) {
     std::unordered_map<const BasicBlock *, size_t> block_index;
     block_index.reserve(blocks.size());
     for (size_t i = 0; i < blocks.size(); ++i) {
@@ -201,6 +209,16 @@ private:
     };
     enqueue(entry_it->second);
 
+    // An adopted root is entered by a call through its address, never by an edge from this scope,
+    // so the fixed point below would otherwise never give it a state.
+    for (BasicBlock *additional : additional_entries) {
+      const auto it = block_index.find(additional);
+      if (it == block_index.end())
+        continue;
+      (void)merge_state(in[it->second], entry_state());
+      enqueue(it->second);
+    }
+
     while (!worklist.empty()) {
       const size_t index = worklist.front();
       worklist.pop_front();
@@ -241,8 +259,9 @@ private:
 
 Gfx1250VgprMsbAnalysis::Gfx1250VgprMsbAnalysis(KernelBlockScope blocks, BasicBlock *entry,
                                                std::span<const ScopedCfgEdge> extra_edges,
-                                               std::span<const uint8_t> text)
-    : impl_(std::make_unique<Impl>(blocks, entry, extra_edges, text)) {}
+                                               std::span<const uint8_t> text,
+                                               std::span<BasicBlock *const> additional_entries)
+    : impl_(std::make_unique<Impl>(blocks, entry, extra_edges, text, additional_entries)) {}
 
 Gfx1250VgprMsbAnalysis::~Gfx1250VgprMsbAnalysis() = default;
 Gfx1250VgprMsbAnalysis::Gfx1250VgprMsbAnalysis(Gfx1250VgprMsbAnalysis &&) noexcept = default;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/gfx1250_vgpr_msb.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/gfx1250_vgpr_msb.h
@@ -31,9 +31,15 @@ public:
   /// @param text Raw .text image, used to read S_SETREG_IMM32_B32 literals safely
   ///        at src_loc()+4. Empty is tolerated: such writes then mark the affected
   ///        banks ambiguous rather than reading a literal.
+  /// @param additional_entries Further blocks that are entered with the same
+  ///        architectural state as @p entry rather than through a CFG edge. A
+  ///        device function whose address is only ever taken has no decoded edge
+  ///        into it, so without this its blocks stay unreachable and every bank
+  ///        query over them answers nullopt. See the note on entry_state().
   Gfx1250VgprMsbAnalysis(KernelBlockScope blocks, BasicBlock *entry,
                          std::span<const ScopedCfgEdge> extra_edges = {},
-                         std::span<const uint8_t> text = {});
+                         std::span<const uint8_t> text = {},
+                         std::span<BasicBlock *const> additional_entries = {});
   ~Gfx1250VgprMsbAnalysis();
 
   Gfx1250VgprMsbAnalysis(const Gfx1250VgprMsbAnalysis &) = delete;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
@@ -188,6 +188,16 @@ struct PcValue {
   /// two builder steps would be erased. A value that stops being contiguous can
   /// never regain the property, so any later delta step keeps it false.
   bool contiguous = true;
+  /// @brief True between a split low `s_add_u32` and the `s_addc_u32` that closes it.
+  ///
+  /// @details The high-half step only advances the recovery range; it never changes @ref offset,
+  /// so a half-built chain is numerically indistinguishable from a finished one. Publishing the
+  /// half-built state would let the patcher regenerate `[begin, end)` -- which stops before the
+  /// carry -- and leave that `s_addc_u32` to apply a stale SCC to the freshly written high half,
+  /// because the gfx1250 replacement is the SCC-neutral `s_add_nc_u64`. The single-instruction
+  /// `s_add_nc_u64` form and the temp-delta patterns that already absorb their own carry never set
+  /// this.
+  bool pending_high_carry = false;
 
   friend bool operator==(const PcValue &, const PcValue &) = default;
 };
@@ -1082,6 +1092,7 @@ instruction_index_for_offset(std::span<const Instruction *const> insts, uint64_t
 
   value.offset += delta;
   value.source_recovery_end_offset = inst.src_loc() + static_cast<uint64_t>(inst.size());
+  value.pending_high_carry = true;
   return true;
 }
 
@@ -1102,6 +1113,7 @@ instruction_index_for_offset(std::span<const Instruction *const> insts, uint64_t
   if (sop2_sreg_inline_zero_to_sreg(inst, word, *addc_u32_opcode, pair_hi, pair_hi) ||
       sop2_sreg_inline_zero_to_sreg(inst, word, *subb_u32_opcode, pair_hi, pair_hi)) {
     value.source_recovery_end_offset = inst.src_loc() + static_cast<uint64_t>(inst.size());
+    value.pending_high_carry = false;
     return true;
   }
 
@@ -1113,6 +1125,7 @@ instruction_index_for_offset(std::span<const Instruction *const> insts, uint64_t
                                 literal)) {
     if (literal == 0 || literal == 0xffffffffu) {
       value.source_recovery_end_offset = inst.src_loc() + static_cast<uint64_t>(inst.size());
+      value.pending_high_carry = false;
       return true;
     }
   }
@@ -1189,6 +1202,40 @@ instruction_index_for_offset(std::span<const Instruction *const> insts, uint64_t
   };
 }
 
+/// @brief Identity of a fixup for deduplication: exactly the fields append_unique() compares.
+struct FixupIdentity {
+  uint64_t call;
+  uint64_t target;
+  uint64_t getpc;
+  uint64_t begin;
+  uint64_t end;
+  uint16_t sreg;
+  friend bool operator==(const FixupIdentity &, const FixupIdentity &) = default;
+};
+
+struct FixupIdentityHash {
+  size_t operator()(const FixupIdentity &id) const noexcept {
+    size_t h = std::hash<uint64_t>{}(id.call);
+    const auto mix = [&h](uint64_t v) {
+      h ^= std::hash<uint64_t>{}(v) + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
+    };
+    mix(id.target);
+    mix(id.getpc);
+    mix(id.begin);
+    mix(id.end);
+    mix(id.sreg);
+    return h;
+  }
+};
+
+[[nodiscard]] FixupIdentity fixup_identity(const IndirectCallFixup &fixup) {
+  return {fixup.source_call_offset,         fixup.source_target_offset,
+          fixup.source_getpc_offset,        fixup.source_recovery_begin_offset,
+          fixup.source_recovery_end_offset, fixup.source_call_sreg};
+}
+
+using FixupIndex = std::unordered_map<FixupIdentity, size_t, FixupIdentityHash>;
+
 bool append_unique(std::vector<IndirectCallFixup> &out, IndirectCallFixup fixup) {
   // Deduplicate only FULLY identical fixups. A consumer with several distinct
   // s_getpc builders reaching the same target keeps the translator rewriting each
@@ -1219,6 +1266,26 @@ bool append_unique(std::vector<IndirectCallFixup> &out, IndirectCallFixup fixup)
     duplicate->source_incomplete = duplicate->source_incomplete || fixup.source_incomplete;
     duplicate->source_requires_xcnt_drain =
         duplicate->source_requires_xcnt_drain || fixup.source_requires_xcnt_drain;
+    return false;
+  }
+  out.push_back(fixup);
+  return true;
+}
+
+/// @brief append_unique() with an O(1) duplicate lookup.
+///
+/// @details Same semantics as the scanning form -- same identity, same monotonic flag merge -- but
+/// the caller keeps an index so accumulating N fixups costs O(N) rather than O(N^2). A large
+/// device library recovers tens of thousands of them, and the scan was quadratic in that count on
+/// every round.
+bool append_unique_indexed(std::vector<IndirectCallFixup> &out, FixupIndex &index,
+                           IndirectCallFixup fixup) {
+  const auto [it, inserted] = index.try_emplace(fixup_identity(fixup), out.size());
+  if (!inserted) {
+    IndirectCallFixup &duplicate = out[it->second];
+    duplicate.source_incomplete = duplicate.source_incomplete || fixup.source_incomplete;
+    duplicate.source_requires_xcnt_drain =
+        duplicate.source_requires_xcnt_drain || fixup.source_requires_xcnt_drain;
     return false;
   }
   out.push_back(fixup);
@@ -1692,10 +1759,21 @@ void scan_block(AnalysisContext &ctx, size_t block_index, std::vector<AnalysisBl
   // Publish every still-live builder's current value. Called only where the
   // tracked pairs are about to stop being tracked, so the published value is
   // the one the original builder range really produces at that point.
+  // A chain still waiting on its s_addc_u32 is not the value the range produces, and no rewrite of
+  // [begin, end) can be right for it: the regenerated range stops before the carry. Poison instead
+  // of publishing, so a whole-scope relocation claim fails closed rather than resting on a value
+  // the program never finished computing.
+  const auto publish_or_poison = [&](uint16_t pair_lo, const PcValue &value) {
+    if (value.pending_high_carry)
+      poison_pc_builder(pc_builders, value.source_getpc_offset);
+    else
+      note_pc_builder(pc_builders, pair_lo, value);
+  };
+
   const auto note_live_pc_builders = [&] {
     for (uint16_t pair_lo : state.active_pairs()) {
       if (const PcValue *value = state.builder(pair_lo))
-        note_pc_builder(pc_builders, pair_lo, *value);
+        publish_or_poison(pair_lo, *value);
     }
   };
 
@@ -1708,11 +1786,18 @@ void scan_block(AnalysisContext &ctx, size_t block_index, std::vector<AnalysisBl
       // s_getpc_b64 writes the address of the following instruction. The
       // low/high add sequence edits this base to the eventual branch target.
       const uint16_t pair_lo = *facts.getpc_sdst;
-      // A second builder overwriting the same pair abandons the first one at an
-      // unknown point in its chain. No single delta rewrite is provably correct
-      // for an abandoned chain, so poison it rather than publish a partial value.
+      // A second builder seeding the same pair is a stable point for the first one, in exactly the
+      // sense note_pc_builder means: the pair stops being tracked as the old builder here, and the
+      // old chain cannot be extended afterwards because any later arithmetic on this pair edits the
+      // new builder's value. Whatever the replaced range produces at this instruction is therefore
+      // final, and it is precisely what any consumer between the two getpcs read -- so publish it.
+      //
+      // Poisoning instead used to abandon a completed producer merely because its pair was reused.
+      // Code that materializes several function pointers through one scratch pair -- build, spill
+      // to a VGPR lane, rebuild -- would leave a poisoned record behind for the first pointer and
+      // defeat any whole-scope or whole-object claim that every code address is relocated.
       if (const PcValue *replaced = state.builder(pair_lo))
-        poison_pc_builder(pc_builders, replaced->source_getpc_offset);
+        publish_or_poison(pair_lo, *replaced);
       seed_pc_builder(pc_builders, inst.src_loc(), pair_lo);
       state.set_builder(pair_lo, PcValue{.offset = static_cast<int64_t>(next_offset),
                                          .source_getpc_offset = inst.src_loc(),
@@ -3310,14 +3395,23 @@ std::optional<uint16_t> s_call_sdst(const Instruction &inst, uint32_t word) {
 [[nodiscard]] std::vector<IndirectCallFixup> discover_indirect_branch_edges_unfiltered(
     std::span<const Instruction *const> insts, std::span<const uint8_t> text, rj_code_arch_t arch,
     std::span<const uint64_t> extra_leaders, ExternalEntryPolicy entry_policy,
-    std::vector<PcAddressBuilder> *pc_builders) {
+    std::vector<PcAddressBuilder> *pc_builders, std::span<const uint64_t> extra_split_points) {
   std::vector<IndirectCallFixup> recovered;
+  FixupIndex recovered_index;
   AnalysisContext ctx = build_context(insts, text, arch);
   std::vector<uint64_t> sorted_extra_leaders(extra_leaders.begin(), extra_leaders.end());
   std::ranges::sort(sorted_extra_leaders);
   sorted_extra_leaders.erase(std::ranges::unique(sorted_extra_leaders).begin(),
                              sorted_extra_leaders.end());
+  // A split point shapes the block graph but says nothing about how a block is entered. Keeping
+  // these out of sorted_extra_leaders is the whole point of the distinction: under ExplicitOnly
+  // every explicit entry is treated as externally entered, so promoting an ordinary helper to one
+  // would discard the incoming SGPR-pair facts its real callers establish and leave otherwise
+  // recoverable getpc flows unresolved.
   std::vector<uint64_t> leaders(sorted_extra_leaders);
+  leaders.insert(leaders.end(), extra_split_points.begin(), extra_split_points.end());
+  std::ranges::sort(leaders);
+  leaders.erase(std::ranges::unique(leaders).begin(), leaders.end());
 
   PcAddressBuilderMap round_builders;
   for (size_t iteration = 0; iteration < kMaxIndirectDiscoveryIterations; ++iteration) {
@@ -3351,7 +3445,7 @@ std::optional<uint16_t> s_call_sdst(const Instruction &inst, uint32_t word) {
 
     bool changed = false;
     for (const IndirectCallFixup &fixup : iteration_recovered)
-      changed |= append_unique(recovered, fixup);
+      changed |= append_unique_indexed(recovered, recovered_index, fixup);
     if (!changed)
       break;
   }
@@ -3389,7 +3483,7 @@ bool is_callee_saved_sgpr(uint16_t sgpr) {
 std::vector<IndirectCallFixup> discover_indirect_branch_edges(
     std::span<const Instruction *const> insts, std::span<const uint8_t> text, rj_code_arch_t arch,
     std::span<const uint64_t> extra_leaders, ExternalEntryPolicy entry_policy,
-    std::vector<PcAddressBuilder> *pc_builders) {
+    std::vector<PcAddressBuilder> *pc_builders, std::span<const uint64_t> extra_split_points) {
   if (pc_builders != nullptr)
     pc_builders->clear();
   if (insts.empty())
@@ -3408,14 +3502,14 @@ std::vector<IndirectCallFixup> discover_indirect_branch_edges(
     // Keep the cheap predicate coupled to every fixup producer. A future
     // recovery path for another consumer kind must extend the predicate above.
     const auto unfiltered = discover_indirect_branch_edges_unfiltered(
-        insts, text, arch, extra_leaders, entry_policy, nullptr);
+        insts, text, arch, extra_leaders, entry_policy, nullptr, extra_split_points);
     assert(unfiltered.empty() && "indirect-recovery prefilter skipped a fixup-producing consumer");
 #endif
     return {};
   }
 
   return discover_indirect_branch_edges_unfiltered(insts, text, arch, extra_leaders, entry_policy,
-                                                   pc_builders);
+                                                   pc_builders, extra_split_points);
 }
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.h
@@ -56,6 +56,14 @@ struct IndirectCallFixup {
   /// the same SGPR pair the drain was ordering, so dropping the wait would let the
   /// pair be rewritten while an operation still has the old value in flight.
   bool source_requires_xcnt_drain = false;
+  /// @brief True when this builder's consumer was replaced by a direct transfer window.
+  ///
+  /// @details The window recomputes the address, so the builder survives only as dead code -- and
+  /// with no consumer left, a later translation pass can account for it only if the rewrite
+  /// lattice can see it. That obliges the rewrite to use the literal64 add form, which is the only
+  /// one the lattice models. A builder whose consumer remains needs no such constraint: the
+  /// consumer is recovered again on the next pass and accounts for the builder through that.
+  bool consumer_replaced_by_window = false;
   uint16_t source_return_sreg = 0;           ///< Low SGPR receiving the return PC for calls.
   uint64_t target_getpc_offset = 0;          ///< Relocated offset of the s_getpc_b64 producer.
   uint64_t target_recovery_begin_offset = 0; ///< Relocated first byte of replaceable builder code.
@@ -153,7 +161,11 @@ struct PcAddressBuilder {
 /// @param insts Decoded instructions with Instruction::src_loc() populated.
 /// @param text Raw .text bytes matching @p insts.
 /// @param arch ISA architecture used for scalar instruction matching.
-/// @param extra_leaders Additional known block starts, usually kernel entries.
+/// @param extra_leaders Additional known block starts that are also EXTERNAL ENTRIES. Under
+///        ExplicitOnly every one of these is treated as externally entered, which discards the
+///        incoming SGPR-pair facts a caller would establish, so pass only offsets that really are
+///        entered from outside the decoded graph. Offsets that merely need to start a block belong
+///        in @p extra_split_points.
 /// @param entry_policy Whether predecessorless blocks are inferred to be external entries.
 /// @param pc_builders Optional sink for every discovered PC-relative address
 ///        producer, sorted by `source_getpc_offset`. Populated only when the
@@ -161,10 +173,14 @@ struct PcAddressBuilder {
 ///        section with no dynamic transfer has no stale-PC branch hazard to
 ///        prove anything about.
 /// @returns Recovered indirect branch/call metadata.
+/// @param extra_split_points Offsets that must start a block without being treated as external
+///        entries. Function-entry symbols and stored-pointer targets belong here: they are real
+///        boundaries, but most of them are ordinary helpers their callers reach by a decoded edge.
 [[nodiscard]] std::vector<IndirectCallFixup> discover_indirect_branch_edges(
     std::span<const Instruction *const> insts, std::span<const uint8_t> text, rj_code_arch_t arch,
     std::span<const uint64_t> extra_leaders = {},
     ExternalEntryPolicy entry_policy = ExternalEntryPolicy::InferPredecessorless,
-    std::vector<PcAddressBuilder> *pc_builders = nullptr);
+    std::vector<PcAddressBuilder> *pc_builders = nullptr,
+    std::span<const uint64_t> extra_split_points = {});
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/liveness.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/liveness.cpp
@@ -174,7 +174,8 @@ LivenessAnalysis::LivenessAnalysis(KernelBlockScope blocks, std::unique_ptr<Exec
   const KernelBlockScope deferred_scope(deferred_blocks_);
   if (options.arch == ROCJITSU_CODE_ARCH_GFX1250 && options.entry_block != nullptr) {
     gfx1250_vgpr_msb_ = std::make_unique<Gfx1250VgprMsbAnalysis>(
-        deferred_scope, options.entry_block, deferred_extra_edges_, options.text);
+        deferred_scope, options.entry_block, deferred_extra_edges_, options.text,
+        options.additional_entry_blocks);
   }
   collect_global_register_usage(deferred_scope, options.text);
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/liveness.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/liveness.h
@@ -73,6 +73,14 @@ struct LivenessAnalysisOptions {
   /// @brief Kernel entry block where architectural VGPR_MSB state is zero.
   BasicBlock *entry_block = nullptr;
 
+  /// @brief Further blocks entered with the same architectural state as entry_block.
+  ///
+  /// @details These are address-taken device functions adopted into this scope. They are reached
+  /// by a call through a pointer rather than by a decoded edge, so without seeding their blocks
+  /// stay unreachable and every VGPR_MSB query over them answers nullopt. The state to seed them
+  /// with is the ABI's, which is the same one entry_block gets.
+  std::span<BasicBlock *const> additional_entry_blocks;
+
   /// @brief Lowest VGPR index that a VGPR scratch query may return.
   ///
   /// @details This is a debug-oriented allocation floor, not a dataflow fact.
@@ -188,6 +196,15 @@ public:
 
   /// @brief gfx1250 VGPR bank selected for @p role before @p inst.
   /// @returns nullopt when this is not a gfx1250 analysis or the state is ambiguous.
+  /// @brief The VGPR_MSB analysis this liveness owns, or nullptr when it has none.
+  ///
+  /// @details Exposed so a caller that needs the same dataflow does not build a second one over
+  /// the same scope: the fixpoint is superlinear in scope size, and on a large object the two
+  /// copies were the same computation run twice.
+  [[nodiscard]] const Gfx1250VgprMsbAnalysis *gfx1250_vgpr_msb() const {
+    return gfx1250_vgpr_msb_.get();
+  }
+
   [[nodiscard]] std::optional<uint8_t> vgpr_msb_bank_before(const Instruction &inst,
                                                             amdgpu::VgprMsbRole role) const;
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_elf.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_elf.h
@@ -183,13 +183,32 @@ inline constexpr uint32_t R_AMDGPU_RELATIVE64 = 13;
 
 inline constexpr uint8_t kElfSymbolBindLocal = 0;
 inline constexpr uint8_t kElfSymbolBindGlobal = 1;
-inline constexpr uint8_t kElfSymbolTypeNone = 0;    // STT_NOTYPE
-inline constexpr uint8_t kElfSymbolTypeObject = 1;  // STT_OBJECT
-inline constexpr uint8_t kElfSymbolTypeFunc = 2;    // STT_FUNC
-inline constexpr uint8_t kElfSymbolTypeSection = 3; // STT_SECTION
+inline constexpr uint8_t kElfSymbolBindWeak = 2;
+inline constexpr uint8_t kElfSymbolVisibilityHidden = 2;   // STV_HIDDEN
+inline constexpr uint8_t kElfSymbolVisibilityInternal = 1; // STV_INTERNAL
+inline constexpr uint8_t kElfSymbolTypeNone = 0;           // STT_NOTYPE
+inline constexpr uint8_t kElfSymbolTypeObject = 1;         // STT_OBJECT
+inline constexpr uint8_t kElfSymbolTypeFunc = 2;           // STT_FUNC
+inline constexpr uint8_t kElfSymbolTypeSection = 3;        // STT_SECTION
 
 inline constexpr uint8_t elf_symbol_bind(uint8_t info) { return info >> 4; }
 inline constexpr uint8_t elf_symbol_type(uint8_t info) { return info & 0xf; }
+inline constexpr uint8_t elf_symbol_visibility(uint8_t other) { return other & 0x3; }
+
+/// @brief Whether a host could resolve this symbol by name and obtain its address.
+///
+/// @details Only external linkage reaches a loader: the HSA executable-symbol API and the dynamic
+/// linker expose `STB_GLOBAL`/`STB_WEAK` definitions that are not hidden or internal. A local
+/// symbol names a compilation-unit-private body -- an anonymous-namespace device function, say --
+/// and no interface hands its address out, so the only way its address can enter the machine is
+/// through this object's own code or relocations.
+inline constexpr bool elf_symbol_is_externally_resolvable(uint8_t info, uint8_t other) {
+  const uint8_t bind = elf_symbol_bind(info);
+  if (bind != kElfSymbolBindGlobal && bind != kElfSymbolBindWeak)
+    return false;
+  const uint8_t visibility = elf_symbol_visibility(other);
+  return visibility != kElfSymbolVisibilityHidden && visibility != kElfSymbolVisibilityInternal;
+}
 inline constexpr uint8_t elf_symbol_info(uint8_t bind, uint8_t type) {
   return static_cast<uint8_t>((bind << 4) | (type & 0xf));
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/basic_block.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/basic_block.cpp
@@ -145,10 +145,10 @@ void BasicBlock::add_static_pc_address_builder(PcAddressBuilder builder) {
   static_pc_address_builders_.push_back(builder);
 }
 
-std::vector<std::unique_ptr<BasicBlock>> BasicBlock::build(const CodeObject &co, Decoder &decoder,
-                                                           rj_code_arch_t arch,
-                                                           std::span<const uint64_t> extra_leaders,
-                                                           ExternalEntryPolicy entry_policy) {
+std::vector<std::unique_ptr<BasicBlock>>
+BasicBlock::build(const CodeObject &co, Decoder &decoder, rj_code_arch_t arch,
+                  std::span<const uint64_t> extra_leaders, ExternalEntryPolicy entry_policy,
+                  std::span<const uint64_t> extra_split_points) {
   std::vector<std::unique_ptr<BasicBlock>> blocks;
 
   for (const auto *sec : co.text_sections()) {
@@ -204,14 +204,22 @@ std::vector<std::unique_ptr<BasicBlock>> BasicBlock::build(const CodeObject &co,
     const auto decoded_span =
         std::span<const Instruction *const>(decoded_insts.data(), decoded_insts.size());
     std::vector<PcAddressBuilder> pc_address_builders;
-    std::vector<IndirectCallFixup> recovered_indirect_targets = discover_indirect_branch_edges(
-        decoded_span, text, arch, extra_leaders, entry_policy, &pc_address_builders);
+    std::vector<IndirectCallFixup> recovered_indirect_targets =
+        discover_indirect_branch_edges(decoded_span, text, arch, extra_leaders, entry_policy,
+                                       &pc_address_builders, extra_split_points);
 
     std::set<uint64_t> leaders;
     leaders.insert(decoded.front()->src_loc());
     for (uint64_t leader : extra_leaders) {
       if (leader < section_end)
         leaders.insert(leader);
+    }
+    // Split points shape the block graph only. They are deliberately absent from the external-entry
+    // set built below, so a helper named by a function symbol keeps the caller facts it is entered
+    // with.
+    for (uint64_t split : extra_split_points) {
+      if (split < section_end)
+        leaders.insert(split);
     }
     for (const IndirectCallFixup &fixup : recovered_indirect_targets) {
       if (fixup.source_call_offset < section_end)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/basic_block.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/basic_block.h
@@ -153,15 +153,22 @@ public:
   /// @param[in] co Code object to analyze.
   /// @param[in] decoder Decoder for the target ISA.
   /// @param[in] arch ISA architecture used to match static PC builders.
-  /// @param[in] extra_leaders Byte offsets that must start a basic block.
+  /// @param[in] extra_leaders Byte offsets that must start a basic block AND are entered from
+  /// outside the decoded graph. Under ExplicitOnly these become the external-entry set, so an
+  /// offset listed here has no incoming caller facts.
   /// @param[in] entry_policy Whether predecessorless blocks are inferred to be
   /// external function entries. Use ExplicitOnly only when extra_leaders
   /// enumerates every externally reachable entry.
+  /// @param[in] extra_split_points Byte offsets that must start a basic block but are NOT external
+  /// entries. Function-entry symbols and stored-pointer targets belong here: they are genuine
+  /// boundaries, yet most are ordinary helpers whose callers reach them by a decoded edge, and
+  /// calling them external would throw those caller facts away.
   /// @returns Ordered list of basic blocks with their decoded instructions.
   static std::vector<std::unique_ptr<BasicBlock>>
   build(const CodeObject &co, Decoder &decoder, rj_code_arch_t arch,
         std::span<const uint64_t> extra_leaders = {},
-        ExternalEntryPolicy entry_policy = ExternalEntryPolicy::InferPredecessorless);
+        ExternalEntryPolicy entry_policy = ExternalEntryPolicy::InferPredecessorless,
+        std::span<const uint64_t> extra_split_points = {});
 
 private:
   void add_instruction(std::unique_ptr<Instruction> inst);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/builders/instruction_builder.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/builders/instruction_builder.cpp
@@ -143,7 +143,7 @@ bool patch_pcrel_branch_offset(const Instruction &inst, std::span<uint32_t> word
 }
 
 bool append_pc_delta_builder(std::vector<uint32_t> &words, rj_code_arch_t arch, uint16_t pc_sreg,
-                             int64_t delta) {
+                             int64_t delta, bool prefer_literal64) {
   constexpr uint16_t kLiteralOperand = 255;
   constexpr uint16_t kLiteral64Operand = 254;
   constexpr uint16_t kInlineInt0 = 128;
@@ -154,7 +154,8 @@ bool append_pc_delta_builder(std::vector<uint32_t> &words, rj_code_arch_t arch, 
     // 32-bit deltas need one literal word; negative or wider deltas use the
     // literal64 form so modulo-2^64 addition preserves their full bit pattern.
     const uint64_t raw_delta = static_cast<uint64_t>(delta);
-    const bool use_literal32 = delta >= 0 && raw_delta <= std::numeric_limits<uint32_t>::max();
+    const bool use_literal32 =
+        !prefer_literal64 && delta >= 0 && raw_delta <= std::numeric_limits<uint32_t>::max();
     auto opcode = scalar_sop2_opcode(arch, ScalarSop2Op::AddNcU64);
     if (!opcode)
       return false;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/builders/instruction_builder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/builders/instruction_builder.h
@@ -779,8 +779,15 @@ inline constexpr uint16_t kDelayAluSaluDep1 = 9;
 /// negative scalar add/sub sequence needed to turn that pair into the final
 /// relocated target. Static PC recovery only records address-builder ranges that
 /// have enough instruction words for this replacement to be written in place.
+/// @param prefer_literal64 On gfx1250, use the literal64 add form even when the delta would fit a
+///        32-bit literal. The relocation lattice models only the literal64 encoding -- and cannot
+///        be widened to the 32-bit one, because the patcher writes an eight-byte delta into the
+///        literal slot -- so a builder that must stay visible to a later translation pass has to
+///        be emitted in that form. Costs one extra word, so callers with a fixed-size window ask
+///        for it only when the window can hold it.
 [[nodiscard]] bool append_pc_delta_builder(std::vector<uint32_t> &words, rj_code_arch_t arch,
-                                           uint16_t pc_sreg, int64_t delta);
+                                           uint16_t pc_sreg, int64_t delta,
+                                           bool prefer_literal64 = false);
 
 /// @brief Encode an s_nop instruction for the given target ISA.
 ///

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -1810,12 +1810,14 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
       // it. Omitting the anonymous ones made an object whose only producers are those slots look
       // producerless, so an unresolved indirect consumer took the rejection path even though this
       // pass discovers, adopts and relocates every one of those addends.
-      !relative_text_addend_targets.empty() ||
-      std::ranges::any_of(pc_relative_address_builders,
-                          [&](const PcRelativeAddressBuilder &builder) {
-                            return builder.target_vaddr >= text_vaddr &&
-                                   builder.target_vaddr - text_vaddr < text.size();
-                          });
+      !relative_text_addend_targets.empty();
+  // Deliberately NOT counting in-text getpc builders. Admitting a transfer on this permission also
+  // promises that every externally resolvable `.text` symbol still names its body, which is kept by
+  // adopting those bodies as roots -- and adoption has to rest on facts read from the image, or the
+  // adopted set differs between passes and `.text` moves. The discovery pass finds a different
+  // number of getpc builders each time (it folds the ones it recovers), so counting them here would
+  // let the promise be made where the adoption backing it cannot be, and materialization would then
+  // refuse the object for a symbol nothing emitted.
 
   // Getpc producers whose builder range the recovered-indirect path rewrites.
   //
@@ -2055,11 +2057,6 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     // gating on it adopts a different set the second time round and grows `.text` between passes.
     // An object with neither producer can never claim the permission, so it never turns the strict
     // symbol requirement on and needs none of these roots.
-    const bool object_stores_code_addresses =
-        std::ranges::any_of(
-            relocation_function_tables,
-            [](const RelocationFunctionTable &table) { return !table.entries.empty(); }) ||
-        !relative_text_addend_targets.empty();
     // And only when the object can actually reach the promise: the strict symbol requirement is
     // turned on by admitting an UNRECOVERED indirect transfer, so an object with no indirect
     // transfer at all can never turn it on. Skipping those keeps their scopes the size they were,
@@ -2071,7 +2068,9 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
           const Instruction *term = block->terminator();
           return term != nullptr && (term->flags() & (INDIRECT_BRANCH | INDIRECT_CALL)) != 0;
         });
-    if (object_stores_code_addresses && object_has_indirect_transfer) {
+    // Same predicate the promise uses, so a permission is never granted without the roots
+    // that satisfy it being adopted.
+    if (object_produces_code_addresses && object_has_indirect_transfer) {
       for (const uint64_t target : externally_resolvable_text_function_offsets())
         adopt(target);
     }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -103,6 +103,27 @@ LegalizationLookupFn select_legalization(rj_code_arch_t guest, rj_code_arch_t ho
   return word;
 }
 
+/// @brief Whether only `s_nop 0` padding separates a builder's last word from its consumer.
+///
+/// @details patch_recovered_builder_fixups() regenerates a builder into the canonical getpc-delta
+/// form and NOP-fills the remainder of the source range, and that form is often one word shorter
+/// than the range it replaces. So a builder that ran flush into its consumer before translation
+/// runs into a nop after it. Nothing reads those words and the recovery chain crosses them
+/// unchanged, but an exact-adjacency test does not -- which would make the next pass classify the
+/// same site differently and wrap a consumer this pass deliberately left dynamic, re-growing the
+/// body it had just kept flat. Treat the padding as part of the run.
+[[nodiscard]] bool builder_runs_into_consumer(std::span<const uint8_t> text, uint64_t recovery_end,
+                                              uint64_t call_offset, rj_code_arch_t arch) {
+  if (recovery_end > call_offset || (call_offset - recovery_end) % sizeof(uint32_t) != 0)
+    return false;
+  const uint32_t nop = build_s_nop(0, arch);
+  for (uint64_t offset = recovery_end; offset < call_offset; offset += sizeof(uint32_t)) {
+    if (text_word_at(text, offset) != nop)
+      return false;
+  }
+  return true;
+}
+
 [[nodiscard]] std::unordered_set<uint64_t>
 generated_branch_island_pool_offsets(std::span<const uint8_t> text, rj_code_arch_t arch) {
   std::unordered_set<uint64_t> offsets;
@@ -568,7 +589,8 @@ reachable_kernel_blocks(const std::vector<std::unique_ptr<BasicBlock>> &blocks,
                         const BlockOffsetIndex &block_index,
                         const BlockPositionIndex &block_positions, BasicBlock &entry,
                         const std::unordered_set<uint64_t> &kernel_entries,
-                        const std::unordered_set<uint64_t> &own_entries) {
+                        const std::unordered_set<uint64_t> &own_entries,
+                        const std::unordered_set<uint64_t> &address_taken_entries) {
   std::vector<uint8_t> reachable(blocks.size(), 0);
   std::vector<size_t> reached_indices;
   std::vector<size_t> stack;
@@ -615,8 +637,26 @@ reachable_kernel_blocks(const std::vector<std::unique_ptr<BasicBlock>> &blocks,
     for (const BasicBlock::CallEdge &call : block->call_edges()) {
       BasicBlock *callee = call.callee;
       assert(callee != nullptr && "BasicBlock call edges should always have a callee");
+      // A body whose address is taken is emitted exactly once, as an adopted root, and every
+      // pointer to it names that one copy. Cloning it into each caller's scope would put the same
+      // source offset at several placements and leave relocate_relative_text_addends() choosing
+      // between them -- which is the reasoning kernel_translation_scopes() already documents for
+      // adopted roots, applied here to the callees a relocation-table dispatch reaches.
+      //
+      // Not doing so is a divergence, not merely waste: the addend is rewritten to the canonical
+      // clone, so a later translation gives every dispatch site a call edge to a clone owned by
+      // some other scope, which that scope then clones again. Each pass adds another copy.
+      //
+      // Only the indirect edges may be dropped. A direct s_call_b64 to the same body leaves a
+      // BranchFixup naming that source offset in this scope, and patch_direct_branch_fixups()
+      // resolves it against the kernel-local layout, so dropping the body makes that call
+      // unresolvable. Nothing rewrites a direct call through the addend, so a local clone cannot
+      // create the placement ambiguity the indirect case has.
+      const bool address_taken_indirect_callee =
+          call.kind == BasicBlock::CallEdgeKind::IndirectSwapPc &&
+          address_taken_entries.contains(callee->start_offset());
       if (!own_entries.contains(callee->start_offset()) &&
-          kernel_entries.contains(callee->start_offset()))
+          (kernel_entries.contains(callee->start_offset()) || address_taken_indirect_callee))
         continue;
       push_block(callee);
     }
@@ -646,13 +686,17 @@ reachable_kernel_blocks(const std::vector<std::unique_ptr<BasicBlock>> &blocks,
 [[nodiscard]] std::vector<KernelTranslationScope>
 kernel_translation_scopes(const std::vector<std::unique_ptr<BasicBlock>> &blocks,
                           const BlockOffsetIndex &block_index, std::span<KdTranslation> kernels,
-                          std::span<const uint64_t> adopted_roots = {}) {
+                          std::span<const uint64_t> adopted_roots = {},
+                          const std::unordered_set<uint64_t> *address_taken_entries = nullptr) {
   std::vector<KernelTranslationScope> scopes;
   const auto entries = kernel_entry_offsets(kernels);
   if (entries.empty())
     return scopes;
 
   const BlockPositionIndex block_positions = build_block_position_index(blocks);
+  static const std::unordered_set<uint64_t> kNoAddressTakenEntries;
+  const std::unordered_set<uint64_t> &address_taken =
+      address_taken_entries != nullptr ? *address_taken_entries : kNoAddressTakenEntries;
   const auto hardware_entries = kernel_hardware_entry_offsets(kernels);
   std::unordered_set<uint64_t> entry_set(hardware_entries.begin(), hardware_entries.end());
   std::vector<KdTranslation *> ordered_kernels;
@@ -688,7 +732,7 @@ kernel_translation_scopes(const std::vector<std::unique_ptr<BasicBlock>> &blocks
 
     scopes.push_back({kernel, entry,
                       reachable_kernel_blocks(blocks, block_index, block_positions, *entry,
-                                              entry_set, own_entries)});
+                                              entry_set, own_entries, address_taken)});
   }
   return scopes;
 }
@@ -718,6 +762,11 @@ adopted_root_return_offsets(const BlockOffsetIndex &block_index,
                             std::span<const uint64_t> adopted_roots,
                             std::span<const uint8_t> text) {
   std::unordered_set<uint64_t> returns;
+  // AMDGPU pads between functions rather than ending one with a terminator, so a forward walk from
+  // one root falls straight through into the next. Several pointer-only functions can share a
+  // scope, and crossing that boundary would classify the next root's s_setpc against this root's
+  // entry state. Every other root is therefore a wall for this walk.
+  const std::unordered_set<uint64_t> root_boundaries(adopted_roots.begin(), adopted_roots.end());
   for (const uint64_t root : adopted_roots) {
     BasicBlock *entry = block_for_offset(block_index, root);
     if (entry == nullptr)
@@ -739,8 +788,12 @@ adopted_root_return_offsets(const BlockOffsetIndex &block_index,
           candidates.emplace_back(
               block, static_cast<uint16_t>(text_word_at(text, term->src_loc()) & 0xffu));
       }
-      for (BasicBlock *succ : block->successors())
+      for (BasicBlock *succ : block->successors()) {
+        // A self-recursive root legitimately re-enters its own entry, so only OTHER roots stop it.
+        if (succ != nullptr && succ != entry && root_boundaries.contains(succ->start_offset()))
+          continue;
         stack.push_back(succ);
+      }
     }
 
     // Whether (vgpr, lane) still holds what `v_writelane_b32` put there from `sgpr`, asked at one
@@ -1000,7 +1053,9 @@ adopted_root_return_offsets(const BlockOffsetIndex &block_index,
     std::span<const PcRelativeDataRelocation> data_relocations,
     std::span<const PcRelativeTextRelocation> code_relocations,
     std::span<const KdTranslation> translations, rj_code_arch_t host_arch, uint32_t target_mach,
-    bool require_every_text_symbol_mapped, std::vector<TranslationDiagnostic> &diagnostics) {
+    bool require_every_text_symbol_mapped,
+    const std::unordered_map<uint64_t, uint64_t> &canonical_code_pointer_placement,
+    std::vector<TranslationDiagnostic> &diagnostics) {
   if (translated_text.size() < original_text_size)
     append_nop_padding(translated_text, original_text_size - translated_text.size(), host_arch);
 
@@ -1023,7 +1078,7 @@ adopted_root_return_offsets(const BlockOffsetIndex &block_index,
   }
 
   if (!patcher.replace_text(translated_text, text_relocations, data_relocations, code_relocations,
-                            require_every_text_symbol_mapped)) {
+                            require_every_text_symbol_mapped, &canonical_code_pointer_placement)) {
     append_error(diagnostics, DiagnosticKind::ResourceLimit,
                  "relocated .text could not be materialized safely; leaving code object unchanged");
     return std::nullopt;
@@ -1458,6 +1513,26 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   std::ranges::sort(block_leaders);
   block_leaders.erase(std::ranges::unique(block_leaders).begin(), block_leaders.end());
 
+  // A device function reached only through a pointer is named by no decoded edge, and AMDGPU pads
+  // between functions with s_nop rather than ending the previous one with a terminator. Without
+  // its symbol as a boundary that padding falls through into the function, putting the entry
+  // inside a block -- which is not something a root can be adopted at or an entry state seeded
+  // for.
+  //
+  // These are SPLIT POINTS, not external entries. Nearly all of them are ordinary helpers their
+  // callers reach by a decoded call, and declaring those externally entered would discard the
+  // incoming SGPR-pair facts that call establishes, turning otherwise recoverable getpc flows
+  // unresolved.
+  const auto text_function_symbol_offsets = discover_text_function_symbol_offsets(obj);
+  const auto relative_text_addend_targets =
+      discover_relative_text_addend_targets(obj, text_function_symbol_offsets);
+  std::vector<uint64_t> block_split_points = text_function_symbol_offsets;
+  block_split_points.insert(block_split_points.end(), relative_text_addend_targets.begin(),
+                            relative_text_addend_targets.end());
+  std::ranges::sort(block_split_points);
+  block_split_points.erase(std::ranges::unique(block_split_points).begin(),
+                           block_split_points.end());
+
   // Phase 2: build a CFG over .text, including recovered indirect targets as
   // block leaders, then compute one source-reachable block set per descriptor
   // root. These sets are intentionally kernel-local: if two roots reach the same
@@ -1467,7 +1542,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   std::vector<std::unique_ptr<BasicBlock>> blocks;
   try {
     blocks = BasicBlock::build(obj, *decoder, guest_arch_, block_leaders,
-                               ExternalEntryPolicy::ExplicitOnly);
+                               ExternalEntryPolicy::ExplicitOnly, block_split_points);
   } catch (const util::InvalidInst &error) {
     append_error(result.diagnostics, DiagnosticKind::Legalization, error.what());
     return leave_unchanged();
@@ -1508,11 +1583,33 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
       std::ranges::any_of(
           relocation_function_tables,
           [](const RelocationFunctionTable &table) { return !table.entries.empty(); }) ||
+      // A stored pointer produces a code address whether or not a symbol names the array holding
+      // it. Omitting the anonymous ones made an object whose only producers are those slots look
+      // producerless, so an unresolved indirect consumer took the rejection path even though this
+      // pass discovers, adopts and relocates every one of those addends.
+      !relative_text_addend_targets.empty() ||
       std::ranges::any_of(pc_relative_address_builders,
                           [&](const PcRelativeAddressBuilder &builder) {
                             return builder.target_vaddr >= text_vaddr &&
                                    builder.target_vaddr - text_vaddr < text.size();
                           });
+
+  // Getpc producers whose builder range the recovered-indirect path rewrites.
+  //
+  // The rewrite lattice is not the only thing that relocates a PC-derived value. A long-branch
+  // expansion -- getpc, split 32-bit add pair, setpc -- is recovered as an indirect transfer, and
+  // the translator rewrites that consumer's whole builder range through pending_builder_fixups and
+  // patch_recovered_builder_fixups. The lattice models only the 64-bit-literal add and deliberately
+  // does not see the split pair, so crediting the lattice alone reports such a producer unaccounted
+  // even though the recovery path leaves nothing stale in it. Teaching the lattice the split form
+  // instead would put two rewriters on one range, which patch_recovered_builder_fixups forbids.
+  std::unordered_set<uint64_t> recovery_rewritten_getpc_offsets;
+  for (const auto &block : blocks) {
+    if (block == nullptr)
+      continue;
+    for (const IndirectCallFixup &fixup : block->static_indirect_call_fixups())
+      recovery_rewritten_getpc_offsets.insert(fixup.source_getpc_offset);
+  }
 
   const bool code_addresses_fully_accounted = [&] {
     // Keyed by the value each add produces, not merely by the getpc that seeded it. One getpc can
@@ -1532,6 +1629,13 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
         // resolved the very same value, which is the evidence that a relocation was emitted for it.
         const auto targets = lattice_targets_by_getpc.find(builder.source_getpc_offset);
         const bool lattice_saw_getpc = targets != lattice_targets_by_getpc.end();
+        // The recovery path rewrites this producer's whole range, so whatever it leaves behind is
+        // already relocated and the lattice does not have to have tracked it. A poisoned producer
+        // is still excluded: two irreconcilable values under one getpc mean a sibling add the
+        // recovered consumer does not cover can keep a stale literal.
+        const bool recovery_rewrites_builder =
+            !builder.poisoned &&
+            recovery_rewritten_getpc_offsets.contains(builder.source_getpc_offset);
         if (builder.resolved && builder.contiguous && builder.source_target_offset >= 0) {
           // Both analyses pinned a value, so demand they agree on it. Accepting the getpc merely
           // because some add under it was tracked is what would let a sibling add keep a stale
@@ -1541,6 +1645,21 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
                                        static_cast<uint64_t>(builder.source_target_offset))) {
             continue;
           }
+          // A bare getpc carries no delta, so the two analyses are entitled to disagree about it:
+          // this pass reports the value at the producer's block exit, which for a getpc whose add
+          // lives in a successor is just the raw PC, while the lattice follows the chain to the
+          // address that add finally produces. Neither reading names something stale -- hardware
+          // supplies the relocated PC for the getpc itself, and the add consuming it is the one
+          // the lattice tracked and will rewrite, which is what lattice_saw_getpc attests.
+          // scope_relocatable_pc_builders makes the same carve-out for a bare producer.
+          const bool bare_getpc_value =
+              builder.source_recovery_begin_offset == builder.source_recovery_end_offset &&
+              static_cast<uint64_t>(builder.source_target_offset) ==
+                  builder.source_recovery_begin_offset;
+          if (bare_getpc_value && lattice_saw_getpc)
+            continue;
+          if (recovery_rewrites_builder)
+            continue;
         } else if (lattice_saw_getpc && !builder.poisoned) {
           // This pass gave up -- it only follows producers that reach a setpc -- but the rewrite
           // lattice did track the getpc, and the lattice is what emits the relocation. Its coverage
@@ -1586,7 +1705,16 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
          relocation_function_tables[dispatch.table_index].entries)
       relocation_table_callee_offsets.insert(entry.target_text_offset);
   }
-  auto scopes = kernel_translation_scopes(blocks, block_index, descriptor_translations);
+  // Bodies whose address a pointer can hold. Computed before the scopes because it decides which
+  // callees a scope may clone, and derived only from input-fixed data -- relocation-table slots and
+  // RELATIVE64 addends -- so the partition it produces is the same on every pass.
+  std::unordered_set<uint64_t> address_taken_entries(relocation_table_callee_offsets.begin(),
+                                                     relocation_table_callee_offsets.end());
+  for (const uint64_t target : relative_text_addend_targets)
+    address_taken_entries.insert(target);
+
+  auto scopes = kernel_translation_scopes(blocks, block_index, descriptor_translations, {},
+                                          &address_taken_entries);
 
   if (can_emit_sidecar_descriptors) {
     std::vector<KdTranslation> sidecar_variants;
@@ -1625,7 +1753,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
       descriptor_translations.insert(descriptor_translations.end(),
                                      std::make_move_iterator(sidecar_variants.begin()),
                                      std::make_move_iterator(sidecar_variants.end()));
-      scopes = kernel_translation_scopes(blocks, block_index, descriptor_translations);
+      scopes = kernel_translation_scopes(blocks, block_index, descriptor_translations, {},
+                                         &address_taken_entries);
     }
   }
 
@@ -1664,6 +1793,15 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
       const BasicBlock *entry = note_address_taken(text_offset);
       if (entry == nullptr)
         return;
+      // block_for_offset() answers with the block CONTAINING the offset, so a target naming a
+      // mid-function label -- or an offset inside an instruction -- would otherwise be adopted as
+      // a root and seeded with the ABI's function-entry VGPR_MSB state it never actually has.
+      // Require the target to be exactly where a block starts. Every adopt() caller shares this
+      // guard so relocation slots, relative addends and getpc targets agree on what an entry is.
+      // A rejected target stays noted as address-taken, so the code-address audit still fails
+      // closed on it rather than silently dropping the reference.
+      if (entry->start_offset() != text_offset)
+        return;
       // Only a body no scope reaches needs adopting. One that several scopes clone is left where it
       // is: lowering it through an unrelated scope would deny it the context its real caller
       // supplies -- DS2 mode inference and liveness are scope-relative -- so the ambiguity between
@@ -1677,28 +1815,75 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
       for (const RelocationFunctionPointer &slot : table.entries)
         adopt(slot.target_text_offset);
     }
+    // Every stored function pointer names a body that has to exist after translation, whether or
+    // not its holder was recognized as a table. relocate_relative_text_addends() rewrites each of
+    // these addends to its target's new placement and refuses the object when a target was never
+    // emitted, so adopting them is what turns that refusal into a translation.
+    for (const uint64_t target : relative_text_addend_targets)
+      adopt(target);
+
+    // Everything adopted so far is input-fixed: relocation-table slots and RELATIVE64 addends are
+    // discovered identically whether or not the object has been translated before. What they reach
+    // is therefore knowable before any analysis-derived root is considered, and rebuilding the
+    // scopes here is what lets the getpc loop below ask a meaningful question. Asked of the
+    // pre-adoption scopes it is inert: in a device-linked object those are the kernel trampolines
+    // and reach none of these bodies, so every candidate the old filter let through was adopted
+    // whether it needed a root of its own or not.
+    std::ranges::sort(adopted_roots);
+    adopted_roots.erase(std::ranges::unique(adopted_roots).begin(), adopted_roots.end());
+    const size_t pointer_root_count = adopted_roots.size();
+    if (pointer_root_count != 0) {
+      scopes = kernel_translation_scopes(blocks, block_index, descriptor_translations,
+                                         adopted_roots, &address_taken_entries);
+      emitting_scopes.clear();
+      for (const KernelTranslationScope &scope : scopes)
+        for (const BasicBlock *block : scope.blocks)
+          ++emitting_scopes[block];
+    }
+
     // A getpc that computes a code address makes that body address-taken just as surely as a
     // relocation slot does, so its target has to be accounted for before the rewrite is permitted.
-    // It is deliberately not adopted, though. A relocation slot is a fixed property of the input:
-    // the same eleven slots are discovered whether or not the object has already been translated.
-    // A getpc builder is not -- translation folds the ones it can prove into direct calls, so a
-    // second pass over translated text discovers a different, smaller set. Adopting from that set
-    // would make the scope partition, and therefore the entire `.text` layout, depend on how much
-    // of the previous layout the analysis happened to recover, which is not a fixed point. A
-    // builder target that no scope reaches instead leaves the code address unaccounted for and the
-    // object is refused, which is the conservative outcome rather than a silent stale address.
+    //
+    // Whether it may also be ADOPTED turns on whether anything already emits it. A target reached
+    // by some decoded edge from the input-fixed closure above is emitted by that closure and needs
+    // no root of its own; one reached only through a pointer is not, and is adopted. That question
+    // survives folding, because folding only ever replaces a recovered edge into a body with a
+    // direct edge into the same body -- the closure is unchanged either way.
+    //
+    // Keying on whether recovery still had a consumer for the builder, as this once did, does not
+    // survive it: pass one folds those consumers into one-word direct transfers, so the next pass
+    // finds the same builders with no consumer, stops excluding them, and adopts thousands of
+    // bodies the first pass had merely noted -- moving the scope partition and with it the whole
+    // `.text` layout. This is the shape a separately compiled device library produces: an address
+    // built with getpc, spilled to a VGPR lane, and later called through s_swap_pc_i64, so no
+    // decoded edge names the body. Refusing those would refuse every device-linked object.
     for (const PcRelativeAddressBuilder &builder : pc_relative_address_builders) {
       if (builder.target_vaddr < text_vaddr || builder.target_vaddr - text_vaddr >= text.size())
         continue;
-      note_address_taken(builder.target_vaddr - text_vaddr);
+      const uint64_t target_text_offset = builder.target_vaddr - text_vaddr;
+      // The addend path already intersects its targets with sized STT_FUNC symbols, because a
+      // stored pointer is only known to name a function when a symbol says so. A recovered getpc
+      // target carries no such evidence on its own -- the same construct materializes branch-table
+      // entries and other intra-function labels -- so require a declared entry here too. Without
+      // it, only note the address: that keeps the audit honest and leaves the conservative refusal
+      // in place rather than adopting something that is not a function.
+      if (!std::ranges::binary_search(text_function_symbol_offsets, target_text_offset)) {
+        note_address_taken(target_text_offset);
+        continue;
+      }
+      adopt(target_text_offset);
     }
     std::ranges::sort(adopted_roots);
     adopted_roots.erase(std::ranges::unique(adopted_roots).begin(), adopted_roots.end());
-    if (!adopted_roots.empty()) {
-      scopes =
-          kernel_translation_scopes(blocks, block_index, descriptor_translations, adopted_roots);
+    // Phase A already built the scopes for the pointer roots, so repeat the walk only when the
+    // getpc loop actually added something.
+    if (adopted_roots.size() != pointer_root_count) {
+      scopes = kernel_translation_scopes(blocks, block_index, descriptor_translations,
+                                         adopted_roots, &address_taken_entries);
     }
   }
+  const std::unordered_set<uint64_t> adopted_root_offsets(adopted_roots.begin(),
+                                                          adopted_roots.end());
   const std::unordered_set<uint64_t> adopted_return_offsets =
       adopted_root_return_offsets(block_index, adopted_roots, text);
 
@@ -1893,6 +2078,10 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   // caller also clones still has exactly one address, and that address is stable no matter which
   // scope happens to hold a clone.
   std::unordered_map<uint64_t, uint64_t> canonical_placement;
+  // Which kernel-scope variant supplied each canonical copy, and the offsets whose clones disagree
+  // on that variant. See the nomination site for why a disagreement disqualifies the offset.
+  std::unordered_map<uint64_t, bool> canonical_placement_is_sidecar;
+  std::unordered_set<uint64_t> canonical_placement_variant_conflict;
 
   // Set when a scope hosting a canonical copy had to grow its own descriptor to lower it. See the
   // assignment for why that combination cannot be made safe from inside the scope loop.
@@ -1910,6 +2099,12 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     size_t code_relocations_begin = 0;
     size_t pending_code_relocations_begin = 0;
     std::vector<uint64_t> canonical_placements_added;
+    // Variant conflicts this scope raised. A skipped scope's text is discarded, so the clone it
+    // disagreed about no longer exists; leaving the conflict behind would withhold a canonical
+    // placement whose surviving clones actually agree and refuse the object over a scope that
+    // contributes nothing. The companion is_sidecar entry is restored with it so a later scope
+    // compares against the variant that really nominated the canonical copy.
+    std::vector<uint64_t> canonical_variant_conflicts_added;
     // The resource verdict is set before descriptor recomputation, which can still skip the scope.
     // Rolling the placements back without also restoring this would leave a skipped host's verdict
     // standing and refuse the object over a scope that no longer contributes anything.
@@ -1938,8 +2133,12 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     // records would write a 64-bit literal into instructions that never asked for one.
     code_relocations.resize(relocation_snapshot.code_relocations_begin);
     pending_code_relocations.resize(relocation_snapshot.pending_code_relocations_begin);
-    for (const uint64_t placed : relocation_snapshot.canonical_placements_added)
+    for (const uint64_t placed : relocation_snapshot.canonical_placements_added) {
       canonical_placement.erase(placed);
+      canonical_placement_is_sidecar.erase(placed);
+    }
+    for (const uint64_t conflicted : relocation_snapshot.canonical_variant_conflicts_added)
+      canonical_placement_variant_conflict.erase(conflicted);
     canonical_host_outgrew_its_descriptor =
         relocation_snapshot.canonical_host_outgrew_its_descriptor;
     for (const DescriptorVariantCheckpoint &saved : descriptor_snapshot) {
@@ -1990,6 +2189,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
         .code_relocations_begin = code_relocations.size(),
         .pending_code_relocations_begin = pending_code_relocations.size(),
         .canonical_placements_added = {},
+        .canonical_variant_conflicts_added = {},
         .canonical_host_outgrew_its_descriptor = canonical_host_outgrew_its_descriptor};
     const auto descriptor_snapshot =
         checkpoint_scope_descriptors(descriptor_translations, *scope.translation);
@@ -2111,11 +2311,24 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
       source_block_by_end_offset.emplace(block->end_offset(), block);
     }
 
+    // An adopted body is entered by a call through its address rather than by an edge from this
+    // scope, so the architectural analyses have to be told it is an entry. Without that its blocks
+    // are never reached by the forward fixed point and every VGPR_MSB query over them is
+    // unanswerable, which fails any lowering that has to prove the mode.
+    std::vector<BasicBlock *> scope_adopted_entry_blocks;
+    if (!adopted_root_offsets.empty()) {
+      for (BasicBlock *block : scope.blocks) {
+        if (block != nullptr && adopted_root_offsets.contains(block->start_offset()))
+          scope_adopted_entry_blocks.push_back(block);
+      }
+    }
+
     LivenessAnalysisOptions liveness_options;
     liveness_options.max_free_vgpr =
         static_cast<uint16_t>(isa_properties(host_arch_).max_addressable_vgprs_per_wf);
     liveness_options.arch = guest_arch_;
     liveness_options.entry_block = scope.entry;
+    liveness_options.additional_entry_blocks = scope_adopted_entry_blocks;
     liveness_options.text = text;
     if (options_.debug_min_free_vgpr)
       liveness_options.min_free_vgpr = *options_.debug_min_free_vgpr;
@@ -2171,15 +2384,22 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     };
     auto append_profile_wmma_completion_wait_if_needed = [&](const Instruction &inst,
                                                              std::vector<uint32_t> &words) {
-      if (wmma_completion_wait_vgpr_msb == nullptr) {
-        if (!scope_requires_liveness) {
-          scope_analysis_edges = scoped_call_liveness_edges(KernelBlockScope(scope.blocks), text);
+      // Liveness already built this exact analysis -- same scope, entry, edges, text and adopted
+      // entries -- so reuse it rather than running the fixpoint a second time.
+      const Gfx1250VgprMsbAnalysis *vgpr_msb = liveness.gfx1250_vgpr_msb();
+      if (vgpr_msb == nullptr) {
+        if (wmma_completion_wait_vgpr_msb == nullptr) {
+          if (!scope_requires_liveness) {
+            scope_analysis_edges = scoped_call_liveness_edges(KernelBlockScope(scope.blocks), text);
+          }
+          wmma_completion_wait_vgpr_msb = std::make_unique<Gfx1250VgprMsbAnalysis>(
+              KernelBlockScope(scope.blocks), scope.entry, scope_analysis_edges, text,
+              scope_adopted_entry_blocks);
         }
-        wmma_completion_wait_vgpr_msb = std::make_unique<Gfx1250VgprMsbAnalysis>(
-            KernelBlockScope(scope.blocks), scope.entry, scope_analysis_edges, text);
+        vgpr_msb = wmma_completion_wait_vgpr_msb.get();
       }
       gfx1250_b0_to_a0_append_wmma_completion_wait_if_needed(inst, source_instruction_by_offset,
-                                                             *wmma_completion_wait_vgpr_msb, words);
+                                                             *vgpr_msb, words);
     };
 
     // Raw marker bytes are only candidates. Preserve a pool for this kernel
@@ -2288,6 +2508,11 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
       std::vector<IndirectCallFixup> fixups;
       bool use_transfer_window = false;
       bool preserve_marked_long_transfer = false;
+      /// @brief The builder runs contiguously into this consumer and both are in this scope.
+      ///
+      /// @details Such a window may degenerate to the original dynamic transfer when the relocated
+      /// target is out of direct-branch range, so it is pinned to the consumer's single word.
+      bool builder_is_contiguous = false;
       uint64_t marked_window_begin = 0;
       uint64_t marked_window_end = 0;
       IndirectCallFixup window_fixup;
@@ -2316,6 +2541,30 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     const bool no_stale_pc_values_in_scope = whole_scope_builder_fixups.has_value();
 
     std::vector<IndirectCallFixup> pending_builder_fixups;
+    // Builders whose consumer became a transfer window. Rewritten when this scope emitted them,
+    // skipped when it did not; see the window-conversion site for why absence is benign here.
+    std::vector<IndirectCallFixup> pending_window_builder_fixups;
+    // Indices over this scope's blocks, built once. The window recognizer below asks three
+    // questions per recovered consumer -- is there a block starting strictly between the getpc and
+    // the call, which block ends at the call, and which block starts at it -- and each was a linear
+    // scan of scope.blocks. A device library gives one scope on the order of a million blocks and
+    // tens of thousands of recovered consumers, so those scans dominated translation: they were
+    // ~57% of samples in a perf profile of the 745 MB RCCL image.
+    std::unordered_map<uint64_t, BasicBlock *> scope_block_by_start;
+    std::unordered_map<uint64_t, BasicBlock *> scope_block_by_end;
+    std::vector<uint64_t> scope_block_starts;
+    scope_block_by_start.reserve(scope.blocks.size());
+    scope_block_by_end.reserve(scope.blocks.size());
+    scope_block_starts.reserve(scope.blocks.size());
+    for (BasicBlock *candidate : scope.blocks) {
+      if (candidate == nullptr)
+        continue;
+      scope_block_by_start.emplace(candidate->start_offset(), candidate);
+      scope_block_by_end.emplace(candidate->end_offset(), candidate);
+      scope_block_starts.push_back(candidate->start_offset());
+    }
+    std::ranges::sort(scope_block_starts);
+
     for (auto &[source_call_offset, consumer] : recovered_indirect_by_call) {
       if (consumer.fixups.empty())
         continue;
@@ -2388,7 +2637,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
         const bool contiguous_builder =
             consumer.fixups.size() == 1 && first.source_getpc_offset >= sizeof(uint32_t) &&
             first.source_recovery_begin_offset == first.source_getpc_offset + sizeof(uint32_t) &&
-            first.source_recovery_end_offset == first.source_call_offset &&
+            builder_runs_into_consumer(text, first.source_recovery_end_offset,
+                                       first.source_call_offset, guest_arch_) &&
             first.source_call_offset <= text.size() &&
             sizeof(uint32_t) <= text.size() - first.source_call_offset;
         const auto getpc_it = source_instruction_by_offset.find(first.source_getpc_offset);
@@ -2398,28 +2648,30 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
         const auto call_it = source_instruction_by_offset.find(first.source_call_offset);
         const Instruction *call =
             call_it == source_instruction_by_offset.end() ? nullptr : call_it->second;
+        // Same three predicates as the scans they replace: first block start strictly inside
+        // (getpc, call); the block ending exactly at the call whose start is at or before the
+        // getpc; and the block starting exactly at the call.
+        const auto interior_it =
+            std::ranges::upper_bound(scope_block_starts, first.source_getpc_offset);
         const bool has_interior_block_entry =
-            std::ranges::any_of(scope.blocks, [&](const BasicBlock *candidate) {
-              return candidate->start_offset() > first.source_getpc_offset &&
-                     candidate->start_offset() < first.source_call_offset;
-            });
-        const auto builder_block_it =
-            std::ranges::find_if(scope.blocks, [&](const BasicBlock *candidate) {
-              return candidate->start_offset() <= first.source_getpc_offset &&
-                     candidate->end_offset() == first.source_call_offset;
-            });
-        const auto call_block_it =
-            std::ranges::find_if(scope.blocks, [&](const BasicBlock *candidate) {
-              return candidate->start_offset() == first.source_call_offset;
-            });
+            interior_it != scope_block_starts.end() && *interior_it < first.source_call_offset;
+        const auto builder_entry = scope_block_by_end.find(first.source_call_offset);
+        BasicBlock *builder_block =
+            builder_entry != scope_block_by_end.end() &&
+                    builder_entry->second->start_offset() <= first.source_getpc_offset
+                ? builder_entry->second
+                : nullptr;
+        const auto call_entry = scope_block_by_start.find(first.source_call_offset);
+        BasicBlock *call_block =
+            call_entry != scope_block_by_start.end() ? call_entry->second : nullptr;
         // Recovered consumers are block leaders by construction, so their
         // canonical fallthrough block is expected. Reject only an additional
         // CFG predecessor that can enter at the consumer and bypass the builder.
         const bool has_external_call_entry =
-            builder_block_it == scope.blocks.end() || call_block_it == scope.blocks.end() ||
-            std::ranges::any_of(
-                (*call_block_it)->predecessors(),
-                [&](const BasicBlock *predecessor) { return predecessor != *builder_block_it; });
+            builder_block == nullptr || call_block == nullptr ||
+            std::ranges::any_of(call_block->predecessors(), [&](const BasicBlock *predecessor) {
+              return predecessor != builder_block;
+            });
         const bool canonical_marked_window =
             contiguous_builder && marker != nullptr &&
             marker->size() == static_cast<int>(sizeof(uint32_t)) &&
@@ -2435,6 +2687,42 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
           consumer.marked_window_end = first.source_call_offset + sizeof(uint32_t);
         } else {
           consumer.use_transfer_window = true;
+          // Both blocks come from this scope's own index, so the scope necessarily emits the
+          // builder bytes and the consumer -- which is what makes the fail-closed routing below
+          // safe rather than merely tidy.
+          consumer.builder_is_contiguous =
+              contiguous_builder && !has_interior_block_entry && !has_external_call_entry;
+          // The window recomputes the address itself, so the builder feeding this consumer is now
+          // dead -- but it is still emitted, and skipping the rewrite below would leave it holding
+          // a delta measured against the body's old position. Harmless to run, since the window
+          // supersedes it, yet indistinguishable on a later pass from a live producer of an
+          // unrelocated code address, which is what made translation non-idempotent.
+          //
+          // Rewriting is the fix rather than erasing: patch_recovered_builder_fixups replaces the
+          // range with the canonical getpc-delta form, which both names the relocated target and
+          // is the shape the rewrite lattice models, so a later pass accounts for it instead of
+          // reporting an unrelocated producer. It cannot collide with the window, which occupies
+          // the consumer rather than the builder range, and owned_by_recovered_builder() keeps the
+          // lattice from writing the same range twice.
+          //
+          // Kept apart from pending_builder_fixups because absence means something different here.
+          // A consumer's own builder must be present or the rewrite it depends on is missing, but
+          // recovery runs over all of `.text` while a scope emits only its own blocks, so a window
+          // consumer can name a builder this scope never emitted. There is nothing stale in bytes
+          // that were not written, and the scope that does emit them rewrites them itself.
+          if (consumer.builder_is_contiguous) {
+            // This window can degenerate to the original dynamic transfer, so its builder is
+            // load-bearing rather than dead. pending_builder_fixups fails closed on a range it
+            // cannot map; the window list silently skips, which would leave the transfer jumping
+            // to a stale address with no diagnostic.
+            pending_builder_fixups.insert(pending_builder_fixups.end(), consumer.fixups.begin(),
+                                          consumer.fixups.end());
+          } else {
+            for (IndirectCallFixup window_builder : consumer.fixups) {
+              window_builder.consumer_replaced_by_window = true;
+              pending_window_builder_fixups.push_back(window_builder);
+            }
+          }
         }
       } else {
         pending_builder_fixups.insert(pending_builder_fixups.end(), consumer.fixups.begin(),
@@ -2479,6 +2767,12 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     uint64_t next_branch_island_pool_offset = first_direct_branch_island_pool_offset();
     struct ActiveMarkedLongTransfer {
       uint64_t source_end = 0;
+      // The window is reserved at a fixed size and regenerated into exactly those bytes, so the
+      // source-to-target map is a pure translation of slope 1 across it. Keeping both ends lets a
+      // block boundary that lands INSIDE the window be mapped affinely instead of falling back to
+      // the running output size, which overshoots to the window's end.
+      uint64_t source_begin = 0;
+      uint64_t target_begin = 0;
     };
     std::optional<ActiveMarkedLongTransfer> active_marked_long_transfer;
     struct ActiveGeneratedIslandPool {
@@ -2633,6 +2927,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
           append_nop_padding(kernel_text, window_bytes, host_arch_);
           active_marked_long_transfer = {
               .source_end = consumer.marked_window_end,
+              .source_begin = consumer.marked_window_begin,
+              .target_begin = target_offset,
           };
           continue;
         }
@@ -2787,7 +3083,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
                .target_window_offset = target_offset,
                .target_sreg = source_fixup.source_call_sreg,
                .return_sreg = source_fixup.source_return_sreg,
-               .is_call = source_fixup.source_is_call});
+               .is_call = source_fixup.source_is_call,
+               .keep_dynamic_when_long = recovered_it->second.builder_is_contiguous});
           append_nop_padding(kernel_text, sizeof(uint32_t), host_arch_);
           continue;
         }
@@ -3034,8 +3331,26 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
                        "with a synthesized s_endpgm boundary",
                        block->end_offset());
       }
+      // A block can END inside a preserved marked long-transfer window: the recognizer only
+      // accepts the window when some block's end_offset() is exactly the consumer offset, which is
+      // window-interior. The window's own instructions are skipped during emission, so
+      // kernel_text.size() has already advanced past the whole reserved window and would place
+      // that boundary one consumer word too far. Map it affinely instead -- the window is
+      // reserved and regenerated at a fixed size, so slope 1 is exact, and it agrees with
+      // kernel_text.size() at the window end where that answer was already right.
+      //
+      // The stale entry was observable: a FUNC symbol ending at the consumer had its st_size
+      // rounded up by one word on re-translation, and the same overshoot would misplace an
+      // st_value or a RELATIVE64 addend naming that offset.
+      const bool ends_inside_marked_window =
+          active_marked_long_transfer &&
+          block->end_offset() >= active_marked_long_transfer->source_begin &&
+          block->end_offset() <= active_marked_long_transfer->source_end;
       placement.target_end =
-          block_generated_island_pool &&
+          ends_inside_marked_window
+              ? active_marked_long_transfer->target_begin +
+                    (block->end_offset() - active_marked_long_transfer->source_begin)
+          : block_generated_island_pool &&
                   block->end_offset() <= block_generated_island_pool->source_end
               ? block_generated_island_pool->target_begin +
                     (block->end_offset() - block_generated_island_pool->source_begin)
@@ -3055,7 +3370,34 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     if (continue_after_failure && has_error_diagnostic(result.diagnostics))
       continue;
 
+    // A preserved marked window is itself a getpc-plus-delta sequence, so re-translating our own
+    // output finds a textbook builder inside one. Whoever claims it -- a multi-target consumer's
+    // recovered fixup or the whole-scope proof -- the claim cannot be honored and must not be:
+    // emission skips the window's interior precisely because the patch layer regenerates the whole
+    // window from recovered_indirect_fixups with an already-relocated delta, so those source
+    // offsets have no one-to-one target. Rewriting the range would fight the regeneration; there
+    // is no stale value in bytes that were never emitted. Claiming them produced a spurious
+    // "builder is not fully present in the relocated body" refusal on a second pass.
+    // Collected once and binary-searched, not rescanned per fixup: a scope can hold tens of
+    // thousands of recovered consumers, and the membership test below runs for every fixup.
+    // Windows are disjoint, so sorting by start makes the containing candidate the last one that
+    // begins at or before the query.
+    std::vector<std::pair<uint64_t, uint64_t>> preserved_marked_windows;
+    for (const auto &entry : recovered_indirect_by_call) {
+      const RecoveredConsumer &consumer = entry.second;
+      if (consumer.preserve_marked_long_transfer)
+        preserved_marked_windows.emplace_back(consumer.marked_window_begin,
+                                              consumer.marked_window_end);
+    }
+    std::ranges::sort(preserved_marked_windows);
+    const auto inside_preserved_marked_window = [&](uint64_t getpc_offset) {
+      const auto it = std::ranges::upper_bound(preserved_marked_windows, getpc_offset, {},
+                                               &std::pair<uint64_t, uint64_t>::first);
+      return it != preserved_marked_windows.begin() && getpc_offset < std::prev(it)->second;
+    };
     for (IndirectCallFixup fixup : pending_builder_fixups) {
+      if (inside_preserved_marked_window(fixup.source_getpc_offset))
+        continue;
       const auto getpc_it = target_offset_by_source_offset.find(fixup.source_getpc_offset);
       const auto begin_it = target_offset_by_source_offset.find(fixup.source_recovery_begin_offset);
       const auto end_it = target_offset_by_source_offset.find(fixup.source_recovery_end_offset);
@@ -3082,6 +3424,23 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     }
     if (skip_scope)
       continue;
+
+    for (IndirectCallFixup fixup : pending_window_builder_fixups) {
+      if (inside_preserved_marked_window(fixup.source_getpc_offset))
+        continue;
+      const auto getpc_it = target_offset_by_source_offset.find(fixup.source_getpc_offset);
+      const auto begin_it = target_offset_by_source_offset.find(fixup.source_recovery_begin_offset);
+      const auto end_it = target_offset_by_source_offset.find(fixup.source_recovery_end_offset);
+      if (getpc_it == target_offset_by_source_offset.end() ||
+          begin_it == target_offset_by_source_offset.end() ||
+          end_it == target_offset_by_source_offset.end()) {
+        continue;
+      }
+      fixup.target_getpc_offset = getpc_it->second;
+      fixup.target_recovery_begin_offset = begin_it->second;
+      fixup.target_recovery_end_offset = end_it->second;
+      layout.recovered_builder_fixups.push_back(fixup);
+    }
 
     // Resolve control flow against the kernel-local body before materializing
     // it in the output section. Direct and recovered-indirect transfers both
@@ -3166,6 +3525,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
               .source_offset = patched_control_flow.source_offset,
               .required_windows = {},
               .message = "control-flow layout growth did not converge",
+              .compact_builder_fallbacks = {},
           };
           break;
         }
@@ -3179,15 +3539,19 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
               .source_offset = patched_control_flow.source_offset,
               .required_windows = {},
               .message = "control-flow layout returned an invalid growth request",
+              .compact_builder_fallbacks = {},
           };
           break;
         }
+        // One entry per instruction in the scope, so rescanning the insertion list for each is
+        // quadratic; share one prefix-summed rebaser across the whole sweep instead.
+        const TextOffsetRebaser rebaser(*insertions);
         for (auto &[source_offset, target_offset] : target_offset_by_source_offset) {
           (void)source_offset;
-          rebase_text_offset(target_offset, *insertions);
+          rebaser.rebase(target_offset);
         }
         for (PendingTrace &trace : pending_traces)
-          rebase_text_offset(trace.target_offset, *insertions);
+          rebaser.rebase(trace.target_offset);
         remaining_growth_words -= requested_growth_words;
       } else if (!layout.long_branch_sgpr) {
         auto sgpr = reserve_long_branch_sgpr_pair(kernel_context);
@@ -3200,6 +3564,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
               .message =
                   "long direct branch requires an additional descriptor-backed SGPR pair after "
                   "semantic expansion",
+              .compact_builder_fallbacks = {},
           };
           break;
         }
@@ -3228,6 +3593,17 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
                               text_relocations_begin, data_relocations_begin, relocation_snapshot))
         continue;
       return leave_unchanged();
+    } else {
+      // Say so here rather than let a later pass refuse the object with nothing naming the cause.
+      // The object emitted now is correct; what it has lost is a builder the relocation lattice
+      // can see, which only bites if an unrecovered indirect transfer also survives.
+      for (const uint64_t source_call_offset : patched.compact_builder_fallbacks) {
+        append_warning(result.diagnostics, DiagnosticKind::ResourceLimit,
+                       "recovered indirect branch builder did not fit the canonical literal64 form "
+                       "and fell back to the compact add; it is invisible to relocation analysis "
+                       "on a later translation",
+                       source_call_offset);
+      }
     }
 
     auto materialized =
@@ -3243,12 +3619,27 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     const uint64_t target_delta = materialized.target_delta;
     // kernel_translation_scopes() gives the adopted roots to the first scope it builds, so that is
     // the scope whose placements are canonical.
+    const bool scope_is_sidecar =
+        scope.translation != nullptr && scope.translation->sidecar_descriptor;
     for (const uint64_t taken : address_taken_offsets) {
       const auto placed = target_offset_by_source_offset.find(taken);
       if (placed == target_offset_by_source_offset.end())
         continue;
-      if (canonical_placement.try_emplace(taken, placed->second + target_delta).second)
+      if (canonical_placement.try_emplace(taken, placed->second + target_delta).second) {
         relocation_snapshot.canonical_placements_added.push_back(taken);
+        canonical_placement_is_sidecar[taken] = scope_is_sidecar;
+        continue;
+      }
+      // Nominating one clone canonical only works when the clones are interchangeable. A
+      // virtual-LDS sidecar clone is lowered against a different LDS model than its hardware-LDS
+      // twin, so a pointer that reached the wrong one would run the wrong lowering. Record the
+      // disagreement and keep those offsets out of the canonical map so the addend path stays
+      // fail-closed for exactly the case the clones are not equivalent.
+      const auto variant = canonical_placement_is_sidecar.find(taken);
+      if (variant != canonical_placement_is_sidecar.end() && variant->second != scope_is_sidecar &&
+          canonical_placement_variant_conflict.insert(taken).second) {
+        relocation_snapshot.canonical_variant_conflicts_added.push_back(taken);
+      }
     }
     for (const auto &[source_offset, target_offset] : target_offset_by_source_offset) {
       text_relocations.push_back(
@@ -3386,9 +3777,15 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     // budget that was never raised. Nothing here can raise that kernel's descriptor -- it may
     // already be translated, and its own recompute happens inside its own scope -- so record the
     // condition and refuse below rather than emit a descriptor that under-provisions a real caller.
+    //
+    // Only a resource the target descriptor actually encodes can under-provision a caller. On
+    // GFX10+ the wavefront SGPR count is a reserved field, so the decoded 8 is the granule-0
+    // artifact rather than a budget, and a long-branch thunk needing an SGPR pair above it raises
+    // nothing and starves nobody. VGPR and private are encoded on every target and still count.
     if (!relocation_snapshot.canonical_placements_added.empty() &&
         (kernel_context.required_vgpr_count > kernel_context.num_vgprs ||
-         kernel_context.required_sgpr_count > kernel_context.num_sgprs ||
+         (arch_descriptor_encodes_sgpr_allocation(host_arch_) &&
+          kernel_context.required_sgpr_count > kernel_context.num_sgprs) ||
          kernel_context.required_private_segment_fixed_size >
              kernel_context.private_segment_fixed_size)) {
       canonical_host_outgrew_its_descriptor = true;
@@ -3582,10 +3979,19 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
 
   // Phase 6 commits the completed translation plan without mixing ELF mutation
   // and sidecar metadata construction into the per-kernel lowering transaction.
+  // A stored function pointer must name the canonical copy of its target. Offsets whose clones
+  // disagreed on kernel-scope variant are withheld, which leaves the addend path fail-closed for
+  // them exactly as before.
+  std::unordered_map<uint64_t, uint64_t> canonical_code_pointer_placement;
+  for (const auto &[source_offset, target_offset] : canonical_placement) {
+    if (!canonical_placement_variant_conflict.contains(source_offset))
+      canonical_code_pointer_placement.emplace(source_offset, target_offset);
+  }
+
   auto materialized = materialize_translated_code_object(
       std::move(patcher), std::move(translated_text), text.size(), text_relocations,
       data_relocations, code_relocations, descriptor_translations, host_arch_, target_mach_,
-      relied_on_relocated_by_construction, result.diagnostics);
+      relied_on_relocated_by_construction, canonical_code_pointer_placement, result.diagnostics);
   if (!materialized)
     return leave_unchanged();
   result.elf_bytes = std::move(*materialized);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -149,6 +149,21 @@ kernarg_supplied_indirect_targets(std::span<BasicBlock *const> blocks, const Bas
       std::ranges::find(blocks, entry) == blocks.end())
     return offsets;
 
+  // The only fact this function can produce is attached to an indirect transfer, so a scope with
+  // none has nothing to say. Checking first avoids running the fixpoint -- an InstDefUse and two
+  // RegisterSet expansions per instruction, per predecessor edge, per sweep -- to build an answer
+  // that is empty by construction. The consumer asks per instruction and its cheaper disjunct is
+  // usually false, so without this the fixpoint runs for effectively every scope of every object;
+  // it measured as the whole of a 22% translation-time regression. An indirect transfer ends its
+  // block, so the terminator is the only place it can be.
+  if (std::ranges::none_of(blocks, [](const BasicBlock *block) {
+        if (block == nullptr)
+          return false;
+        const Instruction *term = block->terminator();
+        return term != nullptr && (term->flags() & (INDIRECT_BRANCH | INDIRECT_CALL)) != 0;
+      }))
+    return offsets;
+
   // Pair-low registers holding the kernarg segment pointer, and those holding a value loaded
   // through it. Tracked separately: only the first may be a load base, only the second may be a
   // transfer target.
@@ -175,19 +190,20 @@ kernarg_supplied_indirect_targets(std::span<BasicBlock *const> blocks, const Bas
   // instruction's full def set rather than a destination operand, so a wide load clears the pairs
   // above it and a def of one half clears the pair it belongs to.
   const auto kill_defs = [&](const Instruction &inst, PairState &state) {
+    if (state.pointer.empty() && state.loaded.empty())
+      return;
     const InstDefUse def_use(inst);
-    for (size_t lo = 0; lo + 1 < REGISTER_SET_MAX_SGPRS; ++lo) {
-      const RegisterRef low{.cls = RegClass::SGPR, .index = static_cast<uint16_t>(lo), .width = 1};
+    // Only the pairs actually being tracked can be killed, and there are a handful at most.
+    // Sweeping the whole SGPR file instead cost two RegisterSet::contains() calls per register per
+    // instruction per sweep, which profiled as half of all translation time.
+    const auto pair_is_defined = [&](uint16_t lo) {
+      const RegisterRef low{.cls = RegClass::SGPR, .index = lo, .width = 1};
       const RegisterRef high{
           .cls = RegClass::SGPR, .index = static_cast<uint16_t>(lo + 1), .width = 1};
-      if (!def_use.defs.contains(low) && !def_use.defs.contains(high))
-        continue;
-      // Writing either half destroys this pair, and only this pair. The pair below is reached on
-      // its own iteration and tested against its own halves -- erasing it here as well would let a
-      // write to s82 destroy s[80:81], which shares no register with it.
-      state.pointer.erase(static_cast<uint16_t>(lo));
-      state.loaded.erase(static_cast<uint16_t>(lo));
-    }
+      return def_use.defs.contains(low) || def_use.defs.contains(high);
+    };
+    std::erase_if(state.pointer, pair_is_defined);
+    std::erase_if(state.loaded, pair_is_defined);
   };
 
   const auto transfer = [&](BasicBlock *block, PairState state, bool record) {
@@ -1716,9 +1732,21 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   // DOES define device functions drags in the rest of that problem -- those bodies would have to be
   // adopted as roots or they are dropped, and their resource envelope propagated into every
   // descriptor that can enter them. Where the object defines none, that obligation is vacuous.
-  const bool object_defines_no_device_function = object_defines_only_kernels(obj);
-  const auto externally_resolvable_text_function_offsets =
-      discover_externally_resolvable_text_function_offsets(obj);
+  // Both walk the whole symbol table, and most objects never reach the code that needs them, so
+  // pay for them on first use. Doing it eagerly cost about 2x the translation time across the
+  // packaged-HSACO corpus -- enough on its own to exhaust the sanitizer job's budget.
+  std::optional<bool> object_defines_no_device_function_cache;
+  const auto object_defines_no_device_function = [&] {
+    if (!object_defines_no_device_function_cache)
+      object_defines_no_device_function_cache = object_defines_only_kernels(obj);
+    return *object_defines_no_device_function_cache;
+  };
+  std::optional<std::vector<uint64_t>> externally_resolvable_cache;
+  const auto externally_resolvable_text_function_offsets = [&]() -> const std::vector<uint64_t> & {
+    if (!externally_resolvable_cache)
+      externally_resolvable_cache = discover_externally_resolvable_text_function_offsets(obj);
+    return *externally_resolvable_cache;
+  };
   const auto relative_text_addend_targets =
       discover_relative_text_addend_targets(obj, text_function_symbol_offsets);
   std::vector<uint64_t> block_split_points = text_function_symbol_offsets;
@@ -2032,8 +2060,19 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
             relocation_function_tables,
             [](const RelocationFunctionTable &table) { return !table.entries.empty(); }) ||
         !relative_text_addend_targets.empty();
-    if (object_stores_code_addresses) {
-      for (const uint64_t target : externally_resolvable_text_function_offsets)
+    // And only when the object can actually reach the promise: the strict symbol requirement is
+    // turned on by admitting an UNRECOVERED indirect transfer, so an object with no indirect
+    // transfer at all can never turn it on. Skipping those keeps their scopes the size they were,
+    // which matters because every later analysis is proportional to blocks emitted.
+    const bool object_has_indirect_transfer =
+        std::ranges::any_of(blocks, [](const std::unique_ptr<BasicBlock> &block) {
+          if (block == nullptr)
+            return false;
+          const Instruction *term = block->terminator();
+          return term != nullptr && (term->flags() & (INDIRECT_BRANCH | INDIRECT_CALL)) != 0;
+        });
+    if (object_stores_code_addresses && object_has_indirect_transfer) {
+      for (const uint64_t target : externally_resolvable_text_function_offsets())
         adopt(target);
     }
 
@@ -2047,7 +2086,18 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     std::ranges::sort(adopted_roots);
     adopted_roots.erase(std::ranges::unique(adopted_roots).begin(), adopted_roots.end());
     const size_t pointer_root_count = adopted_roots.size();
-    if (pointer_root_count != 0) {
+    // The rebuild exists solely so the getpc loop below can ask "does the pointer closure already
+    // emit this?". With no getpc naming an in-text address that loop adopts nothing, so the walk --
+    // a full reachability pass per kernel over every block -- would be paid for an answer nobody
+    // reads. Most objects are in that case, and under a sanitizer the difference is the corpus
+    // job's time budget.
+    const bool has_in_text_getpc_target = std::ranges::any_of(
+        pc_relative_address_builders, [&](const PcRelativeAddressBuilder &builder) {
+          return builder.target_vaddr >= text_vaddr &&
+                 builder.target_vaddr - text_vaddr < text.size();
+        });
+    const bool rebuilt_for_pointer_roots = pointer_root_count != 0 && has_in_text_getpc_target;
+    if (rebuilt_for_pointer_roots) {
       scopes = kernel_translation_scopes(blocks, block_index, descriptor_translations,
                                          adopted_roots, &address_taken_entries);
       emitting_scopes.clear();
@@ -2090,9 +2140,10 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     }
     std::ranges::sort(adopted_roots);
     adopted_roots.erase(std::ranges::unique(adopted_roots).begin(), adopted_roots.end());
-    // Phase A already built the scopes for the pointer roots, so repeat the walk only when the
-    // getpc loop actually added something.
-    if (adopted_roots.size() != pointer_root_count) {
+    // Phase A builds the scopes for the pointer roots only when it had a reason to. Repeat the
+    // walk when it did not, or when the getpc loop added roots on top of what it built.
+    if (!adopted_roots.empty() &&
+        (!rebuilt_for_pointer_roots || adopted_roots.size() != pointer_root_count)) {
       scopes = kernel_translation_scopes(blocks, block_index, descriptor_translations,
                                          adopted_roots, &address_taken_entries);
     }
@@ -2719,10 +2770,18 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     // An adopted root's return is validated from its own body rather than from a call site, so it
     // is added here for whichever scope ended up carrying that body.
     valid_call_return_offsets.insert(adopted_return_offsets.begin(), adopted_return_offsets.end());
-    const std::unordered_set<uint64_t> kernarg_supplied_targets =
-        object_defines_no_device_function && scope.translation != nullptr
-            ? kernarg_supplied_indirect_targets(scope.blocks, scope.entry, *scope.translation)
-            : std::unordered_set<uint64_t>{};
+    // Only an unrecovered indirect transfer ever asks this, and most scopes have none, so run the
+    // fixpoint on first question rather than for every scope.
+    std::optional<std::unordered_set<uint64_t>> kernarg_supplied_cache;
+    const auto kernarg_supplied_targets = [&]() -> const std::unordered_set<uint64_t> & {
+      if (!kernarg_supplied_cache) {
+        kernarg_supplied_cache =
+            scope.translation != nullptr && object_defines_no_device_function()
+                ? kernarg_supplied_indirect_targets(scope.blocks, scope.entry, *scope.translation)
+                : std::unordered_set<uint64_t>{};
+      }
+      return *kernarg_supplied_cache;
+    };
     struct RecoveredConsumer {
       std::vector<IndirectCallFixup> fixups;
       bool use_transfer_window = false;
@@ -3192,7 +3251,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
         // relocate_text_symbols() tolerates so debug labels in padding do not refuse the object.
         const bool target_is_relocated_by_construction =
             (object_produces_code_addresses && code_addresses_fully_accounted) ||
-            kernarg_supplied_targets.contains(offset);
+            kernarg_supplied_targets().contains(offset);
         if ((inst.flags() & (INDIRECT_BRANCH | INDIRECT_CALL)) != 0 &&
             !has_recovered_indirect_call && !has_relocation_table_call &&
             !recovered_indirect_return && !direct_branch_delta &&

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -139,9 +139,14 @@ LegalizationLookupFn select_legalization(rj_code_arch_t guest, rj_code_arch_t ho
 /// the pair is kernarg-loaded and from a latch where it was clobbered must not inherit the
 /// preheader's answer, and the transfers this admits sit inside exactly such loops.
 [[nodiscard]] std::unordered_set<uint64_t>
-kernarg_supplied_indirect_targets(std::span<BasicBlock *const> blocks, const KdTranslation &kd) {
+kernarg_supplied_indirect_targets(std::span<BasicBlock *const> blocks, const BasicBlock *entry,
+                                  const KdTranslation &kd) {
   std::unordered_set<uint64_t> offsets;
-  if (!kd.source_has_kernarg_segment_ptr || blocks.empty())
+  // reachable_kernel_blocks() orders by offset, so blocks.front() can be a backward-reachable
+  // helper or an adopted body rather than the scope entry. Seeding that block with the ABI's
+  // kernarg fact would fabricate provenance for a pair the entry never established.
+  if (!kd.source_has_kernarg_segment_ptr || blocks.empty() || entry == nullptr ||
+      std::ranges::find(blocks, entry) == blocks.end())
     return offsets;
 
   // Pair-low registers holding the kernarg segment pointer, and those holding a value loaded
@@ -249,17 +254,23 @@ kernarg_supplied_indirect_targets(std::span<BasicBlock *const> blocks, const KdT
   // answer; a predecessor without one is treated as TOP and simply skipped by the meet.
   std::unordered_map<const BasicBlock *, PairState> entry_state;
   std::unordered_set<const BasicBlock *> computed;
-  entry_state[blocks.front()] = seed;
-  computed.insert(blocks.front());
+  entry_state[entry] = seed;
+  computed.insert(entry);
 
   // Sweep to a fixpoint rather than draining a change-driven worklist: a block popped before its
   // predecessors were known would otherwise be dropped and never requeued. The lattice is finite
   // and every step is monotone, so the sweep count is a guard, not a semantic bound.
+  //
+  // The guard is not a convergence bound -- this is a descending product lattice and a state can
+  // keep losing facts for more sweeps than the block count -- so exhausting it means the answer is
+  // still an over-approximation. Treating that as proof would admit a transfer the true fixpoint
+  // would have refused, so give up and claim nothing instead.
   const size_t sweep_cap = blocks.size() + 2;
+  bool converged = false;
   for (size_t sweep = 0; sweep < sweep_cap; ++sweep) {
     bool changed = false;
     for (BasicBlock *block : blocks) {
-      if (block == nullptr || block == blocks.front())
+      if (block == nullptr || block == entry)
         continue;
       PairState in;
       bool seeded = false;
@@ -285,9 +296,13 @@ kernarg_supplied_indirect_targets(std::span<BasicBlock *const> blocks, const KdT
         changed = true;
       }
     }
-    if (!changed)
+    if (!changed) {
+      converged = true;
       break;
+    }
   }
+  if (!converged)
+    return offsets;
 
   for (BasicBlock *block : blocks) {
     const auto it = block == nullptr ? entry_state.end() : entry_state.find(block);
@@ -1702,6 +1717,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   // adopted as roots or they are dropped, and their resource envelope propagated into every
   // descriptor that can enter them. Where the object defines none, that obligation is vacuous.
   const bool object_defines_no_device_function = object_defines_only_kernels(obj);
+  const auto externally_resolvable_text_function_offsets =
+      discover_externally_resolvable_text_function_offsets(obj);
   const auto relative_text_addend_targets =
       discover_relative_text_addend_targets(obj, text_function_symbol_offsets);
   std::vector<uint64_t> block_split_points = text_function_symbol_offsets;
@@ -1999,6 +2016,26 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     // emitted, so adopting them is what turns that refusal into a translation.
     for (const uint64_t target : relative_text_addend_targets)
       adopt(target);
+    // Admitting an unrecovered transfer promises that every externally resolvable `.text` symbol
+    // still names its body afterwards -- that promise is what lets an outside holder of a code
+    // address keep it. replace_text() enforces it and refuses when such a symbol has no mapping,
+    // so a body no kernel reaches has to be adopted here or the promise cannot be kept. Symbols
+    // are a fixed property of the input, so this leaves the partition a fixed point.
+    // Gated on the two producers that are pure ELF facts -- a relocation function table and a
+    // RELATIVE64 addend are read from the image, not recovered -- so the adopted set is the same on
+    // every pass. code_addresses_fully_accounted must NOT appear here: it is analysis-derived, so
+    // gating on it adopts a different set the second time round and grows `.text` between passes.
+    // An object with neither producer can never claim the permission, so it never turns the strict
+    // symbol requirement on and needs none of these roots.
+    const bool object_stores_code_addresses =
+        std::ranges::any_of(
+            relocation_function_tables,
+            [](const RelocationFunctionTable &table) { return !table.entries.empty(); }) ||
+        !relative_text_addend_targets.empty();
+    if (object_stores_code_addresses) {
+      for (const uint64_t target : externally_resolvable_text_function_offsets)
+        adopt(target);
+    }
 
     // Everything adopted so far is input-fixed: relocation-table slots and RELATIVE64 addends are
     // discovered identically whether or not the object has been translated before. What they reach
@@ -2684,7 +2721,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     valid_call_return_offsets.insert(adopted_return_offsets.begin(), adopted_return_offsets.end());
     const std::unordered_set<uint64_t> kernarg_supplied_targets =
         object_defines_no_device_function && scope.translation != nullptr
-            ? kernarg_supplied_indirect_targets(scope.blocks, *scope.translation)
+            ? kernarg_supplied_indirect_targets(scope.blocks, scope.entry, *scope.translation)
             : std::unordered_set<uint64_t>{};
     struct RecoveredConsumer {
       std::vector<IndirectCallFixup> fixups;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -171,8 +171,8 @@ kernarg_supplied_indirect_targets(std::span<BasicBlock *const> blocks, const KdT
   // above it and a def of one half clears the pair it belongs to.
   const auto kill_defs = [&](const Instruction &inst, PairState &state) {
     const InstDefUse def_use(inst);
-    for (uint16_t lo = 0; lo + 1 < REGISTER_SET_MAX_SGPRS; ++lo) {
-      const RegisterRef low{.cls = RegClass::SGPR, .index = lo, .width = 1};
+    for (size_t lo = 0; lo + 1 < REGISTER_SET_MAX_SGPRS; ++lo) {
+      const RegisterRef low{.cls = RegClass::SGPR, .index = static_cast<uint16_t>(lo), .width = 1};
       const RegisterRef high{
           .cls = RegClass::SGPR, .index = static_cast<uint16_t>(lo + 1), .width = 1};
       if (!def_use.defs.contains(low) && !def_use.defs.contains(high))
@@ -180,8 +180,8 @@ kernarg_supplied_indirect_targets(std::span<BasicBlock *const> blocks, const KdT
       // Writing either half destroys this pair, and only this pair. The pair below is reached on
       // its own iteration and tested against its own halves -- erasing it here as well would let a
       // write to s82 destroy s[80:81], which shares no register with it.
-      state.pointer.erase(lo);
-      state.loaded.erase(lo);
+      state.pointer.erase(static_cast<uint16_t>(lo));
+      state.loaded.erase(static_cast<uint16_t>(lo));
     }
   };
 
@@ -229,8 +229,8 @@ kernarg_supplied_indirect_targets(std::span<BasicBlock *const> blocks, const KdT
       if (has_pair_dst && loads_through_kernarg && dst_width >= 2) {
         // Only an even-aligned pair wholly inside the loaded range is addressable as a 64-bit
         // transfer operand, so s_load_b96 s[80:82] yields (80,81) and b128 s[80:83] adds (82,83).
-        for (uint16_t lo = dst_lo; lo + 1 < dst_lo + dst_width; lo += 2)
-          state.loaded.insert(lo);
+        for (unsigned lo = dst_lo; lo + 1u < unsigned{dst_lo} + dst_width; lo += 2)
+          state.loaded.insert(static_cast<uint16_t>(lo));
       }
       if (has_pair_dst && copies_pointer && dst_width == 2)
         state.pointer.insert(dst_lo);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -3,6 +3,7 @@
 
 #include "rocjitsu/code/dbt/binary_translator.h"
 
+#include "rocjitsu/analysis/def_use_chain.h"
 #include "rocjitsu/analysis/exec_state.h"
 #include "rocjitsu/analysis/gfx1250_vgpr_msb.h"
 #include "rocjitsu/analysis/liveness.h"
@@ -41,6 +42,7 @@
 #include <array>
 #include <cassert>
 #include <cstring>
+#include <deque>
 #include <functional>
 #include <iterator>
 #include <limits>
@@ -122,6 +124,177 @@ LegalizationLookupFn select_legalization(rj_code_arch_t guest, rj_code_arch_t ho
       return false;
   }
   return true;
+}
+
+/// @brief Indirect transfers in one scope whose target pair was loaded from the kernarg segment.
+///
+/// @details A target this object never computed and never stored still has a provenance when it
+/// arrives through kernarg: the host wrote it, and the only `.text` address a host can hold is one
+/// it read from a symbol, which relocate_text_symbols() rewrites. That is a positive fact about
+/// this operand. It is deliberately not the weaker claim that the object produces no code address
+/// at all -- an undefined live-in also satisfies that, and it has no supplier whatsoever, so
+/// admitting it would accept on absence of evidence.
+///
+/// A meet-over-predecessors fixpoint, not a linear scan. A block reached from a preheader where
+/// the pair is kernarg-loaded and from a latch where it was clobbered must not inherit the
+/// preheader's answer, and the transfers this admits sit inside exactly such loops.
+[[nodiscard]] std::unordered_set<uint64_t>
+kernarg_supplied_indirect_targets(std::span<BasicBlock *const> blocks, const KdTranslation &kd) {
+  std::unordered_set<uint64_t> offsets;
+  if (!kd.source_has_kernarg_segment_ptr || blocks.empty())
+    return offsets;
+
+  // Pair-low registers holding the kernarg segment pointer, and those holding a value loaded
+  // through it. Tracked separately: only the first may be a load base, only the second may be a
+  // transfer target.
+  struct PairState {
+    std::set<uint16_t> pointer;
+    std::set<uint16_t> loaded;
+    bool operator==(const PairState &other) const {
+      return pointer == other.pointer && loaded == other.loaded;
+    }
+  };
+
+  const auto pair_operand = [](const Operand *operand, uint16_t &lo, uint16_t &width) {
+    if (operand == nullptr)
+      return false;
+    const auto ref = operand->to_register_ref();
+    if (!ref || ref->cls != RegClass::SGPR)
+      return false;
+    lo = ref->index;
+    width = ref->width;
+    return true;
+  };
+
+  // Every even-aligned pair start whose whole pair the instruction defines. Driven from the
+  // instruction's full def set rather than a destination operand, so a wide load clears the pairs
+  // above it and a def of one half clears the pair it belongs to.
+  const auto kill_defs = [&](const Instruction &inst, PairState &state) {
+    const InstDefUse def_use(inst);
+    for (uint16_t lo = 0; lo + 1 < REGISTER_SET_MAX_SGPRS; ++lo) {
+      const RegisterRef low{.cls = RegClass::SGPR, .index = lo, .width = 1};
+      const RegisterRef high{
+          .cls = RegClass::SGPR, .index = static_cast<uint16_t>(lo + 1), .width = 1};
+      if (!def_use.defs.contains(low) && !def_use.defs.contains(high))
+        continue;
+      // Writing either half destroys this pair, and only this pair. The pair below is reached on
+      // its own iteration and tested against its own halves -- erasing it here as well would let a
+      // write to s82 destroy s[80:81], which shares no register with it.
+      state.pointer.erase(lo);
+      state.loaded.erase(lo);
+    }
+  };
+
+  const auto transfer = [&](BasicBlock *block, PairState state, bool record) {
+    for (const Instruction &inst : block->instructions()) {
+      const uint64_t flags = inst.flags();
+      const bool is_transfer = (flags & (INDIRECT_BRANCH | INDIRECT_CALL)) != 0;
+      if (is_transfer && record) {
+        // s_setpc takes the target as its only source; s_swappc takes the return pair first.
+        for (int i = 0; i < inst.num_src_operands(); ++i) {
+          uint16_t lo = 0;
+          uint16_t width = 0;
+          if (pair_operand(inst.src_operand(i), lo, width) && width == 2 &&
+              state.loaded.contains(lo)) {
+            offsets.insert(inst.src_loc());
+            break;
+          }
+        }
+      }
+
+      uint16_t base_lo = 0;
+      uint16_t base_width = 0;
+      const bool loads_through_kernarg =
+          inst.mnemonic().starts_with("s_load_b") && inst.num_src_operands() >= 1 &&
+          pair_operand(inst.src_operand(0), base_lo, base_width) && state.pointer.contains(base_lo);
+      uint16_t copy_lo = 0;
+      uint16_t copy_width = 0;
+      const bool copies_pointer = inst.mnemonic() == "s_mov_b64" && inst.num_src_operands() == 1 &&
+                                  pair_operand(inst.src_operand(0), copy_lo, copy_width) &&
+                                  copy_width == 2 && state.pointer.contains(copy_lo);
+
+      uint16_t dst_lo = 0;
+      uint16_t dst_width = 0;
+      const bool has_pair_dst =
+          inst.num_dst_operands() == 1 && pair_operand(inst.dst_operand(0), dst_lo, dst_width);
+
+      kill_defs(inst, state);
+
+      // A call clobbers everything the ABI does not preserve, direct or indirect alike.
+      if ((flags & INDIRECT_CALL) != 0 || inst.mnemonic().starts_with("s_call")) {
+        std::erase_if(state.pointer, [](uint16_t lo) { return !is_callee_saved_sgpr(lo); });
+        std::erase_if(state.loaded, [](uint16_t lo) { return !is_callee_saved_sgpr(lo); });
+      }
+
+      if (has_pair_dst && loads_through_kernarg && dst_width >= 2) {
+        // Only an even-aligned pair wholly inside the loaded range is addressable as a 64-bit
+        // transfer operand, so s_load_b96 s[80:82] yields (80,81) and b128 s[80:83] adds (82,83).
+        for (uint16_t lo = dst_lo; lo + 1 < dst_lo + dst_width; lo += 2)
+          state.loaded.insert(lo);
+      }
+      if (has_pair_dst && copies_pointer && dst_width == 2)
+        state.pointer.insert(dst_lo);
+    }
+    return state;
+  };
+
+  const std::unordered_set<const BasicBlock *> in_scope(blocks.begin(), blocks.end());
+  PairState seed;
+  seed.pointer.insert(kd.kernarg_segment_ptr_sgpr);
+
+  // A must-analysis has to start every non-entry block at TOP, not at the empty set. Starting
+  // empty and intersecting is starting at BOTTOM: the meet can never grow a fact back, so a block
+  // whose predecessors had not been visited yet would be pinned empty for the rest of the run and
+  // the transfer it guards would never be admitted. `computed` marks which blocks hold a real
+  // answer; a predecessor without one is treated as TOP and simply skipped by the meet.
+  std::unordered_map<const BasicBlock *, PairState> entry_state;
+  std::unordered_set<const BasicBlock *> computed;
+  entry_state[blocks.front()] = seed;
+  computed.insert(blocks.front());
+
+  // Sweep to a fixpoint rather than draining a change-driven worklist: a block popped before its
+  // predecessors were known would otherwise be dropped and never requeued. The lattice is finite
+  // and every step is monotone, so the sweep count is a guard, not a semantic bound.
+  const size_t sweep_cap = blocks.size() + 2;
+  for (size_t sweep = 0; sweep < sweep_cap; ++sweep) {
+    bool changed = false;
+    for (BasicBlock *block : blocks) {
+      if (block == nullptr || block == blocks.front())
+        continue;
+      PairState in;
+      bool seeded = false;
+      for (const BasicBlock *predecessor : block->predecessors()) {
+        if (!in_scope.contains(predecessor) || !computed.contains(predecessor))
+          continue;
+        PairState exit =
+            transfer(const_cast<BasicBlock *>(predecessor), entry_state[predecessor], false);
+        if (!seeded) {
+          in = std::move(exit);
+          seeded = true;
+          continue;
+        }
+        std::erase_if(in.pointer, [&](uint16_t lo) { return !exit.pointer.contains(lo); });
+        std::erase_if(in.loaded, [&](uint16_t lo) { return !exit.loaded.contains(lo); });
+      }
+      if (!seeded)
+        continue;
+      const auto it = entry_state.find(block);
+      if (it == entry_state.end() || !(it->second == in)) {
+        entry_state[block] = std::move(in);
+        computed.insert(block);
+        changed = true;
+      }
+    }
+    if (!changed)
+      break;
+  }
+
+  for (BasicBlock *block : blocks) {
+    const auto it = block == nullptr ? entry_state.end() : entry_state.find(block);
+    if (it != entry_state.end())
+      transfer(block, it->second, true);
+  }
+  return offsets;
 }
 
 [[nodiscard]] std::unordered_set<uint64_t>
@@ -1524,6 +1697,11 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   // incoming SGPR-pair facts that call establishes, turning otherwise recoverable getpc flows
   // unresolved.
   const auto text_function_symbol_offsets = discover_text_function_symbol_offsets(obj);
+  // Fences the kernarg admission below. Admitting an externally supplied pointer in an object that
+  // DOES define device functions drags in the rest of that problem -- those bodies would have to be
+  // adopted as roots or they are dropped, and their resource envelope propagated into every
+  // descriptor that can enter them. Where the object defines none, that obligation is vacuous.
+  const bool object_defines_no_device_function = object_defines_only_kernels(obj);
   const auto relative_text_addend_targets =
       discover_relative_text_addend_targets(obj, text_function_symbol_offsets);
   std::vector<uint64_t> block_split_points = text_function_symbol_offsets;
@@ -2504,6 +2682,10 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     // An adopted root's return is validated from its own body rather than from a call site, so it
     // is added here for whichever scope ended up carrying that body.
     valid_call_return_offsets.insert(adopted_return_offsets.begin(), adopted_return_offsets.end());
+    const std::unordered_set<uint64_t> kernarg_supplied_targets =
+        object_defines_no_device_function && scope.translation != nullptr
+            ? kernarg_supplied_indirect_targets(scope.blocks, *scope.translation)
+            : std::unordered_set<uint64_t>{};
     struct RecoveredConsumer {
       std::vector<IndirectCallFixup> fixups;
       bool use_transfer_window = false;
@@ -2972,7 +3154,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
         // plus a byte offset, and a symbol that is present but unreferenced, which
         // relocate_text_symbols() tolerates so debug labels in padding do not refuse the object.
         const bool target_is_relocated_by_construction =
-            object_produces_code_addresses && code_addresses_fully_accounted;
+            (object_produces_code_addresses && code_addresses_fully_accounted) ||
+            kernarg_supplied_targets.contains(offset);
         if ((inst.flags() & (INDIRECT_BRANCH | INDIRECT_CALL)) != 0 &&
             !has_recovered_indirect_call && !has_relocation_table_call &&
             !recovered_indirect_return && !direct_branch_delta &&

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.cpp
@@ -311,7 +311,7 @@ constexpr uint16_t kTtmpRdna4GridX = 9;
 }
 
 [[nodiscard]] bool uses_gfx10_plus_rsrc3(rj_code_arch_t arch) {
-  return arch_is_rdna(arch) || arch == ROCJITSU_CODE_ARCH_GFX1250;
+  return !arch_descriptor_encodes_sgpr_allocation(arch);
 }
 
 [[nodiscard]] std::optional<uint32_t>

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
@@ -584,9 +584,21 @@ void grow_text_function_symbols(std::vector<uint8_t> &image, const Elf64_Ehdr &e
       // An unreferenced symbol normally may stay unmapped, because debug and tooling tables
       // legitimately label padding this translation does not emit. When the caller is relying on
       // every `.text` address being relocated, that tolerance is a hole: a host can resolve such a
-      // symbol and hand the stale address back in, so nothing may stay unmapped.
+      // symbol and hand the stale address back in, so such a symbol may not stay unmapped.
+      //
+      // The hole is only as wide as what a host can actually resolve, which is external linkage.
+      // A local symbol names a compilation-unit-private body that no loader interface hands out,
+      // so its address can only come from this object's own getpc builders or relocation addends --
+      // and those are exactly what the caller's claim already accounts for, the builders through
+      // the code-address audit and the addends through relocate_relative_text_addends(), which
+      // still fails closed on an addend it cannot map. Requiring local symbols to map too would
+      // refuse every separately compiled device library: RCCL's gfx1250 object carries 21446
+      // function symbols, of which 12 are global, and its unreferenced locals are dead bodies no
+      // scope needs to emit.
+      const bool externally_resolvable =
+          elf_symbol_is_externally_resolvable(symbol.st_info, symbol.st_other);
       const bool must_relocate =
-          require_every_text_symbol_mapped ||
+          (require_every_text_symbol_mapped && externally_resolvable) ||
           (referenced != referenced_by_symtab.end() && referenced->second.contains(i));
 
       uint64_t source_text_offset = symbol.st_value;
@@ -594,6 +606,15 @@ void grow_text_function_symbols(std::vector<uint8_t> &image, const Elf64_Ehdr &e
         if (symbol.st_value < text.sh_addr) {
           if (must_relocate)
             return false;
+          // The body this symbol names was not emitted, so its old st_value now points into
+          // whatever got relocated onto that address. Left alone it masquerades as a function entry
+          // on re-translation -- passing the sized-STT_FUNC filter and being adopted as a root that
+          // the first pass never had. Undefine it instead: a symbol with no body is exactly what
+          // this is, and saying so keeps the next pass's view identical to this one's.
+          symbol.st_shndx = SHN_UNDEF;
+          symbol.st_value = 0;
+          symbol.st_size = 0;
+          std::memcpy(image.data() + symbol_offset, &symbol, sizeof(symbol));
           continue;
         }
         source_text_offset = symbol.st_value - text.sh_addr;
@@ -601,12 +622,30 @@ void grow_text_function_symbols(std::vector<uint8_t> &image, const Elf64_Ehdr &e
       if (source_text_offset > old_text_size) {
         if (must_relocate)
           return false;
+        // The body this symbol names was not emitted, so its old st_value now points into
+        // whatever got relocated onto that address. Left alone it masquerades as a function entry
+        // on re-translation -- passing the sized-STT_FUNC filter and being adopted as a root that
+        // the first pass never had. Undefine it instead: a symbol with no body is exactly what
+        // this is, and saying so keeps the next pass's view identical to this one's.
+        symbol.st_shndx = SHN_UNDEF;
+        symbol.st_value = 0;
+        symbol.st_size = 0;
+        std::memcpy(image.data() + symbol_offset, &symbol, sizeof(symbol));
         continue;
       }
       const auto relocated_start = target_by_source.find(source_text_offset);
       if (relocated_start == target_by_source.end()) {
         if (must_relocate)
           return false;
+        // The body this symbol names was not emitted, so its old st_value now points into
+        // whatever got relocated onto that address. Left alone it masquerades as a function entry
+        // on re-translation -- passing the sized-STT_FUNC filter and being adopted as a root that
+        // the first pass never had. Undefine it instead: a symbol with no body is exactly what
+        // this is, and saying so keeps the next pass's view identical to this one's.
+        symbol.st_shndx = SHN_UNDEF;
+        symbol.st_value = 0;
+        symbol.st_size = 0;
+        std::memcpy(image.data() + symbol_offset, &symbol, sizeof(symbol));
         continue;
       }
 
@@ -626,11 +665,11 @@ void grow_text_function_symbols(std::vector<uint8_t> &image, const Elf64_Ehdr &e
   return true;
 }
 
-[[nodiscard]] bool
-relocate_relative_text_addends(std::vector<uint8_t> &image, const Elf64_Ehdr &ehdr,
-                               std::span<const Elf64_Shdr> shdrs, size_t text_index,
-                               uint64_t old_text_size, uint64_t new_text_size,
-                               std::span<const TextOffsetRelocation> relocations) {
+[[nodiscard]] bool relocate_relative_text_addends(
+    std::vector<uint8_t> &image, const Elf64_Ehdr &ehdr, std::span<const Elf64_Shdr> shdrs,
+    size_t text_index, uint64_t old_text_size, uint64_t new_text_size,
+    std::span<const TextOffsetRelocation> relocations,
+    const std::unordered_map<uint64_t, uint64_t> *canonical_code_pointer_placement) {
   if (relocations.empty() || ehdr.e_type != ET_DYN)
     return true;
 
@@ -680,20 +719,42 @@ relocate_relative_text_addends(std::vector<uint8_t> &image, const Elf64_Ehdr &eh
       if (source_offset >= old_text_size)
         continue;
 
-      // This addend IS dereferenced as a function pointer. If its source block
-      // was emitted at conflicting placements across scopes, no single rewrite is
-      // correct — fail closed rather than pick an arbitrary clone.
-      if (conflicting_sources.contains(source_offset))
+      // This addend IS dereferenced as a function pointer. If its source block was emitted at
+      // conflicting placements across scopes, nothing drawn from the placement map alone is the
+      // right answer -- a pointer holds one value and cannot choose between clones. The translator
+      // settles that by nominating one clone canonical for each address-taken body, which is the
+      // copy every stored pointer must name. Use it when the caller supplied one, and keep failing
+      // closed when it did not.
+      uint64_t canonical_target = 0;
+      bool have_canonical = false;
+      if (canonical_code_pointer_placement != nullptr) {
+        const auto canonical = canonical_code_pointer_placement->find(source_offset);
+        if (canonical != canonical_code_pointer_placement->end()) {
+          canonical_target = canonical->second;
+          have_canonical = true;
+        }
+      }
+      if (conflicting_sources.contains(source_offset) && !have_canonical)
         return false;
       const auto relocated = target_by_source.find(source_offset);
       // Leaving an in-text addend unchanged would silently preserve a stale PC.
       // Compatibility was established from the relocation form, but final
       // materialization must also prove that this exact target was emitted.
+      //
+      // The proof is unconditional. A canonical entry says WHICH clone a stored pointer must name
+      // when several were emitted; it is not evidence that any was. This helper takes the
+      // canonical map as an independent input, so treating a canonical hit as its own proof would
+      // let a stale or fabricated entry through -- the translator happens to derive both from the
+      // same placements today, which is not something this function can check.
       if (relocated == target_by_source.end())
         return false;
-      if (relocated->second > std::numeric_limits<uint64_t>::max() - text.sh_addr)
+      const uint64_t placement = have_canonical ? canonical_target : relocated->second;
+      // Whichever clone was chosen still has to lie inside the text actually emitted.
+      if (placement > new_text_size)
         return false;
-      const uint64_t target_addend = text.sh_addr + relocated->second;
+      if (placement > std::numeric_limits<uint64_t>::max() - text.sh_addr)
+        return false;
+      const uint64_t target_addend = text.sh_addr + placement;
       if (target_addend > static_cast<uint64_t>(std::numeric_limits<int64_t>::max()))
         return false;
       rela.r_addend = static_cast<int64_t>(target_addend);
@@ -1112,11 +1173,12 @@ bool CodeObjectPatcher::has_unsupported_relocation_to_text() const {
   return false;
 }
 
-bool CodeObjectPatcher::replace_text(std::span<const uint8_t> new_text,
-                                     std::span<const TextOffsetRelocation> text_relocations,
-                                     std::span<const PcRelativeDataRelocation> data_relocations,
-                                     std::span<const PcRelativeTextRelocation> code_relocations,
-                                     bool require_every_text_symbol_mapped) {
+bool CodeObjectPatcher::replace_text(
+    std::span<const uint8_t> new_text, std::span<const TextOffsetRelocation> text_relocations,
+    std::span<const PcRelativeDataRelocation> data_relocations,
+    std::span<const PcRelativeTextRelocation> code_relocations,
+    bool require_every_text_symbol_mapped,
+    const std::unordered_map<uint64_t, uint64_t> *canonical_code_pointer_placement) {
   // Keep fail-closed behavior for callers that assume word-aligned executable
   // sections; accepting a non-word-aligned replacement can break downstream
   // PC-relative patching and branch-distance checks.
@@ -1282,7 +1344,8 @@ bool CodeObjectPatcher::replace_text(std::span<const uint8_t> new_text,
     return false;
   }
   if (!relocate_relative_text_addends(image_, header, shdrs, *text_index, text_size_,
-                                      new_text.size(), text_relocations)) {
+                                      new_text.size(), text_relocations,
+                                      canonical_code_pointer_placement)) {
     return false;
   }
   // Instrumentation appends a cave without relocating the original body and

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
@@ -612,11 +612,17 @@ void grow_text_function_symbols(std::vector<uint8_t> &image, const Elf64_Ehdr &e
           // the first pass never had. Undefine it instead: a symbol with no body is exactly what
           // this is, and saying so keeps the next pass's view identical to this one's.
           // An externally resolvable symbol is part of this object's interface -- HSA hands out
-          // indirect-function symbols -- so silently turning one into SHN_UNDEF would delete an
-          // exported entry, and would also change what object_defines_only_kernels() sees on the
-          // next pass and with it the kernarg fence. Refuse instead; only a symbol nothing outside
-          // can name may be dropped. Leaving it as it was is the behaviour that predates this
-          // rewrite.
+          // indirect-function symbols -- so undefining one would delete an exported entry, and
+          // would also change what object_defines_only_kernels() sees on the next pass and with it
+          // the kernarg fence. Only a symbol nothing outside can name may be dropped.
+          //
+          // This is reached only with strict mapping off, so nothing in this translation rests on
+          // the promise that the symbol still names its body: an object that could make that
+          // promise adopts these bodies up front, under the same predicate that grants it.
+          // Refusing here instead was tried and is too strong -- it rejects objects that translate
+          // correctly and never claimed anything about the symbol. What is left open is that its
+          // st_value is now stale, which a later pass could rediscover as a sized STT_FUNC at an
+          // offset that has moved; that hazard predates this change and is not closed here.
           if (externally_resolvable)
             continue;
           symbol.st_shndx = SHN_UNDEF;
@@ -636,11 +642,17 @@ void grow_text_function_symbols(std::vector<uint8_t> &image, const Elf64_Ehdr &e
         // the first pass never had. Undefine it instead: a symbol with no body is exactly what
         // this is, and saying so keeps the next pass's view identical to this one's.
         // An externally resolvable symbol is part of this object's interface -- HSA hands out
-        // indirect-function symbols -- so silently turning one into SHN_UNDEF would delete an
-        // exported entry, and would also change what object_defines_only_kernels() sees on the
-        // next pass and with it the kernarg fence. Refuse instead; only a symbol nothing outside
-        // can name may be dropped. Leaving it as it was is the behaviour that predates this
-        // rewrite.
+        // indirect-function symbols -- so undefining one would delete an exported entry, and would
+        // also change what object_defines_only_kernels() sees on the next pass and with it the
+        // kernarg fence. Only a symbol nothing outside can name may be dropped.
+        //
+        // This is reached only with strict mapping off, so nothing in this translation rests on the
+        // promise that the symbol still names its body: an object that could make that promise
+        // adopts these bodies up front, under the same predicate that grants it. Refusing here
+        // instead was tried and is too strong -- it rejects objects that translate correctly and
+        // never claimed anything about the symbol. What is left open is that its st_value is now
+        // stale, which a later pass could rediscover as a sized STT_FUNC at an offset that has
+        // moved; that hazard predates this change and is not closed here.
         if (externally_resolvable)
           continue;
         symbol.st_shndx = SHN_UNDEF;
@@ -659,11 +671,17 @@ void grow_text_function_symbols(std::vector<uint8_t> &image, const Elf64_Ehdr &e
         // the first pass never had. Undefine it instead: a symbol with no body is exactly what
         // this is, and saying so keeps the next pass's view identical to this one's.
         // An externally resolvable symbol is part of this object's interface -- HSA hands out
-        // indirect-function symbols -- so silently turning one into SHN_UNDEF would delete an
-        // exported entry, and would also change what object_defines_only_kernels() sees on the
-        // next pass and with it the kernarg fence. Refuse instead; only a symbol nothing outside
-        // can name may be dropped. Leaving it as it was is the behaviour that predates this
-        // rewrite.
+        // indirect-function symbols -- so undefining one would delete an exported entry, and would
+        // also change what object_defines_only_kernels() sees on the next pass and with it the
+        // kernarg fence. Only a symbol nothing outside can name may be dropped.
+        //
+        // This is reached only with strict mapping off, so nothing in this translation rests on the
+        // promise that the symbol still names its body: an object that could make that promise
+        // adopts these bodies up front, under the same predicate that grants it. Refusing here
+        // instead was tried and is too strong -- it rejects objects that translate correctly and
+        // never claimed anything about the symbol. What is left open is that its st_value is now
+        // stale, which a later pass could rediscover as a sized STT_FUNC at an offset that has
+        // moved; that hazard predates this change and is not closed here.
         if (externally_resolvable)
           continue;
         symbol.st_shndx = SHN_UNDEF;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
@@ -611,6 +611,14 @@ void grow_text_function_symbols(std::vector<uint8_t> &image, const Elf64_Ehdr &e
           // on re-translation -- passing the sized-STT_FUNC filter and being adopted as a root that
           // the first pass never had. Undefine it instead: a symbol with no body is exactly what
           // this is, and saying so keeps the next pass's view identical to this one's.
+          // An externally resolvable symbol is part of this object's interface -- HSA hands out
+          // indirect-function symbols -- so silently turning one into SHN_UNDEF would delete an
+          // exported entry, and would also change what object_defines_only_kernels() sees on the
+          // next pass and with it the kernarg fence. Refuse instead; only a symbol nothing outside
+          // can name may be dropped. Leaving it as it was is the behaviour that predates this
+          // rewrite.
+          if (externally_resolvable)
+            continue;
           symbol.st_shndx = SHN_UNDEF;
           symbol.st_value = 0;
           symbol.st_size = 0;
@@ -627,6 +635,14 @@ void grow_text_function_symbols(std::vector<uint8_t> &image, const Elf64_Ehdr &e
         // on re-translation -- passing the sized-STT_FUNC filter and being adopted as a root that
         // the first pass never had. Undefine it instead: a symbol with no body is exactly what
         // this is, and saying so keeps the next pass's view identical to this one's.
+        // An externally resolvable symbol is part of this object's interface -- HSA hands out
+        // indirect-function symbols -- so silently turning one into SHN_UNDEF would delete an
+        // exported entry, and would also change what object_defines_only_kernels() sees on the
+        // next pass and with it the kernarg fence. Refuse instead; only a symbol nothing outside
+        // can name may be dropped. Leaving it as it was is the behaviour that predates this
+        // rewrite.
+        if (externally_resolvable)
+          continue;
         symbol.st_shndx = SHN_UNDEF;
         symbol.st_value = 0;
         symbol.st_size = 0;
@@ -642,6 +658,14 @@ void grow_text_function_symbols(std::vector<uint8_t> &image, const Elf64_Ehdr &e
         // on re-translation -- passing the sized-STT_FUNC filter and being adopted as a root that
         // the first pass never had. Undefine it instead: a symbol with no body is exactly what
         // this is, and saying so keeps the next pass's view identical to this one's.
+        // An externally resolvable symbol is part of this object's interface -- HSA hands out
+        // indirect-function symbols -- so silently turning one into SHN_UNDEF would delete an
+        // exported entry, and would also change what object_defines_only_kernels() sees on the
+        // next pass and with it the kernarg fence. Refuse instead; only a symbol nothing outside
+        // can name may be dropped. Leaving it as it was is the behaviour that predates this
+        // rewrite.
+        if (externally_resolvable)
+          continue;
         symbol.st_shndx = SHN_UNDEF;
         symbol.st_value = 0;
         symbol.st_size = 0;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.h
@@ -11,6 +11,7 @@
 #include <optional>
 #include <span>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 namespace rocjitsu {
@@ -92,11 +93,13 @@ public:
   /// the executable LOAD segment that contains .text, preserves LOAD alignment,
   /// updates moved symbols and relocation places, and keeps descriptor-relative
   /// entries coherent with explicit descriptor patches applied by DBT.
-  [[nodiscard]] bool replace_text(std::span<const uint8_t> new_text,
-                                  std::span<const TextOffsetRelocation> text_relocations = {},
-                                  std::span<const PcRelativeDataRelocation> data_relocations = {},
-                                  std::span<const PcRelativeTextRelocation> code_relocations = {},
-                                  bool require_every_text_symbol_mapped = false);
+  [[nodiscard]] bool replace_text(
+      std::span<const uint8_t> new_text,
+      std::span<const TextOffsetRelocation> text_relocations = {},
+      std::span<const PcRelativeDataRelocation> data_relocations = {},
+      std::span<const PcRelativeTextRelocation> code_relocations = {},
+      bool require_every_text_symbol_mapped = false,
+      const std::unordered_map<uint64_t, uint64_t> *canonical_code_pointer_placement = nullptr);
 
   /// @brief True if any relocation's place (r_offset) falls inside .text.
   ///

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/kernel_text_layout.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/kernel_text_layout.cpp
@@ -44,7 +44,8 @@ relocation_error(uint64_t source_offset, std::string message,
           .reason = reason,
           .source_offset = source_offset,
           .required_windows = {},
-          .message = std::move(message)};
+          .message = std::move(message),
+          .compact_builder_fallbacks = {}};
 }
 
 [[nodiscard]] KernelTextAppendResult
@@ -341,6 +342,18 @@ KernelTextAppendResult append_relocated_kernel_text(std::vector<uint8_t> &transl
     }
   }
 
+  if (fixup.keep_dynamic_when_long) {
+    // The builder immediately ahead was rewritten in place to the relocated target, so the
+    // original transfer already lands correctly and needs no window at all. Emitting one would
+    // cost five words and leave an unmarked getpc/add/consumer triple for the next pass to wrap.
+    // One word in, one word out, so the reserved window is exact and .text cannot change size.
+    if (fixup.is_call)
+      words.push_back(build_s_swappc_b64(fixup.return_sreg, fixup.target_sreg, arch));
+    else
+      words.push_back(build_s_setpc_b64(fixup.target_sreg, arch));
+    return true;
+  }
+
   // Every long recovered transfer carries the same non-padding marker. A later
   // pass can then preserve the exact window even if CFG compaction has brought
   // its target back within direct SOPP range.
@@ -409,6 +422,30 @@ void rebase_text_offset(uint64_t &offset, std::span<const TextLayoutInsertion> i
       break;
     offset += insertion.size;
   }
+}
+
+TextOffsetRebaser::TextOffsetRebaser(std::span<const TextLayoutInsertion> insertions) {
+  assert(std::ranges::is_sorted(
+      insertions, {}, [](const TextLayoutInsertion &insertion) { return insertion.offset; }));
+  offsets_.reserve(insertions.size());
+  shifts_.reserve(insertions.size());
+  uint64_t running = 0;
+  for (const TextLayoutInsertion &insertion : insertions) {
+    running += insertion.size;
+    offsets_.push_back(insertion.offset);
+    shifts_.push_back(running);
+  }
+}
+
+void TextOffsetRebaser::rebase(uint64_t &offset) const {
+  // Same result as rebase_text_offset(): add every insertion at or before this offset. Done as a
+  // prefix sum plus one binary search rather than a scan, because the scan is called once per
+  // block bound and per fixup, which made it quadratic in a large scope -- 11% of translation time
+  // on a 745 MB device image.
+  const auto it = std::ranges::upper_bound(offsets_, offset);
+  if (it == offsets_.begin())
+    return;
+  offset += shifts_[static_cast<size_t>(std::distance(offsets_.begin(), it)) - 1];
 }
 
 std::optional<std::vector<TextLayoutInsertion>>
@@ -517,22 +554,23 @@ grow_control_flow_windows(std::vector<uint8_t> &text, KernelTextLayout &layout,
     }
   }
 
+  const TextOffsetRebaser rebaser(insertions);
   for (BlockPlacement &block : layout.blocks) {
-    rebase_text_offset(block.target_start, insertions);
-    rebase_text_offset(block.target_end, insertions);
+    rebaser.rebase(block.target_start);
+    rebaser.rebase(block.target_end);
   }
   for (BranchFixup &fixup : layout.branch_fixups)
-    rebase_text_offset(fixup.target_inst_offset, insertions);
+    rebaser.rebase(fixup.target_inst_offset);
   for (RecoveredIndirectFixup &fixup : layout.recovered_indirect_fixups)
-    rebase_text_offset(fixup.target_window_offset, insertions);
+    rebaser.rebase(fixup.target_window_offset);
   for (IndirectCallFixup &fixup : layout.recovered_builder_fixups) {
-    rebase_text_offset(fixup.target_getpc_offset, insertions);
-    rebase_text_offset(fixup.target_recovery_begin_offset, insertions);
-    rebase_text_offset(fixup.target_recovery_end_offset, insertions);
+    rebaser.rebase(fixup.target_getpc_offset);
+    rebaser.rebase(fixup.target_recovery_begin_offset);
+    rebaser.rebase(fixup.target_recovery_end_offset);
   }
   for (uint64_t &slot : layout.branch_island_slots)
-    rebase_text_offset(slot, insertions);
-  rebase_text_offset(layout.body_end, insertions);
+    rebaser.rebase(slot);
+  rebaser.rebase(layout.body_end);
 
   text = std::move(grown_text);
   return insertions;
@@ -952,6 +990,7 @@ TextRelocationResult patch_recovered_builder_fixups(std::vector<uint8_t> &text,
                                                     const KernelTextLayout &layout,
                                                     rj_code_arch_t arch) {
   std::unordered_map<uint64_t, std::tuple<uint64_t, uint64_t, bool>> rewritten_regions;
+  std::vector<uint64_t> compact_builder_fallbacks;
   for (const IndirectCallFixup &fixup : layout.recovered_builder_fixups) {
     auto target_target = target_for_source_offset(layout, fixup.source_target_offset);
     if (!target_target) {
@@ -1013,11 +1052,39 @@ TextRelocationResult patch_recovered_builder_fixups(std::vector<uint8_t> &text,
       }
       replacement_words.push_back(*drain);
     }
-    if (!append_pc_delta_builder(replacement_words, arch, fixup.source_call_sreg, delta)) {
+    // Emit the literal64 add form. This builder survives into the output, so a later translation
+    // pass has to be able to account for it, and the relocation lattice models only that encoding
+    // -- it cannot be widened to the compact one, because the patcher writes an eight-byte delta
+    // into the literal slot.
+    //
+    // Every rewritten builder gets the wide form, not just the ones whose consumer became a
+    // window. Which builders still have a consumer on the NEXT pass is not knowable here -- a
+    // whole-scope fixup has none to begin with, and a recovered consumer can disappear into a
+    // direct transfer -- so predicting who needs to stay visible gets it wrong. Widening
+    // unconditionally and falling back when it does not fit is both simpler and measurably
+    // better: on RCCL it takes the unaccounted-builder count on re-translation from 32 to 0.
+    const size_t replacement_begin = replacement_words.size();
+    if (!append_pc_delta_builder(replacement_words, arch, fixup.source_call_sreg, delta,
+                                 /*prefer_literal64=*/true)) {
       return relocation_error(
           fixup.source_call_offset,
           "target ISA cannot encode canonical recovered indirect branch builder",
           TextLayoutFailureCategory::ResourceLimit);
+    }
+    // The wide form does not always fit a range sized for the compact one. Falling back keeps the
+    // builder correct and keeps objects that translate today translating; what it gives up is
+    // visibility to the lattice, which only matters if an unrecovered indirect transfer also
+    // survives into this object -- and in that case the next pass refuses rather than accepting
+    // something wrong. Widening the range is not available here: the patcher writes in place.
+    if ((replacement_words.size() * sizeof(uint32_t)) > recovery_size) {
+      replacement_words.resize(replacement_begin);
+      if (!append_pc_delta_builder(replacement_words, arch, fixup.source_call_sreg, delta)) {
+        return relocation_error(
+            fixup.source_call_offset,
+            "target ISA cannot encode canonical recovered indirect branch builder",
+            TextLayoutFailureCategory::ResourceLimit);
+      }
+      compact_builder_fallbacks.push_back(fixup.source_call_offset);
     }
 
     const uint64_t replacement_size = replacement_words.size() * sizeof(uint32_t);
@@ -1036,7 +1103,9 @@ TextRelocationResult patch_recovered_builder_fixups(std::vector<uint8_t> &text,
     }
   }
 
-  return relocation_ok();
+  TextRelocationResult result = relocation_ok();
+  result.compact_builder_fallbacks = std::move(compact_builder_fallbacks);
+  return result;
 }
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/kernel_text_layout.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/kernel_text_layout.h
@@ -99,6 +99,14 @@ struct RecoveredIndirectFixup {
   bool is_call = false;     ///< True for swappc-like calls, false for setpc jumps.
   /// Preserve a marked generated long transfer instead of choosing a compact branch.
   bool preserve_marked_long_transfer = false;
+  /// @brief Re-emit the original dynamic transfer instead of growing a long window.
+  ///
+  /// @details Set when the builder immediately ahead of the consumer was rewritten in place to the
+  /// relocated target, so the original transfer already lands correctly. The long window would
+  /// cost five extra words AND leave an unmarked getpc/add/consumer triple that the next pass
+  /// recognizes as wrappable and wraps again -- moving every delta measured past it and making
+  /// translation a two-pass fixed point instead of a one-pass one.
+  bool keep_dynamic_when_long = false;
 };
 
 enum class ControlFlowWindowKind : uint8_t {
@@ -139,6 +147,14 @@ struct TextRelocationResult {
   uint64_t source_offset = 0;
   std::vector<ControlFlowWindowRequirement> required_windows;
   std::string message;
+  /// @brief Consumer offsets whose rewritten builder fell back to the compact add form.
+  ///
+  /// @details The wide literal64 form is requested so the builder stays visible to the relocation
+  /// lattice on a later pass. When it does not fit its source range the compact form is emitted
+  /// instead: correct, but invisible. That only matters if an unrecovered indirect transfer also
+  /// survives into the object, in which case a LATER translation refuses it -- with nothing
+  /// pointing back to where the visibility was lost. Reporting the offsets closes that gap.
+  std::vector<uint64_t> compact_builder_fallbacks;
 };
 
 /// @brief One insertion made while growing a direct-branch patch window.
@@ -257,6 +273,21 @@ grow_control_flow_windows(std::vector<uint8_t> &text, KernelTextLayout &layout,
 
 /// @brief Rebase one offset through a sorted set of text insertions.
 void rebase_text_offset(uint64_t &offset, std::span<const TextLayoutInsertion> insertions);
+
+/// @brief rebase_text_offset() with the insertion prefix sums computed once.
+///
+/// @details Identical result, O(log n) per offset instead of O(n). Build one per insertion list
+/// and reuse it across every offset being rebased; the scanning free function above remains for
+/// one-off callers.
+class TextOffsetRebaser {
+public:
+  explicit TextOffsetRebaser(std::span<const TextLayoutInsertion> insertions);
+  void rebase(uint64_t &offset) const;
+
+private:
+  std::vector<uint64_t> offsets_;
+  std::vector<uint64_t> shifts_;
+};
 
 /// @brief First body offset at which an SGPR-free branch-island pool should appear.
 [[nodiscard]] uint64_t first_direct_branch_island_pool_offset();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/relocation_function_table.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/relocation_function_table.cpp
@@ -371,7 +371,25 @@ bool object_defines_only_kernels(const AmdGpuCodeObject &object) {
       function_names, [&](std::string_view name) { return descriptor_names.contains(name); });
 }
 
+static std::vector<uint64_t> discover_text_function_symbol_offsets(const AmdGpuCodeObject &object,
+                                                                   bool externally_resolvable_only);
+
+std::vector<uint64_t>
+discover_externally_resolvable_text_function_offsets(const AmdGpuCodeObject &object) {
+  std::vector<uint64_t> offsets;
+  for (uint64_t offset :
+       discover_text_function_symbol_offsets(object, /*externally_resolvable_only=*/true))
+    offsets.push_back(offset);
+  return offsets;
+}
+
 std::vector<uint64_t> discover_text_function_symbol_offsets(const AmdGpuCodeObject &object) {
+  return discover_text_function_symbol_offsets(object, /*externally_resolvable_only=*/false);
+}
+
+static std::vector<uint64_t>
+discover_text_function_symbol_offsets(const AmdGpuCodeObject &object,
+                                      bool externally_resolvable_only) {
   const auto *bytes = reinterpret_cast<const uint8_t *>(object.image_data());
   const std::span<const uint8_t> image(bytes, object.image_size());
   Elf64_Ehdr ehdr{};
@@ -406,6 +424,9 @@ std::vector<uint64_t> discover_text_function_symbol_offsets(const AmdGpuCodeObje
       if (!read_object(image, symtab.sh_offset + index * sizeof(Elf64_Sym), symbol))
         continue;
       if (elf_symbol_type(symbol.st_info) != kElfSymbolTypeFunc || symbol.st_size == 0)
+        continue;
+      if (externally_resolvable_only &&
+          !elf_symbol_is_externally_resolvable(symbol.st_info, symbol.st_other))
         continue;
       // The symbol has to belong to `.text` before its value means anything here. This is what
       // makes the ET_REL branch below safe: st_value is section-relative there, so a sized

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/relocation_function_table.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/relocation_function_table.cpp
@@ -18,6 +18,7 @@
 #include <span>
 #include <string_view>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace rocjitsu {
@@ -296,6 +297,79 @@ void run_pair_dataflow(std::span<const std::unique_ptr<BasicBlock>> blocks,
 }
 
 } // namespace
+
+bool object_defines_only_kernels(const AmdGpuCodeObject &object) {
+  // The suffix AMDHSA gives a kernel's descriptor object, matching amdgpu_code_object.cpp and
+  // kernel_symbol.cpp rather than restating the contract in a third place.
+  constexpr std::string_view kKernelDescriptorSymbolSuffix = ".kd";
+  const auto *bytes = reinterpret_cast<const uint8_t *>(object.image_data());
+  const std::span<const uint8_t> image(bytes, object.image_size());
+  Elf64_Ehdr ehdr{};
+  if (!read_object(image, 0, ehdr) || ehdr.e_shentsize != sizeof(Elf64_Shdr) ||
+      !range_in_image(image, ehdr.e_shoff,
+                      static_cast<uint64_t>(ehdr.e_shnum) * sizeof(Elf64_Shdr)))
+    return false;
+
+  std::vector<Elf64_Shdr> sections(ehdr.e_shnum);
+  std::memcpy(sections.data(), image.data() + ehdr.e_shoff, sections.size() * sizeof(Elf64_Shdr));
+
+  if (object.text_sections().size() != 1)
+    return false;
+  const Section &text = *object.text_sections().front();
+  const auto text_index = text_section_index(sections, text);
+  if (!text_index)
+    return false;
+
+  // One symbol's name, bounded at the end of its string table so an unterminated string cannot
+  // run past it.
+  const auto name_at = [&](const Elf64_Shdr &strtab, uint32_t offset) -> std::string_view {
+    if (strtab.sh_type != SHT_STRTAB || !range_in_image(image, strtab.sh_offset, strtab.sh_size) ||
+        offset >= strtab.sh_size)
+      return {};
+    const char *first = reinterpret_cast<const char *>(image.data() + strtab.sh_offset + offset);
+    const size_t bound = static_cast<size_t>(strtab.sh_size - offset);
+    return std::string_view(first, ::strnlen(first, bound));
+  };
+
+  // The two tables have different string tables, so gather every descriptor name across both
+  // before asking whether a function has one: a function is a kernel if a descriptor for it
+  // exists anywhere in the object, not merely in the table that happens to name the function.
+  std::unordered_set<std::string_view> descriptor_names;
+  std::vector<std::string_view> function_names;
+  bool saw_symbol_table = false;
+  for (const Elf64_Shdr &symtab : sections) {
+    if ((symtab.sh_type != SHT_SYMTAB && symtab.sh_type != SHT_DYNSYM) ||
+        symtab.sh_entsize != sizeof(Elf64_Sym) ||
+        !range_in_image(image, symtab.sh_offset, symtab.sh_size))
+      continue;
+    if (symtab.sh_link >= sections.size())
+      return false;
+    const Elf64_Shdr &strtab = sections[symtab.sh_link];
+    saw_symbol_table = true;
+    const size_t count = symtab.sh_size / sizeof(Elf64_Sym);
+    for (size_t index = 0; index < count; ++index) {
+      Elf64_Sym symbol{};
+      if (!read_object(image, symtab.sh_offset + index * sizeof(Elf64_Sym), symbol))
+        return false;
+      const std::string_view name = name_at(strtab, symbol.st_name);
+      if (name.empty())
+        continue;
+      if (name.ends_with(kKernelDescriptorSymbolSuffix)) {
+        descriptor_names.insert(name.substr(0, name.size() - kKernelDescriptorSymbolSuffix.size()));
+        continue;
+      }
+      if (elf_symbol_type(symbol.st_info) == kElfSymbolTypeFunc && symbol.st_size != 0 &&
+          symbol.st_shndx == *text_index) {
+        function_names.push_back(name);
+      }
+    }
+  }
+  if (!saw_symbol_table)
+    return false;
+
+  return std::ranges::all_of(
+      function_names, [&](std::string_view name) { return descriptor_names.contains(name); });
+}
 
 std::vector<uint64_t> discover_text_function_symbol_offsets(const AmdGpuCodeObject &object) {
   const auto *bytes = reinterpret_cast<const uint8_t *>(object.image_data());

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/relocation_function_table.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/relocation_function_table.cpp
@@ -263,7 +263,165 @@ void run_pair_dataflow(std::span<const std::unique_ptr<BasicBlock>> blocks,
                        std::vector<RelocationTableDispatch> *dispatches,
                        std::vector<PcRelativeAddressBuilder> *address_builders);
 
+/// @brief Whether @p vaddr falls inside a section the loader maps.
+///
+/// @details `SHT_NOBITS` still counts: `.bss` occupies no file bytes but is allocated and
+/// writable at run time, so a relocation destined there is a real stored pointer.
+[[nodiscard]] bool vaddr_in_allocated_section(std::span<const Elf64_Shdr> sections,
+                                              uint64_t vaddr) {
+  for (const Elf64_Shdr &section : sections) {
+    if ((section.sh_flags & SHF_ALLOC) == 0 || section.sh_size == 0)
+      continue;
+    if (vaddr >= section.sh_addr && vaddr - section.sh_addr < section.sh_size)
+      return true;
+  }
+  return false;
+}
+
+/// @brief Section-header index of the code object's single `.text`.
+///
+/// @details Symbol values are only interpretable against the section a symbol belongs to, so every
+/// symbol walk here needs the index to compare `st_shndx` against. The section header table is the
+/// authority: match the header whose file offset, address and size are all the ones the parsed
+/// `.text` reports.
+[[nodiscard]] std::optional<size_t> text_section_index(std::span<const Elf64_Shdr> sections,
+                                                       const Section &text) {
+  for (size_t index = 0; index < sections.size(); ++index) {
+    const Elf64_Shdr &section = sections[index];
+    if (section.sh_offset == text.sectionOffset() && section.sh_addr == text.vaddr() &&
+        section.sh_size == text.size())
+      return index;
+  }
+  return std::nullopt;
+}
+
 } // namespace
+
+std::vector<uint64_t> discover_text_function_symbol_offsets(const AmdGpuCodeObject &object) {
+  const auto *bytes = reinterpret_cast<const uint8_t *>(object.image_data());
+  const std::span<const uint8_t> image(bytes, object.image_size());
+  Elf64_Ehdr ehdr{};
+  if (!read_object(image, 0, ehdr) || ehdr.e_shentsize != sizeof(Elf64_Shdr) ||
+      !range_in_image(image, ehdr.e_shoff,
+                      static_cast<uint64_t>(ehdr.e_shnum) * sizeof(Elf64_Shdr)))
+    return {};
+
+  std::vector<Elf64_Shdr> sections(ehdr.e_shnum);
+  std::memcpy(sections.data(), image.data() + ehdr.e_shoff, sections.size() * sizeof(Elf64_Shdr));
+
+  if (object.text_sections().size() != 1)
+    return {};
+  const Section &text = *object.text_sections().front();
+  const uint64_t text_vaddr = text.vaddr();
+  const uint64_t text_size = text.size();
+  // Without the section index a symbol value cannot be interpreted. Refuse to guess: returning
+  // nothing costs the caller its extra split points, while guessing would invent them.
+  const auto text_index = text_section_index(sections, text);
+  if (!text_index)
+    return {};
+
+  std::vector<uint64_t> offsets;
+  for (const Elf64_Shdr &symtab : sections) {
+    if ((symtab.sh_type != SHT_SYMTAB && symtab.sh_type != SHT_DYNSYM) ||
+        symtab.sh_entsize != sizeof(Elf64_Sym) ||
+        !range_in_image(image, symtab.sh_offset, symtab.sh_size))
+      continue;
+    const size_t count = symtab.sh_size / sizeof(Elf64_Sym);
+    for (size_t index = 0; index < count; ++index) {
+      Elf64_Sym symbol{};
+      if (!read_object(image, symtab.sh_offset + index * sizeof(Elf64_Sym), symbol))
+        continue;
+      if (elf_symbol_type(symbol.st_info) != kElfSymbolTypeFunc || symbol.st_size == 0)
+        continue;
+      // The symbol has to belong to `.text` before its value means anything here. This is what
+      // makes the ET_REL branch below safe: st_value is section-relative there, so a sized
+      // function in some other section would otherwise be read as an offset near the start of
+      // `.text` and split a real block. SHN_UNDEF and the other reserved indices are excluded by
+      // the same test, since none of them equal the text index.
+      if (symbol.st_shndx != *text_index)
+        continue;
+      // ET_REL symbol values are already section-relative; every other kind is a virtual address.
+      uint64_t offset = symbol.st_value;
+      if (ehdr.e_type != ET_REL) {
+        if (symbol.st_value < text_vaddr)
+          continue;
+        offset = symbol.st_value - text_vaddr;
+      }
+      if (offset >= text_size || (offset % sizeof(uint32_t)) != 0)
+        continue;
+      offsets.push_back(offset);
+    }
+  }
+  std::ranges::sort(offsets);
+  offsets.erase(std::ranges::unique(offsets).begin(), offsets.end());
+  return offsets;
+}
+
+std::vector<uint64_t>
+discover_relative_text_addend_targets(const AmdGpuCodeObject &object,
+                                      std::span<const uint64_t> function_entry_offsets) {
+  const auto *bytes = reinterpret_cast<const uint8_t *>(object.image_data());
+  const std::span<const uint8_t> image(bytes, object.image_size());
+  Elf64_Ehdr ehdr{};
+  if (!read_object(image, 0, ehdr) || ehdr.e_type != ET_DYN ||
+      ehdr.e_shentsize != sizeof(Elf64_Shdr) ||
+      !range_in_image(image, ehdr.e_shoff,
+                      static_cast<uint64_t>(ehdr.e_shnum) * sizeof(Elf64_Shdr)))
+    return {};
+
+  std::vector<Elf64_Shdr> sections(ehdr.e_shnum);
+  std::memcpy(sections.data(), image.data() + ehdr.e_shoff, sections.size() * sizeof(Elf64_Shdr));
+
+  if (object.text_sections().size() != 1)
+    return {};
+  const Section &text = *object.text_sections().front();
+  const uint64_t text_vaddr = text.vaddr();
+  const uint64_t text_size = text.size();
+
+  std::vector<uint64_t> targets;
+  for (const Elf64_Shdr &relocs : sections) {
+    if (relocs.sh_type != SHT_RELA || relocs.sh_entsize != sizeof(Elf64_Rela) ||
+        !range_in_image(image, relocs.sh_offset, relocs.sh_size))
+      continue;
+    const size_t count = relocs.sh_size / sizeof(Elf64_Rela);
+    for (size_t index = 0; index < count; ++index) {
+      Elf64_Rela rela{};
+      if (!read_object(image, relocs.sh_offset + index * sizeof(Elf64_Rela), rela))
+        continue;
+      // RELATIVE64 is the symbol-less form: the loader stores load_bias + r_addend, so a nonzero
+      // symbol index means some other relocation kind that reuses the type number, not a stored
+      // pointer whose value this pass can predict.
+      if (elf_reloc_type(rela.r_info) != R_AMDGPU_RELATIVE64 || elf_reloc_sym(rela.r_info) != 0 ||
+          rela.r_addend < 0)
+        continue;
+      // The destination has to be memory the loader actually writes. A relocation carried only by
+      // non-loaded metadata never produces a runtime code pointer, so admitting it would let the
+      // code-address audit believe a dynamic transfer is accounted for when nothing holds its
+      // target -- exactly the claim that permits an otherwise unresolved indirect branch.
+      if (!vaddr_in_allocated_section(sections, rela.r_offset))
+        continue;
+      const auto addend = static_cast<uint64_t>(rela.r_addend);
+      if (addend < text_vaddr)
+        continue;
+      const uint64_t offset = addend - text_vaddr;
+      if (offset >= text_size || (offset % sizeof(uint32_t)) != 0)
+        continue;
+      // Only a function entry may be reported. Callers turn each target into a block leader and an
+      // adopted root, and an adopted root is seeded with the ABI's architectural entry state --
+      // both of which are claims about a function boundary, and neither of which is true of a
+      // mid-function label a pointer happens to name. A target with no sized STT_FUNC symbol at
+      // exactly that offset is therefore left out rather than guessed at, which keeps it
+      // unadopted; relocate_relative_text_addends() then finds no placement for its addend and
+      // refuses the object, which is the conservative outcome.
+      if (!std::ranges::binary_search(function_entry_offsets, offset))
+        continue;
+      targets.push_back(offset);
+    }
+  }
+  std::ranges::sort(targets);
+  targets.erase(std::ranges::unique(targets).begin(), targets.end());
+  return targets;
+}
 
 std::vector<RelocationFunctionTable>
 discover_relocation_function_tables(const AmdGpuCodeObject &object) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/relocation_function_table.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/relocation_function_table.h
@@ -144,4 +144,39 @@ analyze_relocation_pairs(std::span<const std::unique_ptr<BasicBlock>> blocks,
 [[nodiscard]] std::vector<RelocationFunctionTable>
 discover_relocation_function_tables(const AmdGpuCodeObject &object);
 
+/// @brief `.text`-relative offsets of every sized `STT_FUNC` symbol in the code object.
+///
+/// @details These are function entries, which makes them block leaders. A separately compiled
+/// device library reaches most of its functions only through a pointer, so nothing in the decoded
+/// instruction stream names them and CFG construction would otherwise let the padding before such
+/// a function fall through into its body -- leaving the entry in the middle of a block, where it
+/// cannot be adopted as a root or seeded with the ABI's architectural entry state.
+///
+/// Like the relocation tables above, and unlike anything derived from recovered dataflow, this set
+/// is a fixed property of the input: the same symbols are found whether or not the object has
+/// already been translated, so using it to partition `.text` stays a fixed point.
+///
+/// @returns Sorted, unique offsets. Empty when the object has no symbol table, more than one
+/// `.text`, or no qualifying symbol.
+[[nodiscard]] std::vector<uint64_t>
+discover_text_function_symbol_offsets(const AmdGpuCodeObject &object);
+
+/// @brief Function entries named by an `R_AMDGPU_RELATIVE64` addend landing in `.text`.
+///
+/// @details Each such addend is a stored function pointer, so its target is an address-taken body
+/// that must be emitted and whose new placement the addend is rewritten to. discover_relocation_
+/// function_tables() finds only the subset held by a qualifying `STT_OBJECT`; a compiler-anonymous
+/// pointer array carries no such symbol, and its targets are just as dereferenced. Addends are ELF
+/// data, so like symbols they are a fixed property of the input and safe to partition `.text` by.
+///
+/// @param function_entry_offsets Sorted function-entry offsets, from
+///        discover_text_function_symbol_offsets(). A target is reported only when it is one of
+///        these. Callers make every target a block leader and an adopted root seeded with the
+///        ABI's entry state, which is only meaningful at a function boundary, so an addend that
+///        names a mid-function label is omitted instead of guessed at -- leaving it unadopted, and
+///        its object refused by relocate_relative_text_addends().
+[[nodiscard]] std::vector<uint64_t>
+discover_relative_text_addend_targets(const AmdGpuCodeObject &object,
+                                      std::span<const uint64_t> function_entry_offsets);
+
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/relocation_function_table.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/relocation_function_table.h
@@ -178,6 +178,19 @@ discover_text_function_symbol_offsets(const AmdGpuCodeObject &object);
 /// the fence.
 [[nodiscard]] bool object_defines_only_kernels(const AmdGpuCodeObject &object);
 
+/// @brief Sized `.text` `STT_FUNC` offsets whose symbol a host could resolve.
+///
+/// @details When a translation relies on the whole-object relocation permission it also promises
+/// that every externally resolvable `.text` symbol still names its body afterwards, because such a
+/// symbol is exactly what an outside holder of a code address looked it up through. Those bodies
+/// therefore have to be emitted, and a body no kernel reaches is emitted only if something adopts
+/// it. Like the other symbol-derived sets here this is a fixed property of the input, so adopting
+/// from it leaves the scope partition a fixed point.
+///
+/// @returns Sorted, unique offsets. Empty when the object has no symbol table or no such symbol.
+[[nodiscard]] std::vector<uint64_t>
+discover_externally_resolvable_text_function_offsets(const AmdGpuCodeObject &object);
+
 /// @brief Function entries named by an `R_AMDGPU_RELATIVE64` addend landing in `.text`.
 ///
 /// @details Each such addend is a stored function pointer, so its target is an address-taken body

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/relocation_function_table.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/relocation_function_table.h
@@ -161,6 +161,23 @@ discover_relocation_function_tables(const AmdGpuCodeObject &object);
 [[nodiscard]] std::vector<uint64_t>
 discover_text_function_symbol_offsets(const AmdGpuCodeObject &object);
 
+/// @brief Whether every sized `STT_FUNC` in `.text` is an AMDHSA kernel.
+///
+/// @details A kernel is `<name>` with a companion `<name>.kd` descriptor object; a device function
+/// has no companion. When this holds the object defines no device-function body, so a pointer
+/// reaching an indirect transfer can only name a body in another code object -- and this
+/// translation has none of its own to adopt as a root, retarget, or grow a descriptor for.
+///
+/// This is a scope fence, not a soundness argument. It bounds what admitting an unproven transfer
+/// would own; the proof that such a target is already relocated has to come from the transfer's
+/// own operand. It is vacuously true for an object with no such symbol, so it must never be the
+/// only gate.
+///
+/// @returns True when no sized `.text` `STT_FUNC` lacks a `<name>.kd`. False when the symbol
+/// tables cannot be read -- unlike its siblings here, an object this cannot inspect must not earn
+/// the fence.
+[[nodiscard]] bool object_defines_only_kernels(const AmdGpuCodeObject &object);
+
 /// @brief Function entries named by an `R_AMDGPU_RELATIVE64` addend landing in `.text`.
 ///
 /// @details Each such addend is a stored function pointer, so its target is an address-taken body

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/isa_traits.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/isa_traits.h
@@ -104,6 +104,16 @@ template <GpuIsa Isa> inline constexpr bool supports_wave_size(uint32_t wf) {
 /// RDNA and gfx1250 descriptors use the ordinary ISA SGPR maximum. gfx1250 is
 /// kept out of arch_is_rdna() because several of its descriptor and register
 /// allocation rules differ from generic RDNA despite sharing the GFX10+ ABI.
+/// @brief Whether @p arch encodes wavefront SGPR allocation in the kernel descriptor.
+///
+/// @details GFX10+ leaves COMPUTE_PGM_RSRC1.GRANULATED_WAVEFRONT_SGPR_COUNT reserved and gives
+/// every wave the architectural SGPR file, so a count decoded from that field is an artifact of
+/// the granule-0 encoding rather than a budget any caller depends on. Only where the field is
+/// live can an SGPR requirement above the decoded count under-provision anyone.
+[[nodiscard]] inline constexpr bool arch_descriptor_encodes_sgpr_allocation(rj_code_arch_t arch) {
+  return !(arch_is_rdna(arch) || arch == ROCJITSU_CODE_ARCH_GFX1250);
+}
+
 [[nodiscard]] inline constexpr uint32_t arch_descriptor_sgpr_allocation_limit(rj_code_arch_t arch) {
   // Architectural descriptor SGPR-allocation ceilings. CDNA descriptors may name
   // up to 112 SGPRs; RDNA up to 106. These are fixed ISA facts (not the smaller

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -3707,6 +3707,107 @@ TEST(CfgAnalysis, Gfx1250DoesNotReuseStashFromSkippedFallthroughPredecessor) {
   EXPECT_TRUE(fixups.empty()) << "must-dataflow must not reuse a skipped-path stash";
 }
 
+// A getpc reseeding a pair the previous builder still owns is a stable point for that builder: no
+// later arithmetic can reach the old chain. Publishing it is what lets code that materializes
+// several function pointers through one scratch pair -- build, spill, rebuild -- still satisfy a
+// whole-object "every code address is relocated" claim. A COMPLETED chain must therefore survive
+// the reseed as a resolved builder.
+/// @brief Decode a hand-assembled gfx1250 word list and run indirect-branch discovery over it.
+///
+/// @details Mirrors BasicBlock::build's decode loop, including its skip of zero alignment padding,
+/// so a fixture written as raw encodings reaches the pass the same way real `.text` does.
+void run_indirect_discovery_for_test(std::vector<uint32_t> words,
+                                     std::vector<PcAddressBuilder> *builders) {
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+
+  const auto *sec = co.text_sections().front();
+  const auto *inst_data = reinterpret_cast<const uint32_t *>(sec->data());
+  const size_t inst_data_size = sec->size() / sizeof(uint32_t);
+  std::vector<std::unique_ptr<Instruction>> owned;
+  for (size_t pc = 0, byte_offset = 0; pc < inst_data_size;) {
+    if (inst_data[pc] == 0) {
+      ++pc;
+      byte_offset += sizeof(uint32_t);
+      continue;
+    }
+    std::unique_ptr<Instruction> inst(decoder->decode(&inst_data[pc], byte_offset));
+    ASSERT_NE(inst, nullptr);
+    const uint32_t inst_words = static_cast<uint32_t>(inst->size()) / sizeof(uint32_t);
+    byte_offset += inst->size();
+    pc += inst_words;
+    owned.push_back(std::move(inst));
+  }
+  std::vector<const Instruction *> decoded_insts;
+  decoded_insts.reserve(owned.size());
+  for (const auto &inst : owned)
+    decoded_insts.push_back(inst.get());
+  const auto text =
+      std::span<const uint8_t>(reinterpret_cast<const uint8_t *>(sec->data()), sec->size());
+
+  (void)discover_indirect_branch_edges(
+      std::span<const Instruction *const>(decoded_insts.data(), decoded_insts.size()), text,
+      ROCJITSU_CODE_ARCH_GFX1250, {}, ExternalEntryPolicy::InferPredecessorless, builders);
+}
+
+TEST(IndirectBranchDiscovery, ReusedPairPublishesTheCompletedBuilderItReplaces) {
+  constexpr uint16_t kPair = 0;
+  constexpr uint16_t kLiteral = 255;
+  constexpr rj_code_arch_t kArch = ROCJITSU_CODE_ARCH_GFX1250;
+  std::vector<uint32_t> words = {
+      build_s_getpc_b64(kPair, kArch),
+      build_s_add_u32(kPair, kPair, kLiteral, kArch),
+      0x00000010u,                                        // literal
+      build_s_addc_u32(kPair + 1, kPair + 1, 128, kArch), // closes the 64-bit edit
+      build_s_getpc_b64(kPair, kArch),                    // reseeds the same pair
+      build_s_add_u32(kPair, kPair, kLiteral, kArch),
+      0x00000008u, // literal
+      build_s_addc_u32(kPair + 1, kPair + 1, 128, kArch),
+      // A consumer is what makes the pass report builders at all.
+      build_s_setpc_b64(kPair, kArch),
+      build_s_endpgm(kArch),
+  };
+
+  std::vector<PcAddressBuilder> builders;
+  run_indirect_discovery_for_test(std::move(words), &builders);
+
+  ASSERT_EQ(builders.size(), 2u);
+  EXPECT_EQ(builders[0].source_getpc_offset, 0u);
+  EXPECT_TRUE(builders[0].resolved) << "a completed chain must survive its pair being reused";
+  EXPECT_FALSE(builders[0].poisoned);
+}
+
+// The same reseed, but the first chain never got its s_addc_u32. The high half is unwritten, so the
+// pair does not hold the address the low add implies. Publishing it would let the patcher
+// regenerate [begin, end) -- which stops before the missing carry -- and claim an address the
+// program never computed, so this one has to fail closed instead.
+TEST(IndirectBranchDiscovery, ReusedPairPoisonsAnAbandonedHalfBuiltBuilder) {
+  constexpr uint16_t kPair = 0;
+  constexpr uint16_t kLiteral = 255;
+  constexpr rj_code_arch_t kArch = ROCJITSU_CODE_ARCH_GFX1250;
+  std::vector<uint32_t> words = {
+      build_s_getpc_b64(kPair, kArch),
+      build_s_add_u32(kPair, kPair, kLiteral, kArch), // low half only -- no s_addc_u32
+      0x00000010u,                                    // literal
+      build_s_getpc_b64(kPair, kArch),                // abandons the half-built chain
+      build_s_add_u32(kPair, kPair, kLiteral, kArch),
+      0x00000008u, // literal
+      build_s_addc_u32(kPair + 1, kPair + 1, 128, kArch),
+      build_s_setpc_b64(kPair, kArch),
+      build_s_endpgm(kArch),
+  };
+
+  std::vector<PcAddressBuilder> builders;
+  run_indirect_discovery_for_test(std::move(words), &builders);
+
+  ASSERT_FALSE(builders.empty());
+  const auto abandoned = std::ranges::find(builders, 0u, &PcAddressBuilder::source_getpc_offset);
+  ASSERT_NE(abandoned, builders.end());
+  EXPECT_TRUE(abandoned->poisoned) << "a chain abandoned before its carry must not be published";
+  EXPECT_FALSE(abandoned->resolved);
+}
+
 TEST(CfgAnalysis, ReversePostOrderStraightLine) {
   auto blocks =
       build_test_blocks({TestOpcode::DefVgpr0, TestOpcode::UseVgpr0, TestOpcode::UseSgpr4});

--- a/emulation/rocjitsu/tests/dbt/support/translate_test_support.cpp
+++ b/emulation/rocjitsu/tests/dbt/support/translate_test_support.cpp
@@ -319,6 +319,206 @@ bool has_warning_at(const TranslatedCodeObject &result, DiagnosticKind kind,
                      });
 }
 
+std::vector<uint8_t> make_minimal_amdgpu_elf_with_two_kernels_and_function_pointers(
+    const std::vector<uint32_t> &text_words, size_t kernel1_entry_word,
+    const std::vector<TestTextFunction> &functions) {
+  constexpr uint64_t text_offset = 0x100;
+  constexpr uint64_t text_vaddr = 0x1100;
+  const uint64_t text_size = text_words.size() * sizeof(uint32_t);
+  constexpr uint64_t load_align = 0x1000;
+  constexpr uint64_t rodata_size = 2 * kKernelDescriptorSize;
+  const uint64_t slot_count = functions.size();
+  const uint64_t table_bytes = slot_count * sizeof(uint64_t);
+
+  std::vector<uint8_t> shstrtab{'\0'};
+  const uint32_t text_name = add_elf_name(shstrtab, ".text");
+  const uint32_t rodata_name = add_elf_name(shstrtab, ".rodata");
+  const uint32_t symtab_name = add_elf_name(shstrtab, ".symtab");
+  const uint32_t strtab_name = add_elf_name(shstrtab, ".strtab");
+  const uint32_t shstrtab_name = add_elf_name(shstrtab, ".shstrtab");
+  const uint32_t table_name = add_elf_name(shstrtab, ".data.rel.ro");
+  const uint32_t rela_name = add_elf_name(shstrtab, ".rela.dyn");
+
+  std::vector<uint8_t> strtab{'\0'};
+  const uint32_t kernel0_name = add_elf_name(strtab, "kernel0.kd");
+  const uint32_t kernel1_name = add_elf_name(strtab, "kernel1.kd");
+  std::vector<uint32_t> helper_names;
+  for (size_t i = 0; i < functions.size(); ++i)
+    helper_names.push_back(add_elf_name(strtab, "helper" + std::to_string(i)));
+  const uint32_t table_symbol_name = add_elf_name(strtab, "function_table");
+
+  const uint64_t rodata_off = align_up_for_test(text_offset + text_size, 8);
+  const uint64_t rodata_va = align_up_for_test(text_vaddr + text_size, 8) + load_align;
+  const uint64_t table_va = rodata_va + load_align;
+  const uint64_t strtab_off = rodata_off + rodata_size;
+  const uint64_t symtab_off = align_up_for_test(strtab_off + strtab.size(), 8);
+  const size_t sym_count = 4 + functions.size();
+  const uint64_t table_off =
+      align_up_for_test(symtab_off + sym_count * sizeof(Elf64_Sym), load_align) +
+      (table_va % load_align);
+  const uint64_t rela_off = table_off + table_bytes;
+  const uint64_t shstrtab_off = rela_off + slot_count * sizeof(Elf64_Rela);
+  const uint64_t shoff = align_up_for_test(shstrtab_off + shstrtab.size(), 8);
+  constexpr uint16_t section_count = 8;
+  constexpr uint16_t phdr_count = 3;
+
+  std::vector<uint8_t> image(shoff + section_count * sizeof(Elf64_Shdr), 0);
+
+  Elf64_Ehdr ehdr{};
+  std::memcpy(ehdr.e_ident, EI_MAGIC, EI_MAGIC_SIZE);
+  ehdr.e_ident[EI_CLASS] = ELFCLASS64;
+  ehdr.e_ident[EI_OSABI] = ELFOSABI_AMDGPU_HSA;
+  ehdr.e_type = ET_DYN;
+  ehdr.e_machine = EM_AMDGPU;
+  ehdr.e_version = 1;
+  ehdr.e_phoff = sizeof(Elf64_Ehdr);
+  ehdr.e_shoff = shoff;
+  ehdr.e_flags = EF_AMDGPU_MACH_AMDGCN_GFX950;
+  ehdr.e_ehsize = sizeof(Elf64_Ehdr);
+  ehdr.e_phentsize = sizeof(Elf64_Phdr);
+  ehdr.e_phnum = phdr_count;
+  ehdr.e_shentsize = sizeof(Elf64_Shdr);
+  ehdr.e_shnum = section_count;
+  ehdr.e_shstrndx = 5;
+  std::memcpy(image.data(), &ehdr, sizeof(ehdr));
+
+  std::array<Elf64_Phdr, phdr_count> phdrs{};
+  phdrs[0].p_type = PT_LOAD;
+  phdrs[0].p_flags = 0x5; // PF_R | PF_X
+  phdrs[0].p_offset = text_offset;
+  phdrs[0].p_vaddr = text_vaddr;
+  phdrs[0].p_paddr = text_vaddr;
+  phdrs[0].p_filesz = text_size;
+  phdrs[0].p_memsz = text_size;
+  phdrs[0].p_align = load_align;
+
+  phdrs[1].p_type = PT_LOAD;
+  phdrs[1].p_flags = 0x4; // PF_R
+  phdrs[1].p_offset = rodata_off;
+  phdrs[1].p_vaddr = rodata_va;
+  phdrs[1].p_paddr = rodata_va;
+  phdrs[1].p_filesz = rodata_size;
+  phdrs[1].p_memsz = rodata_size;
+  phdrs[1].p_align = load_align;
+
+  phdrs[2].p_type = PT_LOAD;
+  phdrs[2].p_flags = 0x6; // PF_R | PF_W
+  phdrs[2].p_offset = table_off;
+  phdrs[2].p_vaddr = table_va;
+  phdrs[2].p_paddr = table_va;
+  phdrs[2].p_filesz = table_bytes;
+  phdrs[2].p_memsz = table_bytes;
+  phdrs[2].p_align = load_align;
+  std::memcpy(image.data() + ehdr.e_phoff, phdrs.data(), phdrs.size() * sizeof(Elf64_Phdr));
+
+  std::memcpy(image.data() + text_offset, text_words.data(), text_size);
+
+  std::vector<uint8_t> descriptors(rodata_size, 0);
+  write_kernel_descriptor_entry_offset(descriptors.data(), static_cast<int64_t>(text_vaddr) -
+                                                               static_cast<int64_t>(rodata_va));
+  write_kernel_descriptor_entry_offset(
+      descriptors.data() + kKernelDescriptorSize,
+      static_cast<int64_t>(text_vaddr + kernel1_entry_word * sizeof(uint32_t)) -
+          static_cast<int64_t>(rodata_va + kKernelDescriptorSize));
+  std::memcpy(image.data() + rodata_off, descriptors.data(), descriptors.size());
+  std::memcpy(image.data() + strtab_off, strtab.data(), strtab.size());
+
+  std::vector<Elf64_Sym> syms(sym_count);
+  syms[1].st_name = kernel0_name;
+  syms[1].st_info = elf_symbol_info(kElfSymbolBindGlobal, kElfSymbolTypeObject);
+  syms[1].st_shndx = 2;
+  syms[1].st_value = rodata_va;
+  syms[1].st_size = kKernelDescriptorSize;
+  syms[2].st_name = kernel1_name;
+  syms[2].st_info = elf_symbol_info(kElfSymbolBindGlobal, kElfSymbolTypeObject);
+  syms[2].st_shndx = 2;
+  syms[2].st_value = rodata_va + kKernelDescriptorSize;
+  syms[2].st_size = kKernelDescriptorSize;
+  for (size_t i = 0; i < functions.size(); ++i) {
+    Elf64_Sym &helper = syms[3 + i];
+    helper.st_name = helper_names[i];
+    helper.st_info = elf_symbol_info(kElfSymbolBindLocal, kElfSymbolTypeFunc);
+    helper.st_shndx = 1;
+    helper.st_value = text_vaddr + functions[i].offset_word * sizeof(uint32_t);
+    helper.st_size = functions[i].words * sizeof(uint32_t);
+  }
+  Elf64_Sym &table_symbol = syms.back();
+  table_symbol.st_name = table_symbol_name;
+  table_symbol.st_info = elf_symbol_info(kElfSymbolBindGlobal, kElfSymbolTypeObject);
+  table_symbol.st_shndx = 6;
+  table_symbol.st_value = table_va;
+  table_symbol.st_size = table_bytes;
+  std::memcpy(image.data() + symtab_off, syms.data(), syms.size() * sizeof(Elf64_Sym));
+
+  for (size_t i = 0; i < functions.size(); ++i) {
+    Elf64_Rela rela{};
+    rela.r_offset = table_va + i * sizeof(uint64_t);
+    rela.r_info = (uint64_t{0} << 32) | rocjitsu::R_AMDGPU_RELATIVE64;
+    rela.r_addend = static_cast<int64_t>(text_vaddr + functions[i].offset_word * sizeof(uint32_t));
+    std::memcpy(image.data() + rela_off + i * sizeof(Elf64_Rela), &rela, sizeof(rela));
+  }
+
+  std::memcpy(image.data() + shstrtab_off, shstrtab.data(), shstrtab.size());
+
+  std::array<Elf64_Shdr, section_count> shdrs{};
+  shdrs[1].sh_name = text_name;
+  shdrs[1].sh_type = SHT_PROGBITS;
+  shdrs[1].sh_flags = SHF_ALLOC | SHF_EXECINSTR;
+  shdrs[1].sh_addr = text_vaddr;
+  shdrs[1].sh_offset = text_offset;
+  shdrs[1].sh_size = text_size;
+  shdrs[1].sh_addralign = sizeof(uint32_t);
+
+  shdrs[2].sh_name = rodata_name;
+  shdrs[2].sh_type = SHT_PROGBITS;
+  shdrs[2].sh_flags = SHF_ALLOC;
+  shdrs[2].sh_addr = rodata_va;
+  shdrs[2].sh_offset = rodata_off;
+  shdrs[2].sh_size = rodata_size;
+  shdrs[2].sh_addralign = 64;
+
+  shdrs[3].sh_name = symtab_name;
+  shdrs[3].sh_type = SHT_SYMTAB;
+  shdrs[3].sh_offset = symtab_off;
+  shdrs[3].sh_size = syms.size() * sizeof(Elf64_Sym);
+  shdrs[3].sh_link = 4;
+  shdrs[3].sh_info = 1;
+  shdrs[3].sh_addralign = 8;
+  shdrs[3].sh_entsize = sizeof(Elf64_Sym);
+
+  shdrs[4].sh_name = strtab_name;
+  shdrs[4].sh_type = SHT_STRTAB;
+  shdrs[4].sh_offset = strtab_off;
+  shdrs[4].sh_size = strtab.size();
+  shdrs[4].sh_addralign = 1;
+
+  shdrs[5].sh_name = shstrtab_name;
+  shdrs[5].sh_type = SHT_STRTAB;
+  shdrs[5].sh_offset = shstrtab_off;
+  shdrs[5].sh_size = shstrtab.size();
+  shdrs[5].sh_addralign = 1;
+
+  shdrs[6].sh_name = table_name;
+  shdrs[6].sh_type = SHT_PROGBITS;
+  shdrs[6].sh_flags = SHF_ALLOC | SHF_WRITE;
+  shdrs[6].sh_addr = table_va;
+  shdrs[6].sh_offset = table_off;
+  shdrs[6].sh_size = table_bytes;
+  shdrs[6].sh_addralign = 8;
+
+  shdrs[7].sh_name = rela_name;
+  shdrs[7].sh_type = SHT_RELA;
+  shdrs[7].sh_offset = rela_off;
+  shdrs[7].sh_size = slot_count * sizeof(Elf64_Rela);
+  shdrs[7].sh_link = 3;
+  shdrs[7].sh_info = 6;
+  shdrs[7].sh_addralign = 8;
+  shdrs[7].sh_entsize = sizeof(Elf64_Rela);
+
+  std::memcpy(image.data() + shoff, shdrs.data(), shdrs.size() * sizeof(Elf64_Shdr));
+  return image;
+}
+
 std::vector<uint8_t>
 make_minimal_amdgpu_elf_with_two_kernel_descriptors(const std::vector<uint32_t> &text_words) {
   constexpr uint64_t text_offset = 0x100;

--- a/emulation/rocjitsu/tests/dbt/support/translate_test_support.h
+++ b/emulation/rocjitsu/tests/dbt/support/translate_test_support.h
@@ -39,6 +39,26 @@ void write_kernel_descriptor_for_test(void *descriptor, const TestKernelDescript
     std::optional<size_t> function_pointer_table_target_words = std::nullopt,
     bool name_function_pointer_table_with_symbol = true);
 [[nodiscard]] std::vector<uint8_t> make_minimal_amdgpu_elf_with_descriptor_after_text();
+/// @brief One sized `STT_FUNC` body in the fixture's `.text`.
+struct TestTextFunction {
+  size_t offset_word = 0;
+  size_t words = 0;
+};
+
+/// @brief Two kernels, N sized local device functions, and one pointer slot naming each.
+///
+/// @details The two-descriptor helper above has no `.text` symbols and no relocation table, and
+/// the single-descriptor helper has both but only one scope. Three properties are needed together
+/// here: two scopes, so a body can be adopted by one and reached from the other; sized `STT_FUNC`
+/// symbols, because adoption now requires a declared entry; and `R_AMDGPU_RELATIVE64` slots, which
+/// are what make a body address-taken to begin with.
+///
+/// Kernel 0 entry is word 0 and kernel 1 entry is @p kernel1_entry_word.
+
+[[nodiscard]] std::vector<uint8_t> make_minimal_amdgpu_elf_with_two_kernels_and_function_pointers(
+    const std::vector<uint32_t> &text_words, size_t kernel1_entry_word,
+    const std::vector<TestTextFunction> &functions);
+
 [[nodiscard]] std::vector<uint8_t> make_minimal_amdgpu_elf_with_two_kernel_descriptors(
     const std::vector<uint32_t> &text_words = {0xBF810000u, 0xBF810000u});
 [[nodiscard]] std::vector<uint8_t> make_large_amdgpu_elf_with_waitcnt_entry();

--- a/emulation/rocjitsu/tests/dbt/translate_gfx1250_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_gfx1250_test.cpp
@@ -2490,8 +2490,9 @@ TEST(BinaryTranslatorE2E, Gfx1250KeepsDirectlyCalledHelperThatIsAlsoAddressTaken
       rocjitsu::build_s_setpc_b64(kReturnSreg, ROCJITSU_CODE_ARCH_GFX1250),   // word 5: return
   };
 
-  auto image = rocjitsu::test_support::make_minimal_amdgpu_elf_with_two_kernels_and_function_pointers(
-      words, /*kernel1_entry_word=*/2, {{.offset_word = 4, .words = 2}});
+  auto image =
+      rocjitsu::test_support::make_minimal_amdgpu_elf_with_two_kernels_and_function_pointers(
+          words, /*kernel1_entry_word=*/2, {{.offset_word = 4, .words = 2}});
   rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
   ASSERT_TRUE(source.is_valid());
 
@@ -2601,10 +2602,12 @@ TEST(BinaryTranslatorE2E, Gfx1250SizedFunctionSymbolEndingInsideMarkedWindowKeep
 
   // The window is regenerated at its reserved size, so the symbol keeps its four words. Mapping
   // the extent to kernel_text.size() instead would report the whole window and round st_size up.
-  const auto first_symbol = rocjitsu::test_support::find_elf_symbol_for_test(first.elf_bytes, "kernel");
+  const auto first_symbol =
+      rocjitsu::test_support::find_elf_symbol_for_test(first.elf_bytes, "kernel");
   ASSERT_TRUE(first_symbol.has_value());
   EXPECT_EQ(first_symbol->st_size, 4 * sizeof(uint32_t));
-  const auto second_symbol = rocjitsu::test_support::find_elf_symbol_for_test(second.elf_bytes, "kernel");
+  const auto second_symbol =
+      rocjitsu::test_support::find_elf_symbol_for_test(second.elf_bytes, "kernel");
   ASSERT_TRUE(second_symbol.has_value());
   EXPECT_EQ(second_symbol->st_size, first_symbol->st_size);
 

--- a/emulation/rocjitsu/tests/dbt/translate_gfx1250_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_gfx1250_test.cpp
@@ -2525,6 +2525,182 @@ TEST(BinaryTranslatorE2E, Gfx1250KeepsDirectlyCalledHelperThatIsAlsoAddressTaken
 // adopt()'s exact-start check, because a mid-instruction offset has no placement either way and
 // relocate_relative_text_addends() then fails. Isolating that check needs a unit test on adopt();
 // what this guards is that the object is never quietly accepted.
+// The kernarg-provenance admission and its guards. A target this object never computed and never
+// stored still has a provenance when it arrives through kernarg: the host wrote it, and the only
+// `.text` address a host can hold is one it read from a symbol that relocate_text_symbols()
+// rewrites. These fixtures carry no pointer table and no getpc, so object_produces_code_addresses
+// is false and the kernarg set is the ONLY route to acceptance -- each case is non-vacuous by
+// construction.
+namespace {
+
+constexpr uint16_t kKernargTargetSreg = 80;
+constexpr uint16_t kKernargReturnSreg = 30;
+
+[[nodiscard]] uint32_t kernarg_load_word(size_t index) {
+  // sbase is encoded halved, so s[0:1] is 0. The analysis matches `s_load_b`, which is the gfx1250
+  // spelling; CDNA's `s_load_dwordx2` would not be recognized.
+  return cdna5::build_smem(cdna5::kSLoadB64Smem, {.sbase = 0, .sdata = kKernargTargetSreg})[index];
+}
+
+[[nodiscard]] rocjitsu::TranslatedCodeObject
+translate_kernarg_fixture(const std::vector<uint32_t> &words, bool enable_kernarg) {
+  auto image = rocjitsu::test_support::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
+  if (enable_kernarg)
+    rocjitsu::enable_kernarg_segment_ptr_sgpr(image);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  EXPECT_TRUE(source.is_valid());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  return translator.translate(source);
+}
+
+[[nodiscard]] bool refused_unrecovered_transfer(const rocjitsu::TranslatedCodeObject &result) {
+  return !result.ok() && rocjitsu::test_support::has_error_containing(
+                             result, rocjitsu::DiagnosticKind::Legalization,
+                             "indirect branch or call target recovery is not implemented");
+}
+
+} // namespace
+
+TEST(BinaryTranslatorE2E, Gfx1250AdmitsKernargLoadedIndirectCallTarget) {
+  const std::vector<uint32_t> words = {
+      kernarg_load_word(0),
+      kernarg_load_word(1),
+      rocjitsu::build_s_swappc_b64(kKernargReturnSreg, kKernargTargetSreg,
+                                   ROCJITSU_CODE_ARCH_GFX1250),
+      rocjitsu::build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250),
+  };
+  EXPECT_TRUE(translate_kernarg_fixture(words, /*enable_kernarg=*/true).ok());
+}
+
+// The same words with no kernarg segment pointer in the descriptor. Nothing then supplies the
+// pair, so the transfer has no provenance and must be refused -- this is what separates "the host
+// wrote it" from "this object simply never computed it", which an undefined live-in also satisfies.
+TEST(BinaryTranslatorE2E, Gfx1250RefusesIndirectCallWhenNoKernargSegmentExists) {
+  const std::vector<uint32_t> words = {
+      kernarg_load_word(0),
+      kernarg_load_word(1),
+      rocjitsu::build_s_swappc_b64(kKernargReturnSreg, kKernargTargetSreg,
+                                   ROCJITSU_CODE_ARCH_GFX1250),
+      rocjitsu::build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250),
+  };
+  EXPECT_TRUE(refused_unrecovered_transfer(translate_kernarg_fixture(words,
+                                                                     /*enable_kernarg=*/false)));
+}
+
+// A write to s82 must not disturb s[80:81]: they share no register. Killing the pair below the one
+// written is the bug this pins.
+TEST(BinaryTranslatorE2E, Gfx1250KernargFactSurvivesWriteToTheRegisterAboveThePair) {
+  const std::vector<uint32_t> words = {
+      kernarg_load_word(0),
+      kernarg_load_word(1),
+      cdna5::build_sop1(cdna5::kSMovB32Sop1,
+                        {.ssrc0 = 128, .sdst = static_cast<uint8_t>(kKernargTargetSreg + 2)})[0],
+      rocjitsu::build_s_swappc_b64(kKernargReturnSreg, kKernargTargetSreg,
+                                   ROCJITSU_CODE_ARCH_GFX1250),
+      rocjitsu::build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250),
+  };
+  EXPECT_TRUE(translate_kernarg_fixture(words, /*enable_kernarg=*/true).ok());
+}
+
+// Clobbered on ONE of the two paths into the consumer. A meet that is not an intersection would
+// carry the surviving path's fact through and admit a transfer whose target is unknown on the
+// other path.
+TEST(BinaryTranslatorE2E, Gfx1250RefusesKernargTargetClobberedOnOnePath) {
+  const std::vector<uint32_t> words = {
+      kernarg_load_word(0),
+      kernarg_load_word(1),
+      cdna5::build_sopp(cdna5::kSCbranchScc0Sopp, {.simm16 = 1})[0],
+      cdna5::build_sop1(cdna5::kSMovB64Sop1,
+                        {.ssrc0 = 128, .sdst = static_cast<uint8_t>(kKernargTargetSreg)})[0],
+      rocjitsu::build_s_swappc_b64(kKernargReturnSreg, kKernargTargetSreg,
+                                   ROCJITSU_CODE_ARCH_GFX1250),
+      rocjitsu::build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250),
+  };
+  EXPECT_TRUE(refused_unrecovered_transfer(translate_kernarg_fixture(words,
+                                                                     /*enable_kernarg=*/true)));
+}
+
+// The control for the case above: same shape, nothing clobbered, so both paths agree and the
+// transfer is admitted. Without it the refusal above could be passing for the wrong reason.
+TEST(BinaryTranslatorE2E, Gfx1250AdmitsKernargTargetLiveOnBothPaths) {
+  const std::vector<uint32_t> words = {
+      kernarg_load_word(0),
+      kernarg_load_word(1),
+      cdna5::build_sopp(cdna5::kSCbranchScc0Sopp, {.simm16 = 1})[0],
+      rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_GFX1250),
+      rocjitsu::build_s_swappc_b64(kKernargReturnSreg, kKernargTargetSreg,
+                                   ROCJITSU_CODE_ARCH_GFX1250),
+      rocjitsu::build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250),
+  };
+  EXPECT_TRUE(translate_kernarg_fixture(words, /*enable_kernarg=*/true).ok());
+}
+
+// A latch edge back into the consumer. A must-analysis that starts non-entry blocks at the empty
+// set instead of top can never grow the fact back across that meet, and would refuse this.
+TEST(BinaryTranslatorE2E, Gfx1250AdmitsKernargTargetReachedThroughALoopLatch) {
+  const std::vector<uint32_t> words = {
+      kernarg_load_word(0),
+      kernarg_load_word(1),
+      rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_GFX1250),
+      rocjitsu::build_s_swappc_b64(kKernargReturnSreg, kKernargTargetSreg,
+                                   ROCJITSU_CODE_ARCH_GFX1250),
+      cdna5::build_sopp(cdna5::kSCbranchScc0Sopp, {.simm16 = static_cast<uint16_t>(-3)})[0],
+      rocjitsu::build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250),
+  };
+  EXPECT_TRUE(translate_kernarg_fixture(words, /*enable_kernarg=*/true).ok());
+}
+
+// adopted_root_return_offsets() walks forward from each adopted root and stops at the next one.
+// AMDGPU pads between functions rather than terminating them, so without that wall root A's walk
+// falls through into root B and classifies a setpc under A's entry state. The wall depends on
+// adopt()'s exact-start guarantee: "the next root starts here" has to be a fact, not a guess.
+//
+// Two plain adjacent bodies cannot show this -- a root's own walk always accepts its own setpc --
+// so the setpc here is SHARED, reached from A by a branch and from B by fallthrough. The bare
+// getpc at word 0 is load-bearing too: it is an unresolved PC producer the lattice never sees, so
+// the whole-object permission is withheld and the misclassification is not masked by it.
+TEST(BinaryTranslatorE2E, Gfx1250StopsAdoptedRootReturnWalkAtTheNextRoot) {
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  constexpr uint16_t kSharedReturnSreg = 30;
+  const std::vector<uint32_t> words = {
+      rocjitsu::build_s_getpc_b64(10, ROCJITSU_CODE_ARCH_GFX1250), // word 0: kernel 0, poisons the
+                                                                   // code-address accounting
+      kGfx1250SEndpgm,                                             // word 1: kernel 1 entry
+      cdna5::build_sopp(cdna5::kSCbranchScc0Sopp, {.simm16 = 3})[0], // word 2: root A -> word 6
+      rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_GFX1250),          // word 3: A falls into B
+      rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_GFX1250),          // word 4: root B
+      rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_GFX1250),          // word 5
+      rocjitsu::build_s_setpc_b64(kSharedReturnSreg,
+                                  ROCJITSU_CODE_ARCH_GFX1250), // word 6: reached from both
+      kGfx1250SEndpgm,                                         // word 7
+  };
+
+  auto image =
+      rocjitsu::test_support::make_minimal_amdgpu_elf_with_two_kernels_and_function_pointers(
+          words, /*kernel1_entry_word=*/1,
+          {{.offset_word = 2, .words = 1}, {.offset_word = 4, .words = 3}});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+
+  // Both walks reach an out-of-body predecessor at the shared setpc and fail closed. Removing the
+  // boundary lets A's walk pull B in, the setpc classifies as A's return, and the object is
+  // accepted with a return proven from the wrong entry state.
+  EXPECT_FALSE(result.ok())
+      << "a setpc shared by two adopted roots must not be classified from one root's entry state";
+  EXPECT_TRUE(rocjitsu::test_support::has_error_containing(
+      result, rocjitsu::DiagnosticKind::Legalization,
+      "indirect branch or call target recovery is not implemented"));
+}
+
 TEST(BinaryTranslatorE2E, Gfx1250RefusesFunctionPointerIntoTheMiddleOfAnInstruction) {
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
   constexpr uint16_t kPcSreg = 4;

--- a/emulation/rocjitsu/tests/dbt/translate_gfx1250_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_gfx1250_test.cpp
@@ -2460,6 +2460,157 @@ TEST(BinaryTranslatorE2E, Gfx1250CompactConditionalLayoutIsIdempotent) {
   EXPECT_EQ(second.elf_bytes, result.elf_bytes);
 }
 
+// A sized FUNC symbol over a compiler long jump, translated twice, asserting the WHOLE ELF image
+// rather than just `.text` -- metadata drift is invisible to a text-only comparison.
+//
+// Scope warning, stated because the name would otherwise overclaim: this does NOT reproduce the
+// st_size overshoot fixed in binary_translator.cpp (block ends inside a preserved marked window
+// mapping to the running output size). That needs the symbol's extent to end exactly on the
+// window's consumer offset in the SECOND pass's view, which depends on where the first pass placed
+// the regenerated window -- not something this fixture can pin without hard-coding a layout. It
+// was verified against the fixture with the fix reverted and still passed. The overshoot is
+// currently covered only by --verify-idempotence on a large device image; a targeted case for it
+// is still missing.
+// An address-taken body is emitted once, as an adopted root, so a scope that does not own it must
+// not clone it -- cloning is what made re-translation diverge. That reasoning covers the INDIRECT
+// edges only. A direct s_call_b64 leaves a BranchFixup in the calling scope, and
+// patch_direct_branch_fixups() resolves it against that scope's own layout, so dropping the body
+// there makes the call unresolvable. Kernel 1 calls the helper directly; the pointer slot adopts it
+// into kernel 0's scope.
+TEST(BinaryTranslatorE2E, Gfx1250KeepsDirectlyCalledHelperThatIsAlsoAddressTaken) {
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  constexpr uint32_t kGfx1250SNop = 0xBF800000u;
+  constexpr uint16_t kReturnSreg = 30;
+  const std::vector<uint32_t> words = {
+      kGfx1250SEndpgm, // word 0: kernel 0 entry
+      kGfx1250SNop,    // word 1: padding
+      rocjitsu::build_s_call_b64(kReturnSreg, 1, ROCJITSU_CODE_ARCH_GFX1250), // word 2: kernel 1
+      kGfx1250SEndpgm,                                                        // word 3
+      kGfx1250SNop,                                                           // word 4: helper
+      rocjitsu::build_s_setpc_b64(kReturnSreg, ROCJITSU_CODE_ARCH_GFX1250),   // word 5: return
+  };
+
+  auto image = rocjitsu::test_support::make_minimal_amdgpu_elf_with_two_kernels_and_function_pointers(
+      words, /*kernel1_entry_word=*/2, {{.offset_word = 4, .words = 2}});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_TRUE(translated.is_valid());
+  rocjitsu::BinaryTranslator verifier(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto second = verifier.translate(translated);
+  ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
+                                                          : second.diagnostics.front().message);
+  EXPECT_EQ(second.elf_bytes, result.elf_bytes);
+}
+
+// block_for_offset() answers with the block CONTAINING an offset, so a pointer naming the literal
+// word of a two-word instruction would otherwise be adopted as a function entry and seeded with the
+// ABI's entry VGPR_MSB state. Refusing is the only safe answer: there is no instruction boundary
+// there to relocate a body from.
+//
+// This pins the required behaviour, not the mechanism. The refusal here survives disabling
+// adopt()'s exact-start check, because a mid-instruction offset has no placement either way and
+// relocate_relative_text_addends() then fails. Isolating that check needs a unit test on adopt();
+// what this guards is that the object is never quietly accepted.
+TEST(BinaryTranslatorE2E, Gfx1250RefusesFunctionPointerIntoTheMiddleOfAnInstruction) {
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  constexpr uint16_t kPcSreg = 4;
+  constexpr uint16_t kGfx1250SAddNcU64Opcode = 83;
+  constexpr uint16_t kLiteralOperand = 255;
+  const std::vector<uint32_t> words = {
+      kGfx1250SEndpgm, // word 0: kernel entry
+      rocjitsu::build_sop2_encoding(ROCJITSU_CODE_ARCH_GFX1250, kGfx1250SAddNcU64Opcode, kPcSreg,
+                                    kPcSreg, kLiteralOperand), // word 1: two-word instruction
+      0x00000010u,                                             // word 2: its literal
+      kGfx1250SEndpgm,                                         // word 3
+  };
+
+  auto image = rocjitsu::test_support::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      words, /*text_function_words=*/1, /*text_function_offset_words=*/2,
+      /*function_pointer_table_target_words=*/2);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+  EXPECT_FALSE(result.ok())
+      << "a pointer into the middle of an instruction must not be adopted as a function entry";
+}
+
+TEST(BinaryTranslatorE2E, Gfx1250SizedFunctionSymbolEndingInsideMarkedWindowKeepsItsSize) {
+  constexpr uint16_t kPcSreg = 4;
+  constexpr uint16_t kGfx1250SAddNcU64Opcode = 83;
+  constexpr uint16_t kLiteralOperand = 255;
+  constexpr uint32_t kTargetOffset = 140000;
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+
+  // The leading nop must be the long-transfer marker, not a plain nop: only a marked window is
+  // preserved across a pass, and only a preserved window has interior offsets that emission
+  // skips. A plain nop makes the consumer compact instead, which never exercises the mapping.
+  std::vector<uint32_t> words = {
+      rocjitsu::build_s_nop(rocjitsu::kLongDirectBranchMarkerNopImmediate,
+                            ROCJITSU_CODE_ARCH_GFX1250),
+      rocjitsu::build_s_getpc_b64(kPcSreg, ROCJITSU_CODE_ARCH_GFX1250),
+      rocjitsu::build_sop2_encoding(ROCJITSU_CODE_ARCH_GFX1250, kGfx1250SAddNcU64Opcode, kPcSreg,
+                                    kPcSreg, kLiteralOperand),
+      kTargetOffset - 2 * sizeof(uint32_t),
+      rocjitsu::build_s_setpc_b64(kPcSreg, ROCJITSU_CODE_ARCH_GFX1250),
+  };
+  words.resize(kTargetOffset / sizeof(uint32_t),
+               rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_GFX1250));
+  words.push_back(kGfx1250SEndpgm);
+
+  // Four words: the marker, the getpc, and its two-word delta add. The extent therefore ends
+  // exactly on the setpc -- strictly inside the window, which spans marker through consumer.
+  auto image = rocjitsu::test_support::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      words, /*text_function_words=*/4, /*text_function_offset_words=*/0);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto first = translator.translate(source);
+  ASSERT_TRUE(first.ok()) << (first.diagnostics.empty() ? "" : first.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(first.elf_bytes.data(), first.elf_bytes.size());
+  ASSERT_TRUE(translated.is_valid());
+  rocjitsu::BinaryTranslator verifier(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto second = verifier.translate(translated);
+  ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
+                                                          : second.diagnostics.front().message);
+
+  // The window is regenerated at its reserved size, so the symbol keeps its four words. Mapping
+  // the extent to kernel_text.size() instead would report the whole window and round st_size up.
+  const auto first_symbol = rocjitsu::test_support::find_elf_symbol_for_test(first.elf_bytes, "kernel");
+  ASSERT_TRUE(first_symbol.has_value());
+  EXPECT_EQ(first_symbol->st_size, 4 * sizeof(uint32_t));
+  const auto second_symbol = rocjitsu::test_support::find_elf_symbol_for_test(second.elf_bytes, "kernel");
+  ASSERT_TRUE(second_symbol.has_value());
+  EXPECT_EQ(second_symbol->st_size, first_symbol->st_size);
+
+  EXPECT_EQ(second.elf_bytes, first.elf_bytes);
+}
+
 TEST(BinaryTranslatorE2E, Gfx1250CompilerLongJumpCompactsIdempotentlyAfterPaddingNop) {
   constexpr uint16_t kPcSreg = 4;
   constexpr uint16_t kGfx1250SAddNcU64Opcode = 83;
@@ -6007,7 +6158,17 @@ TEST(BinaryTranslatorE2E, PatchesRecoveredSetpcTargetAfterRelocation) {
   // and grows only if final placement requires the canonical long form.
   EXPECT_EQ(target_words[0], build_s_getpc_b64(kPcSreg, ROCJITSU_CODE_ARCH_CDNA3));
   EXPECT_EQ(target_words[1], build_s_add_u32(kPcSreg, kPcSreg, kLiteralOperand));
-  EXPECT_EQ(target_words[2], kOriginalGetpcDelta);
+  // The consumer became a branch window, leaving this builder dead -- and the compaction that
+  // drops the unreachable word has to move its delta with it. Pinning the SOURCE delta, as this
+  // test once did, asserted a builder measured against the pre-relocation layout: unreachable at
+  // runtime, but on a re-translation indistinguishable from a live producer of an unrelocated code
+  // address.
+  constexpr uint32_t kRelocatedGetpcDelta =
+      5 * sizeof(uint32_t) - /*the getpc leaves the address of the next instruction=*/
+      sizeof(uint32_t);
+  static_assert(kRelocatedGetpcDelta != kOriginalGetpcDelta,
+                "compaction must actually move the target, or this assertion proves nothing");
+  EXPECT_EQ(target_words[2], kRelocatedGetpcDelta);
   EXPECT_EQ(target_words[3], build_s_addc_u32(kPcSreg + 1, kPcSreg + 1, kInlineInt0));
   EXPECT_EQ(target_words[4], rocjitsu::build_s_branch(0, ROCJITSU_CODE_ARCH_CDNA3));
   EXPECT_EQ(target_words[5], rocjitsu::build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA3));
@@ -6046,7 +6207,17 @@ TEST(BinaryTranslatorE2E, PatchesRecoveredSwappcTargetAfterRelocation) {
   ASSERT_GE(translated.text_sections()[0]->size(), 6 * sizeof(uint32_t));
   EXPECT_EQ(target_words[0], build_s_getpc_b64(kPcSreg, ROCJITSU_CODE_ARCH_CDNA3));
   EXPECT_EQ(target_words[1], build_s_add_u32(kPcSreg, kPcSreg, kLiteralOperand));
-  EXPECT_EQ(target_words[2], kOriginalGetpcDelta);
+  // The consumer became a call window, leaving this builder dead -- and the same compaction that
+  // moves the target has to move its delta with it. Pinning the SOURCE delta here, as this test
+  // once did, asserted a builder still measured against the pre-relocation layout: unreachable at
+  // runtime, but on a re-translation indistinguishable from a live producer of an unrelocated code
+  // address, which is a code object whose translation is not a fixed point.
+  constexpr uint32_t kRelocatedGetpcDelta =
+      5 * sizeof(uint32_t) - /*the getpc leaves the address of the next instruction=*/
+      sizeof(uint32_t);
+  static_assert(kRelocatedGetpcDelta != kOriginalGetpcDelta,
+                "compaction must actually move the target, or this assertion proves nothing");
+  EXPECT_EQ(target_words[2], kRelocatedGetpcDelta);
   EXPECT_EQ(target_words[3], build_s_addc_u32(kPcSreg + 1, kPcSreg + 1, kInlineInt0));
   // The target is non-returning, so relocation drops the dead continuation
   // and compacts the target immediately after the call.
@@ -6203,12 +6374,25 @@ TEST(BinaryTranslatorE2E, TranslatesSwappcCallWhenCalleeSetpcBranchesToReturn) {
       reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
   ASSERT_GE(translated.text_sections()[0]->size(), 12 * sizeof(uint32_t));
   EXPECT_EQ(target_words[0], build_s_getpc_b64(kCallTargetSreg, ROCJITSU_CODE_ARCH_CDNA3));
-  EXPECT_EQ(target_words[2], kOriginalCallTargetDelta);
+  // Both consumers became transfer windows, so both builders are dead -- but each must still name
+  // the instruction it originally named, at that instruction's relocated home. The source builders
+  // point at the callee entry (0x20) and at the return setpc (0x38); compaction drops the
+  // unreachable words between them, landing those at target words 6 and 11. Asserting the SOURCE
+  // deltas here, as this test once did, pinned builders measured against the pre-relocation layout
+  // -- unreachable at runtime, yet on a re-translation indistinguishable from live producers of
+  // unrelocated code addresses, which is a code object whose translation is not a fixed point.
+  constexpr uint32_t kWordBytes = sizeof(uint32_t);
+  constexpr uint32_t kRelocatedCallTargetDelta = (6 - 1) * kWordBytes;
+  constexpr uint32_t kRelocatedReturnTargetDelta = (11 - 7) * kWordBytes;
+  static_assert(kRelocatedCallTargetDelta != kOriginalCallTargetDelta &&
+                    kRelocatedReturnTargetDelta != kOriginalReturnTargetDelta,
+                "compaction must actually move both targets, or these assertions prove nothing");
+  EXPECT_EQ(target_words[2], kRelocatedCallTargetDelta);
   EXPECT_EQ(target_words[4], build_s_call_b64(kReturnSreg, 1))
       << "the swappc call window should patch directly to the compact callee body";
   EXPECT_EQ(target_words[5], rocjitsu::build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA3));
   EXPECT_EQ(target_words[6], build_s_getpc_b64(kReturnTargetSreg, ROCJITSU_CODE_ARCH_CDNA3));
-  EXPECT_EQ(target_words[8], kOriginalReturnTargetDelta);
+  EXPECT_EQ(target_words[8], kRelocatedReturnTargetDelta);
   EXPECT_EQ(target_words[10], rocjitsu::build_s_branch(0, ROCJITSU_CODE_ARCH_CDNA3))
       << "the callee's recovered setpc window is what reaches the return block";
   EXPECT_EQ(target_words[11], build_s_setpc_b64(kReturnSreg, ROCJITSU_CODE_ARCH_CDNA3));
@@ -6247,7 +6431,19 @@ TEST(BinaryTranslatorE2E, PatchesOneRecoveredBuilderUsedByTwoSetpcConsumers) {
   ASSERT_GE(translated.text_sections()[0]->size(), 8 * sizeof(uint32_t));
   EXPECT_EQ(target_words[0], build_s_getpc_b64(kPcSreg, ROCJITSU_CODE_ARCH_CDNA3));
   EXPECT_EQ(target_words[1], build_s_add_u32(kPcSreg, kPcSreg, kLiteralOperand));
-  EXPECT_EQ(target_words[2], kOriginalGetpcDelta);
+  // Both consumers became direct-transfer windows, which leaves this builder dead -- but dead is
+  // not the same as free to be wrong. The unreachable gap at source 0x1c is dropped by compaction,
+  // so the shared target moves from source 0x20 to target word 7 and the delta from the
+  // instruction after the getpc must follow it. Asserting the SOURCE delta here, as this test once
+  // did, pinned a builder still measured against the pre-relocation layout: harmless to run, since
+  // the windows supersede it, but indistinguishable on a re-translation from a live producer of an
+  // unrelocated code address, and so a code object whose translation is not a fixed point.
+  constexpr uint32_t kRelocatedGetpcDelta =
+      7 * sizeof(uint32_t) - /*the getpc leaves the address of the next instruction=*/
+      sizeof(uint32_t);
+  static_assert(kRelocatedGetpcDelta != kOriginalGetpcDelta,
+                "compaction must actually move the target, or this assertion proves nothing");
+  EXPECT_EQ(target_words[2], kRelocatedGetpcDelta);
   EXPECT_EQ(target_words[3], build_s_addc_u32(kPcSreg + 1, kPcSreg + 1, kInlineInt0));
   EXPECT_EQ(target_words[4], cdna3::build_sopp(cdna3::kSCbranchScc1Sopp, {.simm16 = 1})[0]);
   EXPECT_EQ(target_words[5], rocjitsu::build_s_branch(1, ROCJITSU_CODE_ARCH_CDNA3));
@@ -9297,13 +9493,14 @@ TEST(BinaryTranslatorE2E, Gfx1250AdoptsDeviceFunctionBodyReachedByNoScope) {
   EXPECT_EQ(text_words_at_relative64_addend(result.elf_bytes, 2),
             (std::vector<uint32_t>{kGfx1250SNop, kGfx1250SEndpgm}));
 }
-// The same shape with the pointer array's own symbol stripped. Adoption is driven by the
-// discovered function tables, and discovery needs a qualifying `STT_OBJECT` around the slot, so a
-// compiler-anonymous pointer array names no adoptable body. That boundary is pinned here rather
-// than left unstated: the body is still dropped, its addend still has nowhere to point, and
-// replace_text() still refuses the object -- the behavior that predates adoption. Widening it
-// needs reachability asked of the raw relocations rather than of the tables.
-TEST(BinaryTranslatorE2E, Gfx1250RefusesDeviceFunctionBodyHeldByAnUnnamedPointerSlot) {
+// The same shape with the pointer array's own symbol stripped, which is what a compiler-anonymous
+// pointer array looks like. Adoption asks the raw `R_AMDGPU_RELATIVE64` relocations which bodies
+// are address-taken, not just the function tables discovery can name, so the slot still names an
+// adoptable body even though no `STT_OBJECT` wraps it. The table assertion below is what keeps
+// this distinct from the test above: it proves the adoption came from the relocation rather than
+// from table discovery. A separately compiled device library reaches most of its functions exactly
+// this way, so refusing here would refuse every such object.
+TEST(BinaryTranslatorE2E, Gfx1250AdoptsDeviceFunctionBodyHeldByAnUnnamedPointerSlot) {
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
   constexpr uint32_t kGfx1250SNop = 0xBF800000u;
   const std::vector<uint32_t> words = {
@@ -9325,8 +9522,51 @@ TEST(BinaryTranslatorE2E, Gfx1250RefusesDeviceFunctionBodyHeldByAnUnnamedPointer
                                rocjitsu::ProcessorRevision::Gfx1250A0));
   const auto result = translator.translate(source);
 
-  EXPECT_FALSE(result.ok());
-  EXPECT_EQ(result.elf_bytes, image);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+  ASSERT_TRUE(result.dispatchable());
+  EXPECT_NE(result.elf_bytes, image);
+  // Accepting the object is not the property worth pinning -- landing the pointer on the right
+  // bytes is. The addend must name the adopted body, not whatever now occupies its original range.
+  EXPECT_EQ(text_words_at_relative64_addend(result.elf_bytes, 2),
+            (std::vector<uint32_t>{kGfx1250SNop, kGfx1250SEndpgm}));
+}
+
+// An unprovable call through a pointer, in an object whose only code-address producer is an
+// anonymous RELATIVE64 slot. This reaches the producer gate guarding the relocated-by-construction
+// permission: with no discovered table and no getpc builder the object used to look producerless,
+// so the unresolved s_swap_pc_i64 took the rejection path even though the addend naming its callee
+// is discovered, adopted and relocated here. A separately compiled device library is this shape.
+TEST(BinaryTranslatorE2E, Gfx1250AllowsUnprovableCallWhenOnlyProducerIsAnAnonymousPointerSlot) {
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  constexpr uint32_t kGfx1250SNop = 0xBF800000u;
+  // s_swap_pc_i64 s[30:31], s[0:1]. Nothing writes s[0:1], so recovery cannot name a target and
+  // the consumer stays unresolved, which is the only way to reach the gate.
+  constexpr uint32_t kGfx1250SwapPcS30FromS0 = 0xBE9E4900u;
+  const std::vector<uint32_t> words = {
+      kGfx1250SwapPcS30FromS0, kGfx1250SEndpgm, kGfx1250SNop, kGfx1250SNop, kGfx1250SEndpgm,
+  };
+
+  auto image = rocjitsu::test_support::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      words, /*text_function_words=*/2, /*text_function_offset_words=*/3,
+      /*function_pointer_table_target_words=*/3,
+      /*name_function_pointer_table_with_symbol=*/false);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+  ASSERT_TRUE(rocjitsu::discover_relocation_function_tables(source).empty())
+      << "the slot must stay anonymous, or the producer comes from table discovery instead";
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+  ASSERT_TRUE(result.dispatchable());
+  EXPECT_EQ(text_words_at_relative64_addend(result.elf_bytes, 2),
+            (std::vector<uint32_t>{kGfx1250SNop, kGfx1250SEndpgm}));
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250RepointsPcRelativeDataRangeBoundsAfterRelocation) {
@@ -12240,7 +12480,7 @@ TEST(BinaryTranslatorE2E, Gfx1250RecoveredBuilderRewriteKeepsTheXcntDrain) {
 TEST(BinaryTranslatorE2E, Gfx1250RecoveredBuilderRewriteOmitsAnUnneededXcntDrain) {
   constexpr uint64_t kWord = sizeof(uint32_t);
   constexpr uint16_t kPcSreg = 8;
-  constexpr uint16_t kLiteralOperand = 255;
+  constexpr uint16_t kLiteral64Operand = 254;
   std::vector<uint8_t> text(8 * kWord, 0);
   rocjitsu::KernelTextLayout layout;
   layout.body_end = text.size();
@@ -12260,10 +12500,14 @@ TEST(BinaryTranslatorE2E, Gfx1250RecoveredBuilderRewriteOmitsAnUnneededXcntDrain
       rocjitsu::patch_recovered_builder_fixups(text, layout, ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_TRUE(patched.ok) << patched.message;
 
+  // The point of this case is that no XCNT drain precedes the add -- the first word of the range
+  // is the add itself. The literal width is incidental to that, but it is asserted exactly rather
+  // than loosely: the rewrite deliberately emits the literal64 form so the relocation lattice,
+  // which models only that encoding, can still see this builder on a later translation pass.
   uint32_t first = 0;
   std::memcpy(&first, text.data() + kWord, sizeof(first));
   EXPECT_EQ(first, rocjitsu::build_sop2_encoding(ROCJITSU_CODE_ARCH_GFX1250, cdna5::kSAddNcU64Sop2,
-                                                 kPcSreg, kPcSreg, kLiteralOperand));
+                                                 kPcSreg, kPcSreg, kLiteral64Operand));
 }
 
 TEST(BinaryTranslatorE2E, RecoveredBuilderReuseRejectsDisagreeingXcntDrain) {


### PR DESCRIPTION
RCCL's device-linker build emits device functions reached only through a stored or getpc-built pointer, so no decoded edge names them. DBT partitions .text into kernel-reachability closures, so those bodies were never emitted, the addresses naming them could not be relocated, and the object was refused outright -- 33 s_swap_pc_i64 sites in the 745 MB gfx1250 image.

Account for the two producers the code-address audit missed: a long-branch expansion, rewritten by the recovered-indirect path rather than the lattice, and a completed builder whose SGPR pair a later getpc reseeds, which was poisoned instead of published. Then give the pointer-reached bodies somewhere to land -- adopt unfoldable getpc targets and every RELATIVE64 addend target, make ELF STT_FUNC symbols block leaders so a function entry is not buried in the s_nop padding ahead of it, seed adopted roots with the ABI's zero VGPR-MSB entry state, narrow the every-symbol-mapped requirement to symbols a host can actually resolve, and point conflicting addends at the canonical clone, withholding any whose clones disagree on kernel-scope variant so the sidecar case stays fail-closed.