### PR TITLE
feat(cuid): drop the OpenSSL dependency

### DIFF
--- a/projects/amdsmi/src/CMakeLists.txt
+++ b/projects/amdsmi/src/CMakeLists.txt
@@ -138,7 +138,6 @@ if(BUILD_CUID)
         HINTS ${ROCM_DIR_CORE}/include/amdcuid ${CMAKE_PREFIX_PATH}/include/amdcuid
         REQUIRED
     )
-    find_package(OpenSSL REQUIRED)
 endif(BUILD_CUID)
 #
 #   --- When BUILD_BOTH_LIBS: build shared and static; tests/examples link to static ---
@@ -189,7 +188,7 @@ function(amdsmi_configure_common_target _TARGET)
 
     if(BUILD_CUID)
         target_compile_definitions(${_TARGET} PRIVATE BUILD_CUID)
-        target_link_libraries(${_TARGET} PRIVATE ${AMDCUID_LIB} OpenSSL::Crypto)
+        target_link_libraries(${_TARGET} PRIVATE ${AMDCUID_LIB})
         target_include_directories(${_TARGET} PRIVATE ${AMDCUID_INCLUDE_DIR})
     endif()
 

--- a/projects/cuid/.clang-tidy
+++ b/projects/cuid/.clang-tidy
@@ -1,0 +1,57 @@
+# Modelled on projects/amdsmi/.clang-tidy so the two sibling C++ libraries in
+# this monorepo report the same class of findings. Deviations from that file
+# are listed at the bottom with a reason.
+Checks:
+  bugprone*,
+  clang-analyzer*,
+  cert-*,
+  concurrency-*,
+  google*,
+  misc*,
+  modernize*,
+  -abseil*,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-reserved-identifier,
+  -cert-dcl21-cpp,
+  -cert-err58-cpp,
+  -clang-analyzer-security.insecureAPI.strcpy,
+  -clang-diagnostic-sign-conversion,
+  -clang-diagnostic-unused-parameter,
+  -cppcoreguidelines*,
+  -cppcoreguidelines-pro*,
+  -google-readability*,
+  -google-runtime-int,
+  -misc-const-correctness,
+  -misc-include-cleaner,
+  -misc-non-copyable-objects,
+  -misc-unused-parameters,
+  -misc-use-anonymous-namespace,
+  -misc-use-internal-linkage,
+  -modernize-avoid-c-arrays,
+  -modernize-macro-to-enum,
+  -modernize-redundant-void-arg,
+  -modernize-use-auto,
+  -modernize-use-nodiscard,
+  -modernize-use-noexcept,
+  -modernize-use-nullptr,
+  -modernize-use-trailing-return-type,
+  -modernize-use-using,
+  -performance*,
+  -readability*,
+  readability-delete-null-pointer,
+
+# Deviations from projects/amdsmi/.clang-tidy:
+#
+#   +cert-*         libamdcuid handles key material and parses firmware tables
+#                   read from sysfs, so the CERT rules about buffer handling and
+#                   integer conversion earn their keep here. The two noisiest
+#                   and least relevant are disabled individually above:
+#                   dcl21-cpp (postfix operator return types) and err58-cpp
+#                   (throwing static initializers, which are gtest fixtures).
+#   +concurrency-*  CuidDeviceManager is a shared, mutex-guarded singleton
+#                   reached from the public C API, and the daemon serves
+#                   multiple clients.
+#
+# Treat findings as advisory: fix what is real, do not silence what is not.
+HeaderFilterRegex: 'projects/cuid/(lib|cli|daemon)/.*\.(h|hpp)$'
+WarningsAsErrors: ''

--- a/projects/cuid/.codespellrc
+++ b/projects/cuid/.codespellrc
@@ -1,0 +1,10 @@
+[codespell]
+# AMD/ROCm and CUID domain terms that are not typos:
+#   hsa      - Heterogeneous System Architecture
+#   nd       - appears inside identifiers such as "2nd"
+#   renderD  - DRM device node path (/dev/dri/renderD128)
+#   ans      - "ans" appears in ACPI/SMBIOS field names
+#   BA       - PCI BAR-adjacent identifiers
+ignore-words-list = hsa,nd,renderD,ans,BA,inout,cant,indx,ue
+skip = build,build-*,.git,docs/_build
+quiet-level = 2

--- a/projects/cuid/.gersemirc
+++ b/projects/cuid/.gersemirc
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/BlankSpruce/gersemi/0.26.0/gersemi/configuration.schema.json
+
+warn_about_unknown_commands: false
+indent: 4
+line_length: 120

--- a/projects/cuid/.pre-commit-config.yaml
+++ b/projects/cuid/.pre-commit-config.yaml
@@ -1,0 +1,89 @@
+# - How to use (install as git hook — only runs on staged files):
+#     python3 -m pip install pre-commit
+#     cd <repo-root>
+#     pre-commit install -c projects/cuid/.pre-commit-config.yaml
+#
+# - How to run manually on branch changes only (vs develop):
+#     pre-commit run --config projects/cuid/.pre-commit-config.yaml \
+#       --from-ref develop --to-ref HEAD
+#
+# - How to run on all files (CAUTION: reformats everything):
+#     pre-commit run --all-files --config projects/cuid/.pre-commit-config.yaml
+#
+# How to skip:
+#   git commit --no-verify
+# or
+#   SKIP=clang-format git commit
+#   SKIP=gersemi git commit
+
+# Scope every hook to this project. Without this, `pre-commit run --all-files`
+# from the repository root turns the generic hooks (end-of-file-fixer,
+# mixed-line-ending, check-json, codespell) loose on the whole monorepo: the
+# first run of it here rewrote 2223 files across emulation/, rocr-runtime and
+# rocprofiler-*. pre-commit ANDs this with each hook's own `files`, so the
+# per-hook patterns below still apply on top of it.
+files: '^projects/cuid/'
+
+exclude: |
+  (?x)
+    ^projects/cuid/docs/
+    | ^projects/cuid/build.*/
+    | \.(md|rst|rtf)$
+    | \.readthedocs\.yaml$
+fail_fast: false
+
+repos:
+-   repo: https://github.com/codespell-project/codespell
+    rev: v2.4.2
+    hooks:
+    -   id: codespell
+        args: ["-w", "--config", "projects/cuid/.codespellrc"]
+
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-json
+    -   id: check-merge-conflict
+    -   id: check-added-large-files
+    -   id: mixed-line-ending
+
+-   repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v22.1.0
+    hooks:
+    -   id: clang-format
+        files: '^projects/cuid/.*\.(c|cpp|cc|h|hpp)$'
+
+-   repo: https://github.com/BlankSpruce/gersemi
+    rev: 0.26.0
+    hooks:
+    -   id: gersemi
+        files: '^projects/cuid/.*(CMakeLists\.txt|\.cmake(\.in)?)$'
+
+-   repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
+    hooks:
+    -   id: shellcheck
+        # The .sh.in templates carry @CMAKE_VARIABLE@ placeholders, which
+        # shellcheck reads as ordinary words; that is fine for the checks we
+        # care about (quoting, unset variables, portability).
+        files: '^projects/cuid/.*\.(sh|sh\.in)$'
+        types: [file]
+
+-   repo: local
+    hooks:
+    -   id: cuid-sha256-drift
+        name: CUID/rocprofiler-sdk SHA-256 drift
+        description: >-
+            libamdcuid carries a copy of rocprofiler-sdk's SHA-256. A silent
+            divergence would not fail to build, it would change every CUID
+            ever issued, so the two are compared function by function.
+        entry: python3 projects/cuid/tests/check_sha256_drift.py
+        language: system
+        pass_filenames: false
+        # always_run rather than a `files` pattern: the global scope above would
+        # hide a change made only on the rocprofiler-sdk side, which is exactly
+        # the drift this is meant to catch. The check takes milliseconds.
+        always_run: true

--- a/projects/cuid/CMakeLists.txt
+++ b/projects/cuid/CMakeLists.txt
@@ -34,23 +34,11 @@ set(CMAKE_INSTALL_LIBDIR "lib" CACHE STRING "Library install directory")
 
 # Read version from amd_cuid.h so there is a single source of truth
 file(READ "${CMAKE_CURRENT_SOURCE_DIR}/lib/include/amd_cuid.h" _CUID_HEADER)
-string(
-    REGEX MATCH "#define AMDCUID_LIB_VERSION_MAJOR ([0-9]+)"
-    _
-    "${_CUID_HEADER}"
-)
+string(REGEX MATCH "#define AMDCUID_LIB_VERSION_MAJOR ([0-9]+)" _ "${_CUID_HEADER}")
 set(VERSION_MAJOR "${CMAKE_MATCH_1}")
-string(
-    REGEX MATCH "#define AMDCUID_LIB_VERSION_MINOR ([0-9]+)"
-    _
-    "${_CUID_HEADER}"
-)
+string(REGEX MATCH "#define AMDCUID_LIB_VERSION_MINOR ([0-9]+)" _ "${_CUID_HEADER}")
 set(VERSION_MINOR "${CMAKE_MATCH_1}")
-string(
-    REGEX MATCH "#define AMDCUID_LIB_VERSION_PATCH ([0-9]+)"
-    _
-    "${_CUID_HEADER}"
-)
+string(REGEX MATCH "#define AMDCUID_LIB_VERSION_PATCH ([0-9]+)" _ "${_CUID_HEADER}")
 set(VERSION_PATCH "${CMAKE_MATCH_1}")
 set(VERSION_STRING "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
 message("Package version: ${VERSION_STRING}")
@@ -65,19 +53,9 @@ project(${AMDCUID} VERSION "${VERSION_STRING}")
 # CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT is only available after project()
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     if(WIN32)
-        set(CMAKE_INSTALL_PREFIX
-            "C:/Program Files/AMD/ROCM/AMDCUID"
-            CACHE PATH
-            "Default installation directory."
-            FORCE
-        )
+        set(CMAKE_INSTALL_PREFIX "C:/Program Files/AMD/ROCM/AMDCUID" CACHE PATH "Default installation directory." FORCE)
     else() # Linux/Unix
-        set(CMAKE_INSTALL_PREFIX
-            "${ROCM_DIR}/core"
-            CACHE PATH
-            "Default installation directory."
-            FORCE
-        )
+        set(CMAKE_INSTALL_PREFIX "${ROCM_DIR}/core" CACHE PATH "Default installation directory." FORCE)
     endif()
 endif()
 
@@ -86,7 +64,7 @@ endif()
 include(GNUInstallDirs)
 
 # C++ standard for all targets
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # When cmake -DBUILD_TESTS off by default, it will not build the CUID test suite
@@ -121,27 +99,9 @@ if(WIN32)
     set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib) # Import libs
 endif()
 
-# Platform-specific dependencies; use native Windows bcrypt for HMAC, and OpenSSL on Linux/Unix
-if(WIN32)
-    # Use the native Windows bcrypt library and link it directly on Windows targets.
-else()
-    # Prefer a system-installed OpenSSL; fall back to building from source via
-    # FetchContent if the dev package is not present (e.g. in bare containers).
-    find_package(OpenSSL QUIET)
-    if(NOT OPENSSL_FOUND)
-        message(
-            STATUS
-            "OpenSSL not found on system; fetching and building from source"
-        )
-        include(FetchContent)
-        FetchContent_Declare(
-            openssl-cmake
-            GIT_REPOSITORY https://github.com/janbar/openssl-cmake.git
-            GIT_TAG 1.1.1w-20231130
-        )
-        FetchContent_MakeAvailable(openssl-cmake)
-    endif()
-endif()
+# No third-party dependencies. SHA-256 and HMAC-SHA-256 are built from
+# lib/src/sha256.cc; random key material comes from the platform CSPRNG
+# (bcrypt on Windows, getrandom(2)//dev/urandom elsewhere).
 
 message("Build Configuration:")
 message("-----------ROCM_DIR : " ${ROCM_DIR})
@@ -181,9 +141,7 @@ if(UNIX AND NOT APPLE)
         @ONLY
     )
     install(
-        PROGRAMS
-            ${CMAKE_CURRENT_BINARY_DIR}/amdcuid_postinst.sh
-            ${CMAKE_CURRENT_BINARY_DIR}/amdcuid_prerm.sh
+        PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/amdcuid_postinst.sh ${CMAKE_CURRENT_BINARY_DIR}/amdcuid_prerm.sh
         DESTINATION ${CMAKE_INSTALL_DATADIR}/${AMDCUID}
         COMPONENT ${LIB_COMPONENT}
     )
@@ -202,9 +160,7 @@ if(NOT TARGET uninstall)
     )
     add_custom_target(
         uninstall
-        COMMAND
-            ${CMAKE_COMMAND} -P
-            "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+        COMMAND ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
         COMMENT "Uninstalling ${AMDCUID} ..."
     )
 endif()

--- a/projects/cuid/README.md
+++ b/projects/cuid/README.md
@@ -156,9 +156,8 @@ sphinx-build docs docs/_build/html
 
 | Component | Minimum Version | Notes |
 |-----------|-----------------|-------|
-| **OpenSSL** | 1.1.0 | Uses `HMAC_CTX_new()`/`HMAC_CTX_free()` (1.1.x) or `EVP_MAC` API (3.0+) |
 | **CMake** | 3.14 | Build system requirement |
-| **GCC** | 5.0 | C++14 standard required |
+| **GCC** | 7.0 | C++17 standard required |
 | **Kernel** | 2.6+ | Standard sysfs interfaces |
 | **Architecture** | x86_64 required for CPUID-based CPU fields | Limited fallback via `/proc/cpuinfo` on other architectures |
 
@@ -184,7 +183,7 @@ sphinx-build docs docs/_build/html
 
 #### Notes
 
-- **LibreSSL** and **BoringSSL** are supported via the HMAC_CTX backend
+- No third-party crypto dependency: SHA-256 and HMAC-SHA-256 are built from `lib/src/sha256.cc`, so the library links no TLS stack on any platform
 - Root/administrator privileges are required for full functionality (ACPI tables, SMBIOS UUID, PCI config space access)
 - systemd is only needed for `udevd` reloads and optional service management; the daemon can also be started using other mechanisms such as an `@reboot` cron job
 

--- a/projects/cuid/cli/CMakeLists.txt
+++ b/projects/cuid/cli/CMakeLists.txt
@@ -18,15 +18,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-message(
-    "&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&"
-)
-message(
-    "                            Cmake amdcuid_tool                            "
-)
-message(
-    "&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&"
-)
+message("&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")
+message("                            Cmake amdcuid_tool                            ")
+message("&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")
 
 message("")
 message("Build Configuration:")
@@ -53,14 +47,10 @@ target_include_directories(${AMDCUID_TOOL_EXECUTABLE} PRIVATE ${INC_DIR})
 
 # Link against the CUID library (public API only)
 # The tool now uses only the public API defined in amd_cuid.h
-target_link_libraries(${AMDCUID_TOOL_EXECUTABLE} amdcuid_static OpenSSL::Crypto)
+target_link_libraries(${AMDCUID_TOOL_EXECUTABLE} amdcuid_static)
 
 # Install the tool
-install(
-    TARGETS ${AMDCUID_TOOL_EXECUTABLE}
-    DESTINATION ${CMAKE_INSTALL_BINDIR}
-    COMPONENT ${CLI_COMPONENT}
-)
+install(TARGETS ${AMDCUID_TOOL_EXECUTABLE} DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT ${CLI_COMPONENT})
 
 message("&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")
 message("                    Finished Cmake amdcuid_tool                    ")

--- a/projects/cuid/cli/amdcuid_tool.cc
+++ b/projects/cuid/cli/amdcuid_tool.cc
@@ -20,16 +20,19 @@
  * THE SOFTWARE.
  */
 
-#include "include/amd_cuid.h"
-#include <cstring>
 #include <errno.h>
-#include <fstream>
 #include <getopt.h>
+#include <unistd.h>
+
+#include <cctype>
+#include <cstring>
+#include <fstream>
 #include <iostream>
 #include <map>
 #include <string>
-#include <unistd.h>
 #include <vector>
+
+#include "include/amd_cuid.h"
 
 /**
  * @file amdcuid_tool.cc
@@ -46,7 +49,7 @@
  */
 bool is_root() { return geteuid() == 0; }
 
-void print_usage(const char *program_name) {
+void print_usage(const char* program_name) {
   std::cout << "Usage: " << program_name << " [OPTIONS]\n\n";
   std::cout << "AMD Component Unified Identifier (CUID) Tool\n\n";
   std::cout << "Options:\n";
@@ -60,28 +63,22 @@ void print_usage(const char *program_name) {
                "bytes, use with --generate-cuid)\n";
   std::cout << "  --notify-daemon              Notify daemon to refresh device "
                "registry (for udev integration)\n";
-  std::cout
-      << "  --list                       List all devices and their CUIDs\n";
+  std::cout << "  --list                       List all devices and their CUIDs\n";
   std::cout << "  --type <type>                Filter by device type (gpu, "
                "cpu, nic, npu, platform)\n";
-  std::cout
-      << "                               Use with --list or --query-device\n";
+  std::cout << "                               Use with --list or --query-device\n";
   std::cout << "  --show-primary               Show primary CUIDs (requires "
                "root privileges)\n";
-  std::cout
-      << "                               Use with --list or --query-device\n";
+  std::cout << "                               Use with --list or --query-device\n";
   std::cout << "  --query-device <identifier>  Query specific device by device "
                "path or BDF\n";
   std::cout << "  --version                    Show library version\n";
   std::cout << "  --help, -h                   Show this help message\n";
   std::cout << "\nExamples:\n";
-  std::cout
-      << "  # Generate CUID registry with a new random key (requires root)\n";
-  std::cout << "  sudo " << program_name
-            << " --generate-cuid --generate-key\n\n";
+  std::cout << "  # Generate CUID registry with a new random key (requires root)\n";
+  std::cout << "  sudo " << program_name << " --generate-cuid --generate-key\n\n";
   std::cout << "  # Generate CUID registry with existing key file\n";
-  std::cout << "  sudo " << program_name
-            << " --generate-cuid --set-key /path/to/hmac_key.bin\n\n";
+  std::cout << "  sudo " << program_name << " --generate-cuid --set-key /path/to/hmac_key.bin\n\n";
   std::cout << "  # Generate CUID registry using previously set key\n";
   std::cout << "  sudo " << program_name << " --generate-cuid\n\n";
   std::cout << "  # Notify daemon of device changes (called by udev)\n";
@@ -93,47 +90,39 @@ void print_usage(const char *program_name) {
   std::cout << "  # List all devices with primary CUIDs (requires root)\n";
   std::cout << "  sudo " << program_name << " --list --show-primary\n\n";
   std::cout << "  # Query specific device by path\n";
-  std::cout << "  " << program_name
-            << " --query-device /sys/class/drm/renderD128\n\n";
+  std::cout << "  " << program_name << " --query-device /sys/class/drm/renderD128\n\n";
   std::cout << "  # Query device by BDF\n";
-  std::cout << "  " << program_name
-            << " --query-device 0000:03:00.0 --type gpu\n\n";
+  std::cout << "  " << program_name << " --query-device 0000:03:00.0 --type gpu\n\n";
 }
 
-const char *device_type_to_string(amdcuid_device_type_t type) {
+const char* device_type_to_string(amdcuid_device_type_t type) {
   switch (type) {
-  case AMDCUID_DEVICE_TYPE_PLATFORM:
-    return "PLATFORM";
-  case AMDCUID_DEVICE_TYPE_CPU:
-    return "CPU";
-  case AMDCUID_DEVICE_TYPE_GPU:
-    return "GPU";
-  case AMDCUID_DEVICE_TYPE_NIC:
-    return "NIC";
-  case AMDCUID_DEVICE_TYPE_NPU:
-    return "NPU";
-  case AMDCUID_DEVICE_TYPE_NONE:
-    return "NONE";
-  default:
-    return "UNKNOWN";
+    case AMDCUID_DEVICE_TYPE_PLATFORM:
+      return "PLATFORM";
+    case AMDCUID_DEVICE_TYPE_CPU:
+      return "CPU";
+    case AMDCUID_DEVICE_TYPE_GPU:
+      return "GPU";
+    case AMDCUID_DEVICE_TYPE_NIC:
+      return "NIC";
+    case AMDCUID_DEVICE_TYPE_NPU:
+      return "NPU";
+    case AMDCUID_DEVICE_TYPE_NONE:
+      return "NONE";
+    default:
+      return "UNKNOWN";
   }
 }
 
-amdcuid_device_type_t string_to_device_type(const std::string &type_str) {
+amdcuid_device_type_t string_to_device_type(const std::string& type_str) {
   std::string upper = type_str;
-  for (auto &c : upper)
-    c = toupper(c);
+  for (auto& c : upper) c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
 
-  if (upper == "PLATFORM")
-    return AMDCUID_DEVICE_TYPE_PLATFORM;
-  if (upper == "CPU")
-    return AMDCUID_DEVICE_TYPE_CPU;
-  if (upper == "GPU")
-    return AMDCUID_DEVICE_TYPE_GPU;
-  if (upper == "NIC")
-    return AMDCUID_DEVICE_TYPE_NIC;
-  if (upper == "NPU")
-    return AMDCUID_DEVICE_TYPE_NPU;
+  if (upper == "PLATFORM") return AMDCUID_DEVICE_TYPE_PLATFORM;
+  if (upper == "CPU") return AMDCUID_DEVICE_TYPE_CPU;
+  if (upper == "GPU") return AMDCUID_DEVICE_TYPE_GPU;
+  if (upper == "NIC") return AMDCUID_DEVICE_TYPE_NIC;
+  if (upper == "NPU") return AMDCUID_DEVICE_TYPE_NPU;
   return AMDCUID_DEVICE_TYPE_NONE;
 }
 
@@ -143,12 +132,12 @@ amdcuid_device_type_t string_to_device_type(const std::string &type_str) {
  * @param key Output buffer for the key (32 bytes)
  * @return true on success, false on failure
  */
-bool load_key_from_file(const std::string &key_file, uint8_t key[32]) {
+bool load_key_from_file(const std::string& key_file, uint8_t key[32]) {
   std::ifstream file(key_file, std::ios::binary);
   if (!file) {
     return false;
   }
-  file.read(reinterpret_cast<char *>(key), 32);
+  file.read(reinterpret_cast<char*>(key), 32);
   return file.gcount() == 32;
 }
 
@@ -179,24 +168,20 @@ int notify_daemon() {
  * @param result Output string
  * @return Status code
  */
-amdcuid_status_t query_string_property(amdcuid_id_t handle,
-                                       amdcuid_query_t query,
-                                       std::string &result) {
+amdcuid_status_t query_string_property(amdcuid_id_t handle, amdcuid_query_t query,
+                                       std::string& result) {
   // First query to get required size
   uint32_t length = 0;
-  amdcuid_status_t status =
-      amdcuid_query_device_property(handle, query, nullptr, &length);
+  amdcuid_status_t status = amdcuid_query_device_property(handle, query, nullptr, &length);
 
   if (status == AMDCUID_STATUS_INSUFFICIENT_SIZE && length > 0) {
     // Allocate buffer and query again
     std::vector<char> buffer(length);
-    status =
-        amdcuid_query_device_property(handle, query, buffer.data(), &length);
+    status = amdcuid_query_device_property(handle, query, buffer.data(), &length);
     if (status == AMDCUID_STATUS_SUCCESS) {
       // Remove null terminator if present
       result = std::string(buffer.data(),
-                           length > 0 && buffer[length - 1] == '\0' ? length - 1
-                                                                    : length);
+                           length > 0 && buffer[length - 1] == '\0' ? length - 1 : length);
     }
   } else if (status == AMDCUID_STATUS_SUCCESS) {
     result.clear();
@@ -205,16 +190,14 @@ amdcuid_status_t query_string_property(amdcuid_id_t handle,
   return status;
 }
 
-int generate_cuid_files(const std::string &key_file, bool generate_key) {
+int generate_cuid_files(const std::string& key_file, bool generate_key) {
   std::cout << "Generating/refreshing CUID registry...\n" << std::endl;
 
   // Validate key options - cannot use both together
   if (!key_file.empty() && generate_key) {
-    std::cerr
-        << "Error: Cannot use both --generate-key and --set-key together.\n";
+    std::cerr << "Error: Cannot use both --generate-key and --set-key together.\n";
     std::cerr << "Use --generate-key to create a new random key, or\n";
-    std::cerr << "Use --set-key <file> to load an existing key from a file."
-              << std::endl;
+    std::cerr << "Use --set-key <file> to load an existing key from a file." << std::endl;
     return 1;
   }
 
@@ -223,16 +206,15 @@ int generate_cuid_files(const std::string &key_file, bool generate_key) {
     // Load key from file
     uint8_t key[32];
     if (!load_key_from_file(key_file, key)) {
-      std::cerr << "Error: Failed to read HMAC key from file: " << key_file
-                << std::endl;
+      std::cerr << "Error: Failed to read HMAC key from file: " << key_file << std::endl;
       std::cerr << "Key file must be exactly 32 bytes." << std::endl;
       return 1;
     }
 
     amdcuid_status_t status = amdcuid_set_hash_key(key);
     if (status != AMDCUID_STATUS_SUCCESS) {
-      std::cerr << "Error: Failed to set HMAC key: "
-                << amdcuid_status_to_string(status) << std::endl;
+      std::cerr << "Error: Failed to set HMAC key: " << amdcuid_status_to_string(status)
+                << std::endl;
       return 1;
     }
     std::cout << "HMAC key loaded from: " << key_file << std::endl;
@@ -241,15 +223,15 @@ int generate_cuid_files(const std::string &key_file, bool generate_key) {
     uint8_t key[32];
     amdcuid_status_t status = amdcuid_generate_hash_key(key);
     if (status != AMDCUID_STATUS_SUCCESS) {
-      std::cerr << "Error: Failed to generate HMAC key: "
-                << amdcuid_status_to_string(status) << std::endl;
+      std::cerr << "Error: Failed to generate HMAC key: " << amdcuid_status_to_string(status)
+                << std::endl;
       return 1;
     }
 
     status = amdcuid_set_hash_key(key);
     if (status != AMDCUID_STATUS_SUCCESS) {
-      std::cerr << "Error: Failed to set generated HMAC key: "
-                << amdcuid_status_to_string(status) << std::endl;
+      std::cerr << "Error: Failed to set generated HMAC key: " << amdcuid_status_to_string(status)
+                << std::endl;
       return 1;
     }
     std::cout << "Generated new HMAC key." << std::endl;
@@ -262,15 +244,14 @@ int generate_cuid_files(const std::string &key_file, bool generate_key) {
   amdcuid_status_t status = amdcuid_refresh();
 
   if (status != AMDCUID_STATUS_SUCCESS) {
-    std::cerr << "Error: Failed to refresh CUID registry: "
-              << amdcuid_status_to_string(status) << std::endl;
+    std::cerr << "Error: Failed to refresh CUID registry: " << amdcuid_status_to_string(status)
+              << std::endl;
     if (status == AMDCUID_STATUS_KEY_ERROR) {
       std::cerr << "No HMAC key found. Please use --generate-key or --set-key "
                    "<file> to create a key first."
                 << std::endl;
     } else if (status == AMDCUID_STATUS_PERMISSION_DENIED) {
-      std::cerr << "Some devices may require root privileges to discover."
-                << std::endl;
+      std::cerr << "Some devices may require root privileges to discover." << std::endl;
     }
     return 1;
   }
@@ -278,8 +259,7 @@ int generate_cuid_files(const std::string &key_file, bool generate_key) {
   // Count discovered devices
   uint32_t count = 0;
   status = amdcuid_get_all_handles(nullptr, &count);
-  if (status == AMDCUID_STATUS_INSUFFICIENT_SIZE ||
-      status == AMDCUID_STATUS_SUCCESS) {
+  if (status == AMDCUID_STATUS_INSUFFICIENT_SIZE || status == AMDCUID_STATUS_SUCCESS) {
     std::cout << "Discovered " << count << " device(s)" << std::endl;
   }
 
@@ -287,7 +267,7 @@ int generate_cuid_files(const std::string &key_file, bool generate_key) {
   return 0;
 }
 
-int list_devices(bool show_primary, const std::string *filter_type) {
+int list_devices(bool show_primary, const std::string* filter_type) {
   // Check for root privileges if requesting primary CUIDs
   if (show_primary && !is_root()) {
     std::cerr << "Error: Permission denied\n";
@@ -302,8 +282,7 @@ int list_devices(bool show_primary, const std::string *filter_type) {
   if (filter_type) {
     filter_device_type = string_to_device_type(*filter_type);
     if (filter_device_type == AMDCUID_DEVICE_TYPE_NONE) {
-      std::cerr << "Error: Unknown device type '" << *filter_type << "'"
-                << std::endl;
+      std::cerr << "Error: Unknown device type '" << *filter_type << "'" << std::endl;
       std::cerr << "Valid types: platform, cpu, gpu, nic, npu" << std::endl;
       return 1;
     }
@@ -313,8 +292,7 @@ int list_devices(bool show_primary, const std::string *filter_type) {
   uint32_t count = 0;
   amdcuid_status_t status = amdcuid_get_all_handles(nullptr, &count);
 
-  if (status != AMDCUID_STATUS_INSUFFICIENT_SIZE &&
-      status != AMDCUID_STATUS_SUCCESS) {
+  if (status != AMDCUID_STATUS_INSUFFICIENT_SIZE && status != AMDCUID_STATUS_SUCCESS) {
     if (status == AMDCUID_STATUS_UNSUPPORTED) {
       std::cout << "No devices found.\n";
       std::cout << "Please run 'sudo amdcuid_tool --generate-cuid' first to "
@@ -322,8 +300,8 @@ int list_devices(bool show_primary, const std::string *filter_type) {
                 << std::endl;
       return 0;
     }
-    std::cerr << "Error: Failed to get device count: "
-              << amdcuid_status_to_string(status) << std::endl;
+    std::cerr << "Error: Failed to get device count: " << amdcuid_status_to_string(status)
+              << std::endl;
     return 1;
   }
 
@@ -335,19 +313,18 @@ int list_devices(bool show_primary, const std::string *filter_type) {
   std::vector<amdcuid_id_t> handles(count);
   status = amdcuid_get_all_handles(handles.data(), &count);
   if (status != AMDCUID_STATUS_SUCCESS) {
-    std::cerr << "Error: Failed to get device handles: "
-              << amdcuid_status_to_string(status) << std::endl;
+    std::cerr << "Error: Failed to get device handles: " << amdcuid_status_to_string(status)
+              << std::endl;
     return 1;
   }
 
   // Group handles by device type
   std::map<amdcuid_device_type_t, std::vector<amdcuid_id_t>> grouped;
 
-  for (const auto &handle : handles) {
+  for (const auto& handle : handles) {
     amdcuid_device_type_t device_type;
     uint32_t len = sizeof(device_type);
-    status = amdcuid_query_device_property(handle, AMDCUID_QUERY_DEVICE_TYPE,
-                                           &device_type, &len);
+    status = amdcuid_query_device_property(handle, AMDCUID_QUERY_DEVICE_TYPE, &device_type, &len);
     if (status != AMDCUID_STATUS_SUCCESS) {
       continue;
     }
@@ -371,7 +348,7 @@ int list_devices(bool show_primary, const std::string *filter_type) {
 
   // Count total entries after filtering
   size_t total = 0;
-  for (const auto &kv : grouped) {
+  for (const auto& kv : grouped) {
     total += kv.second.size();
   }
 
@@ -381,14 +358,14 @@ int list_devices(bool show_primary, const std::string *filter_type) {
   }
   std::cout << ":\n" << std::endl;
 
-  for (const auto &kv : grouped) {
+  for (const auto& kv : grouped) {
     amdcuid_device_type_t type = kv.first;
-    const std::vector<amdcuid_id_t> &handle_list = kv.second;
+    const std::vector<amdcuid_id_t>& handle_list = kv.second;
     std::string type_str = device_type_to_string(type);
     std::cout << "---- " << type_str << " Devices ----" << std::endl;
 
     int device_index = 0;
-    for (const auto &handle : handle_list) {
+    for (const auto& handle : handle_list) {
       if (type == AMDCUID_DEVICE_TYPE_PLATFORM) {
         std::cout << type_str;
       } else {
@@ -399,11 +376,10 @@ int list_devices(bool show_primary, const std::string *filter_type) {
       if (show_primary) {
         amdcuid_id_t primary_cuid;
         uint32_t len = sizeof(primary_cuid);
-        status = amdcuid_query_device_property(
-            handle, AMDCUID_QUERY_PRIMARY_CUID, &primary_cuid, &len);
+        status =
+            amdcuid_query_device_property(handle, AMDCUID_QUERY_PRIMARY_CUID, &primary_cuid, &len);
         if (status == AMDCUID_STATUS_SUCCESS) {
-          std::cout << "\n  Primary CUID:   "
-                    << amdcuid_id_to_string(primary_cuid);
+          std::cout << "\n  Primary CUID:   " << amdcuid_id_to_string(primary_cuid);
         }
       }
 
@@ -412,8 +388,8 @@ int list_devices(bool show_primary, const std::string *filter_type) {
 
       // Query device path
       std::string device_path;
-      if (query_string_property(handle, AMDCUID_QUERY_DEVICE_PATH,
-                                device_path) == AMDCUID_STATUS_SUCCESS) {
+      if (query_string_property(handle, AMDCUID_QUERY_DEVICE_PATH, device_path) ==
+          AMDCUID_STATUS_SUCCESS) {
         std::cout << "\n  Device Path:    " << device_path;
       }
 
@@ -425,8 +401,8 @@ int list_devices(bool show_primary, const std::string *filter_type) {
   return 0;
 }
 
-int query_device(const std::string &identifier, bool show_primary,
-                 const std::string *device_type_str) {
+int query_device(const std::string& identifier, bool show_primary,
+                 const std::string* device_type_str) {
   // Check for root privileges if requesting primary CUIDs
   if (show_primary && !is_root()) {
     std::cerr << "Error: Permission denied\n";
@@ -440,12 +416,11 @@ int query_device(const std::string &identifier, bool show_primary,
   amdcuid_status_t status;
 
   // Determine device type for lookup
-  amdcuid_device_type_t device_type = AMDCUID_DEVICE_TYPE_GPU; // Default to GPU
+  amdcuid_device_type_t device_type = AMDCUID_DEVICE_TYPE_GPU;  // Default to GPU
   if (device_type_str) {
     device_type = string_to_device_type(*device_type_str);
     if (device_type == AMDCUID_DEVICE_TYPE_NONE) {
-      std::cerr << "Error: Unknown device type '" << *device_type_str << "'"
-                << std::endl;
+      std::cerr << "Error: Unknown device type '" << *device_type_str << "'" << std::endl;
       std::cerr << "Valid types: platform, cpu, gpu, nic, npu" << std::endl;
       return 1;
     }
@@ -464,18 +439,16 @@ int query_device(const std::string &identifier, bool show_primary,
 
   // Check if identifier looks like a BDF (e.g., "0000:c6:00.1" or "c6:00.1").
   // Must not start with '/' (which would indicate a sysfs path).
-  bool is_bdf = (!identifier.empty() && identifier[0] != '/' &&
-                 identifier.find(':') != std::string::npos &&
-                 identifier.find('.') != std::string::npos);
+  bool is_bdf =
+      (!identifier.empty() && identifier[0] != '/' && identifier.find(':') != std::string::npos &&
+       identifier.find('.') != std::string::npos);
 
   if (is_bdf) {
     // Try as BDF
-    status =
-        amdcuid_get_handle_by_bdf(identifier.c_str(), device_type, &handle);
+    status = amdcuid_get_handle_by_bdf(identifier.c_str(), device_type, &handle);
   } else {
     // Try as device path
-    status = amdcuid_get_handle_by_dev_path(identifier.c_str(), device_type,
-                                            &handle);
+    status = amdcuid_get_handle_by_dev_path(identifier.c_str(), device_type, &handle);
   }
 
   if (status != AMDCUID_STATUS_SUCCESS) {
@@ -490,30 +463,25 @@ int query_device(const std::string &identifier, bool show_primary,
   // Query device type
   amdcuid_device_type_t queried_type;
   uint32_t len = sizeof(queried_type);
-  status = amdcuid_query_device_property(handle, AMDCUID_QUERY_DEVICE_TYPE,
-                                         &queried_type, &len);
+  status = amdcuid_query_device_property(handle, AMDCUID_QUERY_DEVICE_TYPE, &queried_type, &len);
   if (status == AMDCUID_STATUS_SUCCESS) {
-    std::cout << "  Type:           " << device_type_to_string(queried_type)
-              << std::endl;
+    std::cout << "  Type:           " << device_type_to_string(queried_type) << std::endl;
   }
 
   // Query primary CUID if requested
   if (show_primary) {
     amdcuid_id_t primary_cuid;
     len = sizeof(primary_cuid);
-    status = amdcuid_query_device_property(handle, AMDCUID_QUERY_PRIMARY_CUID,
-                                           &primary_cuid, &len);
+    status = amdcuid_query_device_property(handle, AMDCUID_QUERY_PRIMARY_CUID, &primary_cuid, &len);
     if (status == AMDCUID_STATUS_SUCCESS) {
-      std::cout << "  Primary CUID:   " << amdcuid_id_to_string(primary_cuid)
-                << std::endl;
+      std::cout << "  Primary CUID:   " << amdcuid_id_to_string(primary_cuid) << std::endl;
     } else if (status == AMDCUID_STATUS_PERMISSION_DENIED) {
       std::cout << "  Primary CUID:   (requires root)" << std::endl;
     }
   }
 
   // Display derived CUID (the handle)
-  std::cout << "  CUID:           " << amdcuid_id_to_string(handle)
-            << std::endl;
+  std::cout << "  CUID:           " << amdcuid_id_to_string(handle) << std::endl;
 
   // Query device path
   std::string device_path;
@@ -525,19 +493,18 @@ int query_device(const std::string &identifier, bool show_primary,
   return 0;
 }
 
-int main(int argc, char *argv[]) {
-  static struct option long_options[] = {
-      {"generate-cuid", no_argument, 0, 'g'},
-      {"generate-key", no_argument, 0, 'k'},
-      {"set-key", required_argument, 0, 's'},
-      {"notify-daemon", no_argument, 0, 'n'},
-      {"list", no_argument, 0, 'l'},
-      {"type", required_argument, 0, 't'},
-      {"show-primary", no_argument, 0, 'p'},
-      {"query-device", required_argument, 0, 'q'},
-      {"version", no_argument, 0, 'v'},
-      {"help", no_argument, 0, 'h'},
-      {0, 0, 0, 0}};
+int main(int argc, char* argv[]) {
+  static struct option long_options[] = {{"generate-cuid", no_argument, 0, 'g'},
+                                         {"generate-key", no_argument, 0, 'k'},
+                                         {"set-key", required_argument, 0, 's'},
+                                         {"notify-daemon", no_argument, 0, 'n'},
+                                         {"list", no_argument, 0, 'l'},
+                                         {"type", required_argument, 0, 't'},
+                                         {"show-primary", no_argument, 0, 'p'},
+                                         {"query-device", required_argument, 0, 'q'},
+                                         {"version", no_argument, 0, 'v'},
+                                         {"help", no_argument, 0, 'h'},
+                                         {0, 0, 0, 0}};
 
   std::string key_file;
   std::string filter_type;
@@ -552,44 +519,45 @@ int main(int argc, char *argv[]) {
   int opt;
   int option_index = 0;
 
-  while ((opt = getopt_long(argc, argv, "gks:nlt:pq:vh", long_options,
-                            &option_index)) != -1) {
+  // Option parsing in main(), before any thread exists.
+  // NOLINTNEXTLINE(concurrency-mt-unsafe)
+  while ((opt = getopt_long(argc, argv, "gks:nlt:pq:vh", long_options, &option_index)) != -1) {
     switch (opt) {
-    case 'g':
-      do_generate = true;
-      break;
-    case 'k':
-      generate_key = true;
-      break;
-    case 's':
-      key_file = optarg;
-      break;
-    case 'n':
-      do_notify = true;
-      break;
-    case 'l':
-      do_list = true;
-      break;
-    case 't':
-      filter_type = optarg;
-      break;
-    case 'p':
-      show_primary = true;
-      break;
-    case 'q':
-      do_query = true;
-      query_identifier = optarg;
-      break;
-    case 'v':
-      std::cout << "AMD CUID Library Version: "
-                << amdcuid_library_version_to_string() << std::endl;
-      return 0;
-    case 'h':
-      print_usage(argv[0]);
-      return 0;
-    default:
-      print_usage(argv[0]);
-      return 1;
+      case 'g':
+        do_generate = true;
+        break;
+      case 'k':
+        generate_key = true;
+        break;
+      case 's':
+        key_file = optarg;
+        break;
+      case 'n':
+        do_notify = true;
+        break;
+      case 'l':
+        do_list = true;
+        break;
+      case 't':
+        filter_type = optarg;
+        break;
+      case 'p':
+        show_primary = true;
+        break;
+      case 'q':
+        do_query = true;
+        query_identifier = optarg;
+        break;
+      case 'v':
+        std::cout << "AMD CUID Library Version: " << amdcuid_library_version_to_string()
+                  << std::endl;
+        return 0;
+      case 'h':
+        print_usage(argv[0]);
+        return 0;
+      default:
+        print_usage(argv[0]);
+        return 1;
     }
   }
 
@@ -607,8 +575,7 @@ int main(int argc, char *argv[]) {
   } else if (do_notify) {
     return notify_daemon();
   } else if (do_list) {
-    return list_devices(show_primary,
-                        filter_type.empty() ? nullptr : &filter_type);
+    return list_devices(show_primary, filter_type.empty() ? nullptr : &filter_type);
   } else if (do_query) {
     return query_device(query_identifier, show_primary,
                         filter_type.empty() ? nullptr : &filter_type);

--- a/projects/cuid/cmake_uninstall.cmake.in
+++ b/projects/cuid/cmake_uninstall.cmake.in
@@ -25,17 +25,10 @@ if(EXISTS "${_prerm}")
     message(STATUS "Running pre-removal script: ${_prerm}")
     execute_process(COMMAND sh "${_prerm}" RESULT_VARIABLE _prerm_result)
     if(NOT _prerm_result EQUAL 0)
-        message(
-            WARNING
-            "Pre-removal script exited with code ${_prerm_result}. "
-            "Continuing with file removal anyway."
-        )
+        message(WARNING "Pre-removal script exited with code ${_prerm_result}. " "Continuing with file removal anyway.")
     endif()
 else()
-    message(
-        STATUS
-        "Pre-removal script not found (${_prerm}); skipping daemon teardown."
-    )
+    message(STATUS "Pre-removal script not found (${_prerm}); skipping daemon teardown.")
 endif()
 
 # Remove all files tracked by cmake --install via install_manifest.txt

--- a/projects/cuid/daemon/CMakeLists.txt
+++ b/projects/cuid/daemon/CMakeLists.txt
@@ -18,15 +18,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-message(
-    "&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&"
-)
-message(
-    "                           Cmake amdcuid_daemon                           "
-)
-message(
-    "&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&"
-)
+message("&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")
+message("                           Cmake amdcuid_daemon                           ")
+message("&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")
 
 message("")
 message("Build Configuration:")
@@ -61,24 +55,13 @@ target_include_directories(${AMDCUID_DAEMON_EXECUTABLE} PRIVATE ${INC_DIR})
 # Pass the resolved config install directory to the daemon at compile time so
 # the HMAC key and daemon configuration paths are always built from a concrete
 # location.
-target_compile_definitions(
-    ${AMDCUID_DAEMON_EXECUTABLE}
-    PRIVATE AMDCUID_CONFIG_DIR="${AMDCUID_SHARED_CONFIG_DIR}"
-)
+target_compile_definitions(${AMDCUID_DAEMON_EXECUTABLE} PRIVATE AMDCUID_CONFIG_DIR="${AMDCUID_SHARED_CONFIG_DIR}")
 
 # Link against the CUID library
-target_link_libraries(
-    ${AMDCUID_DAEMON_EXECUTABLE}
-    amdcuid_static
-    Threads::Threads
-)
+target_link_libraries(${AMDCUID_DAEMON_EXECUTABLE} amdcuid_static Threads::Threads)
 
 # Install the daemon
-install(
-    TARGETS ${AMDCUID_DAEMON_EXECUTABLE}
-    DESTINATION ${CMAKE_INSTALL_BINDIR}
-    COMPONENT ${DAEMON_COMPONENT}
-)
+install(TARGETS ${AMDCUID_DAEMON_EXECUTABLE} DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT ${DAEMON_COMPONENT})
 
 set(DAEMON_CONFIG_FILE amdcuid_daemon.conf)
 install(
@@ -120,19 +103,11 @@ if(UNIX AND NOT APPLE)
 
     # Generate the post-install shell script from a template, substituting the
     # install prefix and config directory baked-in at cmake configure time.
-    configure_file(
-        ${CMAKE_CURRENT_SOURCE_DIR}/postinst.in
-        ${CMAKE_CURRENT_BINARY_DIR}/postinst
-        @ONLY
-    )
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/postinst.in ${CMAKE_CURRENT_BINARY_DIR}/postinst @ONLY)
 
     # Configure the pre-removal script (mirrors postinst: stops service, removes
     # udev rules, cron job, and systemd service symlink).
-    configure_file(
-        ${CMAKE_CURRENT_SOURCE_DIR}/prerm.in
-        ${CMAKE_CURRENT_BINARY_DIR}/prerm
-        @ONLY
-    )
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/prerm.in ${CMAKE_CURRENT_BINARY_DIR}/prerm @ONLY)
 
     # Also install both scripts so they can be re-run manually after a cmake --install.
     install(

--- a/projects/cuid/daemon/amdcuid_daemon.cc
+++ b/projects/cuid/daemon/amdcuid_daemon.cc
@@ -20,25 +20,27 @@
  * THE SOFTWARE.
  */
 
-#include "include/amd_cuid.h"
-#include "src/hmac.h"
-#include "src/ipc_protocol.h"
+#include <fcntl.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/un.h>
+#include <unistd.h>
+
 #include <atomic>
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
-#include <fcntl.h>
 #include <fstream>
 #include <iostream>
 #include <map>
 #include <memory>
 #include <sstream>
-#include <sys/socket.h>
-#include <sys/stat.h>
-#include <sys/un.h>
 #include <thread>
-#include <unistd.h>
 #include <vector>
+
+#include "include/amd_cuid.h"
+#include "src/hmac.h"
+#include "src/ipc_protocol.h"
 
 // static hmac instance for daemon
 static cuid_hmac daemon_hmac = cuid_hmac();
@@ -47,7 +49,7 @@ static cuid_hmac daemon_hmac = cuid_hmac();
 static std::unique_ptr<std::ofstream> g_log_file;
 static bool g_logging_to_file = false;
 
-static std::ostream &log_out() {
+static std::ostream& log_out() {
   if (g_logging_to_file && g_log_file && g_log_file->is_open()) {
     *g_log_file << "timestamp: " << time(nullptr) << ": ";
     return *g_log_file;
@@ -56,7 +58,7 @@ static std::ostream &log_out() {
   return std::cout;
 }
 
-static std::ostream &log_err() {
+static std::ostream& log_err() {
   if (g_logging_to_file && g_log_file && g_log_file->is_open()) {
     *g_log_file << "timestamp: " << time(nullptr) << ": ";
     return *g_log_file;
@@ -67,26 +69,36 @@ static std::ostream &log_err() {
 
 static void init_logging(bool enabled) {
   if (enabled) {
-    g_log_file =
-        std::make_unique<std::ofstream>("/var/log/amdcuid.log", std::ios::app);
+    g_log_file = std::make_unique<std::ofstream>("/var/log/amdcuid.log", std::ios::app);
     if (g_log_file->is_open()) {
       g_logging_to_file = true;
-      // Add timestamp to log entry
+      // Add timestamp to log entry. ctime() formats into a static buffer
+      // shared by every thread; the daemon serves clients concurrently, so
+      // use the reentrant form.
       time_t now = time(nullptr);
-      *g_log_file << "\n=== Log started at " << ctime(&now);
+      struct tm tm_buf{};
+      char stamp[64] = "unknown time";
+      if (localtime_r(&now, &tm_buf) != nullptr) {
+        if (strftime(stamp, sizeof(stamp), "%a %b %e %H:%M:%S %Y", &tm_buf) == 0) {
+          // Fixed 12-character literal into a 64-byte buffer.
+          // NOLINTNEXTLINE(cert-err33-c)
+          std::snprintf(stamp, sizeof(stamp), "unknown time");
+        }
+      }
+      *g_log_file << "\n=== Log started at " << stamp << "\n";
     }
   }
 }
 
 // Daemon Server
 class CuidDaemonServer {
-public:
+ public:
   CuidDaemonServer() : is_running_(false), server_fd_(-1) {}
   ~CuidDaemonServer() { stop(); }
 
   amdcuid_status_t start() {
     if (is_running_) {
-      return AMDCUID_STATUS_SUCCESS; // Already running
+      return AMDCUID_STATUS_SUCCESS;  // Already running
     }
 
     server_fd_ = socket(AF_UNIX, SOCK_STREAM, 0);
@@ -94,17 +106,18 @@ public:
       return AMDCUID_STATUS_IPC_ERROR;
     }
 
-    unlink(AMDCUID_SOCKET_PATH); // Remove existing socket file
+    unlink(AMDCUID_SOCKET_PATH);  // Remove existing socket file
 
     // bind to socket path
     struct sockaddr_un server_addr;
     memset(&server_addr, 0, sizeof(server_addr));
     server_addr.sun_family = AF_UNIX;
-    strncpy(server_addr.sun_path, AMDCUID_SOCKET_PATH,
-            sizeof(server_addr.sun_path) - 1);
+    constexpr size_t kSocketPathLen = sizeof(AMDCUID_SOCKET_PATH) - 1;
+    static_assert(kSocketPathLen < sizeof(server_addr.sun_path),
+                  "AMDCUID_SOCKET_PATH does not fit in sockaddr_un::sun_path");
+    memcpy(server_addr.sun_path, AMDCUID_SOCKET_PATH, kSocketPathLen);
 
-    if (bind(server_fd_, (struct sockaddr *)&server_addr, sizeof(server_addr)) <
-        0) {
+    if (bind(server_fd_, (struct sockaddr*)&server_addr, sizeof(server_addr)) < 0) {
       close(server_fd_);
       return AMDCUID_STATUS_IPC_ERROR;
     }
@@ -139,7 +152,7 @@ public:
     unlink(AMDCUID_SOCKET_PATH);
   }
 
-private:
+ private:
   std::atomic<bool> is_running_;
   int server_fd_;
   std::thread server_thread_;
@@ -157,9 +170,17 @@ private:
   }
 
   void handle_client(int client_fd) {
-    IpcRequest request;
-    if (recv(client_fd, &request, sizeof(request), 0) != sizeof(request)) {
-      return;
+    // recv() on a SOCK_STREAM socket may return a short read, so loop until the
+    // whole fixed-size request has arrived. Anything less is a malformed peer.
+    IpcRequest request{};
+    auto* buf = reinterpret_cast<uint8_t*>(&request);
+    size_t got = 0;
+    while (got < sizeof(request)) {
+      ssize_t n = recv(client_fd, buf + got, sizeof(request) - got, 0);
+      if (n <= 0) {
+        return;
+      }
+      got += static_cast<size_t>(n);
     }
 
     IpcResponse response;
@@ -167,26 +188,29 @@ private:
 
     // Handle different request types
     switch (request.type) {
-    case IpcMessageType::ADD_DEVICE:
-      response.status = handle_add_device(request, response.device_handle);
-      break;
-    case IpcMessageType::REFRESH_DEVICES:
-      response.status = amdcuid_refresh();
-      break;
-    default:
-      response.status = AMDCUID_STATUS_INVALID_ARGUMENT;
-      break;
+      case IpcMessageType::ADD_DEVICE:
+        response.status = handle_add_device(request, response.device_handle);
+        break;
+      case IpcMessageType::REFRESH_DEVICES:
+        response.status = amdcuid_refresh();
+        break;
+      default:
+        response.status = AMDCUID_STATUS_INVALID_ARGUMENT;
+        break;
     }
 
     send(client_fd, &response, sizeof(response), 0);
   }
 
-  amdcuid_status_t handle_add_device(const IpcRequest &request,
-                                     amdcuid_id_t &device_handle) {
-    std::string dev_path(request.device_path);
+  amdcuid_status_t handle_add_device(const IpcRequest& request, amdcuid_id_t& device_handle) {
+    // Never trust the wire buffer to be NUL-terminated.
+    const std::string dev_path = ipc_get_device_path(request);
+    if (dev_path.empty()) {
+      return AMDCUID_STATUS_INVALID_ARGUMENT;
+    }
     amdcuid_device_type_t device_type = request.device_type;
-    amdcuid_status_t status = amdcuid_get_handle_by_dev_path(
-        dev_path.c_str(), device_type, &device_handle);
+    amdcuid_status_t status =
+        amdcuid_get_handle_by_dev_path(dev_path.c_str(), device_type, &device_handle);
 
     return status;
   }
@@ -226,9 +250,8 @@ int main() {
     bool stat_ok = (fstat(fd, &key_stat) == 0);
     close(fd);
     if (!stat_ok || key_stat.st_size != key_length) {
-      log_err() << "Error: HMAC key file has unexpected size ("
-                << (stat_ok ? key_stat.st_size : -1) << " bytes, expected "
-                << key_length << "). Key file may be corrupt; "
+      log_err() << "Error: HMAC key file has unexpected size (" << (stat_ok ? key_stat.st_size : -1)
+                << " bytes, expected " << key_length << "). Key file may be corrupt; "
                 << "remove it to allow regeneration." << std::endl;
       return 1;
     }
@@ -282,8 +305,7 @@ int main() {
                 << amdcuid_status_to_string(status) << ")" << std::endl;
       return 1;
     }
-    log_out() << "Daemon server started, listening for device events..."
-              << std::endl;
+    log_out() << "Daemon server started, listening for device events..." << std::endl;
 
     // Keep the main thread alive while the server is running
     while (true) {
@@ -291,15 +313,11 @@ int main() {
     }
 
     // On shutdown (not reachable in current code)
-    log_out()
-        << "Daemon server stopping, no longer listening for device events."
-        << std::endl;
+    log_out() << "Daemon server stopping, no longer listening for device events." << std::endl;
     server.stop();
   } else {
-    log_out()
-        << "Running in non-daemon mode, generating/updating CUID files once..."
-        << std::endl;
-    // non-daemon mode discovers devices on bootup and updates their CUIDs once
+    log_out() << "Running in non-daemon mode, generating/updating CUID files once..." << std::endl;
+    // non-daemon mode discovers devices at boot and updates their CUIDs once
     // discover devices by refreshing
     amdcuid_status_t status = amdcuid_refresh();
     if (status != AMDCUID_STATUS_SUCCESS) {

--- a/projects/cuid/docs/install/install.rst
+++ b/projects/cuid/docs/install/install.rst
@@ -16,8 +16,7 @@ System requirements
 To build CUID from source, the following dependencies are required:
 
 - CMake v3.14 or later
-- G++ v5.0 or later
-- For Ubuntu or Debian: OpenSSL v1.1 or later
+- G++ v7.0 or later (C++17)
 - For Microsoft Windows: `Bcrypt <https://www.npmjs.com/package/bcrypt?activeTab=code>`_ (Windows Native crypto library)
 
 Building and installing CUID library

--- a/projects/cuid/example/CMakeLists.txt
+++ b/projects/cuid/example/CMakeLists.txt
@@ -18,15 +18,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-message(
-    "&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&"
-)
-message(
-    "                          Cmake amdcuid_example                           "
-)
-message(
-    "&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&"
-)
+message("&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")
+message("                          Cmake amdcuid_example                           ")
+message("&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")
 
 message("")
 message("Build Configuration:")
@@ -46,21 +40,14 @@ set(SRC_LIST main.cc)
 
 add_executable(${AMDCUID_EXAMPLE_EXECUTABLE} ${SRC_LIST})
 
-target_include_directories(
-    ${AMDCUID_EXAMPLE_EXECUTABLE}
-    PRIVATE ${CMAKE_SOURCE_DIR}/lib
-)
+target_include_directories(${AMDCUID_EXAMPLE_EXECUTABLE} PRIVATE ${CMAKE_SOURCE_DIR}/lib)
 
 # Link against the CUID library (public API only)
 # The example now uses only the public API defined in amd_cuid.h
 target_link_libraries(${AMDCUID_EXAMPLE_EXECUTABLE} amdcuid_static pthread)
 
 # Install example source into documentation
-install(
-    FILES ${SRC_LIST}
-    DESTINATION ${CMAKE_INSTALL_DOCDIR}
-    COMPONENT ${EXAMPLE_COMPONENT}
-)
+install(FILES ${SRC_LIST} DESTINATION ${CMAKE_INSTALL_DOCDIR} COMPONENT ${EXAMPLE_COMPONENT})
 
 message("&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")
 message("                  Finished Cmake amdcuid_example                   ")

--- a/projects/cuid/example/main.cc
+++ b/projects/cuid/example/main.cc
@@ -20,10 +20,11 @@
  * THE SOFTWARE.
  */
 
-#include "include/amd_cuid.h"
 #include <climits>
 #include <iostream>
 #include <vector>
+
+#include "include/amd_cuid.h"
 
 int main() {
   amdcuid_status_t err;
@@ -36,8 +37,7 @@ int main() {
     handle_count = available_handle_count;
     handles.resize(handle_count);
     err = amdcuid_get_all_handles(handles.data(), &available_handle_count);
-    if (err != AMDCUID_STATUS_SUCCESS &&
-        err != AMDCUID_STATUS_INSUFFICIENT_SIZE) {
+    if (err != AMDCUID_STATUS_SUCCESS && err != AMDCUID_STATUS_INSUFFICIENT_SIZE) {
       std::cerr << "Failed to get device handles. Error code: " << err << " ("
                 << amdcuid_status_to_string(err) << ")" << std::endl;
       return 1;
@@ -50,11 +50,10 @@ int main() {
   for (uint32_t i = 0; i < handles.size(); ++i) {
     amdcuid_device_type_t device_type;
     uint32_t device_type_size = sizeof(device_type);
-    err = amdcuid_query_device_property(handles[i], AMDCUID_QUERY_DEVICE_TYPE,
-                                        &device_type, &device_type_size);
+    err = amdcuid_query_device_property(handles[i], AMDCUID_QUERY_DEVICE_TYPE, &device_type,
+                                        &device_type_size);
     if (err != AMDCUID_STATUS_SUCCESS) {
-      std::cerr << "Failed to get device type for handle #" << i
-                << ". Error code: " << err << " ("
+      std::cerr << "Failed to get device type for handle #" << i << ". Error code: " << err << " ("
                 << amdcuid_status_to_string(err) << ")" << std::endl;
       continue;
     }
@@ -72,42 +71,36 @@ int main() {
   for (uint32_t i = 0; i < gpu_handles.size(); ++i) {
     uint16_t vendor_id = 0;
     uint32_t data_size = sizeof(vendor_id);
-    err = amdcuid_query_device_property(gpu_handles[i], AMDCUID_QUERY_VENDOR_ID,
-                                        &vendor_id, &data_size);
+    err = amdcuid_query_device_property(gpu_handles[i], AMDCUID_QUERY_VENDOR_ID, &vendor_id,
+                                        &data_size);
     if (err != AMDCUID_STATUS_SUCCESS) {
-      std::cerr << "Failed to get vendor_id for GPU #" << i
-                << ". Error code: " << err << " ("
+      std::cerr << "Failed to get vendor_id for GPU #" << i << ". Error code: " << err << " ("
                 << amdcuid_status_to_string(err) << ")" << std::endl;
     }
 
     char device_node[128] = {0};
     uint32_t device_node_len = sizeof(device_node);
-    err =
-        amdcuid_query_device_property(gpu_handles[i], AMDCUID_QUERY_DEVICE_PATH,
-                                      device_node, &device_node_len);
+    err = amdcuid_query_device_property(gpu_handles[i], AMDCUID_QUERY_DEVICE_PATH, device_node,
+                                        &device_node_len);
     if (err != AMDCUID_STATUS_SUCCESS) {
-      std::cerr << "Failed to get device node for GPU #" << i
-                << ". Error code: " << err << " ("
+      std::cerr << "Failed to get device node for GPU #" << i << ". Error code: " << err << " ("
                 << amdcuid_status_to_string(err) << ")" << std::endl;
       device_node[0] = '\0';
     }
 
     amdcuid_id_t derived_id = {};
     uint32_t derived_id_size = sizeof(derived_id);
-    err = amdcuid_query_device_property(gpu_handles[i],
-                                        AMDCUID_QUERY_DERIVED_CUID, &derived_id,
+    err = amdcuid_query_device_property(gpu_handles[i], AMDCUID_QUERY_DERIVED_CUID, &derived_id,
                                         &derived_id_size);
     if (err != AMDCUID_STATUS_SUCCESS) {
-      std::cerr << "Failed to get derived CUID for GPU #" << i
-                << ". Error code: " << err << " ("
+      std::cerr << "Failed to get derived CUID for GPU #" << i << ". Error code: " << err << " ("
                 << amdcuid_status_to_string(err) << ")" << std::endl;
     }
 
     std::cout << "GPU #" << i << std::dec << " vendor_id: " << vendor_id
-              << " DeviceNode: " << device_node
-              << "  CUID: " << amdcuid_id_to_string(derived_id) << std::endl;
-    std::cout << " Handle: " << amdcuid_id_to_string(gpu_handles[i])
+              << " DeviceNode: " << device_node << "  CUID: " << amdcuid_id_to_string(derived_id)
               << std::endl;
+    std::cout << " Handle: " << amdcuid_id_to_string(gpu_handles[i]) << std::endl;
     std::cout << std::endl;
   }
 
@@ -118,127 +111,110 @@ int main() {
   for (uint32_t i = 0; i < cpu_handles.size(); ++i) {
     uint16_t vendor_id = 0;
     uint32_t data_size = sizeof(vendor_id);
-    err = amdcuid_query_device_property(cpu_handles[i], AMDCUID_QUERY_VENDOR_ID,
-                                        &vendor_id, &data_size);
+    err = amdcuid_query_device_property(cpu_handles[i], AMDCUID_QUERY_VENDOR_ID, &vendor_id,
+                                        &data_size);
     if (err != AMDCUID_STATUS_SUCCESS) {
-      std::cerr << "Failed to get vendor ID for CPU #" << i
-                << ". Error code: " << err << " ("
+      std::cerr << "Failed to get vendor ID for CPU #" << i << ". Error code: " << err << " ("
                 << amdcuid_status_to_string(err) << ")" << std::endl;
       vendor_id = 0;
     }
 
     uint16_t core = 0;
     data_size = sizeof(core);
-    err = amdcuid_query_device_property(cpu_handles[i], AMDCUID_QUERY_CORE_ID,
-                                        &core, &data_size);
+    err = amdcuid_query_device_property(cpu_handles[i], AMDCUID_QUERY_CORE_ID, &core, &data_size);
     if (err != AMDCUID_STATUS_SUCCESS) {
-      std::cerr << "Failed to get core for CPU #" << i
-                << ". Error code: " << err << " ("
+      std::cerr << "Failed to get core for CPU #" << i << ". Error code: " << err << " ("
                 << amdcuid_status_to_string(err) << ")" << std::endl;
       core = 0;
     }
 
     amdcuid_id_t derived_id = {};
     uint32_t derived_id_size = sizeof(derived_id);
-    err = amdcuid_query_device_property(cpu_handles[i],
-                                        AMDCUID_QUERY_DERIVED_CUID, &derived_id,
+    err = amdcuid_query_device_property(cpu_handles[i], AMDCUID_QUERY_DERIVED_CUID, &derived_id,
                                         &derived_id_size);
     if (err != AMDCUID_STATUS_SUCCESS) {
-      std::cerr << "Failed to get derived CUID for CPU #" << i
-                << ". Error code: " << err << " ("
+      std::cerr << "Failed to get derived CUID for CPU #" << i << ". Error code: " << err << " ("
                 << amdcuid_status_to_string(err) << ")" << std::endl;
     }
 
-    std::cout << "CPU #" << i << std::dec << " Core: " << core
-              << " VendorID: " << vendor_id
+    std::cout << "CPU #" << i << std::dec << " Core: " << core << " VendorID: " << vendor_id
               << "  CUID: " << amdcuid_id_to_string(derived_id) << std::endl;
-    std::cout << " Handle: " << amdcuid_id_to_string(cpu_handles[i])
-              << std::endl;
+    std::cout << " Handle: " << amdcuid_id_to_string(cpu_handles[i]) << std::endl;
     std::cout << std::endl;
   }
   // Example handle lookup by device path (only if at least one GPU exists).
   if (!gpu_handles.empty()) {
     char example_device_path[PATH_MAX] = {0};
     uint32_t path_length = sizeof(example_device_path);
-    err =
-        amdcuid_query_device_property(gpu_handles[0], AMDCUID_QUERY_DEVICE_PATH,
-                                      example_device_path, &path_length);
+    err = amdcuid_query_device_property(gpu_handles[0], AMDCUID_QUERY_DEVICE_PATH,
+                                        example_device_path, &path_length);
     if (err != AMDCUID_STATUS_SUCCESS) {
-      std::cerr << "Failed to get device path for GPU #0. Error code: " << err
-                << " (" << amdcuid_status_to_string(err) << ")" << std::endl;
+      std::cerr << "Failed to get device path for GPU #0. Error code: " << err << " ("
+                << amdcuid_status_to_string(err) << ")" << std::endl;
       return 1;
     }
 
     amdcuid_id_t device_handle = {};
-    err = amdcuid_get_handle_by_dev_path(
-        example_device_path, AMDCUID_DEVICE_TYPE_GPU, &device_handle);
+    err = amdcuid_get_handle_by_dev_path(example_device_path, AMDCUID_DEVICE_TYPE_GPU,
+                                         &device_handle);
     if (err != AMDCUID_STATUS_SUCCESS) {
-      std::cerr << "Failed to get device handle for path "
-                << example_device_path << ". Error code: " << err << " ("
-                << amdcuid_status_to_string(err) << ")" << std::endl;
+      std::cerr << "Failed to get device handle for path " << example_device_path
+                << ". Error code: " << err << " (" << amdcuid_status_to_string(err) << ")"
+                << std::endl;
       return 1;
     }
 
     amdcuid_id_t derived_id = {};
     uint32_t derived_id_size = sizeof(derived_id);
-    err =
-        amdcuid_query_device_property(device_handle, AMDCUID_QUERY_DERIVED_CUID,
-                                      &derived_id, &derived_id_size);
+    err = amdcuid_query_device_property(device_handle, AMDCUID_QUERY_DERIVED_CUID, &derived_id,
+                                        &derived_id_size);
     if (err != AMDCUID_STATUS_SUCCESS) {
-      std::cerr << "Failed to get derived CUID for device at path "
-                << example_device_path << ". Error code: " << err << " ("
-                << amdcuid_status_to_string(err) << ")" << std::endl;
+      std::cerr << "Failed to get derived CUID for device at path " << example_device_path
+                << ". Error code: " << err << " (" << amdcuid_status_to_string(err) << ")"
+                << std::endl;
       return 1;
     }
     std::cout << "Device at path " << example_device_path
-              << " has derived CUID: " << amdcuid_id_to_string(derived_id)
-              << std::endl;
+              << " has derived CUID: " << amdcuid_id_to_string(derived_id) << std::endl;
 
     std::string example_bdf;
-    uint32_t bdf_length =
-        13; // typical length of BDF string "0000:00:00.0" + null terminator
+    uint32_t bdf_length = 13;  // typical length of BDF string "0000:00:00.0" + null terminator
     char bdf_buffer[13] = {0};
-    err = amdcuid_query_device_property(gpu_handles[0], AMDCUID_QUERY_BDF,
-                                        bdf_buffer, &bdf_length);
+    err = amdcuid_query_device_property(gpu_handles[0], AMDCUID_QUERY_BDF, bdf_buffer, &bdf_length);
     if (err == AMDCUID_STATUS_SUCCESS) {
       example_bdf = bdf_buffer;
     } else {
-      std::cerr << "Failed to get BDF query input from GPU #0. Error code: "
-                << err << " (" << amdcuid_status_to_string(err) << ")"
-                << std::endl;
+      std::cerr << "Failed to get BDF query input from GPU #0. Error code: " << err << " ("
+                << amdcuid_status_to_string(err) << ")" << std::endl;
       return 1;
     }
 
     // example for getting a specific device handle by BDF and querying its
     // properties
     amdcuid_id_t bdf_device_handle = {};
-    err = amdcuid_get_handle_by_bdf(
-        example_bdf.c_str(), AMDCUID_DEVICE_TYPE_GPU, &bdf_device_handle);
+    err =
+        amdcuid_get_handle_by_bdf(example_bdf.c_str(), AMDCUID_DEVICE_TYPE_GPU, &bdf_device_handle);
     if (err != AMDCUID_STATUS_SUCCESS) {
-      std::cerr << "Failed to get device handle for BDF " << example_bdf
-                << ". Error code: " << err << " ("
-                << amdcuid_status_to_string(err) << ")" << std::endl;
+      std::cerr << "Failed to get device handle for BDF " << example_bdf << ". Error code: " << err
+                << " (" << amdcuid_status_to_string(err) << ")" << std::endl;
       return 1;
     }
 
     amdcuid_id_t derived_id_bdf = {};
     uint32_t derived_id_size2 = sizeof(derived_id_bdf);
-    err = amdcuid_query_device_property(bdf_device_handle,
-                                        AMDCUID_QUERY_DERIVED_CUID,
+    err = amdcuid_query_device_property(bdf_device_handle, AMDCUID_QUERY_DERIVED_CUID,
                                         &derived_id_bdf, &derived_id_size2);
     if (err != AMDCUID_STATUS_SUCCESS) {
-      std::cerr << "Failed to get derived CUID for device at BDF "
-                << example_bdf << ". Error code: " << err << " ("
-                << amdcuid_status_to_string(err) << ")" << std::endl;
+      std::cerr << "Failed to get derived CUID for device at BDF " << example_bdf
+                << ". Error code: " << err << " (" << amdcuid_status_to_string(err) << ")"
+                << std::endl;
       return 1;
     }
     std::cout << "Device at BDF " << example_bdf
-              << " has derived CUID: " << amdcuid_id_to_string(derived_id_bdf)
-              << std::endl;
+              << " has derived CUID: " << amdcuid_id_to_string(derived_id_bdf) << std::endl;
 
   } else {
-    std::cout << "No GPU devices found; skipping GPU path/BDF lookup examples."
-              << std::endl;
+    std::cout << "No GPU devices found; skipping GPU path/BDF lookup examples." << std::endl;
   }
 
   return 0;

--- a/projects/cuid/lib/CMakeLists.txt
+++ b/projects/cuid/lib/CMakeLists.txt
@@ -39,11 +39,6 @@ message("")
 set(SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
 set(INC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-# When built as part of the top-level project, OpenSSL is already resolved
-# (either from the system or via FetchContent). QUIET prevents a redundant
-# hard failure when targets are already available through FetchContent.
-find_package(OpenSSL QUIET)
-
 set(CUID_SOURCES
     ${SRC_DIR}/cuid.cc
     ${SRC_DIR}/cuid_util.cc
@@ -56,6 +51,7 @@ set(CUID_SOURCES
     ${SRC_DIR}/cuid_platform.cc
     ${SRC_DIR}/cuid_file.cc
     ${SRC_DIR}/hmac.cc
+    ${SRC_DIR}/sha256.cc
     ${SRC_DIR}/pci_util.cc
     ${SRC_DIR}/acpi_parser.cc
     ${SRC_DIR}/smbios_util.cc
@@ -74,6 +70,7 @@ set(CUID_HEADERS
     ${SRC_DIR}/cuid_platform.h
     ${SRC_DIR}/cuid_file.h
     ${SRC_DIR}/hmac.h
+    ${SRC_DIR}/sha256.h
     ${SRC_DIR}/ipc_protocol.h
     ${SRC_DIR}/pci_util.h
     ${SRC_DIR}/acpi_parser.h
@@ -86,24 +83,17 @@ add_library(amdcuid_static STATIC ${CUID_SOURCES} ${CUID_HEADERS})
 
 set_property(TARGET amdcuid_static PROPERTY POSITION_INDEPENDENT_CODE ON)
 
-target_include_directories(
-    amdcuid_static
-    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
-    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src
-)
+target_include_directories(amdcuid_static PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 # Pass the version-independent shared config directory to the library at compile
 # time. All installed versions of the library must agree on this path so that
 # the HMAC key is shared and CUIDs remain stable across version upgrades.
-target_compile_definitions(
-    amdcuid_static
-    PRIVATE AMDCUID_CONFIG_DIR="${AMDCUID_SHARED_CONFIG_DIR}"
-)
+target_compile_definitions(amdcuid_static PRIVATE AMDCUID_CONFIG_DIR="${AMDCUID_SHARED_CONFIG_DIR}")
 
+# SHA-256/HMAC comes from src/sha256.cc, so the only external dependency left
+# is the platform CSPRNG: bcrypt on Windows, getrandom(2)//dev/urandom on POSIX.
 if(WIN32)
     target_link_libraries(amdcuid_static PUBLIC bcrypt)
-else()
-    target_link_libraries(amdcuid_static PUBLIC OpenSSL::Crypto)
 endif()
 
 # Static library
@@ -120,11 +110,7 @@ install(
 
 # Install public headers
 set(PUBLIC_HEADERS ${INC_DIR}/amd_cuid.h)
-install(
-    FILES ${PUBLIC_HEADERS}
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${AMDCUID}
-    COMPONENT ${LIB_COMPONENT}
-)
+install(FILES ${PUBLIC_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${AMDCUID} COMPONENT ${LIB_COMPONENT})
 
 if(UNIX AND NOT APPLE)
     configure_file(

--- a/projects/cuid/lib/amdcuid_setup_hmac.sh.in
+++ b/projects/cuid/lib/amdcuid_setup_hmac.sh.in
@@ -34,10 +34,20 @@ chmod 755 "$CONFIG_DIR"
 
 if [ ! -f "$HMAC_KEY_FILE" ]; then
     echo "Generating HMAC key at $HMAC_KEY_FILE..."
-    # openssl is already a hard dependency (libssl); use it to produce 32 bytes
-    # of cryptographically-random key material and immediately restrict access.
-    if ! openssl rand -out "$HMAC_KEY_FILE" 32; then
-        echo "ERROR: Failed to generate HMAC key with openssl." >&2
+    # Create the file with restrictive permissions *before* writing key material
+    # to it, so the secret is never briefly world-readable. /dev/urandom is the
+    # kernel CSPRNG and needs no package beyond coreutils.
+    umask_old=$(umask)
+    umask 077
+    if ! dd if=/dev/urandom of="$HMAC_KEY_FILE" bs=32 count=1 status=none; then
+        echo "ERROR: Failed to generate HMAC key from /dev/urandom." >&2
+        rm -f "$HMAC_KEY_FILE"
+        umask "$umask_old"
+        exit 1
+    fi
+    umask "$umask_old"
+    if [ "$(wc -c <"$HMAC_KEY_FILE")" -ne 32 ]; then
+        echo "ERROR: Short read from /dev/urandom while generating HMAC key." >&2
         rm -f "$HMAC_KEY_FILE"
         exit 1
     fi

--- a/projects/cuid/lib/src/acpi_parser.cc
+++ b/projects/cuid/lib/src/acpi_parser.cc
@@ -21,10 +21,13 @@
  */
 
 #include "src/acpi_parser.h"
-#include <fstream>
-#include <cstring>
-#include <sys/stat.h>
+
 #include <errno.h>
+#include <sys/stat.h>
+
+#include <cstring>
+#include <fstream>
+#include <type_traits>
 
 // MADT entry type constants
 constexpr uint8_t MADT_TYPE_LOCAL_APIC = 0;
@@ -37,163 +40,198 @@ constexpr uint32_t MADT_FLAG_ENABLED = 0x00000001;
 constexpr const char* ACPI_TABLES_PATH = "/sys/firmware/acpi/tables/";
 
 amdcuid_status_t AcpiParser::read_acpi_table(const char* table_name, std::vector<uint8_t>& data) {
-    std::string path = std::string(ACPI_TABLES_PATH) + table_name;
-    
-    // Check if file exists and get size
-    struct stat st;
-    if (stat(path.c_str(), &st) != 0) {
-        if (errno == ENOENT) {
-            return AMDCUID_STATUS_ACPI_ERROR;
-        } else if (errno == EACCES) {
-            return AMDCUID_STATUS_PERMISSION_DENIED;
-        }
-        return AMDCUID_STATUS_FILE_ERROR;
+  std::string path = std::string(ACPI_TABLES_PATH) + table_name;
+
+  // Check if file exists and get size
+  struct stat st;
+  if (stat(path.c_str(), &st) != 0) {
+    if (errno == ENOENT) {
+      return AMDCUID_STATUS_ACPI_ERROR;
+    } else if (errno == EACCES) {
+      return AMDCUID_STATUS_PERMISSION_DENIED;
     }
-    
-    // Read table data
-    std::ifstream file(path, std::ios::binary);
-    if (!file) {
-        if (errno == EACCES) {
-            return AMDCUID_STATUS_PERMISSION_DENIED;
-        }
-        return AMDCUID_STATUS_FILE_ERROR;
+    return AMDCUID_STATUS_FILE_ERROR;
+  }
+
+  // Read table data
+  std::ifstream file(path, std::ios::binary);
+  if (!file) {
+    if (errno == EACCES) {
+      return AMDCUID_STATUS_PERMISSION_DENIED;
     }
-    
-    data.resize(st.st_size);
-    file.read(reinterpret_cast<char*>(data.data()), st.st_size);
-    
-    if (!file) {
-        return AMDCUID_STATUS_FILE_ERROR;
-    }
-    
-    return AMDCUID_STATUS_SUCCESS;
+    return AMDCUID_STATUS_FILE_ERROR;
+  }
+
+  data.resize(st.st_size);
+  file.read(reinterpret_cast<char*>(data.data()), st.st_size);
+
+  if (!file) {
+    return AMDCUID_STATUS_FILE_ERROR;
+  }
+
+  return AMDCUID_STATUS_SUCCESS;
 }
 
 bool AcpiParser::validate_checksum(const uint8_t* data, size_t length) {
-    if (!data || length < sizeof(AcpiTableHeader)) {
-        return false;
-    }
-    
-    uint8_t sum = 0;
-    for (size_t i = 0; i < length; i++) {
-        sum += data[i];
-    }
-    
-    return sum == 0;
+  if (!data || length < sizeof(AcpiTableHeader)) {
+    return false;
+  }
+
+  uint8_t sum = 0;
+  for (size_t i = 0; i < length; i++) {
+    sum += data[i];
+  }
+
+  return sum == 0;
 }
 
-bool AcpiParser::parse_madt_entry(const uint8_t* entry, AcpiCpuInfo& cpu_info) {
-    const MadtEntryHeader* header = reinterpret_cast<const MadtEntryHeader*>(entry);
-    
-    if (header->type == MADT_TYPE_LOCAL_APIC) {
-        if (header->length < sizeof(MadtLocalApic)) {
-            return false;
-        }
-        
-        const MadtLocalApic* apic = reinterpret_cast<const MadtLocalApic*>(entry);
-        
-        cpu_info.apic_id = apic->apic_id;
-        cpu_info.processor_uid = apic->acpi_processor_uid;
-        cpu_info.enabled = (apic->flags & MADT_FLAG_ENABLED) != 0;
-        cpu_info.is_x2apic = false;
-        
-        return true;
-    }
-    else if (header->type == MADT_TYPE_LOCAL_X2APIC) {
-        if (header->length < sizeof(MadtLocalX2Apic)) {
-            return false;
-        }
-        
-        const MadtLocalX2Apic* x2apic = reinterpret_cast<const MadtLocalX2Apic*>(entry);
-        
-        cpu_info.apic_id = x2apic->x2apic_id;
-        cpu_info.processor_uid = x2apic->acpi_processor_uid;
-        cpu_info.enabled = (x2apic->flags & MADT_FLAG_ENABLED) != 0;
-        cpu_info.is_x2apic = true;
-        
-        return true;
-    }
-    
+namespace {
+
+// Copy a packed firmware structure out of a byte buffer. Taking a copy (rather
+// than reinterpret_cast'ing in place) keeps the read inside `src` and keeps the
+// access well-defined regardless of the buffer's provenance or alignment.
+// Returns false when the buffer does not hold a whole T.
+template <typename T>
+bool read_struct(const uint8_t* src, size_t available, T& out) {
+  static_assert(std::is_trivially_copyable<T>::value,
+                "read_struct requires a trivially copyable firmware struct");
+  if (src == nullptr || available < sizeof(T)) {
     return false;
+  }
+  std::memcpy(&out, src, sizeof(T));
+  return true;
+}
+
+}  // namespace
+
+bool AcpiParser::parse_madt_entry(const uint8_t* entry, size_t entry_len, AcpiCpuInfo& cpu_info) {
+  MadtEntryHeader header{};
+  if (!read_struct(entry, entry_len, header)) {
+    return false;
+  }
+
+  if (header.type == MADT_TYPE_LOCAL_APIC) {
+    MadtLocalApic apic{};
+    // header.length is what the firmware claims; entry_len is what the
+    // caller proved is actually present. Both must cover the struct.
+    if (header.length < sizeof(MadtLocalApic) || !read_struct(entry, entry_len, apic)) {
+      return false;
+    }
+
+    cpu_info.apic_id = apic.apic_id;
+    cpu_info.processor_uid = apic.acpi_processor_uid;
+    cpu_info.enabled = (apic.flags & MADT_FLAG_ENABLED) != 0;
+    cpu_info.is_x2apic = false;
+
+    return true;
+  } else if (header.type == MADT_TYPE_LOCAL_X2APIC) {
+    MadtLocalX2Apic x2apic{};
+    if (header.length < sizeof(MadtLocalX2Apic) || !read_struct(entry, entry_len, x2apic)) {
+      return false;
+    }
+
+    cpu_info.apic_id = x2apic.x2apic_id;
+    cpu_info.processor_uid = x2apic.acpi_processor_uid;
+    cpu_info.enabled = (x2apic.flags & MADT_FLAG_ENABLED) != 0;
+    cpu_info.is_x2apic = true;
+
+    return true;
+  }
+
+  return false;
+}
+
+amdcuid_status_t AcpiParser::parse_madt_buffer(const uint8_t* data, size_t size,
+                                               std::vector<AcpiCpuInfo>& cpu_info) {
+  cpu_info.clear();
+
+  // Validate minimum size
+  MadtHeader madt{};
+  if (!read_struct(data, size, madt)) {
+    return AMDCUID_STATUS_INVALID_FORMAT;
+  }
+
+  // Validate signature
+  if (std::memcmp(madt.header.signature, "APIC", 4) != 0) {
+    return AMDCUID_STATUS_INVALID_FORMAT;
+  }
+
+  // Validate table length
+  if (madt.header.length != size) {
+    return AMDCUID_STATUS_INVALID_FORMAT;
+  }
+
+  // Validate checksum
+  if (!validate_checksum(data, size)) {
+    return AMDCUID_STATUS_INVALID_FORMAT;
+  }
+
+  // Walk the interrupt controller structures using offsets rather than
+  // pointers, so no out-of-range pointer is ever formed and the arithmetic
+  // cannot wrap.
+  size_t offset = sizeof(MadtHeader);
+
+  while (offset < size) {
+    // A 2-byte entry header must be fully present before its `length`
+    // field can be read. The previous code tested only `entry < end`, so a
+    // table whose last byte started an entry read length one byte past the
+    // buffer.
+    MadtEntryHeader header{};
+    if (!read_struct(data + offset, size - offset, header)) {
+      return AMDCUID_STATUS_INVALID_FORMAT;
+    }
+
+    // Validate the entry neither overflows the table nor fails to advance.
+    if (header.length < sizeof(MadtEntryHeader) || header.length > size - offset) {
+      return AMDCUID_STATUS_INVALID_FORMAT;
+    }
+
+    // Parse Local APIC or x2APIC entries
+    AcpiCpuInfo info{};
+    if (parse_madt_entry(data + offset, header.length, info)) {
+      cpu_info.push_back(info);
+    }
+
+    offset += header.length;
+  }
+
+  // Should have found at least one CPU
+  if (cpu_info.empty()) {
+    return AMDCUID_STATUS_DEVICE_NOT_FOUND;
+  }
+
+  return AMDCUID_STATUS_SUCCESS;
 }
 
 amdcuid_status_t AcpiParser::parse_madt(std::vector<AcpiCpuInfo>& cpu_info) {
-    cpu_info.clear();
-    
-    // Read MADT/APIC table
-    std::vector<uint8_t> table_data;
-    amdcuid_status_t status = read_acpi_table("APIC", table_data);
-    if (status != AMDCUID_STATUS_SUCCESS) {
-        return status;
-    }
-    
-    // Validate minimum size
-    if (table_data.size() < sizeof(MadtHeader)) {
-        return AMDCUID_STATUS_INVALID_FORMAT;
-    }
-    
-    const MadtHeader* madt = reinterpret_cast<const MadtHeader*>(table_data.data());
-    
-    // Validate signature
-    if (std::memcmp(madt->header.signature, "APIC", 4) != 0) {
-        return AMDCUID_STATUS_INVALID_FORMAT;
-    }
-    
-    // Validate table length
-    if (madt->header.length != table_data.size()) {
-        return AMDCUID_STATUS_INVALID_FORMAT;
-    }
-    
-    // Validate checksum
-    if (!validate_checksum(table_data.data(), madt->header.length)) {
-        return AMDCUID_STATUS_INVALID_FORMAT;
-    }
-    
-    // Parse interrupt controller structures
-    const uint8_t* entry = table_data.data() + sizeof(MadtHeader);
-    const uint8_t* end = table_data.data() + madt->header.length;
-    
-    while (entry < end) {
-        const MadtEntryHeader* header = reinterpret_cast<const MadtEntryHeader*>(entry);
-        
-        // Validate entry doesn't overflow table
-        if (entry + header->length > end || header->length < sizeof(MadtEntryHeader)) {
-            return AMDCUID_STATUS_INVALID_FORMAT;
-        }
-        
-        // Parse Local APIC or x2APIC entries
-        AcpiCpuInfo info;
-        if (parse_madt_entry(entry, info)) {
-            cpu_info.push_back(info);
-        }
-        
-        entry += header->length;
-    }
-    
-    // Should have found at least one CPU
-    if (cpu_info.empty()) {
-        return AMDCUID_STATUS_DEVICE_NOT_FOUND;
-    }
-    
-    return AMDCUID_STATUS_SUCCESS;
+  cpu_info.clear();
+
+  // Read MADT/APIC table
+  std::vector<uint8_t> table_data;
+  amdcuid_status_t status = read_acpi_table("APIC", table_data);
+  if (status != AMDCUID_STATUS_SUCCESS) {
+    return status;
+  }
+
+  return parse_madt_buffer(table_data.data(), table_data.size(), cpu_info);
 }
 
 amdcuid_status_t AcpiParser::get_cpu_count(uint32_t& count) {
-    std::vector<AcpiCpuInfo> cpu_info;
-    amdcuid_status_t status = parse_madt(cpu_info);
-    
-    if (status != AMDCUID_STATUS_SUCCESS) {
-        count = 0;
-        return status;
-    }
-    
-    // Count only enabled CPUs
+  std::vector<AcpiCpuInfo> cpu_info;
+  amdcuid_status_t status = parse_madt(cpu_info);
+
+  if (status != AMDCUID_STATUS_SUCCESS) {
     count = 0;
-    for (const auto& info : cpu_info) {
-        if (info.enabled) {
-            count++;
-        }
+    return status;
+  }
+
+  // Count only enabled CPUs
+  count = 0;
+  for (const auto& info : cpu_info) {
+    if (info.enabled) {
+      count++;
     }
-    
-    return AMDCUID_STATUS_SUCCESS;
+  }
+
+  return AMDCUID_STATUS_SUCCESS;
 }

--- a/projects/cuid/lib/src/acpi_parser.h
+++ b/projects/cuid/lib/src/acpi_parser.h
@@ -23,22 +23,23 @@
 #ifndef ACPI_PARSER_H
 #define ACPI_PARSER_H
 
-#include "include/amd_cuid.h"
 #include <cstdint>
 #include <string>
 #include <vector>
 
+#include "include/amd_cuid.h"
+
 /**
  * @file acpi_parser.h
  * @brief ACPI table parser for extracting CPU identification information
- * 
+ *
  * Parses binary ACPI tables (MADT/APIC, DSDT) to extract processor-specific
  * identifiers like APIC IDs and processor UIDs needed for CPU CUID generation.
- * 
+ *
  * ACPI tables parsed:
  * - MADT (Multiple APIC Description Table): Contains Local APIC entries with APIC IDs
  * - DSDT (Differentiated System Description Table): Contains Processor objects with _UID
- * 
+ *
  * References:
  * - ACPI Specification 6.5: https://uefi.org/specs/ACPI/6.5/
  * - MADT format: Section 5.2.12
@@ -49,129 +50,153 @@
  * @brief Standard ACPI table header (common to all ACPI tables)
  */
 struct AcpiTableHeader {
-    char signature[4];      ///< Table signature (e.g., "APIC", "DSDT")
-    uint32_t length;        ///< Total table length including header
-    uint8_t revision;       ///< Table revision
-    uint8_t checksum;       ///< Checksum of entire table (must sum to 0)
-    char oem_id[6];         ///< OEM identification
-    char oem_table_id[8];   ///< OEM table identifier
-    uint32_t oem_revision;  ///< OEM revision
-    char creator_id[4];     ///< Creator utility ID
-    uint32_t creator_revision; ///< Creator utility revision
+  char signature[4];          ///< Table signature (e.g., "APIC", "DSDT")
+  uint32_t length;            ///< Total table length including header
+  uint8_t revision;           ///< Table revision
+  uint8_t checksum;           ///< Checksum of entire table (must sum to 0)
+  char oem_id[6];             ///< OEM identification
+  char oem_table_id[8];       ///< OEM table identifier
+  uint32_t oem_revision;      ///< OEM revision
+  char creator_id[4];         ///< Creator utility ID
+  uint32_t creator_revision;  ///< Creator utility revision
 } __attribute__((packed));
 
 /**
  * @brief MADT (Multiple APIC Description Table) header
  */
 struct MadtHeader {
-    AcpiTableHeader header;
-    uint32_t local_apic_address; ///< Physical address of local APIC
-    uint32_t flags;              ///< Multiple APIC flags
+  AcpiTableHeader header;
+  uint32_t local_apic_address;  ///< Physical address of local APIC
+  uint32_t flags;               ///< Multiple APIC flags
 } __attribute__((packed));
 
 /**
  * @brief MADT interrupt controller structure header
  */
 struct MadtEntryHeader {
-    uint8_t type;   ///< Entry type (0 = Local APIC, 9 = Local x2APIC, etc.)
-    uint8_t length; ///< Entry length including header
+  uint8_t type;    ///< Entry type (0 = Local APIC, 9 = Local x2APIC, etc.)
+  uint8_t length;  ///< Entry length including header
 } __attribute__((packed));
 
 /**
  * @brief MADT Local APIC entry (type 0)
  */
 struct MadtLocalApic {
-    MadtEntryHeader header;
-    uint8_t acpi_processor_uid; ///< ACPI Processor UID
-    uint8_t apic_id;            ///< Local APIC ID
-    uint32_t flags;             ///< Flags (bit 0: enabled, bit 1: online capable)
+  MadtEntryHeader header;
+  uint8_t acpi_processor_uid;  ///< ACPI Processor UID
+  uint8_t apic_id;             ///< Local APIC ID
+  uint32_t flags;              ///< Flags (bit 0: enabled, bit 1: online capable)
 } __attribute__((packed));
 
 /**
  * @brief MADT Local x2APIC entry (type 9)
  */
 struct MadtLocalX2Apic {
-    MadtEntryHeader header;
-    uint16_t reserved;          ///< Reserved (must be zero)
-    uint32_t x2apic_id;         ///< x2APIC ID
-    uint32_t flags;             ///< Flags (bit 0: enabled, bit 1: online capable)
-    uint32_t acpi_processor_uid; ///< ACPI Processor UID
+  MadtEntryHeader header;
+  uint16_t reserved;            ///< Reserved (must be zero)
+  uint32_t x2apic_id;           ///< x2APIC ID
+  uint32_t flags;               ///< Flags (bit 0: enabled, bit 1: online capable)
+  uint32_t acpi_processor_uid;  ///< ACPI Processor UID
 } __attribute__((packed));
 
 /**
  * @brief CPU identification information from ACPI
  */
 struct AcpiCpuInfo {
-    uint32_t apic_id;           ///< Local APIC or x2APIC ID
-    uint32_t processor_uid;     ///< ACPI Processor UID
-    bool enabled;               ///< CPU is enabled
-    bool is_x2apic;            ///< Uses x2APIC (vs legacy APIC)
+  uint32_t apic_id;        ///< Local APIC or x2APIC ID
+  uint32_t processor_uid;  ///< ACPI Processor UID
+  bool enabled;            ///< CPU is enabled
+  bool is_x2apic;          ///< Uses x2APIC (vs legacy APIC)
 };
 
 /**
  * @brief ACPI table parser for CPU identification
  */
 class AcpiParser {
-public:
-    /**
-     * @brief Parse MADT table to extract CPU APIC IDs and processor UIDs
-     * 
-     * Reads and parses the MADT (Multiple APIC Description Table) from
-     * /sys/firmware/acpi/tables/APIC to extract Local APIC and x2APIC entries.
-     * 
-     * Each entry contains:
-     * - APIC ID: Hardware identifier for the CPU's local APIC
-     * - Processor UID: ACPI processor unique identifier
-     * - Flags: Whether CPU is enabled/online
-     * 
-     * @param cpu_info Output vector of CPU information structures
-     * @return AMDCUID_STATUS_SUCCESS on success
-     *         AMDCUID_STATUS_ACPI_ERROR if MADT table doesn't exist
-     *         AMDCUID_STATUS_PERMISSION_DENIED if access denied (need root)
-     *         AMDCUID_STATUS_INVALID_FORMAT if table format is invalid
-     */
-    static amdcuid_status_t parse_madt(std::vector<AcpiCpuInfo>& cpu_info);
+ public:
+  /**
+   * @brief Parse MADT table to extract CPU APIC IDs and processor UIDs
+   *
+   * Reads and parses the MADT (Multiple APIC Description Table) from
+   * /sys/firmware/acpi/tables/APIC to extract Local APIC and x2APIC entries.
+   *
+   * Each entry contains:
+   * - APIC ID: Hardware identifier for the CPU's local APIC
+   * - Processor UID: ACPI processor unique identifier
+   * - Flags: Whether CPU is enabled/online
+   *
+   * @param cpu_info Output vector of CPU information structures
+   * @return AMDCUID_STATUS_SUCCESS on success
+   *         AMDCUID_STATUS_ACPI_ERROR if MADT table doesn't exist
+   *         AMDCUID_STATUS_PERMISSION_DENIED if access denied (need root)
+   *         AMDCUID_STATUS_INVALID_FORMAT if table format is invalid
+   */
+  [[nodiscard]] static amdcuid_status_t parse_madt(std::vector<AcpiCpuInfo>& cpu_info);
 
-    /**
-     * @brief Validate ACPI table header checksum
-     * 
-     * Verifies that the sum of all bytes in the table equals zero (mod 256).
-     * This is the standard ACPI checksum validation.
-     * 
-     * @param data Pointer to table data
-     * @param length Table length in bytes
-     * @return true if checksum is valid, false otherwise
-     */
-    static bool validate_checksum(const uint8_t* data, size_t length);
+  /**
+   * @brief Parse an in-memory MADT image
+   *
+   * Split out of parse_madt() so the table walker can be exercised against
+   * synthetic (including deliberately malformed) tables without needing root
+   * or a real /sys/firmware/acpi/tables/APIC.
+   *
+   * Every field access is bounds-checked against @p size; a truncated or
+   * self-inconsistent table yields AMDCUID_STATUS_INVALID_FORMAT rather than
+   * reading past the end of the buffer.
+   *
+   * @param data Pointer to the raw table bytes (may be null iff size == 0)
+   * @param size Number of valid bytes at @p data
+   * @param cpu_info Output vector of CPU information structures
+   * @return AMDCUID_STATUS_SUCCESS on success
+   *         AMDCUID_STATUS_INVALID_FORMAT if the table is malformed
+   *         AMDCUID_STATUS_DEVICE_NOT_FOUND if no CPU entries were found
+   */
+  [[nodiscard]] static amdcuid_status_t parse_madt_buffer(const uint8_t* data, size_t size,
+                                                          std::vector<AcpiCpuInfo>& cpu_info);
 
-    /**
-     * @brief Get CPU count from MADT
-     * 
-     * Quick function to count enabled CPUs without full parsing.
-     * 
-     * @param count Output for CPU count
-     * @return AMDCUID_STATUS_SUCCESS on success
-     */
-    static amdcuid_status_t get_cpu_count(uint32_t& count);
+  /**
+   * @brief Validate ACPI table header checksum
+   *
+   * Verifies that the sum of all bytes in the table equals zero (mod 256).
+   * This is the standard ACPI checksum validation.
+   *
+   * @param data Pointer to table data
+   * @param length Table length in bytes
+   * @return true if checksum is valid, false otherwise
+   */
+  static bool validate_checksum(const uint8_t* data, size_t length);
 
-private:
-    /**
-     * @brief Read ACPI table from sysfs
-     * 
-     * @param table_name Name of table (e.g., "APIC", "DSDT")
-     * @param data Output buffer for table data
-     * @return AMDCUID_STATUS_SUCCESS on success
-     */
-    static amdcuid_status_t read_acpi_table(const char* table_name, std::vector<uint8_t>& data);
+  /**
+   * @brief Get CPU count from MADT
+   *
+   * Quick function to count enabled CPUs without full parsing.
+   *
+   * @param count Output for CPU count
+   * @return AMDCUID_STATUS_SUCCESS on success
+   */
+  [[nodiscard]] static amdcuid_status_t get_cpu_count(uint32_t& count);
 
-    /**
-     * @brief Parse individual MADT entry
-     * 
-     * @param entry Pointer to entry data
-     * @param cpu_info Output CPU info if entry is Local APIC or x2APIC
-     * @return true if entry was parsed successfully
-     */
-    static bool parse_madt_entry(const uint8_t* entry, AcpiCpuInfo& cpu_info);
+ private:
+  /**
+   * @brief Read ACPI table from sysfs
+   *
+   * @param table_name Name of table (e.g., "APIC", "DSDT")
+   * @param data Output buffer for table data
+   * @return AMDCUID_STATUS_SUCCESS on success
+   */
+  [[nodiscard]] static amdcuid_status_t read_acpi_table(const char* table_name,
+                                                        std::vector<uint8_t>& data);
+
+  /**
+   * @brief Parse a single MADT interrupt-controller structure
+   *
+   * @param entry Pointer to the entry
+   * @param entry_len Number of bytes available at @p entry; the caller must
+   *        have validated that the entry does not extend past the table
+   * @param cpu_info Output CPU info if entry is Local APIC or x2APIC
+   * @return true if entry was parsed successfully
+   */
+  static bool parse_madt_entry(const uint8_t* entry, size_t entry_len, AcpiCpuInfo& cpu_info);
 };
 
-#endif // ACPI_PARSER_H
+#endif  // ACPI_PARSER_H

--- a/projects/cuid/lib/src/cuid.cc
+++ b/projects/cuid/lib/src/cuid.cc
@@ -20,6 +20,19 @@
  * THE SOFTWARE.
  */
 
+#include <dirent.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <climits>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <mutex>
+#include <sstream>
+#include <vector>
+
 #include "include/amd_cuid.h"
 #include "src/cuid_cpu.h"
 #include "src/cuid_device.h"
@@ -31,95 +44,82 @@
 #include "src/cuid_platform.h"
 #include "src/cuid_util.h"
 #include "src/hmac.h"
-#include <climits>
-#include <cstring>
-#include <dirent.h>
-#include <fcntl.h>
-#include <fstream>
-#include <iostream>
-#include <mutex>
-#include <sstream>
-#include <sys/types.h>
-#include <unistd.h>
-#include <vector>
 
 // Static instance for API
-static CuidDeviceManager &mgr = CuidDeviceManager::instance();
+static CuidDeviceManager& mgr = CuidDeviceManager::instance();
 static cuid_hmac global_hmac = cuid_hmac();
 
-void amdcuid_get_library_version(uint32_t *major, uint32_t *minor,
-                                 uint32_t *patch) {
-  if (major)
-    *major = AMDCUID_LIB_VERSION_MAJOR;
-  if (minor)
-    *minor = AMDCUID_LIB_VERSION_MINOR;
-  if (patch)
-    *patch = AMDCUID_LIB_VERSION_PATCH;
+void amdcuid_get_library_version(uint32_t* major, uint32_t* minor, uint32_t* patch) {
+  if (major) *major = AMDCUID_LIB_VERSION_MAJOR;
+  if (minor) *minor = AMDCUID_LIB_VERSION_MINOR;
+  if (patch) *patch = AMDCUID_LIB_VERSION_PATCH;
 }
 
-const char *amdcuid_library_version_to_string() {
-  static std::string version_str =
-      std::to_string(AMDCUID_LIB_VERSION_MAJOR) + "." +
-      std::to_string(AMDCUID_LIB_VERSION_MINOR) + "." +
-      std::to_string(AMDCUID_LIB_VERSION_PATCH);
+const char* amdcuid_library_version_to_string() {
+  static std::string version_str = std::to_string(AMDCUID_LIB_VERSION_MAJOR) + "." +
+                                   std::to_string(AMDCUID_LIB_VERSION_MINOR) + "." +
+                                   std::to_string(AMDCUID_LIB_VERSION_PATCH);
   return version_str.c_str();
 }
 
-const char *amdcuid_status_to_string(amdcuid_status_t status) {
+const char* amdcuid_status_to_string(amdcuid_status_t status) {
   switch (status) {
-  case AMDCUID_STATUS_SUCCESS:
-    return "SUCCESS";
-  case AMDCUID_STATUS_FILE_NOT_FOUND:
-    return "FILE_NOT_FOUND";
-  case AMDCUID_STATUS_DEVICE_NOT_FOUND:
-    return "DEVICE_NOT_FOUND";
-  case AMDCUID_STATUS_INVALID_ARGUMENT:
-    return "INVALID_ARGUMENT";
-  case AMDCUID_STATUS_PERMISSION_DENIED:
-    return "PERMISSION_DENIED";
-  case AMDCUID_STATUS_UNSUPPORTED:
-    return "UNSUPPORTED";
-  case AMDCUID_STATUS_WRONG_DEVICE_TYPE:
-    return "WRONG_DEVICE_TYPE";
-  case AMDCUID_STATUS_INSUFFICIENT_SIZE:
-    return "INSUFFICIENT_SIZE";
-  case AMDCUID_STATUS_HW_FINGERPRINT_NOT_FOUND:
-    return "HARDWARE_FINGERPRINT_NOT_FOUND";
-  case AMDCUID_STATUS_KEY_ERROR:
-    return "KEY_ERROR";
-  case AMDCUID_STATUS_HMAC_ERROR:
-    return "HMAC_ERROR";
-  case AMDCUID_STATUS_FILE_ERROR:
-    return "FILE_ERROR";
-  case AMDCUID_STATUS_INVALID_FORMAT:
-    return "INVALID_FORMAT";
-  case AMDCUID_STATUS_PCI_ERROR:
-    return "PCI_ERROR";
-  case AMDCUID_STATUS_SMBIOS_ERROR:
-    return "SMBIOS_ERROR";
-  case AMDCUID_STATUS_ACPI_ERROR:
-    return "ACPI_ERROR";
-  case AMDCUID_STATUS_CPUINFO_ERROR:
-    return "CPUINFO_ERROR";
-  case AMDCUID_STATUS_IPC_ERROR:
-    return "IPC_ERROR";
-  default:
-    return "UNKNOWN_ERROR";
+    case AMDCUID_STATUS_SUCCESS:
+      return "SUCCESS";
+    case AMDCUID_STATUS_FILE_NOT_FOUND:
+      return "FILE_NOT_FOUND";
+    case AMDCUID_STATUS_DEVICE_NOT_FOUND:
+      return "DEVICE_NOT_FOUND";
+    case AMDCUID_STATUS_INVALID_ARGUMENT:
+      return "INVALID_ARGUMENT";
+    case AMDCUID_STATUS_PERMISSION_DENIED:
+      return "PERMISSION_DENIED";
+    case AMDCUID_STATUS_UNSUPPORTED:
+      return "UNSUPPORTED";
+    case AMDCUID_STATUS_WRONG_DEVICE_TYPE:
+      return "WRONG_DEVICE_TYPE";
+    case AMDCUID_STATUS_INSUFFICIENT_SIZE:
+      return "INSUFFICIENT_SIZE";
+    case AMDCUID_STATUS_HW_FINGERPRINT_NOT_FOUND:
+      return "HARDWARE_FINGERPRINT_NOT_FOUND";
+    case AMDCUID_STATUS_KEY_ERROR:
+      return "KEY_ERROR";
+    case AMDCUID_STATUS_HMAC_ERROR:
+      return "HMAC_ERROR";
+    case AMDCUID_STATUS_FILE_ERROR:
+      return "FILE_ERROR";
+    case AMDCUID_STATUS_INVALID_FORMAT:
+      return "INVALID_FORMAT";
+    case AMDCUID_STATUS_PCI_ERROR:
+      return "PCI_ERROR";
+    case AMDCUID_STATUS_SMBIOS_ERROR:
+      return "SMBIOS_ERROR";
+    case AMDCUID_STATUS_ACPI_ERROR:
+      return "ACPI_ERROR";
+    case AMDCUID_STATUS_CPUINFO_ERROR:
+      return "CPUINFO_ERROR";
+    case AMDCUID_STATUS_IPC_ERROR:
+      return "IPC_ERROR";
+    default:
+      return "UNKNOWN_ERROR";
   }
 }
 
-const char *amdcuid_id_to_string(amdcuid_id_t cuid_value) {
+const char* amdcuid_id_to_string(amdcuid_id_t cuid_value) {
   // Use thread_local static buffer to avoid returning dangling pointer from
   // temporary string
-  thread_local static char uuid_str[37]; // 36 chars + null terminator
+  thread_local static char uuid_str[37];  // 36 chars + null terminator
   std::string result = CuidUtilities::get_cuid_as_string(&cuid_value);
   std::strncpy(uuid_str, result.c_str(), sizeof(uuid_str) - 1);
   uuid_str[sizeof(uuid_str) - 1] = '\0';
   return uuid_str;
 }
 
-amdcuid_status_t amdcuid_get_all_handles(amdcuid_id_t *handles,
-                                         uint32_t *count) {
+amdcuid_status_t amdcuid_get_all_handles(amdcuid_id_t* handles, uint32_t* count) {
+  if (!count) {
+    return AMDCUID_STATUS_INVALID_ARGUMENT;
+  }
+
   amdcuid_status_t status;
   // get all the devices on the system first
   if (mgr.devices().empty()) {
@@ -132,7 +132,7 @@ amdcuid_status_t amdcuid_get_all_handles(amdcuid_id_t *handles,
   auto handle_list = mgr.get_all_handles();
   auto handle_count = static_cast<uint32_t>(handle_list.size());
   if (handle_count == 0) {
-    handles = nullptr;
+    *count = 0;
     return AMDCUID_STATUS_UNSUPPORTED;
   }
   if (*count < handle_count) {
@@ -151,8 +151,7 @@ amdcuid_status_t amdcuid_get_all_handles(amdcuid_id_t *handles,
 }
 
 // helper function to discover device given dev_path
-DevicePtr discover_device_by_path(const char *dev_path,
-                                  amdcuid_device_type_t device_type) {
+DevicePtr discover_device_by_path(const char* dev_path, amdcuid_device_type_t device_type) {
   DevicePtr device = nullptr;
   amdcuid_status_t status;
 
@@ -210,43 +209,42 @@ DevicePtr discover_device_by_path(const char *dev_path,
     return nullptr;
   }
   switch (device_type) {
-  case AMDCUID_DEVICE_TYPE_GPU: {
-    amdcuid_gpu_info gpu_info = {};
-    status = CuidGpu::discover_single(&gpu_info, real_dev_path);
-    if (status != AMDCUID_STATUS_SUCCESS) {
-      return nullptr;
+    case AMDCUID_DEVICE_TYPE_GPU: {
+      amdcuid_gpu_info gpu_info = {};
+      status = CuidGpu::discover_single(&gpu_info, real_dev_path);
+      if (status != AMDCUID_STATUS_SUCCESS) {
+        return nullptr;
+      }
+      device = std::make_shared<CuidGpu>(gpu_info);
+      break;
     }
-    device = std::make_shared<CuidGpu>(gpu_info);
-    break;
-  }
-  case AMDCUID_DEVICE_TYPE_NIC: {
-    amdcuid_nic_info nic_info = {};
-    status = CuidNic::discover_single(&nic_info, real_dev_path);
-    if (status != AMDCUID_STATUS_SUCCESS) {
-      return nullptr;
+    case AMDCUID_DEVICE_TYPE_NIC: {
+      amdcuid_nic_info nic_info = {};
+      status = CuidNic::discover_single(&nic_info, real_dev_path);
+      if (status != AMDCUID_STATUS_SUCCESS) {
+        return nullptr;
+      }
+      device = std::make_shared<CuidNic>(nic_info);
+      break;
     }
-    device = std::make_shared<CuidNic>(nic_info);
-    break;
-  }
-  case AMDCUID_DEVICE_TYPE_NPU: {
-    amdcuid_npu_info npu_info = {};
-    status = CuidNpu::discover_single(&npu_info, real_dev_path);
-    if (status != AMDCUID_STATUS_SUCCESS) {
-      return nullptr;
+    case AMDCUID_DEVICE_TYPE_NPU: {
+      amdcuid_npu_info npu_info = {};
+      status = CuidNpu::discover_single(&npu_info, real_dev_path);
+      if (status != AMDCUID_STATUS_SUCCESS) {
+        return nullptr;
+      }
+      device = std::make_shared<CuidNpu>(npu_info);
+      break;
     }
-    device = std::make_shared<CuidNpu>(npu_info);
-    break;
-  }
-  default:
-    return nullptr;
+    default:
+      return nullptr;
   }
   return device;
 }
 
-amdcuid_status_t
-amdcuid_get_handle_by_dev_path(const char *dev_path,
-                               amdcuid_device_type_t device_type,
-                               amdcuid_id_t *handle) {
+amdcuid_status_t amdcuid_get_handle_by_dev_path(const char* dev_path,
+                                                amdcuid_device_type_t device_type,
+                                                amdcuid_id_t* handle) {
   if (!dev_path || !handle) {
     return AMDCUID_STATUS_INVALID_ARGUMENT;
   }
@@ -261,10 +259,8 @@ amdcuid_get_handle_by_dev_path(const char *dev_path,
   // CPU and Platform sysfs paths are directories without a /device
   // subdirectory, so the /device suffix would produce an invalid path.
   std::string dev_path_str(dev_path);
-  if (device_type == AMDCUID_DEVICE_TYPE_NIC ||
-      device_type == AMDCUID_DEVICE_TYPE_GPU ||
-      device_type == AMDCUID_DEVICE_TYPE_CPU ||
-      device_type == AMDCUID_DEVICE_TYPE_PLATFORM ||
+  if (device_type == AMDCUID_DEVICE_TYPE_NIC || device_type == AMDCUID_DEVICE_TYPE_GPU ||
+      device_type == AMDCUID_DEVICE_TYPE_CPU || device_type == AMDCUID_DEVICE_TYPE_PLATFORM ||
       device_type == AMDCUID_DEVICE_TYPE_NPU ||
       dev_path_str.find("/sys/class/net/") != std::string::npos ||
       dev_path_str.find("/sys/class/drm/") != std::string::npos ||
@@ -278,7 +274,7 @@ amdcuid_get_handle_by_dev_path(const char *dev_path,
 
   amdcuid_status_t status;
   // check mgr first to see if device is already known
-  for (const auto &device : mgr.devices()) {
+  for (const auto& device : mgr.devices()) {
     std::string device_path;
     status = device->get_device_path(device_path);
     if (status != AMDCUID_STATUS_SUCCESS) {
@@ -337,20 +333,18 @@ amdcuid_get_handle_by_dev_path(const char *dev_path,
   }
 }
 
-amdcuid_status_t amdcuid_get_handle_by_bdf(const char *bdf,
-                                           amdcuid_device_type_t device_type,
-                                           amdcuid_id_t *handle) {
+amdcuid_status_t amdcuid_get_handle_by_bdf(const char* bdf, amdcuid_device_type_t device_type,
+                                           amdcuid_id_t* handle) {
   if (!bdf || !handle) {
     return AMDCUID_STATUS_INVALID_ARGUMENT;
   }
 
-  if (device_type == AMDCUID_DEVICE_TYPE_CPU ||
-      device_type == AMDCUID_DEVICE_TYPE_PLATFORM) {
+  if (device_type == AMDCUID_DEVICE_TYPE_CPU || device_type == AMDCUID_DEVICE_TYPE_PLATFORM) {
     return AMDCUID_STATUS_WRONG_DEVICE_TYPE;
   }
 
   // check mgr first to see if device is already known
-  for (const auto &device : mgr.devices()) {
+  for (const auto& device : mgr.devices()) {
     std::string device_bdf;
     amdcuid_status_t status = device->get_bdf(device_bdf);
     if (status != AMDCUID_STATUS_SUCCESS) {
@@ -391,8 +385,7 @@ amdcuid_status_t amdcuid_get_handle_by_bdf(const char *bdf,
   // of symlink for more reliable matching. NPU paths from bdf_to_device_path
   // may be PCI device directories (not char/block devices), so the fd-based
   // real path resolution would fail.
-  if ((device_type != AMDCUID_DEVICE_TYPE_NIC ||
-       device_path.find("net") == std::string::npos) &&
+  if ((device_type != AMDCUID_DEVICE_TYPE_NIC || device_path.find("net") == std::string::npos) &&
       device_type != AMDCUID_DEVICE_TYPE_NPU) {
     int fd = open(device_path.c_str(), O_RDONLY);
     if (fd < 0) {
@@ -427,15 +420,13 @@ amdcuid_status_t amdcuid_get_handle_by_bdf(const char *bdf,
   }
 }
 
-amdcuid_status_t amdcuid_get_handle_by_fd(int fd,
-                                          amdcuid_device_type_t device_type,
-                                          amdcuid_id_t *handle) {
+amdcuid_status_t amdcuid_get_handle_by_fd(int fd, amdcuid_device_type_t device_type,
+                                          amdcuid_id_t* handle) {
   if (fd < 0 || !handle) {
     return AMDCUID_STATUS_INVALID_ARGUMENT;
   }
 
-  if (device_type == AMDCUID_DEVICE_TYPE_CPU ||
-      device_type == AMDCUID_DEVICE_TYPE_PLATFORM ||
+  if (device_type == AMDCUID_DEVICE_TYPE_CPU || device_type == AMDCUID_DEVICE_TYPE_PLATFORM ||
       device_type == AMDCUID_DEVICE_TYPE_NIC) {
     return AMDCUID_STATUS_WRONG_DEVICE_TYPE;
   }
@@ -444,8 +435,7 @@ amdcuid_status_t amdcuid_get_handle_by_fd(int fd,
   if (device_path.empty()) {
     return AMDCUID_STATUS_DEVICE_NOT_FOUND;
   }
-  return amdcuid_get_handle_by_dev_path(device_path.c_str(), device_type,
-                                        handle);
+  return amdcuid_get_handle_by_dev_path(device_path.c_str(), device_type, handle);
 }
 
 amdcuid_status_t amdcuid_refresh() {
@@ -472,9 +462,8 @@ amdcuid_status_t amdcuid_refresh() {
   return status;
 }
 
-amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle,
-                                               amdcuid_query_t query,
-                                               void *data, uint32_t *length) {
+amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle, amdcuid_query_t query,
+                                               void* data, uint32_t* length) {
   if (!length) {
     return AMDCUID_STATUS_INVALID_ARGUMENT;
   }
@@ -482,216 +471,218 @@ amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle,
   if (!device) {
     return AMDCUID_STATUS_DEVICE_NOT_FOUND;
   }
-  amdcuid_status_t status;
+  // Must be initialized: most cases below only assign `status` inside
+  // `if (data != nullptr)`, so the size-query form of this API
+  // (data == nullptr, *length large enough) would otherwise return the value
+  // of an uninitialized variable.
+  amdcuid_status_t status = AMDCUID_STATUS_SUCCESS;
   switch (query) {
-  case AMDCUID_QUERY_PRIMARY_CUID: {
-    if (geteuid() != 0) {
-      return AMDCUID_STATUS_PERMISSION_DENIED;
-    }
-    if (*length < sizeof(amdcuid_id_t)) {
-      return AMDCUID_STATUS_INSUFFICIENT_SIZE;
-    }
-    amdcuid_primary_id id = {};
-    status = device->get_primary_cuid(id);
-    if (data != nullptr) {
-      std::memcpy(data, &id.UUIDv8_representation, sizeof(amdcuid_id_t));
-    }
-    *length = sizeof(amdcuid_id_t);
-  } break;
-  case AMDCUID_QUERY_DERIVED_CUID: {
-    if (*length < sizeof(amdcuid_id_t)) {
-      return AMDCUID_STATUS_INSUFFICIENT_SIZE;
-    }
-    amdcuid_derived_id sec_id = {};
-    if (geteuid() == 0) {
-      // if elevated, provide hmac in case it needs to get generated
-      status = device->get_derived_cuid(sec_id, &global_hmac);
-    } else {
-      // if not elevated, only get existing derived cuid
-      status = device->get_derived_cuid(sec_id);
-    }
-    if (data != nullptr) {
-      std::memcpy(data, &sec_id.UUIDv8_representation, sizeof(amdcuid_id_t));
-    }
-    *length = sizeof(amdcuid_id_t);
-  } break;
-  case AMDCUID_QUERY_HARDWARE_FINGERPRINT: {
-    if (geteuid() != 0) {
-      return AMDCUID_STATUS_PERMISSION_DENIED;
-    }
-    if (*length < sizeof(uint64_t)) {
-      return AMDCUID_STATUS_INSUFFICIENT_SIZE;
-    }
-    if (data != nullptr) {
-      std::memset(data, 0, sizeof(uint64_t));
-      status = device->get_hardware_fingerprint(*(uint64_t *)data);
-    }
-    *length = sizeof(uint64_t);
-  } break;
-  case AMDCUID_QUERY_DEVICE_PATH: {
-    std::string path;
-    status = device->get_device_path(path);
-    if (status != AMDCUID_STATUS_SUCCESS) {
-      break;
-    }
-    uint32_t required_length =
-        static_cast<uint32_t>(path.size() + 1); // include null terminator
-    if (*length < required_length) {
+    case AMDCUID_QUERY_PRIMARY_CUID: {
+      if (geteuid() != 0) {
+        return AMDCUID_STATUS_PERMISSION_DENIED;
+      }
+      if (*length < sizeof(amdcuid_id_t)) {
+        return AMDCUID_STATUS_INSUFFICIENT_SIZE;
+      }
+      amdcuid_primary_id id = {};
+      status = device->get_primary_cuid(id);
+      if (data != nullptr) {
+        std::memcpy(data, &id.UUIDv8_representation, sizeof(amdcuid_id_t));
+      }
+      *length = sizeof(amdcuid_id_t);
+    } break;
+    case AMDCUID_QUERY_DERIVED_CUID: {
+      if (*length < sizeof(amdcuid_id_t)) {
+        return AMDCUID_STATUS_INSUFFICIENT_SIZE;
+      }
+      amdcuid_derived_id sec_id = {};
+      if (geteuid() == 0) {
+        // if elevated, provide hmac in case it needs to get generated
+        status = device->get_derived_cuid(sec_id, &global_hmac);
+      } else {
+        // if not elevated, only get existing derived cuid
+        status = device->get_derived_cuid(sec_id);
+      }
+      if (data != nullptr) {
+        std::memcpy(data, &sec_id.UUIDv8_representation, sizeof(amdcuid_id_t));
+      }
+      *length = sizeof(amdcuid_id_t);
+    } break;
+    case AMDCUID_QUERY_HARDWARE_FINGERPRINT: {
+      if (geteuid() != 0) {
+        return AMDCUID_STATUS_PERMISSION_DENIED;
+      }
+      if (*length < sizeof(uint64_t)) {
+        return AMDCUID_STATUS_INSUFFICIENT_SIZE;
+      }
+      if (data != nullptr) {
+        std::memset(data, 0, sizeof(uint64_t));
+        status = device->get_hardware_fingerprint(*(uint64_t*)data);
+      }
+      *length = sizeof(uint64_t);
+    } break;
+    case AMDCUID_QUERY_DEVICE_PATH: {
+      std::string path;
+      status = device->get_device_path(path);
+      if (status != AMDCUID_STATUS_SUCCESS) {
+        break;
+      }
+      uint32_t required_length = static_cast<uint32_t>(path.size() + 1);  // include null terminator
+      if (*length < required_length) {
+        *length = required_length;
+        return AMDCUID_STATUS_INSUFFICIENT_SIZE;
+      }
+      if (data != nullptr) {
+        std::memcpy(data, path.c_str(), required_length);
+      }
       *length = required_length;
-      return AMDCUID_STATUS_INSUFFICIENT_SIZE;
-    }
-    if (data != nullptr) {
-      std::memcpy(data, path.c_str(), required_length);
-    }
-    *length = required_length;
-  } break;
-  case AMDCUID_QUERY_DEVICE_TYPE: {
-    if (*length < sizeof(amdcuid_device_type_t)) {
-      return AMDCUID_STATUS_INSUFFICIENT_SIZE;
-    }
-    if (data != nullptr) {
-      amdcuid_device_type_t device_type = device->type();
-      std::memcpy(data, &device_type, sizeof(amdcuid_device_type_t));
-    }
-    *length = sizeof(amdcuid_device_type_t);
-    status = AMDCUID_STATUS_SUCCESS;
-  } break;
-  case AMDCUID_QUERY_VENDOR_ID: {
-    if (*length < sizeof(uint16_t)) {
-      return AMDCUID_STATUS_INSUFFICIENT_SIZE;
-    }
-    if (data != nullptr) {
-      uint16_t vendor_id = 0;
-      status = device->get_vendor_id(vendor_id);
-      std::memcpy(data, &vendor_id, sizeof(uint16_t));
-    }
-    *length = sizeof(uint16_t);
-  } break;
-  case AMDCUID_QUERY_DEVICE_ID: {
-    if (*length < sizeof(uint16_t)) {
-      return AMDCUID_STATUS_INSUFFICIENT_SIZE;
-    }
-    if (data != nullptr) {
-      uint16_t device_id = 0;
-      status = device->get_device_id(device_id);
-      std::memcpy(data, &device_id, sizeof(uint16_t));
-    }
-    *length = sizeof(uint16_t);
-  } break;
-  case AMDCUID_QUERY_REVISION_ID: {
-    if (*length < sizeof(uint8_t)) {
-      return AMDCUID_STATUS_INSUFFICIENT_SIZE;
-    }
-    if (data != nullptr) {
-      uint8_t revision_id = 0;
-      status = device->get_revision_id(revision_id);
-      std::memcpy(data, &revision_id, sizeof(uint8_t));
-    }
-    *length = sizeof(uint8_t);
-  } break;
-  case AMDCUID_QUERY_UNIT_ID: {
-    if (*length < sizeof(uint16_t)) {
-      return AMDCUID_STATUS_INSUFFICIENT_SIZE;
-    }
-    if (data != nullptr) {
-      uint16_t unit_id = 0;
-      status = device->get_unit_id(unit_id);
-      std::memcpy(data, &unit_id, sizeof(uint16_t));
-    }
-    *length = sizeof(uint16_t);
-  } break;
-  case AMDCUID_QUERY_FAMILY: {
-    // only CPU devices will return a valid family
-    if (*length < sizeof(uint16_t)) {
-      return AMDCUID_STATUS_INSUFFICIENT_SIZE;
-    }
-    if (data != nullptr) {
-      uint16_t family = 0;
-      status = device->get_family(family);
-      std::memcpy(data, &family, sizeof(uint16_t));
-    }
-    *length = sizeof(uint16_t);
-  } break;
-  case AMDCUID_QUERY_MODEL: {
-    // only CPU devices will return a valid model
-    if (*length < sizeof(uint16_t)) {
-      return AMDCUID_STATUS_INSUFFICIENT_SIZE;
-    }
-    if (data != nullptr) {
-      uint16_t model = 0;
-      status = device->get_model(model);
-      std::memcpy(data, &model, sizeof(uint16_t));
-    }
-    *length = sizeof(uint16_t);
-  } break;
-  case AMDCUID_QUERY_CORE_ID: {
-    // only CPU devices will return a valid core ID
-    if (*length < sizeof(uint16_t)) {
-      return AMDCUID_STATUS_INSUFFICIENT_SIZE;
-    }
-    if (data != nullptr) {
-      uint16_t core = 0;
-      status = device->get_core(core);
-      std::memcpy(data, &core, sizeof(uint16_t));
-    }
-    *length = sizeof(uint16_t);
-  } break;
-  case AMDCUID_QUERY_PHYSICAL_ID: {
-    // only CPU devices will return a valid physical package ID
-    if (*length < sizeof(uint16_t)) {
-      return AMDCUID_STATUS_INSUFFICIENT_SIZE;
-    }
-    if (data != nullptr) {
-      uint16_t physical_id = 0;
-      status = device->get_physical_id(physical_id);
-      std::memcpy(data, &physical_id, sizeof(uint16_t));
-    }
-    *length = sizeof(uint16_t);
-  } break;
-  case AMDCUID_QUERY_PCI_CLASS: {
-    // only PCI devices (GPU, NIC) will return a valid PCI class
-    if (*length < sizeof(uint16_t)) {
-      return AMDCUID_STATUS_INSUFFICIENT_SIZE;
-    }
-    if (data != nullptr) {
-      uint16_t pci_class = 0;
-      status = device->get_pci_class(pci_class);
-      std::memcpy(data, &pci_class, sizeof(uint16_t));
-    }
-    *length = sizeof(uint16_t);
-  } break;
-  case AMDCUID_QUERY_BDF: {
-    // only PCI devices (GPU, NIC) will return a valid BDF
-    std::string bdf;
-    status = device->get_bdf(bdf);
-    if (status != AMDCUID_STATUS_SUCCESS) {
-      break;
-    }
-    uint32_t required_length =
-        static_cast<uint32_t>(bdf.size() + 1); // include null terminator
-    if (*length < required_length) {
+    } break;
+    case AMDCUID_QUERY_DEVICE_TYPE: {
+      if (*length < sizeof(amdcuid_device_type_t)) {
+        return AMDCUID_STATUS_INSUFFICIENT_SIZE;
+      }
+      if (data != nullptr) {
+        amdcuid_device_type_t device_type = device->type();
+        std::memcpy(data, &device_type, sizeof(amdcuid_device_type_t));
+      }
+      *length = sizeof(amdcuid_device_type_t);
+      status = AMDCUID_STATUS_SUCCESS;
+    } break;
+    case AMDCUID_QUERY_VENDOR_ID: {
+      if (*length < sizeof(uint16_t)) {
+        return AMDCUID_STATUS_INSUFFICIENT_SIZE;
+      }
+      if (data != nullptr) {
+        uint16_t vendor_id = 0;
+        status = device->get_vendor_id(vendor_id);
+        std::memcpy(data, &vendor_id, sizeof(uint16_t));
+      }
+      *length = sizeof(uint16_t);
+    } break;
+    case AMDCUID_QUERY_DEVICE_ID: {
+      if (*length < sizeof(uint16_t)) {
+        return AMDCUID_STATUS_INSUFFICIENT_SIZE;
+      }
+      if (data != nullptr) {
+        uint16_t device_id = 0;
+        status = device->get_device_id(device_id);
+        std::memcpy(data, &device_id, sizeof(uint16_t));
+      }
+      *length = sizeof(uint16_t);
+    } break;
+    case AMDCUID_QUERY_REVISION_ID: {
+      if (*length < sizeof(uint8_t)) {
+        return AMDCUID_STATUS_INSUFFICIENT_SIZE;
+      }
+      if (data != nullptr) {
+        uint8_t revision_id = 0;
+        status = device->get_revision_id(revision_id);
+        std::memcpy(data, &revision_id, sizeof(uint8_t));
+      }
+      *length = sizeof(uint8_t);
+    } break;
+    case AMDCUID_QUERY_UNIT_ID: {
+      if (*length < sizeof(uint16_t)) {
+        return AMDCUID_STATUS_INSUFFICIENT_SIZE;
+      }
+      if (data != nullptr) {
+        uint16_t unit_id = 0;
+        status = device->get_unit_id(unit_id);
+        std::memcpy(data, &unit_id, sizeof(uint16_t));
+      }
+      *length = sizeof(uint16_t);
+    } break;
+    case AMDCUID_QUERY_FAMILY: {
+      // only CPU devices will return a valid family
+      if (*length < sizeof(uint16_t)) {
+        return AMDCUID_STATUS_INSUFFICIENT_SIZE;
+      }
+      if (data != nullptr) {
+        uint16_t family = 0;
+        status = device->get_family(family);
+        std::memcpy(data, &family, sizeof(uint16_t));
+      }
+      *length = sizeof(uint16_t);
+    } break;
+    case AMDCUID_QUERY_MODEL: {
+      // only CPU devices will return a valid model
+      if (*length < sizeof(uint16_t)) {
+        return AMDCUID_STATUS_INSUFFICIENT_SIZE;
+      }
+      if (data != nullptr) {
+        uint16_t model = 0;
+        status = device->get_model(model);
+        std::memcpy(data, &model, sizeof(uint16_t));
+      }
+      *length = sizeof(uint16_t);
+    } break;
+    case AMDCUID_QUERY_CORE_ID: {
+      // only CPU devices will return a valid core ID
+      if (*length < sizeof(uint16_t)) {
+        return AMDCUID_STATUS_INSUFFICIENT_SIZE;
+      }
+      if (data != nullptr) {
+        uint16_t core = 0;
+        status = device->get_core(core);
+        std::memcpy(data, &core, sizeof(uint16_t));
+      }
+      *length = sizeof(uint16_t);
+    } break;
+    case AMDCUID_QUERY_PHYSICAL_ID: {
+      // only CPU devices will return a valid physical package ID
+      if (*length < sizeof(uint16_t)) {
+        return AMDCUID_STATUS_INSUFFICIENT_SIZE;
+      }
+      if (data != nullptr) {
+        uint16_t physical_id = 0;
+        status = device->get_physical_id(physical_id);
+        std::memcpy(data, &physical_id, sizeof(uint16_t));
+      }
+      *length = sizeof(uint16_t);
+    } break;
+    case AMDCUID_QUERY_PCI_CLASS: {
+      // only PCI devices (GPU, NIC) will return a valid PCI class
+      if (*length < sizeof(uint16_t)) {
+        return AMDCUID_STATUS_INSUFFICIENT_SIZE;
+      }
+      if (data != nullptr) {
+        uint16_t pci_class = 0;
+        status = device->get_pci_class(pci_class);
+        std::memcpy(data, &pci_class, sizeof(uint16_t));
+      }
+      *length = sizeof(uint16_t);
+    } break;
+    case AMDCUID_QUERY_BDF: {
+      // only PCI devices (GPU, NIC) will return a valid BDF
+      std::string bdf;
+      status = device->get_bdf(bdf);
+      if (status != AMDCUID_STATUS_SUCCESS) {
+        break;
+      }
+      uint32_t required_length = static_cast<uint32_t>(bdf.size() + 1);  // include null terminator
+      if (*length < required_length) {
+        *length = required_length;
+        return AMDCUID_STATUS_INSUFFICIENT_SIZE;
+      }
+      if (data != nullptr) {
+        std::memcpy(data, bdf.c_str(), required_length);
+      }
       *length = required_length;
-      return AMDCUID_STATUS_INSUFFICIENT_SIZE;
-    }
-    if (data != nullptr) {
-      std::memcpy(data, bdf.c_str(), required_length);
-    }
-    *length = required_length;
-  } break;
-  case AMDCUID_QUERY_TEMPORARY_CUID: {
-    if (*length < sizeof(bool)) {
-      return AMDCUID_STATUS_INSUFFICIENT_SIZE;
-    }
-    if (data != nullptr) {
-      bool is_temporary = false;
-      status = device->is_temporary_cuid(&is_temporary);
-      *(bool *)data = is_temporary;
-    }
-    *length = sizeof(bool);
-  } break;
-  default:
-    status = AMDCUID_STATUS_INVALID_ARGUMENT;
-    break;
+    } break;
+    case AMDCUID_QUERY_TEMPORARY_CUID: {
+      if (*length < sizeof(bool)) {
+        return AMDCUID_STATUS_INSUFFICIENT_SIZE;
+      }
+      if (data != nullptr) {
+        bool is_temporary = false;
+        status = device->is_temporary_cuid(&is_temporary);
+        *(bool*)data = is_temporary;
+      }
+      *length = sizeof(bool);
+    } break;
+    default:
+      status = AMDCUID_STATUS_INVALID_ARGUMENT;
+      break;
   }
 
   return status;
@@ -701,19 +692,26 @@ amdcuid_status_t amdcuid_set_hash_key(const uint8_t key[32]) {
   if (geteuid() != 0) {
     return AMDCUID_STATUS_PERMISSION_DENIED;
   }
+  if (!key) {
+    return AMDCUID_STATUS_INVALID_ARGUMENT;
+  }
 
-  global_hmac.set_hmac_key(key);
+  // Persist first: if the key cannot be written, leave the in-memory key alone
+  // so the process keeps deriving the CUIDs that match what is on disk. The
+  // previous code ignored both failures and reported success regardless.
+  amdcuid_status_t status = global_hmac.store_key(key);
+  if (status != AMDCUID_STATUS_SUCCESS) {
+    return status;
+  }
 
-  return AMDCUID_STATUS_SUCCESS;
+  return global_hmac.set_hmac_key(key);
 }
 
 amdcuid_status_t amdcuid_generate_hash_key(uint8_t key[32]) {
   if (geteuid() != 0) {
     return AMDCUID_STATUS_PERMISSION_DENIED;
   }
-  if (!key)
-    return AMDCUID_STATUS_INVALID_ARGUMENT;
+  if (!key) return AMDCUID_STATUS_INVALID_ARGUMENT;
 
-  global_hmac.generate_key(key);
-  return AMDCUID_STATUS_SUCCESS;
+  return global_hmac.generate_key(key);
 }

--- a/projects/cuid/lib/src/cuid_cpu.cc
+++ b/projects/cuid/lib/src/cuid_cpu.cc
@@ -21,29 +21,31 @@
  */
 
 #include "src/cuid_cpu.h"
-#include "src/cuid_file.h"
-#include "src/cuid_util.h"
-#include "src/hmac.h"
-#include "src/smbios_util.h"
+
+#include <unistd.h>
+
 #include <cstring>
 #include <fstream>
 #include <iostream>
 #include <map>
 #include <sstream>
-#include <unistd.h>
+
+#include "src/cuid_file.h"
+#include "src/cuid_util.h"
+#include "src/hmac.h"
+#include "src/smbios_util.h"
 
 #ifdef __x86_64__
 #include <cpuid.h>
 #endif
 
-CuidCpu::CuidCpu(const amdcuid_cpu_info &i) : m_info(i) {}
+CuidCpu::CuidCpu(const amdcuid_cpu_info& i) : m_info(i) {}
 
 /**
  * @brief Get CPU information from CPUID instruction (x86_64)
  */
-static bool get_cpuid_info(uint16_t &vendor_id, uint16_t &family,
-                           uint16_t &model, uint16_t &device_id,
-                           uint8_t &stepping) {
+static bool get_cpuid_info(uint16_t& vendor_id, uint16_t& family, uint16_t& model,
+                           uint16_t& device_id, uint8_t& stepping) {
 #ifdef __x86_64__
   uint32_t eax, ebx, ecx, edx;
 
@@ -54,9 +56,9 @@ static bool get_cpuid_info(uint16_t &vendor_id, uint16_t &family,
 
   // Check for AMD vendor (AuthenticAMD)
   if (ebx == 0x68747541 && edx == 0x69746E65 && ecx == 0x444D4163) {
-    vendor_id = 0x1022; // AMD vendor ID
+    vendor_id = 0x1022;  // AMD vendor ID
   } else {
-    vendor_id = 0x8086; // Intel or other
+    vendor_id = 0x8086;  // Intel or other
   }
 
   // CPUID leaf 1: Get family, model, stepping
@@ -65,11 +67,11 @@ static bool get_cpuid_info(uint16_t &vendor_id, uint16_t &family,
   }
 
   // Extract CPU signature fields from EAX
-  stepping = eax & 0x0F;                    // Bits 0-3: Stepping
-  uint32_t base_model = (eax >> 4) & 0x0F;  // Bits 4-7: Base Model
-  uint32_t base_family = (eax >> 8) & 0x0F; // Bits 8-11: Base Family
-  uint32_t ext_model = (eax >> 16) & 0x0F;  // Bits 16-19: Extended Model
-  uint32_t ext_family = (eax >> 20) & 0xFF; // Bits 20-27: Extended Family
+  stepping = eax & 0x0F;                     // Bits 0-3: Stepping
+  uint32_t base_model = (eax >> 4) & 0x0F;   // Bits 4-7: Base Model
+  uint32_t base_family = (eax >> 8) & 0x0F;  // Bits 8-11: Base Family
+  uint32_t ext_model = (eax >> 16) & 0x0F;   // Bits 16-19: Extended Model
+  uint32_t ext_family = (eax >> 20) & 0xFF;  // Bits 20-27: Extended Family
 
   // Calculate DisplayFamily and DisplayModel per AMD/Intel spec
   if (base_family == 0x0F) {
@@ -89,7 +91,7 @@ static bool get_cpuid_info(uint16_t &vendor_id, uint16_t &family,
 
   return true;
 #else
-  return false; // Not x86_64, cannot use CPUID
+  return false;  // Not x86_64, cannot use CPUID
 #endif
 }
 
@@ -97,14 +99,14 @@ static bool get_cpuid_info(uint16_t &vendor_id, uint16_t &family,
  * @brief CPU information parsed from /proc/cpuinfo
  */
 struct ProcCpuInfo {
-  int processor = -1;  // Logical processor number
-  int physical_id = 0; // Socket/package ID
-  int core_id = 0;     // Core ID within package
-  int apic_id = 0;     // APIC ID
+  int processor = -1;   // Logical processor number
+  int physical_id = 0;  // Socket/package ID
+  int core_id = 0;      // Core ID within package
+  int apic_id = 0;      // APIC ID
   int family = 0;
   int model = 0;
   int stepping = 0;
-  std::string vendor_id; // "AuthenticAMD" or "GenuineIntel"
+  std::string vendor_id;  // "AuthenticAMD" or "GenuineIntel"
   bool is_amd = false;
 };
 
@@ -114,7 +116,7 @@ struct ProcCpuInfo {
  * This is the primary method for CPU discovery that works without sudo.
  * Returns information about all logical processors on the system.
  */
-static amdcuid_status_t parse_proc_cpuinfo(std::vector<ProcCpuInfo> &cpus) {
+static amdcuid_status_t parse_proc_cpuinfo(std::vector<ProcCpuInfo>& cpus) {
   std::ifstream cpuinfo("/proc/cpuinfo");
   if (!cpuinfo) {
     return AMDCUID_STATUS_CPUINFO_ERROR;
@@ -136,17 +138,14 @@ static amdcuid_status_t parse_proc_cpuinfo(std::vector<ProcCpuInfo> &cpus) {
 
     // Parse key : value
     size_t colon = line.find(':');
-    if (colon == std::string::npos)
-      continue;
+    if (colon == std::string::npos) continue;
 
     std::string key = line.substr(0, colon);
     std::string value = line.substr(colon + 1);
 
     // Trim whitespace
-    while (!key.empty() && (key.back() == ' ' || key.back() == '\t'))
-      key.pop_back();
-    while (!value.empty() && (value.front() == ' ' || value.front() == '\t'))
-      value.erase(0, 1);
+    while (!key.empty() && (key.back() == ' ' || key.back() == '\t')) key.pop_back();
+    while (!value.empty() && (value.front() == ' ' || value.front() == '\t')) value.erase(0, 1);
 
     if (key == "processor") {
       current.processor = std::stoi(value);
@@ -187,7 +186,7 @@ static amdcuid_status_t parse_proc_cpuinfo(std::vector<ProcCpuInfo> &cpus) {
  * The ACPI MADT parsing (which requires root) is moved to
  * get_hardware_fingerprint() where privileged operations are expected.
  */
-amdcuid_status_t CuidCpu::discover(std::vector<DevicePtr> &cpus) {
+amdcuid_status_t CuidCpu::discover(std::vector<DevicePtr>& cpus) {
   cpus.clear();
 
   // Parse /proc/cpuinfo - works without root
@@ -201,14 +200,13 @@ amdcuid_status_t CuidCpu::discover(std::vector<DevicePtr> &cpus) {
   // Get CPU information from CPUID (same for all cores)
   uint16_t vendor_id = 0, family = 0, model = 0, device_id = 0;
   uint8_t stepping = 0;
-  bool cpuid_available =
-      get_cpuid_info(vendor_id, family, model, device_id, stepping);
+  bool cpuid_available = get_cpuid_info(vendor_id, family, model, device_id, stepping);
 
   // Group logical processors by physical package (socket). For each socket,
   // pick the representative entry with the lowest APIC ID — this is the
   // bootstrap processor convention used by firmware to represent the package.
-  std::map<int, const ProcCpuInfo *> socket_rep;
-  for (const auto &proc_info : proc_cpus) {
+  std::map<int, const ProcCpuInfo*> socket_rep;
+  for (const auto& proc_info : proc_cpus) {
     auto it = socket_rep.find(proc_info.physical_id);
     if (it == socket_rep.end() || proc_info.apic_id < it->second->apic_id) {
       socket_rep[proc_info.physical_id] = &proc_info;
@@ -216,8 +214,8 @@ amdcuid_status_t CuidCpu::discover(std::vector<DevicePtr> &cpus) {
   }
 
   // Create one CPU device per physical socket using the representative entry.
-  for (const auto &kv : socket_rep) {
-    const ProcCpuInfo *rep = kv.second;
+  for (const auto& kv : socket_rep) {
+    const ProcCpuInfo* rep = kv.second;
     amdcuid_cpu_info info{};
     std::memset(&info.header, 0, sizeof(info.header));
 
@@ -233,8 +231,7 @@ amdcuid_status_t CuidCpu::discover(std::vector<DevicePtr> &cpus) {
       info.header.fields.cpu.vendor_id = rep->is_amd ? 0x1022 : 0x8086;
       info.header.fields.cpu.family = static_cast<uint16_t>(rep->family);
       info.header.fields.cpu.model = static_cast<uint16_t>(rep->model);
-      info.header.fields.cpu.device_id =
-          static_cast<uint16_t>((rep->family << 8) | rep->model);
+      info.header.fields.cpu.device_id = static_cast<uint16_t>((rep->family << 8) | rep->model);
       info.header.fields.cpu.revision_id = static_cast<uint8_t>(rep->stepping);
     }
 
@@ -242,12 +239,10 @@ amdcuid_status_t CuidCpu::discover(std::vector<DevicePtr> &cpus) {
     // representative used by firmware to identify the socket.
     info.header.fields.cpu.unit_id = static_cast<uint16_t>(rep->apic_id);
     info.header.fields.cpu.physical_id = static_cast<uint16_t>(kv.first);
-    info.header.fields.cpu.core =
-        static_cast<uint16_t>(rep->processor); // logical CPU number
+    info.header.fields.cpu.core = static_cast<uint16_t>(rep->processor);  // logical CPU number
 
     // device_node points to the representative logical CPU's sysfs path.
-    info.device_node =
-        "/sys/devices/system/cpu/cpu" + std::to_string(rep->processor);
+    info.device_node = "/sys/devices/system/cpu/cpu" + std::to_string(rep->processor);
 
     cpus.emplace_back(std::make_shared<CuidCpu>(info));
   }
@@ -261,8 +256,8 @@ amdcuid_status_t CuidCpu::discover(std::vector<DevicePtr> &cpus) {
  * Device path should be like /sys/devices/system/cpu/cpu0
  * Reads topology info from sysfs and CPU info from CPUID.
  */
-amdcuid_status_t CuidCpu::discover_single(amdcuid_cpu_info *cpu_info,
-                                          const std::string &device_path) {
+amdcuid_status_t CuidCpu::discover_single(amdcuid_cpu_info* cpu_info,
+                                          const std::string& device_path) {
   if (!cpu_info) {
     return AMDCUID_STATUS_INVALID_ARGUMENT;
   }
@@ -278,8 +273,7 @@ amdcuid_status_t CuidCpu::discover_single(amdcuid_cpu_info *cpu_info,
 
   std::string physical_package_str =
       CuidUtilities::read_sysfs_file(topology_path + "/physical_package_id");
-  std::string core_id_str =
-      CuidUtilities::read_sysfs_file(topology_path + "/core_id");
+  std::string core_id_str = CuidUtilities::read_sysfs_file(topology_path + "/core_id");
 
   if (physical_package_str.empty() || core_id_str.empty()) {
     return AMDCUID_STATUS_DEVICE_NOT_FOUND;
@@ -304,16 +298,13 @@ amdcuid_status_t CuidCpu::discover_single(amdcuid_cpu_info *cpu_info,
   }
 
   // Set topology fields from sysfs
-  cpu_info->header.fields.cpu.physical_id =
-      static_cast<uint16_t>(std::stoi(physical_package_str));
-  cpu_info->header.fields.cpu.core =
-      static_cast<uint16_t>(std::stoi(core_id_str));
+  cpu_info->header.fields.cpu.physical_id = static_cast<uint16_t>(std::stoi(physical_package_str));
+  cpu_info->header.fields.cpu.core = static_cast<uint16_t>(std::stoi(core_id_str));
 
   // Try to get APIC ID for unit_id (optional, may not be available via sysfs)
   // Extract CPU number from path for processor ID
   size_t num_start = device_path.rfind("cpu") + 3;
-  if (num_start < device_path.length() &&
-      std::isdigit(device_path[num_start])) {
+  if (num_start < device_path.length() && std::isdigit(device_path[num_start])) {
     int processor_id = std::stoi(device_path.substr(num_start));
     cpu_info->header.fields.cpu.unit_id = static_cast<uint16_t>(processor_id);
   }
@@ -330,13 +321,13 @@ amdcuid_status_t CuidCpu::discover_single(amdcuid_cpu_info *cpu_info,
  * PPIN is available on AMD CPUs (CPUID Fn8000_0008.EBX[23]) via MSR 0xC001_083B
  * Requires root privileges to read MSR.
  */
-static bool try_read_ppin(uint64_t &ppin, uint32_t core_id) {
+static bool try_read_ppin(uint64_t& ppin, uint32_t core_id) {
 #ifdef __x86_64__
   // Check if PPIN is supported via CPUID
   uint32_t eax, ebx, ecx, edx;
   if (__get_cpuid(0x80000008, &eax, &ebx, &ecx, &edx)) {
     if (!(ebx & (1 << 23))) {
-      return false; // PPIN not supported
+      return false;  // PPIN not supported
     }
   } else {
     return false;
@@ -347,16 +338,16 @@ static bool try_read_ppin(uint64_t &ppin, uint32_t core_id) {
   std::string msr_path = "/dev/cpu/" + std::to_string(core_id) + "/msr";
   std::ifstream msr(msr_path, std::ios::binary);
   if (!msr) {
-    return false; // No MSR access (need root or msr module)
+    return false;  // No MSR access (need root or msr module)
   }
 
   // AMD PPIN MSR first, fallback to Intel if not found
   const uint64_t AMD_PPIN_MSR = 0xC001083B;
   msr.seekg(AMD_PPIN_MSR);
-  if (!msr.read(reinterpret_cast<char *>(&ppin), sizeof(ppin))) {
+  if (!msr.read(reinterpret_cast<char*>(&ppin), sizeof(ppin))) {
     const uint64_t INTEL_PPIN_MSR = 0x4F;
     msr.seekg(INTEL_PPIN_MSR);
-    if (!msr.read(reinterpret_cast<char *>(&ppin), sizeof(ppin))) {
+    if (!msr.read(reinterpret_cast<char*>(&ppin), sizeof(ppin))) {
       return false;
     }
   }
@@ -377,8 +368,7 @@ static bool try_read_ppin(uint64_t &ppin, uint32_t core_id) {
  * Both tiers produce a per-socket fingerprint consistent with the spec's
  * intent that CPU identity is tied to the physical package, not logical cores.
  */
-amdcuid_status_t
-CuidCpu::get_hardware_fingerprint(uint64_t &fingerprint) const {
+amdcuid_status_t CuidCpu::get_hardware_fingerprint(uint64_t& fingerprint) const {
   // PPIN is an eFuse-burned per-socket serial number — the spec's primary
   // identifier. The core argument only selects which MSR fd to open.
   uint64_t ppin = 0;
@@ -413,7 +403,7 @@ CuidCpu::get_hardware_fingerprint(uint64_t &fingerprint) const {
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidCpu::get_primary_cuid(amdcuid_primary_id &id) const {
+amdcuid_status_t CuidCpu::get_primary_cuid(amdcuid_primary_id& id) const {
   bool temp = false;
   uint64_t fingerprint = 0;
   amdcuid_status_t status = AMDCUID_STATUS_SUCCESS;
@@ -433,14 +423,12 @@ amdcuid_status_t CuidCpu::get_primary_cuid(amdcuid_primary_id &id) const {
       status = primary_file.find_by_device_node(m_info.device_node, entry);
       if (status == AMDCUID_STATUS_SUCCESS && entry.is_temporary == false) {
         id.UUIDv8_representation = entry.primary_cuid;
-        CuidUtilities::remove_UUIDv8_bits(&id.UUIDv8_representation,
-                                          id.raw_bits);
+        CuidUtilities::remove_UUIDv8_bits(&id.UUIDv8_representation, id.raw_bits);
         return AMDCUID_STATUS_SUCCESS;
       }
     }
 
-    status = primary_file.find_by_package_id(
-        m_info.header.fields.cpu.physical_id, entry);
+    status = primary_file.find_by_package_id(m_info.header.fields.cpu.physical_id, entry);
     if (status == AMDCUID_STATUS_SUCCESS && entry.is_temporary == false) {
       id.UUIDv8_representation = entry.primary_cuid;
       CuidUtilities::remove_UUIDv8_bits(&id.UUIDv8_representation, id.raw_bits);
@@ -453,10 +441,8 @@ amdcuid_status_t CuidCpu::get_primary_cuid(amdcuid_primary_id &id) const {
   if (geteuid() != 0 || status != AMDCUID_STATUS_SUCCESS) {
     // Non-root or fingerprint unavailable: use socket index + machine-id as
     // a stable but non-hardware fallback, flagged as temporary.
-    std::string socket_id =
-        "socket:" + std::to_string(m_info.header.fields.cpu.physical_id);
-    amdcuid_status_t fb_status =
-        CuidUtilities::make_fallback_fingerprint(socket_id, fingerprint);
+    std::string socket_id = "socket:" + std::to_string(m_info.header.fields.cpu.physical_id);
+    amdcuid_status_t fb_status = CuidUtilities::make_fallback_fingerprint(socket_id, fingerprint);
     if (fb_status != AMDCUID_STATUS_SUCCESS) {
       return AMDCUID_STATUS_HW_FINGERPRINT_NOT_FOUND;
     }
@@ -465,59 +451,58 @@ amdcuid_status_t CuidCpu::get_primary_cuid(amdcuid_primary_id &id) const {
 
   // Use CuidUtilities::generate_primary_cuid to generate CUID
   amdcuid_primary_id result = {};
-  const auto &h = m_info.header;
+  const auto& h = m_info.header;
   CuidUtilities::generate_primary_cuid(
-      fingerprint, h.fields.cpu.unit_id, h.fields.cpu.revision_id,
-      h.fields.cpu.device_id, h.fields.cpu.vendor_id,
-      static_cast<uint8_t>(AMDCUID_DEVICE_TYPE_CPU), &result, temp);
+      fingerprint, h.fields.cpu.unit_id, h.fields.cpu.revision_id, h.fields.cpu.device_id,
+      h.fields.cpu.vendor_id, static_cast<uint8_t>(AMDCUID_DEVICE_TYPE_CPU), &result, temp);
 
   id = result;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-const amdcuid_cpu_info &CuidCpu::get_info() const { return m_info; }
+const amdcuid_cpu_info& CuidCpu::get_info() const { return m_info; }
 
-amdcuid_status_t CuidCpu::get_vendor_id(uint16_t &vendor_id) const {
+amdcuid_status_t CuidCpu::get_vendor_id(uint16_t& vendor_id) const {
   vendor_id = m_info.header.fields.cpu.vendor_id;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidCpu::get_family(uint16_t &family) const {
+amdcuid_status_t CuidCpu::get_family(uint16_t& family) const {
   family = m_info.header.fields.cpu.family;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidCpu::get_model(uint16_t &model) const {
+amdcuid_status_t CuidCpu::get_model(uint16_t& model) const {
   model = m_info.header.fields.cpu.model;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidCpu::get_device_id(uint16_t &device_id) const {
+amdcuid_status_t CuidCpu::get_device_id(uint16_t& device_id) const {
   device_id = m_info.header.fields.cpu.device_id;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidCpu::get_revision_id(uint8_t &revision_id) const {
+amdcuid_status_t CuidCpu::get_revision_id(uint8_t& revision_id) const {
   revision_id = m_info.header.fields.cpu.revision_id;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidCpu::get_unit_id(uint16_t &unit_id) const {
+amdcuid_status_t CuidCpu::get_unit_id(uint16_t& unit_id) const {
   unit_id = m_info.header.fields.cpu.unit_id;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidCpu::get_core(uint16_t &core) const {
+amdcuid_status_t CuidCpu::get_core(uint16_t& core) const {
   core = m_info.header.fields.cpu.core;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidCpu::get_physical_id(uint16_t &physical_id) const {
+amdcuid_status_t CuidCpu::get_physical_id(uint16_t& physical_id) const {
   physical_id = m_info.header.fields.cpu.physical_id;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidCpu::get_device_path(std::string &path) const {
+amdcuid_status_t CuidCpu::get_device_path(std::string& path) const {
   // Use stored device_node (set from processor number during discovery or file
   // load)
   if (!m_info.device_node.empty()) {
@@ -525,7 +510,6 @@ amdcuid_status_t CuidCpu::get_device_path(std::string &path) const {
     return AMDCUID_STATUS_SUCCESS;
   }
   // Fallback: construct from unit_id (APIC ID) for backward compatibility
-  path = "/sys/devices/system/cpu/cpu" +
-         std::to_string(m_info.header.fields.cpu.unit_id);
+  path = "/sys/devices/system/cpu/cpu" + std::to_string(m_info.header.fields.cpu.unit_id);
   return AMDCUID_STATUS_SUCCESS;
 }

--- a/projects/cuid/lib/src/cuid_cpu.h
+++ b/projects/cuid/lib/src/cuid_cpu.h
@@ -23,42 +23,44 @@
 #ifndef CUID_CPU_H
 #define CUID_CPU_H
 
-
-#include "src/cuid_device.h"
-#include "include/amd_cuid.h"
-#include "src/cuid_internal.h"
-#include <vector>
 #include <memory>
 #include <string>
+#include <vector>
+
+#include "include/amd_cuid.h"
+#include "src/cuid_device.h"
+#include "src/cuid_internal.h"
 
 struct amdcuid_cpu_info {
-    amdcuid_cuid_public_fields header;
-    std::string device_node;  // sysfs path e.g. /sys/devices/system/cpu/cpu0
+  amdcuid_cuid_public_fields header;
+  std::string device_node;  // sysfs path e.g. /sys/devices/system/cpu/cpu0
 };
 
 class CuidCpu : public CuidDevice {
-public:
-    CuidCpu(const amdcuid_cpu_info& i);
-    amdcuid_device_type_t type() const override { return AMDCUID_DEVICE_TYPE_CPU; }
-    amdcuid_status_t get_primary_cuid(amdcuid_primary_id& id) const override;
-    amdcuid_status_t get_hardware_fingerprint(uint64_t& fingerprint) const override;
-    static amdcuid_status_t discover(std::vector<DevicePtr> &cpus);
-    static amdcuid_status_t discover_single(amdcuid_cpu_info* cpu_info, const std::string& device_path);
+ public:
+  CuidCpu(const amdcuid_cpu_info& i);
+  amdcuid_device_type_t type() const override { return AMDCUID_DEVICE_TYPE_CPU; }
+  amdcuid_status_t get_primary_cuid(amdcuid_primary_id& id) const override;
+  amdcuid_status_t get_hardware_fingerprint(uint64_t& fingerprint) const override;
+  static amdcuid_status_t discover(std::vector<DevicePtr>& cpus);
+  static amdcuid_status_t discover_single(amdcuid_cpu_info* cpu_info,
+                                          const std::string& device_path);
 
-    // Virtual accessor overrides
-    amdcuid_status_t get_vendor_id(uint16_t& vendor_id) const override;
-    amdcuid_status_t get_family(uint16_t& family) const override;
-    amdcuid_status_t get_model(uint16_t& model) const override;
-    amdcuid_status_t get_device_id(uint16_t& device_id) const override;
-    amdcuid_status_t get_revision_id(uint8_t& revision_id) const override;
-    amdcuid_status_t get_unit_id(uint16_t& unit_id) const override;
-    amdcuid_status_t get_core(uint16_t& core) const override;
-    amdcuid_status_t get_physical_id(uint16_t& physical_id) const override;
-    amdcuid_status_t get_device_path(std::string& path) const override;
+  // Virtual accessor overrides
+  amdcuid_status_t get_vendor_id(uint16_t& vendor_id) const override;
+  amdcuid_status_t get_family(uint16_t& family) const override;
+  amdcuid_status_t get_model(uint16_t& model) const override;
+  amdcuid_status_t get_device_id(uint16_t& device_id) const override;
+  amdcuid_status_t get_revision_id(uint8_t& revision_id) const override;
+  amdcuid_status_t get_unit_id(uint16_t& unit_id) const override;
+  amdcuid_status_t get_core(uint16_t& core) const override;
+  amdcuid_status_t get_physical_id(uint16_t& physical_id) const override;
+  amdcuid_status_t get_device_path(std::string& path) const override;
 
-    const amdcuid_cpu_info& get_info() const;
-private:
-    amdcuid_cpu_info m_info;
+  const amdcuid_cpu_info& get_info() const;
+
+ private:
+  amdcuid_cpu_info m_info;
 };
 
-#endif // CUID_CPU_H
+#endif  // CUID_CPU_H

--- a/projects/cuid/lib/src/cuid_device.cc
+++ b/projects/cuid/lib/src/cuid_device.cc
@@ -21,6 +21,23 @@
  */
 
 #include "cuid_device.h"
+
+#include <dirent.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <cctype>
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <mutex>
+#include <sstream>
+#include <vector>
+
 #include "cuid_cpu.h"
 #include "cuid_file.h"
 #include "cuid_gpu.h"
@@ -28,22 +45,6 @@
 #include "cuid_npu.h"
 #include "cuid_platform.h"
 #include "cuid_util.h"
-#include <algorithm>
-#include <cctype>
-#include <cerrno>
-#include <cstdio>
-#include <cstring>
-#include <dirent.h>
-#include <fstream>
-#include <iostream>
-#include <iterator>
-#include <mutex>
-#include <openssl/evp.h>
-#include <openssl/sha.h>
-#include <sstream>
-#include <sys/types.h>
-#include <unistd.h>
-#include <vector>
 
 // helper function to get a hash from the raw bytes of a derived ID
 void get_hash_from_raw(uint8_t raw_bytes[16], uint8_t out_hash[14]) {
@@ -56,15 +57,13 @@ void get_hash_from_raw(uint8_t raw_bytes[16], uint8_t out_hash[14]) {
   out_hash[13] = raw_bytes[14] & 0x3F;
 }
 
-void build_derived_id_from_file_entry(const CuidFileEntry &entry,
-                                      amdcuid_derived_id &id) {
+void build_derived_id_from_file_entry(const CuidFileEntry& entry, amdcuid_derived_id& id) {
   id.UUIDv8_representation = entry.derived_cuid;
   CuidUtilities::remove_UUIDv8_bits(&id.UUIDv8_representation, id.raw_bits);
   get_hash_from_raw(id.raw_bits, id.hash);
 }
 
-amdcuid_status_t CuidDevice::get_derived_cuid(amdcuid_derived_id &id,
-                                              cuid_hmac *hmac) const {
+amdcuid_status_t CuidDevice::get_derived_cuid(amdcuid_derived_id& id, cuid_hmac* hmac) const {
   // attempt to find the derived CUID in file first
   CuidFile derived_file(CuidUtilities::cuid_file(), false);
   amdcuid_status_t status = derived_file.load();
@@ -73,90 +72,86 @@ amdcuid_status_t CuidDevice::get_derived_cuid(amdcuid_derived_id &id,
     amdcuid_device_type_t type = this->type();
     // there's only 1 platform entry, so handle that case first
     switch (type) {
-    case AMDCUID_DEVICE_TYPE_PLATFORM: {
-      // for platform, just return the first entry found
-      CuidFileEntry entry;
-      status =
-          derived_file.find_by_device_type(AMDCUID_DEVICE_TYPE_PLATFORM, entry);
-      if (status == AMDCUID_STATUS_SUCCESS) {
-        build_derived_id_from_file_entry(entry, id);
-        return AMDCUID_STATUS_SUCCESS;
-      }
-    } break;
-    case AMDCUID_DEVICE_TYPE_GPU:
-      // search by render node
-      {
-        auto gpu = reinterpret_cast<CuidGpu *>(const_cast<CuidDevice *>(this));
-        if (gpu) {
-          auto info = gpu->get_info();
-          CuidFileEntry entry;
-          status = derived_file.find_by_device_node(info.render_node, entry);
-          if (status == AMDCUID_STATUS_SUCCESS) {
-            build_derived_id_from_file_entry(entry, id);
-            return AMDCUID_STATUS_SUCCESS;
-          }
-        }
-      }
-      break;
-    case AMDCUID_DEVICE_TYPE_CPU: {
-      auto cpu = reinterpret_cast<CuidCpu *>(const_cast<CuidDevice *>(this));
-      if (cpu) {
-        // Try device_node first - unique per logical CPU on SMT systems
-        std::string device_path;
-        if (cpu->get_device_path(device_path) == AMDCUID_STATUS_SUCCESS &&
-            !device_path.empty()) {
-          CuidFileEntry entry;
-          status = derived_file.find_by_device_node(device_path, entry);
-          if (status == AMDCUID_STATUS_SUCCESS) {
-            build_derived_id_from_file_entry(entry, id);
-            return AMDCUID_STATUS_SUCCESS;
-          }
-        }
-        const auto &info = cpu->get_info();
+      case AMDCUID_DEVICE_TYPE_PLATFORM: {
+        // for platform, just return the first entry found
         CuidFileEntry entry;
-        status = derived_file.find_by_package_id(
-            info.header.fields.cpu.physical_id, entry);
+        status = derived_file.find_by_device_type(AMDCUID_DEVICE_TYPE_PLATFORM, entry);
         if (status == AMDCUID_STATUS_SUCCESS) {
           build_derived_id_from_file_entry(entry, id);
           return AMDCUID_STATUS_SUCCESS;
         }
-      }
-    } break;
-    case AMDCUID_DEVICE_TYPE_NIC:
-      // search by device node
-      {
-        auto nic = reinterpret_cast<CuidNic *>(const_cast<CuidDevice *>(this));
-        if (nic) {
-          const auto &info = nic->get_info();
+      } break;
+      case AMDCUID_DEVICE_TYPE_GPU:
+        // search by render node
+        {
+          auto gpu = reinterpret_cast<CuidGpu*>(const_cast<CuidDevice*>(this));
+          if (gpu) {
+            auto info = gpu->get_info();
+            CuidFileEntry entry;
+            status = derived_file.find_by_device_node(info.render_node, entry);
+            if (status == AMDCUID_STATUS_SUCCESS) {
+              build_derived_id_from_file_entry(entry, id);
+              return AMDCUID_STATUS_SUCCESS;
+            }
+          }
+        }
+        break;
+      case AMDCUID_DEVICE_TYPE_CPU: {
+        auto cpu = reinterpret_cast<CuidCpu*>(const_cast<CuidDevice*>(this));
+        if (cpu) {
+          // Try device_node first - unique per logical CPU on SMT systems
+          std::string device_path;
+          if (cpu->get_device_path(device_path) == AMDCUID_STATUS_SUCCESS && !device_path.empty()) {
+            CuidFileEntry entry;
+            status = derived_file.find_by_device_node(device_path, entry);
+            if (status == AMDCUID_STATUS_SUCCESS) {
+              build_derived_id_from_file_entry(entry, id);
+              return AMDCUID_STATUS_SUCCESS;
+            }
+          }
+          const auto& info = cpu->get_info();
           CuidFileEntry entry;
-          amdcuid_status_t status =
-              derived_file.find_by_device_node(info.network_interface, entry);
+          status = derived_file.find_by_package_id(info.header.fields.cpu.physical_id, entry);
           if (status == AMDCUID_STATUS_SUCCESS) {
             build_derived_id_from_file_entry(entry, id);
             return AMDCUID_STATUS_SUCCESS;
           }
         }
-      }
-      break;
-    case AMDCUID_DEVICE_TYPE_NPU:
-      // search by accel node
-      {
-        auto npu = reinterpret_cast<CuidNpu *>(const_cast<CuidDevice *>(this));
-        if (npu) {
-          const auto &info = npu->get_info();
-          CuidFileEntry entry;
-          amdcuid_status_t status =
-              derived_file.find_by_device_node(info.accel_node, entry);
-          if (status == AMDCUID_STATUS_SUCCESS) {
-            build_derived_id_from_file_entry(entry, id);
-            return AMDCUID_STATUS_SUCCESS;
+      } break;
+      case AMDCUID_DEVICE_TYPE_NIC:
+        // search by device node
+        {
+          auto nic = reinterpret_cast<CuidNic*>(const_cast<CuidDevice*>(this));
+          if (nic) {
+            const auto& info = nic->get_info();
+            CuidFileEntry entry;
+            amdcuid_status_t status =
+                derived_file.find_by_device_node(info.network_interface, entry);
+            if (status == AMDCUID_STATUS_SUCCESS) {
+              build_derived_id_from_file_entry(entry, id);
+              return AMDCUID_STATUS_SUCCESS;
+            }
           }
         }
-      }
-      break;
-    default:
-      break;
-      // Will expand with different devices as we implement them
+        break;
+      case AMDCUID_DEVICE_TYPE_NPU:
+        // search by accel node
+        {
+          auto npu = reinterpret_cast<CuidNpu*>(const_cast<CuidDevice*>(this));
+          if (npu) {
+            const auto& info = npu->get_info();
+            CuidFileEntry entry;
+            amdcuid_status_t status = derived_file.find_by_device_node(info.accel_node, entry);
+            if (status == AMDCUID_STATUS_SUCCESS) {
+              build_derived_id_from_file_entry(entry, id);
+              return AMDCUID_STATUS_SUCCESS;
+            }
+          }
+        }
+        break;
+      default:
+        break;
+        // Will expand with different devices as we implement them
     }
   }
 
@@ -165,8 +160,7 @@ amdcuid_status_t CuidDevice::get_derived_cuid(amdcuid_derived_id &id,
   status = get_primary_cuid(primary);
   // check the temporary bit in the primary CUID to determine whether to use the
   // real HMAC key or the temp key for derived CUID generation
-  bool temp = primary.raw_bits[14] &
-              0x20; // check the temp indicator bit in the reserved bits
+  bool temp = primary.raw_bits[14] & 0x20;  // check the temp indicator bit in the reserved bits
   if (temp) {
     // machine id is what needs to be protected and under HMAC system, message
     // is not guaranteed protection when output is well known so use machine id
@@ -176,12 +170,10 @@ amdcuid_status_t CuidDevice::get_derived_cuid(amdcuid_derived_id &id,
     // real HMAC key or primary CUID
     amdcuid_primary_id fixed_app_id = {};
     // Application UUID: UUID_v5(NAMESPACE_DNS, "com.amd.cuid.v1")
-    static const uint8_t CUID_APP_UUID[16] = {
-        0xac, 0x05, 0xca, 0x9f, 0x1a, 0xc4, 0x58, 0xb9,
-        0x92, 0x7e, 0x2e, 0x17, 0x51, 0x47, 0x9c, 0x01};
+    static const uint8_t CUID_APP_UUID[16] = {0xac, 0x05, 0xca, 0x9f, 0x1a, 0xc4, 0x58, 0xb9,
+                                              0x92, 0x7e, 0x2e, 0x17, 0x51, 0x47, 0x9c, 0x01};
     memcpy(fixed_app_id.raw_bits, CUID_APP_UUID, 16);
-    CuidUtilities::add_UUIDv8_bits(fixed_app_id.raw_bits,
-                                   &fixed_app_id.UUIDv8_representation);
+    CuidUtilities::add_UUIDv8_bits(fixed_app_id.raw_bits, &fixed_app_id.UUIDv8_representation);
 
     // Use the machine ID from the primary CUID as the key for HMAC, so that the
     // derived CUID is consistent for the same machine even for non-privileged
@@ -192,8 +184,7 @@ amdcuid_status_t CuidDevice::get_derived_cuid(amdcuid_derived_id &id,
     // key
     cuid_hmac temp_hmac = cuid_hmac(padded_key);
     temp_hmac.set_hmac_algorithm("SHA256");
-    status =
-        CuidUtilities::generate_derived_cuid(&fixed_app_id, &id, &temp_hmac);
+    status = CuidUtilities::generate_derived_cuid(&fixed_app_id, &id, &temp_hmac);
   } else {
     status = CuidUtilities::generate_derived_cuid(&primary, &id, hmac);
   }
@@ -201,7 +192,7 @@ amdcuid_status_t CuidDevice::get_derived_cuid(amdcuid_derived_id &id,
   return status;
 }
 
-amdcuid_status_t CuidDevice::is_temporary_cuid(bool *is_temp) const {
+amdcuid_status_t CuidDevice::is_temporary_cuid(bool* is_temp) const {
   if (!is_temp) {
     return AMDCUID_STATUS_INVALID_ARGUMENT;
   }
@@ -212,8 +203,7 @@ amdcuid_status_t CuidDevice::is_temporary_cuid(bool *is_temp) const {
   if (status != AMDCUID_STATUS_SUCCESS) {
     return status;
   }
-  *is_temp = primary.raw_bits[14] &
-             0x20; // check the temp indicator bit in the reserved bits
+  *is_temp = primary.raw_bits[14] & 0x20;  // check the temp indicator bit in the reserved bits
 
   return AMDCUID_STATUS_SUCCESS;
 }

--- a/projects/cuid/lib/src/cuid_device.h
+++ b/projects/cuid/lib/src/cuid_device.h
@@ -23,67 +23,66 @@
 #ifndef CUID_DEVICE_H
 #define CUID_DEVICE_H
 
-#include "include/amd_cuid.h"
-#include "src/cuid_internal.h"
-#include "src/hmac.h"
 #include <cstdint>
 #include <memory>
 #include <string>
 
+#include "include/amd_cuid.h"
+#include "src/cuid_internal.h"
+#include "src/hmac.h"
+
 class CuidDevice {
-public:
+ public:
   virtual ~CuidDevice() = default;
   virtual amdcuid_device_type_t type() const = 0;
-  virtual amdcuid_status_t get_primary_cuid(amdcuid_primary_id &id) const = 0;
-  virtual amdcuid_status_t
-  get_hardware_fingerprint(uint64_t &fingerprint) const = 0;
-  amdcuid_status_t get_derived_cuid(amdcuid_derived_id &id,
-                                    cuid_hmac *hmac = nullptr) const;
-  amdcuid_status_t is_temporary_cuid(bool *is_temporary) const;
+  virtual amdcuid_status_t get_primary_cuid(amdcuid_primary_id& id) const = 0;
+  virtual amdcuid_status_t get_hardware_fingerprint(uint64_t& fingerprint) const = 0;
+  amdcuid_status_t get_derived_cuid(amdcuid_derived_id& id, cuid_hmac* hmac = nullptr) const;
+  amdcuid_status_t is_temporary_cuid(bool* is_temporary) const;
 
   // Virtual accessors for common device properties with default wrong device
   // type implementations
-  virtual amdcuid_status_t get_vendor_id(uint16_t &vendor_id) const {
+  virtual amdcuid_status_t get_vendor_id(uint16_t& vendor_id) const {
     vendor_id = 0;
     return AMDCUID_STATUS_WRONG_DEVICE_TYPE;
   }
-  virtual amdcuid_status_t get_family(uint16_t &family) const {
+  virtual amdcuid_status_t get_family(uint16_t& family) const {
     family = 0;
     return AMDCUID_STATUS_WRONG_DEVICE_TYPE;
   }
-  virtual amdcuid_status_t get_model(uint16_t &model) const {
+  virtual amdcuid_status_t get_model(uint16_t& model) const {
     model = 0;
     return AMDCUID_STATUS_WRONG_DEVICE_TYPE;
   }
-  virtual amdcuid_status_t get_device_id(uint16_t &device_id) const {
+  virtual amdcuid_status_t get_device_id(uint16_t& device_id) const {
     device_id = 0;
     return AMDCUID_STATUS_WRONG_DEVICE_TYPE;
   }
-  virtual amdcuid_status_t get_revision_id(uint8_t &revision_id) const {
+  virtual amdcuid_status_t get_revision_id(uint8_t& revision_id) const {
     revision_id = 0;
     return AMDCUID_STATUS_WRONG_DEVICE_TYPE;
   }
-  virtual amdcuid_status_t get_unit_id(uint16_t &unit_id) const {
+  virtual amdcuid_status_t get_unit_id(uint16_t& unit_id) const {
     unit_id = 0;
     return AMDCUID_STATUS_WRONG_DEVICE_TYPE;
   }
-  virtual amdcuid_status_t get_pci_class(uint16_t &pci_class) const {
+  virtual amdcuid_status_t get_pci_class(uint16_t& pci_class) const {
     pci_class = 0;
     return AMDCUID_STATUS_WRONG_DEVICE_TYPE;
   }
-  virtual amdcuid_status_t get_core(uint16_t &core) const {
+  virtual amdcuid_status_t get_core(uint16_t& core) const {
     core = 0;
     return AMDCUID_STATUS_WRONG_DEVICE_TYPE;
   }
-  virtual amdcuid_status_t get_physical_id(uint16_t &physical_id) const {
+  virtual amdcuid_status_t get_physical_id(uint16_t& physical_id) const {
     physical_id = 0;
     return AMDCUID_STATUS_WRONG_DEVICE_TYPE;
   }
-  virtual amdcuid_status_t get_bdf(std::string &bdf) const {
+  virtual amdcuid_status_t get_bdf(std::string& bdf) const {
     bdf.clear();
     return AMDCUID_STATUS_WRONG_DEVICE_TYPE;
   }
-  virtual amdcuid_status_t get_device_path(std::string &path) const {
+  virtual amdcuid_status_t get_device_path(std::string& path) const {
     path.clear();
     return AMDCUID_STATUS_WRONG_DEVICE_TYPE;
   }
@@ -91,4 +90,4 @@ public:
 
 typedef std::shared_ptr<CuidDevice> DevicePtr;
 
-#endif // CUID_DEVICE_H
+#endif  // CUID_DEVICE_H

--- a/projects/cuid/lib/src/cuid_device_manager.cc
+++ b/projects/cuid/lib/src/cuid_device_manager.cc
@@ -21,6 +21,14 @@
  */
 
 #include "src/cuid_device_manager.h"
+
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <iostream>
+
 #include "include/amd_cuid.h"
 #include "src/cuid_cpu.h"
 #include "src/cuid_gpu.h"
@@ -29,38 +37,44 @@
 #include "src/cuid_platform.h"
 #include "src/cuid_util.h"
 #include "src/ipc_protocol.h"
-#include <algorithm>
-#include <iostream>
-#include <sys/socket.h>
-#include <sys/un.h>
-#include <unistd.h>
 
 class CuidDaemonIpcClientUtils {
-public:
-  static amdcuid_status_t request_add_device(const char *dev_path,
+ public:
+  // Fill sun_path leaving room for the terminating NUL.
+  static void fill_socket_addr(struct sockaddr_un& addr) {
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    constexpr size_t kPathLen = sizeof(AMDCUID_SOCKET_PATH) - 1;
+    static_assert(kPathLen < sizeof(addr.sun_path),
+                  "AMDCUID_SOCKET_PATH does not fit in sockaddr_un::sun_path");
+    memcpy(addr.sun_path, AMDCUID_SOCKET_PATH, kPathLen);
+  }
+
+  static amdcuid_status_t request_add_device(const char* dev_path,
                                              amdcuid_device_type_t device_type,
-                                             amdcuid_id_t *device_handle) {
+                                             amdcuid_id_t* device_handle) {
+    // Build the request before opening the socket so an over-long path is
+    // rejected without bothering the daemon. `request` is value-initialized so
+    // no uninitialized padding is written to the socket.
+    IpcRequest request{};
+    request.type = IpcMessageType::ADD_DEVICE;
+    request.device_type = device_type;
+    if (!ipc_set_device_path(request, dev_path)) {
+      return AMDCUID_STATUS_INVALID_ARGUMENT;
+    }
+
     int sock_fd = socket(AF_UNIX, SOCK_STREAM, 0);
     if (sock_fd < 0) {
       return AMDCUID_STATUS_IPC_ERROR;
     }
 
     struct sockaddr_un server_addr;
-    memset(&server_addr, 0, sizeof(server_addr));
-    server_addr.sun_family = AF_UNIX;
-    strncpy(server_addr.sun_path, AMDCUID_SOCKET_PATH,
-            sizeof(server_addr.sun_path));
+    fill_socket_addr(server_addr);
 
-    if (connect(sock_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)) <
-        0) {
+    if (connect(sock_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)) < 0) {
       close(sock_fd);
       return AMDCUID_STATUS_IPC_ERROR;
     }
-
-    IpcRequest request;
-    request.type = IpcMessageType::ADD_DEVICE;
-    strncpy(request.device_path, dev_path, sizeof(request.device_path));
-    request.device_type = device_type;
 
     if (send(sock_fd, &request, sizeof(request), 0) != sizeof(request)) {
       close(sock_fd);
@@ -87,23 +101,18 @@ public:
     }
 
     struct sockaddr_un server_addr;
-    memset(&server_addr, 0, sizeof(server_addr));
-    server_addr.sun_family = AF_UNIX;
-    strncpy(server_addr.sun_path, AMDCUID_SOCKET_PATH,
-            sizeof(server_addr.sun_path));
+    fill_socket_addr(server_addr);
 
-    if (connect(sock_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)) <
-        0) {
+    if (connect(sock_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)) < 0) {
       close(sock_fd);
       return AMDCUID_STATUS_IPC_ERROR;
     }
 
-    IpcRequest request;
+    // Value-initialized: device_path/device_type are unused for
+    // REFRESH_DEVICES and must not leak uninitialized stack bytes.
+    IpcRequest request{};
     request.type = IpcMessageType::REFRESH_DEVICES;
-    memset(request.device_path, 0,
-           sizeof(request.device_path)); // Not used for REFRESH_DEVICES
-    request.device_type =
-        AMDCUID_DEVICE_TYPE_NONE; // Not used for REFRESH_DEVICES
+    request.device_type = AMDCUID_DEVICE_TYPE_NONE;
 
     if (send(sock_fd, &request, sizeof(request), 0) != sizeof(request)) {
       close(sock_fd);
@@ -127,13 +136,9 @@ public:
     }
 
     struct sockaddr_un server_addr;
-    memset(&server_addr, 0, sizeof(server_addr));
-    server_addr.sun_family = AF_UNIX;
-    strncpy(server_addr.sun_path, AMDCUID_SOCKET_PATH,
-            sizeof(server_addr.sun_path));
+    fill_socket_addr(server_addr);
 
-    if (connect(sock_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)) <
-        0) {
+    if (connect(sock_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)) < 0) {
       close(sock_fd);
       return false;
     }
@@ -144,7 +149,6 @@ public:
 };
 
 amdcuid_status_t CuidDeviceManager::get_devices_on_system() {
-
   amdcuid_status_t status;
   std::vector<DevicePtr> discovered_devices;
 
@@ -153,7 +157,7 @@ amdcuid_status_t CuidDeviceManager::get_devices_on_system() {
   std::vector<DevicePtr> platform_devices;
   status = CuidPlatform::discover(platform_devices);
   if (status == AMDCUID_STATUS_SUCCESS) {
-    for (const auto &platform_device : platform_devices) {
+    for (const auto& platform_device : platform_devices) {
       discovered_devices.push_back(platform_device);
     }
   }
@@ -161,7 +165,7 @@ amdcuid_status_t CuidDeviceManager::get_devices_on_system() {
   std::vector<DevicePtr> cpu_devices;
   status = CuidCpu::discover(cpu_devices);
   if (status == AMDCUID_STATUS_SUCCESS) {
-    for (const auto &cpu : cpu_devices) {
+    for (const auto& cpu : cpu_devices) {
       discovered_devices.push_back(cpu);
     }
   }
@@ -169,7 +173,7 @@ amdcuid_status_t CuidDeviceManager::get_devices_on_system() {
   std::vector<DevicePtr> gpu_devices;
   status = CuidGpu::discover(gpu_devices);
   if (status == AMDCUID_STATUS_SUCCESS) {
-    for (const auto &gpu : gpu_devices) {
+    for (const auto& gpu : gpu_devices) {
       discovered_devices.push_back(gpu);
     }
   }
@@ -177,7 +181,7 @@ amdcuid_status_t CuidDeviceManager::get_devices_on_system() {
   std::vector<DevicePtr> nic_devices;
   status = CuidNic::discover(nic_devices);
   if (status == AMDCUID_STATUS_SUCCESS) {
-    for (const auto &nic : nic_devices) {
+    for (const auto& nic : nic_devices) {
       discovered_devices.push_back(nic);
     }
   }
@@ -185,7 +189,7 @@ amdcuid_status_t CuidDeviceManager::get_devices_on_system() {
   std::vector<DevicePtr> npu_devices;
   status = CuidNpu::discover(npu_devices);
   if (status == AMDCUID_STATUS_SUCCESS) {
-    for (const auto &npu : npu_devices) {
+    for (const auto& npu : npu_devices) {
       discovered_devices.push_back(npu);
     }
   }
@@ -200,78 +204,75 @@ amdcuid_status_t CuidDeviceManager::get_devices_on_system() {
     devices_ = discovered_devices;
   }
 
-  return discovered_devices.empty() ? AMDCUID_STATUS_DEVICE_NOT_FOUND
-                                    : AMDCUID_STATUS_SUCCESS;
+  return discovered_devices.empty() ? AMDCUID_STATUS_DEVICE_NOT_FOUND : AMDCUID_STATUS_SUCCESS;
 }
 
 // helper function to convert CuidFileEntry to appropriate CuidDevice
-void _convert_entry_to_device(CuidFileEntry &entry, DevicePtr &device) {
-
+void convert_entry_to_device(CuidFileEntry& entry, DevicePtr& device) {
   switch (entry.device_type) {
-  case AMDCUID_DEVICE_TYPE_PLATFORM: {
-    amdcuid_platform_info platform_info = {};
-    platform_info.header.fields.platform.vendor_id = entry.vendor_id;
-    device = std::make_shared<CuidPlatform>(platform_info);
-    break;
-  }
-  case AMDCUID_DEVICE_TYPE_GPU: {
-    amdcuid_gpu_info gpu_info = {};
-    gpu_info.header.fields.gpu.vendor_id = entry.vendor_id;
-    gpu_info.header.fields.gpu.device_id = entry.device_id;
-    gpu_info.header.fields.gpu.pci_class = entry.pci_class;
-    gpu_info.header.fields.gpu.revision_id = entry.revision_id;
-    gpu_info.header.fields.gpu.unit_id = entry.unit_id;
-    gpu_info.render_node = entry.device_node;
-    gpu_info.bdf = entry.bdf;
-    device = std::make_shared<CuidGpu>(gpu_info);
-    break;
-  }
-  case AMDCUID_DEVICE_TYPE_CPU: {
-    amdcuid_cpu_info cpu_info = {};
-    cpu_info.header.fields.cpu.vendor_id = entry.vendor_id;
-    cpu_info.header.fields.cpu.family = entry.family;
-    cpu_info.header.fields.cpu.model = entry.model;
-    cpu_info.header.fields.cpu.device_id = entry.device_id;
-    cpu_info.header.fields.cpu.revision_id = entry.revision_id;
-    cpu_info.header.fields.cpu.unit_id = entry.unit_id;
-    cpu_info.header.fields.cpu.physical_id = entry.package_id;
-    cpu_info.header.fields.cpu.core = entry.core_id;
-    // Restore device_node for unique CPU identification (needed for SMT)
-    cpu_info.device_node = entry.device_node;
-    device = std::make_shared<CuidCpu>(cpu_info);
-    break;
-  }
-  case AMDCUID_DEVICE_TYPE_NIC: {
-    amdcuid_nic_info nic_info = {};
-    nic_info.header.fields.nic.vendor_id = entry.vendor_id;
-    nic_info.header.fields.nic.device_id = entry.device_id;
-    nic_info.header.fields.nic.pci_class = entry.pci_class;
-    nic_info.header.fields.nic.revision_id = entry.revision_id;
-    nic_info.network_interface = entry.device_node;
-    nic_info.bdf = entry.bdf;
-    device = std::make_shared<CuidNic>(nic_info);
-    break;
-  }
-  case AMDCUID_DEVICE_TYPE_NPU: {
-    amdcuid_npu_info npu_info = {};
-    npu_info.header.fields.npu.vendor_id = entry.vendor_id;
-    npu_info.header.fields.npu.device_id = entry.device_id;
-    npu_info.header.fields.npu.pci_class = entry.pci_class;
-    npu_info.header.fields.npu.revision_id = entry.revision_id;
-    npu_info.accel_node = entry.device_node;
-    npu_info.bdf = entry.bdf;
-    device = std::make_shared<CuidNpu>(npu_info);
-    break;
-  }
-  default: {
-    device = nullptr;
-    break;
-  }
+    case AMDCUID_DEVICE_TYPE_PLATFORM: {
+      amdcuid_platform_info platform_info = {};
+      platform_info.header.fields.platform.vendor_id = entry.vendor_id;
+      device = std::make_shared<CuidPlatform>(platform_info);
+      break;
+    }
+    case AMDCUID_DEVICE_TYPE_GPU: {
+      amdcuid_gpu_info gpu_info = {};
+      gpu_info.header.fields.gpu.vendor_id = entry.vendor_id;
+      gpu_info.header.fields.gpu.device_id = entry.device_id;
+      gpu_info.header.fields.gpu.pci_class = entry.pci_class;
+      gpu_info.header.fields.gpu.revision_id = entry.revision_id;
+      gpu_info.header.fields.gpu.unit_id = entry.unit_id;
+      gpu_info.render_node = entry.device_node;
+      gpu_info.bdf = entry.bdf;
+      device = std::make_shared<CuidGpu>(gpu_info);
+      break;
+    }
+    case AMDCUID_DEVICE_TYPE_CPU: {
+      amdcuid_cpu_info cpu_info = {};
+      cpu_info.header.fields.cpu.vendor_id = entry.vendor_id;
+      cpu_info.header.fields.cpu.family = entry.family;
+      cpu_info.header.fields.cpu.model = entry.model;
+      cpu_info.header.fields.cpu.device_id = entry.device_id;
+      cpu_info.header.fields.cpu.revision_id = entry.revision_id;
+      cpu_info.header.fields.cpu.unit_id = entry.unit_id;
+      cpu_info.header.fields.cpu.physical_id = entry.package_id;
+      cpu_info.header.fields.cpu.core = entry.core_id;
+      // Restore device_node for unique CPU identification (needed for SMT)
+      cpu_info.device_node = entry.device_node;
+      device = std::make_shared<CuidCpu>(cpu_info);
+      break;
+    }
+    case AMDCUID_DEVICE_TYPE_NIC: {
+      amdcuid_nic_info nic_info = {};
+      nic_info.header.fields.nic.vendor_id = entry.vendor_id;
+      nic_info.header.fields.nic.device_id = entry.device_id;
+      nic_info.header.fields.nic.pci_class = entry.pci_class;
+      nic_info.header.fields.nic.revision_id = entry.revision_id;
+      nic_info.network_interface = entry.device_node;
+      nic_info.bdf = entry.bdf;
+      device = std::make_shared<CuidNic>(nic_info);
+      break;
+    }
+    case AMDCUID_DEVICE_TYPE_NPU: {
+      amdcuid_npu_info npu_info = {};
+      npu_info.header.fields.npu.vendor_id = entry.vendor_id;
+      npu_info.header.fields.npu.device_id = entry.device_id;
+      npu_info.header.fields.npu.pci_class = entry.pci_class;
+      npu_info.header.fields.npu.revision_id = entry.revision_id;
+      npu_info.accel_node = entry.device_node;
+      npu_info.bdf = entry.bdf;
+      device = std::make_shared<CuidNpu>(npu_info);
+      break;
+    }
+    default: {
+      device = nullptr;
+      break;
+    }
   }
 }
 
-amdcuid_status_t
-CuidDeviceManager::get_devices_from_file_entries(CuidFile &cuid_file) {
+amdcuid_status_t CuidDeviceManager::get_devices_from_file_entries(CuidFile& cuid_file) {
   std::lock_guard<std::mutex> lock(manager_mutex_);
 
   amdcuid_status_t status = cuid_file.load();
@@ -280,9 +281,9 @@ CuidDeviceManager::get_devices_from_file_entries(CuidFile &cuid_file) {
   }
 
   devices_.clear();
-  for (const auto &entry : cuid_file.get_entries()) {
+  for (const auto& entry : cuid_file.get_entries()) {
     DevicePtr device = nullptr;
-    _convert_entry_to_device(const_cast<CuidFileEntry &>(entry), device);
+    convert_entry_to_device(const_cast<CuidFileEntry&>(entry), device);
     if (device) {
       devices_.push_back(device);
     }
@@ -309,9 +310,8 @@ amdcuid_status_t CuidDeviceManager::add_device(DevicePtr device) {
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t
-CuidDeviceManager::get_device_from_file_by_id(amdcuid_id_t &derived_cuid,
-                                              DevicePtr &device) {
+amdcuid_status_t CuidDeviceManager::get_device_from_file_by_id(amdcuid_id_t& derived_cuid,
+                                                               DevicePtr& device) {
   amdcuid_status_t status = AMDCUID_STATUS_DEVICE_NOT_FOUND;
 
   // Search in privileged CUID file first
@@ -337,15 +337,15 @@ CuidDeviceManager::get_device_from_file_by_id(amdcuid_id_t &derived_cuid,
   }
 
   // Create device based on the found entry
-  _convert_entry_to_device(entry, device);
+  convert_entry_to_device(entry, device);
   if (device) {
     add_device(device);
   }
   return status;
 }
 
-amdcuid_status_t CuidDeviceManager::get_device_from_file_by_dev_path(
-    const std::string &device_path, DevicePtr &device) {
+amdcuid_status_t CuidDeviceManager::get_device_from_file_by_dev_path(const std::string& device_path,
+                                                                     DevicePtr& device) {
   amdcuid_status_t status = AMDCUID_STATUS_DEVICE_NOT_FOUND;
 
   // Search in privileged CUID file first
@@ -357,7 +357,7 @@ amdcuid_status_t CuidDeviceManager::get_device_from_file_by_dev_path(
     }
     status = priv_cuid_file_.find_by_device_node(device_path, entry);
     if (status != AMDCUID_STATUS_SUCCESS) {
-      return status; // Not found in either file
+      return status;  // Not found in either file
     }
   } else {
     status = unpriv_cuid_file_.load();
@@ -366,21 +366,20 @@ amdcuid_status_t CuidDeviceManager::get_device_from_file_by_dev_path(
     }
     status = unpriv_cuid_file_.find_by_device_node(device_path, entry);
     if (status != AMDCUID_STATUS_SUCCESS) {
-      return status; // Not found in unprivileged file
+      return status;  // Not found in unprivileged file
     }
   }
 
   // Create device based on the found entry
-  _convert_entry_to_device(entry, device);
+  convert_entry_to_device(entry, device);
   if (device) {
     add_device(device);
   }
   return status;
 }
 
-amdcuid_status_t
-CuidDeviceManager::get_device_from_file_by_bdf(const std::string &bdf,
-                                               DevicePtr &device) {
+amdcuid_status_t CuidDeviceManager::get_device_from_file_by_bdf(const std::string& bdf,
+                                                                DevicePtr& device) {
   amdcuid_status_t status = AMDCUID_STATUS_DEVICE_NOT_FOUND;
 
   // Search in privileged CUID file first
@@ -392,7 +391,7 @@ CuidDeviceManager::get_device_from_file_by_bdf(const std::string &bdf,
     }
     status = priv_cuid_file_.find_by_bdf(bdf, entry);
     if (status != AMDCUID_STATUS_SUCCESS) {
-      return status; // Not found in privileged file
+      return status;  // Not found in privileged file
     }
   } else {
     status = unpriv_cuid_file_.load();
@@ -401,27 +400,26 @@ CuidDeviceManager::get_device_from_file_by_bdf(const std::string &bdf,
     }
     status = unpriv_cuid_file_.find_by_bdf(bdf, entry);
     if (status != AMDCUID_STATUS_SUCCESS) {
-      return status; // Not found in unprivileged file
+      return status;  // Not found in unprivileged file
     }
   }
 
   // Create device based on the found entry
-  _convert_entry_to_device(entry, device);
+  convert_entry_to_device(entry, device);
   if (device) {
     add_device(device);
   }
   return status;
 }
 
-amdcuid_status_t
-CuidDeviceManager::request_device(const std::string &device_path,
-                                  amdcuid_device_type_t device_type,
-                                  DevicePtr &device) {
+amdcuid_status_t CuidDeviceManager::request_device(const std::string& device_path,
+                                                   amdcuid_device_type_t device_type,
+                                                   DevicePtr& device) {
   amdcuid_status_t status;
   if (CuidDaemonIpcClientUtils::is_daemon_running()) {
     amdcuid_id_t device_handle;
-    status = CuidDaemonIpcClientUtils::request_add_device(
-        device_path.c_str(), device_type, &device_handle);
+    status = CuidDaemonIpcClientUtils::request_add_device(device_path.c_str(), device_type,
+                                                          &device_handle);
     if (status == AMDCUID_STATUS_SUCCESS) {
       // Lookup device by handle and return it
       status = get_device_from_file_by_id(device_handle, device);
@@ -500,15 +498,15 @@ amdcuid_status_t CuidDeviceManager::shutdown() {
   return AMDCUID_STATUS_SUCCESS;
 }
 
-CuidDeviceManager &CuidDeviceManager::instance() {
+CuidDeviceManager& CuidDeviceManager::instance() {
   static CuidDeviceManager instance;
   return instance;
 }
 
 void CuidDeviceManager::get_grouped_devices(
-    std::map<amdcuid_device_type_t, std::vector<DevicePtr>> &grouped) {
+    std::map<amdcuid_device_type_t, std::vector<DevicePtr>>& grouped) {
   grouped.clear();
-  for (const auto &entry : devices_) {
+  for (const auto& entry : devices_) {
     grouped[entry->type()].push_back(entry);
   }
 }
@@ -517,11 +515,10 @@ void CuidDeviceManager::build_cuid_index() {
   std::lock_guard<std::mutex> lock(manager_mutex_);
 
   cuid_index_.clear();
-  for (const auto &device : devices_) {
+  for (const auto& device : devices_) {
     amdcuid_derived_id derived;
     if (geteuid() == 0) {
-      if (device->get_derived_cuid(derived, &manager_hmac) ==
-          AMDCUID_STATUS_SUCCESS) {
+      if (device->get_derived_cuid(derived, &manager_hmac) == AMDCUID_STATUS_SUCCESS) {
         cuid_index_[derived.UUIDv8_representation] = device;
       }
     } else {
@@ -532,18 +529,25 @@ void CuidDeviceManager::build_cuid_index() {
   }
 }
 
-DevicePtr
-CuidDeviceManager::lookup_by_handle(const amdcuid_id_t &handle) const {
+DevicePtr CuidDeviceManager::lookup_by_handle(const amdcuid_id_t& handle) const {
+  // cuid_index_ is rebuilt wholesale by build_cuid_index() under this mutex.
+  // Reading it unlocked is a data race that ThreadSanitizer reports against an
+  // ordinary multithreaded consumer of the public API; neither of the two
+  // callers (both in cuid.cc) holds the lock, so taking it here cannot deadlock.
+  std::lock_guard<std::mutex> lock(manager_mutex_);
+
   // Since amdcuid_id_t is our handle, we can use it directly as key
   auto it = cuid_index_.find(handle);
   return (it != cuid_index_.end()) ? it->second : nullptr;
 }
 
 std::vector<amdcuid_id_t> CuidDeviceManager::get_all_handles() const {
+  std::lock_guard<std::mutex> lock(manager_mutex_);
+
   std::vector<amdcuid_id_t> handles;
   handles.reserve(cuid_index_.size());
 
-  for (const auto &pair : cuid_index_) {
+  for (const auto& pair : cuid_index_) {
     // amdcuid_id_t is the handle, so just copy directly
     handles.push_back(pair.first);
   }
@@ -556,8 +560,8 @@ amdcuid_status_t CuidDeviceManager::save_registry_to_files() {
   amdcuid_status_t status = AMDCUID_STATUS_SUCCESS;
   if (geteuid() == 0) {
     // Generate new priv CUID file from current device list
-    status = CuidFileGenerator::generate_priv_from_devices(
-        devices_, priv_cuid_file_.get_file_path());
+    status =
+        CuidFileGenerator::generate_priv_from_devices(devices_, priv_cuid_file_.get_file_path());
     if (status != AMDCUID_STATUS_SUCCESS) {
       return status;
     }
@@ -567,8 +571,8 @@ amdcuid_status_t CuidDeviceManager::save_registry_to_files() {
   }
 
   // Generate new unpriv CUID file from current device list
-  status = CuidFileGenerator::generate_unpriv_from_devices(
-      devices_, unpriv_cuid_file_.get_file_path());
+  status =
+      CuidFileGenerator::generate_unpriv_from_devices(devices_, unpriv_cuid_file_.get_file_path());
   if (status != AMDCUID_STATUS_SUCCESS) {
     return status;
   }

--- a/projects/cuid/lib/src/cuid_device_manager.h
+++ b/projects/cuid/lib/src/cuid_device_manager.h
@@ -23,158 +23,172 @@
 #ifndef CUID_DEVICE_MANAGER_H
 #define CUID_DEVICE_MANAGER_H
 
+#include <cstring>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include "include/amd_cuid.h"
 #include "src/cuid_device.h"
 #include "src/cuid_file.h"
 #include "src/hmac.h"
-#include "include/amd_cuid.h"
-#include <vector>
-#include <memory>
-#include <map>
-#include <cstring>
-#include <mutex>
 
 /**
  * @brief Bitmask set of device types for querying multiple device types.
  *
  * These values are used as bitmasks to specify which device types to include in queries.
- * Each value corresponds to a specific device type, and AMDCUID_DEVICE_TYPE_SET_ALL selects all types.
+ * Each value corresponds to a specific device type, and AMDCUID_DEVICE_TYPE_SET_ALL selects all
+ * types.
  */
 typedef enum {
-    AMDCUID_DEVICE_TYPE_SET_NONE      = 0U,                                    ///< No device types
-    AMDCUID_DEVICE_TYPE_SET_PLATFORM  = 1U << AMDCUID_DEVICE_TYPE_PLATFORM, ///< Platform devices (chassis, motherboard)
-    AMDCUID_DEVICE_TYPE_SET_CPU       = 1U << AMDCUID_DEVICE_TYPE_CPU,      ///< CPU devices
-    AMDCUID_DEVICE_TYPE_SET_GPU       = 1U << AMDCUID_DEVICE_TYPE_GPU,      ///< GPU devices
-    AMDCUID_DEVICE_TYPE_SET_NIC       = 1U << AMDCUID_DEVICE_TYPE_NIC,      ///< NIC devices
-    AMDCUID_DEVICE_TYPE_SET_NPU       = 1U << AMDCUID_DEVICE_TYPE_NPU,      ///< NPU devices
-    AMDCUID_DEVICE_TYPE_SET_ALL       = -1U                                    ///< All device types
+  AMDCUID_DEVICE_TYPE_SET_NONE = 0U,  ///< No device types
+  AMDCUID_DEVICE_TYPE_SET_PLATFORM =
+      1U << AMDCUID_DEVICE_TYPE_PLATFORM,  ///< Platform devices (chassis, motherboard)
+  AMDCUID_DEVICE_TYPE_SET_CPU = 1U << AMDCUID_DEVICE_TYPE_CPU,  ///< CPU devices
+  AMDCUID_DEVICE_TYPE_SET_GPU = 1U << AMDCUID_DEVICE_TYPE_GPU,  ///< GPU devices
+  AMDCUID_DEVICE_TYPE_SET_NIC = 1U << AMDCUID_DEVICE_TYPE_NIC,  ///< NIC devices
+  AMDCUID_DEVICE_TYPE_SET_NPU = 1U << AMDCUID_DEVICE_TYPE_NPU,  ///< NPU devices
+  AMDCUID_DEVICE_TYPE_SET_ALL = -1U                             ///< All device types
 } amdcuid_device_type_set_t;
 
 /**
  * @brief Comparator for amdcuid_id_t (16-byte array comparison) for use as map key.
  */
 struct CuidComparator {
-    bool operator()(const amdcuid_id_t& a, const amdcuid_id_t& b) const {
-        return std::memcmp(a.bytes, b.bytes, 16) < 0;
-    }
+  bool operator()(const amdcuid_id_t& a, const amdcuid_id_t& b) const {
+    return std::memcmp(a.bytes, b.bytes, 16) < 0;
+  }
 };
 
 class CuidDeviceManager {
-public:
-    // Mutex for thread-safe access
-    mutable std::mutex manager_mutex_;
+ public:
+  // Mutex for thread-safe access
+  mutable std::mutex manager_mutex_;
 
-    static CuidDeviceManager& instance();
-    amdcuid_status_t discover_devices(); // should rename to discover_devices() or similar
-    amdcuid_status_t shutdown(); // no need for this function as actual shutdown function, may be useful for unit testing
+  static CuidDeviceManager& instance();
+  amdcuid_status_t discover_devices();  // should rename to discover_devices() or similar
+  amdcuid_status_t shutdown();  // no need for this function as actual shutdown function, may be
+                                // useful for unit testing
 
-    const std::vector<DevicePtr>& devices() const { return devices_; }
-    void get_grouped_devices(std::map<amdcuid_device_type_t, std::vector<DevicePtr>>& grouped);
-    const amdcuid_device_type_set_t& device_types() const { return device_types_; }
+  // Returns a snapshot by value, deliberately not a reference. discover_devices()
+  // replaces devices_ wholesale under manager_mutex_, so a caller iterating a
+  // reference to it can have the vector reallocated underneath its iterators by
+  // another thread. Copying a vector of shared_ptr is cheap and keeps every
+  // device alive for as long as the caller holds the snapshot.
+  std::vector<DevicePtr> devices() const {
+    std::lock_guard<std::mutex> lock(manager_mutex_);
+    return devices_;
+  }
+  void get_grouped_devices(std::map<amdcuid_device_type_t, std::vector<DevicePtr>>& grouped);
+  const amdcuid_device_type_set_t& device_types() const { return device_types_; }
 
-    amdcuid_status_t add_device(DevicePtr device);
+  amdcuid_status_t add_device(DevicePtr device);
 
-    /**
-     * @brief Discover all devices currently present on the system.
-     * 
-     * @return AMDCUID_STATUS_SUCCESS on success, error code otherwise
-     */
-    amdcuid_status_t get_devices_on_system();
+  /**
+   * @brief Discover all devices currently present on the system.
+   *
+   * @return AMDCUID_STATUS_SUCCESS on success, error code otherwise
+   */
+  amdcuid_status_t get_devices_on_system();
 
-    /**
-     * @brief Create devices from CUID file entries.
-     * @param[in] cuid_file The CUID file containing device entries.
-     * 
-     * @return AMDCUID_STATUS_SUCCESS on success, error code otherwise
-     */
-    amdcuid_status_t get_devices_from_file_entries(CuidFile& cuid_file);
+  /**
+   * @brief Create devices from CUID file entries.
+   * @param[in] cuid_file The CUID file containing device entries.
+   *
+   * @return AMDCUID_STATUS_SUCCESS on success, error code otherwise
+   */
+  amdcuid_status_t get_devices_from_file_entries(CuidFile& cuid_file);
 
-    /**
-     * @brief Get device from CUID file by derived CUID and add to device list.
-     * @param[in] derived_cuid The derived CUID to look for.
-     * @param[out] device The device pointer to populate.
-     * 
-     * @return AMDCUID_STATUS_SUCCESS on success, error code otherwise
-     */
-    amdcuid_status_t get_device_from_file_by_id(amdcuid_id_t& derived_cuid, DevicePtr& device);
+  /**
+   * @brief Get device from CUID file by derived CUID and add to device list.
+   * @param[in] derived_cuid The derived CUID to look for.
+   * @param[out] device The device pointer to populate.
+   *
+   * @return AMDCUID_STATUS_SUCCESS on success, error code otherwise
+   */
+  amdcuid_status_t get_device_from_file_by_id(amdcuid_id_t& derived_cuid, DevicePtr& device);
 
-    /**
-     * @brief Get device from CUID file by device path and add to device list.
-     * @param[in] device_path The device path to look for.
-     * @param[out] device The device pointer to populate.
-     * 
-     * @return AMDCUID_STATUS_SUCCESS on success, error code otherwise
-     */
-    amdcuid_status_t get_device_from_file_by_dev_path(const std::string& device_path, DevicePtr& device);
+  /**
+   * @brief Get device from CUID file by device path and add to device list.
+   * @param[in] device_path The device path to look for.
+   * @param[out] device The device pointer to populate.
+   *
+   * @return AMDCUID_STATUS_SUCCESS on success, error code otherwise
+   */
+  amdcuid_status_t get_device_from_file_by_dev_path(const std::string& device_path,
+                                                    DevicePtr& device);
 
-    /**
-     * @brief Get device from CUID file by BDF and add to device list.
-     * @param[in] bdf The BDF to look for.
-     * @param[out] device The device pointer to populate.
-     * 
-     * @return AMDCUID_STATUS_SUCCESS on success, error code otherwise
-     */
-    amdcuid_status_t get_device_from_file_by_bdf(const std::string& bdf, DevicePtr& device);
+  /**
+   * @brief Get device from CUID file by BDF and add to device list.
+   * @param[in] bdf The BDF to look for.
+   * @param[out] device The device pointer to populate.
+   *
+   * @return AMDCUID_STATUS_SUCCESS on success, error code otherwise
+   */
+  amdcuid_status_t get_device_from_file_by_bdf(const std::string& bdf, DevicePtr& device);
 
-    /**
-     * @brief Request addition of a device by its path and type.
-     * @param[in] device_path The device path of the target device.
-     * @param[in] device_type The type of the device (see amdcuid_device_type_t).
-     * @param[out] device Pointer to the device pointer that will be filled with the requested device.
-     * 
-     * @return AMDCUID_STATUS_SUCCESS on success, error code otherwise
-     */
-    amdcuid_status_t request_device(const std::string& device_path, amdcuid_device_type_t device_type, DevicePtr& device);
+  /**
+   * @brief Request addition of a device by its path and type.
+   * @param[in] device_path The device path of the target device.
+   * @param[in] device_type The type of the device (see amdcuid_device_type_t).
+   * @param[out] device Pointer to the device pointer that will be filled with the requested device.
+   *
+   * @return AMDCUID_STATUS_SUCCESS on success, error code otherwise
+   */
+  amdcuid_status_t request_device(const std::string& device_path, amdcuid_device_type_t device_type,
+                                  DevicePtr& device);
 
-    /**
-     * @brief Request a refresh of the device list from the system.
-     * 
-     * @return AMDCUID_STATUS_SUCCESS on success, error code otherwise
-     */
-    amdcuid_status_t request_refresh();
+  /**
+   * @brief Request a refresh of the device list from the system.
+   *
+   * @return AMDCUID_STATUS_SUCCESS on success, error code otherwise
+   */
+  amdcuid_status_t request_refresh();
 
-    /**
-     * @brief Build the CUID index after device discovery.
-     */
-    void build_cuid_index();
+  /**
+   * @brief Build the CUID index after device discovery.
+   */
+  void build_cuid_index();
 
-    /**
-     * @brief Look up a device by its handle (derived CUID).
-     * @param handle The handle containing the derived CUID.
-     * @return Pointer to the device, or nullptr if not found.
-     */
-    DevicePtr lookup_by_handle(const amdcuid_id_t& handle) const;
+  /**
+   * @brief Look up a device by its handle (derived CUID).
+   * @param handle The handle containing the derived CUID.
+   * @return Pointer to the device, or nullptr if not found.
+   */
+  DevicePtr lookup_by_handle(const amdcuid_id_t& handle) const;
 
-    /**
-     * @brief Get all device handles (derived CUIDs).
-     * @return Vector of all handles of devices present on the system.
-     */
-    std::vector<amdcuid_id_t> get_all_handles() const;
+  /**
+   * @brief Get all device handles (derived CUIDs).
+   * @return Vector of all handles of devices present on the system.
+   */
+  std::vector<amdcuid_id_t> get_all_handles() const;
 
-    /**
-     * @brief Save the current device registry to the CUID files.
-     * 
-     * @return AMDCUID_STATUS_SUCCESS on success, error code otherwise
-     */
-    amdcuid_status_t save_registry_to_files();
+  /**
+   * @brief Save the current device registry to the CUID files.
+   *
+   * @return AMDCUID_STATUS_SUCCESS on success, error code otherwise
+   */
+  amdcuid_status_t save_registry_to_files();
 
-private:
-    CuidDeviceManager() = default;
-    ~CuidDeviceManager() = default;
-    CuidDeviceManager(const CuidDeviceManager&) = delete;
-    CuidDeviceManager& operator=(const CuidDeviceManager&) = delete;
+ private:
+  CuidDeviceManager() = default;
+  ~CuidDeviceManager() = default;
+  CuidDeviceManager(const CuidDeviceManager&) = delete;
+  CuidDeviceManager& operator=(const CuidDeviceManager&) = delete;
 
-    std::vector<DevicePtr> devices_;
-    amdcuid_device_type_set_t device_types_;
+  std::vector<DevicePtr> devices_;
+  amdcuid_device_type_set_t device_types_;
 
-    /// Index lookup by derived CUID
-    std::map<amdcuid_id_t, DevicePtr, CuidComparator> cuid_index_;
+  /// Index lookup by derived CUID
+  std::map<amdcuid_id_t, DevicePtr, CuidComparator> cuid_index_;
 
-    // Cuid Files
-    CuidFile unpriv_cuid_file_{CuidUtilities::cuid_file(), true};
-    CuidFile priv_cuid_file_{CuidUtilities::priv_cuid_file(), false};
+  // Cuid Files
+  CuidFile unpriv_cuid_file_{CuidUtilities::cuid_file(), true};
+  CuidFile priv_cuid_file_{CuidUtilities::priv_cuid_file(), false};
 
-    //cuid hmac for deriving cuids
-    cuid_hmac manager_hmac = cuid_hmac();
+  // cuid hmac for deriving cuids
+  cuid_hmac manager_hmac = cuid_hmac();
 };
 
-#endif // CUID_DEVICE_MANAGER_H
+#endif  // CUID_DEVICE_MANAGER_H

--- a/projects/cuid/lib/src/cuid_file.cc
+++ b/projects/cuid/lib/src/cuid_file.cc
@@ -21,6 +21,19 @@
  */
 
 #include "src/cuid_file.h"
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <cerrno>
+#include <cstring>
+#include <fstream>
+#include <iomanip>
+#include <limits>
+#include <sstream>
+
 #include "smbios_util.h"
 #include "src/cuid_cpu.h"
 #include "src/cuid_device.h"
@@ -31,30 +44,22 @@
 #include "src/cuid_platform.h"
 #include "src/cuid_util.h"
 #include "src/hmac.h"
-#include <algorithm>
-#include <cerrno>
-#include <cstring>
-#include <fcntl.h>
-#include <fstream>
-#include <iomanip>
-#include <limits>
-#include <sstream>
-#include <sys/stat.h>
-#include <unistd.h>
 
 // ============================================================================
 // CuidFileLock Implementation
 // ============================================================================
 
-CuidFileLock::CuidFileLock(const std::string &file_path, CuidLockType lock_type)
-    : lock_file_path_(file_path + ".lock"), lock_type_(lock_type), lock_fd_(-1),
+CuidFileLock::CuidFileLock(const std::string& file_path, CuidLockType lock_type)
+    : lock_file_path_(file_path + ".lock"),
+      lock_type_(lock_type),
+      lock_fd_(-1),
       is_locked_(false) {}
 
 CuidFileLock::~CuidFileLock() { release(); }
 
 bool CuidFileLock::acquire() {
   if (is_locked_) {
-    return true; // Already locked
+    return true;  // Already locked
   }
 
   // For shared (read) locks, we only need O_RDONLY access.
@@ -79,10 +84,9 @@ bool CuidFileLock::acquire() {
   if (lock_fd_ < 0 && lock_type_ == CuidLockType::SHARED && errno == ENOENT) {
     // Try to create the lock file - may fail if not privileged, which is OK
     // The file should be created by root when generating CUIDs
-    mode_t old_umask =
-        umask(0); // Temporarily clear umask for proper permissions
+    mode_t old_umask = umask(0);  // Temporarily clear umask for proper permissions
     lock_fd_ = open(lock_file_path_.c_str(), O_RDWR | O_CREAT, 0666);
-    umask(old_umask); // Restore umask
+    umask(old_umask);  // Restore umask
 
     // If created successfully, also chmod to ensure permissions are correct
     if (lock_fd_ >= 0) {
@@ -91,8 +95,8 @@ bool CuidFileLock::acquire() {
   }
 
   if (lock_fd_ < 0) {
-    LOG(ERROR, "CuidFileLock: Failed to open lock file "
-                   << lock_file_path_ << ": " << strerror(errno));
+    LOG(ERROR, "CuidFileLock: Failed to open lock file " << lock_file_path_ << ": "
+                                                         << CuidUtilities::errno_string(errno));
     return false;
   }
 
@@ -101,37 +105,36 @@ bool CuidFileLock::acquire() {
   memset(&fl, 0, sizeof(fl));
   fl.l_whence = SEEK_SET;
   fl.l_start = 0;
-  fl.l_len = 0; // Lock entire file
+  fl.l_len = 0;  // Lock entire file
   fl.l_type = (lock_type_ == CuidLockType::EXCLUSIVE) ? F_WRLCK : F_RDLCK;
 
   // F_SETLKW: blocking call - wait until lock is available
   if (fcntl(lock_fd_, F_SETLKW, &fl) < 0) {
-    LOG(ERROR, "CuidFileLock: Failed to acquire lock on "
-                   << lock_file_path_ << ": " << strerror(errno));
+    LOG(ERROR, "CuidFileLock: Failed to acquire lock on " << lock_file_path_ << ": "
+                                                          << CuidUtilities::errno_string(errno));
     close(lock_fd_);
     lock_fd_ = -1;
     return false;
   }
 
   is_locked_ = true;
-  LOG(DEBUG,
-      "CuidFileLock: Acquired "
-          << (lock_type_ == CuidLockType::EXCLUSIVE ? "exclusive" : "shared")
-          << " lock on " << lock_file_path_);
+  LOG(DEBUG, "CuidFileLock: Acquired "
+                 << (lock_type_ == CuidLockType::EXCLUSIVE ? "exclusive" : "shared") << " lock on "
+                 << lock_file_path_);
   return true;
 }
 
 bool CuidFileLock::acquire_with_timeout(int timeout_seconds) {
   // Special cases
   if (timeout_seconds == 0) {
-    return try_acquire(); // Non-blocking
+    return try_acquire();  // Non-blocking
   }
   if (timeout_seconds < 0) {
-    return acquire(); // Infinite wait
+    return acquire();  // Infinite wait
   }
 
   if (is_locked_) {
-    return true; // Already locked
+    return true;  // Already locked
   }
 
   // For shared (read) locks, we only need O_RDONLY access.
@@ -162,8 +165,8 @@ bool CuidFileLock::acquire_with_timeout(int timeout_seconds) {
   }
 
   if (lock_fd_ < 0) {
-    LOG(ERROR, "CuidFileLock: Failed to open lock file "
-                   << lock_file_path_ << ": " << strerror(errno));
+    LOG(ERROR, "CuidFileLock: Failed to open lock file " << lock_file_path_ << ": "
+                                                         << CuidUtilities::errno_string(errno));
     return false;
   }
 
@@ -172,11 +175,11 @@ bool CuidFileLock::acquire_with_timeout(int timeout_seconds) {
   memset(&fl, 0, sizeof(fl));
   fl.l_whence = SEEK_SET;
   fl.l_start = 0;
-  fl.l_len = 0; // Lock entire file
+  fl.l_len = 0;  // Lock entire file
   fl.l_type = (lock_type_ == CuidLockType::EXCLUSIVE) ? F_WRLCK : F_RDLCK;
 
   // Retry loop with timeout
-  const int retry_interval_ms = 50; // 50ms between retries
+  const int retry_interval_ms = 50;  // 50ms between retries
   const int max_retries = (timeout_seconds * 1000) / retry_interval_ms;
 
   for (int retry = 0; retry <= max_retries; ++retry) {
@@ -184,17 +187,15 @@ bool CuidFileLock::acquire_with_timeout(int timeout_seconds) {
     if (fcntl(lock_fd_, F_SETLK, &fl) == 0) {
       is_locked_ = true;
       LOG(DEBUG, "CuidFileLock: Acquired "
-                     << (lock_type_ == CuidLockType::EXCLUSIVE ? "exclusive"
-                                                               : "shared")
-                     << " lock on " << lock_file_path_ << " after " << retry
-                     << " retries");
+                     << (lock_type_ == CuidLockType::EXCLUSIVE ? "exclusive" : "shared")
+                     << " lock on " << lock_file_path_ << " after " << retry << " retries");
       return true;
     }
 
     // Check if it's a "lock held" error vs real error
     if (errno != EACCES && errno != EAGAIN) {
-      LOG(ERROR, "CuidFileLock: Failed to acquire lock on "
-                     << lock_file_path_ << ": " << strerror(errno));
+      LOG(ERROR, "CuidFileLock: Failed to acquire lock on " << lock_file_path_ << ": "
+                                                            << CuidUtilities::errno_string(errno));
       close(lock_fd_);
       lock_fd_ = -1;
       return false;
@@ -202,13 +203,12 @@ bool CuidFileLock::acquire_with_timeout(int timeout_seconds) {
 
     // Wait before retry (unless this is the last iteration)
     if (retry < max_retries) {
-      usleep(retry_interval_ms * 1000); // Convert ms to microseconds
+      usleep(retry_interval_ms * 1000);  // Convert ms to microseconds
     }
   }
 
   // Timeout reached
-  LOG(WARN, "CuidFileLock: Timeout after " << timeout_seconds
-                                           << " seconds waiting for lock on "
+  LOG(WARN, "CuidFileLock: Timeout after " << timeout_seconds << " seconds waiting for lock on "
                                            << lock_file_path_);
   close(lock_fd_);
   lock_fd_ = -1;
@@ -217,7 +217,7 @@ bool CuidFileLock::acquire_with_timeout(int timeout_seconds) {
 
 bool CuidFileLock::try_acquire() {
   if (is_locked_) {
-    return true; // Already locked
+    return true;  // Already locked
   }
 
   // For shared (read) locks, we only need O_RDONLY access.
@@ -248,8 +248,8 @@ bool CuidFileLock::try_acquire() {
   }
 
   if (lock_fd_ < 0) {
-    LOG(ERROR, "CuidFileLock: Failed to open lock file "
-                   << lock_file_path_ << ": " << strerror(errno));
+    LOG(ERROR, "CuidFileLock: Failed to open lock file " << lock_file_path_ << ": "
+                                                         << CuidUtilities::errno_string(errno));
     return false;
   }
 
@@ -258,18 +258,17 @@ bool CuidFileLock::try_acquire() {
   memset(&fl, 0, sizeof(fl));
   fl.l_whence = SEEK_SET;
   fl.l_start = 0;
-  fl.l_len = 0; // Lock entire file
+  fl.l_len = 0;  // Lock entire file
   fl.l_type = (lock_type_ == CuidLockType::EXCLUSIVE) ? F_WRLCK : F_RDLCK;
 
   // F_SETLK: non-blocking - return immediately if can't acquire
   if (fcntl(lock_fd_, F_SETLK, &fl) < 0) {
     if (errno == EACCES || errno == EAGAIN) {
       // Lock is held by another process
-      LOG(DEBUG, "CuidFileLock: Lock on " << lock_file_path_
-                                          << " held by another process");
+      LOG(DEBUG, "CuidFileLock: Lock on " << lock_file_path_ << " held by another process");
     } else {
       LOG(ERROR, "CuidFileLock: Failed to try_acquire lock on "
-                     << lock_file_path_ << ": " << strerror(errno));
+                     << lock_file_path_ << ": " << CuidUtilities::errno_string(errno));
     }
     close(lock_fd_);
     lock_fd_ = -1;
@@ -277,10 +276,9 @@ bool CuidFileLock::try_acquire() {
   }
 
   is_locked_ = true;
-  LOG(DEBUG,
-      "CuidFileLock: Acquired "
-          << (lock_type_ == CuidLockType::EXCLUSIVE ? "exclusive" : "shared")
-          << " lock on " << lock_file_path_);
+  LOG(DEBUG, "CuidFileLock: Acquired "
+                 << (lock_type_ == CuidLockType::EXCLUSIVE ? "exclusive" : "shared") << " lock on "
+                 << lock_file_path_);
   return true;
 }
 
@@ -294,12 +292,12 @@ void CuidFileLock::release() {
   memset(&fl, 0, sizeof(fl));
   fl.l_whence = SEEK_SET;
   fl.l_start = 0;
-  fl.l_len = 0; // Unlock entire file
+  fl.l_len = 0;  // Unlock entire file
   fl.l_type = F_UNLCK;
 
   if (fcntl(lock_fd_, F_SETLK, &fl) < 0) {
-    LOG(ERROR, "CuidFileLock: Failed to release lock on "
-                   << lock_file_path_ << ": " << strerror(errno));
+    LOG(ERROR, "CuidFileLock: Failed to release lock on " << lock_file_path_ << ": "
+                                                          << CuidUtilities::errno_string(errno));
   }
 
   close(lock_fd_);
@@ -312,7 +310,7 @@ void CuidFileLock::release() {
 // CuidFile Implementation
 // ============================================================================
 
-CuidFile::CuidFile(const std::string &file_path, bool is_privileged)
+CuidFile::CuidFile(const std::string& file_path, bool is_privileged)
     : file_path_(file_path), is_privileged_(is_privileged) {}
 
 bool CuidFile::exists() const {
@@ -320,30 +318,23 @@ bool CuidFile::exists() const {
   return (stat(file_path_.c_str(), &buffer) == 0);
 }
 
-std::string CuidFile::trim(const std::string &str) const {
+std::string CuidFile::trim(const std::string& str) const {
   size_t first = str.find_first_not_of(" \t\r\n");
-  if (first == std::string::npos)
-    return "";
+  if (first == std::string::npos) return "";
   size_t last = str.find_last_not_of(" \t\r\n");
   return str.substr(first, last - first + 1);
 }
 
-amdcuid_device_type_t
-CuidFile::string_to_device_type(const std::string &str) const {
-  if (str == "PLATFORM")
-    return AMDCUID_DEVICE_TYPE_PLATFORM;
-  if (str == "CPU")
-    return AMDCUID_DEVICE_TYPE_CPU;
-  if (str == "GPU")
-    return AMDCUID_DEVICE_TYPE_GPU;
-  if (str == "NIC")
-    return AMDCUID_DEVICE_TYPE_NIC;
-  if (str == "NPU")
-    return AMDCUID_DEVICE_TYPE_NPU;
+amdcuid_device_type_t CuidFile::string_to_device_type(const std::string& str) const {
+  if (str == "PLATFORM") return AMDCUID_DEVICE_TYPE_PLATFORM;
+  if (str == "CPU") return AMDCUID_DEVICE_TYPE_CPU;
+  if (str == "GPU") return AMDCUID_DEVICE_TYPE_GPU;
+  if (str == "NIC") return AMDCUID_DEVICE_TYPE_NIC;
+  if (str == "NPU") return AMDCUID_DEVICE_TYPE_NPU;
   return AMDCUID_DEVICE_TYPE_NONE;
 }
 
-amdcuid_id_t CuidFile::string_to_cuid(const std::string &str) const {
+amdcuid_id_t CuidFile::string_to_cuid(const std::string& str) const {
   amdcuid_id_t id;
   memset(id.bytes, 0, sizeof(id.bytes));
 
@@ -351,25 +342,23 @@ amdcuid_id_t CuidFile::string_to_cuid(const std::string &str) const {
   // Remove dashes and parse hex bytes
   std::string hex_only;
   for (char c : str) {
-    if (c != '-')
-      hex_only += c;
+    if (c != '-') hex_only += c;
   }
 
   if (hex_only.length() != 32) {
-    return id; // Return zero-filled ID on parse error
+    return id;  // Return zero-filled ID on parse error
   }
 
   for (int i = 0; i < 16; ++i) {
-    std::string byte_str = hex_only.substr(i * 2, 2);
+    std::string byte_str = hex_only.substr(static_cast<size_t>(i) * 2, 2);
     id.bytes[i] = static_cast<uint8_t>(std::stoul(byte_str, nullptr, 16));
   }
 
   return id;
 }
 
-bool CuidFile::parse_section_header(const std::string &line,
-                                    amdcuid_device_type_t &type,
-                                    uint32_t &index) const {
+bool CuidFile::parse_section_header(const std::string& line, amdcuid_device_type_t& type,
+                                    uint32_t& index) const {
   // Parse lines like [GPU:0] or [PLATFORM]
   if (line.empty() || line[0] != '[' || line.back() != ']') {
     return false;
@@ -399,8 +388,7 @@ amdcuid_status_t CuidFile::load() {
   // Acquire shared lock for reading
   CuidFileLock lock(file_path_, CuidLockType::SHARED);
   if (!lock.acquire()) {
-    LOG(ERROR,
-        "CuidFile::load: Failed to acquire shared lock for " << file_path_);
+    LOG(ERROR, "CuidFile::load: Failed to acquire shared lock for " << file_path_);
     return AMDCUID_STATUS_FILE_ERROR;
   }
 
@@ -458,11 +446,9 @@ amdcuid_status_t CuidFile::load() {
         } else if (key == "device_node") {
           current_entry.device_node = value;
         } else if (key == "package_id") {
-          current_entry.package_id =
-              static_cast<uint16_t>(std::stoul(value, nullptr, 16));
+          current_entry.package_id = static_cast<uint16_t>(std::stoul(value, nullptr, 16));
         } else if (key == "core_id") {
-          current_entry.core_id =
-              static_cast<uint16_t>(std::stoul(value, nullptr, 16));
+          current_entry.core_id = static_cast<uint16_t>(std::stoul(value, nullptr, 16));
         } else if (key == "bdf") {
           current_entry.bdf = value;
         } else if (key == "mac_address") {
@@ -471,26 +457,19 @@ amdcuid_status_t CuidFile::load() {
           current_entry.hardware_fingerprint =
               static_cast<uint64_t>(std::stoull(value, nullptr, 16));
         } else if (key == "vendor_id") {
-          current_entry.vendor_id =
-              static_cast<uint16_t>(std::stoul(value, nullptr, 16));
+          current_entry.vendor_id = static_cast<uint16_t>(std::stoul(value, nullptr, 16));
         } else if (key == "device_id") {
-          current_entry.device_id =
-              static_cast<uint16_t>(std::stoul(value, nullptr, 16));
+          current_entry.device_id = static_cast<uint16_t>(std::stoul(value, nullptr, 16));
         } else if (key == "revision_id") {
-          current_entry.revision_id =
-              static_cast<uint8_t>(std::stoul(value, nullptr, 16));
+          current_entry.revision_id = static_cast<uint8_t>(std::stoul(value, nullptr, 16));
         } else if (key == "family") {
-          current_entry.family =
-              static_cast<uint16_t>(std::stoul(value, nullptr, 16));
+          current_entry.family = static_cast<uint16_t>(std::stoul(value, nullptr, 16));
         } else if (key == "model") {
-          current_entry.model =
-              static_cast<uint16_t>(std::stoul(value, nullptr, 16));
+          current_entry.model = static_cast<uint16_t>(std::stoul(value, nullptr, 16));
         } else if (key == "pci_class") {
-          current_entry.pci_class =
-              static_cast<uint16_t>(std::stoul(value, nullptr, 16));
+          current_entry.pci_class = static_cast<uint16_t>(std::stoul(value, nullptr, 16));
         } else if (key == "unit_id") {
-          current_entry.unit_id =
-              static_cast<uint16_t>(std::stoul(value, nullptr, 16));
+          current_entry.unit_id = static_cast<uint16_t>(std::stoul(value, nullptr, 16));
         } else if (key == "last_update") {
           current_entry.last_update = std::stol(value, nullptr, 10);
         }
@@ -511,8 +490,7 @@ amdcuid_status_t CuidFile::save() {
   // Acquire exclusive lock for writing
   CuidFileLock lock(file_path_, CuidLockType::EXCLUSIVE);
   if (!lock.acquire()) {
-    LOG(ERROR,
-        "CuidFile::save: Failed to acquire exclusive lock for " << file_path_);
+    LOG(ERROR, "CuidFile::save: Failed to acquire exclusive lock for " << file_path_);
     return AMDCUID_STATUS_FILE_ERROR;
   }
 
@@ -543,84 +521,77 @@ amdcuid_status_t CuidFile::save() {
   get_grouped_entries(grouped);
 
   // Define output order
-  std::vector<amdcuid_device_type_t> order = {
-      AMDCUID_DEVICE_TYPE_GPU, AMDCUID_DEVICE_TYPE_CPU, AMDCUID_DEVICE_TYPE_NIC,
-      AMDCUID_DEVICE_TYPE_NPU, AMDCUID_DEVICE_TYPE_PLATFORM};
+  std::vector<amdcuid_device_type_t> order = {AMDCUID_DEVICE_TYPE_GPU, AMDCUID_DEVICE_TYPE_CPU,
+                                              AMDCUID_DEVICE_TYPE_NIC, AMDCUID_DEVICE_TYPE_NPU,
+                                              AMDCUID_DEVICE_TYPE_PLATFORM};
 
   for (auto type : order) {
-    if (grouped.find(type) == grouped.end())
-      continue;
+    if (grouped.find(type) == grouped.end()) continue;
 
-    for (const auto &entry : grouped[type]) {
+    for (const auto& entry : grouped[type]) {
       // Write section header
       if (entry.device_type == AMDCUID_DEVICE_TYPE_PLATFORM) {
-        file << "[" << CuidUtilities::device_type_to_string(entry.device_type)
-             << "]\n";
+        file << "[" << CuidUtilities::device_type_to_string(entry.device_type) << "]\n";
       } else {
-        file << "[" << CuidUtilities::device_type_to_string(entry.device_type)
-             << ":" << entry.device_index << "]\n";
+        file << "[" << CuidUtilities::device_type_to_string(entry.device_type) << ":"
+             << entry.device_index << "]\n";
       }
 
       // Write primary CUID (privileged file only)
       if (is_privileged_) {
-        file << "primary_cuid="
-             << CuidUtilities::get_cuid_as_string(&entry.primary_cuid) << "\n";
+        file << "primary_cuid=" << CuidUtilities::get_cuid_as_string(&entry.primary_cuid) << "\n";
       }
 
       // Write if CUID is temporary
-      file << "is_temporary=" << (entry.is_temporary ? "true" : "false")
-           << "\n";
+      file << "is_temporary=" << (entry.is_temporary ? "true" : "false") << "\n";
 
       // Write derived CUID
-      file << "derived_cuid="
-           << CuidUtilities::get_cuid_as_string(&entry.derived_cuid) << "\n";
+      file << "derived_cuid=" << CuidUtilities::get_cuid_as_string(&entry.derived_cuid) << "\n";
 
       // Write hardware fingerprint (privileged file only)
       if (is_privileged_) {
-        file << "hardware_fingerprint=0x" << std::hex << std::setw(16)
-             << std::setfill('0') << entry.hardware_fingerprint << "\n";
+        file << "hardware_fingerprint=0x" << std::hex << std::setw(16) << std::setfill('0')
+             << entry.hardware_fingerprint << "\n";
       }
 
       // Write device-specific fields
       if (entry.vendor_id != 0) {
-        file << "vendor_id=0x" << std::hex << std::setw(4) << std::setfill('0')
-             << entry.vendor_id << "\n";
-      }
-      if (entry.device_id != 0) {
-        file << "device_id=0x" << std::hex << std::setw(4) << std::setfill('0')
-             << entry.device_id << "\n";
-      }
-      if (entry.revision_id != 0) {
-        file << "revision_id=0x" << std::hex << std::setw(2)
-             << std::setfill('0') << static_cast<uint16_t>(entry.revision_id)
+        file << "vendor_id=0x" << std::hex << std::setw(4) << std::setfill('0') << entry.vendor_id
              << "\n";
       }
+      if (entry.device_id != 0) {
+        file << "device_id=0x" << std::hex << std::setw(4) << std::setfill('0') << entry.device_id
+             << "\n";
+      }
+      if (entry.revision_id != 0) {
+        file << "revision_id=0x" << std::hex << std::setw(2) << std::setfill('0')
+             << static_cast<uint16_t>(entry.revision_id) << "\n";
+      }
       if (entry.family != 0) {
-        file << "family=0x" << std::hex << std::setw(4) << std::setfill('0')
-             << entry.family << "\n";
+        file << "family=0x" << std::hex << std::setw(4) << std::setfill('0') << entry.family
+             << "\n";
       }
       if (entry.model != 0) {
-        file << "model=0x" << std::hex << std::setw(4) << std::setfill('0')
-             << entry.model << "\n";
+        file << "model=0x" << std::hex << std::setw(4) << std::setfill('0') << entry.model << "\n";
       }
       if (entry.pci_class != 0) {
-        file << "pci_class=0x" << std::hex << std::setw(4) << std::setfill('0')
-             << entry.pci_class << "\n";
+        file << "pci_class=0x" << std::hex << std::setw(4) << std::setfill('0') << entry.pci_class
+             << "\n";
       }
       if (entry.unit_id != std::numeric_limits<uint16_t>::max()) {
-        file << "unit_id=0x" << std::hex << std::setw(4) << std::setfill('0')
-             << entry.unit_id << "\n";
+        file << "unit_id=0x" << std::hex << std::setw(4) << std::setfill('0') << entry.unit_id
+             << "\n";
       }
       if (!entry.device_node.empty()) {
         file << "device_node=" << entry.device_node << "\n";
       }
       if (entry.package_id != std::numeric_limits<uint16_t>::max()) {
-        file << "package_id=0x" << std::hex << std::setw(4) << std::setfill('0')
-             << entry.package_id << "\n";
+        file << "package_id=0x" << std::hex << std::setw(4) << std::setfill('0') << entry.package_id
+             << "\n";
       }
       if (entry.core_id != std::numeric_limits<uint16_t>::max()) {
-        file << "core_id=0x" << std::hex << std::setw(4) << std::setfill('0')
-             << entry.core_id << "\n";
+        file << "core_id=0x" << std::hex << std::setw(4) << std::setfill('0') << entry.core_id
+             << "\n";
       }
       if (!entry.bdf.empty()) {
         file << "bdf=" << entry.bdf << "\n";
@@ -655,9 +626,9 @@ amdcuid_status_t CuidFile::save() {
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidFile::add_entry(const CuidFileEntry &entry) {
+amdcuid_status_t CuidFile::add_entry(const CuidFileEntry& entry) {
   // Check if entry with same derived CUID exists
-  for (auto &existing : entries_) {
+  for (auto& existing : entries_) {
     if (memcmp(existing.derived_cuid.bytes, entry.derived_cuid.bytes,
                sizeof(amdcuid_id_t::bytes)) == 0) {
       // Update existing entry
@@ -671,14 +642,12 @@ amdcuid_status_t CuidFile::add_entry(const CuidFileEntry &entry) {
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidFile::remove_entry(const amdcuid_id_t &handle) {
+amdcuid_status_t CuidFile::remove_entry(const amdcuid_id_t& handle) {
   // search for entry by derived CUID and move that entry to the back, then
   // erase it
-  auto it = std::remove_if(entries_.begin(), entries_.end(),
-                           [&handle](const CuidFileEntry &e) {
-                             return (memcmp(e.derived_cuid.bytes, handle.bytes,
-                                            sizeof(amdcuid_id_t::bytes)) == 0);
-                           });
+  auto it = std::remove_if(entries_.begin(), entries_.end(), [&handle](const CuidFileEntry& e) {
+    return (memcmp(e.derived_cuid.bytes, handle.bytes, sizeof(amdcuid_id_t::bytes)) == 0);
+  });
   if (it != entries_.end()) {
     entries_.erase(it, entries_.end());
     return AMDCUID_STATUS_SUCCESS;
@@ -686,9 +655,9 @@ amdcuid_status_t CuidFile::remove_entry(const amdcuid_id_t &handle) {
   return AMDCUID_STATUS_DEVICE_NOT_FOUND;
 }
 
-amdcuid_status_t CuidFile::find_by_device_node(const std::string &device_node,
-                                               CuidFileEntry &entry) const {
-  for (const auto &e : entries_) {
+amdcuid_status_t CuidFile::find_by_device_node(const std::string& device_node,
+                                               CuidFileEntry& entry) const {
+  for (const auto& e : entries_) {
     if (e.device_node == device_node) {
       entry = e;
       return AMDCUID_STATUS_SUCCESS;
@@ -697,9 +666,8 @@ amdcuid_status_t CuidFile::find_by_device_node(const std::string &device_node,
   return AMDCUID_STATUS_DEVICE_NOT_FOUND;
 }
 
-amdcuid_status_t CuidFile::find_by_bdf(const std::string &bdf,
-                                       CuidFileEntry &entry) const {
-  for (const auto &e : entries_) {
+amdcuid_status_t CuidFile::find_by_bdf(const std::string& bdf, CuidFileEntry& entry) const {
+  for (const auto& e : entries_) {
     if (e.bdf == bdf) {
       entry = e;
       return AMDCUID_STATUS_SUCCESS;
@@ -708,9 +676,8 @@ amdcuid_status_t CuidFile::find_by_bdf(const std::string &bdf,
   return AMDCUID_STATUS_DEVICE_NOT_FOUND;
 }
 
-amdcuid_status_t CuidFile::find_by_package_id(uint16_t package_id,
-                                              CuidFileEntry &entry) const {
-  for (const auto &e : entries_) {
+amdcuid_status_t CuidFile::find_by_package_id(uint16_t package_id, CuidFileEntry& entry) const {
+  for (const auto& e : entries_) {
     if (e.package_id == package_id) {
       entry = e;
       return AMDCUID_STATUS_SUCCESS;
@@ -719,10 +686,9 @@ amdcuid_status_t CuidFile::find_by_package_id(uint16_t package_id,
   return AMDCUID_STATUS_DEVICE_NOT_FOUND;
 }
 
-amdcuid_status_t
-CuidFile::find_by_device_type(amdcuid_device_type_t device_type,
-                              CuidFileEntry &entry) const {
-  for (const auto &e : entries_) {
+amdcuid_status_t CuidFile::find_by_device_type(amdcuid_device_type_t device_type,
+                                               CuidFileEntry& entry) const {
+  for (const auto& e : entries_) {
     if (e.device_type == device_type) {
       entry = e;
       return AMDCUID_STATUS_SUCCESS;
@@ -731,12 +697,10 @@ CuidFile::find_by_device_type(amdcuid_device_type_t device_type,
   return AMDCUID_STATUS_DEVICE_NOT_FOUND;
 }
 
-amdcuid_status_t
-CuidFile::find_by_derived_cuid(const amdcuid_id_t &derived_cuid,
-                               CuidFileEntry &entry) const {
-  for (const auto &e : entries_) {
-    if (memcmp(e.derived_cuid.bytes, derived_cuid.bytes,
-               sizeof(amdcuid_id_t::bytes)) == 0) {
+amdcuid_status_t CuidFile::find_by_derived_cuid(const amdcuid_id_t& derived_cuid,
+                                                CuidFileEntry& entry) const {
+  for (const auto& e : entries_) {
+    if (memcmp(e.derived_cuid.bytes, derived_cuid.bytes, sizeof(amdcuid_id_t::bytes)) == 0) {
       entry = e;
       return AMDCUID_STATUS_SUCCESS;
     }
@@ -745,10 +709,9 @@ CuidFile::find_by_derived_cuid(const amdcuid_id_t &derived_cuid,
 }
 
 void CuidFile::get_grouped_entries(
-    std::map<amdcuid_device_type_t, std::vector<CuidFileEntry>> &grouped)
-    const {
+    std::map<amdcuid_device_type_t, std::vector<CuidFileEntry>>& grouped) const {
   grouped.clear();
-  for (const auto &entry : entries_) {
+  for (const auto& entry : entries_) {
     grouped[entry.device_type].push_back(entry);
   }
 }
@@ -758,9 +721,9 @@ void CuidFile::get_grouped_entries(
 // ============================================================================
 
 // helper function to generate CUID files from a list of devices
-static amdcuid_status_t
-generate_from_devices(const std::vector<std::shared_ptr<CuidDevice>> &devices,
-                      const std::string &file, bool is_privileged) {
+static amdcuid_status_t generate_from_devices(
+    const std::vector<std::shared_ptr<CuidDevice>>& devices, const std::string& file,
+    bool is_privileged) {
   // Create file handlers
   CuidFile cuid_file(file, is_privileged);
 
@@ -774,9 +737,8 @@ generate_from_devices(const std::vector<std::shared_ptr<CuidDevice>> &devices,
   std::map<amdcuid_device_type_t, uint32_t> device_counters;
 
   // Process each device
-  for (const auto &device : devices) {
-    if (!device)
-      continue;
+  for (const auto& device : devices) {
+    if (!device) continue;
 
     CuidFileEntry entry;
     entry.device_type = device->type();
@@ -788,9 +750,8 @@ generate_from_devices(const std::vector<std::shared_ptr<CuidDevice>> &devices,
     bool is_temporary = false;
     status = device->is_temporary_cuid(&is_temporary);
     if (status != AMDCUID_STATUS_SUCCESS) {
-      std::cerr
-          << "Warning: Failed to get temporary CUID status for device type "
-          << entry.device_type << " status: " << status << std::endl;
+      std::cerr << "Warning: Failed to get temporary CUID status for device type "
+                << entry.device_type << " status: " << status << std::endl;
     }
     entry.is_temporary = is_temporary;
 
@@ -799,8 +760,8 @@ generate_from_devices(const std::vector<std::shared_ptr<CuidDevice>> &devices,
       amdcuid_primary_id primary_id = {};
       status = device->get_primary_cuid(primary_id);
       if (status != AMDCUID_STATUS_SUCCESS) {
-        std::cerr << "Warning: Failed to get primary CUID for device type "
-                  << entry.device_type << " status: " << status << std::endl;
+        std::cerr << "Warning: Failed to get primary CUID for device type " << entry.device_type
+                  << " status: " << status << std::endl;
       }
       entry.primary_cuid = primary_id.UUIDv8_representation;
 
@@ -808,9 +769,8 @@ generate_from_devices(const std::vector<std::shared_ptr<CuidDevice>> &devices,
       uint64_t fingerprint = 0;
       status = device->get_hardware_fingerprint(fingerprint);
       if (status != AMDCUID_STATUS_SUCCESS && !is_temporary) {
-        std::cerr
-            << "Warning: Failed to get hardware fingerprint for device type "
-            << entry.device_type << " status: " << status << std::endl;
+        std::cerr << "Warning: Failed to get hardware fingerprint for device type "
+                  << entry.device_type << " status: " << status << std::endl;
       } else {
         entry.hardware_fingerprint = fingerprint;
       }
@@ -819,124 +779,120 @@ generate_from_devices(const std::vector<std::shared_ptr<CuidDevice>> &devices,
     amdcuid_derived_id derived_id = {};
     status = device->get_derived_cuid(derived_id, &hmac);
     if (status != AMDCUID_STATUS_SUCCESS) {
-      std::cerr << "Warning: Failed to generate derived CUID for device type "
-                << entry.device_type << " status: " << status << std::endl;
+      std::cerr << "Warning: Failed to generate derived CUID for device type " << entry.device_type
+                << " status: " << status << std::endl;
     }
     entry.derived_cuid = derived_id.UUIDv8_representation;
 
     // Fill in device-specific information
     switch (entry.device_type) {
-    case AMDCUID_DEVICE_TYPE_GPU: {
-      auto gpu = std::dynamic_pointer_cast<CuidGpu>(device);
-      if (gpu) {
-        const auto &info = gpu->get_info();
-        entry.vendor_id = info.header.fields.gpu.vendor_id;
-        entry.device_id = info.header.fields.gpu.device_id;
-        entry.revision_id = info.header.fields.gpu.revision_id;
-        entry.pci_class = info.header.fields.gpu.pci_class;
-        entry.unit_id = info.header.fields.gpu.unit_id;
-        entry.device_node = info.render_node;
-        entry.bdf = info.bdf;
+      case AMDCUID_DEVICE_TYPE_GPU: {
+        auto gpu = std::dynamic_pointer_cast<CuidGpu>(device);
+        if (gpu) {
+          const auto& info = gpu->get_info();
+          entry.vendor_id = info.header.fields.gpu.vendor_id;
+          entry.device_id = info.header.fields.gpu.device_id;
+          entry.revision_id = info.header.fields.gpu.revision_id;
+          entry.pci_class = info.header.fields.gpu.pci_class;
+          entry.unit_id = info.header.fields.gpu.unit_id;
+          entry.device_node = info.render_node;
+          entry.bdf = info.bdf;
 
-        // if temp CUID, make the fallback fingerprint based on the GPU's PCIe
-        // BDF
-        if (is_temporary) {
-          CuidUtilities::make_fallback_fingerprint(info.bdf,
-                                                   entry.hardware_fingerprint);
+          // if temp CUID, make the fallback fingerprint based on the GPU's PCIe
+          // BDF
+          if (is_temporary) {
+            CuidUtilities::make_fallback_fingerprint(info.bdf, entry.hardware_fingerprint);
+          }
         }
+        break;
       }
-      break;
-    }
-    case AMDCUID_DEVICE_TYPE_CPU: {
-      auto cpu = std::dynamic_pointer_cast<CuidCpu>(device);
-      if (cpu) {
-        const auto &info = cpu->get_info();
-        entry.vendor_id = info.header.fields.cpu.vendor_id;
-        entry.device_id = info.header.fields.cpu.device_id;
-        entry.revision_id = info.header.fields.cpu.revision_id;
-        entry.family = info.header.fields.cpu.family;
-        entry.model = info.header.fields.cpu.model;
-        entry.unit_id = info.header.fields.cpu.unit_id;
-        entry.package_id = info.header.fields.cpu.physical_id;
-        entry.core_id = info.header.fields.cpu.core;
-        // Store device path (unique per logical CPU, needed for SMT)
-        std::string cpu_device_path;
-        if (cpu->get_device_path(cpu_device_path) == AMDCUID_STATUS_SUCCESS) {
-          entry.device_node = cpu_device_path;
+      case AMDCUID_DEVICE_TYPE_CPU: {
+        auto cpu = std::dynamic_pointer_cast<CuidCpu>(device);
+        if (cpu) {
+          const auto& info = cpu->get_info();
+          entry.vendor_id = info.header.fields.cpu.vendor_id;
+          entry.device_id = info.header.fields.cpu.device_id;
+          entry.revision_id = info.header.fields.cpu.revision_id;
+          entry.family = info.header.fields.cpu.family;
+          entry.model = info.header.fields.cpu.model;
+          entry.unit_id = info.header.fields.cpu.unit_id;
+          entry.package_id = info.header.fields.cpu.physical_id;
+          entry.core_id = info.header.fields.cpu.core;
+          // Store device path (unique per logical CPU, needed for SMT)
+          std::string cpu_device_path;
+          if (cpu->get_device_path(cpu_device_path) == AMDCUID_STATUS_SUCCESS) {
+            entry.device_node = cpu_device_path;
+          }
+          // if temp CUID, make the fallback fingerprint based on the CPU's
+          // package
+          if (is_temporary) {
+            CuidUtilities::make_fallback_fingerprint(std::to_string(entry.package_id),
+                                                     entry.hardware_fingerprint);
+          }
         }
-        // if temp CUID, make the fallback fingerprint based on the CPU's
-        // package
-        if (is_temporary) {
-          CuidUtilities::make_fallback_fingerprint(
-              std::to_string(entry.package_id), entry.hardware_fingerprint);
-        }
+        break;
       }
-      break;
-    }
-    case AMDCUID_DEVICE_TYPE_NIC: {
-      auto nic = std::dynamic_pointer_cast<CuidNic>(device);
-      if (nic) {
-        const auto &info = nic->get_info();
-        entry.vendor_id = info.header.fields.nic.vendor_id;
-        entry.device_id = info.header.fields.nic.device_id;
-        entry.revision_id = info.header.fields.nic.revision_id;
-        entry.pci_class = info.header.fields.nic.pci_class;
-        entry.device_node = info.network_interface;
-        std::string mac_address;
-        if (nic->get_mac_address(mac_address) == AMDCUID_STATUS_SUCCESS) {
-          entry.mac_address = mac_address;
-        }
-        entry.bdf = info.bdf;
+      case AMDCUID_DEVICE_TYPE_NIC: {
+        auto nic = std::dynamic_pointer_cast<CuidNic>(device);
+        if (nic) {
+          const auto& info = nic->get_info();
+          entry.vendor_id = info.header.fields.nic.vendor_id;
+          entry.device_id = info.header.fields.nic.device_id;
+          entry.revision_id = info.header.fields.nic.revision_id;
+          entry.pci_class = info.header.fields.nic.pci_class;
+          entry.device_node = info.network_interface;
+          std::string mac_address;
+          if (nic->get_mac_address(mac_address) == AMDCUID_STATUS_SUCCESS) {
+            entry.mac_address = mac_address;
+          }
+          entry.bdf = info.bdf;
 
-        // if temp CUID, make the fallback fingerprint based on the NIC's PCIe
-        // BDF
-        if (is_temporary) {
-          CuidUtilities::make_fallback_fingerprint(info.bdf,
-                                                   entry.hardware_fingerprint);
+          // if temp CUID, make the fallback fingerprint based on the NIC's PCIe
+          // BDF
+          if (is_temporary) {
+            CuidUtilities::make_fallback_fingerprint(info.bdf, entry.hardware_fingerprint);
+          }
         }
+        break;
       }
-      break;
-    }
-    case AMDCUID_DEVICE_TYPE_NPU: {
-      auto npu = std::dynamic_pointer_cast<CuidNpu>(device);
-      if (npu) {
-        const auto &info = npu->get_info();
-        entry.vendor_id = info.header.fields.npu.vendor_id;
-        entry.device_id = info.header.fields.npu.device_id;
-        entry.revision_id = info.header.fields.npu.revision_id;
-        entry.pci_class = info.header.fields.npu.pci_class;
-        entry.device_node = info.accel_node;
-        entry.bdf = info.bdf;
-        // if temp CUID, make the fallback fingerprint based on the NPU's PCIe
-        // BDF
-        if (is_temporary) {
-          CuidUtilities::make_fallback_fingerprint(info.bdf,
-                                                   entry.hardware_fingerprint);
+      case AMDCUID_DEVICE_TYPE_NPU: {
+        auto npu = std::dynamic_pointer_cast<CuidNpu>(device);
+        if (npu) {
+          const auto& info = npu->get_info();
+          entry.vendor_id = info.header.fields.npu.vendor_id;
+          entry.device_id = info.header.fields.npu.device_id;
+          entry.revision_id = info.header.fields.npu.revision_id;
+          entry.pci_class = info.header.fields.npu.pci_class;
+          entry.device_node = info.accel_node;
+          entry.bdf = info.bdf;
+          // if temp CUID, make the fallback fingerprint based on the NPU's PCIe
+          // BDF
+          if (is_temporary) {
+            CuidUtilities::make_fallback_fingerprint(info.bdf, entry.hardware_fingerprint);
+          }
         }
+        break;
       }
-      break;
-    }
-    case AMDCUID_DEVICE_TYPE_PLATFORM: {
-      auto platform = std::dynamic_pointer_cast<CuidPlatform>(device);
-      // Platform only has vendor_id
-      if (platform) {
-        const auto &info = platform->get_info();
-        entry.vendor_id = info.header.fields.platform.vendor_id;
+      case AMDCUID_DEVICE_TYPE_PLATFORM: {
+        auto platform = std::dynamic_pointer_cast<CuidPlatform>(device);
+        // Platform only has vendor_id
+        if (platform) {
+          const auto& info = platform->get_info();
+          entry.vendor_id = info.header.fields.platform.vendor_id;
 
-        // if temp CUID, make the fallback fingerprint based on the platform
-        // product name
-        if (is_temporary) {
-          std::string name = "";
-          std::string family_dummy = "";
-          SmbiosUtil::get_product_info(name, family_dummy);
-          CuidUtilities::make_fallback_fingerprint(name,
-                                                   entry.hardware_fingerprint);
+          // if temp CUID, make the fallback fingerprint based on the platform
+          // product name
+          if (is_temporary) {
+            std::string name = "";
+            std::string family_dummy = "";
+            SmbiosUtil::get_product_info(name, family_dummy);
+            CuidUtilities::make_fallback_fingerprint(name, entry.hardware_fingerprint);
+          }
         }
+        break;
       }
-      break;
-    }
-    default:
-      break;
+      default:
+        break;
     }
 
     // Add to file
@@ -954,13 +910,11 @@ generate_from_devices(const std::vector<std::shared_ptr<CuidDevice>> &devices,
 }
 
 amdcuid_status_t CuidFileGenerator::generate_unpriv_from_devices(
-    const std::vector<std::shared_ptr<CuidDevice>> &devices,
-    const std::string &unpriv_file_path) {
+    const std::vector<std::shared_ptr<CuidDevice>>& devices, const std::string& unpriv_file_path) {
   return generate_from_devices(devices, unpriv_file_path, false);
 }
 
 amdcuid_status_t CuidFileGenerator::generate_priv_from_devices(
-    const std::vector<std::shared_ptr<CuidDevice>> &devices,
-    const std::string &priv_file_path) {
+    const std::vector<std::shared_ptr<CuidDevice>>& devices, const std::string& priv_file_path) {
   return generate_from_devices(devices, priv_file_path, true);
 }

--- a/projects/cuid/lib/src/cuid_file.h
+++ b/projects/cuid/lib/src/cuid_file.h
@@ -23,25 +23,27 @@
 #ifndef CUID_FILE_H
 #define CUID_FILE_H
 
-#include "include/amd_cuid.h"
-#include "src/cuid_util.h"
+#include <fcntl.h>
+#include <unistd.h>
+
 #include <cerrno>
 #include <cstring>
 #include <ctime>
-#include <fcntl.h>
 #include <limits>
 #include <map>
 #include <memory>
 #include <string>
-#include <unistd.h>
 #include <vector>
+
+#include "include/amd_cuid.h"
+#include "src/cuid_util.h"
 
 /**
  * @brief Lock types for file operations
  */
 enum class CuidLockType {
-  SHARED,   ///< Shared lock for reading (multiple readers allowed)
-  EXCLUSIVE ///< Exclusive lock for writing (single writer, no readers)
+  SHARED,    ///< Shared lock for reading (multiple readers allowed)
+  EXCLUSIVE  ///< Exclusive lock for writing (single writer, no readers)
 };
 
 /**
@@ -67,7 +69,7 @@ enum class CuidLockType {
  *   if (lock.acquire()) { ... write operations ... }
  */
 class CuidFileLock {
-public:
+ public:
   /**
    * @brief Construct a file lock for the given CUID file path
    * @param file_path Path to the CUID file (lock file will be file_path +
@@ -75,7 +77,7 @@ public:
    * @param lock_type Type of lock to acquire (SHARED for read, EXCLUSIVE for
    * write)
    */
-  CuidFileLock(const std::string &file_path, CuidLockType lock_type);
+  CuidFileLock(const std::string& file_path, CuidLockType lock_type);
 
   /**
    * @brief Destructor - automatically releases the lock
@@ -83,10 +85,10 @@ public:
   ~CuidFileLock();
 
   // Non-copyable, non-movable (RAII resource)
-  CuidFileLock(const CuidFileLock &) = delete;
-  CuidFileLock &operator=(const CuidFileLock &) = delete;
-  CuidFileLock(CuidFileLock &&) = delete;
-  CuidFileLock &operator=(CuidFileLock &&) = delete;
+  CuidFileLock(const CuidFileLock&) = delete;
+  CuidFileLock& operator=(const CuidFileLock&) = delete;
+  CuidFileLock(CuidFileLock&&) = delete;
+  CuidFileLock& operator=(CuidFileLock&&) = delete;
 
   /**
    * @brief Acquire the lock (blocking)
@@ -123,9 +125,9 @@ public:
    * @brief Get the lock file path
    * @return Path to the lock file
    */
-  const std::string &get_lock_file_path() const { return lock_file_path_; }
+  const std::string& get_lock_file_path() const { return lock_file_path_; }
 
-private:
+ private:
   std::string lock_file_path_;
   CuidLockType lock_type_;
   int lock_fd_;
@@ -134,39 +136,36 @@ private:
 
 struct CuidFileEntry {
   amdcuid_device_type_t device_type;
-  uint32_t device_index = 0; // e.g., 0 for GPU:0, 1 for GPU:1
+  uint32_t device_index = 0;  // e.g., 0 for GPU:0, 1 for GPU:1
 
-  amdcuid_id_t primary_cuid; // Only available in privileged file
+  amdcuid_id_t primary_cuid;  // Only available in privileged file
   amdcuid_id_t derived_cuid;
 
-  uint64_t hardware_fingerprint = 0; // Only available in privileged file
+  uint64_t hardware_fingerprint = 0;  // Only available in privileged file
   uint16_t vendor_id = 0;
   uint16_t device_id = 0;
   uint8_t revision_id = 0;
 
   // Device-specific information
-  uint16_t family = 0;    // For CPU
-  uint16_t model = 0;     // For CPU
-  uint16_t pci_class = 0; // For PCIe devices (GPU, NIC)
-  uint16_t unit_id = std::numeric_limits<uint16_t>::max(); // For CPU and GPU
-  std::string device_node; // For GPU: /sys/class/drm/renderD128, NIC:
-                           // /sys/class/net/eth0
-  uint16_t package_id =
-      std::numeric_limits<uint16_t>::max(); // For CPU, aka physical id, akin to
-                                            // socket id
-  uint16_t core_id =
-      std::numeric_limits<uint16_t>::max(); // For CPU, aka core id within the
-                                            // package
-  std::string bdf;                          // PCIe Bus:Device.Function
-  std::string mac_address;                  // For NIC
+  uint16_t family = 0;                                      // For CPU
+  uint16_t model = 0;                                       // For CPU
+  uint16_t pci_class = 0;                                   // For PCIe devices (GPU, NIC)
+  uint16_t unit_id = std::numeric_limits<uint16_t>::max();  // For CPU and GPU
+  std::string device_node;  // For GPU: /sys/class/drm/renderD128, NIC:
+                            // /sys/class/net/eth0
+  uint16_t package_id = std::numeric_limits<uint16_t>::max();  // For CPU, aka physical id, akin to
+                                                               // socket id
+  uint16_t core_id = std::numeric_limits<uint16_t>::max();     // For CPU, aka core id within the
+                                                               // package
+  std::string bdf;                                             // PCIe Bus:Device.Function
+  std::string mac_address;                                     // For NIC
 
-  bool is_temporary = false; // Indicates if the CUID is temporary (not derived
-                             // from a true hardware fingerprint)
+  bool is_temporary = false;  // Indicates if the CUID is temporary (not derived
+                              // from a true hardware fingerprint)
 
-  time_t last_update; // Unix timestamp
+  time_t last_update;  // Unix timestamp
 
-  CuidFileEntry()
-      : device_type(AMDCUID_DEVICE_TYPE_NONE), device_index(0), last_update(0) {
+  CuidFileEntry() : device_type(AMDCUID_DEVICE_TYPE_NONE), device_index(0), last_update(0) {
     memset(primary_cuid.bytes, 0, sizeof(primary_cuid.bytes));
     memset(derived_cuid.bytes, 0, sizeof(derived_cuid.bytes));
   }
@@ -176,36 +175,33 @@ struct CuidFileEntry {
  * @brief CUID File handler for reading and writing device CUID information
  */
 class CuidFile {
-public:
+ public:
   /**
    * @brief Constructor
    * @param file_path Path to the CUID file (e.g., /tmp/cuid or /tmp/priv_cuid)
    * @param is_privileged Whether this is a privileged file (includes primary
    * CUIDs)
    */
-  CuidFile(const std::string &file_path, bool is_privileged = false);
+  CuidFile(const std::string& file_path, bool is_privileged = false);
 
   amdcuid_status_t load();
   amdcuid_status_t save();
-  amdcuid_status_t add_entry(const CuidFileEntry &entry);
-  amdcuid_status_t remove_entry(const amdcuid_id_t &handle);
+  amdcuid_status_t add_entry(const CuidFileEntry& entry);
+  amdcuid_status_t remove_entry(const amdcuid_id_t& handle);
 
-  const std::vector<CuidFileEntry> &get_entries() const { return entries_; }
+  const std::vector<CuidFileEntry>& get_entries() const { return entries_; }
 
-  amdcuid_status_t find_by_device_node(const std::string &device_node,
-                                       CuidFileEntry &entry) const;
-  amdcuid_status_t find_by_bdf(const std::string &bdf,
-                               CuidFileEntry &entry) const;
-  amdcuid_status_t find_by_package_id(uint16_t package_id,
-                                      CuidFileEntry &entry) const;
+  amdcuid_status_t find_by_device_node(const std::string& device_node, CuidFileEntry& entry) const;
+  amdcuid_status_t find_by_bdf(const std::string& bdf, CuidFileEntry& entry) const;
+  amdcuid_status_t find_by_package_id(uint16_t package_id, CuidFileEntry& entry) const;
   amdcuid_status_t find_by_device_type(amdcuid_device_type_t device_type,
-                                       CuidFileEntry &entry) const;
-  amdcuid_status_t find_by_derived_cuid(const amdcuid_id_t &derived_cuid,
-                                        CuidFileEntry &entry) const;
+                                       CuidFileEntry& entry) const;
+  amdcuid_status_t find_by_derived_cuid(const amdcuid_id_t& derived_cuid,
+                                        CuidFileEntry& entry) const;
 
   void clear() { entries_.clear(); }
   bool exists() const;
-  const std::string &get_file_path() const { return file_path_; }
+  const std::string& get_file_path() const { return file_path_; }
 
   /**
    * @brief Check if this is a privileged file
@@ -213,27 +209,27 @@ public:
   bool is_privileged() const { return is_privileged_; }
 
   // static utility to group entries by device type
-  void get_grouped_entries(std::map<amdcuid_device_type_t,
-                                    std::vector<CuidFileEntry>> &grouped) const;
+  void get_grouped_entries(
+      std::map<amdcuid_device_type_t, std::vector<CuidFileEntry>>& grouped) const;
 
-private:
+ private:
   std::string file_path_;
   bool is_privileged_;
   std::vector<CuidFileEntry> entries_;
 
   // Helper functions
-  amdcuid_device_type_t string_to_device_type(const std::string &str) const;
-  amdcuid_id_t string_to_cuid(const std::string &str) const;
-  std::string trim(const std::string &str) const;
-  bool parse_section_header(const std::string &line,
-                            amdcuid_device_type_t &type, uint32_t &index) const;
+  amdcuid_device_type_t string_to_device_type(const std::string& str) const;
+  amdcuid_id_t string_to_cuid(const std::string& str) const;
+  std::string trim(const std::string& str) const;
+  bool parse_section_header(const std::string& line, amdcuid_device_type_t& type,
+                            uint32_t& index) const;
 };
 
 /**
  * @brief Utility class for generating CUID files from discovered devices
  */
 class CuidFileGenerator {
-public:
+ public:
   /**
    * @brief Generate unprivileged CUID file from device manager
    * @param devices Vector of discovered devices
@@ -242,8 +238,8 @@ public:
    * @return AMDCUID_STATUS_SUCCESS on success, error code otherwise
    */
   static amdcuid_status_t generate_unpriv_from_devices(
-      const std::vector<std::shared_ptr<class CuidDevice>> &devices,
-      const std::string &unprivileged_file = CuidUtilities::cuid_file());
+      const std::vector<std::shared_ptr<class CuidDevice>>& devices,
+      const std::string& unprivileged_file = CuidUtilities::cuid_file());
 
   /**
    * @brief Generate privileged CUID file from device manager
@@ -253,8 +249,8 @@ public:
    * @return AMDCUID_STATUS_SUCCESS on success, error code otherwise
    */
   static amdcuid_status_t generate_priv_from_devices(
-      const std::vector<std::shared_ptr<class CuidDevice>> &devices,
-      const std::string &privileged_file = CuidUtilities::priv_cuid_file());
+      const std::vector<std::shared_ptr<class CuidDevice>>& devices,
+      const std::string& privileged_file = CuidUtilities::priv_cuid_file());
 };
 
-#endif // CUID_FILE_H
+#endif  // CUID_FILE_H

--- a/projects/cuid/lib/src/cuid_gpu.cc
+++ b/projects/cuid/lib/src/cuid_gpu.cc
@@ -21,32 +21,33 @@
  */
 
 #include "cuid_gpu.h"
-#include "cuid_file.h"
-#include "cuid_util.h"
-#include "gim_util.h"
-#include "pci_util.h"
+
+#include <dirent.h>
+#include <sys/types.h>
+#include <unistd.h>
+
 #include <algorithm>
 #include <cstring>
-#include <dirent.h>
 #include <fstream>
 #include <iostream>
 #include <memory>
 #include <set>
 #include <sstream>
-#include <sys/types.h>
-#include <unistd.h>
 
-CuidGpu::CuidGpu(const amdcuid_gpu_info &i) : m_info(i) {}
+#include "cuid_file.h"
+#include "cuid_util.h"
+#include "gim_util.h"
+#include "pci_util.h"
+
+CuidGpu::CuidGpu(const amdcuid_gpu_info& i) : m_info(i) {}
 
 // Helper to check if a /sys/class/drm entry name is a card device (e.g.,
 // "card0", "card1"). Excludes connector entries like "card0-DP-1" or
 // "card0-HDMI-A-1".
-static bool is_card_entry(const char *name) {
-  if (strncmp(name, "card", 4) != 0 || !isdigit(name[4]))
-    return false;
+static bool is_card_entry(const char* name) {
+  if (strncmp(name, "card", 4) != 0 || !isdigit(name[4])) return false;
   for (size_t i = 4; name[i] != '\0'; ++i) {
-    if (!isdigit(name[i]))
-      return false;
+    if (!isdigit(name[i])) return false;
   }
   return true;
 }
@@ -54,14 +55,16 @@ static bool is_card_entry(const char *name) {
 // Resolve the renderD node path for a given card path.
 // If a renderD node exists under the card's device/drm directory, returns
 // "/sys/class/drm/renderDXXX". Otherwise, returns the original card path.
-static std::string resolve_render_node(const std::string &card_path) {
+static std::string resolve_render_node(const std::string& card_path) {
   std::string drm_dir = card_path + "/device/drm";
-  DIR *dir = opendir(drm_dir.c_str());
+  DIR* dir = opendir(drm_dir.c_str());
   if (dir) {
-    struct dirent *entry;
+    struct dirent* entry;
+    // This call site owns its DIR*, which is all POSIX requires for readdir to be
+    // safe; readdir_r is deprecated and must not be adopted.
+    // NOLINTNEXTLINE(concurrency-mt-unsafe)
     while ((entry = readdir(dir)) != nullptr) {
-      if (strncmp(entry->d_name, "renderD", 7) == 0 &&
-          isdigit(entry->d_name[7])) {
+      if (strncmp(entry->d_name, "renderD", 7) == 0 && isdigit(entry->d_name[7])) {
         std::string result = "/sys/class/drm/" + std::string(entry->d_name);
         closedir(dir);
         return result;
@@ -79,12 +82,12 @@ static std::string resolve_render_node(const std::string &card_path) {
 // path which passes "/sys/bus/pci/devices/<bdf>") must not be trimmed --
 // doing so would collapse every device to the parent directory and corrupt
 // the CUID-file identifier.
-std::string CuidGpu::normalize_render_node(const std::string &device_path) {
+std::string CuidGpu::normalize_render_node(const std::string& device_path) {
   std::string full_device_node = device_path;
   const std::string kDeviceSuffix = "/device";
   if (full_device_node.size() > kDeviceSuffix.size() &&
-      full_device_node.compare(full_device_node.size() - kDeviceSuffix.size(),
-                               kDeviceSuffix.size(), kDeviceSuffix) == 0) {
+      full_device_node.compare(full_device_node.size() - kDeviceSuffix.size(), kDeviceSuffix.size(),
+                               kDeviceSuffix) == 0) {
     full_device_node.resize(full_device_node.size() - kDeviceSuffix.size());
   }
 
@@ -98,7 +101,7 @@ std::string CuidGpu::normalize_render_node(const std::string &device_path) {
   return full_device_node;
 }
 
-amdcuid_status_t CuidGpu::discover(std::vector<DevicePtr> &gpus) {
+amdcuid_status_t CuidGpu::discover(std::vector<DevicePtr>& gpus) {
   // Track BDFs we've already added so the GIM enumeration below doesn't
   // create duplicates of GPUs that are also visible via /sys/class/drm.
   std::set<std::string> seen_bdfs;
@@ -110,24 +113,25 @@ amdcuid_status_t CuidGpu::discover(std::vector<DevicePtr> &gpus) {
     gim_client.reset(new cuid::gim::GimClient());
   }
 
-  const char *drm_path = "/sys/class/drm";
-  DIR *dir = opendir(drm_path);
+  const char* drm_path = "/sys/class/drm";
+  DIR* dir = opendir(drm_path);
   if (dir != nullptr) {
-    struct dirent *entry;
+    struct dirent* entry;
+    // This call site owns its DIR*, which is all POSIX requires for readdir to be
+    // safe; readdir_r is deprecated and must not be adopted.
+    // NOLINTNEXTLINE(concurrency-mt-unsafe)
     while ((entry = readdir(dir)) != NULL) {
       // Use card entries (e.g., card0, card1) which are always present for DRM
       // devices, unlike renderD nodes which may be absent with certain drivers
       // (e.g., GIM) or for non-AMD GPUs.
       if (is_card_entry(entry->d_name)) {
         std::string card_name(entry->d_name);
-        std::string device_path =
-            std::string(drm_path) + "/" + card_name + "/device";
+        std::string device_path = std::string(drm_path) + "/" + card_name + "/device";
         amdcuid_gpu_info info = {};
         // Skip partitioned or otherwise unsupported cards; discover_single
         // leaves `info` untouched in that case, so emplacing it would add a
         // zero-filled GPU entry.
-        if (discover_single(&info, device_path, gim_client.get()) ==
-            AMDCUID_STATUS_UNSUPPORTED) {
+        if (discover_single(&info, device_path, gim_client.get()) == AMDCUID_STATUS_UNSUPPORTED) {
           continue;
         }
         if (!info.bdf.empty()) {
@@ -145,7 +149,7 @@ amdcuid_status_t CuidGpu::discover(std::vector<DevicePtr> &gpus) {
   if (gim_client) {
     std::vector<cuid::gim::GimDeviceEntry> gim_devices;
     if (gim_client->get_devices(gim_devices) == AMDCUID_STATUS_SUCCESS) {
-      for (const auto &dev : gim_devices) {
+      for (const auto& dev : gim_devices) {
         if (dev.bdf.empty() || seen_bdfs.count(dev.bdf) > 0) {
           continue;
         }
@@ -180,10 +184,9 @@ amdcuid_status_t CuidGpu::discover(std::vector<DevicePtr> &gpus) {
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidGpu::discover_single(amdcuid_gpu_info *gpu_info,
-                                          const std::string &device_path,
-                                          cuid::gim::GimClient *gim_client) {
-
+amdcuid_status_t CuidGpu::discover_single(amdcuid_gpu_info* gpu_info,
+                                          const std::string& device_path,
+                                          cuid::gim::GimClient* gim_client) {
   amdcuid_gpu_info info = {};
   std::string bdf = CuidUtilities::readlink_bdf(device_path);
 
@@ -197,8 +200,7 @@ amdcuid_status_t CuidGpu::discover_single(amdcuid_gpu_info *gpu_info,
   // where unit_id is 0 (bare metal or passthrough). If config file is missing,
   // that indicates partition which is unsupported for CUID generation.
   std::string config_file = device_path + "/config";
-  if (access(config_file.c_str(), F_OK) == -1 &&
-      info.header.fields.gpu.unit_id == 0) {
+  if (access(config_file.c_str(), F_OK) == -1 && info.header.fields.gpu.unit_id == 0) {
     return AMDCUID_STATUS_UNSUPPORTED;
   }
 
@@ -207,15 +209,11 @@ amdcuid_status_t CuidGpu::discover_single(amdcuid_gpu_info *gpu_info,
     // if file read fails, attempt to get from pci config
     uint8_t vendor_id_bytes[2] = {0};
     const uint16_t offset = 0x0;
-    amdcuid_status_t status =
-        PciUtil::read_pci_config_space(bdf, vendor_id_bytes, 2, offset);
-    uint16_t vendor_id_int =
-        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t *>(vendor_id_bytes));
-    info.header.fields.gpu.vendor_id =
-        (status == AMDCUID_STATUS_SUCCESS) ? vendor_id_int : 0;
+    amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, vendor_id_bytes, 2, offset);
+    uint16_t vendor_id_int = PciUtil::load_le16(vendor_id_bytes);
+    info.header.fields.gpu.vendor_id = (status == AMDCUID_STATUS_SUCCESS) ? vendor_id_int : 0;
   } else {
-    info.header.fields.gpu.vendor_id =
-        (uint16_t)strtol(vendor.c_str(), nullptr, 16);
+    info.header.fields.gpu.vendor_id = (uint16_t)strtol(vendor.c_str(), nullptr, 16);
   }
 
   std::string device = CuidUtilities::read_sysfs_file(device_path + "/device");
@@ -223,28 +221,21 @@ amdcuid_status_t CuidGpu::discover_single(amdcuid_gpu_info *gpu_info,
     // if file read fails, attempt to get from pci config
     uint8_t device_id_bytes[2] = {0};
     const uint16_t offset = 0x2;
-    amdcuid_status_t status =
-        PciUtil::read_pci_config_space(bdf, device_id_bytes, 2, offset);
-    uint16_t device_id_int =
-        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t *>(device_id_bytes));
-    info.header.fields.gpu.device_id =
-        (status == AMDCUID_STATUS_SUCCESS) ? device_id_int : 0;
+    amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, device_id_bytes, 2, offset);
+    uint16_t device_id_int = PciUtil::load_le16(device_id_bytes);
+    info.header.fields.gpu.device_id = (status == AMDCUID_STATUS_SUCCESS) ? device_id_int : 0;
   } else {
-    info.header.fields.gpu.device_id =
-        (uint16_t)strtol(device.c_str(), nullptr, 16);
+    info.header.fields.gpu.device_id = (uint16_t)strtol(device.c_str(), nullptr, 16);
   }
 
-  std::string pci_class =
-      CuidUtilities::read_sysfs_file(device_path + "/class");
+  std::string pci_class = CuidUtilities::read_sysfs_file(device_path + "/class");
   uint16_t pci_class_integer = 0;
   if (pci_class.empty() && !bdf.empty()) {
     // if file read fails, attempt to get from pci config
     uint8_t class_id_bytes[2] = {0};
     const uint16_t offset = 0xa;
-    amdcuid_status_t status =
-        PciUtil::read_pci_config_space(bdf, class_id_bytes, 2, offset);
-    uint16_t class_id_int =
-        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t *>(class_id_bytes));
+    amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, class_id_bytes, 2, offset);
+    uint16_t class_id_int = PciUtil::load_le16(class_id_bytes);
     pci_class_integer = (status == AMDCUID_STATUS_SUCCESS) ? class_id_int : 0;
   } else {
     // sysfs class file returns 24-bit value (class:subclass:prog_if), shift
@@ -253,21 +244,18 @@ amdcuid_status_t CuidGpu::discover_single(amdcuid_gpu_info *gpu_info,
   }
   info.header.fields.gpu.pci_class = pci_class_integer;
 
-  std::string revision_id =
-      CuidUtilities::read_sysfs_file(device_path + "/revision");
+  std::string revision_id = CuidUtilities::read_sysfs_file(device_path + "/revision");
   if (revision_id.empty() && !bdf.empty()) {
     // if file read fails, attempt to get from pci config
-    uint8_t revision_id_bytes[2] = {0};
+    // RevisionID is the single byte at 0x08. The byte at 0x09 is prog-if and
+    // must not be folded in: revision_id is a uint8_t, so a two-byte load left
+    // prog-if in the low half and the revision was discarded by the narrowing.
+    uint8_t revision_id_byte = 0;
     const uint16_t offset = 0x8;
-    amdcuid_status_t status =
-        PciUtil::read_pci_config_space(bdf, revision_id_bytes, 2, offset);
-    uint16_t revision_id_int =
-        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t *>(revision_id_bytes));
-    info.header.fields.gpu.revision_id =
-        (status == AMDCUID_STATUS_SUCCESS) ? revision_id_int : 0;
+    amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, &revision_id_byte, 1, offset);
+    info.header.fields.gpu.revision_id = (status == AMDCUID_STATUS_SUCCESS) ? revision_id_byte : 0;
   } else {
-    info.header.fields.gpu.revision_id =
-        (uint16_t)strtol(revision_id.c_str(), nullptr, 16);
+    info.header.fields.gpu.revision_id = (uint16_t)strtol(revision_id.c_str(), nullptr, 16);
   }
 
   // Determine the device node path. We prefer the renderD node for backward
@@ -289,19 +277,15 @@ amdcuid_status_t CuidGpu::discover_single(amdcuid_gpu_info *gpu_info,
   const bool needs_gim_fallback = !info.bdf.empty() && gim_client != nullptr;
   if (needs_gim_fallback) {
     cuid::gim::GimAsicInfo asic;
-    if (gim_client->get_asic_info_for_bdf(info.bdf, asic) ==
-        AMDCUID_STATUS_SUCCESS) {
+    if (gim_client->get_asic_info_for_bdf(info.bdf, asic) == AMDCUID_STATUS_SUCCESS) {
       if (info.header.fields.gpu.vendor_id == 0) {
-        info.header.fields.gpu.vendor_id =
-            static_cast<uint16_t>(asic.vendor_id);
+        info.header.fields.gpu.vendor_id = static_cast<uint16_t>(asic.vendor_id);
       }
       if (info.header.fields.gpu.device_id == 0) {
-        info.header.fields.gpu.device_id =
-            static_cast<uint16_t>(asic.device_id);
+        info.header.fields.gpu.device_id = static_cast<uint16_t>(asic.device_id);
       }
       if (info.header.fields.gpu.revision_id == 0) {
-        info.header.fields.gpu.revision_id =
-            static_cast<uint8_t>(asic.rev_id);
+        info.header.fields.gpu.revision_id = static_cast<uint8_t>(asic.rev_id);
       }
       // GIM ASIC info omits pci_class; default to the PCI display-controller
       // class so GIM-only GPUs do not report an all-zero class.
@@ -311,8 +295,7 @@ amdcuid_status_t CuidGpu::discover_single(amdcuid_gpu_info *gpu_info,
       // GIM-only devices expose no sysfs unique_id or PCI config space, so
       // carry the ASIC serial as the hardware fingerprint source.
       uint64_t parsed_serial = 0;
-      if (cuid::gim::GimClient::parse_asic_serial(asic.asic_serial,
-                                                  parsed_serial)) {
+      if (cuid::gim::GimClient::parse_asic_serial(asic.asic_serial, parsed_serial)) {
         info.gim_fingerprint = parsed_serial;
         info.gim_fingerprint_valid = true;
       }
@@ -324,27 +307,24 @@ amdcuid_status_t CuidGpu::discover_single(amdcuid_gpu_info *gpu_info,
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t
-CuidGpu::get_hardware_fingerprint(uint64_t &fingerprint) const {
+amdcuid_status_t CuidGpu::get_hardware_fingerprint(uint64_t& fingerprint) const {
   if (geteuid() != 0) {
     return AMDCUID_STATUS_PERMISSION_DENIED;
   }
 
   // For DRM render nodes the PCI attributes live at "<render_node>/device";
   // for GIM-only PCI directories they live directly under render_node.
-  const bool render_node_is_pci_dir =
-      m_info.render_node.find("/sys/bus/pci/devices/") == 0;
+  const bool render_node_is_pci_dir = m_info.render_node.find("/sys/bus/pci/devices/") == 0;
 
   // GIM-only devices have no sysfs unique_id or PCI config space; use the
   // ASIC serial captured during discovery as the fingerprint.
   if (render_node_is_pci_dir && m_info.gim_fingerprint_valid) {
     fingerprint = m_info.gim_fingerprint;
-    return AMDCUID_STATUS_SUCCESS;
+    return CuidUtilities::validate_fingerprint(fingerprint);
   }
 
   const std::string device_attr_prefix =
-      render_node_is_pci_dir ? m_info.render_node
-                             : (m_info.render_node + "/device");
+      render_node_is_pci_dir ? m_info.render_node : (m_info.render_node + "/device");
 
   std::string unique_id_path = device_attr_prefix + "/unique_id";
 
@@ -374,8 +354,7 @@ CuidGpu::get_hardware_fingerprint(uint64_t &fingerprint) const {
   } else if (m_info.header.fields.gpu.unit_id == 0) {
     // attempt to get fingerprint through PCI Config Space if not a VF
     uint16_t offset = 0;
-    amdcuid_status_t status =
-        PciUtil::get_pci_dsn_cap_offset(m_info.bdf, offset);
+    amdcuid_status_t status = PciUtil::get_pci_dsn_cap_offset(m_info.bdf, offset);
     if (status != AMDCUID_STATUS_SUCCESS) {
       // attempt to get fingerprint through VSEC fallback if DSN capability is
       // not found
@@ -388,16 +367,15 @@ CuidGpu::get_hardware_fingerprint(uint64_t &fingerprint) const {
 
     const uint8_t fingerprint_size = 8;
     uint8_t fingerprint_bytes[fingerprint_size] = {0};
-    status = PciUtil::read_pci_config_space(m_info.bdf, fingerprint_bytes,
-                                            fingerprint_size, offset);
+    status =
+        PciUtil::read_pci_config_space(m_info.bdf, fingerprint_bytes, fingerprint_size, offset);
     if (status != AMDCUID_STATUS_SUCCESS) {
       fingerprint = 0;
       return status;
     }
     // pcie config file is little endian, so need to convert to big endian
     uint64_t fingerprint_value = 0;
-    std::memcpy(&fingerprint_value, fingerprint_bytes,
-                sizeof(fingerprint_value));
+    std::memcpy(&fingerprint_value, fingerprint_bytes, sizeof(fingerprint_value));
     fingerprint = PciUtil::le64_to_be64(fingerprint_value);
   } else {
     // partitioned device without unique_id file or pci config cannot get
@@ -405,10 +383,10 @@ CuidGpu::get_hardware_fingerprint(uint64_t &fingerprint) const {
     fingerprint = 0;
     return AMDCUID_STATUS_UNSUPPORTED;
   }
-  return AMDCUID_STATUS_SUCCESS;
+  return CuidUtilities::validate_fingerprint(fingerprint);
 }
 
-amdcuid_status_t CuidGpu::get_primary_cuid(amdcuid_primary_id &id) const {
+amdcuid_status_t CuidGpu::get_primary_cuid(amdcuid_primary_id& id) const {
   amdcuid_status_t status = AMDCUID_STATUS_SUCCESS;
   uint64_t fingerprint = 0;
   bool temp = false;
@@ -445,44 +423,43 @@ amdcuid_status_t CuidGpu::get_primary_cuid(amdcuid_primary_id &id) const {
 
   // Use header fields for the rest
   amdcuid_primary_id result = {};
-  const auto &h = m_info.header;
+  const auto& h = m_info.header;
   CuidUtilities::generate_primary_cuid(
-      fingerprint, h.fields.gpu.unit_id, h.fields.gpu.revision_id,
-      h.fields.gpu.device_id, h.fields.gpu.vendor_id,
-      static_cast<uint8_t>(AMDCUID_DEVICE_TYPE_GPU), &result, temp);
+      fingerprint, h.fields.gpu.unit_id, h.fields.gpu.revision_id, h.fields.gpu.device_id,
+      h.fields.gpu.vendor_id, static_cast<uint8_t>(AMDCUID_DEVICE_TYPE_GPU), &result, temp);
 
   id = result;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-const amdcuid_gpu_info &CuidGpu::get_info() const { return m_info; }
+const amdcuid_gpu_info& CuidGpu::get_info() const { return m_info; }
 
-amdcuid_status_t CuidGpu::get_vendor_id(uint16_t &vendor_id) const {
+amdcuid_status_t CuidGpu::get_vendor_id(uint16_t& vendor_id) const {
   vendor_id = m_info.header.fields.gpu.vendor_id;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidGpu::get_device_id(uint16_t &device_id) const {
+amdcuid_status_t CuidGpu::get_device_id(uint16_t& device_id) const {
   device_id = m_info.header.fields.gpu.device_id;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidGpu::get_pci_class(uint16_t &pci_class) const {
+amdcuid_status_t CuidGpu::get_pci_class(uint16_t& pci_class) const {
   pci_class = m_info.header.fields.gpu.pci_class;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidGpu::get_revision_id(uint8_t &revision_id) const {
+amdcuid_status_t CuidGpu::get_revision_id(uint8_t& revision_id) const {
   revision_id = m_info.header.fields.gpu.revision_id;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidGpu::get_unit_id(uint16_t &unit_id) const {
+amdcuid_status_t CuidGpu::get_unit_id(uint16_t& unit_id) const {
   unit_id = m_info.header.fields.gpu.unit_id;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidGpu::get_bdf(std::string &bdf) const {
+amdcuid_status_t CuidGpu::get_bdf(std::string& bdf) const {
   if (m_info.bdf.empty()) {
     return AMDCUID_STATUS_UNSUPPORTED;
   }
@@ -490,7 +467,7 @@ amdcuid_status_t CuidGpu::get_bdf(std::string &bdf) const {
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidGpu::get_device_path(std::string &path) const {
+amdcuid_status_t CuidGpu::get_device_path(std::string& path) const {
   if (m_info.render_node.empty()) {
     return AMDCUID_STATUS_UNSUPPORTED;
   }

--- a/projects/cuid/lib/src/cuid_gpu.h
+++ b/projects/cuid/lib/src/cuid_gpu.h
@@ -23,18 +23,19 @@
 #ifndef CUID_GPU_H
 #define CUID_GPU_H
 
-#include "include/amd_cuid.h"
-#include "src/cuid_device.h"
-#include "src/cuid_internal.h"
 #include <memory>
 #include <string>
 #include <vector>
 
+#include "include/amd_cuid.h"
+#include "src/cuid_device.h"
+#include "src/cuid_internal.h"
+
 namespace cuid {
 namespace gim {
 class GimClient;
-} // namespace gim
-} // namespace cuid
+}  // namespace gim
+}  // namespace cuid
 
 struct amdcuid_gpu_info {
   amdcuid_cuid_public_fields header;
@@ -49,45 +50,42 @@ struct amdcuid_gpu_info {
 };
 
 class CuidGpu : public CuidDevice {
-public:
-  CuidGpu(const amdcuid_gpu_info &i);
-  amdcuid_device_type_t type() const override {
-    return AMDCUID_DEVICE_TYPE_GPU;
-  }
-  amdcuid_status_t get_primary_cuid(amdcuid_primary_id &id) const override;
-  amdcuid_status_t
-  get_hardware_fingerprint(uint64_t &fingerprint) const override;
-  static amdcuid_status_t discover(std::vector<DevicePtr> &gpus);
+ public:
+  CuidGpu(const amdcuid_gpu_info& i);
+  amdcuid_device_type_t type() const override { return AMDCUID_DEVICE_TYPE_GPU; }
+  amdcuid_status_t get_primary_cuid(amdcuid_primary_id& id) const override;
+  amdcuid_status_t get_hardware_fingerprint(uint64_t& fingerprint) const override;
+  static amdcuid_status_t discover(std::vector<DevicePtr>& gpus);
   // discover_single populates `gpu_info` from `device_path`. When the host
   // runs the GIM SR-IOV driver, sysfs/PCI config space may not expose the
   // device, in which case the caller can pass an already-initialized
   // GimClient via `gim_client` to be used as a fallback. Passing nullptr
   // disables the GIM fallback for that call (used by code paths that have
   // no GimClient handy, e.g. amdcuid_get_handle_by_dev_path).
-  static amdcuid_status_t
-  discover_single(amdcuid_gpu_info *gpu_info, const std::string &device_path,
-                  cuid::gim::GimClient *gim_client = nullptr);
+  static amdcuid_status_t discover_single(amdcuid_gpu_info* gpu_info,
+                                          const std::string& device_path,
+                                          cuid::gim::GimClient* gim_client = nullptr);
 
   // Derive the render_node from an enumeration `device_path`. Strips a
   // trailing "/device" (as passed by /sys/class/drm enumeration) and, for
   // card paths, resolves the associated renderD node when one exists. Paths
   // that are neither (e.g. the GIM "/sys/bus/pci/devices/<bdf>" form) are
   // returned verbatim. Exposed for testing.
-  static std::string normalize_render_node(const std::string &device_path);
+  static std::string normalize_render_node(const std::string& device_path);
 
   // Virtual accessor overrides
-  amdcuid_status_t get_vendor_id(uint16_t &vendor_id) const override;
-  amdcuid_status_t get_device_id(uint16_t &device_id) const override;
-  amdcuid_status_t get_pci_class(uint16_t &pci_class) const override;
-  amdcuid_status_t get_revision_id(uint8_t &revision_id) const override;
-  amdcuid_status_t get_unit_id(uint16_t &unit_id) const override;
-  amdcuid_status_t get_bdf(std::string &bdf) const override;
-  amdcuid_status_t get_device_path(std::string &path) const override;
+  amdcuid_status_t get_vendor_id(uint16_t& vendor_id) const override;
+  amdcuid_status_t get_device_id(uint16_t& device_id) const override;
+  amdcuid_status_t get_pci_class(uint16_t& pci_class) const override;
+  amdcuid_status_t get_revision_id(uint8_t& revision_id) const override;
+  amdcuid_status_t get_unit_id(uint16_t& unit_id) const override;
+  amdcuid_status_t get_bdf(std::string& bdf) const override;
+  amdcuid_status_t get_device_path(std::string& path) const override;
 
-  const amdcuid_gpu_info &get_info() const;
+  const amdcuid_gpu_info& get_info() const;
 
-private:
+ private:
   amdcuid_gpu_info m_info;
 };
 
-#endif // CUID_GPU_H
+#endif  // CUID_GPU_H

--- a/projects/cuid/lib/src/cuid_internal.h
+++ b/projects/cuid/lib/src/cuid_internal.h
@@ -4,64 +4,67 @@
 #define LIB_CUID_INTERNAL_H_
 
 #include <cstdint>
+
 #include "include/amd_cuid.h"
 
 typedef struct {
-    uint16_t vendor_id;      ///< CPU Vendor ID (from CPUID EAX=0)
-    uint16_t family;         ///< CPU Family (from CPUID EAX=1)
-    uint16_t model;          ///< CPU Model (from CPUID EAX=1)
-    uint16_t device_id;      ///< DeviceID = Family & Model combined
-    uint8_t revision_id;     ///< CPU Stepping/RevisionID (from CPUID EAX=1)
-    uint16_t unit_id;        ///< UnitID from APIC ID (from ACPI MADT)
-    uint16_t core;           ///< Core number within package
-    uint16_t physical_id;    ///< Physical package/socket ID
+  uint16_t vendor_id;    ///< CPU Vendor ID (from CPUID EAX=0)
+  uint16_t family;       ///< CPU Family (from CPUID EAX=1)
+  uint16_t model;        ///< CPU Model (from CPUID EAX=1)
+  uint16_t device_id;    ///< DeviceID = Family & Model combined
+  uint8_t revision_id;   ///< CPU Stepping/RevisionID (from CPUID EAX=1)
+  uint16_t unit_id;      ///< UnitID from APIC ID (from ACPI MADT)
+  uint16_t core;         ///< Core number within package
+  uint16_t physical_id;  ///< Physical package/socket ID
 } amdcuid_cuid_public_fields_cpu;
 
 typedef struct {
-    uint16_t vendor_id;
-    uint16_t device_id;
-    uint16_t pci_class;
-    uint8_t revision_id;
-    uint16_t unit_id;
+  uint16_t vendor_id;
+  uint16_t device_id;
+  uint16_t pci_class;
+  uint8_t revision_id;
+  uint16_t unit_id;
 } amdcuid_cuid_public_fields_gpu;
 
 typedef struct {
-    uint16_t vendor_id;
-    uint16_t device_id;
-    uint16_t pci_class;
-    uint8_t revision_id;
+  uint16_t vendor_id;
+  uint16_t device_id;
+  uint16_t pci_class;
+  uint8_t revision_id;
 } amdcuid_cuid_public_fields_nic;
 
 typedef struct {
-    uint16_t vendor_id;
+  uint16_t vendor_id;
 } amdcuid_cuid_public_fields_platform;
 
 typedef struct {
-    uint16_t vendor_id;
-    uint16_t device_id;
-    uint16_t pci_class;
-    uint8_t revision_id;
+  uint16_t vendor_id;
+  uint16_t device_id;
+  uint16_t pci_class;
+  uint8_t revision_id;
 } amdcuid_cuid_public_fields_npu;
 
 typedef struct amdcuid_cuid_public_fields {
-    amdcuid_device_type_t device_type;
-    union {
-        amdcuid_cuid_public_fields_cpu cpu;
-        amdcuid_cuid_public_fields_gpu gpu;
-        amdcuid_cuid_public_fields_nic nic;
-        amdcuid_cuid_public_fields_platform platform;
-        amdcuid_cuid_public_fields_npu npu;
-    } fields;
+  amdcuid_device_type_t device_type;
+  union {
+    amdcuid_cuid_public_fields_cpu cpu;
+    amdcuid_cuid_public_fields_gpu gpu;
+    amdcuid_cuid_public_fields_nic nic;
+    amdcuid_cuid_public_fields_platform platform;
+    amdcuid_cuid_public_fields_npu npu;
+  } fields;
 } amdcuid_cuid_public_fields;
 
 typedef struct amdcuid_primary_id {
-    uint8_t raw_bits[16];               // 122 bits of raw data
-    amdcuid_id_t UUIDv8_representation; // UUIDv8 representation of the primary CUID which adds in the UUIDv8 required bits
+  uint8_t raw_bits[16];                // 122 bits of raw data
+  amdcuid_id_t UUIDv8_representation;  // UUIDv8 representation of the primary CUID which adds in
+                                       // the UUIDv8 required bits
 } amdcuid_primary_id;
 
 typedef struct amdcuid_derived_id {
-    uint8_t hash[14];                   // 110 LSB bits of HMAC hash
-    uint8_t raw_bits[16];               // 122 bits which adds back the unit id bits
-    amdcuid_id_t UUIDv8_representation; // UUIDv8 representation of the derived CUID which adds in the UUIDv8 required bits
+  uint8_t hash[14];                    // 110 LSB bits of HMAC hash
+  uint8_t raw_bits[16];                // 122 bits which adds back the unit id bits
+  amdcuid_id_t UUIDv8_representation;  // UUIDv8 representation of the derived CUID which adds in
+                                       // the UUIDv8 required bits
 } amdcuid_derived_id;
-#endif // LIB_CUID_INTERNAL_H_
+#endif  // LIB_CUID_INTERNAL_H_

--- a/projects/cuid/lib/src/cuid_nic.cc
+++ b/projects/cuid/lib/src/cuid_nic.cc
@@ -21,37 +21,41 @@
  */
 
 #include "cuid_nic.h"
-#include "cuid_file.h"
-#include "cuid_util.h"
-#include "pci_util.h"
-#include <cstring>
+
 #include <dirent.h>
-#include <fstream>
-#include <iostream>
 #include <linux/ethtool.h>
 #include <linux/sockios.h>
 #include <net/if.h>
-#include <sstream>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
 
-CuidNic::CuidNic(const amdcuid_nic_info &i) : m_info(i) {}
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <sstream>
 
-amdcuid_status_t CuidNic::discover(std::vector<DevicePtr> &nics) {
+#include "cuid_file.h"
+#include "cuid_util.h"
+#include "pci_util.h"
+
+CuidNic::CuidNic(const amdcuid_nic_info& i) : m_info(i) {}
+
+amdcuid_status_t CuidNic::discover(std::vector<DevicePtr>& nics) {
   std::string nic_base_path = "/sys/class/net";
-  DIR *dir = opendir(nic_base_path.c_str());
-  if (!dir)
-    return AMDCUID_STATUS_DEVICE_NOT_FOUND;
+  DIR* dir = opendir(nic_base_path.c_str());
+  if (!dir) return AMDCUID_STATUS_DEVICE_NOT_FOUND;
 
-  struct dirent *entry;
+  struct dirent* entry;
+  // This call site owns its DIR*, which is all POSIX requires for readdir to be
+  // safe; readdir_r is deprecated and must not be adopted.
+  // NOLINTNEXTLINE(concurrency-mt-unsafe)
   while ((entry = readdir(dir)) != NULL) {
     // grab everything except the loopback device and hidden entries
     if (strncmp(entry->d_name, "lo", 2) != 0 && entry->d_name[0] != '.') {
       amdcuid_nic_info info = {};
-      std::string device_path =
-          std::string(nic_base_path) + "/" + entry->d_name + "/device";
+      std::string device_path = std::string(nic_base_path) + "/" + entry->d_name + "/device";
       // filter out virtual devices by checking device symlink
       if (CuidUtilities::readlink_bdf(device_path).empty()) {
         continue;
@@ -62,14 +66,13 @@ amdcuid_status_t CuidNic::discover(std::vector<DevicePtr> &nics) {
     }
   }
   closedir(dir);
-  if (nics.size() == 0)
-    return AMDCUID_STATUS_DEVICE_NOT_FOUND;
+  if (nics.size() == 0) return AMDCUID_STATUS_DEVICE_NOT_FOUND;
 
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidNic::discover_single(amdcuid_nic_info *nic_info,
-                                          const std::string &device_path) {
+amdcuid_status_t CuidNic::discover_single(amdcuid_nic_info* nic_info,
+                                          const std::string& device_path) {
   amdcuid_nic_info info = {};
   info.header.device_type = AMDCUID_DEVICE_TYPE_NIC;
 
@@ -80,15 +83,11 @@ amdcuid_status_t CuidNic::discover_single(amdcuid_nic_info *nic_info,
     // if file read fails, attempt to get from pci config
     uint8_t vendor_id_bytes[2] = {0};
     const uint16_t offset = 0x0;
-    amdcuid_status_t status =
-        PciUtil::read_pci_config_space(bdf, vendor_id_bytes, 2, offset);
-    uint16_t vendor_id_int =
-        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t *>(vendor_id_bytes));
-    info.header.fields.nic.vendor_id =
-        (status == AMDCUID_STATUS_SUCCESS) ? vendor_id_int : 0;
+    amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, vendor_id_bytes, 2, offset);
+    uint16_t vendor_id_int = PciUtil::load_le16(vendor_id_bytes);
+    info.header.fields.nic.vendor_id = (status == AMDCUID_STATUS_SUCCESS) ? vendor_id_int : 0;
   } else {
-    info.header.fields.nic.vendor_id =
-        (uint16_t)strtol(vendor.c_str(), nullptr, 16);
+    info.header.fields.nic.vendor_id = (uint16_t)strtol(vendor.c_str(), nullptr, 16);
   }
 
   std::string device = CuidUtilities::read_sysfs_file(device_path + "/device");
@@ -96,28 +95,21 @@ amdcuid_status_t CuidNic::discover_single(amdcuid_nic_info *nic_info,
     // if file read fails, attempt to get from pci config
     uint8_t device_id_bytes[2] = {0};
     const uint16_t offset = 0x2;
-    amdcuid_status_t status =
-        PciUtil::read_pci_config_space(bdf, device_id_bytes, 2, offset);
-    uint16_t device_id_int =
-        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t *>(device_id_bytes));
-    info.header.fields.nic.device_id =
-        (status == AMDCUID_STATUS_SUCCESS) ? device_id_int : 0;
+    amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, device_id_bytes, 2, offset);
+    uint16_t device_id_int = PciUtil::load_le16(device_id_bytes);
+    info.header.fields.nic.device_id = (status == AMDCUID_STATUS_SUCCESS) ? device_id_int : 0;
   } else {
-    info.header.fields.nic.device_id =
-        (uint16_t)strtol(device.c_str(), nullptr, 16);
+    info.header.fields.nic.device_id = (uint16_t)strtol(device.c_str(), nullptr, 16);
   }
 
-  std::string pci_class =
-      CuidUtilities::read_sysfs_file(device_path + "/class");
+  std::string pci_class = CuidUtilities::read_sysfs_file(device_path + "/class");
   uint16_t pci_class_integer = 0;
   if (pci_class.empty() && !bdf.empty()) {
     // if file read fails, attempt to get from pci config
     uint8_t class_id_bytes[2] = {0};
     const uint16_t offset = 0xa;
-    amdcuid_status_t status =
-        PciUtil::read_pci_config_space(bdf, class_id_bytes, 2, offset);
-    uint16_t class_id_int =
-        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t *>(class_id_bytes));
+    amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, class_id_bytes, 2, offset);
+    uint16_t class_id_int = PciUtil::load_le16(class_id_bytes);
     pci_class_integer = (status == AMDCUID_STATUS_SUCCESS) ? class_id_int : 0;
   } else {
     // sysfs class file returns 24-bit value (class:subclass:prog_if), shift
@@ -126,21 +118,18 @@ amdcuid_status_t CuidNic::discover_single(amdcuid_nic_info *nic_info,
   }
   info.header.fields.nic.pci_class = pci_class_integer;
 
-  std::string revision_id =
-      CuidUtilities::read_sysfs_file(device_path + "/revision");
+  std::string revision_id = CuidUtilities::read_sysfs_file(device_path + "/revision");
   if (revision_id.empty() && !bdf.empty()) {
     // if file read fails, attempt to get from pci config
-    uint8_t revision_id_bytes[2] = {0};
+    // RevisionID is the single byte at 0x08. The byte at 0x09 is prog-if and
+    // must not be folded in: revision_id is a uint8_t, so a two-byte load left
+    // prog-if in the low half and the revision was discarded by the narrowing.
+    uint8_t revision_id_byte = 0;
     const uint16_t offset = 0x8;
-    amdcuid_status_t status =
-        PciUtil::read_pci_config_space(bdf, revision_id_bytes, 2, offset);
-    uint16_t revision_id_int =
-        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t *>(revision_id_bytes));
-    info.header.fields.nic.revision_id =
-        (status == AMDCUID_STATUS_SUCCESS) ? revision_id_int : 0;
+    amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, &revision_id_byte, 1, offset);
+    info.header.fields.nic.revision_id = (status == AMDCUID_STATUS_SUCCESS) ? revision_id_byte : 0;
   } else {
-    info.header.fields.nic.revision_id =
-        (uint16_t)strtol(revision_id.c_str(), nullptr, 16);
+    info.header.fields.nic.revision_id = (uint16_t)strtol(revision_id.c_str(), nullptr, 16);
   }
   info.bdf = bdf;
   std::string full_device_node;
@@ -156,8 +145,7 @@ amdcuid_status_t CuidNic::discover_single(amdcuid_nic_info *nic_info,
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t
-CuidNic::get_hardware_fingerprint(uint64_t &fingerprint) const {
+amdcuid_status_t CuidNic::get_hardware_fingerprint(uint64_t& fingerprint) const {
   if (geteuid() != 0) {
     return AMDCUID_STATUS_PERMISSION_DENIED;
   }
@@ -172,14 +160,18 @@ CuidNic::get_hardware_fingerprint(uint64_t &fingerprint) const {
   if (status == AMDCUID_STATUS_SUCCESS) {
     const uint8_t fingerprint_size = 8;
     uint8_t fingerprint_bytes[fingerprint_size] = {0};
-    status = PciUtil::read_pci_config_space(m_info.bdf, fingerprint_bytes,
-                                            fingerprint_size, offset);
+    status =
+        PciUtil::read_pci_config_space(m_info.bdf, fingerprint_bytes, fingerprint_size, offset);
     if (status == AMDCUID_STATUS_SUCCESS) {
       uint64_t fingerprint_value = 0;
-      std::memcpy(&fingerprint_value, fingerprint_bytes,
-                  sizeof(fingerprint_bytes));
+      std::memcpy(&fingerprint_value, fingerprint_bytes, sizeof(fingerprint_bytes));
       fingerprint = PciUtil::le64_to_be64(fingerprint_value);
-      return AMDCUID_STATUS_SUCCESS;
+      if (CuidUtilities::validate_fingerprint(fingerprint) == AMDCUID_STATUS_SUCCESS) {
+        return AMDCUID_STATUS_SUCCESS;
+      }
+      // An all-zero DSN means the capability is present but unprogrammed. Fall
+      // through and try the MAC address instead of claiming identity zero.
+      fingerprint = 0;
     }
   }
   // TODO: serial ID could be found in FRU_ID so should attempt to look there
@@ -193,19 +185,30 @@ CuidNic::get_hardware_fingerprint(uint64_t &fingerprint) const {
   if (!mac_address.empty()) {
     // convert MAC address string to bytes
     uint8_t mac_bytes[6] = {0};
-    sscanf(mac_address.c_str(), "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx", &mac_bytes[0],
-           &mac_bytes[1], &mac_bytes[2], &mac_bytes[3], &mac_bytes[4],
-           &mac_bytes[5]);
+    // An unchecked sscanf leaves mac_bytes partly or wholly zero on a
+    // malformed address, and the caller would then derive a CUID from that
+    // silently. All six octets must convert.
+    // cert-err34-c wants strtoul; the concern it encodes is a conversion that
+    // fails silently, which the count check below rules out.
+    // NOLINTNEXTLINE(cert-err34-c)
+    const int converted = sscanf(  // NOLINT(cert-err34-c)
+        mac_address.c_str(), "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx", &mac_bytes[0], &mac_bytes[1],
+        &mac_bytes[2], &mac_bytes[3], &mac_bytes[4], &mac_bytes[5]);
+    if (converted != 6) {
+      fingerprint = 0;
+      return AMDCUID_STATUS_INVALID_FORMAT;
+    }
     uint64_t mac_fingerprint = 0;
     std::memcpy(&mac_fingerprint, mac_bytes, sizeof(mac_bytes));
     fingerprint = mac_fingerprint;
-    return AMDCUID_STATUS_SUCCESS;
+    // An all-zero MAC is an unconfigured interface, not an identity.
+    return CuidUtilities::validate_fingerprint(fingerprint);
   }
 
   return AMDCUID_STATUS_HW_FINGERPRINT_NOT_FOUND;
 }
 
-amdcuid_status_t CuidNic::get_primary_cuid(amdcuid_primary_id &id) const {
+amdcuid_status_t CuidNic::get_primary_cuid(amdcuid_primary_id& id) const {
   bool temp = false;
   uint64_t fingerprint = 0;
   amdcuid_status_t status = AMDCUID_STATUS_SUCCESS;
@@ -242,9 +245,8 @@ amdcuid_status_t CuidNic::get_primary_cuid(amdcuid_primary_id &id) const {
   }
 
   status = CuidUtilities::generate_primary_cuid(
-      fingerprint, 0, m_info.header.fields.nic.revision_id,
-      m_info.header.fields.nic.device_id, m_info.header.fields.nic.vendor_id,
-      static_cast<uint8_t>(AMDCUID_DEVICE_TYPE_NIC), &id, temp);
+      fingerprint, 0, m_info.header.fields.nic.revision_id, m_info.header.fields.nic.device_id,
+      m_info.header.fields.nic.vendor_id, static_cast<uint8_t>(AMDCUID_DEVICE_TYPE_NIC), &id, temp);
   if (status != AMDCUID_STATUS_SUCCESS) {
     std::memset(&id, 0, sizeof(id));
     return status;
@@ -253,29 +255,29 @@ amdcuid_status_t CuidNic::get_primary_cuid(amdcuid_primary_id &id) const {
   return status;
 }
 
-const amdcuid_nic_info &CuidNic::get_info() const { return m_info; }
+const amdcuid_nic_info& CuidNic::get_info() const { return m_info; }
 
-amdcuid_status_t CuidNic::get_vendor_id(uint16_t &vendor_id) const {
+amdcuid_status_t CuidNic::get_vendor_id(uint16_t& vendor_id) const {
   vendor_id = m_info.header.fields.nic.vendor_id;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidNic::get_device_id(uint16_t &device_id) const {
+amdcuid_status_t CuidNic::get_device_id(uint16_t& device_id) const {
   device_id = m_info.header.fields.nic.device_id;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidNic::get_pci_class(uint16_t &pci_class) const {
+amdcuid_status_t CuidNic::get_pci_class(uint16_t& pci_class) const {
   pci_class = m_info.header.fields.nic.pci_class;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidNic::get_revision_id(uint8_t &revision_id) const {
+amdcuid_status_t CuidNic::get_revision_id(uint8_t& revision_id) const {
   revision_id = m_info.header.fields.nic.revision_id;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidNic::get_bdf(std::string &bdf) const {
+amdcuid_status_t CuidNic::get_bdf(std::string& bdf) const {
   if (m_info.bdf.empty()) {
     return AMDCUID_STATUS_UNSUPPORTED;
   }
@@ -283,7 +285,7 @@ amdcuid_status_t CuidNic::get_bdf(std::string &bdf) const {
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidNic::get_device_path(std::string &path) const {
+amdcuid_status_t CuidNic::get_device_path(std::string& path) const {
   if (m_info.network_interface.empty()) {
     return AMDCUID_STATUS_UNSUPPORTED;
   }
@@ -291,43 +293,40 @@ amdcuid_status_t CuidNic::get_device_path(std::string &path) const {
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidNic::get_mac_address(std::string &mac_address) const {
+amdcuid_status_t CuidNic::get_mac_address(std::string& mac_address) const {
   // Extract interface name from the sysfs path (e.g. /sys/class/net/eth0 ->
   // eth0)
   std::string iface = m_info.network_interface;
   size_t last_slash = iface.rfind('/');
-  if (last_slash != std::string::npos)
-    iface = iface.substr(last_slash + 1);
+  if (last_slash != std::string::npos) iface = iface.substr(last_slash + 1);
 
-  if (iface.empty() || iface.size() >= IFNAMSIZ)
-    return AMDCUID_STATUS_UNSUPPORTED;
+  if (iface.empty() || iface.size() >= IFNAMSIZ) return AMDCUID_STATUS_UNSUPPORTED;
 
   int fd = socket(AF_INET, SOCK_DGRAM, 0);
-  if (fd < 0)
-    return AMDCUID_STATUS_UNSUPPORTED;
+  if (fd < 0) return AMDCUID_STATUS_UNSUPPORTED;
 
-  struct ethtool_perm_addr *epaddr =
-      reinterpret_cast<struct ethtool_perm_addr *>(
-          new uint8_t[sizeof(struct ethtool_perm_addr) + ETH_ALEN]);
+  struct ethtool_perm_addr* epaddr = reinterpret_cast<struct ethtool_perm_addr*>(
+      new uint8_t[sizeof(struct ethtool_perm_addr) + ETH_ALEN]);
   epaddr->cmd = ETHTOOL_GPERMADDR;
   epaddr->size = ETH_ALEN;
 
   struct ifreq ifr = {};
   strncpy(ifr.ifr_name, iface.c_str(), IFNAMSIZ - 1);
-  ifr.ifr_data = reinterpret_cast<char *>(epaddr);
+  ifr.ifr_data = reinterpret_cast<char*>(epaddr);
 
   if (ioctl(fd, SIOCETHTOOL, &ifr) < 0) {
     close(fd);
-    delete[] reinterpret_cast<uint8_t *>(epaddr);
+    delete[] reinterpret_cast<uint8_t*>(epaddr);
     return AMDCUID_STATUS_UNSUPPORTED;
   }
   close(fd);
 
+  // Six %02x plus five separators is exactly 17 characters plus the NUL.
   char buf[18];
-  snprintf(buf, sizeof(buf), "%02x:%02x:%02x:%02x:%02x:%02x", epaddr->data[0],
-           epaddr->data[1], epaddr->data[2], epaddr->data[3], epaddr->data[4],
-           epaddr->data[5]);
-  delete[] reinterpret_cast<uint8_t *>(epaddr);
+  // NOLINTNEXTLINE(cert-err33-c)
+  snprintf(buf, sizeof(buf), "%02x:%02x:%02x:%02x:%02x:%02x", epaddr->data[0], epaddr->data[1],
+           epaddr->data[2], epaddr->data[3], epaddr->data[4], epaddr->data[5]);
+  delete[] reinterpret_cast<uint8_t*>(epaddr);
 
   mac_address = buf;
   return AMDCUID_STATUS_SUCCESS;

--- a/projects/cuid/lib/src/cuid_nic.h
+++ b/projects/cuid/lib/src/cuid_nic.h
@@ -23,43 +23,45 @@
 #ifndef CUID_NIC_H
 #define CUID_NIC_H
 
-
-#include "src/cuid_device.h"
-#include "include/amd_cuid.h"
-#include "src/cuid_internal.h"
-#include <vector>
 #include <memory>
 #include <string>
+#include <vector>
+
+#include "include/amd_cuid.h"
+#include "src/cuid_device.h"
+#include "src/cuid_internal.h"
 
 struct amdcuid_nic_info {
-    amdcuid_cuid_public_fields header;
-    std::string bdf;
-    std::string network_interface;
+  amdcuid_cuid_public_fields header;
+  std::string bdf;
+  std::string network_interface;
 };
 
 class CuidNic : public CuidDevice {
-public:
-    CuidNic(const amdcuid_nic_info& i);
-    amdcuid_device_type_t type() const override { return AMDCUID_DEVICE_TYPE_NIC; }
-    amdcuid_status_t get_primary_cuid(amdcuid_primary_id& id) const override;
-    amdcuid_status_t get_hardware_fingerprint(uint64_t& fingerprint) const override;
-    static amdcuid_status_t discover(std::vector<DevicePtr> &nics);
-    static amdcuid_status_t discover_single(amdcuid_nic_info* nic_info, const std::string& device_path);
+ public:
+  CuidNic(const amdcuid_nic_info& i);
+  amdcuid_device_type_t type() const override { return AMDCUID_DEVICE_TYPE_NIC; }
+  amdcuid_status_t get_primary_cuid(amdcuid_primary_id& id) const override;
+  amdcuid_status_t get_hardware_fingerprint(uint64_t& fingerprint) const override;
+  static amdcuid_status_t discover(std::vector<DevicePtr>& nics);
+  static amdcuid_status_t discover_single(amdcuid_nic_info* nic_info,
+                                          const std::string& device_path);
 
-    // Virtual accessor overrides
-    amdcuid_status_t get_vendor_id(uint16_t& vendor_id) const override;
-    amdcuid_status_t get_device_id(uint16_t& device_id) const override;
-    amdcuid_status_t get_pci_class(uint16_t& pci_class) const override;
-    amdcuid_status_t get_revision_id(uint8_t& revision_id) const override;
-    amdcuid_status_t get_bdf(std::string& bdf) const override;
-    amdcuid_status_t get_device_path(std::string& path) const override;
+  // Virtual accessor overrides
+  amdcuid_status_t get_vendor_id(uint16_t& vendor_id) const override;
+  amdcuid_status_t get_device_id(uint16_t& device_id) const override;
+  amdcuid_status_t get_pci_class(uint16_t& pci_class) const override;
+  amdcuid_status_t get_revision_id(uint8_t& revision_id) const override;
+  amdcuid_status_t get_bdf(std::string& bdf) const override;
+  amdcuid_status_t get_device_path(std::string& path) const override;
 
-    // MAC address accessor
-    amdcuid_status_t get_mac_address(std::string& mac_address) const;
+  // MAC address accessor
+  amdcuid_status_t get_mac_address(std::string& mac_address) const;
 
-    const amdcuid_nic_info& get_info() const;
-private:
-    amdcuid_nic_info m_info;
+  const amdcuid_nic_info& get_info() const;
+
+ private:
+  amdcuid_nic_info m_info;
 };
 
-#endif // CUID_NIC_H
+#endif  // CUID_NIC_H

--- a/projects/cuid/lib/src/cuid_npu.cc
+++ b/projects/cuid/lib/src/cuid_npu.cc
@@ -21,16 +21,19 @@
  */
 
 #include "cuid_npu.h"
-#include "cuid_file.h"
-#include "cuid_util.h"
-#include "pci_util.h"
-#include <cstring>
+
 #include <dirent.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <cstring>
 #include <fstream>
 #include <iostream>
 #include <sstream>
-#include <sys/types.h>
-#include <unistd.h>
+
+#include "cuid_file.h"
+#include "cuid_util.h"
+#include "pci_util.h"
 
 // AMD vendor ID used to filter for AMD NPU devices
 static const uint16_t AMD_VENDOR_ID = 0x1022;
@@ -42,48 +45,42 @@ static const uint16_t PCI_CLASS_SIGNAL_PROCESSING = 0x1100;
 static const uint16_t PCI_CLASS_PROCESSING_ACCEL = 0x1200;
 static const uint16_t PCI_CLASS_BASE_MASK = 0xFF00;
 
-CuidNpu::CuidNpu(const amdcuid_npu_info &i) : m_info(i) {}
+CuidNpu::CuidNpu(const amdcuid_npu_info& i) : m_info(i) {}
 
 // Helper to check if a /sys/class/accel entry name is an accel device
 // (e.g., "accel0", "accel1").
-static bool is_accel_entry(const char *name) {
-  if (strncmp(name, "accel", 5) != 0 || !isdigit(name[5]))
-    return false;
+static bool is_accel_entry(const char* name) {
+  if (strncmp(name, "accel", 5) != 0 || !isdigit(name[5])) return false;
   for (size_t i = 5; name[i] != '\0'; ++i) {
-    if (!isdigit(name[i]))
-      return false;
+    if (!isdigit(name[i])) return false;
   }
   return true;
 }
 
 // Discover NPU devices via /sys/class/accel (when amdxdna driver is loaded)
-static amdcuid_status_t discover_via_accel(std::vector<DevicePtr> &npus) {
-  const char *accel_path = "/sys/class/accel";
-  DIR *dir = opendir(accel_path);
-  if (!dir)
-    return AMDCUID_STATUS_UNSUPPORTED;
+static amdcuid_status_t discover_via_accel(std::vector<DevicePtr>& npus) {
+  const char* accel_path = "/sys/class/accel";
+  DIR* dir = opendir(accel_path);
+  if (!dir) return AMDCUID_STATUS_UNSUPPORTED;
 
-  struct dirent *entry;
+  struct dirent* entry;
+  // This call site owns its DIR*, which is all POSIX requires for readdir to be
+  // safe; readdir_r is deprecated and must not be adopted.
+  // NOLINTNEXTLINE(concurrency-mt-unsafe)
   while ((entry = readdir(dir)) != NULL) {
     if (is_accel_entry(entry->d_name)) {
       std::string accel_name(entry->d_name);
-      std::string device_path =
-          std::string(accel_path) + "/" + accel_name + "/device";
+      std::string device_path = std::string(accel_path) + "/" + accel_name + "/device";
 
       // Read vendor to filter for AMD NPU devices only
-      std::string vendor_str =
-          CuidUtilities::read_sysfs_file(device_path + "/vendor");
-      if (vendor_str.empty())
-        continue;
-      uint16_t vendor_id =
-          static_cast<uint16_t>(strtol(vendor_str.c_str(), nullptr, 16));
-      if (vendor_id != AMD_VENDOR_ID)
-        continue;
+      std::string vendor_str = CuidUtilities::read_sysfs_file(device_path + "/vendor");
+      if (vendor_str.empty()) continue;
+      uint16_t vendor_id = static_cast<uint16_t>(strtol(vendor_str.c_str(), nullptr, 16));
+      if (vendor_id != AMD_VENDOR_ID) continue;
 
       amdcuid_npu_info info = {};
       amdcuid_status_t status = CuidNpu::discover_single(&info, device_path);
-      if (status != AMDCUID_STATUS_SUCCESS)
-        continue;
+      if (status != AMDCUID_STATUS_SUCCESS) continue;
 
       npus.emplace_back(std::make_shared<CuidNpu>(info));
     }
@@ -96,45 +93,37 @@ static amdcuid_status_t discover_via_accel(std::vector<DevicePtr> &npus) {
 // Fallback: discover NPU devices by scanning PCI bus for AMD processing
 // accelerator class devices. This handles systems where /sys/class/accel
 // is not populated (e.g., driver not loaded or accel subsystem absent).
-static amdcuid_status_t discover_via_pci_bus(std::vector<DevicePtr> &npus) {
-  const char *pci_path = "/sys/bus/pci/devices";
-  DIR *dir = opendir(pci_path);
-  if (!dir)
-    return AMDCUID_STATUS_UNSUPPORTED;
+static amdcuid_status_t discover_via_pci_bus(std::vector<DevicePtr>& npus) {
+  const char* pci_path = "/sys/bus/pci/devices";
+  DIR* dir = opendir(pci_path);
+  if (!dir) return AMDCUID_STATUS_UNSUPPORTED;
 
-  struct dirent *entry;
+  struct dirent* entry;
+  // This call site owns its DIR*, which is all POSIX requires for readdir to be
+  // safe; readdir_r is deprecated and must not be adopted.
+  // NOLINTNEXTLINE(concurrency-mt-unsafe)
   while ((entry = readdir(dir)) != NULL) {
-    if (entry->d_name[0] == '.')
-      continue;
+    if (entry->d_name[0] == '.') continue;
 
     std::string device_path = std::string(pci_path) + "/" + entry->d_name;
 
-    std::string vendor_str =
-        CuidUtilities::read_sysfs_file(device_path + "/vendor");
-    if (vendor_str.empty())
-      continue;
-    uint16_t vendor_id =
-        static_cast<uint16_t>(strtol(vendor_str.c_str(), nullptr, 16));
-    if (vendor_id != AMD_VENDOR_ID)
-      continue;
+    std::string vendor_str = CuidUtilities::read_sysfs_file(device_path + "/vendor");
+    if (vendor_str.empty()) continue;
+    uint16_t vendor_id = static_cast<uint16_t>(strtol(vendor_str.c_str(), nullptr, 16));
+    if (vendor_id != AMD_VENDOR_ID) continue;
 
-    std::string class_str =
-        CuidUtilities::read_sysfs_file(device_path + "/class");
-    if (class_str.empty())
-      continue;
+    std::string class_str = CuidUtilities::read_sysfs_file(device_path + "/class");
+    if (class_str.empty()) continue;
     // sysfs class is 24-bit (class:subclass:prog_if), shift to get
     // class:subclass
-    uint16_t pci_class =
-        static_cast<uint16_t>(strtol(class_str.c_str(), nullptr, 16) >> 8);
+    uint16_t pci_class = static_cast<uint16_t>(strtol(class_str.c_str(), nullptr, 16) >> 8);
     uint16_t base_class = pci_class & PCI_CLASS_BASE_MASK;
-    if (base_class != PCI_CLASS_PROCESSING_ACCEL &&
-        base_class != PCI_CLASS_SIGNAL_PROCESSING)
+    if (base_class != PCI_CLASS_PROCESSING_ACCEL && base_class != PCI_CLASS_SIGNAL_PROCESSING)
       continue;
 
     amdcuid_npu_info info = {};
     amdcuid_status_t status = CuidNpu::discover_single(&info, device_path);
-    if (status != AMDCUID_STATUS_SUCCESS)
-      continue;
+    if (status != AMDCUID_STATUS_SUCCESS) continue;
 
     npus.emplace_back(std::make_shared<CuidNpu>(info));
   }
@@ -143,18 +132,17 @@ static amdcuid_status_t discover_via_pci_bus(std::vector<DevicePtr> &npus) {
   return npus.empty() ? AMDCUID_STATUS_UNSUPPORTED : AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidNpu::discover(std::vector<DevicePtr> &npus) {
+amdcuid_status_t CuidNpu::discover(std::vector<DevicePtr>& npus) {
   // Try /sys/class/accel first (when amdxdna driver is loaded)
   amdcuid_status_t status = discover_via_accel(npus);
-  if (status == AMDCUID_STATUS_SUCCESS)
-    return status;
+  if (status == AMDCUID_STATUS_SUCCESS) return status;
 
   // Fallback: scan PCI bus for processing accelerator class devices
   return discover_via_pci_bus(npus);
 }
 
-amdcuid_status_t CuidNpu::discover_single(amdcuid_npu_info *npu_info,
-                                          const std::string &device_path) {
+amdcuid_status_t CuidNpu::discover_single(amdcuid_npu_info* npu_info,
+                                          const std::string& device_path) {
   amdcuid_npu_info info = {};
   std::string bdf = CuidUtilities::readlink_bdf(device_path);
 
@@ -162,64 +150,48 @@ amdcuid_status_t CuidNpu::discover_single(amdcuid_npu_info *npu_info,
   if (vendor.empty() && !bdf.empty()) {
     uint8_t vendor_id_bytes[2] = {0};
     const uint16_t offset = 0x0;
-    amdcuid_status_t status =
-        PciUtil::read_pci_config_space(bdf, vendor_id_bytes, 2, offset);
-    uint16_t vendor_id_int =
-        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t *>(vendor_id_bytes));
-    info.header.fields.npu.vendor_id =
-        (status == AMDCUID_STATUS_SUCCESS) ? vendor_id_int : 0;
+    amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, vendor_id_bytes, 2, offset);
+    uint16_t vendor_id_int = PciUtil::load_le16(vendor_id_bytes);
+    info.header.fields.npu.vendor_id = (status == AMDCUID_STATUS_SUCCESS) ? vendor_id_int : 0;
   } else {
-    info.header.fields.npu.vendor_id =
-        static_cast<uint16_t>(strtol(vendor.c_str(), nullptr, 16));
+    info.header.fields.npu.vendor_id = static_cast<uint16_t>(strtol(vendor.c_str(), nullptr, 16));
   }
 
   std::string device = CuidUtilities::read_sysfs_file(device_path + "/device");
   if (device.empty() && !bdf.empty()) {
     uint8_t device_id_bytes[2] = {0};
     const uint16_t offset = 0x2;
-    amdcuid_status_t status =
-        PciUtil::read_pci_config_space(bdf, device_id_bytes, 2, offset);
-    uint16_t device_id_int =
-        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t *>(device_id_bytes));
-    info.header.fields.npu.device_id =
-        (status == AMDCUID_STATUS_SUCCESS) ? device_id_int : 0;
+    amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, device_id_bytes, 2, offset);
+    uint16_t device_id_int = PciUtil::load_le16(device_id_bytes);
+    info.header.fields.npu.device_id = (status == AMDCUID_STATUS_SUCCESS) ? device_id_int : 0;
   } else {
-    info.header.fields.npu.device_id =
-        static_cast<uint16_t>(strtol(device.c_str(), nullptr, 16));
+    info.header.fields.npu.device_id = static_cast<uint16_t>(strtol(device.c_str(), nullptr, 16));
   }
 
-  std::string pci_class =
-      CuidUtilities::read_sysfs_file(device_path + "/class");
+  std::string pci_class = CuidUtilities::read_sysfs_file(device_path + "/class");
   uint16_t pci_class_integer = 0;
   if (pci_class.empty() && !bdf.empty()) {
     uint8_t class_id_bytes[2] = {0};
     const uint16_t offset = 0xa;
-    amdcuid_status_t status =
-        PciUtil::read_pci_config_space(bdf, class_id_bytes, 2, offset);
-    uint16_t class_id_int =
-        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t *>(class_id_bytes));
+    amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, class_id_bytes, 2, offset);
+    uint16_t class_id_int = PciUtil::load_le16(class_id_bytes);
     pci_class_integer = (status == AMDCUID_STATUS_SUCCESS) ? class_id_int : 0;
   } else {
     // sysfs class file returns 24-bit value (class:subclass:prog_if),
     // shift right by 8 to get 16-bit class:subclass
-    pci_class_integer =
-        static_cast<uint16_t>(strtol(pci_class.c_str(), nullptr, 16) >> 8);
+    pci_class_integer = static_cast<uint16_t>(strtol(pci_class.c_str(), nullptr, 16) >> 8);
   }
   info.header.fields.npu.pci_class = pci_class_integer;
 
-  std::string revision_id =
-      CuidUtilities::read_sysfs_file(device_path + "/revision");
+  std::string revision_id = CuidUtilities::read_sysfs_file(device_path + "/revision");
   if (revision_id.empty() && !bdf.empty()) {
-    uint8_t revision_id_bytes[2] = {0};
+    // RevisionID is the single byte at 0x08. The byte at 0x09 is prog-if and
+    // must not be folded in: revision_id is a uint8_t, so a two-byte load left
+    // prog-if in the low half and the revision was discarded by the narrowing.
+    uint8_t revision_id_byte = 0;
     const uint16_t offset = 0x8;
-    amdcuid_status_t status =
-        PciUtil::read_pci_config_space(bdf, revision_id_bytes, 2, offset);
-    uint16_t revision_id_int =
-        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t *>(revision_id_bytes));
-    info.header.fields.npu.revision_id =
-        (status == AMDCUID_STATUS_SUCCESS)
-            ? static_cast<uint8_t>(revision_id_int)
-            : 0;
+    amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, &revision_id_byte, 1, offset);
+    info.header.fields.npu.revision_id = (status == AMDCUID_STATUS_SUCCESS) ? revision_id_byte : 0;
   } else {
     info.header.fields.npu.revision_id =
         static_cast<uint8_t>(strtol(revision_id.c_str(), nullptr, 16));
@@ -239,8 +211,7 @@ amdcuid_status_t CuidNpu::discover_single(amdcuid_npu_info *npu_info,
     }
   } else if (!bdf.empty()) {
     // Try to resolve /sys/bus/pci/devices/<bdf>/accel/accelN
-    std::string resolved =
-        CuidUtilities::bdf_to_device_path(bdf, AMDCUID_DEVICE_TYPE_NPU);
+    std::string resolved = CuidUtilities::bdf_to_device_path(bdf, AMDCUID_DEVICE_TYPE_NPU);
     if (!resolved.empty()) {
       full_device_node = resolved;
     } else {
@@ -259,8 +230,7 @@ amdcuid_status_t CuidNpu::discover_single(amdcuid_npu_info *npu_info,
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t
-CuidNpu::get_hardware_fingerprint(uint64_t &fingerprint) const {
+amdcuid_status_t CuidNpu::get_hardware_fingerprint(uint64_t& fingerprint) const {
   if (geteuid() != 0) {
     return AMDCUID_STATUS_PERMISSION_DENIED;
   }
@@ -280,13 +250,13 @@ CuidNpu::get_hardware_fingerprint(uint64_t &fingerprint) const {
   if (status == AMDCUID_STATUS_SUCCESS) {
     const uint8_t fingerprint_size = 8;
     uint8_t fingerprint_bytes[fingerprint_size] = {0};
-    status = PciUtil::read_pci_config_space(m_info.bdf, fingerprint_bytes,
-                                            fingerprint_size, offset);
+    status =
+        PciUtil::read_pci_config_space(m_info.bdf, fingerprint_bytes, fingerprint_size, offset);
     if (status == AMDCUID_STATUS_SUCCESS) {
       uint64_t fingerprint_value = 0;
       std::memcpy(&fingerprint_value, fingerprint_bytes, fingerprint_size);
       fingerprint = PciUtil::le64_to_be64(fingerprint_value);
-      return AMDCUID_STATUS_SUCCESS;
+      return CuidUtilities::validate_fingerprint(fingerprint);
     } else {
       fingerprint = 0;
       return status;
@@ -296,7 +266,7 @@ CuidNpu::get_hardware_fingerprint(uint64_t &fingerprint) const {
   return AMDCUID_STATUS_HW_FINGERPRINT_NOT_FOUND;
 }
 
-amdcuid_status_t CuidNpu::get_primary_cuid(amdcuid_primary_id &id) const {
+amdcuid_status_t CuidNpu::get_primary_cuid(amdcuid_primary_id& id) const {
   bool temp = false;
   amdcuid_status_t status = AMDCUID_STATUS_SUCCESS;
   uint64_t fingerprint = 0;
@@ -333,10 +303,9 @@ amdcuid_status_t CuidNpu::get_primary_cuid(amdcuid_primary_id &id) const {
 
   status = CuidUtilities::generate_primary_cuid(
       fingerprint,
-      0, // unit_id: NPUs are not partitioned
+      0,  // unit_id: NPUs are not partitioned
       m_info.header.fields.npu.revision_id, m_info.header.fields.npu.device_id,
-      m_info.header.fields.npu.vendor_id,
-      static_cast<uint8_t>(AMDCUID_DEVICE_TYPE_NPU), &id, temp);
+      m_info.header.fields.npu.vendor_id, static_cast<uint8_t>(AMDCUID_DEVICE_TYPE_NPU), &id, temp);
   if (status != AMDCUID_STATUS_SUCCESS) {
     std::memset(&id, 0, sizeof(id));
     return status;
@@ -345,29 +314,29 @@ amdcuid_status_t CuidNpu::get_primary_cuid(amdcuid_primary_id &id) const {
   return status;
 }
 
-const amdcuid_npu_info &CuidNpu::get_info() const { return m_info; }
+const amdcuid_npu_info& CuidNpu::get_info() const { return m_info; }
 
-amdcuid_status_t CuidNpu::get_vendor_id(uint16_t &vendor_id) const {
+amdcuid_status_t CuidNpu::get_vendor_id(uint16_t& vendor_id) const {
   vendor_id = m_info.header.fields.npu.vendor_id;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidNpu::get_device_id(uint16_t &device_id) const {
+amdcuid_status_t CuidNpu::get_device_id(uint16_t& device_id) const {
   device_id = m_info.header.fields.npu.device_id;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidNpu::get_pci_class(uint16_t &pci_class) const {
+amdcuid_status_t CuidNpu::get_pci_class(uint16_t& pci_class) const {
   pci_class = m_info.header.fields.npu.pci_class;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidNpu::get_revision_id(uint8_t &revision_id) const {
+amdcuid_status_t CuidNpu::get_revision_id(uint8_t& revision_id) const {
   revision_id = m_info.header.fields.npu.revision_id;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidNpu::get_bdf(std::string &bdf) const {
+amdcuid_status_t CuidNpu::get_bdf(std::string& bdf) const {
   if (m_info.bdf.empty()) {
     return AMDCUID_STATUS_UNSUPPORTED;
   }
@@ -375,7 +344,7 @@ amdcuid_status_t CuidNpu::get_bdf(std::string &bdf) const {
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidNpu::get_device_path(std::string &path) const {
+amdcuid_status_t CuidNpu::get_device_path(std::string& path) const {
   if (m_info.accel_node.empty()) {
     return AMDCUID_STATUS_UNSUPPORTED;
   }

--- a/projects/cuid/lib/src/cuid_npu.h
+++ b/projects/cuid/lib/src/cuid_npu.h
@@ -23,42 +23,43 @@
 #ifndef CUID_NPU_H
 #define CUID_NPU_H
 
-#include "include/amd_cuid.h"
-#include "src/cuid_device.h"
-#include "src/cuid_internal.h"
 #include <memory>
 #include <string>
 #include <vector>
 
+#include "include/amd_cuid.h"
+#include "src/cuid_device.h"
+#include "src/cuid_internal.h"
+
 struct amdcuid_npu_info {
-    amdcuid_cuid_public_fields header;
-    // Accel device node: /sys/class/accel/accelN
-    std::string accel_node;
-    std::string bdf;
+  amdcuid_cuid_public_fields header;
+  // Accel device node: /sys/class/accel/accelN
+  std::string accel_node;
+  std::string bdf;
 };
 
 class CuidNpu : public CuidDevice {
-public:
-    CuidNpu(const amdcuid_npu_info& i);
-    amdcuid_device_type_t type() const override { return AMDCUID_DEVICE_TYPE_NPU; }
-    amdcuid_status_t get_primary_cuid(amdcuid_primary_id& id) const override;
-    amdcuid_status_t get_hardware_fingerprint(uint64_t& fingerprint) const override;
-    static amdcuid_status_t discover(std::vector<DevicePtr>& npus);
-    static amdcuid_status_t discover_single(amdcuid_npu_info* npu_info,
-                                            const std::string& device_path);
+ public:
+  CuidNpu(const amdcuid_npu_info& i);
+  amdcuid_device_type_t type() const override { return AMDCUID_DEVICE_TYPE_NPU; }
+  amdcuid_status_t get_primary_cuid(amdcuid_primary_id& id) const override;
+  amdcuid_status_t get_hardware_fingerprint(uint64_t& fingerprint) const override;
+  static amdcuid_status_t discover(std::vector<DevicePtr>& npus);
+  static amdcuid_status_t discover_single(amdcuid_npu_info* npu_info,
+                                          const std::string& device_path);
 
-    // Virtual accessor overrides
-    amdcuid_status_t get_vendor_id(uint16_t& vendor_id) const override;
-    amdcuid_status_t get_device_id(uint16_t& device_id) const override;
-    amdcuid_status_t get_pci_class(uint16_t& pci_class) const override;
-    amdcuid_status_t get_revision_id(uint8_t& revision_id) const override;
-    amdcuid_status_t get_bdf(std::string& bdf) const override;
-    amdcuid_status_t get_device_path(std::string& path) const override;
+  // Virtual accessor overrides
+  amdcuid_status_t get_vendor_id(uint16_t& vendor_id) const override;
+  amdcuid_status_t get_device_id(uint16_t& device_id) const override;
+  amdcuid_status_t get_pci_class(uint16_t& pci_class) const override;
+  amdcuid_status_t get_revision_id(uint8_t& revision_id) const override;
+  amdcuid_status_t get_bdf(std::string& bdf) const override;
+  amdcuid_status_t get_device_path(std::string& path) const override;
 
-    const amdcuid_npu_info& get_info() const;
+  const amdcuid_npu_info& get_info() const;
 
-private:
-    amdcuid_npu_info m_info;
+ private:
+  amdcuid_npu_info m_info;
 };
 
-#endif // CUID_NPU_H
+#endif  // CUID_NPU_H

--- a/projects/cuid/lib/src/cuid_platform.cc
+++ b/projects/cuid/lib/src/cuid_platform.cc
@@ -21,17 +21,20 @@
  */
 
 #include "cuid_platform.h"
-#include "cuid_file.h"
-#include "cuid_util.h"
-#include "smbios_util.h"
+
+#include <unistd.h>
+
 #include <cstring>
 #include <iostream>
 #include <sstream>
-#include <unistd.h>
 
-CuidPlatform::CuidPlatform(const amdcuid_platform_info &i) : m_info({i}) {}
+#include "cuid_file.h"
+#include "cuid_util.h"
+#include "smbios_util.h"
 
-amdcuid_status_t CuidPlatform::discover(std::vector<DevicePtr> &platforms) {
+CuidPlatform::CuidPlatform(const amdcuid_platform_info& i) : m_info({i}) {}
+
+amdcuid_status_t CuidPlatform::discover(std::vector<DevicePtr>& platforms) {
   // Platform is a singleton - only one platform per system
   amdcuid_platform_info info = {};
   info.header.device_type = AMDCUID_DEVICE_TYPE_PLATFORM;
@@ -51,8 +54,7 @@ amdcuid_status_t CuidPlatform::discover(std::vector<DevicePtr> &platforms) {
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t
-CuidPlatform::get_hardware_fingerprint(uint64_t &fingerprint) const {
+amdcuid_status_t CuidPlatform::get_hardware_fingerprint(uint64_t& fingerprint) const {
   amdcuid_status_t status = AMDCUID_STATUS_SUCCESS;
   // Get system UUID from SMBIOS
   uint8_t uuid[16] = {0};
@@ -67,14 +69,10 @@ CuidPlatform::get_hardware_fingerprint(uint64_t &fingerprint) const {
   }
   if (status == AMDCUID_STATUS_SUCCESS && uuid_valid) {
     // use UUID as basis for CUID
-    fingerprint = (static_cast<uint64_t>(uuid[0]) << 56) |
-                  (static_cast<uint64_t>(uuid[1]) << 48) |
-                  (static_cast<uint64_t>(uuid[2]) << 40) |
-                  (static_cast<uint64_t>(uuid[3]) << 32) |
-                  (static_cast<uint64_t>(uuid[4]) << 24) |
-                  (static_cast<uint64_t>(uuid[5]) << 16) |
-                  (static_cast<uint64_t>(uuid[6]) << 8) |
-                  static_cast<uint64_t>(uuid[7]);
+    fingerprint = (static_cast<uint64_t>(uuid[0]) << 56) | (static_cast<uint64_t>(uuid[1]) << 48) |
+                  (static_cast<uint64_t>(uuid[2]) << 40) | (static_cast<uint64_t>(uuid[3]) << 32) |
+                  (static_cast<uint64_t>(uuid[4]) << 24) | (static_cast<uint64_t>(uuid[5]) << 16) |
+                  (static_cast<uint64_t>(uuid[6]) << 8) | static_cast<uint64_t>(uuid[7]);
   } else {
     std::string serial;
     status = SmbiosUtil::get_system_serial(serial);
@@ -93,7 +91,7 @@ CuidPlatform::get_hardware_fingerprint(uint64_t &fingerprint) const {
   return status;
 }
 
-amdcuid_status_t CuidPlatform::get_primary_cuid(amdcuid_primary_id &id) const {
+amdcuid_status_t CuidPlatform::get_primary_cuid(amdcuid_primary_id& id) const {
   bool temp = false;
   // attempt to find the primary CUID in file first
   std::string cuid_file_path = CuidUtilities::priv_cuid_file();
@@ -103,8 +101,7 @@ amdcuid_status_t CuidPlatform::get_primary_cuid(amdcuid_primary_id &id) const {
 
   // for platform, just return the first entry found
   CuidFileEntry entry;
-  amdcuid_status_t status =
-      primary_file.find_by_device_type(AMDCUID_DEVICE_TYPE_PLATFORM, entry);
+  amdcuid_status_t status = primary_file.find_by_device_type(AMDCUID_DEVICE_TYPE_PLATFORM, entry);
   if (status == AMDCUID_STATUS_SUCCESS) {
     id.UUIDv8_representation = entry.primary_cuid;
     CuidUtilities::remove_UUIDv8_bits(&id.UUIDv8_representation, id.raw_bits);
@@ -123,16 +120,16 @@ amdcuid_status_t CuidPlatform::get_primary_cuid(amdcuid_primary_id &id) const {
     temp = true;
   }
 
-  status = CuidUtilities::generate_primary_cuid(
-      fingerprint, 0, 0, 0, m_info.header.fields.platform.vendor_id,
-      AMDCUID_DEVICE_TYPE_PLATFORM, &id, temp);
+  status = CuidUtilities::generate_primary_cuid(fingerprint, 0, 0, 0,
+                                                m_info.header.fields.platform.vendor_id,
+                                                AMDCUID_DEVICE_TYPE_PLATFORM, &id, temp);
 
   return status;
 }
 
-const amdcuid_platform_info &CuidPlatform::get_info() const { return m_info; }
+const amdcuid_platform_info& CuidPlatform::get_info() const { return m_info; }
 
-amdcuid_status_t CuidPlatform::get_vendor_id(uint16_t &vendor_id) const {
+amdcuid_status_t CuidPlatform::get_vendor_id(uint16_t& vendor_id) const {
   vendor_id = m_info.header.fields.platform.vendor_id;
   return AMDCUID_STATUS_SUCCESS;
 }

--- a/projects/cuid/lib/src/cuid_platform.h
+++ b/projects/cuid/lib/src/cuid_platform.h
@@ -23,31 +23,33 @@
 #ifndef CUID_PLATFORM_H
 #define CUID_PLATFORM_H
 
-#include "cuid_device.h"
-#include "include/amd_cuid.h"
-#include "cuid_internal.h"
-#include <vector>
 #include <memory>
+#include <vector>
+
+#include "cuid_device.h"
+#include "cuid_internal.h"
+#include "include/amd_cuid.h"
 
 struct amdcuid_platform_info {
-    amdcuid_cuid_public_fields header;
-    // Add more fields as needed
+  amdcuid_cuid_public_fields header;
+  // Add more fields as needed
 };
 
 class CuidPlatform : public CuidDevice {
-public:
-    CuidPlatform(const amdcuid_platform_info& i);
-    amdcuid_device_type_t type() const override { return AMDCUID_DEVICE_TYPE_PLATFORM; }
-    amdcuid_status_t get_primary_cuid(amdcuid_primary_id& id) const override;
-    amdcuid_status_t get_hardware_fingerprint(uint64_t& fingerprint) const override;
-    static amdcuid_status_t discover(std::vector<DevicePtr> &platforms);
+ public:
+  CuidPlatform(const amdcuid_platform_info& i);
+  amdcuid_device_type_t type() const override { return AMDCUID_DEVICE_TYPE_PLATFORM; }
+  amdcuid_status_t get_primary_cuid(amdcuid_primary_id& id) const override;
+  amdcuid_status_t get_hardware_fingerprint(uint64_t& fingerprint) const override;
+  static amdcuid_status_t discover(std::vector<DevicePtr>& platforms);
 
-    // Virtual accessor overrides
-    amdcuid_status_t get_vendor_id(uint16_t& vendor_id) const override;
+  // Virtual accessor overrides
+  amdcuid_status_t get_vendor_id(uint16_t& vendor_id) const override;
 
-    const amdcuid_platform_info& get_info() const;
-private:
-    amdcuid_platform_info m_info;
+  const amdcuid_platform_info& get_info() const;
+
+ private:
+  amdcuid_platform_info m_info;
 };
 
-#endif // CUID_PLATFORM_H
+#endif  // CUID_PLATFORM_H

--- a/projects/cuid/lib/src/cuid_util.cc
+++ b/projects/cuid/lib/src/cuid_util.cc
@@ -21,73 +21,92 @@
  */
 
 #include "cuid_util.h"
-#include "smbios_util.h"
-#include <algorithm>
-#include <cctype>
-#include <cstring>
+
 #include <dirent.h>
 #include <fcntl.h>
-#include <fstream>
-#include <iostream>
-#include <mutex>
-#include <sstream>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <sys/sysmacros.h>
 #include <sys/types.h>
 #include <unistd.h>
+
+#include <algorithm>
+#include <cctype>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <mutex>
+#include <sstream>
 #include <vector>
 
-const char *Logger::LogLevelName(LogLevel level) const {
+#include "smbios_util.h"
+
+const char* Logger::LogLevelName(LogLevel level) const {
   switch (level) {
-  case DEBUG:
-    return "DEBUG";
-  case INFO:
-    return "INFO";
-  case WARN:
-    return "WARN";
-  case ERROR:
-    return "ERROR";
-  default:
-    return "UNKNOWN";
+    case DEBUG:
+      return "DEBUG";
+    case INFO:
+      return "INFO";
+    case WARN:
+      return "WARN";
+    case ERROR:
+      return "ERROR";
+    default:
+      return "UNKNOWN";
   }
 }
 
-void Logger::log(LogLevel level, const std::string &msg) const {
-  if (level < level_)
-    return;
+void Logger::log(LogLevel level, const std::string& msg) const {
+  if (level < level_) return;
   std::cerr << "[" << LogLevelName(level) << "] " << msg << std::endl;
 }
 
 // Helper to read a sysfs file into a string
-std::string CuidUtilities::read_sysfs_file(const std::string &path) {
+std::string CuidUtilities::errno_string(int err) {
+  char buf[256];
+#if defined(_WIN32)
+  if (strerror_s(buf, sizeof(buf), err) != 0) {
+    return "unknown error " + std::to_string(err);
+  }
+  return std::string(buf);
+#elif defined(_GNU_SOURCE)
+  // GNU strerror_r returns a pointer that may or may not point at buf.
+  const char* msg = strerror_r(err, buf, sizeof(buf));
+  return msg ? std::string(msg) : ("unknown error " + std::to_string(err));
+#else
+  // XSI strerror_r fills buf and returns 0 on success.
+  if (strerror_r(err, buf, sizeof(buf)) != 0) {
+    return "unknown error " + std::to_string(err);
+  }
+  return std::string(buf);
+#endif
+}
+
+std::string CuidUtilities::read_sysfs_file(const std::string& path) {
   std::ifstream file(path);
-  if (!file.is_open())
-    return "";
+  if (!file.is_open()) return "";
   std::stringstream ss;
   ss << file.rdbuf();
   std::string result = ss.str();
   // Remove trailing newline if present
-  if (!result.empty() && result.back() == '\n')
-    result.pop_back();
+  if (!result.empty() && result.back() == '\n') result.pop_back();
   return result;
 }
 
 // Helper to get BDF from symlink, filter out non-PCI BDFs (e.g., USB like
 // 3-10.2:2.0)
-std::string CuidUtilities::readlink_bdf(const std::string &device_path) {
+std::string CuidUtilities::readlink_bdf(const std::string& device_path) {
   char buf[256];
   ssize_t len = readlink(device_path.c_str(), buf, sizeof(buf) - 1);
   if (len > 0) {
     buf[len] = '\0';
     // The symlink is typically ../../../0000:65:00.0 or ../../../3-10.2:2.0
-    const char *bdf = strrchr(buf, '/');
+    const char* bdf = strrchr(buf, '/');
     if (bdf && strlen(bdf + 1) < 32) {
       std::string bdf_str = bdf + 1;
       // Only accept PCI BDFs of the form "dddd:bb:dd.f"
       // Example: 0000:65:00.0
-      if (bdf_str.size() == 12 && bdf_str[4] == ':' && bdf_str[7] == ':' &&
-          bdf_str[10] == '.') {
+      if (bdf_str.size() == 12 && bdf_str[4] == ':' && bdf_str[7] == ':' && bdf_str[10] == '.') {
         return bdf_str;
       }
     }
@@ -99,33 +118,32 @@ std::string CuidUtilities::readlink_bdf(const std::string &device_path) {
 // For GPUs: returns /sys/class/drm/renderDXXX/device or
 //           /sys/class/drm/cardN/device path
 // For NICs: returns /sys/class/net/<iface>/device path
-std::string
-CuidUtilities::bdf_to_device_path(const std::string &bdf,
-                                  amdcuid_device_type_t device_type) {
-  if (bdf.empty())
-    return "";
+std::string CuidUtilities::bdf_to_device_path(const std::string& bdf,
+                                              amdcuid_device_type_t device_type) {
+  if (bdf.empty()) return "";
 
   std::string pci_device_path = "/sys/bus/pci/devices/" + bdf;
   std::string subsystem_dir;
 
   if (device_type == AMDCUID_DEVICE_TYPE_GPU) {
     subsystem_dir = pci_device_path + "/drm";
-    DIR *dir = opendir(subsystem_dir.c_str());
+    DIR* dir = opendir(subsystem_dir.c_str());
     if (dir) {
-      struct dirent *entry;
+      struct dirent* entry;
       std::string card_path;
+      // this call site owns its DIR*, which is all POSIX requires; readdir_r is deprecated and
+      // must not be adopted.
+      // NOLINTNEXTLINE(concurrency-mt-unsafe)
       while ((entry = readdir(dir)) != nullptr) {
         // Prefer renderD* nodes when available
         if (strncmp(entry->d_name, "renderD", 7) == 0) {
-          std::string device_path =
-              "/sys/class/drm/" + std::string(entry->d_name) + "/device";
+          std::string device_path = "/sys/class/drm/" + std::string(entry->d_name) + "/device";
           closedir(dir);
           return device_path;
         }
         // Track card entries as fallback (e.g., card0, card1)
         // Exclude connector entries like card0-DP-1
-        if (strncmp(entry->d_name, "card", 4) == 0 &&
-            isdigit(entry->d_name[4])) {
+        if (strncmp(entry->d_name, "card", 4) == 0 && isdigit(entry->d_name[4])) {
           bool all_digits = true;
           for (size_t i = 4; entry->d_name[i] != '\0'; ++i) {
             if (!isdigit(entry->d_name[i])) {
@@ -134,8 +152,7 @@ CuidUtilities::bdf_to_device_path(const std::string &bdf,
             }
           }
           if (all_digits && card_path.empty()) {
-            card_path =
-                "/sys/class/drm/" + std::string(entry->d_name) + "/device";
+            card_path = "/sys/class/drm/" + std::string(entry->d_name) + "/device";
           }
         }
       }
@@ -148,15 +165,16 @@ CuidUtilities::bdf_to_device_path(const std::string &bdf,
     }
   } else if (device_type == AMDCUID_DEVICE_TYPE_NIC) {
     subsystem_dir = pci_device_path + "/net";
-    DIR *dir = opendir(subsystem_dir.c_str());
+    DIR* dir = opendir(subsystem_dir.c_str());
     if (dir) {
-      struct dirent *entry;
+      struct dirent* entry;
+      // this call site owns its DIR*, which is all POSIX requires; readdir_r is deprecated and
+      // must not be adopted.
+      // NOLINTNEXTLINE(concurrency-mt-unsafe)
       while ((entry = readdir(dir)) != nullptr) {
         // Skip . and ..
-        if (entry->d_name[0] == '.')
-          continue;
-        std::string device_path =
-            "/sys/class/net/" + std::string(entry->d_name) + "/device";
+        if (entry->d_name[0] == '.') continue;
+        std::string device_path = "/sys/class/net/" + std::string(entry->d_name) + "/device";
         closedir(dir);
         return device_path;
       }
@@ -164,18 +182,18 @@ CuidUtilities::bdf_to_device_path(const std::string &bdf,
     }
   } else if (device_type == AMDCUID_DEVICE_TYPE_NPU) {
     subsystem_dir = pci_device_path + "/accel";
-    DIR *dir = opendir(subsystem_dir.c_str());
+    DIR* dir = opendir(subsystem_dir.c_str());
     if (dir) {
-      struct dirent *entry;
+      struct dirent* entry;
+      // this call site owns its DIR*, which is all POSIX requires; readdir_r is deprecated and
+      // must not be adopted.
+      // NOLINTNEXTLINE(concurrency-mt-unsafe)
       while ((entry = readdir(dir)) != nullptr) {
         // Skip . and ..
-        if (entry->d_name[0] == '.')
-          continue;
+        if (entry->d_name[0] == '.') continue;
         // Match accelN entries
-        if (strncmp(entry->d_name, "accel", 5) == 0 &&
-            isdigit(entry->d_name[5])) {
-          std::string device_path =
-              "/sys/class/accel/" + std::string(entry->d_name) + "/device";
+        if (strncmp(entry->d_name, "accel", 5) == 0 && isdigit(entry->d_name[5])) {
+          std::string device_path = "/sys/class/accel/" + std::string(entry->d_name) + "/device";
           closedir(dir);
           return device_path;
         }
@@ -202,15 +220,14 @@ std::string CuidUtilities::real_dev_path_from_fd(int fd) {
   uint32_t minor_num = minor(dev);
 
   // Construct sysfs path from char device numbers first
-  std::string sys_path = "/sys/dev/char/" + std::to_string(major_num) + ":" +
-                         std::to_string(minor_num);
+  std::string sys_path =
+      "/sys/dev/char/" + std::to_string(major_num) + ":" + std::to_string(minor_num);
   char buf[PATH_MAX];
   if (realpath(sys_path.c_str(), buf) != nullptr) {
     return std::string(buf) + "/device";
   } else {
     // attempt to find as a block device now
-    sys_path = "/sys/dev/block/" + std::to_string(major_num) + ":" +
-               std::to_string(minor_num);
+    sys_path = "/sys/dev/block/" + std::to_string(major_num) + ":" + std::to_string(minor_num);
     if (realpath(sys_path.c_str(), buf) != nullptr) {
       return std::string(buf) + "/device";
     }
@@ -219,7 +236,7 @@ std::string CuidUtilities::real_dev_path_from_fd(int fd) {
   return "";
 }
 
-std::string CuidUtilities::get_real_path(const std::string &path) {
+std::string CuidUtilities::get_real_path(const std::string& path) {
   char buf[PATH_MAX];
   if (realpath(path.c_str(), buf) != nullptr) {
     return std::string(buf) + "/device";
@@ -227,16 +244,14 @@ std::string CuidUtilities::get_real_path(const std::string &path) {
   return "";
 }
 
-int CuidUtilities::extract_render_minor(const std::string &path) {
+int CuidUtilities::extract_render_minor(const std::string& path) {
   size_t render_pos = path.find("renderD");
-  if (render_pos == std::string::npos)
-    return -1;
+  if (render_pos == std::string::npos) return -1;
 
-  size_t num_start = render_pos + 7; // length of "renderD"
+  size_t num_start = render_pos + 7;  // length of "renderD"
   size_t num_end = path.find('/', num_start);
-  std::string num_str = (num_end != std::string::npos)
-                            ? path.substr(num_start, num_end - num_start)
-                            : path.substr(num_start);
+  std::string num_str = (num_end != std::string::npos) ? path.substr(num_start, num_end - num_start)
+                                                       : path.substr(num_start);
   try {
     return std::stoi(num_str);
   } catch (...) {
@@ -255,7 +270,7 @@ struct cuid_drm_amdgpu_info {
   uint64_t return_pointer;
   uint32_t return_size;
   uint32_t query;
-  uint8_t padding[16]; // matches the union in the kernel struct
+  uint8_t padding[16];  // matches the union in the kernel struct
 };
 
 struct cuid_amdgpu_dev_info {
@@ -304,7 +319,7 @@ bool is_gpu_vf_mode(int fd) {
   return mode == kAmdgpuIdsFlagsModeVf;
 }
 
-uint16_t get_vf_index_from_sysfs(const std::string &device_path) {
+uint16_t get_vf_index_from_sysfs(const std::string& device_path) {
   // device_path is /sys/class/drm/renderDXXX/device
   // Check if physfn symlink exists (present on VFs visible from the host)
   std::string physfn_path = device_path + "/physfn";
@@ -312,19 +327,16 @@ uint16_t get_vf_index_from_sysfs(const std::string &device_path) {
   // Get our own BDF from the device symlink
   char dev_link[PATH_MAX];
   ssize_t len = readlink(device_path.c_str(), dev_link, sizeof(dev_link) - 1);
-  if (len <= 0)
-    return 0;
+  if (len <= 0) return 0;
   dev_link[len] = '\0';
 
-  const char *our_bdf_ptr = strrchr(dev_link, '/');
-  if (our_bdf_ptr == nullptr)
-    return 0;
+  const char* our_bdf_ptr = strrchr(dev_link, '/');
+  if (our_bdf_ptr == nullptr) return 0;
   std::string our_bdf(our_bdf_ptr + 1);
 
   // Resolve PF sysfs path via physfn symlink
   char pf_real[PATH_MAX];
-  if (realpath(physfn_path.c_str(), pf_real) == nullptr)
-    return 0;
+  if (realpath(physfn_path.c_str(), pf_real) == nullptr) return 0;
   std::string pf_path(pf_real);
 
   // Enumerate virtfnX symlinks on the PF to find our VF index
@@ -332,13 +344,11 @@ uint16_t get_vf_index_from_sysfs(const std::string &device_path) {
     std::string virtfn_symlink = pf_path + "/virtfn" + std::to_string(idx);
     char vfn_link[PATH_MAX];
     len = readlink(virtfn_symlink.c_str(), vfn_link, sizeof(vfn_link) - 1);
-    if (len <= 0)
-      break; // no more VFs
+    if (len <= 0) break;  // no more VFs
     vfn_link[len] = '\0';
 
-    const char *vfn_bdf_ptr = strrchr(vfn_link, '/');
-    if (vfn_bdf_ptr == nullptr)
-      continue;
+    const char* vfn_bdf_ptr = strrchr(vfn_link, '/');
+    if (vfn_bdf_ptr == nullptr) continue;
     if (our_bdf == (vfn_bdf_ptr + 1)) {
       return static_cast<uint16_t>(idx + 1);
     }
@@ -346,15 +356,14 @@ uint16_t get_vf_index_from_sysfs(const std::string &device_path) {
   return 0;
 }
 
-} // anonymous namespace
+}  // anonymous namespace
 
-uint16_t CuidUtilities::get_gpu_vf_id(const std::string &device_path) {
+uint16_t CuidUtilities::get_gpu_vf_id(const std::string& device_path) {
   // Determine if the GPU is an SR-IOV Virtual Function (VF) and return its
   // 1-based VF index as the unit_id. Returns 0 for bare metal, PF,
   // passthrough, or when VF detection is unavailable.
   int render_minor = extract_render_minor(device_path);
-  if (render_minor < 0)
-    return 0;
+  if (render_minor < 0) return 0;
 
   std::string dev_node = "/dev/dri/renderD" + std::to_string(render_minor);
 
@@ -362,40 +371,34 @@ uint16_t CuidUtilities::get_gpu_vf_id(const std::string &device_path) {
   if (fd < 0) {
     // Fall back to read-only if we lack write permission
     fd = open(dev_node.c_str(), O_RDONLY | O_CLOEXEC);
-    if (fd < 0)
-      return 0;
+    if (fd < 0) return 0;
   }
 
   bool is_vf = is_gpu_vf_mode(fd);
   close(fd);
 
-  if (!is_vf)
-    return 0;
+  if (!is_vf) return 0;
 
   // VF detected via ioctl. Try to determine VF index from sysfs.
   uint16_t vf_index = get_vf_index_from_sysfs(device_path);
-  if (vf_index > 0)
-    return vf_index;
+  if (vf_index > 0) return vf_index;
 
   // Could not determine VF index (e.g. inside a guest VM where physfn
   // is not visible). Fall back to 0 per specification.
   return 0;
 }
 
-amdcuid_status_t
-CuidUtilities::make_fallback_fingerprint(const std::string &id,
-                                         uint64_t &fingerprint) {
+amdcuid_status_t CuidUtilities::make_fallback_fingerprint(const std::string& id,
+                                                          uint64_t& fingerprint) {
   std::string system_id;
   amdcuid_status_t status = AMDCUID_STATUS_SUCCESS;
 
   std::ifstream machine_id_file("/etc/machine-id");
-  if (machine_id_file.is_open())
-    std::getline(machine_id_file, system_id);
+  if (machine_id_file.is_open()) std::getline(machine_id_file, system_id);
 
   if (system_id.empty()) {
     std::ifstream hostname_file("/etc/hostname");
-    if (hostname_file.is_open())
-      std::getline(hostname_file, system_id);
+    if (hostname_file.is_open()) std::getline(hostname_file, system_id);
   }
 
   std::string id_hex;
@@ -404,19 +407,17 @@ CuidUtilities::make_fallback_fingerprint(const std::string &id,
 
   std::string combined = id_hex + system_id;
   uint8_t digest[32];
-  status = sha256_unkeyed(reinterpret_cast<const uint8_t *>(combined.data()),
-                          combined.size(), digest);
-  if (status != AMDCUID_STATUS_SUCCESS)
-    return status;
+  status =
+      sha256_unkeyed(reinterpret_cast<const uint8_t*>(combined.data()), combined.size(), digest);
+  if (status != AMDCUID_STATUS_SUCCESS) return status;
 
   std::memcpy(&fingerprint, digest, sizeof(fingerprint));
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t
-CuidUtilities::generate_derived_cuid(const amdcuid_primary_id *primary_id,
-                                     amdcuid_derived_id *derived_id,
-                                     cuid_hmac *hmac) {
+amdcuid_status_t CuidUtilities::generate_derived_cuid(const amdcuid_primary_id* primary_id,
+                                                      amdcuid_derived_id* derived_id,
+                                                      cuid_hmac* hmac) {
   if (!primary_id || !hmac) {
     // Return invalid on null input
     return AMDCUID_STATUS_INVALID_ARGUMENT;
@@ -425,10 +426,9 @@ CuidUtilities::generate_derived_cuid(const amdcuid_primary_id *primary_id,
   uint8_t hash[hash_length];
   size_t hash_len = 0;
 
-  amdcuid_status_t status =
-      static_cast<amdcuid_status_t>(hmac->generate_hmac_sha256(
-          reinterpret_cast<const uint8_t *>(primary_id->raw_bits),
-          sizeof(primary_id->raw_bits), hash, &hash_len));
+  amdcuid_status_t status = static_cast<amdcuid_status_t>(
+      hmac->generate_hmac_sha256(reinterpret_cast<const uint8_t*>(primary_id->raw_bits),
+                                 sizeof(primary_id->raw_bits), hash, &hash_len));
   if (status != AMDCUID_STATUS_SUCCESS) {
     std::cerr << "Error generating HMAC" << std::endl;
     return status;
@@ -437,7 +437,7 @@ CuidUtilities::generate_derived_cuid(const amdcuid_primary_id *primary_id,
   // copy 110 LSB bits of hash to derived_id->hash
   // Using only first 14 bytes (112 bits) of hash, then will mask last 2 bits
   memcpy(derived_id->hash, hash, 14);
-  derived_id->hash[13] &= 0x3F; // 00111111
+  derived_id->hash[13] &= 0x3F;  // 00111111
 
   // Get the unit id parts from the primary ID
   uint8_t reserved_2 = 0;
@@ -460,10 +460,8 @@ CuidUtilities::generate_derived_cuid(const amdcuid_primary_id *primary_id,
   id_bits[14] |= (primary_id->raw_bits[14] & 0x20);
 
   // bits 118-121: reserved bits part 2 (4 bits)
-  id_bits[14] |= (reserved_2 & 0xC)
-                 << 4; // upper 2 bits of reserved bits part 2
-  id_bits[15] |= (reserved_2 & 0x3)
-                 << 6; // lower 2 bits of reserved bits part 2
+  id_bits[14] |= (reserved_2 & 0xC) << 4;  // upper 2 bits of reserved bits part 2
+  id_bits[15] |= (reserved_2 & 0x3) << 6;  // lower 2 bits of reserved bits part 2
   // last 6 bits are padding (bits 122-127)
   id_bits[15] &= 0xC0;
 
@@ -475,20 +473,18 @@ CuidUtilities::generate_derived_cuid(const amdcuid_primary_id *primary_id,
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidUtilities::generate_primary_cuid(
-    uint64_t serial_number, uint16_t unit_id, uint8_t revision_id,
-    uint16_t device_id, uint16_t vendor_id, uint8_t device_type,
-    amdcuid_primary_id *primary_id, bool temp) {
-
+amdcuid_status_t CuidUtilities::generate_primary_cuid(uint64_t serial_number, uint16_t unit_id,
+                                                      uint8_t revision_id, uint16_t device_id,
+                                                      uint16_t vendor_id, uint8_t device_type,
+                                                      amdcuid_primary_id* primary_id, bool temp) {
   // Build 122-bit value in little-endian order
-  uint8_t id_bits[16] = {0}; // 128 bits total (122 bits + 6 bits padding)
+  uint8_t id_bits[16] = {0};  // 128 bits total (122 bits + 6 bits padding)
 
   uint8_t unit_id_part1 = unit_id & 0xFF;
   uint8_t unit_id_part2 = (unit_id >> 8) & 0x1F;
 
   // Bits 0-63: Serial number (8 bytes)
-  for (int i = 0; i < 8; i++)
-    id_bits[i] = (serial_number >> (8 * i)) & 0xFF;
+  for (int i = 0; i < 8; i++) id_bits[i] = (serial_number >> (8 * i)) & 0xFF;
 
   // Bits 64-71: UnitID part 1 (1 byte)
   id_bits[8] = unit_id_part1;
@@ -509,7 +505,7 @@ amdcuid_status_t CuidUtilities::generate_primary_cuid(
   // Bits 118-121: Component Type (4 bits)
   uint8_t temp_bit = temp ? 1 : 0;
   id_bits[14] = (unit_id_part2) | (temp_bit << 5) | ((device_type & 0x3) << 6);
-  id_bits[15] = (device_type & 0xC) << 4; // Last 6 bits are padding
+  id_bits[15] = (device_type & 0xC) << 4;  // Last 6 bits are padding
 
   memcpy(primary_id->raw_bits, id_bits, 16);
 
@@ -520,8 +516,7 @@ amdcuid_status_t CuidUtilities::generate_primary_cuid(
   return AMDCUID_STATUS_SUCCESS;
 }
 
-void CuidUtilities::remove_UUIDv8_bits(amdcuid_id_t *id,
-                                       uint8_t out_raw_bits[16]) {
+void CuidUtilities::remove_UUIDv8_bits(amdcuid_id_t* id, uint8_t out_raw_bits[16]) {
   if (!id || !out_raw_bits) {
     return;
   }
@@ -541,23 +536,16 @@ void CuidUtilities::remove_UUIDv8_bits(amdcuid_id_t *id,
 
   // Bits 64-65: Variant (10b) + Bits 66-127: ID value part 3 (MSB)
   out_raw_bits[8] = ((id->bytes[8] & 0x03) << 6) | ((id->bytes[9] & 0xFC) >> 2);
-  out_raw_bits[9] =
-      ((id->bytes[9] & 0x03) << 6) | ((id->bytes[10] & 0xFC) >> 2);
-  out_raw_bits[10] =
-      ((id->bytes[10] & 0x03) << 6) | ((id->bytes[11] & 0xFC) >> 2);
-  out_raw_bits[11] =
-      ((id->bytes[11] & 0x03) << 6) | ((id->bytes[12] & 0xFC) >> 2);
-  out_raw_bits[12] =
-      ((id->bytes[12] & 0x03) << 6) | ((id->bytes[13] & 0xFC) >> 2);
-  out_raw_bits[13] =
-      ((id->bytes[13] & 0x03) << 6) | ((id->bytes[14] & 0xFC) >> 2);
-  out_raw_bits[14] =
-      ((id->bytes[14] & 0x03) << 6) | ((id->bytes[15] & 0xFC) >> 2);
-  out_raw_bits[15] = (id->bytes[15] & 0x03) << 6; // last 6 bits are padding
+  out_raw_bits[9] = ((id->bytes[9] & 0x03) << 6) | ((id->bytes[10] & 0xFC) >> 2);
+  out_raw_bits[10] = ((id->bytes[10] & 0x03) << 6) | ((id->bytes[11] & 0xFC) >> 2);
+  out_raw_bits[11] = ((id->bytes[11] & 0x03) << 6) | ((id->bytes[12] & 0xFC) >> 2);
+  out_raw_bits[12] = ((id->bytes[12] & 0x03) << 6) | ((id->bytes[13] & 0xFC) >> 2);
+  out_raw_bits[13] = ((id->bytes[13] & 0x03) << 6) | ((id->bytes[14] & 0xFC) >> 2);
+  out_raw_bits[14] = ((id->bytes[14] & 0x03) << 6) | ((id->bytes[15] & 0xFC) >> 2);
+  out_raw_bits[15] = (id->bytes[15] & 0x03) << 6;  // last 6 bits are padding
 }
 
-void CuidUtilities::add_UUIDv8_bits(const uint8_t raw_bits[16],
-                                    amdcuid_id_t *id) {
+void CuidUtilities::add_UUIDv8_bits(const uint8_t raw_bits[16], amdcuid_id_t* id) {
   if (!raw_bits || !id) {
     return;
   }
@@ -572,8 +560,7 @@ void CuidUtilities::add_UUIDv8_bits(const uint8_t raw_bits[16],
   id->bytes[5] = raw_bits[5];
 
   // Bits 48-51: Version (8) + Bits 52-63: ID value part 2
-  id->bytes[6] =
-      ((raw_bits[6] & 0xF0) >> 4) | 0x80; // Version 8 in upper 4 bits
+  id->bytes[6] = ((raw_bits[6] & 0xF0) >> 4) | 0x80;  // Version 8 in upper 4 bits
   id->bytes[7] = ((raw_bits[6] & 0x0F) << 4) | ((raw_bits[7] & 0xF0) >> 4);
 
   // Bits 64-65: Variant (10b) + Bits 66-127: ID value part 3 (MSB)
@@ -588,25 +575,22 @@ void CuidUtilities::add_UUIDv8_bits(const uint8_t raw_bits[16],
   id->bytes[15] = ((raw_bits[14] & 0x3F) << 2) | ((raw_bits[15] & 0xC0) >> 6);
 }
 
-std::string CuidUtilities::get_cuid_as_string(const amdcuid_id_t *id) {
+std::string CuidUtilities::get_cuid_as_string(const amdcuid_id_t* id) {
   // Format as UUIDv8 string: 8-4-4-4-12 hex digits from id->bytes[16]
   // UUID: xxxxxxxx-xxxx-8xxx-yxxx-xxxxxxxxxxxx
-  char uuid_str[37]; // 36 chars + null
-  // Format the bytes into a UUID string
-  snprintf(
-      uuid_str, sizeof(uuid_str),
-      "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
-      id->bytes[0], id->bytes[1], id->bytes[2], id->bytes[3], id->bytes[4],
-      id->bytes[5], id->bytes[6], id->bytes[7], id->bytes[8], id->bytes[9],
-      id->bytes[10], id->bytes[11], id->bytes[12], id->bytes[13], id->bytes[14],
-      id->bytes[15]);
+  char uuid_str[37];  // 36 chars + null
+  // 32 hex digits plus 4 hyphens is exactly 36 characters plus the NUL.
+  // NOLINTNEXTLINE(cert-err33-c)
+  snprintf(uuid_str, sizeof(uuid_str),
+           "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x", id->bytes[0],
+           id->bytes[1], id->bytes[2], id->bytes[3], id->bytes[4], id->bytes[5], id->bytes[6],
+           id->bytes[7], id->bytes[8], id->bytes[9], id->bytes[10], id->bytes[11], id->bytes[12],
+           id->bytes[13], id->bytes[14], id->bytes[15]);
 
   return std::string(uuid_str);
 }
 
-amdcuid_status_t
-CuidUtilities::uuid_string_to_uint8(const std::string &uuid_str,
-                                    uint8_t *uuid) {
+amdcuid_status_t CuidUtilities::uuid_string_to_uint8(const std::string& uuid_str, uint8_t* uuid) {
   if (!uuid) {
     return AMDCUID_STATUS_INVALID_ARGUMENT;
   }
@@ -617,8 +601,7 @@ CuidUtilities::uuid_string_to_uint8(const std::string &uuid_str,
   for (char c : uuid_str) {
     if (c != '-') {
       if (!isxdigit(c)) {
-        std::cerr << "Invalid UUID format: non-hex character found"
-                  << std::endl;
+        std::cerr << "Invalid UUID format: non-hex character found" << std::endl;
         return AMDCUID_STATUS_INVALID_ARGUMENT;
       }
       hex_str += c;
@@ -627,8 +610,8 @@ CuidUtilities::uuid_string_to_uint8(const std::string &uuid_str,
 
   // UUID should be 128 bits = 32 hex characters
   if (hex_str.length() != 32) {
-    std::cerr << "Invalid UUID length: expected 32 hex digits, got "
-              << hex_str.length() << std::endl;
+    std::cerr << "Invalid UUID length: expected 32 hex digits, got " << hex_str.length()
+              << std::endl;
     return AMDCUID_STATUS_INVALID_ARGUMENT;
   }
 
@@ -643,27 +626,26 @@ CuidUtilities::uuid_string_to_uint8(const std::string &uuid_str,
 
 std::string CuidUtilities::device_type_to_string(amdcuid_device_type_t type) {
   switch (type) {
-  case AMDCUID_DEVICE_TYPE_PLATFORM:
-    return "PLATFORM";
-  case AMDCUID_DEVICE_TYPE_CPU:
-    return "CPU";
-  case AMDCUID_DEVICE_TYPE_GPU:
-    return "GPU";
-  case AMDCUID_DEVICE_TYPE_NIC:
-    return "NIC";
-  case AMDCUID_DEVICE_TYPE_NPU:
-    return "NPU";
-  default:
-    return "UNKNOWN";
+    case AMDCUID_DEVICE_TYPE_PLATFORM:
+      return "PLATFORM";
+    case AMDCUID_DEVICE_TYPE_CPU:
+      return "CPU";
+    case AMDCUID_DEVICE_TYPE_GPU:
+      return "GPU";
+    case AMDCUID_DEVICE_TYPE_NIC:
+      return "NIC";
+    case AMDCUID_DEVICE_TYPE_NPU:
+      return "NPU";
+    default:
+      return "UNKNOWN";
   }
 }
 
-bool CuidUtilities::is_valid_bdf(const std::string &bdf) {
+bool CuidUtilities::is_valid_bdf(const std::string& bdf) {
   // Expected format: DDDD:BB:SS.F (e.g. "0000:03:00.0")
-  if (bdf.size() != 12)
-    return false;
+  if (bdf.size() != 12) return false;
   auto is_hex = [](char c) { return std::isxdigit((unsigned char)c); };
-  return is_hex(bdf[0]) && is_hex(bdf[1]) && is_hex(bdf[2]) && is_hex(bdf[3]) &&
-         bdf[4] == ':' && is_hex(bdf[5]) && is_hex(bdf[6]) && bdf[7] == ':' &&
-         is_hex(bdf[8]) && is_hex(bdf[9]) && bdf[10] == '.' && is_hex(bdf[11]);
+  return is_hex(bdf[0]) && is_hex(bdf[1]) && is_hex(bdf[2]) && is_hex(bdf[3]) && bdf[4] == ':' &&
+         is_hex(bdf[5]) && is_hex(bdf[6]) && bdf[7] == ':' && is_hex(bdf[8]) && is_hex(bdf[9]) &&
+         bdf[10] == '.' && is_hex(bdf[11]);
 }

--- a/projects/cuid/lib/src/cuid_util.h
+++ b/projects/cuid/lib/src/cuid_util.h
@@ -23,20 +23,21 @@
 #ifndef CUID_UTIL_H
 #define CUID_UTIL_H
 
-#include "hmac.h"
-#include "include/amd_cuid.h"
-#include "src/cuid_internal.h"
 #include <iostream>
 #include <memory>
 #include <sstream>
 #include <string>
 #include <vector>
 
+#include "hmac.h"
+#include "include/amd_cuid.h"
+#include "src/cuid_internal.h"
+
 enum LogLevel { DEBUG, INFO, WARN, ERROR };
 
 class Logger {
-public:
-  static Logger &instance() {
+ public:
+  static Logger& instance() {
     static Logger logger_;
     return logger_;
   }
@@ -44,60 +45,79 @@ public:
   void set_level(LogLevel level) { level_ = level; }
   LogLevel level() const { return level_; }
 
-  const char *LogLevelName(LogLevel level) const;
+  const char* LogLevelName(LogLevel level) const;
 
-  void log(LogLevel level, const std::string &msg) const;
+  void log(LogLevel level, const std::string& msg) const;
 
-private:
+ private:
   Logger() : level_(INFO) {}
   LogLevel level_;
 };
 
-#define LOG(level, msg)                                                        \
-  do {                                                                         \
-    std::ostringstream _log_stream_;                                           \
-    _log_stream_ << msg;                                                       \
-    Logger::instance().log(level, _log_stream_.str());                         \
+// NOLINTBEGIN(bugprone-macro-parentheses)
+// `msg` is deliberately left unparenthesised. Callers pass a stream-
+// continuation fragment such as `"failed: " << path`, which is only valid
+// glued onto the left of `_log_stream_ <<`. Wrapping it would evaluate
+// `const char[] << std::string` as an expression of its own, which does not
+// compile. clang-tidy cannot see that, so the check is suppressed here rather
+// than obeyed.
+#define LOG(level, msg)                                  \
+  do {                                                   \
+    std::ostringstream _log_stream_;                     \
+    _log_stream_ << msg;                                 \
+    Logger::instance().log((level), _log_stream_.str()); \
   } while (0)
+// NOLINTEND(bugprone-macro-parentheses)
 
 namespace CuidUtilities {
-std::string read_sysfs_file(const std::string &path);
-std::string readlink_bdf(const std::string &device_path);
-std::string bdf_to_device_path(const std::string &bdf,
-                               amdcuid_device_type_t device_type);
+// Thread-safe replacement for strerror(). strerror() returns a pointer into a
+// static buffer, so two threads reporting errors at once can read a torn or
+// wrong message. libamdcuid is linked into multithreaded hosts -- amd_smi and
+// libhsa-runtime64.so among them -- so it must not use it.
+std::string errno_string(int err);
+
+// A zero hardware fingerprint is the absence of an identity, not an identity.
+// Unprogrammed DSN capabilities and unconfigured MAC addresses both read back
+// as all-zero, and reporting that as a successful fingerprint gives every such
+// device on every machine the same primary CUID. Callers use this to convert
+// "read succeeded, value is meaningless" into HW_FINGERPRINT_NOT_FOUND, which
+// routes the device onto the temporary-CUID path it should have been on.
+inline amdcuid_status_t validate_fingerprint(uint64_t fingerprint) {
+  return (fingerprint == 0) ? AMDCUID_STATUS_HW_FINGERPRINT_NOT_FOUND : AMDCUID_STATUS_SUCCESS;
+}
+
+std::string read_sysfs_file(const std::string& path);
+std::string readlink_bdf(const std::string& device_path);
+std::string bdf_to_device_path(const std::string& bdf, amdcuid_device_type_t device_type);
 std::string real_dev_path_from_fd(int fd);
-std::string get_real_path(const std::string &path);
-amdcuid_status_t generate_derived_cuid(const amdcuid_primary_id *primary_id,
-                                       amdcuid_derived_id *derived_id,
-                                       cuid_hmac *hmac);
+std::string get_real_path(const std::string& path);
+amdcuid_status_t generate_derived_cuid(const amdcuid_primary_id* primary_id,
+                                       amdcuid_derived_id* derived_id, cuid_hmac* hmac);
 amdcuid_status_t generate_primary_cuid(uint64_t serial_number, uint16_t unit_id,
-                                       uint8_t revision_id, uint16_t device_id,
-                                       uint16_t vendor_id, uint8_t device_type,
-                                       amdcuid_primary_id *primary_id,
+                                       uint8_t revision_id, uint16_t device_id, uint16_t vendor_id,
+                                       uint8_t device_type, amdcuid_primary_id* primary_id,
                                        bool temp = false);
-void remove_UUIDv8_bits(amdcuid_id_t *id, uint8_t out_raw_bits[16]);
-void add_UUIDv8_bits(const uint8_t raw_bits[16], amdcuid_id_t *id);
-std::string get_cuid_as_string(const amdcuid_id_t *id);
-amdcuid_status_t uuid_string_to_uint8(const std::string &uuid_str,
-                                      uint8_t *uuid);
+void remove_UUIDv8_bits(amdcuid_id_t* id, uint8_t out_raw_bits[16]);
+void add_UUIDv8_bits(const uint8_t raw_bits[16], amdcuid_id_t* id);
+std::string get_cuid_as_string(const amdcuid_id_t* id);
+amdcuid_status_t uuid_string_to_uint8(const std::string& uuid_str, uint8_t* uuid);
 std::string device_type_to_string(amdcuid_device_type_t type);
 
-bool is_valid_bdf(const std::string &bdf);
-amdcuid_status_t make_fallback_fingerprint(const std::string &id,
-                                           uint64_t &fingerprint);
+bool is_valid_bdf(const std::string& bdf);
+amdcuid_status_t make_fallback_fingerprint(const std::string& id, uint64_t& fingerprint);
 
 // GPU VF (SR-IOV Virtual Function) utilities
-int extract_render_minor(const std::string &path);
-uint16_t get_gpu_vf_id(const std::string &device_path);
+int extract_render_minor(const std::string& path);
+uint16_t get_gpu_vf_id(const std::string& device_path);
 
-inline const std::string &cuid_file() {
+inline const std::string& cuid_file() {
   static const std::string path = "/tmp/cuid";
   return path;
 }
-inline const std::string &priv_cuid_file() {
+inline const std::string& priv_cuid_file() {
   static const std::string path = "/tmp/priv_cuid";
   return path;
 }
-} // namespace CuidUtilities
+}  // namespace CuidUtilities
 
 #endif

--- a/projects/cuid/lib/src/gim_util.cc
+++ b/projects/cuid/lib/src/gim_util.cc
@@ -22,7 +22,10 @@
 
 #include "gim_util.h"
 
-#include "cuid_util.h"
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 #include <cctype>
 #include <cerrno>
@@ -30,10 +33,8 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
-#include <fcntl.h>
-#include <sys/ioctl.h>
-#include <sys/stat.h>
-#include <unistd.h>
+
+#include "cuid_util.h"
 
 namespace cuid {
 namespace gim {
@@ -46,7 +47,7 @@ namespace {
 // ABI drift.
 
 constexpr size_t kSmiMaxStringLength = 256;
-constexpr size_t kSmiMaxPayload = 1024;          // uint32_t entries
+constexpr size_t kSmiMaxPayload = 1024;  // uint32_t entries
 constexpr size_t kSmiMaxPayloadBytes = kSmiMaxPayload * sizeof(uint32_t);
 constexpr size_t kSmiMaxDevices = 32;
 
@@ -67,16 +68,14 @@ constexpr uint32_t kSmiVersionBeta1 = 0x00000004u;
 constexpr uint32_t kSmiVersionBeta0 = 0x00000003u;
 constexpr uint32_t kSmiVersionAlpha0 = 0x00000002u;
 
-constexpr uint32_t kHandshakeVersions[] = {
-    kSmiVersionBeta4, kSmiVersionBeta3, kSmiVersionBeta2,
-    kSmiVersionBeta1, kSmiVersionBeta0, kSmiVersionAlpha0};
+constexpr uint32_t kHandshakeVersions[] = {kSmiVersionBeta4, kSmiVersionBeta3, kSmiVersionBeta2,
+                                           kSmiVersionBeta1, kSmiVersionBeta0, kSmiVersionAlpha0};
 
 // _IOWR('S', 0, struct smi_ioctl_cmd). The struct size is encoded in the
 // ioctl number, so we use the same total wire size (4108 bytes) the GIM
 // driver expects for its smi_ioctl_cmd transport.
 constexpr size_t kSmiIoctlCmdSize = 4 + 2 + 2 + 4 + kSmiMaxPayloadBytes;
-constexpr unsigned long kSmiIoctlCmd =
-    _IOC(_IOC_READ | _IOC_WRITE, 'S', 0, kSmiIoctlCmdSize);
+constexpr unsigned long kSmiIoctlCmd = _IOC(_IOC_READ | _IOC_WRITE, 'S', 0, kSmiIoctlCmdSize);
 
 #pragma pack(push, 1)
 struct SmiInHdrWire {
@@ -97,8 +96,7 @@ struct SmiIoctlCmdWire {
   SmiOutHdrWire out_hdr;
   uint8_t payload[kSmiMaxPayloadBytes];
 };
-static_assert(sizeof(SmiIoctlCmdWire) == kSmiIoctlCmdSize,
-              "SmiIoctlCmdWire size mismatch");
+static_assert(sizeof(SmiIoctlCmdWire) == kSmiIoctlCmdSize, "SmiIoctlCmdWire size mismatch");
 
 // SMI handshake input/output payload (struct smi_handshake).
 struct SmiHandshakeWire {
@@ -114,21 +112,19 @@ struct SmiDeviceHandleWire {
   uint64_t handle;
   uint64_t device_id;
 };
-static_assert(sizeof(SmiDeviceHandleWire) == 16,
-              "SmiDeviceHandleWire size mismatch");
+static_assert(sizeof(SmiDeviceHandleWire) == 16, "SmiDeviceHandleWire size mismatch");
 
 // One entry of struct smi_server_static_info::devices[] (Linux, natural
 // alignment). dev_id is a 16-byte smi_device_handle_t, so each entry is 40
 // bytes.
 struct SmiServerDeviceWire {
   SmiDeviceHandleWire dev_id;
-  uint64_t bdf;     // union smi_bdf packed 64-bit value
+  uint64_t bdf;  // union smi_bdf packed 64-bit value
   uint8_t failed;
   uint8_t padding[3];
   uint32_t reserved[3];
 };
-static_assert(sizeof(SmiServerDeviceWire) == 40,
-              "SmiServerDeviceWire size mismatch");
+static_assert(sizeof(SmiServerDeviceWire) == 40, "SmiServerDeviceWire size mismatch");
 
 // struct smi_server_static_info (Linux, natural alignment). The trailing
 // reserved area expands the struct to the full 4096-byte SMI payload; the GIM
@@ -139,8 +135,7 @@ struct SmiServerStaticInfoWire {
   SmiServerDeviceWire devices[kSmiMaxDevices];
   uint64_t reserved[351];
 };
-static_assert(sizeof(SmiServerStaticInfoWire) == 4096,
-              "SmiServerStaticInfoWire size mismatch");
+static_assert(sizeof(SmiServerStaticInfoWire) == 4096, "SmiServerStaticInfoWire size mismatch");
 static_assert(sizeof(SmiServerStaticInfoWire) <= kSmiMaxPayloadBytes,
               "SmiServerStaticInfoWire larger than SMI payload");
 
@@ -149,8 +144,7 @@ static_assert(sizeof(SmiServerStaticInfoWire) <= kSmiMaxPayloadBytes,
 struct SmiDeviceInfoWire {
   SmiDeviceHandleWire dev_id;
 };
-static_assert(sizeof(SmiDeviceInfoWire) == 16,
-              "SmiDeviceInfoWire size mismatch");
+static_assert(sizeof(SmiDeviceInfoWire) == 16, "SmiDeviceInfoWire size mismatch");
 
 // struct smi_asic_info (Linux, natural alignment).
 struct SmiAsicInfoWire {
@@ -185,7 +179,7 @@ static_assert(sizeof(SmiAsicInfoWire) <= kSmiMaxPayloadBytes,
               "SmiAsicInfoWire larger than SMI payload");
 
 // Copy a C string field bounded to its array length, ensuring NUL-termination.
-std::string fixed_string_to_std(const char *src, size_t cap) {
+std::string fixed_string_to_std(const char* src, size_t cap) {
   size_t n = 0;
   while (n < cap && src[n] != '\0') {
     ++n;
@@ -193,11 +187,11 @@ std::string fixed_string_to_std(const char *src, size_t cap) {
   return std::string(src, n);
 }
 
-bool is_canonical_bdf(const std::string &bdf) {
+bool is_canonical_bdf(const std::string& bdf) {
   return bdf.size() == 12 && bdf[4] == ':' && bdf[7] == ':' && bdf[10] == '.';
 }
 
-} // namespace
+}  // namespace
 
 // ----------------------------------------------------------------------------
 // GimClient
@@ -213,7 +207,7 @@ GimClient::~GimClient() {
 }
 
 bool GimClient::is_available() {
-  struct stat st {};
+  struct stat st{};
   if (::stat(kGimSmiDevicePath, &st) != 0) {
     return false;
   }
@@ -232,8 +226,8 @@ amdcuid_status_t GimClient::init() {
     int fd = ::open(kGimSmiDevicePath, O_RDWR | O_CLOEXEC);
     if (fd < 0) {
       const int err = errno;
-      LOG(DEBUG, "GIM: open(" << kGimSmiDevicePath
-                              << ") failed: " << std::strerror(err));
+      LOG(DEBUG,
+          "GIM: open(" << kGimSmiDevicePath << ") failed: " << CuidUtilities::errno_string(err));
       if (err == EACCES || err == EPERM) {
         return AMDCUID_STATUS_PERMISSION_DENIED;
       }
@@ -246,12 +240,10 @@ amdcuid_status_t GimClient::init() {
   for (uint32_t version : kHandshakeVersions) {
     SmiHandshakeWire hs{version};
     SmiHandshakeWire resp{};
-    amdcuid_status_t st = do_ioctl(kSmiCmdCodeHandshake, &hs, sizeof(hs), &resp,
-                                   sizeof(resp));
+    amdcuid_status_t st = do_ioctl(kSmiCmdCodeHandshake, &hs, sizeof(hs), &resp, sizeof(resp));
     if (st == AMDCUID_STATUS_SUCCESS) {
       handshake_done_ = true;
-      LOG(DEBUG, "GIM: handshake succeeded with version 0x" << std::hex
-                                                            << version);
+      LOG(DEBUG, "GIM: handshake succeeded with version 0x" << std::hex << version);
       return AMDCUID_STATUS_SUCCESS;
     }
   }
@@ -262,8 +254,8 @@ amdcuid_status_t GimClient::init() {
   return AMDCUID_STATUS_UNSUPPORTED;
 }
 
-amdcuid_status_t GimClient::do_ioctl(uint32_t cmd_code, const void *in,
-                                     size_t in_len, void *out, size_t out_len) {
+amdcuid_status_t GimClient::do_ioctl(uint32_t cmd_code, const void* in, size_t in_len, void* out,
+                                     size_t out_len) {
   if (fd_ < 0) {
     return AMDCUID_STATUS_UNSUPPORTED;
   }
@@ -283,15 +275,14 @@ amdcuid_status_t GimClient::do_ioctl(uint32_t cmd_code, const void *in,
   if (::ioctl(fd_, kSmiIoctlCmd, &cmd) != 0) {
     const int err = errno;
     LOG(DEBUG, "GIM: ioctl(cmd=0x" << std::hex << cmd_code
-                                   << ") failed: " << std::strerror(err));
+                                   << ") failed: " << CuidUtilities::errno_string(err));
     if (err == EACCES || err == EPERM) {
       return AMDCUID_STATUS_PERMISSION_DENIED;
     }
     return AMDCUID_STATUS_UNSUPPORTED;
   }
   if (cmd.out_hdr.status != 0) {
-    LOG(DEBUG, "GIM: SMI cmd 0x" << std::hex << cmd_code
-                                 << " returned status " << std::dec
+    LOG(DEBUG, "GIM: SMI cmd 0x" << std::hex << cmd_code << " returned status " << std::dec
                                  << cmd.out_hdr.status);
     return AMDCUID_STATUS_UNSUPPORTED;
   }
@@ -301,7 +292,7 @@ amdcuid_status_t GimClient::do_ioctl(uint32_t cmd_code, const void *in,
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t GimClient::get_devices(std::vector<GimDeviceEntry> &out) {
+amdcuid_status_t GimClient::get_devices(std::vector<GimDeviceEntry>& out) {
   out.clear();
   amdcuid_status_t st = init();
   if (st != AMDCUID_STATUS_SUCCESS) {
@@ -310,8 +301,7 @@ amdcuid_status_t GimClient::get_devices(std::vector<GimDeviceEntry> &out) {
 
   SmiServerStaticInfoWire info;
   std::memset(&info, 0, sizeof(info));
-  st = do_ioctl(kSmiCmdCodeGetServerStaticInfo, nullptr, 0, &info,
-                sizeof(info));
+  st = do_ioctl(kSmiCmdCodeGetServerStaticInfo, nullptr, 0, &info, sizeof(info));
   if (st != AMDCUID_STATUS_SUCCESS) {
     return st;
   }
@@ -331,8 +321,7 @@ amdcuid_status_t GimClient::get_devices(std::vector<GimDeviceEntry> &out) {
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t GimClient::lookup_dev_id(const std::string &bdf,
-                                          uint64_t &dev_id) {
+amdcuid_status_t GimClient::lookup_dev_id(const std::string& bdf, uint64_t& dev_id) {
   if (!is_canonical_bdf(bdf)) {
     return AMDCUID_STATUS_INVALID_ARGUMENT;
   }
@@ -341,7 +330,7 @@ amdcuid_status_t GimClient::lookup_dev_id(const std::string &bdf,
   if (st != AMDCUID_STATUS_SUCCESS) {
     return st;
   }
-  for (const auto &e : devices) {
+  for (const auto& e : devices) {
     if (e.bdf == bdf) {
       dev_id = e.dev_id;
       return AMDCUID_STATUS_SUCCESS;
@@ -350,7 +339,7 @@ amdcuid_status_t GimClient::lookup_dev_id(const std::string &bdf,
   return AMDCUID_STATUS_DEVICE_NOT_FOUND;
 }
 
-amdcuid_status_t GimClient::get_asic_info(uint64_t dev_id, GimAsicInfo &info) {
+amdcuid_status_t GimClient::get_asic_info(uint64_t dev_id, GimAsicInfo& info) {
   amdcuid_status_t st = init();
   if (st != AMDCUID_STATUS_SUCCESS) {
     return st;
@@ -370,8 +359,7 @@ amdcuid_status_t GimClient::get_asic_info(uint64_t dev_id, GimAsicInfo &info) {
   info.subvendor_id = raw.subvendor_id;
   info.device_id = raw.device_id;
   info.rev_id = raw.rev_id;
-  info.asic_serial =
-      fixed_string_to_std(raw.asic_serial, kSmiMaxStringLength);
+  info.asic_serial = fixed_string_to_std(raw.asic_serial, kSmiMaxStringLength);
   info.oam_id = raw.oam_id;
   info.num_of_compute_units = raw.num_of_compute_units;
   info.target_graphics_version = raw.target_graphics_version;
@@ -379,8 +367,7 @@ amdcuid_status_t GimClient::get_asic_info(uint64_t dev_id, GimAsicInfo &info) {
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t GimClient::get_asic_info_for_bdf(const std::string &bdf,
-                                                  GimAsicInfo &info) {
+amdcuid_status_t GimClient::get_asic_info_for_bdf(const std::string& bdf, GimAsicInfo& info) {
   uint64_t dev_id = 0;
   amdcuid_status_t st = lookup_dev_id(bdf, dev_id);
   if (st != AMDCUID_STATUS_SUCCESS) {
@@ -389,14 +376,13 @@ amdcuid_status_t GimClient::get_asic_info_for_bdf(const std::string &bdf,
   return get_asic_info(dev_id, info);
 }
 
-bool GimClient::parse_asic_serial(const std::string &serial, uint64_t &out) {
+bool GimClient::parse_asic_serial(const std::string& serial, uint64_t& out) {
   if (serial.empty()) {
     return false;
   }
   // Accept optional 0x/0X prefix.
   size_t pos = 0;
-  if (serial.size() > 2 && serial[0] == '0' &&
-      (serial[1] == 'x' || serial[1] == 'X')) {
+  if (serial.size() > 2 && serial[0] == '0' && (serial[1] == 'x' || serial[1] == 'X')) {
     pos = 2;
   }
   if (pos >= serial.size()) {
@@ -430,11 +416,14 @@ std::string GimClient::format_bdf(uint64_t packed_bdf) {
   const uint32_t device = static_cast<uint32_t>((packed_bdf >> 3) & 0x1Fu);
   const uint32_t bus = static_cast<uint32_t>((packed_bdf >> 8) & 0xFFu);
   const uint32_t domain = static_cast<uint32_t>((packed_bdf >> 16) & 0xFFFFu);
+  // Bounded by construction: domain is masked to 16 bits (4 hex digits), bus to
+  // 8 (2), device to 5 (2) and function to 3 (1 decimal digit), so the longest
+  // output is 4+1+2+1+2+1+1 = 12 characters plus the NUL. It cannot truncate.
   char buf[16];
-  std::snprintf(buf, sizeof(buf), "%04x:%02x:%02x.%u", domain, bus, device,
-                function);
+  // NOLINTNEXTLINE(cert-err33-c)
+  std::snprintf(buf, sizeof(buf), "%04x:%02x:%02x.%u", domain, bus, device, function);
   return std::string(buf);
 }
 
-} // namespace gim
-} // namespace cuid
+}  // namespace gim
+}  // namespace cuid

--- a/projects/cuid/lib/src/gim_util.h
+++ b/projects/cuid/lib/src/gim_util.h
@@ -23,17 +23,18 @@
 #ifndef CUID_GIM_UTIL_H
 #define CUID_GIM_UTIL_H
 
-#include "include/amd_cuid.h"
 #include <cstddef>
 #include <cstdint>
 #include <string>
 #include <vector>
 
+#include "include/amd_cuid.h"
+
 namespace cuid {
 namespace gim {
 
 // GIM SMI character device exposed by the GIM kernel driver.
-constexpr const char *kGimSmiDevicePath = "/dev/gim-smi0";
+constexpr const char* kGimSmiDevicePath = "/dev/gim-smi0";
 
 // Mirror of struct smi_asic_info subset returned by SMI_CMD_CODE_GET_ASIC_INFO
 // in the host AMD-SMI / GIM ABI. Strings are NUL-terminated.
@@ -44,7 +45,7 @@ struct GimAsicInfo {
   uint32_t subvendor_id = 0;
   uint64_t device_id = 0;
   uint32_t rev_id = 0;
-  std::string asic_serial; // hexadecimal string (e.g. "0x1234ABCD")
+  std::string asic_serial;  // hexadecimal string (e.g. "0x1234ABCD")
   uint32_t oam_id = 0;
   uint32_t num_of_compute_units = 0;
   uint64_t target_graphics_version = 0;
@@ -52,21 +53,21 @@ struct GimAsicInfo {
 };
 
 struct GimDeviceEntry {
-  uint64_t dev_id = 0;     // Opaque GIM device handle.
-  std::string bdf;         // Canonical "dddd:bb:dd.f" PCI BDF.
-  bool failed = false;     // Reported by GIM as failed.
+  uint64_t dev_id = 0;  // Opaque GIM device handle.
+  std::string bdf;      // Canonical "dddd:bb:dd.f" PCI BDF.
+  bool failed = false;  // Reported by GIM as failed.
 };
 
 // RAII wrapper around the GIM SMI ioctl interface, used to query device info
 // when sysfs is not populated (GIM SR-IOV hosts). All methods are safe to call
 // when the device node is absent and return AMDCUID_STATUS_UNSUPPORTED then.
 class GimClient {
-public:
+ public:
   GimClient();
   ~GimClient();
 
-  GimClient(const GimClient &) = delete;
-  GimClient &operator=(const GimClient &) = delete;
+  GimClient(const GimClient&) = delete;
+  GimClient& operator=(const GimClient&) = delete;
 
   // Returns true when the GIM SMI character device exists in /dev. Does not
   // require any special privilege.
@@ -86,39 +87,38 @@ public:
 
   // Enumerate all GPUs visible to the GIM driver. Calls init() if not already
   // connected.
-  amdcuid_status_t get_devices(std::vector<GimDeviceEntry> &out);
+  amdcuid_status_t get_devices(std::vector<GimDeviceEntry>& out);
 
   // Look up the GIM device handle for a given canonical PCI BDF string.
-  amdcuid_status_t lookup_dev_id(const std::string &bdf, uint64_t &dev_id);
+  amdcuid_status_t lookup_dev_id(const std::string& bdf, uint64_t& dev_id);
 
   // Query ASIC info (vendor/device/rev IDs, serial, etc.) for a GIM device
   // handle previously returned by get_devices().
-  amdcuid_status_t get_asic_info(uint64_t dev_id, GimAsicInfo &info);
+  amdcuid_status_t get_asic_info(uint64_t dev_id, GimAsicInfo& info);
 
   // Convenience wrapper: lookup then query.
-  amdcuid_status_t get_asic_info_for_bdf(const std::string &bdf,
-                                         GimAsicInfo &info);
+  amdcuid_status_t get_asic_info_for_bdf(const std::string& bdf, GimAsicInfo& info);
 
   // Parse an ASIC serial number reported by GIM as a hexadecimal string into
   // a 64-bit value. Accepts an optional "0x"/"0X" prefix and rejects empty
   // or non-hex input. Returns true on success.
-  static bool parse_asic_serial(const std::string &serial, uint64_t &out);
+  static bool parse_asic_serial(const std::string& serial, uint64_t& out);
 
   // Convert a GIM smi_bdf 64-bit packed value into the canonical
   // "dddd:bb:dd.f" string representation. Exposed for testing.
   static std::string format_bdf(uint64_t packed_bdf);
 
-private:
+ private:
   // Issue a single SMI ioctl. payload buffers are clamped to the SMI payload
   // size; returns AMDCUID_STATUS_INVALID_ARGUMENT if the request is too large.
-  amdcuid_status_t do_ioctl(uint32_t cmd_code, const void *in, size_t in_len,
-                            void *out, size_t out_len);
+  amdcuid_status_t do_ioctl(uint32_t cmd_code, const void* in, size_t in_len, void* out,
+                            size_t out_len);
 
   int fd_ = -1;
   bool handshake_done_ = false;
 };
 
-} // namespace gim
-} // namespace cuid
+}  // namespace gim
+}  // namespace cuid
 
-#endif // CUID_GIM_UTIL_H
+#endif  // CUID_GIM_UTIL_H

--- a/projects/cuid/lib/src/hmac.cc
+++ b/projects/cuid/lib/src/hmac.cc
@@ -20,291 +20,143 @@
  * THE SOFTWARE.
  */
 
-// Backend selection (compile-time):
-//   _WIN32                               -> Windows CNG  (BCrypt)
-//   OpenSSL >= 3.0 (all other platforms) -> EVP_MAC API
-//   OpenSSL <  3.0 (all other platforms) -> HMAC_CTX API
+// HMAC-SHA-256 over the in-tree SHA-256 (sha256.h). One code path on every
+// platform; only the CSPRNG below is platform-specific.
 
 #include "hmac.h"
 
-#include <stdlib.h>
+#include <fcntl.h>
+#include <sys/stat.h>
 
 #include <cerrno>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <fstream>
 #include <iostream>
+
+#include "sha256.h"
+
+#if defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+// bcrypt.h must follow windows.h.
+#include <bcrypt.h>
+#include <direct.h>
+#else
+#include <unistd.h>
+// getrandom(2) needs glibc >= 2.25 (or musl); where it is missing, and where
+// the syscall itself is missing (pre-3.17 kernels, some containers/seccomp
+// profiles), fill_random() falls back to reading /dev/urandom. Define
+// AMDCUID_HAVE_GETRANDOM=0 on the command line to force the fallback path.
+#if !defined(AMDCUID_HAVE_GETRANDOM) && defined(__has_include)
+#if __has_include(<sys/random.h>)
+#define AMDCUID_HAVE_GETRANDOM 1
+#endif
+#endif
+#if AMDCUID_HAVE_GETRANDOM
+#include <sys/random.h>
+#endif
+#endif
 
 #ifndef AMDCUID_CONFIG_DIR
 #error "AMDCUID_CONFIG_DIR must be defined via CMake"
 #endif
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Windows CNG backend (BCrypt)
-// ─────────────────────────────────────────────────────────────────────────────
+namespace {
+
+// Used when no secret is provisioned. Byte-identical to CUID_DEFAULT_SEED in
+// the kernel's amdgpu_cuid.c, so sysfs and this library agree on an
+// unprovisioned machine. Not a substitute for provisioning; callers can check
+// is_using_default_key().
+constexpr char kDefaultSeed[] = "AMD-CUID-DEFAULT-SEED-v1";
+constexpr size_t kDefaultSeedLen = sizeof(kDefaultSeed) - 1;
+
+// The only digest CUID uses. A wider one would overrun the caller's 32-byte
+// output buffer, so set_hmac_algorithm() rejects everything else.
+bool is_sha256_name(const char* name) {
+  if (!name) return true;  // nullptr means "the default", which is SHA-256
+  return std::strcmp(name, "SHA256") == 0 || std::strcmp(name, "SHA-256") == 0 ||
+         std::strcmp(name, "sha256") == 0 || std::strcmp(name, "sha-256") == 0;
+}
+
+// Directory portion of a path, or "." when there is none.
+std::string parent_dir(const std::string& path) {
+  const size_t slash = path.find_last_of('/');
+  if (slash == std::string::npos) return ".";
+  if (slash == 0) return "/";
+  return path.substr(0, slash);
+}
+
+// Create the key directory (0755, as the packaging script does) so the API
+// works on a machine where the post-install script never ran.
+bool ensure_parent_dir(const std::string& path) {
+  const std::string dir = parent_dir(path);
+  struct stat st;
+  if (stat(dir.c_str(), &st) == 0) return S_ISDIR(st.st_mode);
 #if defined(_WIN32)
+  return _mkdir(dir.c_str()) == 0 || errno == EEXIST;
+#else
+  return mkdir(dir.c_str(), S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH) == 0 ||
+         errno == EEXIST;
+#endif
+}
 
-#define WIN32_LEAN_AND_MEAN
-#include <bcrypt.h>
-#include <windows.h>
+// Fill buf with cryptographically secure random bytes.
+bool fill_random(uint8_t* buf, size_t len) {
+#if defined(_WIN32)
+  return BCRYPT_SUCCESS(BCryptGenRandom(nullptr, reinterpret_cast<PUCHAR>(buf),
+                                        static_cast<ULONG>(len), BCRYPT_USE_SYSTEM_PREFERRED_RNG));
+#else
+#if AMDCUID_HAVE_GETRANDOM
+  size_t off = 0;
+  while (off < len) {
+    ssize_t n = getrandom(buf + off, len - off, 0);
+    if (n < 0) {
+      if (errno == EINTR) continue;
+      break;  // ENOSYS on a pre-3.17 kernel; fall through to /dev/urandom
+    }
+    off += static_cast<size_t>(n);
+  }
+  if (off == len) return true;
+#endif
+  std::ifstream urandom("/dev/urandom", std::ios::binary);
+  if (!urandom) return false;
+  urandom.read(reinterpret_cast<char*>(buf), static_cast<std::streamsize>(len));
+  return urandom.gcount() == static_cast<std::streamsize>(len);
+#endif
+}
+
+}  // namespace
 
 struct cuid_hmac::Impl {
-  BCRYPT_ALG_HANDLE hAlg;
   std::string digest_name;
-
-  // Map an OpenSSL-style digest name to the BCrypt HMAC provider ID.
-  static const wchar_t* to_bcrypt_alg(const char* name) {
-    if (!name) return BCRYPT_SHA256_ALGORITHM;
-    if (_stricmp(name, "SHA256") == 0 || _stricmp(name, "SHA-256") == 0)
-      return BCRYPT_SHA256_ALGORITHM;
-    if (_stricmp(name, "SHA1") == 0 || _stricmp(name, "SHA-1") == 0) return BCRYPT_SHA1_ALGORITHM;
-    if (_stricmp(name, "SHA384") == 0 || _stricmp(name, "SHA-384") == 0)
-      return BCRYPT_SHA384_ALGORITHM;
-    if (_stricmp(name, "SHA512") == 0 || _stricmp(name, "SHA-512") == 0)
-      return BCRYPT_SHA512_ALGORITHM;
-    return nullptr;
-  }
 };
 
-cuid_hmac::cuid_hmac() : impl_(nullptr), key(nullptr), key_len(key_length), valid(false) {
+cuid_hmac::cuid_hmac()
+    : impl_(nullptr), key(nullptr), key_len(key_length), valid(false), using_default_key(false) {
+  // getenv races only against setenv, which this library never calls.
+  // NOLINTNEXTLINE(concurrency-mt-unsafe)
   const char* env_path = std::getenv("AMDCUID_HMAC_KEY_PATH");
   key_file_path = (env_path && env_path[0]) ? env_path : AMDCUID_CONFIG_DIR "/hmac_key.bin";
   impl_ = new Impl();
   impl_->digest_name = "SHA256";
-  impl_->hAlg = nullptr;
-
-  NTSTATUS status = BCryptOpenAlgorithmProvider(&impl_->hAlg, BCRYPT_SHA256_ALGORITHM, nullptr,
-                                                BCRYPT_ALG_HANDLE_HMAC_FLAG);
-  if (!BCRYPT_SUCCESS(status)) {
-    std::cerr << "Error opening BCrypt HMAC algorithm provider" << std::endl;
-    delete impl_;
-    impl_ = nullptr;
-    return;
-  }
 
   std::ifstream key_file_stream(key_file_path, std::ios::binary);
   if (!key_file_stream.is_open()) {
-    return;
-  }
-  key_file_stream.seekg(0, std::ios::end);
-  key_len = static_cast<size_t>(key_file_stream.tellg());
-  if (key_len == 0 || key_len != key_length) {  // sanity check on key length
-    std::cerr << "Invalid key length in key file" << std::endl;
-    key_file_stream.close();
-    return;
-  }
-  key_file_stream.seekg(0, std::ios::beg);
-  key = new uint8_t[key_len];
-  key_file_stream.read(reinterpret_cast<char*>(key), key_len);
-  key_file_stream.close();
-
-  valid = true;
-}
-
-cuid_hmac::cuid_hmac(uint8_t key_data[key_length])
-    : impl_(nullptr), key(nullptr), key_len(key_length), valid(false) {
-  impl_ = new Impl();
-  impl_->digest_name = "SHA256";
-  impl_->hAlg = nullptr;
-
-  NTSTATUS status = BCryptOpenAlgorithmProvider(&impl_->hAlg, BCRYPT_SHA256_ALGORITHM, nullptr,
-                                                BCRYPT_ALG_HANDLE_HMAC_FLAG);
-  if (!BCRYPT_SUCCESS(status)) {
-    std::cerr << "Error opening BCrypt HMAC algorithm provider" << std::endl;
-    delete impl_;
-    impl_ = nullptr;
-    return;
-  }
-
-  key = new uint8_t[key_length];
-  std::memcpy(key, key_data, key_length);
-
-  valid = true;
-}
-
-cuid_hmac::~cuid_hmac() {
-  if (impl_) {
-    if (impl_->hAlg) BCryptCloseAlgorithmProvider(impl_->hAlg, 0);
-    delete impl_;
-  }
-  delete[] key;
-}
-
-amdcuid_status_t cuid_hmac::generate_hmac_sha256(const uint8_t* data, size_t data_len,
-                                                 uint8_t* out_hash, size_t* out_len) {
-  if (!impl_ || !impl_->hAlg) {
-    std::cerr << "BCrypt backend not initialized" << std::endl;
-    return AMDCUID_STATUS_HMAC_ERROR;
-  }
-
-  BCRYPT_HASH_HANDLE hHash = nullptr;
-  NTSTATUS status = BCryptCreateHash(impl_->hAlg, &hHash, nullptr, 0, reinterpret_cast<PUCHAR>(key),
-                                     static_cast<ULONG>(key_len), 0);
-  if (!BCRYPT_SUCCESS(status)) {
-    std::cerr << "BCryptCreateHash failed" << std::endl;
-    return AMDCUID_STATUS_HMAC_ERROR;
-  }
-
-  status = BCryptHashData(hHash, const_cast<PUCHAR>(reinterpret_cast<const UCHAR*>(data)),
-                          static_cast<ULONG>(data_len), 0);
-  if (!BCRYPT_SUCCESS(status)) {
-    BCryptDestroyHash(hHash);
-    std::cerr << "BCryptHashData failed" << std::endl;
-    return AMDCUID_STATUS_HMAC_ERROR;
-  }
-
-  DWORD hash_len = 0, result_size = 0;
-  status = BCryptGetProperty(impl_->hAlg, BCRYPT_HASH_LENGTH, reinterpret_cast<PUCHAR>(&hash_len),
-                             sizeof(hash_len), &result_size, 0);
-  if (!BCRYPT_SUCCESS(status)) {
-    BCryptDestroyHash(hHash);
-    return AMDCUID_STATUS_HMAC_ERROR;
-  }
-
-  status = BCryptFinishHash(hHash, reinterpret_cast<PUCHAR>(out_hash), hash_len, 0);
-  BCryptDestroyHash(hHash);
-  if (!BCRYPT_SUCCESS(status)) {
-    std::cerr << "BCryptFinishHash failed" << std::endl;
-    return AMDCUID_STATUS_HMAC_ERROR;
-  }
-
-  *out_len = hash_len;
-  return AMDCUID_STATUS_SUCCESS;
-}
-
-amdcuid_status_t cuid_hmac::set_hmac_algorithm(const char* digest_name) {
-  if (!impl_) return AMDCUID_STATUS_HMAC_ERROR;
-
-  const char* name = digest_name ? digest_name : "SHA256";
-  const wchar_t* alg = Impl::to_bcrypt_alg(name);
-  if (!alg) {
-    std::cerr << "Unsupported digest: " << name << std::endl;
-    return AMDCUID_STATUS_HMAC_ERROR;
-  }
-
-  if (impl_->hAlg) BCryptCloseAlgorithmProvider(impl_->hAlg, 0);
-  impl_->hAlg = nullptr;
-
-  NTSTATUS status =
-      BCryptOpenAlgorithmProvider(&impl_->hAlg, alg, nullptr, BCRYPT_ALG_HANDLE_HMAC_FLAG);
-  if (!BCRYPT_SUCCESS(status)) {
-    std::cerr << "Error opening BCrypt HMAC algorithm provider" << std::endl;
-    return AMDCUID_STATUS_HMAC_ERROR;
-  }
-
-  impl_->digest_name = name;
-  return AMDCUID_STATUS_SUCCESS;
-}
-
-amdcuid_status_t cuid_hmac::set_hmac_key(const uint8_t key_data[key_length]) {
-  delete[] key;
-  key = new uint8_t[key_length];
-  key_len = key_length;
-  std::memcpy(key, key_data, key_length);
-
-  // Remove existing key file if it exists, ignoring error if it doesn't exist
-  if (std::remove(key_file_path.c_str()) != 0 && errno != ENOENT) return AMDCUID_STATUS_KEY_ERROR;
-
-  std::ofstream key_file(key_file_path, std::ios::out | std::ios::binary);
-  if (!key_file) return AMDCUID_STATUS_KEY_ERROR;
-
-  key_file.write(reinterpret_cast<const char*>(key), key_length);
-  if (!key_file) {
-    key_file.close();
-    return AMDCUID_STATUS_KEY_ERROR;
-  }
-  key_file.close();
-
-  return AMDCUID_STATUS_SUCCESS;
-}
-
-amdcuid_status_t cuid_hmac::generate_key(uint8_t out_key[key_length]) {
-  if (!out_key) return AMDCUID_STATUS_INVALID_ARGUMENT;
-  NTSTATUS status = BCryptGenRandom(nullptr, reinterpret_cast<PUCHAR>(out_key), key_length,
-                                    BCRYPT_USE_SYSTEM_PREFERRED_RNG);
-  return BCRYPT_SUCCESS(status) ? AMDCUID_STATUS_SUCCESS : AMDCUID_STATUS_KEY_ERROR;
-}
-
-amdcuid_status_t sha256_unkeyed(const uint8_t* data, size_t data_len, uint8_t out[32]) {
-  BCRYPT_ALG_HANDLE hAlg = nullptr;
-  BCRYPT_HASH_HANDLE hHash = nullptr;
-  if (!BCRYPT_SUCCESS(BCryptOpenAlgorithmProvider(&hAlg, BCRYPT_SHA256_ALGORITHM, nullptr, 0)))
-    return AMDCUID_STATUS_HMAC_ERROR;
-  bool ok = BCRYPT_SUCCESS(BCryptCreateHash(hAlg, &hHash, nullptr, 0, nullptr, 0, 0)) &&
-            BCRYPT_SUCCESS(
-                BCryptHashData(hHash, const_cast<PUCHAR>(data), static_cast<ULONG>(data_len), 0)) &&
-            BCRYPT_SUCCESS(BCryptFinishHash(hHash, out, 32, 0));
-  if (hHash) BCryptDestroyHash(hHash);
-  BCryptCloseAlgorithmProvider(hAlg, 0);
-  return ok ? AMDCUID_STATUS_SUCCESS : AMDCUID_STATUS_HMAC_ERROR;
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// OpenSSL backends (Linux / macOS)
-// ─────────────────────────────────────────────────────────────────────────────
-#else  // !defined(_WIN32)
-
-#include <openssl/evp.h>
-#include <openssl/hmac.h>
-#include <openssl/opensslv.h>
-#include <openssl/rand.h>
-#include <sys/stat.h>
-#include <unistd.h>
-
-// ─────────────────────────────────────────────────────────────────────────────
-// OpenSSL 3.0+  — EVP_MAC API
-//
-// NOTE: LibreSSL (used by Alpine Linux) and BoringSSL (custom builds) both
-// define OPENSSL_VERSION_NUMBER with a fake value below 0x30000000L even on
-// their modern releases, so they fall through to the HMAC_CTX backend below.
-// LibreSSL also defines LIBRESSL_VERSION_NUMBER; BoringSSL defines
-// OPENSSL_IS_BORINGSSL. Neither requires a separate code path because both
-// fully implement the HMAC_CTX API that the 1.x backend uses.
-// ─────────────────────────────────────────────────────────────────────────────
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L && !defined(LIBRESSL_VERSION_NUMBER)
-
-#include <openssl/params.h>
-
-struct cuid_hmac::Impl {
-  EVP_MAC* mac;
-  EVP_MAC_CTX* ctx;
-  std::string digest_name;
-};
-
-cuid_hmac::cuid_hmac() : impl_(nullptr), key(nullptr), key_len(key_length), valid(false) {
-  const char* env_path = std::getenv("AMDCUID_HMAC_KEY_PATH");
-  key_file_path = (env_path && env_path[0]) ? env_path : AMDCUID_CONFIG_DIR "/hmac_key.bin";
-  impl_ = new Impl();
-  impl_->digest_name = "SHA256";
-  impl_->mac = nullptr;
-  impl_->ctx = nullptr;
-
-  impl_->mac = EVP_MAC_fetch(nullptr, "HMAC", nullptr);
-  if (!impl_->mac) {
-    std::cerr << "Error fetching EVP_MAC" << std::endl;
-    delete impl_;
-    impl_ = nullptr;
-    return;
-  }
-
-  impl_->ctx = EVP_MAC_CTX_new(impl_->mac);
-  if (!impl_->ctx) {
-    std::cerr << "Error creating EVP_MAC_CTX" << std::endl;
-    EVP_MAC_free(impl_->mac);
-    delete impl_;
-    impl_ = nullptr;
-    return;
-  }
-
-  std::ifstream key_file_stream(key_file_path, std::ios::binary);
-  if (!key_file_stream.is_open()) {
+    // No key provisioned: use the public default seed, as the kernel does,
+    // rather than failing every privileged lookup on an unprovisioned machine.
+    use_default_key();
     return;
   }
 
   key_file_stream.seekg(0, std::ios::end);
-  key_len = static_cast<size_t>(key_file_stream.tellg());
-  if (key_len == 0 || key_len != key_length) {  // sanity check on key length
-    std::cerr << "Invalid key length in key file" << std::endl;
+  const size_t file_len = static_cast<size_t>(key_file_stream.tellg());
+  if (file_len != key_length) {
+    // Wrong size is corruption, not absence: refuse rather than silently
+    // changing every CUID on the machine.
+    std::cerr << "Invalid key length in " << key_file_path << " (" << file_len
+              << " bytes, expected " << key_length << ")" << std::endl;
     key_file_stream.close();
     return;
   }
@@ -312,149 +164,31 @@ cuid_hmac::cuid_hmac() : impl_(nullptr), key(nullptr), key_len(key_length), vali
 
   key = new uint8_t[key_length];
   key_file_stream.read(reinterpret_cast<char*>(key), key_length);
-  key_file_stream.close();
-
-  valid = true;
-}
-
-cuid_hmac::cuid_hmac(uint8_t key_data[key_length])
-    : impl_(nullptr), key(nullptr), key_len(key_length), valid(false) {
-  impl_ = new Impl();
-  impl_->mac = EVP_MAC_fetch(nullptr, "HMAC", nullptr);
-  if (!impl_->mac) {
-    std::cerr << "Error creating EVP_MAC" << std::endl;
-    return;
-  }
-
-  impl_->ctx = EVP_MAC_CTX_new(impl_->mac);
-  if (!impl_->ctx) {
-    EVP_MAC_free(impl_->mac);
-    impl_->mac = nullptr;
-    std::cerr << "Error creating EVP_MAC_CTX" << std::endl;
-    return;
-  }
-
-  key = new uint8_t[key_len];
-  std::memcpy(key, key_data, key_len);
-
-  valid = true;
-}
-
-cuid_hmac::~cuid_hmac() {
-  if (impl_) {
-    if (impl_->ctx) EVP_MAC_CTX_free(impl_->ctx);
-    if (impl_->mac) EVP_MAC_free(impl_->mac);
-    delete impl_;
-  }
-  delete[] key;
-}
-
-amdcuid_status_t cuid_hmac::generate_hmac_sha256(const uint8_t* data, size_t data_len,
-                                                 uint8_t* out_hash, size_t* out_len) {
-  if (!impl_ || !impl_->ctx) {
-    std::cerr << "MAC context is not initialized" << std::endl;
-    return AMDCUID_STATUS_HMAC_ERROR;
-  }
-
-  OSSL_PARAM params[2];
-  params[0] =
-      OSSL_PARAM_construct_utf8_string("digest", const_cast<char*>(impl_->digest_name.c_str()), 0);
-  params[1] = OSSL_PARAM_construct_end();
-
-  if (EVP_MAC_init(impl_->ctx, reinterpret_cast<const unsigned char*>(key), key_len, params) != 1) {
-    std::cerr << "Error initializing MAC context" << std::endl;
-    return AMDCUID_STATUS_HMAC_ERROR;
-  }
-
-  if (EVP_MAC_update(impl_->ctx, reinterpret_cast<const unsigned char*>(data), data_len) != 1) {
-    std::cerr << "Error updating MAC context" << std::endl;
-    return AMDCUID_STATUS_HMAC_ERROR;
-  }
-
-  if (EVP_MAC_final(impl_->ctx, reinterpret_cast<unsigned char*>(out_hash), out_len,
-                    EVP_MAX_MD_SIZE) != 1) {
-    std::cerr << "Error finalizing MAC" << std::endl;
-    return AMDCUID_STATUS_HMAC_ERROR;
-  }
-
-  return AMDCUID_STATUS_SUCCESS;
-}
-
-amdcuid_status_t cuid_hmac::set_hmac_algorithm(const char* digest_name) {
-  if (!impl_ || !impl_->ctx) {
-    std::cerr << "MAC context is not initialized" << std::endl;
-    return AMDCUID_STATUS_HMAC_ERROR;
-  }
-
-  const char* name = digest_name ? digest_name : "SHA256";
-  OSSL_PARAM params[2];
-  params[0] = OSSL_PARAM_construct_utf8_string("digest", const_cast<char*>(name), 0);
-  params[1] = OSSL_PARAM_construct_end();
-
-  if (EVP_MAC_CTX_set_params(impl_->ctx, params) != 1) {
-    std::cerr << "Error setting HMAC algorithm" << std::endl;
-    return AMDCUID_STATUS_HMAC_ERROR;
-  }
-
-  impl_->digest_name = name;
-  return AMDCUID_STATUS_SUCCESS;
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// OpenSSL 1.x  — HMAC_CTX API
-// ─────────────────────────────────────────────────────────────────────────────
-#else  // OPENSSL_VERSION_NUMBER < 0x30000000L
-
-struct cuid_hmac::Impl {
-  HMAC_CTX* ctx;
-  std::string digest_name;
-};
-
-cuid_hmac::cuid_hmac() : impl_(nullptr), key(nullptr), key_len(0), valid(false) {
-  const char* env_path = std::getenv("AMDCUID_HMAC_KEY_PATH");
-  key_file_path = (env_path && env_path[0]) ? env_path : AMDCUID_CONFIG_DIR "/hmac_key.bin";
-  impl_ = new Impl();
-  impl_->digest_name = "SHA256";
-  impl_->ctx = HMAC_CTX_new();
-  if (!impl_->ctx) {
-    std::cerr << "Error creating HMAC_CTX" << std::endl;
-    delete impl_;
-    impl_ = nullptr;
-    return;
-  }
-
-  std::ifstream key_file_stream(key_file_path, std::ios::binary);
-  if (!key_file_stream.is_open()) {
-    return;
-  }
-
-  key_file_stream.seekg(0, std::ios::end);
-  key_len = static_cast<size_t>(key_file_stream.tellg());
-  if (key_len == 0 || key_len != key_length) {  // sanity check on key length
-    std::cerr << "Invalid key length in key file" << std::endl;
+  if (!key_file_stream) {
+    std::cerr << "Failed to read " << key_file_path << std::endl;
     key_file_stream.close();
+    delete[] key;
+    key = nullptr;
     return;
   }
-  key_file_stream.seekg(0, std::ios::beg);
-
-  key = new uint8_t[key_length];
-  key_file_stream.read(reinterpret_cast<char*>(key), key_length);
   key_file_stream.close();
 
   valid = true;
 }
 
+void cuid_hmac::use_default_key() {
+  delete[] key;
+  key = new uint8_t[kDefaultSeedLen];
+  std::memcpy(key, kDefaultSeed, kDefaultSeedLen);
+  key_len = kDefaultSeedLen;
+  using_default_key = true;
+  valid = true;
+}
+
 cuid_hmac::cuid_hmac(uint8_t key_data[key_length])
-    : impl_(nullptr), key(nullptr), key_len(key_length), valid(false) {
+    : impl_(nullptr), key(nullptr), key_len(key_length), valid(false), using_default_key(false) {
   impl_ = new Impl();
   impl_->digest_name = "SHA256";
-  impl_->ctx = HMAC_CTX_new();
-  if (!impl_->ctx) {
-    std::cerr << "Error creating HMAC_CTX" << std::endl;
-    delete impl_;
-    impl_ = nullptr;
-    return;
-  }
 
   key = new uint8_t[key_length];
   std::memcpy(key, key_data, key_length);
@@ -463,114 +197,150 @@ cuid_hmac::cuid_hmac(uint8_t key_data[key_length])
 }
 
 cuid_hmac::~cuid_hmac() {
-  if (impl_) {
-    if (impl_->ctx) HMAC_CTX_free(impl_->ctx);
-    delete impl_;
+  delete impl_;
+  if (key) {
+    rocm::sha2::secure_zero(key, key_len);
+    delete[] key;
   }
-  delete[] key;
 }
 
 amdcuid_status_t cuid_hmac::generate_hmac_sha256(const uint8_t* data, size_t data_len,
                                                  uint8_t* out_hash, size_t* out_len) {
-  if (!impl_ || !impl_->ctx) {
+  if (!impl_ || !out_hash) {
     std::cerr << "HMAC context is not initialized" << std::endl;
     return AMDCUID_STATUS_HMAC_ERROR;
   }
-
-  const EVP_MD* md = EVP_get_digestbyname(impl_->digest_name.c_str());
-  if (!md) {
-    std::cerr << "Unknown digest: " << impl_->digest_name << std::endl;
-    return AMDCUID_STATUS_HMAC_ERROR;
+  if (!key) {
+    std::cerr << "No HMAC key is set" << std::endl;
+    return AMDCUID_STATUS_KEY_ERROR;
   }
 
-  if (HMAC_Init_ex(impl_->ctx, reinterpret_cast<const void*>(key), static_cast<int>(key_len), md,
-                   nullptr) != 1) {
-    std::cerr << "Error initializing HMAC context" << std::endl;
-    return AMDCUID_STATUS_HMAC_ERROR;
-  }
+  rocm::sha2::hmac_sha256(key, key_len, data, data_len, out_hash);
+  if (out_len) *out_len = rocm::sha2::SHA256_DIGEST_SIZE;
 
-  if (HMAC_Update(impl_->ctx, reinterpret_cast<const unsigned char*>(data), data_len) != 1) {
-    std::cerr << "Error updating HMAC context" << std::endl;
-    return AMDCUID_STATUS_HMAC_ERROR;
-  }
-
-  unsigned int len = 0;
-  if (HMAC_Final(impl_->ctx, reinterpret_cast<unsigned char*>(out_hash), &len) != 1) {
-    std::cerr << "Error finalizing HMAC" << std::endl;
-    return AMDCUID_STATUS_HMAC_ERROR;
-  }
-
-  *out_len = len;
   return AMDCUID_STATUS_SUCCESS;
 }
 
 amdcuid_status_t cuid_hmac::set_hmac_algorithm(const char* digest_name) {
-  if (!impl_ || !impl_->ctx) {
+  if (!impl_) {
     std::cerr << "HMAC context is not initialized" << std::endl;
     return AMDCUID_STATUS_HMAC_ERROR;
   }
 
-  const char* name = digest_name ? digest_name : "SHA256";
-  const EVP_MD* md = EVP_get_digestbyname(name);
-  if (!md) {
-    std::cerr << "Unknown digest: " << name << std::endl;
+  if (!is_sha256_name(digest_name)) {
+    std::cerr << "Unsupported digest: " << digest_name << " (only SHA-256 is supported)"
+              << std::endl;
     return AMDCUID_STATUS_HMAC_ERROR;
   }
 
-  // Re-initialize with the new digest but no key change; HMAC_Init_ex accepts
-  // nullptr key to reuse the existing key when only changing the digest.
-  if (HMAC_Init_ex(impl_->ctx, nullptr, 0, md, nullptr) != 1) {
-    std::cerr << "Error setting HMAC algorithm" << std::endl;
-    return AMDCUID_STATUS_HMAC_ERROR;
-  }
-
-  impl_->digest_name = name;
+  impl_->digest_name = "SHA256";
   return AMDCUID_STATUS_SUCCESS;
 }
 
-#endif  // OPENSSL_VERSION_NUMBER
-
-// ─────────────────────────────────────────────────────────────────────────────
-// set_hmac_key / generate_key  — shared by both OpenSSL backends
-// ─────────────────────────────────────────────────────────────────────────────
-
 amdcuid_status_t cuid_hmac::set_hmac_key(const uint8_t key_data[key_length]) {
-  if (geteuid() != 0) return AMDCUID_STATUS_PERMISSION_DENIED;
+  if (!key_data) return AMDCUID_STATUS_INVALID_ARGUMENT;
 
-  delete[] key;
+  if (key) {
+    rocm::sha2::secure_zero(key, key_len);
+    delete[] key;
+  }
   key = new uint8_t[key_length];
   key_len = key_length;
   std::memcpy(key, key_data, key_length);
-
-  if (std::remove(key_file_path.c_str()) != 0 && errno != ENOENT) return AMDCUID_STATUS_KEY_ERROR;
-
-  // TODO: This is backwards, we're never actually reading the stored key file,
-  // but we're always overwriting it. Need to rethink this Maybe have public
-  // facing API write the stored key file and then call this function to set the
-  // in-memory key, and have this function only update the in-memory key without
-  // touching the file system? That way we can ensure the file is only written
-  // to when we actually want to change the key, and not every time we start the
-  // daemon? Remember to also adjust the Windows CNG implementation to match any
-  // changes made here for consistency.
-  std::ofstream key_file(key_file_path, std::ios::out | std::ios::binary);
-  if (!key_file) return AMDCUID_STATUS_KEY_ERROR;
-  key_file.write(reinterpret_cast<const char*>(key), key_length);
-  if (!key_file) {
-    key_file.close();
-    return AMDCUID_STATUS_KEY_ERROR;
-  }
-  key_file.close();
-
-  if (chmod(key_file_path.c_str(), S_IRUSR | S_IWUSR) != 0) return AMDCUID_STATUS_PERMISSION_DENIED;
+  valid = true;
+  using_default_key = false;
 
   return AMDCUID_STATUS_SUCCESS;
+}
+
+amdcuid_status_t cuid_hmac::store_key(const uint8_t key_data[key_length]) {
+  if (!key_data) return AMDCUID_STATUS_INVALID_ARGUMENT;
+
+  // Write a sibling temp file and rename over the target: atomic, so a reader
+  // never sees a truncated key and a failed write cannot destroy the old one.
+  if (!ensure_parent_dir(key_file_path)) {
+    std::cerr << "Cannot create directory for " << key_file_path << std::endl;
+    return AMDCUID_STATUS_KEY_ERROR;
+  }
+
+  const std::string tmp_path = key_file_path + ".new";
+
+#if defined(_WIN32)
+  {
+    std::ofstream tmp(tmp_path, std::ios::out | std::ios::binary | std::ios::trunc);
+    if (!tmp) return AMDCUID_STATUS_KEY_ERROR;
+    tmp.write(reinterpret_cast<const char*>(key_data), key_length);
+    tmp.flush();
+    if (!tmp) {
+      tmp.close();
+      std::remove(tmp_path.c_str());
+      return AMDCUID_STATUS_KEY_ERROR;
+    }
+  }
+  // rename() refuses to clobber an existing file on Windows.
+  if (!MoveFileExA(tmp_path.c_str(), key_file_path.c_str(), MOVEFILE_REPLACE_EXISTING)) {
+    std::remove(tmp_path.c_str());
+    return AMDCUID_STATUS_KEY_ERROR;
+  }
+  return AMDCUID_STATUS_SUCCESS;
+#else
+  // O_EXCL so we never write into a pre-created file; 0600 from creation.
+  int fd = open(tmp_path.c_str(), O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC, S_IRUSR | S_IWUSR);
+  if (fd < 0 && errno == EEXIST) {
+    // Stale temporary from an interrupted run; it is ours to reclaim.
+    if (unlink(tmp_path.c_str()) != 0) return AMDCUID_STATUS_KEY_ERROR;
+    fd = open(tmp_path.c_str(), O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC, S_IRUSR | S_IWUSR);
+  }
+  if (fd < 0) {
+    return (errno == EACCES || errno == EPERM) ? AMDCUID_STATUS_PERMISSION_DENIED
+                                               : AMDCUID_STATUS_KEY_ERROR;
+  }
+
+  auto fail = [&]() {
+    close(fd);
+    unlink(tmp_path.c_str());
+    return AMDCUID_STATUS_KEY_ERROR;
+  };
+
+  size_t written = 0;
+  while (written < key_length) {
+    ssize_t n = write(fd, key_data + written, key_length - written);
+    if (n < 0) {
+      if (errno == EINTR) continue;
+      return fail();
+    }
+    written += static_cast<size_t>(n);
+  }
+
+  // Durable before the rename, or a crash can leave the file present but empty.
+  if (fsync(fd) != 0) return fail();
+  if (close(fd) != 0) {
+    unlink(tmp_path.c_str());
+    return AMDCUID_STATUS_KEY_ERROR;
+  }
+
+  if (rename(tmp_path.c_str(), key_file_path.c_str()) != 0) {
+    unlink(tmp_path.c_str());
+    return AMDCUID_STATUS_KEY_ERROR;
+  }
+
+  // Persist the directory entry so the rename survives power loss.
+  const size_t slash = key_file_path.find_last_of('/');
+  const std::string dir = (slash == std::string::npos) ? "." : key_file_path.substr(0, slash);
+  int dir_fd = open(dir.empty() ? "/" : dir.c_str(), O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+  if (dir_fd >= 0) {
+    (void)fsync(dir_fd);
+    close(dir_fd);
+  }
+
+  return AMDCUID_STATUS_SUCCESS;
+#endif
 }
 
 amdcuid_status_t cuid_hmac::generate_key(uint8_t out_key[key_length]) {
   if (!out_key) return AMDCUID_STATUS_INVALID_ARGUMENT;
 
-  int success = RAND_bytes(out_key, key_length);
-  if (success != 1) {
+  if (!fill_random(out_key, key_length)) {
     std::cerr << "Error generating random bytes for HMAC key" << std::endl;
     return AMDCUID_STATUS_KEY_ERROR;
   }
@@ -579,10 +349,7 @@ amdcuid_status_t cuid_hmac::generate_key(uint8_t out_key[key_length]) {
 }
 
 amdcuid_status_t sha256_unkeyed(const uint8_t* data, size_t data_len, uint8_t out[32]) {
-  unsigned int len = 0;
-  return EVP_Digest(data, data_len, out, &len, EVP_sha256(), nullptr) == 1
-             ? AMDCUID_STATUS_SUCCESS
-             : AMDCUID_STATUS_HMAC_ERROR;
+  if (!out || (!data && data_len > 0)) return AMDCUID_STATUS_INVALID_ARGUMENT;
+  rocm::sha2::sha256_digest(data, data_len, out);
+  return AMDCUID_STATUS_SUCCESS;
 }
-
-#endif  // _WIN32

--- a/projects/cuid/lib/src/hmac.h
+++ b/projects/cuid/lib/src/hmac.h
@@ -23,47 +23,59 @@
 #ifndef HMAC_H
 #define HMAC_H
 
-#include "include/amd_cuid.h"
 #include <cstddef>
-#include <fstream>
-#include <iostream>
-#include <openssl/evp.h>
-#include <openssl/hmac.h>
+#include <cstdint>
 #include <string>
+
+#include "include/amd_cuid.h"
 
 #define key_length 32
 #define hash_length 32
 
-// cuid_hmac uses a pimpl to hide the crypto-backend context entirely.
-// The active backend is selected at compile time:
-//   _WIN32                              -> Windows CNG  (BCrypt)
-//   OpenSSL >= 3.0  (all other platforms) -> EVP_MAC API
-//   OpenSSL <  3.0  (all other platforms) -> HMAC_CTX API
+// cuid_hmac wraps HMAC-SHA-256 over the in-tree SHA-256 (see sha256.h). There
+// is one implementation on every platform; the pimpl is retained only to keep
+// the class layout stable for existing callers.
 class cuid_hmac {
-private:
-  struct Impl; // defined in hmac.cc per-backend
-  Impl *impl_;
-  uint8_t *key;
+ private:
+  struct Impl;  // defined in hmac.cc
+  void use_default_key();
+  Impl* impl_;
+  uint8_t* key;
   size_t key_len;
   bool valid;
+  bool using_default_key;
   std::string key_file_path;
 
-public:
+ public:
   cuid_hmac();
   cuid_hmac(uint8_t key_data[key_length]);
   ~cuid_hmac();
   bool is_valid() const { return valid; }
 
-  amdcuid_status_t generate_hmac_sha256(const uint8_t *data, size_t data_len,
-                                        uint8_t *out_hash, size_t *out_len);
-  amdcuid_status_t set_hmac_algorithm(const char *digest_name);
+  // True when no key file was found and the public default seed is in use, so
+  // a caller can distinguish a provisioned identity from an unprovisioned one.
+  bool is_using_default_key() const { return using_default_key; }
+
+  amdcuid_status_t generate_hmac_sha256(const uint8_t* data, size_t data_len, uint8_t* out_hash,
+                                        size_t* out_len);
+  amdcuid_status_t set_hmac_algorithm(const char* digest_name);
+
+  // Replace the in-memory key. Purely an in-memory operation: it does not read
+  // or write the key file. Pair it with store_key() to change the key on disk.
   amdcuid_status_t set_hmac_key(const uint8_t key_data[key_length]);
+
+  // Persist a key to key_file_path, replacing any existing one. The file is
+  // created 0600 and swapped into place atomically, so a concurrent reader
+  // sees either the whole old key or the whole new one, never a partial write
+  // and never a moment where the key is readable by other users. Requires
+  // privileges to write the config directory.
+  amdcuid_status_t store_key(const uint8_t key_data[key_length]);
+
   amdcuid_status_t generate_key(uint8_t key[key_length]);
   std::string get_key_file_path() const { return key_file_path; }
 };
 
 // Unkeyed SHA-256 digest of data into a 32-byte output buffer.
-amdcuid_status_t sha256_unkeyed(const uint8_t *data, size_t data_len,
-                                uint8_t out[32]);
+amdcuid_status_t sha256_unkeyed(const uint8_t* data, size_t data_len, uint8_t out[32]);
 
-#endif // HMAC_H
+#endif  // HMAC_H

--- a/projects/cuid/lib/src/ipc_protocol.h
+++ b/projects/cuid/lib/src/ipc_protocol.h
@@ -23,28 +23,55 @@
 #ifndef IPC_PROTOCOL_H
 #define IPC_PROTOCOL_H
 
+#include <cstdint>
+#include <cstring>
+#include <string>
+
 #include "include/amd_cuid.h"
 #include "src/cuid_device.h"
-#include <cstdint>
 
 #define AMDCUID_SOCKET_PATH "/var/run/amdcuid_daemon.sock"
 
-enum class IpcMessageType : uint8_t {
-    ADD_DEVICE = 1,
-    REFRESH_DEVICES = 2
+/// Maximum device path length carried in an IpcRequest, including the
+/// terminating NUL. The path must travel inside the fixed-size message body:
+/// the two peers are separate processes, so a pointer field would be
+/// meaningless (and dangerous) on the receiving side.
+constexpr size_t AMDCUID_IPC_PATH_MAX = 4096;
+
+enum class IpcMessageType : uint8_t { ADD_DEVICE = 1, REFRESH_DEVICES = 2 };
+
+struct IpcRequest {
+  IpcMessageType type;
+  amdcuid_device_type_t device_type;  // used for ADD_DEVICE, AMDCUID_DEVICE_TYPE_NONE otherwise
+  char device_path[AMDCUID_IPC_PATH_MAX];  // used for ADD_DEVICE, empty otherwise
 };
 
-struct IpcRequest
-{
-    IpcMessageType type;
-    char* device_path; // used for ADD_DEVICE, empty otherwise
-    amdcuid_device_type_t device_type; // used for ADD_DEVICE, AMDCUID_DEVICE_TYPE_NONE otherwise
+/// Copy @p src into the fixed-size device_path field, always NUL-terminating.
+/// Returns false when @p src does not fit, so callers reject the request
+/// instead of silently operating on a truncated path.
+inline bool ipc_set_device_path(IpcRequest& request, const char* src) {
+  if (src == nullptr) {
+    return false;
+  }
+  const size_t len = ::strnlen(src, AMDCUID_IPC_PATH_MAX);
+  if (len >= AMDCUID_IPC_PATH_MAX) {
+    return false;  // no room for the terminating NUL
+  }
+  std::memcpy(request.device_path, src, len);
+  request.device_path[len] = '\0';
+  return true;
+}
+
+/// Read the device_path field of a request received off the wire. A malicious
+/// or buggy peer may send an unterminated buffer, so the length is bounded by
+/// the field size rather than trusting a NUL to be present.
+inline std::string ipc_get_device_path(const IpcRequest& request) {
+  return std::string(request.device_path, ::strnlen(request.device_path, AMDCUID_IPC_PATH_MAX));
+}
+
+struct IpcResponse {
+  amdcuid_status_t status;
+  amdcuid_id_t device_handle;  // used for ADD_DEVICE, 0 otherwise
 };
 
-struct IpcResponse
-{
-    amdcuid_status_t status;
-    amdcuid_id_t device_handle; // used for ADD_DEVICE, 0 otherwise
-};
-
-#endif // IPC_PROTOCOL_H
+#endif  // IPC_PROTOCOL_H

--- a/projects/cuid/lib/src/pci_util.cc
+++ b/projects/cuid/lib/src/pci_util.cc
@@ -21,45 +21,37 @@
  */
 
 #include "pci_util.h"
+
+#include <unistd.h>
+
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
 #include "cuid_device.h"
 #include "cuid_device_manager.h"
 #include "cuid_gpu.h"
 #include "cuid_nic.h"
 #include "cuid_util.h"
 #include "include/amd_cuid.h"
-#include <cstring>
-#include <fstream>
-#include <iostream>
-#include <sstream>
-#include <unistd.h>
 
 // Endianness conversion functions
-uint16_t PciUtil::le16_to_be16(uint16_t value) {
-  return ((value & 0x00FF) << 8) | ((value & 0xFF00) >> 8);
-}
-
 uint64_t PciUtil::le64_to_be64(uint64_t value) {
-  return ((value & 0x00000000000000FFULL) << 56) |
-         ((value & 0x000000000000FF00ULL) << 40) |
-         ((value & 0x0000000000FF0000ULL) << 24) |
-         ((value & 0x00000000FF000000ULL) << 8) |
-         ((value & 0x000000FF00000000ULL) >> 8) |
-         ((value & 0x0000FF0000000000ULL) >> 24) |
-         ((value & 0x00FF000000000000ULL) >> 40) |
-         ((value & 0xFF00000000000000ULL) >> 56);
+  return ((value & 0x00000000000000FFULL) << 56) | ((value & 0x000000000000FF00ULL) << 40) |
+         ((value & 0x0000000000FF0000ULL) << 24) | ((value & 0x00000000FF000000ULL) << 8) |
+         ((value & 0x000000FF00000000ULL) >> 8) | ((value & 0x0000FF0000000000ULL) >> 24) |
+         ((value & 0x00FF000000000000ULL) >> 40) | ((value & 0xFF00000000000000ULL) >> 56);
 }
 
 // This function should only work with PCI devices, which currently includes
 // GPUs, NICs, and NPUs. It may later include storage devices as well.
-amdcuid_status_t PciUtil::read_pci_config_space(std::string bdf,
-                                                uint8_t *buffer,
-                                                size_t buffer_size,
-                                                uint16_t offset) {
+amdcuid_status_t PciUtil::read_pci_config_space(std::string bdf, uint8_t* buffer,
+                                                size_t buffer_size, uint16_t offset) {
   if (geteuid() != 0) {
     return AMDCUID_STATUS_PERMISSION_DENIED;
   }
-  if (bdf.empty() || !buffer || buffer_size == 0)
-    return AMDCUID_STATUS_INVALID_ARGUMENT;
+  if (bdf.empty() || !buffer || buffer_size == 0) return AMDCUID_STATUS_INVALID_ARGUMENT;
 
   std::string pci_config_path = "/sys/bus/pci/devices/" + bdf + "/config";
 
@@ -82,20 +74,21 @@ amdcuid_status_t PciUtil::read_pci_config_space(std::string bdf,
     return AMDCUID_STATUS_PCI_ERROR;
   }
 
-  if (static_cast<std::ifstream::pos_type>(offset + buffer_size) > length) {
+  // length is known non-negative from the check above, so compare as unsigned
+  // rather than casting the sum into the signed streamoff that pos_type wraps.
+  if (offset + buffer_size > static_cast<size_t>(length)) {
     config_file.close();
     return AMDCUID_STATUS_PCI_ERROR;
   }
 
-  config_file.seekg(offset, std::ios::beg);
+  config_file.seekg(static_cast<std::streamoff>(offset), std::ios::beg);
   if (!config_file) {
     config_file.close();
     return AMDCUID_STATUS_PCI_ERROR;
   }
 
-  config_file.read(reinterpret_cast<char *>(buffer), buffer_size);
-  if (config_file.fail() ||
-      static_cast<size_t>(config_file.gcount()) != buffer_size) {
+  config_file.read(reinterpret_cast<char*>(buffer), static_cast<std::streamsize>(buffer_size));
+  if (config_file.fail() || static_cast<size_t>(config_file.gcount()) != buffer_size) {
     config_file.close();
     return AMDCUID_STATUS_PCI_ERROR;
   }
@@ -103,28 +96,28 @@ amdcuid_status_t PciUtil::read_pci_config_space(std::string bdf,
 }
 
 // iterate capabilities list to find the relevant capability
-amdcuid_status_t PciUtil::get_pci_dsn_cap_offset(std::string bdf,
-                                                 uint16_t &offset) {
+amdcuid_status_t PciUtil::get_pci_dsn_cap_offset(std::string bdf, uint16_t& offset) {
   if (geteuid() != 0) {
     return AMDCUID_STATUS_PERMISSION_DENIED;
   }
-  if (bdf.empty())
-    return AMDCUID_STATUS_INVALID_ARGUMENT;
+  if (bdf.empty()) return AMDCUID_STATUS_INVALID_ARGUMENT;
 
   // Get the whole PCI config space header
-  uint8_t config_space[4096] = {0};
-  amdcuid_status_t status = read_pci_config_space(bdf, config_space, 4096, 0);
+  uint8_t config_space[kPciConfigSpaceSize] = {0};
+  amdcuid_status_t status = read_pci_config_space(bdf, config_space, sizeof(config_space), 0);
   if (status != AMDCUID_STATUS_SUCCESS) {
     return status;
   }
 
   // Device Serial Number (cap_id 0x0003) is a PCIe Extended Capability.
-  const uint16_t dsn_cap_id = 0x0003; // PCIe DSN capability ID
+  const uint16_t dsn_cap_id = 0x0003;  // PCIe DSN capability ID
 
   // Traverse the extended capability list starting at offset 0x100.
   uint16_t cap_ptr = 0x100;
   for (size_t hops = 0; hops < 1024; ++hops) {
-    if (cap_ptr < 0x100 || cap_ptr + 3 >= sizeof(config_space)) {
+    // Widen to size_t before comparing against sizeof(): cap_ptr promotes to
+    // int, which would otherwise be an implicit signed/unsigned comparison.
+    if (cap_ptr < 0x100 || static_cast<size_t>(cap_ptr) + 3 >= sizeof(config_space)) {
       return AMDCUID_STATUS_UNSUPPORTED;
     }
 
@@ -157,48 +150,46 @@ amdcuid_status_t PciUtil::get_pci_dsn_cap_offset(std::string bdf,
   return AMDCUID_STATUS_UNSUPPORTED;
 }
 
-amdcuid_status_t PciUtil::get_pci_vsec_cap_offset(std::string bdf,
-                                                  uint16_t &offset) {
+amdcuid_status_t PciUtil::get_pci_vsec_cap_offset(std::string bdf, uint16_t& offset) {
   if (geteuid() != 0) {
     return AMDCUID_STATUS_PERMISSION_DENIED;
   }
-  if (bdf.empty())
-    return AMDCUID_STATUS_INVALID_ARGUMENT;
+  if (bdf.empty()) return AMDCUID_STATUS_INVALID_ARGUMENT;
 
   // Get the whole PCI config space header
-  uint8_t config_space[4096] = {0};
-  amdcuid_status_t status = read_pci_config_space(bdf, config_space, 4096, 0);
+  uint8_t config_space[kPciConfigSpaceSize] = {0};
+  amdcuid_status_t status = read_pci_config_space(bdf, config_space, sizeof(config_space), 0);
   if (status != AMDCUID_STATUS_SUCCESS) {
     return status;
   }
 
   // Vendor-Specific Extended Capability (cap_id 0x000B) is a PCIe Extended
   // Capability.
-  const uint16_t vsec_cap_id = 0x0b; // PCIe VSEC capability ID
+  const uint16_t vsec_cap_id = 0x0b;  // PCIe VSEC capability ID
 
   // Traverse the extended capability list starting at offset 0x100.
   uint16_t cap_ptr = 0x100;
   for (size_t hops = 0; hops < 1024; ++hops) {
-    if (cap_ptr < 0x100 || cap_ptr + 7 >= sizeof(config_space)) {
+    // Widen to size_t before comparing against sizeof(): cap_ptr promotes to
+    // int, which would otherwise be an implicit signed/unsigned comparison.
+    if (cap_ptr < 0x100 || static_cast<size_t>(cap_ptr) + 7 >= sizeof(config_space)) {
       return AMDCUID_STATUS_UNSUPPORTED;
     }
 
-    uint32_t cap_header =
-        static_cast<uint32_t>(config_space[cap_ptr]) |
-        (static_cast<uint32_t>(config_space[cap_ptr + 1]) << 8) |
-        (static_cast<uint32_t>(config_space[cap_ptr + 2]) << 16) |
-        (static_cast<uint32_t>(config_space[cap_ptr + 3]) << 24);
+    uint32_t cap_header = static_cast<uint32_t>(config_space[cap_ptr]) |
+                          (static_cast<uint32_t>(config_space[cap_ptr + 1]) << 8) |
+                          (static_cast<uint32_t>(config_space[cap_ptr + 2]) << 16) |
+                          (static_cast<uint32_t>(config_space[cap_ptr + 3]) << 24);
 
     uint16_t cap_id_local = static_cast<uint16_t>(cap_header & 0xFFFF);
     uint16_t next_ptr = static_cast<uint16_t>((cap_header >> 20) & 0x0FFF);
 
     if (cap_id_local == vsec_cap_id) {
       // check vsec header now for correct fields
-      uint32_t vsec_header =
-          static_cast<uint32_t>(config_space[cap_ptr + 4]) |
-          (static_cast<uint32_t>(config_space[cap_ptr + 5]) << 8) |
-          (static_cast<uint32_t>(config_space[cap_ptr + 6]) << 16) |
-          (static_cast<uint32_t>(config_space[cap_ptr + 7]) << 24);
+      uint32_t vsec_header = static_cast<uint32_t>(config_space[cap_ptr + 4]) |
+                             (static_cast<uint32_t>(config_space[cap_ptr + 5]) << 8) |
+                             (static_cast<uint32_t>(config_space[cap_ptr + 6]) << 16) |
+                             (static_cast<uint32_t>(config_space[cap_ptr + 7]) << 24);
 
       // if the VSEC has the required length for our fingerprint, return the
       // offset. Since VSEC ID for serial number/id not typically defined,
@@ -206,8 +197,7 @@ amdcuid_status_t PciUtil::get_pci_vsec_cap_offset(std::string bdf,
       // for the fingerprint rather than checking an ID field in the VSEC
       // header. If one is defined in the future, we will add that check here as
       // well.
-      uint16_t vsec_length =
-          static_cast<uint16_t>((vsec_header >> 20) & 0x0FFF);
+      uint16_t vsec_length = static_cast<uint16_t>((vsec_header >> 20) & 0x0FFF);
       if (vsec_length >= 8) {
         offset = cap_ptr + 8;
         return AMDCUID_STATUS_SUCCESS;

--- a/projects/cuid/lib/src/sha256.cc
+++ b/projects/cuid/lib/src/sha256.cc
@@ -1,0 +1,222 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// The compression function below is verbatim from
+// projects/rocprofiler-sdk/source/lib/common/sha256.cpp. See sha256.h for why
+// there are two copies and what the plan is for collapsing them.
+
+#include "sha256.h"
+
+#include <cstring>
+#include <iomanip>
+#include <sstream>
+
+namespace rocm {
+namespace sha2 {
+
+void secure_zero(void* p, size_t n) {
+  auto* volatile q = static_cast<volatile unsigned char*>(p);
+  while (n-- > 0) *q++ = 0;
+}
+
+sha256::sha256() { reset(); }
+
+sha256::sha256(const std::string& data) {
+  reset();
+  update(data);
+  finalize();
+}
+
+void sha256::update(const uint8_t* data, size_t len) {
+  if (m_finalized) return;
+  for (size_t i = 0; i < len; ++i) {
+    m_data[m_datalen++] = data[i];
+    if (m_datalen == 64) {
+      transform();
+      m_bitlen += 512;
+      m_datalen = 0;
+    }
+  }
+}
+
+void sha256::update(const std::string& data) {
+  update(reinterpret_cast<const uint8_t*>(data.data()), data.size());
+}
+
+void sha256::finalize() {
+  if (m_finalized) return;
+
+  uint32_t idx = m_datalen;
+  if (m_datalen < 56) {
+    m_data[idx++] = 0x80;
+    while (idx < 56) m_data[idx++] = 0x00;
+  } else {
+    m_data[idx++] = 0x80;
+    while (idx < 64) m_data[idx++] = 0x00;
+    transform();
+    std::memset(m_data.data(), 0, 56);
+  }
+
+  m_bitlen += static_cast<uint64_t>(m_datalen) * 8;
+  for (int j = 0; j < 8; ++j) m_data[63 - j] = static_cast<uint8_t>((m_bitlen >> (8 * j)) & 0xFF);
+
+  transform();
+
+  m_finalized = true;
+}
+
+std::string sha256::hexdigest() {
+  finalize();
+
+  auto oss = std::ostringstream{};
+  for (int j = 0; j < 8; ++j) oss << std::hex << std::setfill('0') << std::setw(8) << m_state[j];
+  return oss.str();
+}
+
+std::array<uint32_t, 8> sha256::rawdigest() {
+  finalize();
+
+  return m_state;
+}
+
+void sha256::digest(uint8_t out[SHA256_DIGEST_SIZE]) {
+  finalize();
+
+  for (int j = 0; j < 8; ++j) {
+    out[j * 4 + 0] = static_cast<uint8_t>((m_state[j] >> 24) & 0xFF);
+    out[j * 4 + 1] = static_cast<uint8_t>((m_state[j] >> 16) & 0xFF);
+    out[j * 4 + 2] = static_cast<uint8_t>((m_state[j] >> 8) & 0xFF);
+    out[j * 4 + 3] = static_cast<uint8_t>((m_state[j]) & 0xFF);
+  }
+}
+
+uint32_t sha256::rotr(uint32_t x, uint32_t n) { return (x >> n) | (x << (32 - n)); }
+
+uint32_t sha256::ch(uint32_t x, uint32_t y, uint32_t z) { return (x & y) ^ (~x & z); }
+
+uint32_t sha256::maj(uint32_t x, uint32_t y, uint32_t z) { return (x & y) ^ (x & z) ^ (y & z); }
+
+uint32_t sha256::sig0(uint32_t x) { return rotr(x, 2) ^ rotr(x, 13) ^ rotr(x, 22); }
+
+uint32_t sha256::sig1(uint32_t x) { return rotr(x, 6) ^ rotr(x, 11) ^ rotr(x, 25); }
+
+uint32_t sha256::theta0(uint32_t x) { return rotr(x, 7) ^ rotr(x, 18) ^ (x >> 3); }
+
+uint32_t sha256::theta1(uint32_t x) { return rotr(x, 17) ^ rotr(x, 19) ^ (x >> 10); }
+
+void sha256::transform() {
+  uint32_t m[64];
+  for (int i = 0; i < 16; ++i) {
+    m[i] = (static_cast<uint32_t>(m_data[static_cast<size_t>(i) * 4]) << 24) |
+           (static_cast<uint32_t>(m_data[static_cast<size_t>(i) * 4 + 1]) << 16) |
+           (static_cast<uint32_t>(m_data[static_cast<size_t>(i) * 4 + 2]) << 8) |
+           (static_cast<uint32_t>(m_data[static_cast<size_t>(i) * 4 + 3]));
+  }
+  for (int i = 16; i < 64; ++i) {
+    m[i] = theta1(m[i - 2]) + m[i - 7] + theta0(m[i - 15]) + m[i - 16];
+  }
+
+  uint32_t a = m_state[0];
+  uint32_t b = m_state[1];
+  uint32_t c = m_state[2];
+  uint32_t d = m_state[3];
+  uint32_t e = m_state[4];
+  uint32_t f = m_state[5];
+  uint32_t g = m_state[6];
+  uint32_t h = m_state[7];
+
+  for (int i = 0; i < 64; ++i) {
+    uint32_t t1 = h + sig1(e) + ch(e, f, g) + m_k[i] + m[i];
+    uint32_t t2 = sig0(a) + maj(a, b, c);
+    h = g;
+    g = f;
+    f = e;
+    e = d + t1;
+    d = c;
+    c = b;
+    b = a;
+    a = t1 + t2;
+  }
+
+  m_state[0] += a;
+  m_state[1] += b;
+  m_state[2] += c;
+  m_state[3] += d;
+  m_state[4] += e;
+  m_state[5] += f;
+  m_state[6] += g;
+  m_state[7] += h;
+
+  secure_zero(m, sizeof(m));
+}
+
+void sha256::reset() {
+  m_state = {0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+             0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19};
+  m_data = {};
+  m_datalen = 0;
+  m_bitlen = 0;
+  m_finalized = false;
+}
+
+void sha256_digest(const uint8_t* data, size_t data_len, uint8_t out[SHA256_DIGEST_SIZE]) {
+  sha256 h;
+  if (data_len > 0) h.update(data, data_len);
+  h.digest(out);
+}
+
+void hmac_sha256(const uint8_t* key, size_t key_len, const uint8_t* msg, size_t msg_len,
+                 uint8_t out[SHA256_DIGEST_SIZE]) {
+  uint8_t k0[SHA256_BLOCK_SIZE] = {};
+
+  if (key_len > SHA256_BLOCK_SIZE) {
+    sha256_digest(key, key_len, k0);
+  } else if (key_len > 0) {
+    std::memcpy(k0, key, key_len);
+  }
+
+  uint8_t pad[SHA256_BLOCK_SIZE];
+  uint8_t inner[SHA256_DIGEST_SIZE];
+
+  for (size_t i = 0; i < SHA256_BLOCK_SIZE; ++i) pad[i] = static_cast<uint8_t>(k0[i] ^ 0x36);
+  {
+    sha256 h;
+    h.update(pad, SHA256_BLOCK_SIZE);
+    if (msg_len > 0) h.update(msg, msg_len);
+    h.digest(inner);
+  }
+
+  for (size_t i = 0; i < SHA256_BLOCK_SIZE; ++i) pad[i] = static_cast<uint8_t>(k0[i] ^ 0x5c);
+  {
+    sha256 h;
+    h.update(pad, SHA256_BLOCK_SIZE);
+    h.update(inner, SHA256_DIGEST_SIZE);
+    h.digest(out);
+  }
+
+  secure_zero(k0, sizeof(k0));
+  secure_zero(pad, sizeof(pad));
+  secure_zero(inner, sizeof(inner));
+}
+
+}  // namespace sha2
+}  // namespace rocm

--- a/projects/cuid/lib/src/sha256.h
+++ b/projects/cuid/lib/src/sha256.h
@@ -1,0 +1,112 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// SHA-256 (FIPS 180-4) and HMAC-SHA-256 (RFC 2104).
+//
+// Copy of projects/rocprofiler-sdk/source/lib/common/sha256.{hpp,cpp}, so CUID
+// needs nothing beyond the standard library. Kept API-compatible with it and in
+// a neutral namespace so the two can be merged later by moving these files.
+// tests/check_sha256_drift.py enforces that they stay identical; only update()
+// differs, by rocprofiler's logging call.
+//
+// Not constant-time. For identifier derivation, not bulk secret processing.
+
+#ifndef ROCM_SHA2_SHA256_H
+#define ROCM_SHA2_SHA256_H
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+namespace rocm {
+namespace sha2 {
+
+/// Size of a SHA-256 digest, in bytes.
+constexpr size_t SHA256_DIGEST_SIZE = 32;
+/// SHA-256 compression block size, in bytes. Also the HMAC key block size.
+constexpr size_t SHA256_BLOCK_SIZE = 64;
+
+/// Overwrite a buffer in a way the optimiser is not permitted to elide.
+void secure_zero(void* p, size_t n);
+
+// --- SHA-256 Implementation ---
+class sha256 {
+ public:
+  sha256();
+  explicit sha256(const std::string& data);
+
+  void update(const uint8_t* data, size_t len);
+  void update(const std::string& data);
+
+  void finalize();
+  std::string hexdigest();
+  std::array<uint32_t, 8> rawdigest();
+
+  /// Serialise the digest big-endian: the FIPS 180-4 byte order, and the one
+  /// every other SHA-256 implementation emits. Finalises if not already done.
+  void digest(uint8_t out[SHA256_DIGEST_SIZE]);
+
+ private:
+  bool m_finalized = false;
+  std::array<uint8_t, 64> m_data = {};
+  std::array<uint32_t, 8> m_state = {};
+  uint32_t m_datalen = 0;
+  uint64_t m_bitlen = 0;
+
+  static constexpr std::array<uint32_t, 64> m_k = {
+      0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4,
+      0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe,
+      0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f,
+      0x4a7484aa, 0x5cb0a9dc, 0x76f988da, 0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+      0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc,
+      0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+      0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070, 0x19a4c116,
+      0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+      0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7,
+      0xc67178f2};
+
+  static uint32_t rotr(uint32_t x, uint32_t n);
+  static uint32_t ch(uint32_t x, uint32_t y, uint32_t z);
+  static uint32_t maj(uint32_t x, uint32_t y, uint32_t z);
+  static uint32_t sig0(uint32_t x);
+  static uint32_t sig1(uint32_t x);
+  static uint32_t theta0(uint32_t x);
+  static uint32_t theta1(uint32_t x);
+
+  void transform();
+  void reset();
+};
+
+/// One-shot SHA-256 over a single buffer.
+void sha256_digest(const uint8_t* data, size_t data_len, uint8_t out[SHA256_DIGEST_SIZE]);
+
+/// HMAC-SHA-256 (FIPS 198-1 / RFC 2104). Any key length is accepted: keys
+/// longer than the 64-byte block are hashed down first, shorter keys are
+/// zero-padded, per the standard.
+void hmac_sha256(const uint8_t* key, size_t key_len, const uint8_t* msg, size_t msg_len,
+                 uint8_t out[SHA256_DIGEST_SIZE]);
+
+}  // namespace sha2
+}  // namespace rocm
+
+#endif  // ROCM_SHA2_SHA256_H

--- a/projects/cuid/lib/src/smbios_util.cc
+++ b/projects/cuid/lib/src/smbios_util.cc
@@ -21,236 +21,222 @@
  */
 
 #include "smbios_util.h"
-#include <fstream>
-#include <iostream>
-#include <sstream>
-#include <iomanip>
-#include <cstring>
+
 #include <sys/stat.h>
-#include "cuid_util.h"
 #include <unistd.h>
 
+#include <cstring>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+
+#include "cuid_util.h"
+
 amdcuid_status_t SmbiosUtil::get_system_uuid(uint8_t* uuid) {
-    if (!uuid) {
-        return AMDCUID_STATUS_INVALID_ARGUMENT;
-    }
+  if (!uuid) {
+    return AMDCUID_STATUS_INVALID_ARGUMENT;
+  }
 
-    if (geteuid() != 0){
-        return AMDCUID_STATUS_PERMISSION_DENIED;
-    }
+  if (geteuid() != 0) {
+    return AMDCUID_STATUS_PERMISSION_DENIED;
+  }
 
-    // attempt to read UUID from sysfs first
-    std::string uuid_str = CuidUtilities::read_sysfs_file(std::string(DMI_PATH) + "product_uuid");
-    if (!uuid_str.empty()) {
-        // Convert the UUID string to uint8_t array
-        amdcuid_status_t status = CuidUtilities::uuid_string_to_uint8(uuid_str, uuid);
-        if (status != AMDCUID_STATUS_SUCCESS) {
-            return status;
-        }
-    } else {
-        // try and get UUID from SMBIOS table
-        amdcuid_status_t status = SmbiosUtil::get_uuid_from_smbios_table(uuid);
-        if (status != AMDCUID_STATUS_SUCCESS) {
-            return status;
-        }
+  // attempt to read UUID from sysfs first
+  std::string uuid_str = CuidUtilities::read_sysfs_file(std::string(DMI_PATH) + "product_uuid");
+  if (!uuid_str.empty()) {
+    // Convert the UUID string to uint8_t array
+    amdcuid_status_t status = CuidUtilities::uuid_string_to_uint8(uuid_str, uuid);
+    if (status != AMDCUID_STATUS_SUCCESS) {
+      return status;
     }
+  } else {
+    // try and get UUID from SMBIOS table
+    amdcuid_status_t status = SmbiosUtil::get_uuid_from_smbios_table(uuid);
+    if (status != AMDCUID_STATUS_SUCCESS) {
+      return status;
+    }
+  }
 
-    return AMDCUID_STATUS_SUCCESS;
+  return AMDCUID_STATUS_SUCCESS;
 }
 
 amdcuid_status_t SmbiosUtil::get_uuid_from_smbios_table(uint8_t* uuid) {
+  const std::string smbios_path = std::string(DMI_TABLES_PATH) + "DMI";
+  const std::string smbios_entry_path = std::string(DMI_TABLES_PATH) + "smbios_entry_point";
 
-    const std::string smbios_path = std::string(DMI_TABLES_PATH) + "DMI";
-    const std::string smbios_entry_path = std::string(DMI_TABLES_PATH) + "smbios_entry_point";
+  if (geteuid() != 0) {
+    return AMDCUID_STATUS_PERMISSION_DENIED;
+  }
 
-    if (geteuid() != 0){
-        return AMDCUID_STATUS_PERMISSION_DENIED;
+  // validate the SMBIOS entry point and version. If version is < 2.1, then there won't be a UUID
+  // and we should quit there
+  std::ifstream validate_version(smbios_entry_path);
+  if (validate_version.is_open()) {
+    // check the anchor string first
+    char anchor[4];
+    validate_version.read(anchor, 4);
+    if (std::string(anchor, 4) == "_SM_") {
+      // version starts at offset 0x6
+      validate_version.seekg(0x6);
+      char version_major;
+      char version_minor;
+      validate_version.read(&version_major, 1);
+      validate_version.read(&version_minor, 1);
+      // Check if version is less than 2.1
+      if (version_major < 2 || (version_major == 2 && version_minor < 1)) {
+        return AMDCUID_STATUS_UNSUPPORTED;
+      }
+    } else if (std::string(anchor, 4) == "_SM3") {
+      // version starts at offset 0x7
+      validate_version.seekg(0x7);
+      char version_major;
+      char version_minor;
+      validate_version.read(&version_major, 1);
+      validate_version.read(&version_minor, 1);
+      // Check if version is less than 3.0
+      if (version_major < 3) {
+        return AMDCUID_STATUS_UNSUPPORTED;
+      }
+    } else {
+      // file is corrupted/malformed so
+      return AMDCUID_STATUS_SMBIOS_ERROR;
     }
+  } else {
+    return AMDCUID_STATUS_SMBIOS_ERROR;
+  }
+  // that's all we needed with version so we can close the file
+  validate_version.close();
 
-    // validate the SMBIOS entry point and version. If version is < 2.1, then there won't be a UUID and we should quit there
-    std::ifstream validate_version(smbios_entry_path);
-    if (validate_version.is_open()) {
-        // check the anchor string first
-        char anchor[4];
-        validate_version.read(anchor, 4);
-        if (std::string(anchor, 4) == "_SM_") {
-            // version starts at offset 0x6
-            validate_version.seekg(0x6);
-            char version_major;
-            char version_minor;
-            validate_version.read(&version_major, 1);
-            validate_version.read(&version_minor, 1);
-            // Check if version is less than 2.1
-            if (version_major < 2 || (version_major == 2 && version_minor < 1)) {
-                return AMDCUID_STATUS_UNSUPPORTED;
-            }
-        }
-        else if (std::string(anchor, 4) == "_SM3") {
-            // version starts at offset 0x7
-            validate_version.seekg(0x7);
-            char version_major;
-            char version_minor;
-            validate_version.read(&version_major, 1);
-            validate_version.read(&version_minor, 1);
-            // Check if version is less than 3.0
-            if (version_major < 3) {
-                return AMDCUID_STATUS_UNSUPPORTED;
-            }
-        }
-        else {
-            // file is corrupted/malformed so
-            return AMDCUID_STATUS_SMBIOS_ERROR;
-        }
-    }
-    else {
+  // now search through the DMI struct table to find the System Header and then the UUID
+  std::ifstream struct_table(smbios_path);
+  if (!struct_table) {
+    // failed to open the SMBIOS struct table file
+    return AMDCUID_STATUS_SMBIOS_ERROR;
+  }
+
+  uint8_t type = 0;
+  uint32_t struct_offset = 0;
+  const uint8_t TYPE_SYSTEM_INFO = 0x1;
+  uint8_t smbios_header[4] = {0};
+  struct_table.read(reinterpret_cast<char*>(smbios_header), 4);
+  type = smbios_header[0];
+  // iterate through the table to find the System Header and then the UUID
+  while (type != TYPE_SYSTEM_INFO && !struct_table.eof()) {
+    // move to the next structure and get past the strings section
+    struct_offset += smbios_header[1];
+    struct_table.seekg(struct_offset, std::ios::beg);
+
+    bool peek1, peek2;
+    peek1 = peek2 = false;
+    while (!peek1 || !peek2) {
+      if (struct_table.eof()) {
+        // reached end of file without finding the System Info structure
         return AMDCUID_STATUS_SMBIOS_ERROR;
+      }
+      peek1 = (struct_table.peek() == 0);
+      struct_table.ignore(1);
+      struct_offset++;
+      peek2 = (struct_table.peek() == 0);
     }
-    // that's all we needed with version so we can close the file
-    validate_version.close();
-
-    // now search through the DMI struct table to find the System Header and then the UUID
-    std::ifstream struct_table(smbios_path);
-    if (!struct_table)
-    {
-        // failed to open the SMBIOS struct table file
-        return AMDCUID_STATUS_SMBIOS_ERROR;
-    }
-
-    uint8_t type = 0;
-    uint32_t struct_offset = 0;
-    const uint8_t TYPE_SYSTEM_INFO = 0x1;
-    uint8_t smbios_header[4] = {0};
+    struct_table.ignore(1);  // Skip the double null terminator
+    struct_offset++;
     struct_table.read(reinterpret_cast<char*>(smbios_header), 4);
     type = smbios_header[0];
-    // iterate through the table to find the System Header and then the UUID
-    while (type != TYPE_SYSTEM_INFO && !struct_table.eof())
-    {
-        // move to the next structure and get past the strings section
-        struct_offset += smbios_header[1];
-        struct_table.seekg(struct_offset, std::ios::beg);
+  }
 
-        bool peek1, peek2;
-        peek1 = peek2 = false;
-        while (!peek1 || !peek2) {
-            if (struct_table.eof()) {
-                // reached end of file without finding the System Info structure
-                return AMDCUID_STATUS_SMBIOS_ERROR;
-            }
-            peek1 = (struct_table.peek() == 0);
-            struct_table.ignore(1);
-            struct_offset++;
-            peek2 = (struct_table.peek() == 0);
-        }
-        struct_table.ignore(1); // Skip the double null terminator
-        struct_offset++;
-        struct_table.read(reinterpret_cast<char*>(smbios_header), 4);
-        type = smbios_header[0];
-    }
+  if (type != TYPE_SYSTEM_INFO) {
+    return AMDCUID_STATUS_SMBIOS_ERROR;
+  }
 
-    if (type != TYPE_SYSTEM_INFO) {
-        return AMDCUID_STATUS_SMBIOS_ERROR;
-    }
+  // now at the System Info structure, read the UUID at offset 0x8
+  uint8_t raw_bytes[16] = {0};
+  const uint8_t UUID_OFFSET = 0x8;
+  struct_table.seekg(struct_offset + UUID_OFFSET, std::ios::beg);
+  struct_table.read(reinterpret_cast<char*>(raw_bytes), 16);
 
-    // now at the System Info structure, read the UUID at offset 0x8
-    uint8_t raw_bytes[16] = {0};
-    const uint8_t UUID_OFFSET = 0x8;
-    struct_table.seekg(struct_offset + UUID_OFFSET, std::ios::beg);
-    struct_table.read(reinterpret_cast<char*>(raw_bytes), 16);
+  // we need to store the bytes in such a way that when we use get_cuid_as_string, it prints out the
+  // same way as regular UUIDs
+  uuid[0] = raw_bytes[3];
+  uuid[1] = raw_bytes[2];
+  uuid[2] = raw_bytes[1];
+  uuid[3] = raw_bytes[0];
 
-    // we need to store the bytes in such a way that when we use get_cuid_as_string, it prints out the same way as regular UUIDs
-    uuid[0] = raw_bytes[3];
-    uuid[1] = raw_bytes[2];
-    uuid[2] = raw_bytes[1];
-    uuid[3] = raw_bytes[0];
+  uuid[4] = raw_bytes[5];
+  uuid[5] = raw_bytes[4];
 
-    uuid[4] = raw_bytes[5];
-    uuid[5] = raw_bytes[4];
+  uuid[6] = raw_bytes[7];
+  uuid[7] = raw_bytes[6];
 
-    uuid[6] = raw_bytes[7];
-    uuid[7] = raw_bytes[6];
+  for (int i = 8; i < 16; ++i) {
+    uuid[i] = raw_bytes[i];
+  }
 
-    for (int i = 8; i < 16; ++i) {
-        uuid[i] = raw_bytes[i];
-    }
+  struct_table.close();
 
-    struct_table.close();
-
-    return AMDCUID_STATUS_SUCCESS;
+  return AMDCUID_STATUS_SUCCESS;
 }
 
 // Get system serial number
-amdcuid_status_t SmbiosUtil::get_system_serial(std::string &serial) {
+amdcuid_status_t SmbiosUtil::get_system_serial(std::string& serial) {
+  if (geteuid() != 0) {
+    return AMDCUID_STATUS_PERMISSION_DENIED;
+  }
 
-    if (geteuid() != 0){
-        return AMDCUID_STATUS_PERMISSION_DENIED;
-    }
+  // Try multiple sources in order of preference
+  const char* serial_files[] = {"product_serial", "board_serial", "chassis_serial"};
 
-    // Try multiple sources in order of preference
-    const char* serial_files[] = {
-        "product_serial",
-        "board_serial",
-        "chassis_serial"
-    };
-    
-    for (const char* filename : serial_files) {
-        std::string path = std::string(DMI_PATH) + filename;
-        serial = CuidUtilities::read_sysfs_file(path);
-        
-        if (!serial.empty()) {
-            return AMDCUID_STATUS_SUCCESS;
-        }
+  for (const char* filename : serial_files) {
+    std::string path = std::string(DMI_PATH) + filename;
+    serial = CuidUtilities::read_sysfs_file(path);
+
+    if (!serial.empty()) {
+      return AMDCUID_STATUS_SUCCESS;
     }
-    
-    return AMDCUID_STATUS_SMBIOS_ERROR;
+  }
+
+  return AMDCUID_STATUS_SMBIOS_ERROR;
 }
 
 // Get board information
-amdcuid_status_t SmbiosUtil::get_board_info(std::string &vendor, 
-                                          std::string &name, 
-                                          std::string &version) {
-    vendor = CuidUtilities::read_sysfs_file(std::string(DMI_PATH) + "board_vendor");
-    name = CuidUtilities::read_sysfs_file(std::string(DMI_PATH) + "board_name");
-    version = CuidUtilities::read_sysfs_file(std::string(DMI_PATH) + "board_version");
-    
-    // Consider success if at least one field is available
-    if (!vendor.empty() || 
-        !name.empty() ||
-        !version.empty()) {
-        return AMDCUID_STATUS_SUCCESS;
-    }
-    
-    return AMDCUID_STATUS_SMBIOS_ERROR;
+amdcuid_status_t SmbiosUtil::get_board_info(std::string& vendor, std::string& name,
+                                            std::string& version) {
+  vendor = CuidUtilities::read_sysfs_file(std::string(DMI_PATH) + "board_vendor");
+  name = CuidUtilities::read_sysfs_file(std::string(DMI_PATH) + "board_name");
+  version = CuidUtilities::read_sysfs_file(std::string(DMI_PATH) + "board_version");
+
+  // Consider success if at least one field is available
+  if (!vendor.empty() || !name.empty() || !version.empty()) {
+    return AMDCUID_STATUS_SUCCESS;
+  }
+
+  return AMDCUID_STATUS_SMBIOS_ERROR;
 }
 
 // Get BIOS information
-amdcuid_status_t SmbiosUtil::get_bios_info(std::string &vendor,
-                                         std::string &version,
-                                         std::string &date) {
-    vendor = CuidUtilities::read_sysfs_file(std::string(DMI_PATH) + "bios_vendor");
-    version = CuidUtilities::read_sysfs_file(std::string(DMI_PATH) + "bios_version");
-    date = CuidUtilities::read_sysfs_file(std::string(DMI_PATH) + "bios_date");
-    
-    // Consider success if at least one field is available
-    if (!vendor.empty() || 
-        !version.empty() ||
-        !date.empty()) {
-        return AMDCUID_STATUS_SUCCESS;
-    }
-    
-    return AMDCUID_STATUS_SMBIOS_ERROR;
+amdcuid_status_t SmbiosUtil::get_bios_info(std::string& vendor, std::string& version,
+                                           std::string& date) {
+  vendor = CuidUtilities::read_sysfs_file(std::string(DMI_PATH) + "bios_vendor");
+  version = CuidUtilities::read_sysfs_file(std::string(DMI_PATH) + "bios_version");
+  date = CuidUtilities::read_sysfs_file(std::string(DMI_PATH) + "bios_date");
+
+  // Consider success if at least one field is available
+  if (!vendor.empty() || !version.empty() || !date.empty()) {
+    return AMDCUID_STATUS_SUCCESS;
+  }
+
+  return AMDCUID_STATUS_SMBIOS_ERROR;
 }
 
 // Get product information
-amdcuid_status_t SmbiosUtil::get_product_info(std::string &name,
-                                            std::string &family) {
-    name = CuidUtilities::read_sysfs_file(std::string(DMI_PATH) + "product_name");
-    family = CuidUtilities::read_sysfs_file(std::string(DMI_PATH) + "product_family");
-    
-    // Consider success if at least one field is available
-    if (!name.empty() || 
-        !family.empty()) {
-        return AMDCUID_STATUS_SUCCESS;
-    }
-    
-    return AMDCUID_STATUS_SMBIOS_ERROR;
+amdcuid_status_t SmbiosUtil::get_product_info(std::string& name, std::string& family) {
+  name = CuidUtilities::read_sysfs_file(std::string(DMI_PATH) + "product_name");
+  family = CuidUtilities::read_sysfs_file(std::string(DMI_PATH) + "product_family");
+
+  // Consider success if at least one field is available
+  if (!name.empty() || !family.empty()) {
+    return AMDCUID_STATUS_SUCCESS;
+  }
+
+  return AMDCUID_STATUS_SMBIOS_ERROR;
 }

--- a/projects/cuid/lib/src/smbios_util.h
+++ b/projects/cuid/lib/src/smbios_util.h
@@ -23,20 +23,24 @@
 #ifndef SMBIOS_UTIL_H
 #define SMBIOS_UTIL_H
 
-#include "include/amd_cuid.h"
 #include <iostream>
 
+#include "include/amd_cuid.h"
+
 class SmbiosUtil {
-public:
-    static amdcuid_status_t get_system_uuid(uint8_t* uuid);
-    static amdcuid_status_t get_uuid_from_smbios_table(uint8_t* uuid);
-    static amdcuid_status_t get_system_serial(std::string &serial);
-    static amdcuid_status_t get_board_info(std::string &vendor, std::string &name, std::string &version);
-    static amdcuid_status_t get_bios_info(std::string &vendor, std::string &version, std::string &date);
-    static amdcuid_status_t get_product_info(std::string &name, std::string &family);
-private:
-    static constexpr const char* DMI_PATH = "/sys/class/dmi/id/";
-    static constexpr const char* DMI_TABLES_PATH = "/sys/firmware/dmi/tables/";
+ public:
+  static amdcuid_status_t get_system_uuid(uint8_t* uuid);
+  static amdcuid_status_t get_uuid_from_smbios_table(uint8_t* uuid);
+  static amdcuid_status_t get_system_serial(std::string& serial);
+  static amdcuid_status_t get_board_info(std::string& vendor, std::string& name,
+                                         std::string& version);
+  static amdcuid_status_t get_bios_info(std::string& vendor, std::string& version,
+                                        std::string& date);
+  static amdcuid_status_t get_product_info(std::string& name, std::string& family);
+
+ private:
+  static constexpr const char* DMI_PATH = "/sys/class/dmi/id/";
+  static constexpr const char* DMI_TABLES_PATH = "/sys/firmware/dmi/tables/";
 };
 
-#endif // SMBIOS_UTIL_H
+#endif  // SMBIOS_UTIL_H

--- a/projects/cuid/tests/CMakeLists.txt
+++ b/projects/cuid/tests/CMakeLists.txt
@@ -48,11 +48,7 @@ endif()
 if(NOT GTest_FOUND)
     message("GTest not found on system. Fetching from source...")
     include(FetchContent)
-    FetchContent_Declare(
-        googletest
-        GIT_REPOSITORY https://github.com/google/googletest.git
-        GIT_TAG v1.16.0
-    )
+    FetchContent_Declare(googletest GIT_REPOSITORY https://github.com/google/googletest.git GIT_TAG v1.16.0)
     FetchContent_MakeAvailable(googletest)
 elseif(TARGET GTest::GTest AND NOT TARGET GTest::gtest)
     # MODULE mode found GTest::GTest — create the canonical aliases expected below.
@@ -61,19 +57,60 @@ endif()
 
 set(AMDCUID_TST_EXECUTABLE amdcuid_test)
 
-# Collect all test sources from the three source locations.
-aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR} TEST_SOURCES_ROOT)
-aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/unit TEST_SOURCES_UNIT)
-aux_source_directory(
-    ${CMAKE_CURRENT_SOURCE_DIR}/functional
-    TEST_SOURCES_FUNCTIONAL
+# Sources listed explicitly, as lib/CMakeLists.txt does. aux_source_directory()
+# is evaluated at configure time, so adding a file did not regenerate the build
+# and failed at link until cmake was re-run by hand.
+set(TEST_SOURCES_ROOT
+    ${CMAKE_CURRENT_SOURCE_DIR}/main.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_base.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_common.cc
 )
 
-set(TEST_SOURCES
-    ${TEST_SOURCES_ROOT}
-    ${TEST_SOURCES_UNIT}
-    ${TEST_SOURCES_FUNCTIONAL}
+set(TEST_SOURCES_UNIT
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/acpi_parser_test.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/concurrency_test.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/cuid_gpu_test.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/file_lock_test.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/gim_util_test.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/id_string_test.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/pci_util_test.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/sha256_test.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/status_string_test.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/utilities_test.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/version_read_test.cc
 )
+
+set(TEST_SOURCES_FUNCTIONAL
+    ${CMAKE_CURRENT_SOURCE_DIR}/functional/device_handles_test.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/functional/device_query_test.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/functional/device_refresh_test.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/functional/hmac_test.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/functional/reverse_lookup_test.cc
+)
+
+# Headers are listed so they show up in IDE project trees, as lib/ does.
+set(TEST_HEADERS
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_base.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_common.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/acpi_parser_test.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/concurrency_test.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/cuid_gpu_test.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/file_lock_test.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/gim_util_test.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/id_string_test.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/pci_util_test.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/sha256_test.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/status_string_test.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/utilities_test.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/version_read_test.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/functional/device_handles_test.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/functional/device_query_test.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/functional/device_refresh_test.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/functional/hmac_test.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/functional/reverse_lookup_test.h
+)
+
+set(TEST_SOURCES ${TEST_SOURCES_ROOT} ${TEST_SOURCES_UNIT} ${TEST_SOURCES_FUNCTIONAL} ${TEST_HEADERS})
 
 # Enable testing
 enable_testing()
@@ -90,17 +127,15 @@ target_include_directories(
         ${CMAKE_SOURCE_DIR}/lib
 )
 
-target_link_libraries(${AMDCUID_TST_EXECUTABLE} amdcuid_static GTest::gtest)
+# concurrency_test.cc spawns std::thread, so the suite needs a threading
+# implementation of its own.
+find_package(Threads REQUIRED)
+
+target_link_libraries(${AMDCUID_TST_EXECUTABLE} amdcuid_static GTest::gtest Threads::Threads)
 
 # Register two CTest targets split by privilege level.
-add_test(
-    NAME cuid_unprivileged_tests
-    COMMAND ${AMDCUID_TST_EXECUTABLE} --gtest_filter=cuidtstUnprivileged.*
-)
-add_test(
-    NAME cuid_privileged_tests
-    COMMAND ${AMDCUID_TST_EXECUTABLE} --gtest_filter=cuidtstPrivileged.*
-)
+add_test(NAME cuid_unprivileged_tests COMMAND ${AMDCUID_TST_EXECUTABLE} --gtest_filter=cuidtstUnprivileged.*)
+add_test(NAME cuid_privileged_tests COMMAND ${AMDCUID_TST_EXECUTABLE} --gtest_filter=cuidtstPrivileged.*)
 
 # Platform-specific config directory
 if(WIN32)
@@ -110,11 +145,7 @@ else()
 endif()
 
 # Install the test binary
-install(
-    TARGETS ${AMDCUID_TST_EXECUTABLE}
-    DESTINATION ${TESTS_INSTALL_DIR}
-    COMPONENT ${TESTS_COMPONENT}
-)
+install(TARGETS ${AMDCUID_TST_EXECUTABLE} DESTINATION ${TESTS_INSTALL_DIR} COMPONENT ${TESTS_COMPONENT})
 
 message("&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")
 message("                    Finished Cmake amdcuid_test                    ")

--- a/projects/cuid/tests/check_sha256_drift.py
+++ b/projects/cuid/tests/check_sha256_drift.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""Fail if the two copies of SHA-256 in this repo have drifted apart.
+
+libamdcuid carries a copy of rocprofiler-sdk's SHA-256. A silent divergence
+would not fail to build -- it would change every CUID ever issued.
+
+    python3 projects/cuid/tests/check_sha256_drift.py
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# Both paths are relative to the repository root.
+UPSTREAM = Path("projects/rocprofiler-sdk/source/lib/common/sha256.cpp")
+COPY = Path("projects/cuid/lib/src/sha256.cc")
+
+# update() may differ only by rocprofiler's logging call. Anything else is drift.
+ALLOWED_UPSTREAM_ONLY = ("ROCP_CI_LOG_IF",)
+
+
+def strip_comments(src: str) -> str:
+    src = re.sub(r"//[^\n]*", "", src)
+    return re.sub(r"/\*.*?\*/", "", src, flags=re.S)
+
+
+def member_bodies(path: Path) -> dict[str, str]:
+    """Map sha256::<name> -> body text, for every member defined in the file."""
+    src = strip_comments(path.read_text(encoding="utf-8"))
+    bodies: dict[str, str] = {}
+    for match in re.finditer(r"\bsha256::(\w+)\s*\(", src):
+        open_brace = src.find("{", match.end())
+        if open_brace < 0:
+            continue
+        depth, idx = 0, open_brace
+        while idx < len(src):
+            if src[idx] == "{":
+                depth += 1
+            elif src[idx] == "}":
+                depth -= 1
+                if depth == 0:
+                    break
+            idx += 1
+        bodies.setdefault(match.group(1), src[open_brace + 1 : idx])
+    return bodies
+
+
+def normalise(body: str, drop_allowed: bool) -> str:
+    lines = []
+    for line in body.split("\n"):
+        if drop_allowed and any(tok in line for tok in ALLOWED_UPSTREAM_ONLY):
+            continue
+        lines.append(line)
+    return re.sub(r"\s+", "", "\n".join(lines))
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[3]
+    upstream_path, copy_path = root / UPSTREAM, root / COPY
+
+    for path in (upstream_path, copy_path):
+        if not path.is_file():
+            print(f"error: {path} not found", file=sys.stderr)
+            return 2
+
+    upstream = member_bodies(upstream_path)
+    copy = member_bodies(copy_path)
+
+    if not upstream or not copy:
+        print("error: parsed no sha256:: members; the extractor needs updating", file=sys.stderr)
+        return 2
+
+    problems: list[str] = []
+
+    missing = sorted(set(upstream) - set(copy))
+    if missing:
+        problems.append(
+            f"{COPY} is missing member(s) present upstream: {', '.join(missing)}"
+        )
+
+    for name in sorted(set(upstream) & set(copy)):
+        if normalise(upstream[name], drop_allowed=True) != normalise(copy[name], False):
+            problems.append(f"sha256::{name}() differs between the two copies")
+
+    if problems:
+        print("SHA-256 implementations have drifted apart:\n", file=sys.stderr)
+        for problem in problems:
+            print(f"  - {problem}", file=sys.stderr)
+        print(
+            f"\n  upstream: {UPSTREAM}\n  copy:     {COPY}\n\n"
+            "Reconcile them, or record an intended difference in ALLOWED_UPSTREAM_ONLY.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"sha256 copies agree: {len(set(upstream) & set(copy))} member functions checked")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/projects/cuid/tests/main.cc
+++ b/projects/cuid/tests/main.cc
@@ -23,10 +23,14 @@
 #include "test_common.h"
 
 // Unit tests (no root or device required)
+#include "unit/acpi_parser_test.h"
+#include "unit/concurrency_test.h"
 #include "unit/cuid_gpu_test.h"
 #include "unit/file_lock_test.h"
 #include "unit/gim_util_test.h"
 #include "unit/id_string_test.h"
+#include "unit/pci_util_test.h"
+#include "unit/sha256_test.h"
 #include "unit/status_string_test.h"
 #include "unit/utilities_test.h"
 #include "unit/version_read_test.h"
@@ -63,6 +67,16 @@ TEST(cuidtstUnprivileged, IdString) {
 
 TEST(cuidtstUnprivileged, Utilities) {
   TestUtilities tst;
+  RunGenericTest(&tst);
+}
+
+TEST(cuidtstUnprivileged, Sha256Kat) {
+  TestSha256Kat tst;
+  RunGenericTest(&tst);
+}
+
+TEST(cuidtstUnprivileged, HmacSha256Kat) {
+  TestHmacSha256Kat tst;
   RunGenericTest(&tst);
 }
 
@@ -141,8 +155,23 @@ TEST(cuidtstUnprivileged, GimFormatBdf) {
   RunGenericTest(&tst);
 }
 
+TEST(cuidtstUnprivileged, PciConfigDecode) {
+  TestPciConfigDecode tst;
+  RunGenericTest(&tst);
+}
+
+TEST(cuidtstUnprivileged, ConcurrentApi) {
+  TestConcurrentApi tst;
+  RunGenericTest(&tst);
+}
+
 TEST(cuidtstUnprivileged, CuidGpuRenderNode) {
   TestCuidGpuRenderNode tst;
+  RunGenericTest(&tst);
+}
+
+TEST(cuidtstUnprivileged, AcpiMadtParse) {
+  TestAcpiMadtParse tst;
   RunGenericTest(&tst);
 }
 

--- a/projects/cuid/tests/unit/acpi_parser_test.cc
+++ b/projects/cuid/tests/unit/acpi_parser_test.cc
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "unit/acpi_parser_test.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include "src/acpi_parser.h"
+
+namespace {
+
+// Append the raw bytes of a packed firmware struct to a table image.
+template <typename T>
+void append_struct(std::vector<uint8_t>& table, const T& value) {
+  const auto* bytes = reinterpret_cast<const uint8_t*>(&value);
+  table.insert(table.end(), bytes, bytes + sizeof(T));
+}
+
+// Patch the header length field and recompute the ACPI checksum so the table
+// passes validation. Must be called after all entries have been appended.
+void finalize(std::vector<uint8_t>& table) {
+  const uint32_t length = static_cast<uint32_t>(table.size());
+  std::memcpy(table.data() + offsetof(AcpiTableHeader, length), &length, sizeof(length));
+
+  table[offsetof(AcpiTableHeader, checksum)] = 0;
+  uint8_t sum = 0;
+  for (uint8_t b : table) {
+    sum = static_cast<uint8_t>(sum + b);
+  }
+  table[offsetof(AcpiTableHeader, checksum)] = static_cast<uint8_t>(0u - sum);
+}
+
+// A MADT image with a valid signature/length/checksum and no entries.
+std::vector<uint8_t> make_empty_madt() {
+  MadtHeader madt{};
+  std::memcpy(madt.header.signature, "APIC", 4);
+  madt.header.revision = 5;
+
+  std::vector<uint8_t> table;
+  append_struct(table, madt);
+  return table;
+}
+
+MadtLocalApic make_local_apic(uint8_t uid, uint8_t apic_id, bool enabled) {
+  MadtLocalApic e{};
+  e.header.type = 0;
+  e.header.length = sizeof(MadtLocalApic);
+  e.acpi_processor_uid = uid;
+  e.apic_id = apic_id;
+  e.flags = enabled ? 1u : 0u;
+  return e;
+}
+
+MadtLocalX2Apic make_local_x2apic(uint32_t uid, uint32_t x2apic_id, bool enabled) {
+  MadtLocalX2Apic e{};
+  e.header.type = 9;
+  e.header.length = sizeof(MadtLocalX2Apic);
+  e.x2apic_id = x2apic_id;
+  e.flags = enabled ? 1u : 0u;
+  e.acpi_processor_uid = uid;
+  return e;
+}
+
+}  // namespace
+
+TestAcpiMadtParse::TestAcpiMadtParse() {
+  SetTitle("ACPI MADT Parse");
+  SetDescription(
+      "Parse synthetic MADT tables and verify that malformed/truncated tables are "
+      "rejected without reading past the end of the buffer.");
+}
+
+void TestAcpiMadtParse::SetUp() {}
+
+void TestAcpiMadtParse::Run() {
+  std::vector<AcpiCpuInfo> cpus;
+
+  // Happy path: one Local APIC entry and one x2APIC entry, plus an unknown
+  // entry type that must be skipped rather than reported.
+  {
+    std::vector<uint8_t> table = make_empty_madt();
+    append_struct(table, make_local_apic(/*uid=*/1, /*apic_id=*/0x11, /*enabled=*/true));
+    // Unknown structure type 4 (Local APIC NMI), 6 bytes long.
+    const uint8_t nmi[6] = {4, 6, 0, 0, 0, 0};
+    table.insert(table.end(), nmi, nmi + sizeof(nmi));
+    append_struct(table, make_local_x2apic(/*uid=*/2, /*x2apic_id=*/0x2222, /*enabled=*/false));
+    finalize(table);
+
+    ASSERT_EQ(AcpiParser::parse_madt_buffer(table.data(), table.size(), cpus),
+              AMDCUID_STATUS_SUCCESS);
+    ASSERT_EQ(cpus.size(), 2u);
+
+    EXPECT_EQ(cpus[0].apic_id, 0x11u);
+    EXPECT_EQ(cpus[0].processor_uid, 1u);
+    EXPECT_TRUE(cpus[0].enabled);
+    EXPECT_FALSE(cpus[0].is_x2apic);
+
+    EXPECT_EQ(cpus[1].apic_id, 0x2222u);
+    EXPECT_EQ(cpus[1].processor_uid, 2u);
+    EXPECT_FALSE(cpus[1].enabled);
+    EXPECT_TRUE(cpus[1].is_x2apic);
+  }
+
+  // Regression: a table whose final byte begins an entry. The old walker
+  // tested only `entry < end` and then read entry->length, one byte past the
+  // buffer. It must now be rejected.
+  {
+    std::vector<uint8_t> table = make_empty_madt();
+    append_struct(table, make_local_apic(1, 0x11, true));
+    table.push_back(0);  // dangling entry-header type byte, no length byte
+    finalize(table);
+
+    EXPECT_EQ(AcpiParser::parse_madt_buffer(table.data(), table.size(), cpus),
+              AMDCUID_STATUS_INVALID_FORMAT);
+  }
+
+  // An entry whose declared length runs past the end of the table.
+  {
+    std::vector<uint8_t> table = make_empty_madt();
+    MadtLocalApic e = make_local_apic(1, 0x11, true);
+    e.header.length = sizeof(MadtLocalApic) + 32;  // lies about its size
+    append_struct(table, e);
+    finalize(table);
+
+    EXPECT_EQ(AcpiParser::parse_madt_buffer(table.data(), table.size(), cpus),
+              AMDCUID_STATUS_INVALID_FORMAT);
+  }
+
+  // A zero-length entry would never advance the walker; it must be rejected
+  // rather than spun on.
+  {
+    std::vector<uint8_t> table = make_empty_madt();
+    const uint8_t zero_len[4] = {0, 0, 0, 0};
+    table.insert(table.end(), zero_len, zero_len + sizeof(zero_len));
+    finalize(table);
+
+    EXPECT_EQ(AcpiParser::parse_madt_buffer(table.data(), table.size(), cpus),
+              AMDCUID_STATUS_INVALID_FORMAT);
+  }
+
+  // A Local APIC entry that declares a length smaller than the structure it
+  // claims to be must be skipped, not decoded from adjacent bytes.
+  {
+    std::vector<uint8_t> table = make_empty_madt();
+    const uint8_t short_apic[4] = {0, 4, 7, 7};  // type 0, length 4 (< 8)
+    table.insert(table.end(), short_apic, short_apic + sizeof(short_apic));
+    finalize(table);
+
+    // No usable CPU entries were found.
+    EXPECT_EQ(AcpiParser::parse_madt_buffer(table.data(), table.size(), cpus),
+              AMDCUID_STATUS_DEVICE_NOT_FOUND);
+    EXPECT_TRUE(cpus.empty());
+  }
+
+  // Degenerate inputs must not dereference anything.
+  {
+    EXPECT_EQ(AcpiParser::parse_madt_buffer(nullptr, 0, cpus), AMDCUID_STATUS_INVALID_FORMAT);
+
+    std::vector<uint8_t> truncated = make_empty_madt();
+    truncated.resize(sizeof(AcpiTableHeader));  // shorter than a MadtHeader
+    EXPECT_EQ(AcpiParser::parse_madt_buffer(truncated.data(), truncated.size(), cpus),
+              AMDCUID_STATUS_INVALID_FORMAT);
+  }
+
+  // Wrong signature and bad checksum are both rejected.
+  {
+    std::vector<uint8_t> table = make_empty_madt();
+    append_struct(table, make_local_apic(1, 0x11, true));
+    finalize(table);
+
+    std::vector<uint8_t> wrong_sig = table;
+    wrong_sig[0] = 'X';
+    EXPECT_EQ(AcpiParser::parse_madt_buffer(wrong_sig.data(), wrong_sig.size(), cpus),
+              AMDCUID_STATUS_INVALID_FORMAT);
+
+    std::vector<uint8_t> bad_sum = table;
+    bad_sum[offsetof(AcpiTableHeader, checksum)] ^= 0xFF;
+    EXPECT_EQ(AcpiParser::parse_madt_buffer(bad_sum.data(), bad_sum.size(), cpus),
+              AMDCUID_STATUS_INVALID_FORMAT);
+
+    // Header length disagreeing with the actual buffer size is rejected too.
+    std::vector<uint8_t> short_buf = table;
+    short_buf.pop_back();
+    EXPECT_EQ(AcpiParser::parse_madt_buffer(short_buf.data(), short_buf.size(), cpus),
+              AMDCUID_STATUS_INVALID_FORMAT);
+  }
+}

--- a/projects/cuid/tests/unit/acpi_parser_test.h
+++ b/projects/cuid/tests/unit/acpi_parser_test.h
@@ -20,34 +20,20 @@
  * THE SOFTWARE.
  */
 
-#ifndef PCI_UTIL_H
-#define PCI_UTIL_H
+#ifndef CUID_TEST_UNIT_ACPI_PARSER_TEST_H_
+#define CUID_TEST_UNIT_ACPI_PARSER_TEST_H_
 
-#include <cstdint>
-#include <string>
-#include <vector>
+#include "test_base.h"
 
-#include "include/amd_cuid.h"
-
-/// Size of a PCIe extended configuration space, in bytes.
-constexpr size_t kPciConfigSpaceSize = 4096;
-
-class PciUtil {
+// Parses synthetic MADT images through AcpiParser::parse_madt_buffer. No root
+// and no real /sys/firmware/acpi/tables/APIC required. Covers the happy path
+// (Local APIC + x2APIC entries) and the malformed cases that previously read
+// past the end of the table buffer.
+class TestAcpiMadtParse : public TestBase {
  public:
-  static amdcuid_status_t read_pci_config_space(std::string bdf, uint8_t* buffer,
-                                                size_t buffer_size, uint16_t offset);
-  static amdcuid_status_t get_pci_dsn_cap_offset(std::string bdf, uint16_t& offset);
-  static amdcuid_status_t get_pci_vsec_cap_offset(std::string bdf, uint16_t& offset);
-
-  // Load a 16-bit little-endian config-space field. Use this instead of
-  // casting the buffer to uint16_t*, which violates alignment and aliasing.
-  static uint16_t load_le16(const uint8_t bytes[2]) {
-    return static_cast<uint16_t>(static_cast<uint16_t>(bytes[0]) |
-                                 (static_cast<uint16_t>(bytes[1]) << 8));
-  }
-
-  // Endianness conversion utilities
-  static uint64_t le64_to_be64(uint64_t value);
+  TestAcpiMadtParse();
+  void SetUp() override;
+  void Run() override;
 };
 
-#endif  // PCI_UTIL_H
+#endif  // CUID_TEST_UNIT_ACPI_PARSER_TEST_H_

--- a/projects/cuid/tests/unit/concurrency_test.cc
+++ b/projects/cuid/tests/unit/concurrency_test.cc
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+// Every other test here is single-threaded, so a sanitizer run over the suite
+// cannot see a data race. This one drives the public API from several threads;
+// its real value is under -fsanitize=thread (with setarch -R to disable ASLR).
+
+#include "unit/concurrency_test.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstdio>
+#include <thread>
+#include <vector>
+
+#include "include/amd_cuid.h"
+
+namespace {
+
+constexpr int kThreads = 8;
+constexpr int kIterations = 25;
+
+// Every status the workers are allowed to see. Anything else means the API
+// returned something undefined under concurrency.
+bool acceptable(amdcuid_status_t status) {
+  switch (status) {
+    case AMDCUID_STATUS_SUCCESS:
+    case AMDCUID_STATUS_DEVICE_NOT_FOUND:
+    case AMDCUID_STATUS_UNSUPPORTED:
+    case AMDCUID_STATUS_INSUFFICIENT_SIZE:
+    case AMDCUID_STATUS_PERMISSION_DENIED:
+    case AMDCUID_STATUS_HW_FINGERPRINT_NOT_FOUND:
+    case AMDCUID_STATUS_FILE_NOT_FOUND:
+      return true;
+    default:
+      return false;
+  }
+}
+
+}  // namespace
+
+TestConcurrentApi::TestConcurrentApi() {
+  SetTitle("Concurrent Public API Use");
+  SetDescription(
+      "Drive amdcuid_get_all_handles, amdcuid_query_device_property and "
+      "amdcuid_refresh from several threads at once. Guards the "
+      "CuidDeviceManager locking; run under ThreadSanitizer to detect races.");
+}
+
+void TestConcurrentApi::SetUp() {}
+
+void TestConcurrentApi::Run() {
+  std::atomic<int> bad_status{0};
+  std::atomic<int> observed{0};
+
+  auto worker = [&](int id) {
+    for (int i = 0; i < kIterations; ++i) {
+      uint32_t count = 0;
+      amdcuid_status_t status = amdcuid_get_all_handles(nullptr, &count);
+      if (!acceptable(status)) {
+        ++bad_status;
+        continue;
+      }
+
+      if (status == AMDCUID_STATUS_SUCCESS && count > 0) {
+        std::vector<amdcuid_id_t> handles(count);
+        uint32_t fetched = count;
+        if (amdcuid_get_all_handles(handles.data(), &fetched) == AMDCUID_STATUS_SUCCESS) {
+          ++observed;
+          const uint32_t examine = (fetched < 4) ? fetched : 4;
+          for (uint32_t h = 0; h < examine; ++h) {
+            amdcuid_id_t derived{};
+            uint32_t len = sizeof(derived);
+            if (!acceptable(amdcuid_query_device_property(handles[h], AMDCUID_QUERY_DERIVED_CUID,
+                                                          &derived, &len))) {
+              ++bad_status;
+            }
+            // Size-query form: data == nullptr must still return a defined
+            // status rather than an uninitialized one.
+            uint32_t path_len = 0;
+            if (!acceptable(amdcuid_query_device_property(handles[h], AMDCUID_QUERY_DEVICE_PATH,
+                                                          nullptr, &path_len))) {
+              ++bad_status;
+            }
+          }
+        }
+      }
+
+      // Force a rediscovery underneath the readers. This is what makes the
+      // device list get replaced while other threads are walking it.
+      if ((i % 5) == (id % 5)) {
+        if (!acceptable(amdcuid_refresh())) {
+          ++bad_status;
+        }
+      }
+    }
+  };
+
+  std::vector<std::thread> threads;
+  threads.reserve(kThreads);
+  for (int i = 0; i < kThreads; ++i) {
+    threads.emplace_back(worker, i);
+  }
+  for (auto& t : threads) {
+    t.join();
+  }
+
+  EXPECT_EQ(bad_status.load(), 0) << "public API returned an unexpected status under concurrency";
+
+  IF_VERB(1) {
+    printf("  %d threads x %d iterations, %d successful enumerations\n", kThreads, kIterations,
+           observed.load());
+  }
+}
+
+void TestConcurrentApi::DisplayTestInfo() { TestBase::DisplayTestInfo(); }
+void TestConcurrentApi::DisplayResults() const { TestBase::DisplayResults(); }
+void TestConcurrentApi::Close() {}

--- a/projects/cuid/tests/unit/concurrency_test.h
+++ b/projects/cuid/tests/unit/concurrency_test.h
@@ -20,34 +20,22 @@
  * THE SOFTWARE.
  */
 
-#ifndef PCI_UTIL_H
-#define PCI_UTIL_H
+#ifndef CUID_TEST_UNIT_CONCURRENCY_TEST_H_
+#define CUID_TEST_UNIT_CONCURRENCY_TEST_H_
 
-#include <cstdint>
-#include <string>
-#include <vector>
+#include "test_base.h"
 
-#include "include/amd_cuid.h"
-
-/// Size of a PCIe extended configuration space, in bytes.
-constexpr size_t kPciConfigSpaceSize = 4096;
-
-class PciUtil {
+// Drives the public C API from several threads at once so that
+// CuidDeviceManager's shared state is exercised concurrently. Without this the
+// suite is single-threaded and ThreadSanitizer has nothing to observe.
+class TestConcurrentApi : public TestBase {
  public:
-  static amdcuid_status_t read_pci_config_space(std::string bdf, uint8_t* buffer,
-                                                size_t buffer_size, uint16_t offset);
-  static amdcuid_status_t get_pci_dsn_cap_offset(std::string bdf, uint16_t& offset);
-  static amdcuid_status_t get_pci_vsec_cap_offset(std::string bdf, uint16_t& offset);
-
-  // Load a 16-bit little-endian config-space field. Use this instead of
-  // casting the buffer to uint16_t*, which violates alignment and aliasing.
-  static uint16_t load_le16(const uint8_t bytes[2]) {
-    return static_cast<uint16_t>(static_cast<uint16_t>(bytes[0]) |
-                                 (static_cast<uint16_t>(bytes[1]) << 8));
-  }
-
-  // Endianness conversion utilities
-  static uint64_t le64_to_be64(uint64_t value);
+  TestConcurrentApi();
+  void SetUp() override;
+  void Run() override;
+  void DisplayTestInfo() override;
+  void DisplayResults() const override;
+  void Close() override;
 };
 
-#endif  // PCI_UTIL_H
+#endif  // CUID_TEST_UNIT_CONCURRENCY_TEST_H_

--- a/projects/cuid/tests/unit/gim_util_test.cc
+++ b/projects/cuid/tests/unit/gim_util_test.cc
@@ -40,7 +40,7 @@ using cuid::gim::GimDeviceEntry;
 namespace {
 
 bool gim_dev_present() {
-  struct stat st {};
+  struct stat st{};
   return ::stat("/dev/gim-smi0", &st) == 0;
 }
 
@@ -193,11 +193,10 @@ void TestGimDeviceEnumeration::Run() {
 
   std::set<std::string> seen_bdfs;
   std::set<uint64_t> seen_serials;
-  for (const auto &dev : devices) {
+  for (const auto& dev : devices) {
     // Canonical "dddd:bb:dd.f" is exactly 12 characters and must be unique.
     EXPECT_EQ(dev.bdf.size(), 12u) << "malformed BDF: '" << dev.bdf << "'";
-    EXPECT_NE(dev.bdf.find(':'), std::string::npos)
-        << "malformed BDF: '" << dev.bdf << "'";
+    EXPECT_NE(dev.bdf.find(':'), std::string::npos) << "malformed BDF: '" << dev.bdf << "'";
     EXPECT_TRUE(seen_bdfs.insert(dev.bdf).second)
         << "duplicate BDF indicates a wrong ABI stride: " << dev.bdf;
 
@@ -209,7 +208,7 @@ void TestGimDeviceEnumeration::Run() {
 
     uint64_t serial = 0;
     EXPECT_TRUE(GimClient::parse_asic_serial(info.asic_serial, serial))
-        << "unparseable serial '" << info.asic_serial << "' for " << dev.bdf;
+        << "unparsable serial '" << info.asic_serial << "' for " << dev.bdf;
     // The per-GPU ASIC serial is the CUID hardware fingerprint; duplicates
     // would collapse multiple GPUs into a single CUID.
     EXPECT_TRUE(seen_serials.insert(serial).second)

--- a/projects/cuid/tests/unit/pci_util_test.cc
+++ b/projects/cuid/tests/unit/pci_util_test.cc
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "unit/pci_util_test.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstdio>
+
+#include "src/pci_util.h"
+
+namespace {
+
+// The first 16 bytes of a PCI type-0 configuration header for an AMD device,
+// exactly as they appear on the wire (little-endian):
+//
+//   0x00 vendor  = 0x1002   -> 02 10
+//   0x02 device  = 0x73A1   -> A1 73
+//   0x04 command                    0x06 status
+//   0x08 revision = 0xC1            0x09 prog-if = 0x00
+//   0x0A subclass = 0x00            0x0B class   = 0x03  (display controller)
+constexpr uint8_t kHeader[16] = {
+    0x02, 0x10,  // 0x00 vendor
+    0xA1, 0x73,  // 0x02 device
+    0x07, 0x04,  // 0x04 command
+    0x10, 0x00,  // 0x06 status
+    0xC1,        // 0x08 revision
+    0x00,        // 0x09 prog-if
+    0x00,        // 0x0A subclass
+    0x03,        // 0x0B class
+    0x00, 0x00, 0x00, 0x00,
+};
+
+}  // namespace
+
+TestPciConfigDecode::TestPciConfigDecode() {
+  SetTitle("PCI Config-Space Decode");
+  SetDescription(
+      "Verify the little-endian loads used by the PCI config-space fallback "
+      "produce the same values sysfs reports, and that RevisionID does not "
+      "pick up the prog-if byte.");
+}
+
+void TestPciConfigDecode::SetUp() {}
+
+void TestPciConfigDecode::Run() {
+  // VendorID at 0x00. The historic bug: this was byte-swapped after loading,
+  // so AMD's 0x1002 was recorded as 0x0210.
+  EXPECT_EQ(PciUtil::load_le16(&kHeader[0x00]), 0x1002u);
+  EXPECT_NE(PciUtil::load_le16(&kHeader[0x00]), 0x0210u);
+
+  // DeviceID at 0x02.
+  EXPECT_EQ(PciUtil::load_le16(&kHeader[0x02]), 0x73A1u);
+
+  // Class at 0x0A loads subclass then class, giving 0xCCSS -- the same value
+  // sysfs "class" gives after >>8. Both feed the same CUID field, so they must
+  // agree.
+  const uint16_t from_config = PciUtil::load_le16(&kHeader[0x0A]);
+  const uint32_t sysfs_class_24bit = 0x030000u;  // class 03, subclass 00, prog-if 00
+  EXPECT_EQ(from_config, 0x0300u);
+  EXPECT_EQ(from_config, static_cast<uint16_t>(sysfs_class_24bit >> 8));
+
+  // RevisionID is the single byte at 0x08. Reading two bytes and narrowing
+  // used to keep the prog-if byte at 0x09 instead.
+  EXPECT_EQ(kHeader[0x08], 0xC1u);
+  EXPECT_EQ(static_cast<uint8_t>(PciUtil::load_le16(&kHeader[0x08]) >> 8), kHeader[0x09]);
+
+  // Must work unaligned: every odd offset of a config-space buffer is legal.
+  const uint8_t unaligned[3] = {0xFF, 0x34, 0x12};
+  EXPECT_EQ(PciUtil::load_le16(&unaligned[1]), 0x1234u);
+
+  // Boundary values.
+  const uint8_t zero[2] = {0x00, 0x00};
+  const uint8_t max[2] = {0xFF, 0xFF};
+  EXPECT_EQ(PciUtil::load_le16(zero), 0x0000u);
+  EXPECT_EQ(PciUtil::load_le16(max), 0xFFFFu);
+
+  IF_VERB(1) {
+    printf("  vendor=0x%04x device=0x%04x class=0x%04x revision=0x%02x\n",
+           PciUtil::load_le16(&kHeader[0x00]), PciUtil::load_le16(&kHeader[0x02]), from_config,
+           kHeader[0x08]);
+  }
+}
+
+void TestPciConfigDecode::DisplayTestInfo() { TestBase::DisplayTestInfo(); }
+void TestPciConfigDecode::DisplayResults() const { TestBase::DisplayResults(); }
+void TestPciConfigDecode::Close() {}

--- a/projects/cuid/tests/unit/pci_util_test.h
+++ b/projects/cuid/tests/unit/pci_util_test.h
@@ -20,34 +20,22 @@
  * THE SOFTWARE.
  */
 
-#ifndef PCI_UTIL_H
-#define PCI_UTIL_H
+#ifndef CUID_TEST_UNIT_PCI_UTIL_TEST_H_
+#define CUID_TEST_UNIT_PCI_UTIL_TEST_H_
 
-#include <cstdint>
-#include <string>
-#include <vector>
+#include "test_base.h"
 
-#include "include/amd_cuid.h"
-
-/// Size of a PCIe extended configuration space, in bytes.
-constexpr size_t kPciConfigSpaceSize = 4096;
-
-class PciUtil {
+// Pins the interpretation of PCI configuration-space bytes. These values feed
+// straight into the primary CUID, so getting them wrong silently changes every
+// identifier a machine issues.
+class TestPciConfigDecode : public TestBase {
  public:
-  static amdcuid_status_t read_pci_config_space(std::string bdf, uint8_t* buffer,
-                                                size_t buffer_size, uint16_t offset);
-  static amdcuid_status_t get_pci_dsn_cap_offset(std::string bdf, uint16_t& offset);
-  static amdcuid_status_t get_pci_vsec_cap_offset(std::string bdf, uint16_t& offset);
-
-  // Load a 16-bit little-endian config-space field. Use this instead of
-  // casting the buffer to uint16_t*, which violates alignment and aliasing.
-  static uint16_t load_le16(const uint8_t bytes[2]) {
-    return static_cast<uint16_t>(static_cast<uint16_t>(bytes[0]) |
-                                 (static_cast<uint16_t>(bytes[1]) << 8));
-  }
-
-  // Endianness conversion utilities
-  static uint64_t le64_to_be64(uint64_t value);
+  TestPciConfigDecode();
+  void SetUp() override;
+  void Run() override;
+  void DisplayTestInfo() override;
+  void DisplayResults() const override;
+  void Close() override;
 };
 
-#endif  // PCI_UTIL_H
+#endif  // CUID_TEST_UNIT_PCI_UTIL_TEST_H_

--- a/projects/cuid/tests/unit/sha256_test.cc
+++ b/projects/cuid/tests/unit/sha256_test.cc
@@ -1,0 +1,369 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+// Pins the CUID derivation to FIPS 180-4 / RFC 4231. A regression here changes
+// every CUID ever issued.
+
+#include "unit/sha256_test.h"
+
+#include <gtest/gtest.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "src/hmac.h"
+#include "src/sha256.h"
+
+namespace {
+
+std::string to_hex(const uint8_t* data, size_t len) {
+  static const char kDigits[] = "0123456789abcdef";
+  std::string out;
+  out.reserve(len * 2);
+  for (size_t i = 0; i < len; ++i) {
+    out.push_back(kDigits[data[i] >> 4]);
+    out.push_back(kDigits[data[i] & 0x0F]);
+  }
+  return out;
+}
+
+std::string sha256_hex(const std::string& msg) {
+  uint8_t digest[rocm::sha2::SHA256_DIGEST_SIZE];
+  rocm::sha2::sha256_digest(reinterpret_cast<const uint8_t*>(msg.data()), msg.size(), digest);
+  return to_hex(digest, sizeof(digest));
+}
+
+std::string hmac_hex(const std::vector<uint8_t>& key, const std::vector<uint8_t>& msg) {
+  uint8_t mac[rocm::sha2::SHA256_DIGEST_SIZE];
+  rocm::sha2::hmac_sha256(key.data(), key.size(), msg.data(), msg.size(), mac);
+  return to_hex(mac, sizeof(mac));
+}
+
+std::vector<uint8_t> repeated(uint8_t byte, size_t count) {
+  return std::vector<uint8_t>(count, byte);
+}
+
+std::vector<uint8_t> bytes_of(const char* s) {
+  return std::vector<uint8_t>(reinterpret_cast<const uint8_t*>(s),
+                              reinterpret_cast<const uint8_t*>(s) + std::strlen(s));
+}
+
+}  // namespace
+
+// =============================================================================
+// SHA-256 (FIPS 180-4)
+// =============================================================================
+
+TestSha256Kat::TestSha256Kat() {
+  SetTitle("SHA-256 Known-Answer Vectors");
+  SetDescription(
+      "Verify the in-tree SHA-256 reproduces the FIPS 180-4 published digests, "
+      "including the multi-block and length-encoding edge cases.");
+}
+
+void TestSha256Kat::SetUp() {}
+
+void TestSha256Kat::Run() {
+  // FIPS 180-4 published examples.
+  EXPECT_EQ(sha256_hex(""), "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+  EXPECT_EQ(sha256_hex("abc"), "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+  EXPECT_EQ(sha256_hex("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"),
+            "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1");
+  EXPECT_EQ(sha256_hex("abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmn"
+                       "hijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu"),
+            "cf5b16a778af8380036ce59e7b0492370b249b11e8f07a51afac45037afee9d1");
+
+  // Message lengths that straddle the padding boundary: a 55-byte message is
+  // the largest that still fits its length field in the same block, 56 bytes
+  // forces an extra block, 64 bytes is exactly one block.
+  EXPECT_EQ(sha256_hex(std::string(55, 'a')),
+            "9f4390f8d30c2dd92ec9f095b65e2b9ae9b0a925a5258e241c9f1e910f734318");
+  EXPECT_EQ(sha256_hex(std::string(56, 'a')),
+            "b35439a4ac6f0948b6d6f9e3c6af0f5f590ce20f1bde7090ef7970686ec6738a");
+  EXPECT_EQ(sha256_hex(std::string(64, 'a')),
+            "ffe054fe7ae0cb6dc65c3af9b61d5209f439851db43d0ba5997337df154668eb");
+
+  // One million 'a' -- the classic long-message vector. Fed in 1000-byte
+  // chunks, which also exercises update() across arbitrary boundaries.
+  {
+    rocm::sha2::sha256 hasher;
+    const std::string chunk(1000, 'a');
+    for (int i = 0; i < 1000; ++i) hasher.update(chunk);
+    uint8_t digest[rocm::sha2::SHA256_DIGEST_SIZE];
+    hasher.digest(digest);
+    EXPECT_EQ(to_hex(digest, sizeof(digest)),
+              "cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0");
+  }
+
+  // Streaming byte-at-a-time must equal the one-shot digest.
+  {
+    const std::string msg = "The quick brown fox jumps over the lazy dog";
+    rocm::sha2::sha256 hasher;
+    for (char c : msg) hasher.update(reinterpret_cast<const uint8_t*>(&c), 1);
+    uint8_t streamed[rocm::sha2::SHA256_DIGEST_SIZE];
+    hasher.digest(streamed);
+    EXPECT_EQ(to_hex(streamed, sizeof(streamed)), sha256_hex(msg));
+    EXPECT_EQ(sha256_hex(msg), "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592");
+  }
+
+  // digest() must be idempotent and agree with hexdigest().
+  {
+    rocm::sha2::sha256 hasher(std::string("abc"));
+    uint8_t first[rocm::sha2::SHA256_DIGEST_SIZE];
+    uint8_t second[rocm::sha2::SHA256_DIGEST_SIZE];
+    hasher.digest(first);
+    hasher.digest(second);
+    EXPECT_EQ(0, std::memcmp(first, second, sizeof(first)));
+    EXPECT_EQ(hasher.hexdigest(), to_hex(first, sizeof(first)));
+  }
+
+  // The public wrapper the rest of the library calls.
+  {
+    uint8_t out[32];
+    EXPECT_EQ(AMDCUID_STATUS_SUCCESS,
+              sha256_unkeyed(reinterpret_cast<const uint8_t*>("abc"), 3, out));
+    EXPECT_EQ(to_hex(out, sizeof(out)),
+              "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+    EXPECT_EQ(AMDCUID_STATUS_INVALID_ARGUMENT, sha256_unkeyed(nullptr, 4, out));
+  }
+
+  IF_VERB(1) { printf("  SHA-256 vectors verified\n"); }
+}
+
+void TestSha256Kat::DisplayTestInfo() { TestBase::DisplayTestInfo(); }
+void TestSha256Kat::DisplayResults() const { TestBase::DisplayResults(); }
+void TestSha256Kat::Close() {}
+
+// =============================================================================
+// HMAC-SHA-256 (RFC 4231)
+// =============================================================================
+
+TestHmacSha256Kat::TestHmacSha256Kat() {
+  SetTitle("HMAC-SHA-256 Known-Answer Vectors");
+  SetDescription(
+      "Verify HMAC-SHA-256 reproduces the RFC 4231 test cases, including the "
+      "short-key padding and long-key hash-down paths, and that cuid_hmac "
+      "produces the same MAC through the library API.");
+}
+
+void TestHmacSha256Kat::SetUp() {}
+
+void TestHmacSha256Kat::Run() {
+  // RFC 4231 section 4.2 -- 20-byte key.
+  EXPECT_EQ(hmac_hex(repeated(0x0b, 20), bytes_of("Hi There")),
+            "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7");
+
+  // 4.3 -- 4-byte key (heavily zero-padded).
+  EXPECT_EQ(hmac_hex(bytes_of("Jefe"), bytes_of("what do ya want for nothing?")),
+            "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843");
+
+  // 4.4 -- 20-byte key, 50-byte message.
+  EXPECT_EQ(hmac_hex(repeated(0xaa, 20), repeated(0xdd, 50)),
+            "773ea91e36800e46854db8ebd09181a72959098b3ef8c122d9635514ced565fe");
+
+  // 4.5 -- 25-byte key 0x01..0x19, 50-byte message.
+  {
+    std::vector<uint8_t> key(25);
+    for (size_t i = 0; i < key.size(); ++i) key[i] = static_cast<uint8_t>(i + 1);
+    EXPECT_EQ(hmac_hex(key, repeated(0xcd, 50)),
+              "82558a389a443c0ea4cc819899f2083a85f0faa3e578f8077a2e3ff46729665b");
+  }
+
+  // 4.7 -- 131-byte key, longer than the 64-byte block, so it is hashed down
+  // first. This is the branch most hand-rolled HMACs get wrong.
+  EXPECT_EQ(hmac_hex(repeated(0xaa, 131),
+                     bytes_of("Test Using Larger Than Block-Size Key - Hash Key First")),
+            "60e431591ee0b67f0d8a26aacbf5b77f8e0bc6213728c5140546040f0ee37f54");
+
+  // 4.8 -- long key and long message together.
+  EXPECT_EQ(hmac_hex(repeated(0xaa, 131),
+                     bytes_of("This is a test using a larger than block-size key and a "
+                              "larger than block-size data. The key needs to be hashed "
+                              "before being used by the HMAC algorithm.")),
+            "9b09ffa71b942fcb27635fbcd5b0e944bfdc63644f0713938a7f51535c3a35e2");
+
+  // Exactly one block: neither padded nor hashed down.
+  EXPECT_EQ(hmac_hex(repeated(0x0b, 64), bytes_of("Hi There")),
+            "21cd586aeca0579d99a1c938127c92525a371f807bc5ba6eb78bc825bd4f2be3");
+
+  // Empty key and empty message.
+  EXPECT_EQ(hmac_hex({}, {}), "b613679a0814d9ec772f95d778c35fc5ff1697c493715653c6c712144292c5ad");
+
+  // The same MAC, produced through the class the library actually uses. The
+  // 32-byte key path is the one CUID derivation takes.
+  {
+    uint8_t key[key_length];
+    std::memset(key, 0x0b, sizeof(key));
+    cuid_hmac hmac(key);
+    EXPECT_TRUE(hmac.is_valid());
+    EXPECT_EQ(AMDCUID_STATUS_SUCCESS, hmac.set_hmac_algorithm("SHA256"));
+
+    uint8_t mac[hash_length];
+    size_t mac_len = 0;
+    EXPECT_EQ(
+        AMDCUID_STATUS_SUCCESS,
+        hmac.generate_hmac_sha256(reinterpret_cast<const uint8_t*>("Hi There"), 8, mac, &mac_len));
+    EXPECT_EQ(mac_len, sizeof(mac));
+    EXPECT_EQ(to_hex(mac, sizeof(mac)), hmac_hex(repeated(0x0b, key_length), bytes_of("Hi There")));
+
+    // Only SHA-256 is offered; a wider digest would overrun the caller's
+    // 32-byte output buffer, so it must be refused rather than accepted.
+    EXPECT_EQ(AMDCUID_STATUS_HMAC_ERROR, hmac.set_hmac_algorithm("SHA512"));
+    EXPECT_EQ(AMDCUID_STATUS_SUCCESS, hmac.set_hmac_algorithm("SHA-256"));
+    EXPECT_EQ(AMDCUID_STATUS_SUCCESS, hmac.set_hmac_algorithm(nullptr));
+  }
+
+  // set_hmac_key is in-memory only: it must not create or touch a key file.
+  // store_key is what persists, atomically, at mode 0600.
+  {
+    const std::string dir = "/tmp/amdcuid_store_key_test";
+    const std::string path = dir + "/hmac_key.bin";
+    ::mkdir(dir.c_str(), 0755);
+    ::unlink(path.c_str());
+    ::setenv("AMDCUID_HMAC_KEY_PATH", path.c_str(), 1);
+
+    {
+      cuid_hmac hmac;  // no key file yet
+      // With nothing provisioned the object is usable, keyed with the public
+      // default seed, and says so.
+      EXPECT_TRUE(hmac.is_valid());
+      EXPECT_TRUE(hmac.is_using_default_key());
+      EXPECT_EQ(hmac.get_key_file_path(), path);
+
+      // The default seed must match the kernel's CUID_DEFAULT_SEED byte for
+      // byte, or an unprovisioned machine derives one secondary CUID from
+      // sysfs and a different one from this library.
+      {
+        static const char kKernelDefaultSeed[] = "AMD-CUID-DEFAULT-SEED-v1";
+        uint8_t via_lib[hash_length];
+        size_t via_lib_len = 0;
+        const uint8_t msg[16] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+        EXPECT_EQ(AMDCUID_STATUS_SUCCESS,
+                  hmac.generate_hmac_sha256(msg, sizeof(msg), via_lib, &via_lib_len));
+
+        uint8_t expected[rocm::sha2::SHA256_DIGEST_SIZE];
+        rocm::sha2::hmac_sha256(reinterpret_cast<const uint8_t*>(kKernelDefaultSeed),
+                                sizeof(kKernelDefaultSeed) - 1, msg, sizeof(msg), expected);
+        EXPECT_EQ(to_hex(via_lib, sizeof(via_lib)), to_hex(expected, sizeof(expected)));
+      }
+
+      uint8_t k[key_length];
+      std::memset(k, 0x5a, sizeof(k));
+      EXPECT_EQ(AMDCUID_STATUS_SUCCESS, hmac.set_hmac_key(k));
+      EXPECT_TRUE(hmac.is_valid());
+      EXPECT_FALSE(hmac.is_using_default_key());
+
+      // In-memory only: still nothing on disk.
+      struct stat st;
+      EXPECT_NE(0, ::stat(path.c_str(), &st));
+
+      EXPECT_EQ(AMDCUID_STATUS_SUCCESS, hmac.store_key(k));
+      ASSERT_EQ(0, ::stat(path.c_str(), &st));
+      EXPECT_EQ(static_cast<off_t>(key_length), st.st_size);
+      EXPECT_EQ(0600, st.st_mode & 07777);
+
+      // No temporary file left behind.
+      struct stat tst;
+      EXPECT_NE(0, ::stat((path + ".new").c_str(), &tst));
+
+      // Overwriting an existing key must succeed (the old code unlinked first).
+      std::memset(k, 0xa5, sizeof(k));
+      EXPECT_EQ(AMDCUID_STATUS_SUCCESS, hmac.store_key(k));
+      ASSERT_EQ(0, ::stat(path.c_str(), &st));
+      EXPECT_EQ(static_cast<off_t>(key_length), st.st_size);
+      EXPECT_EQ(0600, st.st_mode & 07777);
+    }
+
+    // A fresh instance must load exactly what was stored and derive the same
+    // MAC as an instance keyed directly.
+    {
+      uint8_t k[key_length];
+      std::memset(k, 0xa5, sizeof(k));
+      cuid_hmac from_file;
+      EXPECT_TRUE(from_file.is_valid());
+      EXPECT_FALSE(from_file.is_using_default_key());
+      cuid_hmac from_mem(k);
+
+      uint8_t a[hash_length], c[hash_length];
+      size_t la = 0, lc = 0;
+      const uint8_t msg[4] = {1, 2, 3, 4};
+      EXPECT_EQ(AMDCUID_STATUS_SUCCESS, from_file.generate_hmac_sha256(msg, sizeof(msg), a, &la));
+      EXPECT_EQ(AMDCUID_STATUS_SUCCESS, from_mem.generate_hmac_sha256(msg, sizeof(msg), c, &lc));
+      EXPECT_EQ(0, std::memcmp(a, c, sizeof(a)));
+    }
+
+    // A wrong-sized key file must be rejected rather than half-loaded.
+    {
+      std::ofstream short_key(path, std::ios::binary | std::ios::trunc);
+      short_key.write("\x01\x02\x03", 3);
+      short_key.close();
+      // Corruption is not absence: a wrong-sized key file must be refused
+      // rather than silently falling back to the default, which would change
+      // every CUID on the machine.
+      cuid_hmac bad;
+      EXPECT_FALSE(bad.is_valid());
+      EXPECT_FALSE(bad.is_using_default_key());
+      uint8_t out[hash_length];
+      size_t n = 0;
+      const uint8_t msg[1] = {0};
+      EXPECT_EQ(AMDCUID_STATUS_KEY_ERROR, bad.generate_hmac_sha256(msg, 1, out, &n));
+    }
+
+    ::unlink(path.c_str());
+    ::rmdir(dir.c_str());
+    ::unsetenv("AMDCUID_HMAC_KEY_PATH");
+  }
+
+  // Null arguments must be rejected, not memcpy'd.
+  {
+    cuid_hmac hmac;
+    EXPECT_EQ(AMDCUID_STATUS_INVALID_ARGUMENT, hmac.set_hmac_key(nullptr));
+    EXPECT_EQ(AMDCUID_STATUS_INVALID_ARGUMENT, hmac.store_key(nullptr));
+  }
+
+  // generate_key must return distinct, non-trivial key material.
+  {
+    cuid_hmac hmac;
+    uint8_t a[key_length] = {};
+    uint8_t b[key_length] = {};
+    EXPECT_EQ(AMDCUID_STATUS_SUCCESS, hmac.generate_key(a));
+    EXPECT_EQ(AMDCUID_STATUS_SUCCESS, hmac.generate_key(b));
+    EXPECT_NE(0, std::memcmp(a, b, sizeof(a)));
+
+    uint8_t zeros[key_length] = {};
+    EXPECT_NE(0, std::memcmp(a, zeros, sizeof(a)));
+    EXPECT_EQ(AMDCUID_STATUS_INVALID_ARGUMENT, hmac.generate_key(nullptr));
+  }
+
+  IF_VERB(1) { printf("  HMAC-SHA-256 vectors verified\n"); }
+}
+
+void TestHmacSha256Kat::DisplayTestInfo() { TestBase::DisplayTestInfo(); }
+void TestHmacSha256Kat::DisplayResults() const { TestBase::DisplayResults(); }
+void TestHmacSha256Kat::Close() {}

--- a/projects/cuid/tests/unit/sha256_test.h
+++ b/projects/cuid/tests/unit/sha256_test.h
@@ -20,34 +20,32 @@
  * THE SOFTWARE.
  */
 
-#ifndef PCI_UTIL_H
-#define PCI_UTIL_H
+#ifndef CUID_TEST_UNIT_SHA256_TEST_H_
+#define CUID_TEST_UNIT_SHA256_TEST_H_
 
-#include <cstdint>
-#include <string>
-#include <vector>
+#include "test_base.h"
 
-#include "include/amd_cuid.h"
-
-/// Size of a PCIe extended configuration space, in bytes.
-constexpr size_t kPciConfigSpaceSize = 4096;
-
-class PciUtil {
+// Known-answer tests for the in-tree SHA-256 (FIPS 180-4) used to derive CUIDs.
+class TestSha256Kat : public TestBase {
  public:
-  static amdcuid_status_t read_pci_config_space(std::string bdf, uint8_t* buffer,
-                                                size_t buffer_size, uint16_t offset);
-  static amdcuid_status_t get_pci_dsn_cap_offset(std::string bdf, uint16_t& offset);
-  static amdcuid_status_t get_pci_vsec_cap_offset(std::string bdf, uint16_t& offset);
-
-  // Load a 16-bit little-endian config-space field. Use this instead of
-  // casting the buffer to uint16_t*, which violates alignment and aliasing.
-  static uint16_t load_le16(const uint8_t bytes[2]) {
-    return static_cast<uint16_t>(static_cast<uint16_t>(bytes[0]) |
-                                 (static_cast<uint16_t>(bytes[1]) << 8));
-  }
-
-  // Endianness conversion utilities
-  static uint64_t le64_to_be64(uint64_t value);
+  TestSha256Kat();
+  void SetUp() override;
+  void Run() override;
+  void DisplayTestInfo() override;
+  void DisplayResults() const override;
+  void Close() override;
 };
 
-#endif  // PCI_UTIL_H
+// Known-answer tests for HMAC-SHA-256 (RFC 4231), the keyed derivation the
+// secondary/derived CUID is built from.
+class TestHmacSha256Kat : public TestBase {
+ public:
+  TestHmacSha256Kat();
+  void SetUp() override;
+  void Run() override;
+  void DisplayTestInfo() override;
+  void DisplayResults() const override;
+  void Close() override;
+};
+
+#endif  // CUID_TEST_UNIT_SHA256_TEST_H_

--- a/projects/rocprofiler-sdk/source/lib/common/sha256.cpp
+++ b/projects/rocprofiler-sdk/source/lib/common/sha256.cpp
@@ -21,24 +21,42 @@
 // THE SOFTWARE.
 
 #include "lib/common/sha256.hpp"
-#include "lib/common/defines.hpp"
-#include "lib/common/logging.hpp"
-#include "lib/common/mpl.hpp"
 
-#include <unistd.h>
+// defines.hpp and mpl.hpp were included but never used. logging.hpp supplies
+// only the misuse diagnostic below; it is pulled in when this file is built as
+// part of rocprofiler-sdk and stubbed out otherwise, so that this translation
+// unit -- like the header -- can be compiled standalone by other components
+// that want SHA-256 without taking a dependency on rocprofiler's logging.
+#if defined(__has_include)
+#    if __has_include("lib/common/logging.hpp")
+#        include "lib/common/logging.hpp"
+#    endif
+#endif
+#if !defined(ROCP_CI_LOG_IF)
+#    include <iostream>
+#    define ROCP_CI_LOG_IF(LEVEL, COND)                                                            \
+        if(false) ::std::cerr
+#endif
+
 #include <array>
 #include <cstdint>
 #include <cstring>
-#include <fstream>
 #include <iomanip>
 #include <sstream>
 #include <string>
-#include <vector>
 
 namespace rocprofiler
 {
 namespace common
 {
+void
+secure_zero(void* p, size_t n)
+{
+    auto* volatile q = static_cast<volatile unsigned char*>(p);
+    while(n-- > 0)
+        *q++ = 0;
+}
+
 sha256::sha256() { reset(); }
 
 sha256::sha256(const std::string& data)
@@ -94,7 +112,7 @@ sha256::finalize()
         std::memset(m_data.data(), 0, 56);
     }
 
-    m_bitlen += m_datalen * 8;
+    m_bitlen += static_cast<uint64_t>(m_datalen) * 8;
     for(int j = 0; j < 8; ++j)
         m_data[63 - j] = static_cast<uint8_t>((m_bitlen >> (8 * j)) & 0xFF);
 
@@ -120,6 +138,20 @@ sha256::rawdigest()
     finalize();
 
     return m_state;
+}
+
+void
+sha256::digest(uint8_t out[SHA256_DIGEST_SIZE])
+{
+    finalize();
+
+    for(int j = 0; j < 8; ++j)
+    {
+        out[j * 4 + 0] = static_cast<uint8_t>((m_state[j] >> 24) & 0xFF);
+        out[j * 4 + 1] = static_cast<uint8_t>((m_state[j] >> 16) & 0xFF);
+        out[j * 4 + 2] = static_cast<uint8_t>((m_state[j] >> 8) & 0xFF);
+        out[j * 4 + 3] = static_cast<uint8_t>((m_state[j]) & 0xFF);
+    }
 }
 
 uint32_t
@@ -170,8 +202,10 @@ sha256::transform()
     uint32_t m[64];
     for(int i = 0; i < 16; ++i)
     {
-        m[i] = (m_data[i * 4] << 24) | (m_data[i * 4 + 1] << 16) | (m_data[i * 4 + 2] << 8) |
-               (m_data[i * 4 + 3]);
+        m[i] = (static_cast<uint32_t>(m_data[static_cast<size_t>(i) * 4]) << 24) |
+               (static_cast<uint32_t>(m_data[static_cast<size_t>(i) * 4 + 1]) << 16) |
+               (static_cast<uint32_t>(m_data[static_cast<size_t>(i) * 4 + 2]) << 8) |
+               (static_cast<uint32_t>(m_data[static_cast<size_t>(i) * 4 + 3]));
     }
     for(int i = 16; i < 64; ++i)
     {
@@ -209,21 +243,25 @@ sha256::transform()
     m_state[5] += f;
     m_state[6] += g;
     m_state[7] += h;
+
+    secure_zero(m, sizeof(m));
 }
 
 void
 sha256::reset()
 {
-    m_state   = {0x6a09e667,
-               0xbb67ae85,
-               0x3c6ef372,
-               0xa54ff53a,
-               0x510e527f,
-               0x9b05688c,
-               0x1f83d9ab,
-               0x5be0cd19};
-    m_datalen = 0;
-    m_bitlen  = 0;
+    m_state     = {0x6a09e667,
+                   0xbb67ae85,
+                   0x3c6ef372,
+                   0xa54ff53a,
+                   0x510e527f,
+                   0x9b05688c,
+                   0x1f83d9ab,
+                   0x5be0cd19};
+    m_data      = {};
+    m_datalen   = 0;
+    m_bitlen    = 0;
+    m_finalized = false;
 }
 }  // namespace common
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/common/sha256.hpp
+++ b/projects/rocprofiler-sdk/source/lib/common/sha256.hpp
@@ -22,10 +22,8 @@
 
 #pragma once
 
-#include "lib/common/defines.hpp"
-#include "lib/common/mpl.hpp"
-
 #include <array>
+#include <cstddef>
 #include <cstdint>
 #include <string>
 
@@ -33,6 +31,15 @@ namespace rocprofiler
 {
 namespace common
 {
+/// Size of a SHA-256 digest, in bytes.
+constexpr size_t SHA256_DIGEST_SIZE = 32;
+/// SHA-256 compression block size, in bytes.
+constexpr size_t SHA256_BLOCK_SIZE = 64;
+
+/// Overwrite a buffer in a way the optimiser is not permitted to elide.
+void
+secure_zero(void* p, size_t n);
+
 // --- SHA-256 Implementation ---
 class sha256
 {
@@ -43,9 +50,18 @@ public:
     void update(const uint8_t* data, size_t len);
     void update(const std::string& data);
 
-    void                    finalize();
-    std::string             hexdigest();
+    void finalize();
+
+    std::string hexdigest();
+
+    /// The state words in host byte order. Prefer digest() when the bytes are
+    /// going anywhere other than straight back into a uint32_t comparison:
+    /// this representation is endianness-dependent.
     std::array<uint32_t, 8> rawdigest();
+
+    /// Serialise the digest big-endian -- the FIPS 180-4 byte order, and what
+    /// every other SHA-256 implementation emits. Finalises if not already done.
+    void digest(uint8_t out[SHA256_DIGEST_SIZE]);
 
 private:
     bool                    m_finalized = false;

--- a/projects/rocprofiler-sdk/source/lib/tests/common/sha256.cpp
+++ b/projects/rocprofiler-sdk/source/lib/tests/common/sha256.cpp
@@ -27,6 +27,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <sstream>
 #include <string>
 
@@ -54,4 +55,50 @@ TEST(common, sha256)
         EXPECT_EQ(_raw, _extract) << fmt::format(
             "i={}, raw[i]={}, hex={}, hexdigest={}", i, _raw, _sub, _hex_digest);
     }
+}
+
+TEST(common, sha256_digest_bytes)
+{
+    // digest() must be the big-endian serialisation of the same state that
+    // hexdigest() prints, so the two can never disagree.
+    auto _val = rocprofiler::common::sha256{};
+    _val.update("rocprofiler-sdk|rocprofiler-sdk-roctx|rocprofiler-sdk-rocpd");
+
+    auto _hex_digest = _val.hexdigest();
+
+    uint8_t _bytes[rocprofiler::common::SHA256_DIGEST_SIZE] = {};
+    _val.digest(_bytes);
+
+    auto _from_bytes = std::string{};
+    for(auto _b : _bytes)
+        _from_bytes += fmt::format("{:02x}", _b);
+
+    EXPECT_EQ(_from_bytes, _hex_digest);
+
+    // Calling it twice must not change the answer.
+    uint8_t _again[rocprofiler::common::SHA256_DIGEST_SIZE] = {};
+    _val.digest(_again);
+    EXPECT_EQ(0, std::memcmp(_bytes, _again, sizeof(_bytes)));
+}
+
+TEST(common, sha256_fips_vectors)
+{
+    auto hex_of = [](const std::string& _msg) {
+        auto _h = rocprofiler::common::sha256{};
+        if(!_msg.empty()) _h.update(_msg);
+        return _h.hexdigest();
+    };
+
+    // FIPS 180-4 published examples, including the empty message and the
+    // 56-byte case that forces a second padding block.
+    EXPECT_EQ(hex_of(""), "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+    EXPECT_EQ(hex_of("abc"), "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+    EXPECT_EQ(hex_of("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"),
+              "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1");
+
+    // Long message fed in chunks: exercises update() across block boundaries.
+    auto _h = rocprofiler::common::sha256{};
+    for(int i = 0; i < 1000; ++i)
+        _h.update(std::string(1000, 'a'));
+    EXPECT_EQ(_h.hexdigest(), "cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0");
 }

--- a/projects/rocr-runtime/runtime/hsa-runtime/CMakeLists.txt
+++ b/projects/rocr-runtime/runtime/hsa-runtime/CMakeLists.txt
@@ -301,9 +301,8 @@ if (${PC_SAMPLING_SUPPORT})
 endif()
 
 if (${AMDCUID_FOUND})
-  find_package(OpenSSL REQUIRED) # Required by CUID library
   target_include_directories(${CORE_RUNTIME_TARGET} PRIVATE ${AMDCUID_INCLUDE_DIR})
-  target_link_libraries(${CORE_RUNTIME_TARGET} PRIVATE ${AMDCUID_LIB} OpenSSL::Crypto)
+  target_link_libraries(${CORE_RUNTIME_TARGET} PRIVATE ${AMDCUID_LIB})
   set_target_properties(${CORE_RUNTIME_TARGET} PROPERTIES
               BUILD_RPATH "${AMDCUID_ROOT}/lib"
               INSTALL_RPATH "${AMDCUID_ROOT}/lib")


### PR DESCRIPTION
Follow-up to #9810.

## Motivation

libamdcuid used libcrypto for three things: HMAC-SHA-256 over 16 bytes, an unkeyed SHA-256, and 32 random bytes. It paid three compile-time backends and 578 lines for them.

With `amdcuid_shared` removed in #9810 the OpenSSL link on `amdcuid_static` is `PUBLIC`, so `libhsa-runtime64.so` and `libamd_smi.so` inherit a libcrypto dependency, and integrating CUID into TheRock would need an OpenSSL sysdep artifact that does not exist there. The bare-container fallback could not work either: `janbar/openssl-cmake` exports plain `crypto`/`ssl` targets and never defines `OpenSSL::Crypto`, so the branch taken when the dev package is absent fails at generate time.

## What this does

`lib/src/sha256.{h,cc}` is the SHA-256 already in this repo under `rocprofiler-sdk`, plus HMAC-SHA-256. `check_sha256_drift.py` and a pre-commit hook keep the two copies identical. `hmac.cc` becomes one code path on every platform; only the CSPRNG is platform-specific. amdsmi and rocr-runtime drop their now-unneeded OpenSSL links.

## Bugs fixed along the way

- `IpcRequest::device_path` was a `char*` sent over a socket: the client wrote through an indeterminate pointer and the daemon dereferenced a peer-supplied one.
- The MADT walk read a 2-byte entry header after checking only 1 byte remained (reproduced under ASan).
- A NIC with an unprogrammed DSN reported `SUCCESS` with fingerprint 0, so every such device shares one primary CUID.
- `amdcuid_set_hash_key` discarded the status and returned `SUCCESS` while writing nothing. Persistence is now atomic; the old path unlinked first, so a failure destroyed the key.
- With no key file every privileged lookup failed — the state of any container. Now falls back to a public default seed matching the kernel's `CUID_DEFAULT_SEED`.
- Data races in `CuidDeviceManager`: `devices()` returned a reference into mutex-protected state that two callers iterate. TSan 11 races → 0.
- `amdcuid_query_device_property` returned an uninitialized status for size queries; `strerror()`/`ctime()` static buffers; unchecked `sscanf` on a MAC.

## Behaviour change

The PCI config-space fallback decoded every field wrongly: an aliasing cast, then `le16_to_be16` byte-swapping an already-correct little-endian value (vendor `0x1002` read back as `0x0210`), and RevisionID picking up prog-if. **This changes the primary CUID of any device that reaches that fallback.** Devices with readable sysfs attributes are unaffected — verified on a 7-device host where all fingerprints are identical before and after.

## Verification

- 25/25 as user, 32/32 as root, from cold state with no key file
- Clean under ASan+LSan, UBSan, and TSan (test suite, CLI, example, daemon in one-shot and server modes)
- clang-tidy: no `bugprone-*`, `cert-err33/34` or `concurrency-*` findings remain
- Tooling matches projects/amdsmi (pre-commit, gersemi, codespell, clang-tidy); 12 hooks green

## Known issues not fixed here

27 `std::sto*` calls that throw across the `extern "C"` boundary, swapped privileged/unprivileged `CuidFile` flags, and a cross-layer CUID divergence from the kernel (component type and payload packing). Happy to file these separately.