### PR TITLE
fix(rocprofiler-sdk): make common::sha256 self-contained, add digest()

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/common/README.md
+++ b/projects/rocprofiler-sdk/source/lib/common/README.md
@@ -180,3 +180,9 @@ g++ test_old_abi.o test_new_abi.o -o cross_abi_test
 ```
 
 The current implementation achieves ABI independence by avoiding `std::regex` entirely, relying instead on minimal standard library components and custom string processing that remains stable across ABI versions.
+
+## SHA-256 Standalone Compilation
+
+`sha256.hpp`/`sha256.cpp` are written so that other repositories can vendor a copy of the implementation without pulling in any rocprofiler-sdk internals (e.g. the CUID library does this to avoid third party dependencies).
+
+`sha256.cpp` normally includes `lib/common/logging.hpp` and routes its diagnostic through `ROCP_CI_LOG_IF`. A standalone consumer, built outside this tree, won't have that header on its include path, so it must define `ROCPROFILER_SDK_SHA256_STANDALONE` for its build of `sha256.cpp`; this swaps in a no-op stub for `ROCP_CI_LOG_IF` instead. In-tree builds of rocprofiler-sdk must leave this macro undefined.

--- a/projects/rocprofiler-sdk/source/lib/common/sha256.cpp
+++ b/projects/rocprofiler-sdk/source/lib/common/sha256.cpp
@@ -44,6 +44,16 @@ namespace common
 {
 namespace
 {
+/// FIPS 180-4 section 5.3.3 initial hash value.
+constexpr std::array<uint32_t, 8> sha256_initial_state = {0x6a09e667,
+                                                          0xbb67ae85,
+                                                          0x3c6ef372,
+                                                          0xa54ff53a,
+                                                          0x510e527f,
+                                                          0x9b05688c,
+                                                          0x1f83d9ab,
+                                                          0x5be0cd19};
+
 /// Zero a buffer without the optimiser eliding it.
 void
 secure_zero(void* p, size_t n)
@@ -249,14 +259,7 @@ sha256::transform()
 void
 sha256::reset()
 {
-    m_state     = {0x6a09e667,
-                   0xbb67ae85,
-                   0x3c6ef372,
-                   0xa54ff53a,
-                   0x510e527f,
-                   0x9b05688c,
-                   0x1f83d9ab,
-                   0x5be0cd19};
+    m_state     = sha256_initial_state;
     m_data      = {};
     m_datalen   = 0;
     m_bitlen    = 0;

--- a/projects/rocprofiler-sdk/source/lib/common/sha256.cpp
+++ b/projects/rocprofiler-sdk/source/lib/common/sha256.cpp
@@ -23,15 +23,12 @@
 #include "lib/common/sha256.hpp"
 
 // Stub out rocprofiler's logging when absent, so this also builds standalone.
-#if defined(__has_include)
-#    if __has_include("lib/common/logging.hpp")
-#        include "lib/common/logging.hpp"
-#    endif
-#endif
-#if !defined(ROCP_CI_LOG_IF)
+#if defined(ROCPROFILER_SDK_SHA256_STANDALONE)
 #    include <iostream>
 #    define ROCP_CI_LOG_IF(LEVEL, COND)                                                            \
-        if(false) ::std::cerr
+        if(COND) ::std::cerr
+#else
+#    include "lib/common/logging.hpp"
 #endif
 
 #include <array>
@@ -45,6 +42,9 @@ namespace rocprofiler
 {
 namespace common
 {
+namespace
+{
+/// Zero a buffer without the optimiser eliding it.
 void
 secure_zero(void* p, size_t n)
 {
@@ -52,6 +52,7 @@ secure_zero(void* p, size_t n)
     while(n-- > 0)
         *q++ = 0;
 }
+}  // namespace
 
 sha256::sha256() { reset(); }
 
@@ -249,13 +250,13 @@ void
 sha256::reset()
 {
     m_state     = {0x6a09e667,
-               0xbb67ae85,
-               0x3c6ef372,
-               0xa54ff53a,
-               0x510e527f,
-               0x9b05688c,
-               0x1f83d9ab,
-               0x5be0cd19};
+                   0xbb67ae85,
+                   0x3c6ef372,
+                   0xa54ff53a,
+                   0x510e527f,
+                   0x9b05688c,
+                   0x1f83d9ab,
+                   0x5be0cd19};
     m_data      = {};
     m_datalen   = 0;
     m_bitlen    = 0;

--- a/projects/rocprofiler-sdk/source/lib/common/sha256.cpp
+++ b/projects/rocprofiler-sdk/source/lib/common/sha256.cpp
@@ -21,24 +21,38 @@
 // THE SOFTWARE.
 
 #include "lib/common/sha256.hpp"
-#include "lib/common/defines.hpp"
-#include "lib/common/logging.hpp"
-#include "lib/common/mpl.hpp"
 
-#include <unistd.h>
+// Stub out rocprofiler's logging when absent, so this also builds standalone.
+#if defined(__has_include)
+#    if __has_include("lib/common/logging.hpp")
+#        include "lib/common/logging.hpp"
+#    endif
+#endif
+#if !defined(ROCP_CI_LOG_IF)
+#    include <iostream>
+#    define ROCP_CI_LOG_IF(LEVEL, COND)                                                            \
+        if(false) ::std::cerr
+#endif
+
 #include <array>
 #include <cstdint>
 #include <cstring>
-#include <fstream>
 #include <iomanip>
 #include <sstream>
 #include <string>
-#include <vector>
 
 namespace rocprofiler
 {
 namespace common
 {
+void
+secure_zero(void* p, size_t n)
+{
+    auto* volatile q = static_cast<volatile unsigned char*>(p);
+    while(n-- > 0)
+        *q++ = 0;
+}
+
 sha256::sha256() { reset(); }
 
 sha256::sha256(const std::string& data)
@@ -94,7 +108,7 @@ sha256::finalize()
         std::memset(m_data.data(), 0, 56);
     }
 
-    m_bitlen += m_datalen * 8;
+    m_bitlen += static_cast<uint64_t>(m_datalen) * 8;
     for(int j = 0; j < 8; ++j)
         m_data[63 - j] = static_cast<uint8_t>((m_bitlen >> (8 * j)) & 0xFF);
 
@@ -120,6 +134,22 @@ sha256::rawdigest()
     finalize();
 
     return m_state;
+}
+
+std::array<uint8_t, SHA256_DIGEST_SIZE>
+sha256::digest()
+{
+    finalize();
+
+    auto out = std::array<uint8_t, SHA256_DIGEST_SIZE>{};
+    for(size_t j = 0; j < m_state.size(); ++j)
+    {
+        out[j * 4 + 0] = static_cast<uint8_t>((m_state[j] >> 24) & 0xFF);
+        out[j * 4 + 1] = static_cast<uint8_t>((m_state[j] >> 16) & 0xFF);
+        out[j * 4 + 2] = static_cast<uint8_t>((m_state[j] >> 8) & 0xFF);
+        out[j * 4 + 3] = static_cast<uint8_t>((m_state[j]) & 0xFF);
+    }
+    return out;
 }
 
 uint32_t
@@ -170,8 +200,10 @@ sha256::transform()
     uint32_t m[64];
     for(int i = 0; i < 16; ++i)
     {
-        m[i] = (m_data[i * 4] << 24) | (m_data[i * 4 + 1] << 16) | (m_data[i * 4 + 2] << 8) |
-               (m_data[i * 4 + 3]);
+        m[i] = (static_cast<uint32_t>(m_data[static_cast<size_t>(i) * 4]) << 24) |
+               (static_cast<uint32_t>(m_data[static_cast<size_t>(i) * 4 + 1]) << 16) |
+               (static_cast<uint32_t>(m_data[static_cast<size_t>(i) * 4 + 2]) << 8) |
+               (static_cast<uint32_t>(m_data[static_cast<size_t>(i) * 4 + 3]));
     }
     for(int i = 16; i < 64; ++i)
     {
@@ -209,12 +241,14 @@ sha256::transform()
     m_state[5] += f;
     m_state[6] += g;
     m_state[7] += h;
+
+    secure_zero(m, sizeof(m));
 }
 
 void
 sha256::reset()
 {
-    m_state   = {0x6a09e667,
+    m_state     = {0x6a09e667,
                0xbb67ae85,
                0x3c6ef372,
                0xa54ff53a,
@@ -222,8 +256,10 @@ sha256::reset()
                0x9b05688c,
                0x1f83d9ab,
                0x5be0cd19};
-    m_datalen = 0;
-    m_bitlen  = 0;
+    m_data      = {};
+    m_datalen   = 0;
+    m_bitlen    = 0;
+    m_finalized = false;
 }
 }  // namespace common
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/common/sha256.hpp
+++ b/projects/rocprofiler-sdk/source/lib/common/sha256.hpp
@@ -22,10 +22,8 @@
 
 #pragma once
 
-#include "lib/common/defines.hpp"
-#include "lib/common/mpl.hpp"
-
 #include <array>
+#include <cstddef>
 #include <cstdint>
 #include <string>
 
@@ -33,6 +31,15 @@ namespace rocprofiler
 {
 namespace common
 {
+/// Size of a SHA-256 digest, in bytes.
+constexpr size_t SHA256_DIGEST_SIZE = 32;
+/// SHA-256 compression block size, in bytes.
+constexpr size_t SHA256_BLOCK_SIZE = 64;
+
+/// Zero a buffer without the optimiser eliding it.
+void
+secure_zero(void* p, size_t n);
+
 // --- SHA-256 Implementation ---
 class sha256
 {
@@ -43,9 +50,15 @@ public:
     void update(const uint8_t* data, size_t len);
     void update(const std::string& data);
 
-    void                    finalize();
-    std::string             hexdigest();
+    void finalize();
+
+    std::string hexdigest();
+
+    /// State words in host byte order. Prefer digest() for bytes.
     std::array<uint32_t, 8> rawdigest();
+
+    /// Digest as big-endian bytes (FIPS 180-4 order). Finalises if needed.
+    std::array<uint8_t, SHA256_DIGEST_SIZE> digest();
 
 private:
     bool                    m_finalized = false;

--- a/projects/rocprofiler-sdk/source/lib/common/sha256.hpp
+++ b/projects/rocprofiler-sdk/source/lib/common/sha256.hpp
@@ -33,12 +33,6 @@ namespace common
 {
 /// Size of a SHA-256 digest, in bytes.
 constexpr size_t SHA256_DIGEST_SIZE = 32;
-/// SHA-256 compression block size, in bytes.
-constexpr size_t SHA256_BLOCK_SIZE = 64;
-
-/// Zero a buffer without the optimiser eliding it.
-void
-secure_zero(void* p, size_t n);
 
 // --- SHA-256 Implementation ---
 class sha256
@@ -50,8 +44,7 @@ public:
     void update(const uint8_t* data, size_t len);
     void update(const std::string& data);
 
-    void finalize();
-
+    void        finalize();
     std::string hexdigest();
 
     /// State words in host byte order. Prefer digest() for bytes.

--- a/projects/rocprofiler-sdk/source/lib/tests/common/sha256.cpp
+++ b/projects/rocprofiler-sdk/source/lib/tests/common/sha256.cpp
@@ -27,6 +27,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <sstream>
 #include <string>
 
@@ -54,4 +55,48 @@ TEST(common, sha256)
         EXPECT_EQ(_raw, _extract) << fmt::format(
             "i={}, raw[i]={}, hex={}, hexdigest={}", i, _raw, _sub, _hex_digest);
     }
+}
+
+TEST(common, sha256_digest_bytes)
+{
+    // digest() must be the big-endian serialisation of the same state that
+    // hexdigest() prints, so the two can never disagree.
+    auto _val = rocprofiler::common::sha256{};
+    _val.update("rocprofiler-sdk|rocprofiler-sdk-roctx|rocprofiler-sdk-rocpd");
+
+    auto _hex_digest = _val.hexdigest();
+
+    auto _bytes = _val.digest();
+
+    auto _from_bytes = std::string{};
+    for(auto _b : _bytes)
+        _from_bytes += fmt::format("{:02x}", _b);
+
+    EXPECT_EQ(_from_bytes, _hex_digest);
+
+    // Calling it twice must not change the answer.
+    EXPECT_EQ(_bytes, _val.digest());
+}
+
+TEST(common, sha256_fips_vectors)
+{
+    auto hex_of = [](const std::string& _msg) {
+        auto _h = rocprofiler::common::sha256{};
+        if(!_msg.empty()) _h.update(_msg);
+        return _h.hexdigest();
+    };
+
+    // FIPS 180-4 published examples, including the empty message and the
+    // 56-byte case that forces a second padding block.
+    EXPECT_EQ(hex_of(""), "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+    EXPECT_EQ(hex_of("abc"), "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+    EXPECT_EQ(hex_of("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"),
+              "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1");
+
+    // Long message fed in chunks: exercises update() across block boundaries.
+    auto _h     = rocprofiler::common::sha256{};
+    auto _chunk = std::string(1000, 'a');
+    for(int i = 0; i < 1000; ++i)
+        _h.update(_chunk);
+    EXPECT_EQ(_h.hexdigest(), "cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0");
 }


### PR DESCRIPTION
Lets other components in this repo use this SHA-256 without pulling in rocprofiler's internals. **The algorithm is unchanged** — every FIPS 180-4 vector produces the same digest before and after.

### Decoupling

- Drop includes that were never used (`defines.hpp`, `mpl.hpp`, `unistd.h`, `fstream`, `vector`). This is what actually severs the dependency on rocprofiler internals; `logging.hpp` was the only remaining one.
- Make the `logging.hpp` include conditional on `ROCPROFILER_SDK_SHA256_STANDALONE`. A consumer vendoring this file outside the tree defines that macro and gets a local `ROCP_CI_LOG_IF` stub instead. In-tree builds must leave it undefined and are byte-for-byte unaffected — verified by checking whether the diagnostic string still lands in the object file.

  Note this is an explicit opt-in, not an automatic `__has_include` probe: an out-of-tree build that forgets the macro fails loudly at the missing include rather than silently compiling with logging stubbed out. `source/lib/common/README.md` documents the contract.

### Correctness

- **`transform()` shifted into the sign bit.** `m_data[i * 4] << 24` promotes a `uint8_t` to `int`, so any input byte ≥ `0x80` shifted left 24 produces a value outside `int` range — undefined behaviour, and reachable for essentially all real input. Now cast to `uint32_t` before shifting.
- **`m_bitlen += m_datalen * 8`** computed the product in 32 bits before widening to the 64-bit accumulator.
- **`reset()` did not clear `m_data`/`m_finalized`**, so an object reset after finalize silently ignored subsequent `update()`s. `reset()` is private today, so this was unobservable from outside the class.
- **Zero the message schedule.** `transform()` leaves 256 bytes of derived state in a stack buffer; it is now wiped with a non-elidable clear before returning.

### API

- Add `digest()`, returning the digest as big-endian bytes per FIPS 180-4. The existing `rawdigest()` returns host-order words, which byte-swaps under any caller that reinterprets them as bytes on a big-endian target. Every current caller uses `hexdigest()`, so nothing changes retroactively.
- Add `SHA256_DIGEST_SIZE` so callers can size buffers without hardcoding 32.

### Tests

Extended `source/lib/tests/common/sha256.cpp` with `digest()`/`hexdigest()` agreement, `digest()` idempotence, and the FIPS 180-4 vectors: empty input, `"abc"`, the 56-byte case that forces a second padding block, and 10^6 `'a'` fed in chunks to exercise `update()` across block boundaries. The pre-existing assertion is untouched and still passes.

### Verification

Compiles standalone with no rocprofiler headers on the include path under `-Wall -Wextra -Wpedantic`; clean under ASan+UBSan with `-fno-sanitize-recover=all`; formatted with the clang-format 11 this project pins.

First of a 4-PR stack; the CUID side consumes this copy.
