### PR TITLE
fix(profiler-hub): obtain SQLite3 amalgamation without requiring Tcl

### DIFF
--- a/profilers/profiler-hub/cmake/sqlite3.cmake
+++ b/profilers/profiler-hub/cmake/sqlite3.cmake
@@ -3,102 +3,238 @@
 
 # ----------------------------------------------------------------------------------------#
 #
-# SQLite3 - cloned from upstream and built from the amalgamation
+# SQLite3 - built locally from the official upstream amalgamation
 #
-# Mirrors the pattern used by sibling rocprofiler-systems
-# (projects/rocprofiler-systems/cmake/SQLite3.cmake): fetch the upstream
-# git repository at a pinned tag, then build locally. Avoids vendoring
-# any binary blobs in the source tree.
+# The amalgamation (sqlite3.c + sqlite3.h) is fetched as the pre-generated source
+# archive published on sqlite.org. That is the same C source `make sqlite3.c`
+# emits from a git checkout, but taking it directly keeps configure free of
+# autoconf, make and - critically - Tcl. SQLite's `sqlite3.c` makefile target
+# runs tool/mksqlite3c.tcl and aborts with
+#
+#   ERROR: This makefile target requires tclsh 8.4 or later
+#
+# on hosts without tclsh, which is not a documented build dependency of this
+# project (see ROCm/rocm-systems#10059). `./configure --disable-tcl` only drops
+# the Tcl *bindings*; it does not lift that requirement.
+#
+# No binary blobs are vendored in the source tree either way. If sqlite.org is
+# unreachable, fall back to the previous git clone + autotools route, which does
+# need tclsh and now says so up front instead of failing with an opaque rc=2.
 #
 # ----------------------------------------------------------------------------------------#
 
 set(SQLITE3_GIT_URL
     "https://github.com/sqlite/sqlite.git"
     CACHE STRING
-    "Upstream SQLite3 git repository URL"
+    "Upstream SQLite3 git repository URL (fallback source)"
 )
 set(SQLITE3_GIT_TAG
     "version-3.45.3"
     CACHE STRING
-    "Upstream SQLite3 git tag to check out"
+    "Upstream SQLite3 version to build, as a git tag"
 )
-
-message(
-    STATUS
-    "[profiler-hub] Cloning SQLite3 from ${SQLITE3_GIT_URL} @ ${SQLITE3_GIT_TAG}"
+set(SQLITE3_AMALGAMATION_URL_BASE
+    "https://www.sqlite.org"
+    CACHE STRING
+    "Base URL serving the official SQLite3 amalgamation archives"
 )
-
-find_package(Git REQUIRED)
-find_program(MAKE_COMMAND NAMES make gmake REQUIRED)
+set(SQLITE3_AMALGAMATION_YEAR
+    "2024"
+    CACHE STRING
+    "Release year folder on sqlite.org for the amalgamation download"
+)
+set(SQLITE3_AMALGAMATION_SHA256
+    "ea170e73e447703e8359308ca2e4366a3ae0c4304a8665896f068c736781c651"
+    CACHE STRING
+    "SHA256 of the SQLite3 amalgamation archive; empty disables verification"
+)
 
 set(SQLITE3_SOURCE_DIR "${PROJECT_BINARY_DIR}/external/sqlite3")
 set(SQLITE3_AMALG_C "${SQLITE3_SOURCE_DIR}/sqlite3.c")
 set(SQLITE3_AMALG_H "${SQLITE3_SOURCE_DIR}/sqlite3.h")
 
-# checkout: shallow + partial first, retry full on failure
-if(NOT EXISTS "${SQLITE3_SOURCE_DIR}/configure")
-    if(EXISTS "${SQLITE3_SOURCE_DIR}")
-        file(REMOVE_RECURSE "${SQLITE3_SOURCE_DIR}")
+if(NOT EXISTS "${SQLITE3_AMALG_C}" OR NOT EXISTS "${SQLITE3_AMALG_H}")
+    # sqlite.org names its archives with the numeric version SQLite reports as
+    # SQLITE_VERSION_NUMBER: 3.45.3 -> 3045003 -> "3450300" in the file name.
+    string(REGEX REPLACE "^version-" "" _sqlite3_version "${SQLITE3_GIT_TAG}")
+    string(REPLACE "." ";" _sqlite3_version_parts "${_sqlite3_version}")
+    list(LENGTH _sqlite3_version_parts _sqlite3_version_len)
+    if(_sqlite3_version_len LESS 3)
+        message(
+            FATAL_ERROR
+            "[profiler-hub] SQLITE3_GIT_TAG must look like version-M.m.p (got ${SQLITE3_GIT_TAG})"
+        )
     endif()
-    execute_process(
-        COMMAND
-            ${GIT_EXECUTABLE} clone --depth 1 --filter=blob:none --branch
-            ${SQLITE3_GIT_TAG} ${SQLITE3_GIT_URL} ${SQLITE3_SOURCE_DIR}
-        RESULT_VARIABLE _sqlite3_clone_rc
+    list(GET _sqlite3_version_parts 0 _sqlite3_major)
+    list(GET _sqlite3_version_parts 1 _sqlite3_minor)
+    list(GET _sqlite3_version_parts 2 _sqlite3_patch)
+    math(
+        EXPR
+        _sqlite3_amalg_version
+        "${_sqlite3_major} * 1000000 + ${_sqlite3_minor} * 10000 + ${_sqlite3_patch} * 100"
     )
-    if(NOT _sqlite3_clone_rc EQUAL 0)
+
+    set(_sqlite3_external_dir "${PROJECT_BINARY_DIR}/external")
+    set(_sqlite3_amalg_name "sqlite-amalgamation-${_sqlite3_amalg_version}")
+    set(_sqlite3_amalg_zip "${_sqlite3_external_dir}/${_sqlite3_amalg_name}.zip")
+    set(_sqlite3_amalg_url
+        "${SQLITE3_AMALGAMATION_URL_BASE}/${SQLITE3_AMALGAMATION_YEAR}/${_sqlite3_amalg_name}.zip"
+    )
+
+    file(MAKE_DIRECTORY "${_sqlite3_external_dir}")
+
+    message(
+        STATUS
+        "[profiler-hub] Downloading SQLite3 ${_sqlite3_version} amalgamation from ${_sqlite3_amalg_url}"
+    )
+    file(
+        DOWNLOAD ${_sqlite3_amalg_url}
+        ${_sqlite3_amalg_zip}
+        STATUS _sqlite3_download_status
+    )
+    list(GET _sqlite3_download_status 0 _sqlite3_download_rc)
+    list(GET _sqlite3_download_status 1 _sqlite3_download_msg)
+
+    set(_sqlite3_have_amalgamation FALSE)
+
+    if(_sqlite3_download_rc EQUAL 0)
+        if(SQLITE3_AMALGAMATION_SHA256)
+            file(SHA256 "${_sqlite3_amalg_zip}" _sqlite3_actual_sha256)
+            if(NOT _sqlite3_actual_sha256 STREQUAL SQLITE3_AMALGAMATION_SHA256)
+                message(
+                    FATAL_ERROR
+                    "[profiler-hub] SQLite3 amalgamation checksum mismatch for "
+                    "${_sqlite3_amalg_url}\n"
+                    "  expected: ${SQLITE3_AMALGAMATION_SHA256}\n"
+                    "  actual:   ${_sqlite3_actual_sha256}\n"
+                    "If SQLITE3_GIT_TAG was changed, update SQLITE3_AMALGAMATION_SHA256 "
+                    "and SQLITE3_AMALGAMATION_YEAR to match."
+                )
+            endif()
+        endif()
+
+        file(
+            ARCHIVE_EXTRACT
+            INPUT ${_sqlite3_amalg_zip}
+            DESTINATION ${_sqlite3_external_dir}
+        )
+        file(MAKE_DIRECTORY "${SQLITE3_SOURCE_DIR}")
+        foreach(_sqlite3_file IN ITEMS sqlite3.c sqlite3.h sqlite3ext.h)
+            if(EXISTS "${_sqlite3_external_dir}/${_sqlite3_amalg_name}/${_sqlite3_file}")
+                file(
+                    COPY "${_sqlite3_external_dir}/${_sqlite3_amalg_name}/${_sqlite3_file}"
+                    DESTINATION ${SQLITE3_SOURCE_DIR}
+                )
+            endif()
+        endforeach()
+
+        if(EXISTS "${SQLITE3_AMALG_C}" AND EXISTS "${SQLITE3_AMALG_H}")
+            set(_sqlite3_have_amalgamation TRUE)
+        else()
+            message(
+                STATUS
+                "[profiler-hub] SQLite3 amalgamation archive did not contain the expected "
+                "sources; falling back to a git checkout"
+            )
+        endif()
+    else()
         message(
             STATUS
-            "[profiler-hub] Optimized clone failed; retrying full clone"
+            "[profiler-hub] SQLite3 amalgamation download failed "
+            "(rc=${_sqlite3_download_rc}: ${_sqlite3_download_msg}); "
+            "falling back to a git checkout"
         )
-        if(EXISTS "${SQLITE3_SOURCE_DIR}")
-            file(REMOVE_RECURSE "${SQLITE3_SOURCE_DIR}")
+    endif()
+
+    if(NOT _sqlite3_have_amalgamation)
+        # Generating the amalgamation from a git checkout runs tool/mksqlite3c.tcl,
+        # so Tcl is mandatory here. Say so before spending time on a clone.
+        find_program(
+            TCLSH_EXECUTABLE
+            NAMES tclsh tclsh8.6 tclsh8.5 tclsh8.4
+        )
+        if(NOT TCLSH_EXECUTABLE)
+            message(
+                FATAL_ERROR
+                "[profiler-hub] Cannot obtain SQLite3: downloading the prebuilt "
+                "amalgamation from ${_sqlite3_amalg_url} failed, and generating it from "
+                "${SQLITE3_GIT_URL} requires tclsh 8.4 or later, which was not found.\n"
+                "Either make sqlite.org reachable, or install Tcl "
+                "(Debian/Ubuntu: 'tcl', RHEL/Fedora: 'tcl')."
+            )
+        endif()
+
+        message(
+            STATUS
+            "[profiler-hub] Cloning SQLite3 from ${SQLITE3_GIT_URL} @ ${SQLITE3_GIT_TAG}"
+        )
+
+        find_package(Git REQUIRED)
+        find_program(MAKE_COMMAND NAMES make gmake REQUIRED)
+
+        # checkout: shallow + partial first, retry full on failure
+        if(NOT EXISTS "${SQLITE3_SOURCE_DIR}/configure")
+            if(EXISTS "${SQLITE3_SOURCE_DIR}")
+                file(REMOVE_RECURSE "${SQLITE3_SOURCE_DIR}")
+            endif()
+            execute_process(
+                COMMAND
+                    ${GIT_EXECUTABLE} clone --depth 1 --filter=blob:none --branch
+                    ${SQLITE3_GIT_TAG} ${SQLITE3_GIT_URL} ${SQLITE3_SOURCE_DIR}
+                RESULT_VARIABLE _sqlite3_clone_rc
+            )
+            if(NOT _sqlite3_clone_rc EQUAL 0)
+                message(
+                    STATUS
+                    "[profiler-hub] Optimized clone failed; retrying full clone"
+                )
+                if(EXISTS "${SQLITE3_SOURCE_DIR}")
+                    file(REMOVE_RECURSE "${SQLITE3_SOURCE_DIR}")
+                endif()
+                execute_process(
+                    COMMAND
+                        ${GIT_EXECUTABLE} clone --branch ${SQLITE3_GIT_TAG}
+                        ${SQLITE3_GIT_URL} ${SQLITE3_SOURCE_DIR}
+                    RESULT_VARIABLE _sqlite3_clone_rc
+                )
+            endif()
+            if(NOT _sqlite3_clone_rc EQUAL 0)
+                message(
+                    FATAL_ERROR
+                    "[profiler-hub] git clone of SQLite3 failed (rc=${_sqlite3_clone_rc})"
+                )
+            endif()
+        endif()
+
+        message(STATUS "[profiler-hub] Generating SQLite3 amalgamation")
+        execute_process(
+            COMMAND ./configure --disable-tcl
+            WORKING_DIRECTORY ${SQLITE3_SOURCE_DIR}
+            RESULT_VARIABLE _sqlite3_configure_rc
+        )
+        if(NOT _sqlite3_configure_rc EQUAL 0)
+            message(
+                FATAL_ERROR
+                "[profiler-hub] SQLite3 ./configure failed (rc=${_sqlite3_configure_rc})"
+            )
         endif()
         execute_process(
-            COMMAND
-                ${GIT_EXECUTABLE} clone --branch ${SQLITE3_GIT_TAG}
-                ${SQLITE3_GIT_URL} ${SQLITE3_SOURCE_DIR}
-            RESULT_VARIABLE _sqlite3_clone_rc
+            COMMAND ${MAKE_COMMAND} sqlite3.c
+            WORKING_DIRECTORY ${SQLITE3_SOURCE_DIR}
+            RESULT_VARIABLE _sqlite3_make_rc
         )
-    endif()
-    if(NOT _sqlite3_clone_rc EQUAL 0)
-        message(
-            FATAL_ERROR
-            "[profiler-hub] git clone of SQLite3 failed (rc=${_sqlite3_clone_rc})"
-        )
-    endif()
-endif()
-
-# generate amalgamation (sqlite3.c + sqlite3.h) via upstream autotools
-if(NOT EXISTS "${SQLITE3_AMALG_C}" OR NOT EXISTS "${SQLITE3_AMALG_H}")
-    message(STATUS "[profiler-hub] Generating SQLite3 amalgamation")
-    execute_process(
-        COMMAND ./configure --disable-tcl
-        WORKING_DIRECTORY ${SQLITE3_SOURCE_DIR}
-        RESULT_VARIABLE _sqlite3_configure_rc
-    )
-    if(NOT _sqlite3_configure_rc EQUAL 0)
-        message(
-            FATAL_ERROR
-            "[profiler-hub] SQLite3 ./configure failed (rc=${_sqlite3_configure_rc})"
-        )
-    endif()
-    execute_process(
-        COMMAND ${MAKE_COMMAND} sqlite3.c
-        WORKING_DIRECTORY ${SQLITE3_SOURCE_DIR}
-        RESULT_VARIABLE _sqlite3_make_rc
-    )
-    if(NOT _sqlite3_make_rc EQUAL 0)
-        message(
-            FATAL_ERROR
-            "[profiler-hub] SQLite3 amalgamation generation failed (rc=${_sqlite3_make_rc})"
-        )
-    endif()
-    if(NOT EXISTS "${SQLITE3_AMALG_C}" OR NOT EXISTS "${SQLITE3_AMALG_H}")
-        message(
-            FATAL_ERROR
-            "[profiler-hub] SQLite3 amalgamation files not found after build"
-        )
+        if(NOT _sqlite3_make_rc EQUAL 0)
+            message(
+                FATAL_ERROR
+                "[profiler-hub] SQLite3 amalgamation generation failed (rc=${_sqlite3_make_rc})"
+            )
+        endif()
+        if(NOT EXISTS "${SQLITE3_AMALG_C}" OR NOT EXISTS "${SQLITE3_AMALG_H}")
+            message(
+                FATAL_ERROR
+                "[profiler-hub] SQLite3 amalgamation files not found after build"
+            )
+        endif()
     endif()
 endif()
 


### PR DESCRIPTION
## Motivation

`rocprofiler-systems` fails at **configure** time on any build host that does not
have Tcl installed.

`profiler-hub` builds its bundled SQLite3 by cloning `sqlite/sqlite` and
generating the amalgamation with `./configure --disable-tcl && make sqlite3.c`.
That make target runs `tool/mksqlite3c.tcl`, so it aborts on hosts without
`tclsh`:

```
sh .../sqlite3/tool/cktclsh.sh 8.4 tclsh
ERROR: This makefile target requires tclsh 8.4 or later.
.../cktclsh.sh: 5: tclsh: not found
make: *** [Makefile:793: has_tclsh84] Error 1
CMake Error at .../profilers/profiler-hub/cmake/sqlite3.cmake:92 (message):
  [profiler-hub] SQLite3 amalgamation generation failed (rc=2)
Call Stack (most recent call first):
  .../profilers/profiler-hub/CMakeLists.txt:137 (include)
-- Configuring incomplete, errors occurred!
```

`./configure --disable-tcl` only drops the Tcl *bindings*; it does not lift the
`tclsh` requirement of the `sqlite3.c` amalgamation target. Tcl is not a
documented build dependency of this project or of ROCm/TheRock.

`rocprofiler-systems` picked up this dependency in #8607, which added
`projects/rocprofiler-systems/cmake/ProfilerHub.cmake` (included unconditionally
from `Packages.cmake`).

### Why this is invisible upstream

TheRock's official Linux build container ships Tcl transitively from its
AlmaLinux 8 base, so CI satisfies the dependency by accident:

```console
$ docker run --rm --entrypoint bash \
    ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:a382085df3ba2419b58aa9051350883a0d0b732a4bc0a4ef60458f8161bb08c6 \
    -lc 'command -v tclsh; rpm -q tcl'
/usr/bin/tclsh
tcl-8.6.8-2.el8.x86_64
```

TheRock's documented Ubuntu prerequisites are `curl autoconf automake make g++`
([`docs/environment_setup_guide.md`](https://github.com/ROCm/TheRock/blob/main/docs/environment_setup_guide.md)),
none of which pull in Tcl. The failure therefore only appears on a lean
Debian/Ubuntu-based build image.

## Technical Details

Take the pre-generated amalgamation archive published on sqlite.org
(`https://www.sqlite.org/<year>/sqlite-amalgamation-<version>.zip`), verified
against a pinned SHA256, instead of generating it from a git checkout.

That is the same C source `make sqlite3.c` emits, so this is behaviour-preserving:
the resulting `profiler-hub-sqlite3-static` target, its compile definitions, and
the `-fvisibility=hidden` symbol sealing from #6979 are all unchanged. What goes
away is the need for Tcl, autoconf and make, plus a 2162-file clone during
configure.

The git checkout + autotools route is **kept as a fallback** for environments that
can reach github.com but not sqlite.org. It is now preceded by an explicit
`tclsh` check, so if both routes are unavailable the error names the missing tool
and the packages that provide it, rather than surfacing an opaque `rc=2`.

This generalises to all platforms the approach #8189 already takes for Windows,
and deliberately reuses that PR's `SQLITE3_AMALGAMATION_YEAR` cache variable
naming so the two changes are straightforward to reconcile.

New/changed cache variables:

| variable | default | purpose |
|---|---|---|
| `SQLITE3_AMALGAMATION_URL_BASE` | `https://www.sqlite.org` | archive host, overridable for mirrors |
| `SQLITE3_AMALGAMATION_YEAR` | `2024` | release-year path component |
| `SQLITE3_AMALGAMATION_SHA256` | pinned | integrity check; empty disables |
| `SQLITE3_GIT_URL` / `SQLITE3_GIT_TAG` | unchanged | now describe the fallback source |

## Issue Tracking

Fixes #10059

## Test Plan

Reproduction and verification were done on a clean `ubuntu:24.04` image with no
`tcl` package, configuring `profilers/profiler-hub` standalone — no ROCm, no
TheRock and no GPU required:

```bash
docker run --rm ubuntu:24.04 bash -lc '
set -e
apt-get update -qq
DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
    git cmake ninja-build build-essential ca-certificates autoconf automake
cd /tmp && git init -q rs && cd rs
git remote add origin https://github.com/ROCm/rocm-systems.git
git fetch -q --filter=blob:none --depth 1 origin <ref>
git sparse-checkout init --cone
git sparse-checkout set profilers/profiler-hub
git checkout -q FETCH_HEAD
cmake -S /tmp/rs/profilers/profiler-hub -B /tmp/phb -GNinja
cmake --build /tmp/phb --target profiler-hub-sqlite3-static
'
```

Three runs: `develop` without Tcl (reproduce), `develop` **with** `tcl` added to
the apt list (A/B control), and this branch without Tcl (fix).

## Test Result

**1. `develop`, no Tcl — reproduces:**

```
tclsh: ABSENT
CMake Error at cmake/sqlite3.cmake:92 (message):
  [profiler-hub] SQLite3 amalgamation generation failed (rc=2)
Call Stack (most recent call first):
  CMakeLists.txt:137 (include)
-- Configuring incomplete, errors occurred!
```

**2. `develop`, identical recipe with `tcl` added — A/B control, passes:**

```
tclsh: /usr/bin/tclsh
-- Configuring done (26.3s)
-- Generating done (0.0s)
```

This isolates `tclsh` as the sole blocker: nothing else about the environment
changed between runs 1 and 2.

**3. This branch, no Tcl — passes:**

```
tclsh: ABSENT
-- [profiler-hub] Downloading SQLite3 3.45.3 amalgamation from https://www.sqlite.org/2024/sqlite-amalgamation-3450300.zip
-- [profiler-hub] SQLite3 amalgamation source: /tmp/phb/external/sqlite3
-- Configuring done (11.0s)
-- Generating done (0.0s)
[1/2] Building C object CMakeFiles/profiler-hub-sqlite3-static.dir/external/sqlite3/sqlite3.c.o
[2/2] Linking C static library lib/libprofiler-hub-sqlite3-static.a
```

The SQLite3 step also gets cheaper: ~26s to ~11s, since the clone and autotools
run are gone.

## Out of scope

Two related defects were found in the same code path while investigating. Both
are recorded in #10059 and deliberately **not** addressed here, to keep this
change reviewable:

1. `ROCPROFSYS_BUILD_SQLITE3=OFF` is silently ignored — TheRock passes it and
   provides SQLite3 to the subproject, but `profiler-hub` bundles its own copy
   unconditionally. #8189's opt-in `PROFILER_HUB_USE_SYSTEM_SQLITE3` would be a
   natural thing for `ProfilerHub.cmake` to forward.
2. `ProfilerHub.cmake` sparse-checkouts `profilers/profiler-hub` from
   `github.com/ROCm/rocm-systems` at a hard-coded commit — the same repository
   `rocprofiler-systems` lives in — so a monorepo/superbuild checkout compiles a
   *different* revision of profiler-hub than the one on disk, and configure gains
   a hard network dependency. Tracked upstream by ROCm/TheRock#6922 and
   ROCm/TheRock#6734.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.

---

*AI tool use disclosure: this change was investigated, authored and tested with
the assistance of Claude (Anthropic), per the AI tool use policy in
`CONTRIBUTING.md`. Every console excerpt above was executed and pasted verbatim.
A human contributor is the author of record and is accountable for the change.*
