### PR TITLE
fix(rocprofiler-compute): update gfx1250 HBM benchmark kernel source

### DIFF
--- a/projects/rocprofiler-compute/CMakeLists.txt
+++ b/projects/rocprofiler-compute/CMakeLists.txt
@@ -604,6 +604,15 @@ add_test(
         ${WORKING_DIR_OPTION}
 )
 
+# Roofline benchmark kernel source contract — no GPU required
+add_test(
+    NAME test_benchmark_base
+    COMMAND
+        ${PYTHON_TEST_COMMAND} -m pytest ${STANDALONEBINARY_TEST_OPTION}
+        --junitxml=tests/test_benchmark_base.xml ${COV_OPTION}
+        tests/test_benchmark_base.py ${WORKING_DIR_OPTION}
+)
+
 # -----------------------------------
 # Data imputation tests
 # -----------------------------------

--- a/projects/rocprofiler-compute/docs/data/metrics/gfx1250_metrics.yaml
+++ b/projects/rocprofiler-compute/docs/data/metrics/gfx1250_metrics.yaml
@@ -408,7 +408,7 @@ Roofline Performance Rates:
     rst: Achieved Int8 WMMA throughput.
     unit: GIOP/s
   HBM Bandwidth:
-    rst: Total HBM bandwidth.
+    rst: Total HBM bandwidth. The peak empirically measured bandwidth reflects peak single-direction (read-only) bandwidth, so write-heavy or mixed kernels fall below it.
     unit: GB/s
   GL2 Cache Bandwidth:
     rst: GL2 Cache bandwidth.

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1250/0400_roofline.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1250/0400_roofline.yaml
@@ -193,7 +193,9 @@ Panel Config:
     #   Achieved Int4 WMMA throughput.
 
     HBM Bandwidth: >-
-      Total HBM bandwidth.
+      Total HBM bandwidth. The peak empirically measured bandwidth reflects
+      peak single-direction (read-only) bandwidth, so write-heavy or mixed
+      kernels fall below it.
     GL2 Cache Bandwidth: >-
       GL2 Cache bandwidth.
 

--- a/projects/rocprofiler-compute/src/roofline/benchmark/gfx12/benchmark_gfx12_base.py
+++ b/projects/rocprofiler-compute/src/roofline/benchmark/gfx12/benchmark_gfx12_base.py
@@ -97,12 +97,22 @@ class Bench_gfx12(benchmark_base.Bench_base):
         self.hbm_bw_src = """
         extern "C" __global__ void HBM_bw(__uint128_t *src, long numSteps)
         {
-            const unsigned int gid = blockDim.x * blockIdx.x + threadIdx.x;
-            __uint128_t tmp = 0;
-            for (long i = 0; i < numSteps; ++i)
-                tmp += src[gid + i * blockDim.x * gridDim.x];
-            if (tmp == (__uint128_t)-1)
-                src[gid] = tmp;
+            unsigned long offset = (unsigned long)blockIdx.x * blockDim.x
+                                   + threadIdx.x;
+            const unsigned long stride = (unsigned long)gridDim.x * blockDim.x;
+            __uint128_t v = 0;
+
+            #pragma unroll 1
+            for (long step = 0; step < numSteps; step++)
+            {
+                #pragma unroll
+                for (int i = 0; i < 16; i++)
+                {
+                    v |= __builtin_nontemporal_load(&src[offset]);
+                    offset += stride;
+                }
+            }
+            if (v == 0) src[0] = v;
         }
         """
 

--- a/projects/rocprofiler-compute/src/roofline/benchmark/gfx12/benchmark_gfx12_base.py
+++ b/projects/rocprofiler-compute/src/roofline/benchmark/gfx12/benchmark_gfx12_base.py
@@ -95,11 +95,14 @@ class Bench_gfx12(benchmark_base.Bench_base):
         # HBM Bandwidth benchmark
         # ----------------------------------------
         self.hbm_bw_src = """
-        template<typename T>
-        __global__ void HBM_bw(T *dst, const T *src)
+        extern "C" __global__ void HBM_bw(__uint128_t *src, long numSteps)
         {
             const unsigned int gid = blockDim.x * blockIdx.x + threadIdx.x;
-            dst[gid] = src[gid];
+            __uint128_t tmp = 0;
+            for (long i = 0; i < numSteps; ++i)
+                tmp += src[gid + i * blockDim.x * gridDim.x];
+            if (tmp == (__uint128_t)-1)
+                src[gid] = tmp;
         }
         """
 

--- a/projects/rocprofiler-compute/tests/test_benchmark_base.py
+++ b/projects/rocprofiler-compute/tests/test_benchmark_base.py
@@ -1,0 +1,192 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
+"""
+Unit tests for the kernel-source contract in roofline/benchmark.
+
+Each benchmark in Bench_base compiles an architecture's kernel source with
+hiprtc and then asks Program.get_kernel() for a specific kernel by name. A
+source that does not define that name still compiles, so the mismatch only
+surfaces as a HIP error on real hardware. These tests resolve every kernel
+name each architecture would request and assert its source defines it.
+
+No GPU is required; the sources are plain strings built in the constructor.
+"""
+
+import pytest
+
+try:
+    from roofline.benchmark.gfx9.benchmark_gfx90a import Bench_gfx90a
+    from roofline.benchmark.gfx9.benchmark_gfx942 import Bench_gfx942
+    from roofline.benchmark.gfx9.benchmark_gfx950 import Bench_gfx950
+    from roofline.benchmark.gfx11.benchmark_gfx1150 import Bench_gfx1150
+    from roofline.benchmark.gfx11.benchmark_gfx1151 import Bench_gfx1151
+    from roofline.benchmark.gfx11.benchmark_gfx1152 import Bench_gfx1152
+    from roofline.benchmark.gfx11.benchmark_gfx1153 import Bench_gfx1153
+    from roofline.benchmark.gfx12.benchmark_gfx1250 import Bench_gfx1250
+except OSError as hip_load_error:
+    # hip_interface and hiprtc_interface dlopen the ROCm libraries at import.
+    pytest.skip(
+        f"ROCm runtime libraries unavailable: {hip_load_error}",
+        allow_module_level=True,
+    )
+
+# =============================================================================
+# Test data
+# =============================================================================
+
+BENCH_CLASSES = [
+    Bench_gfx90a,
+    Bench_gfx942,
+    Bench_gfx950,
+    Bench_gfx1150,
+    Bench_gfx1151,
+    Bench_gfx1152,
+    Bench_gfx1153,
+    Bench_gfx1250,
+]
+
+# set_cache_kernel_selector() derives a kernel name per level present here, so
+# every level is populated to exercise the whole selector.
+CACHE_SIZES = {
+    "L0": 32 * 1024,
+    "L1": 16 * 1024,
+    "L2": 4 * 1024 * 1024,
+    "MALL": 256 * 1024 * 1024,
+}
+
+# Mirrors the source selection in Bench_base.matrix_bench().
+MATRIX_SOURCE_ATTRS = {
+    "F16": "matrix_f16_src",
+    "F32": "matrix_f32_src",
+    "F64": "matrix_f64_src",
+    "F8": "matrix_f8_src",
+    "BF16": "matrix_bf16_src",
+    "I8": "matrix_i8_src",
+}
+PACKED_MATRIX_SOURCE_ATTR = "matrix_f8f6f4_src"
+
+# flops_kernel_selector keys against the names used in Bench.tests.
+FLOPS_TEST_KEYS = {
+    "FP16": "F16",
+    "BF16": "BF16",
+    "FP32": "F32",
+    "FP64": "F64",
+    "INT8": "I8",
+    "INT32": "I32",
+    "INT64": "I64",
+}
+
+# Benchmarks whose launcher hard-codes the kernel name it resolves.
+LITERAL_KERNEL_NAMES = [
+    ("HBM", "hbm_bw_src", "HBM_bw"),
+    ("LDS", "lds_benchmark_src", "LDS_bw"),
+]
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def assert_source_defines(kernel_source, kernel_name, context):
+    """Assert the source defines the symbol Program.get_kernel() resolves.
+
+    get_kernel() routes any name containing "<" through hiprtcGetLoweredName,
+    which needs a matching template in the source. Every other name is looked
+    up verbatim in the code object, which only succeeds when the kernel is
+    declared extern "C" and so escapes C++ name mangling.
+    """
+    assert kernel_source.strip(), f"{context}: kernel source is empty"
+
+    if "<" in kernel_name:
+        template_name = kernel_name.split("<", 1)[0]
+        assert "template" in kernel_source, (
+            f"{context}: {kernel_name} is a template instantiation but the "
+            f"source declares no template"
+        )
+        assert f"__global__ void {template_name}(" in kernel_source, (
+            f"{context}: source does not define __global__ {template_name}"
+        )
+        return
+
+    assert f'extern "C" __global__ void {kernel_name}(' in kernel_source, (
+        f'{context}: source does not define extern "C" __global__ {kernel_name}'
+    )
+
+
+def runs_benchmark(bench, test_key):
+    """Report whether run_benchmark() would launch this benchmark."""
+    return test_key in bench.tests and test_key not in bench.unsupported_data_types
+
+
+# =============================================================================
+# Tests
+# =============================================================================
+
+
+@pytest.mark.parametrize("bench_class", BENCH_CLASSES, ids=lambda cls: cls.__name__)
+def test_literal_kernel_sources_define_their_symbol(bench_class):
+    """HBM and LDS sources must define the names their launchers hard-code."""
+    bench = bench_class(0, dict(CACHE_SIZES))
+
+    for test_key, source_attr, kernel_name in LITERAL_KERNEL_NAMES:
+        if not runs_benchmark(bench, test_key):
+            continue
+        assert_source_defines(
+            getattr(bench, source_attr),
+            kernel_name,
+            f"{bench_class.__name__} {test_key}",
+        )
+
+
+@pytest.mark.parametrize("bench_class", BENCH_CLASSES, ids=lambda cls: cls.__name__)
+def test_cache_kernel_sources_define_selected_symbol(bench_class):
+    """Every cache level selects a Cache_bw instantiation from one source."""
+    bench = bench_class(0, dict(CACHE_SIZES))
+    assert bench.cache_kernel_selector, "no cache kernels selected"
+
+    for cache_type, kernel_name in bench.cache_kernel_selector.items():
+        if not runs_benchmark(bench, cache_type):
+            continue
+        assert_source_defines(
+            bench.cache_bw_src, kernel_name, f"{bench_class.__name__} {cache_type}"
+        )
+
+
+@pytest.mark.parametrize("bench_class", BENCH_CLASSES, ids=lambda cls: cls.__name__)
+def test_flops_kernel_sources_define_selected_symbol(bench_class):
+    """VALU benchmarks read their kernel name from flops_kernel_selector."""
+    bench = bench_class(0, dict(CACHE_SIZES))
+
+    for flops_type, selection in bench.flops_kernel_selector.items():
+        test_key = FLOPS_TEST_KEYS[flops_type]
+        if not runs_benchmark(bench, test_key):
+            continue
+        source_attr = (
+            "bf16_flops_benchmark_src"
+            if flops_type == "BF16"
+            else "flops_benchmark_src"
+        )
+        assert_source_defines(
+            getattr(bench, source_attr),
+            selection[0],
+            f"{bench_class.__name__} {test_key}",
+        )
+
+
+@pytest.mark.parametrize("bench_class", BENCH_CLASSES, ids=lambda cls: cls.__name__)
+def test_matrix_kernel_sources_define_selected_symbol(bench_class):
+    """Matrix benchmarks read their kernel name from matrix_kernel_selector."""
+    bench = bench_class(0, dict(CACHE_SIZES))
+
+    for matrix_type, kernel_name in bench.matrix_kernel_selector.items():
+        test_key = f"{bench.MATRIX_OPS_TYPE}-{matrix_type}"
+        if not runs_benchmark(bench, test_key):
+            continue
+        source_attr = MATRIX_SOURCE_ATTRS.get(matrix_type, PACKED_MATRIX_SOURCE_ATTR)
+        assert_source_defines(
+            getattr(bench, source_attr),
+            kernel_name,
+            f"{bench_class.__name__} {test_key}",
+        )

--- a/projects/rocprofiler-compute/tests/test_categories.yaml
+++ b/projects/rocprofiler-compute/tests/test_categories.yaml
@@ -24,6 +24,7 @@ test_categories:
       - test_roofline_calc
       - test_roofline_analyze
       - test_roofline_main
+      - test_benchmark_base
       - test_num_xcds_spec_class
       - test_profiler_base
       - test_pc_sampling_profile
@@ -83,6 +84,7 @@ test_categories:
       - test_roofline_calc
       - test_roofline_analyze
       - test_roofline_main
+      - test_benchmark_base
       - test_torch_trace_analysis
       - test_torch_trace_coverage
       - test_tui_components
@@ -151,6 +153,7 @@ test_categories:
       - test_roofline_calc
       - test_roofline_analyze
       - test_roofline_main
+      - test_benchmark_base
       - test_torch_trace_analysis
       - test_torch_trace_coverage
       - test_tui_components
@@ -219,6 +222,7 @@ test_categories:
       - test_roofline_calc
       - test_roofline_analyze
       - test_roofline_main
+      - test_benchmark_base
       - test_torch_trace_analysis
       - test_torch_trace_coverage
       - test_tui_components

--- a/projects/rocprofiler-compute/tools/config_management/.config_hashes.json
+++ b/projects/rocprofiler-compute/tools/config_management/.config_hashes.json
@@ -23,7 +23,7 @@
         "0100_system_info.yaml": "b5823ba6b80439996727e3e8982a2ff6",
         "0200_system_speed_of_light.yaml": "18f841ff3cd2a36987bdbb8a2e8766c1",
         "0300_memory_chart.yaml": "a87a7149747459300f24da5f6ba798c1",
-        "0400_roofline.yaml": "2a839ae6e84a846345027ec9758efd11",
+        "0400_roofline.yaml": "c306dacfb67499681dea19a6a3dc15b8",
         "0500_command_processor_cpc.yaml": "393bf6bc23b574912e4df7dc4b74d3c4",
         "0600_workgroup_manager_spi.yaml": "0bc73c166cf74ee86a5b5a5997a80562",
         "0700_workgroup_processor_wgp.yaml": "3b381f97aa02b9d61eb92fddc5d80512",

--- a/projects/rocprofiler-compute/tools/per_arch_metric_definitions/gfx1250_metrics_description.yaml
+++ b/projects/rocprofiler-compute/tools/per_arch_metric_definitions/gfx1250_metrics_description.yaml
@@ -541,8 +541,8 @@ Roofline Performance Rates:
     rst: Achieved Int8 WMMA throughput.
     unit: GIOP/s
   HBM Bandwidth:
-    plain: Total HBM bandwidth.
-    rst: Total HBM bandwidth.
+    plain: Total HBM bandwidth. The peak empirically measured bandwidth reflects peak single-direction (read-only) bandwidth, so write-heavy or mixed kernels fall below it.
+    rst: Total HBM bandwidth. The peak empirically measured bandwidth reflects peak single-direction (read-only) bandwidth, so write-heavy or mixed kernels fall below it.
     unit: GB/s
   GL2 Cache Bandwidth:
     plain: GL2 Cache bandwidth.


### PR DESCRIPTION
## Motivation

Update gfx12 base benchmark file with latest HBM kernel source that was also implemented for gfx9 in commit ccca7e3

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

JIRA ID: AIPROFCOMP-567

## Test Plan

Running --bench-only on gfx1250 system to ensure no HIP Error 500 and completes

## Test Result

Passes and completes as expected.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
