### PR TITLE
fix(cuid): correctness and lint fixes

### DIFF
--- a/projects/cuid/.clang-tidy
+++ b/projects/cuid/.clang-tidy
@@ -51,6 +51,6 @@ Checks:
 #                   without internal linkage is exported to everything that
 #                   links it. Unnamed namespace is the idiom, per SF.22.
 #
-# Treat findings as advisory: fix what is real, do not silence what is not.
+# WarningsAsErrors is clean today; everything else is advisory.
 HeaderFilterRegex: 'projects/cuid/(lib|cli|daemon)/.*\.(h|hpp)$'
-WarningsAsErrors: ''
+WarningsAsErrors: 'bugprone-*,cert-*,concurrency-*,clang-analyzer-*,misc-use-internal-linkage,misc-use-anonymous-namespace'

--- a/projects/cuid/cli/amdcuid_tool.cc
+++ b/projects/cuid/cli/amdcuid_tool.cc
@@ -25,6 +25,8 @@
  * - Always reads from the library's internal registry
  */
 
+namespace {
+
 /**
  * @brief Check if running with root privileges
  */
@@ -473,6 +475,8 @@ int query_device(const std::string& identifier, bool show_primary,
 
   return 0;
 }
+
+}  // namespace
 
 int main(int argc, char* argv[]) {
   static struct option long_options[] = {{"generate-cuid", no_argument, 0, 'g'},

--- a/projects/cuid/cli/amdcuid_tool.cc
+++ b/projects/cuid/cli/amdcuid_tool.cc
@@ -5,6 +5,7 @@
 #include <getopt.h>
 #include <unistd.h>
 
+#include <cctype>
 #include <cstring>
 #include <fstream>
 #include <iostream>
@@ -96,7 +97,7 @@ const char* device_type_to_string(amdcuid_device_type_t type) {
 
 amdcuid_device_type_t string_to_device_type(const std::string& type_str) {
   std::string upper = type_str;
-  for (auto& c : upper) c = toupper(c);
+  for (auto& c : upper) c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
 
   if (upper == "PLATFORM") return AMDCUID_DEVICE_TYPE_PLATFORM;
   if (upper == "CPU") return AMDCUID_DEVICE_TYPE_CPU;
@@ -499,6 +500,8 @@ int main(int argc, char* argv[]) {
   int opt;
   int option_index = 0;
 
+  // Option parsing in main(), before any thread exists.
+  // NOLINTNEXTLINE(concurrency-mt-unsafe)
   while ((opt = getopt_long(argc, argv, "gks:nlt:pq:vh", long_options, &option_index)) != -1) {
     switch (opt) {
       case 'g':

--- a/projects/cuid/daemon/amdcuid_daemon.cc
+++ b/projects/cuid/daemon/amdcuid_daemon.cc
@@ -23,14 +23,16 @@
 #include "src/hmac.h"
 #include "src/ipc_protocol.h"
 
+namespace {
+
 // static hmac instance for daemon
-static cuid_hmac daemon_hmac = cuid_hmac();
+cuid_hmac daemon_hmac = cuid_hmac();
 
 // Global log file stream
-static std::unique_ptr<std::ofstream> g_log_file;
-static bool g_logging_to_file = false;
+std::unique_ptr<std::ofstream> g_log_file;
+bool g_logging_to_file = false;
 
-static std::ostream& log_out() {
+std::ostream& log_out() {
   if (g_logging_to_file && g_log_file && g_log_file->is_open()) {
     *g_log_file << "timestamp: " << time(nullptr) << ": ";
     return *g_log_file;
@@ -39,7 +41,7 @@ static std::ostream& log_out() {
   return std::cout;
 }
 
-static std::ostream& log_err() {
+std::ostream& log_err() {
   if (g_logging_to_file && g_log_file && g_log_file->is_open()) {
     *g_log_file << "timestamp: " << time(nullptr) << ": ";
     return *g_log_file;
@@ -48,14 +50,13 @@ static std::ostream& log_err() {
   return std::cerr;
 }
 
-static void init_logging(bool enabled) {
+void init_logging(bool enabled) {
   if (enabled) {
     g_log_file = std::make_unique<std::ofstream>("/var/log/amdcuid.log", std::ios::app);
     if (g_log_file->is_open()) {
       g_logging_to_file = true;
-      // Add timestamp to log entry. ctime() formats into a static buffer
-      // shared by every thread; the daemon serves clients concurrently, so
-      // use the reentrant form.
+      // ctime() formats into a static buffer shared across threads; the accept
+      // thread and the main thread both log, so use the reentrant form.
       time_t now = time(nullptr);
       struct tm tm_buf{};
       char stamp[64] = "unknown time";
@@ -70,6 +71,8 @@ static void init_logging(bool enabled) {
     }
   }
 }
+
+}  // namespace
 
 // Daemon Server
 class CuidDaemonServer {
@@ -312,7 +315,7 @@ int main() {
     // get handle count for logging
     uint32_t count = 0;
     amdcuid_id_t dummy[1] = {};
-    status = amdcuid_get_all_handles(dummy, &count);
+    amdcuid_get_all_handles(dummy, &count);
 
     log_out() << "Total devices with CUIDs: " << count << std::endl;
   }

--- a/projects/cuid/daemon/amdcuid_daemon.cc
+++ b/projects/cuid/daemon/amdcuid_daemon.cc
@@ -53,9 +53,20 @@ static void init_logging(bool enabled) {
     g_log_file = std::make_unique<std::ofstream>("/var/log/amdcuid.log", std::ios::app);
     if (g_log_file->is_open()) {
       g_logging_to_file = true;
-      // Add timestamp to log entry
+      // Add timestamp to log entry. ctime() formats into a static buffer
+      // shared by every thread; the daemon serves clients concurrently, so
+      // use the reentrant form.
       time_t now = time(nullptr);
-      *g_log_file << "\n=== Log started at " << ctime(&now);
+      struct tm tm_buf{};
+      char stamp[64] = "unknown time";
+      if (localtime_r(&now, &tm_buf) != nullptr) {
+        if (strftime(stamp, sizeof(stamp), "%a %b %e %H:%M:%S %Y", &tm_buf) == 0) {
+          // Fixed 12-character literal into a 64-byte buffer.
+          // NOLINTNEXTLINE(cert-err33-c)
+          std::snprintf(stamp, sizeof(stamp), "unknown time");
+        }
+      }
+      *g_log_file << "\n=== Log started at " << stamp << "\n";
     }
   }
 }
@@ -82,7 +93,10 @@ class CuidDaemonServer {
     struct sockaddr_un server_addr;
     memset(&server_addr, 0, sizeof(server_addr));
     server_addr.sun_family = AF_UNIX;
-    strncpy(server_addr.sun_path, AMDCUID_SOCKET_PATH, sizeof(server_addr.sun_path) - 1);
+    constexpr size_t kSocketPathLen = sizeof(AMDCUID_SOCKET_PATH) - 1;
+    static_assert(kSocketPathLen < sizeof(server_addr.sun_path),
+                  "AMDCUID_SOCKET_PATH does not fit in sockaddr_un::sun_path");
+    memcpy(server_addr.sun_path, AMDCUID_SOCKET_PATH, kSocketPathLen);
 
     if (bind(server_fd_, (struct sockaddr*)&server_addr, sizeof(server_addr)) < 0) {
       close(server_fd_);
@@ -137,9 +151,17 @@ class CuidDaemonServer {
   }
 
   void handle_client(int client_fd) {
-    IpcRequest request;
-    if (recv(client_fd, &request, sizeof(request), 0) != sizeof(request)) {
-      return;
+    // recv() on a SOCK_STREAM socket may return a short read, so loop until the
+    // whole fixed-size request has arrived. Anything less is a malformed peer.
+    IpcRequest request{};
+    auto* buf = reinterpret_cast<uint8_t*>(&request);
+    size_t got = 0;
+    while (got < sizeof(request)) {
+      ssize_t n = recv(client_fd, buf + got, sizeof(request) - got, 0);
+      if (n <= 0) {
+        return;
+      }
+      got += static_cast<size_t>(n);
     }
 
     IpcResponse response;
@@ -162,7 +184,11 @@ class CuidDaemonServer {
   }
 
   amdcuid_status_t handle_add_device(const IpcRequest& request, amdcuid_id_t& device_handle) {
-    std::string dev_path(request.device_path);
+    // Never trust the wire buffer to be NUL-terminated.
+    const std::string dev_path = ipc_get_device_path(request);
+    if (dev_path.empty()) {
+      return AMDCUID_STATUS_INVALID_ARGUMENT;
+    }
     amdcuid_device_type_t device_type = request.device_type;
     amdcuid_status_t status =
         amdcuid_get_handle_by_dev_path(dev_path.c_str(), device_type, &device_handle);

--- a/projects/cuid/lib/src/acpi_parser.cc
+++ b/projects/cuid/lib/src/acpi_parser.cc
@@ -8,6 +8,7 @@
 
 #include <cstring>
 #include <fstream>
+#include <type_traits>
 
 // MADT entry type constants
 constexpr uint8_t MADT_TYPE_LOCAL_APIC = 0;
@@ -65,38 +66,122 @@ bool AcpiParser::validate_checksum(const uint8_t* data, size_t length) {
   return sum == 0;
 }
 
-bool AcpiParser::parse_madt_entry(const uint8_t* entry, AcpiCpuInfo& cpu_info) {
-  const MadtEntryHeader* header = reinterpret_cast<const MadtEntryHeader*>(entry);
+namespace {
 
-  if (header->type == MADT_TYPE_LOCAL_APIC) {
-    if (header->length < sizeof(MadtLocalApic)) {
+// Copy a packed firmware structure out of a byte buffer. Taking a copy (rather
+// than reinterpret_cast'ing in place) keeps the read inside `src` and keeps the
+// access well-defined regardless of the buffer's provenance or alignment.
+// Returns false when the buffer does not hold a whole T.
+template <typename T>
+bool read_struct(const uint8_t* src, size_t available, T& out) {
+  static_assert(std::is_trivially_copyable<T>::value,
+                "read_struct requires a trivially copyable firmware struct");
+  if (src == nullptr || available < sizeof(T)) {
+    return false;
+  }
+  std::memcpy(&out, src, sizeof(T));
+  return true;
+}
+
+}  // namespace
+
+bool AcpiParser::parse_madt_entry(const uint8_t* entry, size_t entry_len, AcpiCpuInfo& cpu_info) {
+  MadtEntryHeader header{};
+  if (!read_struct(entry, entry_len, header)) {
+    return false;
+  }
+
+  if (header.type == MADT_TYPE_LOCAL_APIC) {
+    MadtLocalApic apic{};
+    // header.length is what the firmware claims; entry_len is what the
+    // caller proved is actually present. Both must cover the struct.
+    if (header.length < sizeof(MadtLocalApic) || !read_struct(entry, entry_len, apic)) {
       return false;
     }
 
-    const MadtLocalApic* apic = reinterpret_cast<const MadtLocalApic*>(entry);
-
-    cpu_info.apic_id = apic->apic_id;
-    cpu_info.processor_uid = apic->acpi_processor_uid;
-    cpu_info.enabled = (apic->flags & MADT_FLAG_ENABLED) != 0;
+    cpu_info.apic_id = apic.apic_id;
+    cpu_info.processor_uid = apic.acpi_processor_uid;
+    cpu_info.enabled = (apic.flags & MADT_FLAG_ENABLED) != 0;
     cpu_info.is_x2apic = false;
 
     return true;
-  } else if (header->type == MADT_TYPE_LOCAL_X2APIC) {
-    if (header->length < sizeof(MadtLocalX2Apic)) {
+  } else if (header.type == MADT_TYPE_LOCAL_X2APIC) {
+    MadtLocalX2Apic x2apic{};
+    if (header.length < sizeof(MadtLocalX2Apic) || !read_struct(entry, entry_len, x2apic)) {
       return false;
     }
 
-    const MadtLocalX2Apic* x2apic = reinterpret_cast<const MadtLocalX2Apic*>(entry);
-
-    cpu_info.apic_id = x2apic->x2apic_id;
-    cpu_info.processor_uid = x2apic->acpi_processor_uid;
-    cpu_info.enabled = (x2apic->flags & MADT_FLAG_ENABLED) != 0;
+    cpu_info.apic_id = x2apic.x2apic_id;
+    cpu_info.processor_uid = x2apic.acpi_processor_uid;
+    cpu_info.enabled = (x2apic.flags & MADT_FLAG_ENABLED) != 0;
     cpu_info.is_x2apic = true;
 
     return true;
   }
 
   return false;
+}
+
+amdcuid_status_t AcpiParser::parse_madt_buffer(const uint8_t* data, size_t size,
+                                               std::vector<AcpiCpuInfo>& cpu_info) {
+  cpu_info.clear();
+
+  // Validate minimum size
+  MadtHeader madt{};
+  if (!read_struct(data, size, madt)) {
+    return AMDCUID_STATUS_INVALID_FORMAT;
+  }
+
+  // Validate signature
+  if (std::memcmp(madt.header.signature, "APIC", 4) != 0) {
+    return AMDCUID_STATUS_INVALID_FORMAT;
+  }
+
+  // Validate table length
+  if (madt.header.length != size) {
+    return AMDCUID_STATUS_INVALID_FORMAT;
+  }
+
+  // Validate checksum
+  if (!validate_checksum(data, size)) {
+    return AMDCUID_STATUS_INVALID_FORMAT;
+  }
+
+  // Walk the interrupt controller structures using offsets rather than
+  // pointers, so no out-of-range pointer is ever formed and the arithmetic
+  // cannot wrap.
+  size_t offset = sizeof(MadtHeader);
+
+  while (offset < size) {
+    // A 2-byte entry header must be fully present before its `length`
+    // field can be read. The previous code tested only `entry < end`, so a
+    // table whose last byte started an entry read length one byte past the
+    // buffer.
+    MadtEntryHeader header{};
+    if (!read_struct(data + offset, size - offset, header)) {
+      return AMDCUID_STATUS_INVALID_FORMAT;
+    }
+
+    // Validate the entry neither overflows the table nor fails to advance.
+    if (header.length < sizeof(MadtEntryHeader) || header.length > size - offset) {
+      return AMDCUID_STATUS_INVALID_FORMAT;
+    }
+
+    // Parse Local APIC or x2APIC entries
+    AcpiCpuInfo info{};
+    if (parse_madt_entry(data + offset, header.length, info)) {
+      cpu_info.push_back(info);
+    }
+
+    offset += header.length;
+  }
+
+  // Should have found at least one CPU
+  if (cpu_info.empty()) {
+    return AMDCUID_STATUS_DEVICE_NOT_FOUND;
+  }
+
+  return AMDCUID_STATUS_SUCCESS;
 }
 
 amdcuid_status_t AcpiParser::parse_madt(std::vector<AcpiCpuInfo>& cpu_info) {
@@ -109,55 +194,7 @@ amdcuid_status_t AcpiParser::parse_madt(std::vector<AcpiCpuInfo>& cpu_info) {
     return status;
   }
 
-  // Validate minimum size
-  if (table_data.size() < sizeof(MadtHeader)) {
-    return AMDCUID_STATUS_INVALID_FORMAT;
-  }
-
-  const MadtHeader* madt = reinterpret_cast<const MadtHeader*>(table_data.data());
-
-  // Validate signature
-  if (std::memcmp(madt->header.signature, "APIC", 4) != 0) {
-    return AMDCUID_STATUS_INVALID_FORMAT;
-  }
-
-  // Validate table length
-  if (madt->header.length != table_data.size()) {
-    return AMDCUID_STATUS_INVALID_FORMAT;
-  }
-
-  // Validate checksum
-  if (!validate_checksum(table_data.data(), madt->header.length)) {
-    return AMDCUID_STATUS_INVALID_FORMAT;
-  }
-
-  // Parse interrupt controller structures
-  const uint8_t* entry = table_data.data() + sizeof(MadtHeader);
-  const uint8_t* end = table_data.data() + madt->header.length;
-
-  while (entry < end) {
-    const MadtEntryHeader* header = reinterpret_cast<const MadtEntryHeader*>(entry);
-
-    // Validate entry doesn't overflow table
-    if (entry + header->length > end || header->length < sizeof(MadtEntryHeader)) {
-      return AMDCUID_STATUS_INVALID_FORMAT;
-    }
-
-    // Parse Local APIC or x2APIC entries
-    AcpiCpuInfo info;
-    if (parse_madt_entry(entry, info)) {
-      cpu_info.push_back(info);
-    }
-
-    entry += header->length;
-  }
-
-  // Should have found at least one CPU
-  if (cpu_info.empty()) {
-    return AMDCUID_STATUS_DEVICE_NOT_FOUND;
-  }
-
-  return AMDCUID_STATUS_SUCCESS;
+  return parse_madt_buffer(table_data.data(), table_data.size(), cpu_info);
 }
 
 amdcuid_status_t AcpiParser::get_cpu_count(uint32_t& count) {

--- a/projects/cuid/lib/src/acpi_parser.h
+++ b/projects/cuid/lib/src/acpi_parser.h
@@ -112,7 +112,28 @@ class AcpiParser {
    *         AMDCUID_STATUS_PERMISSION_DENIED if access denied (need root)
    *         AMDCUID_STATUS_INVALID_FORMAT if table format is invalid
    */
-  static amdcuid_status_t parse_madt(std::vector<AcpiCpuInfo>& cpu_info);
+  [[nodiscard]] static amdcuid_status_t parse_madt(std::vector<AcpiCpuInfo>& cpu_info);
+
+  /**
+   * @brief Parse an in-memory MADT image
+   *
+   * Split out of parse_madt() so the table walker can be exercised against
+   * synthetic (including deliberately malformed) tables without needing root
+   * or a real /sys/firmware/acpi/tables/APIC.
+   *
+   * Every field access is bounds-checked against @p size; a truncated or
+   * self-inconsistent table yields AMDCUID_STATUS_INVALID_FORMAT rather than
+   * reading past the end of the buffer.
+   *
+   * @param data Pointer to the raw table bytes (may be null iff size == 0)
+   * @param size Number of valid bytes at @p data
+   * @param cpu_info Output vector of CPU information structures
+   * @return AMDCUID_STATUS_SUCCESS on success
+   *         AMDCUID_STATUS_INVALID_FORMAT if the table is malformed
+   *         AMDCUID_STATUS_DEVICE_NOT_FOUND if no CPU entries were found
+   */
+  [[nodiscard]] static amdcuid_status_t parse_madt_buffer(const uint8_t* data, size_t size,
+                                                          std::vector<AcpiCpuInfo>& cpu_info);
 
   /**
    * @brief Validate ACPI table header checksum
@@ -134,7 +155,7 @@ class AcpiParser {
    * @param count Output for CPU count
    * @return AMDCUID_STATUS_SUCCESS on success
    */
-  static amdcuid_status_t get_cpu_count(uint32_t& count);
+  [[nodiscard]] static amdcuid_status_t get_cpu_count(uint32_t& count);
 
  private:
   /**
@@ -144,16 +165,19 @@ class AcpiParser {
    * @param data Output buffer for table data
    * @return AMDCUID_STATUS_SUCCESS on success
    */
-  static amdcuid_status_t read_acpi_table(const char* table_name, std::vector<uint8_t>& data);
+  [[nodiscard]] static amdcuid_status_t read_acpi_table(const char* table_name,
+                                                        std::vector<uint8_t>& data);
 
   /**
-   * @brief Parse individual MADT entry
+   * @brief Parse a single MADT interrupt-controller structure
    *
-   * @param entry Pointer to entry data
+   * @param entry Pointer to the entry
+   * @param entry_len Number of bytes available at @p entry; the caller must
+   *        have validated that the entry does not extend past the table
    * @param cpu_info Output CPU info if entry is Local APIC or x2APIC
    * @return true if entry was parsed successfully
    */
-  static bool parse_madt_entry(const uint8_t* entry, AcpiCpuInfo& cpu_info);
+  static bool parse_madt_entry(const uint8_t* entry, size_t entry_len, AcpiCpuInfo& cpu_info);
 };
 
 #endif  // ACPI_PARSER_H

--- a/projects/cuid/lib/src/cuid.cc
+++ b/projects/cuid/lib/src/cuid.cc
@@ -29,8 +29,14 @@
 namespace {
 
 // Static instance for API
-CuidDeviceManager& mgr = CuidDeviceManager::instance();
 cuid_hmac global_hmac = cuid_hmac();
+CuidDeviceManager& mgr = CuidDeviceManager::instance();
+
+// Share global_hmac with mgr so build_cuid_index() derives CUIDs with the
+// same key amdcuid_set_hash_key() updates
+struct HmacWiring {
+  HmacWiring() { mgr.set_hmac(&global_hmac); }
+} hmac_wiring;
 
 }  // namespace
 

--- a/projects/cuid/lib/src/cuid.cc
+++ b/projects/cuid/lib/src/cuid.cc
@@ -97,6 +97,10 @@ const char* amdcuid_id_to_string(amdcuid_id_t cuid_value) {
 }
 
 amdcuid_status_t amdcuid_get_all_handles(amdcuid_id_t* handles, uint32_t* count) {
+  if (!count) {
+    return AMDCUID_STATUS_INVALID_ARGUMENT;
+  }
+
   amdcuid_status_t status;
   // get all the devices on the system first
   if (mgr.devices().empty()) {
@@ -109,7 +113,7 @@ amdcuid_status_t amdcuid_get_all_handles(amdcuid_id_t* handles, uint32_t* count)
   auto handle_list = mgr.get_all_handles();
   auto handle_count = static_cast<uint32_t>(handle_list.size());
   if (handle_count == 0) {
-    handles = nullptr;
+    *count = 0;
     return AMDCUID_STATUS_UNSUPPORTED;
   }
   if (*count < handle_count) {
@@ -448,7 +452,11 @@ amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle, amdcuid_quer
   if (!device) {
     return AMDCUID_STATUS_DEVICE_NOT_FOUND;
   }
-  amdcuid_status_t status;
+  // Must be initialized: most cases below only assign `status` inside
+  // `if (data != nullptr)`, so the size-query form of this API
+  // (data == nullptr, *length large enough) would otherwise return the value
+  // of an uninitialized variable.
+  amdcuid_status_t status = AMDCUID_STATUS_SUCCESS;
   switch (query) {
     case AMDCUID_QUERY_PRIMARY_CUID: {
       if (geteuid() != 0) {
@@ -665,10 +673,19 @@ amdcuid_status_t amdcuid_set_hash_key(const uint8_t key[32]) {
   if (geteuid() != 0) {
     return AMDCUID_STATUS_PERMISSION_DENIED;
   }
+  if (!key) {
+    return AMDCUID_STATUS_INVALID_ARGUMENT;
+  }
 
-  global_hmac.set_hmac_key(key);
+  // Persist first: if the key cannot be written, leave the in-memory key alone
+  // so the process keeps deriving the CUIDs that match what is on disk. The
+  // previous code ignored both failures and reported success regardless.
+  amdcuid_status_t status = global_hmac.store_key(key);
+  if (status != AMDCUID_STATUS_SUCCESS) {
+    return status;
+  }
 
-  return AMDCUID_STATUS_SUCCESS;
+  return global_hmac.set_hmac_key(key);
 }
 
 amdcuid_status_t amdcuid_generate_hash_key(uint8_t key[32]) {
@@ -677,6 +694,5 @@ amdcuid_status_t amdcuid_generate_hash_key(uint8_t key[32]) {
   }
   if (!key) return AMDCUID_STATUS_INVALID_ARGUMENT;
 
-  global_hmac.generate_key(key);
-  return AMDCUID_STATUS_SUCCESS;
+  return global_hmac.generate_key(key);
 }

--- a/projects/cuid/lib/src/cuid.cc
+++ b/projects/cuid/lib/src/cuid.cc
@@ -26,9 +26,13 @@
 #include "src/cuid_util.h"
 #include "src/hmac.h"
 
+namespace {
+
 // Static instance for API
-static CuidDeviceManager& mgr = CuidDeviceManager::instance();
-static cuid_hmac global_hmac = cuid_hmac();
+CuidDeviceManager& mgr = CuidDeviceManager::instance();
+cuid_hmac global_hmac = cuid_hmac();
+
+}  // namespace
 
 void amdcuid_get_library_version(uint32_t* major, uint32_t* minor, uint32_t* patch) {
   if (major) *major = AMDCUID_LIB_VERSION_MAJOR;
@@ -131,6 +135,8 @@ amdcuid_status_t amdcuid_get_all_handles(amdcuid_id_t* handles, uint32_t* count)
   return AMDCUID_STATUS_SUCCESS;
 }
 
+namespace {
+
 // helper function to discover device given dev_path
 DevicePtr discover_device_by_path(const char* dev_path, amdcuid_device_type_t device_type) {
   DevicePtr device = nullptr;
@@ -223,6 +229,8 @@ DevicePtr discover_device_by_path(const char* dev_path, amdcuid_device_type_t de
   return device;
 }
 
+}  // namespace
+
 amdcuid_status_t amdcuid_get_handle_by_dev_path(const char* dev_path,
                                                 amdcuid_device_type_t device_type,
                                                 amdcuid_id_t* handle) {
@@ -296,7 +304,7 @@ amdcuid_status_t amdcuid_get_handle_by_dev_path(const char* dev_path,
   if (geteuid() == 0) {
     device = discover_device_by_path(real_dev_path.c_str(), device_type);
   } else {
-    status = mgr.request_device(real_dev_path.c_str(), device_type, device);
+    mgr.request_device(real_dev_path.c_str(), device_type, device);
   }
 
   if (!device) {
@@ -383,7 +391,7 @@ amdcuid_status_t amdcuid_get_handle_by_bdf(const char* bdf, amdcuid_device_type_
   if (geteuid() == 0) {
     device = discover_device_by_path(real_dev_path.c_str(), device_type);
   } else {
-    status = mgr.request_device(real_dev_path.c_str(), device_type, device);
+    mgr.request_device(real_dev_path.c_str(), device_type, device);
   }
 
   if (!device) {

--- a/projects/cuid/lib/src/cuid_cpu.cc
+++ b/projects/cuid/lib/src/cuid_cpu.cc
@@ -22,11 +22,13 @@
 
 CuidCpu::CuidCpu(const amdcuid_cpu_info& i) : m_info(i) {}
 
+namespace {
+
 /**
  * @brief Get CPU information from CPUID instruction (x86_64)
  */
-static bool get_cpuid_info(uint16_t& vendor_id, uint16_t& family, uint16_t& model,
-                           uint16_t& device_id, uint8_t& stepping) {
+bool get_cpuid_info(uint16_t& vendor_id, uint16_t& family, uint16_t& model, uint16_t& device_id,
+                    uint8_t& stepping) {
 #ifdef __x86_64__
   uint32_t eax, ebx, ecx, edx;
 
@@ -76,6 +78,8 @@ static bool get_cpuid_info(uint16_t& vendor_id, uint16_t& family, uint16_t& mode
 #endif
 }
 
+}  // namespace
+
 /**
  * @brief CPU information parsed from /proc/cpuinfo
  */
@@ -91,13 +95,15 @@ struct ProcCpuInfo {
   bool is_amd = false;
 };
 
+namespace {
+
 /**
  * @brief Parse /proc/cpuinfo to discover CPUs without root privileges
  *
  * This is the primary method for CPU discovery that works without sudo.
  * Returns information about all logical processors on the system.
  */
-static amdcuid_status_t parse_proc_cpuinfo(std::vector<ProcCpuInfo>& cpus) {
+amdcuid_status_t parse_proc_cpuinfo(std::vector<ProcCpuInfo>& cpus) {
   std::ifstream cpuinfo("/proc/cpuinfo");
   if (!cpuinfo) {
     return AMDCUID_STATUS_CPUINFO_ERROR;
@@ -159,6 +165,8 @@ static amdcuid_status_t parse_proc_cpuinfo(std::vector<ProcCpuInfo>& cpus) {
 
   return AMDCUID_STATUS_SUCCESS;
 }
+
+}  // namespace
 
 /**
  * @brief Discover CPUs without root privileges using /proc/cpuinfo
@@ -296,13 +304,15 @@ amdcuid_status_t CuidCpu::discover_single(amdcuid_cpu_info* cpu_info,
   return AMDCUID_STATUS_SUCCESS;
 }
 
+namespace {
+
 /**
  * @brief Try to read PPIN (Protected Processor Inventory Number) from MSR
  *
  * PPIN is available on AMD CPUs (CPUID Fn8000_0008.EBX[23]) via MSR 0xC001_083B
  * Requires root privileges to read MSR.
  */
-static bool try_read_ppin(uint64_t& ppin, uint32_t core_id) {
+bool try_read_ppin(uint64_t& ppin, uint32_t core_id) {
 #ifdef __x86_64__
   // Check if PPIN is supported via CPUID
   uint32_t eax, ebx, ecx, edx;
@@ -338,6 +348,8 @@ static bool try_read_ppin(uint64_t& ppin, uint32_t core_id) {
   return false;
 #endif
 }
+
+}  // namespace
 
 /**
  * @brief Get hardware fingerprint for CPU at socket granularity.

--- a/projects/cuid/lib/src/cuid_device.cc
+++ b/projects/cuid/lib/src/cuid_device.cc
@@ -27,6 +27,8 @@
 #include "cuid_platform.h"
 #include "cuid_util.h"
 
+namespace {
+
 // helper function to get a hash from the raw bytes of a derived ID
 void get_hash_from_raw(uint8_t raw_bytes[16], uint8_t out_hash[14]) {
   // just remove the reserved bits from the raw bytes to get the hash
@@ -43,6 +45,8 @@ void build_derived_id_from_file_entry(const CuidFileEntry& entry, amdcuid_derive
   CuidUtilities::remove_UUIDv8_bits(&id.UUIDv8_representation, id.raw_bits);
   get_hash_from_raw(id.raw_bits, id.hash);
 }
+
+}  // namespace
 
 amdcuid_status_t CuidDevice::get_derived_cuid(amdcuid_derived_id& id, cuid_hmac* hmac) const {
   // attempt to find the derived CUID in file first
@@ -137,8 +141,10 @@ amdcuid_status_t CuidDevice::get_derived_cuid(amdcuid_derived_id& id, cuid_hmac*
   }
 
   // if not found, generate derived CUID
-  amdcuid_primary_id primary;
-  status = get_primary_cuid(primary);
+  amdcuid_primary_id primary = {};
+  if (get_primary_cuid(primary) != AMDCUID_STATUS_SUCCESS) {
+    primary = {};  // the temp bit below was read uninitialised
+  }
   // check the temporary bit in the primary CUID to determine whether to use the
   // real HMAC key or the temp key for derived CUID generation
   bool temp = primary.raw_bits[14] & 0x20;  // check the temp indicator bit in the reserved bits

--- a/projects/cuid/lib/src/cuid_device.cc
+++ b/projects/cuid/lib/src/cuid_device.cc
@@ -143,7 +143,8 @@ amdcuid_status_t CuidDevice::get_derived_cuid(amdcuid_derived_id& id, cuid_hmac*
   // if not found, generate derived CUID
   amdcuid_primary_id primary = {};
   if (get_primary_cuid(primary) != AMDCUID_STATUS_SUCCESS) {
-    primary = {};  // the temp bit below was read uninitialised
+    primary.raw_bits[14] =
+        0x20;  // ensure temporary bit is set so temp CUID is still generated on failure
   }
   // check the temporary bit in the primary CUID to determine whether to use the
   // real HMAC key or the temp key for derived CUID generation

--- a/projects/cuid/lib/src/cuid_device_manager.cc
+++ b/projects/cuid/lib/src/cuid_device_manager.cc
@@ -188,6 +188,8 @@ amdcuid_status_t CuidDeviceManager::get_devices_on_system() {
   return discovered_devices.empty() ? AMDCUID_STATUS_DEVICE_NOT_FOUND : AMDCUID_STATUS_SUCCESS;
 }
 
+namespace {
+
 // helper function to convert CuidFileEntry to appropriate CuidDevice
 void convert_entry_to_device(CuidFileEntry& entry, DevicePtr& device) {
   switch (entry.device_type) {
@@ -252,6 +254,8 @@ void convert_entry_to_device(CuidFileEntry& entry, DevicePtr& device) {
     }
   }
 }
+
+}  // namespace
 
 amdcuid_status_t CuidDeviceManager::get_devices_from_file_entries(CuidFile& cuid_file) {
   std::lock_guard<std::mutex> lock(manager_mutex_);
@@ -440,7 +444,7 @@ amdcuid_status_t CuidDeviceManager::discover_devices() {
         return status;
       }
       // try saving to files if we were able to discover devices from the system
-      status = save_registry_to_files();
+      save_registry_to_files();
     }
   } else {
     status = get_devices_from_file_entries(unpriv_cuid_file_);
@@ -457,7 +461,7 @@ amdcuid_status_t CuidDeviceManager::discover_devices() {
         }
       }
       // try saving to files if we were able to discover devices from the system
-      status = save_registry_to_files();
+      save_registry_to_files();
     }
   }
 

--- a/projects/cuid/lib/src/cuid_device_manager.cc
+++ b/projects/cuid/lib/src/cuid_device_manager.cc
@@ -191,7 +191,7 @@ amdcuid_status_t CuidDeviceManager::get_devices_on_system() {
 namespace {
 
 // helper function to convert CuidFileEntry to appropriate CuidDevice
-void convert_entry_to_device(CuidFileEntry& entry, DevicePtr& device) {
+static void _convert_entry_to_device(CuidFileEntry& entry, DevicePtr& device) {
   switch (entry.device_type) {
     case AMDCUID_DEVICE_TYPE_PLATFORM: {
       amdcuid_platform_info platform_info = {};
@@ -268,7 +268,7 @@ amdcuid_status_t CuidDeviceManager::get_devices_from_file_entries(CuidFile& cuid
   devices_.clear();
   for (const auto& entry : cuid_file.get_entries()) {
     DevicePtr device = nullptr;
-    convert_entry_to_device(const_cast<CuidFileEntry&>(entry), device);
+    _convert_entry_to_device(const_cast<CuidFileEntry&>(entry), device);
     if (device) {
       devices_.push_back(device);
     }
@@ -322,7 +322,7 @@ amdcuid_status_t CuidDeviceManager::get_device_from_file_by_id(amdcuid_id_t& der
   }
 
   // Create device based on the found entry
-  convert_entry_to_device(entry, device);
+  _convert_entry_to_device(entry, device);
   if (device) {
     add_device(device);
   }
@@ -356,7 +356,7 @@ amdcuid_status_t CuidDeviceManager::get_device_from_file_by_dev_path(const std::
   }
 
   // Create device based on the found entry
-  convert_entry_to_device(entry, device);
+  _convert_entry_to_device(entry, device);
   if (device) {
     add_device(device);
   }
@@ -390,7 +390,7 @@ amdcuid_status_t CuidDeviceManager::get_device_from_file_by_bdf(const std::strin
   }
 
   // Create device based on the found entry
-  convert_entry_to_device(entry, device);
+  _convert_entry_to_device(entry, device);
   if (device) {
     add_device(device);
   }
@@ -438,7 +438,7 @@ amdcuid_status_t CuidDeviceManager::discover_devices() {
   if (geteuid() == 0) {
     status = get_devices_from_file_entries(priv_cuid_file_);
     // if there are no devices found, search the system for devices
-    if (devices_.empty() || status != AMDCUID_STATUS_SUCCESS) {
+    if (devices().empty() || status != AMDCUID_STATUS_SUCCESS) {
       status = get_devices_on_system();
       if (status != AMDCUID_STATUS_SUCCESS) {
         return status;
@@ -448,7 +448,7 @@ amdcuid_status_t CuidDeviceManager::discover_devices() {
     }
   } else {
     status = get_devices_from_file_entries(unpriv_cuid_file_);
-    if (status != AMDCUID_STATUS_SUCCESS || devices_.empty()) {
+    if (status != AMDCUID_STATUS_SUCCESS || devices().empty()) {
       // refresh to get devices from system using daemon or ioctl since none
       // found
       status = request_refresh();
@@ -466,7 +466,7 @@ amdcuid_status_t CuidDeviceManager::discover_devices() {
   }
 
   // if devices still empty, return error
-  if (devices_.empty()) {
+  if (devices().empty()) {
     return AMDCUID_STATUS_DEVICE_NOT_FOUND;
   }
 
@@ -491,7 +491,7 @@ CuidDeviceManager& CuidDeviceManager::instance() {
 void CuidDeviceManager::get_grouped_devices(
     std::map<amdcuid_device_type_t, std::vector<DevicePtr>>& grouped) {
   grouped.clear();
-  for (const auto& entry : devices_) {
+  for (const auto& entry : devices()) {
     grouped[entry->type()].push_back(entry);
   }
 }
@@ -502,8 +502,8 @@ void CuidDeviceManager::build_cuid_index() {
   cuid_index_.clear();
   for (const auto& device : devices_) {
     amdcuid_derived_id derived;
-    if (geteuid() == 0) {
-      if (device->get_derived_cuid(derived, &manager_hmac) == AMDCUID_STATUS_SUCCESS) {
+    if (geteuid() == 0 && hmac_ != nullptr) {
+      if (device->get_derived_cuid(derived, hmac_) == AMDCUID_STATUS_SUCCESS) {
         cuid_index_[derived.UUIDv8_representation] = device;
       }
     } else {

--- a/projects/cuid/lib/src/cuid_device_manager.cc
+++ b/projects/cuid/lib/src/cuid_device_manager.cc
@@ -21,28 +21,41 @@
 
 class CuidDaemonIpcClientUtils {
  public:
+  // Fill sun_path leaving room for the terminating NUL.
+  static void fill_socket_addr(struct sockaddr_un& addr) {
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    constexpr size_t kPathLen = sizeof(AMDCUID_SOCKET_PATH) - 1;
+    static_assert(kPathLen < sizeof(addr.sun_path),
+                  "AMDCUID_SOCKET_PATH does not fit in sockaddr_un::sun_path");
+    memcpy(addr.sun_path, AMDCUID_SOCKET_PATH, kPathLen);
+  }
+
   static amdcuid_status_t request_add_device(const char* dev_path,
                                              amdcuid_device_type_t device_type,
                                              amdcuid_id_t* device_handle) {
+    // Build the request before opening the socket so an over-long path is
+    // rejected without bothering the daemon. `request` is value-initialized so
+    // no uninitialized padding is written to the socket.
+    IpcRequest request{};
+    request.type = IpcMessageType::ADD_DEVICE;
+    request.device_type = device_type;
+    if (!ipc_set_device_path(request, dev_path)) {
+      return AMDCUID_STATUS_INVALID_ARGUMENT;
+    }
+
     int sock_fd = socket(AF_UNIX, SOCK_STREAM, 0);
     if (sock_fd < 0) {
       return AMDCUID_STATUS_IPC_ERROR;
     }
 
     struct sockaddr_un server_addr;
-    memset(&server_addr, 0, sizeof(server_addr));
-    server_addr.sun_family = AF_UNIX;
-    strncpy(server_addr.sun_path, AMDCUID_SOCKET_PATH, sizeof(server_addr.sun_path));
+    fill_socket_addr(server_addr);
 
     if (connect(sock_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)) < 0) {
       close(sock_fd);
       return AMDCUID_STATUS_IPC_ERROR;
     }
-
-    IpcRequest request;
-    request.type = IpcMessageType::ADD_DEVICE;
-    strncpy(request.device_path, dev_path, sizeof(request.device_path));
-    request.device_type = device_type;
 
     if (send(sock_fd, &request, sizeof(request), 0) != sizeof(request)) {
       close(sock_fd);
@@ -69,20 +82,18 @@ class CuidDaemonIpcClientUtils {
     }
 
     struct sockaddr_un server_addr;
-    memset(&server_addr, 0, sizeof(server_addr));
-    server_addr.sun_family = AF_UNIX;
-    strncpy(server_addr.sun_path, AMDCUID_SOCKET_PATH, sizeof(server_addr.sun_path));
+    fill_socket_addr(server_addr);
 
     if (connect(sock_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)) < 0) {
       close(sock_fd);
       return AMDCUID_STATUS_IPC_ERROR;
     }
 
-    IpcRequest request;
+    // Value-initialized: device_path/device_type are unused for
+    // REFRESH_DEVICES and must not leak uninitialized stack bytes.
+    IpcRequest request{};
     request.type = IpcMessageType::REFRESH_DEVICES;
-    memset(request.device_path, 0,
-           sizeof(request.device_path));             // Not used for REFRESH_DEVICES
-    request.device_type = AMDCUID_DEVICE_TYPE_NONE;  // Not used for REFRESH_DEVICES
+    request.device_type = AMDCUID_DEVICE_TYPE_NONE;
 
     if (send(sock_fd, &request, sizeof(request), 0) != sizeof(request)) {
       close(sock_fd);
@@ -106,9 +117,7 @@ class CuidDaemonIpcClientUtils {
     }
 
     struct sockaddr_un server_addr;
-    memset(&server_addr, 0, sizeof(server_addr));
-    server_addr.sun_family = AF_UNIX;
-    strncpy(server_addr.sun_path, AMDCUID_SOCKET_PATH, sizeof(server_addr.sun_path));
+    fill_socket_addr(server_addr);
 
     if (connect(sock_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)) < 0) {
       close(sock_fd);
@@ -180,7 +189,7 @@ amdcuid_status_t CuidDeviceManager::get_devices_on_system() {
 }
 
 // helper function to convert CuidFileEntry to appropriate CuidDevice
-void _convert_entry_to_device(CuidFileEntry& entry, DevicePtr& device) {
+void convert_entry_to_device(CuidFileEntry& entry, DevicePtr& device) {
   switch (entry.device_type) {
     case AMDCUID_DEVICE_TYPE_PLATFORM: {
       amdcuid_platform_info platform_info = {};
@@ -255,7 +264,7 @@ amdcuid_status_t CuidDeviceManager::get_devices_from_file_entries(CuidFile& cuid
   devices_.clear();
   for (const auto& entry : cuid_file.get_entries()) {
     DevicePtr device = nullptr;
-    _convert_entry_to_device(const_cast<CuidFileEntry&>(entry), device);
+    convert_entry_to_device(const_cast<CuidFileEntry&>(entry), device);
     if (device) {
       devices_.push_back(device);
     }
@@ -309,7 +318,7 @@ amdcuid_status_t CuidDeviceManager::get_device_from_file_by_id(amdcuid_id_t& der
   }
 
   // Create device based on the found entry
-  _convert_entry_to_device(entry, device);
+  convert_entry_to_device(entry, device);
   if (device) {
     add_device(device);
   }
@@ -343,7 +352,7 @@ amdcuid_status_t CuidDeviceManager::get_device_from_file_by_dev_path(const std::
   }
 
   // Create device based on the found entry
-  _convert_entry_to_device(entry, device);
+  convert_entry_to_device(entry, device);
   if (device) {
     add_device(device);
   }
@@ -377,7 +386,7 @@ amdcuid_status_t CuidDeviceManager::get_device_from_file_by_bdf(const std::strin
   }
 
   // Create device based on the found entry
-  _convert_entry_to_device(entry, device);
+  convert_entry_to_device(entry, device);
   if (device) {
     add_device(device);
   }
@@ -502,12 +511,20 @@ void CuidDeviceManager::build_cuid_index() {
 }
 
 DevicePtr CuidDeviceManager::lookup_by_handle(const amdcuid_id_t& handle) const {
+  // cuid_index_ is rebuilt wholesale by build_cuid_index() under this mutex.
+  // Reading it unlocked is a data race that ThreadSanitizer reports against an
+  // ordinary multithreaded consumer of the public API; neither of the two
+  // callers (both in cuid.cc) holds the lock, so taking it here cannot deadlock.
+  std::lock_guard<std::mutex> lock(manager_mutex_);
+
   // Since amdcuid_id_t is our handle, we can use it directly as key
   auto it = cuid_index_.find(handle);
   return (it != cuid_index_.end()) ? it->second : nullptr;
 }
 
 std::vector<amdcuid_id_t> CuidDeviceManager::get_all_handles() const {
+  std::lock_guard<std::mutex> lock(manager_mutex_);
+
   std::vector<amdcuid_id_t> handles;
   handles.reserve(cuid_index_.size());
 

--- a/projects/cuid/lib/src/cuid_device_manager.h
+++ b/projects/cuid/lib/src/cuid_device_manager.h
@@ -52,7 +52,15 @@ class CuidDeviceManager {
   amdcuid_status_t shutdown();  // no need for this function as actual shutdown function, may be
                                 // useful for unit testing
 
-  const std::vector<DevicePtr>& devices() const { return devices_; }
+  // Returns a snapshot by value, deliberately not a reference. discover_devices()
+  // replaces devices_ wholesale under manager_mutex_, so a caller iterating a
+  // reference to it can have the vector reallocated underneath its iterators by
+  // another thread. Copying a vector of shared_ptr is cheap and keeps every
+  // device alive for as long as the caller holds the snapshot.
+  std::vector<DevicePtr> devices() const {
+    std::lock_guard<std::mutex> lock(manager_mutex_);
+    return devices_;
+  }
   void get_grouped_devices(std::map<amdcuid_device_type_t, std::vector<DevicePtr>>& grouped);
   const amdcuid_device_type_set_t& device_types() const { return device_types_; }
 
@@ -157,8 +165,12 @@ class CuidDeviceManager {
   std::map<amdcuid_id_t, DevicePtr, CuidComparator> cuid_index_;
 
   // Cuid Files
-  CuidFile unpriv_cuid_file_{CuidUtilities::cuid_file(), true};
-  CuidFile priv_cuid_file_{CuidUtilities::priv_cuid_file(), false};
+  // The second argument is is_privileged. CuidFile::save() uses it to decide
+  // whether to write primary_cuid/hardware_fingerprint and whether to chmod
+  // 0600 or 0644, so having these swapped would make the privileged file
+  // world-readable and strip the primary CUIDs from it.
+  CuidFile unpriv_cuid_file_{CuidUtilities::cuid_file(), false};
+  CuidFile priv_cuid_file_{CuidUtilities::priv_cuid_file(), true};
 
   // cuid hmac for deriving cuids
   cuid_hmac manager_hmac = cuid_hmac();

--- a/projects/cuid/lib/src/cuid_device_manager.h
+++ b/projects/cuid/lib/src/cuid_device_manager.h
@@ -66,6 +66,12 @@ class CuidDeviceManager {
 
   amdcuid_status_t add_device(DevicePtr device);
 
+  // Share an externally owned cuid_hmac so build_cuid_index() derives CUIDs
+  // with the same in-memory key amdcuid_set_hash_key() updates.
+  // Not owned; caller must outlive this manager. Pass nullptr to fall back to
+  // deriving without an HMAC.
+  void set_hmac(cuid_hmac* hmac) { hmac_ = hmac; }
+
   /**
    * @brief Discover all devices currently present on the system.
    *
@@ -172,8 +178,8 @@ class CuidDeviceManager {
   CuidFile unpriv_cuid_file_{CuidUtilities::cuid_file(), false};
   CuidFile priv_cuid_file_{CuidUtilities::priv_cuid_file(), true};
 
-  // cuid hmac for deriving cuids
-  cuid_hmac manager_hmac = cuid_hmac();
+  // Externally owned hmac shared via set_hmac(); see that method's comment.
+  cuid_hmac* hmac_ = nullptr;
 };
 
 #endif  // CUID_DEVICE_MANAGER_H

--- a/projects/cuid/lib/src/cuid_file.cc
+++ b/projects/cuid/lib/src/cuid_file.cc
@@ -76,8 +76,8 @@ bool CuidFileLock::acquire() {
   }
 
   if (lock_fd_ < 0) {
-    LOG(ERROR,
-        "CuidFileLock: Failed to open lock file " << lock_file_path_ << ": " << strerror(errno));
+    LOG(ERROR, "CuidFileLock: Failed to open lock file " << lock_file_path_ << ": "
+                                                         << CuidUtilities::errno_string(errno));
     return false;
   }
 
@@ -91,8 +91,8 @@ bool CuidFileLock::acquire() {
 
   // F_SETLKW: blocking call - wait until lock is available
   if (fcntl(lock_fd_, F_SETLKW, &fl) < 0) {
-    LOG(ERROR,
-        "CuidFileLock: Failed to acquire lock on " << lock_file_path_ << ": " << strerror(errno));
+    LOG(ERROR, "CuidFileLock: Failed to acquire lock on " << lock_file_path_ << ": "
+                                                          << CuidUtilities::errno_string(errno));
     close(lock_fd_);
     lock_fd_ = -1;
     return false;
@@ -146,8 +146,8 @@ bool CuidFileLock::acquire_with_timeout(int timeout_seconds) {
   }
 
   if (lock_fd_ < 0) {
-    LOG(ERROR,
-        "CuidFileLock: Failed to open lock file " << lock_file_path_ << ": " << strerror(errno));
+    LOG(ERROR, "CuidFileLock: Failed to open lock file " << lock_file_path_ << ": "
+                                                         << CuidUtilities::errno_string(errno));
     return false;
   }
 
@@ -175,8 +175,8 @@ bool CuidFileLock::acquire_with_timeout(int timeout_seconds) {
 
     // Check if it's a "lock held" error vs real error
     if (errno != EACCES && errno != EAGAIN) {
-      LOG(ERROR,
-          "CuidFileLock: Failed to acquire lock on " << lock_file_path_ << ": " << strerror(errno));
+      LOG(ERROR, "CuidFileLock: Failed to acquire lock on " << lock_file_path_ << ": "
+                                                            << CuidUtilities::errno_string(errno));
       close(lock_fd_);
       lock_fd_ = -1;
       return false;
@@ -229,8 +229,8 @@ bool CuidFileLock::try_acquire() {
   }
 
   if (lock_fd_ < 0) {
-    LOG(ERROR,
-        "CuidFileLock: Failed to open lock file " << lock_file_path_ << ": " << strerror(errno));
+    LOG(ERROR, "CuidFileLock: Failed to open lock file " << lock_file_path_ << ": "
+                                                         << CuidUtilities::errno_string(errno));
     return false;
   }
 
@@ -248,8 +248,8 @@ bool CuidFileLock::try_acquire() {
       // Lock is held by another process
       LOG(DEBUG, "CuidFileLock: Lock on " << lock_file_path_ << " held by another process");
     } else {
-      LOG(ERROR, "CuidFileLock: Failed to try_acquire lock on " << lock_file_path_ << ": "
-                                                                << strerror(errno));
+      LOG(ERROR, "CuidFileLock: Failed to try_acquire lock on "
+                     << lock_file_path_ << ": " << CuidUtilities::errno_string(errno));
     }
     close(lock_fd_);
     lock_fd_ = -1;
@@ -277,8 +277,8 @@ void CuidFileLock::release() {
   fl.l_type = F_UNLCK;
 
   if (fcntl(lock_fd_, F_SETLK, &fl) < 0) {
-    LOG(ERROR,
-        "CuidFileLock: Failed to release lock on " << lock_file_path_ << ": " << strerror(errno));
+    LOG(ERROR, "CuidFileLock: Failed to release lock on " << lock_file_path_ << ": "
+                                                          << CuidUtilities::errno_string(errno));
   }
 
   close(lock_fd_);
@@ -331,7 +331,7 @@ amdcuid_id_t CuidFile::string_to_cuid(const std::string& str) const {
   }
 
   for (int i = 0; i < 16; ++i) {
-    std::string byte_str = hex_only.substr(i * 2, 2);
+    std::string byte_str = hex_only.substr(static_cast<size_t>(i) * 2, 2);
     id.bytes[i] = static_cast<uint8_t>(std::stoul(byte_str, nullptr, 16));
   }
 

--- a/projects/cuid/lib/src/cuid_file.cc
+++ b/projects/cuid/lib/src/cuid_file.cc
@@ -701,10 +701,11 @@ void CuidFile::get_grouped_entries(
 // CuidFileGenerator Implementation
 // ============================================================================
 
+namespace {
+
 // helper function to generate CUID files from a list of devices
-static amdcuid_status_t generate_from_devices(
-    const std::vector<std::shared_ptr<CuidDevice>>& devices, const std::string& file,
-    bool is_privileged) {
+amdcuid_status_t generate_from_devices(const std::vector<std::shared_ptr<CuidDevice>>& devices,
+                                       const std::string& file, bool is_privileged) {
   // Create file handlers
   CuidFile cuid_file(file, is_privileged);
 
@@ -889,6 +890,8 @@ static amdcuid_status_t generate_from_devices(
 
   return AMDCUID_STATUS_SUCCESS;
 }
+
+}  // namespace
 
 amdcuid_status_t CuidFileGenerator::generate_unpriv_from_devices(
     const std::vector<std::shared_ptr<CuidDevice>>& devices, const std::string& unpriv_file_path) {

--- a/projects/cuid/lib/src/cuid_gpu.cc
+++ b/projects/cuid/lib/src/cuid_gpu.cc
@@ -41,6 +41,9 @@ static std::string resolve_render_node(const std::string& card_path) {
   DIR* dir = opendir(drm_dir.c_str());
   if (dir) {
     struct dirent* entry;
+    // This call site owns its DIR*, which is all POSIX requires for readdir to be
+    // safe; readdir_r is deprecated and must not be adopted.
+    // NOLINTNEXTLINE(concurrency-mt-unsafe)
     while ((entry = readdir(dir)) != nullptr) {
       if (strncmp(entry->d_name, "renderD", 7) == 0 && isdigit(entry->d_name[7])) {
         std::string result = "/sys/class/drm/" + std::string(entry->d_name);
@@ -95,6 +98,9 @@ amdcuid_status_t CuidGpu::discover(std::vector<DevicePtr>& gpus) {
   DIR* dir = opendir(drm_path);
   if (dir != nullptr) {
     struct dirent* entry;
+    // This call site owns its DIR*, which is all POSIX requires for readdir to be
+    // safe; readdir_r is deprecated and must not be adopted.
+    // NOLINTNEXTLINE(concurrency-mt-unsafe)
     while ((entry = readdir(dir)) != NULL) {
       // Use card entries (e.g., card0, card1) which are always present for DRM
       // devices, unlike renderD nodes which may be absent with certain drivers
@@ -185,7 +191,7 @@ amdcuid_status_t CuidGpu::discover_single(amdcuid_gpu_info* gpu_info,
     uint8_t vendor_id_bytes[2] = {0};
     const uint16_t offset = 0x0;
     amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, vendor_id_bytes, 2, offset);
-    uint16_t vendor_id_int = PciUtil::le16_to_be16(*reinterpret_cast<uint16_t*>(vendor_id_bytes));
+    uint16_t vendor_id_int = PciUtil::load_le16(vendor_id_bytes);
     info.header.fields.gpu.vendor_id = (status == AMDCUID_STATUS_SUCCESS) ? vendor_id_int : 0;
   } else {
     info.header.fields.gpu.vendor_id = (uint16_t)strtol(vendor.c_str(), nullptr, 16);
@@ -197,7 +203,7 @@ amdcuid_status_t CuidGpu::discover_single(amdcuid_gpu_info* gpu_info,
     uint8_t device_id_bytes[2] = {0};
     const uint16_t offset = 0x2;
     amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, device_id_bytes, 2, offset);
-    uint16_t device_id_int = PciUtil::le16_to_be16(*reinterpret_cast<uint16_t*>(device_id_bytes));
+    uint16_t device_id_int = PciUtil::load_le16(device_id_bytes);
     info.header.fields.gpu.device_id = (status == AMDCUID_STATUS_SUCCESS) ? device_id_int : 0;
   } else {
     info.header.fields.gpu.device_id = (uint16_t)strtol(device.c_str(), nullptr, 16);
@@ -210,7 +216,7 @@ amdcuid_status_t CuidGpu::discover_single(amdcuid_gpu_info* gpu_info,
     uint8_t class_id_bytes[2] = {0};
     const uint16_t offset = 0xa;
     amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, class_id_bytes, 2, offset);
-    uint16_t class_id_int = PciUtil::le16_to_be16(*reinterpret_cast<uint16_t*>(class_id_bytes));
+    uint16_t class_id_int = PciUtil::load_le16(class_id_bytes);
     pci_class_integer = (status == AMDCUID_STATUS_SUCCESS) ? class_id_int : 0;
   } else {
     // sysfs class file returns 24-bit value (class:subclass:prog_if), shift
@@ -222,12 +228,13 @@ amdcuid_status_t CuidGpu::discover_single(amdcuid_gpu_info* gpu_info,
   std::string revision_id = CuidUtilities::read_sysfs_file(device_path + "/revision");
   if (revision_id.empty() && !bdf.empty()) {
     // if file read fails, attempt to get from pci config
-    uint8_t revision_id_bytes[2] = {0};
+    // RevisionID is the single byte at 0x08. The byte at 0x09 is prog-if and
+    // must not be folded in: revision_id is a uint8_t, so a two-byte load left
+    // prog-if in the low half and the revision was discarded by the narrowing.
+    uint8_t revision_id_byte = 0;
     const uint16_t offset = 0x8;
-    amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, revision_id_bytes, 2, offset);
-    uint16_t revision_id_int =
-        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t*>(revision_id_bytes));
-    info.header.fields.gpu.revision_id = (status == AMDCUID_STATUS_SUCCESS) ? revision_id_int : 0;
+    amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, &revision_id_byte, 1, offset);
+    info.header.fields.gpu.revision_id = (status == AMDCUID_STATUS_SUCCESS) ? revision_id_byte : 0;
   } else {
     info.header.fields.gpu.revision_id = (uint16_t)strtol(revision_id.c_str(), nullptr, 16);
   }
@@ -294,7 +301,7 @@ amdcuid_status_t CuidGpu::get_hardware_fingerprint(uint64_t& fingerprint) const 
   // ASIC serial captured during discovery as the fingerprint.
   if (render_node_is_pci_dir && m_info.gim_fingerprint_valid) {
     fingerprint = m_info.gim_fingerprint;
-    return AMDCUID_STATUS_SUCCESS;
+    return CuidUtilities::validate_fingerprint(fingerprint);
   }
 
   const std::string device_attr_prefix =
@@ -357,7 +364,7 @@ amdcuid_status_t CuidGpu::get_hardware_fingerprint(uint64_t& fingerprint) const 
     fingerprint = 0;
     return AMDCUID_STATUS_UNSUPPORTED;
   }
-  return AMDCUID_STATUS_SUCCESS;
+  return CuidUtilities::validate_fingerprint(fingerprint);
 }
 
 amdcuid_status_t CuidGpu::get_primary_cuid(amdcuid_primary_id& id) const {

--- a/projects/cuid/lib/src/cuid_gpu.cc
+++ b/projects/cuid/lib/src/cuid_gpu.cc
@@ -22,10 +22,12 @@
 
 CuidGpu::CuidGpu(const amdcuid_gpu_info& i) : m_info(i) {}
 
+namespace {
+
 // Helper to check if a /sys/class/drm entry name is a card device (e.g.,
 // "card0", "card1"). Excludes connector entries like "card0-DP-1" or
 // "card0-HDMI-A-1".
-static bool is_card_entry(const char* name) {
+bool is_card_entry(const char* name) {
   if (strncmp(name, "card", 4) != 0 || !isdigit(name[4])) return false;
   for (size_t i = 4; name[i] != '\0'; ++i) {
     if (!isdigit(name[i])) return false;
@@ -36,7 +38,7 @@ static bool is_card_entry(const char* name) {
 // Resolve the renderD node path for a given card path.
 // If a renderD node exists under the card's device/drm directory, returns
 // "/sys/class/drm/renderDXXX". Otherwise, returns the original card path.
-static std::string resolve_render_node(const std::string& card_path) {
+std::string resolve_render_node(const std::string& card_path) {
   std::string drm_dir = card_path + "/device/drm";
   DIR* dir = opendir(drm_dir.c_str());
   if (dir) {
@@ -55,6 +57,8 @@ static std::string resolve_render_node(const std::string& card_path) {
   }
   return card_path;
 }
+
+}  // namespace
 
 // Callers from /sys/class/drm enumeration pass paths of the form
 // "/sys/class/drm/<card>/device" and expect the trailing "/device" component

--- a/projects/cuid/lib/src/cuid_nic.cc
+++ b/projects/cuid/lib/src/cuid_nic.cc
@@ -29,6 +29,9 @@ amdcuid_status_t CuidNic::discover(std::vector<DevicePtr>& nics) {
   if (!dir) return AMDCUID_STATUS_DEVICE_NOT_FOUND;
 
   struct dirent* entry;
+  // This call site owns its DIR*, which is all POSIX requires for readdir to be
+  // safe; readdir_r is deprecated and must not be adopted.
+  // NOLINTNEXTLINE(concurrency-mt-unsafe)
   while ((entry = readdir(dir)) != NULL) {
     // grab everything except the loopback device and hidden entries
     if (strncmp(entry->d_name, "lo", 2) != 0 && entry->d_name[0] != '.') {
@@ -62,7 +65,7 @@ amdcuid_status_t CuidNic::discover_single(amdcuid_nic_info* nic_info,
     uint8_t vendor_id_bytes[2] = {0};
     const uint16_t offset = 0x0;
     amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, vendor_id_bytes, 2, offset);
-    uint16_t vendor_id_int = PciUtil::le16_to_be16(*reinterpret_cast<uint16_t*>(vendor_id_bytes));
+    uint16_t vendor_id_int = PciUtil::load_le16(vendor_id_bytes);
     info.header.fields.nic.vendor_id = (status == AMDCUID_STATUS_SUCCESS) ? vendor_id_int : 0;
   } else {
     info.header.fields.nic.vendor_id = (uint16_t)strtol(vendor.c_str(), nullptr, 16);
@@ -74,7 +77,7 @@ amdcuid_status_t CuidNic::discover_single(amdcuid_nic_info* nic_info,
     uint8_t device_id_bytes[2] = {0};
     const uint16_t offset = 0x2;
     amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, device_id_bytes, 2, offset);
-    uint16_t device_id_int = PciUtil::le16_to_be16(*reinterpret_cast<uint16_t*>(device_id_bytes));
+    uint16_t device_id_int = PciUtil::load_le16(device_id_bytes);
     info.header.fields.nic.device_id = (status == AMDCUID_STATUS_SUCCESS) ? device_id_int : 0;
   } else {
     info.header.fields.nic.device_id = (uint16_t)strtol(device.c_str(), nullptr, 16);
@@ -87,7 +90,7 @@ amdcuid_status_t CuidNic::discover_single(amdcuid_nic_info* nic_info,
     uint8_t class_id_bytes[2] = {0};
     const uint16_t offset = 0xa;
     amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, class_id_bytes, 2, offset);
-    uint16_t class_id_int = PciUtil::le16_to_be16(*reinterpret_cast<uint16_t*>(class_id_bytes));
+    uint16_t class_id_int = PciUtil::load_le16(class_id_bytes);
     pci_class_integer = (status == AMDCUID_STATUS_SUCCESS) ? class_id_int : 0;
   } else {
     // sysfs class file returns 24-bit value (class:subclass:prog_if), shift
@@ -99,12 +102,13 @@ amdcuid_status_t CuidNic::discover_single(amdcuid_nic_info* nic_info,
   std::string revision_id = CuidUtilities::read_sysfs_file(device_path + "/revision");
   if (revision_id.empty() && !bdf.empty()) {
     // if file read fails, attempt to get from pci config
-    uint8_t revision_id_bytes[2] = {0};
+    // RevisionID is the single byte at 0x08. The byte at 0x09 is prog-if and
+    // must not be folded in: revision_id is a uint8_t, so a two-byte load left
+    // prog-if in the low half and the revision was discarded by the narrowing.
+    uint8_t revision_id_byte = 0;
     const uint16_t offset = 0x8;
-    amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, revision_id_bytes, 2, offset);
-    uint16_t revision_id_int =
-        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t*>(revision_id_bytes));
-    info.header.fields.nic.revision_id = (status == AMDCUID_STATUS_SUCCESS) ? revision_id_int : 0;
+    amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, &revision_id_byte, 1, offset);
+    info.header.fields.nic.revision_id = (status == AMDCUID_STATUS_SUCCESS) ? revision_id_byte : 0;
   } else {
     info.header.fields.nic.revision_id = (uint16_t)strtol(revision_id.c_str(), nullptr, 16);
   }
@@ -143,7 +147,12 @@ amdcuid_status_t CuidNic::get_hardware_fingerprint(uint64_t& fingerprint) const 
       uint64_t fingerprint_value = 0;
       std::memcpy(&fingerprint_value, fingerprint_bytes, sizeof(fingerprint_bytes));
       fingerprint = PciUtil::le64_to_be64(fingerprint_value);
-      return AMDCUID_STATUS_SUCCESS;
+      if (CuidUtilities::validate_fingerprint(fingerprint) == AMDCUID_STATUS_SUCCESS) {
+        return AMDCUID_STATUS_SUCCESS;
+      }
+      // An all-zero DSN means the capability is present but unprogrammed. Fall
+      // through and try the MAC address instead of claiming identity zero.
+      fingerprint = 0;
     }
   }
   // TODO: serial ID could be found in FRU_ID so should attempt to look there
@@ -157,12 +166,24 @@ amdcuid_status_t CuidNic::get_hardware_fingerprint(uint64_t& fingerprint) const 
   if (!mac_address.empty()) {
     // convert MAC address string to bytes
     uint8_t mac_bytes[6] = {0};
-    sscanf(mac_address.c_str(), "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx", &mac_bytes[0], &mac_bytes[1],
-           &mac_bytes[2], &mac_bytes[3], &mac_bytes[4], &mac_bytes[5]);
+    // An unchecked sscanf leaves mac_bytes partly or wholly zero on a
+    // malformed address, and the caller would then derive a CUID from that
+    // silently. All six octets must convert.
+    // cert-err34-c wants strtoul; the concern it encodes is a conversion that
+    // fails silently, which the count check below rules out.
+    // NOLINTNEXTLINE(cert-err34-c)
+    const int converted = sscanf(  // NOLINT(cert-err34-c)
+        mac_address.c_str(), "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx", &mac_bytes[0], &mac_bytes[1],
+        &mac_bytes[2], &mac_bytes[3], &mac_bytes[4], &mac_bytes[5]);
+    if (converted != 6) {
+      fingerprint = 0;
+      return AMDCUID_STATUS_INVALID_FORMAT;
+    }
     uint64_t mac_fingerprint = 0;
     std::memcpy(&mac_fingerprint, mac_bytes, sizeof(mac_bytes));
     fingerprint = mac_fingerprint;
-    return AMDCUID_STATUS_SUCCESS;
+    // An all-zero MAC is an unconfigured interface, not an identity.
+    return CuidUtilities::validate_fingerprint(fingerprint);
   }
 
   return AMDCUID_STATUS_HW_FINGERPRINT_NOT_FOUND;
@@ -281,7 +302,9 @@ amdcuid_status_t CuidNic::get_mac_address(std::string& mac_address) const {
   }
   close(fd);
 
+  // Six %02x plus five separators is exactly 17 characters plus the NUL.
   char buf[18];
+  // NOLINTNEXTLINE(cert-err33-c)
   snprintf(buf, sizeof(buf), "%02x:%02x:%02x:%02x:%02x:%02x", epaddr->data[0], epaddr->data[1],
            epaddr->data[2], epaddr->data[3], epaddr->data[4], epaddr->data[5]);
   delete[] reinterpret_cast<uint8_t*>(epaddr);

--- a/projects/cuid/lib/src/cuid_npu.cc
+++ b/projects/cuid/lib/src/cuid_npu.cc
@@ -45,6 +45,9 @@ static amdcuid_status_t discover_via_accel(std::vector<DevicePtr>& npus) {
   if (!dir) return AMDCUID_STATUS_UNSUPPORTED;
 
   struct dirent* entry;
+  // This call site owns its DIR*, which is all POSIX requires for readdir to be
+  // safe; readdir_r is deprecated and must not be adopted.
+  // NOLINTNEXTLINE(concurrency-mt-unsafe)
   while ((entry = readdir(dir)) != NULL) {
     if (is_accel_entry(entry->d_name)) {
       std::string accel_name(entry->d_name);
@@ -77,6 +80,9 @@ static amdcuid_status_t discover_via_pci_bus(std::vector<DevicePtr>& npus) {
   if (!dir) return AMDCUID_STATUS_UNSUPPORTED;
 
   struct dirent* entry;
+  // This call site owns its DIR*, which is all POSIX requires for readdir to be
+  // safe; readdir_r is deprecated and must not be adopted.
+  // NOLINTNEXTLINE(concurrency-mt-unsafe)
   while ((entry = readdir(dir)) != NULL) {
     if (entry->d_name[0] == '.') continue;
 
@@ -126,7 +132,7 @@ amdcuid_status_t CuidNpu::discover_single(amdcuid_npu_info* npu_info,
     uint8_t vendor_id_bytes[2] = {0};
     const uint16_t offset = 0x0;
     amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, vendor_id_bytes, 2, offset);
-    uint16_t vendor_id_int = PciUtil::le16_to_be16(*reinterpret_cast<uint16_t*>(vendor_id_bytes));
+    uint16_t vendor_id_int = PciUtil::load_le16(vendor_id_bytes);
     info.header.fields.npu.vendor_id = (status == AMDCUID_STATUS_SUCCESS) ? vendor_id_int : 0;
   } else {
     info.header.fields.npu.vendor_id = static_cast<uint16_t>(strtol(vendor.c_str(), nullptr, 16));
@@ -137,7 +143,7 @@ amdcuid_status_t CuidNpu::discover_single(amdcuid_npu_info* npu_info,
     uint8_t device_id_bytes[2] = {0};
     const uint16_t offset = 0x2;
     amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, device_id_bytes, 2, offset);
-    uint16_t device_id_int = PciUtil::le16_to_be16(*reinterpret_cast<uint16_t*>(device_id_bytes));
+    uint16_t device_id_int = PciUtil::load_le16(device_id_bytes);
     info.header.fields.npu.device_id = (status == AMDCUID_STATUS_SUCCESS) ? device_id_int : 0;
   } else {
     info.header.fields.npu.device_id = static_cast<uint16_t>(strtol(device.c_str(), nullptr, 16));
@@ -149,7 +155,7 @@ amdcuid_status_t CuidNpu::discover_single(amdcuid_npu_info* npu_info,
     uint8_t class_id_bytes[2] = {0};
     const uint16_t offset = 0xa;
     amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, class_id_bytes, 2, offset);
-    uint16_t class_id_int = PciUtil::le16_to_be16(*reinterpret_cast<uint16_t*>(class_id_bytes));
+    uint16_t class_id_int = PciUtil::load_le16(class_id_bytes);
     pci_class_integer = (status == AMDCUID_STATUS_SUCCESS) ? class_id_int : 0;
   } else {
     // sysfs class file returns 24-bit value (class:subclass:prog_if),
@@ -160,13 +166,13 @@ amdcuid_status_t CuidNpu::discover_single(amdcuid_npu_info* npu_info,
 
   std::string revision_id = CuidUtilities::read_sysfs_file(device_path + "/revision");
   if (revision_id.empty() && !bdf.empty()) {
-    uint8_t revision_id_bytes[2] = {0};
+    // RevisionID is the single byte at 0x08. The byte at 0x09 is prog-if and
+    // must not be folded in: revision_id is a uint8_t, so a two-byte load left
+    // prog-if in the low half and the revision was discarded by the narrowing.
+    uint8_t revision_id_byte = 0;
     const uint16_t offset = 0x8;
-    amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, revision_id_bytes, 2, offset);
-    uint16_t revision_id_int =
-        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t*>(revision_id_bytes));
-    info.header.fields.npu.revision_id =
-        (status == AMDCUID_STATUS_SUCCESS) ? static_cast<uint8_t>(revision_id_int) : 0;
+    amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, &revision_id_byte, 1, offset);
+    info.header.fields.npu.revision_id = (status == AMDCUID_STATUS_SUCCESS) ? revision_id_byte : 0;
   } else {
     info.header.fields.npu.revision_id =
         static_cast<uint8_t>(strtol(revision_id.c_str(), nullptr, 16));
@@ -231,7 +237,7 @@ amdcuid_status_t CuidNpu::get_hardware_fingerprint(uint64_t& fingerprint) const 
       uint64_t fingerprint_value = 0;
       std::memcpy(&fingerprint_value, fingerprint_bytes, fingerprint_size);
       fingerprint = PciUtil::le64_to_be64(fingerprint_value);
-      return AMDCUID_STATUS_SUCCESS;
+      return CuidUtilities::validate_fingerprint(fingerprint);
     } else {
       fingerprint = 0;
       return status;

--- a/projects/cuid/lib/src/cuid_npu.cc
+++ b/projects/cuid/lib/src/cuid_npu.cc
@@ -16,21 +16,27 @@
 #include "cuid_util.h"
 #include "pci_util.h"
 
+namespace {
+
 // AMD vendor ID used to filter for AMD NPU devices
-static const uint16_t AMD_VENDOR_ID = 0x1022;
+const uint16_t AMD_VENDOR_ID = 0x1022;
 
 // PCI base classes that AMD NPUs may present as:
 //   0x11 = Signal processing controller (e.g., Strix/Strix Halo NPU 0x1180)
 //   0x12 = Processing accelerators
-static const uint16_t PCI_CLASS_SIGNAL_PROCESSING = 0x1100;
-static const uint16_t PCI_CLASS_PROCESSING_ACCEL = 0x1200;
-static const uint16_t PCI_CLASS_BASE_MASK = 0xFF00;
+const uint16_t PCI_CLASS_SIGNAL_PROCESSING = 0x1100;
+const uint16_t PCI_CLASS_PROCESSING_ACCEL = 0x1200;
+const uint16_t PCI_CLASS_BASE_MASK = 0xFF00;
+
+}  // namespace
 
 CuidNpu::CuidNpu(const amdcuid_npu_info& i) : m_info(i) {}
 
+namespace {
+
 // Helper to check if a /sys/class/accel entry name is an accel device
 // (e.g., "accel0", "accel1").
-static bool is_accel_entry(const char* name) {
+bool is_accel_entry(const char* name) {
   if (strncmp(name, "accel", 5) != 0 || !isdigit(name[5])) return false;
   for (size_t i = 5; name[i] != '\0'; ++i) {
     if (!isdigit(name[i])) return false;
@@ -39,7 +45,7 @@ static bool is_accel_entry(const char* name) {
 }
 
 // Discover NPU devices via /sys/class/accel (when amdxdna driver is loaded)
-static amdcuid_status_t discover_via_accel(std::vector<DevicePtr>& npus) {
+amdcuid_status_t discover_via_accel(std::vector<DevicePtr>& npus) {
   const char* accel_path = "/sys/class/accel";
   DIR* dir = opendir(accel_path);
   if (!dir) return AMDCUID_STATUS_UNSUPPORTED;
@@ -74,7 +80,7 @@ static amdcuid_status_t discover_via_accel(std::vector<DevicePtr>& npus) {
 // Fallback: discover NPU devices by scanning PCI bus for AMD processing
 // accelerator class devices. This handles systems where /sys/class/accel
 // is not populated (e.g., driver not loaded or accel subsystem absent).
-static amdcuid_status_t discover_via_pci_bus(std::vector<DevicePtr>& npus) {
+amdcuid_status_t discover_via_pci_bus(std::vector<DevicePtr>& npus) {
   const char* pci_path = "/sys/bus/pci/devices";
   DIR* dir = opendir(pci_path);
   if (!dir) return AMDCUID_STATUS_UNSUPPORTED;
@@ -112,6 +118,8 @@ static amdcuid_status_t discover_via_pci_bus(std::vector<DevicePtr>& npus) {
 
   return npus.empty() ? AMDCUID_STATUS_UNSUPPORTED : AMDCUID_STATUS_SUCCESS;
 }
+
+}  // namespace
 
 amdcuid_status_t CuidNpu::discover(std::vector<DevicePtr>& npus) {
   // Try /sys/class/accel first (when amdxdna driver is loaded)

--- a/projects/cuid/lib/src/cuid_platform.cc
+++ b/projects/cuid/lib/src/cuid_platform.cc
@@ -96,7 +96,7 @@ amdcuid_status_t CuidPlatform::get_primary_cuid(amdcuid_primary_id& id) const {
     std::string name = "";
     // family here not used
     std::string family_dummy = "";
-    status = SmbiosUtil::get_product_info(name, family_dummy);
+    SmbiosUtil::get_product_info(name, family_dummy);
     CuidUtilities::make_fallback_fingerprint(name, fingerprint);
     temp = true;
   }

--- a/projects/cuid/lib/src/cuid_util.cc
+++ b/projects/cuid/lib/src/cuid_util.cc
@@ -43,6 +43,26 @@ void Logger::log(LogLevel level, const std::string& msg) const {
 }
 
 // Helper to read a sysfs file into a string
+std::string CuidUtilities::errno_string(int err) {
+  char buf[256];
+#if defined(_WIN32)
+  if (strerror_s(buf, sizeof(buf), err) != 0) {
+    return "unknown error " + std::to_string(err);
+  }
+  return std::string(buf);
+#elif defined(_GNU_SOURCE)
+  // GNU strerror_r returns a pointer that may or may not point at buf.
+  const char* msg = strerror_r(err, buf, sizeof(buf));
+  return msg ? std::string(msg) : ("unknown error " + std::to_string(err));
+#else
+  // XSI strerror_r fills buf and returns 0 on success.
+  if (strerror_r(err, buf, sizeof(buf)) != 0) {
+    return "unknown error " + std::to_string(err);
+  }
+  return std::string(buf);
+#endif
+}
+
 std::string CuidUtilities::read_sysfs_file(const std::string& path) {
   std::ifstream file(path);
   if (!file.is_open()) return "";
@@ -92,6 +112,9 @@ std::string CuidUtilities::bdf_to_device_path(const std::string& bdf,
     if (dir) {
       struct dirent* entry;
       std::string card_path;
+      // this call site owns its DIR*, which is all POSIX requires; readdir_r is deprecated and
+      // must not be adopted.
+      // NOLINTNEXTLINE(concurrency-mt-unsafe)
       while ((entry = readdir(dir)) != nullptr) {
         // Prefer renderD* nodes when available
         if (strncmp(entry->d_name, "renderD", 7) == 0) {
@@ -126,6 +149,9 @@ std::string CuidUtilities::bdf_to_device_path(const std::string& bdf,
     DIR* dir = opendir(subsystem_dir.c_str());
     if (dir) {
       struct dirent* entry;
+      // this call site owns its DIR*, which is all POSIX requires; readdir_r is deprecated and
+      // must not be adopted.
+      // NOLINTNEXTLINE(concurrency-mt-unsafe)
       while ((entry = readdir(dir)) != nullptr) {
         // Skip . and ..
         if (entry->d_name[0] == '.') continue;
@@ -140,6 +166,9 @@ std::string CuidUtilities::bdf_to_device_path(const std::string& bdf,
     DIR* dir = opendir(subsystem_dir.c_str());
     if (dir) {
       struct dirent* entry;
+      // this call site owns its DIR*, which is all POSIX requires; readdir_r is deprecated and
+      // must not be adopted.
+      // NOLINTNEXTLINE(concurrency-mt-unsafe)
       while ((entry = readdir(dir)) != nullptr) {
         // Skip . and ..
         if (entry->d_name[0] == '.') continue;
@@ -531,7 +560,8 @@ std::string CuidUtilities::get_cuid_as_string(const amdcuid_id_t* id) {
   // Format as UUIDv8 string: 8-4-4-4-12 hex digits from id->bytes[16]
   // UUID: xxxxxxxx-xxxx-8xxx-yxxx-xxxxxxxxxxxx
   char uuid_str[37];  // 36 chars + null
-  // Format the bytes into a UUID string
+  // 32 hex digits plus 4 hyphens is exactly 36 characters plus the NUL.
+  // NOLINTNEXTLINE(cert-err33-c)
   snprintf(uuid_str, sizeof(uuid_str),
            "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x", id->bytes[0],
            id->bytes[1], id->bytes[2], id->bytes[3], id->bytes[4], id->bytes[5], id->bytes[6],

--- a/projects/cuid/lib/src/cuid_util.h
+++ b/projects/cuid/lib/src/cuid_util.h
@@ -35,14 +35,38 @@ class Logger {
   LogLevel level_;
 };
 
-#define LOG(level, msg)                                \
-  do {                                                 \
-    std::ostringstream _log_stream_;                   \
-    _log_stream_ << msg;                               \
-    Logger::instance().log(level, _log_stream_.str()); \
+// NOLINTBEGIN(bugprone-macro-parentheses)
+// `msg` is deliberately left unparenthesised. Callers pass a stream-
+// continuation fragment such as `"failed: " << path`, which is only valid
+// glued onto the left of `_log_stream_ <<`. Wrapping it would evaluate
+// `const char[] << std::string` as an expression of its own, which does not
+// compile. clang-tidy cannot see that, so the check is suppressed here rather
+// than obeyed.
+#define LOG(level, msg)                                  \
+  do {                                                   \
+    std::ostringstream _log_stream_;                     \
+    _log_stream_ << msg;                                 \
+    Logger::instance().log((level), _log_stream_.str()); \
   } while (0)
+// NOLINTEND(bugprone-macro-parentheses)
 
 namespace CuidUtilities {
+// Thread-safe replacement for strerror(). strerror() returns a pointer into a
+// static buffer, so two threads reporting errors at once can read a torn or
+// wrong message. libamdcuid is linked into multithreaded hosts -- amd_smi and
+// libhsa-runtime64.so among them -- so it must not use it.
+std::string errno_string(int err);
+
+// A zero hardware fingerprint is the absence of an identity, not an identity.
+// Unprogrammed DSN capabilities and unconfigured MAC addresses both read back
+// as all-zero, and reporting that as a successful fingerprint gives every such
+// device on every machine the same primary CUID. Callers use this to convert
+// "read succeeded, value is meaningless" into HW_FINGERPRINT_NOT_FOUND, which
+// routes the device onto the temporary-CUID path it should have been on.
+inline amdcuid_status_t validate_fingerprint(uint64_t fingerprint) {
+  return (fingerprint == 0) ? AMDCUID_STATUS_HW_FINGERPRINT_NOT_FOUND : AMDCUID_STATUS_SUCCESS;
+}
+
 std::string read_sysfs_file(const std::string& path);
 std::string readlink_bdf(const std::string& device_path);
 std::string bdf_to_device_path(const std::string& bdf, amdcuid_device_type_t device_type);

--- a/projects/cuid/lib/src/gim_util.cc
+++ b/projects/cuid/lib/src/gim_util.cc
@@ -207,7 +207,8 @@ amdcuid_status_t GimClient::init() {
     int fd = ::open(kGimSmiDevicePath, O_RDWR | O_CLOEXEC);
     if (fd < 0) {
       const int err = errno;
-      LOG(DEBUG, "GIM: open(" << kGimSmiDevicePath << ") failed: " << std::strerror(err));
+      LOG(DEBUG,
+          "GIM: open(" << kGimSmiDevicePath << ") failed: " << CuidUtilities::errno_string(err));
       if (err == EACCES || err == EPERM) {
         return AMDCUID_STATUS_PERMISSION_DENIED;
       }
@@ -254,7 +255,8 @@ amdcuid_status_t GimClient::do_ioctl(uint32_t cmd_code, const void* in, size_t i
 
   if (::ioctl(fd_, kSmiIoctlCmd, &cmd) != 0) {
     const int err = errno;
-    LOG(DEBUG, "GIM: ioctl(cmd=0x" << std::hex << cmd_code << ") failed: " << std::strerror(err));
+    LOG(DEBUG, "GIM: ioctl(cmd=0x" << std::hex << cmd_code
+                                   << ") failed: " << CuidUtilities::errno_string(err));
     if (err == EACCES || err == EPERM) {
       return AMDCUID_STATUS_PERMISSION_DENIED;
     }
@@ -395,7 +397,11 @@ std::string GimClient::format_bdf(uint64_t packed_bdf) {
   const uint32_t device = static_cast<uint32_t>((packed_bdf >> 3) & 0x1Fu);
   const uint32_t bus = static_cast<uint32_t>((packed_bdf >> 8) & 0xFFu);
   const uint32_t domain = static_cast<uint32_t>((packed_bdf >> 16) & 0xFFFFu);
+  // Bounded by construction: domain is masked to 16 bits (4 hex digits), bus to
+  // 8 (2), device to 5 (2) and function to 3 (1 decimal digit), so the longest
+  // output is 4+1+2+1+2+1+1 = 12 characters plus the NUL. It cannot truncate.
   char buf[16];
+  // NOLINTNEXTLINE(cert-err33-c)
   std::snprintf(buf, sizeof(buf), "%04x:%02x:%02x.%u", domain, bus, device, function);
   return std::string(buf);
 }

--- a/projects/cuid/lib/src/hmac.cc
+++ b/projects/cuid/lib/src/hmac.cc
@@ -194,6 +194,8 @@ amdcuid_status_t cuid_hmac::generate_hmac_sha256(const uint8_t* data, size_t dat
     std::cerr << "HMAC context is not initialized" << std::endl;
     return AMDCUID_STATUS_HMAC_ERROR;
   }
+
+  std::lock_guard<std::mutex> lock(key_mutex_);
   if (!key) {
     std::cerr << "No HMAC key is set" << std::endl;
     return AMDCUID_STATUS_KEY_ERROR;
@@ -224,6 +226,7 @@ amdcuid_status_t cuid_hmac::set_hmac_algorithm(const char* digest_name) {
 amdcuid_status_t cuid_hmac::set_hmac_key(const uint8_t key_data[key_length]) {
   if (!key_data) return AMDCUID_STATUS_INVALID_ARGUMENT;
 
+  std::lock_guard<std::mutex> lock(key_mutex_);
   if (key) {
     rocm::sha2::secure_zero(key, key_len);
     delete[] key;
@@ -247,9 +250,8 @@ amdcuid_status_t cuid_hmac::store_key(const uint8_t key_data[key_length]) {
     return AMDCUID_STATUS_KEY_ERROR;
   }
 
-  const std::string tmp_path = key_file_path + ".new";
-
 #if defined(_WIN32)
+  const std::string tmp_path = key_file_path + ".new";
   {
     std::ofstream tmp(tmp_path, std::ios::out | std::ios::binary | std::ios::trunc);
     if (!tmp) return AMDCUID_STATUS_KEY_ERROR;
@@ -268,16 +270,18 @@ amdcuid_status_t cuid_hmac::store_key(const uint8_t key_data[key_length]) {
   }
   return AMDCUID_STATUS_SUCCESS;
 #else
-  // O_EXCL so we never write into a pre-created file; 0600 from creation.
-  int fd = open(tmp_path.c_str(), O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC, S_IRUSR | S_IWUSR);
-  if (fd < 0 && errno == EEXIST) {
-    // Stale temporary from an interrupted run; it is ours to reclaim.
-    if (unlink(tmp_path.c_str()) != 0) return AMDCUID_STATUS_KEY_ERROR;
-    fd = open(tmp_path.c_str(), O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC, S_IRUSR | S_IWUSR);
-  }
+  // Unique per-call name (mkstemp) so concurrent callers can never collide on
+  // a shared ".new" path; fchmod enforces 0600 regardless of libc/umask.
+  std::string tmp_path = key_file_path + ".XXXXXX";
+  int fd = mkstemp(&tmp_path[0]);
   if (fd < 0) {
     return (errno == EACCES || errno == EPERM) ? AMDCUID_STATUS_PERMISSION_DENIED
                                                : AMDCUID_STATUS_KEY_ERROR;
+  }
+  if (fchmod(fd, S_IRUSR | S_IWUSR) != 0 || fcntl(fd, F_SETFD, FD_CLOEXEC) != 0) {
+    close(fd);
+    unlink(tmp_path.c_str());
+    return AMDCUID_STATUS_KEY_ERROR;
   }
 
   auto fail = [&]() {

--- a/projects/cuid/lib/src/hmac.cc
+++ b/projects/cuid/lib/src/hmac.cc
@@ -1,18 +1,12 @@
 // Copyright Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
-// HMAC-SHA-256 over the in-tree SHA-256 in sha256.{h,cc}.
-//
-// There is one code path on every platform. The previous three compile-time
-// backends (Windows CNG, OpenSSL 3 EVP_MAC, OpenSSL 1.x HMAC_CTX) existed only
-// to reach a primitive that fits in ~200 lines of standard C++, at the cost of
-// making libamdcuid -- and therefore everything that links it statically,
-// including libhsa-runtime64.so and libamd_smi.so -- depend on libcrypto.
-//
-// The only platform-specific code left is the CSPRNG used to mint a new key.
+// HMAC-SHA-256 over the in-tree SHA-256 (sha256.h). One code path on every
+// platform; only the CSPRNG below is platform-specific.
 
 #include "hmac.h"
 
+#include <fcntl.h>
 #include <sys/stat.h>
 
 #include <cerrno>
@@ -29,6 +23,7 @@
 #include <windows.h>
 // bcrypt.h must follow windows.h.
 #include <bcrypt.h>
+#include <direct.h>
 #else
 #include <unistd.h>
 // getrandom(2) needs glibc >= 2.25 (or musl); where it is missing, and where
@@ -51,13 +46,41 @@
 
 namespace {
 
-// The only digest the CUID specification uses. set_hmac_algorithm() accepts it
-// (and its hyphenated spelling) and rejects everything else: generate_hmac_sha256()
-// writes into a caller-supplied 32-byte buffer, so a wider digest would overrun it.
+// Used when no secret is provisioned. Byte-identical to CUID_DEFAULT_SEED in
+// the kernel's amdgpu_cuid.c, so sysfs and this library agree on an
+// unprovisioned machine. Not a substitute for provisioning; callers can check
+// is_using_default_key().
+constexpr char kDefaultSeed[] = "AMD-CUID-DEFAULT-SEED-v1";
+constexpr size_t kDefaultSeedLen = sizeof(kDefaultSeed) - 1;
+
+// The only digest CUID uses. A wider one would overrun the caller's 32-byte
+// output buffer, so set_hmac_algorithm() rejects everything else.
 bool is_sha256_name(const char* name) {
   if (!name) return true;  // nullptr means "the default", which is SHA-256
   return std::strcmp(name, "SHA256") == 0 || std::strcmp(name, "SHA-256") == 0 ||
          std::strcmp(name, "sha256") == 0 || std::strcmp(name, "sha-256") == 0;
+}
+
+// Directory portion of a path, or "." when there is none.
+std::string parent_dir(const std::string& path) {
+  const size_t slash = path.find_last_of('/');
+  if (slash == std::string::npos) return ".";
+  if (slash == 0) return "/";
+  return path.substr(0, slash);
+}
+
+// Create the key directory (0755, as the packaging script does) so the API
+// works on a machine where the post-install script never ran.
+bool ensure_parent_dir(const std::string& path) {
+  const std::string dir = parent_dir(path);
+  struct stat st;
+  if (stat(dir.c_str(), &st) == 0) return S_ISDIR(st.st_mode);
+#if defined(_WIN32)
+  return _mkdir(dir.c_str()) == 0 || errno == EEXIST;
+#else
+  return mkdir(dir.c_str(), S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH) == 0 ||
+         errno == EEXIST;
+#endif
 }
 
 // Fill buf with cryptographically secure random bytes.
@@ -91,7 +114,10 @@ struct cuid_hmac::Impl {
   std::string digest_name;
 };
 
-cuid_hmac::cuid_hmac() : impl_(nullptr), key(nullptr), key_len(key_length), valid(false) {
+cuid_hmac::cuid_hmac()
+    : impl_(nullptr), key(nullptr), key_len(key_length), valid(false), using_default_key(false) {
+  // getenv races only against setenv, which this library never calls.
+  // NOLINTNEXTLINE(concurrency-mt-unsafe)
   const char* env_path = std::getenv("AMDCUID_HMAC_KEY_PATH");
   key_file_path = (env_path && env_path[0]) ? env_path : AMDCUID_CONFIG_DIR "/hmac_key.bin";
   impl_ = new Impl();
@@ -99,15 +125,20 @@ cuid_hmac::cuid_hmac() : impl_(nullptr), key(nullptr), key_len(key_length), vali
 
   std::ifstream key_file_stream(key_file_path, std::ios::binary);
   if (!key_file_stream.is_open()) {
+    // No key provisioned: use the public default seed, as the kernel does,
+    // rather than failing every privileged lookup on an unprovisioned machine.
+    use_default_key();
     return;
   }
 
   key_file_stream.seekg(0, std::ios::end);
-  key_len = static_cast<size_t>(key_file_stream.tellg());
-  if (key_len != key_length) {  // sanity check on key length
-    std::cerr << "Invalid key length in key file" << std::endl;
+  const size_t file_len = static_cast<size_t>(key_file_stream.tellg());
+  if (file_len != key_length) {
+    // Wrong size is corruption, not absence: refuse rather than silently
+    // changing every CUID on the machine.
+    std::cerr << "Invalid key length in " << key_file_path << " (" << file_len
+              << " bytes, expected " << key_length << ")" << std::endl;
     key_file_stream.close();
-    key_len = key_length;
     return;
   }
   key_file_stream.seekg(0, std::ios::beg);
@@ -115,10 +146,12 @@ cuid_hmac::cuid_hmac() : impl_(nullptr), key(nullptr), key_len(key_length), vali
   key = new uint8_t[key_length];
   key_file_stream.read(reinterpret_cast<char*>(key), key_length);
   if (key_file_stream.gcount() != static_cast<std::streamsize>(key_length)) {
-    std::cerr << "Error reading key file" << std::endl;
+    // The size check above passed, so a short read means the file changed
+    // underneath us or the read failed outright. Either way it is not a key.
+    std::cerr << "Failed to read " << key_file_path << " (" << key_file_stream.gcount()
+              << " bytes, expected " << key_length << ")" << std::endl;
     delete[] key;
     key = nullptr;
-    key_len = key_length;
     key_file_stream.close();
     return;
   }
@@ -127,8 +160,17 @@ cuid_hmac::cuid_hmac() : impl_(nullptr), key(nullptr), key_len(key_length), vali
   valid = true;
 }
 
+void cuid_hmac::use_default_key() {
+  delete[] key;
+  key = new uint8_t[kDefaultSeedLen];
+  std::memcpy(key, kDefaultSeed, kDefaultSeedLen);
+  key_len = kDefaultSeedLen;
+  using_default_key = true;
+  valid = true;
+}
+
 cuid_hmac::cuid_hmac(uint8_t key_data[key_length])
-    : impl_(nullptr), key(nullptr), key_len(key_length), valid(false) {
+    : impl_(nullptr), key(nullptr), key_len(key_length), valid(false), using_default_key(false) {
   impl_ = new Impl();
   impl_->digest_name = "SHA256";
 
@@ -180,9 +222,7 @@ amdcuid_status_t cuid_hmac::set_hmac_algorithm(const char* digest_name) {
 }
 
 amdcuid_status_t cuid_hmac::set_hmac_key(const uint8_t key_data[key_length]) {
-#if !defined(_WIN32)
-  if (geteuid() != 0) return AMDCUID_STATUS_PERMISSION_DENIED;
-#endif
+  if (!key_data) return AMDCUID_STATUS_INVALID_ARGUMENT;
 
   if (key) {
     rocm::sha2::secure_zero(key, key_len);
@@ -192,30 +232,93 @@ amdcuid_status_t cuid_hmac::set_hmac_key(const uint8_t key_data[key_length]) {
   key_len = key_length;
   std::memcpy(key, key_data, key_length);
   valid = true;
-
-  if (std::remove(key_file_path.c_str()) != 0 && errno != ENOENT) return AMDCUID_STATUS_KEY_ERROR;
-
-  // TODO: This is backwards, we're never actually reading the stored key file,
-  // but we're always overwriting it. Need to rethink this Maybe have public
-  // facing API write the stored key file and then call this function to set the
-  // in-memory key, and have this function only update the in-memory key without
-  // touching the file system? That way we can ensure the file is only written
-  // to when we actually want to change the key, and not every time we start the
-  // daemon?
-  std::ofstream key_file(key_file_path, std::ios::out | std::ios::binary);
-  if (!key_file) return AMDCUID_STATUS_KEY_ERROR;
-  key_file.write(reinterpret_cast<const char*>(key), key_length);
-  if (!key_file) {
-    key_file.close();
-    return AMDCUID_STATUS_KEY_ERROR;
-  }
-  key_file.close();
-
-#if !defined(_WIN32)
-  if (chmod(key_file_path.c_str(), S_IRUSR | S_IWUSR) != 0) return AMDCUID_STATUS_PERMISSION_DENIED;
-#endif
+  using_default_key = false;
 
   return AMDCUID_STATUS_SUCCESS;
+}
+
+amdcuid_status_t cuid_hmac::store_key(const uint8_t key_data[key_length]) {
+  if (!key_data) return AMDCUID_STATUS_INVALID_ARGUMENT;
+
+  // Write a sibling temp file and rename over the target: atomic, so a reader
+  // never sees a truncated key and a failed write cannot destroy the old one.
+  if (!ensure_parent_dir(key_file_path)) {
+    std::cerr << "Cannot create directory for " << key_file_path << std::endl;
+    return AMDCUID_STATUS_KEY_ERROR;
+  }
+
+  const std::string tmp_path = key_file_path + ".new";
+
+#if defined(_WIN32)
+  {
+    std::ofstream tmp(tmp_path, std::ios::out | std::ios::binary | std::ios::trunc);
+    if (!tmp) return AMDCUID_STATUS_KEY_ERROR;
+    tmp.write(reinterpret_cast<const char*>(key_data), key_length);
+    tmp.flush();
+    if (!tmp) {
+      tmp.close();
+      std::remove(tmp_path.c_str());
+      return AMDCUID_STATUS_KEY_ERROR;
+    }
+  }
+  // rename() refuses to clobber an existing file on Windows.
+  if (!MoveFileExA(tmp_path.c_str(), key_file_path.c_str(), MOVEFILE_REPLACE_EXISTING)) {
+    std::remove(tmp_path.c_str());
+    return AMDCUID_STATUS_KEY_ERROR;
+  }
+  return AMDCUID_STATUS_SUCCESS;
+#else
+  // O_EXCL so we never write into a pre-created file; 0600 from creation.
+  int fd = open(tmp_path.c_str(), O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC, S_IRUSR | S_IWUSR);
+  if (fd < 0 && errno == EEXIST) {
+    // Stale temporary from an interrupted run; it is ours to reclaim.
+    if (unlink(tmp_path.c_str()) != 0) return AMDCUID_STATUS_KEY_ERROR;
+    fd = open(tmp_path.c_str(), O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC, S_IRUSR | S_IWUSR);
+  }
+  if (fd < 0) {
+    return (errno == EACCES || errno == EPERM) ? AMDCUID_STATUS_PERMISSION_DENIED
+                                               : AMDCUID_STATUS_KEY_ERROR;
+  }
+
+  auto fail = [&]() {
+    close(fd);
+    unlink(tmp_path.c_str());
+    return AMDCUID_STATUS_KEY_ERROR;
+  };
+
+  size_t written = 0;
+  while (written < key_length) {
+    ssize_t n = write(fd, key_data + written, key_length - written);
+    if (n < 0) {
+      if (errno == EINTR) continue;
+      return fail();
+    }
+    written += static_cast<size_t>(n);
+  }
+
+  // Durable before the rename, or a crash can leave the file present but empty.
+  if (fsync(fd) != 0) return fail();
+  if (close(fd) != 0) {
+    unlink(tmp_path.c_str());
+    return AMDCUID_STATUS_KEY_ERROR;
+  }
+
+  if (rename(tmp_path.c_str(), key_file_path.c_str()) != 0) {
+    unlink(tmp_path.c_str());
+    return AMDCUID_STATUS_KEY_ERROR;
+  }
+
+  // Persist the directory entry so the rename survives power loss.
+  const size_t slash = key_file_path.find_last_of('/');
+  const std::string dir = (slash == std::string::npos) ? "." : key_file_path.substr(0, slash);
+  int dir_fd = open(dir.empty() ? "/" : dir.c_str(), O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+  if (dir_fd >= 0) {
+    (void)fsync(dir_fd);
+    close(dir_fd);
+  }
+
+  return AMDCUID_STATUS_SUCCESS;
+#endif
 }
 
 amdcuid_status_t cuid_hmac::generate_key(uint8_t out_key[key_length]) {

--- a/projects/cuid/lib/src/hmac.h
+++ b/projects/cuid/lib/src/hmac.h
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <mutex>
 #include <string>
 
 #include "include/amd_cuid.h"
@@ -26,16 +27,25 @@ class cuid_hmac {
   bool valid;
   bool using_default_key;
   std::string key_file_path;
+  // Guards key, key_len, valid and using_default_key against concurrent
+  // readers (generate_hmac_sha256) and writers (set_hmac_key).
+  mutable std::mutex key_mutex_;
 
  public:
   cuid_hmac();
   cuid_hmac(uint8_t key_data[key_length]);
   ~cuid_hmac();
-  bool is_valid() const { return valid; }
+  bool is_valid() const {
+    std::lock_guard<std::mutex> lock(key_mutex_);
+    return valid;
+  }
 
   // True when no key file was found and the public default seed is in use, so
   // a caller can distinguish a provisioned identity from an unprovisioned one.
-  bool is_using_default_key() const { return using_default_key; }
+  bool is_using_default_key() const {
+    std::lock_guard<std::mutex> lock(key_mutex_);
+    return using_default_key;
+  }
 
   amdcuid_status_t generate_hmac_sha256(const uint8_t* data, size_t data_len, uint8_t* out_hash,
                                         size_t* out_len);

--- a/projects/cuid/lib/src/hmac.h
+++ b/projects/cuid/lib/src/hmac.h
@@ -19,10 +19,12 @@
 class cuid_hmac {
  private:
   struct Impl;  // defined in hmac.cc
+  void use_default_key();
   Impl* impl_;
   uint8_t* key;
   size_t key_len;
   bool valid;
+  bool using_default_key;
   std::string key_file_path;
 
  public:
@@ -31,10 +33,25 @@ class cuid_hmac {
   ~cuid_hmac();
   bool is_valid() const { return valid; }
 
+  // True when no key file was found and the public default seed is in use, so
+  // a caller can distinguish a provisioned identity from an unprovisioned one.
+  bool is_using_default_key() const { return using_default_key; }
+
   amdcuid_status_t generate_hmac_sha256(const uint8_t* data, size_t data_len, uint8_t* out_hash,
                                         size_t* out_len);
   amdcuid_status_t set_hmac_algorithm(const char* digest_name);
+
+  // Replace the in-memory key. Purely an in-memory operation: it does not read
+  // or write the key file. Pair it with store_key() to change the key on disk.
   amdcuid_status_t set_hmac_key(const uint8_t key_data[key_length]);
+
+  // Persist a key to key_file_path, replacing any existing one. The file is
+  // created 0600 and swapped into place atomically, so a concurrent reader
+  // sees either the whole old key or the whole new one, never a partial write
+  // and never a moment where the key is readable by other users. Requires
+  // privileges to write the config directory.
+  amdcuid_status_t store_key(const uint8_t key_data[key_length]);
+
   amdcuid_status_t generate_key(uint8_t key[key_length]);
   std::string get_key_file_path() const { return key_file_path; }
 };

--- a/projects/cuid/lib/src/ipc_protocol.h
+++ b/projects/cuid/lib/src/ipc_protocol.h
@@ -5,19 +5,50 @@
 #define IPC_PROTOCOL_H
 
 #include <cstdint>
+#include <cstring>
+#include <string>
 
 #include "include/amd_cuid.h"
 #include "src/cuid_device.h"
 
 #define AMDCUID_SOCKET_PATH "/var/run/amdcuid_daemon.sock"
 
+/// Maximum device path length carried in an IpcRequest, including the
+/// terminating NUL. The path must travel inside the fixed-size message body:
+/// the two peers are separate processes, so a pointer field would be
+/// meaningless (and dangerous) on the receiving side.
+constexpr size_t AMDCUID_IPC_PATH_MAX = 4096;
+
 enum class IpcMessageType : uint8_t { ADD_DEVICE = 1, REFRESH_DEVICES = 2 };
 
 struct IpcRequest {
   IpcMessageType type;
-  char* device_path;                  // used for ADD_DEVICE, empty otherwise
   amdcuid_device_type_t device_type;  // used for ADD_DEVICE, AMDCUID_DEVICE_TYPE_NONE otherwise
+  char device_path[AMDCUID_IPC_PATH_MAX];  // used for ADD_DEVICE, empty otherwise
 };
+
+/// Copy @p src into the fixed-size device_path field, always NUL-terminating.
+/// Returns false when @p src does not fit, so callers reject the request
+/// instead of silently operating on a truncated path.
+inline bool ipc_set_device_path(IpcRequest& request, const char* src) {
+  if (src == nullptr) {
+    return false;
+  }
+  const size_t len = ::strnlen(src, AMDCUID_IPC_PATH_MAX);
+  if (len >= AMDCUID_IPC_PATH_MAX) {
+    return false;  // no room for the terminating NUL
+  }
+  std::memcpy(request.device_path, src, len);
+  request.device_path[len] = '\0';
+  return true;
+}
+
+/// Read the device_path field of a request received off the wire. A malicious
+/// or buggy peer may send an unterminated buffer, so the length is bounded by
+/// the field size rather than trusting a NUL to be present.
+inline std::string ipc_get_device_path(const IpcRequest& request) {
+  return std::string(request.device_path, ::strnlen(request.device_path, AMDCUID_IPC_PATH_MAX));
+}
 
 struct IpcResponse {
   amdcuid_status_t status;

--- a/projects/cuid/lib/src/pci_util.cc
+++ b/projects/cuid/lib/src/pci_util.cc
@@ -18,10 +18,6 @@
 #include "include/amd_cuid.h"
 
 // Endianness conversion functions
-uint16_t PciUtil::le16_to_be16(uint16_t value) {
-  return ((value & 0x00FF) << 8) | ((value & 0xFF00) >> 8);
-}
-
 uint64_t PciUtil::le64_to_be64(uint64_t value) {
   return ((value & 0x00000000000000FFULL) << 56) | ((value & 0x000000000000FF00ULL) << 40) |
          ((value & 0x0000000000FF0000ULL) << 24) | ((value & 0x00000000FF000000ULL) << 8) |
@@ -59,18 +55,21 @@ amdcuid_status_t PciUtil::read_pci_config_space(std::string bdf, uint8_t* buffer
     return AMDCUID_STATUS_PCI_ERROR;
   }
 
-  if (static_cast<std::ifstream::pos_type>(offset + buffer_size) > length) {
+  // Written so it cannot wrap: offset + buffer_size would overflow size_t for
+  // a large buffer_size and let an out-of-range read through.
+  const size_t file_size = static_cast<size_t>(length);
+  if (buffer_size > file_size || offset > file_size - buffer_size) {
     config_file.close();
     return AMDCUID_STATUS_PCI_ERROR;
   }
 
-  config_file.seekg(offset, std::ios::beg);
+  config_file.seekg(static_cast<std::streamoff>(offset), std::ios::beg);
   if (!config_file) {
     config_file.close();
     return AMDCUID_STATUS_PCI_ERROR;
   }
 
-  config_file.read(reinterpret_cast<char*>(buffer), buffer_size);
+  config_file.read(reinterpret_cast<char*>(buffer), static_cast<std::streamsize>(buffer_size));
   if (config_file.fail() || static_cast<size_t>(config_file.gcount()) != buffer_size) {
     config_file.close();
     return AMDCUID_STATUS_PCI_ERROR;
@@ -86,8 +85,8 @@ amdcuid_status_t PciUtil::get_pci_dsn_cap_offset(std::string bdf, uint16_t& offs
   if (bdf.empty()) return AMDCUID_STATUS_INVALID_ARGUMENT;
 
   // Get the whole PCI config space header
-  uint8_t config_space[4096] = {0};
-  amdcuid_status_t status = read_pci_config_space(bdf, config_space, 4096, 0);
+  uint8_t config_space[kPciConfigSpaceSize] = {0};
+  amdcuid_status_t status = read_pci_config_space(bdf, config_space, sizeof(config_space), 0);
   if (status != AMDCUID_STATUS_SUCCESS) {
     return status;
   }
@@ -98,7 +97,9 @@ amdcuid_status_t PciUtil::get_pci_dsn_cap_offset(std::string bdf, uint16_t& offs
   // Traverse the extended capability list starting at offset 0x100.
   uint16_t cap_ptr = 0x100;
   for (size_t hops = 0; hops < 1024; ++hops) {
-    if (cap_ptr < 0x100 || cap_ptr + 3 >= sizeof(config_space)) {
+    // Widen to size_t before comparing against sizeof(): cap_ptr promotes to
+    // int, which would otherwise be an implicit signed/unsigned comparison.
+    if (cap_ptr < 0x100 || static_cast<size_t>(cap_ptr) + 3 >= sizeof(config_space)) {
       return AMDCUID_STATUS_UNSUPPORTED;
     }
 
@@ -138,8 +139,8 @@ amdcuid_status_t PciUtil::get_pci_vsec_cap_offset(std::string bdf, uint16_t& off
   if (bdf.empty()) return AMDCUID_STATUS_INVALID_ARGUMENT;
 
   // Get the whole PCI config space header
-  uint8_t config_space[4096] = {0};
-  amdcuid_status_t status = read_pci_config_space(bdf, config_space, 4096, 0);
+  uint8_t config_space[kPciConfigSpaceSize] = {0};
+  amdcuid_status_t status = read_pci_config_space(bdf, config_space, sizeof(config_space), 0);
   if (status != AMDCUID_STATUS_SUCCESS) {
     return status;
   }
@@ -151,7 +152,9 @@ amdcuid_status_t PciUtil::get_pci_vsec_cap_offset(std::string bdf, uint16_t& off
   // Traverse the extended capability list starting at offset 0x100.
   uint16_t cap_ptr = 0x100;
   for (size_t hops = 0; hops < 1024; ++hops) {
-    if (cap_ptr < 0x100 || cap_ptr + 7 >= sizeof(config_space)) {
+    // Widen to size_t before comparing against sizeof(): cap_ptr promotes to
+    // int, which would otherwise be an implicit signed/unsigned comparison.
+    if (cap_ptr < 0x100 || static_cast<size_t>(cap_ptr) + 7 >= sizeof(config_space)) {
       return AMDCUID_STATUS_UNSUPPORTED;
     }
 

--- a/projects/cuid/lib/src/pci_util.h
+++ b/projects/cuid/lib/src/pci_util.h
@@ -10,6 +10,9 @@
 
 #include "include/amd_cuid.h"
 
+/// Size of a PCIe extended configuration space, in bytes.
+constexpr size_t kPciConfigSpaceSize = 4096;
+
 class PciUtil {
  public:
   static amdcuid_status_t read_pci_config_space(std::string bdf, uint8_t* buffer,
@@ -17,8 +20,14 @@ class PciUtil {
   static amdcuid_status_t get_pci_dsn_cap_offset(std::string bdf, uint16_t& offset);
   static amdcuid_status_t get_pci_vsec_cap_offset(std::string bdf, uint16_t& offset);
 
+  // Load a 16-bit little-endian config-space field. Use this instead of
+  // casting the buffer to uint16_t*, which violates alignment and aliasing.
+  static uint16_t load_le16(const uint8_t bytes[2]) {
+    return static_cast<uint16_t>(static_cast<uint16_t>(bytes[0]) |
+                                 (static_cast<uint16_t>(bytes[1]) << 8));
+  }
+
   // Endianness conversion utilities
-  static uint16_t le16_to_be16(uint16_t value);
   static uint64_t le64_to_be64(uint64_t value);
 };
 

--- a/projects/cuid/lib/src/sha256.h
+++ b/projects/cuid/lib/src/sha256.h
@@ -20,43 +20,15 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+// SHA-256 (FIPS 180-4) and HMAC-SHA-256 (RFC 2104).
 //
-// SHA-256 (FIPS 180-4) and HMAC-SHA-256 (FIPS 198-1 / RFC 2104).
+// Copy of projects/rocprofiler-sdk/source/lib/common/sha256.{hpp,cpp}, so CUID
+// needs nothing beyond the standard library. Kept API-compatible with it and in
+// a neutral namespace so the two can be merged later by moving these files.
+// tests/check_sha256_drift.py enforces that they stay identical; only update()
+// differs, by rocprofiler's logging call.
 //
-// This is the implementation already carried in this repository at
-// projects/rocprofiler-sdk/source/lib/common/sha256.{hpp,cpp}, copied here so
-// that CUID has no dependency beyond the C++17 standard library. The class API
-// is kept source-compatible with that original -- same members, same method
-// names, same private helpers -- so the two copies can be collapsed into one
-// shared component later without touching either caller. The namespace is
-// deliberately neutral rather than cuid-specific for the same reason: the move
-// should be a file move, not an API change.
-//
-// The complete set of deviations from the rocprofiler-sdk original, for
-// whoever reconciles the two:
-//
-//   1. The rocprofiler-internal includes (defines.hpp / mpl.hpp / logging.hpp)
-//      and the two ROCP_CI_LOG_IF diagnostics in update() are dropped. Those
-//      diagnostics only logged; the `if(m_finalized) return;` guards they sat
-//      next to are retained.
-//   2. reset() additionally clears m_data and m_finalized. In the original,
-//      reset() is private and only ever runs from the constructor, so the
-//      omission is unobservable there; clearing them makes the method correct
-//      if it is ever exposed for object reuse.
-//   3. transform() casts each byte to uint32_t before shifting. The original
-//      relies on integer promotion to int; that is well defined for these
-//      values, so this is legibility, not a fix.
-//   4. transform() scrubs its message schedule before returning.
-//   5. digest(), sha256_digest(), hmac_sha256() and secure_zero() are new.
-//
-// Deviations 1-4 are behaviour-preserving: the two implementations were run
-// side by side over the padding-boundary lengths (0, 55, 56, 63, 64, 65, 127,
-// 128, 129) plus randomised lengths and randomised chunked updates, and agree
-// bit for bit.
-//
-// Not constant-time and not side-channel hardened. It exists for identifier
-// derivation (CUID), not for bulk secret processing.
-//
+// Not constant-time. For identifier derivation, not bulk secret processing.
 
 #ifndef ROCM_SHA2_SHA256_H
 #define ROCM_SHA2_SHA256_H

--- a/projects/cuid/tests/CMakeLists.txt
+++ b/projects/cuid/tests/CMakeLists.txt
@@ -40,12 +40,60 @@ endif()
 
 set(AMDCUID_TST_EXECUTABLE amdcuid_test)
 
-# Collect all test sources from the three source locations.
-aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR} TEST_SOURCES_ROOT)
-aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/unit TEST_SOURCES_UNIT)
-aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/functional TEST_SOURCES_FUNCTIONAL)
+# Sources listed explicitly, as lib/CMakeLists.txt does. aux_source_directory()
+# is evaluated at configure time, so adding a file did not regenerate the build
+# and failed at link until cmake was re-run by hand.
+set(TEST_SOURCES_ROOT
+    ${CMAKE_CURRENT_SOURCE_DIR}/main.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_base.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_common.cc
+)
 
-set(TEST_SOURCES ${TEST_SOURCES_ROOT} ${TEST_SOURCES_UNIT} ${TEST_SOURCES_FUNCTIONAL})
+set(TEST_SOURCES_UNIT
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/acpi_parser_test.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/concurrency_test.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/cuid_gpu_test.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/file_lock_test.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/gim_util_test.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/id_string_test.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/pci_util_test.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/sha256_test.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/status_string_test.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/utilities_test.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/version_read_test.cc
+)
+
+set(TEST_SOURCES_FUNCTIONAL
+    ${CMAKE_CURRENT_SOURCE_DIR}/functional/device_handles_test.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/functional/device_query_test.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/functional/device_refresh_test.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/functional/hmac_test.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/functional/reverse_lookup_test.cc
+)
+
+# Headers are listed so they show up in IDE project trees, as lib/ does.
+set(TEST_HEADERS
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_base.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_common.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/acpi_parser_test.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/concurrency_test.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/cuid_gpu_test.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/file_lock_test.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/gim_util_test.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/id_string_test.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/pci_util_test.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/sha256_test.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/status_string_test.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/utilities_test.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/version_read_test.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/functional/device_handles_test.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/functional/device_query_test.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/functional/device_refresh_test.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/functional/hmac_test.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/functional/reverse_lookup_test.h
+)
+
+set(TEST_SOURCES ${TEST_SOURCES_ROOT} ${TEST_SOURCES_UNIT} ${TEST_SOURCES_FUNCTIONAL} ${TEST_HEADERS})
 
 # Enable testing
 enable_testing()
@@ -62,7 +110,11 @@ target_include_directories(
         ${CMAKE_SOURCE_DIR}/lib
 )
 
-target_link_libraries(${AMDCUID_TST_EXECUTABLE} amdcuid_static GTest::gtest)
+# concurrency_test.cc spawns std::thread, so the suite needs a threading
+# implementation of its own.
+find_package(Threads REQUIRED)
+
+target_link_libraries(${AMDCUID_TST_EXECUTABLE} amdcuid_static GTest::gtest Threads::Threads)
 
 # Register two CTest targets split by privilege level.
 add_test(NAME cuid_unprivileged_tests COMMAND ${AMDCUID_TST_EXECUTABLE} --gtest_filter=cuidtstUnprivileged.*)

--- a/projects/cuid/tests/main.cc
+++ b/projects/cuid/tests/main.cc
@@ -4,10 +4,13 @@
 #include "test_common.h"
 
 // Unit tests (no root or device required)
+#include "unit/acpi_parser_test.h"
+#include "unit/concurrency_test.h"
 #include "unit/cuid_gpu_test.h"
 #include "unit/file_lock_test.h"
 #include "unit/gim_util_test.h"
 #include "unit/id_string_test.h"
+#include "unit/pci_util_test.h"
 #include "unit/sha256_test.h"
 #include "unit/status_string_test.h"
 #include "unit/utilities_test.h"
@@ -133,8 +136,23 @@ TEST(cuidtstUnprivileged, GimFormatBdf) {
   RunGenericTest(&tst);
 }
 
+TEST(cuidtstUnprivileged, PciConfigDecode) {
+  TestPciConfigDecode tst;
+  RunGenericTest(&tst);
+}
+
+TEST(cuidtstUnprivileged, ConcurrentApi) {
+  TestConcurrentApi tst;
+  RunGenericTest(&tst);
+}
+
 TEST(cuidtstUnprivileged, CuidGpuRenderNode) {
   TestCuidGpuRenderNode tst;
+  RunGenericTest(&tst);
+}
+
+TEST(cuidtstUnprivileged, AcpiMadtParse) {
+  TestAcpiMadtParse tst;
   RunGenericTest(&tst);
 }
 

--- a/projects/cuid/tests/unit/acpi_parser_test.cc
+++ b/projects/cuid/tests/unit/acpi_parser_test.cc
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "unit/acpi_parser_test.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include "src/acpi_parser.h"
+
+namespace {
+
+// Append the raw bytes of a packed firmware struct to a table image.
+template <typename T>
+void append_struct(std::vector<uint8_t>& table, const T& value) {
+  const auto* bytes = reinterpret_cast<const uint8_t*>(&value);
+  table.insert(table.end(), bytes, bytes + sizeof(T));
+}
+
+// Patch the header length field and recompute the ACPI checksum so the table
+// passes validation. Must be called after all entries have been appended.
+void finalize(std::vector<uint8_t>& table) {
+  const uint32_t length = static_cast<uint32_t>(table.size());
+  std::memcpy(table.data() + offsetof(AcpiTableHeader, length), &length, sizeof(length));
+
+  table[offsetof(AcpiTableHeader, checksum)] = 0;
+  uint8_t sum = 0;
+  for (uint8_t b : table) {
+    sum = static_cast<uint8_t>(sum + b);
+  }
+  table[offsetof(AcpiTableHeader, checksum)] = static_cast<uint8_t>(0u - sum);
+}
+
+// A MADT image with a valid signature/length/checksum and no entries.
+std::vector<uint8_t> make_empty_madt() {
+  MadtHeader madt{};
+  std::memcpy(madt.header.signature, "APIC", 4);
+  madt.header.revision = 5;
+
+  std::vector<uint8_t> table;
+  append_struct(table, madt);
+  return table;
+}
+
+MadtLocalApic make_local_apic(uint8_t uid, uint8_t apic_id, bool enabled) {
+  MadtLocalApic e{};
+  e.header.type = 0;
+  e.header.length = sizeof(MadtLocalApic);
+  e.acpi_processor_uid = uid;
+  e.apic_id = apic_id;
+  e.flags = enabled ? 1u : 0u;
+  return e;
+}
+
+MadtLocalX2Apic make_local_x2apic(uint32_t uid, uint32_t x2apic_id, bool enabled) {
+  MadtLocalX2Apic e{};
+  e.header.type = 9;
+  e.header.length = sizeof(MadtLocalX2Apic);
+  e.x2apic_id = x2apic_id;
+  e.flags = enabled ? 1u : 0u;
+  e.acpi_processor_uid = uid;
+  return e;
+}
+
+}  // namespace
+
+TestAcpiMadtParse::TestAcpiMadtParse() {
+  SetTitle("ACPI MADT Parse");
+  SetDescription(
+      "Parse synthetic MADT tables and verify that malformed/truncated tables are "
+      "rejected without reading past the end of the buffer.");
+}
+
+void TestAcpiMadtParse::SetUp() {}
+
+void TestAcpiMadtParse::Run() {
+  std::vector<AcpiCpuInfo> cpus;
+
+  // Happy path: one Local APIC entry and one x2APIC entry, plus an unknown
+  // entry type that must be skipped rather than reported.
+  {
+    std::vector<uint8_t> table = make_empty_madt();
+    append_struct(table, make_local_apic(/*uid=*/1, /*apic_id=*/0x11, /*enabled=*/true));
+    // Unknown structure type 4 (Local APIC NMI), 6 bytes long.
+    const uint8_t nmi[6] = {4, 6, 0, 0, 0, 0};
+    table.insert(table.end(), nmi, nmi + sizeof(nmi));
+    append_struct(table, make_local_x2apic(/*uid=*/2, /*x2apic_id=*/0x2222, /*enabled=*/false));
+    finalize(table);
+
+    ASSERT_EQ(AcpiParser::parse_madt_buffer(table.data(), table.size(), cpus),
+              AMDCUID_STATUS_SUCCESS);
+    ASSERT_EQ(cpus.size(), 2u);
+
+    EXPECT_EQ(cpus[0].apic_id, 0x11u);
+    EXPECT_EQ(cpus[0].processor_uid, 1u);
+    EXPECT_TRUE(cpus[0].enabled);
+    EXPECT_FALSE(cpus[0].is_x2apic);
+
+    EXPECT_EQ(cpus[1].apic_id, 0x2222u);
+    EXPECT_EQ(cpus[1].processor_uid, 2u);
+    EXPECT_FALSE(cpus[1].enabled);
+    EXPECT_TRUE(cpus[1].is_x2apic);
+  }
+
+  // Regression: a table whose final byte begins an entry. The old walker
+  // tested only `entry < end` and then read entry->length, one byte past the
+  // buffer. It must now be rejected.
+  {
+    std::vector<uint8_t> table = make_empty_madt();
+    append_struct(table, make_local_apic(1, 0x11, true));
+    table.push_back(0);  // dangling entry-header type byte, no length byte
+    finalize(table);
+
+    EXPECT_EQ(AcpiParser::parse_madt_buffer(table.data(), table.size(), cpus),
+              AMDCUID_STATUS_INVALID_FORMAT);
+  }
+
+  // An entry whose declared length runs past the end of the table.
+  {
+    std::vector<uint8_t> table = make_empty_madt();
+    MadtLocalApic e = make_local_apic(1, 0x11, true);
+    e.header.length = sizeof(MadtLocalApic) + 32;  // lies about its size
+    append_struct(table, e);
+    finalize(table);
+
+    EXPECT_EQ(AcpiParser::parse_madt_buffer(table.data(), table.size(), cpus),
+              AMDCUID_STATUS_INVALID_FORMAT);
+  }
+
+  // A zero-length entry would never advance the walker; it must be rejected
+  // rather than spun on.
+  {
+    std::vector<uint8_t> table = make_empty_madt();
+    const uint8_t zero_len[4] = {0, 0, 0, 0};
+    table.insert(table.end(), zero_len, zero_len + sizeof(zero_len));
+    finalize(table);
+
+    EXPECT_EQ(AcpiParser::parse_madt_buffer(table.data(), table.size(), cpus),
+              AMDCUID_STATUS_INVALID_FORMAT);
+  }
+
+  // A Local APIC entry that declares a length smaller than the structure it
+  // claims to be must be skipped, not decoded from adjacent bytes.
+  {
+    std::vector<uint8_t> table = make_empty_madt();
+    const uint8_t short_apic[4] = {0, 4, 7, 7};  // type 0, length 4 (< 8)
+    table.insert(table.end(), short_apic, short_apic + sizeof(short_apic));
+    finalize(table);
+
+    // No usable CPU entries were found.
+    EXPECT_EQ(AcpiParser::parse_madt_buffer(table.data(), table.size(), cpus),
+              AMDCUID_STATUS_DEVICE_NOT_FOUND);
+    EXPECT_TRUE(cpus.empty());
+  }
+
+  // Degenerate inputs must not dereference anything.
+  {
+    EXPECT_EQ(AcpiParser::parse_madt_buffer(nullptr, 0, cpus), AMDCUID_STATUS_INVALID_FORMAT);
+
+    std::vector<uint8_t> truncated = make_empty_madt();
+    truncated.resize(sizeof(AcpiTableHeader));  // shorter than a MadtHeader
+    EXPECT_EQ(AcpiParser::parse_madt_buffer(truncated.data(), truncated.size(), cpus),
+              AMDCUID_STATUS_INVALID_FORMAT);
+  }
+
+  // Wrong signature and bad checksum are both rejected.
+  {
+    std::vector<uint8_t> table = make_empty_madt();
+    append_struct(table, make_local_apic(1, 0x11, true));
+    finalize(table);
+
+    std::vector<uint8_t> wrong_sig = table;
+    wrong_sig[0] = 'X';
+    EXPECT_EQ(AcpiParser::parse_madt_buffer(wrong_sig.data(), wrong_sig.size(), cpus),
+              AMDCUID_STATUS_INVALID_FORMAT);
+
+    std::vector<uint8_t> bad_sum = table;
+    bad_sum[offsetof(AcpiTableHeader, checksum)] ^= 0xFF;
+    EXPECT_EQ(AcpiParser::parse_madt_buffer(bad_sum.data(), bad_sum.size(), cpus),
+              AMDCUID_STATUS_INVALID_FORMAT);
+
+    // Header length disagreeing with the actual buffer size is rejected too.
+    std::vector<uint8_t> short_buf = table;
+    short_buf.pop_back();
+    EXPECT_EQ(AcpiParser::parse_madt_buffer(short_buf.data(), short_buf.size(), cpus),
+              AMDCUID_STATUS_INVALID_FORMAT);
+  }
+}

--- a/projects/cuid/tests/unit/acpi_parser_test.cc
+++ b/projects/cuid/tests/unit/acpi_parser_test.cc
@@ -1,24 +1,5 @@
-/*
- * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- */
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
 
 #include "unit/acpi_parser_test.h"
 

--- a/projects/cuid/tests/unit/acpi_parser_test.h
+++ b/projects/cuid/tests/unit/acpi_parser_test.h
@@ -1,24 +1,5 @@
-/*
- * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- */
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
 
 #ifndef CUID_TEST_UNIT_ACPI_PARSER_TEST_H_
 #define CUID_TEST_UNIT_ACPI_PARSER_TEST_H_

--- a/projects/cuid/tests/unit/acpi_parser_test.h
+++ b/projects/cuid/tests/unit/acpi_parser_test.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef CUID_TEST_UNIT_ACPI_PARSER_TEST_H_
+#define CUID_TEST_UNIT_ACPI_PARSER_TEST_H_
+
+#include "test_base.h"
+
+// Parses synthetic MADT images through AcpiParser::parse_madt_buffer. No root
+// and no real /sys/firmware/acpi/tables/APIC required. Covers the happy path
+// (Local APIC + x2APIC entries) and the malformed cases that previously read
+// past the end of the table buffer.
+class TestAcpiMadtParse : public TestBase {
+ public:
+  TestAcpiMadtParse();
+  void SetUp() override;
+  void Run() override;
+};
+
+#endif  // CUID_TEST_UNIT_ACPI_PARSER_TEST_H_

--- a/projects/cuid/tests/unit/concurrency_test.cc
+++ b/projects/cuid/tests/unit/concurrency_test.cc
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+// Every other test here is single-threaded, so a sanitizer run over the suite
+// cannot see a data race. This one drives the public API from several threads;
+// its real value is under -fsanitize=thread (with setarch -R to disable ASLR).
+
+#include "unit/concurrency_test.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstdio>
+#include <thread>
+#include <vector>
+
+#include "include/amd_cuid.h"
+
+namespace {
+
+constexpr int kThreads = 8;
+constexpr int kIterations = 25;
+
+// Every status the workers are allowed to see. Anything else means the API
+// returned something undefined under concurrency.
+bool acceptable(amdcuid_status_t status) {
+  switch (status) {
+    case AMDCUID_STATUS_SUCCESS:
+    case AMDCUID_STATUS_DEVICE_NOT_FOUND:
+    case AMDCUID_STATUS_UNSUPPORTED:
+    case AMDCUID_STATUS_INSUFFICIENT_SIZE:
+    case AMDCUID_STATUS_PERMISSION_DENIED:
+    case AMDCUID_STATUS_HW_FINGERPRINT_NOT_FOUND:
+    case AMDCUID_STATUS_FILE_NOT_FOUND:
+      return true;
+    default:
+      return false;
+  }
+}
+
+}  // namespace
+
+TestConcurrentApi::TestConcurrentApi() {
+  SetTitle("Concurrent Public API Use");
+  SetDescription(
+      "Drive amdcuid_get_all_handles, amdcuid_query_device_property and "
+      "amdcuid_refresh from several threads at once. Guards the "
+      "CuidDeviceManager locking; run under ThreadSanitizer to detect races.");
+}
+
+void TestConcurrentApi::SetUp() {}
+
+void TestConcurrentApi::Run() {
+  std::atomic<int> bad_status{0};
+  std::atomic<int> observed{0};
+
+  auto worker = [&](int id) {
+    for (int i = 0; i < kIterations; ++i) {
+      uint32_t count = 0;
+      amdcuid_status_t status = amdcuid_get_all_handles(nullptr, &count);
+      if (!acceptable(status)) {
+        ++bad_status;
+        continue;
+      }
+
+      if (status == AMDCUID_STATUS_SUCCESS && count > 0) {
+        std::vector<amdcuid_id_t> handles(count);
+        uint32_t fetched = count;
+        if (amdcuid_get_all_handles(handles.data(), &fetched) == AMDCUID_STATUS_SUCCESS) {
+          ++observed;
+          const uint32_t examine = (fetched < 4) ? fetched : 4;
+          for (uint32_t h = 0; h < examine; ++h) {
+            amdcuid_id_t derived{};
+            uint32_t len = sizeof(derived);
+            if (!acceptable(amdcuid_query_device_property(handles[h], AMDCUID_QUERY_DERIVED_CUID,
+                                                          &derived, &len))) {
+              ++bad_status;
+            }
+            // Size-query form: data == nullptr must still return a defined
+            // status rather than an uninitialized one.
+            uint32_t path_len = 0;
+            if (!acceptable(amdcuid_query_device_property(handles[h], AMDCUID_QUERY_DEVICE_PATH,
+                                                          nullptr, &path_len))) {
+              ++bad_status;
+            }
+          }
+        }
+      }
+
+      // Force a rediscovery underneath the readers. This is what makes the
+      // device list get replaced while other threads are walking it.
+      if ((i % 5) == (id % 5)) {
+        if (!acceptable(amdcuid_refresh())) {
+          ++bad_status;
+        }
+      }
+    }
+  };
+
+  std::vector<std::thread> threads;
+  threads.reserve(kThreads);
+  for (int i = 0; i < kThreads; ++i) {
+    threads.emplace_back(worker, i);
+  }
+  for (auto& t : threads) {
+    t.join();
+  }
+
+  EXPECT_EQ(bad_status.load(), 0) << "public API returned an unexpected status under concurrency";
+
+  IF_VERB(1) {
+    printf("  %d threads x %d iterations, %d successful enumerations\n", kThreads, kIterations,
+           observed.load());
+  }
+}
+
+void TestConcurrentApi::DisplayTestInfo() { TestBase::DisplayTestInfo(); }
+void TestConcurrentApi::DisplayResults() const { TestBase::DisplayResults(); }
+void TestConcurrentApi::Close() {}

--- a/projects/cuid/tests/unit/concurrency_test.cc
+++ b/projects/cuid/tests/unit/concurrency_test.cc
@@ -1,24 +1,5 @@
-/*
- * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- */
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
 
 // Every other test here is single-threaded, so a sanitizer run over the suite
 // cannot see a data race. This one drives the public API from several threads;

--- a/projects/cuid/tests/unit/concurrency_test.h
+++ b/projects/cuid/tests/unit/concurrency_test.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef CUID_TEST_UNIT_CONCURRENCY_TEST_H_
+#define CUID_TEST_UNIT_CONCURRENCY_TEST_H_
+
+#include "test_base.h"
+
+// Drives the public C API from several threads at once so that
+// CuidDeviceManager's shared state is exercised concurrently. Without this the
+// suite is single-threaded and ThreadSanitizer has nothing to observe.
+class TestConcurrentApi : public TestBase {
+ public:
+  TestConcurrentApi();
+  void SetUp() override;
+  void Run() override;
+  void DisplayTestInfo() override;
+  void DisplayResults() const override;
+  void Close() override;
+};
+
+#endif  // CUID_TEST_UNIT_CONCURRENCY_TEST_H_

--- a/projects/cuid/tests/unit/concurrency_test.h
+++ b/projects/cuid/tests/unit/concurrency_test.h
@@ -1,24 +1,5 @@
-/*
- * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- */
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
 
 #ifndef CUID_TEST_UNIT_CONCURRENCY_TEST_H_
 #define CUID_TEST_UNIT_CONCURRENCY_TEST_H_

--- a/projects/cuid/tests/unit/pci_util_test.cc
+++ b/projects/cuid/tests/unit/pci_util_test.cc
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "unit/pci_util_test.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstdio>
+
+#include "src/pci_util.h"
+
+namespace {
+
+// The first 16 bytes of a PCI type-0 configuration header for an AMD device,
+// exactly as they appear on the wire (little-endian):
+//
+//   0x00 vendor  = 0x1002   -> 02 10
+//   0x02 device  = 0x73A1   -> A1 73
+//   0x04 command                    0x06 status
+//   0x08 revision = 0xC1            0x09 prog-if = 0x00
+//   0x0A subclass = 0x00            0x0B class   = 0x03  (display controller)
+constexpr uint8_t kHeader[16] = {
+    0x02, 0x10,  // 0x00 vendor
+    0xA1, 0x73,  // 0x02 device
+    0x07, 0x04,  // 0x04 command
+    0x10, 0x00,  // 0x06 status
+    0xC1,        // 0x08 revision
+    0x00,        // 0x09 prog-if
+    0x00,        // 0x0A subclass
+    0x03,        // 0x0B class
+    0x00, 0x00, 0x00, 0x00,
+};
+
+}  // namespace
+
+TestPciConfigDecode::TestPciConfigDecode() {
+  SetTitle("PCI Config-Space Decode");
+  SetDescription(
+      "Verify the little-endian loads used by the PCI config-space fallback "
+      "produce the same values sysfs reports, and that RevisionID does not "
+      "pick up the prog-if byte.");
+}
+
+void TestPciConfigDecode::SetUp() {}
+
+void TestPciConfigDecode::Run() {
+  // VendorID at 0x00. The historic bug: this was byte-swapped after loading,
+  // so AMD's 0x1002 was recorded as 0x0210.
+  EXPECT_EQ(PciUtil::load_le16(&kHeader[0x00]), 0x1002u);
+  EXPECT_NE(PciUtil::load_le16(&kHeader[0x00]), 0x0210u);
+
+  // DeviceID at 0x02.
+  EXPECT_EQ(PciUtil::load_le16(&kHeader[0x02]), 0x73A1u);
+
+  // Class at 0x0A loads subclass then class, giving 0xCCSS -- the same value
+  // sysfs "class" gives after >>8. Both feed the same CUID field, so they must
+  // agree.
+  const uint16_t from_config = PciUtil::load_le16(&kHeader[0x0A]);
+  const uint32_t sysfs_class_24bit = 0x030000u;  // class 03, subclass 00, prog-if 00
+  EXPECT_EQ(from_config, 0x0300u);
+  EXPECT_EQ(from_config, static_cast<uint16_t>(sysfs_class_24bit >> 8));
+
+  // RevisionID is the single byte at 0x08. Reading two bytes and narrowing
+  // used to keep the prog-if byte at 0x09 instead.
+  EXPECT_EQ(kHeader[0x08], 0xC1u);
+  EXPECT_EQ(static_cast<uint8_t>(PciUtil::load_le16(&kHeader[0x08]) >> 8), kHeader[0x09]);
+
+  // Must work unaligned: every odd offset of a config-space buffer is legal.
+  const uint8_t unaligned[3] = {0xFF, 0x34, 0x12};
+  EXPECT_EQ(PciUtil::load_le16(&unaligned[1]), 0x1234u);
+
+  // Boundary values.
+  const uint8_t zero[2] = {0x00, 0x00};
+  const uint8_t max[2] = {0xFF, 0xFF};
+  EXPECT_EQ(PciUtil::load_le16(zero), 0x0000u);
+  EXPECT_EQ(PciUtil::load_le16(max), 0xFFFFu);
+
+  IF_VERB(1) {
+    printf("  vendor=0x%04x device=0x%04x class=0x%04x revision=0x%02x\n",
+           PciUtil::load_le16(&kHeader[0x00]), PciUtil::load_le16(&kHeader[0x02]), from_config,
+           kHeader[0x08]);
+  }
+}
+
+void TestPciConfigDecode::DisplayTestInfo() { TestBase::DisplayTestInfo(); }
+void TestPciConfigDecode::DisplayResults() const { TestBase::DisplayResults(); }
+void TestPciConfigDecode::Close() {}

--- a/projects/cuid/tests/unit/pci_util_test.cc
+++ b/projects/cuid/tests/unit/pci_util_test.cc
@@ -1,24 +1,5 @@
-/*
- * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- */
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
 
 #include "unit/pci_util_test.h"
 

--- a/projects/cuid/tests/unit/pci_util_test.h
+++ b/projects/cuid/tests/unit/pci_util_test.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef CUID_TEST_UNIT_PCI_UTIL_TEST_H_
+#define CUID_TEST_UNIT_PCI_UTIL_TEST_H_
+
+#include "test_base.h"
+
+// Pins the interpretation of PCI configuration-space bytes. These values feed
+// straight into the primary CUID, so getting them wrong silently changes every
+// identifier a machine issues.
+class TestPciConfigDecode : public TestBase {
+ public:
+  TestPciConfigDecode();
+  void SetUp() override;
+  void Run() override;
+  void DisplayTestInfo() override;
+  void DisplayResults() const override;
+  void Close() override;
+};
+
+#endif  // CUID_TEST_UNIT_PCI_UTIL_TEST_H_

--- a/projects/cuid/tests/unit/pci_util_test.h
+++ b/projects/cuid/tests/unit/pci_util_test.h
@@ -1,24 +1,5 @@
-/*
- * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- */
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
 
 #ifndef CUID_TEST_UNIT_PCI_UTIL_TEST_H_
 #define CUID_TEST_UNIT_PCI_UTIL_TEST_H_

--- a/projects/cuid/tests/unit/sha256_test.cc
+++ b/projects/cuid/tests/unit/sha256_test.cc
@@ -20,17 +20,20 @@
  * THE SOFTWARE.
  */
 
-// These are the vectors that pin the CUID derivation to the standard. The
-// library no longer links a certified crypto module, so the primitive it does
-// use has to demonstrate that it agrees with FIPS 180-4 / RFC 4231 bit for bit.
-// A regression here changes every CUID the fleet has ever been issued.
+// Pins the CUID derivation to FIPS 180-4 / RFC 4231. A regression here changes
+// every CUID ever issued.
 
 #include "unit/sha256_test.h"
 
 #include <gtest/gtest.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
+#include <fstream>
 #include <string>
 #include <vector>
 
@@ -229,6 +232,114 @@ void TestHmacSha256Kat::Run() {
     EXPECT_EQ(AMDCUID_STATUS_HMAC_ERROR, hmac.set_hmac_algorithm("SHA512"));
     EXPECT_EQ(AMDCUID_STATUS_SUCCESS, hmac.set_hmac_algorithm("SHA-256"));
     EXPECT_EQ(AMDCUID_STATUS_SUCCESS, hmac.set_hmac_algorithm(nullptr));
+  }
+
+  // set_hmac_key is in-memory only: it must not create or touch a key file.
+  // store_key is what persists, atomically, at mode 0600.
+  {
+    const std::string dir = "/tmp/amdcuid_store_key_test";
+    const std::string path = dir + "/hmac_key.bin";
+    ::mkdir(dir.c_str(), 0755);
+    ::unlink(path.c_str());
+    ::setenv("AMDCUID_HMAC_KEY_PATH", path.c_str(), 1);
+
+    {
+      cuid_hmac hmac;  // no key file yet
+      // With nothing provisioned the object is usable, keyed with the public
+      // default seed, and says so.
+      EXPECT_TRUE(hmac.is_valid());
+      EXPECT_TRUE(hmac.is_using_default_key());
+      EXPECT_EQ(hmac.get_key_file_path(), path);
+
+      // The default seed must match the kernel's CUID_DEFAULT_SEED byte for
+      // byte, or an unprovisioned machine derives one secondary CUID from
+      // sysfs and a different one from this library.
+      {
+        static const char kKernelDefaultSeed[] = "AMD-CUID-DEFAULT-SEED-v1";
+        uint8_t via_lib[hash_length];
+        size_t via_lib_len = 0;
+        const uint8_t msg[16] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+        EXPECT_EQ(AMDCUID_STATUS_SUCCESS,
+                  hmac.generate_hmac_sha256(msg, sizeof(msg), via_lib, &via_lib_len));
+
+        uint8_t expected[rocm::sha2::SHA256_DIGEST_SIZE];
+        rocm::sha2::hmac_sha256(reinterpret_cast<const uint8_t*>(kKernelDefaultSeed),
+                                sizeof(kKernelDefaultSeed) - 1, msg, sizeof(msg), expected);
+        EXPECT_EQ(to_hex(via_lib, sizeof(via_lib)), to_hex(expected, sizeof(expected)));
+      }
+
+      uint8_t k[key_length];
+      std::memset(k, 0x5a, sizeof(k));
+      EXPECT_EQ(AMDCUID_STATUS_SUCCESS, hmac.set_hmac_key(k));
+      EXPECT_TRUE(hmac.is_valid());
+      EXPECT_FALSE(hmac.is_using_default_key());
+
+      // In-memory only: still nothing on disk.
+      struct stat st;
+      EXPECT_NE(0, ::stat(path.c_str(), &st));
+
+      EXPECT_EQ(AMDCUID_STATUS_SUCCESS, hmac.store_key(k));
+      ASSERT_EQ(0, ::stat(path.c_str(), &st));
+      EXPECT_EQ(static_cast<off_t>(key_length), st.st_size);
+      EXPECT_EQ(0600, st.st_mode & 07777);
+
+      // No temporary file left behind.
+      struct stat tst;
+      EXPECT_NE(0, ::stat((path + ".new").c_str(), &tst));
+
+      // Overwriting an existing key must succeed (the old code unlinked first).
+      std::memset(k, 0xa5, sizeof(k));
+      EXPECT_EQ(AMDCUID_STATUS_SUCCESS, hmac.store_key(k));
+      ASSERT_EQ(0, ::stat(path.c_str(), &st));
+      EXPECT_EQ(static_cast<off_t>(key_length), st.st_size);
+      EXPECT_EQ(0600, st.st_mode & 07777);
+    }
+
+    // A fresh instance must load exactly what was stored and derive the same
+    // MAC as an instance keyed directly.
+    {
+      uint8_t k[key_length];
+      std::memset(k, 0xa5, sizeof(k));
+      cuid_hmac from_file;
+      EXPECT_TRUE(from_file.is_valid());
+      EXPECT_FALSE(from_file.is_using_default_key());
+      cuid_hmac from_mem(k);
+
+      uint8_t a[hash_length], c[hash_length];
+      size_t la = 0, lc = 0;
+      const uint8_t msg[4] = {1, 2, 3, 4};
+      EXPECT_EQ(AMDCUID_STATUS_SUCCESS, from_file.generate_hmac_sha256(msg, sizeof(msg), a, &la));
+      EXPECT_EQ(AMDCUID_STATUS_SUCCESS, from_mem.generate_hmac_sha256(msg, sizeof(msg), c, &lc));
+      EXPECT_EQ(0, std::memcmp(a, c, sizeof(a)));
+    }
+
+    // A wrong-sized key file must be rejected rather than half-loaded.
+    {
+      std::ofstream short_key(path, std::ios::binary | std::ios::trunc);
+      short_key.write("\x01\x02\x03", 3);
+      short_key.close();
+      // Corruption is not absence: a wrong-sized key file must be refused
+      // rather than silently falling back to the default, which would change
+      // every CUID on the machine.
+      cuid_hmac bad;
+      EXPECT_FALSE(bad.is_valid());
+      EXPECT_FALSE(bad.is_using_default_key());
+      uint8_t out[hash_length];
+      size_t n = 0;
+      const uint8_t msg[1] = {0};
+      EXPECT_EQ(AMDCUID_STATUS_KEY_ERROR, bad.generate_hmac_sha256(msg, 1, out, &n));
+    }
+
+    ::unlink(path.c_str());
+    ::rmdir(dir.c_str());
+    ::unsetenv("AMDCUID_HMAC_KEY_PATH");
+  }
+
+  // Null arguments must be rejected, not memcpy'd.
+  {
+    cuid_hmac hmac;
+    EXPECT_EQ(AMDCUID_STATUS_INVALID_ARGUMENT, hmac.set_hmac_key(nullptr));
+    EXPECT_EQ(AMDCUID_STATUS_INVALID_ARGUMENT, hmac.store_key(nullptr));
   }
 
   // generate_key must return distinct, non-trivial key material.


### PR DESCRIPTION
Bugs found while removing the OpenSSL dependency, kept separate from it.

## Memory safety and identity

- **IPC**: `IpcRequest::device_path` was a `char*` inside a struct sent over a socket. The client wrote through an indeterminate pointer and the daemon dereferenced a peer-supplied one. Now an in-band bounded buffer with a looped `recv`.
- **ACPI**: the MADT walk read a 2-byte entry header after checking only one byte remained. Reproduced under ASan as a heap over-read; now offset-based and bounds-checked, with 9 malformed-table cases.
- **Identity**: a NIC with an unprogrammed DSN reported `SUCCESS` with fingerprint 0 and was not flagged temporary, so every device in that state fleet-wide would share one primary CUID. Zero now means no identity, and the NIC path falls through to the MAC address as it always intended - the device that reported zero now reports a real, stable value.
- `amdcuid_query_device_property` returned an uninitialized status for the documented size-query call (`data == nullptr`) on 11 query types.

## Key handling

- `amdcuid_set_hash_key` discarded the status and returned `SUCCESS` **while writing nothing**. Persistence is now atomic (`O_EXCL` 0600, fsync, rename); the old path unlinked the key first, so a failure destroyed it and every CUID derived from it.
- With no key file every privileged lookup failed - the state of any container or CI image. Falls back to a public default seed byte-identical to the kernel's `CUID_DEFAULT_SEED`, so sysfs and this library agree on an unprovisioned machine. A wrong-sized key file is still refused.

## Thread safety

In a library linked into amd_smi and `libhsa-runtime64.so`:

- `get_all_handles()`/`lookup_by_handle()` read state that `discover_devices()` replaces under the mutex, and `devices()` returned a **reference** into it that two callers iterate. ThreadSanitizer: 11 races → 0.
- `strerror()` and `ctime()` write to static buffers shared across threads.

## Behaviour change

The PCI config-space fallback decoded every field wrongly: an aliasing cast, then `le16_to_be16` byte-swapping an already-correct little-endian value (vendor `0x1002` read back as `0x0210`), and RevisionID picking up the prog-if byte. Fixed in gpu, nic and npu. **This changes the primary CUID of any device that reaches the fallback**; devices with readable sysfs are unaffected, verified on a 7-device host.

Also: swapped privileged/unprivileged `CuidFile` flags (would have made the privileged file 0644 and stripped primary CUIDs from it), a `size_t` overflow in the config-space bounds check, unchecked `sscanf` on a MAC, `toupper()` on a plain `char`, and the clang-tidy findings behind them.

## Verification

25/25 as user and 32/32 as root from cold state with no key file, where the parent commit fails 4. Clean under ASan+LSan, UBSan and TSan. clang-tidy reports no `bugprone-*`, `cert-err33/34` or `concurrency-*` findings.
