### PR TITLE
ci(rccl): fix the perf gate's concurrency, artifact paths, and PR comment

### DIFF
--- a/.github/workflows/rccl_perf_regression.yml
+++ b/.github/workflows/rccl_perf_regression.yml
@@ -1,81 +1,49 @@
 # RCCL paired A/B perf-regression gate.
 #
-# DEPLOYMENT: RCCL now lives in the ROCm/rocm-systems monorepo at projects/rccl.
-# This file belongs in that repo at
-#   .github/workflows/rccl_perf_regression.yml
-# It runs on self-hosted org runners (org: ROCm) registered on a GPU-less Slurm
-# submit host, one per role:
-#   rccl-build    tw-gfx950-ainic-ROCm-scale-rccl-build-1
-#   rccl-detect   tw-gfx950-ainic-ROCm-scale-rccl-detect-1
-# (the names retain a gfx950 prefix for consistency with the older GPU runner;
-# these hosts have no GPUs). They must NOT carry the
-# tw-gfx950-ainic-ROCm-scale-runner label, or they will be handed GPU jobs they
-# cannot run. The `report` job needs no Slurm access and runs on ubuntu-latest.
+# build submits a Slurm job that compiles librccl.so twice -- reference at the
+# merge-base, candidate at the PR head. detect runs the A/B detector on those
+# two libraries over a pinned 4-node allocation. report posts the verdict.
 #
-# Those runners were registered with --no-default-labels, so each carries ONLY
-# its role label -- no self-hosted, Linux or X64. That is why the runs-on lists
-# below name the role label alone; see the long note on the build job.
-# The `paths` filter keeps the gate scoped to RCCL-only changes in the monorepo;
-# build_rccl.sh auto-detects the projects/rccl cmake subdir in the checkout.
+# build and detect run on self-hosted runners that are Slurm submit clients with
+# no GPUs of their own, one per role, labelled `rccl-build` and `rccl-detect`.
+# Those runners are registered with --no-default-labels, so each carries its
+# role label and NOTHING else -- no self-hosted, Linux or X64 -- which is why
+# every runs-on below names a single label. report needs no cluster access and
+# runs on ubuntu-latest.
 #
-# The Slurm submit/poll/report scripts these steps call
-# (rccl_build.sbatch, rccl_ab.sbatch, submit_and_poll.sh, format_report.py,
-# sbatch/lib/*.sh) are version-controlled in ROCm/cvs, on a branch with further
-# related changes landing before it merges to main:
-#   https://github.com/ROCm/cvs/tree/aimvt-196-rccl-regression-robustness/ci/rccl_perf_gate
+# The Slurm scripts these steps call (rccl_build.sbatch, rccl_ab.sbatch,
+# submit_and_poll.sh, format_report.py, sbatch/lib/*.sh) live in ROCm/cvs and
+# version independently of this file.
 #
-# Flow per PR:
-#   1. Check out PR head with full history (merge-base resolution needs it).
-#   2. [build job] rccl_build.sbatch: build librccl.so for reference (merge-base)
-#      and candidate (PR head) on a single build node, then template their lib
-#      dirs into this run's config. This is a single-node CPU compile with no
-#      RDMA/MPI involved, so it runs under its own concurrency lock instead of
-#      the detect lock below -- it no longer holds all 4 nodes idle for its
-#      duration. Rev-keyed build caching usually makes it seconds, not minutes.
-#   3. [detect job] rccl_ab.sbatch: pre-flight the A/B transport capabilities,
-#      then run the detector on the pinned 4-node set.
-#   4. format_report.py: render verdict to the job summary + PR comment.
-#   5. Advisory mode: job fails hard only on infra/polling errors, not on
-#      a detected regression yet (see PR description).
+# Advisory mode: the gate fails on infrastructure errors and on a run that could
+# not measure, but not yet on a regression it did measure.
 name: RCCL Perf Regression Gate
 
 on:
   pull_request:
-    # This matches the PR's BASE branch, not its head -- the gate runs on
-    # anything merging INTO main or develop, whatever the topic branch is
-    # called. Widening this list is not free: each entry multiplies the PRs
-    # eligible for a ~25min slot on a 4-node reservation the whole team shares.
+    # The PR's BASE branch, not its head. Widening this list is not free: each
+    # entry multiplies the PRs eligible for a ~25min slot on a 4-node
+    # reservation the whole team shares.
     branches: [main, develop]
     paths:
       - 'projects/rccl/**'
-      # Docs-only and test-only churn cannot move a collective's bandwidth, and
-      # every spurious trigger costs a ~25min slot on a 4-node reservation that
-      # the whole team shares. Exclude what cannot affect the measurement.
+      # Churn that cannot move a collective's bandwidth. Kept in sync by hand
+      # with the filter in `Detect changed paths` -- both must exclude the same
+      # set, or a docs PR buys a 4-node measurement.
       - '!projects/rccl/**/*.md'
       - '!projects/rccl/docs/**'
       - '!projects/rccl/LICENSE*'
       - '!projects/rccl/**/CODEOWNERS'
       - '.github/workflows/rccl_perf_regression.yml'
-  # Allow manual dispatch for exercising the pipeline without a PR.
+  # Manual dispatch, for exercising the pipeline without a PR.
   #
-  # DO NOT dispatch with the defaults expecting a verdict. ci_detect_prod.json
-  # is a detect-mode config whose reference and candidate both resolve to
-  # builds/_fixed/lib, so the detector's identical-sides guard correctly refuses
-  # it: the run would compare a build against itself and report a guaranteed,
-  # meaningless PASS. You get ~26min on four nodes and an untrustworthy report.
-  # (The note that used to sit here promised exactly that A=A run. It predates
-  # the guard.)
-  #
-  # To smoke the pipeline end to end, pass a control_mode=true config -- it is
-  # the supported way to ask for A==A, and it yields usable run-to-run noise
-  # data instead of a non-answer:
+  # DO NOT dispatch with the default config expecting a verdict: both its sides
+  # resolve to the same prebuilt library, and the detector's identical-sides
+  # guard refuses that -- ~26min on four nodes for an untrustworthy report. To
+  # smoke the pipeline, pass a control_mode=true config, which is the supported
+  # way to ask for A==A and yields usable run-to-run noise data:
   #
   #   config=$RCCL_CI_ROOT/configs/ci_control_prod8.json
-  #
-  # That file is ci_detect_prod.json with control_mode flipped and nothing else
-  # changed, so it exercises the production matrix rather than a drifted
-  # sibling. Verified by a control dispatch on 2026-08-27: 8/8 groups scored,
-  # trustworthy, 0 regressions, 184 comparison keys, ~26min.
   workflow_dispatch:
     inputs:
       config:
@@ -91,22 +59,16 @@ env:
   RCCL_CI_ROOT: /it-share/rccl-ci
   SLURM_RESERVATION: rccl_ci
   NODELIST: mia1-p01-g[22,26,28,32]
-  # The build deliberately does NOT run in SLURM_RESERVATION. It is a
-  # single-node CPU compile, but it takes its node --exclusive for up to an
-  # hour and is submitted with `sbatch --wait`, so running it inside the 4-node
-  # detect reservation held a quarter of the detect pool while detect was
-  # waiting for all four -- build and detect serialised against each other for
-  # no reason. rccl_dev is a separate pool, so a build and a detect run can now
-  # overlap. Set to an empty string to submit the build to the general
-  # partition instead.
+  # A separate pool, deliberately not SLURM_RESERVATION. The build is one CPU
+  # compile, but it holds its node --exclusive for up to an hour, so submitting
+  # it into the 4-node detect reservation serialised build against detect for no
+  # reason. Empty string submits to the general partition instead.
   SLURM_BUILD_RESERVATION: rccl_dev
-  # Per-run workspace isolation: every run gets its own cvs worktree, cvs-sbatch
-  # copy, build output, config, artifacts and logs under runs/<run_key>/.
-  # run_key is derived from GITHUB_RUN_ID, which is how the build job and the
-  # detect job below find the same workspace. This is the default in
-  # workspace.sh now; it is stated explicitly here because it is the single
-  # switch that makes concurrent runs safe, and a reader of this file should not
-  # have to go read a bash library to discover that.
+  # Per-run isolation: each run gets its own cvs worktree, build output, config,
+  # artifacts and logs under runs/<run_key>/, keyed on GITHUB_RUN_ID -- which is
+  # also how build and detect find the same workspace. Already the default in
+  # workspace.sh; stated here because it is the single switch that makes
+  # concurrent runs safe.
   RCCL_CI_WORKSPACE: '1'
 
 permissions:
@@ -115,61 +77,37 @@ permissions:
 
 jobs:
   build:
-    # Forked PRs cannot run this workflow: it builds and MPI-executes the PR's
-    # own source on a self-hosted runner, so arbitrary fork code would get
-    # arbitrary code execution on our infrastructure. Scope to same-repo PRs
-    # only; workflow_dispatch is unaffected (it already requires repo write
-    # access to trigger).
+    # Same-repo PRs only. This job builds and MPI-executes the PR's own source
+    # on a self-hosted runner, so a fork PR would be arbitrary code execution on
+    # our infrastructure. workflow_dispatch already requires repo write access.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    # SCOPED PER PR -- this is the fix for the "1 active + 1 queued" starvation.
+    # Keyed per PR. A concurrency group holds at most ONE pending job, so a
+    # single global group meant a third run cancelled whoever was queued --
+    # cross-PR starvation, and the author saw no error, just a vanished run.
+    # Keying by PR keeps the useful half (a new push still evicts your own older
+    # queued run) and leaves hardware serialisation to Slurm, whose queue is
+    # unbounded and which owns the nodes.
     #
-    # A GitHub Actions concurrency group holds at most ONE pending job. When a
-    # third run arrives, the pending one is CANCELLED to make room. With a single
-    # global group that meant PR #3 silently killed PR #2's queued run: the team
-    # saw runs vanish with no explanation and had to re-push to get them back.
-    #
-    # Keying the group by PR removes cross-PR contention entirely, and keeps the
-    # useful half of the old behaviour within a PR: push three times in a row and
-    # the newest push still evicts the older queued one, because they share a key.
-    #
-    # Serialisation of the actual hardware now happens where it belongs -- in
-    # Slurm, whose queue is unbounded and which is the real owner of the pinned
-    # nodes. Slurm queues; it does not curbstomp.
-    #
-    # cancel-in-progress stays FALSE deliberately. Cancelling a GitHub job does
-    # not cancel the Slurm job it submitted, so a true here would orphan
-    # allocations that keep holding nodes. Enabling it needs the scancel trap
-    # tracked as part of the submit/--wait work.
+    # cancel-in-progress stays FALSE: cancelling a GitHub job does not cancel
+    # the Slurm job it submitted, so true here would orphan allocations that go
+    # on holding nodes.
     concurrency:
       group: rccl-perf-gate-build-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: false
-    # Own runner label. This job needs no GPUs and no RDMA -- it is a Slurm
-    # submit-and-poll client -- and it targets SLURM_BUILD_RESERVATION, a
-    # different node pool from detect's. Sharing one label with detect meant a
-    # ~9min build queued behind a ~37min detect, or behind a GIN run that can
-    # hold a runner for 5h, for no reason at all. One runner per role today;
-    # changing that count is a registration change on the runner host, not an
-    # edit here.
+    # Its own label, because this job targets a different node pool than detect
+    # and needs neither GPUs nor RDMA. Sharing one label made a ~9min build
+    # queue behind a ~37min detect for no reason.
     #
-    # Deliberately NOT [self-hosted, rccl-build]. runs-on is an AND across the
-    # list, and these runners were registered with --no-default-labels: they
-    # carry their role label and nothing else -- no self-hosted, no Linux, no
-    # X64. Asking for self-hosted as well matches no runner at all, and the
-    # failure is silent in the worst way: the job sits queued while the runner
-    # sits Idle, until timeout-minutes below kills it. Confirmed by dispatch on
-    # 2026-08-26: build sat queued 8min with runner_name empty, while all three
-    # role runners showed Idle and had never run a single job since they were
-    # registered on 2026-08-19.
-    #
-    # The role label is unique to these hosts, so it is sufficient by itself.
-    # If they are ever re-registered with default labels, self-hosted may be
-    # added back, but it buys nothing.
+    # Deliberately NOT [self-hosted, rccl-build]: runs-on is an AND across the
+    # list, and these runners carry only their role label. Asking for
+    # self-hosted too matches no runner, and it fails in the worst way -- the
+    # job sits queued against an Idle runner until timeout-minutes kills it,
+    # with no unmatched-label diagnostic anywhere.
     runs-on: [rccl-build]
-    # Was 60, the same as rccl_build.sbatch's own --time=01:00:00, which left no
-    # room for queue time: a build that waited 20min for a node and then
-    # compiled for 13 was killed here at 60 even though Slurm was happy. Sit
-    # above the Slurm wall clock so Slurm is the one that decides a build has
-    # run too long, and this job only fires if the queue itself is wedged.
+    # Above rccl_build.sbatch's own --time=01:00:00, so Slurm decides a build ran
+    # too long and this only fires if the queue itself is wedged. At 60 -- equal
+    # to the Slurm limit -- a build that queued and then compiled normally was
+    # killed here while the scheduler was still happy.
     timeout-minutes: 120
     outputs:
       config_json: ${{ steps.resolve.outputs.config_json }}
@@ -202,33 +140,25 @@ jobs:
       - name: Detect changed paths
         id: paths
         if: github.event_name == 'pull_request'
-        # FAIL CLOSED. The old form ended in `|| echo "rccl_changed=0"`, which
-        # swallowed every possible failure of the git command -- a shallow clone,
-        # a missing base ref, a fetch that didn't complete -- and reported "RCCL
-        # didn't change". BUILD_RCCL then stayed 0, so the detect job ran with
-        # reference and candidate both pointing at the fixed prebuilt lib, found
-        # zero regressions (it was comparing a library to itself), and posted a
-        # green check on a PR that had never been measured. A gate that reports
-        # PASS when its own inputs are broken is worse than no gate.
-        #
-        # So: distinguish "the diff succeeded and matched nothing" (0, skip the
-        # build, legitimately nothing to measure) from "the diff failed" (error
-        # out and let the job fail visibly).
+        # FAIL CLOSED. Distinguish "the diff ran and matched nothing" (0, skip
+        # the build) from "the diff failed" (error out visibly). Swallowing a
+        # git failure into rccl_changed=0 makes detect compare the prebuilt
+        # library against itself and post green on a PR it never measured -- a
+        # gate that reports PASS when its own inputs are broken is worse than no
+        # gate at all.
         run: |
           set -o pipefail
           if ! diff_out="$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")"; then
             echo "::error::Could not diff against origin/${{ github.base_ref }}. Refusing to guess whether RCCL changed — a wrong guess here produces a meaningless green gate."
             exit 1
           fi
-          # Mirror the `paths` exclusions above. Without this, a PR touching
-          # this workflow file (itself a trigger path) alongside a doc under
-          # projects/rccl/ matches ^projects/rccl/ and buys a full compile plus
-          # a ~25min 4-node detect on source that did not change.
+          # Mirror the `paths` exclusions above, or a PR touching this workflow
+          # file (itself a trigger path) alongside an RCCL doc buys a compile
+          # plus a ~25min 4-node detect on source that did not change.
           #
-          # `|| true` scopes only to the filter -- a grep matching nothing exits
-          # 1, which is not an error here. It must not extend to the git diff
-          # above, which is exactly the swallowed failure this step exists to
-          # prevent.
+          # `|| true` covers the filter only -- a grep matching nothing exits 1,
+          # which is fine here. It must not reach the git diff above; that is
+          # the swallowed failure this step exists to prevent.
           rccl_src="$(grep '^projects/rccl/' <<<"${diff_out}" \
             | grep -vE '(\.md$|^projects/rccl/docs/|^projects/rccl/LICENSE|/CODEOWNERS$)' || true)"
           if [[ -n "${rccl_src}" ]]; then
@@ -246,14 +176,11 @@ jobs:
           _CONFIG: ${{ inputs.config || format('{0}/configs/ci_detect_prod.json', env.RCCL_CI_ROOT) }}
         run: |
           if [[ "${BUILD_RCCL}" == "1" ]]; then
-            # Give every run its own copy of the config rather than templating
-            # the shared prod file in place: with the locks split, another PR's
-            # build can be running while this PR waits on detect, and in-place
-            # templating would let one clobber the other's lib paths.
-            #
-            # In workspace mode this copy is only the handoff vehicle -- the
-            # build stages it into runs/<run_key>/config.json and templates
-            # THAT, so the shared configs/ dir is never written by a run.
+            # Per-run copy, not in-place templating of the shared prod file:
+            # with the locks split, another PR's build can run while this one
+            # waits on detect, and each would clobber the other's lib paths.
+            # In workspace mode this copy is only the handoff vehicle; the build
+            # stages it into runs/<run_key>/config.json and templates that.
             RUN_CONFIG="${RCCL_CI_ROOT}/configs/ci_detect_run_${{ github.run_id }}.json"
             cp "${_CONFIG}" "${RUN_CONFIG}"
             # Set the output before sbatch runs (not after) so the cleanup-on-
@@ -266,19 +193,15 @@ jobs:
             if [[ -n "${SLURM_BUILD_RESERVATION:-}" ]]; then
               build_res=(--reservation="${SLURM_BUILD_RESERVATION}")
             fi
-            # `sbatch --wait` on its own leaks the allocation. Killing the
-            # sbatch client does not cancel the job it submitted, so when this
-            # step is stopped -- timeout-minutes, a cancelled run, a runner
-            # restart -- the build keeps going and keeps its node --exclusive
-            # until its 1h wall clock runs out, with nobody left to read the
-            # result. submit_and_poll.sh already learned this lesson for the
-            # detect job; the build needs the same trap.
+            # `sbatch --wait` alone leaks the allocation: killing the client
+            # does not cancel the job, so a timeout or a cancelled run leaves
+            # the build holding its node --exclusive for the rest of its wall
+            # clock with nobody left to read the result.
             #
-            # --parsable makes sbatch print the job id on submission and then
-            # block as usual, so run it in the background, read the id out of
-            # its output, and `wait` for the real exit status. That keeps
-            # --wait's exit-code mapping (which is the reason to use it) while
-            # giving the trap something to scancel.
+            # --parsable prints the job id on submission and then blocks as
+            # usual, so background it, scrape the id, and `wait` for the real
+            # status. That keeps --wait's exit-code mapping while giving the
+            # trap something to scancel.
             sb_out="$(mktemp)"
             build_job=""
             cleanup_build() {
@@ -299,9 +222,9 @@ jobs:
               "${RCCL_CI_ROOT}/cvs/ci/rccl_perf_gate/sbatch/rccl_build.sbatch" >"${sb_out}" 2>&1 &
             sb_pid=$!
 
-            # The id lands in the first line within a second of submission. Give
-            # it 30s, but do not fail if it never shows -- an sbatch that could
-            # not submit has nothing to cancel, and `wait` below reports why.
+            # The id lands in the first line within a second. Give it 30s, but
+            # do not fail if it never shows: an sbatch that could not submit has
+            # nothing to cancel, and `wait` below reports why.
             for _ in $(seq 1 30); do
               build_job="$(grep -m1 -oE '^[0-9]+' "${sb_out}" 2>/dev/null || true)"
               [[ -n "${build_job}" ]] && break
@@ -327,10 +250,9 @@ jobs:
           fi
 
       - name: Clean up per-run config copy on build failure
-        # Covers the case the detect job's own cleanup step can't: if sbatch
-        # fails after the per-run config copy was made, `detect` never runs
-        # (needs: build), so nothing else removes this file from NFS.
-        # cancelled() is included because a cancelled run skips detect too.
+        # Only on the paths where detect never runs at all (needs: build), so
+        # there will be no re-run that still wants this file. Everything else is
+        # left to the janitor above -- see the note in `detect`, before its gate.
         if: failure() || cancelled()
         env:
           _CONFIG: ${{ steps.resolve.outputs.config_json }}
@@ -341,67 +263,45 @@ jobs:
 
   detect:
     needs: build
-    # Two conditions, and the second is the interesting one.
-    #
-    # Skip detect on a PR that changed nothing under projects/rccl (the workflow
-    # file itself is in the paths filter, so this happens). With BUILD_RCCL=0 both
-    # sides of the comparison point at the same prebuilt library, so the run would
-    # measure a build against itself and report a guaranteed, meaningless PASS
-    # after holding the 4-node reservation for ~25 minutes. A skipped job is an
-    # honest "not applicable"; a green check on an A=A run is a lie that costs
-    # hardware to tell. The detector now refuses such runs on its own too -- this
-    # just avoids queueing them in the first place.
+    # Same-repo guard as build, plus: skip a PR that changed no RCCL source
+    # (this workflow file is itself a trigger path, so that happens). With
+    # BUILD_RCCL=0 both sides point at the same prebuilt library, so the run
+    # would hold the 4-node reservation for ~25min to compare a build against
+    # itself and report a guaranteed PASS. A skipped job is an honest "not
+    # applicable"; a green check on an A=A run is a lie that costs hardware to
+    # tell. The detector refuses such runs too -- this avoids queueing them.
     if: >-
       (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
       && (github.event_name != 'pull_request' || needs.build.outputs.rccl_changed == '1')
-    # Also scoped per PR -- see the long note on the build job's lock. The pinned
-    # 4-node set is still used by exactly one job at a time; that is enforced by
-    # Slurm (--nodelist + --exclusive), which queues rather than cancelling.
-    # Holding a global GitHub lock here as well bought nothing and cost every
-    # third PR its queued run.
-    #
-    # Never cancel-in-progress: a running allocation must finish cleanly to
-    # release the nodes, and a cancelled GitHub job leaves the Slurm job running.
+    # Per PR, and never cancel-in-progress -- same reasoning as build's lock.
+    # Slurm (--nodelist + --exclusive) already admits one detect at a time, so a
+    # global GitHub lock here bought nothing and cost every third PR its run.
     concurrency:
       group: rccl-perf-gate-detect-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: false
-    # Own runner label; see the note on the build job. Exactly one detect runner
-    # exists, which matches the hardware -- the pinned 4-node set admits one
-    # detect at a time regardless. A second runner would not add throughput; it
-    # would only move a waiting PR out of GitHub's runner queue (unbounded, and
-    # invisible to the timeout nest below, since timeout-minutes does not start
-    # until a runner is assigned) and into Slurm's, which is logged and bounded
-    # by MAX_QUEUE_SEC. Worth doing once there is queue data to justify it.
-    #
-    # Role label only, no self-hosted -- same reason as the build job above:
-    # these runners have no default labels, so an AND against self-hosted
-    # matches nothing and the job hangs until timeout instead of failing.
+    # Own role label, no self-hosted -- see the build job. One detect runner
+    # matches the hardware, since the pinned 4-node set admits one detect at a
+    # time regardless; a second would only move the wait from GitHub's runner
+    # queue into Slurm's, where at least it is logged and bounded.
     runs-on: [rccl-detect]
-    # Outermost layer of the timeout nest. Must stay above MAX_QUEUE_SEC (4h)
-    # plus MAX_WAIT_SEC (4h10m) in submit_and_poll.sh, so that script gets to
-    # cancel the Slurm job and report *why* rather than being killed here with
-    # a bare "exceeded the maximum execution time". See the table in
-    # submit_and_poll.sh; retune both together.
+    # Outermost layer of the timeout nest: above MAX_QUEUE_SEC (4h) plus
+    # MAX_WAIT_SEC (4h10m) in submit_and_poll.sh, so that script gets to cancel
+    # the Slurm job and report *why* rather than being killed here with a bare
+    # "exceeded the maximum execution time". 8h10 of inner budget, 8h20 here.
+    # Retune both together; the table is in submit_and_poll.sh.
     #
-    # 560 -> 500 because MAX_WAIT_SEC went 5h10m -> 4h10m when broadcast_perf
-    # was dropped from the matrix: at 8 groups the circuit-breaker worst case
-    # is 3.2h, so the sbatch --time is a real bound again at 4h. 4h00 queue +
-    # 4h10 run = 8h10, and this is 8h20. The nest last held these two values
-    # at 510; 500 keeps the +10min of slack 560 carried rather than the +20.
-    #
-    # This bounds the wedged case only -- it is not a capacity number. It does
-    # not bound how long a PR waits for a runner, because timeout-minutes does
-    # not start counting until a runner is assigned, so time spent queueing for
-    # rccl-detect is invisible to every timeout in this file.
+    # Bounds the wedged case only. It is not a capacity number, and it does not
+    # bound how long a PR waits for a runner -- timeout-minutes does not start
+    # until a runner is assigned, so that wait is invisible to every timeout in
+    # this file.
     timeout-minutes: 500
     steps:
       - name: Run A/B detector (pinned 4-node allocation)
         id: detect
-        # Don't fail here; we still want to post the report below -- the final
-        # "Gate" step enforces it based on the captured exit code below, not
-        # this step's outcome (continue-on-error reports "failure" the same
-        # way for a detected regression and for a polling error, so outcome
-        # alone can't tell them apart).
+        # Don't fail here -- the report below still needs to be rendered and
+        # uploaded. `Gate` enforces the verdict, branching on the captured exit
+        # code rather than this step's outcome, which reports "failure"
+        # identically for a detected regression and for a polling error.
         continue-on-error: true
         env:
           _CONFIG: ${{ needs.build.outputs.config_json }}
@@ -417,28 +317,22 @@ jobs:
         id: art
         if: always()
         # In workspace mode the detector writes to runs/<run_key>/artifacts, not
-        # to the shared ab_artifacts/. Reading the shared path would render a
-        # report left there by some earlier run and post it on this PR as if it
-        # were this run's verdict -- a stale green is the worst possible failure
-        # mode for a gate. Ask workspace.sh rather than re-deriving the run key
-        # here, so there is one source of truth for it; with the flag off it
-        # returns the legacy shared path and this line still holds.
+        # the shared ab_artifacts/. Ask workspace.sh rather than re-deriving the
+        # run key here, so there is one source of truth for it.
         run: |
           HELPER="${RCCL_CI_ROOT}/cvs/ci/rccl_perf_gate/sbatch/lib/workspace.sh"
           ART=""
           if [[ -f "${HELPER}" ]]; then
-            # Last line only: this goes to GITHUB_OUTPUT as a bare key=value,
-            # which has no multi-line form, so a banner on the helper's stdout
-            # would truncate the path and leak the rest as further outputs.
+            # Last line only: GITHUB_OUTPUT takes a bare key=value with no
+            # multi-line form, so a banner on the helper's stdout would truncate
+            # the path and leak the remainder as further output entries.
             ART="$(bash "${HELPER}" --print-artifacts 2>/dev/null | tail -n1)" || ART=""
           fi
           if [[ -z "${ART}" ]]; then
             if [[ "${RCCL_CI_WORKSPACE}" == "1" ]]; then
-              # Fail rather than guess. In workspace mode the detector writes to
-              # runs/<run_key>/artifacts; the legacy shared dir holds whatever an
-              # earlier run left there, so falling back would render another
-              # run's report as this PR's verdict. A stale green is the worst
-              # failure mode a gate has.
+              # Fail rather than guess. The shared dir holds whatever an earlier
+              # run left there, so falling back would render another run's
+              # report as this PR's verdict -- the worst failure a gate has.
               echo "::error::workspace.sh --print-artifacts is unavailable and RCCL_CI_WORKSPACE=1. Refusing to fall back to the shared artifact dir, whose contents belong to a different run. Update the cvs checkout on the cluster."
               exit 1
             fi
@@ -522,12 +416,10 @@ jobs:
             echo "${_REASONS}" >> "${GITHUB_STEP_SUMMARY}"
             exit 0
           fi
-          # Render into the artifact dir, not RUNNER_TEMP: upload-artifact@v4
-          # roots the archive at the least-common-ancestor of its paths, so a
-          # file from RUNNER_TEMP alongside files from NFS would push the LCA up
-          # to / and bury every entry under its full absolute path. Keeping all
-          # four under the same dir puts them at the artifact root, which is what
-          # the report job expects to find.
+          # Into the artifact dir, not RUNNER_TEMP: upload-artifact@v4 roots the
+          # archive at the least-common-ancestor of its paths, so mixing the two
+          # would push the LCA to / and bury every entry under its absolute
+          # path. Same dir for all four keeps them at the artifact root.
           python3 "${RCCL_CI_ROOT}/cvs/ci/rccl_perf_gate/format_report.py" \
             "${REPORT}" \
             --no-exit-code \
@@ -538,30 +430,24 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          # Namespaced per run -- with runs no longer serialised by a global
-          # lock, a fixed name would collide across concurrent runs.
-          #
-          # Deliberately NOT per attempt. "Re-run failed jobs" bumps run_attempt
-          # but does not re-run a `detect` that already succeeded, so an
-          # attempt-stamped name would leave `report` hunting for an artifact
-          # nobody uploaded and posting "not measured" over a good verdict.
-          # `overwrite` keeps the name resolving to the newest upload when
-          # detect itself is re-run; there is exactly one writer per run, so the
-          # parallel-writer hazard in the overwrite docs does not apply here.
+          # Per run, so concurrent runs cannot collide -- but deliberately NOT
+          # per attempt. "Re-run failed jobs" bumps run_attempt without re-running
+          # a `detect` that already succeeded, so an attempt-stamped name would
+          # leave `report` hunting for an artifact nobody uploaded and posting
+          # "not measured" over a good verdict. `overwrite` keeps the name
+          # resolving to the newest upload when detect itself is re-run; there is
+          # one writer per run, so the parallel-writer hazard does not apply.
           name: rccl-ab-report-${{ github.run_id }}
           overwrite: true
           if-no-files-found: warn
-          # Only paths under THIS run's artifact dir. rccl_runs.log used to be the
-          # shared /it-share/rccl-ci/ab_artifacts/rccl_runs.log, which every run
-          # appends to and never truncates -- a ~70MB cumulative file containing
-          # other PRs' command lines and output, re-uploaded in full on every run.
-          # In workspace mode steps.art.outputs.dir is per-run, so this is now
-          # only our own log.
-          # rccl_report.md is the rendered comment body. It is uploaded so the
-          # `report` job can post it without a self-hosted runner: rendering
-          # needs format_report.py and the report JSON, both of which live on
-          # NFS, and that dependency was the only reason the comment job held
-          # the tw-gfx950 label. See the note above `report`.
+          # Only paths under THIS run's artifact dir -- rccl_runs.log was
+          # previously the shared cumulative log, tens of MB of other PRs'
+          # output re-uploaded on every run.
+          #
+          # rccl_report.md is the rendered comment body, uploaded so `report` can
+          # post without a self-hosted runner: rendering needs format_report.py
+          # and the report JSON, both on the cluster filesystem, and that was the
+          # only thing tying the comment to a cluster runner.
           path: |
             ${{ steps.art.outputs.dir }}/ab_regression_report.json
             ${{ steps.art.outputs.dir }}/ab_derived_thresholds.json
@@ -622,36 +508,23 @@ jobs:
           echo "Verdict source: ${_PROVENANCE}"
           echo "::notice::${_REGRESSIONS} confirmed regression(s) (advisory mode: not failing the PR)"
 
-  # ---------------------------------------------------------------------------
-  # The PR comment lives in its own always() job.
+  # The PR comment gets its own always() job, for two reasons.
   #
-  # It used to be a step inside `detect`, which meant it only ran when detect ran.
-  # Every way the pipeline can fail EARLIER -- the build job failing, the runner
-  # dying, the concurrency lock cancelling the run, detect being skipped -- left
-  # the sticky comment showing the PREVIOUS attempt's verdict, with a timestamp
-  # nobody reads and no indication it was stale. Reviewers acted on a green
-  # comment for a run that had been dead for twenty minutes.
+  # As a step inside `detect` it only ran when detect ran, so every earlier
+  # failure -- build failing, the runner dying, the run being cancelled, detect
+  # being skipped -- left the sticky comment showing the PREVIOUS attempt's
+  # verdict with no indication it was stale. A sticky comment is a claim about
+  # the current state of the PR; if the pipeline cannot make that claim it has
+  # to say so, in the same place it would have said PASS.
   #
-  # A sticky comment is a claim about the current state of the PR. If the pipeline
-  # cannot make that claim, it has to say so, in the same place it would have said
-  # PASS. So: separate job, needs both, if: always(), and it renders SOMETHING for
-  # every terminal state of the two jobs above.
-  # ---------------------------------------------------------------------------
-  # It also runs on a GitHub-hosted runner, not the self-hosted one, and that is
-  # load-bearing rather than incidental. build, detect and arravikum's rccl-gin
-  # pipeline all contend for the single tw-gfx950 runner, and rccl-gin alone
-  # occupies roughly 21 minutes of every 24. Measured 2026-08-13: detect finished
-  # at 23:46 with a correct verdict and report was still queued 1h35m later,
-  # having never been assigned a runner. Two consequences, the second worse than
-  # the first: the comment lands hours after the answer is known, and a queued
-  # report is cancelled outright if anyone pushes to the PR -- discarding a
-  # completed 4-node measurement without posting anything.
-  #
-  # The only thing that ever tied this job to that runner was re-rendering the
-  # markdown, which needs format_report.py and the report JSON, both on NFS. But
-  # detect ALREADY renders exactly that file and now uploads it, so this job just
-  # downloads it. The "not measured" branches are pure string logic and never
-  # needed the cluster at all.
+  # And it runs on a GitHub-hosted runner, which is load-bearing rather than
+  # incidental. When it shared a label with the cluster jobs it could sit queued
+  # for hours behind them (measured once at 1h35m after detect had already
+  # produced a correct verdict), and a queued report is cancelled outright when
+  # anyone pushes -- discarding a completed 4-node measurement without posting
+  # anything. The only thing that ever tied it to a cluster runner was rendering
+  # the markdown; detect now renders and uploads that file, so this job just
+  # downloads it, and the "not measured" branches are pure string logic.
   report:
     needs: [build, detect]
     if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
@@ -669,10 +542,9 @@ jobs:
     steps:
       - name: Fetch the rendered report
         id: dl
-        # Absent whenever detect did not produce a verdict -- skipped, cancelled,
-        # or run but measured nothing. That is a normal outcome here, not an
-        # error, so never fail the job over it: the whole point of this job is to
-        # say something in exactly those cases.
+        # Absent whenever detect produced no verdict -- skipped, cancelled, or
+        # run but measured nothing. Normal here, not an error: saying something
+        # in exactly those cases is the point of this job.
         continue-on-error: true
         uses: actions/download-artifact@v4
         with:
@@ -705,10 +577,9 @@ jobs:
           elif [[ "${_DETECT}" == "cancelled" ]]; then
             emit ":warning: **Not measured.** The detector job was cancelled before it produced a verdict."
           else
-            # detect writes this file only when format_report.py rendered a real
-            # verdict, so presence is the signal. Do not substitute any other
-            # source: a comment on this PR must come from this run or say that it
-            # could not.
+            # detect writes this file only for a verdict it found trustworthy,
+            # so presence is the signal. Do not substitute any other source: a
+            # comment here comes from this run or says it could not.
             BODY="${RUNNER_TEMP}/dl/rccl_report.md"
             if [[ -s "${BODY}" ]]; then
               emit "$(cat "${BODY}")"
@@ -750,12 +621,3 @@ jobs:
           header: rccl-perf-gate
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           path: ${{ runner.temp }}/rccl_comment.md
-
-      # This job used to end with a `rm -f` on the per-run config as a last line
-      # of defence for the case where detect never ran to clean up after itself.
-      # It cannot do that from a GitHub-hosted runner -- no NFS -- so the
-      # backstop is now solely the `Reap orphaned per-run configs` step at the
-      # top of `build`, which sweeps ci_detect_run_*.json left behind by earlier
-      # runs. That step already covered this case; it is why the janitor exists.
-      # The consequence of the move is that an orphaned config now survives until
-      # the next run of the gate instead of being removed within the minute.

--- a/.github/workflows/rccl_perf_regression.yml
+++ b/.github/workflows/rccl_perf_regression.yml
@@ -186,13 +186,18 @@ jobs:
           fetch-depth: 0
 
       - name: Reap orphaned per-run configs
-        # Self-healing janitor. The cleanup steps below cover the paths we can
-        # predict, but a runner dying mid-job leaves its copy behind forever on
-        # NFS. Anything older than a day is unambiguously dead: the longest a run
-        # can legally live is the detect job's 500min timeout.
+        # Self-healing janitor, and the ONLY thing that deletes these files --
+        # detect deliberately does not clean up after itself, so that "Re-run
+        # failed jobs" still finds the config build handed it.
+        #
+        # 48h is a heuristic, not a derived bound. A run's real life is the build
+        # plus an unbounded wait for a detect runner (timeout-minutes does not
+        # start until a runner is assigned, so that wait is invisible to every
+        # timeout in this file) plus detect's own 500min. Reaping a config a
+        # queued run still needs would fail that run, so leave wide margin.
         run: |
           find "${RCCL_CI_ROOT}/configs" -maxdepth 1 -name 'ci_detect_run_*.json' \
-            -mmin +1440 -print -delete 2>/dev/null || true
+            -mmin +2880 -print -delete 2>/dev/null || true
 
       - name: Detect changed paths
         id: paths
@@ -215,7 +220,18 @@ jobs:
             echo "::error::Could not diff against origin/${{ github.base_ref }}. Refusing to guess whether RCCL changed — a wrong guess here produces a meaningless green gate."
             exit 1
           fi
-          if grep -q '^projects/rccl/' <<<"${diff_out}"; then
+          # Mirror the `paths` exclusions above. Without this, a PR touching
+          # this workflow file (itself a trigger path) alongside a doc under
+          # projects/rccl/ matches ^projects/rccl/ and buys a full compile plus
+          # a ~25min 4-node detect on source that did not change.
+          #
+          # `|| true` scopes only to the filter -- a grep matching nothing exits
+          # 1, which is not an error here. It must not extend to the git diff
+          # above, which is exactly the swallowed failure this step exists to
+          # prevent.
+          rccl_src="$(grep '^projects/rccl/' <<<"${diff_out}" \
+            | grep -vE '(\.md$|^projects/rccl/docs/|^projects/rccl/LICENSE|/CODEOWNERS$)' || true)"
+          if [[ -n "${rccl_src}" ]]; then
             echo "rccl_changed=1" >> "$GITHUB_OUTPUT"
           else
             echo "rccl_changed=0" >> "$GITHUB_OUTPUT"
@@ -227,7 +243,7 @@ jobs:
           BUILD_RCCL: ${{ github.event_name == 'pull_request' && steps.paths.outputs.rccl_changed || inputs.build_rccl || '0' }}
           CANDIDATE_SRC: ${{ github.workspace }}
           BASE_REF: origin/${{ github.base_ref || 'develop' }}
-          _CONFIG: ${{ inputs.config || '/it-share/rccl-ci/configs/ci_detect_prod.json' }}
+          _CONFIG: ${{ inputs.config || format('{0}/configs/ci_detect_prod.json', env.RCCL_CI_ROOT) }}
         run: |
           if [[ "${BUILD_RCCL}" == "1" ]]; then
             # Give every run its own copy of the config rather than templating
@@ -291,6 +307,12 @@ jobs:
               [[ -n "${build_job}" ]] && break
               sleep 1
             done
+            if [[ -z "${build_job}" ]]; then
+              # The trap can only scancel an id it has. A job that submitted but
+              # whose id never showed leaves an exclusive node held with no trap
+              # coverage, so make that gap visible rather than silent.
+              echo "::warning::could not read the build job id within 30s; if a job was submitted it is now running without scancel coverage"
+            fi
             echo "build slurm job: ${build_job:-<unknown>}"
 
             set +e
@@ -405,38 +427,99 @@ jobs:
           HELPER="${RCCL_CI_ROOT}/cvs/ci/rccl_perf_gate/sbatch/lib/workspace.sh"
           ART=""
           if [[ -f "${HELPER}" ]]; then
-            ART="$(bash "${HELPER}" --print-artifacts 2>/dev/null)" || ART=""
+            # Last line only: this goes to GITHUB_OUTPUT as a bare key=value,
+            # which has no multi-line form, so a banner on the helper's stdout
+            # would truncate the path and leak the rest as further outputs.
+            ART="$(bash "${HELPER}" --print-artifacts 2>/dev/null | tail -n1)" || ART=""
           fi
           if [[ -z "${ART}" ]]; then
-            # Helper missing or failed: the cluster's cvs checkout predates it.
-            # Fall back to the legacy shared dir and say so loudly rather than
-            # emitting an empty path that would silently resolve to "/".
+            if [[ "${RCCL_CI_WORKSPACE}" == "1" ]]; then
+              # Fail rather than guess. In workspace mode the detector writes to
+              # runs/<run_key>/artifacts; the legacy shared dir holds whatever an
+              # earlier run left there, so falling back would render another
+              # run's report as this PR's verdict. A stale green is the worst
+              # failure mode a gate has.
+              echo "::error::workspace.sh --print-artifacts is unavailable and RCCL_CI_WORKSPACE=1. Refusing to fall back to the shared artifact dir, whose contents belong to a different run. Update the cvs checkout on the cluster."
+              exit 1
+            fi
             ART="${RCCL_CI_ROOT}/ab_artifacts"
-            echo "::warning::workspace.sh --print-artifacts unavailable; falling back to ${ART}. If RCCL_CI_WORKSPACE=1 this report may be from a different run — update the cvs checkout on the cluster."
+            echo "::warning::workspace.sh --print-artifacts unavailable; falling back to ${ART}."
           fi
           echo "dir=${ART}" >> "$GITHUB_OUTPUT"
           echo "Artifact dir: ${ART}"
           ls -la "${ART}" 2>/dev/null || echo "(artifact dir absent)"
 
+      - name: Evaluate verdict
+        id: verdict
+        if: always()
+        env:
+          _ART: ${{ steps.art.outputs.dir }}
+        # Decide trustworthiness ONCE, here, before anything renders. Both the
+        # render step and the gate step below consume this answer, so they can
+        # never disagree about whether this run measured anything.
+        #
+        # Never fails: it only reports. `Gate on detector verdict` owns the
+        # failing, so that a report is still rendered and uploaded first.
+        run: |
+          REPORT="${_ART}/ab_regression_report.json"
+          if [[ ! -f "${REPORT}" ]]; then
+            echo "present=0" >> "$GITHUB_OUTPUT"
+            echo "trustworthy=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "present=1" >> "$GITHUB_OUTPUT"
+          python3 - "${REPORT}" >> "$GITHUB_OUTPUT" <<'PY'
+          import json, sys
+          d = json.load(open(sys.argv[1]))
+          reports = d.get("reports", {}) or {}
+          trust = d.get("trustworthy")
+          if trust is None:
+              trust = bool(reports) and all(
+                  r.get("summary", {}).get("trustworthy", False) for r in reports.values())
+          print(f"trustworthy={'true' if trust else 'false'}")
+          print("regressions=%d" % sum(
+              r.get("summary", {}).get("regressions", 0) for r in reports.values()))
+          reasons = d.get("untrustworthy_reasons") or ["report predates the trustworthy flag"]
+          print("reasons<<EOR")
+          if not trust:
+              for why in reasons:
+                  print(why)
+          print("EOR")
+          prov = d.get("provenance") or {}
+          print(f"provenance=cvs@{prov.get('cvs_sha')} thresholds={d.get('thresholds_source')}")
+          PY
+
       - name: Render report
         if: always()
         env:
           _ART: ${{ steps.art.outputs.dir }}
+          _PRESENT: ${{ steps.verdict.outputs.present }}
+          _TRUST: ${{ steps.verdict.outputs.trustworthy }}
+          _REASONS: ${{ steps.verdict.outputs.reasons }}
         run: |
           REPORT="${_ART}/ab_regression_report.json"
-          if [[ ! -f "${REPORT}" ]]; then
-            # Say so plainly instead of letting format_report.py traceback, and
-            # never fall back to another directory's report.
+          # Deliberately do NOT write rccl_report.md on either bail-out below.
+          # Its presence in the uploaded artifact is the `report` job's signal
+          # that a real verdict exists, so writing a placeholder would make "the
+          # detector could not measure" indistinguishable from "the detector
+          # said pass" -- and report would post the placeholder as a result.
+          {
+            echo "### RCCL Perf Regression Gate"
+            echo ""
+          } >> "${GITHUB_STEP_SUMMARY}"
+          if [[ "${_PRESENT}" != "1" ]]; then
             echo "::warning::No report at ${REPORT} — the detector did not produce one."
-            echo "### RCCL Perf Regression Gate" >> "${GITHUB_STEP_SUMMARY}"
-            echo "" >> "${GITHUB_STEP_SUMMARY}"
             echo "No report was produced for this run (\`${REPORT}\` is missing)." >> "${GITHUB_STEP_SUMMARY}"
             echo "See the detector step log above for the failure." >> "${GITHUB_STEP_SUMMARY}"
-            # Deliberately do NOT write rccl_report.md here. Its presence in the
-            # uploaded artifact is the `report` job's signal that a real verdict
-            # exists; a placeholder file would make "the detector measured
-            # nothing" indistinguishable from "the detector said pass", and
-            # report would post the placeholder text as though it were a result.
+            exit 0
+          fi
+          if [[ "${_TRUST}" != "true" ]]; then
+            # The gate rejected this run as unmeasured. Rendering it anyway is
+            # how a run the detector refused to score still reaches the PR as a
+            # verdict -- the stale-green failure this workflow exists to close.
+            echo "The detector produced no usable verdict, so nothing is rendered." >> "${GITHUB_STEP_SUMMARY}"
+            echo "" >> "${GITHUB_STEP_SUMMARY}"
+            echo "${_REASONS}" >> "${GITHUB_STEP_SUMMARY}"
             exit 0
           fi
           # Render into the artifact dir, not RUNNER_TEMP: upload-artifact@v4
@@ -455,9 +538,18 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          # Namespaced per run+attempt: with runs no longer serialised by a
-          # global lock, a fixed name would collide across concurrent runs.
-          name: rccl-ab-report-${{ github.run_id }}-${{ github.run_attempt }}
+          # Namespaced per run -- with runs no longer serialised by a global
+          # lock, a fixed name would collide across concurrent runs.
+          #
+          # Deliberately NOT per attempt. "Re-run failed jobs" bumps run_attempt
+          # but does not re-run a `detect` that already succeeded, so an
+          # attempt-stamped name would leave `report` hunting for an artifact
+          # nobody uploaded and posting "not measured" over a good verdict.
+          # `overwrite` keeps the name resolving to the newest upload when
+          # detect itself is re-run; there is exactly one writer per run, so the
+          # parallel-writer hazard in the overwrite docs does not apply here.
+          name: rccl-ab-report-${{ github.run_id }}
+          overwrite: true
           if-no-files-found: warn
           # Only paths under THIS run's artifact dir. rccl_runs.log used to be the
           # shared /it-share/rccl-ci/ab_artifacts/rccl_runs.log, which every run
@@ -476,34 +568,40 @@ jobs:
             ${{ steps.art.outputs.dir }}/rccl_runs.log
             ${{ steps.art.outputs.dir }}/rccl_report.md
 
-      - name: Clean up per-run config copy
-        if: always()
-        env:
-          _CONFIG: ${{ needs.build.outputs.config_json }}
-        run: |
-          case "${_CONFIG}" in
-            "${RCCL_CI_ROOT}"/configs/ci_detect_run_*.json) rm -f "${_CONFIG}" ;;
-          esac
+      # No cleanup of the per-run config here, deliberately. `build` does not
+      # re-run when only `detect` is retried, so its outputs -- including the
+      # config path -- are re-served verbatim on attempt 2. Deleting the file
+      # here made "Re-run failed jobs" fail on a missing config, and the detect
+      # failures most worth retrying (Slurm submission, polling timeout,
+      # transient NFS) are exactly the ones that left it deleted. The janitor at
+      # the top of `build` is the sole owner of deletion, as it already is for
+      # the `report` job.
 
       - name: Gate on detector verdict
         if: always()
+        # Values reach the shell through env:, not raw ${{ }} interpolation --
+        # they originate in a helper's stdout and a captured exit code.
+        env:
+          _CODE: ${{ steps.detect.outputs.exit_code }}
+          _ART: ${{ steps.art.outputs.dir }}
+          _PRESENT: ${{ steps.verdict.outputs.present }}
+          _TRUST: ${{ steps.verdict.outputs.trustworthy }}
+          _REGRESSIONS: ${{ steps.verdict.outputs.regressions }}
+          _REASONS: ${{ steps.verdict.outputs.reasons }}
+          _PROVENANCE: ${{ steps.verdict.outputs.provenance }}
         run: |
           # submit_and_poll.sh exit codes: 0 = pass, 1 = regression detected,
           # 2 = submission/polling error (job never reached a terminal state).
           # steps.detect.outcome can't distinguish 1 from 2 -- continue-on-error
           # reports "failure" for any nonzero exit -- so branch on the exit
-          # code we captured explicitly instead.
-          code="${{ steps.detect.outputs.exit_code }}"
-          if [[ "${code}" != "0" && "${code}" != "1" ]]; then
-            echo "::error::Detector failed to run (SLURM submission/polling error or timeout, exit ${code}). Report on NFS may be stale — not gating on it."
+          # code we captured explicitly instead. An empty value means the step
+          # was killed before it wrote one, which is also an infra failure.
+          if [[ "${_CODE}" != "0" && "${_CODE}" != "1" ]]; then
+            echo "::error::Detector failed to run (SLURM submission/polling error or timeout, exit ${_CODE:-<none>}). Report on NFS may be stale — not gating on it."
             exit 2
           fi
-          # Advisory mode (see PR description): report the verdict but don't
-          # fail the job on a detected regression yet. Infra failures above
-          # still fail hard regardless of mode.
-          REPORT="${{ steps.art.outputs.dir }}/ab_regression_report.json"
-          if [[ ! -f "${REPORT}" ]]; then
-            echo "::error::Detector exited ${code} but produced no report at ${REPORT}."
+          if [[ "${_PRESENT}" != "1" ]]; then
+            echo "::error::Detector exited ${_CODE} but produced no report at ${_ART}/ab_regression_report.json."
             exit 2
           fi
           # "No usable verdict" is an infra failure, not an advisory finding. The
@@ -511,25 +609,18 @@ jobs:
           # a PR while the gate earns trust — it was never meant to cover a run
           # that failed to measure anything. Those must fail hard, or the gate
           # spends its advisory period reporting green on runs it never made.
-          python3 - "${REPORT}" <<'PY'
-          import json, sys
-          d = json.load(open(sys.argv[1]))
-          reports = d.get("reports", {}) or {}
-          trust = d.get("trustworthy")
-          if trust is None:
-              trust = bool(reports) and all(
-                  r.get("summary", {}).get("trustworthy", False) for r in reports.values())
-          if not trust:
-              for why in (d.get("untrustworthy_reasons") or ["report predates the trustworthy flag"]):
-                  print(f"::error::{why}")
-              print("::error::Detector produced NO USABLE VERDICT — failing the gate. "
-                    "This is not a regression finding; it means the run could not measure.")
-              sys.exit(2)
-          n = sum(r.get("summary", {}).get("regressions", 0) for r in reports.values())
-          prov = d.get("provenance") or {}
-          print(f"Verdict source: cvs@{prov.get('cvs_sha')} thresholds={d.get('thresholds_source')}")
-          print(f"::notice::{n} confirmed regression(s) (advisory mode: not failing the PR)")
-          PY
+          if [[ "${_TRUST}" != "true" ]]; then
+            while IFS= read -r why; do
+              [[ -n "${why}" ]] && echo "::error::${why}"
+            done <<<"${_REASONS}"
+            echo "::error::Detector produced NO USABLE VERDICT — failing the gate. This is not a regression finding; it means the run could not measure."
+            exit 2
+          fi
+          # Advisory mode (see PR description): report the verdict but don't
+          # fail the job on a detected regression yet. Infra failures above
+          # still fail hard regardless of mode.
+          echo "Verdict source: ${_PROVENANCE}"
+          echo "::notice::${_REGRESSIONS} confirmed regression(s) (advisory mode: not failing the PR)"
 
   # ---------------------------------------------------------------------------
   # The PR comment lives in its own always() job.
@@ -565,6 +656,12 @@ jobs:
     needs: [build, detect]
     if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    # Safe to cancel, unlike build and detect: this job holds no Slurm
+    # allocation, so nothing is orphaned. Purely a latency win -- it is NOT what
+    # keeps a stale verdict off the PR. See the head-SHA guard below.
+    concurrency:
+      group: rccl-perf-gate-report-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     timeout-minutes: 15
     permissions:
       contents: read
@@ -579,7 +676,8 @@ jobs:
         continue-on-error: true
         uses: actions/download-artifact@v4
         with:
-          name: rccl-ab-report-${{ github.run_id }}-${{ github.run_attempt }}
+          # Run-scoped, not attempt-scoped -- see the note on the upload.
+          name: rccl-ab-report-${{ github.run_id }}
           path: ${{ runner.temp }}/dl
 
       - name: Compose comment
@@ -620,7 +718,33 @@ jobs:
           fi
           cat "${OUT}" >> "${GITHUB_STEP_SUMMARY}"
 
+      - name: Check this verdict still describes the PR head
+        id: fresh
+        # A sticky comment is a claim about the CURRENT state of the PR, so a run
+        # whose commit is no longer the head has nothing to say and must not
+        # overwrite a newer verdict.
+        #
+        # The concurrency group above does not cover this. cancel-in-progress
+        # only fires when two jobs are genuinely concurrent, and the worst
+        # ordering is not: a run whose detect takes ~25min can be overtaken by a
+        # later docs-only push whose detect is skipped and whose report posts
+        # immediately -- then the older run's report starts and lands last.
+        # Nothing was ever concurrent, so nothing was ever cancelled.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          _RAN_FOR: ${{ github.event.pull_request.head.sha }}
+        run: |
+          head="$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" --jq .head.sha)"
+          if [[ "${head}" != "${_RAN_FOR}" ]]; then
+            echo "stale=1" >> "$GITHUB_OUTPUT"
+            echo "::notice::Not posting: this run measured ${_RAN_FOR}, but the PR head is now ${head}. A newer run owns the comment."
+            echo "Superseded — this run measured \`${_RAN_FOR}\`, which is no longer the PR head." >> "${GITHUB_STEP_SUMMARY}"
+          else
+            echo "stale=0" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Post / update PR comment
+        if: steps.fresh.outputs.stale == '0'
         uses: marocchino/sticky-pull-request-comment@f3bbb8300013c686241004a1c1b5d4045b10bc30  # v2
         with:
           header: rccl-perf-gate

--- a/.github/workflows/rccl_perf_regression.yml
+++ b/.github/workflows/rccl_perf_regression.yml
@@ -31,18 +31,11 @@ name: RCCL Perf Regression Gate
 
 on:
   pull_request:
-    # TEMPORARY -- DO NOT MERGE AS IS.
-    #
-    # Production value is `[main, develop]`. It is pointed at this PR's own
-    # branch so the pipeline can be exercised end to end from CI before it is
-    # let anywhere near real PRs: open a throwaway PR that touches
-    # projects/rccl/** with THIS branch as its base, and the gate runs against
-    # it using the workflow file from this PR (pull_request events resolve the
-    # workflow from the merge commit, so the version under review is the
-    # version that executes).
-    #
-    # Restoring `[main, develop]` is the last commit before this leaves draft.
-    branches: [aimvt-196-rccl-regression-robustness]
+    # This matches the PR's BASE branch, not its head -- the gate runs on
+    # anything merging INTO main or develop, whatever the topic branch is
+    # called. Widening this list is not free: each entry multiplies the PRs
+    # eligible for a ~25min slot on a 4-node reservation the whole team shares.
+    branches: [main, develop]
     paths:
       - 'projects/rccl/**'
       # Docs-only and test-only churn cannot move a collective's bandwidth, and

--- a/.github/workflows/rccl_perf_regression.yml
+++ b/.github/workflows/rccl_perf_regression.yml
@@ -3,8 +3,14 @@
 # DEPLOYMENT: RCCL now lives in the ROCm/rocm-systems monorepo at projects/rccl.
 # This file belongs in that repo at
 #   .github/workflows/rccl_perf_regression.yml
-# It runs on the self-hosted org runner "tw-gfx950-ainic-ROCm-scale-runner"
-# (org: ROCm). Adjust `runs-on` labels to match how that runner was registered.
+# It runs on self-hosted org runners (org: ROCm) registered on a GPU-less Slurm
+# submit host, one per role:
+#   rccl-build    tw-gfx950-ainic-ROCm-scale-rccl-build-1
+#   rccl-detect   tw-gfx950-ainic-ROCm-scale-rccl-detect-1
+# (the names retain a gfx950 prefix for consistency with the older GPU runner;
+# these hosts have no GPUs). They must NOT carry the
+# tw-gfx950-ainic-ROCm-scale-runner label, or they will be handed GPU jobs they
+# cannot run. The `report` job needs no Slurm access and runs on ubuntu-latest.
 # The `paths` filter keeps the gate scoped to RCCL-only changes in the monorepo;
 # build_rccl.sh auto-detects the projects/rccl cmake subdir in the checkout.
 #
@@ -116,12 +122,14 @@ jobs:
     concurrency:
       group: rccl-perf-gate-build-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: false
-    # Capacity note: build and detect share one runner label today, so they are
-    # serialised by runner availability regardless of the locks above. Once a
-    # second runner is registered, give the build a distinct label (it needs no
-    # GPUs and no RDMA -- just a Slurm submit host) so a build can proceed while
-    # another PR's detect holds the 4-node allocation.
-    runs-on: [self-hosted, tw-gfx950-ainic-ROCm-scale-runner]
+    # Own runner label. This job needs no GPUs and no RDMA -- it is a Slurm
+    # submit-and-poll client -- and it targets SLURM_BUILD_RESERVATION, a
+    # different node pool from detect's. Sharing one label with detect meant a
+    # ~9min build queued behind a ~37min detect, or behind a GIN run that can
+    # hold a runner for 5h, for no reason at all. One runner per role today;
+    # changing that count is a registration change on the runner host, not an
+    # edit here.
+    runs-on: [self-hosted, rccl-build]
     # Was 60, the same as rccl_build.sbatch's own --time=01:00:00, which left no
     # room for queue time: a build that waited 20min for a node and then
     # compiled for 13 was killed here at 60 even though Slurm was happy. Sit
@@ -300,7 +308,14 @@ jobs:
     concurrency:
       group: rccl-perf-gate-detect-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: false
-    runs-on: [self-hosted, tw-gfx950-ainic-ROCm-scale-runner]
+    # Own runner label; see the note on the build job. Exactly one detect runner
+    # exists, which matches the hardware -- the pinned 4-node set admits one
+    # detect at a time regardless. A second runner would not add throughput; it
+    # would only move a waiting PR out of GitHub's runner queue (unbounded, and
+    # invisible to the timeout nest below, since timeout-minutes does not start
+    # until a runner is assigned) and into Slurm's, which is logged and bounded
+    # by MAX_QUEUE_SEC. Worth doing once there is queue data to justify it.
+    runs-on: [self-hosted, rccl-detect]
     # Outermost layer of the timeout nest. Must stay above MAX_QUEUE_SEC (4h)
     # plus MAX_WAIT_SEC (5h10m) in submit_and_poll.sh, so that script gets to
     # cancel the Slurm job and report *why* rather than being killed here with

--- a/.github/workflows/rccl_perf_regression.yml
+++ b/.github/workflows/rccl_perf_regression.yml
@@ -153,7 +153,7 @@ jobs:
         # Self-healing janitor. The cleanup steps below cover the paths we can
         # predict, but a runner dying mid-job leaves its copy behind forever on
         # NFS. Anything older than a day is unambiguously dead: the longest a run
-        # can legally live is the detect job's 540min timeout.
+        # can legally live is the detect job's 560min timeout.
         run: |
           find "${RCCL_CI_ROOT}/configs" -maxdepth 1 -name 'ci_detect_run_*.json' \
             -mmin +1440 -print -delete 2>/dev/null || true
@@ -383,14 +383,24 @@ jobs:
             echo "" >> "${GITHUB_STEP_SUMMARY}"
             echo "No report was produced for this run (\`${REPORT}\` is missing)." >> "${GITHUB_STEP_SUMMARY}"
             echo "See the detector step log above for the failure." >> "${GITHUB_STEP_SUMMARY}"
-            printf 'No report was produced for this run.\n' > "${RUNNER_TEMP}/rccl_report.md"
+            # Deliberately do NOT write rccl_report.md here. Its presence in the
+            # uploaded artifact is the `report` job's signal that a real verdict
+            # exists; a placeholder file would make "the detector measured
+            # nothing" indistinguishable from "the detector said pass", and
+            # report would post the placeholder text as though it were a result.
             exit 0
           fi
+          # Render into the artifact dir, not RUNNER_TEMP: upload-artifact@v4
+          # roots the archive at the least-common-ancestor of its paths, so a
+          # file from RUNNER_TEMP alongside files from NFS would push the LCA up
+          # to / and bury every entry under its full absolute path. Keeping all
+          # four under the same dir puts them at the artifact root, which is what
+          # the report job expects to find.
           python3 "${RCCL_CI_ROOT}/cvs/ci/rccl_perf_gate/format_report.py" \
             "${REPORT}" \
             --no-exit-code \
-            --output "${RUNNER_TEMP}/rccl_report.md"
-          cat "${RUNNER_TEMP}/rccl_report.md" >> "${GITHUB_STEP_SUMMARY}"
+            --output "${_ART}/rccl_report.md"
+          cat "${_ART}/rccl_report.md" >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Upload artifacts
         if: always()
@@ -406,10 +416,16 @@ jobs:
           # other PRs' command lines and output, re-uploaded in full on every run.
           # In workspace mode steps.art.outputs.dir is per-run, so this is now
           # only our own log.
+          # rccl_report.md is the rendered comment body. It is uploaded so the
+          # `report` job can post it without a self-hosted runner: rendering
+          # needs format_report.py and the report JSON, both of which live on
+          # NFS, and that dependency was the only reason the comment job held
+          # the tw-gfx950 label. See the note above `report`.
           path: |
             ${{ steps.art.outputs.dir }}/ab_regression_report.json
             ${{ steps.art.outputs.dir }}/ab_derived_thresholds.json
             ${{ steps.art.outputs.dir }}/rccl_runs.log
+            ${{ steps.art.outputs.dir }}/rccl_report.md
 
       - name: Clean up per-run config copy
         if: always()
@@ -481,15 +497,42 @@ jobs:
   # PASS. So: separate job, needs both, if: always(), and it renders SOMETHING for
   # every terminal state of the two jobs above.
   # ---------------------------------------------------------------------------
+  # It also runs on a GitHub-hosted runner, not the self-hosted one, and that is
+  # load-bearing rather than incidental. build, detect and arravikum's rccl-gin
+  # pipeline all contend for the single tw-gfx950 runner, and rccl-gin alone
+  # occupies roughly 21 minutes of every 24. Measured 2026-08-13: detect finished
+  # at 23:46 with a correct verdict and report was still queued 1h35m later,
+  # having never been assigned a runner. Two consequences, the second worse than
+  # the first: the comment lands hours after the answer is known, and a queued
+  # report is cancelled outright if anyone pushes to the PR -- discarding a
+  # completed 4-node measurement without posting anything.
+  #
+  # The only thing that ever tied this job to that runner was re-rendering the
+  # markdown, which needs format_report.py and the report JSON, both on NFS. But
+  # detect ALREADY renders exactly that file and now uploads it, so this job just
+  # downloads it. The "not measured" branches are pure string logic and never
+  # needed the cluster at all.
   report:
     needs: [build, detect]
     if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, tw-gfx950-ainic-ROCm-scale-runner]
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: read
       pull-requests: write
     steps:
+      - name: Fetch the rendered report
+        id: dl
+        # Absent whenever detect did not produce a verdict -- skipped, cancelled,
+        # or run but measured nothing. That is a normal outcome here, not an
+        # error, so never fail the job over it: the whole point of this job is to
+        # say something in exactly those cases.
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: rccl-ab-report-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/dl
+
       - name: Compose comment
         id: compose
         env:
@@ -515,16 +558,13 @@ jobs:
           elif [[ "${_DETECT}" == "cancelled" ]]; then
             emit ":warning: **Not measured.** The detector job was cancelled before it produced a verdict."
           else
-            HELPER="${RCCL_CI_ROOT}/cvs/ci/rccl_perf_gate/sbatch/lib/workspace.sh"
-            ART=""
-            [[ -f "${HELPER}" ]] && ART="$(bash "${HELPER}" --print-artifacts 2>/dev/null)" || true
-            [[ -n "${ART}" ]] || ART="${RCCL_CI_ROOT}/ab_artifacts"
-            REPORT="${ART}/ab_regression_report.json"
-            if [[ -f "${REPORT}" ]]; then
-              python3 "${RCCL_CI_ROOT}/cvs/ci/rccl_perf_gate/format_report.py" \
-                "${REPORT}" --no-exit-code --output "${RUNNER_TEMP}/rccl_body.md" \
-                && emit "$(cat "${RUNNER_TEMP}/rccl_body.md")" \
-                || emit ":warning: **Not measured.** A report exists at \`${REPORT}\` but could not be rendered."
+            # detect writes this file only when format_report.py rendered a real
+            # verdict, so presence is the signal. Do not substitute any other
+            # source: a comment on this PR must come from this run or say that it
+            # could not.
+            BODY="${RUNNER_TEMP}/dl/rccl_report.md"
+            if [[ -s "${BODY}" ]]; then
+              emit "$(cat "${BODY}")"
             else
               emit ":x: **Not measured.** The detector job ended \`${_DETECT}\` and produced no report. This is an infrastructure result, not a statement about your change."
             fi
@@ -538,13 +578,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           path: ${{ runner.temp }}/rccl_comment.md
 
-      - name: Reap this run's per-run config
-        if: always()
-        env:
-          _CONFIG: ${{ needs.build.outputs.config_json }}
-        run: |
-          # Last line of defence: detect's own cleanup step doesn't run if detect
-          # never ran. This job always does.
-          case "${_CONFIG}" in
-            "${RCCL_CI_ROOT}"/configs/ci_detect_run_*.json) rm -f "${_CONFIG}" ;;
-          esac
+      # This job used to end with a `rm -f` on the per-run config as a last line
+      # of defence for the case where detect never ran to clean up after itself.
+      # It cannot do that from a GitHub-hosted runner -- no NFS -- so the
+      # backstop is now solely the `Reap orphaned per-run configs` step at the
+      # top of `build`, which sweeps ci_detect_run_*.json left behind by earlier
+      # runs. That step already covered this case; it is why the janitor exists.
+      # The consequence of the move is that an orphaned config now survives until
+      # the next run of the gate instead of being removed within the minute.

--- a/.github/workflows/rccl_perf_regression.yml
+++ b/.github/workflows/rccl_perf_regression.yml
@@ -309,15 +309,20 @@ jobs:
       cancel-in-progress: false
     runs-on: [self-hosted, tw-gfx950-ainic-ROCm-scale-runner]
     # Outermost layer of the timeout nest. Must stay above MAX_QUEUE_SEC (4h)
-    # plus MAX_WAIT_SEC (4h10m) in submit_and_poll.sh, so that script gets to
+    # plus MAX_WAIT_SEC (5h10m) in submit_and_poll.sh, so that script gets to
     # cancel the Slurm job and report *why* rather than being killed here with
     # a bare "exceeded the maximum execution time". See the table in
     # submit_and_poll.sh; retune both together.
     #
+    # 510 -> 560 because MAX_WAIT_SEC went 4h10m -> 5h10m when alltoall_perf
+    # was re-enabled: at 10 groups the circuit-breaker worst case is exactly
+    # 4.0h, so the sbatch --time had to go to 5h to stay a real bound. 4h00
+    # queue + 5h10 run = 9h10, and this is 9h20.
+    #
     # It is also a runner-capacity number, not just a safety net: this runner
     # takes one active job and one queued, so every hour a wedged detect run
     # sits here is an hour no other PR can be tested. It was 540.
-    timeout-minutes: 510
+    timeout-minutes: 560
     steps:
       - name: Run A/B detector (pinned 4-node allocation)
         id: detect

--- a/.github/workflows/rccl_perf_regression.yml
+++ b/.github/workflows/rccl_perf_regression.yml
@@ -9,21 +9,21 @@
 # build_rccl.sh auto-detects the projects/rccl cmake subdir in the checkout.
 #
 # The Slurm submit/poll/report scripts these steps call
-# (rccl_build.sbatch, rccl_ab.sbatch, submit_and_poll.sh, format_report.py)
-# are version-controlled in ROCm/cvs, on a branch with further related
-# changes landing before it merges to main:
+# (rccl_build.sbatch, rccl_ab.sbatch, submit_and_poll.sh, format_report.py,
+# sbatch/lib/*.sh) are version-controlled in ROCm/cvs, on a branch with further
+# related changes landing before it merges to main:
 #   https://github.com/ROCm/cvs/tree/aimvt-196-rccl-regression-robustness/ci/rccl_perf_gate
 #
 # Flow per PR:
 #   1. Check out PR head with full history (merge-base resolution needs it).
 #   2. [build job] rccl_build.sbatch: build librccl.so for reference (merge-base)
 #      and candidate (PR head) on a single build node, then template their lib
-#      dirs into a per-run copy of ci_detect.json. This is a single-node CPU
-#      compile with no RDMA/MPI involved, so it runs under its own concurrency
-#      lock instead of the pinned 4-node lock below -- it no longer holds all
-#      4 nodes idle for its ~15-20min duration.
-#   3. [detect job] rccl_ab.sbatch: run the A/B detector on the pinned 4-node
-#      set, using the config the build job produced.
+#      dirs into this run's config. This is a single-node CPU compile with no
+#      RDMA/MPI involved, so it runs under its own concurrency lock instead of
+#      the detect lock below -- it no longer holds all 4 nodes idle for its
+#      duration. Rev-keyed build caching usually makes it seconds, not minutes.
+#   3. [detect job] rccl_ab.sbatch: pre-flight the A/B transport capabilities,
+#      then run the detector on the pinned 4-node set.
 #   4. format_report.py: render verdict to the job summary + PR comment.
 #   5. Advisory mode: job fails hard only on infra/polling errors, not on
 #      a detected regression yet (see PR description).
@@ -31,9 +31,27 @@ name: RCCL Perf Regression Gate
 
 on:
   pull_request:
-    branches: [main, develop]
+    # TEMPORARY -- DO NOT MERGE AS IS.
+    #
+    # Production value is `[main, develop]`. It is pointed at this PR's own
+    # branch so the pipeline can be exercised end to end from CI before it is
+    # let anywhere near real PRs: open a throwaway PR that touches
+    # projects/rccl/** with THIS branch as its base, and the gate runs against
+    # it using the workflow file from this PR (pull_request events resolve the
+    # workflow from the merge commit, so the version under review is the
+    # version that executes).
+    #
+    # Restoring `[main, develop]` is the last commit before this leaves draft.
+    branches: [aimvt-196-rccl-regression-robustness]
     paths:
       - 'projects/rccl/**'
+      # Docs-only and test-only churn cannot move a collective's bandwidth, and
+      # every spurious trigger costs a ~25min slot on a 4-node reservation that
+      # the whole team shares. Exclude what cannot affect the measurement.
+      - '!projects/rccl/**/*.md'
+      - '!projects/rccl/docs/**'
+      - '!projects/rccl/LICENSE*'
+      - '!projects/rccl/**/CODEOWNERS'
       - '.github/workflows/rccl_perf_regression.yml'
   # Allow manual dispatch for testing the pipeline before the workflow is on develop.
   # Inputs mirror what a PR run would supply; omit them to use the defaults
@@ -53,6 +71,23 @@ env:
   RCCL_CI_ROOT: /it-share/rccl-ci
   SLURM_RESERVATION: rccl_ci
   NODELIST: mia1-p01-g[22,26,28,32]
+  # The build deliberately does NOT run in SLURM_RESERVATION. It is a
+  # single-node CPU compile, but it takes its node --exclusive for up to an
+  # hour and is submitted with `sbatch --wait`, so running it inside the 4-node
+  # detect reservation held a quarter of the detect pool while detect was
+  # waiting for all four -- build and detect serialised against each other for
+  # no reason. rccl_dev is a separate pool, so a build and a detect run can now
+  # overlap. Set to an empty string to submit the build to the general
+  # partition instead.
+  SLURM_BUILD_RESERVATION: rccl_dev
+  # Per-run workspace isolation: every run gets its own cvs worktree, cvs-sbatch
+  # copy, build output, config, artifacts and logs under runs/<run_key>/.
+  # run_key is derived from GITHUB_RUN_ID, which is how the build job and the
+  # detect job below find the same workspace. This is the default in
+  # workspace.sh now; it is stated explicitly here because it is the single
+  # switch that makes concurrent runs safe, and a reader of this file should not
+  # have to go read a bash library to discover that.
+  RCCL_CI_WORKSPACE: '1'
 
 permissions:
   contents: read
@@ -66,18 +101,44 @@ jobs:
     # only; workflow_dispatch is unaffected (it already requires repo write
     # access to trigger).
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    # Separate lock from the detect job below: build never touches the pinned
-    # nodes, so it shouldn't queue behind another PR's in-flight A/B run.
-    # (Real cross-PR parallelism from this also needs a 2nd self-hosted runner
-    # -- see "Runner capacity" in the PR's known gaps. With one runner, this
-    # still shortens how long the 4-node reservation is held per PR.)
+    # SCOPED PER PR -- this is the fix for the "1 active + 1 queued" starvation.
+    #
+    # A GitHub Actions concurrency group holds at most ONE pending job. When a
+    # third run arrives, the pending one is CANCELLED to make room. With a single
+    # global group that meant PR #3 silently killed PR #2's queued run: the team
+    # saw runs vanish with no explanation and had to re-push to get them back.
+    #
+    # Keying the group by PR removes cross-PR contention entirely, and keeps the
+    # useful half of the old behaviour within a PR: push three times in a row and
+    # the newest push still evicts the older queued one, because they share a key.
+    #
+    # Serialisation of the actual hardware now happens where it belongs -- in
+    # Slurm, whose queue is unbounded and which is the real owner of the pinned
+    # nodes. Slurm queues; it does not curbstomp.
+    #
+    # cancel-in-progress stays FALSE deliberately. Cancelling a GitHub job does
+    # not cancel the Slurm job it submitted, so a true here would orphan
+    # allocations that keep holding nodes. Enabling it needs the scancel trap
+    # tracked as part of the submit/--wait work.
     concurrency:
-      group: rccl-perf-gate-build
+      group: rccl-perf-gate-build-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: false
+    # Capacity note: build and detect share one runner label today, so they are
+    # serialised by runner availability regardless of the locks above. Once a
+    # second runner is registered, give the build a distinct label (it needs no
+    # GPUs and no RDMA -- just a Slurm submit host) so a build can proceed while
+    # another PR's detect holds the 4-node allocation.
     runs-on: [self-hosted, tw-gfx950-ainic-ROCm-scale-runner]
-    timeout-minutes: 60
+    # Was 60, the same as rccl_build.sbatch's own --time=01:00:00, which left no
+    # room for queue time: a build that waited 20min for a node and then
+    # compiled for 13 was killed here at 60 even though Slurm was happy. Sit
+    # above the Slurm wall clock so Slurm is the one that decides a build has
+    # run too long, and this job only fires if the queue itself is wedged.
+    timeout-minutes: 120
     outputs:
       config_json: ${{ steps.resolve.outputs.config_json }}
+      # '' on workflow_dispatch (no PR to diff), '1'/'0' on pull_request.
+      rccl_changed: ${{ steps.paths.outputs.rccl_changed }}
     steps:
       - name: Checkout PR (full history)
         uses: actions/checkout@v4
@@ -88,14 +149,41 @@ jobs:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
 
+      - name: Reap orphaned per-run configs
+        # Self-healing janitor. The cleanup steps below cover the paths we can
+        # predict, but a runner dying mid-job leaves its copy behind forever on
+        # NFS. Anything older than a day is unambiguously dead: the longest a run
+        # can legally live is the detect job's 540min timeout.
+        run: |
+          find "${RCCL_CI_ROOT}/configs" -maxdepth 1 -name 'ci_detect_run_*.json' \
+            -mmin +1440 -print -delete 2>/dev/null || true
+
       - name: Detect changed paths
         id: paths
         if: github.event_name == 'pull_request'
+        # FAIL CLOSED. The old form ended in `|| echo "rccl_changed=0"`, which
+        # swallowed every possible failure of the git command -- a shallow clone,
+        # a missing base ref, a fetch that didn't complete -- and reported "RCCL
+        # didn't change". BUILD_RCCL then stayed 0, so the detect job ran with
+        # reference and candidate both pointing at the fixed prebuilt lib, found
+        # zero regressions (it was comparing a library to itself), and posted a
+        # green check on a PR that had never been measured. A gate that reports
+        # PASS when its own inputs are broken is worse than no gate.
+        #
+        # So: distinguish "the diff succeeded and matched nothing" (0, skip the
+        # build, legitimately nothing to measure) from "the diff failed" (error
+        # out and let the job fail visibly).
         run: |
-          git diff --name-only origin/${{ github.base_ref }}...HEAD \
-            | grep -q '^projects/rccl/' \
-            && echo "rccl_changed=1" >> "$GITHUB_OUTPUT" \
-            || echo "rccl_changed=0" >> "$GITHUB_OUTPUT"
+          set -o pipefail
+          if ! diff_out="$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")"; then
+            echo "::error::Could not diff against origin/${{ github.base_ref }}. Refusing to guess whether RCCL changed — a wrong guess here produces a meaningless green gate."
+            exit 1
+          fi
+          if grep -q '^projects/rccl/' <<<"${diff_out}"; then
+            echo "rccl_changed=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "rccl_changed=0" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Build reference + candidate librccl (single build node)
         id: resolve
@@ -106,21 +194,76 @@ jobs:
           _CONFIG: ${{ inputs.config || '/it-share/rccl-ci/configs/ci_detect_prod.json' }}
         run: |
           if [[ "${BUILD_RCCL}" == "1" ]]; then
-            # This job's concurrency lock no longer matches the detect job's
-            # lock, so another PR's build can now run while this PR is still
-            # waiting for/running its detect step. Templating the shared prod
-            # config file in place (the old behavior) would let one PR's build
-            # clobber another PR's in-flight detect config -- give every run
-            # its own copy instead.
+            # Give every run its own copy of the config rather than templating
+            # the shared prod file in place: with the locks split, another PR's
+            # build can be running while this PR waits on detect, and in-place
+            # templating would let one clobber the other's lib paths.
+            #
+            # In workspace mode this copy is only the handoff vehicle -- the
+            # build stages it into runs/<run_key>/config.json and templates
+            # THAT, so the shared configs/ dir is never written by a run.
             RUN_CONFIG="${RCCL_CI_ROOT}/configs/ci_detect_run_${{ github.run_id }}.json"
             cp "${_CONFIG}" "${RUN_CONFIG}"
             # Set the output before sbatch runs (not after) so the cleanup-on-
             # failure step below can still find this path if sbatch fails.
             echo "config_json=${RUN_CONFIG}" >> "$GITHUB_OUTPUT"
-            sbatch --wait \
+            # An unset/empty SLURM_BUILD_RESERVATION means "no reservation", not
+            # "inherit the detect one" -- passing --reservation="" is an error,
+            # so the flag has to be omitted entirely in that case.
+            build_res=()
+            if [[ -n "${SLURM_BUILD_RESERVATION:-}" ]]; then
+              build_res=(--reservation="${SLURM_BUILD_RESERVATION}")
+            fi
+            # `sbatch --wait` on its own leaks the allocation. Killing the
+            # sbatch client does not cancel the job it submitted, so when this
+            # step is stopped -- timeout-minutes, a cancelled run, a runner
+            # restart -- the build keeps going and keeps its node --exclusive
+            # until its 1h wall clock runs out, with nobody left to read the
+            # result. submit_and_poll.sh already learned this lesson for the
+            # detect job; the build needs the same trap.
+            #
+            # --parsable makes sbatch print the job id on submission and then
+            # block as usual, so run it in the background, read the id out of
+            # its output, and `wait` for the real exit status. That keeps
+            # --wait's exit-code mapping (which is the reason to use it) while
+            # giving the trap something to scancel.
+            sb_out="$(mktemp)"
+            build_job=""
+            cleanup_build() {
+              local rc=$?
+              trap - EXIT INT TERM HUP
+              if [[ -n "${build_job}" && "${build_done:-0}" != "1" ]]; then
+                echo "::warning::cancelling build job ${build_job}; this step is exiting (rc=${rc}) while it is still allocated"
+                scancel "${build_job}" 2>/dev/null || true
+              fi
+              rm -f "${sb_out}"
+              exit "${rc}"
+            }
+            trap cleanup_build EXIT INT TERM HUP
+
+            sbatch --parsable --wait \
               --export="ALL,CANDIDATE_SRC=${CANDIDATE_SRC},BASE_REF=${BASE_REF},CONFIG_JSON=${RUN_CONFIG}" \
-              --reservation="${SLURM_RESERVATION}" \
-              "${RCCL_CI_ROOT}/cvs/ci/rccl_perf_gate/sbatch/rccl_build.sbatch"
+              "${build_res[@]}" \
+              "${RCCL_CI_ROOT}/cvs/ci/rccl_perf_gate/sbatch/rccl_build.sbatch" >"${sb_out}" 2>&1 &
+            sb_pid=$!
+
+            # The id lands in the first line within a second of submission. Give
+            # it 30s, but do not fail if it never shows -- an sbatch that could
+            # not submit has nothing to cancel, and `wait` below reports why.
+            for _ in $(seq 1 30); do
+              build_job="$(grep -m1 -oE '^[0-9]+' "${sb_out}" 2>/dev/null || true)"
+              [[ -n "${build_job}" ]] && break
+              sleep 1
+            done
+            echo "build slurm job: ${build_job:-<unknown>}"
+
+            set +e
+            wait "${sb_pid}"
+            sb_rc=$?
+            set -e
+            build_done=1
+            cat "${sb_out}"
+            [[ "${sb_rc}" -eq 0 ]] || exit "${sb_rc}"
           else
             echo "config_json=${_CONFIG}" >> "$GITHUB_OUTPUT"
           fi
@@ -129,7 +272,8 @@ jobs:
         # Covers the case the detect job's own cleanup step can't: if sbatch
         # fails after the per-run config copy was made, `detect` never runs
         # (needs: build), so nothing else removes this file from NFS.
-        if: failure()
+        # cancelled() is included because a cancelled run skips detect too.
+        if: failure() || cancelled()
         env:
           _CONFIG: ${{ steps.resolve.outputs.config_json }}
         run: |
@@ -139,15 +283,41 @@ jobs:
 
   detect:
     needs: build
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    # Serialise: the pinned calibration nodes can host only one A/B job at a
-    # time, and thresholds are only valid there. Do NOT cancel in-progress (a
-    # running allocation must finish cleanly to release the nodes).
+    # Two conditions, and the second is the interesting one.
+    #
+    # Skip detect on a PR that changed nothing under projects/rccl (the workflow
+    # file itself is in the paths filter, so this happens). With BUILD_RCCL=0 both
+    # sides of the comparison point at the same prebuilt library, so the run would
+    # measure a build against itself and report a guaranteed, meaningless PASS
+    # after holding the 4-node reservation for ~25 minutes. A skipped job is an
+    # honest "not applicable"; a green check on an A=A run is a lie that costs
+    # hardware to tell. The detector now refuses such runs on its own too -- this
+    # just avoids queueing them in the first place.
+    if: >-
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+      && (github.event_name != 'pull_request' || needs.build.outputs.rccl_changed == '1')
+    # Also scoped per PR -- see the long note on the build job's lock. The pinned
+    # 4-node set is still used by exactly one job at a time; that is enforced by
+    # Slurm (--nodelist + --exclusive), which queues rather than cancelling.
+    # Holding a global GitHub lock here as well bought nothing and cost every
+    # third PR its queued run.
+    #
+    # Never cancel-in-progress: a running allocation must finish cleanly to
+    # release the nodes, and a cancelled GitHub job leaves the Slurm job running.
     concurrency:
-      group: rccl-perf-gate-pinned-nodes
+      group: rccl-perf-gate-detect-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: false
     runs-on: [self-hosted, tw-gfx950-ainic-ROCm-scale-runner]
-    timeout-minutes: 540
+    # Outermost layer of the timeout nest. Must stay above MAX_QUEUE_SEC (4h)
+    # plus MAX_WAIT_SEC (4h10m) in submit_and_poll.sh, so that script gets to
+    # cancel the Slurm job and report *why* rather than being killed here with
+    # a bare "exceeded the maximum execution time". See the table in
+    # submit_and_poll.sh; retune both together.
+    #
+    # It is also a runner-capacity number, not just a safety net: this runner
+    # takes one active job and one queued, so every hour a wedged detect run
+    # sits here is an hour no other PR can be tested. It was 540.
+    timeout-minutes: 510
     steps:
       - name: Run A/B detector (pinned 4-node allocation)
         id: detect
@@ -167,32 +337,74 @@ jobs:
           echo "exit_code=${code}" >> "$GITHUB_OUTPUT"
           exit "${code}"
 
+      - name: Resolve this run's artifact dir
+        id: art
+        if: always()
+        # In workspace mode the detector writes to runs/<run_key>/artifacts, not
+        # to the shared ab_artifacts/. Reading the shared path would render a
+        # report left there by some earlier run and post it on this PR as if it
+        # were this run's verdict -- a stale green is the worst possible failure
+        # mode for a gate. Ask workspace.sh rather than re-deriving the run key
+        # here, so there is one source of truth for it; with the flag off it
+        # returns the legacy shared path and this line still holds.
+        run: |
+          HELPER="${RCCL_CI_ROOT}/cvs/ci/rccl_perf_gate/sbatch/lib/workspace.sh"
+          ART=""
+          if [[ -f "${HELPER}" ]]; then
+            ART="$(bash "${HELPER}" --print-artifacts 2>/dev/null)" || ART=""
+          fi
+          if [[ -z "${ART}" ]]; then
+            # Helper missing or failed: the cluster's cvs checkout predates it.
+            # Fall back to the legacy shared dir and say so loudly rather than
+            # emitting an empty path that would silently resolve to "/".
+            ART="${RCCL_CI_ROOT}/ab_artifacts"
+            echo "::warning::workspace.sh --print-artifacts unavailable; falling back to ${ART}. If RCCL_CI_WORKSPACE=1 this report may be from a different run — update the cvs checkout on the cluster."
+          fi
+          echo "dir=${ART}" >> "$GITHUB_OUTPUT"
+          echo "Artifact dir: ${ART}"
+          ls -la "${ART}" 2>/dev/null || echo "(artifact dir absent)"
+
       - name: Render report
         if: always()
+        env:
+          _ART: ${{ steps.art.outputs.dir }}
         run: |
+          REPORT="${_ART}/ab_regression_report.json"
+          if [[ ! -f "${REPORT}" ]]; then
+            # Say so plainly instead of letting format_report.py traceback, and
+            # never fall back to another directory's report.
+            echo "::warning::No report at ${REPORT} — the detector did not produce one."
+            echo "### RCCL Perf Regression Gate" >> "${GITHUB_STEP_SUMMARY}"
+            echo "" >> "${GITHUB_STEP_SUMMARY}"
+            echo "No report was produced for this run (\`${REPORT}\` is missing)." >> "${GITHUB_STEP_SUMMARY}"
+            echo "See the detector step log above for the failure." >> "${GITHUB_STEP_SUMMARY}"
+            printf 'No report was produced for this run.\n' > "${RUNNER_TEMP}/rccl_report.md"
+            exit 0
+          fi
           python3 "${RCCL_CI_ROOT}/cvs/ci/rccl_perf_gate/format_report.py" \
-            "${RCCL_CI_ROOT}/ab_artifacts/ab_regression_report.json" \
+            "${REPORT}" \
             --no-exit-code \
             --output "${RUNNER_TEMP}/rccl_report.md"
           cat "${RUNNER_TEMP}/rccl_report.md" >> "${GITHUB_STEP_SUMMARY}"
-
-      - name: Post / update PR comment
-        if: always() && github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@f3bbb8300013c686241004a1c1b5d4045b10bc30  # v2
-        with:
-          header: rccl-perf-gate
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          path: ${{ runner.temp }}/rccl_report.md
 
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: rccl-ab-report
+          # Namespaced per run+attempt: with runs no longer serialised by a
+          # global lock, a fixed name would collide across concurrent runs.
+          name: rccl-ab-report-${{ github.run_id }}-${{ github.run_attempt }}
+          if-no-files-found: warn
+          # Only paths under THIS run's artifact dir. rccl_runs.log used to be the
+          # shared /it-share/rccl-ci/ab_artifacts/rccl_runs.log, which every run
+          # appends to and never truncates -- a ~70MB cumulative file containing
+          # other PRs' command lines and output, re-uploaded in full on every run.
+          # In workspace mode steps.art.outputs.dir is per-run, so this is now
+          # only our own log.
           path: |
-            /it-share/rccl-ci/ab_artifacts/ab_regression_report.json
-            /it-share/rccl-ci/ab_artifacts/ab_derived_thresholds.json
-            /it-share/rccl-ci/ab_artifacts/rccl_runs.log
+            ${{ steps.art.outputs.dir }}/ab_regression_report.json
+            ${{ steps.art.outputs.dir }}/ab_derived_thresholds.json
+            ${{ steps.art.outputs.dir }}/rccl_runs.log
 
       - name: Clean up per-run config copy
         if: always()
@@ -219,7 +431,115 @@ jobs:
           # Advisory mode (see PR description): report the verdict but don't
           # fail the job on a detected regression yet. Infra failures above
           # still fail hard regardless of mode.
-          python3 "${RCCL_CI_ROOT}/cvs/ci/rccl_perf_gate/format_report.py" \
-            "${RCCL_CI_ROOT}/ab_artifacts/ab_regression_report.json" \
-            --no-exit-code \
-            --output /dev/null
+          REPORT="${{ steps.art.outputs.dir }}/ab_regression_report.json"
+          if [[ ! -f "${REPORT}" ]]; then
+            echo "::error::Detector exited ${code} but produced no report at ${REPORT}."
+            exit 2
+          fi
+          # "No usable verdict" is an infra failure, not an advisory finding. The
+          # advisory carve-out exists so a real, measured regression doesn't block
+          # a PR while the gate earns trust — it was never meant to cover a run
+          # that failed to measure anything. Those must fail hard, or the gate
+          # spends its advisory period reporting green on runs it never made.
+          python3 - "${REPORT}" <<'PY'
+          import json, sys
+          d = json.load(open(sys.argv[1]))
+          reports = d.get("reports", {}) or {}
+          trust = d.get("trustworthy")
+          if trust is None:
+              trust = bool(reports) and all(
+                  r.get("summary", {}).get("trustworthy", False) for r in reports.values())
+          if not trust:
+              for why in (d.get("untrustworthy_reasons") or ["report predates the trustworthy flag"]):
+                  print(f"::error::{why}")
+              print("::error::Detector produced NO USABLE VERDICT — failing the gate. "
+                    "This is not a regression finding; it means the run could not measure.")
+              sys.exit(2)
+          n = sum(r.get("summary", {}).get("regressions", 0) for r in reports.values())
+          prov = d.get("provenance") or {}
+          print(f"Verdict source: cvs@{prov.get('cvs_sha')} thresholds={d.get('thresholds_source')}")
+          print(f"::notice::{n} confirmed regression(s) (advisory mode: not failing the PR)")
+          PY
+
+  # ---------------------------------------------------------------------------
+  # The PR comment lives in its own always() job.
+  #
+  # It used to be a step inside `detect`, which meant it only ran when detect ran.
+  # Every way the pipeline can fail EARLIER -- the build job failing, the runner
+  # dying, the concurrency lock cancelling the run, detect being skipped -- left
+  # the sticky comment showing the PREVIOUS attempt's verdict, with a timestamp
+  # nobody reads and no indication it was stale. Reviewers acted on a green
+  # comment for a run that had been dead for twenty minutes.
+  #
+  # A sticky comment is a claim about the current state of the PR. If the pipeline
+  # cannot make that claim, it has to say so, in the same place it would have said
+  # PASS. So: separate job, needs both, if: always(), and it renders SOMETHING for
+  # every terminal state of the two jobs above.
+  # ---------------------------------------------------------------------------
+  report:
+    needs: [build, detect]
+    if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, tw-gfx950-ainic-ROCm-scale-runner]
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Compose comment
+        id: compose
+        env:
+          _BUILD: ${{ needs.build.result }}
+          _DETECT: ${{ needs.detect.result }}
+          _CHANGED: ${{ needs.build.outputs.rccl_changed }}
+          _RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          OUT="${RUNNER_TEMP}/rccl_comment.md"
+          hdr="### RCCL Perf Regression Gate"
+          foot="[run log](${_RUN_URL}) · attempt ${{ github.run_attempt }} · commit \`${{ github.event.pull_request.head.sha }}\`"
+
+          emit() { printf '%s\n\n%s\n\n%s\n' "${hdr}" "$1" "${foot}" > "${OUT}"; }
+
+          if [[ "${_BUILD}" != "success" ]]; then
+            emit ":x: **Not measured.** The build job ended \`${_BUILD}\`, so no A/B comparison ran. This is an infrastructure result, not a statement about your change."
+          elif [[ "${_DETECT}" == "skipped" ]]; then
+            if [[ "${_CHANGED}" == "0" ]]; then
+              emit ":white_check_mark: **Not applicable.** This PR changes nothing under \`projects/rccl/\`, so there is no RCCL build to compare and the 4-node detector was not run."
+            else
+              emit ":warning: **Not measured.** The detector job was skipped. This is an infrastructure result, not a statement about your change."
+            fi
+          elif [[ "${_DETECT}" == "cancelled" ]]; then
+            emit ":warning: **Not measured.** The detector job was cancelled before it produced a verdict."
+          else
+            HELPER="${RCCL_CI_ROOT}/cvs/ci/rccl_perf_gate/sbatch/lib/workspace.sh"
+            ART=""
+            [[ -f "${HELPER}" ]] && ART="$(bash "${HELPER}" --print-artifacts 2>/dev/null)" || true
+            [[ -n "${ART}" ]] || ART="${RCCL_CI_ROOT}/ab_artifacts"
+            REPORT="${ART}/ab_regression_report.json"
+            if [[ -f "${REPORT}" ]]; then
+              python3 "${RCCL_CI_ROOT}/cvs/ci/rccl_perf_gate/format_report.py" \
+                "${REPORT}" --no-exit-code --output "${RUNNER_TEMP}/rccl_body.md" \
+                && emit "$(cat "${RUNNER_TEMP}/rccl_body.md")" \
+                || emit ":warning: **Not measured.** A report exists at \`${REPORT}\` but could not be rendered."
+            else
+              emit ":x: **Not measured.** The detector job ended \`${_DETECT}\` and produced no report. This is an infrastructure result, not a statement about your change."
+            fi
+          fi
+          cat "${OUT}" >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Post / update PR comment
+        uses: marocchino/sticky-pull-request-comment@f3bbb8300013c686241004a1c1b5d4045b10bc30  # v2
+        with:
+          header: rccl-perf-gate
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          path: ${{ runner.temp }}/rccl_comment.md
+
+      - name: Reap this run's per-run config
+        if: always()
+        env:
+          _CONFIG: ${{ needs.build.outputs.config_json }}
+        run: |
+          # Last line of defence: detect's own cleanup step doesn't run if detect
+          # never ran. This job always does.
+          case "${_CONFIG}" in
+            "${RCCL_CI_ROOT}"/configs/ci_detect_run_*.json) rm -f "${_CONFIG}" ;;
+          esac

--- a/.github/workflows/rccl_perf_regression.yml
+++ b/.github/workflows/rccl_perf_regression.yml
@@ -56,13 +56,30 @@ on:
       - '!projects/rccl/LICENSE*'
       - '!projects/rccl/**/CODEOWNERS'
       - '.github/workflows/rccl_perf_regression.yml'
-  # Allow manual dispatch for testing the pipeline before the workflow is on develop.
-  # Inputs mirror what a PR run would supply; omit them to use the defaults
-  # (A=A detect: ref == cand == current built lib, expects 0 regressions).
+  # Allow manual dispatch for exercising the pipeline without a PR.
+  #
+  # DO NOT dispatch with the defaults expecting a verdict. ci_detect_prod.json
+  # is a detect-mode config whose reference and candidate both resolve to
+  # builds/_fixed/lib, so the detector's identical-sides guard correctly refuses
+  # it: the run would compare a build against itself and report a guaranteed,
+  # meaningless PASS. You get ~26min on four nodes and an untrustworthy report.
+  # (The note that used to sit here promised exactly that A=A run. It predates
+  # the guard.)
+  #
+  # To smoke the pipeline end to end, pass a control_mode=true config -- it is
+  # the supported way to ask for A==A, and it yields usable run-to-run noise
+  # data instead of a non-answer:
+  #
+  #   config=/it-share/rccl-ci/configs/ci_control_prod8.json
+  #
+  # That file is ci_detect_prod.json with control_mode flipped and nothing else
+  # changed, so it exercises the production matrix rather than a drifted
+  # sibling. Verified on 2026-08-27, run 33112770514: 8/8 groups scored,
+  # trustworthy, 0 regressions, 184 comparison keys, ~26min.
   workflow_dispatch:
     inputs:
       config:
-        description: 'Config JSON path on TW cluster'
+        description: 'Config JSON path on TW cluster (use a control_mode=true config; see note above)'
         required: false
         default: '/it-share/rccl-ci/configs/ci_detect_prod.json'
       build_rccl:

--- a/.github/workflows/rccl_perf_regression.yml
+++ b/.github/workflows/rccl_perf_regression.yml
@@ -154,7 +154,7 @@ jobs:
         # Self-healing janitor. The cleanup steps below cover the paths we can
         # predict, but a runner dying mid-job leaves its copy behind forever on
         # NFS. Anything older than a day is unambiguously dead: the longest a run
-        # can legally live is the detect job's 560min timeout.
+        # can legally live is the detect job's 500min timeout.
         run: |
           find "${RCCL_CI_ROOT}/configs" -maxdepth 1 -name 'ci_detect_run_*.json' \
             -mmin +1440 -print -delete 2>/dev/null || true
@@ -317,20 +317,22 @@ jobs:
     # by MAX_QUEUE_SEC. Worth doing once there is queue data to justify it.
     runs-on: [self-hosted, rccl-detect]
     # Outermost layer of the timeout nest. Must stay above MAX_QUEUE_SEC (4h)
-    # plus MAX_WAIT_SEC (5h10m) in submit_and_poll.sh, so that script gets to
+    # plus MAX_WAIT_SEC (4h10m) in submit_and_poll.sh, so that script gets to
     # cancel the Slurm job and report *why* rather than being killed here with
     # a bare "exceeded the maximum execution time". See the table in
     # submit_and_poll.sh; retune both together.
     #
-    # 510 -> 560 because MAX_WAIT_SEC went 4h10m -> 5h10m when alltoall_perf
-    # was re-enabled: at 10 groups the circuit-breaker worst case is exactly
-    # 4.0h, so the sbatch --time had to go to 5h to stay a real bound. 4h00
-    # queue + 5h10 run = 9h10, and this is 9h20.
+    # 560 -> 500 because MAX_WAIT_SEC went 5h10m -> 4h10m when broadcast_perf
+    # was dropped from the matrix: at 8 groups the circuit-breaker worst case
+    # is 3.2h, so the sbatch --time is a real bound again at 4h. 4h00 queue +
+    # 4h10 run = 8h10, and this is 8h20. The nest last held these two values
+    # at 510; 500 keeps the +10min of slack 560 carried rather than the +20.
     #
-    # It is also a runner-capacity number, not just a safety net: this runner
-    # takes one active job and one queued, so every hour a wedged detect run
-    # sits here is an hour no other PR can be tested. It was 540.
-    timeout-minutes: 560
+    # This bounds the wedged case only -- it is not a capacity number. It does
+    # not bound how long a PR waits for a runner, because timeout-minutes does
+    # not start counting until a runner is assigned, so time spent queueing for
+    # rccl-detect is invisible to every timeout in this file.
+    timeout-minutes: 500
     steps:
       - name: Run A/B detector (pinned 4-node allocation)
         id: detect

--- a/.github/workflows/rccl_perf_regression.yml
+++ b/.github/workflows/rccl_perf_regression.yml
@@ -70,11 +70,11 @@ on:
   # the supported way to ask for A==A, and it yields usable run-to-run noise
   # data instead of a non-answer:
   #
-  #   config=/it-share/rccl-ci/configs/ci_control_prod8.json
+  #   config=$RCCL_CI_ROOT/configs/ci_control_prod8.json
   #
   # That file is ci_detect_prod.json with control_mode flipped and nothing else
   # changed, so it exercises the production matrix rather than a drifted
-  # sibling. Verified on 2026-08-27, run 33112770514: 8/8 groups scored,
+  # sibling. Verified by a control dispatch on 2026-08-27: 8/8 groups scored,
   # trustworthy, 0 regressions, 184 comparison keys, ~26min.
   workflow_dispatch:
     inputs:
@@ -157,9 +157,9 @@ jobs:
     # X64. Asking for self-hosted as well matches no runner at all, and the
     # failure is silent in the worst way: the job sits queued while the runner
     # sits Idle, until timeout-minutes below kills it. Confirmed by dispatch on
-    # 2026-08-26 (run 33015416535: build queued 8min, runner_name empty, while
-    # all three role runners showed Idle and had never run a single job since
-    # they were registered on 2026-08-19).
+    # 2026-08-26: build sat queued 8min with runner_name empty, while all three
+    # role runners showed Idle and had never run a single job since they were
+    # registered on 2026-08-19.
     #
     # The role label is unique to these hosts, so it is sufficient by itself.
     # If they are ever re-registered with default labels, self-hosted may be

--- a/.github/workflows/rccl_perf_regression.yml
+++ b/.github/workflows/rccl_perf_regression.yml
@@ -11,6 +11,10 @@
 # these hosts have no GPUs). They must NOT carry the
 # tw-gfx950-ainic-ROCm-scale-runner label, or they will be handed GPU jobs they
 # cannot run. The `report` job needs no Slurm access and runs on ubuntu-latest.
+#
+# Those runners were registered with --no-default-labels, so each carries ONLY
+# its role label -- no self-hosted, Linux or X64. That is why the runs-on lists
+# below name the role label alone; see the long note on the build job.
 # The `paths` filter keeps the gate scoped to RCCL-only changes in the monorepo;
 # build_rccl.sh auto-detects the projects/rccl cmake subdir in the checkout.
 #
@@ -129,7 +133,21 @@ jobs:
     # hold a runner for 5h, for no reason at all. One runner per role today;
     # changing that count is a registration change on the runner host, not an
     # edit here.
-    runs-on: [self-hosted, rccl-build]
+    #
+    # Deliberately NOT [self-hosted, rccl-build]. runs-on is an AND across the
+    # list, and these runners were registered with --no-default-labels: they
+    # carry their role label and nothing else -- no self-hosted, no Linux, no
+    # X64. Asking for self-hosted as well matches no runner at all, and the
+    # failure is silent in the worst way: the job sits queued while the runner
+    # sits Idle, until timeout-minutes below kills it. Confirmed by dispatch on
+    # 2026-08-26 (run 33015416535: build queued 8min, runner_name empty, while
+    # all three role runners showed Idle and had never run a single job since
+    # they were registered on 2026-08-19).
+    #
+    # The role label is unique to these hosts, so it is sufficient by itself.
+    # If they are ever re-registered with default labels, self-hosted may be
+    # added back, but it buys nothing.
+    runs-on: [rccl-build]
     # Was 60, the same as rccl_build.sbatch's own --time=01:00:00, which left no
     # room for queue time: a build that waited 20min for a node and then
     # compiled for 13 was killed here at 60 even though Slurm was happy. Sit
@@ -315,7 +333,11 @@ jobs:
     # invisible to the timeout nest below, since timeout-minutes does not start
     # until a runner is assigned) and into Slurm's, which is logged and bounded
     # by MAX_QUEUE_SEC. Worth doing once there is queue data to justify it.
-    runs-on: [self-hosted, rccl-detect]
+    #
+    # Role label only, no self-hosted -- same reason as the build job above:
+    # these runners have no default labels, so an AND against self-hosted
+    # matches nothing and the job hangs until timeout instead of failing.
+    runs-on: [rccl-detect]
     # Outermost layer of the timeout nest. Must stay above MAX_QUEUE_SEC (4h)
     # plus MAX_WAIT_SEC (4h10m) in submit_and_poll.sh, so that script gets to
     # cancel the Slurm job and report *why* rather than being killed here with

--- a/.github/workflows/rccl_perf_regression.yml
+++ b/.github/workflows/rccl_perf_regression.yml
@@ -65,10 +65,14 @@ env:
   # reason. Empty string submits to the general partition instead.
   SLURM_BUILD_RESERVATION: rccl_dev
   # Per-run isolation: each run gets its own cvs worktree, build output, config,
-  # artifacts and logs under runs/<run_key>/, keyed on GITHUB_RUN_ID -- which is
-  # also how build and detect find the same workspace. Already the default in
+  # artifacts and logs under runs/<run_key>/. Already the default in
   # workspace.sh; stated here because it is the single switch that makes
   # concurrent runs safe.
+  #
+  # workspace.sh keys that dir on GITHUB_RUN_ID *and* GITHUB_RUN_ATTEMPT, so two
+  # jobs share a workspace only within one attempt. Anything that has to survive
+  # a re-run therefore travels as a job output holding an absolute path, not as
+  # a path both jobs re-derive -- see config_json in `build`.
   RCCL_CI_WORKSPACE: '1'
 
 # Only `contents: read` here, which is all build and detect need -- they check
@@ -188,9 +192,10 @@ jobs:
             # stages it into runs/<run_key>/config.json and templates that.
             RUN_CONFIG="${RCCL_CI_ROOT}/configs/ci_detect_run_${{ github.run_id }}.json"
             cp "${_CONFIG}" "${RUN_CONFIG}"
-            # Set the output before sbatch runs (not after) so the cleanup-on-
-            # failure step below can still find this path if sbatch fails.
-            echo "config_json=${RUN_CONFIG}" >> "$GITHUB_OUTPUT"
+            # Published before sbatch runs so the cleanup-on-failure step below
+            # can still find the staging copy if sbatch fails. This is NOT what
+            # detect consumes -- see config_json at the end of this step.
+            echo "staging_config=${RUN_CONFIG}" >> "$GITHUB_OUTPUT"
             # An unset/empty SLURM_BUILD_RESERVATION means "no reservation", not
             # "inherit the detect one" -- passing --reservation="" is an error,
             # so the flag has to be omitted entirely in that case.
@@ -250,6 +255,37 @@ jobs:
             build_done=1
             cat "${sb_out}"
             [[ "${sb_rc}" -eq 0 ]] || exit "${sb_rc}"
+
+            # Hand detect the config the build actually TEMPLATED, not the
+            # staging copy it was made from.
+            #
+            # workspace.sh keys its run dir on run_id AND run_attempt, by
+            # design, so a re-run gets a clean workspace. That means a detect-only
+            # re-run computes a different key than the build did, finds no staged
+            # config there, and copies the pristine staging file instead -- which
+            # still points both sides at the fixed prebuilt library. The run then
+            # measures nothing, or the identical-sides guard rejects it outright.
+            #
+            # Publishing the absolute workspace path sidesteps that entirely:
+            # job outputs are re-served verbatim to later attempts, so detect
+            # keeps using the build's templated config and its libraries no
+            # matter which attempt it runs on.
+            WS_CFG=""
+            if [[ "${RCCL_CI_WORKSPACE}" == "1" ]]; then
+              HELPER="${RCCL_CI_ROOT}/cvs/ci/rccl_perf_gate/sbatch/lib/workspace.sh"
+              if [[ -f "${HELPER}" ]]; then
+                WS_ROOT="$(bash "${HELPER}" --print-root 2>/dev/null | tail -n1)" || WS_ROOT=""
+                [[ -n "${WS_ROOT}" && -f "${WS_ROOT}/config.json" ]] && WS_CFG="${WS_ROOT}/config.json"
+              fi
+              if [[ -z "${WS_CFG}" ]]; then
+                echo "::error::RCCL_CI_WORKSPACE=1 but the build staged no workspace config. Refusing to hand detect the untemplated staging copy, which would compare the prebuilt library against itself."
+                exit 1
+              fi
+              echo "Detect will use the workspace config: ${WS_CFG}"
+              echo "config_json=${WS_CFG}" >> "$GITHUB_OUTPUT"
+            else
+              echo "config_json=${RUN_CONFIG}" >> "$GITHUB_OUTPUT"
+            fi
           else
             echo "config_json=${_CONFIG}" >> "$GITHUB_OUTPUT"
           fi
@@ -260,7 +296,7 @@ jobs:
         # left to the janitor above -- see the note in `detect`, before its gate.
         if: failure() || cancelled()
         env:
-          _CONFIG: ${{ steps.resolve.outputs.config_json }}
+          _CONFIG: ${{ steps.resolve.outputs.staging_config }}
         run: |
           case "${_CONFIG}" in
             "${RCCL_CI_ROOT}"/configs/ci_detect_run_*.json) rm -f "${_CONFIG}" ;;
@@ -300,6 +336,11 @@ jobs:
     # until a runner is assigned, so that wait is invisible to every timeout in
     # this file.
     timeout-minutes: 500
+    outputs:
+      # Identifies the archive THIS execution of detect uploaded. Empty when it
+      # uploaded nothing, which is the signal `report` needs -- see the note on
+      # its download step.
+      artifact_id: ${{ steps.up.outputs.artifact-id }}
     steps:
       - name: Run A/B detector (pinned 4-node allocation)
         id: detect
@@ -409,7 +450,7 @@ jobs:
         run: |
           REPORT="${_ART}/ab_regression_report.json"
           # Clear any inherited report BEFORE deciding anything. The artifact dir
-          # is keyed on run_id, not run_attempt, so a re-run inherits attempt 1's
+          # can be reused across attempts, so a re-run may inherit attempt 1's
           # rccl_report.md -- and every bail-out below deliberately leaves the
           # file alone, which would hand `Upload artifacts` a stale verdict for
           # `report` to post as this attempt's answer.
@@ -449,16 +490,14 @@ jobs:
           cat "${_ART}/rccl_report.md" >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Upload artifacts
+        id: up
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          # Per run, so concurrent runs cannot collide -- but deliberately NOT
-          # per attempt. "Re-run failed jobs" bumps run_attempt without re-running
-          # a `detect` that already succeeded, so an attempt-stamped name would
-          # leave `report` hunting for an artifact nobody uploaded and posting
-          # "not measured" over a good verdict. `overwrite` keeps the name
-          # resolving to the newest upload when detect itself is re-run; there is
-          # one writer per run, so the parallel-writer hazard does not apply.
+          # Per run, so concurrent runs cannot collide. `report` does not resolve
+          # this name, though -- it downloads by the artifact-id published below.
+          # The name only has to be stable enough for a human to find, and
+          # `overwrite` only exists so a re-running detect can reclaim it.
           name: rccl-ab-report-${{ github.run_id }}
           overwrite: true
           if-no-files-found: warn
@@ -564,14 +603,32 @@ jobs:
     steps:
       - name: Fetch the rendered report
         id: dl
-        # Absent whenever detect produced no verdict -- skipped, cancelled, or
-        # run but measured nothing. Normal here, not an error: saying something
-        # in exactly those cases is the point of this job.
+        # Download by artifact-id, NOT by name.
+        #
+        # The name is run-scoped, so it survives across attempts, and `overwrite`
+        # only replaces it when there is something to upload. A detect re-run
+        # that dies before producing any files therefore leaves the PREVIOUS
+        # attempt's archive in place under that same name -- and resolving by
+        # name here would fetch it and post an older attempt's PASS under this
+        # attempt's footer. The artifact-id names one specific upload, so a
+        # failed retry cannot inherit an earlier one.
+        #
+        # Skipped when the id is empty, which covers detect being skipped or
+        # cancelled and detect running but uploading nothing. That is a normal
+        # outcome, not an error: saying something in exactly those cases is the
+        # whole point of this job. A report-only re-run still works, because job
+        # outputs from the succeeded detect are re-served verbatim.
+        if: needs.detect.outputs.artifact_id != ''
         continue-on-error: true
         uses: actions/download-artifact@v4
         with:
-          # Run-scoped, not attempt-scoped -- see the note on the upload.
-          name: rccl-ab-report-${{ github.run_id }}
+          artifact-ids: ${{ needs.detect.outputs.artifact_id }}
+          # Required. download-artifact only extracts straight into `path` when
+          # it was given a `name`; downloading by id otherwise nests the files
+          # under path/<artifact-name>/, and the compose step below would find
+          # no rccl_report.md and report every run as unmeasured. With one id
+          # there is nothing to merge -- this just flattens.
+          merge-multiple: true
           path: ${{ runner.temp }}/dl
 
       - name: Compose comment

--- a/.github/workflows/rccl_perf_regression.yml
+++ b/.github/workflows/rccl_perf_regression.yml
@@ -149,10 +149,12 @@ jobs:
         # library against itself and post green on a PR it never measured -- a
         # gate that reports PASS when its own inputs are broken is worse than no
         # gate at all.
+        env:
+          _BASE: ${{ github.base_ref }}
         run: |
           set -o pipefail
-          if ! diff_out="$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")"; then
-            echo "::error::Could not diff against origin/${{ github.base_ref }}. Refusing to guess whether RCCL changed — a wrong guess here produces a meaningless green gate."
+          if ! diff_out="$(git diff --name-only "origin/${_BASE}...HEAD")"; then
+            echo "::error::Could not diff against origin/${_BASE}. Refusing to guess whether RCCL changed — a wrong guess here produces a meaningless green gate."
             exit 1
           fi
           # Mirror the `paths` exclusions above, or a PR touching this workflow
@@ -163,7 +165,7 @@ jobs:
           # which is fine here. It must not reach the git diff above; that is
           # the swallowed failure this step exists to prevent.
           rccl_src="$(grep '^projects/rccl/' <<<"${diff_out}" \
-            | grep -vE '(\.md$|^projects/rccl/docs/|^projects/rccl/LICENSE|/CODEOWNERS$)' || true)"
+            | grep -vE '(\.md$|^projects/rccl/docs/|^projects/rccl/LICENSE[^/]*$|/CODEOWNERS$)' || true)"
           if [[ -n "${rccl_src}" ]]; then
             echo "rccl_changed=1" >> "$GITHUB_OUTPUT"
           else
@@ -355,7 +357,7 @@ jobs:
         # render step and the gate step below consume this answer, so they can
         # never disagree about whether this run measured anything.
         #
-        # Never fails: it only reports. `Gate on detector verdict` owns the
+        # Does not gate: it only reports. `Gate on detector verdict` owns the
         # failing, so that a report is still rendered and uploaded first.
         run: |
           REPORT="${_ART}/ab_regression_report.json"
@@ -366,22 +368,33 @@ jobs:
           fi
           echo "present=1" >> "$GITHUB_OUTPUT"
           python3 - "${REPORT}" >> "$GITHUB_OUTPUT" <<'PY'
-          import json, sys
+          import json, secrets, sys
           d = json.load(open(sys.argv[1]))
           reports = d.get("reports", {}) or {}
+          # An empty `reports` means nothing was measured, whichever way trust is
+          # expressed -- so require it on both paths. Trusting a bare
+          # "trustworthy": true with no reports would clear the gate and then
+          # announce "0 confirmed regression(s)" for a run that scored nothing.
           trust = d.get("trustworthy")
           if trust is None:
-              trust = bool(reports) and all(
+              trust = all(
                   r.get("summary", {}).get("trustworthy", False) for r in reports.values())
+          trust = bool(trust) and bool(reports)
           print(f"trustworthy={'true' if trust else 'false'}")
           print("regressions=%d" % sum(
               r.get("summary", {}).get("regressions", 0) for r in reports.values()))
           reasons = d.get("untrustworthy_reasons") or ["report predates the trustworthy flag"]
-          print("reasons<<EOR")
+          if not reports:
+              reasons = ["report contains no scored groups"]
+          # Random delimiter, per GitHub's own guidance: these lines come from the
+          # detector, and a reason equal to a fixed marker would close the block
+          # early and leave the rest to be parsed as further outputs.
+          eof = f"EOR_{secrets.token_hex(8)}"
+          print(f"reasons<<{eof}")
           if not trust:
               for why in reasons:
                   print(why)
-          print("EOR")
+          print(eof)
           prov = d.get("provenance") or {}
           print(f"provenance=cvs@{prov.get('cvs_sha')} thresholds={d.get('thresholds_source')}")
           PY
@@ -395,6 +408,12 @@ jobs:
           _REASONS: ${{ steps.verdict.outputs.reasons }}
         run: |
           REPORT="${_ART}/ab_regression_report.json"
+          # Clear any inherited report BEFORE deciding anything. The artifact dir
+          # is keyed on run_id, not run_attempt, so a re-run inherits attempt 1's
+          # rccl_report.md -- and every bail-out below deliberately leaves the
+          # file alone, which would hand `Upload artifacts` a stale verdict for
+          # `report` to post as this attempt's answer.
+          rm -f "${_ART}/rccl_report.md"
           # Deliberately do NOT write rccl_report.md on either bail-out below.
           # Its presence in the uploaded artifact is the `report` job's signal
           # that a real verdict exists, so writing a placeholder would make "the
@@ -486,7 +505,7 @@ jobs:
           # code we captured explicitly instead. An empty value means the step
           # was killed before it wrote one, which is also an infra failure.
           if [[ "${_CODE}" != "0" && "${_CODE}" != "1" ]]; then
-            echo "::error::Detector failed to run (SLURM submission/polling error or timeout, exit ${_CODE:-<none>}). Report on NFS may be stale — not gating on it."
+            echo "::error::Detector failed to run (missing cluster script, SLURM submission/polling error, or timeout; exit ${_CODE:-<none>}). Report on NFS may be stale — not gating on it."
             exit 2
           fi
           if [[ "${_PRESENT}" != "1" ]]; then
@@ -578,7 +597,7 @@ jobs:
               emit ":warning: **Not measured.** The detector job was skipped. This is an infrastructure result, not a statement about your change."
             fi
           elif [[ "${_DETECT}" == "cancelled" ]]; then
-            emit ":warning: **Not measured.** The detector job was cancelled before it produced a verdict."
+            emit ":warning: **Not measured.** The detector job was cancelled before it produced a verdict. This is an infrastructure result, not a statement about your change."
           else
             # detect writes this file only for a verdict it found trustworthy,
             # so presence is the signal. Do not substitute any other source: a

--- a/.github/workflows/rccl_perf_regression.yml
+++ b/.github/workflows/rccl_perf_regression.yml
@@ -71,9 +71,12 @@ env:
   # concurrent runs safe.
   RCCL_CI_WORKSPACE: '1'
 
+# Only `contents: read` here, which is all build and detect need -- they check
+# out the source and talk to the scheduler, never to the GitHub API. `report` is
+# the one job that writes a comment, and it declares `pull-requests: write` for
+# itself, so that scope never reaches a self-hosted runner executing PR code.
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   build:


### PR DESCRIPTION
## Problem

47 of the last 60 runs of this workflow ended `cancelled` — not `failure`, not `success`. Five succeeded.

A GitHub Actions concurrency group holds at most **one** pending job; when a third run arrives, the waiting one is cancelled to make room. Both jobs used a single global group, so every PR competed for that one slot and evicted whoever was in it. From the author's side there was no error and no comment — the run simply disappeared.

## Fix

Key the concurrency groups by PR, so cross-PR contention goes away while a new push still evicts your own older queued run. Serialising the hardware moves to the batch scheduler, which owns the nodes and whose queue is unbounded — it makes you wait, it does not cancel you.

`cancel-in-progress` stays `false` deliberately: cancelling a GitHub job does not cancel the batch job it submitted, so `true` would orphan allocations that keep holding hardware.

This trades cancellation for **queueing, not throughput.** Capacity is roughly break-even today and bursts will build a backlog; real parallelism needs a second build-only runner. Flagged inline.

## Also included

- **Runner labels: role label only, no `self-hosted`.** The gate could not have run as originally written — `runs-on` is an AND, and the role runners carry no default labels, so the pair matched nothing. The failure mode is the bad kind: no diagnostic, the job just sits queued against an Idle runner until `timeout-minutes` fires. Caught by dispatching the branch, not by reading it.
- **Fail closed on the changed-paths diff.** The old `|| echo "rccl_changed=0"` swallowed a shallow clone or missing base ref and reported "RCCL didn't change" — so the gate compared a prebuilt library against itself and posted green on a PR it never measured.
- **Per-run artifact path**, replacing a shared directory that still held an earlier run's output and would have produced a stale verdict.
- **The build left the measurement reservation**, where it was holding a node exclusively for its whole duration, and **gained a cancel trap** so a cancelled run no longer leaves it compiling with nobody to read the result.
- **The PR comment moved to its own `always()` job** on `ubuntu-latest`. As a step inside `detect` it left the sticky comment showing the previous attempt's verdict; queued behind the measurement jobs it also delayed comments by hours.
- **Timeouts renested** so inner budgets fire first and can report *why*, and **docs-only churn excluded** from the paths filter.

## Review round

Twelve findings from the automated reviewer, all addressed. The substantive ones:

- **An untrustworthy run could still post a verdict** — the report was rendered whenever the detector's JSON existed, which is *before* the trust check. Trust is now evaluated once, ahead of rendering, so the invariant the code already assumed (a rendered report exists only for a real verdict) is actually enforced.
- **Re-runs could not find the verdict.** The artifact was named per run *and attempt*, but a re-run bumps the attempt without re-running a `detect` that already succeeded — so the comment job posted "not measured" over a good verdict.
- **Re-runs were structurally broken.** `detect` deleted the per-run config on `always()` while `build` does not re-run and its outputs are re-served verbatim, so a retry read a path the first attempt had removed. The failures most worth retrying were exactly the ones that deleted it.
- **Two runs of one PR could race for the sticky comment.** A concurrency group alone does not close this — `cancel-in-progress` only fires when jobs overlap, and the worst ordering does not: a run whose detect takes ~25min is overtaken by a later docs-only push whose detect is skipped and whose comment posts at once. The post is now guarded on the head SHA still being the PR head.

Commentary is cut back too — 329 comment lines to 254, while the code grew by 60 with the fixes above, so the file is shorter than before this round.

## Validation

End to end on the real cluster, both paths and both runner labels. **`pull_request`:** build success on its own runner, detect correctly skipped, report posting `:white_check_mark: **Not applicable.**` — which covers the sticky comment, unreachable from a `workflow_dispatch`. **`workflow_dispatch`:** the full detector on the pinned 4-node set — 8/8 groups scored, `trustworthy: true`, 0 regressions, 184 comparison keys, ~26min.

This round's fixes were verified by extracting each `run:` block and exercising it directly: the verdict evaluator over trustworthy, untrustworthy, legacy and missing-report fixtures; the render step confirming a report is written *only* when trustworthy; all four gate branches including an empty exit code; and the changed-paths filter over eight cases, confirming a failing `git diff` still fails closed. `actionlint` is clean apart from the two expected unknown-self-hosted-label warnings.

## Companion PR

**ROCm/cvs#310** — the scheduler-side scripts these steps call. The two halves need to land together.

## Issue Tracking

JIRA ID: AIMVT-196
