### PR TITLE
style(cuid): add lint tooling and apply the formatters

### DIFF
--- a/.github/workflows/cuid-formatting.yml
+++ b/.github/workflows/cuid-formatting.yml
@@ -1,0 +1,48 @@
+name: CUID Formatting
+
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - 'projects/cuid/**'
+  pull_request:
+    paths:
+      - '.github/workflows/cuid-formatting.yml'
+      - 'projects/cuid/**'
+      - '!**/*.md'
+      - '!**/*.rst'
+      - '!**/*.rtf'
+      - '!**/.readthedocs.yaml'
+      - '!projects/cuid/docs/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  # PRs: group by PR number so a new commit cancels in-flight runs.
+  # Pushes: group by SHA so postsubmit runs never cancel each other.
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-24.04
+    env:
+      # PRs diff against the base branch; pushes diff against the pre-push tip.
+      FROM_REF: ${{ github.event.pull_request.base.ref && format('origin/{0}', github.event.pull_request.base.ref) || github.event.before }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0 # required for --from-ref/--to-ref
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+        with:
+          # Use the cuid project pre-commit config and only check files changed
+          # in this push/PR.
+          extra_args: >-
+            --config projects/cuid/.pre-commit-config.yaml
+            --from-ref ${{ env.FROM_REF }}
+            --to-ref HEAD

--- a/.github/workflows/cuid-workflow.yml
+++ b/.github/workflows/cuid-workflow.yml
@@ -153,3 +153,63 @@ jobs:
         with:
           name: cuid-test-results-${{ matrix.os }}
           path: /tmp/test-results-${{ matrix.os }}
+
+  clang-tidy:
+    name: clang-tidy
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
+    runs-on:
+      - self-hosted
+      - ${{ vars.RUNNER_TYPE }}
+    container:
+      # this runs once rather than across full build-and-test matrix
+      image: ${{ vars.Ubuntu22_DOCKER_IMAGE }}
+      options: --rm -u root
+
+    steps:
+      - name: Clean workspace
+        run: find "$GITHUB_WORKSPACE" -mindepth 1 -delete
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set Project Directory
+        run: |
+          # Find the directory containing the main CMakeLists.txt for CUID
+          # Prioritize finding it in projects/cuid
+          TARGET_DIR=$(find $GITHUB_WORKSPACE -path "*/projects/cuid/CMakeLists.txt" -exec dirname {} \;)
+
+          if [ -z "$TARGET_DIR" ]; then
+            echo "Could not find CMakeLists.txt in projects/cuid. Searching workspace..."
+            TARGET_DIR=$(find $GITHUB_WORKSPACE -name "CMakeLists.txt" | grep "projects/cuid" | head -n 1 | xargs dirname)
+          fi
+
+          if [ -z "$TARGET_DIR" ]; then
+             echo "Could not find CMakeLists.txt for CUID."
+             exit 1
+          fi
+
+          echo "PROJECT_DIR=$TARGET_DIR" >> $GITHUB_ENV
+
+      - name: Configure CUID
+        run: |
+          set -e
+
+          # Build daemon so its sources land in compile_commands.json
+          BUILD_FOLDER=${{ env.PROJECT_DIR }}/build
+          rm -rf $BUILD_FOLDER
+          mkdir -p $BUILD_FOLDER
+          cd $BUILD_FOLDER
+
+          cmake ${{ env.PROJECT_DIR }} -DBUILD_TESTS=ON -DBUILD_DAEMON=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+          make -j $(nproc)
+
+      - name: Run clang-tidy
+        run: |
+          set -e
+
+          if ! command -v clang-tidy &> /dev/null; then
+            apt-get update && apt-get install -y clang-tidy
+          fi
+
+          cd ${{ env.PROJECT_DIR }}
+          # .clang-tidy at the project root is picked up per-file automatically.
+          clang-tidy -p build $(find lib/src cli daemon -name '*.cc')

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ exclude: |
     | shared/amdgpu-windows-interop
     # these projects have their own pre-commit-config.yaml
     | projects/amdsmi/
+    | projects/cuid/
     | projects/rdc/
     | projects/rocm-smi-lib/
     | projects/rocprofiler-compute/

--- a/projects/cuid/.clang-tidy
+++ b/projects/cuid/.clang-tidy
@@ -1,0 +1,57 @@
+# Modelled on projects/amdsmi/.clang-tidy so the two sibling C++ libraries in
+# this monorepo report the same class of findings. Deviations from that file
+# are listed at the bottom with a reason.
+Checks:
+  bugprone*,
+  clang-analyzer*,
+  cert-*,
+  concurrency-*,
+  google*,
+  misc*,
+  modernize*,
+  -abseil*,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-reserved-identifier,
+  -cert-dcl21-cpp,
+  -cert-err58-cpp,
+  -clang-analyzer-security.insecureAPI.strcpy,
+  -clang-diagnostic-sign-conversion,
+  -clang-diagnostic-unused-parameter,
+  -cppcoreguidelines*,
+  -cppcoreguidelines-pro*,
+  -google-readability*,
+  -google-runtime-int,
+  -misc-const-correctness,
+  -misc-include-cleaner,
+  -misc-non-copyable-objects,
+  -misc-unused-parameters,
+  -misc-use-anonymous-namespace,
+  -misc-use-internal-linkage,
+  -modernize-avoid-c-arrays,
+  -modernize-macro-to-enum,
+  -modernize-redundant-void-arg,
+  -modernize-use-auto,
+  -modernize-use-nodiscard,
+  -modernize-use-noexcept,
+  -modernize-use-nullptr,
+  -modernize-use-trailing-return-type,
+  -modernize-use-using,
+  -performance*,
+  -readability*,
+  readability-delete-null-pointer,
+
+# Deviations from projects/amdsmi/.clang-tidy:
+#
+#   +cert-*         libamdcuid handles key material and parses firmware tables
+#                   read from sysfs, so the CERT rules about buffer handling and
+#                   integer conversion earn their keep here. The two noisiest
+#                   and least relevant are disabled individually above:
+#                   dcl21-cpp (postfix operator return types) and err58-cpp
+#                   (throwing static initializers, which are gtest fixtures).
+#   +concurrency-*  CuidDeviceManager is a shared, mutex-guarded singleton
+#                   reached from the public C API, and the daemon serves
+#                   multiple clients.
+#
+# Treat findings as advisory: fix what is real, do not silence what is not.
+HeaderFilterRegex: 'projects/cuid/(lib|cli|daemon)/.*\.(h|hpp)$'
+WarningsAsErrors: ''

--- a/projects/cuid/.clang-tidy
+++ b/projects/cuid/.clang-tidy
@@ -1,6 +1,4 @@
-# Modelled on projects/amdsmi/.clang-tidy so the two sibling C++ libraries in
-# this monorepo report the same class of findings. Deviations from that file
-# are listed at the bottom with a reason.
+# Check list for projects/cuid. Each disable below is here on its own merits.
 Checks:
   bugprone*,
   clang-analyzer*,
@@ -25,8 +23,6 @@ Checks:
   -misc-include-cleaner,
   -misc-non-copyable-objects,
   -misc-unused-parameters,
-  -misc-use-anonymous-namespace,
-  -misc-use-internal-linkage,
   -modernize-avoid-c-arrays,
   -modernize-macro-to-enum,
   -modernize-redundant-void-arg,
@@ -40,7 +36,7 @@ Checks:
   -readability*,
   readability-delete-null-pointer,
 
-# Deviations from projects/amdsmi/.clang-tidy:
+# Notes:
 #
 #   +cert-*         libamdcuid handles key material and parses firmware tables
 #                   read from sysfs, so the CERT rules about buffer handling and
@@ -51,6 +47,9 @@ Checks:
 #   +concurrency-*  CuidDeviceManager is a shared, mutex-guarded singleton
 #                   reached from the public C API, and the daemon serves
 #                   multiple clients.
+#   +misc-use-*     libamdcuid is a static library, so a file-scope helper
+#                   without internal linkage is exported to everything that
+#                   links it. Unnamed namespace is the idiom, per SF.22.
 #
 # Treat findings as advisory: fix what is real, do not silence what is not.
 HeaderFilterRegex: 'projects/cuid/(lib|cli|daemon)/.*\.(h|hpp)$'

--- a/projects/cuid/.codespellrc
+++ b/projects/cuid/.codespellrc
@@ -1,0 +1,10 @@
+[codespell]
+# AMD/ROCm and CUID domain terms that are not typos:
+#   hsa      - Heterogeneous System Architecture
+#   nd       - appears inside identifiers such as "2nd"
+#   renderD  - DRM device node path (/dev/dri/renderD128)
+#   ans      - "ans" appears in ACPI/SMBIOS field names
+#   BA       - PCI BAR-adjacent identifiers
+ignore-words-list = hsa,nd,renderD,ans,BA,inout,cant,indx,ue
+skip = build,build-*,.git,docs/_build
+quiet-level = 2

--- a/projects/cuid/.gersemirc
+++ b/projects/cuid/.gersemirc
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/BlankSpruce/gersemi/0.26.0/gersemi/configuration.schema.json
+
+warn_about_unknown_commands: false
+indent: 4
+line_length: 120

--- a/projects/cuid/.pre-commit-config.yaml
+++ b/projects/cuid/.pre-commit-config.yaml
@@ -1,0 +1,89 @@
+# - How to use (install as git hook — only runs on staged files):
+#     python3 -m pip install pre-commit
+#     cd <repo-root>
+#     pre-commit install -c projects/cuid/.pre-commit-config.yaml
+#
+# - How to run manually on branch changes only (vs develop):
+#     pre-commit run --config projects/cuid/.pre-commit-config.yaml \
+#       --from-ref develop --to-ref HEAD
+#
+# - How to run on all files (CAUTION: reformats everything):
+#     pre-commit run --all-files --config projects/cuid/.pre-commit-config.yaml
+#
+# How to skip:
+#   git commit --no-verify
+# or
+#   SKIP=clang-format git commit
+#   SKIP=gersemi git commit
+
+# Scope every hook to this project. Without this, `pre-commit run --all-files`
+# from the repository root turns the generic hooks (end-of-file-fixer,
+# mixed-line-ending, check-json, codespell) loose on the whole monorepo: the
+# first run of it here rewrote 2223 files across emulation/, rocr-runtime and
+# rocprofiler-*. pre-commit ANDs this with each hook's own `files`, so the
+# per-hook patterns below still apply on top of it.
+files: '^projects/cuid/'
+
+exclude: |
+  (?x)
+    ^projects/cuid/docs/
+    | ^projects/cuid/build.*/
+    | \.(md|rst|rtf)$
+    | \.readthedocs\.yaml$
+fail_fast: false
+
+repos:
+-   repo: https://github.com/codespell-project/codespell
+    rev: v2.4.2
+    hooks:
+    -   id: codespell
+        args: ["-w", "--config", "projects/cuid/.codespellrc"]
+
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-json
+    -   id: check-merge-conflict
+    -   id: check-added-large-files
+    -   id: mixed-line-ending
+
+-   repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v22.1.0
+    hooks:
+    -   id: clang-format
+        files: '^projects/cuid/.*\.(c|cpp|cc|h|hpp)$'
+
+-   repo: https://github.com/BlankSpruce/gersemi
+    rev: 0.26.0
+    hooks:
+    -   id: gersemi
+        files: '^projects/cuid/.*(CMakeLists\.txt|\.cmake(\.in)?)$'
+
+-   repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
+    hooks:
+    -   id: shellcheck
+        # The .sh.in templates carry @CMAKE_VARIABLE@ placeholders, which
+        # shellcheck reads as ordinary words; that is fine for the checks we
+        # care about (quoting, unset variables, portability).
+        files: '^projects/cuid/.*\.(sh|sh\.in)$'
+        types: [file]
+
+-   repo: local
+    hooks:
+    -   id: cuid-sha256-drift
+        name: CUID/rocprofiler-sdk SHA-256 drift
+        description: >-
+            libamdcuid carries a copy of rocprofiler-sdk's SHA-256. A silent
+            divergence would not fail to build, it would change every CUID
+            ever issued, so the two are compared function by function.
+        entry: python3 projects/cuid/tests/check_sha256_drift.py
+        language: system
+        pass_filenames: false
+        # always_run rather than a `files` pattern: the global scope above would
+        # hide a change made only on the rocprofiler-sdk side, which is exactly
+        # the drift this is meant to catch. The check takes milliseconds.
+        always_run: true

--- a/projects/cuid/CMakeLists.txt
+++ b/projects/cuid/CMakeLists.txt
@@ -17,23 +17,11 @@ set(CMAKE_INSTALL_LIBDIR "lib" CACHE STRING "Library install directory")
 
 # Read version from amd_cuid.h so there is a single source of truth
 file(READ "${CMAKE_CURRENT_SOURCE_DIR}/lib/include/amd_cuid.h" _CUID_HEADER)
-string(
-    REGEX MATCH "#define AMDCUID_LIB_VERSION_MAJOR ([0-9]+)"
-    _
-    "${_CUID_HEADER}"
-)
+string(REGEX MATCH "#define AMDCUID_LIB_VERSION_MAJOR ([0-9]+)" _ "${_CUID_HEADER}")
 set(VERSION_MAJOR "${CMAKE_MATCH_1}")
-string(
-    REGEX MATCH "#define AMDCUID_LIB_VERSION_MINOR ([0-9]+)"
-    _
-    "${_CUID_HEADER}"
-)
+string(REGEX MATCH "#define AMDCUID_LIB_VERSION_MINOR ([0-9]+)" _ "${_CUID_HEADER}")
 set(VERSION_MINOR "${CMAKE_MATCH_1}")
-string(
-    REGEX MATCH "#define AMDCUID_LIB_VERSION_PATCH ([0-9]+)"
-    _
-    "${_CUID_HEADER}"
-)
+string(REGEX MATCH "#define AMDCUID_LIB_VERSION_PATCH ([0-9]+)" _ "${_CUID_HEADER}")
 set(VERSION_PATCH "${CMAKE_MATCH_1}")
 set(VERSION_STRING "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
 message("Package version: ${VERSION_STRING}")
@@ -48,19 +36,9 @@ project(${AMDCUID} VERSION "${VERSION_STRING}")
 # CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT is only available after project()
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     if(WIN32)
-        set(CMAKE_INSTALL_PREFIX
-            "C:/Program Files/AMD/ROCM/AMDCUID"
-            CACHE PATH
-            "Default installation directory."
-            FORCE
-        )
+        set(CMAKE_INSTALL_PREFIX "C:/Program Files/AMD/ROCM/AMDCUID" CACHE PATH "Default installation directory." FORCE)
     else() # Linux/Unix
-        set(CMAKE_INSTALL_PREFIX
-            "${ROCM_DIR}/core"
-            CACHE PATH
-            "Default installation directory."
-            FORCE
-        )
+        set(CMAKE_INSTALL_PREFIX "${ROCM_DIR}/core" CACHE PATH "Default installation directory." FORCE)
     endif()
 endif()
 
@@ -146,9 +124,7 @@ if(UNIX AND NOT APPLE)
         @ONLY
     )
     install(
-        PROGRAMS
-            ${CMAKE_CURRENT_BINARY_DIR}/amdcuid_postinst.sh
-            ${CMAKE_CURRENT_BINARY_DIR}/amdcuid_prerm.sh
+        PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/amdcuid_postinst.sh ${CMAKE_CURRENT_BINARY_DIR}/amdcuid_prerm.sh
         DESTINATION ${CMAKE_INSTALL_DATADIR}/${AMDCUID}
         COMPONENT ${LIB_COMPONENT}
     )
@@ -167,9 +143,7 @@ if(NOT TARGET uninstall)
     )
     add_custom_target(
         uninstall
-        COMMAND
-            ${CMAKE_COMMAND} -P
-            "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+        COMMAND ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
         COMMENT "Uninstalling ${AMDCUID} ..."
     )
 endif()

--- a/projects/cuid/cli/CMakeLists.txt
+++ b/projects/cuid/cli/CMakeLists.txt
@@ -1,15 +1,9 @@
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-message(
-    "&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&"
-)
-message(
-    "                            Cmake amdcuid_tool                            "
-)
-message(
-    "&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&"
-)
+message("&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")
+message("                            Cmake amdcuid_tool                            ")
+message("&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")
 
 message("")
 message("Build Configuration:")
@@ -39,11 +33,7 @@ target_include_directories(${AMDCUID_TOOL_EXECUTABLE} PRIVATE ${INC_DIR})
 target_link_libraries(${AMDCUID_TOOL_EXECUTABLE} amdcuid_static)
 
 # Install the tool
-install(
-    TARGETS ${AMDCUID_TOOL_EXECUTABLE}
-    DESTINATION ${CMAKE_INSTALL_BINDIR}
-    COMPONENT ${CLI_COMPONENT}
-)
+install(TARGETS ${AMDCUID_TOOL_EXECUTABLE} DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT ${CLI_COMPONENT})
 
 message("&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")
 message("                    Finished Cmake amdcuid_tool                    ")

--- a/projects/cuid/cli/amdcuid_tool.cc
+++ b/projects/cuid/cli/amdcuid_tool.cc
@@ -1,16 +1,18 @@
 // Copyright Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
-#include "include/amd_cuid.h"
-#include <cstring>
 #include <errno.h>
-#include <fstream>
 #include <getopt.h>
+#include <unistd.h>
+
+#include <cstring>
+#include <fstream>
 #include <iostream>
 #include <map>
 #include <string>
-#include <unistd.h>
 #include <vector>
+
+#include "include/amd_cuid.h"
 
 /**
  * @file amdcuid_tool.cc
@@ -27,7 +29,7 @@
  */
 bool is_root() { return geteuid() == 0; }
 
-void print_usage(const char *program_name) {
+void print_usage(const char* program_name) {
   std::cout << "Usage: " << program_name << " [OPTIONS]\n\n";
   std::cout << "AMD Component Unified Identifier (CUID) Tool\n\n";
   std::cout << "Options:\n";
@@ -41,28 +43,22 @@ void print_usage(const char *program_name) {
                "bytes, use with --generate-cuid)\n";
   std::cout << "  --notify-daemon              Notify daemon to refresh device "
                "registry (for udev integration)\n";
-  std::cout
-      << "  --list                       List all devices and their CUIDs\n";
+  std::cout << "  --list                       List all devices and their CUIDs\n";
   std::cout << "  --type <type>                Filter by device type (gpu, "
                "cpu, nic, npu, platform)\n";
-  std::cout
-      << "                               Use with --list or --query-device\n";
+  std::cout << "                               Use with --list or --query-device\n";
   std::cout << "  --show-primary               Show primary CUIDs (requires "
                "root privileges)\n";
-  std::cout
-      << "                               Use with --list or --query-device\n";
+  std::cout << "                               Use with --list or --query-device\n";
   std::cout << "  --query-device <identifier>  Query specific device by device "
                "path or BDF\n";
   std::cout << "  --version                    Show library version\n";
   std::cout << "  --help, -h                   Show this help message\n";
   std::cout << "\nExamples:\n";
-  std::cout
-      << "  # Generate CUID registry with a new random key (requires root)\n";
-  std::cout << "  sudo " << program_name
-            << " --generate-cuid --generate-key\n\n";
+  std::cout << "  # Generate CUID registry with a new random key (requires root)\n";
+  std::cout << "  sudo " << program_name << " --generate-cuid --generate-key\n\n";
   std::cout << "  # Generate CUID registry with existing key file\n";
-  std::cout << "  sudo " << program_name
-            << " --generate-cuid --set-key /path/to/hmac_key.bin\n\n";
+  std::cout << "  sudo " << program_name << " --generate-cuid --set-key /path/to/hmac_key.bin\n\n";
   std::cout << "  # Generate CUID registry using previously set key\n";
   std::cout << "  sudo " << program_name << " --generate-cuid\n\n";
   std::cout << "  # Notify daemon of device changes (called by udev)\n";
@@ -74,47 +70,39 @@ void print_usage(const char *program_name) {
   std::cout << "  # List all devices with primary CUIDs (requires root)\n";
   std::cout << "  sudo " << program_name << " --list --show-primary\n\n";
   std::cout << "  # Query specific device by path\n";
-  std::cout << "  " << program_name
-            << " --query-device /sys/class/drm/renderD128\n\n";
+  std::cout << "  " << program_name << " --query-device /sys/class/drm/renderD128\n\n";
   std::cout << "  # Query device by BDF\n";
-  std::cout << "  " << program_name
-            << " --query-device 0000:03:00.0 --type gpu\n\n";
+  std::cout << "  " << program_name << " --query-device 0000:03:00.0 --type gpu\n\n";
 }
 
-const char *device_type_to_string(amdcuid_device_type_t type) {
+const char* device_type_to_string(amdcuid_device_type_t type) {
   switch (type) {
-  case AMDCUID_DEVICE_TYPE_PLATFORM:
-    return "PLATFORM";
-  case AMDCUID_DEVICE_TYPE_CPU:
-    return "CPU";
-  case AMDCUID_DEVICE_TYPE_GPU:
-    return "GPU";
-  case AMDCUID_DEVICE_TYPE_NIC:
-    return "NIC";
-  case AMDCUID_DEVICE_TYPE_NPU:
-    return "NPU";
-  case AMDCUID_DEVICE_TYPE_NONE:
-    return "NONE";
-  default:
-    return "UNKNOWN";
+    case AMDCUID_DEVICE_TYPE_PLATFORM:
+      return "PLATFORM";
+    case AMDCUID_DEVICE_TYPE_CPU:
+      return "CPU";
+    case AMDCUID_DEVICE_TYPE_GPU:
+      return "GPU";
+    case AMDCUID_DEVICE_TYPE_NIC:
+      return "NIC";
+    case AMDCUID_DEVICE_TYPE_NPU:
+      return "NPU";
+    case AMDCUID_DEVICE_TYPE_NONE:
+      return "NONE";
+    default:
+      return "UNKNOWN";
   }
 }
 
-amdcuid_device_type_t string_to_device_type(const std::string &type_str) {
+amdcuid_device_type_t string_to_device_type(const std::string& type_str) {
   std::string upper = type_str;
-  for (auto &c : upper)
-    c = toupper(c);
+  for (auto& c : upper) c = toupper(c);
 
-  if (upper == "PLATFORM")
-    return AMDCUID_DEVICE_TYPE_PLATFORM;
-  if (upper == "CPU")
-    return AMDCUID_DEVICE_TYPE_CPU;
-  if (upper == "GPU")
-    return AMDCUID_DEVICE_TYPE_GPU;
-  if (upper == "NIC")
-    return AMDCUID_DEVICE_TYPE_NIC;
-  if (upper == "NPU")
-    return AMDCUID_DEVICE_TYPE_NPU;
+  if (upper == "PLATFORM") return AMDCUID_DEVICE_TYPE_PLATFORM;
+  if (upper == "CPU") return AMDCUID_DEVICE_TYPE_CPU;
+  if (upper == "GPU") return AMDCUID_DEVICE_TYPE_GPU;
+  if (upper == "NIC") return AMDCUID_DEVICE_TYPE_NIC;
+  if (upper == "NPU") return AMDCUID_DEVICE_TYPE_NPU;
   return AMDCUID_DEVICE_TYPE_NONE;
 }
 
@@ -124,12 +112,12 @@ amdcuid_device_type_t string_to_device_type(const std::string &type_str) {
  * @param key Output buffer for the key (32 bytes)
  * @return true on success, false on failure
  */
-bool load_key_from_file(const std::string &key_file, uint8_t key[32]) {
+bool load_key_from_file(const std::string& key_file, uint8_t key[32]) {
   std::ifstream file(key_file, std::ios::binary);
   if (!file) {
     return false;
   }
-  file.read(reinterpret_cast<char *>(key), 32);
+  file.read(reinterpret_cast<char*>(key), 32);
   return file.gcount() == 32;
 }
 
@@ -160,24 +148,20 @@ int notify_daemon() {
  * @param result Output string
  * @return Status code
  */
-amdcuid_status_t query_string_property(amdcuid_id_t handle,
-                                       amdcuid_query_t query,
-                                       std::string &result) {
+amdcuid_status_t query_string_property(amdcuid_id_t handle, amdcuid_query_t query,
+                                       std::string& result) {
   // First query to get required size
   uint32_t length = 0;
-  amdcuid_status_t status =
-      amdcuid_query_device_property(handle, query, nullptr, &length);
+  amdcuid_status_t status = amdcuid_query_device_property(handle, query, nullptr, &length);
 
   if (status == AMDCUID_STATUS_INSUFFICIENT_SIZE && length > 0) {
     // Allocate buffer and query again
     std::vector<char> buffer(length);
-    status =
-        amdcuid_query_device_property(handle, query, buffer.data(), &length);
+    status = amdcuid_query_device_property(handle, query, buffer.data(), &length);
     if (status == AMDCUID_STATUS_SUCCESS) {
       // Remove null terminator if present
       result = std::string(buffer.data(),
-                           length > 0 && buffer[length - 1] == '\0' ? length - 1
-                                                                    : length);
+                           length > 0 && buffer[length - 1] == '\0' ? length - 1 : length);
     }
   } else if (status == AMDCUID_STATUS_SUCCESS) {
     result.clear();
@@ -186,16 +170,14 @@ amdcuid_status_t query_string_property(amdcuid_id_t handle,
   return status;
 }
 
-int generate_cuid_files(const std::string &key_file, bool generate_key) {
+int generate_cuid_files(const std::string& key_file, bool generate_key) {
   std::cout << "Generating/refreshing CUID registry...\n" << std::endl;
 
   // Validate key options - cannot use both together
   if (!key_file.empty() && generate_key) {
-    std::cerr
-        << "Error: Cannot use both --generate-key and --set-key together.\n";
+    std::cerr << "Error: Cannot use both --generate-key and --set-key together.\n";
     std::cerr << "Use --generate-key to create a new random key, or\n";
-    std::cerr << "Use --set-key <file> to load an existing key from a file."
-              << std::endl;
+    std::cerr << "Use --set-key <file> to load an existing key from a file." << std::endl;
     return 1;
   }
 
@@ -204,16 +186,15 @@ int generate_cuid_files(const std::string &key_file, bool generate_key) {
     // Load key from file
     uint8_t key[32];
     if (!load_key_from_file(key_file, key)) {
-      std::cerr << "Error: Failed to read HMAC key from file: " << key_file
-                << std::endl;
+      std::cerr << "Error: Failed to read HMAC key from file: " << key_file << std::endl;
       std::cerr << "Key file must be exactly 32 bytes." << std::endl;
       return 1;
     }
 
     amdcuid_status_t status = amdcuid_set_hash_key(key);
     if (status != AMDCUID_STATUS_SUCCESS) {
-      std::cerr << "Error: Failed to set HMAC key: "
-                << amdcuid_status_to_string(status) << std::endl;
+      std::cerr << "Error: Failed to set HMAC key: " << amdcuid_status_to_string(status)
+                << std::endl;
       return 1;
     }
     std::cout << "HMAC key loaded from: " << key_file << std::endl;
@@ -222,15 +203,15 @@ int generate_cuid_files(const std::string &key_file, bool generate_key) {
     uint8_t key[32];
     amdcuid_status_t status = amdcuid_generate_hash_key(key);
     if (status != AMDCUID_STATUS_SUCCESS) {
-      std::cerr << "Error: Failed to generate HMAC key: "
-                << amdcuid_status_to_string(status) << std::endl;
+      std::cerr << "Error: Failed to generate HMAC key: " << amdcuid_status_to_string(status)
+                << std::endl;
       return 1;
     }
 
     status = amdcuid_set_hash_key(key);
     if (status != AMDCUID_STATUS_SUCCESS) {
-      std::cerr << "Error: Failed to set generated HMAC key: "
-                << amdcuid_status_to_string(status) << std::endl;
+      std::cerr << "Error: Failed to set generated HMAC key: " << amdcuid_status_to_string(status)
+                << std::endl;
       return 1;
     }
     std::cout << "Generated new HMAC key." << std::endl;
@@ -243,15 +224,14 @@ int generate_cuid_files(const std::string &key_file, bool generate_key) {
   amdcuid_status_t status = amdcuid_refresh();
 
   if (status != AMDCUID_STATUS_SUCCESS) {
-    std::cerr << "Error: Failed to refresh CUID registry: "
-              << amdcuid_status_to_string(status) << std::endl;
+    std::cerr << "Error: Failed to refresh CUID registry: " << amdcuid_status_to_string(status)
+              << std::endl;
     if (status == AMDCUID_STATUS_KEY_ERROR) {
       std::cerr << "No HMAC key found. Please use --generate-key or --set-key "
                    "<file> to create a key first."
                 << std::endl;
     } else if (status == AMDCUID_STATUS_PERMISSION_DENIED) {
-      std::cerr << "Some devices may require root privileges to discover."
-                << std::endl;
+      std::cerr << "Some devices may require root privileges to discover." << std::endl;
     }
     return 1;
   }
@@ -259,8 +239,7 @@ int generate_cuid_files(const std::string &key_file, bool generate_key) {
   // Count discovered devices
   uint32_t count = 0;
   status = amdcuid_get_all_handles(nullptr, &count);
-  if (status == AMDCUID_STATUS_INSUFFICIENT_SIZE ||
-      status == AMDCUID_STATUS_SUCCESS) {
+  if (status == AMDCUID_STATUS_INSUFFICIENT_SIZE || status == AMDCUID_STATUS_SUCCESS) {
     std::cout << "Discovered " << count << " device(s)" << std::endl;
   }
 
@@ -268,7 +247,7 @@ int generate_cuid_files(const std::string &key_file, bool generate_key) {
   return 0;
 }
 
-int list_devices(bool show_primary, const std::string *filter_type) {
+int list_devices(bool show_primary, const std::string* filter_type) {
   // Check for root privileges if requesting primary CUIDs
   if (show_primary && !is_root()) {
     std::cerr << "Error: Permission denied\n";
@@ -283,8 +262,7 @@ int list_devices(bool show_primary, const std::string *filter_type) {
   if (filter_type) {
     filter_device_type = string_to_device_type(*filter_type);
     if (filter_device_type == AMDCUID_DEVICE_TYPE_NONE) {
-      std::cerr << "Error: Unknown device type '" << *filter_type << "'"
-                << std::endl;
+      std::cerr << "Error: Unknown device type '" << *filter_type << "'" << std::endl;
       std::cerr << "Valid types: platform, cpu, gpu, nic, npu" << std::endl;
       return 1;
     }
@@ -294,8 +272,7 @@ int list_devices(bool show_primary, const std::string *filter_type) {
   uint32_t count = 0;
   amdcuid_status_t status = amdcuid_get_all_handles(nullptr, &count);
 
-  if (status != AMDCUID_STATUS_INSUFFICIENT_SIZE &&
-      status != AMDCUID_STATUS_SUCCESS) {
+  if (status != AMDCUID_STATUS_INSUFFICIENT_SIZE && status != AMDCUID_STATUS_SUCCESS) {
     if (status == AMDCUID_STATUS_UNSUPPORTED) {
       std::cout << "No devices found.\n";
       std::cout << "Please run 'sudo amdcuid_tool --generate-cuid' first to "
@@ -303,8 +280,8 @@ int list_devices(bool show_primary, const std::string *filter_type) {
                 << std::endl;
       return 0;
     }
-    std::cerr << "Error: Failed to get device count: "
-              << amdcuid_status_to_string(status) << std::endl;
+    std::cerr << "Error: Failed to get device count: " << amdcuid_status_to_string(status)
+              << std::endl;
     return 1;
   }
 
@@ -316,19 +293,18 @@ int list_devices(bool show_primary, const std::string *filter_type) {
   std::vector<amdcuid_id_t> handles(count);
   status = amdcuid_get_all_handles(handles.data(), &count);
   if (status != AMDCUID_STATUS_SUCCESS) {
-    std::cerr << "Error: Failed to get device handles: "
-              << amdcuid_status_to_string(status) << std::endl;
+    std::cerr << "Error: Failed to get device handles: " << amdcuid_status_to_string(status)
+              << std::endl;
     return 1;
   }
 
   // Group handles by device type
   std::map<amdcuid_device_type_t, std::vector<amdcuid_id_t>> grouped;
 
-  for (const auto &handle : handles) {
+  for (const auto& handle : handles) {
     amdcuid_device_type_t device_type;
     uint32_t len = sizeof(device_type);
-    status = amdcuid_query_device_property(handle, AMDCUID_QUERY_DEVICE_TYPE,
-                                           &device_type, &len);
+    status = amdcuid_query_device_property(handle, AMDCUID_QUERY_DEVICE_TYPE, &device_type, &len);
     if (status != AMDCUID_STATUS_SUCCESS) {
       continue;
     }
@@ -352,7 +328,7 @@ int list_devices(bool show_primary, const std::string *filter_type) {
 
   // Count total entries after filtering
   size_t total = 0;
-  for (const auto &kv : grouped) {
+  for (const auto& kv : grouped) {
     total += kv.second.size();
   }
 
@@ -362,14 +338,14 @@ int list_devices(bool show_primary, const std::string *filter_type) {
   }
   std::cout << ":\n" << std::endl;
 
-  for (const auto &kv : grouped) {
+  for (const auto& kv : grouped) {
     amdcuid_device_type_t type = kv.first;
-    const std::vector<amdcuid_id_t> &handle_list = kv.second;
+    const std::vector<amdcuid_id_t>& handle_list = kv.second;
     std::string type_str = device_type_to_string(type);
     std::cout << "---- " << type_str << " Devices ----" << std::endl;
 
     int device_index = 0;
-    for (const auto &handle : handle_list) {
+    for (const auto& handle : handle_list) {
       if (type == AMDCUID_DEVICE_TYPE_PLATFORM) {
         std::cout << type_str;
       } else {
@@ -380,11 +356,10 @@ int list_devices(bool show_primary, const std::string *filter_type) {
       if (show_primary) {
         amdcuid_id_t primary_cuid;
         uint32_t len = sizeof(primary_cuid);
-        status = amdcuid_query_device_property(
-            handle, AMDCUID_QUERY_PRIMARY_CUID, &primary_cuid, &len);
+        status =
+            amdcuid_query_device_property(handle, AMDCUID_QUERY_PRIMARY_CUID, &primary_cuid, &len);
         if (status == AMDCUID_STATUS_SUCCESS) {
-          std::cout << "\n  Primary CUID:   "
-                    << amdcuid_id_to_string(primary_cuid);
+          std::cout << "\n  Primary CUID:   " << amdcuid_id_to_string(primary_cuid);
         }
       }
 
@@ -393,8 +368,8 @@ int list_devices(bool show_primary, const std::string *filter_type) {
 
       // Query device path
       std::string device_path;
-      if (query_string_property(handle, AMDCUID_QUERY_DEVICE_PATH,
-                                device_path) == AMDCUID_STATUS_SUCCESS) {
+      if (query_string_property(handle, AMDCUID_QUERY_DEVICE_PATH, device_path) ==
+          AMDCUID_STATUS_SUCCESS) {
         std::cout << "\n  Device Path:    " << device_path;
       }
 
@@ -406,8 +381,8 @@ int list_devices(bool show_primary, const std::string *filter_type) {
   return 0;
 }
 
-int query_device(const std::string &identifier, bool show_primary,
-                 const std::string *device_type_str) {
+int query_device(const std::string& identifier, bool show_primary,
+                 const std::string* device_type_str) {
   // Check for root privileges if requesting primary CUIDs
   if (show_primary && !is_root()) {
     std::cerr << "Error: Permission denied\n";
@@ -421,12 +396,11 @@ int query_device(const std::string &identifier, bool show_primary,
   amdcuid_status_t status;
 
   // Determine device type for lookup
-  amdcuid_device_type_t device_type = AMDCUID_DEVICE_TYPE_GPU; // Default to GPU
+  amdcuid_device_type_t device_type = AMDCUID_DEVICE_TYPE_GPU;  // Default to GPU
   if (device_type_str) {
     device_type = string_to_device_type(*device_type_str);
     if (device_type == AMDCUID_DEVICE_TYPE_NONE) {
-      std::cerr << "Error: Unknown device type '" << *device_type_str << "'"
-                << std::endl;
+      std::cerr << "Error: Unknown device type '" << *device_type_str << "'" << std::endl;
       std::cerr << "Valid types: platform, cpu, gpu, nic, npu" << std::endl;
       return 1;
     }
@@ -445,18 +419,16 @@ int query_device(const std::string &identifier, bool show_primary,
 
   // Check if identifier looks like a BDF (e.g., "0000:c6:00.1" or "c6:00.1").
   // Must not start with '/' (which would indicate a sysfs path).
-  bool is_bdf = (!identifier.empty() && identifier[0] != '/' &&
-                 identifier.find(':') != std::string::npos &&
-                 identifier.find('.') != std::string::npos);
+  bool is_bdf =
+      (!identifier.empty() && identifier[0] != '/' && identifier.find(':') != std::string::npos &&
+       identifier.find('.') != std::string::npos);
 
   if (is_bdf) {
     // Try as BDF
-    status =
-        amdcuid_get_handle_by_bdf(identifier.c_str(), device_type, &handle);
+    status = amdcuid_get_handle_by_bdf(identifier.c_str(), device_type, &handle);
   } else {
     // Try as device path
-    status = amdcuid_get_handle_by_dev_path(identifier.c_str(), device_type,
-                                            &handle);
+    status = amdcuid_get_handle_by_dev_path(identifier.c_str(), device_type, &handle);
   }
 
   if (status != AMDCUID_STATUS_SUCCESS) {
@@ -471,30 +443,25 @@ int query_device(const std::string &identifier, bool show_primary,
   // Query device type
   amdcuid_device_type_t queried_type;
   uint32_t len = sizeof(queried_type);
-  status = amdcuid_query_device_property(handle, AMDCUID_QUERY_DEVICE_TYPE,
-                                         &queried_type, &len);
+  status = amdcuid_query_device_property(handle, AMDCUID_QUERY_DEVICE_TYPE, &queried_type, &len);
   if (status == AMDCUID_STATUS_SUCCESS) {
-    std::cout << "  Type:           " << device_type_to_string(queried_type)
-              << std::endl;
+    std::cout << "  Type:           " << device_type_to_string(queried_type) << std::endl;
   }
 
   // Query primary CUID if requested
   if (show_primary) {
     amdcuid_id_t primary_cuid;
     len = sizeof(primary_cuid);
-    status = amdcuid_query_device_property(handle, AMDCUID_QUERY_PRIMARY_CUID,
-                                           &primary_cuid, &len);
+    status = amdcuid_query_device_property(handle, AMDCUID_QUERY_PRIMARY_CUID, &primary_cuid, &len);
     if (status == AMDCUID_STATUS_SUCCESS) {
-      std::cout << "  Primary CUID:   " << amdcuid_id_to_string(primary_cuid)
-                << std::endl;
+      std::cout << "  Primary CUID:   " << amdcuid_id_to_string(primary_cuid) << std::endl;
     } else if (status == AMDCUID_STATUS_PERMISSION_DENIED) {
       std::cout << "  Primary CUID:   (requires root)" << std::endl;
     }
   }
 
   // Display derived CUID (the handle)
-  std::cout << "  CUID:           " << amdcuid_id_to_string(handle)
-            << std::endl;
+  std::cout << "  CUID:           " << amdcuid_id_to_string(handle) << std::endl;
 
   // Query device path
   std::string device_path;
@@ -506,19 +473,18 @@ int query_device(const std::string &identifier, bool show_primary,
   return 0;
 }
 
-int main(int argc, char *argv[]) {
-  static struct option long_options[] = {
-      {"generate-cuid", no_argument, 0, 'g'},
-      {"generate-key", no_argument, 0, 'k'},
-      {"set-key", required_argument, 0, 's'},
-      {"notify-daemon", no_argument, 0, 'n'},
-      {"list", no_argument, 0, 'l'},
-      {"type", required_argument, 0, 't'},
-      {"show-primary", no_argument, 0, 'p'},
-      {"query-device", required_argument, 0, 'q'},
-      {"version", no_argument, 0, 'v'},
-      {"help", no_argument, 0, 'h'},
-      {0, 0, 0, 0}};
+int main(int argc, char* argv[]) {
+  static struct option long_options[] = {{"generate-cuid", no_argument, 0, 'g'},
+                                         {"generate-key", no_argument, 0, 'k'},
+                                         {"set-key", required_argument, 0, 's'},
+                                         {"notify-daemon", no_argument, 0, 'n'},
+                                         {"list", no_argument, 0, 'l'},
+                                         {"type", required_argument, 0, 't'},
+                                         {"show-primary", no_argument, 0, 'p'},
+                                         {"query-device", required_argument, 0, 'q'},
+                                         {"version", no_argument, 0, 'v'},
+                                         {"help", no_argument, 0, 'h'},
+                                         {0, 0, 0, 0}};
 
   std::string key_file;
   std::string filter_type;
@@ -533,44 +499,43 @@ int main(int argc, char *argv[]) {
   int opt;
   int option_index = 0;
 
-  while ((opt = getopt_long(argc, argv, "gks:nlt:pq:vh", long_options,
-                            &option_index)) != -1) {
+  while ((opt = getopt_long(argc, argv, "gks:nlt:pq:vh", long_options, &option_index)) != -1) {
     switch (opt) {
-    case 'g':
-      do_generate = true;
-      break;
-    case 'k':
-      generate_key = true;
-      break;
-    case 's':
-      key_file = optarg;
-      break;
-    case 'n':
-      do_notify = true;
-      break;
-    case 'l':
-      do_list = true;
-      break;
-    case 't':
-      filter_type = optarg;
-      break;
-    case 'p':
-      show_primary = true;
-      break;
-    case 'q':
-      do_query = true;
-      query_identifier = optarg;
-      break;
-    case 'v':
-      std::cout << "AMD CUID Library Version: "
-                << amdcuid_library_version_to_string() << std::endl;
-      return 0;
-    case 'h':
-      print_usage(argv[0]);
-      return 0;
-    default:
-      print_usage(argv[0]);
-      return 1;
+      case 'g':
+        do_generate = true;
+        break;
+      case 'k':
+        generate_key = true;
+        break;
+      case 's':
+        key_file = optarg;
+        break;
+      case 'n':
+        do_notify = true;
+        break;
+      case 'l':
+        do_list = true;
+        break;
+      case 't':
+        filter_type = optarg;
+        break;
+      case 'p':
+        show_primary = true;
+        break;
+      case 'q':
+        do_query = true;
+        query_identifier = optarg;
+        break;
+      case 'v':
+        std::cout << "AMD CUID Library Version: " << amdcuid_library_version_to_string()
+                  << std::endl;
+        return 0;
+      case 'h':
+        print_usage(argv[0]);
+        return 0;
+      default:
+        print_usage(argv[0]);
+        return 1;
     }
   }
 
@@ -588,8 +553,7 @@ int main(int argc, char *argv[]) {
   } else if (do_notify) {
     return notify_daemon();
   } else if (do_list) {
-    return list_devices(show_primary,
-                        filter_type.empty() ? nullptr : &filter_type);
+    return list_devices(show_primary, filter_type.empty() ? nullptr : &filter_type);
   } else if (do_query) {
     return query_device(query_identifier, show_primary,
                         filter_type.empty() ? nullptr : &filter_type);

--- a/projects/cuid/cmake_uninstall.cmake.in
+++ b/projects/cuid/cmake_uninstall.cmake.in
@@ -8,17 +8,10 @@ if(EXISTS "${_prerm}")
     message(STATUS "Running pre-removal script: ${_prerm}")
     execute_process(COMMAND sh "${_prerm}" RESULT_VARIABLE _prerm_result)
     if(NOT _prerm_result EQUAL 0)
-        message(
-            WARNING
-            "Pre-removal script exited with code ${_prerm_result}. "
-            "Continuing with file removal anyway."
-        )
+        message(WARNING "Pre-removal script exited with code ${_prerm_result}. " "Continuing with file removal anyway.")
     endif()
 else()
-    message(
-        STATUS
-        "Pre-removal script not found (${_prerm}); skipping daemon teardown."
-    )
+    message(STATUS "Pre-removal script not found (${_prerm}); skipping daemon teardown.")
 endif()
 
 # Remove all files tracked by cmake --install via install_manifest.txt

--- a/projects/cuid/daemon/CMakeLists.txt
+++ b/projects/cuid/daemon/CMakeLists.txt
@@ -1,15 +1,9 @@
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-message(
-    "&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&"
-)
-message(
-    "                           Cmake amdcuid_daemon                           "
-)
-message(
-    "&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&"
-)
+message("&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")
+message("                           Cmake amdcuid_daemon                           ")
+message("&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")
 
 message("")
 message("Build Configuration:")
@@ -44,24 +38,13 @@ target_include_directories(${AMDCUID_DAEMON_EXECUTABLE} PRIVATE ${INC_DIR})
 # Pass the resolved config install directory to the daemon at compile time so
 # the HMAC key and daemon configuration paths are always built from a concrete
 # location.
-target_compile_definitions(
-    ${AMDCUID_DAEMON_EXECUTABLE}
-    PRIVATE AMDCUID_CONFIG_DIR="${AMDCUID_SHARED_CONFIG_DIR}"
-)
+target_compile_definitions(${AMDCUID_DAEMON_EXECUTABLE} PRIVATE AMDCUID_CONFIG_DIR="${AMDCUID_SHARED_CONFIG_DIR}")
 
 # Link against the CUID library
-target_link_libraries(
-    ${AMDCUID_DAEMON_EXECUTABLE}
-    amdcuid_static
-    Threads::Threads
-)
+target_link_libraries(${AMDCUID_DAEMON_EXECUTABLE} amdcuid_static Threads::Threads)
 
 # Install the daemon
-install(
-    TARGETS ${AMDCUID_DAEMON_EXECUTABLE}
-    DESTINATION ${CMAKE_INSTALL_BINDIR}
-    COMPONENT ${DAEMON_COMPONENT}
-)
+install(TARGETS ${AMDCUID_DAEMON_EXECUTABLE} DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT ${DAEMON_COMPONENT})
 
 set(DAEMON_CONFIG_FILE amdcuid_daemon.conf)
 install(
@@ -103,19 +86,11 @@ if(UNIX AND NOT APPLE)
 
     # Generate the post-install shell script from a template, substituting the
     # install prefix and config directory baked-in at cmake configure time.
-    configure_file(
-        ${CMAKE_CURRENT_SOURCE_DIR}/postinst.in
-        ${CMAKE_CURRENT_BINARY_DIR}/postinst
-        @ONLY
-    )
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/postinst.in ${CMAKE_CURRENT_BINARY_DIR}/postinst @ONLY)
 
     # Configure the pre-removal script (mirrors postinst: stops service, removes
     # udev rules, cron job, and systemd service symlink).
-    configure_file(
-        ${CMAKE_CURRENT_SOURCE_DIR}/prerm.in
-        ${CMAKE_CURRENT_BINARY_DIR}/prerm
-        @ONLY
-    )
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/prerm.in ${CMAKE_CURRENT_BINARY_DIR}/prerm @ONLY)
 
     # Also install both scripts so they can be re-run manually after a cmake --install.
     install(

--- a/projects/cuid/daemon/amdcuid_daemon.cc
+++ b/projects/cuid/daemon/amdcuid_daemon.cc
@@ -1,25 +1,27 @@
 // Copyright Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
-#include "include/amd_cuid.h"
-#include "src/hmac.h"
-#include "src/ipc_protocol.h"
+#include <fcntl.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/un.h>
+#include <unistd.h>
+
 #include <atomic>
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
-#include <fcntl.h>
 #include <fstream>
 #include <iostream>
 #include <map>
 #include <memory>
 #include <sstream>
-#include <sys/socket.h>
-#include <sys/stat.h>
-#include <sys/un.h>
 #include <thread>
-#include <unistd.h>
 #include <vector>
+
+#include "include/amd_cuid.h"
+#include "src/hmac.h"
+#include "src/ipc_protocol.h"
 
 // static hmac instance for daemon
 static cuid_hmac daemon_hmac = cuid_hmac();
@@ -28,7 +30,7 @@ static cuid_hmac daemon_hmac = cuid_hmac();
 static std::unique_ptr<std::ofstream> g_log_file;
 static bool g_logging_to_file = false;
 
-static std::ostream &log_out() {
+static std::ostream& log_out() {
   if (g_logging_to_file && g_log_file && g_log_file->is_open()) {
     *g_log_file << "timestamp: " << time(nullptr) << ": ";
     return *g_log_file;
@@ -37,7 +39,7 @@ static std::ostream &log_out() {
   return std::cout;
 }
 
-static std::ostream &log_err() {
+static std::ostream& log_err() {
   if (g_logging_to_file && g_log_file && g_log_file->is_open()) {
     *g_log_file << "timestamp: " << time(nullptr) << ": ";
     return *g_log_file;
@@ -48,8 +50,7 @@ static std::ostream &log_err() {
 
 static void init_logging(bool enabled) {
   if (enabled) {
-    g_log_file =
-        std::make_unique<std::ofstream>("/var/log/amdcuid.log", std::ios::app);
+    g_log_file = std::make_unique<std::ofstream>("/var/log/amdcuid.log", std::ios::app);
     if (g_log_file->is_open()) {
       g_logging_to_file = true;
       // Add timestamp to log entry
@@ -61,13 +62,13 @@ static void init_logging(bool enabled) {
 
 // Daemon Server
 class CuidDaemonServer {
-public:
+ public:
   CuidDaemonServer() : is_running_(false), server_fd_(-1) {}
   ~CuidDaemonServer() { stop(); }
 
   amdcuid_status_t start() {
     if (is_running_) {
-      return AMDCUID_STATUS_SUCCESS; // Already running
+      return AMDCUID_STATUS_SUCCESS;  // Already running
     }
 
     server_fd_ = socket(AF_UNIX, SOCK_STREAM, 0);
@@ -75,17 +76,15 @@ public:
       return AMDCUID_STATUS_IPC_ERROR;
     }
 
-    unlink(AMDCUID_SOCKET_PATH); // Remove existing socket file
+    unlink(AMDCUID_SOCKET_PATH);  // Remove existing socket file
 
     // bind to socket path
     struct sockaddr_un server_addr;
     memset(&server_addr, 0, sizeof(server_addr));
     server_addr.sun_family = AF_UNIX;
-    strncpy(server_addr.sun_path, AMDCUID_SOCKET_PATH,
-            sizeof(server_addr.sun_path) - 1);
+    strncpy(server_addr.sun_path, AMDCUID_SOCKET_PATH, sizeof(server_addr.sun_path) - 1);
 
-    if (bind(server_fd_, (struct sockaddr *)&server_addr, sizeof(server_addr)) <
-        0) {
+    if (bind(server_fd_, (struct sockaddr*)&server_addr, sizeof(server_addr)) < 0) {
       close(server_fd_);
       return AMDCUID_STATUS_IPC_ERROR;
     }
@@ -120,7 +119,7 @@ public:
     unlink(AMDCUID_SOCKET_PATH);
   }
 
-private:
+ private:
   std::atomic<bool> is_running_;
   int server_fd_;
   std::thread server_thread_;
@@ -148,26 +147,25 @@ private:
 
     // Handle different request types
     switch (request.type) {
-    case IpcMessageType::ADD_DEVICE:
-      response.status = handle_add_device(request, response.device_handle);
-      break;
-    case IpcMessageType::REFRESH_DEVICES:
-      response.status = amdcuid_refresh();
-      break;
-    default:
-      response.status = AMDCUID_STATUS_INVALID_ARGUMENT;
-      break;
+      case IpcMessageType::ADD_DEVICE:
+        response.status = handle_add_device(request, response.device_handle);
+        break;
+      case IpcMessageType::REFRESH_DEVICES:
+        response.status = amdcuid_refresh();
+        break;
+      default:
+        response.status = AMDCUID_STATUS_INVALID_ARGUMENT;
+        break;
     }
 
     send(client_fd, &response, sizeof(response), 0);
   }
 
-  amdcuid_status_t handle_add_device(const IpcRequest &request,
-                                     amdcuid_id_t &device_handle) {
+  amdcuid_status_t handle_add_device(const IpcRequest& request, amdcuid_id_t& device_handle) {
     std::string dev_path(request.device_path);
     amdcuid_device_type_t device_type = request.device_type;
-    amdcuid_status_t status = amdcuid_get_handle_by_dev_path(
-        dev_path.c_str(), device_type, &device_handle);
+    amdcuid_status_t status =
+        amdcuid_get_handle_by_dev_path(dev_path.c_str(), device_type, &device_handle);
 
     return status;
   }
@@ -207,9 +205,8 @@ int main() {
     bool stat_ok = (fstat(fd, &key_stat) == 0);
     close(fd);
     if (!stat_ok || key_stat.st_size != key_length) {
-      log_err() << "Error: HMAC key file has unexpected size ("
-                << (stat_ok ? key_stat.st_size : -1) << " bytes, expected "
-                << key_length << "). Key file may be corrupt; "
+      log_err() << "Error: HMAC key file has unexpected size (" << (stat_ok ? key_stat.st_size : -1)
+                << " bytes, expected " << key_length << "). Key file may be corrupt; "
                 << "remove it to allow regeneration." << std::endl;
       return 1;
     }
@@ -263,8 +260,7 @@ int main() {
                 << amdcuid_status_to_string(status) << ")" << std::endl;
       return 1;
     }
-    log_out() << "Daemon server started, listening for device events..."
-              << std::endl;
+    log_out() << "Daemon server started, listening for device events..." << std::endl;
 
     // Keep the main thread alive while the server is running
     while (true) {
@@ -272,15 +268,11 @@ int main() {
     }
 
     // On shutdown (not reachable in current code)
-    log_out()
-        << "Daemon server stopping, no longer listening for device events."
-        << std::endl;
+    log_out() << "Daemon server stopping, no longer listening for device events." << std::endl;
     server.stop();
   } else {
-    log_out()
-        << "Running in non-daemon mode, generating/updating CUID files once..."
-        << std::endl;
-    // non-daemon mode discovers devices on bootup and updates their CUIDs once
+    log_out() << "Running in non-daemon mode, generating/updating CUID files once..." << std::endl;
+    // non-daemon mode discovers devices at boot and updates their CUIDs once
     // discover devices by refreshing
     amdcuid_status_t status = amdcuid_refresh();
     if (status != AMDCUID_STATUS_SUCCESS) {

--- a/projects/cuid/example/CMakeLists.txt
+++ b/projects/cuid/example/CMakeLists.txt
@@ -1,15 +1,9 @@
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-message(
-    "&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&"
-)
-message(
-    "                          Cmake amdcuid_example                           "
-)
-message(
-    "&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&"
-)
+message("&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")
+message("                          Cmake amdcuid_example                           ")
+message("&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")
 
 message("")
 message("Build Configuration:")
@@ -29,21 +23,14 @@ set(SRC_LIST main.cc)
 
 add_executable(${AMDCUID_EXAMPLE_EXECUTABLE} ${SRC_LIST})
 
-target_include_directories(
-    ${AMDCUID_EXAMPLE_EXECUTABLE}
-    PRIVATE ${CMAKE_SOURCE_DIR}/lib
-)
+target_include_directories(${AMDCUID_EXAMPLE_EXECUTABLE} PRIVATE ${CMAKE_SOURCE_DIR}/lib)
 
 # Link against the CUID library (public API only)
 # The example now uses only the public API defined in amd_cuid.h
 target_link_libraries(${AMDCUID_EXAMPLE_EXECUTABLE} amdcuid_static pthread)
 
 # Install example source into documentation
-install(
-    FILES ${SRC_LIST}
-    DESTINATION ${CMAKE_INSTALL_DOCDIR}
-    COMPONENT ${EXAMPLE_COMPONENT}
-)
+install(FILES ${SRC_LIST} DESTINATION ${CMAKE_INSTALL_DOCDIR} COMPONENT ${EXAMPLE_COMPONENT})
 
 message("&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")
 message("                  Finished Cmake amdcuid_example                   ")

--- a/projects/cuid/example/main.cc
+++ b/projects/cuid/example/main.cc
@@ -1,10 +1,11 @@
 // Copyright Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
-#include "include/amd_cuid.h"
 #include <climits>
 #include <iostream>
 #include <vector>
+
+#include "include/amd_cuid.h"
 
 int main() {
   amdcuid_status_t err;
@@ -17,8 +18,7 @@ int main() {
     handle_count = available_handle_count;
     handles.resize(handle_count);
     err = amdcuid_get_all_handles(handles.data(), &available_handle_count);
-    if (err != AMDCUID_STATUS_SUCCESS &&
-        err != AMDCUID_STATUS_INSUFFICIENT_SIZE) {
+    if (err != AMDCUID_STATUS_SUCCESS && err != AMDCUID_STATUS_INSUFFICIENT_SIZE) {
       std::cerr << "Failed to get device handles. Error code: " << err << " ("
                 << amdcuid_status_to_string(err) << ")" << std::endl;
       return 1;
@@ -31,11 +31,10 @@ int main() {
   for (uint32_t i = 0; i < handles.size(); ++i) {
     amdcuid_device_type_t device_type;
     uint32_t device_type_size = sizeof(device_type);
-    err = amdcuid_query_device_property(handles[i], AMDCUID_QUERY_DEVICE_TYPE,
-                                        &device_type, &device_type_size);
+    err = amdcuid_query_device_property(handles[i], AMDCUID_QUERY_DEVICE_TYPE, &device_type,
+                                        &device_type_size);
     if (err != AMDCUID_STATUS_SUCCESS) {
-      std::cerr << "Failed to get device type for handle #" << i
-                << ". Error code: " << err << " ("
+      std::cerr << "Failed to get device type for handle #" << i << ". Error code: " << err << " ("
                 << amdcuid_status_to_string(err) << ")" << std::endl;
       continue;
     }
@@ -53,42 +52,36 @@ int main() {
   for (uint32_t i = 0; i < gpu_handles.size(); ++i) {
     uint16_t vendor_id = 0;
     uint32_t data_size = sizeof(vendor_id);
-    err = amdcuid_query_device_property(gpu_handles[i], AMDCUID_QUERY_VENDOR_ID,
-                                        &vendor_id, &data_size);
+    err = amdcuid_query_device_property(gpu_handles[i], AMDCUID_QUERY_VENDOR_ID, &vendor_id,
+                                        &data_size);
     if (err != AMDCUID_STATUS_SUCCESS) {
-      std::cerr << "Failed to get vendor_id for GPU #" << i
-                << ". Error code: " << err << " ("
+      std::cerr << "Failed to get vendor_id for GPU #" << i << ". Error code: " << err << " ("
                 << amdcuid_status_to_string(err) << ")" << std::endl;
     }
 
     char device_node[128] = {0};
     uint32_t device_node_len = sizeof(device_node);
-    err =
-        amdcuid_query_device_property(gpu_handles[i], AMDCUID_QUERY_DEVICE_PATH,
-                                      device_node, &device_node_len);
+    err = amdcuid_query_device_property(gpu_handles[i], AMDCUID_QUERY_DEVICE_PATH, device_node,
+                                        &device_node_len);
     if (err != AMDCUID_STATUS_SUCCESS) {
-      std::cerr << "Failed to get device node for GPU #" << i
-                << ". Error code: " << err << " ("
+      std::cerr << "Failed to get device node for GPU #" << i << ". Error code: " << err << " ("
                 << amdcuid_status_to_string(err) << ")" << std::endl;
       device_node[0] = '\0';
     }
 
     amdcuid_id_t derived_id = {};
     uint32_t derived_id_size = sizeof(derived_id);
-    err = amdcuid_query_device_property(gpu_handles[i],
-                                        AMDCUID_QUERY_DERIVED_CUID, &derived_id,
+    err = amdcuid_query_device_property(gpu_handles[i], AMDCUID_QUERY_DERIVED_CUID, &derived_id,
                                         &derived_id_size);
     if (err != AMDCUID_STATUS_SUCCESS) {
-      std::cerr << "Failed to get derived CUID for GPU #" << i
-                << ". Error code: " << err << " ("
+      std::cerr << "Failed to get derived CUID for GPU #" << i << ". Error code: " << err << " ("
                 << amdcuid_status_to_string(err) << ")" << std::endl;
     }
 
     std::cout << "GPU #" << i << std::dec << " vendor_id: " << vendor_id
-              << " DeviceNode: " << device_node
-              << "  CUID: " << amdcuid_id_to_string(derived_id) << std::endl;
-    std::cout << " Handle: " << amdcuid_id_to_string(gpu_handles[i])
+              << " DeviceNode: " << device_node << "  CUID: " << amdcuid_id_to_string(derived_id)
               << std::endl;
+    std::cout << " Handle: " << amdcuid_id_to_string(gpu_handles[i]) << std::endl;
     std::cout << std::endl;
   }
 
@@ -99,127 +92,110 @@ int main() {
   for (uint32_t i = 0; i < cpu_handles.size(); ++i) {
     uint16_t vendor_id = 0;
     uint32_t data_size = sizeof(vendor_id);
-    err = amdcuid_query_device_property(cpu_handles[i], AMDCUID_QUERY_VENDOR_ID,
-                                        &vendor_id, &data_size);
+    err = amdcuid_query_device_property(cpu_handles[i], AMDCUID_QUERY_VENDOR_ID, &vendor_id,
+                                        &data_size);
     if (err != AMDCUID_STATUS_SUCCESS) {
-      std::cerr << "Failed to get vendor ID for CPU #" << i
-                << ". Error code: " << err << " ("
+      std::cerr << "Failed to get vendor ID for CPU #" << i << ". Error code: " << err << " ("
                 << amdcuid_status_to_string(err) << ")" << std::endl;
       vendor_id = 0;
     }
 
     uint16_t core = 0;
     data_size = sizeof(core);
-    err = amdcuid_query_device_property(cpu_handles[i], AMDCUID_QUERY_CORE_ID,
-                                        &core, &data_size);
+    err = amdcuid_query_device_property(cpu_handles[i], AMDCUID_QUERY_CORE_ID, &core, &data_size);
     if (err != AMDCUID_STATUS_SUCCESS) {
-      std::cerr << "Failed to get core for CPU #" << i
-                << ". Error code: " << err << " ("
+      std::cerr << "Failed to get core for CPU #" << i << ". Error code: " << err << " ("
                 << amdcuid_status_to_string(err) << ")" << std::endl;
       core = 0;
     }
 
     amdcuid_id_t derived_id = {};
     uint32_t derived_id_size = sizeof(derived_id);
-    err = amdcuid_query_device_property(cpu_handles[i],
-                                        AMDCUID_QUERY_DERIVED_CUID, &derived_id,
+    err = amdcuid_query_device_property(cpu_handles[i], AMDCUID_QUERY_DERIVED_CUID, &derived_id,
                                         &derived_id_size);
     if (err != AMDCUID_STATUS_SUCCESS) {
-      std::cerr << "Failed to get derived CUID for CPU #" << i
-                << ". Error code: " << err << " ("
+      std::cerr << "Failed to get derived CUID for CPU #" << i << ". Error code: " << err << " ("
                 << amdcuid_status_to_string(err) << ")" << std::endl;
     }
 
-    std::cout << "CPU #" << i << std::dec << " Core: " << core
-              << " VendorID: " << vendor_id
+    std::cout << "CPU #" << i << std::dec << " Core: " << core << " VendorID: " << vendor_id
               << "  CUID: " << amdcuid_id_to_string(derived_id) << std::endl;
-    std::cout << " Handle: " << amdcuid_id_to_string(cpu_handles[i])
-              << std::endl;
+    std::cout << " Handle: " << amdcuid_id_to_string(cpu_handles[i]) << std::endl;
     std::cout << std::endl;
   }
   // Example handle lookup by device path (only if at least one GPU exists).
   if (!gpu_handles.empty()) {
     char example_device_path[PATH_MAX] = {0};
     uint32_t path_length = sizeof(example_device_path);
-    err =
-        amdcuid_query_device_property(gpu_handles[0], AMDCUID_QUERY_DEVICE_PATH,
-                                      example_device_path, &path_length);
+    err = amdcuid_query_device_property(gpu_handles[0], AMDCUID_QUERY_DEVICE_PATH,
+                                        example_device_path, &path_length);
     if (err != AMDCUID_STATUS_SUCCESS) {
-      std::cerr << "Failed to get device path for GPU #0. Error code: " << err
-                << " (" << amdcuid_status_to_string(err) << ")" << std::endl;
+      std::cerr << "Failed to get device path for GPU #0. Error code: " << err << " ("
+                << amdcuid_status_to_string(err) << ")" << std::endl;
       return 1;
     }
 
     amdcuid_id_t device_handle = {};
-    err = amdcuid_get_handle_by_dev_path(
-        example_device_path, AMDCUID_DEVICE_TYPE_GPU, &device_handle);
+    err = amdcuid_get_handle_by_dev_path(example_device_path, AMDCUID_DEVICE_TYPE_GPU,
+                                         &device_handle);
     if (err != AMDCUID_STATUS_SUCCESS) {
-      std::cerr << "Failed to get device handle for path "
-                << example_device_path << ". Error code: " << err << " ("
-                << amdcuid_status_to_string(err) << ")" << std::endl;
+      std::cerr << "Failed to get device handle for path " << example_device_path
+                << ". Error code: " << err << " (" << amdcuid_status_to_string(err) << ")"
+                << std::endl;
       return 1;
     }
 
     amdcuid_id_t derived_id = {};
     uint32_t derived_id_size = sizeof(derived_id);
-    err =
-        amdcuid_query_device_property(device_handle, AMDCUID_QUERY_DERIVED_CUID,
-                                      &derived_id, &derived_id_size);
+    err = amdcuid_query_device_property(device_handle, AMDCUID_QUERY_DERIVED_CUID, &derived_id,
+                                        &derived_id_size);
     if (err != AMDCUID_STATUS_SUCCESS) {
-      std::cerr << "Failed to get derived CUID for device at path "
-                << example_device_path << ". Error code: " << err << " ("
-                << amdcuid_status_to_string(err) << ")" << std::endl;
+      std::cerr << "Failed to get derived CUID for device at path " << example_device_path
+                << ". Error code: " << err << " (" << amdcuid_status_to_string(err) << ")"
+                << std::endl;
       return 1;
     }
     std::cout << "Device at path " << example_device_path
-              << " has derived CUID: " << amdcuid_id_to_string(derived_id)
-              << std::endl;
+              << " has derived CUID: " << amdcuid_id_to_string(derived_id) << std::endl;
 
     std::string example_bdf;
-    uint32_t bdf_length =
-        13; // typical length of BDF string "0000:00:00.0" + null terminator
+    uint32_t bdf_length = 13;  // typical length of BDF string "0000:00:00.0" + null terminator
     char bdf_buffer[13] = {0};
-    err = amdcuid_query_device_property(gpu_handles[0], AMDCUID_QUERY_BDF,
-                                        bdf_buffer, &bdf_length);
+    err = amdcuid_query_device_property(gpu_handles[0], AMDCUID_QUERY_BDF, bdf_buffer, &bdf_length);
     if (err == AMDCUID_STATUS_SUCCESS) {
       example_bdf = bdf_buffer;
     } else {
-      std::cerr << "Failed to get BDF query input from GPU #0. Error code: "
-                << err << " (" << amdcuid_status_to_string(err) << ")"
-                << std::endl;
+      std::cerr << "Failed to get BDF query input from GPU #0. Error code: " << err << " ("
+                << amdcuid_status_to_string(err) << ")" << std::endl;
       return 1;
     }
 
     // example for getting a specific device handle by BDF and querying its
     // properties
     amdcuid_id_t bdf_device_handle = {};
-    err = amdcuid_get_handle_by_bdf(
-        example_bdf.c_str(), AMDCUID_DEVICE_TYPE_GPU, &bdf_device_handle);
+    err =
+        amdcuid_get_handle_by_bdf(example_bdf.c_str(), AMDCUID_DEVICE_TYPE_GPU, &bdf_device_handle);
     if (err != AMDCUID_STATUS_SUCCESS) {
-      std::cerr << "Failed to get device handle for BDF " << example_bdf
-                << ". Error code: " << err << " ("
-                << amdcuid_status_to_string(err) << ")" << std::endl;
+      std::cerr << "Failed to get device handle for BDF " << example_bdf << ". Error code: " << err
+                << " (" << amdcuid_status_to_string(err) << ")" << std::endl;
       return 1;
     }
 
     amdcuid_id_t derived_id_bdf = {};
     uint32_t derived_id_size2 = sizeof(derived_id_bdf);
-    err = amdcuid_query_device_property(bdf_device_handle,
-                                        AMDCUID_QUERY_DERIVED_CUID,
+    err = amdcuid_query_device_property(bdf_device_handle, AMDCUID_QUERY_DERIVED_CUID,
                                         &derived_id_bdf, &derived_id_size2);
     if (err != AMDCUID_STATUS_SUCCESS) {
-      std::cerr << "Failed to get derived CUID for device at BDF "
-                << example_bdf << ". Error code: " << err << " ("
-                << amdcuid_status_to_string(err) << ")" << std::endl;
+      std::cerr << "Failed to get derived CUID for device at BDF " << example_bdf
+                << ". Error code: " << err << " (" << amdcuid_status_to_string(err) << ")"
+                << std::endl;
       return 1;
     }
     std::cout << "Device at BDF " << example_bdf
-              << " has derived CUID: " << amdcuid_id_to_string(derived_id_bdf)
-              << std::endl;
+              << " has derived CUID: " << amdcuid_id_to_string(derived_id_bdf) << std::endl;
 
   } else {
-    std::cout << "No GPU devices found; skipping GPU path/BDF lookup examples."
-              << std::endl;
+    std::cout << "No GPU devices found; skipping GPU path/BDF lookup examples." << std::endl;
   }
 
   return 0;

--- a/projects/cuid/lib/CMakeLists.txt
+++ b/projects/cuid/lib/CMakeLists.txt
@@ -66,19 +66,12 @@ add_library(amdcuid_static STATIC ${CUID_SOURCES} ${CUID_HEADERS})
 
 set_property(TARGET amdcuid_static PROPERTY POSITION_INDEPENDENT_CODE ON)
 
-target_include_directories(
-    amdcuid_static
-    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
-    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src
-)
+target_include_directories(amdcuid_static PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 # Pass the version-independent shared config directory to the library at compile
 # time. All installed versions of the library must agree on this path so that
 # the HMAC key is shared and CUIDs remain stable across version upgrades.
-target_compile_definitions(
-    amdcuid_static
-    PRIVATE AMDCUID_CONFIG_DIR="${AMDCUID_SHARED_CONFIG_DIR}"
-)
+target_compile_definitions(amdcuid_static PRIVATE AMDCUID_CONFIG_DIR="${AMDCUID_SHARED_CONFIG_DIR}")
 
 # SHA-256/HMAC comes from src/sha256.cc, so the only external dependency left
 # is the platform CSPRNG: bcrypt on Windows, getrandom(2)//dev/urandom on POSIX.
@@ -100,11 +93,7 @@ install(
 
 # Install public headers
 set(PUBLIC_HEADERS ${INC_DIR}/amd_cuid.h)
-install(
-    FILES ${PUBLIC_HEADERS}
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${AMDCUID}
-    COMPONENT ${LIB_COMPONENT}
-)
+install(FILES ${PUBLIC_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${AMDCUID} COMPONENT ${LIB_COMPONENT})
 
 if(UNIX AND NOT APPLE)
     configure_file(

--- a/projects/cuid/lib/src/acpi_parser.cc
+++ b/projects/cuid/lib/src/acpi_parser.cc
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: MIT
 
 #include "src/acpi_parser.h"
-#include <fstream>
-#include <cstring>
-#include <sys/stat.h>
+
 #include <errno.h>
+#include <sys/stat.h>
+
+#include <cstring>
+#include <fstream>
 
 // MADT entry type constants
 constexpr uint8_t MADT_TYPE_LOCAL_APIC = 0;
@@ -18,163 +20,162 @@ constexpr uint32_t MADT_FLAG_ENABLED = 0x00000001;
 constexpr const char* ACPI_TABLES_PATH = "/sys/firmware/acpi/tables/";
 
 amdcuid_status_t AcpiParser::read_acpi_table(const char* table_name, std::vector<uint8_t>& data) {
-    std::string path = std::string(ACPI_TABLES_PATH) + table_name;
-    
-    // Check if file exists and get size
-    struct stat st;
-    if (stat(path.c_str(), &st) != 0) {
-        if (errno == ENOENT) {
-            return AMDCUID_STATUS_ACPI_ERROR;
-        } else if (errno == EACCES) {
-            return AMDCUID_STATUS_PERMISSION_DENIED;
-        }
-        return AMDCUID_STATUS_FILE_ERROR;
+  std::string path = std::string(ACPI_TABLES_PATH) + table_name;
+
+  // Check if file exists and get size
+  struct stat st;
+  if (stat(path.c_str(), &st) != 0) {
+    if (errno == ENOENT) {
+      return AMDCUID_STATUS_ACPI_ERROR;
+    } else if (errno == EACCES) {
+      return AMDCUID_STATUS_PERMISSION_DENIED;
     }
-    
-    // Read table data
-    std::ifstream file(path, std::ios::binary);
-    if (!file) {
-        if (errno == EACCES) {
-            return AMDCUID_STATUS_PERMISSION_DENIED;
-        }
-        return AMDCUID_STATUS_FILE_ERROR;
+    return AMDCUID_STATUS_FILE_ERROR;
+  }
+
+  // Read table data
+  std::ifstream file(path, std::ios::binary);
+  if (!file) {
+    if (errno == EACCES) {
+      return AMDCUID_STATUS_PERMISSION_DENIED;
     }
-    
-    data.resize(st.st_size);
-    file.read(reinterpret_cast<char*>(data.data()), st.st_size);
-    
-    if (!file) {
-        return AMDCUID_STATUS_FILE_ERROR;
-    }
-    
-    return AMDCUID_STATUS_SUCCESS;
+    return AMDCUID_STATUS_FILE_ERROR;
+  }
+
+  data.resize(st.st_size);
+  file.read(reinterpret_cast<char*>(data.data()), st.st_size);
+
+  if (!file) {
+    return AMDCUID_STATUS_FILE_ERROR;
+  }
+
+  return AMDCUID_STATUS_SUCCESS;
 }
 
 bool AcpiParser::validate_checksum(const uint8_t* data, size_t length) {
-    if (!data || length < sizeof(AcpiTableHeader)) {
-        return false;
-    }
-    
-    uint8_t sum = 0;
-    for (size_t i = 0; i < length; i++) {
-        sum += data[i];
-    }
-    
-    return sum == 0;
+  if (!data || length < sizeof(AcpiTableHeader)) {
+    return false;
+  }
+
+  uint8_t sum = 0;
+  for (size_t i = 0; i < length; i++) {
+    sum += data[i];
+  }
+
+  return sum == 0;
 }
 
 bool AcpiParser::parse_madt_entry(const uint8_t* entry, AcpiCpuInfo& cpu_info) {
-    const MadtEntryHeader* header = reinterpret_cast<const MadtEntryHeader*>(entry);
-    
-    if (header->type == MADT_TYPE_LOCAL_APIC) {
-        if (header->length < sizeof(MadtLocalApic)) {
-            return false;
-        }
-        
-        const MadtLocalApic* apic = reinterpret_cast<const MadtLocalApic*>(entry);
-        
-        cpu_info.apic_id = apic->apic_id;
-        cpu_info.processor_uid = apic->acpi_processor_uid;
-        cpu_info.enabled = (apic->flags & MADT_FLAG_ENABLED) != 0;
-        cpu_info.is_x2apic = false;
-        
-        return true;
+  const MadtEntryHeader* header = reinterpret_cast<const MadtEntryHeader*>(entry);
+
+  if (header->type == MADT_TYPE_LOCAL_APIC) {
+    if (header->length < sizeof(MadtLocalApic)) {
+      return false;
     }
-    else if (header->type == MADT_TYPE_LOCAL_X2APIC) {
-        if (header->length < sizeof(MadtLocalX2Apic)) {
-            return false;
-        }
-        
-        const MadtLocalX2Apic* x2apic = reinterpret_cast<const MadtLocalX2Apic*>(entry);
-        
-        cpu_info.apic_id = x2apic->x2apic_id;
-        cpu_info.processor_uid = x2apic->acpi_processor_uid;
-        cpu_info.enabled = (x2apic->flags & MADT_FLAG_ENABLED) != 0;
-        cpu_info.is_x2apic = true;
-        
-        return true;
+
+    const MadtLocalApic* apic = reinterpret_cast<const MadtLocalApic*>(entry);
+
+    cpu_info.apic_id = apic->apic_id;
+    cpu_info.processor_uid = apic->acpi_processor_uid;
+    cpu_info.enabled = (apic->flags & MADT_FLAG_ENABLED) != 0;
+    cpu_info.is_x2apic = false;
+
+    return true;
+  } else if (header->type == MADT_TYPE_LOCAL_X2APIC) {
+    if (header->length < sizeof(MadtLocalX2Apic)) {
+      return false;
     }
-    
-    return false;
+
+    const MadtLocalX2Apic* x2apic = reinterpret_cast<const MadtLocalX2Apic*>(entry);
+
+    cpu_info.apic_id = x2apic->x2apic_id;
+    cpu_info.processor_uid = x2apic->acpi_processor_uid;
+    cpu_info.enabled = (x2apic->flags & MADT_FLAG_ENABLED) != 0;
+    cpu_info.is_x2apic = true;
+
+    return true;
+  }
+
+  return false;
 }
 
 amdcuid_status_t AcpiParser::parse_madt(std::vector<AcpiCpuInfo>& cpu_info) {
-    cpu_info.clear();
-    
-    // Read MADT/APIC table
-    std::vector<uint8_t> table_data;
-    amdcuid_status_t status = read_acpi_table("APIC", table_data);
-    if (status != AMDCUID_STATUS_SUCCESS) {
-        return status;
+  cpu_info.clear();
+
+  // Read MADT/APIC table
+  std::vector<uint8_t> table_data;
+  amdcuid_status_t status = read_acpi_table("APIC", table_data);
+  if (status != AMDCUID_STATUS_SUCCESS) {
+    return status;
+  }
+
+  // Validate minimum size
+  if (table_data.size() < sizeof(MadtHeader)) {
+    return AMDCUID_STATUS_INVALID_FORMAT;
+  }
+
+  const MadtHeader* madt = reinterpret_cast<const MadtHeader*>(table_data.data());
+
+  // Validate signature
+  if (std::memcmp(madt->header.signature, "APIC", 4) != 0) {
+    return AMDCUID_STATUS_INVALID_FORMAT;
+  }
+
+  // Validate table length
+  if (madt->header.length != table_data.size()) {
+    return AMDCUID_STATUS_INVALID_FORMAT;
+  }
+
+  // Validate checksum
+  if (!validate_checksum(table_data.data(), madt->header.length)) {
+    return AMDCUID_STATUS_INVALID_FORMAT;
+  }
+
+  // Parse interrupt controller structures
+  const uint8_t* entry = table_data.data() + sizeof(MadtHeader);
+  const uint8_t* end = table_data.data() + madt->header.length;
+
+  while (entry < end) {
+    const MadtEntryHeader* header = reinterpret_cast<const MadtEntryHeader*>(entry);
+
+    // Validate entry doesn't overflow table
+    if (entry + header->length > end || header->length < sizeof(MadtEntryHeader)) {
+      return AMDCUID_STATUS_INVALID_FORMAT;
     }
-    
-    // Validate minimum size
-    if (table_data.size() < sizeof(MadtHeader)) {
-        return AMDCUID_STATUS_INVALID_FORMAT;
+
+    // Parse Local APIC or x2APIC entries
+    AcpiCpuInfo info;
+    if (parse_madt_entry(entry, info)) {
+      cpu_info.push_back(info);
     }
-    
-    const MadtHeader* madt = reinterpret_cast<const MadtHeader*>(table_data.data());
-    
-    // Validate signature
-    if (std::memcmp(madt->header.signature, "APIC", 4) != 0) {
-        return AMDCUID_STATUS_INVALID_FORMAT;
-    }
-    
-    // Validate table length
-    if (madt->header.length != table_data.size()) {
-        return AMDCUID_STATUS_INVALID_FORMAT;
-    }
-    
-    // Validate checksum
-    if (!validate_checksum(table_data.data(), madt->header.length)) {
-        return AMDCUID_STATUS_INVALID_FORMAT;
-    }
-    
-    // Parse interrupt controller structures
-    const uint8_t* entry = table_data.data() + sizeof(MadtHeader);
-    const uint8_t* end = table_data.data() + madt->header.length;
-    
-    while (entry < end) {
-        const MadtEntryHeader* header = reinterpret_cast<const MadtEntryHeader*>(entry);
-        
-        // Validate entry doesn't overflow table
-        if (entry + header->length > end || header->length < sizeof(MadtEntryHeader)) {
-            return AMDCUID_STATUS_INVALID_FORMAT;
-        }
-        
-        // Parse Local APIC or x2APIC entries
-        AcpiCpuInfo info;
-        if (parse_madt_entry(entry, info)) {
-            cpu_info.push_back(info);
-        }
-        
-        entry += header->length;
-    }
-    
-    // Should have found at least one CPU
-    if (cpu_info.empty()) {
-        return AMDCUID_STATUS_DEVICE_NOT_FOUND;
-    }
-    
-    return AMDCUID_STATUS_SUCCESS;
+
+    entry += header->length;
+  }
+
+  // Should have found at least one CPU
+  if (cpu_info.empty()) {
+    return AMDCUID_STATUS_DEVICE_NOT_FOUND;
+  }
+
+  return AMDCUID_STATUS_SUCCESS;
 }
 
 amdcuid_status_t AcpiParser::get_cpu_count(uint32_t& count) {
-    std::vector<AcpiCpuInfo> cpu_info;
-    amdcuid_status_t status = parse_madt(cpu_info);
-    
-    if (status != AMDCUID_STATUS_SUCCESS) {
-        count = 0;
-        return status;
-    }
-    
-    // Count only enabled CPUs
+  std::vector<AcpiCpuInfo> cpu_info;
+  amdcuid_status_t status = parse_madt(cpu_info);
+
+  if (status != AMDCUID_STATUS_SUCCESS) {
     count = 0;
-    for (const auto& info : cpu_info) {
-        if (info.enabled) {
-            count++;
-        }
+    return status;
+  }
+
+  // Count only enabled CPUs
+  count = 0;
+  for (const auto& info : cpu_info) {
+    if (info.enabled) {
+      count++;
     }
-    
-    return AMDCUID_STATUS_SUCCESS;
+  }
+
+  return AMDCUID_STATUS_SUCCESS;
 }

--- a/projects/cuid/lib/src/acpi_parser.h
+++ b/projects/cuid/lib/src/acpi_parser.h
@@ -4,22 +4,23 @@
 #ifndef ACPI_PARSER_H
 #define ACPI_PARSER_H
 
-#include "include/amd_cuid.h"
 #include <cstdint>
 #include <string>
 #include <vector>
 
+#include "include/amd_cuid.h"
+
 /**
  * @file acpi_parser.h
  * @brief ACPI table parser for extracting CPU identification information
- * 
+ *
  * Parses binary ACPI tables (MADT/APIC, DSDT) to extract processor-specific
  * identifiers like APIC IDs and processor UIDs needed for CPU CUID generation.
- * 
+ *
  * ACPI tables parsed:
  * - MADT (Multiple APIC Description Table): Contains Local APIC entries with APIC IDs
  * - DSDT (Differentiated System Description Table): Contains Processor objects with _UID
- * 
+ *
  * References:
  * - ACPI Specification 6.5: https://uefi.org/specs/ACPI/6.5/
  * - MADT format: Section 5.2.12
@@ -30,129 +31,129 @@
  * @brief Standard ACPI table header (common to all ACPI tables)
  */
 struct AcpiTableHeader {
-    char signature[4];      ///< Table signature (e.g., "APIC", "DSDT")
-    uint32_t length;        ///< Total table length including header
-    uint8_t revision;       ///< Table revision
-    uint8_t checksum;       ///< Checksum of entire table (must sum to 0)
-    char oem_id[6];         ///< OEM identification
-    char oem_table_id[8];   ///< OEM table identifier
-    uint32_t oem_revision;  ///< OEM revision
-    char creator_id[4];     ///< Creator utility ID
-    uint32_t creator_revision; ///< Creator utility revision
+  char signature[4];          ///< Table signature (e.g., "APIC", "DSDT")
+  uint32_t length;            ///< Total table length including header
+  uint8_t revision;           ///< Table revision
+  uint8_t checksum;           ///< Checksum of entire table (must sum to 0)
+  char oem_id[6];             ///< OEM identification
+  char oem_table_id[8];       ///< OEM table identifier
+  uint32_t oem_revision;      ///< OEM revision
+  char creator_id[4];         ///< Creator utility ID
+  uint32_t creator_revision;  ///< Creator utility revision
 } __attribute__((packed));
 
 /**
  * @brief MADT (Multiple APIC Description Table) header
  */
 struct MadtHeader {
-    AcpiTableHeader header;
-    uint32_t local_apic_address; ///< Physical address of local APIC
-    uint32_t flags;              ///< Multiple APIC flags
+  AcpiTableHeader header;
+  uint32_t local_apic_address;  ///< Physical address of local APIC
+  uint32_t flags;               ///< Multiple APIC flags
 } __attribute__((packed));
 
 /**
  * @brief MADT interrupt controller structure header
  */
 struct MadtEntryHeader {
-    uint8_t type;   ///< Entry type (0 = Local APIC, 9 = Local x2APIC, etc.)
-    uint8_t length; ///< Entry length including header
+  uint8_t type;    ///< Entry type (0 = Local APIC, 9 = Local x2APIC, etc.)
+  uint8_t length;  ///< Entry length including header
 } __attribute__((packed));
 
 /**
  * @brief MADT Local APIC entry (type 0)
  */
 struct MadtLocalApic {
-    MadtEntryHeader header;
-    uint8_t acpi_processor_uid; ///< ACPI Processor UID
-    uint8_t apic_id;            ///< Local APIC ID
-    uint32_t flags;             ///< Flags (bit 0: enabled, bit 1: online capable)
+  MadtEntryHeader header;
+  uint8_t acpi_processor_uid;  ///< ACPI Processor UID
+  uint8_t apic_id;             ///< Local APIC ID
+  uint32_t flags;              ///< Flags (bit 0: enabled, bit 1: online capable)
 } __attribute__((packed));
 
 /**
  * @brief MADT Local x2APIC entry (type 9)
  */
 struct MadtLocalX2Apic {
-    MadtEntryHeader header;
-    uint16_t reserved;          ///< Reserved (must be zero)
-    uint32_t x2apic_id;         ///< x2APIC ID
-    uint32_t flags;             ///< Flags (bit 0: enabled, bit 1: online capable)
-    uint32_t acpi_processor_uid; ///< ACPI Processor UID
+  MadtEntryHeader header;
+  uint16_t reserved;            ///< Reserved (must be zero)
+  uint32_t x2apic_id;           ///< x2APIC ID
+  uint32_t flags;               ///< Flags (bit 0: enabled, bit 1: online capable)
+  uint32_t acpi_processor_uid;  ///< ACPI Processor UID
 } __attribute__((packed));
 
 /**
  * @brief CPU identification information from ACPI
  */
 struct AcpiCpuInfo {
-    uint32_t apic_id;           ///< Local APIC or x2APIC ID
-    uint32_t processor_uid;     ///< ACPI Processor UID
-    bool enabled;               ///< CPU is enabled
-    bool is_x2apic;            ///< Uses x2APIC (vs legacy APIC)
+  uint32_t apic_id;        ///< Local APIC or x2APIC ID
+  uint32_t processor_uid;  ///< ACPI Processor UID
+  bool enabled;            ///< CPU is enabled
+  bool is_x2apic;          ///< Uses x2APIC (vs legacy APIC)
 };
 
 /**
  * @brief ACPI table parser for CPU identification
  */
 class AcpiParser {
-public:
-    /**
-     * @brief Parse MADT table to extract CPU APIC IDs and processor UIDs
-     * 
-     * Reads and parses the MADT (Multiple APIC Description Table) from
-     * /sys/firmware/acpi/tables/APIC to extract Local APIC and x2APIC entries.
-     * 
-     * Each entry contains:
-     * - APIC ID: Hardware identifier for the CPU's local APIC
-     * - Processor UID: ACPI processor unique identifier
-     * - Flags: Whether CPU is enabled/online
-     * 
-     * @param cpu_info Output vector of CPU information structures
-     * @return AMDCUID_STATUS_SUCCESS on success
-     *         AMDCUID_STATUS_ACPI_ERROR if MADT table doesn't exist
-     *         AMDCUID_STATUS_PERMISSION_DENIED if access denied (need root)
-     *         AMDCUID_STATUS_INVALID_FORMAT if table format is invalid
-     */
-    static amdcuid_status_t parse_madt(std::vector<AcpiCpuInfo>& cpu_info);
+ public:
+  /**
+   * @brief Parse MADT table to extract CPU APIC IDs and processor UIDs
+   *
+   * Reads and parses the MADT (Multiple APIC Description Table) from
+   * /sys/firmware/acpi/tables/APIC to extract Local APIC and x2APIC entries.
+   *
+   * Each entry contains:
+   * - APIC ID: Hardware identifier for the CPU's local APIC
+   * - Processor UID: ACPI processor unique identifier
+   * - Flags: Whether CPU is enabled/online
+   *
+   * @param cpu_info Output vector of CPU information structures
+   * @return AMDCUID_STATUS_SUCCESS on success
+   *         AMDCUID_STATUS_ACPI_ERROR if MADT table doesn't exist
+   *         AMDCUID_STATUS_PERMISSION_DENIED if access denied (need root)
+   *         AMDCUID_STATUS_INVALID_FORMAT if table format is invalid
+   */
+  static amdcuid_status_t parse_madt(std::vector<AcpiCpuInfo>& cpu_info);
 
-    /**
-     * @brief Validate ACPI table header checksum
-     * 
-     * Verifies that the sum of all bytes in the table equals zero (mod 256).
-     * This is the standard ACPI checksum validation.
-     * 
-     * @param data Pointer to table data
-     * @param length Table length in bytes
-     * @return true if checksum is valid, false otherwise
-     */
-    static bool validate_checksum(const uint8_t* data, size_t length);
+  /**
+   * @brief Validate ACPI table header checksum
+   *
+   * Verifies that the sum of all bytes in the table equals zero (mod 256).
+   * This is the standard ACPI checksum validation.
+   *
+   * @param data Pointer to table data
+   * @param length Table length in bytes
+   * @return true if checksum is valid, false otherwise
+   */
+  static bool validate_checksum(const uint8_t* data, size_t length);
 
-    /**
-     * @brief Get CPU count from MADT
-     * 
-     * Quick function to count enabled CPUs without full parsing.
-     * 
-     * @param count Output for CPU count
-     * @return AMDCUID_STATUS_SUCCESS on success
-     */
-    static amdcuid_status_t get_cpu_count(uint32_t& count);
+  /**
+   * @brief Get CPU count from MADT
+   *
+   * Quick function to count enabled CPUs without full parsing.
+   *
+   * @param count Output for CPU count
+   * @return AMDCUID_STATUS_SUCCESS on success
+   */
+  static amdcuid_status_t get_cpu_count(uint32_t& count);
 
-private:
-    /**
-     * @brief Read ACPI table from sysfs
-     * 
-     * @param table_name Name of table (e.g., "APIC", "DSDT")
-     * @param data Output buffer for table data
-     * @return AMDCUID_STATUS_SUCCESS on success
-     */
-    static amdcuid_status_t read_acpi_table(const char* table_name, std::vector<uint8_t>& data);
+ private:
+  /**
+   * @brief Read ACPI table from sysfs
+   *
+   * @param table_name Name of table (e.g., "APIC", "DSDT")
+   * @param data Output buffer for table data
+   * @return AMDCUID_STATUS_SUCCESS on success
+   */
+  static amdcuid_status_t read_acpi_table(const char* table_name, std::vector<uint8_t>& data);
 
-    /**
-     * @brief Parse individual MADT entry
-     * 
-     * @param entry Pointer to entry data
-     * @param cpu_info Output CPU info if entry is Local APIC or x2APIC
-     * @return true if entry was parsed successfully
-     */
-    static bool parse_madt_entry(const uint8_t* entry, AcpiCpuInfo& cpu_info);
+  /**
+   * @brief Parse individual MADT entry
+   *
+   * @param entry Pointer to entry data
+   * @param cpu_info Output CPU info if entry is Local APIC or x2APIC
+   * @return true if entry was parsed successfully
+   */
+  static bool parse_madt_entry(const uint8_t* entry, AcpiCpuInfo& cpu_info);
 };
 
-#endif // ACPI_PARSER_H
+#endif  // ACPI_PARSER_H

--- a/projects/cuid/lib/src/cuid.cc
+++ b/projects/cuid/lib/src/cuid.cc
@@ -1,6 +1,19 @@
 // Copyright Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
+#include <dirent.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <climits>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <mutex>
+#include <sstream>
+#include <vector>
+
 #include "include/amd_cuid.h"
 #include "src/cuid_cpu.h"
 #include "src/cuid_device.h"
@@ -12,95 +25,78 @@
 #include "src/cuid_platform.h"
 #include "src/cuid_util.h"
 #include "src/hmac.h"
-#include <climits>
-#include <cstring>
-#include <dirent.h>
-#include <fcntl.h>
-#include <fstream>
-#include <iostream>
-#include <mutex>
-#include <sstream>
-#include <sys/types.h>
-#include <unistd.h>
-#include <vector>
 
 // Static instance for API
-static CuidDeviceManager &mgr = CuidDeviceManager::instance();
+static CuidDeviceManager& mgr = CuidDeviceManager::instance();
 static cuid_hmac global_hmac = cuid_hmac();
 
-void amdcuid_get_library_version(uint32_t *major, uint32_t *minor,
-                                 uint32_t *patch) {
-  if (major)
-    *major = AMDCUID_LIB_VERSION_MAJOR;
-  if (minor)
-    *minor = AMDCUID_LIB_VERSION_MINOR;
-  if (patch)
-    *patch = AMDCUID_LIB_VERSION_PATCH;
+void amdcuid_get_library_version(uint32_t* major, uint32_t* minor, uint32_t* patch) {
+  if (major) *major = AMDCUID_LIB_VERSION_MAJOR;
+  if (minor) *minor = AMDCUID_LIB_VERSION_MINOR;
+  if (patch) *patch = AMDCUID_LIB_VERSION_PATCH;
 }
 
-const char *amdcuid_library_version_to_string() {
-  static std::string version_str =
-      std::to_string(AMDCUID_LIB_VERSION_MAJOR) + "." +
-      std::to_string(AMDCUID_LIB_VERSION_MINOR) + "." +
-      std::to_string(AMDCUID_LIB_VERSION_PATCH);
+const char* amdcuid_library_version_to_string() {
+  static std::string version_str = std::to_string(AMDCUID_LIB_VERSION_MAJOR) + "." +
+                                   std::to_string(AMDCUID_LIB_VERSION_MINOR) + "." +
+                                   std::to_string(AMDCUID_LIB_VERSION_PATCH);
   return version_str.c_str();
 }
 
-const char *amdcuid_status_to_string(amdcuid_status_t status) {
+const char* amdcuid_status_to_string(amdcuid_status_t status) {
   switch (status) {
-  case AMDCUID_STATUS_SUCCESS:
-    return "SUCCESS";
-  case AMDCUID_STATUS_FILE_NOT_FOUND:
-    return "FILE_NOT_FOUND";
-  case AMDCUID_STATUS_DEVICE_NOT_FOUND:
-    return "DEVICE_NOT_FOUND";
-  case AMDCUID_STATUS_INVALID_ARGUMENT:
-    return "INVALID_ARGUMENT";
-  case AMDCUID_STATUS_PERMISSION_DENIED:
-    return "PERMISSION_DENIED";
-  case AMDCUID_STATUS_UNSUPPORTED:
-    return "UNSUPPORTED";
-  case AMDCUID_STATUS_WRONG_DEVICE_TYPE:
-    return "WRONG_DEVICE_TYPE";
-  case AMDCUID_STATUS_INSUFFICIENT_SIZE:
-    return "INSUFFICIENT_SIZE";
-  case AMDCUID_STATUS_HW_FINGERPRINT_NOT_FOUND:
-    return "HARDWARE_FINGERPRINT_NOT_FOUND";
-  case AMDCUID_STATUS_KEY_ERROR:
-    return "KEY_ERROR";
-  case AMDCUID_STATUS_HMAC_ERROR:
-    return "HMAC_ERROR";
-  case AMDCUID_STATUS_FILE_ERROR:
-    return "FILE_ERROR";
-  case AMDCUID_STATUS_INVALID_FORMAT:
-    return "INVALID_FORMAT";
-  case AMDCUID_STATUS_PCI_ERROR:
-    return "PCI_ERROR";
-  case AMDCUID_STATUS_SMBIOS_ERROR:
-    return "SMBIOS_ERROR";
-  case AMDCUID_STATUS_ACPI_ERROR:
-    return "ACPI_ERROR";
-  case AMDCUID_STATUS_CPUINFO_ERROR:
-    return "CPUINFO_ERROR";
-  case AMDCUID_STATUS_IPC_ERROR:
-    return "IPC_ERROR";
-  default:
-    return "UNKNOWN_ERROR";
+    case AMDCUID_STATUS_SUCCESS:
+      return "SUCCESS";
+    case AMDCUID_STATUS_FILE_NOT_FOUND:
+      return "FILE_NOT_FOUND";
+    case AMDCUID_STATUS_DEVICE_NOT_FOUND:
+      return "DEVICE_NOT_FOUND";
+    case AMDCUID_STATUS_INVALID_ARGUMENT:
+      return "INVALID_ARGUMENT";
+    case AMDCUID_STATUS_PERMISSION_DENIED:
+      return "PERMISSION_DENIED";
+    case AMDCUID_STATUS_UNSUPPORTED:
+      return "UNSUPPORTED";
+    case AMDCUID_STATUS_WRONG_DEVICE_TYPE:
+      return "WRONG_DEVICE_TYPE";
+    case AMDCUID_STATUS_INSUFFICIENT_SIZE:
+      return "INSUFFICIENT_SIZE";
+    case AMDCUID_STATUS_HW_FINGERPRINT_NOT_FOUND:
+      return "HARDWARE_FINGERPRINT_NOT_FOUND";
+    case AMDCUID_STATUS_KEY_ERROR:
+      return "KEY_ERROR";
+    case AMDCUID_STATUS_HMAC_ERROR:
+      return "HMAC_ERROR";
+    case AMDCUID_STATUS_FILE_ERROR:
+      return "FILE_ERROR";
+    case AMDCUID_STATUS_INVALID_FORMAT:
+      return "INVALID_FORMAT";
+    case AMDCUID_STATUS_PCI_ERROR:
+      return "PCI_ERROR";
+    case AMDCUID_STATUS_SMBIOS_ERROR:
+      return "SMBIOS_ERROR";
+    case AMDCUID_STATUS_ACPI_ERROR:
+      return "ACPI_ERROR";
+    case AMDCUID_STATUS_CPUINFO_ERROR:
+      return "CPUINFO_ERROR";
+    case AMDCUID_STATUS_IPC_ERROR:
+      return "IPC_ERROR";
+    default:
+      return "UNKNOWN_ERROR";
   }
 }
 
-const char *amdcuid_id_to_string(amdcuid_id_t cuid_value) {
+const char* amdcuid_id_to_string(amdcuid_id_t cuid_value) {
   // Use thread_local static buffer to avoid returning dangling pointer from
   // temporary string
-  thread_local static char uuid_str[37]; // 36 chars + null terminator
+  thread_local static char uuid_str[37];  // 36 chars + null terminator
   std::string result = CuidUtilities::get_cuid_as_string(&cuid_value);
   std::strncpy(uuid_str, result.c_str(), sizeof(uuid_str) - 1);
   uuid_str[sizeof(uuid_str) - 1] = '\0';
   return uuid_str;
 }
 
-amdcuid_status_t amdcuid_get_all_handles(amdcuid_id_t *handles,
-                                         uint32_t *count) {
+amdcuid_status_t amdcuid_get_all_handles(amdcuid_id_t* handles, uint32_t* count) {
   amdcuid_status_t status;
   // get all the devices on the system first
   if (mgr.devices().empty()) {
@@ -132,8 +128,7 @@ amdcuid_status_t amdcuid_get_all_handles(amdcuid_id_t *handles,
 }
 
 // helper function to discover device given dev_path
-DevicePtr discover_device_by_path(const char *dev_path,
-                                  amdcuid_device_type_t device_type) {
+DevicePtr discover_device_by_path(const char* dev_path, amdcuid_device_type_t device_type) {
   DevicePtr device = nullptr;
   amdcuid_status_t status;
 
@@ -191,43 +186,42 @@ DevicePtr discover_device_by_path(const char *dev_path,
     return nullptr;
   }
   switch (device_type) {
-  case AMDCUID_DEVICE_TYPE_GPU: {
-    amdcuid_gpu_info gpu_info = {};
-    status = CuidGpu::discover_single(&gpu_info, real_dev_path);
-    if (status != AMDCUID_STATUS_SUCCESS) {
-      return nullptr;
+    case AMDCUID_DEVICE_TYPE_GPU: {
+      amdcuid_gpu_info gpu_info = {};
+      status = CuidGpu::discover_single(&gpu_info, real_dev_path);
+      if (status != AMDCUID_STATUS_SUCCESS) {
+        return nullptr;
+      }
+      device = std::make_shared<CuidGpu>(gpu_info);
+      break;
     }
-    device = std::make_shared<CuidGpu>(gpu_info);
-    break;
-  }
-  case AMDCUID_DEVICE_TYPE_NIC: {
-    amdcuid_nic_info nic_info = {};
-    status = CuidNic::discover_single(&nic_info, real_dev_path);
-    if (status != AMDCUID_STATUS_SUCCESS) {
-      return nullptr;
+    case AMDCUID_DEVICE_TYPE_NIC: {
+      amdcuid_nic_info nic_info = {};
+      status = CuidNic::discover_single(&nic_info, real_dev_path);
+      if (status != AMDCUID_STATUS_SUCCESS) {
+        return nullptr;
+      }
+      device = std::make_shared<CuidNic>(nic_info);
+      break;
     }
-    device = std::make_shared<CuidNic>(nic_info);
-    break;
-  }
-  case AMDCUID_DEVICE_TYPE_NPU: {
-    amdcuid_npu_info npu_info = {};
-    status = CuidNpu::discover_single(&npu_info, real_dev_path);
-    if (status != AMDCUID_STATUS_SUCCESS) {
-      return nullptr;
+    case AMDCUID_DEVICE_TYPE_NPU: {
+      amdcuid_npu_info npu_info = {};
+      status = CuidNpu::discover_single(&npu_info, real_dev_path);
+      if (status != AMDCUID_STATUS_SUCCESS) {
+        return nullptr;
+      }
+      device = std::make_shared<CuidNpu>(npu_info);
+      break;
     }
-    device = std::make_shared<CuidNpu>(npu_info);
-    break;
-  }
-  default:
-    return nullptr;
+    default:
+      return nullptr;
   }
   return device;
 }
 
-amdcuid_status_t
-amdcuid_get_handle_by_dev_path(const char *dev_path,
-                               amdcuid_device_type_t device_type,
-                               amdcuid_id_t *handle) {
+amdcuid_status_t amdcuid_get_handle_by_dev_path(const char* dev_path,
+                                                amdcuid_device_type_t device_type,
+                                                amdcuid_id_t* handle) {
   if (!dev_path || !handle) {
     return AMDCUID_STATUS_INVALID_ARGUMENT;
   }
@@ -242,10 +236,8 @@ amdcuid_get_handle_by_dev_path(const char *dev_path,
   // CPU and Platform sysfs paths are directories without a /device
   // subdirectory, so the /device suffix would produce an invalid path.
   std::string dev_path_str(dev_path);
-  if (device_type == AMDCUID_DEVICE_TYPE_NIC ||
-      device_type == AMDCUID_DEVICE_TYPE_GPU ||
-      device_type == AMDCUID_DEVICE_TYPE_CPU ||
-      device_type == AMDCUID_DEVICE_TYPE_PLATFORM ||
+  if (device_type == AMDCUID_DEVICE_TYPE_NIC || device_type == AMDCUID_DEVICE_TYPE_GPU ||
+      device_type == AMDCUID_DEVICE_TYPE_CPU || device_type == AMDCUID_DEVICE_TYPE_PLATFORM ||
       device_type == AMDCUID_DEVICE_TYPE_NPU ||
       dev_path_str.find("/sys/class/net/") != std::string::npos ||
       dev_path_str.find("/sys/class/drm/") != std::string::npos ||
@@ -259,7 +251,7 @@ amdcuid_get_handle_by_dev_path(const char *dev_path,
 
   amdcuid_status_t status;
   // check mgr first to see if device is already known
-  for (const auto &device : mgr.devices()) {
+  for (const auto& device : mgr.devices()) {
     std::string device_path;
     status = device->get_device_path(device_path);
     if (status != AMDCUID_STATUS_SUCCESS) {
@@ -318,20 +310,18 @@ amdcuid_get_handle_by_dev_path(const char *dev_path,
   }
 }
 
-amdcuid_status_t amdcuid_get_handle_by_bdf(const char *bdf,
-                                           amdcuid_device_type_t device_type,
-                                           amdcuid_id_t *handle) {
+amdcuid_status_t amdcuid_get_handle_by_bdf(const char* bdf, amdcuid_device_type_t device_type,
+                                           amdcuid_id_t* handle) {
   if (!bdf || !handle) {
     return AMDCUID_STATUS_INVALID_ARGUMENT;
   }
 
-  if (device_type == AMDCUID_DEVICE_TYPE_CPU ||
-      device_type == AMDCUID_DEVICE_TYPE_PLATFORM) {
+  if (device_type == AMDCUID_DEVICE_TYPE_CPU || device_type == AMDCUID_DEVICE_TYPE_PLATFORM) {
     return AMDCUID_STATUS_WRONG_DEVICE_TYPE;
   }
 
   // check mgr first to see if device is already known
-  for (const auto &device : mgr.devices()) {
+  for (const auto& device : mgr.devices()) {
     std::string device_bdf;
     amdcuid_status_t status = device->get_bdf(device_bdf);
     if (status != AMDCUID_STATUS_SUCCESS) {
@@ -372,8 +362,7 @@ amdcuid_status_t amdcuid_get_handle_by_bdf(const char *bdf,
   // of symlink for more reliable matching. NPU paths from bdf_to_device_path
   // may be PCI device directories (not char/block devices), so the fd-based
   // real path resolution would fail.
-  if ((device_type != AMDCUID_DEVICE_TYPE_NIC ||
-       device_path.find("net") == std::string::npos) &&
+  if ((device_type != AMDCUID_DEVICE_TYPE_NIC || device_path.find("net") == std::string::npos) &&
       device_type != AMDCUID_DEVICE_TYPE_NPU) {
     int fd = open(device_path.c_str(), O_RDONLY);
     if (fd < 0) {
@@ -408,15 +397,13 @@ amdcuid_status_t amdcuid_get_handle_by_bdf(const char *bdf,
   }
 }
 
-amdcuid_status_t amdcuid_get_handle_by_fd(int fd,
-                                          amdcuid_device_type_t device_type,
-                                          amdcuid_id_t *handle) {
+amdcuid_status_t amdcuid_get_handle_by_fd(int fd, amdcuid_device_type_t device_type,
+                                          amdcuid_id_t* handle) {
   if (fd < 0 || !handle) {
     return AMDCUID_STATUS_INVALID_ARGUMENT;
   }
 
-  if (device_type == AMDCUID_DEVICE_TYPE_CPU ||
-      device_type == AMDCUID_DEVICE_TYPE_PLATFORM ||
+  if (device_type == AMDCUID_DEVICE_TYPE_CPU || device_type == AMDCUID_DEVICE_TYPE_PLATFORM ||
       device_type == AMDCUID_DEVICE_TYPE_NIC) {
     return AMDCUID_STATUS_WRONG_DEVICE_TYPE;
   }
@@ -425,8 +412,7 @@ amdcuid_status_t amdcuid_get_handle_by_fd(int fd,
   if (device_path.empty()) {
     return AMDCUID_STATUS_DEVICE_NOT_FOUND;
   }
-  return amdcuid_get_handle_by_dev_path(device_path.c_str(), device_type,
-                                        handle);
+  return amdcuid_get_handle_by_dev_path(device_path.c_str(), device_type, handle);
 }
 
 amdcuid_status_t amdcuid_refresh() {
@@ -453,9 +439,8 @@ amdcuid_status_t amdcuid_refresh() {
   return status;
 }
 
-amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle,
-                                               amdcuid_query_t query,
-                                               void *data, uint32_t *length) {
+amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle, amdcuid_query_t query,
+                                               void* data, uint32_t* length) {
   if (!length) {
     return AMDCUID_STATUS_INVALID_ARGUMENT;
   }
@@ -465,214 +450,212 @@ amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle,
   }
   amdcuid_status_t status;
   switch (query) {
-  case AMDCUID_QUERY_PRIMARY_CUID: {
-    if (geteuid() != 0) {
-      return AMDCUID_STATUS_PERMISSION_DENIED;
-    }
-    if (*length < sizeof(amdcuid_id_t)) {
-      return AMDCUID_STATUS_INSUFFICIENT_SIZE;
-    }
-    amdcuid_primary_id id = {};
-    status = device->get_primary_cuid(id);
-    if (data != nullptr) {
-      std::memcpy(data, &id.UUIDv8_representation, sizeof(amdcuid_id_t));
-    }
-    *length = sizeof(amdcuid_id_t);
-  } break;
-  case AMDCUID_QUERY_DERIVED_CUID: {
-    if (*length < sizeof(amdcuid_id_t)) {
-      return AMDCUID_STATUS_INSUFFICIENT_SIZE;
-    }
-    amdcuid_derived_id sec_id = {};
-    if (geteuid() == 0) {
-      // if elevated, provide hmac in case it needs to get generated
-      status = device->get_derived_cuid(sec_id, &global_hmac);
-    } else {
-      // if not elevated, only get existing derived cuid
-      status = device->get_derived_cuid(sec_id);
-    }
-    if (data != nullptr) {
-      std::memcpy(data, &sec_id.UUIDv8_representation, sizeof(amdcuid_id_t));
-    }
-    *length = sizeof(amdcuid_id_t);
-  } break;
-  case AMDCUID_QUERY_HARDWARE_FINGERPRINT: {
-    if (geteuid() != 0) {
-      return AMDCUID_STATUS_PERMISSION_DENIED;
-    }
-    if (*length < sizeof(uint64_t)) {
-      return AMDCUID_STATUS_INSUFFICIENT_SIZE;
-    }
-    if (data != nullptr) {
-      std::memset(data, 0, sizeof(uint64_t));
-      status = device->get_hardware_fingerprint(*(uint64_t *)data);
-    }
-    *length = sizeof(uint64_t);
-  } break;
-  case AMDCUID_QUERY_DEVICE_PATH: {
-    std::string path;
-    status = device->get_device_path(path);
-    if (status != AMDCUID_STATUS_SUCCESS) {
-      break;
-    }
-    uint32_t required_length =
-        static_cast<uint32_t>(path.size() + 1); // include null terminator
-    if (*length < required_length) {
+    case AMDCUID_QUERY_PRIMARY_CUID: {
+      if (geteuid() != 0) {
+        return AMDCUID_STATUS_PERMISSION_DENIED;
+      }
+      if (*length < sizeof(amdcuid_id_t)) {
+        return AMDCUID_STATUS_INSUFFICIENT_SIZE;
+      }
+      amdcuid_primary_id id = {};
+      status = device->get_primary_cuid(id);
+      if (data != nullptr) {
+        std::memcpy(data, &id.UUIDv8_representation, sizeof(amdcuid_id_t));
+      }
+      *length = sizeof(amdcuid_id_t);
+    } break;
+    case AMDCUID_QUERY_DERIVED_CUID: {
+      if (*length < sizeof(amdcuid_id_t)) {
+        return AMDCUID_STATUS_INSUFFICIENT_SIZE;
+      }
+      amdcuid_derived_id sec_id = {};
+      if (geteuid() == 0) {
+        // if elevated, provide hmac in case it needs to get generated
+        status = device->get_derived_cuid(sec_id, &global_hmac);
+      } else {
+        // if not elevated, only get existing derived cuid
+        status = device->get_derived_cuid(sec_id);
+      }
+      if (data != nullptr) {
+        std::memcpy(data, &sec_id.UUIDv8_representation, sizeof(amdcuid_id_t));
+      }
+      *length = sizeof(amdcuid_id_t);
+    } break;
+    case AMDCUID_QUERY_HARDWARE_FINGERPRINT: {
+      if (geteuid() != 0) {
+        return AMDCUID_STATUS_PERMISSION_DENIED;
+      }
+      if (*length < sizeof(uint64_t)) {
+        return AMDCUID_STATUS_INSUFFICIENT_SIZE;
+      }
+      if (data != nullptr) {
+        std::memset(data, 0, sizeof(uint64_t));
+        status = device->get_hardware_fingerprint(*(uint64_t*)data);
+      }
+      *length = sizeof(uint64_t);
+    } break;
+    case AMDCUID_QUERY_DEVICE_PATH: {
+      std::string path;
+      status = device->get_device_path(path);
+      if (status != AMDCUID_STATUS_SUCCESS) {
+        break;
+      }
+      uint32_t required_length = static_cast<uint32_t>(path.size() + 1);  // include null terminator
+      if (*length < required_length) {
+        *length = required_length;
+        return AMDCUID_STATUS_INSUFFICIENT_SIZE;
+      }
+      if (data != nullptr) {
+        std::memcpy(data, path.c_str(), required_length);
+      }
       *length = required_length;
-      return AMDCUID_STATUS_INSUFFICIENT_SIZE;
-    }
-    if (data != nullptr) {
-      std::memcpy(data, path.c_str(), required_length);
-    }
-    *length = required_length;
-  } break;
-  case AMDCUID_QUERY_DEVICE_TYPE: {
-    if (*length < sizeof(amdcuid_device_type_t)) {
-      return AMDCUID_STATUS_INSUFFICIENT_SIZE;
-    }
-    if (data != nullptr) {
-      amdcuid_device_type_t device_type = device->type();
-      std::memcpy(data, &device_type, sizeof(amdcuid_device_type_t));
-    }
-    *length = sizeof(amdcuid_device_type_t);
-    status = AMDCUID_STATUS_SUCCESS;
-  } break;
-  case AMDCUID_QUERY_VENDOR_ID: {
-    if (*length < sizeof(uint16_t)) {
-      return AMDCUID_STATUS_INSUFFICIENT_SIZE;
-    }
-    if (data != nullptr) {
-      uint16_t vendor_id = 0;
-      status = device->get_vendor_id(vendor_id);
-      std::memcpy(data, &vendor_id, sizeof(uint16_t));
-    }
-    *length = sizeof(uint16_t);
-  } break;
-  case AMDCUID_QUERY_DEVICE_ID: {
-    if (*length < sizeof(uint16_t)) {
-      return AMDCUID_STATUS_INSUFFICIENT_SIZE;
-    }
-    if (data != nullptr) {
-      uint16_t device_id = 0;
-      status = device->get_device_id(device_id);
-      std::memcpy(data, &device_id, sizeof(uint16_t));
-    }
-    *length = sizeof(uint16_t);
-  } break;
-  case AMDCUID_QUERY_REVISION_ID: {
-    if (*length < sizeof(uint8_t)) {
-      return AMDCUID_STATUS_INSUFFICIENT_SIZE;
-    }
-    if (data != nullptr) {
-      uint8_t revision_id = 0;
-      status = device->get_revision_id(revision_id);
-      std::memcpy(data, &revision_id, sizeof(uint8_t));
-    }
-    *length = sizeof(uint8_t);
-  } break;
-  case AMDCUID_QUERY_UNIT_ID: {
-    if (*length < sizeof(uint16_t)) {
-      return AMDCUID_STATUS_INSUFFICIENT_SIZE;
-    }
-    if (data != nullptr) {
-      uint16_t unit_id = 0;
-      status = device->get_unit_id(unit_id);
-      std::memcpy(data, &unit_id, sizeof(uint16_t));
-    }
-    *length = sizeof(uint16_t);
-  } break;
-  case AMDCUID_QUERY_FAMILY: {
-    // only CPU devices will return a valid family
-    if (*length < sizeof(uint16_t)) {
-      return AMDCUID_STATUS_INSUFFICIENT_SIZE;
-    }
-    if (data != nullptr) {
-      uint16_t family = 0;
-      status = device->get_family(family);
-      std::memcpy(data, &family, sizeof(uint16_t));
-    }
-    *length = sizeof(uint16_t);
-  } break;
-  case AMDCUID_QUERY_MODEL: {
-    // only CPU devices will return a valid model
-    if (*length < sizeof(uint16_t)) {
-      return AMDCUID_STATUS_INSUFFICIENT_SIZE;
-    }
-    if (data != nullptr) {
-      uint16_t model = 0;
-      status = device->get_model(model);
-      std::memcpy(data, &model, sizeof(uint16_t));
-    }
-    *length = sizeof(uint16_t);
-  } break;
-  case AMDCUID_QUERY_CORE_ID: {
-    // only CPU devices will return a valid core ID
-    if (*length < sizeof(uint16_t)) {
-      return AMDCUID_STATUS_INSUFFICIENT_SIZE;
-    }
-    if (data != nullptr) {
-      uint16_t core = 0;
-      status = device->get_core(core);
-      std::memcpy(data, &core, sizeof(uint16_t));
-    }
-    *length = sizeof(uint16_t);
-  } break;
-  case AMDCUID_QUERY_PHYSICAL_ID: {
-    // only CPU devices will return a valid physical package ID
-    if (*length < sizeof(uint16_t)) {
-      return AMDCUID_STATUS_INSUFFICIENT_SIZE;
-    }
-    if (data != nullptr) {
-      uint16_t physical_id = 0;
-      status = device->get_physical_id(physical_id);
-      std::memcpy(data, &physical_id, sizeof(uint16_t));
-    }
-    *length = sizeof(uint16_t);
-  } break;
-  case AMDCUID_QUERY_PCI_CLASS: {
-    // only PCI devices (GPU, NIC) will return a valid PCI class
-    if (*length < sizeof(uint16_t)) {
-      return AMDCUID_STATUS_INSUFFICIENT_SIZE;
-    }
-    if (data != nullptr) {
-      uint16_t pci_class = 0;
-      status = device->get_pci_class(pci_class);
-      std::memcpy(data, &pci_class, sizeof(uint16_t));
-    }
-    *length = sizeof(uint16_t);
-  } break;
-  case AMDCUID_QUERY_BDF: {
-    // only PCI devices (GPU, NIC) will return a valid BDF
-    std::string bdf;
-    status = device->get_bdf(bdf);
-    if (status != AMDCUID_STATUS_SUCCESS) {
-      break;
-    }
-    uint32_t required_length =
-        static_cast<uint32_t>(bdf.size() + 1); // include null terminator
-    if (*length < required_length) {
+    } break;
+    case AMDCUID_QUERY_DEVICE_TYPE: {
+      if (*length < sizeof(amdcuid_device_type_t)) {
+        return AMDCUID_STATUS_INSUFFICIENT_SIZE;
+      }
+      if (data != nullptr) {
+        amdcuid_device_type_t device_type = device->type();
+        std::memcpy(data, &device_type, sizeof(amdcuid_device_type_t));
+      }
+      *length = sizeof(amdcuid_device_type_t);
+      status = AMDCUID_STATUS_SUCCESS;
+    } break;
+    case AMDCUID_QUERY_VENDOR_ID: {
+      if (*length < sizeof(uint16_t)) {
+        return AMDCUID_STATUS_INSUFFICIENT_SIZE;
+      }
+      if (data != nullptr) {
+        uint16_t vendor_id = 0;
+        status = device->get_vendor_id(vendor_id);
+        std::memcpy(data, &vendor_id, sizeof(uint16_t));
+      }
+      *length = sizeof(uint16_t);
+    } break;
+    case AMDCUID_QUERY_DEVICE_ID: {
+      if (*length < sizeof(uint16_t)) {
+        return AMDCUID_STATUS_INSUFFICIENT_SIZE;
+      }
+      if (data != nullptr) {
+        uint16_t device_id = 0;
+        status = device->get_device_id(device_id);
+        std::memcpy(data, &device_id, sizeof(uint16_t));
+      }
+      *length = sizeof(uint16_t);
+    } break;
+    case AMDCUID_QUERY_REVISION_ID: {
+      if (*length < sizeof(uint8_t)) {
+        return AMDCUID_STATUS_INSUFFICIENT_SIZE;
+      }
+      if (data != nullptr) {
+        uint8_t revision_id = 0;
+        status = device->get_revision_id(revision_id);
+        std::memcpy(data, &revision_id, sizeof(uint8_t));
+      }
+      *length = sizeof(uint8_t);
+    } break;
+    case AMDCUID_QUERY_UNIT_ID: {
+      if (*length < sizeof(uint16_t)) {
+        return AMDCUID_STATUS_INSUFFICIENT_SIZE;
+      }
+      if (data != nullptr) {
+        uint16_t unit_id = 0;
+        status = device->get_unit_id(unit_id);
+        std::memcpy(data, &unit_id, sizeof(uint16_t));
+      }
+      *length = sizeof(uint16_t);
+    } break;
+    case AMDCUID_QUERY_FAMILY: {
+      // only CPU devices will return a valid family
+      if (*length < sizeof(uint16_t)) {
+        return AMDCUID_STATUS_INSUFFICIENT_SIZE;
+      }
+      if (data != nullptr) {
+        uint16_t family = 0;
+        status = device->get_family(family);
+        std::memcpy(data, &family, sizeof(uint16_t));
+      }
+      *length = sizeof(uint16_t);
+    } break;
+    case AMDCUID_QUERY_MODEL: {
+      // only CPU devices will return a valid model
+      if (*length < sizeof(uint16_t)) {
+        return AMDCUID_STATUS_INSUFFICIENT_SIZE;
+      }
+      if (data != nullptr) {
+        uint16_t model = 0;
+        status = device->get_model(model);
+        std::memcpy(data, &model, sizeof(uint16_t));
+      }
+      *length = sizeof(uint16_t);
+    } break;
+    case AMDCUID_QUERY_CORE_ID: {
+      // only CPU devices will return a valid core ID
+      if (*length < sizeof(uint16_t)) {
+        return AMDCUID_STATUS_INSUFFICIENT_SIZE;
+      }
+      if (data != nullptr) {
+        uint16_t core = 0;
+        status = device->get_core(core);
+        std::memcpy(data, &core, sizeof(uint16_t));
+      }
+      *length = sizeof(uint16_t);
+    } break;
+    case AMDCUID_QUERY_PHYSICAL_ID: {
+      // only CPU devices will return a valid physical package ID
+      if (*length < sizeof(uint16_t)) {
+        return AMDCUID_STATUS_INSUFFICIENT_SIZE;
+      }
+      if (data != nullptr) {
+        uint16_t physical_id = 0;
+        status = device->get_physical_id(physical_id);
+        std::memcpy(data, &physical_id, sizeof(uint16_t));
+      }
+      *length = sizeof(uint16_t);
+    } break;
+    case AMDCUID_QUERY_PCI_CLASS: {
+      // only PCI devices (GPU, NIC) will return a valid PCI class
+      if (*length < sizeof(uint16_t)) {
+        return AMDCUID_STATUS_INSUFFICIENT_SIZE;
+      }
+      if (data != nullptr) {
+        uint16_t pci_class = 0;
+        status = device->get_pci_class(pci_class);
+        std::memcpy(data, &pci_class, sizeof(uint16_t));
+      }
+      *length = sizeof(uint16_t);
+    } break;
+    case AMDCUID_QUERY_BDF: {
+      // only PCI devices (GPU, NIC) will return a valid BDF
+      std::string bdf;
+      status = device->get_bdf(bdf);
+      if (status != AMDCUID_STATUS_SUCCESS) {
+        break;
+      }
+      uint32_t required_length = static_cast<uint32_t>(bdf.size() + 1);  // include null terminator
+      if (*length < required_length) {
+        *length = required_length;
+        return AMDCUID_STATUS_INSUFFICIENT_SIZE;
+      }
+      if (data != nullptr) {
+        std::memcpy(data, bdf.c_str(), required_length);
+      }
       *length = required_length;
-      return AMDCUID_STATUS_INSUFFICIENT_SIZE;
-    }
-    if (data != nullptr) {
-      std::memcpy(data, bdf.c_str(), required_length);
-    }
-    *length = required_length;
-  } break;
-  case AMDCUID_QUERY_TEMPORARY_CUID: {
-    if (*length < sizeof(bool)) {
-      return AMDCUID_STATUS_INSUFFICIENT_SIZE;
-    }
-    if (data != nullptr) {
-      bool is_temporary = false;
-      status = device->is_temporary_cuid(&is_temporary);
-      *(bool *)data = is_temporary;
-    }
-    *length = sizeof(bool);
-  } break;
-  default:
-    status = AMDCUID_STATUS_INVALID_ARGUMENT;
-    break;
+    } break;
+    case AMDCUID_QUERY_TEMPORARY_CUID: {
+      if (*length < sizeof(bool)) {
+        return AMDCUID_STATUS_INSUFFICIENT_SIZE;
+      }
+      if (data != nullptr) {
+        bool is_temporary = false;
+        status = device->is_temporary_cuid(&is_temporary);
+        *(bool*)data = is_temporary;
+      }
+      *length = sizeof(bool);
+    } break;
+    default:
+      status = AMDCUID_STATUS_INVALID_ARGUMENT;
+      break;
   }
 
   return status;
@@ -692,8 +675,7 @@ amdcuid_status_t amdcuid_generate_hash_key(uint8_t key[32]) {
   if (geteuid() != 0) {
     return AMDCUID_STATUS_PERMISSION_DENIED;
   }
-  if (!key)
-    return AMDCUID_STATUS_INVALID_ARGUMENT;
+  if (!key) return AMDCUID_STATUS_INVALID_ARGUMENT;
 
   global_hmac.generate_key(key);
   return AMDCUID_STATUS_SUCCESS;

--- a/projects/cuid/lib/src/cuid_cpu.cc
+++ b/projects/cuid/lib/src/cuid_cpu.cc
@@ -2,29 +2,31 @@
 // SPDX-License-Identifier: MIT
 
 #include "src/cuid_cpu.h"
-#include "src/cuid_file.h"
-#include "src/cuid_util.h"
-#include "src/hmac.h"
-#include "src/smbios_util.h"
+
+#include <unistd.h>
+
 #include <cstring>
 #include <fstream>
 #include <iostream>
 #include <map>
 #include <sstream>
-#include <unistd.h>
+
+#include "src/cuid_file.h"
+#include "src/cuid_util.h"
+#include "src/hmac.h"
+#include "src/smbios_util.h"
 
 #ifdef __x86_64__
 #include <cpuid.h>
 #endif
 
-CuidCpu::CuidCpu(const amdcuid_cpu_info &i) : m_info(i) {}
+CuidCpu::CuidCpu(const amdcuid_cpu_info& i) : m_info(i) {}
 
 /**
  * @brief Get CPU information from CPUID instruction (x86_64)
  */
-static bool get_cpuid_info(uint16_t &vendor_id, uint16_t &family,
-                           uint16_t &model, uint16_t &device_id,
-                           uint8_t &stepping) {
+static bool get_cpuid_info(uint16_t& vendor_id, uint16_t& family, uint16_t& model,
+                           uint16_t& device_id, uint8_t& stepping) {
 #ifdef __x86_64__
   uint32_t eax, ebx, ecx, edx;
 
@@ -35,9 +37,9 @@ static bool get_cpuid_info(uint16_t &vendor_id, uint16_t &family,
 
   // Check for AMD vendor (AuthenticAMD)
   if (ebx == 0x68747541 && edx == 0x69746E65 && ecx == 0x444D4163) {
-    vendor_id = 0x1022; // AMD vendor ID
+    vendor_id = 0x1022;  // AMD vendor ID
   } else {
-    vendor_id = 0x8086; // Intel or other
+    vendor_id = 0x8086;  // Intel or other
   }
 
   // CPUID leaf 1: Get family, model, stepping
@@ -46,11 +48,11 @@ static bool get_cpuid_info(uint16_t &vendor_id, uint16_t &family,
   }
 
   // Extract CPU signature fields from EAX
-  stepping = eax & 0x0F;                    // Bits 0-3: Stepping
-  uint32_t base_model = (eax >> 4) & 0x0F;  // Bits 4-7: Base Model
-  uint32_t base_family = (eax >> 8) & 0x0F; // Bits 8-11: Base Family
-  uint32_t ext_model = (eax >> 16) & 0x0F;  // Bits 16-19: Extended Model
-  uint32_t ext_family = (eax >> 20) & 0xFF; // Bits 20-27: Extended Family
+  stepping = eax & 0x0F;                     // Bits 0-3: Stepping
+  uint32_t base_model = (eax >> 4) & 0x0F;   // Bits 4-7: Base Model
+  uint32_t base_family = (eax >> 8) & 0x0F;  // Bits 8-11: Base Family
+  uint32_t ext_model = (eax >> 16) & 0x0F;   // Bits 16-19: Extended Model
+  uint32_t ext_family = (eax >> 20) & 0xFF;  // Bits 20-27: Extended Family
 
   // Calculate DisplayFamily and DisplayModel per AMD/Intel spec
   if (base_family == 0x0F) {
@@ -70,7 +72,7 @@ static bool get_cpuid_info(uint16_t &vendor_id, uint16_t &family,
 
   return true;
 #else
-  return false; // Not x86_64, cannot use CPUID
+  return false;  // Not x86_64, cannot use CPUID
 #endif
 }
 
@@ -78,14 +80,14 @@ static bool get_cpuid_info(uint16_t &vendor_id, uint16_t &family,
  * @brief CPU information parsed from /proc/cpuinfo
  */
 struct ProcCpuInfo {
-  int processor = -1;  // Logical processor number
-  int physical_id = 0; // Socket/package ID
-  int core_id = 0;     // Core ID within package
-  int apic_id = 0;     // APIC ID
+  int processor = -1;   // Logical processor number
+  int physical_id = 0;  // Socket/package ID
+  int core_id = 0;      // Core ID within package
+  int apic_id = 0;      // APIC ID
   int family = 0;
   int model = 0;
   int stepping = 0;
-  std::string vendor_id; // "AuthenticAMD" or "GenuineIntel"
+  std::string vendor_id;  // "AuthenticAMD" or "GenuineIntel"
   bool is_amd = false;
 };
 
@@ -95,7 +97,7 @@ struct ProcCpuInfo {
  * This is the primary method for CPU discovery that works without sudo.
  * Returns information about all logical processors on the system.
  */
-static amdcuid_status_t parse_proc_cpuinfo(std::vector<ProcCpuInfo> &cpus) {
+static amdcuid_status_t parse_proc_cpuinfo(std::vector<ProcCpuInfo>& cpus) {
   std::ifstream cpuinfo("/proc/cpuinfo");
   if (!cpuinfo) {
     return AMDCUID_STATUS_CPUINFO_ERROR;
@@ -117,17 +119,14 @@ static amdcuid_status_t parse_proc_cpuinfo(std::vector<ProcCpuInfo> &cpus) {
 
     // Parse key : value
     size_t colon = line.find(':');
-    if (colon == std::string::npos)
-      continue;
+    if (colon == std::string::npos) continue;
 
     std::string key = line.substr(0, colon);
     std::string value = line.substr(colon + 1);
 
     // Trim whitespace
-    while (!key.empty() && (key.back() == ' ' || key.back() == '\t'))
-      key.pop_back();
-    while (!value.empty() && (value.front() == ' ' || value.front() == '\t'))
-      value.erase(0, 1);
+    while (!key.empty() && (key.back() == ' ' || key.back() == '\t')) key.pop_back();
+    while (!value.empty() && (value.front() == ' ' || value.front() == '\t')) value.erase(0, 1);
 
     if (key == "processor") {
       current.processor = std::stoi(value);
@@ -168,7 +167,7 @@ static amdcuid_status_t parse_proc_cpuinfo(std::vector<ProcCpuInfo> &cpus) {
  * The ACPI MADT parsing (which requires root) is moved to
  * get_hardware_fingerprint() where privileged operations are expected.
  */
-amdcuid_status_t CuidCpu::discover(std::vector<DevicePtr> &cpus) {
+amdcuid_status_t CuidCpu::discover(std::vector<DevicePtr>& cpus) {
   cpus.clear();
 
   // Parse /proc/cpuinfo - works without root
@@ -182,14 +181,13 @@ amdcuid_status_t CuidCpu::discover(std::vector<DevicePtr> &cpus) {
   // Get CPU information from CPUID (same for all cores)
   uint16_t vendor_id = 0, family = 0, model = 0, device_id = 0;
   uint8_t stepping = 0;
-  bool cpuid_available =
-      get_cpuid_info(vendor_id, family, model, device_id, stepping);
+  bool cpuid_available = get_cpuid_info(vendor_id, family, model, device_id, stepping);
 
   // Group logical processors by physical package (socket). For each socket,
   // pick the representative entry with the lowest APIC ID — this is the
   // bootstrap processor convention used by firmware to represent the package.
-  std::map<int, const ProcCpuInfo *> socket_rep;
-  for (const auto &proc_info : proc_cpus) {
+  std::map<int, const ProcCpuInfo*> socket_rep;
+  for (const auto& proc_info : proc_cpus) {
     auto it = socket_rep.find(proc_info.physical_id);
     if (it == socket_rep.end() || proc_info.apic_id < it->second->apic_id) {
       socket_rep[proc_info.physical_id] = &proc_info;
@@ -197,8 +195,8 @@ amdcuid_status_t CuidCpu::discover(std::vector<DevicePtr> &cpus) {
   }
 
   // Create one CPU device per physical socket using the representative entry.
-  for (const auto &kv : socket_rep) {
-    const ProcCpuInfo *rep = kv.second;
+  for (const auto& kv : socket_rep) {
+    const ProcCpuInfo* rep = kv.second;
     amdcuid_cpu_info info{};
     std::memset(&info.header, 0, sizeof(info.header));
 
@@ -214,8 +212,7 @@ amdcuid_status_t CuidCpu::discover(std::vector<DevicePtr> &cpus) {
       info.header.fields.cpu.vendor_id = rep->is_amd ? 0x1022 : 0x8086;
       info.header.fields.cpu.family = static_cast<uint16_t>(rep->family);
       info.header.fields.cpu.model = static_cast<uint16_t>(rep->model);
-      info.header.fields.cpu.device_id =
-          static_cast<uint16_t>((rep->family << 8) | rep->model);
+      info.header.fields.cpu.device_id = static_cast<uint16_t>((rep->family << 8) | rep->model);
       info.header.fields.cpu.revision_id = static_cast<uint8_t>(rep->stepping);
     }
 
@@ -223,12 +220,10 @@ amdcuid_status_t CuidCpu::discover(std::vector<DevicePtr> &cpus) {
     // representative used by firmware to identify the socket.
     info.header.fields.cpu.unit_id = static_cast<uint16_t>(rep->apic_id);
     info.header.fields.cpu.physical_id = static_cast<uint16_t>(kv.first);
-    info.header.fields.cpu.core =
-        static_cast<uint16_t>(rep->processor); // logical CPU number
+    info.header.fields.cpu.core = static_cast<uint16_t>(rep->processor);  // logical CPU number
 
     // device_node points to the representative logical CPU's sysfs path.
-    info.device_node =
-        "/sys/devices/system/cpu/cpu" + std::to_string(rep->processor);
+    info.device_node = "/sys/devices/system/cpu/cpu" + std::to_string(rep->processor);
 
     cpus.emplace_back(std::make_shared<CuidCpu>(info));
   }
@@ -242,8 +237,8 @@ amdcuid_status_t CuidCpu::discover(std::vector<DevicePtr> &cpus) {
  * Device path should be like /sys/devices/system/cpu/cpu0
  * Reads topology info from sysfs and CPU info from CPUID.
  */
-amdcuid_status_t CuidCpu::discover_single(amdcuid_cpu_info *cpu_info,
-                                          const std::string &device_path) {
+amdcuid_status_t CuidCpu::discover_single(amdcuid_cpu_info* cpu_info,
+                                          const std::string& device_path) {
   if (!cpu_info) {
     return AMDCUID_STATUS_INVALID_ARGUMENT;
   }
@@ -259,8 +254,7 @@ amdcuid_status_t CuidCpu::discover_single(amdcuid_cpu_info *cpu_info,
 
   std::string physical_package_str =
       CuidUtilities::read_sysfs_file(topology_path + "/physical_package_id");
-  std::string core_id_str =
-      CuidUtilities::read_sysfs_file(topology_path + "/core_id");
+  std::string core_id_str = CuidUtilities::read_sysfs_file(topology_path + "/core_id");
 
   if (physical_package_str.empty() || core_id_str.empty()) {
     return AMDCUID_STATUS_DEVICE_NOT_FOUND;
@@ -285,16 +279,13 @@ amdcuid_status_t CuidCpu::discover_single(amdcuid_cpu_info *cpu_info,
   }
 
   // Set topology fields from sysfs
-  cpu_info->header.fields.cpu.physical_id =
-      static_cast<uint16_t>(std::stoi(physical_package_str));
-  cpu_info->header.fields.cpu.core =
-      static_cast<uint16_t>(std::stoi(core_id_str));
+  cpu_info->header.fields.cpu.physical_id = static_cast<uint16_t>(std::stoi(physical_package_str));
+  cpu_info->header.fields.cpu.core = static_cast<uint16_t>(std::stoi(core_id_str));
 
   // Try to get APIC ID for unit_id (optional, may not be available via sysfs)
   // Extract CPU number from path for processor ID
   size_t num_start = device_path.rfind("cpu") + 3;
-  if (num_start < device_path.length() &&
-      std::isdigit(device_path[num_start])) {
+  if (num_start < device_path.length() && std::isdigit(device_path[num_start])) {
     int processor_id = std::stoi(device_path.substr(num_start));
     cpu_info->header.fields.cpu.unit_id = static_cast<uint16_t>(processor_id);
   }
@@ -311,13 +302,13 @@ amdcuid_status_t CuidCpu::discover_single(amdcuid_cpu_info *cpu_info,
  * PPIN is available on AMD CPUs (CPUID Fn8000_0008.EBX[23]) via MSR 0xC001_083B
  * Requires root privileges to read MSR.
  */
-static bool try_read_ppin(uint64_t &ppin, uint32_t core_id) {
+static bool try_read_ppin(uint64_t& ppin, uint32_t core_id) {
 #ifdef __x86_64__
   // Check if PPIN is supported via CPUID
   uint32_t eax, ebx, ecx, edx;
   if (__get_cpuid(0x80000008, &eax, &ebx, &ecx, &edx)) {
     if (!(ebx & (1 << 23))) {
-      return false; // PPIN not supported
+      return false;  // PPIN not supported
     }
   } else {
     return false;
@@ -328,16 +319,16 @@ static bool try_read_ppin(uint64_t &ppin, uint32_t core_id) {
   std::string msr_path = "/dev/cpu/" + std::to_string(core_id) + "/msr";
   std::ifstream msr(msr_path, std::ios::binary);
   if (!msr) {
-    return false; // No MSR access (need root or msr module)
+    return false;  // No MSR access (need root or msr module)
   }
 
   // AMD PPIN MSR first, fallback to Intel if not found
   const uint64_t AMD_PPIN_MSR = 0xC001083B;
   msr.seekg(AMD_PPIN_MSR);
-  if (!msr.read(reinterpret_cast<char *>(&ppin), sizeof(ppin))) {
+  if (!msr.read(reinterpret_cast<char*>(&ppin), sizeof(ppin))) {
     const uint64_t INTEL_PPIN_MSR = 0x4F;
     msr.seekg(INTEL_PPIN_MSR);
-    if (!msr.read(reinterpret_cast<char *>(&ppin), sizeof(ppin))) {
+    if (!msr.read(reinterpret_cast<char*>(&ppin), sizeof(ppin))) {
       return false;
     }
   }
@@ -358,8 +349,7 @@ static bool try_read_ppin(uint64_t &ppin, uint32_t core_id) {
  * Both tiers produce a per-socket fingerprint consistent with the spec's
  * intent that CPU identity is tied to the physical package, not logical cores.
  */
-amdcuid_status_t
-CuidCpu::get_hardware_fingerprint(uint64_t &fingerprint) const {
+amdcuid_status_t CuidCpu::get_hardware_fingerprint(uint64_t& fingerprint) const {
   // PPIN is an eFuse-burned per-socket serial number — the spec's primary
   // identifier. The core argument only selects which MSR fd to open.
   uint64_t ppin = 0;
@@ -394,7 +384,7 @@ CuidCpu::get_hardware_fingerprint(uint64_t &fingerprint) const {
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidCpu::get_primary_cuid(amdcuid_primary_id &id) const {
+amdcuid_status_t CuidCpu::get_primary_cuid(amdcuid_primary_id& id) const {
   bool temp = false;
   uint64_t fingerprint = 0;
   amdcuid_status_t status = AMDCUID_STATUS_SUCCESS;
@@ -414,14 +404,12 @@ amdcuid_status_t CuidCpu::get_primary_cuid(amdcuid_primary_id &id) const {
       status = primary_file.find_by_device_node(m_info.device_node, entry);
       if (status == AMDCUID_STATUS_SUCCESS && entry.is_temporary == false) {
         id.UUIDv8_representation = entry.primary_cuid;
-        CuidUtilities::remove_UUIDv8_bits(&id.UUIDv8_representation,
-                                          id.raw_bits);
+        CuidUtilities::remove_UUIDv8_bits(&id.UUIDv8_representation, id.raw_bits);
         return AMDCUID_STATUS_SUCCESS;
       }
     }
 
-    status = primary_file.find_by_package_id(
-        m_info.header.fields.cpu.physical_id, entry);
+    status = primary_file.find_by_package_id(m_info.header.fields.cpu.physical_id, entry);
     if (status == AMDCUID_STATUS_SUCCESS && entry.is_temporary == false) {
       id.UUIDv8_representation = entry.primary_cuid;
       CuidUtilities::remove_UUIDv8_bits(&id.UUIDv8_representation, id.raw_bits);
@@ -434,10 +422,8 @@ amdcuid_status_t CuidCpu::get_primary_cuid(amdcuid_primary_id &id) const {
   if (geteuid() != 0 || status != AMDCUID_STATUS_SUCCESS) {
     // Non-root or fingerprint unavailable: use socket index + machine-id as
     // a stable but non-hardware fallback, flagged as temporary.
-    std::string socket_id =
-        "socket:" + std::to_string(m_info.header.fields.cpu.physical_id);
-    amdcuid_status_t fb_status =
-        CuidUtilities::make_fallback_fingerprint(socket_id, fingerprint);
+    std::string socket_id = "socket:" + std::to_string(m_info.header.fields.cpu.physical_id);
+    amdcuid_status_t fb_status = CuidUtilities::make_fallback_fingerprint(socket_id, fingerprint);
     if (fb_status != AMDCUID_STATUS_SUCCESS) {
       return AMDCUID_STATUS_HW_FINGERPRINT_NOT_FOUND;
     }
@@ -446,59 +432,58 @@ amdcuid_status_t CuidCpu::get_primary_cuid(amdcuid_primary_id &id) const {
 
   // Use CuidUtilities::generate_primary_cuid to generate CUID
   amdcuid_primary_id result = {};
-  const auto &h = m_info.header;
+  const auto& h = m_info.header;
   CuidUtilities::generate_primary_cuid(
-      fingerprint, h.fields.cpu.unit_id, h.fields.cpu.revision_id,
-      h.fields.cpu.device_id, h.fields.cpu.vendor_id,
-      static_cast<uint8_t>(AMDCUID_DEVICE_TYPE_CPU), &result, temp);
+      fingerprint, h.fields.cpu.unit_id, h.fields.cpu.revision_id, h.fields.cpu.device_id,
+      h.fields.cpu.vendor_id, static_cast<uint8_t>(AMDCUID_DEVICE_TYPE_CPU), &result, temp);
 
   id = result;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-const amdcuid_cpu_info &CuidCpu::get_info() const { return m_info; }
+const amdcuid_cpu_info& CuidCpu::get_info() const { return m_info; }
 
-amdcuid_status_t CuidCpu::get_vendor_id(uint16_t &vendor_id) const {
+amdcuid_status_t CuidCpu::get_vendor_id(uint16_t& vendor_id) const {
   vendor_id = m_info.header.fields.cpu.vendor_id;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidCpu::get_family(uint16_t &family) const {
+amdcuid_status_t CuidCpu::get_family(uint16_t& family) const {
   family = m_info.header.fields.cpu.family;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidCpu::get_model(uint16_t &model) const {
+amdcuid_status_t CuidCpu::get_model(uint16_t& model) const {
   model = m_info.header.fields.cpu.model;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidCpu::get_device_id(uint16_t &device_id) const {
+amdcuid_status_t CuidCpu::get_device_id(uint16_t& device_id) const {
   device_id = m_info.header.fields.cpu.device_id;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidCpu::get_revision_id(uint8_t &revision_id) const {
+amdcuid_status_t CuidCpu::get_revision_id(uint8_t& revision_id) const {
   revision_id = m_info.header.fields.cpu.revision_id;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidCpu::get_unit_id(uint16_t &unit_id) const {
+amdcuid_status_t CuidCpu::get_unit_id(uint16_t& unit_id) const {
   unit_id = m_info.header.fields.cpu.unit_id;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidCpu::get_core(uint16_t &core) const {
+amdcuid_status_t CuidCpu::get_core(uint16_t& core) const {
   core = m_info.header.fields.cpu.core;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidCpu::get_physical_id(uint16_t &physical_id) const {
+amdcuid_status_t CuidCpu::get_physical_id(uint16_t& physical_id) const {
   physical_id = m_info.header.fields.cpu.physical_id;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidCpu::get_device_path(std::string &path) const {
+amdcuid_status_t CuidCpu::get_device_path(std::string& path) const {
   // Use stored device_node (set from processor number during discovery or file
   // load)
   if (!m_info.device_node.empty()) {
@@ -506,7 +491,6 @@ amdcuid_status_t CuidCpu::get_device_path(std::string &path) const {
     return AMDCUID_STATUS_SUCCESS;
   }
   // Fallback: construct from unit_id (APIC ID) for backward compatibility
-  path = "/sys/devices/system/cpu/cpu" +
-         std::to_string(m_info.header.fields.cpu.unit_id);
+  path = "/sys/devices/system/cpu/cpu" + std::to_string(m_info.header.fields.cpu.unit_id);
   return AMDCUID_STATUS_SUCCESS;
 }

--- a/projects/cuid/lib/src/cuid_cpu.h
+++ b/projects/cuid/lib/src/cuid_cpu.h
@@ -4,42 +4,44 @@
 #ifndef CUID_CPU_H
 #define CUID_CPU_H
 
-
-#include "src/cuid_device.h"
-#include "include/amd_cuid.h"
-#include "src/cuid_internal.h"
-#include <vector>
 #include <memory>
 #include <string>
+#include <vector>
+
+#include "include/amd_cuid.h"
+#include "src/cuid_device.h"
+#include "src/cuid_internal.h"
 
 struct amdcuid_cpu_info {
-    amdcuid_cuid_public_fields header;
-    std::string device_node;  // sysfs path e.g. /sys/devices/system/cpu/cpu0
+  amdcuid_cuid_public_fields header;
+  std::string device_node;  // sysfs path e.g. /sys/devices/system/cpu/cpu0
 };
 
 class CuidCpu : public CuidDevice {
-public:
-    CuidCpu(const amdcuid_cpu_info& i);
-    amdcuid_device_type_t type() const override { return AMDCUID_DEVICE_TYPE_CPU; }
-    amdcuid_status_t get_primary_cuid(amdcuid_primary_id& id) const override;
-    amdcuid_status_t get_hardware_fingerprint(uint64_t& fingerprint) const override;
-    static amdcuid_status_t discover(std::vector<DevicePtr> &cpus);
-    static amdcuid_status_t discover_single(amdcuid_cpu_info* cpu_info, const std::string& device_path);
+ public:
+  CuidCpu(const amdcuid_cpu_info& i);
+  amdcuid_device_type_t type() const override { return AMDCUID_DEVICE_TYPE_CPU; }
+  amdcuid_status_t get_primary_cuid(amdcuid_primary_id& id) const override;
+  amdcuid_status_t get_hardware_fingerprint(uint64_t& fingerprint) const override;
+  static amdcuid_status_t discover(std::vector<DevicePtr>& cpus);
+  static amdcuid_status_t discover_single(amdcuid_cpu_info* cpu_info,
+                                          const std::string& device_path);
 
-    // Virtual accessor overrides
-    amdcuid_status_t get_vendor_id(uint16_t& vendor_id) const override;
-    amdcuid_status_t get_family(uint16_t& family) const override;
-    amdcuid_status_t get_model(uint16_t& model) const override;
-    amdcuid_status_t get_device_id(uint16_t& device_id) const override;
-    amdcuid_status_t get_revision_id(uint8_t& revision_id) const override;
-    amdcuid_status_t get_unit_id(uint16_t& unit_id) const override;
-    amdcuid_status_t get_core(uint16_t& core) const override;
-    amdcuid_status_t get_physical_id(uint16_t& physical_id) const override;
-    amdcuid_status_t get_device_path(std::string& path) const override;
+  // Virtual accessor overrides
+  amdcuid_status_t get_vendor_id(uint16_t& vendor_id) const override;
+  amdcuid_status_t get_family(uint16_t& family) const override;
+  amdcuid_status_t get_model(uint16_t& model) const override;
+  amdcuid_status_t get_device_id(uint16_t& device_id) const override;
+  amdcuid_status_t get_revision_id(uint8_t& revision_id) const override;
+  amdcuid_status_t get_unit_id(uint16_t& unit_id) const override;
+  amdcuid_status_t get_core(uint16_t& core) const override;
+  amdcuid_status_t get_physical_id(uint16_t& physical_id) const override;
+  amdcuid_status_t get_device_path(std::string& path) const override;
 
-    const amdcuid_cpu_info& get_info() const;
-private:
-    amdcuid_cpu_info m_info;
+  const amdcuid_cpu_info& get_info() const;
+
+ private:
+  amdcuid_cpu_info m_info;
 };
 
-#endif // CUID_CPU_H
+#endif  // CUID_CPU_H

--- a/projects/cuid/lib/src/cuid_device.cc
+++ b/projects/cuid/lib/src/cuid_device.cc
@@ -2,6 +2,23 @@
 // SPDX-License-Identifier: MIT
 
 #include "cuid_device.h"
+
+#include <dirent.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <cctype>
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <mutex>
+#include <sstream>
+#include <vector>
+
 #include "cuid_cpu.h"
 #include "cuid_file.h"
 #include "cuid_gpu.h"
@@ -9,20 +26,6 @@
 #include "cuid_npu.h"
 #include "cuid_platform.h"
 #include "cuid_util.h"
-#include <algorithm>
-#include <cctype>
-#include <cerrno>
-#include <cstdio>
-#include <cstring>
-#include <dirent.h>
-#include <fstream>
-#include <iostream>
-#include <iterator>
-#include <mutex>
-#include <sstream>
-#include <sys/types.h>
-#include <unistd.h>
-#include <vector>
 
 // helper function to get a hash from the raw bytes of a derived ID
 void get_hash_from_raw(uint8_t raw_bytes[16], uint8_t out_hash[14]) {
@@ -35,15 +38,13 @@ void get_hash_from_raw(uint8_t raw_bytes[16], uint8_t out_hash[14]) {
   out_hash[13] = raw_bytes[14] & 0x3F;
 }
 
-void build_derived_id_from_file_entry(const CuidFileEntry &entry,
-                                      amdcuid_derived_id &id) {
+void build_derived_id_from_file_entry(const CuidFileEntry& entry, amdcuid_derived_id& id) {
   id.UUIDv8_representation = entry.derived_cuid;
   CuidUtilities::remove_UUIDv8_bits(&id.UUIDv8_representation, id.raw_bits);
   get_hash_from_raw(id.raw_bits, id.hash);
 }
 
-amdcuid_status_t CuidDevice::get_derived_cuid(amdcuid_derived_id &id,
-                                              cuid_hmac *hmac) const {
+amdcuid_status_t CuidDevice::get_derived_cuid(amdcuid_derived_id& id, cuid_hmac* hmac) const {
   // attempt to find the derived CUID in file first
   CuidFile derived_file(CuidUtilities::cuid_file(), false);
   amdcuid_status_t status = derived_file.load();
@@ -52,90 +53,86 @@ amdcuid_status_t CuidDevice::get_derived_cuid(amdcuid_derived_id &id,
     amdcuid_device_type_t type = this->type();
     // there's only 1 platform entry, so handle that case first
     switch (type) {
-    case AMDCUID_DEVICE_TYPE_PLATFORM: {
-      // for platform, just return the first entry found
-      CuidFileEntry entry;
-      status =
-          derived_file.find_by_device_type(AMDCUID_DEVICE_TYPE_PLATFORM, entry);
-      if (status == AMDCUID_STATUS_SUCCESS) {
-        build_derived_id_from_file_entry(entry, id);
-        return AMDCUID_STATUS_SUCCESS;
-      }
-    } break;
-    case AMDCUID_DEVICE_TYPE_GPU:
-      // search by render node
-      {
-        auto gpu = reinterpret_cast<CuidGpu *>(const_cast<CuidDevice *>(this));
-        if (gpu) {
-          auto info = gpu->get_info();
-          CuidFileEntry entry;
-          status = derived_file.find_by_device_node(info.render_node, entry);
-          if (status == AMDCUID_STATUS_SUCCESS) {
-            build_derived_id_from_file_entry(entry, id);
-            return AMDCUID_STATUS_SUCCESS;
-          }
-        }
-      }
-      break;
-    case AMDCUID_DEVICE_TYPE_CPU: {
-      auto cpu = reinterpret_cast<CuidCpu *>(const_cast<CuidDevice *>(this));
-      if (cpu) {
-        // Try device_node first - unique per logical CPU on SMT systems
-        std::string device_path;
-        if (cpu->get_device_path(device_path) == AMDCUID_STATUS_SUCCESS &&
-            !device_path.empty()) {
-          CuidFileEntry entry;
-          status = derived_file.find_by_device_node(device_path, entry);
-          if (status == AMDCUID_STATUS_SUCCESS) {
-            build_derived_id_from_file_entry(entry, id);
-            return AMDCUID_STATUS_SUCCESS;
-          }
-        }
-        const auto &info = cpu->get_info();
+      case AMDCUID_DEVICE_TYPE_PLATFORM: {
+        // for platform, just return the first entry found
         CuidFileEntry entry;
-        status = derived_file.find_by_package_id(
-            info.header.fields.cpu.physical_id, entry);
+        status = derived_file.find_by_device_type(AMDCUID_DEVICE_TYPE_PLATFORM, entry);
         if (status == AMDCUID_STATUS_SUCCESS) {
           build_derived_id_from_file_entry(entry, id);
           return AMDCUID_STATUS_SUCCESS;
         }
-      }
-    } break;
-    case AMDCUID_DEVICE_TYPE_NIC:
-      // search by device node
-      {
-        auto nic = reinterpret_cast<CuidNic *>(const_cast<CuidDevice *>(this));
-        if (nic) {
-          const auto &info = nic->get_info();
+      } break;
+      case AMDCUID_DEVICE_TYPE_GPU:
+        // search by render node
+        {
+          auto gpu = reinterpret_cast<CuidGpu*>(const_cast<CuidDevice*>(this));
+          if (gpu) {
+            auto info = gpu->get_info();
+            CuidFileEntry entry;
+            status = derived_file.find_by_device_node(info.render_node, entry);
+            if (status == AMDCUID_STATUS_SUCCESS) {
+              build_derived_id_from_file_entry(entry, id);
+              return AMDCUID_STATUS_SUCCESS;
+            }
+          }
+        }
+        break;
+      case AMDCUID_DEVICE_TYPE_CPU: {
+        auto cpu = reinterpret_cast<CuidCpu*>(const_cast<CuidDevice*>(this));
+        if (cpu) {
+          // Try device_node first - unique per logical CPU on SMT systems
+          std::string device_path;
+          if (cpu->get_device_path(device_path) == AMDCUID_STATUS_SUCCESS && !device_path.empty()) {
+            CuidFileEntry entry;
+            status = derived_file.find_by_device_node(device_path, entry);
+            if (status == AMDCUID_STATUS_SUCCESS) {
+              build_derived_id_from_file_entry(entry, id);
+              return AMDCUID_STATUS_SUCCESS;
+            }
+          }
+          const auto& info = cpu->get_info();
           CuidFileEntry entry;
-          amdcuid_status_t status =
-              derived_file.find_by_device_node(info.network_interface, entry);
+          status = derived_file.find_by_package_id(info.header.fields.cpu.physical_id, entry);
           if (status == AMDCUID_STATUS_SUCCESS) {
             build_derived_id_from_file_entry(entry, id);
             return AMDCUID_STATUS_SUCCESS;
           }
         }
-      }
-      break;
-    case AMDCUID_DEVICE_TYPE_NPU:
-      // search by accel node
-      {
-        auto npu = reinterpret_cast<CuidNpu *>(const_cast<CuidDevice *>(this));
-        if (npu) {
-          const auto &info = npu->get_info();
-          CuidFileEntry entry;
-          amdcuid_status_t status =
-              derived_file.find_by_device_node(info.accel_node, entry);
-          if (status == AMDCUID_STATUS_SUCCESS) {
-            build_derived_id_from_file_entry(entry, id);
-            return AMDCUID_STATUS_SUCCESS;
+      } break;
+      case AMDCUID_DEVICE_TYPE_NIC:
+        // search by device node
+        {
+          auto nic = reinterpret_cast<CuidNic*>(const_cast<CuidDevice*>(this));
+          if (nic) {
+            const auto& info = nic->get_info();
+            CuidFileEntry entry;
+            amdcuid_status_t status =
+                derived_file.find_by_device_node(info.network_interface, entry);
+            if (status == AMDCUID_STATUS_SUCCESS) {
+              build_derived_id_from_file_entry(entry, id);
+              return AMDCUID_STATUS_SUCCESS;
+            }
           }
         }
-      }
-      break;
-    default:
-      break;
-      // Will expand with different devices as we implement them
+        break;
+      case AMDCUID_DEVICE_TYPE_NPU:
+        // search by accel node
+        {
+          auto npu = reinterpret_cast<CuidNpu*>(const_cast<CuidDevice*>(this));
+          if (npu) {
+            const auto& info = npu->get_info();
+            CuidFileEntry entry;
+            amdcuid_status_t status = derived_file.find_by_device_node(info.accel_node, entry);
+            if (status == AMDCUID_STATUS_SUCCESS) {
+              build_derived_id_from_file_entry(entry, id);
+              return AMDCUID_STATUS_SUCCESS;
+            }
+          }
+        }
+        break;
+      default:
+        break;
+        // Will expand with different devices as we implement them
     }
   }
 
@@ -144,8 +141,7 @@ amdcuid_status_t CuidDevice::get_derived_cuid(amdcuid_derived_id &id,
   status = get_primary_cuid(primary);
   // check the temporary bit in the primary CUID to determine whether to use the
   // real HMAC key or the temp key for derived CUID generation
-  bool temp = primary.raw_bits[14] &
-              0x20; // check the temp indicator bit in the reserved bits
+  bool temp = primary.raw_bits[14] & 0x20;  // check the temp indicator bit in the reserved bits
   if (temp) {
     // machine id is what needs to be protected and under HMAC system, message
     // is not guaranteed protection when output is well known so use machine id
@@ -155,12 +151,10 @@ amdcuid_status_t CuidDevice::get_derived_cuid(amdcuid_derived_id &id,
     // real HMAC key or primary CUID
     amdcuid_primary_id fixed_app_id = {};
     // Application UUID: UUID_v5(NAMESPACE_DNS, "com.amd.cuid.v1")
-    static const uint8_t CUID_APP_UUID[16] = {
-        0xac, 0x05, 0xca, 0x9f, 0x1a, 0xc4, 0x58, 0xb9,
-        0x92, 0x7e, 0x2e, 0x17, 0x51, 0x47, 0x9c, 0x01};
+    static const uint8_t CUID_APP_UUID[16] = {0xac, 0x05, 0xca, 0x9f, 0x1a, 0xc4, 0x58, 0xb9,
+                                              0x92, 0x7e, 0x2e, 0x17, 0x51, 0x47, 0x9c, 0x01};
     memcpy(fixed_app_id.raw_bits, CUID_APP_UUID, 16);
-    CuidUtilities::add_UUIDv8_bits(fixed_app_id.raw_bits,
-                                   &fixed_app_id.UUIDv8_representation);
+    CuidUtilities::add_UUIDv8_bits(fixed_app_id.raw_bits, &fixed_app_id.UUIDv8_representation);
 
     // Use the machine ID from the primary CUID as the key for HMAC, so that the
     // derived CUID is consistent for the same machine even for non-privileged
@@ -171,8 +165,7 @@ amdcuid_status_t CuidDevice::get_derived_cuid(amdcuid_derived_id &id,
     // key
     cuid_hmac temp_hmac = cuid_hmac(padded_key);
     temp_hmac.set_hmac_algorithm("SHA256");
-    status =
-        CuidUtilities::generate_derived_cuid(&fixed_app_id, &id, &temp_hmac);
+    status = CuidUtilities::generate_derived_cuid(&fixed_app_id, &id, &temp_hmac);
   } else {
     status = CuidUtilities::generate_derived_cuid(&primary, &id, hmac);
   }
@@ -180,7 +173,7 @@ amdcuid_status_t CuidDevice::get_derived_cuid(amdcuid_derived_id &id,
   return status;
 }
 
-amdcuid_status_t CuidDevice::is_temporary_cuid(bool *is_temp) const {
+amdcuid_status_t CuidDevice::is_temporary_cuid(bool* is_temp) const {
   if (!is_temp) {
     return AMDCUID_STATUS_INVALID_ARGUMENT;
   }
@@ -191,8 +184,7 @@ amdcuid_status_t CuidDevice::is_temporary_cuid(bool *is_temp) const {
   if (status != AMDCUID_STATUS_SUCCESS) {
     return status;
   }
-  *is_temp = primary.raw_bits[14] &
-             0x20; // check the temp indicator bit in the reserved bits
+  *is_temp = primary.raw_bits[14] & 0x20;  // check the temp indicator bit in the reserved bits
 
   return AMDCUID_STATUS_SUCCESS;
 }

--- a/projects/cuid/lib/src/cuid_device.h
+++ b/projects/cuid/lib/src/cuid_device.h
@@ -4,67 +4,66 @@
 #ifndef CUID_DEVICE_H
 #define CUID_DEVICE_H
 
-#include "include/amd_cuid.h"
-#include "src/cuid_internal.h"
-#include "src/hmac.h"
 #include <cstdint>
 #include <memory>
 #include <string>
 
+#include "include/amd_cuid.h"
+#include "src/cuid_internal.h"
+#include "src/hmac.h"
+
 class CuidDevice {
-public:
+ public:
   virtual ~CuidDevice() = default;
   virtual amdcuid_device_type_t type() const = 0;
-  virtual amdcuid_status_t get_primary_cuid(amdcuid_primary_id &id) const = 0;
-  virtual amdcuid_status_t
-  get_hardware_fingerprint(uint64_t &fingerprint) const = 0;
-  amdcuid_status_t get_derived_cuid(amdcuid_derived_id &id,
-                                    cuid_hmac *hmac = nullptr) const;
-  amdcuid_status_t is_temporary_cuid(bool *is_temporary) const;
+  virtual amdcuid_status_t get_primary_cuid(amdcuid_primary_id& id) const = 0;
+  virtual amdcuid_status_t get_hardware_fingerprint(uint64_t& fingerprint) const = 0;
+  amdcuid_status_t get_derived_cuid(amdcuid_derived_id& id, cuid_hmac* hmac = nullptr) const;
+  amdcuid_status_t is_temporary_cuid(bool* is_temporary) const;
 
   // Virtual accessors for common device properties with default wrong device
   // type implementations
-  virtual amdcuid_status_t get_vendor_id(uint16_t &vendor_id) const {
+  virtual amdcuid_status_t get_vendor_id(uint16_t& vendor_id) const {
     vendor_id = 0;
     return AMDCUID_STATUS_WRONG_DEVICE_TYPE;
   }
-  virtual amdcuid_status_t get_family(uint16_t &family) const {
+  virtual amdcuid_status_t get_family(uint16_t& family) const {
     family = 0;
     return AMDCUID_STATUS_WRONG_DEVICE_TYPE;
   }
-  virtual amdcuid_status_t get_model(uint16_t &model) const {
+  virtual amdcuid_status_t get_model(uint16_t& model) const {
     model = 0;
     return AMDCUID_STATUS_WRONG_DEVICE_TYPE;
   }
-  virtual amdcuid_status_t get_device_id(uint16_t &device_id) const {
+  virtual amdcuid_status_t get_device_id(uint16_t& device_id) const {
     device_id = 0;
     return AMDCUID_STATUS_WRONG_DEVICE_TYPE;
   }
-  virtual amdcuid_status_t get_revision_id(uint8_t &revision_id) const {
+  virtual amdcuid_status_t get_revision_id(uint8_t& revision_id) const {
     revision_id = 0;
     return AMDCUID_STATUS_WRONG_DEVICE_TYPE;
   }
-  virtual amdcuid_status_t get_unit_id(uint16_t &unit_id) const {
+  virtual amdcuid_status_t get_unit_id(uint16_t& unit_id) const {
     unit_id = 0;
     return AMDCUID_STATUS_WRONG_DEVICE_TYPE;
   }
-  virtual amdcuid_status_t get_pci_class(uint16_t &pci_class) const {
+  virtual amdcuid_status_t get_pci_class(uint16_t& pci_class) const {
     pci_class = 0;
     return AMDCUID_STATUS_WRONG_DEVICE_TYPE;
   }
-  virtual amdcuid_status_t get_core(uint16_t &core) const {
+  virtual amdcuid_status_t get_core(uint16_t& core) const {
     core = 0;
     return AMDCUID_STATUS_WRONG_DEVICE_TYPE;
   }
-  virtual amdcuid_status_t get_physical_id(uint16_t &physical_id) const {
+  virtual amdcuid_status_t get_physical_id(uint16_t& physical_id) const {
     physical_id = 0;
     return AMDCUID_STATUS_WRONG_DEVICE_TYPE;
   }
-  virtual amdcuid_status_t get_bdf(std::string &bdf) const {
+  virtual amdcuid_status_t get_bdf(std::string& bdf) const {
     bdf.clear();
     return AMDCUID_STATUS_WRONG_DEVICE_TYPE;
   }
-  virtual amdcuid_status_t get_device_path(std::string &path) const {
+  virtual amdcuid_status_t get_device_path(std::string& path) const {
     path.clear();
     return AMDCUID_STATUS_WRONG_DEVICE_TYPE;
   }
@@ -72,4 +71,4 @@ public:
 
 typedef std::shared_ptr<CuidDevice> DevicePtr;
 
-#endif // CUID_DEVICE_H
+#endif  // CUID_DEVICE_H

--- a/projects/cuid/lib/src/cuid_device_manager.cc
+++ b/projects/cuid/lib/src/cuid_device_manager.cc
@@ -2,6 +2,14 @@
 // SPDX-License-Identifier: MIT
 
 #include "src/cuid_device_manager.h"
+
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <iostream>
+
 #include "include/amd_cuid.h"
 #include "src/cuid_cpu.h"
 #include "src/cuid_gpu.h"
@@ -10,17 +18,12 @@
 #include "src/cuid_platform.h"
 #include "src/cuid_util.h"
 #include "src/ipc_protocol.h"
-#include <algorithm>
-#include <iostream>
-#include <sys/socket.h>
-#include <sys/un.h>
-#include <unistd.h>
 
 class CuidDaemonIpcClientUtils {
-public:
-  static amdcuid_status_t request_add_device(const char *dev_path,
+ public:
+  static amdcuid_status_t request_add_device(const char* dev_path,
                                              amdcuid_device_type_t device_type,
-                                             amdcuid_id_t *device_handle) {
+                                             amdcuid_id_t* device_handle) {
     int sock_fd = socket(AF_UNIX, SOCK_STREAM, 0);
     if (sock_fd < 0) {
       return AMDCUID_STATUS_IPC_ERROR;
@@ -29,11 +32,9 @@ public:
     struct sockaddr_un server_addr;
     memset(&server_addr, 0, sizeof(server_addr));
     server_addr.sun_family = AF_UNIX;
-    strncpy(server_addr.sun_path, AMDCUID_SOCKET_PATH,
-            sizeof(server_addr.sun_path));
+    strncpy(server_addr.sun_path, AMDCUID_SOCKET_PATH, sizeof(server_addr.sun_path));
 
-    if (connect(sock_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)) <
-        0) {
+    if (connect(sock_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)) < 0) {
       close(sock_fd);
       return AMDCUID_STATUS_IPC_ERROR;
     }
@@ -70,11 +71,9 @@ public:
     struct sockaddr_un server_addr;
     memset(&server_addr, 0, sizeof(server_addr));
     server_addr.sun_family = AF_UNIX;
-    strncpy(server_addr.sun_path, AMDCUID_SOCKET_PATH,
-            sizeof(server_addr.sun_path));
+    strncpy(server_addr.sun_path, AMDCUID_SOCKET_PATH, sizeof(server_addr.sun_path));
 
-    if (connect(sock_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)) <
-        0) {
+    if (connect(sock_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)) < 0) {
       close(sock_fd);
       return AMDCUID_STATUS_IPC_ERROR;
     }
@@ -82,9 +81,8 @@ public:
     IpcRequest request;
     request.type = IpcMessageType::REFRESH_DEVICES;
     memset(request.device_path, 0,
-           sizeof(request.device_path)); // Not used for REFRESH_DEVICES
-    request.device_type =
-        AMDCUID_DEVICE_TYPE_NONE; // Not used for REFRESH_DEVICES
+           sizeof(request.device_path));             // Not used for REFRESH_DEVICES
+    request.device_type = AMDCUID_DEVICE_TYPE_NONE;  // Not used for REFRESH_DEVICES
 
     if (send(sock_fd, &request, sizeof(request), 0) != sizeof(request)) {
       close(sock_fd);
@@ -110,11 +108,9 @@ public:
     struct sockaddr_un server_addr;
     memset(&server_addr, 0, sizeof(server_addr));
     server_addr.sun_family = AF_UNIX;
-    strncpy(server_addr.sun_path, AMDCUID_SOCKET_PATH,
-            sizeof(server_addr.sun_path));
+    strncpy(server_addr.sun_path, AMDCUID_SOCKET_PATH, sizeof(server_addr.sun_path));
 
-    if (connect(sock_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)) <
-        0) {
+    if (connect(sock_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)) < 0) {
       close(sock_fd);
       return false;
     }
@@ -125,7 +121,6 @@ public:
 };
 
 amdcuid_status_t CuidDeviceManager::get_devices_on_system() {
-
   amdcuid_status_t status;
   std::vector<DevicePtr> discovered_devices;
 
@@ -134,7 +129,7 @@ amdcuid_status_t CuidDeviceManager::get_devices_on_system() {
   std::vector<DevicePtr> platform_devices;
   status = CuidPlatform::discover(platform_devices);
   if (status == AMDCUID_STATUS_SUCCESS) {
-    for (const auto &platform_device : platform_devices) {
+    for (const auto& platform_device : platform_devices) {
       discovered_devices.push_back(platform_device);
     }
   }
@@ -142,7 +137,7 @@ amdcuid_status_t CuidDeviceManager::get_devices_on_system() {
   std::vector<DevicePtr> cpu_devices;
   status = CuidCpu::discover(cpu_devices);
   if (status == AMDCUID_STATUS_SUCCESS) {
-    for (const auto &cpu : cpu_devices) {
+    for (const auto& cpu : cpu_devices) {
       discovered_devices.push_back(cpu);
     }
   }
@@ -150,7 +145,7 @@ amdcuid_status_t CuidDeviceManager::get_devices_on_system() {
   std::vector<DevicePtr> gpu_devices;
   status = CuidGpu::discover(gpu_devices);
   if (status == AMDCUID_STATUS_SUCCESS) {
-    for (const auto &gpu : gpu_devices) {
+    for (const auto& gpu : gpu_devices) {
       discovered_devices.push_back(gpu);
     }
   }
@@ -158,7 +153,7 @@ amdcuid_status_t CuidDeviceManager::get_devices_on_system() {
   std::vector<DevicePtr> nic_devices;
   status = CuidNic::discover(nic_devices);
   if (status == AMDCUID_STATUS_SUCCESS) {
-    for (const auto &nic : nic_devices) {
+    for (const auto& nic : nic_devices) {
       discovered_devices.push_back(nic);
     }
   }
@@ -166,7 +161,7 @@ amdcuid_status_t CuidDeviceManager::get_devices_on_system() {
   std::vector<DevicePtr> npu_devices;
   status = CuidNpu::discover(npu_devices);
   if (status == AMDCUID_STATUS_SUCCESS) {
-    for (const auto &npu : npu_devices) {
+    for (const auto& npu : npu_devices) {
       discovered_devices.push_back(npu);
     }
   }
@@ -181,78 +176,75 @@ amdcuid_status_t CuidDeviceManager::get_devices_on_system() {
     devices_ = discovered_devices;
   }
 
-  return discovered_devices.empty() ? AMDCUID_STATUS_DEVICE_NOT_FOUND
-                                    : AMDCUID_STATUS_SUCCESS;
+  return discovered_devices.empty() ? AMDCUID_STATUS_DEVICE_NOT_FOUND : AMDCUID_STATUS_SUCCESS;
 }
 
 // helper function to convert CuidFileEntry to appropriate CuidDevice
-void _convert_entry_to_device(CuidFileEntry &entry, DevicePtr &device) {
-
+void _convert_entry_to_device(CuidFileEntry& entry, DevicePtr& device) {
   switch (entry.device_type) {
-  case AMDCUID_DEVICE_TYPE_PLATFORM: {
-    amdcuid_platform_info platform_info = {};
-    platform_info.header.fields.platform.vendor_id = entry.vendor_id;
-    device = std::make_shared<CuidPlatform>(platform_info);
-    break;
-  }
-  case AMDCUID_DEVICE_TYPE_GPU: {
-    amdcuid_gpu_info gpu_info = {};
-    gpu_info.header.fields.gpu.vendor_id = entry.vendor_id;
-    gpu_info.header.fields.gpu.device_id = entry.device_id;
-    gpu_info.header.fields.gpu.pci_class = entry.pci_class;
-    gpu_info.header.fields.gpu.revision_id = entry.revision_id;
-    gpu_info.header.fields.gpu.unit_id = entry.unit_id;
-    gpu_info.render_node = entry.device_node;
-    gpu_info.bdf = entry.bdf;
-    device = std::make_shared<CuidGpu>(gpu_info);
-    break;
-  }
-  case AMDCUID_DEVICE_TYPE_CPU: {
-    amdcuid_cpu_info cpu_info = {};
-    cpu_info.header.fields.cpu.vendor_id = entry.vendor_id;
-    cpu_info.header.fields.cpu.family = entry.family;
-    cpu_info.header.fields.cpu.model = entry.model;
-    cpu_info.header.fields.cpu.device_id = entry.device_id;
-    cpu_info.header.fields.cpu.revision_id = entry.revision_id;
-    cpu_info.header.fields.cpu.unit_id = entry.unit_id;
-    cpu_info.header.fields.cpu.physical_id = entry.package_id;
-    cpu_info.header.fields.cpu.core = entry.core_id;
-    // Restore device_node for unique CPU identification (needed for SMT)
-    cpu_info.device_node = entry.device_node;
-    device = std::make_shared<CuidCpu>(cpu_info);
-    break;
-  }
-  case AMDCUID_DEVICE_TYPE_NIC: {
-    amdcuid_nic_info nic_info = {};
-    nic_info.header.fields.nic.vendor_id = entry.vendor_id;
-    nic_info.header.fields.nic.device_id = entry.device_id;
-    nic_info.header.fields.nic.pci_class = entry.pci_class;
-    nic_info.header.fields.nic.revision_id = entry.revision_id;
-    nic_info.network_interface = entry.device_node;
-    nic_info.bdf = entry.bdf;
-    device = std::make_shared<CuidNic>(nic_info);
-    break;
-  }
-  case AMDCUID_DEVICE_TYPE_NPU: {
-    amdcuid_npu_info npu_info = {};
-    npu_info.header.fields.npu.vendor_id = entry.vendor_id;
-    npu_info.header.fields.npu.device_id = entry.device_id;
-    npu_info.header.fields.npu.pci_class = entry.pci_class;
-    npu_info.header.fields.npu.revision_id = entry.revision_id;
-    npu_info.accel_node = entry.device_node;
-    npu_info.bdf = entry.bdf;
-    device = std::make_shared<CuidNpu>(npu_info);
-    break;
-  }
-  default: {
-    device = nullptr;
-    break;
-  }
+    case AMDCUID_DEVICE_TYPE_PLATFORM: {
+      amdcuid_platform_info platform_info = {};
+      platform_info.header.fields.platform.vendor_id = entry.vendor_id;
+      device = std::make_shared<CuidPlatform>(platform_info);
+      break;
+    }
+    case AMDCUID_DEVICE_TYPE_GPU: {
+      amdcuid_gpu_info gpu_info = {};
+      gpu_info.header.fields.gpu.vendor_id = entry.vendor_id;
+      gpu_info.header.fields.gpu.device_id = entry.device_id;
+      gpu_info.header.fields.gpu.pci_class = entry.pci_class;
+      gpu_info.header.fields.gpu.revision_id = entry.revision_id;
+      gpu_info.header.fields.gpu.unit_id = entry.unit_id;
+      gpu_info.render_node = entry.device_node;
+      gpu_info.bdf = entry.bdf;
+      device = std::make_shared<CuidGpu>(gpu_info);
+      break;
+    }
+    case AMDCUID_DEVICE_TYPE_CPU: {
+      amdcuid_cpu_info cpu_info = {};
+      cpu_info.header.fields.cpu.vendor_id = entry.vendor_id;
+      cpu_info.header.fields.cpu.family = entry.family;
+      cpu_info.header.fields.cpu.model = entry.model;
+      cpu_info.header.fields.cpu.device_id = entry.device_id;
+      cpu_info.header.fields.cpu.revision_id = entry.revision_id;
+      cpu_info.header.fields.cpu.unit_id = entry.unit_id;
+      cpu_info.header.fields.cpu.physical_id = entry.package_id;
+      cpu_info.header.fields.cpu.core = entry.core_id;
+      // Restore device_node for unique CPU identification (needed for SMT)
+      cpu_info.device_node = entry.device_node;
+      device = std::make_shared<CuidCpu>(cpu_info);
+      break;
+    }
+    case AMDCUID_DEVICE_TYPE_NIC: {
+      amdcuid_nic_info nic_info = {};
+      nic_info.header.fields.nic.vendor_id = entry.vendor_id;
+      nic_info.header.fields.nic.device_id = entry.device_id;
+      nic_info.header.fields.nic.pci_class = entry.pci_class;
+      nic_info.header.fields.nic.revision_id = entry.revision_id;
+      nic_info.network_interface = entry.device_node;
+      nic_info.bdf = entry.bdf;
+      device = std::make_shared<CuidNic>(nic_info);
+      break;
+    }
+    case AMDCUID_DEVICE_TYPE_NPU: {
+      amdcuid_npu_info npu_info = {};
+      npu_info.header.fields.npu.vendor_id = entry.vendor_id;
+      npu_info.header.fields.npu.device_id = entry.device_id;
+      npu_info.header.fields.npu.pci_class = entry.pci_class;
+      npu_info.header.fields.npu.revision_id = entry.revision_id;
+      npu_info.accel_node = entry.device_node;
+      npu_info.bdf = entry.bdf;
+      device = std::make_shared<CuidNpu>(npu_info);
+      break;
+    }
+    default: {
+      device = nullptr;
+      break;
+    }
   }
 }
 
-amdcuid_status_t
-CuidDeviceManager::get_devices_from_file_entries(CuidFile &cuid_file) {
+amdcuid_status_t CuidDeviceManager::get_devices_from_file_entries(CuidFile& cuid_file) {
   std::lock_guard<std::mutex> lock(manager_mutex_);
 
   amdcuid_status_t status = cuid_file.load();
@@ -261,9 +253,9 @@ CuidDeviceManager::get_devices_from_file_entries(CuidFile &cuid_file) {
   }
 
   devices_.clear();
-  for (const auto &entry : cuid_file.get_entries()) {
+  for (const auto& entry : cuid_file.get_entries()) {
     DevicePtr device = nullptr;
-    _convert_entry_to_device(const_cast<CuidFileEntry &>(entry), device);
+    _convert_entry_to_device(const_cast<CuidFileEntry&>(entry), device);
     if (device) {
       devices_.push_back(device);
     }
@@ -290,9 +282,8 @@ amdcuid_status_t CuidDeviceManager::add_device(DevicePtr device) {
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t
-CuidDeviceManager::get_device_from_file_by_id(amdcuid_id_t &derived_cuid,
-                                              DevicePtr &device) {
+amdcuid_status_t CuidDeviceManager::get_device_from_file_by_id(amdcuid_id_t& derived_cuid,
+                                                               DevicePtr& device) {
   amdcuid_status_t status = AMDCUID_STATUS_DEVICE_NOT_FOUND;
 
   // Search in privileged CUID file first
@@ -325,8 +316,8 @@ CuidDeviceManager::get_device_from_file_by_id(amdcuid_id_t &derived_cuid,
   return status;
 }
 
-amdcuid_status_t CuidDeviceManager::get_device_from_file_by_dev_path(
-    const std::string &device_path, DevicePtr &device) {
+amdcuid_status_t CuidDeviceManager::get_device_from_file_by_dev_path(const std::string& device_path,
+                                                                     DevicePtr& device) {
   amdcuid_status_t status = AMDCUID_STATUS_DEVICE_NOT_FOUND;
 
   // Search in privileged CUID file first
@@ -338,7 +329,7 @@ amdcuid_status_t CuidDeviceManager::get_device_from_file_by_dev_path(
     }
     status = priv_cuid_file_.find_by_device_node(device_path, entry);
     if (status != AMDCUID_STATUS_SUCCESS) {
-      return status; // Not found in either file
+      return status;  // Not found in either file
     }
   } else {
     status = unpriv_cuid_file_.load();
@@ -347,7 +338,7 @@ amdcuid_status_t CuidDeviceManager::get_device_from_file_by_dev_path(
     }
     status = unpriv_cuid_file_.find_by_device_node(device_path, entry);
     if (status != AMDCUID_STATUS_SUCCESS) {
-      return status; // Not found in unprivileged file
+      return status;  // Not found in unprivileged file
     }
   }
 
@@ -359,9 +350,8 @@ amdcuid_status_t CuidDeviceManager::get_device_from_file_by_dev_path(
   return status;
 }
 
-amdcuid_status_t
-CuidDeviceManager::get_device_from_file_by_bdf(const std::string &bdf,
-                                               DevicePtr &device) {
+amdcuid_status_t CuidDeviceManager::get_device_from_file_by_bdf(const std::string& bdf,
+                                                                DevicePtr& device) {
   amdcuid_status_t status = AMDCUID_STATUS_DEVICE_NOT_FOUND;
 
   // Search in privileged CUID file first
@@ -373,7 +363,7 @@ CuidDeviceManager::get_device_from_file_by_bdf(const std::string &bdf,
     }
     status = priv_cuid_file_.find_by_bdf(bdf, entry);
     if (status != AMDCUID_STATUS_SUCCESS) {
-      return status; // Not found in privileged file
+      return status;  // Not found in privileged file
     }
   } else {
     status = unpriv_cuid_file_.load();
@@ -382,7 +372,7 @@ CuidDeviceManager::get_device_from_file_by_bdf(const std::string &bdf,
     }
     status = unpriv_cuid_file_.find_by_bdf(bdf, entry);
     if (status != AMDCUID_STATUS_SUCCESS) {
-      return status; // Not found in unprivileged file
+      return status;  // Not found in unprivileged file
     }
   }
 
@@ -394,15 +384,14 @@ CuidDeviceManager::get_device_from_file_by_bdf(const std::string &bdf,
   return status;
 }
 
-amdcuid_status_t
-CuidDeviceManager::request_device(const std::string &device_path,
-                                  amdcuid_device_type_t device_type,
-                                  DevicePtr &device) {
+amdcuid_status_t CuidDeviceManager::request_device(const std::string& device_path,
+                                                   amdcuid_device_type_t device_type,
+                                                   DevicePtr& device) {
   amdcuid_status_t status;
   if (CuidDaemonIpcClientUtils::is_daemon_running()) {
     amdcuid_id_t device_handle;
-    status = CuidDaemonIpcClientUtils::request_add_device(
-        device_path.c_str(), device_type, &device_handle);
+    status = CuidDaemonIpcClientUtils::request_add_device(device_path.c_str(), device_type,
+                                                          &device_handle);
     if (status == AMDCUID_STATUS_SUCCESS) {
       // Lookup device by handle and return it
       status = get_device_from_file_by_id(device_handle, device);
@@ -481,15 +470,15 @@ amdcuid_status_t CuidDeviceManager::shutdown() {
   return AMDCUID_STATUS_SUCCESS;
 }
 
-CuidDeviceManager &CuidDeviceManager::instance() {
+CuidDeviceManager& CuidDeviceManager::instance() {
   static CuidDeviceManager instance;
   return instance;
 }
 
 void CuidDeviceManager::get_grouped_devices(
-    std::map<amdcuid_device_type_t, std::vector<DevicePtr>> &grouped) {
+    std::map<amdcuid_device_type_t, std::vector<DevicePtr>>& grouped) {
   grouped.clear();
-  for (const auto &entry : devices_) {
+  for (const auto& entry : devices_) {
     grouped[entry->type()].push_back(entry);
   }
 }
@@ -498,11 +487,10 @@ void CuidDeviceManager::build_cuid_index() {
   std::lock_guard<std::mutex> lock(manager_mutex_);
 
   cuid_index_.clear();
-  for (const auto &device : devices_) {
+  for (const auto& device : devices_) {
     amdcuid_derived_id derived;
     if (geteuid() == 0) {
-      if (device->get_derived_cuid(derived, &manager_hmac) ==
-          AMDCUID_STATUS_SUCCESS) {
+      if (device->get_derived_cuid(derived, &manager_hmac) == AMDCUID_STATUS_SUCCESS) {
         cuid_index_[derived.UUIDv8_representation] = device;
       }
     } else {
@@ -513,8 +501,7 @@ void CuidDeviceManager::build_cuid_index() {
   }
 }
 
-DevicePtr
-CuidDeviceManager::lookup_by_handle(const amdcuid_id_t &handle) const {
+DevicePtr CuidDeviceManager::lookup_by_handle(const amdcuid_id_t& handle) const {
   // Since amdcuid_id_t is our handle, we can use it directly as key
   auto it = cuid_index_.find(handle);
   return (it != cuid_index_.end()) ? it->second : nullptr;
@@ -524,7 +511,7 @@ std::vector<amdcuid_id_t> CuidDeviceManager::get_all_handles() const {
   std::vector<amdcuid_id_t> handles;
   handles.reserve(cuid_index_.size());
 
-  for (const auto &pair : cuid_index_) {
+  for (const auto& pair : cuid_index_) {
     // amdcuid_id_t is the handle, so just copy directly
     handles.push_back(pair.first);
   }
@@ -537,8 +524,8 @@ amdcuid_status_t CuidDeviceManager::save_registry_to_files() {
   amdcuid_status_t status = AMDCUID_STATUS_SUCCESS;
   if (geteuid() == 0) {
     // Generate new priv CUID file from current device list
-    status = CuidFileGenerator::generate_priv_from_devices(
-        devices_, priv_cuid_file_.get_file_path());
+    status =
+        CuidFileGenerator::generate_priv_from_devices(devices_, priv_cuid_file_.get_file_path());
     if (status != AMDCUID_STATUS_SUCCESS) {
       return status;
     }
@@ -548,8 +535,8 @@ amdcuid_status_t CuidDeviceManager::save_registry_to_files() {
   }
 
   // Generate new unpriv CUID file from current device list
-  status = CuidFileGenerator::generate_unpriv_from_devices(
-      devices_, unpriv_cuid_file_.get_file_path());
+  status =
+      CuidFileGenerator::generate_unpriv_from_devices(devices_, unpriv_cuid_file_.get_file_path());
   if (status != AMDCUID_STATUS_SUCCESS) {
     return status;
   }

--- a/projects/cuid/lib/src/cuid_device_manager.h
+++ b/projects/cuid/lib/src/cuid_device_manager.h
@@ -4,158 +4,164 @@
 #ifndef CUID_DEVICE_MANAGER_H
 #define CUID_DEVICE_MANAGER_H
 
+#include <cstring>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include "include/amd_cuid.h"
 #include "src/cuid_device.h"
 #include "src/cuid_file.h"
 #include "src/hmac.h"
-#include "include/amd_cuid.h"
-#include <vector>
-#include <memory>
-#include <map>
-#include <cstring>
-#include <mutex>
 
 /**
  * @brief Bitmask set of device types for querying multiple device types.
  *
  * These values are used as bitmasks to specify which device types to include in queries.
- * Each value corresponds to a specific device type, and AMDCUID_DEVICE_TYPE_SET_ALL selects all types.
+ * Each value corresponds to a specific device type, and AMDCUID_DEVICE_TYPE_SET_ALL selects all
+ * types.
  */
 typedef enum {
-    AMDCUID_DEVICE_TYPE_SET_NONE      = 0U,                                    ///< No device types
-    AMDCUID_DEVICE_TYPE_SET_PLATFORM  = 1U << AMDCUID_DEVICE_TYPE_PLATFORM, ///< Platform devices (chassis, motherboard)
-    AMDCUID_DEVICE_TYPE_SET_CPU       = 1U << AMDCUID_DEVICE_TYPE_CPU,      ///< CPU devices
-    AMDCUID_DEVICE_TYPE_SET_GPU       = 1U << AMDCUID_DEVICE_TYPE_GPU,      ///< GPU devices
-    AMDCUID_DEVICE_TYPE_SET_NIC       = 1U << AMDCUID_DEVICE_TYPE_NIC,      ///< NIC devices
-    AMDCUID_DEVICE_TYPE_SET_NPU       = 1U << AMDCUID_DEVICE_TYPE_NPU,      ///< NPU devices
-    AMDCUID_DEVICE_TYPE_SET_ALL       = -1U                                    ///< All device types
+  AMDCUID_DEVICE_TYPE_SET_NONE = 0U,  ///< No device types
+  AMDCUID_DEVICE_TYPE_SET_PLATFORM =
+      1U << AMDCUID_DEVICE_TYPE_PLATFORM,  ///< Platform devices (chassis, motherboard)
+  AMDCUID_DEVICE_TYPE_SET_CPU = 1U << AMDCUID_DEVICE_TYPE_CPU,  ///< CPU devices
+  AMDCUID_DEVICE_TYPE_SET_GPU = 1U << AMDCUID_DEVICE_TYPE_GPU,  ///< GPU devices
+  AMDCUID_DEVICE_TYPE_SET_NIC = 1U << AMDCUID_DEVICE_TYPE_NIC,  ///< NIC devices
+  AMDCUID_DEVICE_TYPE_SET_NPU = 1U << AMDCUID_DEVICE_TYPE_NPU,  ///< NPU devices
+  AMDCUID_DEVICE_TYPE_SET_ALL = -1U                             ///< All device types
 } amdcuid_device_type_set_t;
 
 /**
  * @brief Comparator for amdcuid_id_t (16-byte array comparison) for use as map key.
  */
 struct CuidComparator {
-    bool operator()(const amdcuid_id_t& a, const amdcuid_id_t& b) const {
-        return std::memcmp(a.bytes, b.bytes, 16) < 0;
-    }
+  bool operator()(const amdcuid_id_t& a, const amdcuid_id_t& b) const {
+    return std::memcmp(a.bytes, b.bytes, 16) < 0;
+  }
 };
 
 class CuidDeviceManager {
-public:
-    // Mutex for thread-safe access
-    mutable std::mutex manager_mutex_;
+ public:
+  // Mutex for thread-safe access
+  mutable std::mutex manager_mutex_;
 
-    static CuidDeviceManager& instance();
-    amdcuid_status_t discover_devices(); // should rename to discover_devices() or similar
-    amdcuid_status_t shutdown(); // no need for this function as actual shutdown function, may be useful for unit testing
+  static CuidDeviceManager& instance();
+  amdcuid_status_t discover_devices();  // should rename to discover_devices() or similar
+  amdcuid_status_t shutdown();  // no need for this function as actual shutdown function, may be
+                                // useful for unit testing
 
-    const std::vector<DevicePtr>& devices() const { return devices_; }
-    void get_grouped_devices(std::map<amdcuid_device_type_t, std::vector<DevicePtr>>& grouped);
-    const amdcuid_device_type_set_t& device_types() const { return device_types_; }
+  const std::vector<DevicePtr>& devices() const { return devices_; }
+  void get_grouped_devices(std::map<amdcuid_device_type_t, std::vector<DevicePtr>>& grouped);
+  const amdcuid_device_type_set_t& device_types() const { return device_types_; }
 
-    amdcuid_status_t add_device(DevicePtr device);
+  amdcuid_status_t add_device(DevicePtr device);
 
-    /**
-     * @brief Discover all devices currently present on the system.
-     * 
-     * @return AMDCUID_STATUS_SUCCESS on success, error code otherwise
-     */
-    amdcuid_status_t get_devices_on_system();
+  /**
+   * @brief Discover all devices currently present on the system.
+   *
+   * @return AMDCUID_STATUS_SUCCESS on success, error code otherwise
+   */
+  amdcuid_status_t get_devices_on_system();
 
-    /**
-     * @brief Create devices from CUID file entries.
-     * @param[in] cuid_file The CUID file containing device entries.
-     * 
-     * @return AMDCUID_STATUS_SUCCESS on success, error code otherwise
-     */
-    amdcuid_status_t get_devices_from_file_entries(CuidFile& cuid_file);
+  /**
+   * @brief Create devices from CUID file entries.
+   * @param[in] cuid_file The CUID file containing device entries.
+   *
+   * @return AMDCUID_STATUS_SUCCESS on success, error code otherwise
+   */
+  amdcuid_status_t get_devices_from_file_entries(CuidFile& cuid_file);
 
-    /**
-     * @brief Get device from CUID file by derived CUID and add to device list.
-     * @param[in] derived_cuid The derived CUID to look for.
-     * @param[out] device The device pointer to populate.
-     * 
-     * @return AMDCUID_STATUS_SUCCESS on success, error code otherwise
-     */
-    amdcuid_status_t get_device_from_file_by_id(amdcuid_id_t& derived_cuid, DevicePtr& device);
+  /**
+   * @brief Get device from CUID file by derived CUID and add to device list.
+   * @param[in] derived_cuid The derived CUID to look for.
+   * @param[out] device The device pointer to populate.
+   *
+   * @return AMDCUID_STATUS_SUCCESS on success, error code otherwise
+   */
+  amdcuid_status_t get_device_from_file_by_id(amdcuid_id_t& derived_cuid, DevicePtr& device);
 
-    /**
-     * @brief Get device from CUID file by device path and add to device list.
-     * @param[in] device_path The device path to look for.
-     * @param[out] device The device pointer to populate.
-     * 
-     * @return AMDCUID_STATUS_SUCCESS on success, error code otherwise
-     */
-    amdcuid_status_t get_device_from_file_by_dev_path(const std::string& device_path, DevicePtr& device);
+  /**
+   * @brief Get device from CUID file by device path and add to device list.
+   * @param[in] device_path The device path to look for.
+   * @param[out] device The device pointer to populate.
+   *
+   * @return AMDCUID_STATUS_SUCCESS on success, error code otherwise
+   */
+  amdcuid_status_t get_device_from_file_by_dev_path(const std::string& device_path,
+                                                    DevicePtr& device);
 
-    /**
-     * @brief Get device from CUID file by BDF and add to device list.
-     * @param[in] bdf The BDF to look for.
-     * @param[out] device The device pointer to populate.
-     * 
-     * @return AMDCUID_STATUS_SUCCESS on success, error code otherwise
-     */
-    amdcuid_status_t get_device_from_file_by_bdf(const std::string& bdf, DevicePtr& device);
+  /**
+   * @brief Get device from CUID file by BDF and add to device list.
+   * @param[in] bdf The BDF to look for.
+   * @param[out] device The device pointer to populate.
+   *
+   * @return AMDCUID_STATUS_SUCCESS on success, error code otherwise
+   */
+  amdcuid_status_t get_device_from_file_by_bdf(const std::string& bdf, DevicePtr& device);
 
-    /**
-     * @brief Request addition of a device by its path and type.
-     * @param[in] device_path The device path of the target device.
-     * @param[in] device_type The type of the device (see amdcuid_device_type_t).
-     * @param[out] device Pointer to the device pointer that will be filled with the requested device.
-     * 
-     * @return AMDCUID_STATUS_SUCCESS on success, error code otherwise
-     */
-    amdcuid_status_t request_device(const std::string& device_path, amdcuid_device_type_t device_type, DevicePtr& device);
+  /**
+   * @brief Request addition of a device by its path and type.
+   * @param[in] device_path The device path of the target device.
+   * @param[in] device_type The type of the device (see amdcuid_device_type_t).
+   * @param[out] device Pointer to the device pointer that will be filled with the requested device.
+   *
+   * @return AMDCUID_STATUS_SUCCESS on success, error code otherwise
+   */
+  amdcuid_status_t request_device(const std::string& device_path, amdcuid_device_type_t device_type,
+                                  DevicePtr& device);
 
-    /**
-     * @brief Request a refresh of the device list from the system.
-     * 
-     * @return AMDCUID_STATUS_SUCCESS on success, error code otherwise
-     */
-    amdcuid_status_t request_refresh();
+  /**
+   * @brief Request a refresh of the device list from the system.
+   *
+   * @return AMDCUID_STATUS_SUCCESS on success, error code otherwise
+   */
+  amdcuid_status_t request_refresh();
 
-    /**
-     * @brief Build the CUID index after device discovery.
-     */
-    void build_cuid_index();
+  /**
+   * @brief Build the CUID index after device discovery.
+   */
+  void build_cuid_index();
 
-    /**
-     * @brief Look up a device by its handle (derived CUID).
-     * @param handle The handle containing the derived CUID.
-     * @return Pointer to the device, or nullptr if not found.
-     */
-    DevicePtr lookup_by_handle(const amdcuid_id_t& handle) const;
+  /**
+   * @brief Look up a device by its handle (derived CUID).
+   * @param handle The handle containing the derived CUID.
+   * @return Pointer to the device, or nullptr if not found.
+   */
+  DevicePtr lookup_by_handle(const amdcuid_id_t& handle) const;
 
-    /**
-     * @brief Get all device handles (derived CUIDs).
-     * @return Vector of all handles of devices present on the system.
-     */
-    std::vector<amdcuid_id_t> get_all_handles() const;
+  /**
+   * @brief Get all device handles (derived CUIDs).
+   * @return Vector of all handles of devices present on the system.
+   */
+  std::vector<amdcuid_id_t> get_all_handles() const;
 
-    /**
-     * @brief Save the current device registry to the CUID files.
-     * 
-     * @return AMDCUID_STATUS_SUCCESS on success, error code otherwise
-     */
-    amdcuid_status_t save_registry_to_files();
+  /**
+   * @brief Save the current device registry to the CUID files.
+   *
+   * @return AMDCUID_STATUS_SUCCESS on success, error code otherwise
+   */
+  amdcuid_status_t save_registry_to_files();
 
-private:
-    CuidDeviceManager() = default;
-    ~CuidDeviceManager() = default;
-    CuidDeviceManager(const CuidDeviceManager&) = delete;
-    CuidDeviceManager& operator=(const CuidDeviceManager&) = delete;
+ private:
+  CuidDeviceManager() = default;
+  ~CuidDeviceManager() = default;
+  CuidDeviceManager(const CuidDeviceManager&) = delete;
+  CuidDeviceManager& operator=(const CuidDeviceManager&) = delete;
 
-    std::vector<DevicePtr> devices_;
-    amdcuid_device_type_set_t device_types_;
+  std::vector<DevicePtr> devices_;
+  amdcuid_device_type_set_t device_types_;
 
-    /// Index lookup by derived CUID
-    std::map<amdcuid_id_t, DevicePtr, CuidComparator> cuid_index_;
+  /// Index lookup by derived CUID
+  std::map<amdcuid_id_t, DevicePtr, CuidComparator> cuid_index_;
 
-    // Cuid Files
-    CuidFile unpriv_cuid_file_{CuidUtilities::cuid_file(), true};
-    CuidFile priv_cuid_file_{CuidUtilities::priv_cuid_file(), false};
+  // Cuid Files
+  CuidFile unpriv_cuid_file_{CuidUtilities::cuid_file(), true};
+  CuidFile priv_cuid_file_{CuidUtilities::priv_cuid_file(), false};
 
-    //cuid hmac for deriving cuids
-    cuid_hmac manager_hmac = cuid_hmac();
+  // cuid hmac for deriving cuids
+  cuid_hmac manager_hmac = cuid_hmac();
 };
 
-#endif // CUID_DEVICE_MANAGER_H
+#endif  // CUID_DEVICE_MANAGER_H

--- a/projects/cuid/lib/src/cuid_file.cc
+++ b/projects/cuid/lib/src/cuid_file.cc
@@ -2,6 +2,19 @@
 // SPDX-License-Identifier: MIT
 
 #include "src/cuid_file.h"
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <cerrno>
+#include <cstring>
+#include <fstream>
+#include <iomanip>
+#include <limits>
+#include <sstream>
+
 #include "smbios_util.h"
 #include "src/cuid_cpu.h"
 #include "src/cuid_device.h"
@@ -12,30 +25,22 @@
 #include "src/cuid_platform.h"
 #include "src/cuid_util.h"
 #include "src/hmac.h"
-#include <algorithm>
-#include <cerrno>
-#include <cstring>
-#include <fcntl.h>
-#include <fstream>
-#include <iomanip>
-#include <limits>
-#include <sstream>
-#include <sys/stat.h>
-#include <unistd.h>
 
 // ============================================================================
 // CuidFileLock Implementation
 // ============================================================================
 
-CuidFileLock::CuidFileLock(const std::string &file_path, CuidLockType lock_type)
-    : lock_file_path_(file_path + ".lock"), lock_type_(lock_type), lock_fd_(-1),
+CuidFileLock::CuidFileLock(const std::string& file_path, CuidLockType lock_type)
+    : lock_file_path_(file_path + ".lock"),
+      lock_type_(lock_type),
+      lock_fd_(-1),
       is_locked_(false) {}
 
 CuidFileLock::~CuidFileLock() { release(); }
 
 bool CuidFileLock::acquire() {
   if (is_locked_) {
-    return true; // Already locked
+    return true;  // Already locked
   }
 
   // For shared (read) locks, we only need O_RDONLY access.
@@ -60,10 +65,9 @@ bool CuidFileLock::acquire() {
   if (lock_fd_ < 0 && lock_type_ == CuidLockType::SHARED && errno == ENOENT) {
     // Try to create the lock file - may fail if not privileged, which is OK
     // The file should be created by root when generating CUIDs
-    mode_t old_umask =
-        umask(0); // Temporarily clear umask for proper permissions
+    mode_t old_umask = umask(0);  // Temporarily clear umask for proper permissions
     lock_fd_ = open(lock_file_path_.c_str(), O_RDWR | O_CREAT, 0666);
-    umask(old_umask); // Restore umask
+    umask(old_umask);  // Restore umask
 
     // If created successfully, also chmod to ensure permissions are correct
     if (lock_fd_ >= 0) {
@@ -72,8 +76,8 @@ bool CuidFileLock::acquire() {
   }
 
   if (lock_fd_ < 0) {
-    LOG(ERROR, "CuidFileLock: Failed to open lock file "
-                   << lock_file_path_ << ": " << strerror(errno));
+    LOG(ERROR,
+        "CuidFileLock: Failed to open lock file " << lock_file_path_ << ": " << strerror(errno));
     return false;
   }
 
@@ -82,37 +86,36 @@ bool CuidFileLock::acquire() {
   memset(&fl, 0, sizeof(fl));
   fl.l_whence = SEEK_SET;
   fl.l_start = 0;
-  fl.l_len = 0; // Lock entire file
+  fl.l_len = 0;  // Lock entire file
   fl.l_type = (lock_type_ == CuidLockType::EXCLUSIVE) ? F_WRLCK : F_RDLCK;
 
   // F_SETLKW: blocking call - wait until lock is available
   if (fcntl(lock_fd_, F_SETLKW, &fl) < 0) {
-    LOG(ERROR, "CuidFileLock: Failed to acquire lock on "
-                   << lock_file_path_ << ": " << strerror(errno));
+    LOG(ERROR,
+        "CuidFileLock: Failed to acquire lock on " << lock_file_path_ << ": " << strerror(errno));
     close(lock_fd_);
     lock_fd_ = -1;
     return false;
   }
 
   is_locked_ = true;
-  LOG(DEBUG,
-      "CuidFileLock: Acquired "
-          << (lock_type_ == CuidLockType::EXCLUSIVE ? "exclusive" : "shared")
-          << " lock on " << lock_file_path_);
+  LOG(DEBUG, "CuidFileLock: Acquired "
+                 << (lock_type_ == CuidLockType::EXCLUSIVE ? "exclusive" : "shared") << " lock on "
+                 << lock_file_path_);
   return true;
 }
 
 bool CuidFileLock::acquire_with_timeout(int timeout_seconds) {
   // Special cases
   if (timeout_seconds == 0) {
-    return try_acquire(); // Non-blocking
+    return try_acquire();  // Non-blocking
   }
   if (timeout_seconds < 0) {
-    return acquire(); // Infinite wait
+    return acquire();  // Infinite wait
   }
 
   if (is_locked_) {
-    return true; // Already locked
+    return true;  // Already locked
   }
 
   // For shared (read) locks, we only need O_RDONLY access.
@@ -143,8 +146,8 @@ bool CuidFileLock::acquire_with_timeout(int timeout_seconds) {
   }
 
   if (lock_fd_ < 0) {
-    LOG(ERROR, "CuidFileLock: Failed to open lock file "
-                   << lock_file_path_ << ": " << strerror(errno));
+    LOG(ERROR,
+        "CuidFileLock: Failed to open lock file " << lock_file_path_ << ": " << strerror(errno));
     return false;
   }
 
@@ -153,11 +156,11 @@ bool CuidFileLock::acquire_with_timeout(int timeout_seconds) {
   memset(&fl, 0, sizeof(fl));
   fl.l_whence = SEEK_SET;
   fl.l_start = 0;
-  fl.l_len = 0; // Lock entire file
+  fl.l_len = 0;  // Lock entire file
   fl.l_type = (lock_type_ == CuidLockType::EXCLUSIVE) ? F_WRLCK : F_RDLCK;
 
   // Retry loop with timeout
-  const int retry_interval_ms = 50; // 50ms between retries
+  const int retry_interval_ms = 50;  // 50ms between retries
   const int max_retries = (timeout_seconds * 1000) / retry_interval_ms;
 
   for (int retry = 0; retry <= max_retries; ++retry) {
@@ -165,17 +168,15 @@ bool CuidFileLock::acquire_with_timeout(int timeout_seconds) {
     if (fcntl(lock_fd_, F_SETLK, &fl) == 0) {
       is_locked_ = true;
       LOG(DEBUG, "CuidFileLock: Acquired "
-                     << (lock_type_ == CuidLockType::EXCLUSIVE ? "exclusive"
-                                                               : "shared")
-                     << " lock on " << lock_file_path_ << " after " << retry
-                     << " retries");
+                     << (lock_type_ == CuidLockType::EXCLUSIVE ? "exclusive" : "shared")
+                     << " lock on " << lock_file_path_ << " after " << retry << " retries");
       return true;
     }
 
     // Check if it's a "lock held" error vs real error
     if (errno != EACCES && errno != EAGAIN) {
-      LOG(ERROR, "CuidFileLock: Failed to acquire lock on "
-                     << lock_file_path_ << ": " << strerror(errno));
+      LOG(ERROR,
+          "CuidFileLock: Failed to acquire lock on " << lock_file_path_ << ": " << strerror(errno));
       close(lock_fd_);
       lock_fd_ = -1;
       return false;
@@ -183,13 +184,12 @@ bool CuidFileLock::acquire_with_timeout(int timeout_seconds) {
 
     // Wait before retry (unless this is the last iteration)
     if (retry < max_retries) {
-      usleep(retry_interval_ms * 1000); // Convert ms to microseconds
+      usleep(retry_interval_ms * 1000);  // Convert ms to microseconds
     }
   }
 
   // Timeout reached
-  LOG(WARN, "CuidFileLock: Timeout after " << timeout_seconds
-                                           << " seconds waiting for lock on "
+  LOG(WARN, "CuidFileLock: Timeout after " << timeout_seconds << " seconds waiting for lock on "
                                            << lock_file_path_);
   close(lock_fd_);
   lock_fd_ = -1;
@@ -198,7 +198,7 @@ bool CuidFileLock::acquire_with_timeout(int timeout_seconds) {
 
 bool CuidFileLock::try_acquire() {
   if (is_locked_) {
-    return true; // Already locked
+    return true;  // Already locked
   }
 
   // For shared (read) locks, we only need O_RDONLY access.
@@ -229,8 +229,8 @@ bool CuidFileLock::try_acquire() {
   }
 
   if (lock_fd_ < 0) {
-    LOG(ERROR, "CuidFileLock: Failed to open lock file "
-                   << lock_file_path_ << ": " << strerror(errno));
+    LOG(ERROR,
+        "CuidFileLock: Failed to open lock file " << lock_file_path_ << ": " << strerror(errno));
     return false;
   }
 
@@ -239,18 +239,17 @@ bool CuidFileLock::try_acquire() {
   memset(&fl, 0, sizeof(fl));
   fl.l_whence = SEEK_SET;
   fl.l_start = 0;
-  fl.l_len = 0; // Lock entire file
+  fl.l_len = 0;  // Lock entire file
   fl.l_type = (lock_type_ == CuidLockType::EXCLUSIVE) ? F_WRLCK : F_RDLCK;
 
   // F_SETLK: non-blocking - return immediately if can't acquire
   if (fcntl(lock_fd_, F_SETLK, &fl) < 0) {
     if (errno == EACCES || errno == EAGAIN) {
       // Lock is held by another process
-      LOG(DEBUG, "CuidFileLock: Lock on " << lock_file_path_
-                                          << " held by another process");
+      LOG(DEBUG, "CuidFileLock: Lock on " << lock_file_path_ << " held by another process");
     } else {
-      LOG(ERROR, "CuidFileLock: Failed to try_acquire lock on "
-                     << lock_file_path_ << ": " << strerror(errno));
+      LOG(ERROR, "CuidFileLock: Failed to try_acquire lock on " << lock_file_path_ << ": "
+                                                                << strerror(errno));
     }
     close(lock_fd_);
     lock_fd_ = -1;
@@ -258,10 +257,9 @@ bool CuidFileLock::try_acquire() {
   }
 
   is_locked_ = true;
-  LOG(DEBUG,
-      "CuidFileLock: Acquired "
-          << (lock_type_ == CuidLockType::EXCLUSIVE ? "exclusive" : "shared")
-          << " lock on " << lock_file_path_);
+  LOG(DEBUG, "CuidFileLock: Acquired "
+                 << (lock_type_ == CuidLockType::EXCLUSIVE ? "exclusive" : "shared") << " lock on "
+                 << lock_file_path_);
   return true;
 }
 
@@ -275,12 +273,12 @@ void CuidFileLock::release() {
   memset(&fl, 0, sizeof(fl));
   fl.l_whence = SEEK_SET;
   fl.l_start = 0;
-  fl.l_len = 0; // Unlock entire file
+  fl.l_len = 0;  // Unlock entire file
   fl.l_type = F_UNLCK;
 
   if (fcntl(lock_fd_, F_SETLK, &fl) < 0) {
-    LOG(ERROR, "CuidFileLock: Failed to release lock on "
-                   << lock_file_path_ << ": " << strerror(errno));
+    LOG(ERROR,
+        "CuidFileLock: Failed to release lock on " << lock_file_path_ << ": " << strerror(errno));
   }
 
   close(lock_fd_);
@@ -293,7 +291,7 @@ void CuidFileLock::release() {
 // CuidFile Implementation
 // ============================================================================
 
-CuidFile::CuidFile(const std::string &file_path, bool is_privileged)
+CuidFile::CuidFile(const std::string& file_path, bool is_privileged)
     : file_path_(file_path), is_privileged_(is_privileged) {}
 
 bool CuidFile::exists() const {
@@ -301,30 +299,23 @@ bool CuidFile::exists() const {
   return (stat(file_path_.c_str(), &buffer) == 0);
 }
 
-std::string CuidFile::trim(const std::string &str) const {
+std::string CuidFile::trim(const std::string& str) const {
   size_t first = str.find_first_not_of(" \t\r\n");
-  if (first == std::string::npos)
-    return "";
+  if (first == std::string::npos) return "";
   size_t last = str.find_last_not_of(" \t\r\n");
   return str.substr(first, last - first + 1);
 }
 
-amdcuid_device_type_t
-CuidFile::string_to_device_type(const std::string &str) const {
-  if (str == "PLATFORM")
-    return AMDCUID_DEVICE_TYPE_PLATFORM;
-  if (str == "CPU")
-    return AMDCUID_DEVICE_TYPE_CPU;
-  if (str == "GPU")
-    return AMDCUID_DEVICE_TYPE_GPU;
-  if (str == "NIC")
-    return AMDCUID_DEVICE_TYPE_NIC;
-  if (str == "NPU")
-    return AMDCUID_DEVICE_TYPE_NPU;
+amdcuid_device_type_t CuidFile::string_to_device_type(const std::string& str) const {
+  if (str == "PLATFORM") return AMDCUID_DEVICE_TYPE_PLATFORM;
+  if (str == "CPU") return AMDCUID_DEVICE_TYPE_CPU;
+  if (str == "GPU") return AMDCUID_DEVICE_TYPE_GPU;
+  if (str == "NIC") return AMDCUID_DEVICE_TYPE_NIC;
+  if (str == "NPU") return AMDCUID_DEVICE_TYPE_NPU;
   return AMDCUID_DEVICE_TYPE_NONE;
 }
 
-amdcuid_id_t CuidFile::string_to_cuid(const std::string &str) const {
+amdcuid_id_t CuidFile::string_to_cuid(const std::string& str) const {
   amdcuid_id_t id;
   memset(id.bytes, 0, sizeof(id.bytes));
 
@@ -332,12 +323,11 @@ amdcuid_id_t CuidFile::string_to_cuid(const std::string &str) const {
   // Remove dashes and parse hex bytes
   std::string hex_only;
   for (char c : str) {
-    if (c != '-')
-      hex_only += c;
+    if (c != '-') hex_only += c;
   }
 
   if (hex_only.length() != 32) {
-    return id; // Return zero-filled ID on parse error
+    return id;  // Return zero-filled ID on parse error
   }
 
   for (int i = 0; i < 16; ++i) {
@@ -348,9 +338,8 @@ amdcuid_id_t CuidFile::string_to_cuid(const std::string &str) const {
   return id;
 }
 
-bool CuidFile::parse_section_header(const std::string &line,
-                                    amdcuid_device_type_t &type,
-                                    uint32_t &index) const {
+bool CuidFile::parse_section_header(const std::string& line, amdcuid_device_type_t& type,
+                                    uint32_t& index) const {
   // Parse lines like [GPU:0] or [PLATFORM]
   if (line.empty() || line[0] != '[' || line.back() != ']') {
     return false;
@@ -380,8 +369,7 @@ amdcuid_status_t CuidFile::load() {
   // Acquire shared lock for reading
   CuidFileLock lock(file_path_, CuidLockType::SHARED);
   if (!lock.acquire()) {
-    LOG(ERROR,
-        "CuidFile::load: Failed to acquire shared lock for " << file_path_);
+    LOG(ERROR, "CuidFile::load: Failed to acquire shared lock for " << file_path_);
     return AMDCUID_STATUS_FILE_ERROR;
   }
 
@@ -439,11 +427,9 @@ amdcuid_status_t CuidFile::load() {
         } else if (key == "device_node") {
           current_entry.device_node = value;
         } else if (key == "package_id") {
-          current_entry.package_id =
-              static_cast<uint16_t>(std::stoul(value, nullptr, 16));
+          current_entry.package_id = static_cast<uint16_t>(std::stoul(value, nullptr, 16));
         } else if (key == "core_id") {
-          current_entry.core_id =
-              static_cast<uint16_t>(std::stoul(value, nullptr, 16));
+          current_entry.core_id = static_cast<uint16_t>(std::stoul(value, nullptr, 16));
         } else if (key == "bdf") {
           current_entry.bdf = value;
         } else if (key == "mac_address") {
@@ -452,26 +438,19 @@ amdcuid_status_t CuidFile::load() {
           current_entry.hardware_fingerprint =
               static_cast<uint64_t>(std::stoull(value, nullptr, 16));
         } else if (key == "vendor_id") {
-          current_entry.vendor_id =
-              static_cast<uint16_t>(std::stoul(value, nullptr, 16));
+          current_entry.vendor_id = static_cast<uint16_t>(std::stoul(value, nullptr, 16));
         } else if (key == "device_id") {
-          current_entry.device_id =
-              static_cast<uint16_t>(std::stoul(value, nullptr, 16));
+          current_entry.device_id = static_cast<uint16_t>(std::stoul(value, nullptr, 16));
         } else if (key == "revision_id") {
-          current_entry.revision_id =
-              static_cast<uint8_t>(std::stoul(value, nullptr, 16));
+          current_entry.revision_id = static_cast<uint8_t>(std::stoul(value, nullptr, 16));
         } else if (key == "family") {
-          current_entry.family =
-              static_cast<uint16_t>(std::stoul(value, nullptr, 16));
+          current_entry.family = static_cast<uint16_t>(std::stoul(value, nullptr, 16));
         } else if (key == "model") {
-          current_entry.model =
-              static_cast<uint16_t>(std::stoul(value, nullptr, 16));
+          current_entry.model = static_cast<uint16_t>(std::stoul(value, nullptr, 16));
         } else if (key == "pci_class") {
-          current_entry.pci_class =
-              static_cast<uint16_t>(std::stoul(value, nullptr, 16));
+          current_entry.pci_class = static_cast<uint16_t>(std::stoul(value, nullptr, 16));
         } else if (key == "unit_id") {
-          current_entry.unit_id =
-              static_cast<uint16_t>(std::stoul(value, nullptr, 16));
+          current_entry.unit_id = static_cast<uint16_t>(std::stoul(value, nullptr, 16));
         } else if (key == "last_update") {
           current_entry.last_update = std::stol(value, nullptr, 10);
         }
@@ -492,8 +471,7 @@ amdcuid_status_t CuidFile::save() {
   // Acquire exclusive lock for writing
   CuidFileLock lock(file_path_, CuidLockType::EXCLUSIVE);
   if (!lock.acquire()) {
-    LOG(ERROR,
-        "CuidFile::save: Failed to acquire exclusive lock for " << file_path_);
+    LOG(ERROR, "CuidFile::save: Failed to acquire exclusive lock for " << file_path_);
     return AMDCUID_STATUS_FILE_ERROR;
   }
 
@@ -524,84 +502,77 @@ amdcuid_status_t CuidFile::save() {
   get_grouped_entries(grouped);
 
   // Define output order
-  std::vector<amdcuid_device_type_t> order = {
-      AMDCUID_DEVICE_TYPE_GPU, AMDCUID_DEVICE_TYPE_CPU, AMDCUID_DEVICE_TYPE_NIC,
-      AMDCUID_DEVICE_TYPE_NPU, AMDCUID_DEVICE_TYPE_PLATFORM};
+  std::vector<amdcuid_device_type_t> order = {AMDCUID_DEVICE_TYPE_GPU, AMDCUID_DEVICE_TYPE_CPU,
+                                              AMDCUID_DEVICE_TYPE_NIC, AMDCUID_DEVICE_TYPE_NPU,
+                                              AMDCUID_DEVICE_TYPE_PLATFORM};
 
   for (auto type : order) {
-    if (grouped.find(type) == grouped.end())
-      continue;
+    if (grouped.find(type) == grouped.end()) continue;
 
-    for (const auto &entry : grouped[type]) {
+    for (const auto& entry : grouped[type]) {
       // Write section header
       if (entry.device_type == AMDCUID_DEVICE_TYPE_PLATFORM) {
-        file << "[" << CuidUtilities::device_type_to_string(entry.device_type)
-             << "]\n";
+        file << "[" << CuidUtilities::device_type_to_string(entry.device_type) << "]\n";
       } else {
-        file << "[" << CuidUtilities::device_type_to_string(entry.device_type)
-             << ":" << entry.device_index << "]\n";
+        file << "[" << CuidUtilities::device_type_to_string(entry.device_type) << ":"
+             << entry.device_index << "]\n";
       }
 
       // Write primary CUID (privileged file only)
       if (is_privileged_) {
-        file << "primary_cuid="
-             << CuidUtilities::get_cuid_as_string(&entry.primary_cuid) << "\n";
+        file << "primary_cuid=" << CuidUtilities::get_cuid_as_string(&entry.primary_cuid) << "\n";
       }
 
       // Write if CUID is temporary
-      file << "is_temporary=" << (entry.is_temporary ? "true" : "false")
-           << "\n";
+      file << "is_temporary=" << (entry.is_temporary ? "true" : "false") << "\n";
 
       // Write derived CUID
-      file << "derived_cuid="
-           << CuidUtilities::get_cuid_as_string(&entry.derived_cuid) << "\n";
+      file << "derived_cuid=" << CuidUtilities::get_cuid_as_string(&entry.derived_cuid) << "\n";
 
       // Write hardware fingerprint (privileged file only)
       if (is_privileged_) {
-        file << "hardware_fingerprint=0x" << std::hex << std::setw(16)
-             << std::setfill('0') << entry.hardware_fingerprint << "\n";
+        file << "hardware_fingerprint=0x" << std::hex << std::setw(16) << std::setfill('0')
+             << entry.hardware_fingerprint << "\n";
       }
 
       // Write device-specific fields
       if (entry.vendor_id != 0) {
-        file << "vendor_id=0x" << std::hex << std::setw(4) << std::setfill('0')
-             << entry.vendor_id << "\n";
-      }
-      if (entry.device_id != 0) {
-        file << "device_id=0x" << std::hex << std::setw(4) << std::setfill('0')
-             << entry.device_id << "\n";
-      }
-      if (entry.revision_id != 0) {
-        file << "revision_id=0x" << std::hex << std::setw(2)
-             << std::setfill('0') << static_cast<uint16_t>(entry.revision_id)
+        file << "vendor_id=0x" << std::hex << std::setw(4) << std::setfill('0') << entry.vendor_id
              << "\n";
       }
+      if (entry.device_id != 0) {
+        file << "device_id=0x" << std::hex << std::setw(4) << std::setfill('0') << entry.device_id
+             << "\n";
+      }
+      if (entry.revision_id != 0) {
+        file << "revision_id=0x" << std::hex << std::setw(2) << std::setfill('0')
+             << static_cast<uint16_t>(entry.revision_id) << "\n";
+      }
       if (entry.family != 0) {
-        file << "family=0x" << std::hex << std::setw(4) << std::setfill('0')
-             << entry.family << "\n";
+        file << "family=0x" << std::hex << std::setw(4) << std::setfill('0') << entry.family
+             << "\n";
       }
       if (entry.model != 0) {
-        file << "model=0x" << std::hex << std::setw(4) << std::setfill('0')
-             << entry.model << "\n";
+        file << "model=0x" << std::hex << std::setw(4) << std::setfill('0') << entry.model << "\n";
       }
       if (entry.pci_class != 0) {
-        file << "pci_class=0x" << std::hex << std::setw(4) << std::setfill('0')
-             << entry.pci_class << "\n";
+        file << "pci_class=0x" << std::hex << std::setw(4) << std::setfill('0') << entry.pci_class
+             << "\n";
       }
       if (entry.unit_id != std::numeric_limits<uint16_t>::max()) {
-        file << "unit_id=0x" << std::hex << std::setw(4) << std::setfill('0')
-             << entry.unit_id << "\n";
+        file << "unit_id=0x" << std::hex << std::setw(4) << std::setfill('0') << entry.unit_id
+             << "\n";
       }
       if (!entry.device_node.empty()) {
         file << "device_node=" << entry.device_node << "\n";
       }
       if (entry.package_id != std::numeric_limits<uint16_t>::max()) {
-        file << "package_id=0x" << std::hex << std::setw(4) << std::setfill('0')
-             << entry.package_id << "\n";
+        file << "package_id=0x" << std::hex << std::setw(4) << std::setfill('0') << entry.package_id
+             << "\n";
       }
       if (entry.core_id != std::numeric_limits<uint16_t>::max()) {
-        file << "core_id=0x" << std::hex << std::setw(4) << std::setfill('0')
-             << entry.core_id << "\n";
+        file << "core_id=0x" << std::hex << std::setw(4) << std::setfill('0') << entry.core_id
+             << "\n";
       }
       if (!entry.bdf.empty()) {
         file << "bdf=" << entry.bdf << "\n";
@@ -636,9 +607,9 @@ amdcuid_status_t CuidFile::save() {
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidFile::add_entry(const CuidFileEntry &entry) {
+amdcuid_status_t CuidFile::add_entry(const CuidFileEntry& entry) {
   // Check if entry with same derived CUID exists
-  for (auto &existing : entries_) {
+  for (auto& existing : entries_) {
     if (memcmp(existing.derived_cuid.bytes, entry.derived_cuid.bytes,
                sizeof(amdcuid_id_t::bytes)) == 0) {
       // Update existing entry
@@ -652,14 +623,12 @@ amdcuid_status_t CuidFile::add_entry(const CuidFileEntry &entry) {
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidFile::remove_entry(const amdcuid_id_t &handle) {
+amdcuid_status_t CuidFile::remove_entry(const amdcuid_id_t& handle) {
   // search for entry by derived CUID and move that entry to the back, then
   // erase it
-  auto it = std::remove_if(entries_.begin(), entries_.end(),
-                           [&handle](const CuidFileEntry &e) {
-                             return (memcmp(e.derived_cuid.bytes, handle.bytes,
-                                            sizeof(amdcuid_id_t::bytes)) == 0);
-                           });
+  auto it = std::remove_if(entries_.begin(), entries_.end(), [&handle](const CuidFileEntry& e) {
+    return (memcmp(e.derived_cuid.bytes, handle.bytes, sizeof(amdcuid_id_t::bytes)) == 0);
+  });
   if (it != entries_.end()) {
     entries_.erase(it, entries_.end());
     return AMDCUID_STATUS_SUCCESS;
@@ -667,9 +636,9 @@ amdcuid_status_t CuidFile::remove_entry(const amdcuid_id_t &handle) {
   return AMDCUID_STATUS_DEVICE_NOT_FOUND;
 }
 
-amdcuid_status_t CuidFile::find_by_device_node(const std::string &device_node,
-                                               CuidFileEntry &entry) const {
-  for (const auto &e : entries_) {
+amdcuid_status_t CuidFile::find_by_device_node(const std::string& device_node,
+                                               CuidFileEntry& entry) const {
+  for (const auto& e : entries_) {
     if (e.device_node == device_node) {
       entry = e;
       return AMDCUID_STATUS_SUCCESS;
@@ -678,9 +647,8 @@ amdcuid_status_t CuidFile::find_by_device_node(const std::string &device_node,
   return AMDCUID_STATUS_DEVICE_NOT_FOUND;
 }
 
-amdcuid_status_t CuidFile::find_by_bdf(const std::string &bdf,
-                                       CuidFileEntry &entry) const {
-  for (const auto &e : entries_) {
+amdcuid_status_t CuidFile::find_by_bdf(const std::string& bdf, CuidFileEntry& entry) const {
+  for (const auto& e : entries_) {
     if (e.bdf == bdf) {
       entry = e;
       return AMDCUID_STATUS_SUCCESS;
@@ -689,9 +657,8 @@ amdcuid_status_t CuidFile::find_by_bdf(const std::string &bdf,
   return AMDCUID_STATUS_DEVICE_NOT_FOUND;
 }
 
-amdcuid_status_t CuidFile::find_by_package_id(uint16_t package_id,
-                                              CuidFileEntry &entry) const {
-  for (const auto &e : entries_) {
+amdcuid_status_t CuidFile::find_by_package_id(uint16_t package_id, CuidFileEntry& entry) const {
+  for (const auto& e : entries_) {
     if (e.package_id == package_id) {
       entry = e;
       return AMDCUID_STATUS_SUCCESS;
@@ -700,10 +667,9 @@ amdcuid_status_t CuidFile::find_by_package_id(uint16_t package_id,
   return AMDCUID_STATUS_DEVICE_NOT_FOUND;
 }
 
-amdcuid_status_t
-CuidFile::find_by_device_type(amdcuid_device_type_t device_type,
-                              CuidFileEntry &entry) const {
-  for (const auto &e : entries_) {
+amdcuid_status_t CuidFile::find_by_device_type(amdcuid_device_type_t device_type,
+                                               CuidFileEntry& entry) const {
+  for (const auto& e : entries_) {
     if (e.device_type == device_type) {
       entry = e;
       return AMDCUID_STATUS_SUCCESS;
@@ -712,12 +678,10 @@ CuidFile::find_by_device_type(amdcuid_device_type_t device_type,
   return AMDCUID_STATUS_DEVICE_NOT_FOUND;
 }
 
-amdcuid_status_t
-CuidFile::find_by_derived_cuid(const amdcuid_id_t &derived_cuid,
-                               CuidFileEntry &entry) const {
-  for (const auto &e : entries_) {
-    if (memcmp(e.derived_cuid.bytes, derived_cuid.bytes,
-               sizeof(amdcuid_id_t::bytes)) == 0) {
+amdcuid_status_t CuidFile::find_by_derived_cuid(const amdcuid_id_t& derived_cuid,
+                                                CuidFileEntry& entry) const {
+  for (const auto& e : entries_) {
+    if (memcmp(e.derived_cuid.bytes, derived_cuid.bytes, sizeof(amdcuid_id_t::bytes)) == 0) {
       entry = e;
       return AMDCUID_STATUS_SUCCESS;
     }
@@ -726,10 +690,9 @@ CuidFile::find_by_derived_cuid(const amdcuid_id_t &derived_cuid,
 }
 
 void CuidFile::get_grouped_entries(
-    std::map<amdcuid_device_type_t, std::vector<CuidFileEntry>> &grouped)
-    const {
+    std::map<amdcuid_device_type_t, std::vector<CuidFileEntry>>& grouped) const {
   grouped.clear();
-  for (const auto &entry : entries_) {
+  for (const auto& entry : entries_) {
     grouped[entry.device_type].push_back(entry);
   }
 }
@@ -739,9 +702,9 @@ void CuidFile::get_grouped_entries(
 // ============================================================================
 
 // helper function to generate CUID files from a list of devices
-static amdcuid_status_t
-generate_from_devices(const std::vector<std::shared_ptr<CuidDevice>> &devices,
-                      const std::string &file, bool is_privileged) {
+static amdcuid_status_t generate_from_devices(
+    const std::vector<std::shared_ptr<CuidDevice>>& devices, const std::string& file,
+    bool is_privileged) {
   // Create file handlers
   CuidFile cuid_file(file, is_privileged);
 
@@ -755,9 +718,8 @@ generate_from_devices(const std::vector<std::shared_ptr<CuidDevice>> &devices,
   std::map<amdcuid_device_type_t, uint32_t> device_counters;
 
   // Process each device
-  for (const auto &device : devices) {
-    if (!device)
-      continue;
+  for (const auto& device : devices) {
+    if (!device) continue;
 
     CuidFileEntry entry;
     entry.device_type = device->type();
@@ -769,9 +731,8 @@ generate_from_devices(const std::vector<std::shared_ptr<CuidDevice>> &devices,
     bool is_temporary = false;
     status = device->is_temporary_cuid(&is_temporary);
     if (status != AMDCUID_STATUS_SUCCESS) {
-      std::cerr
-          << "Warning: Failed to get temporary CUID status for device type "
-          << entry.device_type << " status: " << status << std::endl;
+      std::cerr << "Warning: Failed to get temporary CUID status for device type "
+                << entry.device_type << " status: " << status << std::endl;
     }
     entry.is_temporary = is_temporary;
 
@@ -780,8 +741,8 @@ generate_from_devices(const std::vector<std::shared_ptr<CuidDevice>> &devices,
       amdcuid_primary_id primary_id = {};
       status = device->get_primary_cuid(primary_id);
       if (status != AMDCUID_STATUS_SUCCESS) {
-        std::cerr << "Warning: Failed to get primary CUID for device type "
-                  << entry.device_type << " status: " << status << std::endl;
+        std::cerr << "Warning: Failed to get primary CUID for device type " << entry.device_type
+                  << " status: " << status << std::endl;
       }
       entry.primary_cuid = primary_id.UUIDv8_representation;
 
@@ -789,9 +750,8 @@ generate_from_devices(const std::vector<std::shared_ptr<CuidDevice>> &devices,
       uint64_t fingerprint = 0;
       status = device->get_hardware_fingerprint(fingerprint);
       if (status != AMDCUID_STATUS_SUCCESS && !is_temporary) {
-        std::cerr
-            << "Warning: Failed to get hardware fingerprint for device type "
-            << entry.device_type << " status: " << status << std::endl;
+        std::cerr << "Warning: Failed to get hardware fingerprint for device type "
+                  << entry.device_type << " status: " << status << std::endl;
       } else {
         entry.hardware_fingerprint = fingerprint;
       }
@@ -800,124 +760,120 @@ generate_from_devices(const std::vector<std::shared_ptr<CuidDevice>> &devices,
     amdcuid_derived_id derived_id = {};
     status = device->get_derived_cuid(derived_id, &hmac);
     if (status != AMDCUID_STATUS_SUCCESS) {
-      std::cerr << "Warning: Failed to generate derived CUID for device type "
-                << entry.device_type << " status: " << status << std::endl;
+      std::cerr << "Warning: Failed to generate derived CUID for device type " << entry.device_type
+                << " status: " << status << std::endl;
     }
     entry.derived_cuid = derived_id.UUIDv8_representation;
 
     // Fill in device-specific information
     switch (entry.device_type) {
-    case AMDCUID_DEVICE_TYPE_GPU: {
-      auto gpu = std::dynamic_pointer_cast<CuidGpu>(device);
-      if (gpu) {
-        const auto &info = gpu->get_info();
-        entry.vendor_id = info.header.fields.gpu.vendor_id;
-        entry.device_id = info.header.fields.gpu.device_id;
-        entry.revision_id = info.header.fields.gpu.revision_id;
-        entry.pci_class = info.header.fields.gpu.pci_class;
-        entry.unit_id = info.header.fields.gpu.unit_id;
-        entry.device_node = info.render_node;
-        entry.bdf = info.bdf;
+      case AMDCUID_DEVICE_TYPE_GPU: {
+        auto gpu = std::dynamic_pointer_cast<CuidGpu>(device);
+        if (gpu) {
+          const auto& info = gpu->get_info();
+          entry.vendor_id = info.header.fields.gpu.vendor_id;
+          entry.device_id = info.header.fields.gpu.device_id;
+          entry.revision_id = info.header.fields.gpu.revision_id;
+          entry.pci_class = info.header.fields.gpu.pci_class;
+          entry.unit_id = info.header.fields.gpu.unit_id;
+          entry.device_node = info.render_node;
+          entry.bdf = info.bdf;
 
-        // if temp CUID, make the fallback fingerprint based on the GPU's PCIe
-        // BDF
-        if (is_temporary) {
-          CuidUtilities::make_fallback_fingerprint(info.bdf,
-                                                   entry.hardware_fingerprint);
+          // if temp CUID, make the fallback fingerprint based on the GPU's PCIe
+          // BDF
+          if (is_temporary) {
+            CuidUtilities::make_fallback_fingerprint(info.bdf, entry.hardware_fingerprint);
+          }
         }
+        break;
       }
-      break;
-    }
-    case AMDCUID_DEVICE_TYPE_CPU: {
-      auto cpu = std::dynamic_pointer_cast<CuidCpu>(device);
-      if (cpu) {
-        const auto &info = cpu->get_info();
-        entry.vendor_id = info.header.fields.cpu.vendor_id;
-        entry.device_id = info.header.fields.cpu.device_id;
-        entry.revision_id = info.header.fields.cpu.revision_id;
-        entry.family = info.header.fields.cpu.family;
-        entry.model = info.header.fields.cpu.model;
-        entry.unit_id = info.header.fields.cpu.unit_id;
-        entry.package_id = info.header.fields.cpu.physical_id;
-        entry.core_id = info.header.fields.cpu.core;
-        // Store device path (unique per logical CPU, needed for SMT)
-        std::string cpu_device_path;
-        if (cpu->get_device_path(cpu_device_path) == AMDCUID_STATUS_SUCCESS) {
-          entry.device_node = cpu_device_path;
+      case AMDCUID_DEVICE_TYPE_CPU: {
+        auto cpu = std::dynamic_pointer_cast<CuidCpu>(device);
+        if (cpu) {
+          const auto& info = cpu->get_info();
+          entry.vendor_id = info.header.fields.cpu.vendor_id;
+          entry.device_id = info.header.fields.cpu.device_id;
+          entry.revision_id = info.header.fields.cpu.revision_id;
+          entry.family = info.header.fields.cpu.family;
+          entry.model = info.header.fields.cpu.model;
+          entry.unit_id = info.header.fields.cpu.unit_id;
+          entry.package_id = info.header.fields.cpu.physical_id;
+          entry.core_id = info.header.fields.cpu.core;
+          // Store device path (unique per logical CPU, needed for SMT)
+          std::string cpu_device_path;
+          if (cpu->get_device_path(cpu_device_path) == AMDCUID_STATUS_SUCCESS) {
+            entry.device_node = cpu_device_path;
+          }
+          // if temp CUID, make the fallback fingerprint based on the CPU's
+          // package
+          if (is_temporary) {
+            CuidUtilities::make_fallback_fingerprint(std::to_string(entry.package_id),
+                                                     entry.hardware_fingerprint);
+          }
         }
-        // if temp CUID, make the fallback fingerprint based on the CPU's
-        // package
-        if (is_temporary) {
-          CuidUtilities::make_fallback_fingerprint(
-              std::to_string(entry.package_id), entry.hardware_fingerprint);
-        }
+        break;
       }
-      break;
-    }
-    case AMDCUID_DEVICE_TYPE_NIC: {
-      auto nic = std::dynamic_pointer_cast<CuidNic>(device);
-      if (nic) {
-        const auto &info = nic->get_info();
-        entry.vendor_id = info.header.fields.nic.vendor_id;
-        entry.device_id = info.header.fields.nic.device_id;
-        entry.revision_id = info.header.fields.nic.revision_id;
-        entry.pci_class = info.header.fields.nic.pci_class;
-        entry.device_node = info.network_interface;
-        std::string mac_address;
-        if (nic->get_mac_address(mac_address) == AMDCUID_STATUS_SUCCESS) {
-          entry.mac_address = mac_address;
-        }
-        entry.bdf = info.bdf;
+      case AMDCUID_DEVICE_TYPE_NIC: {
+        auto nic = std::dynamic_pointer_cast<CuidNic>(device);
+        if (nic) {
+          const auto& info = nic->get_info();
+          entry.vendor_id = info.header.fields.nic.vendor_id;
+          entry.device_id = info.header.fields.nic.device_id;
+          entry.revision_id = info.header.fields.nic.revision_id;
+          entry.pci_class = info.header.fields.nic.pci_class;
+          entry.device_node = info.network_interface;
+          std::string mac_address;
+          if (nic->get_mac_address(mac_address) == AMDCUID_STATUS_SUCCESS) {
+            entry.mac_address = mac_address;
+          }
+          entry.bdf = info.bdf;
 
-        // if temp CUID, make the fallback fingerprint based on the NIC's PCIe
-        // BDF
-        if (is_temporary) {
-          CuidUtilities::make_fallback_fingerprint(info.bdf,
-                                                   entry.hardware_fingerprint);
+          // if temp CUID, make the fallback fingerprint based on the NIC's PCIe
+          // BDF
+          if (is_temporary) {
+            CuidUtilities::make_fallback_fingerprint(info.bdf, entry.hardware_fingerprint);
+          }
         }
+        break;
       }
-      break;
-    }
-    case AMDCUID_DEVICE_TYPE_NPU: {
-      auto npu = std::dynamic_pointer_cast<CuidNpu>(device);
-      if (npu) {
-        const auto &info = npu->get_info();
-        entry.vendor_id = info.header.fields.npu.vendor_id;
-        entry.device_id = info.header.fields.npu.device_id;
-        entry.revision_id = info.header.fields.npu.revision_id;
-        entry.pci_class = info.header.fields.npu.pci_class;
-        entry.device_node = info.accel_node;
-        entry.bdf = info.bdf;
-        // if temp CUID, make the fallback fingerprint based on the NPU's PCIe
-        // BDF
-        if (is_temporary) {
-          CuidUtilities::make_fallback_fingerprint(info.bdf,
-                                                   entry.hardware_fingerprint);
+      case AMDCUID_DEVICE_TYPE_NPU: {
+        auto npu = std::dynamic_pointer_cast<CuidNpu>(device);
+        if (npu) {
+          const auto& info = npu->get_info();
+          entry.vendor_id = info.header.fields.npu.vendor_id;
+          entry.device_id = info.header.fields.npu.device_id;
+          entry.revision_id = info.header.fields.npu.revision_id;
+          entry.pci_class = info.header.fields.npu.pci_class;
+          entry.device_node = info.accel_node;
+          entry.bdf = info.bdf;
+          // if temp CUID, make the fallback fingerprint based on the NPU's PCIe
+          // BDF
+          if (is_temporary) {
+            CuidUtilities::make_fallback_fingerprint(info.bdf, entry.hardware_fingerprint);
+          }
         }
+        break;
       }
-      break;
-    }
-    case AMDCUID_DEVICE_TYPE_PLATFORM: {
-      auto platform = std::dynamic_pointer_cast<CuidPlatform>(device);
-      // Platform only has vendor_id
-      if (platform) {
-        const auto &info = platform->get_info();
-        entry.vendor_id = info.header.fields.platform.vendor_id;
+      case AMDCUID_DEVICE_TYPE_PLATFORM: {
+        auto platform = std::dynamic_pointer_cast<CuidPlatform>(device);
+        // Platform only has vendor_id
+        if (platform) {
+          const auto& info = platform->get_info();
+          entry.vendor_id = info.header.fields.platform.vendor_id;
 
-        // if temp CUID, make the fallback fingerprint based on the platform
-        // product name
-        if (is_temporary) {
-          std::string name = "";
-          std::string family_dummy = "";
-          SmbiosUtil::get_product_info(name, family_dummy);
-          CuidUtilities::make_fallback_fingerprint(name,
-                                                   entry.hardware_fingerprint);
+          // if temp CUID, make the fallback fingerprint based on the platform
+          // product name
+          if (is_temporary) {
+            std::string name = "";
+            std::string family_dummy = "";
+            SmbiosUtil::get_product_info(name, family_dummy);
+            CuidUtilities::make_fallback_fingerprint(name, entry.hardware_fingerprint);
+          }
         }
+        break;
       }
-      break;
-    }
-    default:
-      break;
+      default:
+        break;
     }
 
     // Add to file
@@ -935,13 +891,11 @@ generate_from_devices(const std::vector<std::shared_ptr<CuidDevice>> &devices,
 }
 
 amdcuid_status_t CuidFileGenerator::generate_unpriv_from_devices(
-    const std::vector<std::shared_ptr<CuidDevice>> &devices,
-    const std::string &unpriv_file_path) {
+    const std::vector<std::shared_ptr<CuidDevice>>& devices, const std::string& unpriv_file_path) {
   return generate_from_devices(devices, unpriv_file_path, false);
 }
 
 amdcuid_status_t CuidFileGenerator::generate_priv_from_devices(
-    const std::vector<std::shared_ptr<CuidDevice>> &devices,
-    const std::string &priv_file_path) {
+    const std::vector<std::shared_ptr<CuidDevice>>& devices, const std::string& priv_file_path) {
   return generate_from_devices(devices, priv_file_path, true);
 }

--- a/projects/cuid/lib/src/cuid_file.h
+++ b/projects/cuid/lib/src/cuid_file.h
@@ -4,25 +4,27 @@
 #ifndef CUID_FILE_H
 #define CUID_FILE_H
 
-#include "include/amd_cuid.h"
-#include "src/cuid_util.h"
+#include <fcntl.h>
+#include <unistd.h>
+
 #include <cerrno>
 #include <cstring>
 #include <ctime>
-#include <fcntl.h>
 #include <limits>
 #include <map>
 #include <memory>
 #include <string>
-#include <unistd.h>
 #include <vector>
+
+#include "include/amd_cuid.h"
+#include "src/cuid_util.h"
 
 /**
  * @brief Lock types for file operations
  */
 enum class CuidLockType {
-  SHARED,   ///< Shared lock for reading (multiple readers allowed)
-  EXCLUSIVE ///< Exclusive lock for writing (single writer, no readers)
+  SHARED,    ///< Shared lock for reading (multiple readers allowed)
+  EXCLUSIVE  ///< Exclusive lock for writing (single writer, no readers)
 };
 
 /**
@@ -48,7 +50,7 @@ enum class CuidLockType {
  *   if (lock.acquire()) { ... write operations ... }
  */
 class CuidFileLock {
-public:
+ public:
   /**
    * @brief Construct a file lock for the given CUID file path
    * @param file_path Path to the CUID file (lock file will be file_path +
@@ -56,7 +58,7 @@ public:
    * @param lock_type Type of lock to acquire (SHARED for read, EXCLUSIVE for
    * write)
    */
-  CuidFileLock(const std::string &file_path, CuidLockType lock_type);
+  CuidFileLock(const std::string& file_path, CuidLockType lock_type);
 
   /**
    * @brief Destructor - automatically releases the lock
@@ -64,10 +66,10 @@ public:
   ~CuidFileLock();
 
   // Non-copyable, non-movable (RAII resource)
-  CuidFileLock(const CuidFileLock &) = delete;
-  CuidFileLock &operator=(const CuidFileLock &) = delete;
-  CuidFileLock(CuidFileLock &&) = delete;
-  CuidFileLock &operator=(CuidFileLock &&) = delete;
+  CuidFileLock(const CuidFileLock&) = delete;
+  CuidFileLock& operator=(const CuidFileLock&) = delete;
+  CuidFileLock(CuidFileLock&&) = delete;
+  CuidFileLock& operator=(CuidFileLock&&) = delete;
 
   /**
    * @brief Acquire the lock (blocking)
@@ -104,9 +106,9 @@ public:
    * @brief Get the lock file path
    * @return Path to the lock file
    */
-  const std::string &get_lock_file_path() const { return lock_file_path_; }
+  const std::string& get_lock_file_path() const { return lock_file_path_; }
 
-private:
+ private:
   std::string lock_file_path_;
   CuidLockType lock_type_;
   int lock_fd_;
@@ -115,39 +117,36 @@ private:
 
 struct CuidFileEntry {
   amdcuid_device_type_t device_type;
-  uint32_t device_index = 0; // e.g., 0 for GPU:0, 1 for GPU:1
+  uint32_t device_index = 0;  // e.g., 0 for GPU:0, 1 for GPU:1
 
-  amdcuid_id_t primary_cuid; // Only available in privileged file
+  amdcuid_id_t primary_cuid;  // Only available in privileged file
   amdcuid_id_t derived_cuid;
 
-  uint64_t hardware_fingerprint = 0; // Only available in privileged file
+  uint64_t hardware_fingerprint = 0;  // Only available in privileged file
   uint16_t vendor_id = 0;
   uint16_t device_id = 0;
   uint8_t revision_id = 0;
 
   // Device-specific information
-  uint16_t family = 0;    // For CPU
-  uint16_t model = 0;     // For CPU
-  uint16_t pci_class = 0; // For PCIe devices (GPU, NIC)
-  uint16_t unit_id = std::numeric_limits<uint16_t>::max(); // For CPU and GPU
-  std::string device_node; // For GPU: /sys/class/drm/renderD128, NIC:
-                           // /sys/class/net/eth0
-  uint16_t package_id =
-      std::numeric_limits<uint16_t>::max(); // For CPU, aka physical id, akin to
-                                            // socket id
-  uint16_t core_id =
-      std::numeric_limits<uint16_t>::max(); // For CPU, aka core id within the
-                                            // package
-  std::string bdf;                          // PCIe Bus:Device.Function
-  std::string mac_address;                  // For NIC
+  uint16_t family = 0;                                      // For CPU
+  uint16_t model = 0;                                       // For CPU
+  uint16_t pci_class = 0;                                   // For PCIe devices (GPU, NIC)
+  uint16_t unit_id = std::numeric_limits<uint16_t>::max();  // For CPU and GPU
+  std::string device_node;  // For GPU: /sys/class/drm/renderD128, NIC:
+                            // /sys/class/net/eth0
+  uint16_t package_id = std::numeric_limits<uint16_t>::max();  // For CPU, aka physical id, akin to
+                                                               // socket id
+  uint16_t core_id = std::numeric_limits<uint16_t>::max();     // For CPU, aka core id within the
+                                                               // package
+  std::string bdf;                                             // PCIe Bus:Device.Function
+  std::string mac_address;                                     // For NIC
 
-  bool is_temporary = false; // Indicates if the CUID is temporary (not derived
-                             // from a true hardware fingerprint)
+  bool is_temporary = false;  // Indicates if the CUID is temporary (not derived
+                              // from a true hardware fingerprint)
 
-  time_t last_update; // Unix timestamp
+  time_t last_update;  // Unix timestamp
 
-  CuidFileEntry()
-      : device_type(AMDCUID_DEVICE_TYPE_NONE), device_index(0), last_update(0) {
+  CuidFileEntry() : device_type(AMDCUID_DEVICE_TYPE_NONE), device_index(0), last_update(0) {
     memset(primary_cuid.bytes, 0, sizeof(primary_cuid.bytes));
     memset(derived_cuid.bytes, 0, sizeof(derived_cuid.bytes));
   }
@@ -157,36 +156,33 @@ struct CuidFileEntry {
  * @brief CUID File handler for reading and writing device CUID information
  */
 class CuidFile {
-public:
+ public:
   /**
    * @brief Constructor
    * @param file_path Path to the CUID file (e.g., /tmp/cuid or /tmp/priv_cuid)
    * @param is_privileged Whether this is a privileged file (includes primary
    * CUIDs)
    */
-  CuidFile(const std::string &file_path, bool is_privileged = false);
+  CuidFile(const std::string& file_path, bool is_privileged = false);
 
   amdcuid_status_t load();
   amdcuid_status_t save();
-  amdcuid_status_t add_entry(const CuidFileEntry &entry);
-  amdcuid_status_t remove_entry(const amdcuid_id_t &handle);
+  amdcuid_status_t add_entry(const CuidFileEntry& entry);
+  amdcuid_status_t remove_entry(const amdcuid_id_t& handle);
 
-  const std::vector<CuidFileEntry> &get_entries() const { return entries_; }
+  const std::vector<CuidFileEntry>& get_entries() const { return entries_; }
 
-  amdcuid_status_t find_by_device_node(const std::string &device_node,
-                                       CuidFileEntry &entry) const;
-  amdcuid_status_t find_by_bdf(const std::string &bdf,
-                               CuidFileEntry &entry) const;
-  amdcuid_status_t find_by_package_id(uint16_t package_id,
-                                      CuidFileEntry &entry) const;
+  amdcuid_status_t find_by_device_node(const std::string& device_node, CuidFileEntry& entry) const;
+  amdcuid_status_t find_by_bdf(const std::string& bdf, CuidFileEntry& entry) const;
+  amdcuid_status_t find_by_package_id(uint16_t package_id, CuidFileEntry& entry) const;
   amdcuid_status_t find_by_device_type(amdcuid_device_type_t device_type,
-                                       CuidFileEntry &entry) const;
-  amdcuid_status_t find_by_derived_cuid(const amdcuid_id_t &derived_cuid,
-                                        CuidFileEntry &entry) const;
+                                       CuidFileEntry& entry) const;
+  amdcuid_status_t find_by_derived_cuid(const amdcuid_id_t& derived_cuid,
+                                        CuidFileEntry& entry) const;
 
   void clear() { entries_.clear(); }
   bool exists() const;
-  const std::string &get_file_path() const { return file_path_; }
+  const std::string& get_file_path() const { return file_path_; }
 
   /**
    * @brief Check if this is a privileged file
@@ -194,27 +190,27 @@ public:
   bool is_privileged() const { return is_privileged_; }
 
   // static utility to group entries by device type
-  void get_grouped_entries(std::map<amdcuid_device_type_t,
-                                    std::vector<CuidFileEntry>> &grouped) const;
+  void get_grouped_entries(
+      std::map<amdcuid_device_type_t, std::vector<CuidFileEntry>>& grouped) const;
 
-private:
+ private:
   std::string file_path_;
   bool is_privileged_;
   std::vector<CuidFileEntry> entries_;
 
   // Helper functions
-  amdcuid_device_type_t string_to_device_type(const std::string &str) const;
-  amdcuid_id_t string_to_cuid(const std::string &str) const;
-  std::string trim(const std::string &str) const;
-  bool parse_section_header(const std::string &line,
-                            amdcuid_device_type_t &type, uint32_t &index) const;
+  amdcuid_device_type_t string_to_device_type(const std::string& str) const;
+  amdcuid_id_t string_to_cuid(const std::string& str) const;
+  std::string trim(const std::string& str) const;
+  bool parse_section_header(const std::string& line, amdcuid_device_type_t& type,
+                            uint32_t& index) const;
 };
 
 /**
  * @brief Utility class for generating CUID files from discovered devices
  */
 class CuidFileGenerator {
-public:
+ public:
   /**
    * @brief Generate unprivileged CUID file from device manager
    * @param devices Vector of discovered devices
@@ -223,8 +219,8 @@ public:
    * @return AMDCUID_STATUS_SUCCESS on success, error code otherwise
    */
   static amdcuid_status_t generate_unpriv_from_devices(
-      const std::vector<std::shared_ptr<class CuidDevice>> &devices,
-      const std::string &unprivileged_file = CuidUtilities::cuid_file());
+      const std::vector<std::shared_ptr<class CuidDevice>>& devices,
+      const std::string& unprivileged_file = CuidUtilities::cuid_file());
 
   /**
    * @brief Generate privileged CUID file from device manager
@@ -234,8 +230,8 @@ public:
    * @return AMDCUID_STATUS_SUCCESS on success, error code otherwise
    */
   static amdcuid_status_t generate_priv_from_devices(
-      const std::vector<std::shared_ptr<class CuidDevice>> &devices,
-      const std::string &privileged_file = CuidUtilities::priv_cuid_file());
+      const std::vector<std::shared_ptr<class CuidDevice>>& devices,
+      const std::string& privileged_file = CuidUtilities::priv_cuid_file());
 };
 
-#endif // CUID_FILE_H
+#endif  // CUID_FILE_H

--- a/projects/cuid/lib/src/cuid_gpu.cc
+++ b/projects/cuid/lib/src/cuid_gpu.cc
@@ -2,32 +2,33 @@
 // SPDX-License-Identifier: MIT
 
 #include "cuid_gpu.h"
-#include "cuid_file.h"
-#include "cuid_util.h"
-#include "gim_util.h"
-#include "pci_util.h"
+
+#include <dirent.h>
+#include <sys/types.h>
+#include <unistd.h>
+
 #include <algorithm>
 #include <cstring>
-#include <dirent.h>
 #include <fstream>
 #include <iostream>
 #include <memory>
 #include <set>
 #include <sstream>
-#include <sys/types.h>
-#include <unistd.h>
 
-CuidGpu::CuidGpu(const amdcuid_gpu_info &i) : m_info(i) {}
+#include "cuid_file.h"
+#include "cuid_util.h"
+#include "gim_util.h"
+#include "pci_util.h"
+
+CuidGpu::CuidGpu(const amdcuid_gpu_info& i) : m_info(i) {}
 
 // Helper to check if a /sys/class/drm entry name is a card device (e.g.,
 // "card0", "card1"). Excludes connector entries like "card0-DP-1" or
 // "card0-HDMI-A-1".
-static bool is_card_entry(const char *name) {
-  if (strncmp(name, "card", 4) != 0 || !isdigit(name[4]))
-    return false;
+static bool is_card_entry(const char* name) {
+  if (strncmp(name, "card", 4) != 0 || !isdigit(name[4])) return false;
   for (size_t i = 4; name[i] != '\0'; ++i) {
-    if (!isdigit(name[i]))
-      return false;
+    if (!isdigit(name[i])) return false;
   }
   return true;
 }
@@ -35,14 +36,13 @@ static bool is_card_entry(const char *name) {
 // Resolve the renderD node path for a given card path.
 // If a renderD node exists under the card's device/drm directory, returns
 // "/sys/class/drm/renderDXXX". Otherwise, returns the original card path.
-static std::string resolve_render_node(const std::string &card_path) {
+static std::string resolve_render_node(const std::string& card_path) {
   std::string drm_dir = card_path + "/device/drm";
-  DIR *dir = opendir(drm_dir.c_str());
+  DIR* dir = opendir(drm_dir.c_str());
   if (dir) {
-    struct dirent *entry;
+    struct dirent* entry;
     while ((entry = readdir(dir)) != nullptr) {
-      if (strncmp(entry->d_name, "renderD", 7) == 0 &&
-          isdigit(entry->d_name[7])) {
+      if (strncmp(entry->d_name, "renderD", 7) == 0 && isdigit(entry->d_name[7])) {
         std::string result = "/sys/class/drm/" + std::string(entry->d_name);
         closedir(dir);
         return result;
@@ -60,12 +60,12 @@ static std::string resolve_render_node(const std::string &card_path) {
 // path which passes "/sys/bus/pci/devices/<bdf>") must not be trimmed --
 // doing so would collapse every device to the parent directory and corrupt
 // the CUID-file identifier.
-std::string CuidGpu::normalize_render_node(const std::string &device_path) {
+std::string CuidGpu::normalize_render_node(const std::string& device_path) {
   std::string full_device_node = device_path;
   const std::string kDeviceSuffix = "/device";
   if (full_device_node.size() > kDeviceSuffix.size() &&
-      full_device_node.compare(full_device_node.size() - kDeviceSuffix.size(),
-                               kDeviceSuffix.size(), kDeviceSuffix) == 0) {
+      full_device_node.compare(full_device_node.size() - kDeviceSuffix.size(), kDeviceSuffix.size(),
+                               kDeviceSuffix) == 0) {
     full_device_node.resize(full_device_node.size() - kDeviceSuffix.size());
   }
 
@@ -79,7 +79,7 @@ std::string CuidGpu::normalize_render_node(const std::string &device_path) {
   return full_device_node;
 }
 
-amdcuid_status_t CuidGpu::discover(std::vector<DevicePtr> &gpus) {
+amdcuid_status_t CuidGpu::discover(std::vector<DevicePtr>& gpus) {
   // Track BDFs we've already added so the GIM enumeration below doesn't
   // create duplicates of GPUs that are also visible via /sys/class/drm.
   std::set<std::string> seen_bdfs;
@@ -91,24 +91,22 @@ amdcuid_status_t CuidGpu::discover(std::vector<DevicePtr> &gpus) {
     gim_client.reset(new cuid::gim::GimClient());
   }
 
-  const char *drm_path = "/sys/class/drm";
-  DIR *dir = opendir(drm_path);
+  const char* drm_path = "/sys/class/drm";
+  DIR* dir = opendir(drm_path);
   if (dir != nullptr) {
-    struct dirent *entry;
+    struct dirent* entry;
     while ((entry = readdir(dir)) != NULL) {
       // Use card entries (e.g., card0, card1) which are always present for DRM
       // devices, unlike renderD nodes which may be absent with certain drivers
       // (e.g., GIM) or for non-AMD GPUs.
       if (is_card_entry(entry->d_name)) {
         std::string card_name(entry->d_name);
-        std::string device_path =
-            std::string(drm_path) + "/" + card_name + "/device";
+        std::string device_path = std::string(drm_path) + "/" + card_name + "/device";
         amdcuid_gpu_info info = {};
         // Skip partitioned or otherwise unsupported cards; discover_single
         // leaves `info` untouched in that case, so emplacing it would add a
         // zero-filled GPU entry.
-        if (discover_single(&info, device_path, gim_client.get()) ==
-            AMDCUID_STATUS_UNSUPPORTED) {
+        if (discover_single(&info, device_path, gim_client.get()) == AMDCUID_STATUS_UNSUPPORTED) {
           continue;
         }
         if (!info.bdf.empty()) {
@@ -126,7 +124,7 @@ amdcuid_status_t CuidGpu::discover(std::vector<DevicePtr> &gpus) {
   if (gim_client) {
     std::vector<cuid::gim::GimDeviceEntry> gim_devices;
     if (gim_client->get_devices(gim_devices) == AMDCUID_STATUS_SUCCESS) {
-      for (const auto &dev : gim_devices) {
+      for (const auto& dev : gim_devices) {
         if (dev.bdf.empty() || seen_bdfs.count(dev.bdf) > 0) {
           continue;
         }
@@ -161,10 +159,9 @@ amdcuid_status_t CuidGpu::discover(std::vector<DevicePtr> &gpus) {
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidGpu::discover_single(amdcuid_gpu_info *gpu_info,
-                                          const std::string &device_path,
-                                          cuid::gim::GimClient *gim_client) {
-
+amdcuid_status_t CuidGpu::discover_single(amdcuid_gpu_info* gpu_info,
+                                          const std::string& device_path,
+                                          cuid::gim::GimClient* gim_client) {
   amdcuid_gpu_info info = {};
   std::string bdf = CuidUtilities::readlink_bdf(device_path);
 
@@ -178,8 +175,7 @@ amdcuid_status_t CuidGpu::discover_single(amdcuid_gpu_info *gpu_info,
   // where unit_id is 0 (bare metal or passthrough). If config file is missing,
   // that indicates partition which is unsupported for CUID generation.
   std::string config_file = device_path + "/config";
-  if (access(config_file.c_str(), F_OK) == -1 &&
-      info.header.fields.gpu.unit_id == 0) {
+  if (access(config_file.c_str(), F_OK) == -1 && info.header.fields.gpu.unit_id == 0) {
     return AMDCUID_STATUS_UNSUPPORTED;
   }
 
@@ -188,15 +184,11 @@ amdcuid_status_t CuidGpu::discover_single(amdcuid_gpu_info *gpu_info,
     // if file read fails, attempt to get from pci config
     uint8_t vendor_id_bytes[2] = {0};
     const uint16_t offset = 0x0;
-    amdcuid_status_t status =
-        PciUtil::read_pci_config_space(bdf, vendor_id_bytes, 2, offset);
-    uint16_t vendor_id_int =
-        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t *>(vendor_id_bytes));
-    info.header.fields.gpu.vendor_id =
-        (status == AMDCUID_STATUS_SUCCESS) ? vendor_id_int : 0;
+    amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, vendor_id_bytes, 2, offset);
+    uint16_t vendor_id_int = PciUtil::le16_to_be16(*reinterpret_cast<uint16_t*>(vendor_id_bytes));
+    info.header.fields.gpu.vendor_id = (status == AMDCUID_STATUS_SUCCESS) ? vendor_id_int : 0;
   } else {
-    info.header.fields.gpu.vendor_id =
-        (uint16_t)strtol(vendor.c_str(), nullptr, 16);
+    info.header.fields.gpu.vendor_id = (uint16_t)strtol(vendor.c_str(), nullptr, 16);
   }
 
   std::string device = CuidUtilities::read_sysfs_file(device_path + "/device");
@@ -204,28 +196,21 @@ amdcuid_status_t CuidGpu::discover_single(amdcuid_gpu_info *gpu_info,
     // if file read fails, attempt to get from pci config
     uint8_t device_id_bytes[2] = {0};
     const uint16_t offset = 0x2;
-    amdcuid_status_t status =
-        PciUtil::read_pci_config_space(bdf, device_id_bytes, 2, offset);
-    uint16_t device_id_int =
-        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t *>(device_id_bytes));
-    info.header.fields.gpu.device_id =
-        (status == AMDCUID_STATUS_SUCCESS) ? device_id_int : 0;
+    amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, device_id_bytes, 2, offset);
+    uint16_t device_id_int = PciUtil::le16_to_be16(*reinterpret_cast<uint16_t*>(device_id_bytes));
+    info.header.fields.gpu.device_id = (status == AMDCUID_STATUS_SUCCESS) ? device_id_int : 0;
   } else {
-    info.header.fields.gpu.device_id =
-        (uint16_t)strtol(device.c_str(), nullptr, 16);
+    info.header.fields.gpu.device_id = (uint16_t)strtol(device.c_str(), nullptr, 16);
   }
 
-  std::string pci_class =
-      CuidUtilities::read_sysfs_file(device_path + "/class");
+  std::string pci_class = CuidUtilities::read_sysfs_file(device_path + "/class");
   uint16_t pci_class_integer = 0;
   if (pci_class.empty() && !bdf.empty()) {
     // if file read fails, attempt to get from pci config
     uint8_t class_id_bytes[2] = {0};
     const uint16_t offset = 0xa;
-    amdcuid_status_t status =
-        PciUtil::read_pci_config_space(bdf, class_id_bytes, 2, offset);
-    uint16_t class_id_int =
-        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t *>(class_id_bytes));
+    amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, class_id_bytes, 2, offset);
+    uint16_t class_id_int = PciUtil::le16_to_be16(*reinterpret_cast<uint16_t*>(class_id_bytes));
     pci_class_integer = (status == AMDCUID_STATUS_SUCCESS) ? class_id_int : 0;
   } else {
     // sysfs class file returns 24-bit value (class:subclass:prog_if), shift
@@ -234,21 +219,17 @@ amdcuid_status_t CuidGpu::discover_single(amdcuid_gpu_info *gpu_info,
   }
   info.header.fields.gpu.pci_class = pci_class_integer;
 
-  std::string revision_id =
-      CuidUtilities::read_sysfs_file(device_path + "/revision");
+  std::string revision_id = CuidUtilities::read_sysfs_file(device_path + "/revision");
   if (revision_id.empty() && !bdf.empty()) {
     // if file read fails, attempt to get from pci config
     uint8_t revision_id_bytes[2] = {0};
     const uint16_t offset = 0x8;
-    amdcuid_status_t status =
-        PciUtil::read_pci_config_space(bdf, revision_id_bytes, 2, offset);
+    amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, revision_id_bytes, 2, offset);
     uint16_t revision_id_int =
-        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t *>(revision_id_bytes));
-    info.header.fields.gpu.revision_id =
-        (status == AMDCUID_STATUS_SUCCESS) ? revision_id_int : 0;
+        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t*>(revision_id_bytes));
+    info.header.fields.gpu.revision_id = (status == AMDCUID_STATUS_SUCCESS) ? revision_id_int : 0;
   } else {
-    info.header.fields.gpu.revision_id =
-        (uint16_t)strtol(revision_id.c_str(), nullptr, 16);
+    info.header.fields.gpu.revision_id = (uint16_t)strtol(revision_id.c_str(), nullptr, 16);
   }
 
   // Determine the device node path. We prefer the renderD node for backward
@@ -270,19 +251,15 @@ amdcuid_status_t CuidGpu::discover_single(amdcuid_gpu_info *gpu_info,
   const bool needs_gim_fallback = !info.bdf.empty() && gim_client != nullptr;
   if (needs_gim_fallback) {
     cuid::gim::GimAsicInfo asic;
-    if (gim_client->get_asic_info_for_bdf(info.bdf, asic) ==
-        AMDCUID_STATUS_SUCCESS) {
+    if (gim_client->get_asic_info_for_bdf(info.bdf, asic) == AMDCUID_STATUS_SUCCESS) {
       if (info.header.fields.gpu.vendor_id == 0) {
-        info.header.fields.gpu.vendor_id =
-            static_cast<uint16_t>(asic.vendor_id);
+        info.header.fields.gpu.vendor_id = static_cast<uint16_t>(asic.vendor_id);
       }
       if (info.header.fields.gpu.device_id == 0) {
-        info.header.fields.gpu.device_id =
-            static_cast<uint16_t>(asic.device_id);
+        info.header.fields.gpu.device_id = static_cast<uint16_t>(asic.device_id);
       }
       if (info.header.fields.gpu.revision_id == 0) {
-        info.header.fields.gpu.revision_id =
-            static_cast<uint8_t>(asic.rev_id);
+        info.header.fields.gpu.revision_id = static_cast<uint8_t>(asic.rev_id);
       }
       // GIM ASIC info omits pci_class; default to the PCI display-controller
       // class so GIM-only GPUs do not report an all-zero class.
@@ -292,8 +269,7 @@ amdcuid_status_t CuidGpu::discover_single(amdcuid_gpu_info *gpu_info,
       // GIM-only devices expose no sysfs unique_id or PCI config space, so
       // carry the ASIC serial as the hardware fingerprint source.
       uint64_t parsed_serial = 0;
-      if (cuid::gim::GimClient::parse_asic_serial(asic.asic_serial,
-                                                  parsed_serial)) {
+      if (cuid::gim::GimClient::parse_asic_serial(asic.asic_serial, parsed_serial)) {
         info.gim_fingerprint = parsed_serial;
         info.gim_fingerprint_valid = true;
       }
@@ -305,16 +281,14 @@ amdcuid_status_t CuidGpu::discover_single(amdcuid_gpu_info *gpu_info,
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t
-CuidGpu::get_hardware_fingerprint(uint64_t &fingerprint) const {
+amdcuid_status_t CuidGpu::get_hardware_fingerprint(uint64_t& fingerprint) const {
   if (geteuid() != 0) {
     return AMDCUID_STATUS_PERMISSION_DENIED;
   }
 
   // For DRM render nodes the PCI attributes live at "<render_node>/device";
   // for GIM-only PCI directories they live directly under render_node.
-  const bool render_node_is_pci_dir =
-      m_info.render_node.find("/sys/bus/pci/devices/") == 0;
+  const bool render_node_is_pci_dir = m_info.render_node.find("/sys/bus/pci/devices/") == 0;
 
   // GIM-only devices have no sysfs unique_id or PCI config space; use the
   // ASIC serial captured during discovery as the fingerprint.
@@ -324,8 +298,7 @@ CuidGpu::get_hardware_fingerprint(uint64_t &fingerprint) const {
   }
 
   const std::string device_attr_prefix =
-      render_node_is_pci_dir ? m_info.render_node
-                             : (m_info.render_node + "/device");
+      render_node_is_pci_dir ? m_info.render_node : (m_info.render_node + "/device");
 
   std::string unique_id_path = device_attr_prefix + "/unique_id";
 
@@ -355,8 +328,7 @@ CuidGpu::get_hardware_fingerprint(uint64_t &fingerprint) const {
   } else if (m_info.header.fields.gpu.unit_id == 0) {
     // attempt to get fingerprint through PCI Config Space if not a VF
     uint16_t offset = 0;
-    amdcuid_status_t status =
-        PciUtil::get_pci_dsn_cap_offset(m_info.bdf, offset);
+    amdcuid_status_t status = PciUtil::get_pci_dsn_cap_offset(m_info.bdf, offset);
     if (status != AMDCUID_STATUS_SUCCESS) {
       // attempt to get fingerprint through VSEC fallback if DSN capability is
       // not found
@@ -369,16 +341,15 @@ CuidGpu::get_hardware_fingerprint(uint64_t &fingerprint) const {
 
     const uint8_t fingerprint_size = 8;
     uint8_t fingerprint_bytes[fingerprint_size] = {0};
-    status = PciUtil::read_pci_config_space(m_info.bdf, fingerprint_bytes,
-                                            fingerprint_size, offset);
+    status =
+        PciUtil::read_pci_config_space(m_info.bdf, fingerprint_bytes, fingerprint_size, offset);
     if (status != AMDCUID_STATUS_SUCCESS) {
       fingerprint = 0;
       return status;
     }
     // pcie config file is little endian, so need to convert to big endian
     uint64_t fingerprint_value = 0;
-    std::memcpy(&fingerprint_value, fingerprint_bytes,
-                sizeof(fingerprint_value));
+    std::memcpy(&fingerprint_value, fingerprint_bytes, sizeof(fingerprint_value));
     fingerprint = PciUtil::le64_to_be64(fingerprint_value);
   } else {
     // partitioned device without unique_id file or pci config cannot get
@@ -389,7 +360,7 @@ CuidGpu::get_hardware_fingerprint(uint64_t &fingerprint) const {
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidGpu::get_primary_cuid(amdcuid_primary_id &id) const {
+amdcuid_status_t CuidGpu::get_primary_cuid(amdcuid_primary_id& id) const {
   amdcuid_status_t status = AMDCUID_STATUS_SUCCESS;
   uint64_t fingerprint = 0;
   bool temp = false;
@@ -426,44 +397,43 @@ amdcuid_status_t CuidGpu::get_primary_cuid(amdcuid_primary_id &id) const {
 
   // Use header fields for the rest
   amdcuid_primary_id result = {};
-  const auto &h = m_info.header;
+  const auto& h = m_info.header;
   CuidUtilities::generate_primary_cuid(
-      fingerprint, h.fields.gpu.unit_id, h.fields.gpu.revision_id,
-      h.fields.gpu.device_id, h.fields.gpu.vendor_id,
-      static_cast<uint8_t>(AMDCUID_DEVICE_TYPE_GPU), &result, temp);
+      fingerprint, h.fields.gpu.unit_id, h.fields.gpu.revision_id, h.fields.gpu.device_id,
+      h.fields.gpu.vendor_id, static_cast<uint8_t>(AMDCUID_DEVICE_TYPE_GPU), &result, temp);
 
   id = result;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-const amdcuid_gpu_info &CuidGpu::get_info() const { return m_info; }
+const amdcuid_gpu_info& CuidGpu::get_info() const { return m_info; }
 
-amdcuid_status_t CuidGpu::get_vendor_id(uint16_t &vendor_id) const {
+amdcuid_status_t CuidGpu::get_vendor_id(uint16_t& vendor_id) const {
   vendor_id = m_info.header.fields.gpu.vendor_id;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidGpu::get_device_id(uint16_t &device_id) const {
+amdcuid_status_t CuidGpu::get_device_id(uint16_t& device_id) const {
   device_id = m_info.header.fields.gpu.device_id;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidGpu::get_pci_class(uint16_t &pci_class) const {
+amdcuid_status_t CuidGpu::get_pci_class(uint16_t& pci_class) const {
   pci_class = m_info.header.fields.gpu.pci_class;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidGpu::get_revision_id(uint8_t &revision_id) const {
+amdcuid_status_t CuidGpu::get_revision_id(uint8_t& revision_id) const {
   revision_id = m_info.header.fields.gpu.revision_id;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidGpu::get_unit_id(uint16_t &unit_id) const {
+amdcuid_status_t CuidGpu::get_unit_id(uint16_t& unit_id) const {
   unit_id = m_info.header.fields.gpu.unit_id;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidGpu::get_bdf(std::string &bdf) const {
+amdcuid_status_t CuidGpu::get_bdf(std::string& bdf) const {
   if (m_info.bdf.empty()) {
     return AMDCUID_STATUS_UNSUPPORTED;
   }
@@ -471,7 +441,7 @@ amdcuid_status_t CuidGpu::get_bdf(std::string &bdf) const {
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidGpu::get_device_path(std::string &path) const {
+amdcuid_status_t CuidGpu::get_device_path(std::string& path) const {
   if (m_info.render_node.empty()) {
     return AMDCUID_STATUS_UNSUPPORTED;
   }

--- a/projects/cuid/lib/src/cuid_gpu.h
+++ b/projects/cuid/lib/src/cuid_gpu.h
@@ -4,18 +4,19 @@
 #ifndef CUID_GPU_H
 #define CUID_GPU_H
 
-#include "include/amd_cuid.h"
-#include "src/cuid_device.h"
-#include "src/cuid_internal.h"
 #include <memory>
 #include <string>
 #include <vector>
 
+#include "include/amd_cuid.h"
+#include "src/cuid_device.h"
+#include "src/cuid_internal.h"
+
 namespace cuid {
 namespace gim {
 class GimClient;
-} // namespace gim
-} // namespace cuid
+}  // namespace gim
+}  // namespace cuid
 
 struct amdcuid_gpu_info {
   amdcuid_cuid_public_fields header;
@@ -30,45 +31,42 @@ struct amdcuid_gpu_info {
 };
 
 class CuidGpu : public CuidDevice {
-public:
-  CuidGpu(const amdcuid_gpu_info &i);
-  amdcuid_device_type_t type() const override {
-    return AMDCUID_DEVICE_TYPE_GPU;
-  }
-  amdcuid_status_t get_primary_cuid(amdcuid_primary_id &id) const override;
-  amdcuid_status_t
-  get_hardware_fingerprint(uint64_t &fingerprint) const override;
-  static amdcuid_status_t discover(std::vector<DevicePtr> &gpus);
+ public:
+  CuidGpu(const amdcuid_gpu_info& i);
+  amdcuid_device_type_t type() const override { return AMDCUID_DEVICE_TYPE_GPU; }
+  amdcuid_status_t get_primary_cuid(amdcuid_primary_id& id) const override;
+  amdcuid_status_t get_hardware_fingerprint(uint64_t& fingerprint) const override;
+  static amdcuid_status_t discover(std::vector<DevicePtr>& gpus);
   // discover_single populates `gpu_info` from `device_path`. When the host
   // runs the GIM SR-IOV driver, sysfs/PCI config space may not expose the
   // device, in which case the caller can pass an already-initialized
   // GimClient via `gim_client` to be used as a fallback. Passing nullptr
   // disables the GIM fallback for that call (used by code paths that have
   // no GimClient handy, e.g. amdcuid_get_handle_by_dev_path).
-  static amdcuid_status_t
-  discover_single(amdcuid_gpu_info *gpu_info, const std::string &device_path,
-                  cuid::gim::GimClient *gim_client = nullptr);
+  static amdcuid_status_t discover_single(amdcuid_gpu_info* gpu_info,
+                                          const std::string& device_path,
+                                          cuid::gim::GimClient* gim_client = nullptr);
 
   // Derive the render_node from an enumeration `device_path`. Strips a
   // trailing "/device" (as passed by /sys/class/drm enumeration) and, for
   // card paths, resolves the associated renderD node when one exists. Paths
   // that are neither (e.g. the GIM "/sys/bus/pci/devices/<bdf>" form) are
   // returned verbatim. Exposed for testing.
-  static std::string normalize_render_node(const std::string &device_path);
+  static std::string normalize_render_node(const std::string& device_path);
 
   // Virtual accessor overrides
-  amdcuid_status_t get_vendor_id(uint16_t &vendor_id) const override;
-  amdcuid_status_t get_device_id(uint16_t &device_id) const override;
-  amdcuid_status_t get_pci_class(uint16_t &pci_class) const override;
-  amdcuid_status_t get_revision_id(uint8_t &revision_id) const override;
-  amdcuid_status_t get_unit_id(uint16_t &unit_id) const override;
-  amdcuid_status_t get_bdf(std::string &bdf) const override;
-  amdcuid_status_t get_device_path(std::string &path) const override;
+  amdcuid_status_t get_vendor_id(uint16_t& vendor_id) const override;
+  amdcuid_status_t get_device_id(uint16_t& device_id) const override;
+  amdcuid_status_t get_pci_class(uint16_t& pci_class) const override;
+  amdcuid_status_t get_revision_id(uint8_t& revision_id) const override;
+  amdcuid_status_t get_unit_id(uint16_t& unit_id) const override;
+  amdcuid_status_t get_bdf(std::string& bdf) const override;
+  amdcuid_status_t get_device_path(std::string& path) const override;
 
-  const amdcuid_gpu_info &get_info() const;
+  const amdcuid_gpu_info& get_info() const;
 
-private:
+ private:
   amdcuid_gpu_info m_info;
 };
 
-#endif // CUID_GPU_H
+#endif  // CUID_GPU_H

--- a/projects/cuid/lib/src/cuid_internal.h
+++ b/projects/cuid/lib/src/cuid_internal.h
@@ -4,64 +4,67 @@
 #define LIB_CUID_INTERNAL_H_
 
 #include <cstdint>
+
 #include "include/amd_cuid.h"
 
 typedef struct {
-    uint16_t vendor_id;      ///< CPU Vendor ID (from CPUID EAX=0)
-    uint16_t family;         ///< CPU Family (from CPUID EAX=1)
-    uint16_t model;          ///< CPU Model (from CPUID EAX=1)
-    uint16_t device_id;      ///< DeviceID = Family & Model combined
-    uint8_t revision_id;     ///< CPU Stepping/RevisionID (from CPUID EAX=1)
-    uint16_t unit_id;        ///< UnitID from APIC ID (from ACPI MADT)
-    uint16_t core;           ///< Core number within package
-    uint16_t physical_id;    ///< Physical package/socket ID
+  uint16_t vendor_id;    ///< CPU Vendor ID (from CPUID EAX=0)
+  uint16_t family;       ///< CPU Family (from CPUID EAX=1)
+  uint16_t model;        ///< CPU Model (from CPUID EAX=1)
+  uint16_t device_id;    ///< DeviceID = Family & Model combined
+  uint8_t revision_id;   ///< CPU Stepping/RevisionID (from CPUID EAX=1)
+  uint16_t unit_id;      ///< UnitID from APIC ID (from ACPI MADT)
+  uint16_t core;         ///< Core number within package
+  uint16_t physical_id;  ///< Physical package/socket ID
 } amdcuid_cuid_public_fields_cpu;
 
 typedef struct {
-    uint16_t vendor_id;
-    uint16_t device_id;
-    uint16_t pci_class;
-    uint8_t revision_id;
-    uint16_t unit_id;
+  uint16_t vendor_id;
+  uint16_t device_id;
+  uint16_t pci_class;
+  uint8_t revision_id;
+  uint16_t unit_id;
 } amdcuid_cuid_public_fields_gpu;
 
 typedef struct {
-    uint16_t vendor_id;
-    uint16_t device_id;
-    uint16_t pci_class;
-    uint8_t revision_id;
+  uint16_t vendor_id;
+  uint16_t device_id;
+  uint16_t pci_class;
+  uint8_t revision_id;
 } amdcuid_cuid_public_fields_nic;
 
 typedef struct {
-    uint16_t vendor_id;
+  uint16_t vendor_id;
 } amdcuid_cuid_public_fields_platform;
 
 typedef struct {
-    uint16_t vendor_id;
-    uint16_t device_id;
-    uint16_t pci_class;
-    uint8_t revision_id;
+  uint16_t vendor_id;
+  uint16_t device_id;
+  uint16_t pci_class;
+  uint8_t revision_id;
 } amdcuid_cuid_public_fields_npu;
 
 typedef struct amdcuid_cuid_public_fields {
-    amdcuid_device_type_t device_type;
-    union {
-        amdcuid_cuid_public_fields_cpu cpu;
-        amdcuid_cuid_public_fields_gpu gpu;
-        amdcuid_cuid_public_fields_nic nic;
-        amdcuid_cuid_public_fields_platform platform;
-        amdcuid_cuid_public_fields_npu npu;
-    } fields;
+  amdcuid_device_type_t device_type;
+  union {
+    amdcuid_cuid_public_fields_cpu cpu;
+    amdcuid_cuid_public_fields_gpu gpu;
+    amdcuid_cuid_public_fields_nic nic;
+    amdcuid_cuid_public_fields_platform platform;
+    amdcuid_cuid_public_fields_npu npu;
+  } fields;
 } amdcuid_cuid_public_fields;
 
 typedef struct amdcuid_primary_id {
-    uint8_t raw_bits[16];               // 122 bits of raw data
-    amdcuid_id_t UUIDv8_representation; // UUIDv8 representation of the primary CUID which adds in the UUIDv8 required bits
+  uint8_t raw_bits[16];                // 122 bits of raw data
+  amdcuid_id_t UUIDv8_representation;  // UUIDv8 representation of the primary CUID which adds in
+                                       // the UUIDv8 required bits
 } amdcuid_primary_id;
 
 typedef struct amdcuid_derived_id {
-    uint8_t hash[14];                   // 110 LSB bits of HMAC hash
-    uint8_t raw_bits[16];               // 122 bits which adds back the unit id bits
-    amdcuid_id_t UUIDv8_representation; // UUIDv8 representation of the derived CUID which adds in the UUIDv8 required bits
+  uint8_t hash[14];                    // 110 LSB bits of HMAC hash
+  uint8_t raw_bits[16];                // 122 bits which adds back the unit id bits
+  amdcuid_id_t UUIDv8_representation;  // UUIDv8 representation of the derived CUID which adds in
+                                       // the UUIDv8 required bits
 } amdcuid_derived_id;
-#endif // LIB_CUID_INTERNAL_H_
+#endif  // LIB_CUID_INTERNAL_H_

--- a/projects/cuid/lib/src/cuid_nic.cc
+++ b/projects/cuid/lib/src/cuid_nic.cc
@@ -2,37 +2,38 @@
 // SPDX-License-Identifier: MIT
 
 #include "cuid_nic.h"
-#include "cuid_file.h"
-#include "cuid_util.h"
-#include "pci_util.h"
-#include <cstring>
+
 #include <dirent.h>
-#include <fstream>
-#include <iostream>
 #include <linux/ethtool.h>
 #include <linux/sockios.h>
 #include <net/if.h>
-#include <sstream>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
 
-CuidNic::CuidNic(const amdcuid_nic_info &i) : m_info(i) {}
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <sstream>
 
-amdcuid_status_t CuidNic::discover(std::vector<DevicePtr> &nics) {
+#include "cuid_file.h"
+#include "cuid_util.h"
+#include "pci_util.h"
+
+CuidNic::CuidNic(const amdcuid_nic_info& i) : m_info(i) {}
+
+amdcuid_status_t CuidNic::discover(std::vector<DevicePtr>& nics) {
   std::string nic_base_path = "/sys/class/net";
-  DIR *dir = opendir(nic_base_path.c_str());
-  if (!dir)
-    return AMDCUID_STATUS_DEVICE_NOT_FOUND;
+  DIR* dir = opendir(nic_base_path.c_str());
+  if (!dir) return AMDCUID_STATUS_DEVICE_NOT_FOUND;
 
-  struct dirent *entry;
+  struct dirent* entry;
   while ((entry = readdir(dir)) != NULL) {
     // grab everything except the loopback device and hidden entries
     if (strncmp(entry->d_name, "lo", 2) != 0 && entry->d_name[0] != '.') {
       amdcuid_nic_info info = {};
-      std::string device_path =
-          std::string(nic_base_path) + "/" + entry->d_name + "/device";
+      std::string device_path = std::string(nic_base_path) + "/" + entry->d_name + "/device";
       // filter out virtual devices by checking device symlink
       if (CuidUtilities::readlink_bdf(device_path).empty()) {
         continue;
@@ -43,14 +44,13 @@ amdcuid_status_t CuidNic::discover(std::vector<DevicePtr> &nics) {
     }
   }
   closedir(dir);
-  if (nics.size() == 0)
-    return AMDCUID_STATUS_DEVICE_NOT_FOUND;
+  if (nics.size() == 0) return AMDCUID_STATUS_DEVICE_NOT_FOUND;
 
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidNic::discover_single(amdcuid_nic_info *nic_info,
-                                          const std::string &device_path) {
+amdcuid_status_t CuidNic::discover_single(amdcuid_nic_info* nic_info,
+                                          const std::string& device_path) {
   amdcuid_nic_info info = {};
   info.header.device_type = AMDCUID_DEVICE_TYPE_NIC;
 
@@ -61,15 +61,11 @@ amdcuid_status_t CuidNic::discover_single(amdcuid_nic_info *nic_info,
     // if file read fails, attempt to get from pci config
     uint8_t vendor_id_bytes[2] = {0};
     const uint16_t offset = 0x0;
-    amdcuid_status_t status =
-        PciUtil::read_pci_config_space(bdf, vendor_id_bytes, 2, offset);
-    uint16_t vendor_id_int =
-        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t *>(vendor_id_bytes));
-    info.header.fields.nic.vendor_id =
-        (status == AMDCUID_STATUS_SUCCESS) ? vendor_id_int : 0;
+    amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, vendor_id_bytes, 2, offset);
+    uint16_t vendor_id_int = PciUtil::le16_to_be16(*reinterpret_cast<uint16_t*>(vendor_id_bytes));
+    info.header.fields.nic.vendor_id = (status == AMDCUID_STATUS_SUCCESS) ? vendor_id_int : 0;
   } else {
-    info.header.fields.nic.vendor_id =
-        (uint16_t)strtol(vendor.c_str(), nullptr, 16);
+    info.header.fields.nic.vendor_id = (uint16_t)strtol(vendor.c_str(), nullptr, 16);
   }
 
   std::string device = CuidUtilities::read_sysfs_file(device_path + "/device");
@@ -77,28 +73,21 @@ amdcuid_status_t CuidNic::discover_single(amdcuid_nic_info *nic_info,
     // if file read fails, attempt to get from pci config
     uint8_t device_id_bytes[2] = {0};
     const uint16_t offset = 0x2;
-    amdcuid_status_t status =
-        PciUtil::read_pci_config_space(bdf, device_id_bytes, 2, offset);
-    uint16_t device_id_int =
-        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t *>(device_id_bytes));
-    info.header.fields.nic.device_id =
-        (status == AMDCUID_STATUS_SUCCESS) ? device_id_int : 0;
+    amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, device_id_bytes, 2, offset);
+    uint16_t device_id_int = PciUtil::le16_to_be16(*reinterpret_cast<uint16_t*>(device_id_bytes));
+    info.header.fields.nic.device_id = (status == AMDCUID_STATUS_SUCCESS) ? device_id_int : 0;
   } else {
-    info.header.fields.nic.device_id =
-        (uint16_t)strtol(device.c_str(), nullptr, 16);
+    info.header.fields.nic.device_id = (uint16_t)strtol(device.c_str(), nullptr, 16);
   }
 
-  std::string pci_class =
-      CuidUtilities::read_sysfs_file(device_path + "/class");
+  std::string pci_class = CuidUtilities::read_sysfs_file(device_path + "/class");
   uint16_t pci_class_integer = 0;
   if (pci_class.empty() && !bdf.empty()) {
     // if file read fails, attempt to get from pci config
     uint8_t class_id_bytes[2] = {0};
     const uint16_t offset = 0xa;
-    amdcuid_status_t status =
-        PciUtil::read_pci_config_space(bdf, class_id_bytes, 2, offset);
-    uint16_t class_id_int =
-        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t *>(class_id_bytes));
+    amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, class_id_bytes, 2, offset);
+    uint16_t class_id_int = PciUtil::le16_to_be16(*reinterpret_cast<uint16_t*>(class_id_bytes));
     pci_class_integer = (status == AMDCUID_STATUS_SUCCESS) ? class_id_int : 0;
   } else {
     // sysfs class file returns 24-bit value (class:subclass:prog_if), shift
@@ -107,21 +96,17 @@ amdcuid_status_t CuidNic::discover_single(amdcuid_nic_info *nic_info,
   }
   info.header.fields.nic.pci_class = pci_class_integer;
 
-  std::string revision_id =
-      CuidUtilities::read_sysfs_file(device_path + "/revision");
+  std::string revision_id = CuidUtilities::read_sysfs_file(device_path + "/revision");
   if (revision_id.empty() && !bdf.empty()) {
     // if file read fails, attempt to get from pci config
     uint8_t revision_id_bytes[2] = {0};
     const uint16_t offset = 0x8;
-    amdcuid_status_t status =
-        PciUtil::read_pci_config_space(bdf, revision_id_bytes, 2, offset);
+    amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, revision_id_bytes, 2, offset);
     uint16_t revision_id_int =
-        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t *>(revision_id_bytes));
-    info.header.fields.nic.revision_id =
-        (status == AMDCUID_STATUS_SUCCESS) ? revision_id_int : 0;
+        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t*>(revision_id_bytes));
+    info.header.fields.nic.revision_id = (status == AMDCUID_STATUS_SUCCESS) ? revision_id_int : 0;
   } else {
-    info.header.fields.nic.revision_id =
-        (uint16_t)strtol(revision_id.c_str(), nullptr, 16);
+    info.header.fields.nic.revision_id = (uint16_t)strtol(revision_id.c_str(), nullptr, 16);
   }
   info.bdf = bdf;
   std::string full_device_node;
@@ -137,8 +122,7 @@ amdcuid_status_t CuidNic::discover_single(amdcuid_nic_info *nic_info,
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t
-CuidNic::get_hardware_fingerprint(uint64_t &fingerprint) const {
+amdcuid_status_t CuidNic::get_hardware_fingerprint(uint64_t& fingerprint) const {
   if (geteuid() != 0) {
     return AMDCUID_STATUS_PERMISSION_DENIED;
   }
@@ -153,12 +137,11 @@ CuidNic::get_hardware_fingerprint(uint64_t &fingerprint) const {
   if (status == AMDCUID_STATUS_SUCCESS) {
     const uint8_t fingerprint_size = 8;
     uint8_t fingerprint_bytes[fingerprint_size] = {0};
-    status = PciUtil::read_pci_config_space(m_info.bdf, fingerprint_bytes,
-                                            fingerprint_size, offset);
+    status =
+        PciUtil::read_pci_config_space(m_info.bdf, fingerprint_bytes, fingerprint_size, offset);
     if (status == AMDCUID_STATUS_SUCCESS) {
       uint64_t fingerprint_value = 0;
-      std::memcpy(&fingerprint_value, fingerprint_bytes,
-                  sizeof(fingerprint_bytes));
+      std::memcpy(&fingerprint_value, fingerprint_bytes, sizeof(fingerprint_bytes));
       fingerprint = PciUtil::le64_to_be64(fingerprint_value);
       return AMDCUID_STATUS_SUCCESS;
     }
@@ -174,9 +157,8 @@ CuidNic::get_hardware_fingerprint(uint64_t &fingerprint) const {
   if (!mac_address.empty()) {
     // convert MAC address string to bytes
     uint8_t mac_bytes[6] = {0};
-    sscanf(mac_address.c_str(), "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx", &mac_bytes[0],
-           &mac_bytes[1], &mac_bytes[2], &mac_bytes[3], &mac_bytes[4],
-           &mac_bytes[5]);
+    sscanf(mac_address.c_str(), "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx", &mac_bytes[0], &mac_bytes[1],
+           &mac_bytes[2], &mac_bytes[3], &mac_bytes[4], &mac_bytes[5]);
     uint64_t mac_fingerprint = 0;
     std::memcpy(&mac_fingerprint, mac_bytes, sizeof(mac_bytes));
     fingerprint = mac_fingerprint;
@@ -186,7 +168,7 @@ CuidNic::get_hardware_fingerprint(uint64_t &fingerprint) const {
   return AMDCUID_STATUS_HW_FINGERPRINT_NOT_FOUND;
 }
 
-amdcuid_status_t CuidNic::get_primary_cuid(amdcuid_primary_id &id) const {
+amdcuid_status_t CuidNic::get_primary_cuid(amdcuid_primary_id& id) const {
   bool temp = false;
   uint64_t fingerprint = 0;
   amdcuid_status_t status = AMDCUID_STATUS_SUCCESS;
@@ -223,9 +205,8 @@ amdcuid_status_t CuidNic::get_primary_cuid(amdcuid_primary_id &id) const {
   }
 
   status = CuidUtilities::generate_primary_cuid(
-      fingerprint, 0, m_info.header.fields.nic.revision_id,
-      m_info.header.fields.nic.device_id, m_info.header.fields.nic.vendor_id,
-      static_cast<uint8_t>(AMDCUID_DEVICE_TYPE_NIC), &id, temp);
+      fingerprint, 0, m_info.header.fields.nic.revision_id, m_info.header.fields.nic.device_id,
+      m_info.header.fields.nic.vendor_id, static_cast<uint8_t>(AMDCUID_DEVICE_TYPE_NIC), &id, temp);
   if (status != AMDCUID_STATUS_SUCCESS) {
     std::memset(&id, 0, sizeof(id));
     return status;
@@ -234,29 +215,29 @@ amdcuid_status_t CuidNic::get_primary_cuid(amdcuid_primary_id &id) const {
   return status;
 }
 
-const amdcuid_nic_info &CuidNic::get_info() const { return m_info; }
+const amdcuid_nic_info& CuidNic::get_info() const { return m_info; }
 
-amdcuid_status_t CuidNic::get_vendor_id(uint16_t &vendor_id) const {
+amdcuid_status_t CuidNic::get_vendor_id(uint16_t& vendor_id) const {
   vendor_id = m_info.header.fields.nic.vendor_id;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidNic::get_device_id(uint16_t &device_id) const {
+amdcuid_status_t CuidNic::get_device_id(uint16_t& device_id) const {
   device_id = m_info.header.fields.nic.device_id;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidNic::get_pci_class(uint16_t &pci_class) const {
+amdcuid_status_t CuidNic::get_pci_class(uint16_t& pci_class) const {
   pci_class = m_info.header.fields.nic.pci_class;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidNic::get_revision_id(uint8_t &revision_id) const {
+amdcuid_status_t CuidNic::get_revision_id(uint8_t& revision_id) const {
   revision_id = m_info.header.fields.nic.revision_id;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidNic::get_bdf(std::string &bdf) const {
+amdcuid_status_t CuidNic::get_bdf(std::string& bdf) const {
   if (m_info.bdf.empty()) {
     return AMDCUID_STATUS_UNSUPPORTED;
   }
@@ -264,7 +245,7 @@ amdcuid_status_t CuidNic::get_bdf(std::string &bdf) const {
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidNic::get_device_path(std::string &path) const {
+amdcuid_status_t CuidNic::get_device_path(std::string& path) const {
   if (m_info.network_interface.empty()) {
     return AMDCUID_STATUS_UNSUPPORTED;
   }
@@ -272,43 +253,38 @@ amdcuid_status_t CuidNic::get_device_path(std::string &path) const {
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidNic::get_mac_address(std::string &mac_address) const {
+amdcuid_status_t CuidNic::get_mac_address(std::string& mac_address) const {
   // Extract interface name from the sysfs path (e.g. /sys/class/net/eth0 ->
   // eth0)
   std::string iface = m_info.network_interface;
   size_t last_slash = iface.rfind('/');
-  if (last_slash != std::string::npos)
-    iface = iface.substr(last_slash + 1);
+  if (last_slash != std::string::npos) iface = iface.substr(last_slash + 1);
 
-  if (iface.empty() || iface.size() >= IFNAMSIZ)
-    return AMDCUID_STATUS_UNSUPPORTED;
+  if (iface.empty() || iface.size() >= IFNAMSIZ) return AMDCUID_STATUS_UNSUPPORTED;
 
   int fd = socket(AF_INET, SOCK_DGRAM, 0);
-  if (fd < 0)
-    return AMDCUID_STATUS_UNSUPPORTED;
+  if (fd < 0) return AMDCUID_STATUS_UNSUPPORTED;
 
-  struct ethtool_perm_addr *epaddr =
-      reinterpret_cast<struct ethtool_perm_addr *>(
-          new uint8_t[sizeof(struct ethtool_perm_addr) + ETH_ALEN]);
+  struct ethtool_perm_addr* epaddr = reinterpret_cast<struct ethtool_perm_addr*>(
+      new uint8_t[sizeof(struct ethtool_perm_addr) + ETH_ALEN]);
   epaddr->cmd = ETHTOOL_GPERMADDR;
   epaddr->size = ETH_ALEN;
 
   struct ifreq ifr = {};
   strncpy(ifr.ifr_name, iface.c_str(), IFNAMSIZ - 1);
-  ifr.ifr_data = reinterpret_cast<char *>(epaddr);
+  ifr.ifr_data = reinterpret_cast<char*>(epaddr);
 
   if (ioctl(fd, SIOCETHTOOL, &ifr) < 0) {
     close(fd);
-    delete[] reinterpret_cast<uint8_t *>(epaddr);
+    delete[] reinterpret_cast<uint8_t*>(epaddr);
     return AMDCUID_STATUS_UNSUPPORTED;
   }
   close(fd);
 
   char buf[18];
-  snprintf(buf, sizeof(buf), "%02x:%02x:%02x:%02x:%02x:%02x", epaddr->data[0],
-           epaddr->data[1], epaddr->data[2], epaddr->data[3], epaddr->data[4],
-           epaddr->data[5]);
-  delete[] reinterpret_cast<uint8_t *>(epaddr);
+  snprintf(buf, sizeof(buf), "%02x:%02x:%02x:%02x:%02x:%02x", epaddr->data[0], epaddr->data[1],
+           epaddr->data[2], epaddr->data[3], epaddr->data[4], epaddr->data[5]);
+  delete[] reinterpret_cast<uint8_t*>(epaddr);
 
   mac_address = buf;
   return AMDCUID_STATUS_SUCCESS;

--- a/projects/cuid/lib/src/cuid_nic.h
+++ b/projects/cuid/lib/src/cuid_nic.h
@@ -4,43 +4,45 @@
 #ifndef CUID_NIC_H
 #define CUID_NIC_H
 
-
-#include "src/cuid_device.h"
-#include "include/amd_cuid.h"
-#include "src/cuid_internal.h"
-#include <vector>
 #include <memory>
 #include <string>
+#include <vector>
+
+#include "include/amd_cuid.h"
+#include "src/cuid_device.h"
+#include "src/cuid_internal.h"
 
 struct amdcuid_nic_info {
-    amdcuid_cuid_public_fields header;
-    std::string bdf;
-    std::string network_interface;
+  amdcuid_cuid_public_fields header;
+  std::string bdf;
+  std::string network_interface;
 };
 
 class CuidNic : public CuidDevice {
-public:
-    CuidNic(const amdcuid_nic_info& i);
-    amdcuid_device_type_t type() const override { return AMDCUID_DEVICE_TYPE_NIC; }
-    amdcuid_status_t get_primary_cuid(amdcuid_primary_id& id) const override;
-    amdcuid_status_t get_hardware_fingerprint(uint64_t& fingerprint) const override;
-    static amdcuid_status_t discover(std::vector<DevicePtr> &nics);
-    static amdcuid_status_t discover_single(amdcuid_nic_info* nic_info, const std::string& device_path);
+ public:
+  CuidNic(const amdcuid_nic_info& i);
+  amdcuid_device_type_t type() const override { return AMDCUID_DEVICE_TYPE_NIC; }
+  amdcuid_status_t get_primary_cuid(amdcuid_primary_id& id) const override;
+  amdcuid_status_t get_hardware_fingerprint(uint64_t& fingerprint) const override;
+  static amdcuid_status_t discover(std::vector<DevicePtr>& nics);
+  static amdcuid_status_t discover_single(amdcuid_nic_info* nic_info,
+                                          const std::string& device_path);
 
-    // Virtual accessor overrides
-    amdcuid_status_t get_vendor_id(uint16_t& vendor_id) const override;
-    amdcuid_status_t get_device_id(uint16_t& device_id) const override;
-    amdcuid_status_t get_pci_class(uint16_t& pci_class) const override;
-    amdcuid_status_t get_revision_id(uint8_t& revision_id) const override;
-    amdcuid_status_t get_bdf(std::string& bdf) const override;
-    amdcuid_status_t get_device_path(std::string& path) const override;
+  // Virtual accessor overrides
+  amdcuid_status_t get_vendor_id(uint16_t& vendor_id) const override;
+  amdcuid_status_t get_device_id(uint16_t& device_id) const override;
+  amdcuid_status_t get_pci_class(uint16_t& pci_class) const override;
+  amdcuid_status_t get_revision_id(uint8_t& revision_id) const override;
+  amdcuid_status_t get_bdf(std::string& bdf) const override;
+  amdcuid_status_t get_device_path(std::string& path) const override;
 
-    // MAC address accessor
-    amdcuid_status_t get_mac_address(std::string& mac_address) const;
+  // MAC address accessor
+  amdcuid_status_t get_mac_address(std::string& mac_address) const;
 
-    const amdcuid_nic_info& get_info() const;
-private:
-    amdcuid_nic_info m_info;
+  const amdcuid_nic_info& get_info() const;
+
+ private:
+  amdcuid_nic_info m_info;
 };
 
-#endif // CUID_NIC_H
+#endif  // CUID_NIC_H

--- a/projects/cuid/lib/src/cuid_npu.cc
+++ b/projects/cuid/lib/src/cuid_npu.cc
@@ -2,16 +2,19 @@
 // SPDX-License-Identifier: MIT
 
 #include "cuid_npu.h"
-#include "cuid_file.h"
-#include "cuid_util.h"
-#include "pci_util.h"
-#include <cstring>
+
 #include <dirent.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <cstring>
 #include <fstream>
 #include <iostream>
 #include <sstream>
-#include <sys/types.h>
-#include <unistd.h>
+
+#include "cuid_file.h"
+#include "cuid_util.h"
+#include "pci_util.h"
 
 // AMD vendor ID used to filter for AMD NPU devices
 static const uint16_t AMD_VENDOR_ID = 0x1022;
@@ -23,48 +26,39 @@ static const uint16_t PCI_CLASS_SIGNAL_PROCESSING = 0x1100;
 static const uint16_t PCI_CLASS_PROCESSING_ACCEL = 0x1200;
 static const uint16_t PCI_CLASS_BASE_MASK = 0xFF00;
 
-CuidNpu::CuidNpu(const amdcuid_npu_info &i) : m_info(i) {}
+CuidNpu::CuidNpu(const amdcuid_npu_info& i) : m_info(i) {}
 
 // Helper to check if a /sys/class/accel entry name is an accel device
 // (e.g., "accel0", "accel1").
-static bool is_accel_entry(const char *name) {
-  if (strncmp(name, "accel", 5) != 0 || !isdigit(name[5]))
-    return false;
+static bool is_accel_entry(const char* name) {
+  if (strncmp(name, "accel", 5) != 0 || !isdigit(name[5])) return false;
   for (size_t i = 5; name[i] != '\0'; ++i) {
-    if (!isdigit(name[i]))
-      return false;
+    if (!isdigit(name[i])) return false;
   }
   return true;
 }
 
 // Discover NPU devices via /sys/class/accel (when amdxdna driver is loaded)
-static amdcuid_status_t discover_via_accel(std::vector<DevicePtr> &npus) {
-  const char *accel_path = "/sys/class/accel";
-  DIR *dir = opendir(accel_path);
-  if (!dir)
-    return AMDCUID_STATUS_UNSUPPORTED;
+static amdcuid_status_t discover_via_accel(std::vector<DevicePtr>& npus) {
+  const char* accel_path = "/sys/class/accel";
+  DIR* dir = opendir(accel_path);
+  if (!dir) return AMDCUID_STATUS_UNSUPPORTED;
 
-  struct dirent *entry;
+  struct dirent* entry;
   while ((entry = readdir(dir)) != NULL) {
     if (is_accel_entry(entry->d_name)) {
       std::string accel_name(entry->d_name);
-      std::string device_path =
-          std::string(accel_path) + "/" + accel_name + "/device";
+      std::string device_path = std::string(accel_path) + "/" + accel_name + "/device";
 
       // Read vendor to filter for AMD NPU devices only
-      std::string vendor_str =
-          CuidUtilities::read_sysfs_file(device_path + "/vendor");
-      if (vendor_str.empty())
-        continue;
-      uint16_t vendor_id =
-          static_cast<uint16_t>(strtol(vendor_str.c_str(), nullptr, 16));
-      if (vendor_id != AMD_VENDOR_ID)
-        continue;
+      std::string vendor_str = CuidUtilities::read_sysfs_file(device_path + "/vendor");
+      if (vendor_str.empty()) continue;
+      uint16_t vendor_id = static_cast<uint16_t>(strtol(vendor_str.c_str(), nullptr, 16));
+      if (vendor_id != AMD_VENDOR_ID) continue;
 
       amdcuid_npu_info info = {};
       amdcuid_status_t status = CuidNpu::discover_single(&info, device_path);
-      if (status != AMDCUID_STATUS_SUCCESS)
-        continue;
+      if (status != AMDCUID_STATUS_SUCCESS) continue;
 
       npus.emplace_back(std::make_shared<CuidNpu>(info));
     }
@@ -77,45 +71,34 @@ static amdcuid_status_t discover_via_accel(std::vector<DevicePtr> &npus) {
 // Fallback: discover NPU devices by scanning PCI bus for AMD processing
 // accelerator class devices. This handles systems where /sys/class/accel
 // is not populated (e.g., driver not loaded or accel subsystem absent).
-static amdcuid_status_t discover_via_pci_bus(std::vector<DevicePtr> &npus) {
-  const char *pci_path = "/sys/bus/pci/devices";
-  DIR *dir = opendir(pci_path);
-  if (!dir)
-    return AMDCUID_STATUS_UNSUPPORTED;
+static amdcuid_status_t discover_via_pci_bus(std::vector<DevicePtr>& npus) {
+  const char* pci_path = "/sys/bus/pci/devices";
+  DIR* dir = opendir(pci_path);
+  if (!dir) return AMDCUID_STATUS_UNSUPPORTED;
 
-  struct dirent *entry;
+  struct dirent* entry;
   while ((entry = readdir(dir)) != NULL) {
-    if (entry->d_name[0] == '.')
-      continue;
+    if (entry->d_name[0] == '.') continue;
 
     std::string device_path = std::string(pci_path) + "/" + entry->d_name;
 
-    std::string vendor_str =
-        CuidUtilities::read_sysfs_file(device_path + "/vendor");
-    if (vendor_str.empty())
-      continue;
-    uint16_t vendor_id =
-        static_cast<uint16_t>(strtol(vendor_str.c_str(), nullptr, 16));
-    if (vendor_id != AMD_VENDOR_ID)
-      continue;
+    std::string vendor_str = CuidUtilities::read_sysfs_file(device_path + "/vendor");
+    if (vendor_str.empty()) continue;
+    uint16_t vendor_id = static_cast<uint16_t>(strtol(vendor_str.c_str(), nullptr, 16));
+    if (vendor_id != AMD_VENDOR_ID) continue;
 
-    std::string class_str =
-        CuidUtilities::read_sysfs_file(device_path + "/class");
-    if (class_str.empty())
-      continue;
+    std::string class_str = CuidUtilities::read_sysfs_file(device_path + "/class");
+    if (class_str.empty()) continue;
     // sysfs class is 24-bit (class:subclass:prog_if), shift to get
     // class:subclass
-    uint16_t pci_class =
-        static_cast<uint16_t>(strtol(class_str.c_str(), nullptr, 16) >> 8);
+    uint16_t pci_class = static_cast<uint16_t>(strtol(class_str.c_str(), nullptr, 16) >> 8);
     uint16_t base_class = pci_class & PCI_CLASS_BASE_MASK;
-    if (base_class != PCI_CLASS_PROCESSING_ACCEL &&
-        base_class != PCI_CLASS_SIGNAL_PROCESSING)
+    if (base_class != PCI_CLASS_PROCESSING_ACCEL && base_class != PCI_CLASS_SIGNAL_PROCESSING)
       continue;
 
     amdcuid_npu_info info = {};
     amdcuid_status_t status = CuidNpu::discover_single(&info, device_path);
-    if (status != AMDCUID_STATUS_SUCCESS)
-      continue;
+    if (status != AMDCUID_STATUS_SUCCESS) continue;
 
     npus.emplace_back(std::make_shared<CuidNpu>(info));
   }
@@ -124,18 +107,17 @@ static amdcuid_status_t discover_via_pci_bus(std::vector<DevicePtr> &npus) {
   return npus.empty() ? AMDCUID_STATUS_UNSUPPORTED : AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidNpu::discover(std::vector<DevicePtr> &npus) {
+amdcuid_status_t CuidNpu::discover(std::vector<DevicePtr>& npus) {
   // Try /sys/class/accel first (when amdxdna driver is loaded)
   amdcuid_status_t status = discover_via_accel(npus);
-  if (status == AMDCUID_STATUS_SUCCESS)
-    return status;
+  if (status == AMDCUID_STATUS_SUCCESS) return status;
 
   // Fallback: scan PCI bus for processing accelerator class devices
   return discover_via_pci_bus(npus);
 }
 
-amdcuid_status_t CuidNpu::discover_single(amdcuid_npu_info *npu_info,
-                                          const std::string &device_path) {
+amdcuid_status_t CuidNpu::discover_single(amdcuid_npu_info* npu_info,
+                                          const std::string& device_path) {
   amdcuid_npu_info info = {};
   std::string bdf = CuidUtilities::readlink_bdf(device_path);
 
@@ -143,64 +125,48 @@ amdcuid_status_t CuidNpu::discover_single(amdcuid_npu_info *npu_info,
   if (vendor.empty() && !bdf.empty()) {
     uint8_t vendor_id_bytes[2] = {0};
     const uint16_t offset = 0x0;
-    amdcuid_status_t status =
-        PciUtil::read_pci_config_space(bdf, vendor_id_bytes, 2, offset);
-    uint16_t vendor_id_int =
-        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t *>(vendor_id_bytes));
-    info.header.fields.npu.vendor_id =
-        (status == AMDCUID_STATUS_SUCCESS) ? vendor_id_int : 0;
+    amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, vendor_id_bytes, 2, offset);
+    uint16_t vendor_id_int = PciUtil::le16_to_be16(*reinterpret_cast<uint16_t*>(vendor_id_bytes));
+    info.header.fields.npu.vendor_id = (status == AMDCUID_STATUS_SUCCESS) ? vendor_id_int : 0;
   } else {
-    info.header.fields.npu.vendor_id =
-        static_cast<uint16_t>(strtol(vendor.c_str(), nullptr, 16));
+    info.header.fields.npu.vendor_id = static_cast<uint16_t>(strtol(vendor.c_str(), nullptr, 16));
   }
 
   std::string device = CuidUtilities::read_sysfs_file(device_path + "/device");
   if (device.empty() && !bdf.empty()) {
     uint8_t device_id_bytes[2] = {0};
     const uint16_t offset = 0x2;
-    amdcuid_status_t status =
-        PciUtil::read_pci_config_space(bdf, device_id_bytes, 2, offset);
-    uint16_t device_id_int =
-        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t *>(device_id_bytes));
-    info.header.fields.npu.device_id =
-        (status == AMDCUID_STATUS_SUCCESS) ? device_id_int : 0;
+    amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, device_id_bytes, 2, offset);
+    uint16_t device_id_int = PciUtil::le16_to_be16(*reinterpret_cast<uint16_t*>(device_id_bytes));
+    info.header.fields.npu.device_id = (status == AMDCUID_STATUS_SUCCESS) ? device_id_int : 0;
   } else {
-    info.header.fields.npu.device_id =
-        static_cast<uint16_t>(strtol(device.c_str(), nullptr, 16));
+    info.header.fields.npu.device_id = static_cast<uint16_t>(strtol(device.c_str(), nullptr, 16));
   }
 
-  std::string pci_class =
-      CuidUtilities::read_sysfs_file(device_path + "/class");
+  std::string pci_class = CuidUtilities::read_sysfs_file(device_path + "/class");
   uint16_t pci_class_integer = 0;
   if (pci_class.empty() && !bdf.empty()) {
     uint8_t class_id_bytes[2] = {0};
     const uint16_t offset = 0xa;
-    amdcuid_status_t status =
-        PciUtil::read_pci_config_space(bdf, class_id_bytes, 2, offset);
-    uint16_t class_id_int =
-        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t *>(class_id_bytes));
+    amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, class_id_bytes, 2, offset);
+    uint16_t class_id_int = PciUtil::le16_to_be16(*reinterpret_cast<uint16_t*>(class_id_bytes));
     pci_class_integer = (status == AMDCUID_STATUS_SUCCESS) ? class_id_int : 0;
   } else {
     // sysfs class file returns 24-bit value (class:subclass:prog_if),
     // shift right by 8 to get 16-bit class:subclass
-    pci_class_integer =
-        static_cast<uint16_t>(strtol(pci_class.c_str(), nullptr, 16) >> 8);
+    pci_class_integer = static_cast<uint16_t>(strtol(pci_class.c_str(), nullptr, 16) >> 8);
   }
   info.header.fields.npu.pci_class = pci_class_integer;
 
-  std::string revision_id =
-      CuidUtilities::read_sysfs_file(device_path + "/revision");
+  std::string revision_id = CuidUtilities::read_sysfs_file(device_path + "/revision");
   if (revision_id.empty() && !bdf.empty()) {
     uint8_t revision_id_bytes[2] = {0};
     const uint16_t offset = 0x8;
-    amdcuid_status_t status =
-        PciUtil::read_pci_config_space(bdf, revision_id_bytes, 2, offset);
+    amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, revision_id_bytes, 2, offset);
     uint16_t revision_id_int =
-        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t *>(revision_id_bytes));
+        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t*>(revision_id_bytes));
     info.header.fields.npu.revision_id =
-        (status == AMDCUID_STATUS_SUCCESS)
-            ? static_cast<uint8_t>(revision_id_int)
-            : 0;
+        (status == AMDCUID_STATUS_SUCCESS) ? static_cast<uint8_t>(revision_id_int) : 0;
   } else {
     info.header.fields.npu.revision_id =
         static_cast<uint8_t>(strtol(revision_id.c_str(), nullptr, 16));
@@ -220,8 +186,7 @@ amdcuid_status_t CuidNpu::discover_single(amdcuid_npu_info *npu_info,
     }
   } else if (!bdf.empty()) {
     // Try to resolve /sys/bus/pci/devices/<bdf>/accel/accelN
-    std::string resolved =
-        CuidUtilities::bdf_to_device_path(bdf, AMDCUID_DEVICE_TYPE_NPU);
+    std::string resolved = CuidUtilities::bdf_to_device_path(bdf, AMDCUID_DEVICE_TYPE_NPU);
     if (!resolved.empty()) {
       full_device_node = resolved;
     } else {
@@ -240,8 +205,7 @@ amdcuid_status_t CuidNpu::discover_single(amdcuid_npu_info *npu_info,
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t
-CuidNpu::get_hardware_fingerprint(uint64_t &fingerprint) const {
+amdcuid_status_t CuidNpu::get_hardware_fingerprint(uint64_t& fingerprint) const {
   if (geteuid() != 0) {
     return AMDCUID_STATUS_PERMISSION_DENIED;
   }
@@ -261,8 +225,8 @@ CuidNpu::get_hardware_fingerprint(uint64_t &fingerprint) const {
   if (status == AMDCUID_STATUS_SUCCESS) {
     const uint8_t fingerprint_size = 8;
     uint8_t fingerprint_bytes[fingerprint_size] = {0};
-    status = PciUtil::read_pci_config_space(m_info.bdf, fingerprint_bytes,
-                                            fingerprint_size, offset);
+    status =
+        PciUtil::read_pci_config_space(m_info.bdf, fingerprint_bytes, fingerprint_size, offset);
     if (status == AMDCUID_STATUS_SUCCESS) {
       uint64_t fingerprint_value = 0;
       std::memcpy(&fingerprint_value, fingerprint_bytes, fingerprint_size);
@@ -277,7 +241,7 @@ CuidNpu::get_hardware_fingerprint(uint64_t &fingerprint) const {
   return AMDCUID_STATUS_HW_FINGERPRINT_NOT_FOUND;
 }
 
-amdcuid_status_t CuidNpu::get_primary_cuid(amdcuid_primary_id &id) const {
+amdcuid_status_t CuidNpu::get_primary_cuid(amdcuid_primary_id& id) const {
   bool temp = false;
   amdcuid_status_t status = AMDCUID_STATUS_SUCCESS;
   uint64_t fingerprint = 0;
@@ -314,10 +278,9 @@ amdcuid_status_t CuidNpu::get_primary_cuid(amdcuid_primary_id &id) const {
 
   status = CuidUtilities::generate_primary_cuid(
       fingerprint,
-      0, // unit_id: NPUs are not partitioned
+      0,  // unit_id: NPUs are not partitioned
       m_info.header.fields.npu.revision_id, m_info.header.fields.npu.device_id,
-      m_info.header.fields.npu.vendor_id,
-      static_cast<uint8_t>(AMDCUID_DEVICE_TYPE_NPU), &id, temp);
+      m_info.header.fields.npu.vendor_id, static_cast<uint8_t>(AMDCUID_DEVICE_TYPE_NPU), &id, temp);
   if (status != AMDCUID_STATUS_SUCCESS) {
     std::memset(&id, 0, sizeof(id));
     return status;
@@ -326,29 +289,29 @@ amdcuid_status_t CuidNpu::get_primary_cuid(amdcuid_primary_id &id) const {
   return status;
 }
 
-const amdcuid_npu_info &CuidNpu::get_info() const { return m_info; }
+const amdcuid_npu_info& CuidNpu::get_info() const { return m_info; }
 
-amdcuid_status_t CuidNpu::get_vendor_id(uint16_t &vendor_id) const {
+amdcuid_status_t CuidNpu::get_vendor_id(uint16_t& vendor_id) const {
   vendor_id = m_info.header.fields.npu.vendor_id;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidNpu::get_device_id(uint16_t &device_id) const {
+amdcuid_status_t CuidNpu::get_device_id(uint16_t& device_id) const {
   device_id = m_info.header.fields.npu.device_id;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidNpu::get_pci_class(uint16_t &pci_class) const {
+amdcuid_status_t CuidNpu::get_pci_class(uint16_t& pci_class) const {
   pci_class = m_info.header.fields.npu.pci_class;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidNpu::get_revision_id(uint8_t &revision_id) const {
+amdcuid_status_t CuidNpu::get_revision_id(uint8_t& revision_id) const {
   revision_id = m_info.header.fields.npu.revision_id;
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidNpu::get_bdf(std::string &bdf) const {
+amdcuid_status_t CuidNpu::get_bdf(std::string& bdf) const {
   if (m_info.bdf.empty()) {
     return AMDCUID_STATUS_UNSUPPORTED;
   }
@@ -356,7 +319,7 @@ amdcuid_status_t CuidNpu::get_bdf(std::string &bdf) const {
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidNpu::get_device_path(std::string &path) const {
+amdcuid_status_t CuidNpu::get_device_path(std::string& path) const {
   if (m_info.accel_node.empty()) {
     return AMDCUID_STATUS_UNSUPPORTED;
   }

--- a/projects/cuid/lib/src/cuid_npu.h
+++ b/projects/cuid/lib/src/cuid_npu.h
@@ -4,42 +4,43 @@
 #ifndef CUID_NPU_H
 #define CUID_NPU_H
 
-#include "include/amd_cuid.h"
-#include "src/cuid_device.h"
-#include "src/cuid_internal.h"
 #include <memory>
 #include <string>
 #include <vector>
 
+#include "include/amd_cuid.h"
+#include "src/cuid_device.h"
+#include "src/cuid_internal.h"
+
 struct amdcuid_npu_info {
-    amdcuid_cuid_public_fields header;
-    // Accel device node: /sys/class/accel/accelN
-    std::string accel_node;
-    std::string bdf;
+  amdcuid_cuid_public_fields header;
+  // Accel device node: /sys/class/accel/accelN
+  std::string accel_node;
+  std::string bdf;
 };
 
 class CuidNpu : public CuidDevice {
-public:
-    CuidNpu(const amdcuid_npu_info& i);
-    amdcuid_device_type_t type() const override { return AMDCUID_DEVICE_TYPE_NPU; }
-    amdcuid_status_t get_primary_cuid(amdcuid_primary_id& id) const override;
-    amdcuid_status_t get_hardware_fingerprint(uint64_t& fingerprint) const override;
-    static amdcuid_status_t discover(std::vector<DevicePtr>& npus);
-    static amdcuid_status_t discover_single(amdcuid_npu_info* npu_info,
-                                            const std::string& device_path);
+ public:
+  CuidNpu(const amdcuid_npu_info& i);
+  amdcuid_device_type_t type() const override { return AMDCUID_DEVICE_TYPE_NPU; }
+  amdcuid_status_t get_primary_cuid(amdcuid_primary_id& id) const override;
+  amdcuid_status_t get_hardware_fingerprint(uint64_t& fingerprint) const override;
+  static amdcuid_status_t discover(std::vector<DevicePtr>& npus);
+  static amdcuid_status_t discover_single(amdcuid_npu_info* npu_info,
+                                          const std::string& device_path);
 
-    // Virtual accessor overrides
-    amdcuid_status_t get_vendor_id(uint16_t& vendor_id) const override;
-    amdcuid_status_t get_device_id(uint16_t& device_id) const override;
-    amdcuid_status_t get_pci_class(uint16_t& pci_class) const override;
-    amdcuid_status_t get_revision_id(uint8_t& revision_id) const override;
-    amdcuid_status_t get_bdf(std::string& bdf) const override;
-    amdcuid_status_t get_device_path(std::string& path) const override;
+  // Virtual accessor overrides
+  amdcuid_status_t get_vendor_id(uint16_t& vendor_id) const override;
+  amdcuid_status_t get_device_id(uint16_t& device_id) const override;
+  amdcuid_status_t get_pci_class(uint16_t& pci_class) const override;
+  amdcuid_status_t get_revision_id(uint8_t& revision_id) const override;
+  amdcuid_status_t get_bdf(std::string& bdf) const override;
+  amdcuid_status_t get_device_path(std::string& path) const override;
 
-    const amdcuid_npu_info& get_info() const;
+  const amdcuid_npu_info& get_info() const;
 
-private:
-    amdcuid_npu_info m_info;
+ private:
+  amdcuid_npu_info m_info;
 };
 
-#endif // CUID_NPU_H
+#endif  // CUID_NPU_H

--- a/projects/cuid/lib/src/cuid_platform.cc
+++ b/projects/cuid/lib/src/cuid_platform.cc
@@ -2,17 +2,20 @@
 // SPDX-License-Identifier: MIT
 
 #include "cuid_platform.h"
-#include "cuid_file.h"
-#include "cuid_util.h"
-#include "smbios_util.h"
+
+#include <unistd.h>
+
 #include <cstring>
 #include <iostream>
 #include <sstream>
-#include <unistd.h>
 
-CuidPlatform::CuidPlatform(const amdcuid_platform_info &i) : m_info({i}) {}
+#include "cuid_file.h"
+#include "cuid_util.h"
+#include "smbios_util.h"
 
-amdcuid_status_t CuidPlatform::discover(std::vector<DevicePtr> &platforms) {
+CuidPlatform::CuidPlatform(const amdcuid_platform_info& i) : m_info({i}) {}
+
+amdcuid_status_t CuidPlatform::discover(std::vector<DevicePtr>& platforms) {
   // Platform is a singleton - only one platform per system
   amdcuid_platform_info info = {};
   info.header.device_type = AMDCUID_DEVICE_TYPE_PLATFORM;
@@ -32,8 +35,7 @@ amdcuid_status_t CuidPlatform::discover(std::vector<DevicePtr> &platforms) {
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t
-CuidPlatform::get_hardware_fingerprint(uint64_t &fingerprint) const {
+amdcuid_status_t CuidPlatform::get_hardware_fingerprint(uint64_t& fingerprint) const {
   amdcuid_status_t status = AMDCUID_STATUS_SUCCESS;
   // Get system UUID from SMBIOS
   uint8_t uuid[16] = {0};
@@ -48,14 +50,10 @@ CuidPlatform::get_hardware_fingerprint(uint64_t &fingerprint) const {
   }
   if (status == AMDCUID_STATUS_SUCCESS && uuid_valid) {
     // use UUID as basis for CUID
-    fingerprint = (static_cast<uint64_t>(uuid[0]) << 56) |
-                  (static_cast<uint64_t>(uuid[1]) << 48) |
-                  (static_cast<uint64_t>(uuid[2]) << 40) |
-                  (static_cast<uint64_t>(uuid[3]) << 32) |
-                  (static_cast<uint64_t>(uuid[4]) << 24) |
-                  (static_cast<uint64_t>(uuid[5]) << 16) |
-                  (static_cast<uint64_t>(uuid[6]) << 8) |
-                  static_cast<uint64_t>(uuid[7]);
+    fingerprint = (static_cast<uint64_t>(uuid[0]) << 56) | (static_cast<uint64_t>(uuid[1]) << 48) |
+                  (static_cast<uint64_t>(uuid[2]) << 40) | (static_cast<uint64_t>(uuid[3]) << 32) |
+                  (static_cast<uint64_t>(uuid[4]) << 24) | (static_cast<uint64_t>(uuid[5]) << 16) |
+                  (static_cast<uint64_t>(uuid[6]) << 8) | static_cast<uint64_t>(uuid[7]);
   } else {
     std::string serial;
     status = SmbiosUtil::get_system_serial(serial);
@@ -74,7 +72,7 @@ CuidPlatform::get_hardware_fingerprint(uint64_t &fingerprint) const {
   return status;
 }
 
-amdcuid_status_t CuidPlatform::get_primary_cuid(amdcuid_primary_id &id) const {
+amdcuid_status_t CuidPlatform::get_primary_cuid(amdcuid_primary_id& id) const {
   bool temp = false;
   // attempt to find the primary CUID in file first
   std::string cuid_file_path = CuidUtilities::priv_cuid_file();
@@ -84,8 +82,7 @@ amdcuid_status_t CuidPlatform::get_primary_cuid(amdcuid_primary_id &id) const {
 
   // for platform, just return the first entry found
   CuidFileEntry entry;
-  amdcuid_status_t status =
-      primary_file.find_by_device_type(AMDCUID_DEVICE_TYPE_PLATFORM, entry);
+  amdcuid_status_t status = primary_file.find_by_device_type(AMDCUID_DEVICE_TYPE_PLATFORM, entry);
   if (status == AMDCUID_STATUS_SUCCESS) {
     id.UUIDv8_representation = entry.primary_cuid;
     CuidUtilities::remove_UUIDv8_bits(&id.UUIDv8_representation, id.raw_bits);
@@ -104,16 +101,16 @@ amdcuid_status_t CuidPlatform::get_primary_cuid(amdcuid_primary_id &id) const {
     temp = true;
   }
 
-  status = CuidUtilities::generate_primary_cuid(
-      fingerprint, 0, 0, 0, m_info.header.fields.platform.vendor_id,
-      AMDCUID_DEVICE_TYPE_PLATFORM, &id, temp);
+  status = CuidUtilities::generate_primary_cuid(fingerprint, 0, 0, 0,
+                                                m_info.header.fields.platform.vendor_id,
+                                                AMDCUID_DEVICE_TYPE_PLATFORM, &id, temp);
 
   return status;
 }
 
-const amdcuid_platform_info &CuidPlatform::get_info() const { return m_info; }
+const amdcuid_platform_info& CuidPlatform::get_info() const { return m_info; }
 
-amdcuid_status_t CuidPlatform::get_vendor_id(uint16_t &vendor_id) const {
+amdcuid_status_t CuidPlatform::get_vendor_id(uint16_t& vendor_id) const {
   vendor_id = m_info.header.fields.platform.vendor_id;
   return AMDCUID_STATUS_SUCCESS;
 }

--- a/projects/cuid/lib/src/cuid_platform.h
+++ b/projects/cuid/lib/src/cuid_platform.h
@@ -4,31 +4,33 @@
 #ifndef CUID_PLATFORM_H
 #define CUID_PLATFORM_H
 
-#include "cuid_device.h"
-#include "include/amd_cuid.h"
-#include "cuid_internal.h"
-#include <vector>
 #include <memory>
+#include <vector>
+
+#include "cuid_device.h"
+#include "cuid_internal.h"
+#include "include/amd_cuid.h"
 
 struct amdcuid_platform_info {
-    amdcuid_cuid_public_fields header;
-    // Add more fields as needed
+  amdcuid_cuid_public_fields header;
+  // Add more fields as needed
 };
 
 class CuidPlatform : public CuidDevice {
-public:
-    CuidPlatform(const amdcuid_platform_info& i);
-    amdcuid_device_type_t type() const override { return AMDCUID_DEVICE_TYPE_PLATFORM; }
-    amdcuid_status_t get_primary_cuid(amdcuid_primary_id& id) const override;
-    amdcuid_status_t get_hardware_fingerprint(uint64_t& fingerprint) const override;
-    static amdcuid_status_t discover(std::vector<DevicePtr> &platforms);
+ public:
+  CuidPlatform(const amdcuid_platform_info& i);
+  amdcuid_device_type_t type() const override { return AMDCUID_DEVICE_TYPE_PLATFORM; }
+  amdcuid_status_t get_primary_cuid(amdcuid_primary_id& id) const override;
+  amdcuid_status_t get_hardware_fingerprint(uint64_t& fingerprint) const override;
+  static amdcuid_status_t discover(std::vector<DevicePtr>& platforms);
 
-    // Virtual accessor overrides
-    amdcuid_status_t get_vendor_id(uint16_t& vendor_id) const override;
+  // Virtual accessor overrides
+  amdcuid_status_t get_vendor_id(uint16_t& vendor_id) const override;
 
-    const amdcuid_platform_info& get_info() const;
-private:
-    amdcuid_platform_info m_info;
+  const amdcuid_platform_info& get_info() const;
+
+ private:
+  amdcuid_platform_info m_info;
 };
 
-#endif // CUID_PLATFORM_H
+#endif  // CUID_PLATFORM_H

--- a/projects/cuid/lib/src/cuid_util.cc
+++ b/projects/cuid/lib/src/cuid_util.cc
@@ -2,73 +2,72 @@
 // SPDX-License-Identifier: MIT
 
 #include "cuid_util.h"
-#include "smbios_util.h"
-#include <algorithm>
-#include <cctype>
-#include <cstring>
+
 #include <dirent.h>
 #include <fcntl.h>
-#include <fstream>
-#include <iostream>
-#include <mutex>
-#include <sstream>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <sys/sysmacros.h>
 #include <sys/types.h>
 #include <unistd.h>
+
+#include <algorithm>
+#include <cctype>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <mutex>
+#include <sstream>
 #include <vector>
 
-const char *Logger::LogLevelName(LogLevel level) const {
+#include "smbios_util.h"
+
+const char* Logger::LogLevelName(LogLevel level) const {
   switch (level) {
-  case DEBUG:
-    return "DEBUG";
-  case INFO:
-    return "INFO";
-  case WARN:
-    return "WARN";
-  case ERROR:
-    return "ERROR";
-  default:
-    return "UNKNOWN";
+    case DEBUG:
+      return "DEBUG";
+    case INFO:
+      return "INFO";
+    case WARN:
+      return "WARN";
+    case ERROR:
+      return "ERROR";
+    default:
+      return "UNKNOWN";
   }
 }
 
-void Logger::log(LogLevel level, const std::string &msg) const {
-  if (level < level_)
-    return;
+void Logger::log(LogLevel level, const std::string& msg) const {
+  if (level < level_) return;
   std::cerr << "[" << LogLevelName(level) << "] " << msg << std::endl;
 }
 
 // Helper to read a sysfs file into a string
-std::string CuidUtilities::read_sysfs_file(const std::string &path) {
+std::string CuidUtilities::read_sysfs_file(const std::string& path) {
   std::ifstream file(path);
-  if (!file.is_open())
-    return "";
+  if (!file.is_open()) return "";
   std::stringstream ss;
   ss << file.rdbuf();
   std::string result = ss.str();
   // Remove trailing newline if present
-  if (!result.empty() && result.back() == '\n')
-    result.pop_back();
+  if (!result.empty() && result.back() == '\n') result.pop_back();
   return result;
 }
 
 // Helper to get BDF from symlink, filter out non-PCI BDFs (e.g., USB like
 // 3-10.2:2.0)
-std::string CuidUtilities::readlink_bdf(const std::string &device_path) {
+std::string CuidUtilities::readlink_bdf(const std::string& device_path) {
   char buf[256];
   ssize_t len = readlink(device_path.c_str(), buf, sizeof(buf) - 1);
   if (len > 0) {
     buf[len] = '\0';
     // The symlink is typically ../../../0000:65:00.0 or ../../../3-10.2:2.0
-    const char *bdf = strrchr(buf, '/');
+    const char* bdf = strrchr(buf, '/');
     if (bdf && strlen(bdf + 1) < 32) {
       std::string bdf_str = bdf + 1;
       // Only accept PCI BDFs of the form "dddd:bb:dd.f"
       // Example: 0000:65:00.0
-      if (bdf_str.size() == 12 && bdf_str[4] == ':' && bdf_str[7] == ':' &&
-          bdf_str[10] == '.') {
+      if (bdf_str.size() == 12 && bdf_str[4] == ':' && bdf_str[7] == ':' && bdf_str[10] == '.') {
         return bdf_str;
       }
     }
@@ -80,33 +79,29 @@ std::string CuidUtilities::readlink_bdf(const std::string &device_path) {
 // For GPUs: returns /sys/class/drm/renderDXXX/device or
 //           /sys/class/drm/cardN/device path
 // For NICs: returns /sys/class/net/<iface>/device path
-std::string
-CuidUtilities::bdf_to_device_path(const std::string &bdf,
-                                  amdcuid_device_type_t device_type) {
-  if (bdf.empty())
-    return "";
+std::string CuidUtilities::bdf_to_device_path(const std::string& bdf,
+                                              amdcuid_device_type_t device_type) {
+  if (bdf.empty()) return "";
 
   std::string pci_device_path = "/sys/bus/pci/devices/" + bdf;
   std::string subsystem_dir;
 
   if (device_type == AMDCUID_DEVICE_TYPE_GPU) {
     subsystem_dir = pci_device_path + "/drm";
-    DIR *dir = opendir(subsystem_dir.c_str());
+    DIR* dir = opendir(subsystem_dir.c_str());
     if (dir) {
-      struct dirent *entry;
+      struct dirent* entry;
       std::string card_path;
       while ((entry = readdir(dir)) != nullptr) {
         // Prefer renderD* nodes when available
         if (strncmp(entry->d_name, "renderD", 7) == 0) {
-          std::string device_path =
-              "/sys/class/drm/" + std::string(entry->d_name) + "/device";
+          std::string device_path = "/sys/class/drm/" + std::string(entry->d_name) + "/device";
           closedir(dir);
           return device_path;
         }
         // Track card entries as fallback (e.g., card0, card1)
         // Exclude connector entries like card0-DP-1
-        if (strncmp(entry->d_name, "card", 4) == 0 &&
-            isdigit(entry->d_name[4])) {
+        if (strncmp(entry->d_name, "card", 4) == 0 && isdigit(entry->d_name[4])) {
           bool all_digits = true;
           for (size_t i = 4; entry->d_name[i] != '\0'; ++i) {
             if (!isdigit(entry->d_name[i])) {
@@ -115,8 +110,7 @@ CuidUtilities::bdf_to_device_path(const std::string &bdf,
             }
           }
           if (all_digits && card_path.empty()) {
-            card_path =
-                "/sys/class/drm/" + std::string(entry->d_name) + "/device";
+            card_path = "/sys/class/drm/" + std::string(entry->d_name) + "/device";
           }
         }
       }
@@ -129,15 +123,13 @@ CuidUtilities::bdf_to_device_path(const std::string &bdf,
     }
   } else if (device_type == AMDCUID_DEVICE_TYPE_NIC) {
     subsystem_dir = pci_device_path + "/net";
-    DIR *dir = opendir(subsystem_dir.c_str());
+    DIR* dir = opendir(subsystem_dir.c_str());
     if (dir) {
-      struct dirent *entry;
+      struct dirent* entry;
       while ((entry = readdir(dir)) != nullptr) {
         // Skip . and ..
-        if (entry->d_name[0] == '.')
-          continue;
-        std::string device_path =
-            "/sys/class/net/" + std::string(entry->d_name) + "/device";
+        if (entry->d_name[0] == '.') continue;
+        std::string device_path = "/sys/class/net/" + std::string(entry->d_name) + "/device";
         closedir(dir);
         return device_path;
       }
@@ -145,18 +137,15 @@ CuidUtilities::bdf_to_device_path(const std::string &bdf,
     }
   } else if (device_type == AMDCUID_DEVICE_TYPE_NPU) {
     subsystem_dir = pci_device_path + "/accel";
-    DIR *dir = opendir(subsystem_dir.c_str());
+    DIR* dir = opendir(subsystem_dir.c_str());
     if (dir) {
-      struct dirent *entry;
+      struct dirent* entry;
       while ((entry = readdir(dir)) != nullptr) {
         // Skip . and ..
-        if (entry->d_name[0] == '.')
-          continue;
+        if (entry->d_name[0] == '.') continue;
         // Match accelN entries
-        if (strncmp(entry->d_name, "accel", 5) == 0 &&
-            isdigit(entry->d_name[5])) {
-          std::string device_path =
-              "/sys/class/accel/" + std::string(entry->d_name) + "/device";
+        if (strncmp(entry->d_name, "accel", 5) == 0 && isdigit(entry->d_name[5])) {
+          std::string device_path = "/sys/class/accel/" + std::string(entry->d_name) + "/device";
           closedir(dir);
           return device_path;
         }
@@ -183,15 +172,14 @@ std::string CuidUtilities::real_dev_path_from_fd(int fd) {
   uint32_t minor_num = minor(dev);
 
   // Construct sysfs path from char device numbers first
-  std::string sys_path = "/sys/dev/char/" + std::to_string(major_num) + ":" +
-                         std::to_string(minor_num);
+  std::string sys_path =
+      "/sys/dev/char/" + std::to_string(major_num) + ":" + std::to_string(minor_num);
   char buf[PATH_MAX];
   if (realpath(sys_path.c_str(), buf) != nullptr) {
     return std::string(buf) + "/device";
   } else {
     // attempt to find as a block device now
-    sys_path = "/sys/dev/block/" + std::to_string(major_num) + ":" +
-               std::to_string(minor_num);
+    sys_path = "/sys/dev/block/" + std::to_string(major_num) + ":" + std::to_string(minor_num);
     if (realpath(sys_path.c_str(), buf) != nullptr) {
       return std::string(buf) + "/device";
     }
@@ -200,7 +188,7 @@ std::string CuidUtilities::real_dev_path_from_fd(int fd) {
   return "";
 }
 
-std::string CuidUtilities::get_real_path(const std::string &path) {
+std::string CuidUtilities::get_real_path(const std::string& path) {
   char buf[PATH_MAX];
   if (realpath(path.c_str(), buf) != nullptr) {
     return std::string(buf) + "/device";
@@ -208,16 +196,14 @@ std::string CuidUtilities::get_real_path(const std::string &path) {
   return "";
 }
 
-int CuidUtilities::extract_render_minor(const std::string &path) {
+int CuidUtilities::extract_render_minor(const std::string& path) {
   size_t render_pos = path.find("renderD");
-  if (render_pos == std::string::npos)
-    return -1;
+  if (render_pos == std::string::npos) return -1;
 
-  size_t num_start = render_pos + 7; // length of "renderD"
+  size_t num_start = render_pos + 7;  // length of "renderD"
   size_t num_end = path.find('/', num_start);
-  std::string num_str = (num_end != std::string::npos)
-                            ? path.substr(num_start, num_end - num_start)
-                            : path.substr(num_start);
+  std::string num_str = (num_end != std::string::npos) ? path.substr(num_start, num_end - num_start)
+                                                       : path.substr(num_start);
   try {
     return std::stoi(num_str);
   } catch (...) {
@@ -236,7 +222,7 @@ struct cuid_drm_amdgpu_info {
   uint64_t return_pointer;
   uint32_t return_size;
   uint32_t query;
-  uint8_t padding[16]; // matches the union in the kernel struct
+  uint8_t padding[16];  // matches the union in the kernel struct
 };
 
 struct cuid_amdgpu_dev_info {
@@ -285,7 +271,7 @@ bool is_gpu_vf_mode(int fd) {
   return mode == kAmdgpuIdsFlagsModeVf;
 }
 
-uint16_t get_vf_index_from_sysfs(const std::string &device_path) {
+uint16_t get_vf_index_from_sysfs(const std::string& device_path) {
   // device_path is /sys/class/drm/renderDXXX/device
   // Check if physfn symlink exists (present on VFs visible from the host)
   std::string physfn_path = device_path + "/physfn";
@@ -293,19 +279,16 @@ uint16_t get_vf_index_from_sysfs(const std::string &device_path) {
   // Get our own BDF from the device symlink
   char dev_link[PATH_MAX];
   ssize_t len = readlink(device_path.c_str(), dev_link, sizeof(dev_link) - 1);
-  if (len <= 0)
-    return 0;
+  if (len <= 0) return 0;
   dev_link[len] = '\0';
 
-  const char *our_bdf_ptr = strrchr(dev_link, '/');
-  if (our_bdf_ptr == nullptr)
-    return 0;
+  const char* our_bdf_ptr = strrchr(dev_link, '/');
+  if (our_bdf_ptr == nullptr) return 0;
   std::string our_bdf(our_bdf_ptr + 1);
 
   // Resolve PF sysfs path via physfn symlink
   char pf_real[PATH_MAX];
-  if (realpath(physfn_path.c_str(), pf_real) == nullptr)
-    return 0;
+  if (realpath(physfn_path.c_str(), pf_real) == nullptr) return 0;
   std::string pf_path(pf_real);
 
   // Enumerate virtfnX symlinks on the PF to find our VF index
@@ -313,13 +296,11 @@ uint16_t get_vf_index_from_sysfs(const std::string &device_path) {
     std::string virtfn_symlink = pf_path + "/virtfn" + std::to_string(idx);
     char vfn_link[PATH_MAX];
     len = readlink(virtfn_symlink.c_str(), vfn_link, sizeof(vfn_link) - 1);
-    if (len <= 0)
-      break; // no more VFs
+    if (len <= 0) break;  // no more VFs
     vfn_link[len] = '\0';
 
-    const char *vfn_bdf_ptr = strrchr(vfn_link, '/');
-    if (vfn_bdf_ptr == nullptr)
-      continue;
+    const char* vfn_bdf_ptr = strrchr(vfn_link, '/');
+    if (vfn_bdf_ptr == nullptr) continue;
     if (our_bdf == (vfn_bdf_ptr + 1)) {
       return static_cast<uint16_t>(idx + 1);
     }
@@ -327,15 +308,14 @@ uint16_t get_vf_index_from_sysfs(const std::string &device_path) {
   return 0;
 }
 
-} // anonymous namespace
+}  // anonymous namespace
 
-uint16_t CuidUtilities::get_gpu_vf_id(const std::string &device_path) {
+uint16_t CuidUtilities::get_gpu_vf_id(const std::string& device_path) {
   // Determine if the GPU is an SR-IOV Virtual Function (VF) and return its
   // 1-based VF index as the unit_id. Returns 0 for bare metal, PF,
   // passthrough, or when VF detection is unavailable.
   int render_minor = extract_render_minor(device_path);
-  if (render_minor < 0)
-    return 0;
+  if (render_minor < 0) return 0;
 
   std::string dev_node = "/dev/dri/renderD" + std::to_string(render_minor);
 
@@ -343,40 +323,34 @@ uint16_t CuidUtilities::get_gpu_vf_id(const std::string &device_path) {
   if (fd < 0) {
     // Fall back to read-only if we lack write permission
     fd = open(dev_node.c_str(), O_RDONLY | O_CLOEXEC);
-    if (fd < 0)
-      return 0;
+    if (fd < 0) return 0;
   }
 
   bool is_vf = is_gpu_vf_mode(fd);
   close(fd);
 
-  if (!is_vf)
-    return 0;
+  if (!is_vf) return 0;
 
   // VF detected via ioctl. Try to determine VF index from sysfs.
   uint16_t vf_index = get_vf_index_from_sysfs(device_path);
-  if (vf_index > 0)
-    return vf_index;
+  if (vf_index > 0) return vf_index;
 
   // Could not determine VF index (e.g. inside a guest VM where physfn
   // is not visible). Fall back to 0 per specification.
   return 0;
 }
 
-amdcuid_status_t
-CuidUtilities::make_fallback_fingerprint(const std::string &id,
-                                         uint64_t &fingerprint) {
+amdcuid_status_t CuidUtilities::make_fallback_fingerprint(const std::string& id,
+                                                          uint64_t& fingerprint) {
   std::string system_id;
   amdcuid_status_t status = AMDCUID_STATUS_SUCCESS;
 
   std::ifstream machine_id_file("/etc/machine-id");
-  if (machine_id_file.is_open())
-    std::getline(machine_id_file, system_id);
+  if (machine_id_file.is_open()) std::getline(machine_id_file, system_id);
 
   if (system_id.empty()) {
     std::ifstream hostname_file("/etc/hostname");
-    if (hostname_file.is_open())
-      std::getline(hostname_file, system_id);
+    if (hostname_file.is_open()) std::getline(hostname_file, system_id);
   }
 
   std::string id_hex;
@@ -385,19 +359,17 @@ CuidUtilities::make_fallback_fingerprint(const std::string &id,
 
   std::string combined = id_hex + system_id;
   uint8_t digest[32];
-  status = sha256_unkeyed(reinterpret_cast<const uint8_t *>(combined.data()),
-                          combined.size(), digest);
-  if (status != AMDCUID_STATUS_SUCCESS)
-    return status;
+  status =
+      sha256_unkeyed(reinterpret_cast<const uint8_t*>(combined.data()), combined.size(), digest);
+  if (status != AMDCUID_STATUS_SUCCESS) return status;
 
   std::memcpy(&fingerprint, digest, sizeof(fingerprint));
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t
-CuidUtilities::generate_derived_cuid(const amdcuid_primary_id *primary_id,
-                                     amdcuid_derived_id *derived_id,
-                                     cuid_hmac *hmac) {
+amdcuid_status_t CuidUtilities::generate_derived_cuid(const amdcuid_primary_id* primary_id,
+                                                      amdcuid_derived_id* derived_id,
+                                                      cuid_hmac* hmac) {
   if (!primary_id || !hmac) {
     // Return invalid on null input
     return AMDCUID_STATUS_INVALID_ARGUMENT;
@@ -406,10 +378,9 @@ CuidUtilities::generate_derived_cuid(const amdcuid_primary_id *primary_id,
   uint8_t hash[hash_length];
   size_t hash_len = 0;
 
-  amdcuid_status_t status =
-      static_cast<amdcuid_status_t>(hmac->generate_hmac_sha256(
-          reinterpret_cast<const uint8_t *>(primary_id->raw_bits),
-          sizeof(primary_id->raw_bits), hash, &hash_len));
+  amdcuid_status_t status = static_cast<amdcuid_status_t>(
+      hmac->generate_hmac_sha256(reinterpret_cast<const uint8_t*>(primary_id->raw_bits),
+                                 sizeof(primary_id->raw_bits), hash, &hash_len));
   if (status != AMDCUID_STATUS_SUCCESS) {
     std::cerr << "Error generating HMAC" << std::endl;
     return status;
@@ -418,7 +389,7 @@ CuidUtilities::generate_derived_cuid(const amdcuid_primary_id *primary_id,
   // copy 110 LSB bits of hash to derived_id->hash
   // Using only first 14 bytes (112 bits) of hash, then will mask last 2 bits
   memcpy(derived_id->hash, hash, 14);
-  derived_id->hash[13] &= 0x3F; // 00111111
+  derived_id->hash[13] &= 0x3F;  // 00111111
 
   // Get the unit id parts from the primary ID
   uint8_t reserved_2 = 0;
@@ -441,10 +412,8 @@ CuidUtilities::generate_derived_cuid(const amdcuid_primary_id *primary_id,
   id_bits[14] |= (primary_id->raw_bits[14] & 0x20);
 
   // bits 118-121: reserved bits part 2 (4 bits)
-  id_bits[14] |= (reserved_2 & 0xC)
-                 << 4; // upper 2 bits of reserved bits part 2
-  id_bits[15] |= (reserved_2 & 0x3)
-                 << 6; // lower 2 bits of reserved bits part 2
+  id_bits[14] |= (reserved_2 & 0xC) << 4;  // upper 2 bits of reserved bits part 2
+  id_bits[15] |= (reserved_2 & 0x3) << 6;  // lower 2 bits of reserved bits part 2
   // last 6 bits are padding (bits 122-127)
   id_bits[15] &= 0xC0;
 
@@ -456,20 +425,18 @@ CuidUtilities::generate_derived_cuid(const amdcuid_primary_id *primary_id,
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidUtilities::generate_primary_cuid(
-    uint64_t serial_number, uint16_t unit_id, uint8_t revision_id,
-    uint16_t device_id, uint16_t vendor_id, uint8_t device_type,
-    amdcuid_primary_id *primary_id, bool temp) {
-
+amdcuid_status_t CuidUtilities::generate_primary_cuid(uint64_t serial_number, uint16_t unit_id,
+                                                      uint8_t revision_id, uint16_t device_id,
+                                                      uint16_t vendor_id, uint8_t device_type,
+                                                      amdcuid_primary_id* primary_id, bool temp) {
   // Build 122-bit value in little-endian order
-  uint8_t id_bits[16] = {0}; // 128 bits total (122 bits + 6 bits padding)
+  uint8_t id_bits[16] = {0};  // 128 bits total (122 bits + 6 bits padding)
 
   uint8_t unit_id_part1 = unit_id & 0xFF;
   uint8_t unit_id_part2 = (unit_id >> 8) & 0x1F;
 
   // Bits 0-63: Serial number (8 bytes)
-  for (int i = 0; i < 8; i++)
-    id_bits[i] = (serial_number >> (8 * i)) & 0xFF;
+  for (int i = 0; i < 8; i++) id_bits[i] = (serial_number >> (8 * i)) & 0xFF;
 
   // Bits 64-71: UnitID part 1 (1 byte)
   id_bits[8] = unit_id_part1;
@@ -490,7 +457,7 @@ amdcuid_status_t CuidUtilities::generate_primary_cuid(
   // Bits 118-121: Component Type (4 bits)
   uint8_t temp_bit = temp ? 1 : 0;
   id_bits[14] = (unit_id_part2) | (temp_bit << 5) | ((device_type & 0x3) << 6);
-  id_bits[15] = (device_type & 0xC) << 4; // Last 6 bits are padding
+  id_bits[15] = (device_type & 0xC) << 4;  // Last 6 bits are padding
 
   memcpy(primary_id->raw_bits, id_bits, 16);
 
@@ -501,8 +468,7 @@ amdcuid_status_t CuidUtilities::generate_primary_cuid(
   return AMDCUID_STATUS_SUCCESS;
 }
 
-void CuidUtilities::remove_UUIDv8_bits(amdcuid_id_t *id,
-                                       uint8_t out_raw_bits[16]) {
+void CuidUtilities::remove_UUIDv8_bits(amdcuid_id_t* id, uint8_t out_raw_bits[16]) {
   if (!id || !out_raw_bits) {
     return;
   }
@@ -522,23 +488,16 @@ void CuidUtilities::remove_UUIDv8_bits(amdcuid_id_t *id,
 
   // Bits 64-65: Variant (10b) + Bits 66-127: ID value part 3 (MSB)
   out_raw_bits[8] = ((id->bytes[8] & 0x03) << 6) | ((id->bytes[9] & 0xFC) >> 2);
-  out_raw_bits[9] =
-      ((id->bytes[9] & 0x03) << 6) | ((id->bytes[10] & 0xFC) >> 2);
-  out_raw_bits[10] =
-      ((id->bytes[10] & 0x03) << 6) | ((id->bytes[11] & 0xFC) >> 2);
-  out_raw_bits[11] =
-      ((id->bytes[11] & 0x03) << 6) | ((id->bytes[12] & 0xFC) >> 2);
-  out_raw_bits[12] =
-      ((id->bytes[12] & 0x03) << 6) | ((id->bytes[13] & 0xFC) >> 2);
-  out_raw_bits[13] =
-      ((id->bytes[13] & 0x03) << 6) | ((id->bytes[14] & 0xFC) >> 2);
-  out_raw_bits[14] =
-      ((id->bytes[14] & 0x03) << 6) | ((id->bytes[15] & 0xFC) >> 2);
-  out_raw_bits[15] = (id->bytes[15] & 0x03) << 6; // last 6 bits are padding
+  out_raw_bits[9] = ((id->bytes[9] & 0x03) << 6) | ((id->bytes[10] & 0xFC) >> 2);
+  out_raw_bits[10] = ((id->bytes[10] & 0x03) << 6) | ((id->bytes[11] & 0xFC) >> 2);
+  out_raw_bits[11] = ((id->bytes[11] & 0x03) << 6) | ((id->bytes[12] & 0xFC) >> 2);
+  out_raw_bits[12] = ((id->bytes[12] & 0x03) << 6) | ((id->bytes[13] & 0xFC) >> 2);
+  out_raw_bits[13] = ((id->bytes[13] & 0x03) << 6) | ((id->bytes[14] & 0xFC) >> 2);
+  out_raw_bits[14] = ((id->bytes[14] & 0x03) << 6) | ((id->bytes[15] & 0xFC) >> 2);
+  out_raw_bits[15] = (id->bytes[15] & 0x03) << 6;  // last 6 bits are padding
 }
 
-void CuidUtilities::add_UUIDv8_bits(const uint8_t raw_bits[16],
-                                    amdcuid_id_t *id) {
+void CuidUtilities::add_UUIDv8_bits(const uint8_t raw_bits[16], amdcuid_id_t* id) {
   if (!raw_bits || !id) {
     return;
   }
@@ -553,8 +512,7 @@ void CuidUtilities::add_UUIDv8_bits(const uint8_t raw_bits[16],
   id->bytes[5] = raw_bits[5];
 
   // Bits 48-51: Version (8) + Bits 52-63: ID value part 2
-  id->bytes[6] =
-      ((raw_bits[6] & 0xF0) >> 4) | 0x80; // Version 8 in upper 4 bits
+  id->bytes[6] = ((raw_bits[6] & 0xF0) >> 4) | 0x80;  // Version 8 in upper 4 bits
   id->bytes[7] = ((raw_bits[6] & 0x0F) << 4) | ((raw_bits[7] & 0xF0) >> 4);
 
   // Bits 64-65: Variant (10b) + Bits 66-127: ID value part 3 (MSB)
@@ -569,25 +527,21 @@ void CuidUtilities::add_UUIDv8_bits(const uint8_t raw_bits[16],
   id->bytes[15] = ((raw_bits[14] & 0x3F) << 2) | ((raw_bits[15] & 0xC0) >> 6);
 }
 
-std::string CuidUtilities::get_cuid_as_string(const amdcuid_id_t *id) {
+std::string CuidUtilities::get_cuid_as_string(const amdcuid_id_t* id) {
   // Format as UUIDv8 string: 8-4-4-4-12 hex digits from id->bytes[16]
   // UUID: xxxxxxxx-xxxx-8xxx-yxxx-xxxxxxxxxxxx
-  char uuid_str[37]; // 36 chars + null
+  char uuid_str[37];  // 36 chars + null
   // Format the bytes into a UUID string
-  snprintf(
-      uuid_str, sizeof(uuid_str),
-      "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
-      id->bytes[0], id->bytes[1], id->bytes[2], id->bytes[3], id->bytes[4],
-      id->bytes[5], id->bytes[6], id->bytes[7], id->bytes[8], id->bytes[9],
-      id->bytes[10], id->bytes[11], id->bytes[12], id->bytes[13], id->bytes[14],
-      id->bytes[15]);
+  snprintf(uuid_str, sizeof(uuid_str),
+           "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x", id->bytes[0],
+           id->bytes[1], id->bytes[2], id->bytes[3], id->bytes[4], id->bytes[5], id->bytes[6],
+           id->bytes[7], id->bytes[8], id->bytes[9], id->bytes[10], id->bytes[11], id->bytes[12],
+           id->bytes[13], id->bytes[14], id->bytes[15]);
 
   return std::string(uuid_str);
 }
 
-amdcuid_status_t
-CuidUtilities::uuid_string_to_uint8(const std::string &uuid_str,
-                                    uint8_t *uuid) {
+amdcuid_status_t CuidUtilities::uuid_string_to_uint8(const std::string& uuid_str, uint8_t* uuid) {
   if (!uuid) {
     return AMDCUID_STATUS_INVALID_ARGUMENT;
   }
@@ -598,8 +552,7 @@ CuidUtilities::uuid_string_to_uint8(const std::string &uuid_str,
   for (char c : uuid_str) {
     if (c != '-') {
       if (!isxdigit(c)) {
-        std::cerr << "Invalid UUID format: non-hex character found"
-                  << std::endl;
+        std::cerr << "Invalid UUID format: non-hex character found" << std::endl;
         return AMDCUID_STATUS_INVALID_ARGUMENT;
       }
       hex_str += c;
@@ -608,8 +561,8 @@ CuidUtilities::uuid_string_to_uint8(const std::string &uuid_str,
 
   // UUID should be 128 bits = 32 hex characters
   if (hex_str.length() != 32) {
-    std::cerr << "Invalid UUID length: expected 32 hex digits, got "
-              << hex_str.length() << std::endl;
+    std::cerr << "Invalid UUID length: expected 32 hex digits, got " << hex_str.length()
+              << std::endl;
     return AMDCUID_STATUS_INVALID_ARGUMENT;
   }
 
@@ -624,27 +577,26 @@ CuidUtilities::uuid_string_to_uint8(const std::string &uuid_str,
 
 std::string CuidUtilities::device_type_to_string(amdcuid_device_type_t type) {
   switch (type) {
-  case AMDCUID_DEVICE_TYPE_PLATFORM:
-    return "PLATFORM";
-  case AMDCUID_DEVICE_TYPE_CPU:
-    return "CPU";
-  case AMDCUID_DEVICE_TYPE_GPU:
-    return "GPU";
-  case AMDCUID_DEVICE_TYPE_NIC:
-    return "NIC";
-  case AMDCUID_DEVICE_TYPE_NPU:
-    return "NPU";
-  default:
-    return "UNKNOWN";
+    case AMDCUID_DEVICE_TYPE_PLATFORM:
+      return "PLATFORM";
+    case AMDCUID_DEVICE_TYPE_CPU:
+      return "CPU";
+    case AMDCUID_DEVICE_TYPE_GPU:
+      return "GPU";
+    case AMDCUID_DEVICE_TYPE_NIC:
+      return "NIC";
+    case AMDCUID_DEVICE_TYPE_NPU:
+      return "NPU";
+    default:
+      return "UNKNOWN";
   }
 }
 
-bool CuidUtilities::is_valid_bdf(const std::string &bdf) {
+bool CuidUtilities::is_valid_bdf(const std::string& bdf) {
   // Expected format: DDDD:BB:SS.F (e.g. "0000:03:00.0")
-  if (bdf.size() != 12)
-    return false;
+  if (bdf.size() != 12) return false;
   auto is_hex = [](char c) { return std::isxdigit((unsigned char)c); };
-  return is_hex(bdf[0]) && is_hex(bdf[1]) && is_hex(bdf[2]) && is_hex(bdf[3]) &&
-         bdf[4] == ':' && is_hex(bdf[5]) && is_hex(bdf[6]) && bdf[7] == ':' &&
-         is_hex(bdf[8]) && is_hex(bdf[9]) && bdf[10] == '.' && is_hex(bdf[11]);
+  return is_hex(bdf[0]) && is_hex(bdf[1]) && is_hex(bdf[2]) && is_hex(bdf[3]) && bdf[4] == ':' &&
+         is_hex(bdf[5]) && is_hex(bdf[6]) && bdf[7] == ':' && is_hex(bdf[8]) && is_hex(bdf[9]) &&
+         bdf[10] == '.' && is_hex(bdf[11]);
 }

--- a/projects/cuid/lib/src/cuid_util.h
+++ b/projects/cuid/lib/src/cuid_util.h
@@ -4,20 +4,21 @@
 #ifndef CUID_UTIL_H
 #define CUID_UTIL_H
 
-#include "hmac.h"
-#include "include/amd_cuid.h"
-#include "src/cuid_internal.h"
 #include <iostream>
 #include <memory>
 #include <sstream>
 #include <string>
 #include <vector>
 
+#include "hmac.h"
+#include "include/amd_cuid.h"
+#include "src/cuid_internal.h"
+
 enum LogLevel { DEBUG, INFO, WARN, ERROR };
 
 class Logger {
-public:
-  static Logger &instance() {
+ public:
+  static Logger& instance() {
     static Logger logger_;
     return logger_;
   }
@@ -25,60 +26,55 @@ public:
   void set_level(LogLevel level) { level_ = level; }
   LogLevel level() const { return level_; }
 
-  const char *LogLevelName(LogLevel level) const;
+  const char* LogLevelName(LogLevel level) const;
 
-  void log(LogLevel level, const std::string &msg) const;
+  void log(LogLevel level, const std::string& msg) const;
 
-private:
+ private:
   Logger() : level_(INFO) {}
   LogLevel level_;
 };
 
-#define LOG(level, msg)                                                        \
-  do {                                                                         \
-    std::ostringstream _log_stream_;                                           \
-    _log_stream_ << msg;                                                       \
-    Logger::instance().log(level, _log_stream_.str());                         \
+#define LOG(level, msg)                                \
+  do {                                                 \
+    std::ostringstream _log_stream_;                   \
+    _log_stream_ << msg;                               \
+    Logger::instance().log(level, _log_stream_.str()); \
   } while (0)
 
 namespace CuidUtilities {
-std::string read_sysfs_file(const std::string &path);
-std::string readlink_bdf(const std::string &device_path);
-std::string bdf_to_device_path(const std::string &bdf,
-                               amdcuid_device_type_t device_type);
+std::string read_sysfs_file(const std::string& path);
+std::string readlink_bdf(const std::string& device_path);
+std::string bdf_to_device_path(const std::string& bdf, amdcuid_device_type_t device_type);
 std::string real_dev_path_from_fd(int fd);
-std::string get_real_path(const std::string &path);
-amdcuid_status_t generate_derived_cuid(const amdcuid_primary_id *primary_id,
-                                       amdcuid_derived_id *derived_id,
-                                       cuid_hmac *hmac);
+std::string get_real_path(const std::string& path);
+amdcuid_status_t generate_derived_cuid(const amdcuid_primary_id* primary_id,
+                                       amdcuid_derived_id* derived_id, cuid_hmac* hmac);
 amdcuid_status_t generate_primary_cuid(uint64_t serial_number, uint16_t unit_id,
-                                       uint8_t revision_id, uint16_t device_id,
-                                       uint16_t vendor_id, uint8_t device_type,
-                                       amdcuid_primary_id *primary_id,
+                                       uint8_t revision_id, uint16_t device_id, uint16_t vendor_id,
+                                       uint8_t device_type, amdcuid_primary_id* primary_id,
                                        bool temp = false);
-void remove_UUIDv8_bits(amdcuid_id_t *id, uint8_t out_raw_bits[16]);
-void add_UUIDv8_bits(const uint8_t raw_bits[16], amdcuid_id_t *id);
-std::string get_cuid_as_string(const amdcuid_id_t *id);
-amdcuid_status_t uuid_string_to_uint8(const std::string &uuid_str,
-                                      uint8_t *uuid);
+void remove_UUIDv8_bits(amdcuid_id_t* id, uint8_t out_raw_bits[16]);
+void add_UUIDv8_bits(const uint8_t raw_bits[16], amdcuid_id_t* id);
+std::string get_cuid_as_string(const amdcuid_id_t* id);
+amdcuid_status_t uuid_string_to_uint8(const std::string& uuid_str, uint8_t* uuid);
 std::string device_type_to_string(amdcuid_device_type_t type);
 
-bool is_valid_bdf(const std::string &bdf);
-amdcuid_status_t make_fallback_fingerprint(const std::string &id,
-                                           uint64_t &fingerprint);
+bool is_valid_bdf(const std::string& bdf);
+amdcuid_status_t make_fallback_fingerprint(const std::string& id, uint64_t& fingerprint);
 
 // GPU VF (SR-IOV Virtual Function) utilities
-int extract_render_minor(const std::string &path);
-uint16_t get_gpu_vf_id(const std::string &device_path);
+int extract_render_minor(const std::string& path);
+uint16_t get_gpu_vf_id(const std::string& device_path);
 
-inline const std::string &cuid_file() {
+inline const std::string& cuid_file() {
   static const std::string path = "/tmp/cuid";
   return path;
 }
-inline const std::string &priv_cuid_file() {
+inline const std::string& priv_cuid_file() {
   static const std::string path = "/tmp/priv_cuid";
   return path;
 }
-} // namespace CuidUtilities
+}  // namespace CuidUtilities
 
 #endif

--- a/projects/cuid/lib/src/gim_util.cc
+++ b/projects/cuid/lib/src/gim_util.cc
@@ -3,7 +3,10 @@
 
 #include "gim_util.h"
 
-#include "cuid_util.h"
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 #include <cctype>
 #include <cerrno>
@@ -11,10 +14,8 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
-#include <fcntl.h>
-#include <sys/ioctl.h>
-#include <sys/stat.h>
-#include <unistd.h>
+
+#include "cuid_util.h"
 
 namespace cuid {
 namespace gim {
@@ -27,7 +28,7 @@ namespace {
 // ABI drift.
 
 constexpr size_t kSmiMaxStringLength = 256;
-constexpr size_t kSmiMaxPayload = 1024;          // uint32_t entries
+constexpr size_t kSmiMaxPayload = 1024;  // uint32_t entries
 constexpr size_t kSmiMaxPayloadBytes = kSmiMaxPayload * sizeof(uint32_t);
 constexpr size_t kSmiMaxDevices = 32;
 
@@ -48,16 +49,14 @@ constexpr uint32_t kSmiVersionBeta1 = 0x00000004u;
 constexpr uint32_t kSmiVersionBeta0 = 0x00000003u;
 constexpr uint32_t kSmiVersionAlpha0 = 0x00000002u;
 
-constexpr uint32_t kHandshakeVersions[] = {
-    kSmiVersionBeta4, kSmiVersionBeta3, kSmiVersionBeta2,
-    kSmiVersionBeta1, kSmiVersionBeta0, kSmiVersionAlpha0};
+constexpr uint32_t kHandshakeVersions[] = {kSmiVersionBeta4, kSmiVersionBeta3, kSmiVersionBeta2,
+                                           kSmiVersionBeta1, kSmiVersionBeta0, kSmiVersionAlpha0};
 
 // _IOWR('S', 0, struct smi_ioctl_cmd). The struct size is encoded in the
 // ioctl number, so we use the same total wire size (4108 bytes) the GIM
 // driver expects for its smi_ioctl_cmd transport.
 constexpr size_t kSmiIoctlCmdSize = 4 + 2 + 2 + 4 + kSmiMaxPayloadBytes;
-constexpr unsigned long kSmiIoctlCmd =
-    _IOC(_IOC_READ | _IOC_WRITE, 'S', 0, kSmiIoctlCmdSize);
+constexpr unsigned long kSmiIoctlCmd = _IOC(_IOC_READ | _IOC_WRITE, 'S', 0, kSmiIoctlCmdSize);
 
 #pragma pack(push, 1)
 struct SmiInHdrWire {
@@ -78,8 +77,7 @@ struct SmiIoctlCmdWire {
   SmiOutHdrWire out_hdr;
   uint8_t payload[kSmiMaxPayloadBytes];
 };
-static_assert(sizeof(SmiIoctlCmdWire) == kSmiIoctlCmdSize,
-              "SmiIoctlCmdWire size mismatch");
+static_assert(sizeof(SmiIoctlCmdWire) == kSmiIoctlCmdSize, "SmiIoctlCmdWire size mismatch");
 
 // SMI handshake input/output payload (struct smi_handshake).
 struct SmiHandshakeWire {
@@ -95,21 +93,19 @@ struct SmiDeviceHandleWire {
   uint64_t handle;
   uint64_t device_id;
 };
-static_assert(sizeof(SmiDeviceHandleWire) == 16,
-              "SmiDeviceHandleWire size mismatch");
+static_assert(sizeof(SmiDeviceHandleWire) == 16, "SmiDeviceHandleWire size mismatch");
 
 // One entry of struct smi_server_static_info::devices[] (Linux, natural
 // alignment). dev_id is a 16-byte smi_device_handle_t, so each entry is 40
 // bytes.
 struct SmiServerDeviceWire {
   SmiDeviceHandleWire dev_id;
-  uint64_t bdf;     // union smi_bdf packed 64-bit value
+  uint64_t bdf;  // union smi_bdf packed 64-bit value
   uint8_t failed;
   uint8_t padding[3];
   uint32_t reserved[3];
 };
-static_assert(sizeof(SmiServerDeviceWire) == 40,
-              "SmiServerDeviceWire size mismatch");
+static_assert(sizeof(SmiServerDeviceWire) == 40, "SmiServerDeviceWire size mismatch");
 
 // struct smi_server_static_info (Linux, natural alignment). The trailing
 // reserved area expands the struct to the full 4096-byte SMI payload; the GIM
@@ -120,8 +116,7 @@ struct SmiServerStaticInfoWire {
   SmiServerDeviceWire devices[kSmiMaxDevices];
   uint64_t reserved[351];
 };
-static_assert(sizeof(SmiServerStaticInfoWire) == 4096,
-              "SmiServerStaticInfoWire size mismatch");
+static_assert(sizeof(SmiServerStaticInfoWire) == 4096, "SmiServerStaticInfoWire size mismatch");
 static_assert(sizeof(SmiServerStaticInfoWire) <= kSmiMaxPayloadBytes,
               "SmiServerStaticInfoWire larger than SMI payload");
 
@@ -130,8 +125,7 @@ static_assert(sizeof(SmiServerStaticInfoWire) <= kSmiMaxPayloadBytes,
 struct SmiDeviceInfoWire {
   SmiDeviceHandleWire dev_id;
 };
-static_assert(sizeof(SmiDeviceInfoWire) == 16,
-              "SmiDeviceInfoWire size mismatch");
+static_assert(sizeof(SmiDeviceInfoWire) == 16, "SmiDeviceInfoWire size mismatch");
 
 // struct smi_asic_info (Linux, natural alignment).
 struct SmiAsicInfoWire {
@@ -166,7 +160,7 @@ static_assert(sizeof(SmiAsicInfoWire) <= kSmiMaxPayloadBytes,
               "SmiAsicInfoWire larger than SMI payload");
 
 // Copy a C string field bounded to its array length, ensuring NUL-termination.
-std::string fixed_string_to_std(const char *src, size_t cap) {
+std::string fixed_string_to_std(const char* src, size_t cap) {
   size_t n = 0;
   while (n < cap && src[n] != '\0') {
     ++n;
@@ -174,11 +168,11 @@ std::string fixed_string_to_std(const char *src, size_t cap) {
   return std::string(src, n);
 }
 
-bool is_canonical_bdf(const std::string &bdf) {
+bool is_canonical_bdf(const std::string& bdf) {
   return bdf.size() == 12 && bdf[4] == ':' && bdf[7] == ':' && bdf[10] == '.';
 }
 
-} // namespace
+}  // namespace
 
 // ----------------------------------------------------------------------------
 // GimClient
@@ -194,7 +188,7 @@ GimClient::~GimClient() {
 }
 
 bool GimClient::is_available() {
-  struct stat st {};
+  struct stat st{};
   if (::stat(kGimSmiDevicePath, &st) != 0) {
     return false;
   }
@@ -213,8 +207,7 @@ amdcuid_status_t GimClient::init() {
     int fd = ::open(kGimSmiDevicePath, O_RDWR | O_CLOEXEC);
     if (fd < 0) {
       const int err = errno;
-      LOG(DEBUG, "GIM: open(" << kGimSmiDevicePath
-                              << ") failed: " << std::strerror(err));
+      LOG(DEBUG, "GIM: open(" << kGimSmiDevicePath << ") failed: " << std::strerror(err));
       if (err == EACCES || err == EPERM) {
         return AMDCUID_STATUS_PERMISSION_DENIED;
       }
@@ -227,12 +220,10 @@ amdcuid_status_t GimClient::init() {
   for (uint32_t version : kHandshakeVersions) {
     SmiHandshakeWire hs{version};
     SmiHandshakeWire resp{};
-    amdcuid_status_t st = do_ioctl(kSmiCmdCodeHandshake, &hs, sizeof(hs), &resp,
-                                   sizeof(resp));
+    amdcuid_status_t st = do_ioctl(kSmiCmdCodeHandshake, &hs, sizeof(hs), &resp, sizeof(resp));
     if (st == AMDCUID_STATUS_SUCCESS) {
       handshake_done_ = true;
-      LOG(DEBUG, "GIM: handshake succeeded with version 0x" << std::hex
-                                                            << version);
+      LOG(DEBUG, "GIM: handshake succeeded with version 0x" << std::hex << version);
       return AMDCUID_STATUS_SUCCESS;
     }
   }
@@ -243,8 +234,8 @@ amdcuid_status_t GimClient::init() {
   return AMDCUID_STATUS_UNSUPPORTED;
 }
 
-amdcuid_status_t GimClient::do_ioctl(uint32_t cmd_code, const void *in,
-                                     size_t in_len, void *out, size_t out_len) {
+amdcuid_status_t GimClient::do_ioctl(uint32_t cmd_code, const void* in, size_t in_len, void* out,
+                                     size_t out_len) {
   if (fd_ < 0) {
     return AMDCUID_STATUS_UNSUPPORTED;
   }
@@ -263,16 +254,14 @@ amdcuid_status_t GimClient::do_ioctl(uint32_t cmd_code, const void *in,
 
   if (::ioctl(fd_, kSmiIoctlCmd, &cmd) != 0) {
     const int err = errno;
-    LOG(DEBUG, "GIM: ioctl(cmd=0x" << std::hex << cmd_code
-                                   << ") failed: " << std::strerror(err));
+    LOG(DEBUG, "GIM: ioctl(cmd=0x" << std::hex << cmd_code << ") failed: " << std::strerror(err));
     if (err == EACCES || err == EPERM) {
       return AMDCUID_STATUS_PERMISSION_DENIED;
     }
     return AMDCUID_STATUS_UNSUPPORTED;
   }
   if (cmd.out_hdr.status != 0) {
-    LOG(DEBUG, "GIM: SMI cmd 0x" << std::hex << cmd_code
-                                 << " returned status " << std::dec
+    LOG(DEBUG, "GIM: SMI cmd 0x" << std::hex << cmd_code << " returned status " << std::dec
                                  << cmd.out_hdr.status);
     return AMDCUID_STATUS_UNSUPPORTED;
   }
@@ -282,7 +271,7 @@ amdcuid_status_t GimClient::do_ioctl(uint32_t cmd_code, const void *in,
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t GimClient::get_devices(std::vector<GimDeviceEntry> &out) {
+amdcuid_status_t GimClient::get_devices(std::vector<GimDeviceEntry>& out) {
   out.clear();
   amdcuid_status_t st = init();
   if (st != AMDCUID_STATUS_SUCCESS) {
@@ -291,8 +280,7 @@ amdcuid_status_t GimClient::get_devices(std::vector<GimDeviceEntry> &out) {
 
   SmiServerStaticInfoWire info;
   std::memset(&info, 0, sizeof(info));
-  st = do_ioctl(kSmiCmdCodeGetServerStaticInfo, nullptr, 0, &info,
-                sizeof(info));
+  st = do_ioctl(kSmiCmdCodeGetServerStaticInfo, nullptr, 0, &info, sizeof(info));
   if (st != AMDCUID_STATUS_SUCCESS) {
     return st;
   }
@@ -312,8 +300,7 @@ amdcuid_status_t GimClient::get_devices(std::vector<GimDeviceEntry> &out) {
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t GimClient::lookup_dev_id(const std::string &bdf,
-                                          uint64_t &dev_id) {
+amdcuid_status_t GimClient::lookup_dev_id(const std::string& bdf, uint64_t& dev_id) {
   if (!is_canonical_bdf(bdf)) {
     return AMDCUID_STATUS_INVALID_ARGUMENT;
   }
@@ -322,7 +309,7 @@ amdcuid_status_t GimClient::lookup_dev_id(const std::string &bdf,
   if (st != AMDCUID_STATUS_SUCCESS) {
     return st;
   }
-  for (const auto &e : devices) {
+  for (const auto& e : devices) {
     if (e.bdf == bdf) {
       dev_id = e.dev_id;
       return AMDCUID_STATUS_SUCCESS;
@@ -331,7 +318,7 @@ amdcuid_status_t GimClient::lookup_dev_id(const std::string &bdf,
   return AMDCUID_STATUS_DEVICE_NOT_FOUND;
 }
 
-amdcuid_status_t GimClient::get_asic_info(uint64_t dev_id, GimAsicInfo &info) {
+amdcuid_status_t GimClient::get_asic_info(uint64_t dev_id, GimAsicInfo& info) {
   amdcuid_status_t st = init();
   if (st != AMDCUID_STATUS_SUCCESS) {
     return st;
@@ -351,8 +338,7 @@ amdcuid_status_t GimClient::get_asic_info(uint64_t dev_id, GimAsicInfo &info) {
   info.subvendor_id = raw.subvendor_id;
   info.device_id = raw.device_id;
   info.rev_id = raw.rev_id;
-  info.asic_serial =
-      fixed_string_to_std(raw.asic_serial, kSmiMaxStringLength);
+  info.asic_serial = fixed_string_to_std(raw.asic_serial, kSmiMaxStringLength);
   info.oam_id = raw.oam_id;
   info.num_of_compute_units = raw.num_of_compute_units;
   info.target_graphics_version = raw.target_graphics_version;
@@ -360,8 +346,7 @@ amdcuid_status_t GimClient::get_asic_info(uint64_t dev_id, GimAsicInfo &info) {
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t GimClient::get_asic_info_for_bdf(const std::string &bdf,
-                                                  GimAsicInfo &info) {
+amdcuid_status_t GimClient::get_asic_info_for_bdf(const std::string& bdf, GimAsicInfo& info) {
   uint64_t dev_id = 0;
   amdcuid_status_t st = lookup_dev_id(bdf, dev_id);
   if (st != AMDCUID_STATUS_SUCCESS) {
@@ -370,14 +355,13 @@ amdcuid_status_t GimClient::get_asic_info_for_bdf(const std::string &bdf,
   return get_asic_info(dev_id, info);
 }
 
-bool GimClient::parse_asic_serial(const std::string &serial, uint64_t &out) {
+bool GimClient::parse_asic_serial(const std::string& serial, uint64_t& out) {
   if (serial.empty()) {
     return false;
   }
   // Accept optional 0x/0X prefix.
   size_t pos = 0;
-  if (serial.size() > 2 && serial[0] == '0' &&
-      (serial[1] == 'x' || serial[1] == 'X')) {
+  if (serial.size() > 2 && serial[0] == '0' && (serial[1] == 'x' || serial[1] == 'X')) {
     pos = 2;
   }
   if (pos >= serial.size()) {
@@ -412,10 +396,9 @@ std::string GimClient::format_bdf(uint64_t packed_bdf) {
   const uint32_t bus = static_cast<uint32_t>((packed_bdf >> 8) & 0xFFu);
   const uint32_t domain = static_cast<uint32_t>((packed_bdf >> 16) & 0xFFFFu);
   char buf[16];
-  std::snprintf(buf, sizeof(buf), "%04x:%02x:%02x.%u", domain, bus, device,
-                function);
+  std::snprintf(buf, sizeof(buf), "%04x:%02x:%02x.%u", domain, bus, device, function);
   return std::string(buf);
 }
 
-} // namespace gim
-} // namespace cuid
+}  // namespace gim
+}  // namespace cuid

--- a/projects/cuid/lib/src/gim_util.h
+++ b/projects/cuid/lib/src/gim_util.h
@@ -4,17 +4,18 @@
 #ifndef CUID_GIM_UTIL_H
 #define CUID_GIM_UTIL_H
 
-#include "include/amd_cuid.h"
 #include <cstddef>
 #include <cstdint>
 #include <string>
 #include <vector>
 
+#include "include/amd_cuid.h"
+
 namespace cuid {
 namespace gim {
 
 // GIM SMI character device exposed by the GIM kernel driver.
-constexpr const char *kGimSmiDevicePath = "/dev/gim-smi0";
+constexpr const char* kGimSmiDevicePath = "/dev/gim-smi0";
 
 // Mirror of struct smi_asic_info subset returned by SMI_CMD_CODE_GET_ASIC_INFO
 // in the host AMD-SMI / GIM ABI. Strings are NUL-terminated.
@@ -25,7 +26,7 @@ struct GimAsicInfo {
   uint32_t subvendor_id = 0;
   uint64_t device_id = 0;
   uint32_t rev_id = 0;
-  std::string asic_serial; // hexadecimal string (e.g. "0x1234ABCD")
+  std::string asic_serial;  // hexadecimal string (e.g. "0x1234ABCD")
   uint32_t oam_id = 0;
   uint32_t num_of_compute_units = 0;
   uint64_t target_graphics_version = 0;
@@ -33,21 +34,21 @@ struct GimAsicInfo {
 };
 
 struct GimDeviceEntry {
-  uint64_t dev_id = 0;     // Opaque GIM device handle.
-  std::string bdf;         // Canonical "dddd:bb:dd.f" PCI BDF.
-  bool failed = false;     // Reported by GIM as failed.
+  uint64_t dev_id = 0;  // Opaque GIM device handle.
+  std::string bdf;      // Canonical "dddd:bb:dd.f" PCI BDF.
+  bool failed = false;  // Reported by GIM as failed.
 };
 
 // RAII wrapper around the GIM SMI ioctl interface, used to query device info
 // when sysfs is not populated (GIM SR-IOV hosts). All methods are safe to call
 // when the device node is absent and return AMDCUID_STATUS_UNSUPPORTED then.
 class GimClient {
-public:
+ public:
   GimClient();
   ~GimClient();
 
-  GimClient(const GimClient &) = delete;
-  GimClient &operator=(const GimClient &) = delete;
+  GimClient(const GimClient&) = delete;
+  GimClient& operator=(const GimClient&) = delete;
 
   // Returns true when the GIM SMI character device exists in /dev. Does not
   // require any special privilege.
@@ -67,39 +68,38 @@ public:
 
   // Enumerate all GPUs visible to the GIM driver. Calls init() if not already
   // connected.
-  amdcuid_status_t get_devices(std::vector<GimDeviceEntry> &out);
+  amdcuid_status_t get_devices(std::vector<GimDeviceEntry>& out);
 
   // Look up the GIM device handle for a given canonical PCI BDF string.
-  amdcuid_status_t lookup_dev_id(const std::string &bdf, uint64_t &dev_id);
+  amdcuid_status_t lookup_dev_id(const std::string& bdf, uint64_t& dev_id);
 
   // Query ASIC info (vendor/device/rev IDs, serial, etc.) for a GIM device
   // handle previously returned by get_devices().
-  amdcuid_status_t get_asic_info(uint64_t dev_id, GimAsicInfo &info);
+  amdcuid_status_t get_asic_info(uint64_t dev_id, GimAsicInfo& info);
 
   // Convenience wrapper: lookup then query.
-  amdcuid_status_t get_asic_info_for_bdf(const std::string &bdf,
-                                         GimAsicInfo &info);
+  amdcuid_status_t get_asic_info_for_bdf(const std::string& bdf, GimAsicInfo& info);
 
   // Parse an ASIC serial number reported by GIM as a hexadecimal string into
   // a 64-bit value. Accepts an optional "0x"/"0X" prefix and rejects empty
   // or non-hex input. Returns true on success.
-  static bool parse_asic_serial(const std::string &serial, uint64_t &out);
+  static bool parse_asic_serial(const std::string& serial, uint64_t& out);
 
   // Convert a GIM smi_bdf 64-bit packed value into the canonical
   // "dddd:bb:dd.f" string representation. Exposed for testing.
   static std::string format_bdf(uint64_t packed_bdf);
 
-private:
+ private:
   // Issue a single SMI ioctl. payload buffers are clamped to the SMI payload
   // size; returns AMDCUID_STATUS_INVALID_ARGUMENT if the request is too large.
-  amdcuid_status_t do_ioctl(uint32_t cmd_code, const void *in, size_t in_len,
-                            void *out, size_t out_len);
+  amdcuid_status_t do_ioctl(uint32_t cmd_code, const void* in, size_t in_len, void* out,
+                            size_t out_len);
 
   int fd_ = -1;
   bool handshake_done_ = false;
 };
 
-} // namespace gim
-} // namespace cuid
+}  // namespace gim
+}  // namespace cuid
 
-#endif // CUID_GIM_UTIL_H
+#endif  // CUID_GIM_UTIL_H

--- a/projects/cuid/lib/src/hmac.h
+++ b/projects/cuid/lib/src/hmac.h
@@ -4,10 +4,11 @@
 #ifndef HMAC_H
 #define HMAC_H
 
-#include "include/amd_cuid.h"
 #include <cstddef>
 #include <cstdint>
 #include <string>
+
+#include "include/amd_cuid.h"
 
 #define key_length 32
 #define hash_length 32
@@ -16,30 +17,29 @@
 // is one implementation on every platform; the pimpl is retained only to keep
 // the class layout stable for existing callers.
 class cuid_hmac {
-private:
-  struct Impl; // defined in hmac.cc
-  Impl *impl_;
-  uint8_t *key;
+ private:
+  struct Impl;  // defined in hmac.cc
+  Impl* impl_;
+  uint8_t* key;
   size_t key_len;
   bool valid;
   std::string key_file_path;
 
-public:
+ public:
   cuid_hmac();
   cuid_hmac(uint8_t key_data[key_length]);
   ~cuid_hmac();
   bool is_valid() const { return valid; }
 
-  amdcuid_status_t generate_hmac_sha256(const uint8_t *data, size_t data_len,
-                                        uint8_t *out_hash, size_t *out_len);
-  amdcuid_status_t set_hmac_algorithm(const char *digest_name);
+  amdcuid_status_t generate_hmac_sha256(const uint8_t* data, size_t data_len, uint8_t* out_hash,
+                                        size_t* out_len);
+  amdcuid_status_t set_hmac_algorithm(const char* digest_name);
   amdcuid_status_t set_hmac_key(const uint8_t key_data[key_length]);
   amdcuid_status_t generate_key(uint8_t key[key_length]);
   std::string get_key_file_path() const { return key_file_path; }
 };
 
 // Unkeyed SHA-256 digest of data into a 32-byte output buffer.
-amdcuid_status_t sha256_unkeyed(const uint8_t *data, size_t data_len,
-                                uint8_t out[32]);
+amdcuid_status_t sha256_unkeyed(const uint8_t* data, size_t data_len, uint8_t out[32]);
 
-#endif // HMAC_H
+#endif  // HMAC_H

--- a/projects/cuid/lib/src/ipc_protocol.h
+++ b/projects/cuid/lib/src/ipc_protocol.h
@@ -4,28 +4,24 @@
 #ifndef IPC_PROTOCOL_H
 #define IPC_PROTOCOL_H
 
+#include <cstdint>
+
 #include "include/amd_cuid.h"
 #include "src/cuid_device.h"
-#include <cstdint>
 
 #define AMDCUID_SOCKET_PATH "/var/run/amdcuid_daemon.sock"
 
-enum class IpcMessageType : uint8_t {
-    ADD_DEVICE = 1,
-    REFRESH_DEVICES = 2
+enum class IpcMessageType : uint8_t { ADD_DEVICE = 1, REFRESH_DEVICES = 2 };
+
+struct IpcRequest {
+  IpcMessageType type;
+  char* device_path;                  // used for ADD_DEVICE, empty otherwise
+  amdcuid_device_type_t device_type;  // used for ADD_DEVICE, AMDCUID_DEVICE_TYPE_NONE otherwise
 };
 
-struct IpcRequest
-{
-    IpcMessageType type;
-    char* device_path; // used for ADD_DEVICE, empty otherwise
-    amdcuid_device_type_t device_type; // used for ADD_DEVICE, AMDCUID_DEVICE_TYPE_NONE otherwise
+struct IpcResponse {
+  amdcuid_status_t status;
+  amdcuid_id_t device_handle;  // used for ADD_DEVICE, 0 otherwise
 };
 
-struct IpcResponse
-{
-    amdcuid_status_t status;
-    amdcuid_id_t device_handle; // used for ADD_DEVICE, 0 otherwise
-};
-
-#endif // IPC_PROTOCOL_H
+#endif  // IPC_PROTOCOL_H

--- a/projects/cuid/lib/src/pci_util.cc
+++ b/projects/cuid/lib/src/pci_util.cc
@@ -2,17 +2,20 @@
 // SPDX-License-Identifier: MIT
 
 #include "pci_util.h"
+
+#include <unistd.h>
+
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
 #include "cuid_device.h"
 #include "cuid_device_manager.h"
 #include "cuid_gpu.h"
 #include "cuid_nic.h"
 #include "cuid_util.h"
 #include "include/amd_cuid.h"
-#include <cstring>
-#include <fstream>
-#include <iostream>
-#include <sstream>
-#include <unistd.h>
 
 // Endianness conversion functions
 uint16_t PciUtil::le16_to_be16(uint16_t value) {
@@ -20,27 +23,20 @@ uint16_t PciUtil::le16_to_be16(uint16_t value) {
 }
 
 uint64_t PciUtil::le64_to_be64(uint64_t value) {
-  return ((value & 0x00000000000000FFULL) << 56) |
-         ((value & 0x000000000000FF00ULL) << 40) |
-         ((value & 0x0000000000FF0000ULL) << 24) |
-         ((value & 0x00000000FF000000ULL) << 8) |
-         ((value & 0x000000FF00000000ULL) >> 8) |
-         ((value & 0x0000FF0000000000ULL) >> 24) |
-         ((value & 0x00FF000000000000ULL) >> 40) |
-         ((value & 0xFF00000000000000ULL) >> 56);
+  return ((value & 0x00000000000000FFULL) << 56) | ((value & 0x000000000000FF00ULL) << 40) |
+         ((value & 0x0000000000FF0000ULL) << 24) | ((value & 0x00000000FF000000ULL) << 8) |
+         ((value & 0x000000FF00000000ULL) >> 8) | ((value & 0x0000FF0000000000ULL) >> 24) |
+         ((value & 0x00FF000000000000ULL) >> 40) | ((value & 0xFF00000000000000ULL) >> 56);
 }
 
 // This function should only work with PCI devices, which currently includes
 // GPUs, NICs, and NPUs. It may later include storage devices as well.
-amdcuid_status_t PciUtil::read_pci_config_space(std::string bdf,
-                                                uint8_t *buffer,
-                                                size_t buffer_size,
-                                                uint16_t offset) {
+amdcuid_status_t PciUtil::read_pci_config_space(std::string bdf, uint8_t* buffer,
+                                                size_t buffer_size, uint16_t offset) {
   if (geteuid() != 0) {
     return AMDCUID_STATUS_PERMISSION_DENIED;
   }
-  if (bdf.empty() || !buffer || buffer_size == 0)
-    return AMDCUID_STATUS_INVALID_ARGUMENT;
+  if (bdf.empty() || !buffer || buffer_size == 0) return AMDCUID_STATUS_INVALID_ARGUMENT;
 
   std::string pci_config_path = "/sys/bus/pci/devices/" + bdf + "/config";
 
@@ -74,9 +70,8 @@ amdcuid_status_t PciUtil::read_pci_config_space(std::string bdf,
     return AMDCUID_STATUS_PCI_ERROR;
   }
 
-  config_file.read(reinterpret_cast<char *>(buffer), buffer_size);
-  if (config_file.fail() ||
-      static_cast<size_t>(config_file.gcount()) != buffer_size) {
+  config_file.read(reinterpret_cast<char*>(buffer), buffer_size);
+  if (config_file.fail() || static_cast<size_t>(config_file.gcount()) != buffer_size) {
     config_file.close();
     return AMDCUID_STATUS_PCI_ERROR;
   }
@@ -84,13 +79,11 @@ amdcuid_status_t PciUtil::read_pci_config_space(std::string bdf,
 }
 
 // iterate capabilities list to find the relevant capability
-amdcuid_status_t PciUtil::get_pci_dsn_cap_offset(std::string bdf,
-                                                 uint16_t &offset) {
+amdcuid_status_t PciUtil::get_pci_dsn_cap_offset(std::string bdf, uint16_t& offset) {
   if (geteuid() != 0) {
     return AMDCUID_STATUS_PERMISSION_DENIED;
   }
-  if (bdf.empty())
-    return AMDCUID_STATUS_INVALID_ARGUMENT;
+  if (bdf.empty()) return AMDCUID_STATUS_INVALID_ARGUMENT;
 
   // Get the whole PCI config space header
   uint8_t config_space[4096] = {0};
@@ -100,7 +93,7 @@ amdcuid_status_t PciUtil::get_pci_dsn_cap_offset(std::string bdf,
   }
 
   // Device Serial Number (cap_id 0x0003) is a PCIe Extended Capability.
-  const uint16_t dsn_cap_id = 0x0003; // PCIe DSN capability ID
+  const uint16_t dsn_cap_id = 0x0003;  // PCIe DSN capability ID
 
   // Traverse the extended capability list starting at offset 0x100.
   uint16_t cap_ptr = 0x100;
@@ -138,13 +131,11 @@ amdcuid_status_t PciUtil::get_pci_dsn_cap_offset(std::string bdf,
   return AMDCUID_STATUS_UNSUPPORTED;
 }
 
-amdcuid_status_t PciUtil::get_pci_vsec_cap_offset(std::string bdf,
-                                                  uint16_t &offset) {
+amdcuid_status_t PciUtil::get_pci_vsec_cap_offset(std::string bdf, uint16_t& offset) {
   if (geteuid() != 0) {
     return AMDCUID_STATUS_PERMISSION_DENIED;
   }
-  if (bdf.empty())
-    return AMDCUID_STATUS_INVALID_ARGUMENT;
+  if (bdf.empty()) return AMDCUID_STATUS_INVALID_ARGUMENT;
 
   // Get the whole PCI config space header
   uint8_t config_space[4096] = {0};
@@ -155,7 +146,7 @@ amdcuid_status_t PciUtil::get_pci_vsec_cap_offset(std::string bdf,
 
   // Vendor-Specific Extended Capability (cap_id 0x000B) is a PCIe Extended
   // Capability.
-  const uint16_t vsec_cap_id = 0x0b; // PCIe VSEC capability ID
+  const uint16_t vsec_cap_id = 0x0b;  // PCIe VSEC capability ID
 
   // Traverse the extended capability list starting at offset 0x100.
   uint16_t cap_ptr = 0x100;
@@ -164,22 +155,20 @@ amdcuid_status_t PciUtil::get_pci_vsec_cap_offset(std::string bdf,
       return AMDCUID_STATUS_UNSUPPORTED;
     }
 
-    uint32_t cap_header =
-        static_cast<uint32_t>(config_space[cap_ptr]) |
-        (static_cast<uint32_t>(config_space[cap_ptr + 1]) << 8) |
-        (static_cast<uint32_t>(config_space[cap_ptr + 2]) << 16) |
-        (static_cast<uint32_t>(config_space[cap_ptr + 3]) << 24);
+    uint32_t cap_header = static_cast<uint32_t>(config_space[cap_ptr]) |
+                          (static_cast<uint32_t>(config_space[cap_ptr + 1]) << 8) |
+                          (static_cast<uint32_t>(config_space[cap_ptr + 2]) << 16) |
+                          (static_cast<uint32_t>(config_space[cap_ptr + 3]) << 24);
 
     uint16_t cap_id_local = static_cast<uint16_t>(cap_header & 0xFFFF);
     uint16_t next_ptr = static_cast<uint16_t>((cap_header >> 20) & 0x0FFF);
 
     if (cap_id_local == vsec_cap_id) {
       // check vsec header now for correct fields
-      uint32_t vsec_header =
-          static_cast<uint32_t>(config_space[cap_ptr + 4]) |
-          (static_cast<uint32_t>(config_space[cap_ptr + 5]) << 8) |
-          (static_cast<uint32_t>(config_space[cap_ptr + 6]) << 16) |
-          (static_cast<uint32_t>(config_space[cap_ptr + 7]) << 24);
+      uint32_t vsec_header = static_cast<uint32_t>(config_space[cap_ptr + 4]) |
+                             (static_cast<uint32_t>(config_space[cap_ptr + 5]) << 8) |
+                             (static_cast<uint32_t>(config_space[cap_ptr + 6]) << 16) |
+                             (static_cast<uint32_t>(config_space[cap_ptr + 7]) << 24);
 
       // if the VSEC has the required length for our fingerprint, return the
       // offset. Since VSEC ID for serial number/id not typically defined,
@@ -187,8 +176,7 @@ amdcuid_status_t PciUtil::get_pci_vsec_cap_offset(std::string bdf,
       // for the fingerprint rather than checking an ID field in the VSEC
       // header. If one is defined in the future, we will add that check here as
       // well.
-      uint16_t vsec_length =
-          static_cast<uint16_t>((vsec_header >> 20) & 0x0FFF);
+      uint16_t vsec_length = static_cast<uint16_t>((vsec_header >> 20) & 0x0FFF);
       if (vsec_length >= 8) {
         offset = cap_ptr + 8;
         return AMDCUID_STATUS_SUCCESS;

--- a/projects/cuid/lib/src/pci_util.h
+++ b/projects/cuid/lib/src/pci_util.h
@@ -4,25 +4,22 @@
 #ifndef PCI_UTIL_H
 #define PCI_UTIL_H
 
-#include "include/amd_cuid.h"
 #include <cstdint>
 #include <string>
 #include <vector>
 
+#include "include/amd_cuid.h"
+
 class PciUtil {
-public:
-  static amdcuid_status_t read_pci_config_space(std::string bdf,
-                                                uint8_t *buffer,
-                                                size_t buffer_size,
-                                                uint16_t offset);
-  static amdcuid_status_t get_pci_dsn_cap_offset(std::string bdf,
-                                                 uint16_t &offset);
-  static amdcuid_status_t get_pci_vsec_cap_offset(std::string bdf,
-                                                  uint16_t &offset);
+ public:
+  static amdcuid_status_t read_pci_config_space(std::string bdf, uint8_t* buffer,
+                                                size_t buffer_size, uint16_t offset);
+  static amdcuid_status_t get_pci_dsn_cap_offset(std::string bdf, uint16_t& offset);
+  static amdcuid_status_t get_pci_vsec_cap_offset(std::string bdf, uint16_t& offset);
 
   // Endianness conversion utilities
   static uint16_t le16_to_be16(uint16_t value);
   static uint64_t le64_to_be64(uint64_t value);
 };
 
-#endif // PCI_UTIL_H
+#endif  // PCI_UTIL_H

--- a/projects/cuid/lib/src/smbios_util.cc
+++ b/projects/cuid/lib/src/smbios_util.cc
@@ -2,236 +2,222 @@
 // SPDX-License-Identifier: MIT
 
 #include "smbios_util.h"
-#include <fstream>
-#include <iostream>
-#include <sstream>
-#include <iomanip>
-#include <cstring>
+
 #include <sys/stat.h>
-#include "cuid_util.h"
 #include <unistd.h>
 
+#include <cstring>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+
+#include "cuid_util.h"
+
 amdcuid_status_t SmbiosUtil::get_system_uuid(uint8_t* uuid) {
-    if (!uuid) {
-        return AMDCUID_STATUS_INVALID_ARGUMENT;
-    }
+  if (!uuid) {
+    return AMDCUID_STATUS_INVALID_ARGUMENT;
+  }
 
-    if (geteuid() != 0){
-        return AMDCUID_STATUS_PERMISSION_DENIED;
-    }
+  if (geteuid() != 0) {
+    return AMDCUID_STATUS_PERMISSION_DENIED;
+  }
 
-    // attempt to read UUID from sysfs first
-    std::string uuid_str = CuidUtilities::read_sysfs_file(std::string(DMI_PATH) + "product_uuid");
-    if (!uuid_str.empty()) {
-        // Convert the UUID string to uint8_t array
-        amdcuid_status_t status = CuidUtilities::uuid_string_to_uint8(uuid_str, uuid);
-        if (status != AMDCUID_STATUS_SUCCESS) {
-            return status;
-        }
-    } else {
-        // try and get UUID from SMBIOS table
-        amdcuid_status_t status = SmbiosUtil::get_uuid_from_smbios_table(uuid);
-        if (status != AMDCUID_STATUS_SUCCESS) {
-            return status;
-        }
+  // attempt to read UUID from sysfs first
+  std::string uuid_str = CuidUtilities::read_sysfs_file(std::string(DMI_PATH) + "product_uuid");
+  if (!uuid_str.empty()) {
+    // Convert the UUID string to uint8_t array
+    amdcuid_status_t status = CuidUtilities::uuid_string_to_uint8(uuid_str, uuid);
+    if (status != AMDCUID_STATUS_SUCCESS) {
+      return status;
     }
+  } else {
+    // try and get UUID from SMBIOS table
+    amdcuid_status_t status = SmbiosUtil::get_uuid_from_smbios_table(uuid);
+    if (status != AMDCUID_STATUS_SUCCESS) {
+      return status;
+    }
+  }
 
-    return AMDCUID_STATUS_SUCCESS;
+  return AMDCUID_STATUS_SUCCESS;
 }
 
 amdcuid_status_t SmbiosUtil::get_uuid_from_smbios_table(uint8_t* uuid) {
+  const std::string smbios_path = std::string(DMI_TABLES_PATH) + "DMI";
+  const std::string smbios_entry_path = std::string(DMI_TABLES_PATH) + "smbios_entry_point";
 
-    const std::string smbios_path = std::string(DMI_TABLES_PATH) + "DMI";
-    const std::string smbios_entry_path = std::string(DMI_TABLES_PATH) + "smbios_entry_point";
+  if (geteuid() != 0) {
+    return AMDCUID_STATUS_PERMISSION_DENIED;
+  }
 
-    if (geteuid() != 0){
-        return AMDCUID_STATUS_PERMISSION_DENIED;
+  // validate the SMBIOS entry point and version. If version is < 2.1, then there won't be a UUID
+  // and we should quit there
+  std::ifstream validate_version(smbios_entry_path);
+  if (validate_version.is_open()) {
+    // check the anchor string first
+    char anchor[4];
+    validate_version.read(anchor, 4);
+    if (std::string(anchor, 4) == "_SM_") {
+      // version starts at offset 0x6
+      validate_version.seekg(0x6);
+      char version_major;
+      char version_minor;
+      validate_version.read(&version_major, 1);
+      validate_version.read(&version_minor, 1);
+      // Check if version is less than 2.1
+      if (version_major < 2 || (version_major == 2 && version_minor < 1)) {
+        return AMDCUID_STATUS_UNSUPPORTED;
+      }
+    } else if (std::string(anchor, 4) == "_SM3") {
+      // version starts at offset 0x7
+      validate_version.seekg(0x7);
+      char version_major;
+      char version_minor;
+      validate_version.read(&version_major, 1);
+      validate_version.read(&version_minor, 1);
+      // Check if version is less than 3.0
+      if (version_major < 3) {
+        return AMDCUID_STATUS_UNSUPPORTED;
+      }
+    } else {
+      // file is corrupted/malformed so
+      return AMDCUID_STATUS_SMBIOS_ERROR;
     }
+  } else {
+    return AMDCUID_STATUS_SMBIOS_ERROR;
+  }
+  // that's all we needed with version so we can close the file
+  validate_version.close();
 
-    // validate the SMBIOS entry point and version. If version is < 2.1, then there won't be a UUID and we should quit there
-    std::ifstream validate_version(smbios_entry_path);
-    if (validate_version.is_open()) {
-        // check the anchor string first
-        char anchor[4];
-        validate_version.read(anchor, 4);
-        if (std::string(anchor, 4) == "_SM_") {
-            // version starts at offset 0x6
-            validate_version.seekg(0x6);
-            char version_major;
-            char version_minor;
-            validate_version.read(&version_major, 1);
-            validate_version.read(&version_minor, 1);
-            // Check if version is less than 2.1
-            if (version_major < 2 || (version_major == 2 && version_minor < 1)) {
-                return AMDCUID_STATUS_UNSUPPORTED;
-            }
-        }
-        else if (std::string(anchor, 4) == "_SM3") {
-            // version starts at offset 0x7
-            validate_version.seekg(0x7);
-            char version_major;
-            char version_minor;
-            validate_version.read(&version_major, 1);
-            validate_version.read(&version_minor, 1);
-            // Check if version is less than 3.0
-            if (version_major < 3) {
-                return AMDCUID_STATUS_UNSUPPORTED;
-            }
-        }
-        else {
-            // file is corrupted/malformed so
-            return AMDCUID_STATUS_SMBIOS_ERROR;
-        }
-    }
-    else {
+  // now search through the DMI struct table to find the System Header and then the UUID
+  std::ifstream struct_table(smbios_path);
+  if (!struct_table) {
+    // failed to open the SMBIOS struct table file
+    return AMDCUID_STATUS_SMBIOS_ERROR;
+  }
+
+  uint8_t type = 0;
+  uint32_t struct_offset = 0;
+  const uint8_t TYPE_SYSTEM_INFO = 0x1;
+  uint8_t smbios_header[4] = {0};
+  struct_table.read(reinterpret_cast<char*>(smbios_header), 4);
+  type = smbios_header[0];
+  // iterate through the table to find the System Header and then the UUID
+  while (type != TYPE_SYSTEM_INFO && !struct_table.eof()) {
+    // move to the next structure and get past the strings section
+    struct_offset += smbios_header[1];
+    struct_table.seekg(struct_offset, std::ios::beg);
+
+    bool peek1, peek2;
+    peek1 = peek2 = false;
+    while (!peek1 || !peek2) {
+      if (struct_table.eof()) {
+        // reached end of file without finding the System Info structure
         return AMDCUID_STATUS_SMBIOS_ERROR;
+      }
+      peek1 = (struct_table.peek() == 0);
+      struct_table.ignore(1);
+      struct_offset++;
+      peek2 = (struct_table.peek() == 0);
     }
-    // that's all we needed with version so we can close the file
-    validate_version.close();
-
-    // now search through the DMI struct table to find the System Header and then the UUID
-    std::ifstream struct_table(smbios_path);
-    if (!struct_table)
-    {
-        // failed to open the SMBIOS struct table file
-        return AMDCUID_STATUS_SMBIOS_ERROR;
-    }
-
-    uint8_t type = 0;
-    uint32_t struct_offset = 0;
-    const uint8_t TYPE_SYSTEM_INFO = 0x1;
-    uint8_t smbios_header[4] = {0};
+    struct_table.ignore(1);  // Skip the double null terminator
+    struct_offset++;
     struct_table.read(reinterpret_cast<char*>(smbios_header), 4);
     type = smbios_header[0];
-    // iterate through the table to find the System Header and then the UUID
-    while (type != TYPE_SYSTEM_INFO && !struct_table.eof())
-    {
-        // move to the next structure and get past the strings section
-        struct_offset += smbios_header[1];
-        struct_table.seekg(struct_offset, std::ios::beg);
+  }
 
-        bool peek1, peek2;
-        peek1 = peek2 = false;
-        while (!peek1 || !peek2) {
-            if (struct_table.eof()) {
-                // reached end of file without finding the System Info structure
-                return AMDCUID_STATUS_SMBIOS_ERROR;
-            }
-            peek1 = (struct_table.peek() == 0);
-            struct_table.ignore(1);
-            struct_offset++;
-            peek2 = (struct_table.peek() == 0);
-        }
-        struct_table.ignore(1); // Skip the double null terminator
-        struct_offset++;
-        struct_table.read(reinterpret_cast<char*>(smbios_header), 4);
-        type = smbios_header[0];
-    }
+  if (type != TYPE_SYSTEM_INFO) {
+    return AMDCUID_STATUS_SMBIOS_ERROR;
+  }
 
-    if (type != TYPE_SYSTEM_INFO) {
-        return AMDCUID_STATUS_SMBIOS_ERROR;
-    }
+  // now at the System Info structure, read the UUID at offset 0x8
+  uint8_t raw_bytes[16] = {0};
+  const uint8_t UUID_OFFSET = 0x8;
+  struct_table.seekg(struct_offset + UUID_OFFSET, std::ios::beg);
+  struct_table.read(reinterpret_cast<char*>(raw_bytes), 16);
 
-    // now at the System Info structure, read the UUID at offset 0x8
-    uint8_t raw_bytes[16] = {0};
-    const uint8_t UUID_OFFSET = 0x8;
-    struct_table.seekg(struct_offset + UUID_OFFSET, std::ios::beg);
-    struct_table.read(reinterpret_cast<char*>(raw_bytes), 16);
+  // we need to store the bytes in such a way that when we use get_cuid_as_string, it prints out the
+  // same way as regular UUIDs
+  uuid[0] = raw_bytes[3];
+  uuid[1] = raw_bytes[2];
+  uuid[2] = raw_bytes[1];
+  uuid[3] = raw_bytes[0];
 
-    // we need to store the bytes in such a way that when we use get_cuid_as_string, it prints out the same way as regular UUIDs
-    uuid[0] = raw_bytes[3];
-    uuid[1] = raw_bytes[2];
-    uuid[2] = raw_bytes[1];
-    uuid[3] = raw_bytes[0];
+  uuid[4] = raw_bytes[5];
+  uuid[5] = raw_bytes[4];
 
-    uuid[4] = raw_bytes[5];
-    uuid[5] = raw_bytes[4];
+  uuid[6] = raw_bytes[7];
+  uuid[7] = raw_bytes[6];
 
-    uuid[6] = raw_bytes[7];
-    uuid[7] = raw_bytes[6];
+  for (int i = 8; i < 16; ++i) {
+    uuid[i] = raw_bytes[i];
+  }
 
-    for (int i = 8; i < 16; ++i) {
-        uuid[i] = raw_bytes[i];
-    }
+  struct_table.close();
 
-    struct_table.close();
-
-    return AMDCUID_STATUS_SUCCESS;
+  return AMDCUID_STATUS_SUCCESS;
 }
 
 // Get system serial number
-amdcuid_status_t SmbiosUtil::get_system_serial(std::string &serial) {
+amdcuid_status_t SmbiosUtil::get_system_serial(std::string& serial) {
+  if (geteuid() != 0) {
+    return AMDCUID_STATUS_PERMISSION_DENIED;
+  }
 
-    if (geteuid() != 0){
-        return AMDCUID_STATUS_PERMISSION_DENIED;
-    }
+  // Try multiple sources in order of preference
+  const char* serial_files[] = {"product_serial", "board_serial", "chassis_serial"};
 
-    // Try multiple sources in order of preference
-    const char* serial_files[] = {
-        "product_serial",
-        "board_serial",
-        "chassis_serial"
-    };
-    
-    for (const char* filename : serial_files) {
-        std::string path = std::string(DMI_PATH) + filename;
-        serial = CuidUtilities::read_sysfs_file(path);
-        
-        if (!serial.empty()) {
-            return AMDCUID_STATUS_SUCCESS;
-        }
+  for (const char* filename : serial_files) {
+    std::string path = std::string(DMI_PATH) + filename;
+    serial = CuidUtilities::read_sysfs_file(path);
+
+    if (!serial.empty()) {
+      return AMDCUID_STATUS_SUCCESS;
     }
-    
-    return AMDCUID_STATUS_SMBIOS_ERROR;
+  }
+
+  return AMDCUID_STATUS_SMBIOS_ERROR;
 }
 
 // Get board information
-amdcuid_status_t SmbiosUtil::get_board_info(std::string &vendor, 
-                                          std::string &name, 
-                                          std::string &version) {
-    vendor = CuidUtilities::read_sysfs_file(std::string(DMI_PATH) + "board_vendor");
-    name = CuidUtilities::read_sysfs_file(std::string(DMI_PATH) + "board_name");
-    version = CuidUtilities::read_sysfs_file(std::string(DMI_PATH) + "board_version");
-    
-    // Consider success if at least one field is available
-    if (!vendor.empty() || 
-        !name.empty() ||
-        !version.empty()) {
-        return AMDCUID_STATUS_SUCCESS;
-    }
-    
-    return AMDCUID_STATUS_SMBIOS_ERROR;
+amdcuid_status_t SmbiosUtil::get_board_info(std::string& vendor, std::string& name,
+                                            std::string& version) {
+  vendor = CuidUtilities::read_sysfs_file(std::string(DMI_PATH) + "board_vendor");
+  name = CuidUtilities::read_sysfs_file(std::string(DMI_PATH) + "board_name");
+  version = CuidUtilities::read_sysfs_file(std::string(DMI_PATH) + "board_version");
+
+  // Consider success if at least one field is available
+  if (!vendor.empty() || !name.empty() || !version.empty()) {
+    return AMDCUID_STATUS_SUCCESS;
+  }
+
+  return AMDCUID_STATUS_SMBIOS_ERROR;
 }
 
 // Get BIOS information
-amdcuid_status_t SmbiosUtil::get_bios_info(std::string &vendor,
-                                         std::string &version,
-                                         std::string &date) {
-    vendor = CuidUtilities::read_sysfs_file(std::string(DMI_PATH) + "bios_vendor");
-    version = CuidUtilities::read_sysfs_file(std::string(DMI_PATH) + "bios_version");
-    date = CuidUtilities::read_sysfs_file(std::string(DMI_PATH) + "bios_date");
-    
-    // Consider success if at least one field is available
-    if (!vendor.empty() || 
-        !version.empty() ||
-        !date.empty()) {
-        return AMDCUID_STATUS_SUCCESS;
-    }
-    
-    return AMDCUID_STATUS_SMBIOS_ERROR;
+amdcuid_status_t SmbiosUtil::get_bios_info(std::string& vendor, std::string& version,
+                                           std::string& date) {
+  vendor = CuidUtilities::read_sysfs_file(std::string(DMI_PATH) + "bios_vendor");
+  version = CuidUtilities::read_sysfs_file(std::string(DMI_PATH) + "bios_version");
+  date = CuidUtilities::read_sysfs_file(std::string(DMI_PATH) + "bios_date");
+
+  // Consider success if at least one field is available
+  if (!vendor.empty() || !version.empty() || !date.empty()) {
+    return AMDCUID_STATUS_SUCCESS;
+  }
+
+  return AMDCUID_STATUS_SMBIOS_ERROR;
 }
 
 // Get product information
-amdcuid_status_t SmbiosUtil::get_product_info(std::string &name,
-                                            std::string &family) {
-    name = CuidUtilities::read_sysfs_file(std::string(DMI_PATH) + "product_name");
-    family = CuidUtilities::read_sysfs_file(std::string(DMI_PATH) + "product_family");
-    
-    // Consider success if at least one field is available
-    if (!name.empty() || 
-        !family.empty()) {
-        return AMDCUID_STATUS_SUCCESS;
-    }
-    
-    return AMDCUID_STATUS_SMBIOS_ERROR;
+amdcuid_status_t SmbiosUtil::get_product_info(std::string& name, std::string& family) {
+  name = CuidUtilities::read_sysfs_file(std::string(DMI_PATH) + "product_name");
+  family = CuidUtilities::read_sysfs_file(std::string(DMI_PATH) + "product_family");
+
+  // Consider success if at least one field is available
+  if (!name.empty() || !family.empty()) {
+    return AMDCUID_STATUS_SUCCESS;
+  }
+
+  return AMDCUID_STATUS_SMBIOS_ERROR;
 }

--- a/projects/cuid/lib/src/smbios_util.h
+++ b/projects/cuid/lib/src/smbios_util.h
@@ -4,20 +4,24 @@
 #ifndef SMBIOS_UTIL_H
 #define SMBIOS_UTIL_H
 
-#include "include/amd_cuid.h"
 #include <iostream>
 
+#include "include/amd_cuid.h"
+
 class SmbiosUtil {
-public:
-    static amdcuid_status_t get_system_uuid(uint8_t* uuid);
-    static amdcuid_status_t get_uuid_from_smbios_table(uint8_t* uuid);
-    static amdcuid_status_t get_system_serial(std::string &serial);
-    static amdcuid_status_t get_board_info(std::string &vendor, std::string &name, std::string &version);
-    static amdcuid_status_t get_bios_info(std::string &vendor, std::string &version, std::string &date);
-    static amdcuid_status_t get_product_info(std::string &name, std::string &family);
-private:
-    static constexpr const char* DMI_PATH = "/sys/class/dmi/id/";
-    static constexpr const char* DMI_TABLES_PATH = "/sys/firmware/dmi/tables/";
+ public:
+  static amdcuid_status_t get_system_uuid(uint8_t* uuid);
+  static amdcuid_status_t get_uuid_from_smbios_table(uint8_t* uuid);
+  static amdcuid_status_t get_system_serial(std::string& serial);
+  static amdcuid_status_t get_board_info(std::string& vendor, std::string& name,
+                                         std::string& version);
+  static amdcuid_status_t get_bios_info(std::string& vendor, std::string& version,
+                                        std::string& date);
+  static amdcuid_status_t get_product_info(std::string& name, std::string& family);
+
+ private:
+  static constexpr const char* DMI_PATH = "/sys/class/dmi/id/";
+  static constexpr const char* DMI_TABLES_PATH = "/sys/firmware/dmi/tables/";
 };
 
-#endif // SMBIOS_UTIL_H
+#endif  // SMBIOS_UTIL_H

--- a/projects/cuid/tests/CMakeLists.txt
+++ b/projects/cuid/tests/CMakeLists.txt
@@ -31,11 +31,7 @@ endif()
 if(NOT GTest_FOUND)
     message("GTest not found on system. Fetching from source...")
     include(FetchContent)
-    FetchContent_Declare(
-        googletest
-        GIT_REPOSITORY https://github.com/google/googletest.git
-        GIT_TAG v1.16.0
-    )
+    FetchContent_Declare(googletest GIT_REPOSITORY https://github.com/google/googletest.git GIT_TAG v1.16.0)
     FetchContent_MakeAvailable(googletest)
 elseif(TARGET GTest::GTest AND NOT TARGET GTest::gtest)
     # MODULE mode found GTest::GTest — create the canonical aliases expected below.
@@ -47,16 +43,9 @@ set(AMDCUID_TST_EXECUTABLE amdcuid_test)
 # Collect all test sources from the three source locations.
 aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR} TEST_SOURCES_ROOT)
 aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/unit TEST_SOURCES_UNIT)
-aux_source_directory(
-    ${CMAKE_CURRENT_SOURCE_DIR}/functional
-    TEST_SOURCES_FUNCTIONAL
-)
+aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/functional TEST_SOURCES_FUNCTIONAL)
 
-set(TEST_SOURCES
-    ${TEST_SOURCES_ROOT}
-    ${TEST_SOURCES_UNIT}
-    ${TEST_SOURCES_FUNCTIONAL}
-)
+set(TEST_SOURCES ${TEST_SOURCES_ROOT} ${TEST_SOURCES_UNIT} ${TEST_SOURCES_FUNCTIONAL})
 
 # Enable testing
 enable_testing()
@@ -76,14 +65,8 @@ target_include_directories(
 target_link_libraries(${AMDCUID_TST_EXECUTABLE} amdcuid_static GTest::gtest)
 
 # Register two CTest targets split by privilege level.
-add_test(
-    NAME cuid_unprivileged_tests
-    COMMAND ${AMDCUID_TST_EXECUTABLE} --gtest_filter=cuidtstUnprivileged.*
-)
-add_test(
-    NAME cuid_privileged_tests
-    COMMAND ${AMDCUID_TST_EXECUTABLE} --gtest_filter=cuidtstPrivileged.*
-)
+add_test(NAME cuid_unprivileged_tests COMMAND ${AMDCUID_TST_EXECUTABLE} --gtest_filter=cuidtstUnprivileged.*)
+add_test(NAME cuid_privileged_tests COMMAND ${AMDCUID_TST_EXECUTABLE} --gtest_filter=cuidtstPrivileged.*)
 
 # Platform-specific config directory
 if(WIN32)
@@ -93,11 +76,7 @@ else()
 endif()
 
 # Install the test binary
-install(
-    TARGETS ${AMDCUID_TST_EXECUTABLE}
-    DESTINATION ${TESTS_INSTALL_DIR}
-    COMPONENT ${TESTS_COMPONENT}
-)
+install(TARGETS ${AMDCUID_TST_EXECUTABLE} DESTINATION ${TESTS_INSTALL_DIR} COMPONENT ${TESTS_COMPONENT})
 
 message("&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")
 message("                    Finished Cmake amdcuid_test                    ")

--- a/projects/cuid/tests/unit/gim_util_test.cc
+++ b/projects/cuid/tests/unit/gim_util_test.cc
@@ -21,7 +21,7 @@ using cuid::gim::GimDeviceEntry;
 namespace {
 
 bool gim_dev_present() {
-  struct stat st {};
+  struct stat st{};
   return ::stat("/dev/gim-smi0", &st) == 0;
 }
 
@@ -174,11 +174,10 @@ void TestGimDeviceEnumeration::Run() {
 
   std::set<std::string> seen_bdfs;
   std::set<uint64_t> seen_serials;
-  for (const auto &dev : devices) {
+  for (const auto& dev : devices) {
     // Canonical "dddd:bb:dd.f" is exactly 12 characters and must be unique.
     EXPECT_EQ(dev.bdf.size(), 12u) << "malformed BDF: '" << dev.bdf << "'";
-    EXPECT_NE(dev.bdf.find(':'), std::string::npos)
-        << "malformed BDF: '" << dev.bdf << "'";
+    EXPECT_NE(dev.bdf.find(':'), std::string::npos) << "malformed BDF: '" << dev.bdf << "'";
     EXPECT_TRUE(seen_bdfs.insert(dev.bdf).second)
         << "duplicate BDF indicates a wrong ABI stride: " << dev.bdf;
 
@@ -190,7 +189,7 @@ void TestGimDeviceEnumeration::Run() {
 
     uint64_t serial = 0;
     EXPECT_TRUE(GimClient::parse_asic_serial(info.asic_serial, serial))
-        << "unparseable serial '" << info.asic_serial << "' for " << dev.bdf;
+        << "unparsable serial '" << info.asic_serial << "' for " << dev.bdf;
     // The per-GPU ASIC serial is the CUID hardware fingerprint; duplicates
     // would collapse multiple GPUs into a single CUID.
     EXPECT_TRUE(seen_serials.insert(serial).second)


### PR DESCRIPTION
`projects/cuid` had a `.clang-format` that nothing enforced and nothing complied with: **all 34 C++ files needed reformatting.** No CMake formatter config, no spell check, no shell check, no clang-tidy config either, while the sibling C++ libraries here (amdsmi, rdc, rocm-smi-lib) all carry the same four.

Adds that same set rather than inventing a local dialect - `.pre-commit-config.yaml`, `.gersemirc`, `.codespellrc`, `.clang-tidy`, modelled on `projects/amdsmi` - and applies clang-format and gersemi.

Two pieces of wiring come with it, without which the config is decorative:

- `projects/cuid/` is added to the root `.pre-commit-config.yaml` exclude list, next to the projects already listed there under "these projects have their own pre-commit-config.yaml". Otherwise cuid is covered twice, by the root config's clang-format **v18.1.4** and this one's **v22.1.0**, and the two disagree - v18 wants `struct stat st {};` where v22 wants `st{};`.
- `.github/workflows/cuid-formatting.yml` runs it, modelled on `rocprofiler-compute-formatting.yml`. The generic `pre-formatting.yml` does not: it triggers only on `pull_request` against `testbranch`, which is how the root config went unenforced and cuid drifted this far in the first place.

**Formatting only, and that is checked rather than asserted:** for 33 of the 34 reformatted files the token multiset is identical before and after, so not one token was added or removed. The only token-order change anywhere is clang-format's include sorting. The single exception is codespell, which rewrites one string literal in `gim_util_test.cc` (`"unparseable serial"` -> `"unparsable serial"`) and one comment in `amdcuid_daemon.cc` (`bootup` -> `at boot`; codespell offers two corrections for that word so it cannot autofix it, and the hook fails until it is reworded). gersemi reflowed the CMake files.

Deliberately its own PR so the mechanical noise never has to be read alongside a behavioural change. Test results are unchanged from the parent commit (22/22 unprivileged), which is the point.
