### PR TITLE
fix(rocprofiler-systems): stage pinned trace_processor_shell for Perfetto validation

### DIFF
--- a/.github/workflows/rocprofiler-systems-build-group.yml
+++ b/.github/workflows/rocprofiler-systems-build-group.yml
@@ -130,11 +130,6 @@ jobs:
         shell: bash
         working-directory: projects/rocprofiler-systems/
         run: |
-          if [ "${{ matrix.os_major }}" = "8" ]; then
-            wget https://commondatastorage.googleapis.com/perfetto-luci-artifacts/v47.0/linux-amd64/trace_processor_shell -P /opt/trace_processor/bin &&
-            chmod +x /opt/trace_processor/bin/trace_processor_shell
-            echo "ROCPROFSYS_TRACE_PROC_SHELL=/opt/trace_processor/bin/trace_processor_shell" >> $GITHUB_ENV
-          fi
           if [ "${{ matrix.os_major }}" = "10" ]; then
             dnf install -y --enablerepo=crb mpich mpich-devel
             echo "/usr/lib64/mpich/bin" >> $GITHUB_PATH
@@ -345,7 +340,9 @@ jobs:
         working-directory: projects/rocprofiler-systems/
         run: |
           set +e
-          RUNNING_PROCS=$(pgrep trace_processor_shell)
+          # -f is required: the process name is truncated to 15 characters, so
+          # pgrep refuses this pattern unless it matches the full command line
+          RUNNING_PROCS=$(pgrep -f trace_processor_shell)
           if [ -n "${RUNNING_PROCS}" ]; then kill -s 9 ${RUNNING_PROCS}; fi
 
       - &_step-ctest-artifacts

--- a/projects/rocprofiler-systems/tests/CMakeLists.txt
+++ b/projects/rocprofiler-systems/tests/CMakeLists.txt
@@ -46,7 +46,7 @@ rocprofiler_systems_add_cache_option(
 )
 
 set(_trace_processor_shell
-    ${CMAKE_BINARY_DIR}/share/rocprofiler-systems/tests/trace_processor_shell
+    "${CMAKE_BINARY_DIR}/share/rocprofiler-systems/tests/trace_processor_shell"
 )
 set(_trace_processor_shell_permissions
     OWNER_READ
@@ -61,24 +61,24 @@ set(_trace_processor_shell_permissions
 # the pinned binary is x86-64; other architectures need their own URL and checksum
 set(_download_trace_processor_shell ${ROCPROFSYS_DOWNLOAD_TRACE_PROCESSOR_SHELL})
 if(
-    ROCPROFSYS_TRACE_PROCESSOR_SHELL_URL MATCHES "linux-amd64"
+    "${ROCPROFSYS_TRACE_PROCESSOR_SHELL_URL}" MATCHES "linux-amd64"
     AND NOT CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64)$"
 )
     set(_download_trace_processor_shell OFF)
 endif()
 
-file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/share/rocprofiler-systems/tests)
+file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/share/rocprofiler-systems/tests")
 
 if(ROCPROFSYS_TRACE_PROCESSOR_SHELL)
-    if(EXISTS ${ROCPROFSYS_TRACE_PROCESSOR_SHELL})
+    if(EXISTS "${ROCPROFSYS_TRACE_PROCESSOR_SHELL}")
         file(
-            COPY_FILE ${ROCPROFSYS_TRACE_PROCESSOR_SHELL}
-            ${_trace_processor_shell}
+            COPY_FILE "${ROCPROFSYS_TRACE_PROCESSOR_SHELL}"
+            "${_trace_processor_shell}"
             ONLY_IF_DIFFERENT
         )
         file(
             CHMOD
-            ${_trace_processor_shell}
+            "${_trace_processor_shell}"
             PERMISSIONS ${_trace_processor_shell_permissions}
         )
     else()
@@ -89,21 +89,21 @@ if(ROCPROFSYS_TRACE_PROCESSOR_SHELL)
     endif()
 elseif(_download_trace_processor_shell)
     # a previously staged binary is reused only when its contents still match
-    if(EXISTS ${_trace_processor_shell})
-        file(SHA256 ${_trace_processor_shell} _sha256)
+    if(EXISTS "${_trace_processor_shell}")
+        file(SHA256 "${_trace_processor_shell}" _sha256)
         if(NOT "${_sha256}" STREQUAL "${ROCPROFSYS_TRACE_PROCESSOR_SHELL_SHA256}")
-            file(REMOVE ${_trace_processor_shell})
+            file(REMOVE "${_trace_processor_shell}")
         endif()
     endif()
 
-    if(NOT EXISTS ${_trace_processor_shell})
+    if(NOT EXISTS "${_trace_processor_shell}")
         rocprofiler_systems_message(
             STATUS
             "Downloading ${ROCPROFSYS_TRACE_PROCESSOR_SHELL_URL}"
         )
         file(
-            DOWNLOAD ${ROCPROFSYS_TRACE_PROCESSOR_SHELL_URL}
-            ${_trace_processor_shell}.tmp
+            DOWNLOAD "${ROCPROFSYS_TRACE_PROCESSOR_SHELL_URL}"
+            "${_trace_processor_shell}.tmp"
             STATUS _download_status
             TLS_VERIFY ON
             INACTIVITY_TIMEOUT 10
@@ -116,12 +116,12 @@ elseif(_download_trace_processor_shell)
         if(NOT _download_code EQUAL 0)
             set(_download_error "${_download_message}")
         else()
-            file(SHA256 ${_trace_processor_shell}.tmp _sha256)
+            file(SHA256 "${_trace_processor_shell}.tmp" _sha256)
             if("${_sha256}" STREQUAL "${ROCPROFSYS_TRACE_PROCESSOR_SHELL_SHA256}")
-                file(RENAME ${_trace_processor_shell}.tmp ${_trace_processor_shell})
+                file(RENAME "${_trace_processor_shell}.tmp" "${_trace_processor_shell}")
                 file(
                     CHMOD
-                    ${_trace_processor_shell}
+                    "${_trace_processor_shell}"
                     PERMISSIONS ${_trace_processor_shell_permissions}
                 )
             else()
@@ -132,7 +132,7 @@ elseif(_download_trace_processor_shell)
         endif()
 
         if(_download_error)
-            file(REMOVE ${_trace_processor_shell}.tmp)
+            file(REMOVE "${_trace_processor_shell}.tmp")
             rocprofiler_systems_message(
                 WARNING
                 "Could not stage a trace_processor_shell from ${ROCPROFSYS_TRACE_PROCESSOR_SHELL_URL} (${_download_error}). Perfetto validation will download one on demand, which is slower and can fail on hosts without network access."

--- a/projects/rocprofiler-systems/tests/CMakeLists.txt
+++ b/projects/rocprofiler-systems/tests/CMakeLists.txt
@@ -11,6 +11,138 @@ include(${CMAKE_CURRENT_LIST_DIR}/rocprof-sys-pytest.cmake)
 
 # ------------------------------------------------------------------------------#
 #
+# Perfetto trace_processor_shell
+#
+# To be used only by the build tree, not installed
+#
+# ------------------------------------------------------------------------------#
+
+rocprofiler_systems_add_option(
+    ROCPROFSYS_DOWNLOAD_TRACE_PROCESSOR_SHELL
+    "Download a pinned perfetto trace_processor_shell for the test suite"
+    ON
+    NO_FEATURE
+)
+rocprofiler_systems_add_cache_option(
+    ROCPROFSYS_TRACE_PROCESSOR_SHELL_URL
+    "URL of the prebuilt perfetto trace_processor_shell used by the test suite"
+    STRING
+    "https://commondatastorage.googleapis.com/perfetto-luci-artifacts/v47.0/linux-amd64/trace_processor_shell"
+    NO_FEATURE
+)
+rocprofiler_systems_add_cache_option(
+    ROCPROFSYS_TRACE_PROCESSOR_SHELL_SHA256
+    "Expected SHA256 of ROCPROFSYS_TRACE_PROCESSOR_SHELL_URL"
+    STRING
+    "832425c3c7934904d1e0ec1721beb51423de7dbcf399a899973f2b6b464603fa"
+    NO_FEATURE
+)
+rocprofiler_systems_add_cache_option(
+    ROCPROFSYS_TRACE_PROCESSOR_SHELL
+    "Existing trace_processor_shell to stage instead of downloading one"
+    FILEPATH
+    ""
+    NO_FEATURE
+)
+
+set(_trace_processor_shell
+    ${CMAKE_BINARY_DIR}/share/rocprofiler-systems/tests/trace_processor_shell
+)
+set(_trace_processor_shell_permissions
+    OWNER_READ
+    OWNER_WRITE
+    OWNER_EXECUTE
+    GROUP_READ
+    GROUP_EXECUTE
+    WORLD_READ
+    WORLD_EXECUTE
+)
+
+# the pinned binary is x86-64; other architectures need their own URL and checksum
+set(_download_trace_processor_shell ${ROCPROFSYS_DOWNLOAD_TRACE_PROCESSOR_SHELL})
+if(
+    ROCPROFSYS_TRACE_PROCESSOR_SHELL_URL MATCHES "linux-amd64"
+    AND NOT CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64)$"
+)
+    set(_download_trace_processor_shell OFF)
+endif()
+
+file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/share/rocprofiler-systems/tests)
+
+if(ROCPROFSYS_TRACE_PROCESSOR_SHELL)
+    if(EXISTS ${ROCPROFSYS_TRACE_PROCESSOR_SHELL})
+        file(
+            COPY_FILE ${ROCPROFSYS_TRACE_PROCESSOR_SHELL}
+            ${_trace_processor_shell}
+            ONLY_IF_DIFFERENT
+        )
+        file(
+            CHMOD
+            ${_trace_processor_shell}
+            PERMISSIONS ${_trace_processor_shell_permissions}
+        )
+    else()
+        rocprofiler_systems_message(
+            WARNING
+            "ROCPROFSYS_TRACE_PROCESSOR_SHELL does not exist: ${ROCPROFSYS_TRACE_PROCESSOR_SHELL}. Perfetto validation will download a trace_processor_shell on demand."
+        )
+    endif()
+elseif(_download_trace_processor_shell)
+    # a previously staged binary is reused only when its contents still match
+    if(EXISTS ${_trace_processor_shell})
+        file(SHA256 ${_trace_processor_shell} _sha256)
+        if(NOT "${_sha256}" STREQUAL "${ROCPROFSYS_TRACE_PROCESSOR_SHELL_SHA256}")
+            file(REMOVE ${_trace_processor_shell})
+        endif()
+    endif()
+
+    if(NOT EXISTS ${_trace_processor_shell})
+        rocprofiler_systems_message(
+            STATUS
+            "Downloading ${ROCPROFSYS_TRACE_PROCESSOR_SHELL_URL}"
+        )
+        file(
+            DOWNLOAD ${ROCPROFSYS_TRACE_PROCESSOR_SHELL_URL}
+            ${_trace_processor_shell}.tmp
+            STATUS _download_status
+            TLS_VERIFY ON
+            INACTIVITY_TIMEOUT 10
+            TIMEOUT 40
+        )
+        list(GET _download_status 0 _download_code)
+        list(GET _download_status 1 _download_message)
+
+        set(_download_error "")
+        if(NOT _download_code EQUAL 0)
+            set(_download_error "${_download_message}")
+        else()
+            file(SHA256 ${_trace_processor_shell}.tmp _sha256)
+            if("${_sha256}" STREQUAL "${ROCPROFSYS_TRACE_PROCESSOR_SHELL_SHA256}")
+                file(RENAME ${_trace_processor_shell}.tmp ${_trace_processor_shell})
+                file(
+                    CHMOD
+                    ${_trace_processor_shell}
+                    PERMISSIONS ${_trace_processor_shell_permissions}
+                )
+            else()
+                set(_download_error
+                    "expected SHA256 ${ROCPROFSYS_TRACE_PROCESSOR_SHELL_SHA256}, got ${_sha256}"
+                )
+            endif()
+        endif()
+
+        if(_download_error)
+            file(REMOVE ${_trace_processor_shell}.tmp)
+            rocprofiler_systems_message(
+                WARNING
+                "Could not stage a trace_processor_shell from ${ROCPROFSYS_TRACE_PROCESSOR_SHELL_URL} (${_download_error}). Perfetto validation will download one on demand, which is slower and can fail on hosts without network access."
+            )
+        endif()
+    endif()
+endif()
+
+# ------------------------------------------------------------------------------#
+#
 # Move test files to build directory
 #
 # ------------------------------------------------------------------------------#

--- a/projects/rocprofiler-systems/tests/README.md
+++ b/projects/rocprofiler-systems/tests/README.md
@@ -82,5 +82,5 @@ export ROCPROFSYS_TRACE_PROC_SHELL=/tmp/$USER/trace_processor_shell
 
 Configure with `-DROCPROFSYS_TRACE_PROCESSOR_SHELL=<path>` to stage an existing binary,
 `-DROCPROFSYS_DOWNLOAD_TRACE_PROCESSOR_SHELL=OFF` to skip the download, or
-`-DROCPROFSYS_TRACE_PROCESSOR_SHELL_URL` and `-DROCPROFSYS_TRACE_PROCESSOR_SHELL_SHA256` to fetch
-a different build.
+`-DROCPROFSYS_TRACE_PROCESSOR_SHELL_URL=<url>` and
+`-DROCPROFSYS_TRACE_PROCESSOR_SHELL_SHA256=<sha256>` to fetch a different build.

--- a/projects/rocprofiler-systems/tests/README.md
+++ b/projects/rocprofiler-systems/tests/README.md
@@ -65,12 +65,22 @@ For example, in a venv, passing `ROCPROFSYS_TEST_EXECUTABLE=$(which python3)` sh
 | `ROCPROFSYS_DISABLE_TEST_CACHE` | Disables caching used by the tests | `OFF` |
 | `ROCM_PATH` | Path to ROCm installation | `/opt/rocm` |
 
-#### Perfetto GLIBC Issue
+#### Trace Processor Shell
 
-If Perfetto validation fails due to GLIBC version mismatch (this may occur on RHEL 8.x or SUSE 15.5), download a compatible `trace_processor_shell` binary and set `ROCPROFSYS_TRACE_PROC_SHELL`:
+Perfetto validation needs a `trace_processor_shell` binary. The build downloads a pinned copy and
+stages it in the build tree, where the validation script picks it up automatically. If none was
+staged, or the staged one cannot run on the host, the Perfetto Python API downloads one on demand
+instead, which needs network access at test time.
+
+Set `ROCPROFSYS_TRACE_PROC_SHELL` to use a specific binary in preference to both:
 
 ```bash
 curl -L https://commondatastorage.googleapis.com/perfetto-luci-artifacts/v47.0/linux-amd64/trace_processor_shell -o /tmp/$USER/trace_processor_shell
 chmod +x /tmp/$USER/trace_processor_shell
 export ROCPROFSYS_TRACE_PROC_SHELL=/tmp/$USER/trace_processor_shell
 ```
+
+Configure with `-DROCPROFSYS_TRACE_PROCESSOR_SHELL=<path>` to stage an existing binary,
+`-DROCPROFSYS_DOWNLOAD_TRACE_PROCESSOR_SHELL=OFF` to skip the download, or
+`-DROCPROFSYS_TRACE_PROCESSOR_SHELL_URL` and `-DROCPROFSYS_TRACE_PROCESSOR_SHELL_SHA256` to fetch
+a different build.

--- a/projects/rocprofiler-systems/tests/pytest/build_standalone.sh
+++ b/projects/rocprofiler-systems/tests/pytest/build_standalone.sh
@@ -122,7 +122,7 @@ Environment Variables:
     ROCPROFSYS_KEEP_TEST_OUTPUT     - Keep test output on success (ON/OFF, default: ON)
     ROCPROFSYS_USE_ROCPD            - Enable/disable ROCpd validation (ON/OFF, default: ON if available)
     ROCPROFSYS_VALIDATE_PERFETTO    - Enable/disable Perfetto validation (ON/OFF, default: ON if available)
-    ROCPROFSYS_TRACE_PROC_SHELL     - Path to trace_processor_shell binary (auto-detected)
+    ROCPROFSYS_TRACE_PROC_SHELL     - Path to trace_processor_shell binary (default: the binary staged in the build tree, else a Perfetto download)
     ROCM_PATH                       - Path to ROCm installation (default: /opt/rocm)
     ROCM_LLVM_OBJDUMP               - Path to ROCm's llvm-objdump (default: auto-detected)
 """

--- a/projects/rocprofiler-systems/tests/pytest/conftest.py
+++ b/projects/rocprofiler-systems/tests/pytest/conftest.py
@@ -1487,6 +1487,28 @@ def _generate_rocprofsys_config_header() -> list[str]:
             signal.signal(signal.SIGALRM, _previous_handler)
 
 
+def _trace_processor_shell_status(tests_dir: Path) -> str:
+    """Report which trace_processor_shell Perfetto validation will use.
+
+    Mirrors resolve_trace_processor_shell() in validate-perfetto-proto.py, minus its
+    ``-t`` argument, so a CI log shows whether the build staged a binary before any
+    Perfetto test runs and had to report it the hard way.
+    """
+
+    def usable(path: Path) -> bool:
+        return path.is_file() and os.access(path, os.X_OK)
+
+    override = os.environ.get("ROCPROFSYS_TRACE_PROC_SHELL")
+    if override and usable(Path(override)):
+        return f"{override} ($ROCPROFSYS_TRACE_PROC_SHELL)"
+
+    staged = tests_dir / "trace_processor_shell"
+    if usable(staged):
+        return f"{staged} (staged by the build)"
+
+    return "none staged, perfetto will download one on demand"
+
+
 def _build_rocprofsys_config_header() -> list[str]:
     """Collect system configuration and format it as printable header lines."""
     try:
@@ -1566,6 +1588,19 @@ def _build_rocprofsys_config_header() -> list[str]:
     def _subrow(label: str, value) -> str:
         return f"    {label:<{W}}{value}"
 
+    # Build mode only: the staged binary is a build-tree test aid and is not installed,
+    # so in install mode this would always report the download fallback
+    trace_processor_rows = (
+        []
+        if rocprof_config.is_installed
+        else [
+            _row(
+                "Trace processor:",
+                _trace_processor_shell_status(rocprof_config.rocprofsys_tests_dir),
+            )
+        ]
+    )
+
     header = [
         "",
         "=" * 70,
@@ -1580,6 +1615,7 @@ def _build_rocprofsys_config_header() -> list[str]:
         _row("Output dir:", rocprof_config.test_output_dir),
         _row("Validate ROCPD:", check_use_rocpd()),
         _row("Validate Perfetto:", check_use_perfetto()),
+        *trace_processor_rows,
         "-" * 70,
         "Core Executables:",
         _row("Instrument:", rocprof_config.rocprofsys_instrument),

--- a/projects/rocprofiler-systems/tests/pytest/rocprofsys/validators.py
+++ b/projects/rocprofiler-systems/tests/pytest/rocprofsys/validators.py
@@ -213,9 +213,14 @@ def _run_validation_script(
         if result.returncode == 0:
             message = result.stdout.strip()
         else:
+            # Both streams: the traceback goes to stderr, but the context needed
+            # to read it (paths, counts, what the script decided) is on stdout
             message = (
-                result.stderr.strip()
-                or result.stdout.strip()
+                "\n".join(
+                    stream
+                    for stream in (result.stdout.strip(), result.stderr.strip())
+                    if stream
+                )
                 or f"Exit code: {result.returncode}"
             )
 
@@ -274,7 +279,9 @@ def validate_perfetto_trace(
         counter_names: Counter names to validate (--counter-names flag)
         key_names: Debug key names to check (--key-names flag)
         key_counts: Expected counts for debug keys (--key-counts flag)
-        trace_processor_path: Path to trace_processor_shell (-t flag)
+        trace_processor_path: Path to trace_processor_shell (-t flag). When omitted,
+            validate-perfetto-proto.py falls back to $ROCPROFSYS_TRACE_PROC_SHELL, then
+            to the binary staged next to it by the build, then to a Perfetto download
         print_output: Whether to print trace data (-p flag)
         check_counter_pairing: Verify counter tracks have paired start/end entries
         timeout: Validation timeout in seconds
@@ -284,11 +291,6 @@ def validate_perfetto_trace(
     """
     if not trace_path.exists():
         return ValidationResult(False, f"Trace file not found: {trace_path}")
-
-    # Allow override of trace_processor_path to allow perfetto validation using older GLIBC versions
-    env_path = os.environ.get("ROCPROFSYS_TRACE_PROC_SHELL")
-    if env_path:
-        trace_processor_path = Path(env_path)
 
     args = ["-i", str(trace_path)]
 

--- a/projects/rocprofiler-systems/tests/validate-perfetto-proto.py
+++ b/projects/rocprofiler-systems/tests/validate-perfetto-proto.py
@@ -57,10 +57,10 @@ def resolve_trace_processor_shell(bin_path=None):
     return None
 
 
-def _construct_trace_processor(inp, bin_path, load_timeout, max_tries, retry_wait):
+def _construct_trace_processor(inp, bin_path, load_timeout, max_retries, retry_wait):
     """Construct a TraceProcessor, retrying transient startup failures."""
 
-    for attempt in range(max_tries + 1):
+    for attempt in range(max_retries + 1):
         # Not verbose: the shell would inherit this process's stderr and, if it
         # outlives a failed attempt, hold that pipe open until the caller's
         # timeout. Perfetto reports the shell's output in the exception since 0.11.
@@ -74,7 +74,7 @@ def _construct_trace_processor(inp, bin_path, load_timeout, max_tries, retry_wai
         try:
             return TraceProcessor(trace=inp, config=config)
         except Exception as ex:
-            if attempt >= max_tries:
+            if attempt >= max_retries:
                 raise
 
             wait = retry_wait * (attempt + 1)
@@ -85,7 +85,7 @@ def _construct_trace_processor(inp, bin_path, load_timeout, max_tries, retry_wai
             time.sleep(wait)
 
 
-def load_trace(inp, max_tries=1, retry_wait=1, bin_path=None):
+def load_trace(inp, max_retries=1, retry_wait=1, bin_path=None):
     """Occasionally connecting to the trace processor fails with HTTP errors
     so this function tries to reduce spurious test failures"""
 
@@ -94,7 +94,7 @@ def load_trace(inp, max_tries=1, retry_wait=1, bin_path=None):
     if bin_path is not None:
         try:
             return _construct_trace_processor(
-                inp, bin_path, LOCAL_LOAD_TIMEOUT, max_tries, retry_wait
+                inp, bin_path, LOCAL_LOAD_TIMEOUT, max_retries, retry_wait
             )
         except Exception as ex:
             sys.stderr.write(f"{ex}\n")
@@ -110,7 +110,7 @@ def load_trace(inp, max_tries=1, retry_wait=1, bin_path=None):
             )
 
     return _construct_trace_processor(
-        inp, None, DOWNLOAD_LOAD_TIMEOUT, max_tries, retry_wait
+        inp, None, DOWNLOAD_LOAD_TIMEOUT, max_retries, retry_wait
     )
 
 

--- a/projects/rocprofiler-systems/tests/validate-perfetto-proto.py
+++ b/projects/rocprofiler-systems/tests/validate-perfetto-proto.py
@@ -3,6 +3,7 @@
 # Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
+import atexit
 import sys
 import os
 import time
@@ -11,39 +12,106 @@ from collections import defaultdict
 
 from perfetto.trace_processor import TraceProcessor, TraceProcessorConfig
 
+# Override for hosts where the staged binary cannot run, e.g. a GLIBC too old
+TRACE_PROCESSOR_SHELL_ENV = "ROCPROFSYS_TRACE_PROC_SHELL"
 
-def load_trace(inp, max_tries=5, retry_wait=1, bin_path=None):
+# The build stages a pinned trace_processor_shell next to this script
+STAGED_TRACE_PROCESSOR_SHELL = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "trace_processor_shell"
+)
+
+# Perfetto's 2s default cannot cover a shell it downloads inside the load window.
+# Both paths together must stay under the 120s timeout in rocprofsys/validators.py.
+LOCAL_LOAD_TIMEOUT = 5
+DOWNLOAD_LOAD_TIMEOUT = 20
+
+
+def resolve_trace_processor_shell(bin_path=None):
+    """Return the trace_processor_shell to use, or None to let perfetto fetch one.
+
+    Precedence: the ``-t`` argument, then ``$ROCPROFSYS_TRACE_PROC_SHELL``, then
+    the binary staged alongside this script by the build.
+    """
+
+    def usable(path):
+        return path and os.path.isfile(path) and os.access(path, os.X_OK)
+
+    requested = [
+        (bin_path, "-t"),
+        (os.environ.get(TRACE_PROCESSOR_SHELL_ENV), f"${TRACE_PROCESSOR_SHELL_ENV}"),
+    ]
+
+    for path, origin in requested:
+        if not path:
+            continue
+        if usable(path):
+            print(f"trace_processor path ({origin}): {path}")
+            return path
+        print(f"Ignoring trace_processor path from {origin}: {path} is not executable")
+
+    if usable(STAGED_TRACE_PROCESSOR_SHELL):
+        print(f"trace_processor path (staged): {STAGED_TRACE_PROCESSOR_SHELL}")
+        return STAGED_TRACE_PROCESSOR_SHELL
+
+    print("trace_processor path: none staged, perfetto will download one on demand")
+    return None
+
+
+def _construct_trace_processor(inp, bin_path, load_timeout, max_tries, retry_wait):
+    """Construct a TraceProcessor, retrying transient startup failures."""
+
+    for attempt in range(max_tries + 1):
+        # Not verbose: the shell would inherit this process's stderr and, if it
+        # outlives a failed attempt, hold that pipe open until the caller's
+        # timeout. Perfetto reports the shell's output in the exception since 0.11.
+        config = TraceProcessorConfig()
+        # load_timeout does not exist before perfetto 0.11
+        if hasattr(config, "load_timeout"):
+            config.load_timeout = load_timeout + attempt
+        if bin_path and hasattr(config, "bin_path"):
+            config.bin_path = bin_path
+
+        try:
+            return TraceProcessor(trace=inp, config=config)
+        except Exception as ex:
+            if attempt >= max_tries:
+                raise
+
+            wait = retry_wait * (attempt + 1)
+            sys.stderr.write(
+                f"{ex}\nRetrying trace processor construction after {wait} seconds...\n"
+            )
+            sys.stderr.flush()
+            time.sleep(wait)
+
+
+def load_trace(inp, max_tries=1, retry_wait=1, bin_path=None):
     """Occasionally connecting to the trace processor fails with HTTP errors
     so this function tries to reduce spurious test failures"""
 
-    tries = 0
-    tp = None
+    bin_path = resolve_trace_processor_shell(bin_path)
 
-    # Check if bin_path is set and if it exists
-    print("trace_processor path: ", bin_path)
-    if bin_path and not os.path.isfile(bin_path):
-        print(f"Path {bin_path} does not exist. Using the default path.")
-        bin_path = None
-
-    while tp is None:
+    if bin_path is not None:
         try:
-            if bin_path:
-                config = TraceProcessorConfig(bin_path=bin_path)
-                tp = TraceProcessor(trace=inp, config=config)
-            else:
-                tp = TraceProcessor(trace=inp)
-            break
+            return _construct_trace_processor(
+                inp, bin_path, LOCAL_LOAD_TIMEOUT, max_tries, retry_wait
+            )
         except Exception as ex:
             sys.stderr.write(f"{ex}\n")
             sys.stderr.flush()
+            # Letting perfetto resolve its own shell is what ran before the build
+            # staged one. Keeping it as a fallback means a host that cannot run the
+            # staged binary, e.g. one whose GLIBC is too old, still validates. On
+            # stdout because a run that then passes reports stdout only, and the
+            # path resolved above would otherwise be the only thing in the log.
+            print(
+                f"{bin_path} could not serve the trace, falling back to a "
+                "trace_processor_shell downloaded by perfetto"
+            )
 
-            if tries >= max_tries:
-                raise
-            else:
-                time.sleep(retry_wait)
-        finally:
-            tries += 1
-    return tp
+    return _construct_trace_processor(
+        inp, None, DOWNLOAD_LOAD_TIMEOUT, max_tries, retry_wait
+    )
 
 
 def validate_perfetto(data, labels, counts, depths, useSubstringForLabels=False):
@@ -255,8 +323,9 @@ if __name__ == "__main__":
 
     tp = load_trace(args.input, bin_path=args.trace_processor_shell)
 
-    if tp is None:
-        raise ValueError(f"trace {args.input} could not be loaded")
+    # Every TraceProcessor owns a trace_processor_shell serving the parsed trace
+    # over HTTP. Closing it here keeps failed runs from leaving shells behind.
+    atexit.register(tp.close)
 
     pdata = {}
     # get data from perfetto


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Perfetto validation relied on the perfetto Python API fetching `trace_processor_shell` itself on first use, into a shared temp path, with only a 2 second budget for the shell to respond. Every Perfetto test therefore depended on network access and a warm cache.

Very rarely, I noticed the download fail and some tests would just fail with a missing `trace_processor_shell`. I lost the most recent log, but it resembled:
```
trace_processor path:  None
Trace processor failed to start.
stdout: 
stderr: /home/<user>/.local/share/perfetto/prebuilts/trace_processor_shell-<hash>: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by /home/<user>/.local/share/perfetto/prebuilts/trace_processor_shell-<hash>)

Trace processor failed to start.
stdout: 
stderr: ...
[same block, six times total]

Traceback (most recent call last):
  File ".../share/rocprofiler-systems/tests/validate-perfetto-proto.py", line 39, in load_trace
    tp = TraceProcessor(trace=inp)
  ...
perfetto.common.exceptions.PerfettoException: Trace processor failed to start.
```

Two related problems: nothing closed a `TraceProcessor`, so failed runs left `trace_processor_shell` processes behind holding HTTP ports, and the CI step meant to clean them up never matched any (I had 45 left over shells on my computer).

This also somewhat follows the approach used by the SDK: https://github.com/ROCm/rocm-systems/blob/develop/projects/rocprofiler-sdk/tests/pytest-packages/CMakeLists.txt

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

- The build stages a SHA256-pinned perfetto v47.0 `trace_processor_shell` into `<build>/share/rocprofiler-systems/tests/`, next to `validate-perfetto-proto.py`, which picks it up as a sibling. Build tree only, deliberately not installed. 
  - The download is verified before it is renamed into place and made executable. A failure warns and does not error out. In this case, we fall back to the old behavior of downloading.
- `validate-perfetto-proto.py` resolves the shell in order: `-t`, then `$ROCPROFSYS_TRACE_PROC_SHELL`, then the staged binary. If the chosen binary cannot serve the trace, it falls back to perfetto's own download, which is the behavior that predates this change, so a host that cannot run the staged binary still validates. It also raises perfetto's 2 second `load_timeout` and closes the `TraceProcessor` via `atexit` so runs stop leaking shells.
- `validators.py` drops its `$ROCPROFSYS_TRACE_PROC_SHELL` lookup, now handled one level down by the script, and reports both stdout and stderr on failure rather than stderr alone.
- The pytest config header prints which shell will be used, in build mode only, so CI logs answer this before any Perfetto test runs.
- CI: drop the RHEL 8 download workaround, and fix `pgrep trace_processor_shell` to `pgrep -f`. The process name truncates to 15 characters, so the bare pattern was rejected and that cleanup step had always been a no-op.

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

JIRA ID: AIPROFSYST-727

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Workflows.

## Test Result

<!-- Briefly summarize test outcomes. -->

See workflows.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
