### PR TITLE
fix(rocprofiler-sdk): avoid target aborts on temp file failures in attach

### DIFF
--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/registration.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/registration.h
@@ -57,6 +57,9 @@ typedef void (*rocprofiler_client_detach_t)(rocprofiler_client_id_t);
  * configuration.
  * @param [in] tool_data `tool_data` field returned from ::rocprofiler_configure_attach in
  * ::rocprofiler_tool_configure_result_t.
+ * @return int
+ * @retval 0 attach succeeded
+ * @retval non-zero attach failed
  */
 ROCPROFILER_SDK_EXPERIMENTAL
 typedef int (*rocprofiler_tool_attach_t)(rocprofiler_client_detach_t detach_func,

--- a/projects/rocprofiler-sdk/source/lib/common/container/ring_buffer.cpp
+++ b/projects/rocprofiler-sdk/source/lib/common/container/ring_buffer.cpp
@@ -213,7 +213,7 @@ ring_buffer::reset()
 }
 //
 
-void
+bool
 ring_buffer::save(std::fstream& _fs)
 {
     auto _read_count  = m_read_count.load();
@@ -222,6 +222,7 @@ ring_buffer::save(std::fstream& _fs)
     _fs.write(reinterpret_cast<char*>(&_read_count), sizeof(_read_count));
     _fs.write(reinterpret_cast<char*>(&_write_count), sizeof(_write_count));
     _fs.write(reinterpret_cast<char*>(m_ptr), m_size * sizeof(char));
+    return _fs.good();
 }
 //
 

--- a/projects/rocprofiler-sdk/source/lib/common/container/ring_buffer.hpp
+++ b/projects/rocprofiler-sdk/source/lib/common/container/ring_buffer.hpp
@@ -133,7 +133,7 @@ struct ring_buffer
     std::string as_string() const;
 
     /// save the entire buffer to a filestream
-    void save(std::fstream& _fs);
+    bool save(std::fstream& _fs);
 
     /// load the entire buffer from a filestream
     void load(std::fstream& _fs);

--- a/projects/rocprofiler-sdk/source/lib/output/counter_info.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/counter_info.cpp
@@ -50,13 +50,14 @@ tool_counter_record_t::read() const
     return _tmp_file.read<tool_counter_value_t>(*record.fpos);
 }
 
-void
+bool
 tool_counter_record_t::write(const tool_counter_record_t::container_type& _data)
 {
-    if(_data.empty()) return;
+    if(_data.empty()) return false;
 
     auto& _tmp_file = CHECK_NOTNULL(get_tmp_file_buffer<tool_counter_value_t>(counter_value))->file;
     record.fpos     = _tmp_file.write<tool_counter_value_t>(_data.data(), _data.size());
+    return record.fpos.has_value();
 }
 
 tool_spm_counter_record_t::container_type
@@ -69,14 +70,15 @@ tool_spm_counter_record_t::read() const
     return _tmp_file.read<tool_spm_counter_value_t>(*record.fpos);
 }
 
-void
+bool
 tool_spm_counter_record_t::write(const tool_spm_counter_record_t::container_type& _data)
 {
-    if(_data.empty()) return;
+    if(_data.empty()) return false;
 
     auto& _tmp_file =
         CHECK_NOTNULL(get_tmp_file_buffer<tool_spm_counter_value_t>(spm_counter_value))->file;
     record.fpos = _tmp_file.write<tool_spm_counter_value_t>(_data.data(), _data.size());
+    return record.fpos.has_value();
 }
 }  // namespace tool
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/output/counter_info.hpp
+++ b/projects/rocprofiler-sdk/source/lib/output/counter_info.hpp
@@ -113,7 +113,7 @@ struct tool_counter_record_t
     }
 
     container_type read() const;
-    void           write(const container_type& data);
+    bool           write(const container_type& data);
 };
 
 struct tool_spm_counter_value_t
@@ -153,7 +153,7 @@ struct tool_spm_counter_record_t
     }
 
     container_type read() const;
-    void           write(const container_type& data);
+    bool           write(const container_type& data);
 };
 }  // namespace tool
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/output/output_config.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/output_config.cpp
@@ -83,9 +83,20 @@ output_config::parse_env()
     perfetto_buffer_size = common::get_env("ROCPROF_PERFETTO_BUFFER_SIZE_KB", perfetto_buffer_size);
     defaults::validate_perfetto_buffer_size(perfetto_buffer_size);
 
-    output_path    = common::get_env("ROCPROF_OUTPUT_PATH", output_path);
-    output_file    = common::get_env("ROCPROF_OUTPUT_FILE_NAME", output_file);
-    tmp_directory  = common::get_env("ROCPROF_TMPDIR", tmp_directory);
+    const auto previous_output_path = output_path;
+    const auto previous_tmp_dir     = tmp_directory;
+
+    output_path = common::get_env("ROCPROF_OUTPUT_PATH", output_path);
+    output_file = common::get_env("ROCPROF_OUTPUT_FILE_NAME", output_file);
+
+    if(auto tmp_dir = common::get_env_optional("ROCPROF_TMPDIR"))
+    {
+        tmp_directory = *tmp_dir;
+    }
+    else if(previous_tmp_dir == previous_output_path)
+    {
+        tmp_directory = output_path;
+    }
     kernel_rename  = common::get_env("ROCPROF_KERNEL_RENAME", false);
     group_by_queue = common::get_env("ROCPROF_GROUP_BY_QUEUE", false);
     annotate_args  = common::get_env("ROCPROF_ANNOTATE_ARGS", false);

--- a/projects/rocprofiler-sdk/source/lib/output/output_config.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/output_config.cpp
@@ -93,6 +93,8 @@ output_config::parse_env()
     {
         tmp_directory = *tmp_dir;
     }
+    // Keep the default tmp directory aligned with ROCPROF_OUTPUT_PATH when it was not
+    // explicitly overridden, while preserving a caller-provided tmp_directory value.
     else if(previous_tmp_dir == previous_output_path)
     {
         tmp_directory = output_path;

--- a/projects/rocprofiler-sdk/source/lib/output/tmp_file.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/tmp_file.cpp
@@ -25,23 +25,79 @@
 #include "lib/common/filesystem.hpp"
 #include "lib/common/logging.hpp"
 
+#include <cerrno>
+#include <cstring>
+
 namespace fs = ::rocprofiler::common::filesystem;
+
+namespace
+{
+bool
+ensure_parent_directory(const std::string& filename)
+{
+    auto fpath = fs::path{filename}.parent_path();
+    if(fpath.empty()) return true;
+
+    auto ec = std::error_code{};
+    if(fs::exists(fpath, ec)) return true;
+
+    if(ec)
+    {
+        ROCP_ERROR << "failed to stat temporary file directory '" << fpath.string() << "' for '"
+                   << filename << "' :: " << ec.message();
+        return false;
+    }
+
+    fs::create_directories(fpath, ec);
+    if(ec)
+    {
+        ROCP_ERROR << "failed to create temporary file directory '" << fpath.string() << "' for '"
+                   << filename << "' :: " << ec.message();
+        return false;
+    }
+
+    return true;
+}
+
+bool
+ensure_file_exists(const std::string& filename, std::ios::openmode mode = std::ofstream::out)
+{
+    auto ec = std::error_code{};
+    if(fs::exists(filename, ec)) return true;
+
+    if(ec)
+    {
+        ROCP_ERROR << "failed to stat temporary file '" << filename << "' :: " << ec.message();
+        return false;
+    }
+
+    auto ofs = std::ofstream{};
+    ofs.open(filename, mode);
+    if(!ofs)
+    {
+        ROCP_ERROR << "failed to create temporary file: '" << filename << "'";
+        return false;
+    }
+
+    return true;
+}
+}  // namespace
 
 bool
 tmp_file::fopen(const char* _mode)
 {
-    auto fpath = fs::path{filename}.parent_path();
-    if(!fs::exists(fpath)) fs::create_directories(fpath);
+    if(!ensure_parent_directory(filename)) return false;
 
-    if(!fs::exists(filename))
-    {
-        // if the filepath does not exist, open in out mode to create it
-        std::ofstream _ofs{filename};
-    }
+    // if the filepath does not exist, open in out mode to create it
+    if(!ensure_file_exists(filename)) return false;
 
     ROCP_INFO << "opening (via fopen) temporary file: '" << filename << "'...";
     file = std::fopen(filename.c_str(), _mode);
-    if(file) fd = ::fileno(file);
+    if(file)
+        fd = ::fileno(file);
+    else
+        ROCP_ERROR << "failed to open temporary file via fopen: '" << filename
+                   << "' :: " << std::strerror(errno);
 
     return (file != nullptr && fd > 0);
 }
@@ -110,15 +166,10 @@ tmp_file::close()
 bool
 tmp_file::open(std::ios::openmode _mode)
 {
-    auto fpath = fs::path{filename}.parent_path();
-    if(!fs::exists(fpath)) fs::create_directories(fpath);
+    if(!ensure_parent_directory(filename)) return false;
 
-    if(!fs::exists(filename))
-    {
-        // if the filepath does not exist, open in out mode to create it
-        std::ofstream _ofs{};
-        _ofs.open(filename, std::ofstream::binary | std::ofstream::out);
-    }
+    // if the filepath does not exist, open in out mode to create it
+    if(!ensure_file_exists(filename, std::ofstream::binary | std::ofstream::out)) return false;
 
     if(stream.is_open() && stream.good())
     {
@@ -128,6 +179,8 @@ tmp_file::open(std::ios::openmode _mode)
 
     ROCP_INFO << "opening temporary file: '" << filename << "'...";
     stream.open(filename, _mode);
+    if(!stream.is_open() || !stream.good())
+        ROCP_ERROR << "failed to open temporary file: '" << filename << "'";
     return (stream.is_open() && stream.good());
 }
 
@@ -135,20 +188,26 @@ bool
 tmp_file::remove()
 {
     close();
-    if(fs::exists(filename))
+    auto ec = std::error_code{};
+    if(fs::exists(filename, ec))
     {
         ROCP_INFO << "removing temporary file: '" << filename << "'...";
-        auto _ec  = std::error_code{};
-        auto _ret = fs::remove(filename, _ec);
+        auto _ret = fs::remove(filename, ec);
 
-        if(_ec)
+        if(ec)
             ROCP_WARNING << fmt::format(
-                "Error removing temporary file '{}' :: {}", filename, _ec.message());
+                "Error removing temporary file '{}' :: {}", filename, ec.message());
         else if(!_ret)
             ROCP_WARNING << fmt::format("Error removing temporary file '{}' :: Unknown error",
                                         filename);
 
         return _ret;
+    }
+    else if(ec)
+    {
+        ROCP_WARNING << fmt::format(
+            "Error checking temporary file '{}' for removal :: {}", filename, ec.message());
+        return false;
     }
 
     return true;
@@ -157,7 +216,15 @@ tmp_file::remove()
 bool
 tmp_file::exists() const
 {
-    return fs::exists(filename);
+    auto ec  = std::error_code{};
+    auto ret = fs::exists(filename, ec);
+    if(ec)
+    {
+        ROCP_WARNING << fmt::format(
+            "Error checking temporary file '{}' :: {}", filename, ec.message());
+        return false;
+    }
+    return ret;
 }
 
 tmp_file::operator bool() const

--- a/projects/rocprofiler-sdk/source/lib/output/tmp_file.hpp
+++ b/projects/rocprofiler-sdk/source/lib/output/tmp_file.hpp
@@ -29,6 +29,7 @@
 #include <fstream>
 #include <ios>
 #include <mutex>
+#include <optional>
 #include <set>
 #include <string>
 #include <type_traits>
@@ -49,10 +50,10 @@ struct tmp_file
     explicit operator bool() const;
 
     template <typename Tp>
-    std::streampos write(const Tp* data, size_t num_records);
+    std::optional<std::streampos> write(const Tp* data, size_t num_records);
 
     template <typename Tp>
-    std::streampos write(const Tp& data);
+    std::optional<std::streampos> write(const Tp& data);
 
     template <typename Tp>
     std::vector<Tp> read(std::streampos seekpos);
@@ -67,23 +68,32 @@ struct tmp_file
 };
 
 template <typename Tp>
-std::streampos
+std::optional<std::streampos>
 tmp_file::write(const Tp* data, size_t num_records)
 {
     auto lk = std::unique_lock<std::mutex>{file_mutex};
 
-    if(!stream.is_open()) open();
+    if(!stream.is_open() && !open())
+    {
+        ROCP_ERROR << "failed to open temporary file for write: '" << filename << "'";
+        return std::nullopt;
+    }
     ROCP_CI_LOG_IF(WARNING, stream.tellg() != stream.tellp())  // this should always be true
         << "tellg=" << stream.tellg() << ", tellp=" << stream.tellp();
 
     auto pos = stream.tellp();
     stream.write(reinterpret_cast<const char*>(&num_records), sizeof(size_t));
     stream.write(reinterpret_cast<const char*>(data), num_records * sizeof(Tp));
+    if(!stream.good())
+    {
+        ROCP_ERROR << "failed to write temporary file: '" << filename << "'";
+        return std::nullopt;
+    }
     return pos;
 }
 
 template <typename Tp>
-std::streampos
+std::optional<std::streampos>
 tmp_file::write(const Tp& data)
 {
     static_assert(std::is_standard_layout<Tp>::value, "only supports standard layout types");
@@ -91,7 +101,11 @@ tmp_file::write(const Tp& data)
 
     auto lk = std::unique_lock<std::mutex>{file_mutex};
 
-    if(!stream.is_open()) open();
+    if(!stream.is_open() && !open())
+    {
+        ROCP_ERROR << "failed to open temporary file for write: '" << filename << "'";
+        return std::nullopt;
+    }
     ROCP_CI_LOG_IF(WARNING, stream.tellg() != stream.tellp())
         << fmt::format("tellg={}, tellp={}", stream.tellg(), stream.tellp());
 
@@ -99,6 +113,11 @@ tmp_file::write(const Tp& data)
     size_t num_records = 1;
     stream.write(reinterpret_cast<const char*>(&num_records), sizeof(size_t));
     stream.write(reinterpret_cast<const char*>(&data), num_records * sizeof(Tp));
+    if(!stream.good())
+    {
+        ROCP_ERROR << "failed to write temporary file: '" << filename << "'";
+        return std::nullopt;
+    }
     return pos;
 }
 
@@ -107,7 +126,11 @@ std::vector<Tp>
 tmp_file::read(std::streampos seekpos)
 {
     auto lk = std::unique_lock<std::mutex>{file_mutex};
-    if(!stream.is_open()) open();
+    if(!stream.is_open() && !open())
+    {
+        ROCP_ERROR << "failed to open temporary file for read: '" << filename << "'";
+        return {};
+    }
 
     stream.seekg(seekpos);
     size_t num_elements = 0;

--- a/projects/rocprofiler-sdk/source/lib/output/tmp_file_buffer.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/tmp_file_buffer.cpp
@@ -23,10 +23,19 @@
 #include "tmp_file_buffer.hpp"
 #include "domain_type.hpp"
 #include "lib/common/filesystem.hpp"
+#include "lib/common/logging.hpp"
 
 #include <fmt/format.h>
 
+#include <cerrno>
+#include <cstring>
+#include <fstream>
+#include <optional>
+#include <string>
+#include <string_view>
 #include <utility>
+
+#include <unistd.h>
 
 namespace rocprofiler
 {
@@ -43,6 +52,54 @@ compose_tmp_file_name(const output_config& cfg, domain_type buffer_type)
         fmt::format("{}-{}.dat", "%ppid%-%pid%", get_domain_trace_file_name(buffer_type));
 
     return rocprofiler::tool::format_path(filename.string());
+}
+
+std::optional<std::string>
+prepare_required_storage(const output_config& cfg)
+{
+    auto tmp_directory = fs::path{rocprofiler::tool::format_path(cfg.tmp_directory)};
+    auto probe_dir     = tmp_directory / ".rocprofv3";
+    auto probe_path =
+        probe_dir / fmt::format("attach-storage-probe-{}", static_cast<int>(::getpid()));
+
+    auto ec = std::error_code{};
+    fs::create_directories(probe_dir, ec);
+    if(ec)
+    {
+        return fmt::format("failed to create temporary storage directory '{}' :: {}",
+                           probe_dir.string(),
+                           ec.message());
+    }
+
+    {
+        auto ofs = std::ofstream{probe_path, std::ios::binary | std::ios::out | std::ios::trunc};
+        if(!ofs)
+        {
+            return fmt::format("failed to open temporary storage probe file '{}' :: {}",
+                               probe_path.string(),
+                               std::strerror(errno));
+        }
+
+        constexpr auto probe_bytes = std::string_view{"rocprofv3-attach-storage-probe"};
+        ofs.write(probe_bytes.data(), static_cast<std::streamsize>(probe_bytes.size()));
+        ofs.flush();
+        if(!ofs)
+        {
+            fs::remove(probe_path, ec);
+            return fmt::format("failed to write temporary storage probe file '{}' :: {}",
+                               probe_path.string(),
+                               std::strerror(errno));
+        }
+    }
+
+    if(!fs::remove(probe_path, ec) || ec)
+    {
+        ROCP_WARNING << fmt::format("failed to remove temporary storage probe file '{}' :: {}",
+                                    probe_path.string(),
+                                    ec ? ec.message() : "unknown error");
+    }
+
+    return std::nullopt;
 }
 
 tmp_file_name_callback_t&

--- a/projects/rocprofiler-sdk/source/lib/output/tmp_file_buffer.hpp
+++ b/projects/rocprofiler-sdk/source/lib/output/tmp_file_buffer.hpp
@@ -106,7 +106,7 @@ get_tmp_file_buffer(domain_type type)
 }
 
 template <typename Tp>
-void
+bool
 offload_buffer(domain_type type)
 {
     auto* filebuf = get_tmp_file_buffer<Tp>(type);
@@ -115,7 +115,7 @@ offload_buffer(domain_type type)
     {
         ROCP_CI_LOG(WARNING) << "rocprofv3 cannot offload buffer for "
                              << get_domain_column_name(type) << ". Buffer has been destroyed.";
-        return;
+        return false;
     }
 
     auto _lk = std::lock_guard<std::mutex>(filebuf->file.file_mutex);
@@ -126,7 +126,7 @@ offload_buffer(domain_type type)
                                   _nbytes,
                                   get_domain_column_name(type),
                                   filebuf->file.filename);
-        return;
+        return false;
     }
     auto& _fs = filebuf->file.stream;
 
@@ -138,13 +138,23 @@ offload_buffer(domain_type type)
     ROCP_TRACE << fmt::format(
         "offloading {} B from {} buffer to tmp file", _nbytes, get_domain_column_name(type));
 
-    filebuf->file.file_pos.emplace(_fs.tellp());
+    auto _pos = _fs.tellp();
+    if(!filebuf->buffer.save(_fs))
+    {
+        ROCP_ERROR << fmt::format("failed to offload {} B from {} buffer to temporary file '{}'",
+                                  _nbytes,
+                                  get_domain_column_name(type),
+                                  filebuf->file.filename);
+        return false;
+    }
+
+    filebuf->file.file_pos.emplace(_pos);
     filebuf->nbytes += _nbytes;
-    filebuf->buffer.save(_fs);
     filebuf->buffer.clear();
 
     ROCP_CI_LOG_IF(ERROR, !filebuf->buffer.is_empty())
         << "buffer is not empty after offload: count=" << filebuf->buffer.count();
+    return true;
 }
 
 template <typename Tp>
@@ -169,7 +179,14 @@ write_ring_buffer(Tp _v, domain_type type)
     auto* ptr = filebuf->buffer.request(false);
     if(ptr == nullptr)
     {
-        offload_buffer<Tp>(type);
+        if(!offload_buffer<Tp>(type))
+        {
+            ROCP_ERROR << "rocprofv3 is dropping record from domain "
+                       << get_domain_column_name(type)
+                       << " because temporary storage is unavailable.";
+            return;
+        }
+
         ptr = filebuf->buffer.request(false);
 
         // if failed, try again

--- a/projects/rocprofiler-sdk/source/lib/output/tmp_file_buffer.hpp
+++ b/projects/rocprofiler-sdk/source/lib/output/tmp_file_buffer.hpp
@@ -34,6 +34,7 @@
 
 #include <deque>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <tuple>
 #include <type_traits>
@@ -50,6 +51,9 @@ using tmp_file_name_callback_t = std::function<std::string(domain_type)>;
 
 std::string
 compose_tmp_file_name(const output_config& cfg, domain_type buffer_type);
+
+std::optional<std::string>
+prepare_required_storage(const output_config& cfg);
 
 tmp_file_name_callback_t&
 get_tmp_file_name_callback();

--- a/projects/rocprofiler-sdk/source/lib/output/tmp_file_buffer.hpp
+++ b/projects/rocprofiler-sdk/source/lib/output/tmp_file_buffer.hpp
@@ -118,9 +118,17 @@ offload_buffer(domain_type type)
         return;
     }
 
-    auto                  _lk      = std::lock_guard<std::mutex>(filebuf->file.file_mutex);
-    [[maybe_unused]] auto _success = filebuf->file.open();
-    auto&                 _fs      = filebuf->file.stream;
+    auto _lk = std::lock_guard<std::mutex>(filebuf->file.file_mutex);
+    if(!filebuf->file.open())
+    {
+        auto _nbytes = (filebuf->buffer.count() * filebuf->buffer.data_size());
+        ROCP_ERROR << fmt::format("failed to offload {} B from {} buffer to temporary file '{}'",
+                                  _nbytes,
+                                  get_domain_column_name(type),
+                                  filebuf->file.filename);
+        return;
+    }
+    auto& _fs = filebuf->file.stream;
 
     ROCP_CI_LOG_IF(WARNING, _fs.tellg() != _fs.tellp())  // this should always be true
         << "tellg=" << _fs.tellg() << ", tellp=" << _fs.tellp();

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -1882,9 +1882,8 @@ counter_record_callback(rocprofiler_dispatch_counting_service_data_t dispatch_da
             tool::tool_counter_value_t{_counter_id, record_data[count].counter_value});
     }
 
-    if(!serialized_records.empty())
+    if(!serialized_records.empty() && counter_record.write(serialized_records))
     {
-        counter_record.write(serialized_records);
         tool::write_ring_buffer(counter_record, domain_type::COUNTER_COLLECTION);
     }
 }
@@ -2032,9 +2031,8 @@ spm_data_callback(const rocprofiler_spm_dispatch_counting_service_data_t* dispat
                 _counter_id, records[count]->value, records[count]->timestamp, records[count]->id});
         }
 
-        if(!serialized_records.empty())
+        if(!serialized_records.empty() && counter_record.write(serialized_records))
         {
-            counter_record.write(serialized_records);
             tool::write_ring_buffer(counter_record, domain_type::SPM_COUNTER_COLLECTION);
         }
     }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -2519,6 +2519,12 @@ tool_attach(rocprofiler_client_detach_t /*detach_func*/,
            "After the initial attachment, it is recommended to just use `rocprofv3 --pid=<pid> [-o "
            "<output_file> -d <output_directory> ...]` to attach to a new process.";
 
+    if(auto err = tool::prepare_required_storage(tool::get_config()))
+    {
+        ROCP_ERROR << "Attach aborted: required profiling storage is unavailable: " << *err;
+        return -1;
+    }
+
     assign_attach_output_session_suffix();
 
     pid_t instrumented_pid = getpid();   // The process being profiled

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/attach.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/attach.cpp
@@ -36,8 +36,7 @@ rocprofiler_detach(void) ROCPROFILER_API;
 rocprofiler_status_t
 rocprofiler_attach(void)
 {
-    rocprofiler::registration::attach();
-    return ROCPROFILER_STATUS_SUCCESS;
+    return rocprofiler::registration::attach();
 }
 
 rocprofiler_status_t

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
@@ -754,7 +754,9 @@ invoke_client_attaches()
         return ROCPROFILER_STATUS_ERROR_NOT_AVAILABLE;
     }
 
-    auto ret = ROCPROFILER_STATUS_ERROR_NOT_IMPLEMENTED;
+    auto ret              = ROCPROFILER_STATUS_ERROR_NOT_IMPLEMENTED;
+    auto attached_clients = std::vector<client_library*>{};
+
     for(auto& itr : *get_clients())
     {
         if(itr && itr->configure_attach_result && itr->configure_attach_result->tool_attach)
@@ -764,11 +766,43 @@ invoke_client_attaches()
             ROCP_INFO << fmt::format(
                 "Client {} is attaching... Number of contexts: {}", itr->name, _contexts.size());
 
-            itr->configure_attach_result->tool_attach(nullptr,
-                                                      _contexts.data(),
-                                                      _contexts.size(),
-                                                      itr->configure_attach_result->tool_data);
+            auto attach_status = itr->configure_attach_result->tool_attach(
+                nullptr,
+                _contexts.data(),
+                _contexts.size(),
+                itr->configure_attach_result->tool_data);
 
+            if(attach_status != 0)
+            {
+                ROCP_ERROR << fmt::format(
+                    "Client {} failed to attach with status {}", itr->name, attach_status);
+
+                for(auto* prev : attached_clients)
+                {
+                    if(!prev || !prev->configure_attach_result ||
+                       !prev->configure_attach_result->tool_detach)
+                        continue;
+
+                    context::stop_client_contexts(prev->internal_client_id);
+                    hsa::async_copy_sync();
+                    hsa::queue_controller_sync();
+                    pc_sampling::service_sync(prev->internal_client_id);
+
+                    auto _fini_status = get_fini_status();
+                    if(_fini_status == 0) set_fini_status(-1);
+                    prev->configure_attach_result->tool_detach(
+                        prev->configure_attach_result->tool_data);
+                    if(_fini_status == 0) set_fini_status(_fini_status);
+                    context::deactivate_client_contexts(prev->internal_client_id);
+                }
+
+                if(get_attach_status())
+                    get_attach_status()->is_attached.store(false, std::memory_order_release);
+
+                return ROCPROFILER_STATUS_ERROR;
+            }
+
+            attached_clients.emplace_back(&(*itr));
             ret = ROCPROFILER_STATUS_SUCCESS;
         }
         else if(itr)

--- a/projects/rocprofiler-sdk/source/lib/tests/common/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/tests/common/CMakeLists.txt
@@ -10,6 +10,7 @@ set(common_sources
     environment.cpp
     md5sum.cpp
     mpl.cpp
+    output_config.cpp
     parse.cpp
     regex.cpp
     sha256.cpp

--- a/projects/rocprofiler-sdk/source/lib/tests/common/output_config.cpp
+++ b/projects/rocprofiler-sdk/source/lib/tests/common/output_config.cpp
@@ -1,0 +1,106 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "lib/output/output_config.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace
+{
+struct scoped_env
+{
+    scoped_env(const char* name, std::optional<std::string_view> value)
+    : name_v{name}
+    {
+        if(auto* current = std::getenv(name_v.c_str())) previous_v = std::string{current};
+
+        if(value)
+            setenv(name_v.c_str(), std::string{*value}.c_str(), 1);
+        else
+            unsetenv(name_v.c_str());
+    }
+
+    ~scoped_env()
+    {
+        if(previous_v)
+            setenv(name_v.c_str(), previous_v->c_str(), 1);
+        else
+            unsetenv(name_v.c_str());
+    }
+
+    std::string                name_v     = {};
+    std::optional<std::string> previous_v = {};
+};
+
+struct scoped_output_config_env
+{
+    scoped_env output_format{"ROCPROF_OUTPUT_FORMAT", std::nullopt};
+    scoped_env perfetto_backend{"ROCPROF_PERFETTO_BACKEND", std::nullopt};
+    scoped_env perfetto_buffer_size{"ROCPROF_PERFETTO_BUFFER_SIZE_KB", std::nullopt};
+    scoped_env stats_summary_unit{"ROCPROF_STATS_SUMMARY_UNITS", std::nullopt};
+};
+}  // namespace
+
+TEST(output_config, tmp_directory_follows_output_path_when_unset)
+{
+    auto clean_env   = scoped_output_config_env{};
+    auto output_path = scoped_env{"ROCPROF_OUTPUT_PATH", "/tmp/rocprof-output"};
+    auto tmp_dir     = scoped_env{"ROCPROF_TMPDIR", std::nullopt};
+
+    auto cfg = rocprofiler::tool::output_config::load_from_env();
+
+    EXPECT_EQ(cfg.output_path, "/tmp/rocprof-output");
+    EXPECT_EQ(cfg.tmp_directory, "/tmp/rocprof-output");
+}
+
+TEST(output_config, tmp_directory_env_overrides_output_path)
+{
+    auto clean_env   = scoped_output_config_env{};
+    auto output_path = scoped_env{"ROCPROF_OUTPUT_PATH", "/tmp/rocprof-output"};
+    auto tmp_dir     = scoped_env{"ROCPROF_TMPDIR", "/tmp/rocprof-tmp"};
+
+    auto cfg = rocprofiler::tool::output_config::load_from_env();
+
+    EXPECT_EQ(cfg.output_path, "/tmp/rocprof-output");
+    EXPECT_EQ(cfg.tmp_directory, "/tmp/rocprof-tmp");
+}
+
+TEST(output_config, custom_tmp_directory_is_preserved_when_not_implicit)
+{
+    auto clean_env   = scoped_output_config_env{};
+    auto output_path = scoped_env{"ROCPROF_OUTPUT_PATH", "/tmp/rocprof-output"};
+    auto tmp_dir     = scoped_env{"ROCPROF_TMPDIR", std::nullopt};
+
+    auto cfg          = rocprofiler::tool::output_config{};
+    cfg.output_path   = "/tmp/original-output";
+    cfg.tmp_directory = "/tmp/custom-tmp";
+    auto env_resolved = rocprofiler::tool::output_config::load_from_env(std::move(cfg));
+
+    EXPECT_EQ(env_resolved.output_path, "/tmp/rocprof-output");
+    EXPECT_EQ(env_resolved.tmp_directory, "/tmp/custom-tmp");
+}


### PR DESCRIPTION
## Motivation

`rocprofv3 attach` can abort the target process when temporary trace storage cannot be created.

In attach mode, buffered trace data is offloaded to temporary files under `ROCPROF_TMPDIR`. When `ROCPROF_TMPDIR` is not explicitly set, the temporary directory defaults to the output path, which initially resolves from `%cwd%`.

However, `rocprofv3 -d <path>` updates `ROCPROF_OUTPUT_PATH` without updating the implicit temporary directory. When attaching to a target whose working directory is read-only, such as `/opt` inside a container, rocprofiler may therefore attempt to create `/opt/.rocprofv3` even when a writable output directory was provided with `-d`. Failure to create the temporary directory could throw a filesystem exception inside the target process and abort the workload.

## Technical Details

* Keep the temporary directory synchronized with `ROCPROF_OUTPUT_PATH` when it has not been explicitly configured.
* Preserve an explicitly configured `ROCPROF_TMPDIR` or programmatically customized temporary directory.
* Use non-throwing filesystem operations when creating temporary directories and report failures with diagnostics instead of propagating filesystem exceptions into the target.
* Propagate temporary-file open and write failures through the buffered output path.
* Only publish temporary-file positions and clear buffered records after the offload succeeds.
* Drop records when temporary storage is unavailable instead of allowing the failure to reach a fatal buffer-allocation path.
* Avoid publishing counter and SPM records when their backing temporary-file writes fail.

This prevents profiler temporary-storage failures from aborting an attached workload.

## Issue Tracking

JIRA ID: ROCM-29133

## Test Plan

* Added output configuration tests verifying:

  * the implicit temporary directory follows `ROCPROF_OUTPUT_PATH`;
  * an explicit `ROCPROF_TMPDIR` takes precedence;
  * a separately configured temporary directory is preserved.
* Verify `rocprofv3 attach` from a target with a read-only working directory while specifying a writable output directory with `-d`.
* Verify temporary files are created under the configured output directory and the target remains running.

## Test Result

* New and existing output configuration tests pass.
* Verified attach does not abort the target when its working directory is read-only and a writable output directory is provided.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
