### PR TITLE
[RCCL] Make NCCL_CHECK_MODE effective and cover symmetric abort

### DIFF
--- a/projects/rccl/CHANGELOG.md
+++ b/projects/rccl/CHANGELOG.md
@@ -18,6 +18,7 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 
 ### Fixed
 * `NCCL_MAX_P2P_NCHANNELS` opt-in is now detected from the environment rather than from the parameter value. The value defaults to `MAXCHANNELS`, so every unset run was treated as an opt-in past the historical `4*CHANNEL_LIMIT` (64) bound. As a result, P2P channels on non-gfx1250 architectures were limited only by the collective channel count, and the gfx950 (MI350) multi-node P2P caps never applied. Set `NCCL_MAX_P2P_NCHANNELS` explicitly to restore a higher bound.
+* Fixed `NCCL_CHECK_MODE` having no effect. `commAlloc` reset `comm->checkMode` from the deprecated `NCCL_CHECK_POINTERS` after `NCCL_CHECK_MODE` had already been parsed, so `DEBUG_LOCAL` was only reachable through the deprecated variable and `DEBUG_GLOBAL`, which validates symmetric buffer registration across ranks, was unreachable entirely.
 
 ### Known issues
 * The improved AllGatherV support breaks the NCCL profiler support for ncclBroadcast operations, limiting visibility to API events. `NCCL_ALLGATHERV_ENABLE=0` can be used as a workaround until it is fixed in a future release.

--- a/projects/rccl/docs/api-reference/env-variables.rst
+++ b/projects/rccl/docs/api-reference/env-variables.rst
@@ -147,6 +147,71 @@ in the following table.
         | Write logs to a file rather than ``stdout``.
       - | The filename can be formatted using ``%h`` for hostname, ``%p`` for pid, and ``%%`` to escape the ``%`` character. It is recommended to use ``%p`` to output to individual files per pid to avoid mixing or potentially overwriting the output. Example usage: ``NCCL_DEBUG_FILE=debugfile.%h.%p``
 
+    * - | ``NCCL_CHECK_MODE``
+        | Selects how thoroughly RCCL validates the arguments of every
+          collective call. Checking costs latency, so it is disabled by default
+          and intended for development and bring-up. See
+          :ref:`check-mode` for what each mode detects.
+      - | ``DEFAULT``: No argument validation (default).
+        | ``DEBUG_LOCAL``: Validate the buffer pointers locally on each rank.
+          Replaces the deprecated ``NCCL_CHECK_POINTERS``.
+        | ``DEBUG_GLOBAL``: Also validate arguments across ranks, including
+          symmetric buffer registration.
+        | Values other than ``DEBUG_LOCAL`` and ``DEBUG_GLOBAL`` leave the mode
+          unchanged, so writing ``DEFAULT`` does not switch checking off again.
+
+    * - | ``NCCL_CHECK_POINTERS``
+        | Deprecated. Enables local validation of the buffer pointers passed to
+          each collective.
+      - | ``0``: Disabled (default).
+        | ``1``: Enabled, equivalent to ``NCCL_CHECK_MODE=DEBUG_LOCAL``.
+        | Use ``NCCL_CHECK_MODE`` instead. When both are set, ``DEBUG_LOCAL`` or
+          ``DEBUG_GLOBAL`` wins; any other ``NCCL_CHECK_MODE`` value keeps the
+          mode selected by ``NCCL_CHECK_POINTERS=1``.
+
+.. _check-mode:
+
+Validating collective arguments
+-------------------------------
+
+``NCCL_CHECK_MODE=DEBUG_LOCAL`` inspects only what a rank can see by itself: it
+verifies that the ``sendbuff`` and ``recvbuff`` arguments are valid device
+pointers that belong to the device the communicator was created on. Passing a
+host pointer or a pointer from another device makes the collective return
+``ncclInvalidArgument`` instead of faulting inside the kernel.
+
+``NCCL_CHECK_MODE=DEBUG_GLOBAL`` adds cross-rank validation of symmetric buffer
+registration. The symmetric kernels require every rank to describe its buffers
+identically, because a rank addresses a peer's buffer by applying its own offsets
+to the peer's symmetric window. RCCL cannot verify that from a single rank, so at
+group launch the ranks exchange the identity of the windows backing their buffers
+and compare against rank 0. A collective is rejected with
+``ncclInvalidArgument`` when:
+
+* Some ranks pass buffers registered with ``NCCL_WIN_COLL_SYMMETRIC`` while
+  others pass unregistered buffers.
+* The ranks pass buffers from windows registered at different positions in the
+  symmetric address space.
+* The ranks pass buffers at different offsets inside their windows.
+
+Each rejection is reported by rank 0 with a ``WARN`` message naming the
+collective, the message size, and the first rank that disagrees, so set
+``NCCL_DEBUG=WARN`` when using this mode. Setting ``NCCL_DEBUG=INFO`` with
+``NCCL_DEBUG_SUBSYS=COLL`` additionally prints a ``SymCheck`` line per rank with
+the window and user offsets that were compared.
+
+Without this mode such a mismatch is not diagnosed: RCCL silently falls back to
+the general kernels for calls it cannot serve symmetrically, so the collective
+still produces correct results but loses the performance of the symmetric path.
+Enable ``DEBUG_GLOBAL`` when a workload registers symmetric windows yet does not
+reach the expected symmetric performance.
+
+.. note::
+
+   ``DEBUG_GLOBAL`` adds a bootstrap all-gather to every group launch, which is
+   far more expensive than the collective itself for small messages. Use it to
+   diagnose a configuration, not in production.
+
 Algorithm and protocol control
 ==============================
 

--- a/projects/rccl/docs/how-to/fault-tolerance.rst
+++ b/projects/rccl/docs/how-to/fault-tolerance.rst
@@ -117,6 +117,34 @@ asynchronous errors at the same time, instead of blocking in
        }
    }
 
+.. _ft-symmetric-abort:
+
+Aborting symmetric-memory collectives
+=====================================
+
+Collectives that run on symmetric memory are served by the built-in symmetric
+kernels, which exchange data directly between peer GPUs instead of going through
+a proxy thread. A rank that never reaches the collective therefore leaves its
+peers parked inside a device-side spin loop, where the host cannot see them.
+
+Because there is no proxy thread and no device-side timeout on this path, neither
+:cpp:func:`ncclCommGetAsyncError` nor a communicator timeout will ever report the
+missing peer. Deciding when to give up is therefore the caller's responsibility:
+drive the abort from your own deadline or an out-of-band watchdog, not from a loop
+waiting for an async error that never arrives.
+
+:cpp:func:`ncclCommAbort` releases the parked kernels and the stream drains, with
+a short delay because the abort flag is only sampled periodically. The same rules
+as in :ref:`ft-recovery` apply: the communicator must be non-blocking and no
+thread may be inside an RCCL call when :cpp:func:`ncclCommAbort` is invoked.
+
+.. note::
+
+   Symmetric memory requires ``NCCL_CUMEM_ENABLE=1`` and a host platform that
+   supports virtual memory management. When symmetric memory is unavailable,
+   collectives fall back to the general kernels, whose abort path is handled by
+   the proxy thread instead.
+
 .. _ft-recovery:
 
 Recovering from a failure

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -783,7 +783,6 @@ static ncclResult_t commAlloc(struct ncclComm* comm, struct ncclComm* parent, in
   TRACE(NCCL_INIT, "comm %p rank %d nranks %d cudaDev %d busId %lx compCap %d", comm, rank, ndev, comm->cudaDev,
         comm->busId, comm->compCap);
 
-  comm->checkMode = ncclParamCheckPointers() == 1 ? ncclCheckModeDebugLocal : ncclCheckModeDefault;
   comm->dmaBufSupport = (dmaBufSupported(comm) == ncclSuccess) ? true : false;
 
   // Initialize memory manager

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -698,6 +698,7 @@ if(BUILD_TESTS)
       CommNetMismatchMPITests.cpp
       test_sparse_send_recv.cpp
       DdaAllReduceMPITests.cpp
+      SymmetricAbortCheckModeMPITests.cpp
     )
 
     add_executable(rccl-UnitTestsMPI ${MPI_TEST_SOURCE_FILES})

--- a/projects/rccl/test/SymmetricAbortCheckModeMPITests.cpp
+++ b/projects/rccl/test/SymmetricAbortCheckModeMPITests.cpp
@@ -1,0 +1,554 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+/**
+ * @file SymmetricAbortCheckModeMPITests.cpp
+ * @brief Tests for abort support in symmetric kernels and NCCL_CHECK_MODE
+ *
+ * Covers the two halves of the NCCL 2.29.7 release-note item
+ * "Symmetric memory: Added support for abort in symmetric kernels. Added
+ * NCCL_CHECK_MODE=DEBUG to validate symmetric buffer registration."
+ *
+ * SymCheckMode_* exercises the host-side validation in src/misc/argcheck.cc:
+ *   - NCCL_CHECK_MODE=DEBUG_LOCAL  validates the buffer pointers locally.
+ *   - NCCL_CHECK_MODE=DEBUG_GLOBAL additionally runs registrationCheck(), which
+ *     bootstrap-allgathers the symmetric window identity of every rank and
+ *     rejects the collective when the ranks disagree.
+ * The validation is opt-in, so a matching Default_* test documents that the same
+ * mismatch is accepted when the variable is unset.
+ *
+ * SymAbort_* exercises the device-side abort: the spin loops that the symmetric
+ * kernels rely on must poll ncclDevComm::abortFlag via nccl::utility::testAbort()
+ * so that ncclCommAbort() can unblock a kernel whose peer never arrives. The two
+ * tests pin NCCL_SYM_KERNEL so that each of the two distinct spin loops is
+ * covered:
+ *   AllReduce_AGxLL_R     -> ncclLLA2ASession::recvUnrolled  (LL all-to-all)
+ *   AllReduce_RSxLD_AGxST -> ncclLsaBarrierSession::wait     (LSA barrier)
+ *
+ * REQUIRED Environment Variables:
+ *   NCCL_CUMEM_ENABLE=1          Enables cuMem API for symmetric support
+ *   HSA_NO_SCRATCH_RECLAIM=1     Required for multi-GPU RCCL tests
+ *
+ * Symmetric memory additionally needs a Linux kernel >= 6.8 (cuMem/VMM gate in
+ * src/misc/rocmwrap.cc); every test here skips when it is unavailable.
+ *
+ * Run examples:
+ *   mpirun -np 8 --bind-to none -x NCCL_CUMEM_ENABLE=1 \
+ *     ./rccl-UnitTestsMPI --gtest_filter=SymCheckMode_*
+ *   mpirun -np 8 --bind-to none -x NCCL_CUMEM_ENABLE=1 \
+ *     ./rccl-UnitTestsMPI --gtest_filter=SymAbort_*
+ */
+
+#include "DeviceBufferHelpers.hpp"
+#include "MPIHelpers.hpp"
+#include "MPITestBase.hpp"
+#include "ResourceGuards.hpp"
+#include "TestChecks.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <string>
+#include <thread>
+#include <vector>
+
+#ifdef MPI_TESTS_ENABLED
+
+using namespace MPITestConstants;
+using namespace RCCLTestGuards;
+using namespace RCCLTestHelpers;
+
+namespace {
+
+constexpr int MIN_RANKS = 2;
+// Small enough that the LL symmetric kernels stay eligible.
+constexpr size_t ABORT_COUNT = 1024;
+// Large enough that the window has room for the offset-mismatch scenario.
+constexpr size_t CHECK_COUNT = 64 * 1024;
+
+// ncclCommAbort() has to reach the device through host-pinned memory, so give
+// the kernel a generous but bounded window to notice the flag.
+constexpr int ABORT_DELAY_MS = 3000;
+constexpr int ABORT_DEADLINE_MS = 30000;
+
+// NCCL_CHECK_MODE and NCCL_SYM_KERNEL are read during ncclCommInitRank, so the
+// tests set them before creating the communicator and restore them afterwards.
+class ScopedEnv
+{
+public:
+    ScopedEnv(const char* name, const char* value)
+        : name_(name)
+    {
+        const char* prev = std::getenv(name);
+        if (prev) {
+            had_ = true;
+            prev_ = prev;
+        }
+        if (value) {
+            setenv(name, value, 1);
+        } else {
+            unsetenv(name);
+        }
+    }
+
+    ~ScopedEnv()
+    {
+        if (had_) {
+            setenv(name_.c_str(), prev_.c_str(), 1);
+        } else {
+            unsetenv(name_.c_str());
+        }
+    }
+
+    ScopedEnv(const ScopedEnv&) = delete;
+    ScopedEnv& operator=(const ScopedEnv&) = delete;
+
+private:
+    std::string name_;
+    std::string prev_;
+    bool had_ = false;
+};
+
+} // namespace
+
+// ============================================================================
+// Shared fixture: symmetric window allocation + availability probing
+// ============================================================================
+
+class SymmetricAbortCheckModeBase : public MPITestBase
+{
+protected:
+    struct Alloc {
+        void* ptr = nullptr;
+    };
+
+    struct Win {
+        ncclWindow_t win = nullptr;
+        ncclComm_t comm = nullptr;
+    };
+
+    std::vector<Alloc> allocs_;
+    std::vector<Win> wins_;
+
+    void TearDown() override
+    {
+        for (auto it = wins_.rbegin(); it != wins_.rend(); ++it) {
+            if (it->win && it->comm) ncclCommWindowDeregister(it->comm, it->win);
+        }
+        wins_.clear();
+
+        for (auto it = allocs_.rbegin(); it != allocs_.rend(); ++it) {
+            if (it->ptr) ncclMemFree(it->ptr);
+        }
+        allocs_.clear();
+
+        MPITestBase::TearDown();
+    }
+
+    void* allocSymBuf(size_t size)
+    {
+        void* ptr = nullptr;
+        if (ncclMemAlloc(&ptr, size) != ncclSuccess || ptr == nullptr) return nullptr;
+        allocs_.push_back({ptr});
+        return ptr;
+    }
+
+    ncclWindow_t registerSymWindow(ncclComm_t comm, void* buf, size_t size)
+    {
+        ncclWindow_t win = nullptr;
+        if (ncclCommWindowRegister(comm, buf, size, &win, NCCL_WIN_COLL_SYMMETRIC) != ncclSuccess) {
+            return nullptr;
+        }
+        wins_.push_back({win, comm});
+        return win;
+    }
+
+    // Mirrors SymmetricWindowMPITests: symmetric memory needs cuMem opted in and
+    // ncclMemAlloc working. The communicator is created by the caller so that
+    // NCCL_CHECK_MODE / NCCL_SYM_KERNEL can be installed first.
+    bool symmetricPrerequisitesMet(int minRanks = MIN_RANKS)
+    {
+        const char* cuMemEnv = std::getenv("NCCL_CUMEM_ENABLE");
+        if (!cuMemEnv || std::string(cuMemEnv) != "1") return false;
+        if (!validateTestPrerequisites(minRanks)) return false;
+
+        void* probe = nullptr;
+        if (ncclMemAlloc(&probe, 4096) != ncclSuccess || probe == nullptr) return false;
+        ncclMemFree(probe);
+        return true;
+    }
+
+    // A rank that reports "reject" while its peers report "accept" would deadlock
+    // the next collective, so every assertion about the outcome is agreed on by
+    // all ranks first.
+    static bool allRanksAgree(bool local)
+    {
+        int in = local ? 1 : 0;
+        int out = 0;
+        MPI_Allreduce(&in, &out, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD);
+        return out != 0;
+    }
+};
+
+// ============================================================================
+// NCCL_CHECK_MODE: symmetric buffer registration validation
+// ============================================================================
+
+class SymCheckMode_Registration : public SymmetricAbortCheckModeBase
+{
+protected:
+    enum class Deviation {
+        None,          // every rank registers both buffers at offset 0
+        Unregistered,  // the odd rank leaves its send buffer outside any window
+        ShiftedOffset, // the odd rank starts further into its send window
+    };
+
+    // Runs one AllReduce under the current NCCL_CHECK_MODE and returns the
+    // result that every rank observed.
+    ncclResult_t runAllReduce(Deviation deviation)
+    {
+        const size_t count = CHECK_COUNT;
+        // Four times the payload leaves room to shift the user offset.
+        const size_t winBytes = count * sizeof(float) * 4;
+
+        ncclComm_t comm = getActiveCommunicator();
+        hipStream_t stream = getActiveStream();
+        int rank = 0, nRanks = 0;
+        ncclCommUserRank(comm, &rank);
+        ncclCommCount(comm, &nRanks);
+
+        // Rank 1 is the deviating rank: registrationCheck() compares every rank
+        // against rank 0, so the deviation must not live on rank 0.
+        const int oddRank = 1;
+        const bool isOdd = (rank == oddRank);
+
+        void* sendBuf = allocSymBuf(winBytes);
+        void* recvBuf = allocSymBuf(winBytes);
+        if (!sendBuf || !recvBuf) return ncclInternalError;
+
+        // ncclCommWindowRegister is collective, so every rank must register the
+        // same number of windows: a rank that skipped one would leave its peers
+        // waiting in the next registration while it has moved on to the AllReduce.
+        // Register both buffers everywhere and express the deviation through the
+        // pointer handed to the collective instead.
+        if (registerSymWindow(comm, sendBuf, winBytes) == nullptr) return ncclInternalError;
+        if (registerSymWindow(comm, recvBuf, winBytes) == nullptr) return ncclInternalError;
+
+        float* sendPtr = static_cast<float*>(sendBuf);
+        float* recvPtr = static_cast<float*>(recvBuf);
+
+        if (isOdd && deviation == Deviation::Unregistered) {
+            // Hand the collective a symmetric buffer that no window covers: every
+            // peer still passes a registered buffer, so registrationCheck()
+            // disagrees with rank 0 without unbalancing the registration itself.
+            void* unregBuf = allocSymBuf(winBytes);
+            if (!unregBuf) return ncclInternalError;
+            sendPtr = static_cast<float*>(unregBuf);
+        } else if (isOdd && deviation == Deviation::ShiftedOffset) {
+            // Registered, but starting further into the window than its peers,
+            // which the symmetric kernels cannot express.
+            sendPtr = reinterpret_cast<float*>(static_cast<char*>(sendBuf) + 8192);
+        }
+
+        ncclResult_t res = ncclAllReduce(sendPtr, recvPtr, count, ncclFloat, ncclSum, comm, stream);
+        if (res == ncclSuccess && hipStreamSynchronize(stream) != hipSuccess) {
+            res = ncclInternalError;
+        }
+
+        // The ranks must agree on the outcome; a split result (some ranks reject,
+        // others accept) is itself a failure rather than something to hide behind
+        // MPI_MAX, which would let a mixed outcome masquerade as the expected one.
+        int localRes = static_cast<int>(res);
+        int maxRes = 0;
+        int minRes = 0;
+        MPI_Allreduce(&localRes, &maxRes, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+        MPI_Allreduce(&localRes, &minRes, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD);
+        if (minRes != maxRes) return ncclInternalError;
+        return static_cast<ncclResult_t>(maxRes);
+    }
+};
+
+TEST_F(SymCheckMode_Registration, DebugGlobal_MatchingRegistration_Succeeds)
+{
+    ScopedEnv checkMode("NCCL_CHECK_MODE", "DEBUG_GLOBAL");
+    if (!symmetricPrerequisitesMet()) {
+        GTEST_SKIP() << "Requires symmetric support (NCCL_CUMEM_ENABLE=1, kernel >= 6.8) with 2+ ranks";
+    }
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+
+    // The global check must be transparent when every rank agrees.
+    ASSERT_MPI_EQ(ncclSuccess, runAllReduce(Deviation::None));
+}
+
+TEST_F(SymCheckMode_Registration, DebugGlobal_RegistrationMismatch_Rejected)
+{
+    ScopedEnv checkMode("NCCL_CHECK_MODE", "DEBUG_GLOBAL");
+    if (!symmetricPrerequisitesMet()) {
+        GTEST_SKIP() << "Requires symmetric support (NCCL_CUMEM_ENABLE=1, kernel >= 6.8) with 2+ ranks";
+    }
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+
+    // One rank passes a buffer that is not in any symmetric window while the
+    // others pass registered buffers: isSymRegistered disagrees with rank 0.
+    ASSERT_MPI_EQ(ncclInvalidArgument, runAllReduce(Deviation::Unregistered));
+}
+
+TEST_F(SymCheckMode_Registration, DebugGlobal_UserOffsetMismatch_Rejected)
+{
+    ScopedEnv checkMode("NCCL_CHECK_MODE", "DEBUG_GLOBAL");
+    if (!symmetricPrerequisitesMet()) {
+        GTEST_SKIP() << "Requires symmetric support (NCCL_CUMEM_ENABLE=1, kernel >= 6.8) with 2+ ranks";
+    }
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+
+    // Every rank registers a window, but one rank's buffer starts at a different
+    // offset inside it, which the symmetric kernels cannot express.
+    ASSERT_MPI_EQ(ncclInvalidArgument, runAllReduce(Deviation::ShiftedOffset));
+}
+
+TEST_F(SymCheckMode_Registration, Default_RegistrationMismatch_Accepted)
+{
+    ScopedEnv checkMode("NCCL_CHECK_MODE", nullptr);
+    if (!symmetricPrerequisitesMet()) {
+        GTEST_SKIP() << "Requires symmetric support (NCCL_CUMEM_ENABLE=1, kernel >= 6.8) with 2+ ranks";
+    }
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+
+    // Same mismatch as above: without the variable the library must stay on the
+    // fast path and fall back instead of diagnosing.
+    ASSERT_MPI_EQ(ncclSuccess, runAllReduce(Deviation::Unregistered));
+}
+
+// ============================================================================
+// NCCL_CHECK_MODE=DEBUG_LOCAL: local pointer validation
+// ============================================================================
+
+// These do not need symmetric memory, so they guard the NCCL_CHECK_MODE
+// plumbing on any platform: a mode that reaches comm->checkMode must make the
+// library reject a host pointer where a device pointer is required.
+class SymCheckMode_Local : public SymmetricAbortCheckModeBase
+{
+protected:
+    void expectHostPointerRejected(ncclResult_t expected)
+    {
+        ncclComm_t comm = getActiveCommunicator();
+        hipStream_t stream = getActiveStream();
+
+        std::vector<float> hostBuf(CHECK_COUNT, 1.0f);
+        void* devBuf = nullptr;
+        ASSERT_EQ(hipSuccess, hipMalloc(&devBuf, CHECK_COUNT * sizeof(float)));
+
+        ncclResult_t res =
+            ncclAllReduce(hostBuf.data(), devBuf, CHECK_COUNT, ncclFloat, ncclSum, comm, stream);
+
+        // Agree on the result across ranks before touching the stream: a rank that
+        // wrongly accepted the host pointer would otherwise launch a kernel on
+        // unmapped memory and block in hipStreamSynchronize while its peers fail.
+        // A correct rejection enqueues nothing, so there is nothing to drain.
+        ASSERT_MPI_EQ(expected, res);
+        ASSERT_EQ(hipSuccess, hipFree(devBuf));
+    }
+};
+
+TEST_F(SymCheckMode_Local, DebugLocal_HostPointer_Rejected)
+{
+    ScopedEnv checkMode("NCCL_CHECK_MODE", "DEBUG_LOCAL");
+    if (!validateTestPrerequisites(1)) {
+        GTEST_SKIP() << "Needs at least 1 process";
+    }
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+
+    expectHostPointerRejected(ncclInvalidArgument);
+}
+
+TEST_F(SymCheckMode_Local, DebugGlobal_HostPointer_Rejected)
+{
+    ScopedEnv checkMode("NCCL_CHECK_MODE", "DEBUG_GLOBAL");
+    if (!validateTestPrerequisites(1)) {
+        GTEST_SKIP() << "Needs at least 1 process";
+    }
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+
+    // DEBUG_GLOBAL is a superset of DEBUG_LOCAL, so the local check must still
+    // fire. This is the cheapest signal that the mode reached the communicator
+    // at all, which regressed once when commAlloc() reset comm->checkMode after
+    // the environment had already been parsed.
+    expectHostPointerRejected(ncclInvalidArgument);
+}
+
+// The deprecated NCCL_CHECK_POINTERS is intentionally not tested here. It is an
+// NCCL_PARAM, latched on first read (src/include/param.h) and evaluated on every
+// ncclCommInitRank (src/init.cc), so the two tests above already pin it at 0 for
+// the lifetime of the process; a later setenv() in this same binary has no
+// effect. NCCL_CHECK_MODE works because it is re-read through ncclGetEnv() on
+// each communicator, and DEBUG_LOCAL already covers the same rejection path.
+
+// The opt-in nature of the checking is covered by
+// SymCheckMode_Registration.Default_RegistrationMismatch_Accepted, which uses a
+// mismatch that is safe to actually execute. Enqueuing a host pointer without a
+// check mode would let the kernel dereference unmapped memory and take the whole
+// process down with it, so that combination is deliberately not tested.
+
+// ============================================================================
+// Abort inside symmetric kernels
+// ============================================================================
+
+class SymAbort_Kernel : public SymmetricAbortCheckModeBase
+{
+protected:
+    // All ranks but the last enqueue a symmetric AllReduce, so the kernel parks
+    // in its device-side spin loop waiting for a peer that never arrives. A
+    // watchdog thread then calls ncclCommAbort(); the kernel must observe the
+    // abort flag and return, which lets the stream drain.
+    //
+    // The communicator is created and cleaned up here instead of through the
+    // fixture: ncclCommAbort() is only defined for non-blocking communicators
+    // (docs/how-to/fault-tolerance.rst), and an aborted communicator frees itself
+    // and reclaims its still-registered windows, so nothing here may be handed to
+    // the fixture's window/allocation teardown.
+    void runAbortScenario(const char* symKernel)
+    {
+        ScopedEnv kernelEnv("NCCL_SYM_KERNEL", symKernel);
+        if (!symmetricPrerequisitesMet()) {
+            GTEST_SKIP() << "Requires symmetric support (NCCL_CUMEM_ENABLE=1, kernel >= 6.8) with 2+ ranks";
+        }
+
+        int rank = 0, nRanks = 0;
+        MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+        MPI_Comm_size(MPI_COMM_WORLD, &nRanks);
+
+        ncclUniqueId id;
+        if (rank == 0) ASSERT_MPI_EQ(ncclSuccess, ncclGetUniqueId(&id));
+        MPI_Bcast(&id, sizeof(id), MPI_BYTE, 0, MPI_COMM_WORLD);
+
+        // Non-blocking so the watchdog can abort while the main thread is only
+        // polling the stream, never parked inside a blocking RCCL call.
+        ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+        config.blocking     = 0;
+        ncclComm_t comm     = nullptr;
+        ncclResult_t initRes = ncclCommInitRankConfig(&comm, nRanks, id, rank, &config);
+        ASSERT_MPI_NE(comm, nullptr);
+        ASSERT_MPI_EQ(ncclSuccess, waitComm(comm, initRes));
+
+        hipStream_t stream = nullptr;
+        ASSERT_EQ(hipSuccess, hipStreamCreate(&stream));
+
+        const size_t bytes = ABORT_COUNT * sizeof(float);
+        void* sendBuf = nullptr;
+        void* recvBuf = nullptr;
+        ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&sendBuf, bytes));
+        ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&recvBuf, bytes));
+
+        // Register the windows directly (not via the fixture): the comm is aborted
+        // below, which reclaims these windows, so a fixture deregister would run
+        // through freed memory.
+        ncclWindow_t sendWin = nullptr;
+        ncclWindow_t recvWin = nullptr;
+        ncclResult_t regRes =
+            waitComm(comm, ncclCommWindowRegister(comm, sendBuf, bytes, &sendWin, NCCL_WIN_COLL_SYMMETRIC));
+        if (regRes == ncclSuccess) {
+            regRes =
+                waitComm(comm, ncclCommWindowRegister(comm, recvBuf, bytes, &recvWin, NCCL_WIN_COLL_SYMMETRIC));
+        }
+        if (!allRanksAgree(regRes == ncclSuccess && sendWin != nullptr && recvWin != nullptr)) {
+            static_cast<void>(ncclCommAbort(comm));
+            static_cast<void>(hipStreamDestroy(stream));
+            static_cast<void>(ncclMemFree(sendBuf));
+            static_cast<void>(ncclMemFree(recvBuf));
+            GTEST_SKIP() << "Symmetric window registration unavailable";
+        }
+
+        // Warm up with every rank participating so the symmetric path (device
+        // comm, teams, LL buffers) is fully established before the stall.
+        ncclResult_t warmup =
+            waitComm(comm, ncclAllReduce(sendBuf, recvBuf, ABORT_COUNT, ncclFloat, ncclSum, comm, stream));
+        ASSERT_MPI_EQ(ncclSuccess, warmup);
+        ASSERT_EQ(hipSuccess, hipStreamSynchronize(stream));
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        std::atomic<bool> aborted{false};
+        std::thread watchdog([&]() {
+            std::this_thread::sleep_for(std::chrono::milliseconds(ABORT_DELAY_MS));
+            aborted.store(true);
+            ncclCommAbort(comm);
+        });
+
+        const int deserter = nRanks - 1;
+        bool drained = true;
+
+        if (rank != deserter) {
+            // The symmetric kernel launches directly on the stream, so poll the
+            // stream rather than the async error. A rejected enqueue is
+            // acceptable: it means the abort landed before the launch; only a
+            // launched kernel has to honour the flag.
+            ncclResult_t enq =
+                ncclAllReduce(sendBuf, recvBuf, ABORT_COUNT, ncclFloat, ncclSum, comm, stream);
+            if (enq == ncclSuccess || enq == ncclInProgress) {
+                drained = waitForStream(stream, symKernel);
+            }
+        }
+
+        watchdog.join();
+        EXPECT_TRUE(aborted.load());
+        EXPECT_TRUE(drained) << "Symmetric kernel " << symKernel
+                             << " did not return after ncclCommAbort";
+
+        // The comm has been aborted (and with it its windows), so only the local
+        // stream and device buffers are released here.
+        static_cast<void>(hipStreamDestroy(stream));
+        static_cast<void>(ncclMemFree(sendBuf));
+        static_cast<void>(ncclMemFree(recvBuf));
+        MPI_Barrier(MPI_COMM_WORLD);
+    }
+
+private:
+    // Drives a non-blocking communicator to a settled state and returns the final
+    // async error. The triggering call's ncclInProgress is folded in so call
+    // sites can wrap the RCCL call directly.
+    static ncclResult_t waitComm(ncclComm_t comm, ncclResult_t res = ncclInProgress)
+    {
+        if (res != ncclInProgress) return res;
+        ncclResult_t state = ncclInProgress;
+        do {
+            if (ncclCommGetAsyncError(comm, &state) != ncclSuccess) return ncclInternalError;
+        } while (state == ncclInProgress);
+        return state;
+    }
+
+    // Polls instead of blocking so that a kernel ignoring the abort flag is
+    // reported as a failure rather than hanging the whole suite.
+    static bool waitForStream(hipStream_t stream, const char* symKernel)
+    {
+        const auto deadline =
+            std::chrono::steady_clock::now() + std::chrono::milliseconds(ABORT_DEADLINE_MS);
+        while (std::chrono::steady_clock::now() < deadline) {
+            hipError_t query = hipStreamQuery(stream);
+            if (query != hipErrorNotReady) {
+                // Either success or a launch failure: the kernel is no longer
+                // resident, which is what the abort is supposed to achieve.
+                return true;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        }
+        TEST_INFO("Symmetric kernel %s still resident %d ms after ncclCommAbort", symKernel,
+            ABORT_DEADLINE_MS);
+        return false;
+    }
+};
+
+TEST_F(SymAbort_Kernel, LLAllToAll_AbortReleasesKernel)
+{
+    // Exercises ncclLLA2ASession::recvUnrolled().
+    runAbortScenario("AllReduce_AGxLL_R");
+}
+
+TEST_F(SymAbort_Kernel, LsaBarrier_AbortReleasesKernel)
+{
+    // Exercises ncclLsaBarrierSession::wait().
+    runAbortScenario("AllReduce_RSxLD_AGxST");
+}
+
+#endif // MPI_TESTS_ENABLED

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -1950,6 +1950,29 @@
         }
       ]
     },
+    "symmetric_abort_checkmode_tests": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 2,
+      "num_nodes": 1,
+      "num_gpus": 2,
+      "timeout": 180,
+      "description": "NCCL_CHECK_MODE validation (AICOMRCCL-806). The SymAbort_Kernel abort tests exist in the binary but are omitted here until CI has a host with working cuMem VMM (kernel >= 6.8, ROCm >= 7.12 driver), where the symmetric kernels actually park and ncclCommAbort can release them. Each test runs as its own process.",
+      "env_variables": {
+        "NCCL_DEBUG": "INFO",
+        "NCCL_CUMEM_ENABLE": "1",
+        "HSA_NO_SCRATCH_RECLAIM": "1"
+      },
+      "tests": [
+        { "name": "SymCheckMode_Local_DebugLocal", "description": "NCCL_CHECK_MODE=DEBUG_LOCAL rejects a host pointer where a device pointer is required.", "test_filter": "SymCheckMode_Local.DebugLocal_HostPointer_Rejected" },
+        { "name": "SymCheckMode_Local_DebugGlobal", "description": "NCCL_CHECK_MODE=DEBUG_GLOBAL keeps the local host-pointer check active.", "test_filter": "SymCheckMode_Local.DebugGlobal_HostPointer_Rejected" },
+        { "name": "SymCheckMode_Registration_Match", "description": "DEBUG_GLOBAL is transparent when every rank registers matching symmetric windows.", "test_filter": "SymCheckMode_Registration.DebugGlobal_MatchingRegistration_Succeeds" },
+        { "name": "SymCheckMode_Registration_Mismatch", "description": "DEBUG_GLOBAL rejects a collective when one rank's buffer is outside any window.", "test_filter": "SymCheckMode_Registration.DebugGlobal_RegistrationMismatch_Rejected" },
+        { "name": "SymCheckMode_Registration_OffsetMismatch", "description": "DEBUG_GLOBAL rejects a user-offset mismatch inside the window.", "test_filter": "SymCheckMode_Registration.DebugGlobal_UserOffsetMismatch_Rejected" },
+        { "name": "SymCheckMode_Registration_DefaultAccepts", "description": "Without NCCL_CHECK_MODE the same mismatch is accepted on the fast path.", "test_filter": "SymCheckMode_Registration.Default_RegistrationMismatch_Accepted" }
+      ]
+    },
     "net_ib_branch_coverage": {
       "extends": "net_ib_base",
       "timeout": 60,
@@ -4625,6 +4648,12 @@
       "name": "Symmetric Window Tests - Single Node",
       "description": "Symmetric window registration tests for relaxed one-buffer path validation",
       "config": "symmetric_window_tests",
+      "enabled": true
+    },
+    {
+      "name": "Symmetric Abort + CheckMode Tests - Single Node",
+      "description": "NCCL_CHECK_MODE validation and symmetric-kernel abort (AICOMRCCL-806)",
+      "config": "symmetric_abort_checkmode_tests",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce.json
@@ -2184,6 +2184,29 @@
         }
       ]
     },
+    "symmetric_abort_checkmode_tests": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 2,
+      "num_nodes": 1,
+      "num_gpus": 2,
+      "timeout": 180,
+      "description": "NCCL_CHECK_MODE validation (AICOMRCCL-806). The SymAbort_Kernel abort tests exist in the binary but are omitted here until CI has a host with working cuMem VMM (kernel >= 6.8, ROCm >= 7.12 driver), where the symmetric kernels actually park and ncclCommAbort can release them. Each test runs as its own process.",
+      "env_variables": {
+        "NCCL_DEBUG": "INFO",
+        "NCCL_CUMEM_ENABLE": "1",
+        "HSA_NO_SCRATCH_RECLAIM": "1"
+      },
+      "tests": [
+        { "name": "SymCheckMode_Local_DebugLocal", "description": "NCCL_CHECK_MODE=DEBUG_LOCAL rejects a host pointer where a device pointer is required.", "test_filter": "SymCheckMode_Local.DebugLocal_HostPointer_Rejected" },
+        { "name": "SymCheckMode_Local_DebugGlobal", "description": "NCCL_CHECK_MODE=DEBUG_GLOBAL keeps the local host-pointer check active.", "test_filter": "SymCheckMode_Local.DebugGlobal_HostPointer_Rejected" },
+        { "name": "SymCheckMode_Registration_Match", "description": "DEBUG_GLOBAL is transparent when every rank registers matching symmetric windows.", "test_filter": "SymCheckMode_Registration.DebugGlobal_MatchingRegistration_Succeeds" },
+        { "name": "SymCheckMode_Registration_Mismatch", "description": "DEBUG_GLOBAL rejects a collective when one rank's buffer is outside any window.", "test_filter": "SymCheckMode_Registration.DebugGlobal_RegistrationMismatch_Rejected" },
+        { "name": "SymCheckMode_Registration_OffsetMismatch", "description": "DEBUG_GLOBAL rejects a user-offset mismatch inside the window.", "test_filter": "SymCheckMode_Registration.DebugGlobal_UserOffsetMismatch_Rejected" },
+        { "name": "SymCheckMode_Registration_DefaultAccepts", "description": "Without NCCL_CHECK_MODE the same mismatch is accepted on the fast path.", "test_filter": "SymCheckMode_Registration.Default_RegistrationMismatch_Accepted" }
+      ]
+    },
     "net_ib_branch_coverage": {
       "extends": "net_ib_base",
       "timeout": 60,
@@ -4883,6 +4906,12 @@
       "name": "Symmetric Window Tests - Single Node",
       "description": "Symmetric window registration tests for relaxed one-buffer path validation",
       "config": "symmetric_window_tests",
+      "enabled": true
+    },
+    {
+      "name": "Symmetric Abort + CheckMode Tests - Single Node",
+      "description": "NCCL_CHECK_MODE validation and symmetric-kernel abort (AICOMRCCL-806)",
+      "config": "symmetric_abort_checkmode_tests",
       "enabled": true
     }
   ]


### PR DESCRIPTION
## Motivation

Make NCCL_CHECK_MODE actually take effect, and add MPI test coverage for the check-mode and symmetric-registration paths.

## Technical Details

- src/init.cc: remove the stray assignment that reset comm->checkMode after envConfigOverride() had already parsed NCCL_CHECK_MODE, so DEBUG_LOCAL and DEBUG_GLOBAL now reach the communicator.
- test: add SymmetricAbortCheckModeMPITests.cpp (registered in test/CMakeLists.txt) covering local host-pointer rejection, cross-rank symmetric registration checks, and symmetric-kernel abort.
- CI: wire the passing check-mode and registration tests into the mi355x_thor2_roce and mi300x_mellanox_ib runner configs (np2, one process per test).
- docs: document NCCL_CHECK_MODE in env-variables.rst and fault-tolerance.rst, plus a CHANGELOG entry.

## Issue Tracking

JIRA ID : AICOMRCCL-806

## Test Plan

Built RCCL in a ROCm 7.2 container and ran the suite at np2 on two MI355X nodes (mia1-p01-g29 and mia1-p01-g30), each test in its own process.

## Test Result

All tests wired into CI pass on both nodes:

- SymCheckMode_Local.DebugLocal_HostPointer_Rejected: PASS
- SymCheckMode_Local.DebugGlobal_HostPointer_Rejected: PASS
- SymCheckMode_Registration.DebugGlobal_MatchingRegistration_Succeeds: PASS
- SymCheckMode_Registration.DebugGlobal_RegistrationMismatch_Rejected: PASS
- SymCheckMode_Registration.DebugGlobal_UserOffsetMismatch_Rejected: PASS
- SymCheckMode_Registration.Default_RegistrationMismatch_Accepted: PASS

The SymAbort_Kernel tests stay in the binary but are not wired into CI yet. Releasing a parked symmetric kernel needs a host where cuMem VMM is active (kernel >= 6.8, ROCm >= 7.12 driver); on the available runtime RCCL disables cuMem, so the kernels never park and abort cannot be exercised. They will be added to CI once suitable hardware is available.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
