### PR TITLE
rocjitsu: recover gfx1250 scratch-spilled call targets

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
@@ -5,6 +5,11 @@
 
 #include "rocjitsu/analysis/control_flow.h"
 #include "rocjitsu/code/builders/instruction_builder.h"
+#if __has_include("rocjitsu/isa/arch/amdgpu/generated/gfx1250/machine_insts.h")
+#include "rocjitsu/isa/arch/amdgpu/generated/gfx1250/machine_insts.h"
+#else
+#include "rocjitsu/isa/arch/amdgpu/gfx1250/machine_insts.h"
+#endif
 #include "rocjitsu/isa/instruction.h"
 #include "rocjitsu/isa/operand.h"
 #include "rocjitsu/isa/register_set.h"
@@ -1982,8 +1987,28 @@ struct StashedPcHalf {
   friend bool operator==(const StashedPcHalf &, const StashedPcHalf &) = default;
 };
 
+struct ScratchSpillSlot {
+  uint16_t saddr = 0;
+  int32_t byte_offset = 0;
+
+  friend bool operator==(const ScratchSpillSlot &, const ScratchSpillSlot &) = default;
+};
+
+struct ScratchSpillSlotHash {
+  size_t operator()(const ScratchSpillSlot &slot) const {
+    return std::hash<uint16_t>{}(slot.saddr) ^ (std::hash<int32_t>{}(slot.byte_offset) << 1);
+  }
+};
+
+struct ScratchSpillValue {
+  std::unordered_map<uint16_t, StashedPcHalf> lanes;
+
+  friend bool operator==(const ScratchSpillValue &, const ScratchSpillValue &) = default;
+};
+
 struct VectorLaneFlowState {
   std::unordered_map<VectorLaneSlot, StashedPcHalf, VectorLaneSlotHash> slots;
+  std::unordered_map<ScratchSpillSlot, ScratchSpillValue, ScratchSpillSlotHash> scratch_spills;
   std::optional<uint8_t> vgpr_msb_imm;
 
   friend bool operator==(const VectorLaneFlowState &, const VectorLaneFlowState &) = default;
@@ -2064,6 +2089,8 @@ void recover_vector_lane_stashed_pcs(AnalysisContext &ctx, const std::vector<Ana
 
   constexpr unsigned kDstBankShift = 6;  // s_set_vgpr_msb immediate DST field.
   constexpr unsigned kSrc0BankShift = 0; // s_set_vgpr_msb immediate SRC0 field.
+  constexpr unsigned kSrc1BankShift = 3; // s_set_vgpr_msb immediate SRC1 field.
+  constexpr uint16_t kInlineIntNeg1 = 193;
 
   const auto scan_block = [&](const AnalysisBlock &block, VectorLaneFlowState state,
                               bool emit_fixups) {
@@ -2078,10 +2105,87 @@ void recover_vector_lane_stashed_pcs(AnalysisContext &ctx, const std::vector<Ana
       return static_cast<uint16_t>(low + static_cast<uint16_t>(bank) * 256u);
     };
 
+    const auto full_exec_setup_immediately_precedes = [&](size_t index, uint16_t scratch_saddr) {
+      if (index == block.first_index)
+        return false;
+      const Instruction &previous = *ctx.insts[index - 1];
+      if (previous.mnemonic() != "s_or_saveexec_b32")
+        return false;
+      const auto saved_exec = operand_register(previous.dst_operand(0), RegClass::SGPR);
+      if (!saved_exec || saved_exec->index == scratch_saddr)
+        return false;
+      for (int src_index = 0; src_index < previous.num_src_operands(); ++src_index) {
+        const Operand *source = previous.src_operand(src_index);
+        if (source != nullptr && source->encoding_value() == kInlineIntNeg1)
+          return true;
+      }
+      return false;
+    };
+
+    const auto canonical_scratch_slot =
+        [&](const Instruction &inst, int saddr_operand_index) -> std::optional<ScratchSpillSlot> {
+      // Restrict provenance to the compiler's scalar-base, immediate-offset
+      // form. A VGPR address makes aliasing data-dependent and must fail closed.
+      const auto saddr = operand_register(inst.src_operand(saddr_operand_index), RegClass::SGPR);
+      if (!saddr || inst.raw_encoding() == nullptr || inst.size() < 12)
+        return std::nullopt;
+      gfx1250::VscratchMachineInst encoded{};
+      std::memcpy(&encoded, inst.raw_encoding(), sizeof(encoded));
+      // The decoder exposes src_operand(0) as a VGPR even when SVE=0 and the
+      // disassembly prints `off`; SVE, not the decoded operand, controls whether
+      // VADDR participates in address calculation.
+      if (encoded.sve != 0 || encoded.saddr != saddr->index)
+        return std::nullopt;
+      const int32_t byte_offset = static_cast<int32_t>(encoded.ioffset << 8) >> 8;
+      return ScratchSpillSlot{.saddr = saddr->index, .byte_offset = byte_offset};
+    };
+
+    const auto scratch_store_width = [](std::string_view mnemonic) -> std::optional<uint32_t> {
+      if (mnemonic == "scratch_store_b8")
+        return 1;
+      if (mnemonic == "scratch_store_b16")
+        return 2;
+      if (mnemonic == "scratch_store_b32")
+        return 4;
+      if (mnemonic == "scratch_store_b64")
+        return 8;
+      if (mnemonic == "scratch_store_b96")
+        return 12;
+      if (mnemonic == "scratch_store_b128")
+        return 16;
+      return std::nullopt;
+    };
+
+    const auto invalidate_scratch_store_aliases = [&](std::optional<ScratchSpillSlot> store,
+                                                      std::optional<uint32_t> width) {
+      if (!store || !width) {
+        state.scratch_spills.clear();
+        return;
+      }
+      const int64_t store_begin = store->byte_offset;
+      const int64_t store_end = store_begin + static_cast<int64_t>(*width);
+      std::erase_if(state.scratch_spills, [&](const auto &item) {
+        // Different scalar bases are not proven disjoint.
+        if (item.first.saddr != store->saddr)
+          return true;
+        const int64_t saved_begin = item.first.byte_offset;
+        const int64_t saved_end = saved_begin + static_cast<int64_t>(sizeof(uint32_t));
+        return store_begin < saved_end && saved_begin < store_end;
+      });
+    };
+
     for (size_t index = block.first_index; index <= block.last_index; ++index) {
       const Instruction &inst = *ctx.insts[index];
       const InstructionFacts &facts = ctx.facts[index];
       const std::string_view mnemonic = inst.mnemonic();
+
+      if (!state.scratch_spills.empty()) {
+        ensure_written_sgprs(ctx, index);
+        ctx.facts[index].written_sgprs.for_each([&](uint16_t sgpr) {
+          std::erase_if(state.scratch_spills,
+                        [&](const auto &item) { return item.first.saddr == sgpr; });
+        });
+      }
 
       if (!active_read_halves.empty()) {
         ensure_written_sgprs(ctx, index);
@@ -2110,6 +2214,74 @@ void recover_vector_lane_stashed_pcs(AnalysisContext &ctx, const std::vector<Ana
         // stash there survives (see is_callee_saved_vgpr).
         std::erase_if(state.slots,
                       [](const auto &item) { return !is_callee_saved_vgpr(item.first.vgpr); });
+        // A conforming AMDGPU callee owns a disjoint scratch frame and therefore
+        // preserves caller spill slots. This is the scratch-memory counterpart
+        // of the callee-saved VGPR invariant above. Hand-written code that
+        // violates the calling convention remains outside this proof.
+      }
+
+      if (mnemonic == "scratch_store_b32") {
+        const auto source = operand_register(inst.src_operand(1), RegClass::VGPR);
+        const auto source_phys =
+            source ? physical_vgpr(source->index, kSrc1BankShift) : std::nullopt;
+        const auto spill = canonical_scratch_slot(inst, 2);
+        invalidate_scratch_store_aliases(spill, sizeof(uint32_t));
+        if (spill && source_phys && full_exec_setup_immediately_precedes(index, spill->saddr)) {
+          ScratchSpillValue saved;
+          for (const auto &[slot, value] : state.slots) {
+            if (slot.vgpr == *source_phys)
+              saved.lanes.emplace(slot.lane, value);
+          }
+          if (!saved.lanes.empty())
+            state.scratch_spills[*spill] = std::move(saved);
+        }
+        if (!builders.active_pairs().empty())
+          invalidate_written_sgprs(ctx, index, builders);
+        continue;
+      }
+
+      if (mnemonic.starts_with("scratch_store_")) {
+        // Preserve only proven non-overlapping ranges on the same scalar base.
+        // Unknown forms/bases and overlaps fail closed.
+        invalidate_scratch_store_aliases(canonical_scratch_slot(inst, 2),
+                                         scratch_store_width(mnemonic));
+      }
+
+      // A scratch atomic is both a read and a write at an address whose width
+      // and aliasing cannot be derived generically from the mnemonic. Current
+      // gfx1250 tables do not decode these opcodes, but fail closed if support
+      // is added so an atomic can never leave stale PC provenance behind.
+      if (internal::invalidates_scratch_provenance(mnemonic))
+        state.scratch_spills.clear();
+
+      // Flat memory writes can address the private/scratch aperture. Without a
+      // proven address-space and alias result, retaining a caller scratch fact
+      // across any flat store or atomic would be unsound.
+      if (mnemonic.starts_with("flat_store_") || mnemonic.starts_with("flat_atomic_"))
+        state.scratch_spills.clear();
+
+      if (mnemonic == "scratch_load_b32") {
+        const auto destination = operand_register(inst.dst_operand(0), RegClass::VGPR);
+        const auto destination_phys =
+            destination ? physical_vgpr(destination->index, kDstBankShift) : std::nullopt;
+        const auto spill = canonical_scratch_slot(inst, 1);
+        if (spill && destination_phys &&
+            full_exec_setup_immediately_precedes(index, spill->saddr)) {
+          auto saved = state.scratch_spills.find(*spill);
+          if (saved != state.scratch_spills.end()) {
+            std::erase_if(state.slots,
+                          [&](const auto &item) { return item.first.vgpr == *destination_phys; });
+            for (const auto &[lane, value] : saved->second.lanes)
+              state.slots[VectorLaneSlot{*destination_phys, lane}] = value;
+            // A load does not consume or modify the saved memory value. Keep
+            // the provenance live across loop backedges until an actual store
+            // or scalar-base rewrite invalidates it.
+            if (!builders.active_pairs().empty())
+              invalidate_written_sgprs(ctx, index, builders);
+            continue;
+          }
+        }
+        // No exact provenance: fall through to ordinary VGPR-def invalidation.
       }
 
       if (mnemonic == "v_writelane_b32") {
@@ -2261,6 +2433,14 @@ void recover_vector_lane_stashed_pcs(AnalysisContext &ctx, const std::vector<Ana
         else
           ++it;
       }
+      for (auto it = new_entry.scratch_spills.begin(); it != new_entry.scratch_spills.end();) {
+        auto incoming = exit_states[predecessor].scratch_spills.find(it->first);
+        if (incoming == exit_states[predecessor].scratch_spills.end() ||
+            incoming->second != it->second)
+          it = new_entry.scratch_spills.erase(it);
+        else
+          ++it;
+      }
       if (new_entry.vgpr_msb_imm != exit_states[predecessor].vgpr_msb_imm)
         new_entry.vgpr_msb_imm = std::nullopt;
     }
@@ -2280,6 +2460,7 @@ void recover_vector_lane_stashed_pcs(AnalysisContext &ctx, const std::vector<Ana
         new_entry = std::move(external_entry);
       } else {
         new_entry.slots.clear();
+        new_entry.scratch_spills.clear();
         if (new_entry.vgpr_msb_imm != external_entry.vgpr_msb_imm)
           new_entry.vgpr_msb_imm = std::nullopt;
       }
@@ -2500,6 +2681,10 @@ std::optional<uint16_t> s_call_sdst(const Instruction &inst, uint32_t word) {
 }
 
 } // namespace
+
+bool internal::invalidates_scratch_provenance(std::string_view mnemonic) {
+  return mnemonic.starts_with("scratch_atomic_");
+}
 
 bool is_callee_saved_vgpr(uint16_t phys_vgpr) {
   return phys_vgpr >= 40 && phys_vgpr <= 255 && ((phys_vgpr - 40) % 16) < 8;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.h
@@ -10,9 +10,18 @@
 
 #include <cstdint>
 #include <span>
+#include <string_view>
 #include <vector>
 
 namespace rocjitsu {
+
+namespace internal {
+
+/// @brief Whether an unmodelled memory instruction must kill tracked scratch provenance.
+/// @details Internal test seam for the fail-closed mnemonic policy used by indirect-call recovery.
+[[nodiscard]] bool invalidates_scratch_provenance(std::string_view mnemonic);
+
+} // namespace internal
 
 class Instruction;
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -1189,6 +1189,14 @@ adopted_root_return_offsets(const BlockOffsetIndex &block_index,
 
 namespace internal {
 
+bool same_recovered_builder_identity(const IndirectCallFixup &lhs, const IndirectCallFixup &rhs) {
+  return lhs.source_getpc_offset == rhs.source_getpc_offset &&
+         lhs.source_recovery_begin_offset == rhs.source_recovery_begin_offset &&
+         lhs.source_recovery_end_offset == rhs.source_recovery_end_offset &&
+         lhs.source_target_offset == rhs.source_target_offset &&
+         lhs.source_requires_xcnt_drain == rhs.source_requires_xcnt_drain;
+}
+
 /// @brief Prove that every external entry into an incomplete-consumer scope is
 ///        an entry-state root that cannot carry an original `.text` pointer.
 ///
@@ -2322,6 +2330,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
 
       const IndirectCallFixup &first = consumer.fixups.front();
       bool single_effective_target = true;
+      bool single_builder_identity = true;
       for (const IndirectCallFixup &fixup : consumer.fixups) {
         if (fixup.source_call_sreg != first.source_call_sreg ||
             fixup.source_is_call != first.source_is_call ||
@@ -2340,6 +2349,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
         }
         if (fixup.source_target_offset != first.source_target_offset)
           single_effective_target = false;
+        if (!internal::same_recovered_builder_identity(fixup, first))
+          single_builder_identity = false;
       }
       if (skip_scope)
         break;
@@ -2386,15 +2397,24 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
       if (single_effective_target) {
         consumer.window_fixup = first;
         const bool contiguous_builder =
-            consumer.fixups.size() == 1 && first.source_getpc_offset >= sizeof(uint32_t) &&
+            first.source_getpc_offset >= sizeof(uint32_t) &&
             first.source_recovery_begin_offset == first.source_getpc_offset + sizeof(uint32_t) &&
             first.source_recovery_end_offset == first.source_call_offset &&
             first.source_call_offset <= text.size() &&
             sizeof(uint32_t) <= text.size() - first.source_call_offset;
-        const auto getpc_it = source_instruction_by_offset.find(first.source_getpc_offset);
-        const Instruction *getpc =
-            getpc_it == source_instruction_by_offset.end() ? nullptr : getpc_it->second;
-        const Instruction *marker = getpc == nullptr ? nullptr : getpc->previous_instruction();
+        uint32_t marker_word = 0;
+        const uint64_t marker_offset = first.source_getpc_offset - sizeof(uint32_t);
+        const bool has_marker_word =
+            first.source_getpc_offset >= sizeof(uint32_t) &&
+            first.source_getpc_offset <= text.size() &&
+            (std::memcpy(&marker_word, text.data() + marker_offset, sizeof(marker_word)),
+             marker_word == build_s_nop(kLongDirectBranchMarkerNopImmediate, guest_arch_));
+        const auto marker_it = source_instruction_by_offset.find(marker_offset);
+        const Instruction *marker =
+            marker_it == source_instruction_by_offset.end() ? nullptr : marker_it->second;
+        const bool has_decoded_marker =
+            marker != nullptr && marker->size() == static_cast<int>(sizeof(uint32_t)) &&
+            marker->raw_encoding() != nullptr && marker->raw_encoding()[0] == marker_word;
         const auto call_it = source_instruction_by_offset.find(first.source_call_offset);
         const Instruction *call =
             call_it == source_instruction_by_offset.end() ? nullptr : call_it->second;
@@ -2420,18 +2440,14 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
             std::ranges::any_of(
                 (*call_block_it)->predecessors(),
                 [&](const BasicBlock *predecessor) { return predecessor != *builder_block_it; });
-        const bool canonical_marked_window =
-            contiguous_builder && marker != nullptr &&
-            marker->size() == static_cast<int>(sizeof(uint32_t)) &&
-            marker->src_loc() + sizeof(uint32_t) == first.source_getpc_offset &&
-            marker->raw_encoding() != nullptr &&
-            marker->raw_encoding()[0] ==
-                build_s_nop(kLongDirectBranchMarkerNopImmediate, guest_arch_) &&
-            call != nullptr && call->size() == static_cast<int>(sizeof(uint32_t)) &&
-            !has_interior_block_entry && !has_external_call_entry;
+        const bool canonical_marked_window = single_builder_identity && contiguous_builder &&
+                                             has_marker_word && has_decoded_marker &&
+                                             call != nullptr &&
+                                             call->size() == static_cast<int>(sizeof(uint32_t)) &&
+                                             !has_interior_block_entry && !has_external_call_entry;
         if (canonical_marked_window) {
           consumer.preserve_marked_long_transfer = true;
-          consumer.marked_window_begin = marker->src_loc();
+          consumer.marked_window_begin = marker_offset;
           consumer.marked_window_end = first.source_call_offset + sizeof(uint32_t);
         } else {
           consumer.use_transfer_window = true;
@@ -2460,6 +2476,17 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
       if (consumer.preserve_marked_long_transfer)
         marked_long_transfer_by_start.emplace(consumer.marked_window_begin, &consumer);
     }
+    // A repeated pass can propagate the PC value built by a translator-generated
+    // marked long-transfer window to a distant consumer. Regenerating the marked
+    // window already relocates that exact semantic builder. Suppress only an
+    // identical builder proof; a positional test is insufficient because the
+    // encoded delta builder can change width between translation passes.
+    std::erase_if(pending_builder_fixups, [&](const IndirectCallFixup &fixup) {
+      return std::ranges::any_of(marked_long_transfer_by_start, [&](const auto &item) {
+        const IndirectCallFixup &owner = item.second->window_fixup;
+        return internal::same_recovered_builder_identity(fixup, owner);
+      });
+    });
 
     std::vector<uint8_t> kernel_text;
     std::vector<PendingTrace> pending_traces;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator_internal.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator_internal.h
@@ -19,8 +19,15 @@
 namespace rocjitsu {
 
 class BasicBlock;
+struct IndirectCallFixup;
 
 namespace internal {
+
+/// @brief Compare the complete semantic identity of two recovered PC builders.
+/// @details Marked-window idempotence may suppress a repeated rewrite only for
+/// the same getpc, recovery range, target, and xcnt-drain requirement.
+[[nodiscard]] bool same_recovered_builder_identity(const IndirectCallFixup &lhs,
+                                                   const IndirectCallFixup &rhs);
 
 /// @brief Decide whether every external entry into an incomplete-consumer scope
 ///        is an entry-state root that cannot carry an original `.text` pointer.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
@@ -534,7 +534,10 @@ void grow_text_function_symbols(std::vector<uint8_t> &image, const Elf64_Ehdr &e
   // avoid an O(symbols * relocations) search below.
   std::unordered_map<size_t, std::unordered_set<uint32_t>> referenced_by_symtab;
   for (const Elf64_Shdr &relocs : shdrs) {
-    if (relocs.sh_type != SHT_RELA || relocs.sh_entsize != sizeof(Elf64_Rela) ||
+    const bool is_rela = relocs.sh_type == SHT_RELA;
+    const bool is_rel = relocs.sh_type == SHT_REL;
+    const uint64_t expected_entsize = is_rela ? sizeof(Elf64_Rela) : sizeof(Elf64_Rel);
+    if ((!is_rela && !is_rel) || relocs.sh_entsize != expected_entsize ||
         relocs.sh_link >= shdrs.size() ||
         !image_contains_range(image.size(), relocs.sh_offset, relocs.sh_size)) {
       continue;
@@ -544,11 +547,19 @@ void grow_text_function_symbols(std::vector<uint8_t> &image, const Elf64_Ehdr &e
         !image_contains_range(image.size(), symtab.sh_offset, symtab.sh_size)) {
       continue;
     }
-    const size_t count = relocs.sh_size / sizeof(Elf64_Rela);
+    const size_t count = relocs.sh_size / expected_entsize;
     for (size_t i = 0; i < count; ++i) {
-      Elf64_Rela rela{};
-      std::memcpy(&rela, image.data() + relocs.sh_offset + i * sizeof(rela), sizeof(rela));
-      const uint32_t symbol_index = elf_reloc_sym(rela.r_info);
+      uint64_t r_info = 0;
+      if (is_rela) {
+        Elf64_Rela rela{};
+        std::memcpy(&rela, image.data() + relocs.sh_offset + i * expected_entsize, sizeof(rela));
+        r_info = rela.r_info;
+      } else {
+        Elf64_Rel rel{};
+        std::memcpy(&rel, image.data() + relocs.sh_offset + i * expected_entsize, sizeof(rel));
+        r_info = rel.r_info;
+      }
+      const uint32_t symbol_index = elf_reloc_sym(r_info);
       if (symbol_index == 0 ||
           static_cast<uint64_t>(symbol_index) * sizeof(Elf64_Sym) + sizeof(Elf64_Sym) >
               symtab.sh_size) {
@@ -581,13 +592,22 @@ void grow_text_function_symbols(std::vector<uint8_t> &image, const Elf64_Ehdr &e
         continue;
 
       const auto referenced = referenced_by_symtab.find(symtab_index);
+      const bool is_referenced =
+          referenced != referenced_by_symtab.end() && referenced->second.contains(i);
       // An unreferenced symbol normally may stay unmapped, because debug and tooling tables
       // legitimately label padding this translation does not emit. When the caller is relying on
       // every `.text` address being relocated, that tolerance is a hole: a host can resolve such a
       // symbol and hand the stale address back in, so nothing may stay unmapped.
-      const bool must_relocate =
-          require_every_text_symbol_mapped ||
-          (referenced != referenced_by_symtab.end() && referenced->second.contains(i));
+      const bool must_relocate = require_every_text_symbol_mapped || is_referenced;
+
+      // Local symbols with no relocation references are tooling/debug boundaries,
+      // not runtime-visible code addresses. Opportunistically remapping one can
+      // make ownership of a shared CFG terminator drift by one instruction on a
+      // repeated translation. Preserve it verbatim so the first translation is
+      // already a fixed point. Referenced symbols and the all-symbol proof mode
+      // still take the exact, fail-closed relocation path below.
+      if (!must_relocate && elf_symbol_bind(symbol.st_info) == kElfSymbolBindLocal)
+        continue;
 
       uint64_t source_text_offset = symbol.st_value;
       if (ehdr.e_type != ET_REL) {

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -46,6 +46,12 @@
 namespace rocjitsu {
 namespace {
 
+TEST(CfgAnalysis, ScratchAtomicsInvalidateTrackedScratchProvenance) {
+  EXPECT_TRUE(internal::invalidates_scratch_provenance("scratch_atomic_swap_b32"));
+  EXPECT_TRUE(internal::invalidates_scratch_provenance("scratch_atomic_cmpswap_b64"));
+  EXPECT_FALSE(internal::invalidates_scratch_provenance("scratch_load_b32"));
+}
+
 class TestOperand : public Operand {
 public:
   TestOperand() = default;
@@ -2524,6 +2530,327 @@ TEST(CfgAnalysis, Gfx1250IndirectCallKillsCarriedLaneStash) {
   ASSERT_EQ(total_fixups, 1u);
   ASSERT_NE(call_fixup, nullptr);
   EXPECT_EQ(call_fixup->source_target_offset, 80u);
+}
+
+TEST(CfgAnalysis, Gfx1250ScratchSpillRestoresCalleeSavedLaneStash) {
+  constexpr uint16_t kCallPcSreg = 8;
+  constexpr uint16_t kReturnSreg = 30;
+  constexpr auto stale_getpc = gfx1250::build_sop1(gfx1250::kSGetPcI64Sop1, {.sdst = 0});
+  constexpr auto call_getpc = gfx1250::build_sop1(gfx1250::kSGetPcI64Sop1, {.sdst = kCallPcSreg});
+  constexpr auto call_add = gfx1250::build_sop2(
+      gfx1250::kSAddNcU64Sop2, {.ssrc0 = kCallPcSreg, .ssrc1 = 254, .sdst = kCallPcSreg});
+  constexpr auto call =
+      gfx1250::build_sop1(gfx1250::kSSwapPcI64Sop1, {.ssrc0 = kCallPcSreg, .sdst = kReturnSreg});
+  constexpr auto stale_call =
+      gfx1250::build_sop1(gfx1250::kSSwapPcI64Sop1, {.ssrc0 = 0, .sdst = 28});
+
+  // Mirror the RCCL caller-save sequence: save a fixed-lane PC stash to the
+  // canonical (s33,+20) scratch slot under full EXEC, call, and reload the
+  // same slot under full EXEC. The load is a real v44 definition, so recovery
+  // depends on scratch provenance rather than merely preserving callee-saved
+  // v44 across the call.
+  std::vector<uint32_t> words = {
+      stale_getpc[0], // 0x00: s_get_pc_i64 s[0:1].
+      0xA980FE00u,
+      120u,
+      0u, // 0x04: stale target 0x04 + 120 = 0x7c.
+      0xD761002Cu,
+      0x02010000u, // 0x10: v44 lane 0 <- s0.
+      0xD761002Cu,
+      0x02010201u, // 0x18: v44 lane 1 <- s1.
+      call_getpc[0],
+      call_add[0],
+      92u,
+      0u,          // 0x24: call target 0x24 + 92 = 0x80.
+      0xBEE922C1u, // 0x30: s_or_saveexec_b32 s105, -1.
+      0xED0680A1u,
+      0x16000000u,
+      0x00001400u, // 0x34: scratch_store_b32 off, v44, s33 offset:20.
+      0xBFC50000u, // 0x40: s_wait_xcnt 0.
+      0xBEFE0069u, // 0x44: s_mov_b32 exec_lo, s105.
+      call[0],     // 0x48: resolved intervening indirect call.
+      0xBEE922C1u, // 0x4c: s_or_saveexec_b32 s105, -1.
+      0xED0500A1u,
+      0x0000002Cu,
+      0x00001400u, // 0x50: scratch_load_b32 v44, off, s33 offset:20.
+      0xBFC50000u, // 0x5c: s_wait_xcnt 0.
+      0xBEFE0069u, // 0x60: s_mov_b32 exec_lo, s105.
+      0xD7600000u,
+      0x0201012Cu, // 0x64: v44 lane 0 -> s0.
+      0xD7600001u,
+      0x0201032Cu,                                // 0x6c: v44 lane 1 -> s1.
+      stale_call[0],                              // 0x74: recovered continuation call.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x78: continuation.
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250), // 0x7c: stashed target.
+      rocjitsu::build_s_setpc_b64(kReturnSreg, ROCJITSU_CODE_ARCH_GFX1250),
+      // 0x80: callee return.
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+
+  const IndirectCallFixup *continuation_fixup = nullptr;
+  for (const auto &block : blocks) {
+    for (const auto &fixup : block->static_indirect_call_fixups()) {
+      if (fixup.source_call_offset == 116)
+        continuation_fixup = &fixup;
+    }
+  }
+  ASSERT_NE(continuation_fixup, nullptr);
+  EXPECT_EQ(continuation_fixup->source_target_offset, 124u);
+}
+
+TEST(CfgAnalysis, Gfx1250ScratchSpillOffsetMismatchFailsClosed) {
+  constexpr uint16_t kCallPcSreg = 8;
+  constexpr uint16_t kReturnSreg = 30;
+  constexpr auto getpc = gfx1250::build_sop1(gfx1250::kSGetPcI64Sop1, {.sdst = 0});
+  constexpr auto call_getpc = gfx1250::build_sop1(gfx1250::kSGetPcI64Sop1, {.sdst = kCallPcSreg});
+  constexpr auto call_add = gfx1250::build_sop2(
+      gfx1250::kSAddNcU64Sop2, {.ssrc0 = kCallPcSreg, .ssrc1 = 254, .sdst = kCallPcSreg});
+  constexpr auto call =
+      gfx1250::build_sop1(gfx1250::kSSwapPcI64Sop1, {.ssrc0 = kCallPcSreg, .sdst = kReturnSreg});
+
+  std::vector<uint32_t> words = {
+      getpc[0],
+      0xA980FE00u,
+      120u,
+      0u,
+      0xD761002Cu,
+      0x02010000u,
+      0xD761002Cu,
+      0x02010201u,
+      call_getpc[0],
+      call_add[0],
+      92u,
+      0u,
+      0xBEE922C1u,
+      0xED0680A1u,
+      0x16000000u,
+      0x00001400u,
+      0xBFC50000u,
+      0xBEFE0069u,
+      call[0],
+      0xBEE922C1u,
+      0xED0500A1u,
+      0x0000002Cu,
+      0x00001800u, // Mismatch: reload (s33,+24), not the saved (s33,+20).
+      0xBFC50000u,
+      0xBEFE0069u,
+      0xD7600000u,
+      0x0201012Cu,
+      0xD7600001u,
+      0x0201032Cu,
+      0xBE9C4900u,
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250),
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250),
+      rocjitsu::build_s_setpc_b64(kReturnSreg, ROCJITSU_CODE_ARCH_GFX1250),
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  size_t continuation_fixups = 0;
+  for (const auto &block : blocks) {
+    for (const auto &fixup : block->static_indirect_call_fixups())
+      continuation_fixups += fixup.source_call_offset == 116;
+  }
+  EXPECT_EQ(continuation_fixups, 0u);
+}
+
+TEST(CfgAnalysis, Gfx1250ScratchSpillSignedOffsetOverlapFailsClosed) {
+  constexpr uint16_t kCallPcSreg = 8;
+  constexpr uint16_t kReturnSreg = 30;
+  constexpr auto getpc = gfx1250::build_sop1(gfx1250::kSGetPcI64Sop1, {.sdst = 0});
+  constexpr auto call_getpc = gfx1250::build_sop1(gfx1250::kSGetPcI64Sop1, {.sdst = kCallPcSreg});
+  constexpr auto call_add = gfx1250::build_sop2(
+      gfx1250::kSAddNcU64Sop2, {.ssrc0 = kCallPcSreg, .ssrc1 = 254, .sdst = kCallPcSreg});
+  constexpr auto call =
+      gfx1250::build_sop1(gfx1250::kSSwapPcI64Sop1, {.ssrc0 = kCallPcSreg, .sdst = kReturnSreg});
+  constexpr auto spill = gfx1250::build_vscratch(gfx1250::kScratchStoreB32Vscratch,
+                                                 {.saddr = 33, .vsrc = 44, .ioffset = 0});
+  constexpr auto overlapping_store = gfx1250::build_vscratch(
+      gfx1250::kScratchStoreB32Vscratch,
+      {.saddr = 33, .vsrc = 1, .ioffset = 0x00fffffeu}); // Signed -2: overlaps [0, 4).
+  constexpr auto reload = gfx1250::build_vscratch(gfx1250::kScratchLoadB32Vscratch,
+                                                  {.saddr = 33, .vdst = 44, .ioffset = 0});
+
+  std::vector<uint32_t> words = {
+      getpc[0],
+      0xA980FE00u,
+      144u,
+      0u,
+      0xD761002Cu,
+      0x02010000u,
+      0xD761002Cu,
+      0x02010201u,
+      call_getpc[0],
+      call_add[0],
+      116u,
+      0u,
+      0xBEE922C1u,
+      spill[0],
+      spill[1],
+      spill[2],
+      0xBFC50000u,
+      0xBEFE0069u,
+      call[0],
+      0xBEE922C1u,
+      overlapping_store[0],
+      overlapping_store[1],
+      overlapping_store[2],
+      0xBFC50000u,
+      0xBEFE0069u,
+      0xBEE922C1u,
+      reload[0],
+      reload[1],
+      reload[2],
+      0xBFC50000u,
+      0xBEFE0069u,
+      0xD7600000u,
+      0x0201012Cu,
+      0xD7600001u,
+      0x0201032Cu,
+      0xBE9C4900u,
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250),
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250),
+      rocjitsu::build_s_setpc_b64(kReturnSreg, ROCJITSU_CODE_ARCH_GFX1250),
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  size_t continuation_fixups = 0;
+  for (const auto &block : blocks) {
+    for (const auto &fixup : block->static_indirect_call_fixups())
+      continuation_fixups += fixup.source_call_offset == 140;
+  }
+  EXPECT_EQ(continuation_fixups, 0u);
+}
+
+TEST(CfgAnalysis, Gfx1250ScratchSpillSaveExecBaseOverlapFailsClosed) {
+  constexpr uint16_t kCallPcSreg = 8;
+  constexpr uint16_t kReturnSreg = 30;
+  constexpr auto getpc = gfx1250::build_sop1(gfx1250::kSGetPcI64Sop1, {.sdst = 0});
+  constexpr auto call_getpc = gfx1250::build_sop1(gfx1250::kSGetPcI64Sop1, {.sdst = kCallPcSreg});
+  constexpr auto call_add = gfx1250::build_sop2(
+      gfx1250::kSAddNcU64Sop2, {.ssrc0 = kCallPcSreg, .ssrc1 = 254, .sdst = kCallPcSreg});
+  constexpr auto call =
+      gfx1250::build_sop1(gfx1250::kSSwapPcI64Sop1, {.ssrc0 = kCallPcSreg, .sdst = kReturnSreg});
+
+  std::vector<uint32_t> words = {
+      getpc[0],
+      0xA980FE00u,
+      120u,
+      0u,
+      0xD761002Cu,
+      0x02010000u,
+      0xD761002Cu,
+      0x02010201u,
+      call_getpc[0],
+      call_add[0],
+      92u,
+      0u,
+      0xBEE922C1u,
+      0xED0680E9u,
+      0x16000000u,
+      0x00001400u, // Invalid: saveexec dst and saddr are both s105.
+      0xBFC50000u,
+      0xBEFE0069u,
+      call[0],
+      0xBEE922C1u,
+      0xED0500E9u,
+      0x0000002Cu,
+      0x00001400u,
+      0xBFC50000u,
+      0xBEFE0069u,
+      0xD7600000u,
+      0x0201012Cu,
+      0xD7600001u,
+      0x0201032Cu,
+      0xBE9C4900u,
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250),
+      build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250),
+      rocjitsu::build_s_setpc_b64(kReturnSreg, ROCJITSU_CODE_ARCH_GFX1250),
+  };
+
+  TestCodeObject co(std::move(words));
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+  size_t continuation_fixups = 0;
+  for (const auto &block : blocks) {
+    for (const auto &fixup : block->static_indirect_call_fixups())
+      continuation_fixups += fixup.source_call_offset == 116;
+  }
+  EXPECT_EQ(continuation_fixups, 0u);
+}
+
+TEST(CfgAnalysis, Gfx1250ScratchSpillFlatWriteAliasFailsClosed) {
+  constexpr uint16_t kCallPcSreg = 8;
+  constexpr uint16_t kReturnSreg = 30;
+  constexpr auto getpc = gfx1250::build_sop1(gfx1250::kSGetPcI64Sop1, {.sdst = 0});
+  constexpr auto call_getpc = gfx1250::build_sop1(gfx1250::kSGetPcI64Sop1, {.sdst = kCallPcSreg});
+  constexpr auto call_add = gfx1250::build_sop2(
+      gfx1250::kSAddNcU64Sop2, {.ssrc0 = kCallPcSreg, .ssrc1 = 254, .sdst = kCallPcSreg});
+  constexpr auto call =
+      gfx1250::build_sop1(gfx1250::kSSwapPcI64Sop1, {.ssrc0 = kCallPcSreg, .sdst = kReturnSreg});
+  for (const uint16_t opcode : {gfx1250::kFlatStoreB32Vflat, gfx1250::kFlatAtomicAddU32Vflat}) {
+    SCOPED_TRACE(opcode);
+    const auto flat_write = gfx1250::build_vflat(opcode, {.saddr = 0, .vsrc = 1});
+    std::vector<uint32_t> words = {
+        getpc[0],
+        0xA980FE00u,
+        132u,
+        0u,
+        0xD761002Cu,
+        0x02010000u,
+        0xD761002Cu,
+        0x02010201u,
+        call_getpc[0],
+        call_add[0],
+        104u,
+        0u,
+        0xBEE922C1u,
+        0xED0680A1u,
+        0x16000000u,
+        0x00001400u,
+        0xBFC50000u,
+        0xBEFE0069u,
+        call[0],
+        flat_write[0],
+        flat_write[1],
+        flat_write[2],
+        0xBEE922C1u,
+        0xED0500A1u,
+        0x0000002Cu,
+        0x00001400u,
+        0xBFC50000u,
+        0xBEFE0069u,
+        0xD7600000u,
+        0x0201012Cu,
+        0xD7600001u,
+        0x0201032Cu,
+        0xBE9C4900u,
+        build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250),
+        build_s_endpgm(ROCJITSU_CODE_ARCH_GFX1250),
+        rocjitsu::build_s_setpc_b64(kReturnSreg, ROCJITSU_CODE_ARCH_GFX1250),
+    };
+
+    TestCodeObject co(std::move(words));
+    auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+    ASSERT_NE(decoder, nullptr);
+    auto blocks = BasicBlock::build(co, *decoder, ROCJITSU_CODE_ARCH_GFX1250);
+    size_t continuation_fixups = 0;
+    for (const auto &block : blocks) {
+      for (const auto &fixup : block->static_indirect_call_fixups())
+        continuation_fixups += fixup.source_call_offset == 128;
+    }
+    EXPECT_EQ(continuation_fixups, 0u);
+  }
 }
 
 TEST(CfgAnalysis, Gfx1250CalleeSavedLaneStashSurvivesIndirectCall) {

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -19,6 +19,7 @@
 #include "rocjitsu/code/amdgpu_elf.h"
 #include "rocjitsu/code/builders/instruction_builder.h"
 #include "rocjitsu/code/dbt/binary_translator.h"
+#include "rocjitsu/code/dbt/binary_translator_internal.h"
 #include "rocjitsu/code/dbt/encoding_translator.h"
 #include "rocjitsu/code/dbt/generated/encoding_cdna4_to_cdna3.h"
 #include "rocjitsu/code/dbt/generated/encoding_cdna4_to_rdna4.h"
@@ -969,8 +970,9 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_relocation_after_text(
 // chosen type, defined either in .text or .data. Ordinary zero-addend text
 // symbols can follow their relocated st_value; section symbols and nonzero
 // addends need relocation-specific reconstruction and remain unsupported.
-std::vector<uint8_t> make_amdgpu_elf_with_symbol_relocation(uint8_t sym_type, bool defined_in_text,
-                                                            int64_t addend = 0) {
+std::vector<uint8_t>
+make_amdgpu_elf_with_symbol_relocation(uint8_t sym_type, bool defined_in_text, int64_t addend = 0,
+                                       uint8_t sym_bind = kElfSymbolBindGlobal) {
   constexpr uint64_t text_offset = 0x100;
   constexpr uint64_t text_vaddr = 0x1100;
   constexpr uint64_t text_size = 8;
@@ -1048,7 +1050,7 @@ std::vector<uint8_t> make_amdgpu_elf_with_symbol_relocation(uint8_t sym_type, bo
 
   std::array<Elf64_Sym, sym_count> syms{};
   syms[1].st_name = sym_name;
-  syms[1].st_info = elf_symbol_info(kElfSymbolBindGlobal, sym_type);
+  syms[1].st_info = elf_symbol_info(sym_bind, sym_type);
   syms[1].st_shndx = defined_in_text ? text_index : data_index;
   syms[1].st_value = defined_in_text ? text_vaddr : data_vaddr;
   syms[1].st_size = defined_in_text ? text_size : data_size;
@@ -2330,6 +2332,80 @@ TEST(CodeObjectPatcher, ReplaceTextRelocatesTextSymbolsWithExactOffsetMap) {
   EXPECT_EQ(symbols[2].st_size, 12u);
 }
 
+TEST(CodeObjectPatcher, ReplaceTextLeavesUnreferencedLocalTextSymbolStable) {
+  auto image = make_minimal_amdgpu_elf_with_load_segments();
+  auto ehdr = read_elf_struct_for_test<Elf64_Ehdr>(image, 0);
+  auto shdrs = read_elf_array_for_test<Elf64_Shdr>(image, ehdr.e_shoff, ehdr.e_shnum);
+  const auto symtab = std::ranges::find_if(
+      shdrs, [](const Elf64_Shdr &section) { return section.sh_type == SHT_SYMTAB; });
+  ASSERT_NE(symtab, shdrs.end());
+  auto symbols = read_elf_array_for_test<Elf64_Sym>(image, symtab->sh_offset,
+                                                    symtab->sh_size / sizeof(Elf64_Sym));
+  ASSERT_GE(symbols.size(), 3u);
+  symbols[2].st_info = elf_symbol_info(kElfSymbolBindLocal, kElfSymbolTypeFunc);
+  std::memcpy(image.data() + symtab->sh_offset, symbols.data(), symbols.size() * sizeof(Elf64_Sym));
+
+  AmdGpuCodeObject co(image.data(), image.size());
+  ASSERT_TRUE(co.is_valid());
+  CodeObjectPatcher patcher(co);
+  const std::array<uint32_t, 4> text_words = {0xBF800000u, 0xBF800000u, 0xBF800000u, 0xBF800000u};
+  const auto *text_bytes = reinterpret_cast<const uint8_t *>(text_words.data());
+  constexpr std::array<TextOffsetRelocation, 2> relocations = {
+      TextOffsetRelocation{.source_offset = 0, .target_offset = 4},
+      TextOffsetRelocation{.source_offset = 8, .target_offset = 16},
+  };
+  ASSERT_TRUE(patcher.replace_text({text_bytes, sizeof(text_words)}, relocations));
+
+  const auto patched = patcher.emit();
+  ehdr = read_elf_struct_for_test<Elf64_Ehdr>(patched, 0);
+  shdrs = read_elf_array_for_test<Elf64_Shdr>(patched, ehdr.e_shoff, ehdr.e_shnum);
+  const auto patched_symtab = std::ranges::find_if(
+      shdrs, [](const Elf64_Shdr &section) { return section.sh_type == SHT_SYMTAB; });
+  ASSERT_NE(patched_symtab, shdrs.end());
+  symbols = read_elf_array_for_test<Elf64_Sym>(patched, patched_symtab->sh_offset,
+                                               patched_symtab->sh_size / sizeof(Elf64_Sym));
+  ASSERT_GE(symbols.size(), 3u);
+  EXPECT_EQ(symbols[2].st_value, 0x1100u);
+  EXPECT_EQ(symbols[2].st_size, 8u);
+}
+
+TEST(CodeObjectPatcher, ReplaceTextRelocatesLocalSymbolInAllSymbolProofMode) {
+  auto image = make_minimal_amdgpu_elf_with_load_segments();
+  auto ehdr = read_elf_struct_for_test<Elf64_Ehdr>(image, 0);
+  auto shdrs = read_elf_array_for_test<Elf64_Shdr>(image, ehdr.e_shoff, ehdr.e_shnum);
+  const auto symtab = std::ranges::find_if(
+      shdrs, [](const Elf64_Shdr &section) { return section.sh_type == SHT_SYMTAB; });
+  ASSERT_NE(symtab, shdrs.end());
+  auto symbols = read_elf_array_for_test<Elf64_Sym>(image, symtab->sh_offset,
+                                                    symtab->sh_size / sizeof(Elf64_Sym));
+  ASSERT_GE(symbols.size(), 3u);
+  symbols[2].st_info = elf_symbol_info(kElfSymbolBindLocal, kElfSymbolTypeFunc);
+  std::memcpy(image.data() + symtab->sh_offset, symbols.data(), symbols.size() * sizeof(Elf64_Sym));
+
+  AmdGpuCodeObject co(image.data(), image.size());
+  ASSERT_TRUE(co.is_valid());
+  CodeObjectPatcher patcher(co);
+  const std::array<uint32_t, 4> text_words = {0xBF800000u, 0xBF800000u, 0xBF800000u, 0xBF800000u};
+  constexpr std::array<TextOffsetRelocation, 2> relocations = {
+      TextOffsetRelocation{.source_offset = 0, .target_offset = 4},
+      TextOffsetRelocation{.source_offset = 8, .target_offset = 16},
+  };
+  ASSERT_TRUE(patcher.replace_text(
+      {reinterpret_cast<const uint8_t *>(text_words.data()), sizeof(text_words)}, relocations, {},
+      {}, /*require_every_text_symbol_mapped=*/true));
+  const auto patched = patcher.emit();
+  ehdr = read_elf_struct_for_test<Elf64_Ehdr>(patched, 0);
+  shdrs = read_elf_array_for_test<Elf64_Shdr>(patched, ehdr.e_shoff, ehdr.e_shnum);
+  const auto patched_symtab = std::ranges::find_if(
+      shdrs, [](const Elf64_Shdr &section) { return section.sh_type == SHT_SYMTAB; });
+  ASSERT_NE(patched_symtab, shdrs.end());
+  symbols = read_elf_array_for_test<Elf64_Sym>(patched, patched_symtab->sh_offset,
+                                               patched_symtab->sh_size / sizeof(Elf64_Sym));
+  ASSERT_GE(symbols.size(), 3u);
+  EXPECT_EQ(symbols[2].st_value, 0x1104u);
+  EXPECT_EQ(symbols[2].st_size, 12u);
+}
+
 TEST(CodeObjectPatcher, AppendsNonAllocSectionWithoutMovingLoadableSegments) {
   auto image = make_minimal_amdgpu_elf_with_load_segments();
   AmdGpuCodeObject co(image.data(), image.size());
@@ -2591,6 +2667,38 @@ TEST(CodeObjectPatcher, RelocatesReferencedTextSymbolWithExactOffsetMap) {
   ASSERT_GE(symbols.size(), 2u);
   EXPECT_EQ(symbols[1].st_value, 0x1104u);
   EXPECT_EQ(symbols[1].st_size, 12u);
+}
+
+TEST(CodeObjectPatcher, RejectsLocalTextSymbolReferencedByRel) {
+  auto image = make_amdgpu_elf_with_symbol_relocation(kElfSymbolTypeFunc, /*defined_in_text=*/true,
+                                                      /*addend=*/0, kElfSymbolBindLocal);
+  auto ehdr = read_elf_struct_for_test<Elf64_Ehdr>(image, 0);
+  auto shdrs = read_elf_array_for_test<Elf64_Shdr>(image, ehdr.e_shoff, ehdr.e_shnum);
+  const auto rela = std::ranges::find_if(
+      shdrs, [](const Elf64_Shdr &section) { return section.sh_type == SHT_RELA; });
+  ASSERT_NE(rela, shdrs.end());
+  const size_t rela_index = static_cast<size_t>(rela - shdrs.begin());
+  const Elf64_Rela rela_record = read_elf_struct_for_test<Elf64_Rela>(image, rela->sh_offset);
+  const Elf64_Rel rel_record{.r_offset = rela_record.r_offset, .r_info = rela_record.r_info};
+  std::memcpy(image.data() + rela->sh_offset, &rel_record, sizeof(rel_record));
+  shdrs[rela_index].sh_type = SHT_REL;
+  shdrs[rela_index].sh_size = sizeof(Elf64_Rel);
+  shdrs[rela_index].sh_entsize = sizeof(Elf64_Rel);
+  std::memcpy(image.data() + ehdr.e_shoff, shdrs.data(), shdrs.size() * sizeof(Elf64_Shdr));
+
+  AmdGpuCodeObject object(image.data(), image.size());
+  ASSERT_TRUE(object.is_valid());
+  CodeObjectPatcher patcher(object);
+  const std::array<uint32_t, 4> expanded_text = {0xBF800000u, 0xBF800000u, 0xBF800000u,
+                                                 0xBF800000u};
+  constexpr std::array<TextOffsetRelocation, 2> mappings = {
+      TextOffsetRelocation{.source_offset = 0, .target_offset = 4},
+      TextOffsetRelocation{.source_offset = 8, .target_offset = 16},
+  };
+  const auto bytes = std::span<const uint8_t>(
+      reinterpret_cast<const uint8_t *>(expanded_text.data()), sizeof(expanded_text));
+  EXPECT_FALSE(patcher.replace_text(bytes, mappings))
+      << "an implicit-addend REL reference must fail closed rather than leave a local target stale";
 }
 
 TEST(CodeObjectPatcher, RejectsReferencedTextSymbolWithoutExactOffsetMap) {
@@ -5370,6 +5478,32 @@ TEST(BinaryTranslatorE2E, Gfx1250LongDirectBranchGrowthIsIdempotent) {
   ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
                                                           : second.diagnostics.front().message);
   EXPECT_EQ(second.elf_bytes, result.elf_bytes);
+}
+
+TEST(BinaryTranslator, MarkedWindowSuppressionRequiresExactBuilderIdentity) {
+  rocjitsu::IndirectCallFixup owner{.source_getpc_offset = 8,
+                                    .source_recovery_begin_offset = 12,
+                                    .source_recovery_end_offset = 40,
+                                    .source_call_offset = 40,
+                                    .source_target_offset = 200,
+                                    .source_requires_xcnt_drain = true};
+  EXPECT_TRUE(rocjitsu::internal::same_recovered_builder_identity(owner, owner));
+
+  auto different = owner;
+  different.source_getpc_offset += 4;
+  EXPECT_FALSE(rocjitsu::internal::same_recovered_builder_identity(owner, different));
+  different = owner;
+  different.source_recovery_begin_offset += 4;
+  EXPECT_FALSE(rocjitsu::internal::same_recovered_builder_identity(owner, different));
+  different = owner;
+  different.source_recovery_end_offset -= 4;
+  EXPECT_FALSE(rocjitsu::internal::same_recovered_builder_identity(owner, different));
+  different = owner;
+  different.source_target_offset += 4;
+  EXPECT_FALSE(rocjitsu::internal::same_recovered_builder_identity(owner, different));
+  different = owner;
+  different.source_requires_xcnt_drain = false;
+  EXPECT_FALSE(rocjitsu::internal::same_recovered_builder_identity(owner, different));
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250LongBranchReportsSgprExhaustionAfterSemanticExpansion) {


### PR DESCRIPTION
## Summary

- recover gfx1250 PC provenance when a callee-saved VGPR lane stash is spilled to and restored from a canonical caller scratch slot
- preserve translator-generated long-transfer ownership across repeated translation using exact builder identity
- keep unreferenced local text-symbol boundaries stable so B0-to-A0 output is byte-idempotent on a second A0 pass

## Root cause

RCCL change `91347a4f5a` (#8945) added gfx1250 FP8 unroll 8/16/32 variants and made `runRing`/`runTree` noinline. The Aug. 11 kpack consequently contains a 745,305,160-byte generic code object with a real indirect-call sequence in which the compiler:

1. saves a recovered PC value in fixed lanes of callee-saved `v44`;
2. spills `v44` to the caller-owned `(s33, +20)` scratch slot under full EXEC;
3. crosses one or more conforming AMDGPU calls; and
4. reloads the same slot before `s_swap_pc_i64`.

RocJitsu tracked the VGPR lane value but not its canonical scratch spill/reload, so it lost the call-target proof and rejected eager translation. This patch fixes that translator legalization defect. In isolated J19-6 validation the corrected translator completed this object with status 0 for `alltoall_perf` and `all_reduce_perf`; those workloads later encountered point-in-time `HSA_STATUS_ERROR_MEMORY_APERTURE_VIOLATION` failures in HIP buffer setup. Those later GPU-memory failures are preserved as separate workload-state evidence and are not attributed to the translator defect.

The large object also exposed two repeated-translation issues after the original legalization failure was removed: a distant consumer could rediscover an already regenerated marked long-transfer builder, and an unreferenced local `.symtab` function boundary could drift by one instruction between passes despite identical `.text`.

## Correctness model

Scratch provenance is generated only for the compiler's canonical gfx1250 scalar-base, immediate-offset, SVE=0, full-EXEC b32 store. It is killed by overlapping or ambiguous scratch stores and writes to the scalar base, preserved only across a conforming AMDGPU callee's disjoint caller frame, and restored only by an exact full-EXEC b32 load. CFG joins retain only identical facts from every reachable predecessor. Mismatched offsets and saveexec/base overlap fail closed.

Repeated builder suppression requires exact equality with the recognized marked-window owner: getpc offset, recovery range, target, and xcnt-drain requirement. Positional containment is intentionally insufficient because the regenerated PC-delta builder may change width.

Unreferenced local text symbols are tooling/debug labels rather than runtime-linkable code addresses, so they remain unchanged. Referenced symbols and the all-symbol relocation proof mode retain exact fail-closed relocation.

## Validation

- focused scratch/alias/builder/symbol regressions: 11/11 PASS, including signed-offset zero crossing, atomic fail-closed invalidation, and exact marked-window builder identity
- full non-RCCL CTest gate: 2,975/2,975 PASS with four expected disabled/skipped tests; five unfiltered `RcclDaemonTest` cases are separately classified environment failures because DRM ioctl `0xbf` is rejected
- ASan+UBSan build PASS; focused sanitizer gate 4/4 PASS
- exact RCCL input: 745,305,160 bytes, SHA-256 `3ad68a2d911cf83304f5ee4b11ec62d00f6636086f01beee93754e6fbad0b6c5`
- strict B0-to-A0 plus A0-to-A0 byte-idempotence: PASS; output SHA-256 `0f1e604b152379ca24ad57badf782329cf876d85354a4ac32094825cb9a34ad4`
- PR10037 integration: portable AOT `written=1 held=0 skipped=0 failed=0`; second lookup `written=0 held=1 skipped=0 failed=0`; exact runtime hook cache-hit assertion PASS
- isolated J19-6 RCCL `alltoall_perf`/`all_reduce_perf` on reserved GPUs: each exact translation completed once with status 0 and no legalization error; workloads later returned rc3 in HIP buffer setup with separately classified point-in-time aperture violations
- pinned 31-row custom-kernel matrix spanning native HIP, ATOM/AITER, Tensile, MHC, compressor, A8W8, and sparse-prefill objects: 31 successful translations, zero translation/legalization errors; workload accounting 7 PASS, 23 point-in-time aperture failures, 1 prerequisite NOT_RUN

## Integration notes

ROCm/rocm-systems#10037 and ROCm/TheRock#7288 add RCCL AOT/cache generation and packaging but still invoke this translator. This correctness fix should land before their cache is generated. When stacking, bump the portable prebuilt cache nonce/epoch so a fixed runtime cannot consume a stale pre-fix translation.

JIRA ID: ROCM-29371
