### PR TITLE
[kpack] Unlink existing destination before copy2 in the artifact splitter

### DIFF
--- a/shared/kpack/python/rocm_kpack/artifact_splitter.py
+++ b/shared/kpack/python/rocm_kpack/artifact_splitter.py
@@ -214,7 +214,13 @@ class GenericCopyVisitor:
                 dest_path.unlink()
             os.symlink(link_target, dest_path)
         else:
-            # Copy regular file
+            # Copy regular file. Unlink any existing destination first (as the
+            # symlink branch above already does) so copy2 creates a file owned by
+            # the current user. Otherwise copy2's copystat() chmod/utime fails
+            # with EPERM when re-driving an artifacts tree whose destination is
+            # owned by another user.
+            if dest_path.exists() or dest_path.is_symlink():
+                dest_path.unlink()
             shutil.copy2(file_path, dest_path)
         self.copied_count += 1
 
@@ -676,9 +682,14 @@ class ArtifactSplitter:
                 # Create parent directories
                 dest_path.parent.mkdir(parents=True, exist_ok=True)
 
-                # Copy the file (will move after generic is created)
+                # Copy the file (will move after generic is created). Unlink any
+                # existing (possibly not-owned) destination first so copy2's
+                # copystat() chmod/utime does not EPERM when re-driving an
+                # artifacts tree whose destination is owned by another user.
                 if self.verbose:
                     print(f"    Moving: {rel_path}")
+                if dest_path.exists() or dest_path.is_symlink():
+                    dest_path.unlink()
                 shutil.copy2(file_path, dest_path)
 
             # Update or create artifact manifest for this architecture artifact

--- a/shared/kpack/tests/test_artifact_splitter_integration.py
+++ b/shared/kpack/tests/test_artifact_splitter_integration.py
@@ -760,6 +760,91 @@ class TestArtifactSplitterIntegration:
         # Verify the symlink chain works (can resolve to real file)
         assert (generic_lib_dir / "librocrand.so").resolve().name == "librocrand.so.1.1"
 
+    def test_split_never_copies_onto_existing_destination(self, toolchain, tmp_path):
+        """
+        Re-driving a split into an output tree that already has content must not
+        copy2() onto a pre-existing destination file.
+
+        shutil.copy2() calls copystat(), which chmod/utimes the destination. If
+        the destination already exists and is owned by a *different* user - the
+        case when a prebuilt artifacts tree is re-driven by another user, e.g. a
+        container build whose tree was staged by another UID - those calls fail
+        with EPERM ("Operation not permitted") and the split aborts, even though
+        the file contents themselves are writable.
+
+        Creating a second UID requires root, so rather than reproduce the
+        ownership itself this test asserts the invariant that makes the failure
+        impossible: every destination is unlinked before copy2() runs, exactly as
+        the symlink branch of GenericCopyVisitor.visit_file() already does.
+
+        Covers both copy2() call sites: GenericCopyVisitor.visit_file() (regular
+        files) and ArtifactSplitter.process_database_files() (database files).
+        """
+        input_dir = tmp_path / "test_artifact"
+        input_dir.mkdir()
+
+        prefix = "math-libs/BLAS/rocBLAS/stage"
+        write_artifact_manifest(input_dir, [prefix])
+
+        lib_dir = input_dir / prefix / "lib"
+        lib_dir.mkdir(parents=True)
+        (lib_dir / "libtest.so").write_text("mock host library")
+
+        # A database file exercises the second copy2() call site.
+        db_dir = lib_dir / "rocblas" / "library"
+        db_dir.mkdir(parents=True)
+        (db_dir / "TensileLibrary_gfx1100.dat").write_text("mock tensile data")
+
+        output_dir = tmp_path / "output"
+
+        def make_splitter():
+            return ArtifactSplitter(
+                artifact_prefix="blas_lib",
+                toolchain=toolchain,
+                database_handlers=[RocBLASHandler()],
+                verbose=False,
+            )
+
+        # First split populates the output tree.
+        make_splitter().split(input_dir, output_dir)
+
+        generic_lib = output_dir / "blas_lib_generic" / prefix / "lib" / "libtest.so"
+        arch_db = (
+            output_dir
+            / "blas_lib_gfx1100"
+            / prefix
+            / "lib/rocblas/library/TensileLibrary_gfx1100.dat"
+        )
+        assert generic_lib.exists(), "first split should populate the generic artifact"
+        assert arch_db.exists(), "first split should populate the per-arch artifact"
+
+        # Second split re-drives the same output tree. Emulate a destination
+        # owned by another user: copystat() on an existing destination raises
+        # EPERM. If the splitter unlinks first, this never triggers.
+        real_copy2 = shutil.copy2
+        copied_onto_existing = []
+
+        def guarded_copy2(src, dst, *args, **kwargs):
+            if Path(dst).exists() or Path(dst).is_symlink():
+                copied_onto_existing.append(str(dst))
+                raise PermissionError(1, "Operation not permitted")
+            return real_copy2(src, dst, *args, **kwargs)
+
+        with patch.object(shutil, "copy2", guarded_copy2):
+            make_splitter().split(input_dir, output_dir)
+
+        assert not copied_onto_existing, (
+            "copy2() was called onto pre-existing destination(s), which EPERMs in "
+            "copystat() when the destination is owned by another user: "
+            f"{copied_onto_existing}"
+        )
+
+        # The re-driven split still produces correct output.
+        assert generic_lib.exists()
+        assert generic_lib.read_text() == "mock host library"
+        assert arch_db.exists()
+        assert arch_db.read_text() == "mock tensile data"
+
     def test_overlay_produces_merged_kpack_directory(
         self, test_assets_dir, toolchain, tmp_path
     ):


### PR DESCRIPTION
Fixes #10067.

## Problem

`rocm_kpack`'s artifact splitter aborts with `PermissionError: [Errno 1] Operation not permitted` when it copies a file onto a destination that already exists and is owned by a **different user**:

```
File "rocm_kpack/artifact_splitter.py", line 218, in visit_file
    shutil.copy2(file_path, dest_path)
File "/usr/lib/python3.12/shutil.py", line 476, in copy2
    copystat(src, dst, follow_symlinks=follow_symlinks)
File "/usr/lib/python3.12/shutil.py", line 384, in copystat
    lookup("utime")(dst, ns=(st.st_atime_ns, st.st_mtime_ns),
PermissionError: [Errno 1] Operation not permitted
```

`shutil.copy2()` is `copyfile()` **plus** `copystat()`, and `copystat()` calls `os.utime()` and `os.chmod()` on the destination. Write permission on a file is not sufficient for either: `utimes(2)` with explicit timestamps and `chmod(2)` both require the caller to *own* the file (or hold `CAP_FOWNER`), otherwise the kernel returns `EPERM`. So when the destination already exists and belongs to another user, the contents copy fine and then the metadata step kills the whole split.

This bites whenever a prebuilt artifacts tree is re-driven by a different UID than the one that staged it — a container image shipping a populated artifacts tree that is then run as another user, or a shared build tree re-used across CI accounts.

Two `shutil.copy2()` call sites on `develop` write onto a destination without removing what is already there:

| line | context |
|---|---|
| 218 | `GenericCopyVisitor.visit_file()` — regular-file copy into the generic artifact |
| 682 | `ArtifactSplitter.process_database_files()` — database-file copy into the per-arch artifact |

The symlink branch four lines above line 218 **already** unlinks the destination first; the regular-file path is simply inconsistent with the branch it sits next to.

## Change

Unlink any existing destination before `copy2()` at both call sites, so `copy2()` always creates a file owned by the current user. The condition matches the adjacent symlink branch — `exists() or is_symlink()` rather than `exists()` alone — which additionally stops `copy2()` from following a **dangling** symlink at the destination and writing outside the artifact tree (`Path.exists()` follows symlinks and is `False` for a broken one).

This also makes the copy idempotent in the ordinary same-user case: the file is created fresh rather than having its contents overwritten in place.

## Test

`test_split_never_copies_onto_existing_destination` in `tests/test_artifact_splitter_integration.py`.

Creating a second UID requires root, so instead of reproducing the foreign ownership the test asserts the invariant that makes the failure impossible: neither `copy2()` call site is ever invoked onto a destination that already exists. It splits once to populate the output tree, then re-drives the same split with `shutil.copy2()` wrapped so that it raises `PermissionError(EPERM)` if the destination is already present — exactly what the kernel does when the destination belongs to another user. The artifact carries both a regular library and a rocBLAS database file so both call sites are covered.

## Verification

Two-UID reproduction from #10067, run in a clean `ubuntu:24.04` container against `develop` @ `291668f` — `alice` stages and splits an artifacts tree with `umask 002`, then `bob` (same group, tree group-writable) re-drives the identical split:

```
before:  Error: [Errno 1] Operation not permitted      EXIT=1
after:   Splitting complete!                            EXIT=0
```

with the output files afterwards owned by `bob` rather than `alice`. The second call site was reproduced the same way via `--split-databases rocblas`, failing at line 682 before the change (`process_database_files()` runs before `copy_generic_artifact()`) and succeeding after.

Full kpack suite in that container, `pytest tests/ --ignore=tests/test_wheel_splitter.py`:

| | result |
|---|---|
| `develop` + new test | `158 failed, 314 passed, 4 skipped` |
| this branch | `157 failed, 315 passed, 4 skipped` |

Exactly one test moves from fail to pass — the regression test added here. No new failures. The pre-existing failures are environmental in that container, not related to this change: the test assets are Git LFS pointers in a blobless sparse clone, and `clang-offload-bundler` / `file` are not installed. `test_wheel_splitter.py` is excluded because it requires `rocm-bootstrap`.

## Notes

- No file overlap with #10060 (`artifact_utils.py`, `binutils.py`, `elf/surgery.py`, `elf_test_utils.py`, `test_artifact_utils.py`, `test_binutils.py`); this branch touches only `artifact_splitter.py` and `test_artifact_splitter_integration.py`, and is based on `develop`, not on that branch.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.

---

*AI tool use disclosure: this change was upstreamed with the assistance of Claude (Anthropic). The two-UID reproduction, the `EPERM`-vs-`EACCES` distinction, both tracebacks and the test results above were run and checked by hand.*

