### PR TITLE
fix(rocprofiler-sdk): Add timestamps to thread trace shader data

### DIFF
--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/thread-trace/core.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/thread-trace/core.h
@@ -111,6 +111,19 @@ typedef enum rocprofiler_thread_trace_shader_data_flags_t
 } rocprofiler_thread_trace_shader_data_flags_t;
 
 /**
+ * @brief GPU and system clock values for a thread trace buffer record.
+ *
+ * @p gpu_clock is the timestamp in the GPU clock domain.
+ * @p system_clock is the same timestamp in the system clock domain.
+ * Approximate. Both values are zero when the data has no GPU-defined boundary.
+ */
+typedef struct rocprofiler_thread_trace_timestamp_t
+{
+    uint64_t                gpu_clock;
+    rocprofiler_timestamp_t system_clock;
+} rocprofiler_thread_trace_timestamp_t;
+
+/**
  * @brief Bundle of shader data delivered to
  * rocprofiler_thread_trace_shader_data_callback_t.
  */
@@ -125,6 +138,11 @@ typedef struct rocprofiler_thread_trace_shader_data_t
 
     rocprofiler_agent_id_t                       agent;  ///< Identifier for the target agent.
     rocprofiler_thread_trace_shader_data_flags_t flags;  ///< Flags for this data chunk.
+
+    /// Timestamp at which collection into this data chunk began.
+    rocprofiler_thread_trace_timestamp_t start_timestamp;
+    /// Timestamp at which collection into this data chunk ended.
+    rocprofiler_thread_trace_timestamp_t end_timestamp;
 } rocprofiler_thread_trace_shader_data_t;
 
 /**

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/aql_profile_v2.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/aql_profile_v2.h
@@ -458,6 +458,12 @@ typedef hsa_status_t (*aqlprofile_pmc_data_callback_t)(aqlprofile_pmc_event_t ev
                                                        uint64_t               counter_value,
                                                        void*                  userdata);
 
+typedef struct aqlprofile_att_gpu_clock_t
+{
+    uint64_t start;   ///< Most recent start-packet clock.
+    uint64_t latest;  ///< Most recent swap- or stop-packet clock.
+} aqlprofile_att_gpu_clock_t;
+
 /**
  * @brief Data callback for thread trace. This will be called at least once per shader engine
  * @param[in] shader Shader Engine ID
@@ -628,6 +634,20 @@ typedef struct aqlprofile_att_buffer_status_t
     bool     error;
     uint64_t read_offset;
 } aqlprofile_att_buffer_status_t;
+
+/**
+ * @brief Read GPU clocks written by the ATT start/stop/swap packets.
+ *
+ * This query only reads the trace control buffer and does not update buffer status.
+ *
+ * @param[out] out Latest GPU clock values.
+ * @param[in] handle Handle returned by aqlprofile_att_create_packets().
+ * @param[in] shader_engine_id Shader engine (SE) ID.
+ */
+hsa_status_t
+aqlprofile_att_get_gpu_clock(aqlprofile_att_gpu_clock_t* out,
+                             aqlprofile_handle_t         handle,
+                             int                         shader_engine_id);
 
 /**
  * @brief Fn to retrieve buffer status.

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/core/threadtrace.cpp
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/core/threadtrace.cpp
@@ -298,6 +298,11 @@ _internal_aqlprofile_att_create_packets(aqlprofile_handle_t*                  ha
     MemoryManager::RegisterManager(memorymgr);
 
     auto* control_ptr = memorymgr->GetTraceControlBuf<pm4_builder::TraceControl>();
+    for(size_t i = 0; i < se_number_total; ++i)
+    {
+        control_ptr[i].gpu_clock_start  = 0;
+        control_ptr[i].gpu_clock_latest = 0;
+    }
 
     trace_config.control_buffer_ptr  = control_ptr;
     trace_config.control_buffer_size = control_size;
@@ -443,6 +448,31 @@ aqlprofile_att_update_buffer_status(aqlprofile_att_buffer_status_t* out,
         out->read_offset = sizeof(uint16_t) * (control.wptr_doublebuffer >> 30);
     }
 
+    return HSA_STATUS_SUCCESS;
+}
+
+PUBLIC_API hsa_status_t
+aqlprofile_att_get_gpu_clock(aqlprofile_att_gpu_clock_t* out,
+                             aqlprofile_handle_t         handle,
+                             int                         shader_engine_id)
+{
+    if(out == nullptr || shader_engine_id < 0) return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+
+    auto  generic_manager = MemoryManager::GetManager(handle.handle);
+    auto* manager         = dynamic_cast<TraceMemoryManager*>(generic_manager.get());
+    if(manager == nullptr) return HSA_STATUS_ERROR;
+
+    auto* factory = aql_profile::Pm4Factory::Create(manager->GetAgent());
+    if(static_cast<uint32_t>(shader_engine_id) >= factory->GetShaderEnginesNumber())
+        return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+
+    const auto se_per_xcc =
+        factory->GetShaderEnginesNumber() / std::max(1u, factory->GetXccNumber());
+    volatile auto& control = manager->GetTraceControlBuf<
+        pm4_builder::TraceControl>()[static_cast<uint32_t>(shader_engine_id) / se_per_xcc];
+
+    out->start  = control.gpu_clock_start;
+    out->latest = control.gpu_clock_latest;
     return HSA_STATUS_SUCCESS;
 }
 

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/cmd_builder.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/cmd_builder.h
@@ -305,7 +305,7 @@ public:
     /// @param cmdBuf  command buffer to be appended with launch command
     virtual void BuildPrimeL2(CmdBuffer* cmdBuf, uint64_t addr) = 0;
 
-    /// @brief Generates RT packets into thread trace buffer (gfx9 only)
+    /// @brief Generates an RT timestamp marker in the thread trace buffer (GFX9 only).
     /// @param cmdBuf  command buffer to be appended with launch command
     /// @param dst  where gpu clock data is r/w. Must persist during packet dispatch
     /// @param reg  userdata register address
@@ -314,6 +314,11 @@ public:
                                      uint64_t*       dst,
                                      const Register& reg,
                                      uint32_t        header){};
+
+    /// @brief Copies the GPU clock to memory without writing SQ thread-trace userdata registers.
+    /// @param cmdBuf command buffer to be appended with the copy command
+    /// @param dst destination for the GPU clock; must persist during packet dispatch
+    virtual void BuildReadGPUClockPacket(CmdBuffer* cmdBuf, uint64_t* dst){};
 
     /// @brief Release resources used by CmdBuilder
     virtual ~CmdBuilder(){};

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/gfx10_cmd_builder.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/gfx10_cmd_builder.h
@@ -477,6 +477,24 @@ public:
     {
         BuildCopyRegDataPacket(cmd, get_addr(reg), dst_addr, size, wait);
     }
+
+    void BuildReadGPUClockPacket(CmdBuffer* cmd_buffer, uint64_t* dst) override
+    {
+        const auto addr   = reinterpret_cast<uint64_t>(dst);
+        uint32_t   header = MakePacket3Header(PACKET3_COPY_DATA, 6 * sizeof(uint32_t));
+        uint32_t   control =
+            PACKET3_COPY_DATA__SRC_SEL(PACKET3_COPY_DATA__SRC_SEL__GPU_CLOCK_COUNT) |
+            PACKET3_COPY_DATA__SRC_CACHE_POLICY(PACKET3_COPY_DATA__SRC_CACHE_POLICY__LRU) |
+            PACKET3_COPY_DATA__DST_SEL(PACKET3_COPY_DATA__DST_SEL__TC_L2) |
+            PACKET3_COPY_DATA__DST_CACHE_POLICY(PACKET3_COPY_DATA__DST_CACHE_POLICY__LRU) |
+            PACKET3_COPY_DATA__WR_CONFIRM(PACKET3_COPY_DATA__WR_CONFIRM__WAIT_FOR_CONFIRMATION) |
+            PACKET3_COPY_DATA__COUNT_SEL(PACKET3_COPY_DATA__COUNT_SEL__64_BITS_OF_DATA);
+        uint32_t dst_lo = PACKET3_COPY_DATA__DST_64B_ADDR_LO(Low32(addr) >> 3);
+        uint32_t dst_hi = PACKET3_COPY_DATA__DST_ADDR_HI(High32(addr));
+
+        uint32_t packet[6] = {header, control, 0, 0, dst_lo, dst_hi};
+        APPEND_COMMAND_WRAPPER(cmd_buffer, packet);
+    }
 };
 }  // namespace pm4_builder
 

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/gfx11_cmd_builder.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/gfx11_cmd_builder.h
@@ -499,6 +499,24 @@ public:
     {
         BuildCopyRegDataPacket(cmd, get_addr(reg), dst_addr, size, wait);
     }
+
+    void BuildReadGPUClockPacket(CmdBuffer* cmd_buffer, uint64_t* dst) override
+    {
+        const auto addr   = reinterpret_cast<uint64_t>(dst);
+        uint32_t   header = MakePacket3Header(PACKET3_COPY_DATA, 6 * sizeof(uint32_t));
+        uint32_t   control =
+            PACKET3_COPY_DATA__SRC_SEL(PACKET3_COPY_DATA__SRC_SEL__GPU_CLOCK_COUNT) |
+            PACKET3_COPY_DATA__SRC_CACHE_POLICY(PACKET3_COPY_DATA__SRC_CACHE_POLICY__LRU) |
+            PACKET3_COPY_DATA__DST_SEL(PACKET3_COPY_DATA__DST_SEL__TC_L2) |
+            PACKET3_COPY_DATA__DST_CACHE_POLICY(PACKET3_COPY_DATA__DST_CACHE_POLICY__LRU) |
+            PACKET3_COPY_DATA__WR_CONFIRM(PACKET3_COPY_DATA__WR_CONFIRM__WAIT_FOR_CONFIRMATION) |
+            PACKET3_COPY_DATA__COUNT_SEL(PACKET3_COPY_DATA__COUNT_SEL__64_BITS_OF_DATA);
+        uint32_t dst_lo = PACKET3_COPY_DATA__DST_64B_ADDR_LO(Low32(addr) >> 3);
+        uint32_t dst_hi = PACKET3_COPY_DATA__DST_ADDR_HI(High32(addr));
+
+        uint32_t packet[6] = {header, control, 0, 0, dst_lo, dst_hi};
+        APPEND_COMMAND_WRAPPER(cmd_buffer, packet);
+    }
 };
 
 }  // namespace pm4_builder

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/gfx12_cmd_builder.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/gfx12_cmd_builder.h
@@ -796,6 +796,24 @@ public:
     {
         BuildCopyRegDataPacket(cmd, get_addr(reg), dst_addr, size, wait);
     }
+
+    void BuildReadGPUClockPacket(CmdBuffer* cmd_buffer, uint64_t* dst) override
+    {
+        const auto addr   = reinterpret_cast<uint64_t>(dst);
+        uint32_t   header = MakePacket3Header(PACKET3_COPY_DATA, 6 * sizeof(uint32_t));
+        uint32_t   control =
+            PACKET3_COPY_DATA__SRC_SEL(PACKET3_COPY_DATA__SRC_SEL__GPU_CLOCK_COUNT) |
+            PACKET3_COPY_DATA__SRC_TEMPORAL(PACKET3_COPY_DATA__SRC_TEMPORAL__LU) |
+            PACKET3_COPY_DATA__DST_SEL(PACKET3_COPY_DATA__DST_SEL__TC_L2) |
+            PACKET3_COPY_DATA__DST_TEMPORAL(PACKET3_COPY_DATA__DST_TEMPORAL__LU) |
+            PACKET3_COPY_DATA__WR_CONFIRM(PACKET3_COPY_DATA__WR_CONFIRM__WAIT_FOR_CONFIRMATION) |
+            PACKET3_COPY_DATA__COUNT_SEL(PACKET3_COPY_DATA__COUNT_SEL__64_BITS_OF_DATA);
+        uint32_t dst_lo = PACKET3_COPY_DATA__DST_64B_ADDR_LO(Low32(addr) >> 3);
+        uint32_t dst_hi = PACKET3_COPY_DATA__DST_ADDR_HI(High32(addr));
+
+        uint32_t packet[6] = {header, control, 0, 0, dst_lo, dst_hi};
+        APPEND_COMMAND_WRAPPER(cmd_buffer, packet);
+    }
 };
 
 }  // namespace pm4_builder

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/gfx9_cmd_builder.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/gfx9_cmd_builder.h
@@ -627,6 +627,12 @@ public:
             APPEND_COMMAND_WRAPPER(cmdBuf, copy_data);
         }
     }
+
+    void BuildReadGPUClockPacket(CmdBuffer* cmdBuf, uint64_t* dst) override
+    {
+        auto copy_data = ClockRetrievePacket(dst);
+        APPEND_COMMAND_WRAPPER(cmdBuf, copy_data);
+    }
 };
 
 }  // namespace pm4_builder

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/sqtt_builder.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/sqtt_builder.h
@@ -95,8 +95,8 @@ struct TraceControl
     uint32_t cntr{0};
     uint32_t wptr{0};
     uint32_t status2{0};
-    uint64_t gpu_clock_cnt_start{0};
-    uint64_t gpu_clock_cnt_end{0};
+    uint64_t gpu_clock_start{0};
+    uint64_t gpu_clock_latest{0};
     uint32_t status_double_buffer{0};
     uint32_t wptr_doublebuffer{0};
 };
@@ -533,7 +533,6 @@ public:
                 (1 + cu_per_se) * ((config->perfcounters.size() + 3) & ~3) * config->perfPeriod;
             builder.BuildWriteUConfigRegPacket(cmd_buffer, userdata_channel, packet.u32All);
         }
-        if(Primitives::GFXIP_LEVEL == 9 && config->enable_rt_timestamp)
         {
             for(size_t xcc = 0; xcc < GetXCCNumber(); xcc++)
             {
@@ -541,8 +540,10 @@ public:
 
                 XCC_Packet_Lock<Builder> lock(builder, cmd_buffer, GetXCCNumber(), xcc);
                 auto& control = reinterpret_cast<TraceControl*>(config->control_buffer_ptr)[xcc];
-                InsertTimestampMarker(cmd_buffer, &control.gpu_clock_cnt_start);
+                CaptureClock(cmd_buffer, &control.gpu_clock_start, config->enable_rt_timestamp);
             }
+            builder.BuildCacheFlushPacket(
+                cmd_buffer, size_t(config->control_buffer_ptr), config->control_buffer_size);
         }
     }
 
@@ -553,22 +554,20 @@ public:
         builder.BuildWriteWaitIdlePacket(cmd_buffer);
         const uint32_t se_number_xcc = se_number_total / std::max(1u, GetXCCNumber());
 
+        {
+            for(size_t xcc = 0; xcc < GetXCCNumber(); xcc++)
+            {
+                if(!isXccEnabled(xcc, se_number_xcc, config)) continue;
+
+                XCC_Packet_Lock<Builder> lock(builder, cmd_buffer, GetXCCNumber(), xcc);
+                auto& control = reinterpret_cast<TraceControl*>(config->control_buffer_ptr)[xcc];
+                CaptureClock(cmd_buffer, &control.gpu_clock_latest, config->enable_rt_timestamp);
+            }
+            builder.BuildWriteWaitIdlePacket(cmd_buffer);
+        }
+
         if(Primitives::GFXIP_LEVEL == 9)
         {
-            if(config->enable_rt_timestamp)
-            {
-                for(size_t xcc = 0; xcc < GetXCCNumber(); xcc++)
-                {
-                    if(!isXccEnabled(xcc, se_number_xcc, config)) continue;
-
-                    XCC_Packet_Lock<Builder> lock(builder, cmd_buffer, GetXCCNumber(), xcc);
-                    auto&                    control =
-                        reinterpret_cast<TraceControl*>(config->control_buffer_ptr)[xcc];
-                    InsertTimestampMarker(cmd_buffer, &control.gpu_clock_cnt_end);
-                }
-                builder.BuildWriteWaitIdlePacket(cmd_buffer);
-            }
-
             // Program the thread trace mode register to disable thread trace
             builder.BuildWriteUConfigRegPacket(cmd_buffer,
                                                Primitives::SQ_THREAD_TRACE_MODE_ADDR,
@@ -744,14 +743,30 @@ public:
 
     virtual void InsertTimestampMarker(CmdBuffer* cmd_buffer, uint64_t* addr) override
     {
-        rocprof_trace_decoder_packet_header_t header{};
-        header.opcode = ROCPROF_TRACE_DECODER_PACKET_OPCODE_RT_TIMESTAMP;
-        header.type   = 0;
-        header.data20 = 0;
+        if constexpr(Primitives::GFXIP_LEVEL == 9)
+        {
+            rocprof_trace_decoder_packet_header_t header{};
+            header.opcode = ROCPROF_TRACE_DECODER_PACKET_OPCODE_RT_TIMESTAMP;
+            header.type   = 0;
+            header.data20 = 0;
 
-        SetGRBMToBroadcast(cmd_buffer);
-        builder.BuildGPUClockPacket(
-            cmd_buffer, addr, Primitives::SQ_THREAD_TRACE_USERDATA_3, header.u32All);
+            SetGRBMToBroadcast(cmd_buffer);
+            builder.BuildGPUClockPacket(
+                cmd_buffer, addr, Primitives::SQ_THREAD_TRACE_USERDATA_3, header.u32All);
+        }
+    }
+
+    void CaptureClock(CmdBuffer* cmd_buffer, uint64_t* addr, bool emit_marker)
+    {
+        if constexpr(Primitives::GFXIP_LEVEL == 9)
+        {
+            if(emit_marker)
+            {
+                InsertTimestampMarker(cmd_buffer, addr);
+                return;
+            }
+        }
+        builder.BuildReadGPUClockPacket(cmd_buffer, addr);
     }
 
     template <typename T>
@@ -837,7 +852,12 @@ public:
             WriteConfigPacket(cmd_buffer, reg_lo, buff1_lo);
             WriteConfigPacket(cmd_buffer, reg_hi, buff1_hi);
         }
+        auto& control =
+            reinterpret_cast<TraceControl*>(config->control_buffer_ptr)[se_id / se_per_xcc];
+        builder.BuildReadGPUClockPacket(cmd_buffer, &control.gpu_clock_latest);
         builder.BuildCacheFlushPacket(cmd_buffer, size_t(prev), config->data_buffer_size);
+        builder.BuildCacheFlushPacket(
+            cmd_buffer, size_t(config->control_buffer_ptr), config->control_buffer_size);
 
         SetGRBMToBroadcast(cmd_buffer);
     }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/att_no_intercept_quick_scan.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/att_no_intercept_quick_scan.cpp
@@ -294,6 +294,8 @@ forward_cut(agent_state_t&                         state,
     shader_data.read_offset      = 0;
     shader_data.agent            = state.id;
     shader_data.flags            = ROCPROFILER_THREAD_TRACE_SHADER_DATA_FLAGS_NONE;
+    shader_data.start_timestamp  = original.start_timestamp;
+    shader_data.end_timestamp    = original.end_timestamp;
 
     auto userdata  = rocprofiler_user_data_t{};
     userdata.value = capture_id.fetch_add(1);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/aql_packet.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/aql_packet.cpp
@@ -277,6 +277,21 @@ SQTTBufferingPackets::query_buffer_status()
     return query;
 }
 
+aqlprofile_att_gpu_clock_t
+get_gpu_clock(aqlprofile_handle_t handle, int shader_engine_id)
+{
+    auto  clock = aqlprofile_att_gpu_clock_t{};
+    auto* dl    = rocprofiler::thread_trace::get_aqlprofile_dl();
+    if(dl && dl->get_gpu_clock_fn) dl->get_gpu_clock_fn(&clock, handle, shader_engine_id);
+    return clock;
+}
+
+aqlprofile_att_gpu_clock_t
+SQTTBufferingPackets::get_gpu_clock() const
+{
+    return hsa::get_gpu_clock(handle, shader_engine_id);
+}
+
 CodeobjMarkerAQLPacket::CodeobjMarkerAQLPacket(const TraceMemoryPool& _tracepool,
                                                uint64_t               id,
                                                uint64_t               addr,

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/aql_packet.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/aql_packet.hpp
@@ -274,6 +274,9 @@ struct sqtt_buffer_status_t
     bool                         gpu_full{};
 };
 
+aqlprofile_att_gpu_clock_t
+get_gpu_clock(aqlprofile_handle_t handle, int shader_engine_id);
+
 // Virtual members for mocking in tests
 class SQTTBufferingPackets
 {
@@ -283,6 +286,7 @@ public:
 
     hsa_ext_amd_aql_pm4_packet_t                query_status{};
     virtual std::optional<sqtt_buffer_status_t> query_buffer_status();
+    virtual aqlprofile_att_gpu_clock_t          get_gpu_clock() const;
 
     void reset_current_buffer() { current_buffer = 0; };
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
@@ -69,6 +69,9 @@ struct cbdata_t
     rocprofiler_thread_trace_shader_data_callback_t cb_fn      = nullptr;
     const rocprofiler_user_data_t*                  userdata   = nullptr;
     uint64_t                                        next_chunk = 0;
+
+    rocprofiler_thread_trace_timestamp_t start_timestamp{};
+    rocprofiler_thread_trace_timestamp_t end_timestamp{};
 };
 
 // Keeps track of a single client registering for serialized thread trace
@@ -98,6 +101,8 @@ thread_trace_callback(uint32_t shader, void* buffer, uint64_t size, void* callba
     shader_data.read_offset      = 0;
     shader_data.agent            = cb_data.agent;
     shader_data.flags            = ROCPROFILER_THREAD_TRACE_SHADER_DATA_FLAGS_END;
+    shader_data.start_timestamp  = cb_data.start_timestamp;
+    shader_data.end_timestamp    = cb_data.end_timestamp;
 
     cb_data.cb_fn(shader_data, *cb_data.userdata);
     // The iterator guarantees the last chunk is tagged with END; here we just
@@ -207,6 +212,13 @@ ThreadTracerAgent::iterate_data(aqlprofile_handle_t handle, rocprofiler_user_dat
     cbdata_t cb_dt{};
 
     cb_dt.agent = agent_id;
+    int se_id   = 0;
+    for(auto mask = params.shader_engine_mask; (mask & 1) == 0; mask >>= 1)
+        ++se_id;
+
+    auto clock            = hsa::get_gpu_clock(handle, se_id);
+    cb_dt.start_timestamp = convert_timestamp(queue->hsa_agent, clock.start);
+    cb_dt.end_timestamp   = convert_timestamp(queue->hsa_agent, clock.latest);
     // Walk each buffer produced by the ATT runtime and forward it to the
     // registered shader callback.
     cb_dt.cb_fn    = params.shader_cb_fn;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/dl.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/dl.cpp
@@ -84,12 +84,15 @@ AQLProfileDL::AQLProfileDL()
     // and would not see handles registered by the vendored aqlprofile_att_create_packets.
     get_buffer_packets_fn   = &aqlprofile_att_get_buffer_packets;
     update_buffer_status_fn = &aqlprofile_att_update_buffer_status;
+    get_gpu_clock_fn        = &aqlprofile_att_get_gpu_clock;
 #else
     // External aqlprofile: load symbols from libhsa-amd-aqlprofile64.so
     get_buffer_packets_fn = reinterpret_cast<GetBufferPacketsFn*>(
         dlsym(RTLD_DEFAULT, "aqlprofile_att_get_buffer_packets"));
     update_buffer_status_fn = reinterpret_cast<UpdateBufferStatusFn*>(
         dlsym(RTLD_DEFAULT, "aqlprofile_att_update_buffer_status"));
+    get_gpu_clock_fn =
+        reinterpret_cast<GetGPUClockFn*>(dlsym(RTLD_DEFAULT, "aqlprofile_att_get_gpu_clock"));
 
     if(valid()) return;
 
@@ -114,6 +117,8 @@ AQLProfileDL::AQLProfileDL()
         reinterpret_cast<GetBufferPacketsFn*>(dlsym(handle, "aqlprofile_att_get_buffer_packets"));
     update_buffer_status_fn = reinterpret_cast<UpdateBufferStatusFn*>(
         dlsym(handle, "aqlprofile_att_update_buffer_status"));
+    get_gpu_clock_fn =
+        reinterpret_cast<GetGPUClockFn*>(dlsym(handle, "aqlprofile_att_get_gpu_clock"));
 #endif
 }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/dl.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/dl.hpp
@@ -57,6 +57,7 @@ class AQLProfileDL
 {
     using GetBufferPacketsFn   = decltype(aqlprofile_att_get_buffer_packets);
     using UpdateBufferStatusFn = decltype(aqlprofile_att_update_buffer_status);
+    using GetGPUClockFn        = decltype(aqlprofile_att_get_gpu_clock);
 
 public:
     AQLProfileDL();
@@ -69,6 +70,7 @@ public:
 
     GetBufferPacketsFn*   get_buffer_packets_fn   = nullptr;
     UpdateBufferStatusFn* update_buffer_status_fn = nullptr;
+    GetGPUClockFn*        get_gpu_clock_fn        = nullptr;
     void*                 handle                  = nullptr;
 };
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/tests/producer_consumer.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/tests/producer_consumer.cpp
@@ -91,15 +91,23 @@ make_mock_queue(const hsa::AgentCache& agent)
 
 using query_status_t = std::function<std::optional<hsa::sqtt_buffer_status_t>(void)>;
 
+using query_clock_t = std::function<aqlprofile_att_gpu_clock_t(void)>;
+
 class MockPackets : public hsa::SQTTBufferingPackets
 {
 public:
-    MockPackets(aqlprofile_handle_t _handle, query_status_t _query)
+    MockPackets(aqlprofile_handle_t _handle, query_status_t _query, query_clock_t _clock)
     : hsa::SQTTBufferingPackets(_handle, 0)
-    , query_fn(_query){};
+    , query_fn(std::move(_query))
+    , clock_fn(std::move(_clock)){};
 
     std::optional<hsa::sqtt_buffer_status_t> query_buffer_status() override { return query_fn(); };
-    query_status_t                           query_fn;
+    aqlprofile_att_gpu_clock_t               get_gpu_clock() const override
+    {
+        return clock_fn ? clock_fn() : aqlprofile_att_gpu_clock_t{};
+    }
+    query_status_t query_fn;
+    query_clock_t  clock_fn;
 };
 
 struct consumer_producer_t
@@ -120,7 +128,8 @@ struct consumer_producer_t
 consumer_producer_t
 start_threads(rocprofiler_thread_trace_shader_data_callback_t cb_fn,
               query_status_t                                  query_fn,
-              rocprofiler_user_data_t                         userdata)
+              rocprofiler_user_data_t                         userdata,
+              query_clock_t                                   clock = {})
 {
     // Build a synthetic queue + packet stack that mimics the runtime so we can
     // exercise the producer/consumer pairing without a real GPU.
@@ -158,7 +167,8 @@ start_threads(rocprofiler_thread_trace_shader_data_callback_t cb_fn,
     // them here or the producer aborts with small_vector::at out_of_range.
     control_packet->populate_before();
     control_packet->populate_after();
-    auto buffer_packet    = std::make_unique<MockPackets>(control_packet->GetHandle(), query_fn);
+    auto buffer_packet =
+        std::make_unique<MockPackets>(control_packet->GetHandle(), query_fn, clock);
     buffer_packet->header = 1;
 
     auto mock_queue          = make_mock_queue(*agent);
@@ -243,6 +253,95 @@ TEST(thread_trace, status_query)
 
     threads.flag->store(rocprofiler::thread_trace::WORKER_FLAG_STOP);
     threads.join_all();
+}
+
+TEST(thread_trace, timestamps_follow_buffer_boundaries)
+{
+    using timestamp_t = rocprofiler_thread_trace_timestamp_t;
+    struct state_t
+    {
+        std::atomic<size_t>                                     data_callbacks{0};
+        std::mutex                                              mut;
+        std::map<uint64_t, std::pair<timestamp_t, timestamp_t>> timestamps;
+    } state;
+
+    rocprofiler::thread_trace::test_init();
+
+    auto* ext_table           = rocprofiler::hsa::get_amd_ext_table();
+    auto  original_convert_fn = ext_table->hsa_amd_profiling_convert_tick_to_system_domain_fn;
+    ext_table->hsa_amd_profiling_convert_tick_to_system_domain_fn =
+        [](hsa_agent_t, uint64_t gpu_clock, uint64_t* system_clock) {
+            *system_clock = gpu_clock * 10;
+            return HSA_STATUS_SUCCESS;
+        };
+
+    auto fetch_cb = [](rocprofiler_thread_trace_shader_data_t shader_data,
+                       rocprofiler_user_data_t                userdata) {
+        auto* callback_state = static_cast<state_t*>(userdata.ptr);
+        {
+            auto lock = std::lock_guard{callback_state->mut};
+            callback_state->timestamps.emplace(
+                shader_data.chunk_index,
+                std::make_pair(shader_data.start_timestamp, shader_data.end_timestamp));
+        }
+        callback_state->data_callbacks.fetch_add(1);
+    };
+
+    auto input_buffer =
+        std::vector<size_t>(rocprofiler::thread_trace::MOCK_BUFFER_SIZE / sizeof(size_t));
+    auto status_calls = std::atomic<size_t>{0};
+    auto query_status = [&]() -> std::optional<rocprofiler::hsa::sqtt_buffer_status_t> {
+        auto called = status_calls.load();
+        if(called >= 2 || called > state.data_callbacks.load()) return std::nullopt;
+        status_calls.fetch_add(1);
+        auto status = rocprofiler::hsa::sqtt_buffer_status_t{};
+        status.data = input_buffer.data();
+        status.size = rocprofiler::thread_trace::MOCK_BUFFER_SIZE;
+        return status;
+    };
+
+    auto clock_calls = std::atomic<uint64_t>{0};
+    auto query_clock = [&]() {
+        auto call = clock_calls.fetch_add(1);
+        return aqlprofile_att_gpu_clock_t{100, 100 * (call + 1)};
+    };
+    auto userdata = rocprofiler_user_data_t{.ptr = &state};
+    auto threads  =
+        rocprofiler::thread_trace::start_threads(fetch_cb, query_status, userdata, query_clock);
+
+    while(state.data_callbacks.load() < 3)
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    threads.flag->store(rocprofiler::thread_trace::WORKER_FLAG_STOP);
+    threads.join_all();
+    ext_table->hsa_amd_profiling_convert_tick_to_system_domain_fn = original_convert_fn;
+
+    auto lock = std::lock_guard{state.mut};
+    ASSERT_GE(state.timestamps.size(), 4u);
+    const auto& header = state.timestamps.at(0);
+    const auto& first  = state.timestamps.at(1);
+    const auto& second = state.timestamps.at(2);
+    const auto& final  = state.timestamps.at(3);
+
+    EXPECT_EQ(header.first.gpu_clock, 0u);
+    EXPECT_EQ(header.first.system_clock, 0u);
+    EXPECT_EQ(header.second.gpu_clock, 0u);
+    EXPECT_EQ(header.second.system_clock, 0u);
+
+    EXPECT_EQ(first.first.gpu_clock, 100u);
+    EXPECT_EQ(first.second.gpu_clock, 200u);
+    EXPECT_EQ(second.first.gpu_clock, first.second.gpu_clock);
+    EXPECT_EQ(second.second.gpu_clock, 300u);
+    EXPECT_EQ(final.first.gpu_clock, second.second.gpu_clock);
+    EXPECT_EQ(final.second.gpu_clock, 400u);
+
+    for(const auto& [chunk, timestamps] : state.timestamps)
+    {
+        if(chunk == 0) continue;
+        EXPECT_LT(timestamps.first.gpu_clock, timestamps.second.gpu_clock);
+        EXPECT_LT(timestamps.first.system_clock, timestamps.second.system_clock);
+        EXPECT_EQ(timestamps.first.system_clock, timestamps.first.gpu_clock * 10);
+        EXPECT_EQ(timestamps.second.system_clock, timestamps.second.gpu_clock * 10);
+    }
 }
 
 TEST(thread_trace, multiple_calls)

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/tests/producer_consumer.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/tests/producer_consumer.cpp
@@ -306,7 +306,7 @@ TEST(thread_trace, timestamps_follow_buffer_boundaries)
         return aqlprofile_att_gpu_clock_t{100, 100 * (call + 1)};
     };
     auto userdata = rocprofiler_user_data_t{.ptr = &state};
-    auto threads  =
+    auto threads =
         rocprofiler::thread_trace::start_threads(fetch_cb, query_status, userdata, query_clock);
 
     while(state.data_callbacks.load() < 3)

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/threading.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/threading.cpp
@@ -41,6 +41,28 @@ namespace thread_trace
 {
 constexpr double SQTT_BANDWIDTH_DEFAULT = 60E9;  // 60GB/s, for wiggle room
 
+rocprofiler_thread_trace_timestamp_t
+convert_timestamp(hsa_agent_t agent, uint64_t gpu_clock)
+{
+    auto result      = rocprofiler_thread_trace_timestamp_t{};
+    result.gpu_clock = gpu_clock;
+    if(gpu_clock == 0) return result;
+
+    auto* ext_table = hsa::get_amd_ext_table();
+    if(ext_table == nullptr ||
+       ext_table->hsa_amd_profiling_convert_tick_to_system_domain_fn == nullptr)
+        return result;
+
+    auto status = ext_table->hsa_amd_profiling_convert_tick_to_system_domain_fn(
+        agent, gpu_clock, &result.system_clock);
+    if(status != HSA_STATUS_SUCCESS)
+    {
+        result.system_clock = 0;
+        ROCP_CI_LOG(ERROR) << "Failed to convert thread trace GPU clock: " << status;
+    }
+    return result;
+}
+
 namespace
 {
 using buffer_slot_t = triple_buffer_shared_data_t::buffer_slot_t;
@@ -143,6 +165,8 @@ consumer_loop(
         shader_data.read_offset      = slot.read_offset;
         shader_data.agent            = agent_id;
         shader_data.flags = static_cast<rocprofiler_thread_trace_shader_data_flags_t>(slot.flags);
+        shader_data.start_timestamp = slot.start_timestamp;
+        shader_data.end_timestamp   = slot.end_timestamp;
 
         callback_fn(shader_data, userdata);
 
@@ -187,6 +211,8 @@ producer_loop(
     uint64_t next_chunk_index = 0;
     int64_t  shader_engine_id = parameters.shader_engine_id;
 
+    auto current_ts = rocprofiler_thread_trace_timestamp_t{};
+
     auto sleep_fn = [&]() {
         sched_yield();
         std::this_thread::sleep_for(std::chrono::microseconds(interval_microseconds));
@@ -214,7 +240,10 @@ producer_loop(
                                 int      flags,
                                 size_t   slot_idx,
                                 bool     isHeader    = false,
-                                uint64_t read_offset = 0) {
+                                uint64_t read_offset = 0,
+
+                                rocprofiler_thread_trace_timestamp_t start_ts = {},
+                                rocprofiler_thread_trace_timestamp_t end_ts   = {}) {
         auto t0 = std::chrono::system_clock::now();
 
         auto&       buffer      = buffers[slot_idx];
@@ -225,6 +254,8 @@ producer_loop(
         buffer.se_id            = shader_engine_id;
         buffer.chunk_index      = next_chunk_index++;
         buffer.read_offset      = read_offset;
+        buffer.start_timestamp  = start_ts;
+        buffer.end_timestamp    = end_ts;
 
         if(!isHeader)
             parameters.copy_data_fn(
@@ -262,11 +293,20 @@ producer_loop(
 
     // Drain remaining ATT data after a stop; waits for a free slot to land it in.
     auto iterate_trace = [&]() {
-        size_t idx  = wait_for_free_slot();
-        auto   wptr = iterate_data(parameters.control_packet->GetHandle());
+        size_t idx    = wait_for_free_slot();
+        auto   wptr   = iterate_data(parameters.control_packet->GetHandle());
+        auto   end_ts = convert_timestamp(queue.hsa_agent, buffer_packet.get_gpu_clock().latest);
         buffer_packet.reset_current_buffer();
         ROCP_INFO << "Iterate data with size: " << wptr.size;
-        send_to_consumer(wptr.data, wptr.size, ROCPROFILER_THREAD_TRACE_SHADER_DATA_FLAGS_END, idx);
+        send_to_consumer(wptr.data,
+                         wptr.size,
+                         ROCPROFILER_THREAD_TRACE_SHADER_DATA_FLAGS_END,
+                         idx,
+                         false,
+                         0,
+                         current_ts,
+                         end_ts);
+        current_ts = end_ts;
     };
 
     std::array<uint64_t, 4> header_plus_zeros{};  // Used for warmup the decoder path
@@ -288,6 +328,7 @@ producer_loop(
 
     // Wait until ATT start packets have been executed
     signal_wait(*parameters.start_pkt_signal);
+    current_ts = convert_timestamp(queue.hsa_agent, buffer_packet.get_gpu_clock().start);
 
     while(worker_flag.load() == WORKER_FLAG_RUNNING)
     {
@@ -303,6 +344,8 @@ producer_loop(
             ROCP_TRACE << "Sending buffer swap";
             // PHASE 2: trigger GPU buffer swap and stage the data into a CPU slot
             att_queue_submit(queue, &status->packet, &submit_signal.sig);
+            if(!submit_wait_timeout()) break;
+            auto swap_ts = convert_timestamp(queue.hsa_agent, buffer_packet.get_gpu_clock().latest);
             ROCP_FATAL_IF(status->size != buffer_size)
                 << "GPU buffer overflow: " << status->size << " vs " << buffer_size;
 
@@ -320,8 +363,15 @@ producer_loop(
 
             // If CPU was full we must wait for a slot before we can publish.
             if(cpu_full) slot_idx = wait_for_free_slot();
-            send_to_consumer(
-                status->data, buffer_size, flags, slot_idx, false, status->read_offset);
+            send_to_consumer(status->data,
+                             buffer_size,
+                             flags,
+                             slot_idx,
+                             false,
+                             status->read_offset,
+                             current_ts,
+                             swap_ts);
+            current_ts = swap_ts;
 
             if(cpu_full || status->gpu_full)
             {
@@ -329,6 +379,8 @@ producer_loop(
                 send_header();
 
                 att_queue_submit_and_wait_last(queue, parameters.control_packet->before_krn_pkt);
+                current_ts =
+                    convert_timestamp(queue.hsa_agent, buffer_packet.get_gpu_clock().start);
             }
             // The status_query test verifies we immediately poll again after consuming a
             // buffer, so skip the backoff when a flip just occurred.

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/threading.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/threading.hpp
@@ -48,6 +48,9 @@ copy_data_sync(void*         dst,
 
 typedef decltype(copy_data_sync) copy_data_t;
 
+rocprofiler_thread_trace_timestamp_t
+convert_timestamp(hsa_agent_t agent, uint64_t gpu_clock);
+
 /// Shared state coordinating the single producer and N worker threads.
 ///
 /// Each slot is owned by exactly one consumer thread; the producer hands
@@ -76,6 +79,9 @@ struct triple_buffer_shared_data_t
         int64_t  se_id{0};
         uint64_t chunk_index{0};
         uint64_t read_offset{0};
+
+        rocprofiler_thread_trace_timestamp_t start_timestamp{};
+        rocprofiler_thread_trace_timestamp_t end_timestamp{};
 
         /// Producer sets true after writing slot fields; consumer stores
         /// false after running the callback.

--- a/projects/rocprofiler-sdk/tests/tools/thread-trace-callbacks.cpp
+++ b/projects/rocprofiler-sdk/tests/tools/thread-trace-callbacks.cpp
@@ -73,6 +73,9 @@ void
 shader_data_callback(rocprofiler_thread_trace_shader_data_t shader_data,
                      rocprofiler_user_data_t /* userdata */)
 {
+    assert(shader_data.start_timestamp.gpu_clock <= shader_data.end_timestamp.gpu_clock);
+    assert(shader_data.start_timestamp.system_clock <= shader_data.end_timestamp.system_clock);
+
     auto parse = [](rocprofiler_thread_trace_decoder_record_type_t record_type_id,
                     void*                                          trace_events,
                     uint64_t                                       trace_size,


### PR DESCRIPTION
## Motivation

Thread trace shader callbacks need timestamps in GPU and Sys clock for proper correlation with API tracing.

JIRA ID : ROCM-26029

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
