### PR TITLE
[kpack] Do not treat SHT_NOBITS .hip_fatbin as device code

### DIFF
--- a/shared/kpack/python/rocm_kpack/artifact_utils.py
+++ b/shared/kpack/python/rocm_kpack/artifact_utils.py
@@ -101,6 +101,11 @@ def is_fat_binary(file_path: Path, toolchain: Toolchain) -> bool:
     For ELF binaries, checks for .hip_fatbin section.
     For PE/COFF binaries, checks for .hip_fat section.
 
+    An ELF whose .hip_fatbin section is SHT_NOBITS is *not* a fat binary: the
+    section header survives but the contents do not live in the file. This is
+    the shape of a separated debug file produced by `objcopy --only-keep-debug`
+    (TheRock's `*_dbg` artifacts), which carries no device code to split.
+
     Args:
         file_path: Path to the file to check
         toolchain: Toolchain instance with readelf path
@@ -128,7 +133,10 @@ def is_fat_binary(file_path: Path, toolchain: Toolchain) -> bool:
 
     if fmt == "elf":
         surgery = ElfSurgery.load(file_path)
-        return surgery.find_section(".hip_fatbin") is not None
+        section = surgery.find_section(".hip_fatbin")
+        if section is None:
+            return False
+        return not section.header.is_nobits
     else:
         surgery = CoffSurgery.load(file_path)
         return surgery.find_section(".hip_fat") is not None

--- a/shared/kpack/tests/elf_test_utils.py
+++ b/shared/kpack/tests/elf_test_utils.py
@@ -215,3 +215,71 @@ def get_hip_fatbin_size(binary_path: Path) -> Optional[int]:
             return struct.unpack("<Q", data[sh_off + 0x20 : sh_off + 0x28])[0]
 
     return None
+
+
+def patch_hip_fatbin_to_nobits(
+    source_path: Path,
+    output_path: Path,
+) -> Path:
+    """
+    Create a copy of an ELF binary whose .hip_fatbin section is SHT_NOBITS.
+
+    This reproduces the shape of a *separated debug file* — the output of
+    ``objcopy --only-keep-debug``, which TheRock publishes as its ``*_dbg``
+    artifacts. Such a file keeps every allocated section header (including
+    ``.hip_fatbin``) but converts them to SHT_NOBITS, so the section occupies
+    no file space and holds no device code.
+
+    Patching the section header is sufficient and keeps the helper hermetic
+    (no objcopy required to build the fixture).
+
+    Args:
+        source_path: Path to source ELF binary with a .hip_fatbin section
+        output_path: Path for the patched output binary
+
+    Returns:
+        Path to the created output file
+
+    Raises:
+        ElfPatchError: If source is not a valid ELF or has no .hip_fatbin
+        FileNotFoundError: If source file doesn't exist
+    """
+    if not source_path.exists():
+        raise FileNotFoundError(f"Source binary not found: {source_path}")
+
+    data = bytearray(source_path.read_bytes())
+
+    if data[:4] != b"\x7fELF":
+        raise ElfPatchError(f"Not an ELF file: {source_path}")
+
+    e_shoff = struct.unpack("<Q", data[0x28:0x30])[0]
+    e_shentsize = struct.unpack("<H", data[0x3A:0x3C])[0]
+    e_shnum = struct.unpack("<H", data[0x3C:0x3E])[0]
+    e_shstrndx = struct.unpack("<H", data[0x3E:0x40])[0]
+
+    if e_shentsize != 64:
+        raise ElfPatchError(
+            f"Unexpected section header size: {e_shentsize} (expected 64)"
+        )
+
+    shstrtab_hdr_off = e_shoff + e_shstrndx * e_shentsize
+    shstrtab_offset = struct.unpack(
+        "<Q", data[shstrtab_hdr_off + 0x18 : shstrtab_hdr_off + 0x20]
+    )[0]
+
+    for i in range(e_shnum):
+        sh_off = e_shoff + i * e_shentsize
+        sh_name_idx = struct.unpack("<I", data[sh_off : sh_off + 4])[0]
+
+        name_start = shstrtab_offset + sh_name_idx
+        name_end = data.index(0, name_start)
+        section_name = data[name_start:name_end].decode("ascii", errors="replace")
+
+        if section_name == ".hip_fatbin":
+            # sh_type lives at offset 0x04 in Elf64_Shdr; SHT_NOBITS == 8.
+            struct.pack_into("<I", data, sh_off + 0x04, 8)
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(data)
+            return output_path
+
+    raise ElfPatchError(f"No .hip_fatbin section found in: {source_path}")

--- a/shared/kpack/tests/test_artifact_utils.py
+++ b/shared/kpack/tests/test_artifact_utils.py
@@ -12,6 +12,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+from elf_test_utils import patch_hip_fatbin_to_nobits
 from rocm_kpack.artifact_utils import (
     read_artifact_manifest,
     write_artifact_manifest,
@@ -315,6 +316,28 @@ class TestIsFatBinary:
         assert (
             is_fat_binary(host_only, toolchain) is False
         ), f"Expected host-only binary: {host_only}"
+
+    def test_is_fat_binary_nobits_hip_fatbin(
+        self, test_assets_dir, tmp_path, toolchain
+    ):
+        """A separated debug file is not a fat binary.
+
+        `objcopy --only-keep-debug` keeps the .hip_fatbin section header but
+        converts it to SHT_NOBITS. There is no device code left in the file and
+        `objcopy --dump-section` produces no output for it, so is_fat_binary()
+        must return False.
+        """
+        source = test_assets_dir / "bundled_binaries/linux/cov5/test_kernel_single.exe"
+        assert source.exists(), f"Test asset not found: {source}"
+        assert is_fat_binary(source, toolchain) is True
+
+        debug_copy = patch_hip_fatbin_to_nobits(
+            source, tmp_path / "test_kernel_single.exe.debug"
+        )
+
+        assert (
+            is_fat_binary(debug_copy, toolchain) is False
+        ), "SHT_NOBITS .hip_fatbin must not be treated as device code"
 
 
 class TestExtractArchitectureFromTarget:

--- a/shared/kpack/tests/test_binutils.py
+++ b/shared/kpack/tests/test_binutils.py
@@ -6,7 +6,9 @@ import struct
 
 import pytest
 
+from elf_test_utils import patch_hip_fatbin_to_nobits
 from rocm_kpack import binutils
+from rocm_kpack.elf.surgery import ElfSurgery
 from rocm_kpack.tools import bulk_unbundle
 
 
@@ -197,3 +199,43 @@ def test_bulk_unbundle_output_dir_requires_one_input(
 
     assert exc.value.code == 2
     assert "--output-dir requires exactly one input file" in capsys.readouterr().err
+
+
+def test_has_fatbin_section_rejects_nobits(test_assets_dir: Path, tmp_path: Path):
+    """ElfSurgery.has_fatbin_section() must ignore a SHT_NOBITS .hip_fatbin.
+
+    Separated debug files (`objcopy --only-keep-debug`) keep the section
+    header but hold no section content.
+    """
+    source = test_assets_dir / "bundled_binaries/linux/cov5/test_kernel_single.exe"
+    assert ElfSurgery.has_fatbin_section(source) is True
+
+    debug_copy = patch_hip_fatbin_to_nobits(
+        source, tmp_path / "test_kernel_single.exe.debug"
+    )
+    assert ElfSurgery.has_fatbin_section(debug_copy) is False
+
+
+def test_bundled_binary_nobits_is_standalone(
+    test_assets_dir: Path, tmp_path: Path, toolchain: binutils.Toolchain
+):
+    """A separated debug file must not be classified as BUNDLED.
+
+    Regression test: it previously was, and the subsequent
+    `objcopy --dump-section .hip_fatbin=<tmp>/fatbin.o` exited 0 without
+    writing anything (GNU objcopy only warns for a section with no contents),
+    so unbundling died with `FileNotFoundError: .../fatbin.o`.
+    """
+    source = test_assets_dir / "bundled_binaries/linux/cov5/test_kernel_single.exe"
+    assert (
+        binutils.BundledBinary(source, toolchain=toolchain).binary_type
+        == binutils.BinaryType.BUNDLED
+    )
+
+    debug_copy = patch_hip_fatbin_to_nobits(
+        source, tmp_path / "test_kernel_single.exe.debug"
+    )
+    assert (
+        binutils.BundledBinary(debug_copy, toolchain=toolchain).binary_type
+        == binutils.BinaryType.STANDALONE
+    )


### PR DESCRIPTION
## Motivation

`split_artifacts.py` fails on every `*_dbg` artifact whose component contains
device code, while the `_lib` / `_dev` / `_run` / `_test` / `_doc` splits of the
same components all succeed. In one TheRock build this took out five unrelated
components at once (`fft_dbg`, `prim_dbg`, `rand_dbg`, `rccl_dbg`,
`rocalution_dbg`), which is then reported downstream as

```
ERROR: Only uploaded 215/220 artifacts - 5 failed
```

**This PR has been rebased and narrowed.** #10037 landed after the first
revision and independently fixed two of the three detection paths, so what
remains here is the one that is still broken.

## Technical Details

TheRock's `*_dbg` artifacts consist entirely of separated debug files
(`.build-id/**/*.debug`) produced by `objcopy --only-keep-debug`. That keeps
every allocated section **header** but converts the sections to `SHT_NOBITS`,
so `.hip_fatbin` is still listed in the section header table while occupying
zero bytes of file content:

```
  [13] .hip_fatbin       NOBITS           0000000000026000  00000308
       00000000002110e0  0000000000000000   A       0     0     4096
```

Three detection paths tested only for the presence of the section *name*:

| location | state on `develop` today |
|---|---|
| `ElfSurgery.has_fatbin_section()` | **fixed by #10037** — `_section_location()` returns `None` for `SHT_NOBITS` |
| `BundledBinary._detect_binary_type()` | **fixed by #10037** — now routed through `has_fatbin_section()`, and `_get_bundler_input()` no longer shells out to `objcopy` at all |
| `artifact_utils.is_fat_binary()` | **still broken** — `surgery.find_section(".hip_fatbin") is not None` |

Because `is_fat_binary()` still reports the `.debug` file as carrying device
code, it is handed to the splitter regardless. `BundledBinary` now correctly
classifies it `STANDALONE`, which means the raw debug ELF is passed straight to
the fatbin parser as though it were bundler output.

So the bug is not fixed — the error message just moved:

```
before #10037:  Error: [Errno 2] No such file or directory: '/tmp/tmpk44fr8qi/fatbin.o'
on develop now: Error: Unrecognized fatbin format: first 4 bytes are b'\x7fELF'
```

Both are exit 1 with no `artifact_manifest.txt` written.

### Changes

- `artifact_utils.is_fat_binary()` — return `False` for a `SHT_NOBITS`
  `.hip_fatbin` (uses the existing `SectionHeader.is_nobits`). A `*_dbg`
  artifact is then simply skipped as having nothing to split.

Dropped from the first revision, since #10037 landed equivalent and more
thorough behaviour: the `binutils.py` and `elf/surgery.py` changes, including
the `objcopy` exit-code guard, which is moot now that the `--dump-section` call
is gone.

Kept: the two `binutils` regression tests. #10037 introduced the
`has_fatbin_section()` / `BundledBinary` behaviour incidentally, as part of a
bounds-checking refactor, and nothing currently pins it against the real
`.hip_fatbin` case.

## Test Plan

- Three regression tests:
  - `tests/test_artifact_utils.py::TestIsFatBinary::test_is_fat_binary_nobits_hip_fatbin`
    — fails on `develop`, passes here.
  - `tests/test_binutils.py::test_has_fatbin_section_rejects_nobits`
  - `tests/test_binutils.py::test_bundled_binary_nobits_is_standalone`
    — these two pass on `develop` as of #10037; they are here to keep it that way.
- Hermetic helper `tests/elf_test_utils.py::patch_hip_fatbin_to_nobits()` builds
  the fixture by patching `sh_type` in the section header, so the tests need no
  `objcopy`.

Public end-to-end repro (any architecture, no GPU needed — substitute your own
`--offload-arch`):

```bash
cat > k.hip <<'EOF'
#include <hip/hip_runtime.h>
__global__ void k(float* p){ p[threadIdx.x] = 1.0f; }
extern "C" void launch(float* p){ hipLaunchKernelGGL(k, dim3(1), dim3(64), 0, 0, p); }
EOF
hipcc -g -fPIC -shared --offload-arch=gfx1100 -o libdemo.so k.hip
objcopy --only-keep-debug libdemo.so libdemo.so.debug
mkdir -p art/demo/stage/lib out && cp libdemo.so.debug art/demo/stage/lib/
echo demo/stage > art/artifact_manifest.txt
PYTHONPATH=shared/kpack/python python3 \
  shared/kpack/python/rocm_kpack/tools/split_artifacts.py \
  --artifact-dir ./art --output-dir ./out --artifact-prefix demo_dbg \
  --clang-offload-bundler "$(which clang-offload-bundler)" \
  --gpu-targets gfx1100 --verbose
```

## Test Result

`shared/kpack` suite (`pytest tests/ --ignore=tests/test_wheel_splitter.py`,
`test_wheel_splitter` needs `rocm-bootstrap`), same container, `develop` at
`43d92d40`:

| | result |
|---|---|
| `develop` | `1 failed, 494 passed, 4 skipped` |
| this branch | `1 failed, 497 passed, 4 skipped` |

The 3 extra passes are the tests added here. The 1 failure —
`tests/elf/test_surgery.py::TestVerifyAll::test_verify_all_valid_binary` — is
`gdb not found` in that container, fails identically on `develop`, and is
untouched by this change. No new failures.

End-to-end, `develop` → this branch, run against the four real TheRock `*_dbg`
artifacts that fail today plus the public repro above (`--offload-arch=gfx1260`):

```
demo_dbg (public repro)  Unrecognized fatbin format → exit 0, "Total: 0 fat binaries"
fft_dbg                  Unrecognized fatbin format → exit 0, artifact_manifest.txt written
prim_dbg                 Unrecognized fatbin format → exit 0, artifact_manifest.txt written
rand_dbg                 Unrecognized fatbin format → exit 0, artifact_manifest.txt written
rocalution_dbg           Unrecognized fatbin format → exit 0, artifact_manifest.txt written
```

(`rccl_dbg` is `_generic`-only in the build tree I have on hand, so there is no
arch-split input to exercise; it is the same code path.)

## Issue Tracking

GitHub issue: https://github.com/ROCm/rocm-systems/issues/10058

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.

---

*AI tool use disclosure: this change was developed with the assistance of Claude
(Anthropic). The root cause, the `objcopy` exit-code behaviour, the test results
and the end-to-end verification above were all run and checked by hand.*
