### PR TITLE
JIRA ID : ROCM-28252 Restore RCCL comm-init CPU-affinity behavior to 2.29.7 (#9404)

### DIFF
--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -2335,7 +2335,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   TRACE(NCCL_INIT, "rank %d nranks %d - DONE", rank, nranks);
 
 exit:
-  if (ncclOsCpuCount(comm->cpuAffinity)) ncclOsSetAffinity(affinitySave);
+  if (ncclOsCpuCount(comm->cpuAffinity)) ncclOsSetAffinity(comm->cpuAffinity); // RCCL 2.29.7 behavior: leave calling thread pinned to GPU-local NUMA
   /* If split resource is shared, we are not able to unlink the proxy ops pool here since the child comm can
    * attach the proxy ops pool of parent at any time; otherwise, unlink it here to make sure the pool will be
    * properly cleaned up. */


### PR DESCRIPTION
Cherry-picks commit 28c871f into the ROCm 10.0 release branch.

JIRA ID: AIRDEL-34

---

Restore RCCL comm-init CPU-affinity behavior to 2.29.7

## Motivation

Between RCCL 2.29.7 and 2.30.4 the affinity restore at the end of initTransportsRank() (src/init.cc) changed:

  2.29.7:  ncclOsSetAffinity(comm->cpuAffinity);   // "restore" ==
    re-apply GPU-local NUMA mask
  2.30.4:  ncclOsSetAffinity(affinitySave);         // restore the
    ORIGINAL process mask

During init both versions save the caller's mask (affinitySave), then pin the calling thread to the GPU-local NUMA cores (comm->cpuAffinity) so RCCL's host buffers are allocated locally. 2.29.7 never actually restores the original mask on the exit path -- it re-applies comm->cpuAffinity -- so after ncclCommInitRank() returns, the calling (main) thread stays pinned to the GPU-local NUMA node. Any threads spawned afterwards (e.g. the video-decode worker pool that calls hipHostMalloc/hipHostFree per frame) inherit that narrow GPU-local affinity, keeping pinned host allocations NUMA-local. 2.30.4 "fixes" the restore, so the process (and its later-spawned threads) float across all NUMA nodes, which inflates hipHostMalloc/hipHostFree latency ~5-6% step-wide.

This patch reverts the single line to the 2.29.7 behavior for A/B builds so librccl.so alone can be swapped to test the affinity hypothesis.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

ROCM-28252 

## Test Plan

Test end-to-end workload performance

## Test Result

Resolved QPS drop

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.

---------