### PR TITLE
Preemptively align AllReduce's DDA-vs-CE dispatch with #9777

### DIFF
--- a/projects/rccl/src/collectives.cc
+++ b/projects/rccl/src/collectives.cc
@@ -216,6 +216,29 @@ static bool rcclDdaEnabled(const ncclComm* comm, size_t totalBytes, size_t gfx94
   return threshold > 0 && totalBytes <= threshold;
 }
 
+// Decides whether ncclAllReduce_impl takes the DDA path for this call. Kept as a small named helper
+// (rather than an inline expression) so the dispatch decision is reachable from host unit tests; the
+// logic is identical to the guard at the AllReduce call site below.
+//
+// `ceAllReduceAllowed` is the caller's single source of truth for "will CE AllReduce actually service
+// this call" -- computed once at the call site from rcclUseCeAllReduce() plus whatever additional
+// gating the CE AllReduce implementation requires (graph latch, ncclGroupDepth, force/symReg
+// eligibility, etc). This helper does not re-derive CE eligibility itself: threading the same boolean
+// through both the early CE return and this guard keeps the two decisions from silently drifting apart
+// as CE AllReduce's own eligibility rules evolve.
+bool rcclAllReduceShouldTakeDdaPath(const ncclComm* comm, size_t count, ncclDataType_t datatype,
+                                    bool symEligible, bool ceAllReduceAllowed) {
+  const size_t msgBytes = count * ncclTypeSize(datatype);
+  // gfx1250 DDA fabric AR is bounded by rcclDdaEnabled (RCCL_DDA_THRESHOLD) and the per-tier
+  // thresholds, so it may claim the full range regardless of CE eligibility -- ddaFabricArch1250
+  // forces this branch unconditionally. On other arches, yield to DDA whenever CE won't actually
+  // service this call; yielding on message size alone left comms without CE's prerequisites (e.g.
+  // gfx950 with symmetricSupport off) with no DDA and no CE, falling back to the generic ring/tree
+  // kernel across the whole 4 MiB+ range that DDA still wins.
+  const bool ddaFabricArch1250 = IsArchMatch(comm->archName, "gfx1250");
+  return !symEligible && (ddaFabricArch1250 || !ceAllReduceAllowed) && rcclDdaEnabled(comm, msgBytes, 8388608);
+}
+
 // Check if symmteric kernels is requested for this collective
 static bool isSymmetricKernelRequested(ncclComm* comm, ncclFunc_t coll, int symkOp, ncclDataType_t datatype,
                                        size_t nElts, const void* sendbuff, void* recvbuff) {
@@ -639,12 +662,7 @@ ncclResult_t ncclAllReduce_impl(const void* sendbuff, void* recvbuff, size_t cou
   info.ceCapturing = ceCapturing;
   info.ceArGraphAllowed = ceArGraphAllowed;
   info.ceGraphDecisionValid = true;
-  size_t msgBytes = count * ncclTypeSize(datatype);
-  // gfx1250 DDA fabric AR is bounded by rcclDdaEnabled (RCCL_DDA_THRESHOLD) and
-  // the per-tier thresholds, so it may claim the full range; the CE min-size cap
-  // only applies to the other arches' DDA paths.
-  const bool ddaFabricArch1250 = IsArchMatch(comm->archName, "gfx1250");
-  if (!symEligible && rcclDdaEnabled(comm, count * ncclTypeSize(datatype), 8388608) && !ceAllReduceAllowed) {
+  if (rcclAllReduceShouldTakeDdaPath(comm, count, datatype, symEligible, ceAllReduceAllowed)) {
     if (IsArchMatch(comm->archName, "gfx1250")) {
       // Small-message fast lane: LL protocol (no GPU barrier).
       if (rcclParamDdaLL() && (count * ncclTypeSize(datatype)) <= (size_t)rcclParamDdaLLThreshold() &&

--- a/projects/rccl/src/include/rccl_common.h
+++ b/projects/rccl/src/include/rccl_common.h
@@ -139,6 +139,13 @@ bool rcclUseCeAllReduce(struct ncclComm* comm, size_t count, ncclDataType_t data
 void rcclCeAllReduceGraphLatchTick(struct ncclComm* comm, bool ceCapturing);
 // Pure query: is CE AllReduce currently allowed on this comm?
 bool rcclCeAllReduceAllowed(struct ncclComm* comm);
+// Decides whether ncclAllReduce_impl takes the DDA path for this call. Mirrors the guard in
+// collectives.cc exactly: DDA runs when the buffers are not symmetric-kernel eligible, CE AllReduce
+// will not service the call per the caller-computed `ceAllReduceAllowed` (non-gfx1250 only; gfx1250
+// always keeps the DDA fabric path), and DDA is enabled for this arch/size. Host-side and GPU-free so
+// the dispatch decision can be unit tested.
+bool rcclAllReduceShouldTakeDdaPath(const struct ncclComm* comm, size_t count, ncclDataType_t datatype,
+                                    bool symEligible, bool ceAllReduceAllowed);
 void rcclSetPxn(struct ncclComm* comm, int& rcclPxnDisable);
 void rcclSetP2pNetChunkSize(struct ncclComm* comm, int& rcclP2pNetChunkSize);
 ncclResult_t rcclFuncMaxSendRecvCount(ncclFunc_t func, int nRanks, size_t count, size_t& maxCount);

--- a/projects/rccl/test/RcclWrapTests.cpp
+++ b/projects/rccl/test/RcclWrapTests.cpp
@@ -2002,4 +2002,185 @@ TEST(Rcclwrap, AdjustChannels_Gfx950SingleNode8Ranks_MainColl_NoDouble)
 
 #endif // ENABLE_WARP_SPEED
 
+// ---------------------------------------------------------------------------
+// rcclAllReduceShouldTakeDdaPath: the AllReduce DDA-vs-CE dispatch decision.
+//
+// The helper returns true when ncclAllReduce_impl should take the DDA path, and
+// false when it should yield (to CE AllReduce, the symmetric kernel, or the
+// generic ring/tree fallback). DDA is taken when the buffers are not
+// symmetric-kernel eligible, CE AllReduce will not service the call, and DDA is
+// enabled for this arch and size.
+//
+// `ceAllReduceAllowed` is passed in directly rather than derived inside the
+// test: the call site computes it once from rcclUseCeAllReduce() plus whatever
+// additional gating CE AllReduce requires (graph latch, ncclGroupDepth,
+// force/symReg, op/dtype/size/divisibility support, etc). Driving it directly
+// keeps these cases independent of RCCL_CE_ALLREDUCE's default and of CE
+// AllReduce's own eligibility rules -- each case just asserts what the DDA
+// guard does for a given (symEligible, ceAllReduceAllowed) combination.
+//
+// These tests drive the real decision (no GPU): RCCL_DDA_ENABLE defaults to 1
+// and ncclGroupDepth to 0, so rcclDdaEnabled() runs its real arch/threshold logic.
+namespace
+{
+// Fill a zero-initialized comm with just the fields the decision reads. Filled by
+// reference because ncclComm is not copyable.
+void InitDdaDecisionComm(ncclComm& comm, const char* arch, int nRanks, int nNodes, bool symmetricSupport)
+{
+    comm.archName         = const_cast<char*>(arch);
+    comm.nRanks           = nRanks;
+    comm.nNodes           = nNodes;
+    comm.symmetricSupport = symmetricSupport ? 1 : 0;
+}
+
+// count for a target byte size and datatype.
+size_t CountForBytes(size_t bytes, ncclDataType_t dt)
+{
+    return bytes / ncclTypeSize(dt);
+}
+} // namespace
+
+// gfx950 with symmetricSupport off: CE cannot run, so an 8 MiB call (at/above the
+// 4 MiB CE minimum) must still take DDA rather than fall to the generic kernel.
+TEST(RcclAllReduceDdaDecision, Gfx950_SymOff_LargeMsg_TakesDda)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx950", 8, 1, /*symmetricSupport=*/false);
+    size_t   count = CountForBytes(8ull * 1024 * 1024, ncclFloat32);
+    EXPECT_TRUE(rcclAllReduceShouldTakeDdaPath(&comm, count, ncclFloat32,
+                                               /*symEligible=*/false, /*ceAllReduceAllowed=*/false));
+}
+
+// gfx950, small message with CE unavailable: squarely in DDA's range, takes DDA.
+TEST(RcclAllReduceDdaDecision, Gfx950_SymOff_SmallMsg_TakesDda)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx950", 8, 1, /*symmetricSupport=*/false);
+    size_t   count = CountForBytes(2ull * 1024 * 1024, ncclFloat32);
+    EXPECT_TRUE(rcclAllReduceShouldTakeDdaPath(&comm, count, ncclFloat32,
+                                               /*symEligible=*/false, /*ceAllReduceAllowed=*/false));
+}
+
+// gfx950 with symmetricSupport on and every CE prerequisite met: CE will service
+// the call, so the DDA guard must yield (returns false).
+TEST(RcclAllReduceDdaDecision, Gfx950_SymOn_CeEligible_YieldsToCe)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx950", 8, 1, /*symmetricSupport=*/true);
+    size_t   count = CountForBytes(8ull * 1024 * 1024, ncclFloat32); // divisible by 8 ranks
+    EXPECT_FALSE(rcclAllReduceShouldTakeDdaPath(&comm, count, ncclFloat32,
+                                                /*symEligible=*/false, /*ceAllReduceAllowed=*/true));
+}
+
+// CE eligible by size/op/dtype but disabled by the graph latch (folded into the
+// caller's ceAllReduceAllowed=false): CE will not run, so DDA must reclaim the call.
+TEST(RcclAllReduceDdaDecision, Gfx950_SymOn_GraphLatched_TakesDda)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx950", 8, 1, /*symmetricSupport=*/true);
+    size_t   count = CountForBytes(8ull * 1024 * 1024, ncclFloat32);
+    EXPECT_TRUE(rcclAllReduceShouldTakeDdaPath(&comm, count, ncclFloat32,
+                                               /*symEligible=*/false, /*ceAllReduceAllowed=*/false));
+}
+
+// CE declines on an unsupported op (folded into ceAllReduceAllowed=false) even
+// with symmetricSupport on, so DDA reclaims the call.
+TEST(RcclAllReduceDdaDecision, Gfx950_SymOn_UnsupportedOp_TakesDda)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx950", 8, 1, /*symmetricSupport=*/true);
+    size_t   count = CountForBytes(8ull * 1024 * 1024, ncclFloat32);
+    EXPECT_TRUE(rcclAllReduceShouldTakeDdaPath(&comm, count, ncclFloat32,
+                                               /*symEligible=*/false, /*ceAllReduceAllowed=*/false));
+}
+
+// gfx942 with symmetricSupport off: a 6 MiB call is within the 8 MiB gfx942 DDA
+// cap and, with CE unavailable, takes DDA.
+TEST(RcclAllReduceDdaDecision, Gfx942_SymOff_MidMsg_TakesDda)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx942", 8, 1, /*symmetricSupport=*/false);
+    size_t   count = CountForBytes(6ull * 1024 * 1024, ncclFloat32);
+    EXPECT_TRUE(rcclAllReduceShouldTakeDdaPath(&comm, count, ncclFloat32,
+                                               /*symEligible=*/false, /*ceAllReduceAllowed=*/false));
+}
+
+// gfx942 above its 8 MiB DDA cap: rcclDdaEnabled returns false, so no DDA.
+TEST(RcclAllReduceDdaDecision, Gfx942_SymOff_AboveCap_NoDda)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx942", 8, 1, /*symmetricSupport=*/false);
+    size_t   count = CountForBytes(9ull * 1024 * 1024, ncclFloat32);
+    EXPECT_FALSE(rcclAllReduceShouldTakeDdaPath(&comm, count, ncclFloat32,
+                                                /*symEligible=*/false, /*ceAllReduceAllowed=*/false));
+}
+
+// gfx942 with symmetricSupport on and every CE prerequisite met: CE claims the call
+// and the DDA guard yields, even though 6 MiB is within the 8 MiB gfx942 DDA cap.
+// Mirror of Gfx942_SymOff_MidMsg_TakesDda: ceAllReduceAllowed flips the decision.
+TEST(RcclAllReduceDdaDecision, Gfx942_SymOn_CeEligible_YieldsToCe)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx942", 8, 1, /*symmetricSupport=*/true);
+    size_t   count = CountForBytes(6ull * 1024 * 1024, ncclFloat32); // divisible by 8 ranks
+    EXPECT_FALSE(rcclAllReduceShouldTakeDdaPath(&comm, count, ncclFloat32,
+                                                /*symEligible=*/false, /*ceAllReduceAllowed=*/true));
+}
+
+// gfx942 with symmetricSupport on but CE declines on an unsupported op (folded
+// into ceAllReduceAllowed=false): DDA reclaims the call since 6 MiB is within
+// the 8 MiB gfx942 cap.
+TEST(RcclAllReduceDdaDecision, Gfx942_SymOn_UnsupportedOp_TakesDda)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx942", 8, 1, /*symmetricSupport=*/true);
+    size_t   count = CountForBytes(6ull * 1024 * 1024, ncclFloat32);
+    EXPECT_TRUE(rcclAllReduceShouldTakeDdaPath(&comm, count, ncclFloat32,
+                                               /*symEligible=*/false, /*ceAllReduceAllowed=*/false));
+}
+
+// gfx1250 forces the DDA fabric path regardless of CE eligibility: the
+// ddaFabricArch1250 short-circuit means CE never claims the call on this arch.
+// ceAllReduceAllowed=true (the call is otherwise fully CE-eligible: 64 MiB, sum,
+// divisible), so the short-circuit is the only reason DDA is chosen here.
+TEST(RcclAllReduceDdaDecision, Gfx1250_CeEligible_StillTakesDda)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx1250", 8, 1, /*symmetricSupport=*/true);
+    size_t   count = CountForBytes(64ull * 1024 * 1024, ncclFloat32); // CE-eligible size, divisible by 8
+    EXPECT_TRUE(rcclAllReduceShouldTakeDdaPath(&comm, count, ncclFloat32,
+                                               /*symEligible=*/false, /*ceAllReduceAllowed=*/true));
+}
+
+// An arch DDA never runs on: rcclDdaEnabled returns false, so no DDA on any size.
+TEST(RcclAllReduceDdaDecision, UnsupportedArch_NoDda)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx90a", 8, 1, /*symmetricSupport=*/false);
+    size_t   count = CountForBytes(2ull * 1024 * 1024, ncclFloat32);
+    EXPECT_FALSE(rcclAllReduceShouldTakeDdaPath(&comm, count, ncclFloat32,
+                                                /*symEligible=*/false, /*ceAllReduceAllowed=*/false));
+}
+
+// gfx942/gfx950 DDA requires the full 8-GPU node; fewer ranks disables it.
+TEST(RcclAllReduceDdaDecision, Gfx950_TooFewRanks_NoDda)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx950", 4, 1, /*symmetricSupport=*/false);
+    size_t   count = CountForBytes(2ull * 1024 * 1024, ncclFloat32);
+    EXPECT_FALSE(rcclAllReduceShouldTakeDdaPath(&comm, count, ncclFloat32,
+                                                /*symEligible=*/false, /*ceAllReduceAllowed=*/false));
+}
+
+// Symmetric-kernel eligible buffers win outright: the DDA guard yields (returns false)
+// regardless of arch/size.
+TEST(RcclAllReduceDdaDecision, SymEligible_YieldsToSymmetricKernel)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx950", 8, 1, /*symmetricSupport=*/false);
+    size_t   count = CountForBytes(2ull * 1024 * 1024, ncclFloat32);
+    EXPECT_FALSE(rcclAllReduceShouldTakeDdaPath(&comm, count, ncclFloat32,
+                                                /*symEligible=*/true, /*ceAllReduceAllowed=*/true));
+}
+
 } // namespace RcclUnitTesting


### PR DESCRIPTION
## Motivation

Preemptively align AllReduce's DDA-vs-CE dispatch with #9777 by threading the fully-computed ceAllReduceAllowed through a shared rcclAllReduceShouldTakeDdaPath() helper (plus its 13 unit tests), so DDA still reclaims calls CE can't service instead of falling back to the generic ring/tree kernel.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

JIRA ID: AICOMRCCL-1044

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
