### PR TITLE
feat(ci): disable multi-arch CI presubmit trigger

### DIFF
--- a/.github/workflows/therock-multi-arch-ci.yml
+++ b/.github/workflows/therock-multi-arch-ci.yml
@@ -28,11 +28,11 @@
 name: TheRock Multi-Arch CI
 
 on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
+  # pull_request:
+  #   types:
+  #     - opened
+  #     - synchronize
+  #     - reopened
   workflow_dispatch:
     inputs:
       linux_amdgpu_families:


### PR DESCRIPTION
Comment out the pull_request trigger to temporarily disable multi-arch CI running on PRs.
