### PR TITLE
fix(rocprofiler-sdk): name rocpd marker regions after the ROCTx message

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
@@ -1982,6 +1982,12 @@ write_rocpd(
                             tool_metadata.get_marker_message(itr.correlation_id.internal);
                         if(!message.empty())
                         {
+                            // name the region after the user-provided ROCTx message rather
+                            // than the synthetic API name (e.g. "warm up" instead of
+                            // "roctxThreadRangeA"). Matches generatePerfetto.cpp. The message
+                            // remains in extdata for consumers already reading it from there.
+                            name = message;
+
                             msg = get_json_string(
                                 [](auto& ar, std::string_view _msg) {
                                     ar(cereal::make_nvp("message", std::string{_msg}));


### PR DESCRIPTION
The rocpd writer named marker regions after the synthetic API operation (e.g. "roctxThreadRangeA") and relegated the user's ROCTx message to the extdata JSON blob. Consumers reading rocpd_region.name_id therefore saw an API name instead of the message the user annotated their code with.

generatePerfetto.cpp already resolves the marker message for the event name; generateRocpd.cpp fetched the same message but only wrote it to extdata. Assign it to the region name as well so the two writers agree.

The message continues to be written to extdata, so consumers already using JSON_EXTRACT(extdata, '$.message') -- e.g. rocpd/summary.py -- are unaffected. Marker messages are pre-interned into the string table, so the string_entries lookup is safe.

Verified with tests/bin/transpose under --marker-trace --output-format rocpd. rocpd_region rows are now named run (2), run/iteration (1000) and run/iteration/sync (100), matching the application's nesting and iteration counts, and both name_id and extdata.message carry the message.

Instantaneous markers (roctxMarkA) are unchanged: they are written to rocpd_sample, which has no name column, and are tracked separately.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->
JIRA ID: ROCM-29460

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Verified with tests/bin/transpose under --marker-trace --output-format rocpd. rocpd_region rows are now named run (2), run/iteration (1000) and run/iteration/sync (100), matching the application's nesting and iteration counts, and both name_id and extdata.message carry the message.
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
