### PR TITLE
fix(rocprofiler-sdk): Unit test on gfxip > 9

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/tests/producer_consumer.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/tests/producer_consumer.cpp
@@ -158,7 +158,7 @@ start_threads(rocprofiler_thread_trace_shader_data_callback_t cb_fn,
     // them here or the producer aborts with small_vector::at out_of_range.
     control_packet->populate_before();
     control_packet->populate_after();
-    auto buffer_packet = std::make_unique<MockPackets>(control_packet->GetHandle(), query_fn);
+    auto buffer_packet    = std::make_unique<MockPackets>(control_packet->GetHandle(), query_fn);
     buffer_packet->header = 1;
 
     auto mock_queue          = make_mock_queue(*agent);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/tests/producer_consumer.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/tests/producer_consumer.cpp
@@ -159,6 +159,7 @@ start_threads(rocprofiler_thread_trace_shader_data_callback_t cb_fn,
     control_packet->populate_before();
     control_packet->populate_after();
     auto buffer_packet = std::make_unique<MockPackets>(control_packet->GetHandle(), query_fn);
+    buffer_packet->header = 1;
 
     auto mock_queue          = make_mock_queue(*agent);
     auto worker_data         = std::make_shared<triple_buffer_shared_data_t>();


### PR DESCRIPTION
## Motivation

The producer/consumer unit tests expect a header > 0 causing test failures on gfxip > 9

JIRA ID : AIPROFSDK-858

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
