### PR TITLE
Enable host-UT coverage measurement and add tests based on it

### DIFF
--- a/projects/rccl/.gitignore
+++ b/projects/rccl/.gitignore
@@ -1,6 +1,10 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION. All rights reserved.
 # Modifications Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 *.gcov
+# llvm source-based coverage: the instrumented binaries drop these wherever
+# they are run from, and rccl-HostUnitTests is built with coverage by default.
+*.profraw
+*.profdata
 /coverage/
 build*/
 install*/

--- a/projects/rccl/test/AltRsmiTests.cpp
+++ b/projects/rccl/test/AltRsmiTests.cpp
@@ -499,6 +499,28 @@ TEST(AltRsmiTest, ARSMIInitCalledTwiceIsShortCircuited) {
   );
 }
 
+TEST(AltRsmiTest, ARSMIInitBadKfdPathFailsToOpenDir) {
+  RUN_ISOLATED_TEST(
+    "ARSMIInitBadKfdPathFailsToOpenDir",
+    []() {
+      AltRsmiTestUtils::ResetState();
+
+      // PID-scoped like kTestDrmBasePath, and via temp_directory_path() rather
+      // than a hardcoded /tmp: the path must be guaranteed absent, including
+      // when several CI jobs share a node.
+      const std::string missingPath =
+          std::filesystem::temp_directory_path().string() +
+          "/rccl_alt_rsmi_missing_" + std::to_string(getpid());
+      ASSERT_FALSE(std::filesystem::exists(missingPath));
+      AltRsmiTestUtils::SetNodesPath(missingPath);
+
+      EXPECT_EQ(ARSMI_init(), 1);
+
+      AltRsmiTestUtils::ResetState();
+    }
+  );
+}
+
 TEST(AltRsmiTest, ARSMIInitMissingIoLinksPropertiesFile) {
   RUN_ISOLATED_TEST(
     "ARSMIInitMissingIoLinksPropertiesFile",

--- a/projects/rccl/test/AltRsmiTests.cpp
+++ b/projects/rccl/test/AltRsmiTests.cpp
@@ -454,6 +454,51 @@ TEST(AltRsmiTest, ARSMIInitDefault) {
   );
 }
 
+TEST(AltRsmiTest, ARSMIInitCalledTwiceIsShortCircuited) {
+  RUN_ISOLATED_TEST(
+    "ARSMIInitCalledTwiceIsShortCircuited",
+    []() {
+      setupTestEnvironment();
+
+      ASSERT_EQ(ARSMI_init(), 0);
+      uint32_t num_devices = 0;
+      ASSERT_EQ(ARSMI_get_num_devices(&num_devices), 0);
+      ASSERT_EQ(num_devices, 2);
+
+      // Add a third node behind ARSMI's back before calling init again.
+      // Without this the test cannot fail: ARSMI_allSystemNodes is a local
+      // rebuilt from scratch on every call, so a re-scan of an unchanged
+      // directory writes the same ARSMI_num_devices and is indistinguishable
+      // from the early return. Changing the directory is what makes "did not
+      // re-scan" observable -- a re-scan would report 3 devices here.
+      createDirectory("2");
+      createFile("2/gpu_id", "4098\n");
+      createFile("2/properties",
+                 "unique_id 16336014475442738427\n"
+                 "location_id 23554\n"
+                 "domain 0\n"
+                 "vendor_id 4098\n");
+
+      // Second call must hit the "already initialized" early return
+      // (ARSMI_num_devices > 0) without re-scanning the KFD nodes directory.
+      const int secondInit = ARSMI_init();
+      const int getRc = ARSMI_get_num_devices(&num_devices);
+
+      // Drop the extra node before asserting. kTestKFDPath is shared, not
+      // PID-scoped, and a failed ASSERT returns without reaching
+      // cleanupTestEnvironment -- leaving a third node behind would make every
+      // later test that expects 2 devices fail for an unrelated reason.
+      removeDirectoryImpl(std::string(kTestKFDPath) + "/2");
+
+      ASSERT_EQ(secondInit, 0);
+      ASSERT_EQ(getRc, 0);
+      ASSERT_EQ(num_devices, 2);
+
+      cleanupTestEnvironment();
+    }
+  );
+}
+
 TEST(AltRsmiTest, ARSMIInitMissingIoLinksPropertiesFile) {
   RUN_ISOLATED_TEST(
     "ARSMIInitMissingIoLinksPropertiesFile",

--- a/projects/rccl/test/IommuPassthrough_test.cpp
+++ b/projects/rccl/test/IommuPassthrough_test.cpp
@@ -71,6 +71,12 @@ TEST_F(IommuPassthroughTest, IommuPassthroughOkWithCmdline) {
   EXPECT_TRUE(ncclIommuPassthroughOk("iommu=pt"));
 }
 
+TEST_F(IommuPassthroughTest, ContentHasOptionNullOrEmptyOption) {
+  const std::string content = "CONFIG_IOMMU_DEFAULT_PASSTHROUGH=y\n";
+  EXPECT_FALSE(ncclKernelConfigContentHasOption(content, nullptr));
+  EXPECT_FALSE(ncclKernelConfigContentHasOption(content, ""));
+}
+
 TEST_F(IommuPassthroughTest, ReadFileMissingOption) {
   writeConfig("CONFIG_64BIT=y\n");
   std::string content;

--- a/projects/rccl/test/IommuPassthrough_test.cpp
+++ b/projects/rccl/test/IommuPassthrough_test.cpp
@@ -77,6 +77,12 @@ TEST_F(IommuPassthroughTest, ContentHasOptionNullOrEmptyOption) {
   EXPECT_FALSE(ncclKernelConfigContentHasOption(content, ""));
 }
 
+TEST_F(IommuPassthroughTest, ReadFileNullArgs) {
+  std::string content;
+  EXPECT_FALSE(ncclKernelConfigReadFile(nullptr, &content));
+  EXPECT_FALSE(ncclKernelConfigReadFile(tempPath.c_str(), nullptr));
+}
+
 TEST_F(IommuPassthroughTest, ReadFileMissingOption) {
   writeConfig("CONFIG_64BIT=y\n");
   std::string content;

--- a/projects/rccl/test/IommuPassthrough_test.cpp
+++ b/projects/rccl/test/IommuPassthrough_test.cpp
@@ -8,6 +8,7 @@
 #include "gtest/gtest.h"
 
 #include <cstdio>
+#include <filesystem>
 #include <fstream>
 #include <string>
 #include <unistd.h>
@@ -81,6 +82,18 @@ TEST_F(IommuPassthroughTest, ReadFileNullArgs) {
   std::string content;
   EXPECT_FALSE(ncclKernelConfigReadFile(nullptr, &content));
   EXPECT_FALSE(ncclKernelConfigReadFile(tempPath.c_str(), nullptr));
+}
+
+TEST_F(IommuPassthroughTest, ReadFileNonexistentPath) {
+  // PID-scoped so a stale path from a parallel CI job on the same node cannot
+  // make this test silently exercise the success path instead.
+  const std::string missingPath =
+      std::filesystem::temp_directory_path().string() +
+      "/rccl_kernel_config_missing_" + std::to_string(getpid());
+  ASSERT_FALSE(std::filesystem::exists(missingPath));
+
+  std::string content;
+  EXPECT_FALSE(ncclKernelConfigReadFile(missingPath.c_str(), &content));
 }
 
 TEST_F(IommuPassthroughTest, ReadFileMissingOption) {

--- a/projects/rccl/test/common/LogCapture.hpp
+++ b/projects/rccl/test/common/LogCapture.hpp
@@ -1,0 +1,43 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <utility>
+
+namespace RcclUnitTesting {
+
+/**
+ * @brief Run @p body and return everything it wrote to stderr.
+ *
+ * RCCL's WARN/INFO macros go to stderr, so a test that needs to assert on what
+ * a function *reported* — rather than only on what it returned — has to capture
+ * the stream. gtest exposes that as CaptureStderr/GetCapturedStderr under
+ * testing::internal; this wrapper keeps the dependency on an internal API in
+ * one place instead of spreading it across test files.
+ *
+ * Captures are not nestable: gtest keeps a single stderr capture slot, so a
+ * second CaptureLog inside @p body would abort.
+ *
+ * @par Example:
+ * @code
+ * ncclResult_t res = ncclSuccess;
+ * const std::string log = CaptureLog([&]() { res = doSomething(); });
+ * EXPECT_EQ(res, ncclInvalidUsage);
+ * EXPECT_NE(log.find("expected warning"), std::string::npos);
+ * @endcode
+ */
+template <typename Fn>
+std::string CaptureLog(Fn&& body) {
+  testing::internal::CaptureStderr();
+  std::forward<Fn>(body)();
+  return testing::internal::GetCapturedStderr();
+}
+
+}  // namespace RcclUnitTesting

--- a/projects/rccl/test/host/CMakeLists.txt
+++ b/projects/rccl/test/host/CMakeLists.txt
@@ -384,9 +384,17 @@ target_compile_definitions(rccl-UnitTestsMicro PRIVATE
   NCCL_OS_LINUX
   ROCM_VERSION=70000
   P2P_CC_PATH="${RCCL_HIPIFY_DIR}/src/transport/p2p_tmp.cc"
+  # Same fallback-vs-runtime conflicts the host target guards against: without
+  # these, p2p-test.cc redefines hipMemFabricHandle_st and the amdsmi fabric
+  # enumerators on ROCm 7.14+, and the standalone build fails.
+  $<$<BOOL:${AMDSMI_FABRIC_API}>:AMDSMI_FABRIC_DIRECT>
+  $<$<BOOL:${HIP_FABRIC_API}>:HIP_FABRIC_API>
 )
 
-target_link_options(rccl-UnitTestsMicro PRIVATE -no-hip-rt)
+# -no-pie for the same reason as rccl-HostUnitTests: the RCCL-vendored
+# libgtest.a used by this standalone path is built without -fPIC, so a PIE
+# link fails with "relocation R_X86_64_32 cannot be used against local symbol".
+target_link_options(rccl-UnitTestsMicro PRIVATE -no-hip-rt -no-pie)
 target_link_libraries(rccl-UnitTestsMicro PRIVATE
   GTest::GTest
   Threads::Threads

--- a/projects/rccl/test/host/CMakeLists.txt
+++ b/projects/rccl/test/host/CMakeLists.txt
@@ -345,12 +345,38 @@ target_compile_definitions(rccl-HostUnitTests PRIVATE
   $<$<BOOL:${HIP_FABRIC_API}>:HIP_FABRIC_API>
 )
 
+# llvm source-based coverage (host-only build: no -Xarch_device split needed
+# because --offload-host-only never runs the amdgcn device pass; see the
+# CMAKE_CXX_FLAGS_INIT above). On by default so the binary always produces a
+# profile; disable with -DHOST_UT_COVERAGE=OFF.
+#
+# RCCL_TEST_CODE_COVERAGE is what makes process-isolated tests flush their
+# counters in the forked child (test/common/ProcessIsolatedTestRunner.cpp).
+# Without it those tests run but contribute nothing to the profile, so it is
+# tied to the same switch rather than exposed separately.
+# rccl-source-wrappers must be instrumented too: mem_manager.cc reaches the
+# binary through that static library, so instrumenting only the executable
+# silently drops it from the report -- the profile still looks healthy, it just
+# has no record of that file at all.
+option(HOST_UT_COVERAGE "Build rccl-HostUnitTests with llvm source-based coverage" ON)
+if(HOST_UT_COVERAGE)
+  target_compile_options(rccl-HostUnitTests PRIVATE -fprofile-instr-generate -fcoverage-mapping)
+  target_link_options(rccl-HostUnitTests PRIVATE -fprofile-instr-generate -fcoverage-mapping)
+  target_compile_definitions(rccl-HostUnitTests PRIVATE RCCL_TEST_CODE_COVERAGE=1)
+  target_compile_options(rccl-source-wrappers PRIVATE -fprofile-instr-generate -fcoverage-mapping)
+endif()
+
 target_link_options(rccl-HostUnitTests PRIVATE -no-hip-rt -no-pie)
 
 target_link_libraries(rccl-HostUnitTests PRIVATE
   GTest::GTest
   Threads::Threads
   fmt::fmt-header-only
+  # RCCL_TEST_CODE_COVERAGE compiles a dlsym() call in
+  # ProcessIsolatedTestRunner.cpp; the in-tree test build links dl for the same
+  # runner. Empty on platforms where libdl is folded into libc (glibc >= 2.34),
+  # required on older ones.
+  ${CMAKE_DL_LIBS}
   -Wl,--whole-archive
   rccl-source-wrappers
   -Wl,--no-whole-archive

--- a/projects/rccl/test/host/CMakeLists.txt
+++ b/projects/rccl/test/host/CMakeLists.txt
@@ -345,7 +345,7 @@ target_compile_definitions(rccl-HostUnitTests PRIVATE
   $<$<BOOL:${HIP_FABRIC_API}>:HIP_FABRIC_API>
 )
 
-target_link_options(rccl-HostUnitTests PRIVATE -no-hip-rt)
+target_link_options(rccl-HostUnitTests PRIVATE -no-hip-rt -no-pie)
 
 target_link_libraries(rccl-HostUnitTests PRIVATE
   GTest::GTest

--- a/projects/rccl/test/host/CMakeLists.txt
+++ b/projects/rccl/test/host/CMakeLists.txt
@@ -253,6 +253,33 @@ else()
   message(STATUS "amdsmi fabric API not found (AMDSMI_FABRIC_DIRECT disabled)")
 endif()
 
+# --- Detect HIP fabric API support (mirrors top-level CMakeLists.txt) ---
+# mem_manager.h only defines its own hipMemFabricHandle_st fallback when
+# HIP_FABRIC_API is undefined; on HIP runtimes that already provide the type
+# (e.g. ROCm 7.14+), omitting this define causes a redefinition conflict
+# with hip_runtime_api.h.
+# Compile-only (STATIC_LIBRARY), like the amdsmi probe above: with the default
+# EXECUTABLE target type these checks link, which drags in the HIP runtime at
+# configure time even though the binary itself is linked with -no-hip-rt.
+include(CheckSymbolExists)
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+check_symbol_exists("hipMemImportFromShareableHandle" "hip/hip_runtime_api.h" HIP_FABRIC_API_FUNC)
+check_cxx_source_compiles("
+  #include <hip/hip_runtime_api.h>
+  int main() {
+    hipMemFabricHandle_t handle;
+    (void)handle;
+    return 0;
+  }
+" HIP_FABRIC_HANDLE_TYPE)
+set(CMAKE_TRY_COMPILE_TARGET_TYPE EXECUTABLE)
+if(HIP_FABRIC_API_FUNC AND HIP_FABRIC_HANDLE_TYPE)
+  set(HIP_FABRIC_API ON)
+  message(STATUS "HIP Fabric API enabled (hipMemImportFromShareableHandle and hipMemFabricHandle_t found)")
+else()
+  set(HIP_FABRIC_API OFF)
+endif()
+
 # --- Common include paths for hipified RCCL headers ---
 set(RCCL_INCLUDE_DIRS
   ${RCCL_HIPIFY_DIR}/src/include
@@ -279,6 +306,7 @@ target_compile_definitions(rccl-source-wrappers PRIVATE
   NCCL_OS_LINUX
   ROCM_VERSION=70000
   $<$<BOOL:${AMDSMI_FABRIC_API}>:AMDSMI_FABRIC_DIRECT>
+  $<$<BOOL:${HIP_FABRIC_API}>:HIP_FABRIC_API>
 )
 target_link_libraries(rccl-source-wrappers PRIVATE
   GTest::GTest
@@ -314,6 +342,7 @@ target_compile_definitions(rccl-HostUnitTests PRIVATE
   RCCL_EXPOSE_STATIC
   ARSMI_TEST_BUILD
   $<$<BOOL:${AMDSMI_FABRIC_API}>:AMDSMI_FABRIC_DIRECT>
+  $<$<BOOL:${HIP_FABRIC_API}>:HIP_FABRIC_API>
 )
 
 target_link_options(rccl-HostUnitTests PRIVATE -no-hip-rt)

--- a/projects/rccl/test/host/CMakeLists.txt
+++ b/projects/rccl/test/host/CMakeLists.txt
@@ -184,6 +184,20 @@ if(NOT GTest_FOUND)
   endif()
 endif()
 
+# Both find_package(GTest) code paths above (system and RCCL-vendored) export
+# only the modern GTest::gtest target; GTest::GTest is a legacy alias CMake's
+# own FindGTest module stopped providing. Add it once here instead of after
+# every branch so target_link_libraries(... GTest::GTest) below works
+# regardless of which resolution path was taken.
+if(TARGET GTest::gtest AND NOT TARGET GTest::GTest)
+  # Promote before aliasing: GTest's package config creates GTest::gtest as a
+  # non-GLOBAL imported target, and ALIAS of one of those needs CMake 3.18,
+  # above this project's declared 3.16 minimum. Promotion works from 3.11 and
+  # only from the directory that created the target, which is this file.
+  set_target_properties(GTest::gtest PROPERTIES IMPORTED_GLOBAL TRUE)
+  add_library(GTest::GTest ALIAS GTest::gtest)
+endif()
+
 # --- Resolve fmt: system -> FetchContent fallback ---
 find_package(fmt QUIET)
 if(NOT fmt_FOUND)

--- a/projects/rccl/test/host/CMakeLists.txt
+++ b/projects/rccl/test/host/CMakeLists.txt
@@ -321,6 +321,7 @@ add_executable(rccl-HostUnitTests
   ${RCCL_TEST_DIR}/VersionInfoTests.cpp
   ${RCCL_TEST_DIR}/DdaCollCommonTests.cpp
   ${RCCL_TEST_DIR}/RomeTopoConsensusTests.cpp
+  RomeTopoConsensusLogTests.cpp
   ${RCCL_TEST_DIR}/MiscTests.cpp
   ${RCCL_TEST_DIR}/VersionGateTests.cpp
   ${RCCL_TEST_DIR}/TimeoutTests.cpp

--- a/projects/rccl/test/host/RomeTopoConsensusLogTests.cpp
+++ b/projects/rccl/test/host/RomeTopoConsensusLogTests.cpp
@@ -1,0 +1,90 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Vote-outcome tests for rcclCheckRomeTopoModelIdxConsensus.
+//
+// These live in the host-only binary rather than next to the rest of the
+// RomeTopoConsensus tests because they assert on what the function *logged*,
+// and that is only observable here. rccl-HostUnitTests links the stub
+// ncclDebugLog from test/host/wrapper_link_stubs.cpp, which writes WARN
+// straight to stderr; rccl-UnitTests, which also compiles
+// test/RomeTopoConsensusTests.cpp, links the real logger, where output goes to
+// ncclDebugFile (stdout by default) and the default ERROR level suppresses WARN
+// entirely. Keeping these cases out of the shared file avoids assertions that
+// would depend on which logger happens to be linked.
+
+#include "graph/rome_topo_consensus.h"
+#include "common/LogCapture.hpp"
+#include "gtest/gtest.h"
+
+#include <string>
+#include <vector>
+
+namespace RcclUnitTesting {
+namespace {
+
+// Runs one consensus check that is expected to fail, and pins *which* index won
+// the vote.
+//
+// Asserting the return code alone would not do that:
+// rcclCheckRomeTopoModelIdxConsensus reports ncclInvalidUsage for any
+// disagreement, so with several groups the result is identical no matter which
+// index wins -- a broken tie-break would look exactly like a correct one. The
+// emitted "voted refIdx N from K of M" is the only channel through which the
+// function reports its decision, so each case pins that string.
+//
+// All ranks share one hostname and host hash: those feed only the per-host
+// listing of mismatching ranks inside the warning, so a single host keeps the
+// message deterministic and each case focused on the vote itself.
+void expectMismatchWithVote(const std::vector<int>& idx, const std::string& expectedVote) {
+  const int nranks = static_cast<int>(idx.size());
+  ncclResult_t result = ncclSuccess;
+  const std::string log = CaptureLog([&]() {
+    result = rcclCheckRomeTopoModelIdxConsensus(
+        nranks,
+        [&](int r) { return idx[r]; },
+        [](int) { return "h"; },
+        [](int) { return 1ULL; });
+  });
+  EXPECT_EQ(result, ncclInvalidUsage);
+  EXPECT_NE(log.find(expectedVote), std::string::npos)
+      << "expected the warning to contain: " << expectedVote
+      << "\nactual log:\n" << log;
+}
+
+}  // namespace
+
+TEST(RomeTopoConsensusLog, threeWayVoteStrictLoserAndTieBreakLoser) {
+  // Which arms of the plurality comparison on rome_topo_consensus.cc:36 each
+  // case reaches depends on the order the loop walks `tallies`, a
+  // std::unordered_map. That order is deterministic but not obvious: it follows
+  // both `key % bucket_count` (reserve(nranks) sizes the table -- 7 buckets for
+  // nranks 6 and 7, 5 for nranks 5) and the order the keys were first inserted.
+  // It was established empirically per case rather than derived, so each case
+  // states the order it relies on.
+
+  // Vote counts 4 (key 1), 2 (key 2), 1 (key 8), visited as 2, 8, 1. Key 2
+  // takes `cnt > refVotes` True (refVotes -1 -> 2), then key 8 has cnt 1, so
+  // `cnt > refVotes` is False *and* `cnt == refVotes` is False too -- closing
+  // the `cnt == refVotes` False arm.
+  expectMismatchWithVote({1, 1, 1, 1, 2, 2, 8}, "voted refIdx 1 from 4 of 7");
+
+  // Three groups tied at 2 votes, first ranks 0 (key 1), 2 (key 2), 4 (key 8).
+  // Same 2, 8, 1 order: key 2 leads, key 8 ties on votes but has the higher
+  // firstRank -- closing the `firstRank < refFirstRank` False arm -- and key 1
+  // then satisfies both, exercising the True arm as well.
+  expectMismatchWithVote({1, 1, 2, 2, 8, 8}, "voted refIdx 1 from 2 of 6");
+
+  // Pins the strictness of the comparison itself, which the two cases above
+  // cannot: in both, the group that should win is visited last, so weakening
+  // `cnt > refVotes` to `cnt >= refVotes` elects the same index and goes
+  // unnoticed. Here keys 2 and 1 tie at 2 votes with first ranks 1 and 3 and
+  // the visit order is 2, 1, 6, so the tie must be broken by the lower first
+  // rank: `>` keeps key 2, `>=` would hand it to key 1.
+  expectMismatchWithVote({6, 2, 2, 1, 1}, "voted refIdx 2 from 2 of 5");
+}
+
+}  // namespace RcclUnitTesting

--- a/projects/rccl/test/mem_manager/MemManagerTests.cpp
+++ b/projects/rccl/test/mem_manager/MemManagerTests.cpp
@@ -22,6 +22,7 @@
 #include "utils.h"
 
 #include "ProcessIsolatedTestRunner.hpp"
+#include "ResourceGuards.hpp"
 
 namespace RcclUnitTesting
 {
@@ -150,6 +151,44 @@ TEST_F(MemManagerTest, Init_Success)
     EXPECT_EQ(m->totalOffload, 0u);
     EXPECT_EQ(m->totalOffloadImported, 0u);
     EXPECT_EQ(m->cpuBackupUsage, 0u);
+}
+
+TEST_F(MemManagerTest, NotInitialized_GuardsAllEntryPoints)
+{
+    ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+    ncclMemManager* m = comm->memManager;
+
+    // Whitebox-clear the initialized flag without going through Destroy, so the
+    // manager struct stays alive and every guarded entry point can be probed.
+    // Production reads this field via COMPILER_ATOMIC_LOAD; a plain store is
+    // fine here because the fixture is single-threaded.
+    m->initialized = 0;
+
+    // Destroy's guard (probed below) detaches the manager from comm without
+    // freeing it, and TearDown only frees when comm->memManager is non-null --
+    // so from here on an early return or a thrown exception would leak the
+    // manager. Re-arm and reattach on scope exit instead of at the end of the
+    // body, so the fixture always runs the real teardown.
+    auto restoreManager = RCCLTestGuards::makeScopeGuard([&]() {
+        m->initialized  = 1;
+        comm->memManager = m;
+    });
+
+    EXPECT_EQ(ncclMemTrack(m, fakePtr(1), 4096, fakeHandle(), kFakeHandleType, ncclMemScratch),
+              ncclInternalError);
+    EXPECT_EQ(ncclMemUntrack(m, fakePtr(1), 4096), ncclInternalError);
+    EXPECT_EQ(ncclDynMemMarkExportToPeer(m, fakePtr(1), /*peerRank=*/1), ncclInternalError);
+    EXPECT_EQ(m->numEntries, 0);
+    EXPECT_EQ(m->entries, nullptr);
+
+    // Destroy's guard takes a different path: it treats an uninitialized
+    // manager as already-torn-down, detaches it from comm, and succeeds
+    // without freeing (avoids a double free if Destroy already ran once).
+    EXPECT_EQ(ncclMemManagerDestroy(comm), ncclSuccess);
+    EXPECT_EQ(comm->memManager, nullptr);
+
+    // restoreManager reattaches `m` here, so the fixture's TearDown runs the
+    // real teardown path: destroy the placement-new mutex, then free.
 }
 
 TEST_F(MemManagerTest, Init_NullComm)


### PR DESCRIPTION
## Motivation

`rccl-HostUnitTests` (#9320) is a CPU-only test binary, but on ROCm 7.14+ the standalone
`test/host` project does not build at all, and nothing in it turns coverage on — so branch
coverage for host-testable code was never measured. This PR restores the build, enables
coverage by default, and closes gaps the resulting report exposed. No GPU, no HIP allocation.

## Technical Details

**Build (6 commits).** Three independent blockers: the legacy `GTest::GTest` alias is missing
on the vendored GTest path, `hipMemFabricHandle_st` collides with `hip_runtime_api.h` without
a `HIP_FABRIC_API` guard, and the vendored `libgtest.a` is non-PIC so the link needs
`-no-pie`. The redefinition predates #9817 — it already broke `rccl-source-wrappers` — and
`rccl-UnitTestsMicro` inherits it, so the fixes cover that target too.

Coverage is then on by default via `HOST_UT_COVERAGE`, mirroring #9817. Two non-obvious bits:
`rccl-source-wrappers` must be instrumented as well, since `mem_manager.cc` reaches the binary
through it and otherwise disappears from the report entirely; and `RCCL_TEST_CODE_COVERAGE`
rides the same switch, since it is what makes process-isolated tests flush counters in the
forked child.

**Tests (7 commits, one per test).** Each targets branches confirmed `BRDA == 0` beforehand:
the not-initialized guards in `mem_manager.cc`, both False arms of the plurality tie-break in
`rome_topo_consensus.cc`, null/empty-argument and missing-file paths in `kernel_config.cc`,
and the repeated-init and bad-KFD-path arms in `alt_rsmi.cc`.

Three notes. The tie-break test asserts the emitted `voted refIdx N from K of M`, because the
function returns `ncclInvalidUsage` for any disagreement and the return value alone cannot
tell a correct tie-break from a broken one; it lives in `test/host/` because that assertion
only holds where the stub logger is linked. The `alt_rsmi` double-init test adds a KFD node
between the two calls, since re-scanning an unchanged directory is indistinguishable from the
early return, then removes it before asserting so a failure cannot poison later tests. And
`rome_topo_consensus.cc:47` plus `mem_manager.cc:206`/`:214` are structurally unreachable —
documented, deliberately untested.

Nothing outside `test/` is touched — no CHANGELOG entry needed.

## Issue Tracking

JIRA ID: AICOMNET-379

## Test Plan

Configure and build with nothing but the compiler path, run the suite, export with
`llvm-profdata merge -sparse` + `llvm-cov export -format=lcov` (`BRF`/`BRH`), measuring the
last pre-test commit and HEAD through the same pipeline; repeat five times to see which
figures reproduce. Mutation-test every new test: break the branch it claims to cover and
require it to fail.

## Test Result

**282 tests, 0 failures** (baseline 275); `rccl-UnitTestsMicro` builds and passes its 30 too.
Every test commit builds and passes on its own, 275 → 282 monotonically. The first two build
commits do not build in isolation — the blockers are independent but all required at once.

**Mutation: 8/8 detected** — removing the `!initialized` guard, inverting the tie-break,
weakening `cnt >` to `>=`, dropping either null check, dropping `!is_open()`, dropping the
already-initialized early return, dropping the opendir failure return.

| File | Branch (`BRF`/`BRH`) | Lines |
|---|---|---|
| `kernel_config.cc` | 13.46% → **23.08%** | 18.92% → 18.92% |
| `rome_topo_consensus.cc` | 91.18% → **97.06%** | 98.11% → 98.11% |
| `alt_rsmi.cc` | 76.98% → **77.66%** | 91.71% → 92.55% |
| `mem_manager.cc` | not reproducible, see below | 33.69% → **35.13%** |

`mem_manager.cc` branch coverage varies run to run — five runs of one binary gave 210, 217,
223, 223, 224 while line coverage stayed at 293 — because thread interleaving in that file's
concurrency tests decides which branches are taken. No aggregate delta is claimed for it; the
four guard branches the new test targets are hit in every run and their removal is caught by
mutation. Note also that `llvm-cov`'s lcov export is not self-consistent: `BRF`/`BRH` counts
branches its own `BRDA` lines do not enumerate (1150 vs 656 here). The table uses `BRF`/`BRH`,
what `genhtml` shows.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.